### PR TITLE
ci: scope CodeQL to security-extended + exclude tests

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,23 @@
+name: "MyFreeApps CodeQL config"
+
+# Use security-focused queries only — drop the 'security-and-quality' suite,
+# which produces hundreds of style/maintainability notes that bury real signal.
+queries:
+  - uses: security-extended
+
+paths-ignore:
+  # Test files — frequently use loose regex patterns and intentional dummy values
+  # that trigger false positives on real-world security rules.
+  - "**/__tests__/**"
+  - "**/e2e/**"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.spec.ts"
+  - "**/*.spec.tsx"
+  - "**/test_*.py"
+  - "**/tests/**"
+  # Snapshot/build artifacts
+  - "**/dist/**"
+  - "**/build/**"
+  - "**/node_modules/**"
+  - "**/.venv/**"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,7 +32,7 @@ jobs:
         uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
         with:
           languages: ${{ matrix.language }}
-          queries: security-extended,security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2


### PR DESCRIPTION
Add a CodeQL config file to:

1. Drop the `security-and-quality` query pack (produces 245+ style notes burying real security signal)
2. Exclude test paths (`__tests__/`, `e2e/`, `test_*.py`, `*.spec.*`, `*.test.*`) — they intentionally use loose patterns

## Effect on PR #44
Cuts alert volume substantially. Real findings (SQL exec in admin tool, SHA1 in HIBP — both intentional) will still surface and be addressed with inline suppressions in MyBookkeeper standalone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)