### PR TITLE
fix(myjobhunter): deploy from shared /srv/mybookkeeper clone

### DIFF
--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -28,7 +28,9 @@ jobs:
           command_timeout: 10m
           script: |
             set -e
-            cd /srv/myjobhunter
+            # Shared MyFreeApps clone on the VPS — also used by myrestaurantreviews.
+            # The directory is historically named /srv/mybookkeeper from before the monorepo rename.
+            cd /srv/mybookkeeper
 
             echo "--- Pull latest code ---"
             git pull --ff-only


### PR DESCRIPTION
## Summary

The existing `deploy-myjobhunter.yml` hardcoded `/srv/myjobhunter` which would have required manually creating a second MyFreeApps clone on the VPS. MyRestaurantReviews already deploys from the shared `/srv/mybookkeeper/` clone (legacy directory name from before the monorepo rename). Using the same shared clone eliminates the manual step — Phase 1 VPS setup is now just the one-time Caddy routing entry for `myjobhunter.165-245-134-251.sslip.io`.

## Data isolation

No implications. Each app's `docker-compose.yml` creates its own named volumes (`pg_data`, `frontend_dist`, `caddy_data`, `caddy_config`) in its own Docker Compose project namespace, so postgres databases for myjobhunter and myrestaurantreviews remain fully isolated.

## Type of change

- [x] Bug fix

## Checklist

- [x] gitleaks pre-commit passes
- [x] No new secrets committed
- [x] No schema / data model change

## Security notes

N/A — workflow path change only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)