### PR TITLE
feat: extract shared frontend package (@platform/ui)

### DIFF
--- a/apps/mybookkeeper/frontend/src/shared/hooks/useCurrentOrg.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useCurrentOrg.ts
@@ -1,0 +1,15 @@
+import { useSelector } from "react-redux";
+import type { RootState } from "@/shared/store";
+import type { OrgWithRole } from "@/shared/types/organization/org-with-role";
+
+export function useCurrentOrg(): OrgWithRole | null {
+  return useSelector((state: RootState) => {
+    const { activeOrgId, organizations } = state.organization;
+    if (!activeOrgId) return null;
+    return organizations.find((o) => o.id === activeOrgId) ?? null;
+  });
+}
+
+export function useActiveOrgId(): string | null {
+  return useSelector((state: RootState) => state.organization.activeOrgId);
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useCurrentUser.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useCurrentUser.ts
@@ -1,0 +1,23 @@
+import { useGetMeQuery } from "@/shared/store/authApi";
+import type { ApiError } from "@/shared/types/api-error";
+import type { Role } from "@/shared/types/user/role";
+
+export function useCurrentUser() {
+  const { data: user, isLoading, isError, error } = useGetMeQuery();
+  return {
+    user: user ?? null,
+    isLoading,
+    isError,
+    error: error as ApiError | undefined,
+  };
+}
+
+export function useHasRole(...roles: Role[]): boolean {
+  const { user } = useCurrentUser();
+  if (!user) return false;
+  return roles.includes(user.role);
+}
+
+export function useIsAdmin(): boolean {
+  return useHasRole("admin");
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useDashboardFilter.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useDashboardFilter.ts
@@ -1,0 +1,185 @@
+import { useState, useMemo, useCallback } from "react";
+import { REVENUE_TAGS, EXPENSE_TAGS } from "@/shared/lib/constants";
+import { ALL_DASHBOARD_CATEGORIES, getCategoriesForPreset } from "@/shared/lib/dashboard-filter-config";
+import type { CategoryFilterPreset, CategoryFilterState } from "@/shared/types/dashboard/category-filter";
+import type { SummaryResponse } from "@/shared/types/summary/summary";
+import type { MonthSummary } from "@/shared/types/summary/month-summary";
+import type { MonthExpenseSummary } from "@/shared/types/summary/month-expense-summary";
+import type { PropertySummary } from "@/shared/types/summary/property-summary";
+
+export interface FilteredSummary {
+  revenue: number;
+  expenses: number;
+  profit: number;
+  by_category: Record<string, number>;
+  by_month: MonthSummary[];
+  by_month_expense: MonthExpenseSummary[];
+  by_property: PropertySummary[];
+  by_property_month: SummaryResponse["by_property_month"];
+}
+
+interface UseDashboardFilterReturn {
+  filterState: CategoryFilterState;
+  filteredSummary: FilteredSummary | undefined;
+  toggleCategory: (category: string) => void;
+  selectOnly: (category: string) => void;
+  setPreset: (preset: CategoryFilterPreset) => void;
+  resetCategories: () => void;
+  isFiltered: boolean;
+}
+
+function setsEqual(a: Set<string>, b: Set<string>): boolean {
+  if (a.size !== b.size) return false;
+  for (const item of a) {
+    if (!b.has(item)) return false;
+  }
+  return true;
+}
+
+function detectPreset(categories: Set<string>): CategoryFilterPreset {
+  if (setsEqual(categories, getCategoriesForPreset("all"))) return "all";
+  if (setsEqual(categories, getCategoriesForPreset("income"))) return "income";
+  if (setsEqual(categories, getCategoriesForPreset("expenses"))) return "expenses";
+  return "all";
+}
+
+function filterByCategory(
+  summary: SummaryResponse,
+  selected: Set<string>,
+): FilteredSummary {
+  const includesRevenue = [...selected].some((c) => REVENUE_TAGS.has(c));
+
+  // Filter by_category
+  const filteredByCategory: Record<string, number> = {};
+  for (const [cat, amount] of Object.entries(summary.by_category)) {
+    if (selected.has(cat)) {
+      filteredByCategory[cat] = amount;
+    }
+  }
+
+  // Filter by_month_expense: only include selected expense categories
+  const filteredByMonthExpense: MonthExpenseSummary[] = summary.by_month_expense.map((row) => {
+    const filtered: MonthExpenseSummary = { month: row.month };
+    for (const [key, val] of Object.entries(row)) {
+      if (key === "month") continue;
+      if (selected.has(key) && typeof val === "number") {
+        (filtered as unknown as Record<string, number | string>)[key] = val;
+      }
+    }
+    return filtered;
+  });
+
+  // Recalculate totals from filtered categories
+  let totalRevenue = 0;
+  let totalExpenses = 0;
+
+  for (const [cat, amount] of Object.entries(summary.by_category)) {
+    if (!selected.has(cat)) continue;
+    if (REVENUE_TAGS.has(cat)) {
+      totalRevenue += amount;
+    } else if (EXPENSE_TAGS.has(cat)) {
+      totalExpenses += amount;
+    }
+  }
+
+  // Recalculate by_month from filtered data
+  const filteredByMonth: MonthSummary[] = summary.by_month.map((row) => {
+    const expenseRow = summary.by_month_expense.find((e) => e.month === row.month);
+    let monthExpenses = 0;
+    if (expenseRow) {
+      for (const [key, val] of Object.entries(expenseRow)) {
+        if (key === "month") continue;
+        if (selected.has(key) && typeof val === "number") {
+          monthExpenses += val;
+        }
+      }
+    }
+
+    const monthRevenue = includesRevenue ? row.revenue : 0;
+    return {
+      month: row.month,
+      revenue: monthRevenue,
+      expenses: monthExpenses,
+      profit: monthRevenue - monthExpenses,
+    };
+  });
+
+  // Property sections always stay visible — they show totals regardless of category filter
+  // Property filtering is handled server-side via property_ids param
+  return {
+    revenue: totalRevenue,
+    expenses: totalExpenses,
+    profit: totalRevenue - totalExpenses,
+    by_category: filteredByCategory,
+    by_month: filteredByMonth,
+    by_month_expense: filteredByMonthExpense,
+    by_property: summary.by_property,
+    by_property_month: summary.by_property_month,
+  };
+}
+
+export function useDashboardFilter(summary: SummaryResponse | undefined): UseDashboardFilterReturn {
+  const [selectedCategories, setSelectedCategories] = useState<Set<string>>(
+    () => new Set(ALL_DASHBOARD_CATEGORIES),
+  );
+
+  const preset = useMemo(() => detectPreset(selectedCategories), [selectedCategories]);
+
+  const isFiltered = useMemo(() => {
+    return !setsEqual(selectedCategories, ALL_DASHBOARD_CATEGORIES);
+  }, [selectedCategories]);
+
+  const toggleCategory = useCallback((category: string) => {
+    setSelectedCategories((prev) => {
+      const next = new Set(prev);
+      if (next.has(category)) {
+        next.delete(category);
+      } else {
+        next.add(category);
+      }
+      // If removing the last category, reset to all instead of blocking
+      if (next.size === 0) return new Set(ALL_DASHBOARD_CATEGORIES);
+      return next;
+    });
+  }, []);
+
+  const selectOnly = useCallback((category: string) => {
+    setSelectedCategories((prev) => {
+      const isIncome = REVENUE_TAGS.has(category);
+      const isExpense = EXPENSE_TAGS.has(category);
+      const next = new Set<string>();
+      // Keep the other group's current selections
+      for (const cat of prev) {
+        if (isIncome && EXPENSE_TAGS.has(cat)) next.add(cat);
+        if (isExpense && REVENUE_TAGS.has(cat)) next.add(cat);
+      }
+      // Select only the clicked category within its group
+      next.add(category);
+      return next;
+    });
+  }, []);
+
+  const setPreset = useCallback((newPreset: CategoryFilterPreset) => {
+    setSelectedCategories(getCategoriesForPreset(newPreset));
+  }, []);
+
+  const resetCategories = useCallback(() => {
+    setSelectedCategories(new Set(ALL_DASHBOARD_CATEGORIES));
+  }, []);
+
+  const filteredSummary = useMemo(() => {
+    if (!summary) return undefined;
+    if (!isFiltered) return summary as FilteredSummary;
+    return filterByCategory(summary, selectedCategories);
+  }, [summary, selectedCategories, isFiltered]);
+
+  return {
+    filterState: { selectedCategories, preset },
+    filteredSummary,
+    toggleCategory,
+    selectOnly,
+    setPreset,
+    resetCategories,
+    isFiltered,
+  };
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useDismissable.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useDismissable.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from "react";
+
+/**
+ * Hook for info banners that can be dismissed and persist their dismissed state
+ * in localStorage. Used across pages (Documents, Integrations, Analytics, etc.)
+ * to avoid duplicating the same pattern 9 times.
+ */
+export function useDismissable(storageKey: string): {
+  dismissed: boolean;
+  dismiss: () => void;
+  reset: () => void;
+} {
+  const [dismissed, setDismissed] = useState<boolean>(
+    () => localStorage.getItem(storageKey) === "1",
+  );
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    localStorage.setItem(storageKey, "1");
+  }, [storageKey]);
+
+  const reset = useCallback(() => {
+    setDismissed(false);
+    localStorage.removeItem(storageKey);
+  }, [storageKey]);
+
+  return { dismissed, dismiss, reset };
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useDocumentColumns.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useDocumentColumns.tsx
@@ -1,0 +1,163 @@
+import { useMemo } from "react";
+import { createColumnHelper } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
+import { FileCheck, Trash2 } from "lucide-react";
+import { formatDate, timeAgo } from "@/shared/utils/date";
+import { DOCUMENT_TYPE_LABELS } from "@/shared/lib/constants";
+import type { Document } from "@/shared/types/document/document";
+import Button from "@/shared/components/ui/Button";
+import StatusBadge from "@/app/features/documents/StatusBadge";
+import IndeterminateCheckbox from "@/shared/components/ui/IndeterminateCheckbox";
+
+interface ColumnActions {
+  onDelete: (id: string) => void;
+  onToggleEscrow?: (id: string, currentValue: boolean) => void;
+  canWrite?: boolean;
+}
+
+const columnHelper = createColumnHelper<Document>();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useDocumentColumns(actions: ColumnActions): ColumnDef<Document, any>[] {
+  const { onDelete, onToggleEscrow, canWrite = true } = actions;
+
+  return useMemo(
+    () => [
+      columnHelper.display({
+        id: "select",
+        enableSorting: false,
+        header: ({ table }) => (
+          <IndeterminateCheckbox
+            checked={table.getIsAllRowsSelected()}
+            indeterminate={table.getIsSomeRowsSelected()}
+            onChange={table.getToggleAllRowsSelectedHandler()}
+            onClick={(e) => e.stopPropagation()}
+            aria-label="Select all documents"
+          />
+        ),
+        cell: ({ row }) => (
+          <IndeterminateCheckbox
+            checked={row.getIsSelected()}
+            onChange={row.getToggleSelectedHandler()}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={`Select ${row.original.file_name ?? "document"}`}
+          />
+        ),
+      }),
+      columnHelper.accessor("status", {
+        header: "Status",
+        enableSorting: true,
+        cell: ({ getValue, row }) => (
+          <div>
+            <StatusBadge status={getValue()} errorMessage={row.original.error_message} />
+            {row.original.is_escrow_paid && (
+              <span className="ml-1.5 inline-flex items-center gap-1 text-xs px-1.5 py-0.5 rounded bg-blue-100 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400">
+                <FileCheck size={10} />
+                Reference
+              </span>
+            )}
+            {getValue() === "failed" && row.original.error_message && (
+              <p className="text-xs text-red-600 dark:text-red-400 mt-1 max-w-[240px]">
+                {row.original.error_message}
+              </p>
+            )}
+          </div>
+        ),
+        filterFn: (row, _columnId, filterValue: string[]) => {
+          return filterValue.includes(row.getValue<string>("status"));
+        },
+      }),
+      columnHelper.accessor("file_name", {
+        header: "File",
+        enableSorting: true,
+        enableColumnFilter: true,
+        sortingFn: (rowA, rowB) => {
+          const a = rowA.original.file_name ?? "";
+          const b = rowB.original.file_name ?? "";
+          return a.localeCompare(b);
+        },
+        filterFn: "includesString",
+        cell: ({ getValue }) => (
+          <span className="block" title={getValue() ?? undefined}>
+            {getValue() ?? "\u2014"}
+          </span>
+        ),
+      }),
+      columnHelper.accessor("document_type", {
+        header: "Type",
+        enableSorting: true,
+        cell: ({ getValue }) => {
+          const raw = getValue();
+          return (
+            <span className="text-muted-foreground">
+              {raw ? (DOCUMENT_TYPE_LABELS[raw] ?? raw) : "\u2014"}
+            </span>
+          );
+        },
+        filterFn: (row, _columnId, filterValue: string[]) => {
+          const val = row.getValue<string | null>("document_type") ?? "";
+          return filterValue.includes(val);
+        },
+      }),
+      columnHelper.accessor("source", {
+        header: () => <span title="Where this document came from — uploaded by you or imported from Gmail">Source</span>,
+        enableSorting: true,
+        cell: ({ getValue }) => (
+          <span className="text-xs px-2 py-0.5 rounded bg-muted">
+            {getValue() === "email" ? "Email" : "Upload"}
+          </span>
+        ),
+        filterFn: (row, _columnId, filterValue: string[]) => {
+          return filterValue.includes(row.getValue<string>("source"));
+        },
+      }),
+      columnHelper.accessor("created_at", {
+        header: "Uploaded",
+        enableSorting: true,
+        sortingFn: (rowA, rowB) => {
+          const a = rowA.original.created_at ?? "";
+          const b = rowB.original.created_at ?? "";
+          return a.localeCompare(b);
+        },
+        cell: ({ getValue }) => (
+          <span className="text-muted-foreground" title={formatDate(getValue())}>
+            {timeAgo(getValue())}
+          </span>
+        ),
+      }),
+      columnHelper.display({
+        id: "actions",
+        enableSorting: false,
+        header: () => null,
+        cell: ({ row }) => {
+          if (!canWrite) return null;
+          return (
+            <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+              {onToggleEscrow && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => onToggleEscrow(row.original.id, row.original.is_escrow_paid)}
+                  title={row.original.is_escrow_paid ? "Unmark as reference-only" : "Mark as reference-only (escrow-paid)"}
+                  className={`p-1.5 ${row.original.is_escrow_paid ? "text-blue-600" : "text-muted-foreground hover:text-blue-600"}`}
+                >
+                  <FileCheck size={14} />
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onDelete(row.original.id)}
+                title="Delete"
+                className="p-1.5 text-destructive hover:text-destructive"
+              >
+                <Trash2 size={14} />
+              </Button>
+            </div>
+          );
+        },
+      }),
+    ],
+    [onDelete, onToggleEscrow, canWrite],
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useKeyboardClose.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useKeyboardClose.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+export function useKeyboardClose(onClose: () => void): void {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useMediaQuery.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useMediaQuery.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useOrgRole.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useOrgRole.ts
@@ -1,0 +1,17 @@
+import type { OrgRole } from "@/shared/types/organization/org-role";
+import { useCurrentOrg } from "./useCurrentOrg";
+
+export function useOrgRole(): OrgRole | null {
+  const org = useCurrentOrg();
+  return org?.org_role ?? null;
+}
+
+export function useIsOrgAdmin(): boolean {
+  const role = useOrgRole();
+  return role === "owner" || role === "admin";
+}
+
+export function useCanWrite(): boolean {
+  const role = useOrgRole();
+  return role !== "viewer";
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useTheme.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useTheme.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+const STORAGE_KEY = "v1_theme";
+
+function getSystemTheme(): "light" | "dark" {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme: Theme) {
+  const resolved = theme === "system" ? getSystemTheme() : theme;
+  document.documentElement.classList.toggle("dark", resolved === "dark");
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return (stored === "light" || stored === "dark" || stored === "system") ? stored : "system";
+  });
+
+  const setTheme = useCallback((next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+    applyTheme(next);
+  }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  // Listen for system theme changes when in "system" mode
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  return { theme, setTheme };
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useToast.ts
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useToast.ts
@@ -1,0 +1,10 @@
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+
+interface UseToastReturn {
+  showError: (message: string) => void;
+  showSuccess: (message: string) => void;
+}
+
+export function useToast(): UseToastReturn {
+  return { showError, showSuccess };
+}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useTransactionColumns.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useTransactionColumns.tsx
@@ -1,0 +1,212 @@
+import { useMemo } from "react";
+import { createColumnHelper } from "@tanstack/react-table";
+import type { ColumnDef } from "@tanstack/react-table";
+import { Trash2, Check, Landmark, Home, Copy } from "lucide-react";
+import { compareAsc, parseISO } from "date-fns/fp";
+import { formatCurrency } from "@/shared/utils/currency";
+import { formatDate } from "@/shared/utils/date";
+import { formatTag } from "@/shared/utils/tag";
+import { TAG_COLORS } from "@/shared/lib/constants";
+import type { Transaction } from "@/shared/types/transaction/transaction";
+import Button from "@/shared/components/ui/Button";
+import Badge from "@/shared/components/ui/Badge";
+import TransactionStatusBadge from "@/app/features/transactions/TransactionStatusBadge";
+import TransactionTypeBadge from "@/app/features/transactions/TransactionTypeBadge";
+import IndeterminateCheckbox from "@/shared/components/ui/IndeterminateCheckbox";
+
+interface ColumnActions {
+  onDelete: (id: string) => void;
+  onApprove: (id: string) => void;
+  busyId: string | null;
+  duplicateIds?: Set<string>;
+  canWrite?: boolean;
+}
+
+const columnHelper = createColumnHelper<Transaction>();
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function useTransactionColumns(propertyMap: ReadonlyMap<string, string>, actions: ColumnActions): ColumnDef<Transaction, any>[] {
+  const { onDelete, onApprove, busyId, duplicateIds, canWrite = true } = actions;
+
+  return useMemo(() => [
+    columnHelper.display({
+      id: "select",
+      enableSorting: false,
+      header: ({ table }) => (
+        <IndeterminateCheckbox
+          checked={table.getIsAllRowsSelected()}
+          indeterminate={table.getIsSomeRowsSelected()}
+          onChange={table.getToggleAllRowsSelectedHandler()}
+          onClick={(e) => e.stopPropagation()}
+          aria-label="Select all transactions"
+        />
+      ),
+      cell: ({ row }) => (
+        <IndeterminateCheckbox
+          checked={row.getIsSelected()}
+          onChange={row.getToggleSelectedHandler()}
+          onClick={(e) => e.stopPropagation()}
+          aria-label={`Select ${row.original.vendor ?? "transaction"}`}
+        />
+      ),
+    }),
+    columnHelper.accessor("status", {
+      header: () => <span title="Approved = included in reports. Pending = not reviewed. Needs Review = I wasn't confident in the category.">Status</span>,
+      cell: ({ getValue, row }) => (
+        <div className="flex items-center gap-1.5">
+          <TransactionStatusBadge status={getValue()} />
+          {duplicateIds?.has(row.original.id) && (
+            <span className="inline-flex items-center gap-0.5 text-xs px-1.5 py-0.5 rounded bg-orange-100 text-orange-700 dark:bg-orange-900/30 dark:text-orange-400" title="Possible duplicate">
+              <Copy size={10} />
+            </span>
+          )}
+        </div>
+      ),
+      filterFn: (row, _columnId, filterValue: string[]) => {
+        return filterValue.includes(row.getValue<string>("status"));
+      },
+    }),
+    columnHelper.accessor("transaction_date", {
+      header: "Date",
+      sortingFn: (rowA, rowB) => {
+        const a = rowA.original.transaction_date ? parseISO(rowA.original.transaction_date) : new Date(0);
+        const b = rowB.original.transaction_date ? parseISO(rowB.original.transaction_date) : new Date(0);
+        return compareAsc(b)(a);
+      },
+      filterFn: (row, _columnId, filterValue: [string, string]) => {
+        const val = row.original.transaction_date;
+        if (!val) return false;
+        const dateOnly = val.slice(0, 10);
+        const [from, to] = filterValue;
+        if (from && dateOnly < from) return false;
+        if (to && dateOnly > to) return false;
+        return true;
+      },
+      cell: ({ getValue }) => <span className="text-muted-foreground">{formatDate(getValue())}</span>,
+    }),
+    columnHelper.accessor("vendor", {
+      header: "Vendor",
+      cell: ({ getValue, row }) => {
+        const vendor = getValue() ?? "\u2014";
+        const source = row.original.external_source;
+        const pending = row.original.is_pending;
+        return (
+          <div className="flex items-center gap-1.5">
+            {source === "plaid" ? (
+              <span title="Bank transaction"><Landmark size={13} className="text-blue-500 shrink-0" /></span>
+            ) : source === "airbnb" ? (
+              <span title="Airbnb"><Home size={13} className="text-rose-500 shrink-0" /></span>
+            ) : null}
+            <span>{vendor}</span>
+            {pending ? <Badge label="Pending" color="gray" /> : null}
+          </div>
+        );
+      },
+      filterFn: (row, _columnId, filterValue: string[]) => {
+        const val = row.getValue<string | null>("vendor");
+        if (filterValue.includes("__empty__") && (!val || val.trim() === "")) return true;
+        return val != null && filterValue.includes(val);
+      },
+    }),
+    columnHelper.accessor("amount", {
+      header: () => <span className="block text-right">Amount</span>,
+      sortingFn: (rowA, rowB) => {
+        const a = parseFloat(rowA.original.amount) || 0;
+        const b = parseFloat(rowB.original.amount) || 0;
+        return a - b;
+      },
+      cell: ({ getValue, row }) => {
+        const isIncome = row.original.transaction_type === "income";
+        return (
+          <span className={`block text-right font-medium ${isIncome ? "text-green-600" : ""}`}>
+            {isIncome ? "+" : ""}{formatCurrency(getValue())}
+          </span>
+        );
+      },
+    }),
+    columnHelper.accessor("transaction_type", {
+      header: "Type",
+      cell: ({ getValue }) => <TransactionTypeBadge type={getValue()} />,
+      filterFn: (row, _columnId, filterValue: string[]) => {
+        return filterValue.includes(row.getValue<string>("transaction_type"));
+      },
+    }),
+    columnHelper.accessor("category", {
+      header: "Category",
+      cell: ({ getValue }) => {
+        const cat = getValue();
+        const color = TAG_COLORS[cat] ?? "#94a3b8";
+        return (
+          <span
+            className="rounded px-1.5 py-0.5 text-[10px] font-medium text-white"
+            style={{ backgroundColor: color }}
+          >
+            {formatTag(cat)}
+          </span>
+        );
+      },
+      filterFn: (row, _columnId, filterValue: string[]) => {
+        return filterValue.includes(row.getValue<string>("category"));
+      },
+    }),
+    columnHelper.accessor("property_id", {
+      header: "Property",
+      sortingFn: (rowA, rowB) => {
+        const a = propertyMap.get(rowA.original.property_id ?? "") ?? "";
+        const b = propertyMap.get(rowB.original.property_id ?? "") ?? "";
+        return a.localeCompare(b);
+      },
+      cell: ({ getValue }) => (
+        <span className="text-muted-foreground">{getValue() ? (propertyMap.get(getValue()!) ?? "\u2014") : "\u2014"}</span>
+      ),
+      filterFn: (row, _columnId, filterValue: string[]) => {
+        const val = row.getValue<string | null>("property_id");
+        if (filterValue.includes("__empty__") && !val) return true;
+        return val != null && filterValue.includes(val);
+      },
+    }),
+    columnHelper.accessor("tax_relevant", {
+      header: () => <span title="Whether this transaction is included in your Tax Report. Set automatically based on category.">Tax</span>,
+      cell: ({ getValue }) => (getValue() ? "Yes" : "No"),
+      filterFn: (row, _columnId, filterValue: string[]) => {
+        const val = String(row.original.tax_relevant);
+        return filterValue.includes(val);
+      },
+    }),
+    columnHelper.display({
+      id: "actions",
+      enableSorting: false,
+      header: () => null,
+      cell: ({ row }) => {
+        const isPending = row.original.status === "pending" || row.original.status === "needs_review";
+        if (!canWrite) return null;
+        return (
+          <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+            {isPending && row.original.property_id && (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onApprove(row.original.id)}
+                disabled={busyId === row.original.id}
+                title="Approve"
+                className="p-1.5 text-green-600 hover:text-green-700"
+              >
+                <Check size={14} />
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onDelete(row.original.id)}
+              disabled={busyId === row.original.id}
+              title="Delete"
+              className="p-1.5 text-destructive hover:text-destructive"
+            >
+              <Trash2 size={14} />
+            </Button>
+          </div>
+        );
+      },
+    }),
+  ], [propertyMap, busyId, onDelete, onApprove, duplicateIds, canWrite]);
+}

--- a/packages/shared-frontend/src/components/icons/ChevronDown.tsx
+++ b/packages/shared-frontend/src/components/icons/ChevronDown.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  className?: string;
+}
+
+export default function ChevronDown({ className = "h-4 w-4" }: Props) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M6 9l6 6 6-6" />
+    </svg>
+  );
+}

--- a/packages/shared-frontend/src/components/icons/ExternalLink.tsx
+++ b/packages/shared-frontend/src/components/icons/ExternalLink.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  className?: string;
+}
+
+export default function ExternalLink({ className = "h-3 w-3" }: Props) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M18 13v6a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2h6M15 3h6v6M10 14L21 3" />
+    </svg>
+  );
+}

--- a/packages/shared-frontend/src/components/icons/RetryIcon.tsx
+++ b/packages/shared-frontend/src/components/icons/RetryIcon.tsx
@@ -1,0 +1,18 @@
+interface Props {
+  className?: string;
+}
+
+export default function RetryIcon({ className = "h-4 w-4" }: Props) {
+  return (
+    <svg
+      className={className}
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+    >
+      <path d="M1 4v6h6M23 20v-6h-6" />
+      <path d="M20.49 9A9 9 0 0 0 5.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 0 1 3.51 15" />
+    </svg>
+  );
+}

--- a/packages/shared-frontend/src/components/icons/Spinner.tsx
+++ b/packages/shared-frontend/src/components/icons/Spinner.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  className?: string;
+}
+
+export default function Spinner({ className = "h-4 w-4" }: Props) {
+  return (
+    <svg className={`animate-spin ${className}`} viewBox="0 0 24 24" fill="none">
+      <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+      <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+    </svg>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/AlertBox.tsx
+++ b/packages/shared-frontend/src/components/ui/AlertBox.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+type AlertVariant = "info" | "warning" | "error" | "success";
+
+interface AlertBoxProps {
+  variant: AlertVariant;
+  children: ReactNode;
+  className?: string;
+}
+
+const VARIANT_STYLES: Record<AlertVariant, string> = {
+  info: "bg-blue-50 border-blue-200 text-blue-800 dark:bg-blue-950 dark:border-blue-800 dark:text-blue-200",
+  warning: "bg-orange-50 border-orange-200 text-orange-800 dark:bg-orange-950 dark:border-orange-800 dark:text-orange-200",
+  error: "bg-red-50 border-red-200 text-red-600 dark:bg-red-950 dark:border-red-800 dark:text-red-300",
+  success: "bg-green-50 border-green-200 text-green-800 dark:bg-green-950 dark:border-green-800 dark:text-green-200",
+};
+
+export default function AlertBox({ variant, children, className = "" }: AlertBoxProps) {
+  return (
+    <div className={`rounded-md border p-3 text-sm ${VARIANT_STYLES[variant]} ${className}`}>
+      {children}
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/Badge.tsx
+++ b/packages/shared-frontend/src/components/ui/Badge.tsx
@@ -1,0 +1,24 @@
+export type BadgeColor = "gray" | "blue" | "yellow" | "orange" | "green" | "red" | "purple";
+
+interface Props {
+  label: string;
+  color: BadgeColor;
+}
+
+const COLOR_CLASSES: Record<BadgeColor, string> = {
+  gray: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  blue: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+  yellow: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
+  orange: "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
+  green: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+  red: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+  purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+};
+
+export default function Badge({ label, color }: Props) {
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${COLOR_CLASSES[color]}`}>
+      {label}
+    </span>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/Button.tsx
+++ b/packages/shared-frontend/src/components/ui/Button.tsx
@@ -1,0 +1,32 @@
+import { cn } from "@/shared/utils/cn";
+
+type Variant = "primary" | "secondary" | "ghost" | "destructive" | "link";
+type Size = "md" | "sm";
+
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: Variant;
+  size?: Size;
+}
+
+const isBlock = (v: Variant) => v === "primary" || v === "secondary";
+
+export default function Button({ variant = "primary", size = "md", className, ...props }: Props) {
+  return (
+    <button
+      className={cn(
+        "inline-flex items-center font-medium disabled:opacity-50",
+        variant === "primary" && "bg-primary text-primary-foreground hover:opacity-90",
+        variant === "secondary" && "border hover:bg-muted",
+        variant === "ghost" && "text-muted-foreground hover:underline px-2",
+        variant === "destructive" && "text-destructive hover:underline",
+        variant === "link" && "text-primary hover:underline",
+        isBlock(variant) && size === "md" && "rounded-md px-4 py-2 text-sm min-h-[44px]",
+        isBlock(variant) && size === "sm" && "rounded px-3 py-1.5 text-xs min-h-[44px] sm:min-h-[32px]",
+        !isBlock(variant) && size === "md" && "text-sm",
+        !isBlock(variant) && size === "sm" && "text-xs",
+        className,
+      )}
+      {...props}
+    />
+  );
+}

--- a/packages/shared-frontend/src/components/ui/Card.tsx
+++ b/packages/shared-frontend/src/components/ui/Card.tsx
@@ -1,0 +1,16 @@
+import { cn } from "@/shared/utils/cn";
+
+interface Props {
+  title?: string;
+  children: React.ReactNode;
+  className?: string;
+}
+
+export default function Card({ title, children, className }: Props) {
+  return (
+    <div className={cn("bg-card border rounded-lg p-6", className)}>
+      {title ? <h2 className="text-base font-medium mb-4">{title}</h2> : null}
+      {children}
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/ConfirmDialog.tsx
+++ b/packages/shared-frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,57 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import Button from "./Button";
+
+interface Props {
+  open: boolean;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  variant?: "danger" | "default";
+  isLoading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+  children?: React.ReactNode;
+}
+
+export default function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = "Cancel",
+  variant = "default",
+  isLoading = false,
+  onConfirm,
+  onCancel,
+  children,
+}: Props) {
+  return (
+    <Dialog.Root open={open} onOpenChange={(isOpen) => { if (!isOpen) onCancel(); }}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[70]" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-sm rounded-lg border bg-card p-6 shadow-lg">
+          <Dialog.Title className="text-base font-semibold">{title}</Dialog.Title>
+          <Dialog.Description className="text-sm text-muted-foreground mt-2">
+            {description}
+          </Dialog.Description>
+          {children}
+          <div className="flex justify-end gap-2 mt-6">
+            <Button variant="ghost" size="sm" onClick={onCancel}>{cancelLabel}</Button>
+            <button
+              onClick={onConfirm}
+              disabled={isLoading}
+              className={`px-3 py-1.5 text-sm font-medium rounded-md transition-colors disabled:opacity-50 ${
+                variant === "danger"
+                  ? "bg-red-600 text-white hover:bg-red-700"
+                  : "bg-primary text-primary-foreground hover:bg-primary/90"
+              }`}
+            >
+              {isLoading ? "Processing..." : confirmLabel}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/CopyField.tsx
+++ b/packages/shared-frontend/src/components/ui/CopyField.tsx
@@ -1,0 +1,37 @@
+import { useState } from "react";
+import { Check, Copy } from "lucide-react";
+
+interface Props {
+  label: string;
+  value: string;
+}
+
+export default function CopyField({ label, value }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    await navigator.clipboard.writeText(value);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  return (
+    <div className="flex items-center justify-between gap-4 bg-muted rounded-md px-4 py-3">
+      <div className="min-w-0">
+        <p className="text-xs text-muted-foreground">{label}</p>
+        <p className="text-sm font-mono truncate">{value}</p>
+      </div>
+      <button
+        onClick={handleCopy}
+        className="shrink-0 p-2 rounded-md hover:bg-background transition-colors min-w-[36px] min-h-[36px] flex items-center justify-center"
+        aria-label={`Copy ${label}`}
+      >
+        {copied ? (
+          <Check size={16} className="text-green-600" />
+        ) : (
+          <Copy size={16} className="text-muted-foreground" />
+        )}
+      </button>
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/EmptyState.tsx
+++ b/packages/shared-frontend/src/components/ui/EmptyState.tsx
@@ -1,0 +1,20 @@
+interface Props {
+  message: string;
+  action?: { label: string; onClick: () => void };
+}
+
+export default function EmptyState({ message, action }: Props) {
+  return (
+    <div className="text-center text-muted-foreground text-sm py-8">
+      <p>{message}</p>
+      {action && (
+        <button
+          onClick={action.onClick}
+          className="mt-2 text-sm font-medium text-primary hover:underline"
+        >
+          {action.label}
+        </button>
+      )}
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/FormField.tsx
+++ b/packages/shared-frontend/src/components/ui/FormField.tsx
@@ -1,0 +1,22 @@
+interface Props {
+  label: string;
+  required?: boolean;
+  highlight?: boolean;
+  dirty?: boolean;
+  children: React.ReactNode;
+}
+
+export default function FormField({ label, required, highlight, dirty, children }: Props) {
+  return (
+    <div>
+      <label className="flex items-center gap-1.5 text-xs font-medium mb-1">
+        {highlight && <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-orange-400" />}
+        {dirty && !highlight && <span className="shrink-0 w-1.5 h-1.5 rounded-full bg-blue-400" />}
+        <span>{label}</span>
+        {dirty && <span className="text-blue-400 text-[10px] ml-1">modified</span>}
+        {required ? <span className="text-red-500 ml-0.5">*</span> : null}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/IndeterminateCheckbox.tsx
+++ b/packages/shared-frontend/src/components/ui/IndeterminateCheckbox.tsx
@@ -1,0 +1,27 @@
+import { useRef, useEffect } from "react";
+
+interface Props {
+  checked: boolean;
+  indeterminate?: boolean;
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+  onClick?: React.MouseEventHandler<HTMLInputElement>;
+  "aria-label"?: string;
+}
+
+export default function IndeterminateCheckbox({ checked, indeterminate, onChange, onClick, "aria-label": ariaLabel }: Props) {
+  const ref = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (ref.current) ref.current.indeterminate = !!indeterminate;
+  }, [indeterminate]);
+  return (
+    <input
+      ref={ref}
+      type="checkbox"
+      checked={checked}
+      onChange={onChange ?? (() => {})}
+      onClick={onClick}
+      className="cursor-pointer"
+      aria-label={ariaLabel}
+    />
+  );
+}

--- a/packages/shared-frontend/src/components/ui/LoadingButton.tsx
+++ b/packages/shared-frontend/src/components/ui/LoadingButton.tsx
@@ -1,0 +1,32 @@
+import Button from "@/shared/components/ui/Button";
+import Spinner from "@/shared/components/icons/Spinner";
+
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  isLoading?: boolean;
+  loadingText?: string;
+  variant?: "primary" | "secondary" | "ghost" | "destructive" | "link";
+  size?: "md" | "sm";
+}
+
+export default function LoadingButton({
+  isLoading,
+  loadingText,
+  variant,
+  size,
+  children,
+  disabled,
+  ...props
+}: Props) {
+  return (
+    <Button variant={variant} size={size} disabled={disabled || isLoading} {...props}>
+      {isLoading ? (
+        <span className="flex items-center gap-2">
+          <Spinner />
+          {loadingText ?? children}
+        </span>
+      ) : (
+        children
+      )}
+    </Button>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/LoadingState.tsx
+++ b/packages/shared-frontend/src/components/ui/LoadingState.tsx
@@ -1,0 +1,16 @@
+interface Props {
+  text?: string;
+  fullHeight?: boolean;
+}
+
+export default function LoadingState({ text = "Loading...", fullHeight = false }: Props) {
+  if (fullHeight) {
+    return (
+      <div className="h-full flex items-center justify-center">
+        <p className="text-muted-foreground text-sm">{text}</p>
+      </div>
+    );
+  }
+
+  return <p className="text-muted-foreground text-sm">{text}</p>;
+}

--- a/packages/shared-frontend/src/components/ui/Panel.tsx
+++ b/packages/shared-frontend/src/components/ui/Panel.tsx
@@ -1,0 +1,77 @@
+import { createPortal } from "react-dom";
+import { X } from "lucide-react";
+import { Drawer } from "vaul";
+import { useKeyboardClose } from "@/shared/hooks/useKeyboardClose";
+import { useMediaQuery } from "@/shared/hooks/useMediaQuery";
+
+interface Props {
+  position: "right" | "center";
+  width?: string;
+  onClose: () => void;
+  children: React.ReactNode;
+}
+
+export default function Panel({ position, width, onClose, children }: Props) {
+  useKeyboardClose(onClose);
+  const isMobile = useMediaQuery("(max-width: 768px)");
+
+  if (isMobile && position === "right") {
+    return (
+      <Drawer.Root open onOpenChange={(o) => !o && onClose()}>
+        <Drawer.Portal>
+          <Drawer.Overlay className="fixed inset-0 bg-black/50 z-[60]" />
+          <Drawer.Content className="fixed bottom-0 left-0 right-0 z-[60] bg-card rounded-t-xl max-h-[90vh] flex flex-col overflow-hidden">
+            <Drawer.Title className="sr-only">Panel</Drawer.Title>
+            <div className="mx-auto w-12 h-1.5 flex-shrink-0 rounded-full bg-muted-foreground/30 my-3" />
+            <div className="flex-1 min-h-0 flex flex-col overflow-y-auto overscroll-contain">
+              {children}
+            </div>
+          </Drawer.Content>
+        </Drawer.Portal>
+      </Drawer.Root>
+    );
+  }
+
+  return createPortal(
+    <>
+      <div
+        className={`fixed inset-0 ${position === "center" ? "bg-black/60 z-[60]" : "bg-black/20 z-40"}`}
+        onClick={onClose}
+      />
+
+      {position === "right" ? (
+        <aside
+          className="fixed right-0 top-0 h-screen w-full sm:w-auto bg-background border-l shadow-xl z-50 flex flex-col"
+          style={{ maxWidth: "100vw", ...(width ? { width } : { width: "440px" }) }}
+        >
+          {children}
+        </aside>
+      ) : (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center pointer-events-none"
+        >
+          <div
+            className="relative bg-white rounded-lg shadow-2xl flex flex-col pointer-events-auto"
+            style={{ width: width ?? "90vw", height: "90vh" }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {children}
+          </div>
+        </div>
+      )}
+    </>,
+    document.body,
+  );
+}
+
+export function PanelCloseButton({ onClose, label }: { onClose: () => void; label?: string }) {
+  return (
+    <button
+      onClick={onClose}
+      className="text-muted-foreground hover:text-foreground min-h-[44px] min-w-[44px] flex items-center justify-center rounded"
+      aria-label={label ?? "Close panel"}
+    >
+      <X size={18} />
+    </button>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/SectionHeader.tsx
+++ b/packages/shared-frontend/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,17 @@
+interface Props {
+  title: string;
+  subtitle?: React.ReactNode;
+  actions?: React.ReactNode;
+}
+
+export default function SectionHeader({ title, subtitle, actions }: Props) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+      <div className="min-w-0">
+        <h1 className="text-2xl font-semibold">{title}</h1>
+        {subtitle ? <p className="text-sm text-muted-foreground mt-0.5">{subtitle}</p> : null}
+      </div>
+      {actions ? <div className="flex flex-wrap gap-2">{actions}</div> : null}
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/Select.tsx
+++ b/packages/shared-frontend/src/components/ui/Select.tsx
@@ -1,0 +1,24 @@
+import { forwardRef } from "react";
+import { cn } from "@/shared/utils/cn";
+
+interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
+  children: React.ReactNode;
+}
+
+const Select = forwardRef<HTMLSelectElement, Props>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={cn("border rounded-md px-3 py-2 text-sm", className)}
+        {...props}
+      >
+        {children}
+      </select>
+    );
+  }
+);
+
+Select.displayName = "Select";
+
+export default Select;

--- a/packages/shared-frontend/src/components/ui/Skeleton.tsx
+++ b/packages/shared-frontend/src/components/ui/Skeleton.tsx
@@ -1,0 +1,9 @@
+interface Props {
+  className?: string;
+}
+
+export default function Skeleton({ className = "h-4 w-full" }: Props) {
+  return (
+    <div className={`animate-pulse rounded bg-muted ${className}`} />
+  );
+}

--- a/packages/shared-frontend/src/components/ui/TilePicker.tsx
+++ b/packages/shared-frontend/src/components/ui/TilePicker.tsx
@@ -1,0 +1,50 @@
+import { cn } from "@/shared/utils/cn";
+
+export interface TileOption {
+  value: string;
+  label: string;
+  description: string;
+}
+
+interface Props {
+  options: TileOption[];
+  value: string;
+  onChange: (value: string) => void;
+  columns?: 1 | 2;
+}
+
+export default function TilePicker({ options, value, onChange, columns = 1 }: Props) {
+  return (
+    <div className={cn("grid gap-3", columns === 2 ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1")}>
+      {options.map((option) => {
+        const selected = value === option.value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={cn(
+              "text-left rounded-lg border p-4 transition-colors min-h-[44px] flex items-start gap-3",
+              selected
+                ? "border-primary bg-primary/5 ring-1 ring-primary"
+                : "border-border hover:border-primary/50 hover:bg-muted/40",
+            )}
+          >
+            <span
+              className={cn(
+                "mt-0.5 flex h-4 w-4 shrink-0 items-center justify-center rounded-full border-2",
+                selected ? "border-primary bg-primary" : "border-muted-foreground",
+              )}
+            >
+              {selected && <span className="block h-1.5 w-1.5 rounded-full bg-primary-foreground" />}
+            </span>
+            <span>
+              <span className="block font-medium text-sm">{option.label}</span>
+              <span className="block text-xs text-muted-foreground mt-0.5">{option.description}</span>
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/Toaster.tsx
+++ b/packages/shared-frontend/src/components/ui/Toaster.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
+import * as Toast from "@radix-ui/react-toast";
+import { XCircle, CheckCircle2, X } from "lucide-react";
+import { subscribe } from "@/shared/lib/toast-store";
+import type { ToastEvent } from "@/shared/lib/toast-store";
+
+const DURATION_MS = 6000;
+
+export default function Toaster() {
+  const [toasts, setToasts] = useState<ToastEvent[]>([]);
+
+  useEffect(() => {
+    return subscribe((toast) => {
+      setToasts((prev) => [...prev, toast]);
+    });
+  }, []);
+
+  const handleOpenChange = useCallback((open: boolean, id: string) => {
+    if (!open) {
+      setToasts((prev) => prev.filter((t) => t.id !== id));
+    }
+  }, []);
+
+  return (
+    <Toast.Provider duration={DURATION_MS}>
+      {toasts.map((toast) => (
+        <Toast.Root
+          key={toast.id}
+          open
+          onOpenChange={(open) => handleOpenChange(open, toast.id)}
+          className={`flex items-start gap-3 px-4 py-3 rounded-lg shadow-lg text-sm ${
+            toast.variant === "error"
+              ? "bg-red-50 border border-red-200 text-red-800 dark:bg-red-950 dark:border-red-800 dark:text-red-200"
+              : "bg-green-50 border border-green-200 text-green-800 dark:bg-green-950 dark:border-green-800 dark:text-green-200"
+          }`}
+        >
+          {toast.variant === "error" ? (
+            <XCircle className="h-5 w-5 text-red-500 shrink-0 mt-0.5" />
+          ) : (
+            <CheckCircle2 className="h-5 w-5 text-green-500 shrink-0 mt-0.5" />
+          )}
+          <Toast.Description className="flex-1">
+            {toast.message}
+          </Toast.Description>
+          <Toast.Close className="shrink-0 text-current opacity-50 hover:opacity-100">
+            <X className="h-4 w-4" />
+          </Toast.Close>
+        </Toast.Root>
+      ))}
+      <Toast.Viewport
+        className="fixed top-4 right-4 left-4 z-50 space-y-2 max-w-md sm:left-auto sm:w-[390px] outline-none pointer-events-none [&>*]:pointer-events-auto"
+        label="Notifications"
+      />
+    </Toast.Provider>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/TurnstileWidget.tsx
+++ b/packages/shared-frontend/src/components/ui/TurnstileWidget.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useCallback } from "react";
+
+const TURNSTILE_SITE_KEY = import.meta.env.VITE_TURNSTILE_SITE_KEY ?? "";
+
+interface TurnstileWidgetProps {
+  onVerify: (token: string) => void;
+  onExpire?: () => void;
+}
+
+declare global {
+  interface Window {
+    turnstile?: {
+      render: (container: HTMLElement, options: Record<string, unknown>) => string;
+      reset: (widgetId: string) => void;
+      remove: (widgetId: string) => void;
+    };
+  }
+}
+
+export default function TurnstileWidget({ onVerify, onExpire }: TurnstileWidgetProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const widgetIdRef = useRef<string | null>(null);
+
+  const renderWidget = useCallback(() => {
+    if (!containerRef.current || !window.turnstile || widgetIdRef.current) return;
+    widgetIdRef.current = window.turnstile.render(containerRef.current, {
+      sitekey: TURNSTILE_SITE_KEY,
+      callback: onVerify,
+      "expired-callback": onExpire,
+      theme: "auto",
+    });
+  }, [onVerify, onExpire]);
+
+  useEffect(() => {
+    if (!TURNSTILE_SITE_KEY) return;
+
+    if (window.turnstile) {
+      renderWidget();
+      return;
+    }
+
+    const script = document.createElement("script");
+    script.src = "https://challenges.cloudflare.com/turnstile/v0/api.js?render=explicit";
+    script.async = true;
+    script.onload = renderWidget;
+    document.head.appendChild(script);
+
+    return () => {
+      if (widgetIdRef.current && window.turnstile) {
+        window.turnstile.remove(widgetIdRef.current);
+        widgetIdRef.current = null;
+      }
+    };
+  }, [renderWidget]);
+
+  if (!TURNSTILE_SITE_KEY) return null;
+
+  return <div ref={containerRef} className="flex justify-center" />;
+}

--- a/packages/shared-frontend/src/hooks/useDismissable.ts
+++ b/packages/shared-frontend/src/hooks/useDismissable.ts
@@ -1,0 +1,28 @@
+import { useState, useCallback } from "react";
+
+/**
+ * Hook for info banners that can be dismissed and persist their dismissed state
+ * in localStorage. Used across pages (Documents, Integrations, Analytics, etc.)
+ * to avoid duplicating the same pattern 9 times.
+ */
+export function useDismissable(storageKey: string): {
+  dismissed: boolean;
+  dismiss: () => void;
+  reset: () => void;
+} {
+  const [dismissed, setDismissed] = useState<boolean>(
+    () => localStorage.getItem(storageKey) === "1",
+  );
+
+  const dismiss = useCallback(() => {
+    setDismissed(true);
+    localStorage.setItem(storageKey, "1");
+  }, [storageKey]);
+
+  const reset = useCallback(() => {
+    setDismissed(false);
+    localStorage.removeItem(storageKey);
+  }, [storageKey]);
+
+  return { dismissed, dismiss, reset };
+}

--- a/packages/shared-frontend/src/hooks/useKeyboardClose.ts
+++ b/packages/shared-frontend/src/hooks/useKeyboardClose.ts
@@ -1,0 +1,11 @@
+import { useEffect } from "react";
+
+export function useKeyboardClose(onClose: () => void): void {
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose]);
+}

--- a/packages/shared-frontend/src/hooks/useMediaQuery.ts
+++ b/packages/shared-frontend/src/hooks/useMediaQuery.ts
@@ -1,0 +1,14 @@
+import { useState, useEffect } from "react";
+
+export function useMediaQuery(query: string): boolean {
+  const [matches, setMatches] = useState(() => window.matchMedia(query).matches);
+
+  useEffect(() => {
+    const mql = window.matchMedia(query);
+    const handler = (e: MediaQueryListEvent) => setMatches(e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, [query]);
+
+  return matches;
+}

--- a/packages/shared-frontend/src/hooks/useTheme.ts
+++ b/packages/shared-frontend/src/hooks/useTheme.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+
+type Theme = "light" | "dark" | "system";
+
+const STORAGE_KEY = "v1_theme";
+
+function getSystemTheme(): "light" | "dark" {
+  return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+}
+
+function applyTheme(theme: Theme) {
+  const resolved = theme === "system" ? getSystemTheme() : theme;
+  document.documentElement.classList.toggle("dark", resolved === "dark");
+}
+
+export function useTheme() {
+  const [theme, setThemeState] = useState<Theme>(() => {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    return (stored === "light" || stored === "dark" || stored === "system") ? stored : "system";
+  });
+
+  const setTheme = useCallback((next: Theme) => {
+    localStorage.setItem(STORAGE_KEY, next);
+    setThemeState(next);
+    applyTheme(next);
+  }, []);
+
+  useEffect(() => {
+    applyTheme(theme);
+  }, [theme]);
+
+  // Listen for system theme changes when in "system" mode
+  useEffect(() => {
+    if (theme !== "system") return;
+    const mq = window.matchMedia("(prefers-color-scheme: dark)");
+    const handler = () => applyTheme("system");
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, [theme]);
+
+  return { theme, setTheme };
+}

--- a/packages/shared-frontend/src/hooks/useToast.ts
+++ b/packages/shared-frontend/src/hooks/useToast.ts
@@ -1,0 +1,10 @@
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+
+interface UseToastReturn {
+  showError: (message: string) => void;
+  showSuccess: (message: string) => void;
+}
+
+export function useToast(): UseToastReturn {
+  return { showError, showSuccess };
+}

--- a/packages/shared-frontend/src/index.ts
+++ b/packages/shared-frontend/src/index.ts
@@ -1,3 +1,20 @@
 // @platform/ui — shared frontend components, hooks, and utilities
-// Components, hooks, and utils will be added in Phase 4
-export {};
+//
+// Import from subpaths:
+//   import Button from "@platform/ui/components/ui/Button"
+//   import { cn } from "@platform/ui/utils/cn"
+//   import { useTheme } from "@platform/ui/hooks/useTheme"
+//   import api from "@platform/ui/lib/api"
+//   import { baseApi } from "@platform/ui/store/baseApi"
+
+// Re-export key utilities for convenience
+export { cn } from "./utils/cn";
+export { formatCurrency } from "./utils/currency";
+export { formatDate, timeAgo } from "./utils/date";
+export { formatTag } from "./utils/tag";
+export { getErrorMessage } from "./utils/errorMessage";
+export { showError, showSuccess, subscribe } from "./lib/toast-store";
+export type { ToastEvent, ToastVariant } from "./lib/toast-store";
+export { notifyAuthChange, useIsAuthenticated } from "./lib/auth-store";
+export { baseApi } from "./store/baseApi";
+export { axiosBaseQuery } from "./store/baseQuery";

--- a/packages/shared-frontend/src/lib/api.ts
+++ b/packages/shared-frontend/src/lib/api.ts
@@ -1,0 +1,40 @@
+import axios from "axios";
+import { notifyAuthChange } from "./auth-store";
+
+const api = axios.create({
+  baseURL: "/api",
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+
+  const orgId = localStorage.getItem("v1_activeOrgId");
+  if (orgId) {
+    config.headers["X-Organization-Id"] = orgId;
+  }
+
+  return config;
+});
+
+api.interceptors.response.use(
+  (res) => res,
+  (err) => {
+    if (err.response?.status === 401) {
+      const isLoginRequest = err.config?.url?.includes("/auth/");
+      const isAlreadyOnLogin = window.location.pathname === "/login";
+      if (!isLoginRequest && !isAlreadyOnLogin) {
+        localStorage.removeItem("token");
+        notifyAuthChange();
+      }
+    }
+    if (err.response?.status === 403) {
+      err.message = err.response?.data?.detail ?? "You don't have permission to do that.";
+    }
+    return Promise.reject(err);
+  }
+);
+
+export default api;

--- a/packages/shared-frontend/src/lib/auth-store.ts
+++ b/packages/shared-frontend/src/lib/auth-store.ts
@@ -1,0 +1,48 @@
+import { useSyncExternalStore } from "react";
+
+// Reactive auth store — allows React components to re-render immediately
+// when the JWT token is added or removed (e.g., by the axios 401 interceptor,
+// by an explicit logout, or by a sibling tab via the browser storage event).
+// This module has zero dependencies on api.ts or auth.ts to avoid circular imports.
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+// Single shared storage-event handler so every subscriber reacts to cross-tab
+// token changes without each hook instance attaching its own listener.
+function handleStorageEvent(event: StorageEvent): void {
+  // `event.key === null` means localStorage.clear() was called
+  if (event.key === "token" || event.key === null) {
+    listeners.forEach((l) => l());
+  }
+}
+
+if (typeof window !== "undefined") {
+  window.addEventListener("storage", handleStorageEvent);
+}
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function notifyAuthChange(): void {
+  listeners.forEach((l) => l());
+}
+
+function getSnapshot(): boolean {
+  const token = localStorage.getItem("token");
+  if (!token) return false;
+  try {
+    const payload = JSON.parse(atob(token.split(".")[1]));
+    return typeof payload.exp === "number" && payload.exp * 1000 > Date.now();
+  } catch {
+    return false;
+  }
+}
+
+export function useIsAuthenticated(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/packages/shared-frontend/src/lib/toast-store.ts
+++ b/packages/shared-frontend/src/lib/toast-store.ts
@@ -1,0 +1,36 @@
+type ToastVariant = "error" | "success";
+
+interface ToastEvent {
+  id: string;
+  message: string;
+  variant: ToastVariant;
+}
+
+type Listener = (toast: ToastEvent) => void;
+
+const listeners = new Set<Listener>();
+
+function subscribe(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function dispatch(message: string, variant: ToastVariant): void {
+  const event: ToastEvent = {
+    id: crypto.randomUUID(),
+    message,
+    variant,
+  };
+  listeners.forEach((listener) => listener(event));
+}
+
+function showError(message: string): void {
+  dispatch(message, "error");
+}
+
+function showSuccess(message: string): void {
+  dispatch(message, "success");
+}
+
+export { subscribe, showError, showSuccess };
+export type { ToastEvent, ToastVariant };

--- a/packages/shared-frontend/src/store/baseApi.ts
+++ b/packages/shared-frontend/src/store/baseApi.ts
@@ -1,0 +1,17 @@
+import { createApi } from "@reduxjs/toolkit/query/react";
+import { axiosBaseQuery } from "./baseQuery";
+
+/**
+ * Base RTK Query API — apps extend this with their own tagTypes and endpoints.
+ *
+ * Usage in app:
+ *   import { baseApi } from "@platform/ui/store/baseApi";
+ *   export const appApi = baseApi.enhanceEndpoints({ addTagTypes: ["Document", "User"] });
+ *   // or just use baseApi directly and inject endpoints
+ */
+export const baseApi = createApi({
+  reducerPath: "api",
+  baseQuery: axiosBaseQuery,
+  tagTypes: [],
+  endpoints: () => ({}),
+});

--- a/packages/shared-frontend/src/store/baseQuery.ts
+++ b/packages/shared-frontend/src/store/baseQuery.ts
@@ -1,0 +1,25 @@
+import type { BaseQueryFn } from "@reduxjs/toolkit/query";
+import type { AxiosError } from "axios";
+import api from "@/shared/lib/api";
+import type { Args } from "@/shared/types/api-args";
+import type { ApiError } from "@/shared/types/api-error";
+
+export const axiosBaseQuery: BaseQueryFn<Args, unknown, ApiError> = async ({
+  url,
+  method = "GET",
+  data,
+  params,
+}) => {
+  try {
+    const result = await api({ url, method, data, params });
+    return { data: result.data };
+  } catch (err) {
+    const error = err as AxiosError;
+    return {
+      error: {
+        status: error.response?.status,
+        data: error.response?.data ?? error.message,
+      },
+    };
+  }
+};

--- a/packages/shared-frontend/src/types/api-args.ts
+++ b/packages/shared-frontend/src/types/api-args.ts
@@ -1,0 +1,8 @@
+import type { AxiosRequestConfig } from "axios";
+
+export type Args = {
+  url: string;
+  method?: AxiosRequestConfig["method"];
+  data?: unknown;
+  params?: Record<string, unknown>;
+};

--- a/packages/shared-frontend/src/types/api-error.ts
+++ b/packages/shared-frontend/src/types/api-error.ts
@@ -1,0 +1,4 @@
+export type ApiError = {
+  status?: number;
+  data: unknown;
+};

--- a/packages/shared-frontend/src/utils/cn.ts
+++ b/packages/shared-frontend/src/utils/cn.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/shared-frontend/src/utils/currency.ts
+++ b/packages/shared-frontend/src/utils/currency.ts
@@ -1,0 +1,6 @@
+export function formatCurrency(amount: number | string | null | undefined): string {
+  if (amount == null) return "—";
+  const n = typeof amount === "string" ? parseFloat(amount) : amount;
+  if (isNaN(n)) return "—";
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n);
+}

--- a/packages/shared-frontend/src/utils/date.ts
+++ b/packages/shared-frontend/src/utils/date.ts
@@ -1,0 +1,10 @@
+import { format, parseISO, formatDistanceToNowStrict } from "date-fns";
+
+export function formatDate(date: string | null | undefined): string {
+  if (!date) return "—";
+  return format(parseISO(date), "MMM d, yyyy");
+}
+
+export function timeAgo(date: string): string {
+  return formatDistanceToNowStrict(parseISO(date), { addSuffix: true });
+}

--- a/packages/shared-frontend/src/utils/errorMessage.ts
+++ b/packages/shared-frontend/src/utils/errorMessage.ts
@@ -1,0 +1,16 @@
+export function extractErrorMessage(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (typeof err === "string") return err;
+  if (typeof err === "object" && err !== null) {
+    const obj = err as Record<string, unknown>;
+    if (typeof obj.data === "object" && obj.data !== null) {
+      const data = obj.data as Record<string, unknown>;
+      if (typeof data.detail === "string") return data.detail;
+    }
+    if (typeof obj.data === "string") return obj.data;
+    if (typeof obj.message === "string") return obj.message;
+    if (typeof obj.detail === "string") return obj.detail;
+    if (typeof obj.error === "string") return obj.error;
+  }
+  return "An unexpected error occurred";
+}

--- a/packages/shared-frontend/src/utils/tag.ts
+++ b/packages/shared-frontend/src/utils/tag.ts
@@ -1,0 +1,3 @@
+export function formatTag(tag: string): string {
+  return tag.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/packages/shared-frontend/tsconfig.json
+++ b/packages/shared-frontend/tsconfig.json
@@ -13,7 +13,7 @@
     "outDir": "dist",
     "baseUrl": ".",
     "paths": {
-      "@platform/ui/*": ["src/*"]
+      "@/shared/*": ["src/*"]
     }
   },
   "include": ["src"]


### PR DESCRIPTION
## Summary
- Extract 40 reusable frontend files into `packages/shared-frontend/`
- 18 UI components, 4 icons, 5 hooks, 5 utils, 3 lib files, 2 store base files, 2 types
- tsconfig `@/shared/*` alias for internal resolution
- `baseApi` has empty tagTypes — apps inject their own
- MyBookkeeper keeps its own copies for now; new apps import from `@platform/ui`
- Also fixes missing hooks directory in MyBookkeeper app copy

## Test plan
- [ ] Verify shared package internal imports resolve via tsconfig paths
- [ ] Verify MyBookkeeper frontend still builds with its own copies
- [ ] Verify new app can import from `@platform/ui` subpaths

🤖 Generated with [Claude Code](https://claude.com/claude-code)