### PR TITLE
chore(deploy): use per-app VPS directories (/srv/myjobhunter, /srv/myrestaurantreviews)

### DIFF
--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -28,9 +28,7 @@ jobs:
           command_timeout: 10m
           script: |
             set -e
-            # Shared MyFreeApps clone on the VPS — also used by myrestaurantreviews.
-            # The directory is historically named /srv/mybookkeeper from before the monorepo rename.
-            cd /srv/mybookkeeper
+            cd /srv/myjobhunter
 
             echo "--- Pull latest code ---"
             git pull --ff-only

--- a/.github/workflows/deploy-myrestaurantreviews.yml
+++ b/.github/workflows/deploy-myrestaurantreviews.yml
@@ -28,7 +28,7 @@ jobs:
           command_timeout: 10m
           script: |
             set -e
-            cd /srv/mybookkeeper
+            cd /srv/myrestaurantreviews
 
             echo "--- Pull latest code ---"
             git pull --ff-only

--- a/apps/myrestaurantreviews/deploy/Caddyfile
+++ b/apps/myrestaurantreviews/deploy/Caddyfile
@@ -13,7 +13,7 @@ myrestaurantreviews.165-245-134-251.sslip.io {
     }
 
     handle {
-        root * /srv/mybookkeeper/apps/myrestaurantreviews/frontend/dist
+        root * /srv/myrestaurantreviews/apps/myrestaurantreviews/frontend/dist
         try_files {path} /index.html
         file_server
     }


### PR DESCRIPTION
## Summary

Each MyFreeApps app now deploys from its own VPS directory rather than a shared `/srv/mybookkeeper` clone. Gives per-app failure isolation, a consistent naming pattern, and makes room for MyBookkeeper to join later as `/srv/mybookkeeper` without legacy ambiguity.

## Changes

- `deploy-myjobhunter.yml` → `cd /srv/myjobhunter`
- `deploy-myrestaurantreviews.yml` → `cd /srv/myrestaurantreviews`
- `apps/myrestaurantreviews/deploy/Caddyfile` → static root updated to match

## Before merging — VPS setup

```bash
# Rename the existing clone for myrestaurantreviews
sudo mv /srv/mybookkeeper /srv/myrestaurantreviews

# Add a new clone for myjobhunter
sudo git clone https://github.com/jykwon91/MyFreeApps.git /srv/myjobhunter
sudo chown -R <your-user>:<your-group> /srv/myjobhunter

# Create the backend .env.docker for myjobhunter
sudo cp /srv/myjobhunter/apps/myjobhunter/backend/.env.example \
        /srv/myjobhunter/apps/myjobhunter/backend/.env.docker
sudo vim /srv/myjobhunter/apps/myjobhunter/backend/.env.docker
# Fill in SECRET_KEY, ENCRYPTION_KEY, ANTHROPIC_API_KEY, TAVILY_API_KEY,
# GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET — see .env.example for required vars

# First-time compose up
cd /srv/myjobhunter
sudo DB_PASSWORD=<pick-a-strong-one> \
    docker compose -f apps/myjobhunter/docker-compose.yml up -d --build

# Add Caddy host-level route
sudo tee -a /etc/caddy/Caddyfile <<EOF

myjobhunter.165-245-134-251.sslip.io {
    reverse_proxy 127.0.0.1:8092
}
EOF
sudo systemctl reload caddy
```

## Why per-app dirs

- **Naming clarity**: directory name equals app name
- **Failure isolation**: one app's git state or broken deploy cannot affect another
- **Independent lifecycles**: pull, deploy, rollback per app
- **Future-proof**: when MyBookkeeper eventually migrates in, it slots into `/srv/mybookkeeper/` as a fresh clone — consistent with the pattern

## Volume / DB safety

- `docker compose` project namespace is derived from the compose file directory, so renaming `/srv/mybookkeeper` → `/srv/myrestaurantreviews` keeps the same project name and the same named volumes. No data loss.
- MyJobHunter starts fresh (new clone, new DB volume). Empty DB on first boot is expected — alembic migrations run on startup.

## Type of change

- [x] Chore (infra)

## Checklist

- [x] gitleaks pre-commit passes
- [x] No secrets committed
- [x] No code changes (workflow + Caddyfile example only)

## Security notes

N/A — deployment path rename only. VPS-side `.env.docker` for myjobhunter is created out of band (not committed); the PR description documents the one-time setup so future auditors can reconstruct the process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)