### PR TITLE
fix(ci): replace hallucinated appleboy/ssh-action SHA in deploy workflows

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Deploy to VPS
-        uses: appleboy/ssh-action@7eaf76671a0d7b0e8e43c4da68a9062720ab5174 # v1.2.0
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}

--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Deploy to VPS
-        uses: appleboy/ssh-action@7eaf76671a0d7b0e8e43c4da68a9062720ab5174 # v1.2.0
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}


### PR DESCRIPTION
Both deploy-mybookkeeper.yml and deploy-myjobhunter.yml referenced an action SHA that doesn't exist (`7eaf76671a0d7b0e8e43c4da68a9062720ab5174`). Hallucinated — first 13 chars match real v1.2.0, then diverges.

Bumped to verified v1.2.5: `0ff4204d59e8e51228ff73bce53f80d53301dee2`.

Every Deploy MyBookkeeper run since PR #44 merge has failed at action-resolution. This unblocks the auto-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)