### PR TITLE
ci(mybookkeeper, myjobhunter): add backend tests + frontend build to PR CI

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -1,0 +1,118 @@
+name: MyBookkeeper CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/mybookkeeper/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ci-mybookkeeper.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mybookkeeper/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ci-mybookkeeper.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-mybookkeeper-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  backend-deps-resolve:
+    name: backend-deps-resolve / mybookkeeper
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: apps/mybookkeeper/backend/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Verify lockfile is consistent with pyproject.toml
+        working-directory: apps/mybookkeeper/backend
+        run: uv lock --check
+
+      - name: Sync backend dependencies from lockfile
+        working-directory: apps/mybookkeeper/backend
+        run: uv sync --frozen
+
+  backend-tests:
+    name: backend-tests / mybookkeeper
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: apps/mybookkeeper/backend/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Sync backend dependencies
+        working-directory: apps/mybookkeeper/backend
+        run: uv sync --frozen
+
+      - name: Install test-only dependencies
+        working-directory: apps/mybookkeeper/backend
+        # Test deps are not pinned in pyproject.toml; install into the uv venv.
+        # Mirrors the standalone repo's CI pattern (pytest + pytest-asyncio + aiosqlite).
+        run: uv pip install pytest pytest-asyncio aiosqlite
+
+      - name: Run pytest
+        working-directory: apps/mybookkeeper/backend
+        env:
+          # Dummy values — tests use in-memory sqlite, not these envs, but pydantic-settings may require them.
+          DATABASE_URL: "sqlite+aiosqlite:///:memory:"
+          DATABASE_URL_SYNC: "sqlite:///:memory:"
+          SECRET_KEY: placeholder-not-real-secret-key # gitleaks:allow
+          ENCRYPTION_KEY: placeholder-not-real-encryption-key # gitleaks:allow
+          ANTHROPIC_API_KEY: sk-ant-placeholder-not-real
+          GOOGLE_CLIENT_ID: placeholder-not-real-google-client
+          GOOGLE_CLIENT_SECRET: placeholder-not-real-google-secret
+        run: uv run pytest -q -m "not integration"
+
+  frontend-build:
+    name: frontend-build / mybookkeeper
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspace dependencies
+        # Root package.json is an npm workspace covering all apps' frontends.
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build --workspace=mybookkeeper-frontend

--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -1,0 +1,125 @@
+name: MyJobHunter CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/myjobhunter/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ci-myjobhunter.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/myjobhunter/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ci-myjobhunter.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-myjobhunter-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  backend-deps-resolve:
+    name: backend-deps-resolve / myjobhunter
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: apps/myjobhunter/backend/requirements.txt
+
+      - name: Resolve backend requirements
+        working-directory: apps/myjobhunter/backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+  backend-tests:
+    name: backend-tests / myjobhunter
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test
+      DATABASE_URL_SYNC: postgresql://postgres:postgres@localhost:5432/test
+      SECRET_KEY: placeholder-not-real-secret-key # gitleaks:allow
+      ENCRYPTION_KEY: placeholder-not-real-encryption-key # gitleaks:allow
+      ANTHROPIC_API_KEY: sk-ant-placeholder-not-real
+      TAVILY_API_KEY: tvly-placeholder-not-real
+      GOOGLE_CLIENT_ID: placeholder-not-real-google-client
+      GOOGLE_CLIENT_SECRET: placeholder-not-real-google-secret
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: apps/myjobhunter/backend/requirements.txt
+
+      - name: Install backend dependencies
+        working-directory: apps/myjobhunter/backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run alembic migrations
+        working-directory: apps/myjobhunter/backend
+        run: PYTHONPATH=. alembic upgrade head
+
+      - name: Run pytest
+        working-directory: apps/myjobhunter/backend
+        run: python -m pytest -q
+
+  frontend-build:
+    name: frontend-build / myjobhunter
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspace dependencies
+        # Root package.json is an npm workspace covering all apps' frontends.
+        run: npm ci
+
+      - name: Build frontend
+        run: npm run build --workspace=myjobhunter-frontend

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,14 @@
+# Gitleaks fingerprints to ignore.
+#
+# Format: <commit-sha>:<file>:<rule-id>:<line>
+#
+# Why: PR CI for new test gates initially landed CI dummy env values
+# (ENCRYPTION_KEY, etc.) with entropy >3.8 that tripped the
+# generic-api-key rule even though they were obvious placeholders. The
+# follow-up commit b21b592 swapped them for low-entropy "change-me-*" /
+# "placeholder" strings that hit the existing .gitleaks.toml allowlist.
+# These two fingerprints reference the original (now-superseded)
+# commit and exist only so gitleaks doesn't keep flagging the diff
+# when scanning the full PR history.
+3aaf8937165dc8b7d6f65c2543f83e1e0478089a:.github/workflows/ci-mybookkeeper.yml:generic-api-key:92
+3aaf8937165dc8b7d6f65c2543f83e1e0478089a:.github/workflows/ci-myjobhunter.yml:generic-api-key:74


### PR DESCRIPTION
## Why

The repo's PR-level CI today runs only **CodeQL + Dependency Review + Gitleaks**. None of those catch:

- Backend test regressions (pytest)
- Backend lockfile drift (e.g. `pyproject.toml` ↔ `uv.lock` mismatch)
- Frontend build failures (e.g. `package-lock.json` drift, type errors)

Today's MyBookkeeper deploy broke in production because of exactly this gap — backend lockfile drift slipped through PR review and only surfaced when the deploy ran. This PR closes that hole by adding test/build gates that run on every PR touching either app.

## What this adds

Two new path-filtered workflows. Both run on `pull_request` and `push` to `main`, with `paths:` filters scoped to the relevant app (and `packages/**` + the root npm workspace files, since those affect the build).

### `.github/workflows/ci-mybookkeeper.yml`

Triggers on `apps/mybookkeeper/**`, `packages/**`, or root npm files.

| Job | What it runs |
|---|---|
| `backend-deps-resolve / mybookkeeper` | `uv lock --check` + `uv sync --frozen` — catches lockfile drift before it reaches deploy |
| `backend-tests / mybookkeeper` | `uv sync` + install test deps + `uv run pytest -q -m "not integration"` (uses in-memory sqlite — no Postgres service needed) |
| `frontend-build / mybookkeeper` | `npm ci` at workspace root + `npm run build --workspace=mybookkeeper-frontend` |

### `.github/workflows/ci-myjobhunter.yml`

Same three-job structure for `apps/myjobhunter/**`. Backend tests need a real Postgres (the conftest creates a real engine from `settings.database_url`), so this workflow spins up a `postgres:16-alpine` service container and runs `alembic upgrade head` before pytest.

### Action pinning

All four actions used are pinned to verified upstream commit SHAs (verified via `gh api repos/<owner>/<repo>/git/commits/<sha>` per `rules/verify-action-sha.md`):

| Action | SHA | Version |
|---|---|---|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | v6.0.2 (already used in repo) |
| `actions/setup-node` | `48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e` | v6.4.0 (already used in repo) |
| `actions/setup-python` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` | v6.2.0 (new, verified) |
| `astral-sh/setup-uv` | `08807647e7069bb48b6ef5acd8ec9567f424441b` | v8.1.0 (new, verified) |

Workflow `permissions:` is locked to `contents: read`. No secrets are referenced. Concurrency groups cancel duplicate PR runs.

### What this does NOT touch

- `deploy-mybookkeeper.yml` and `deploy-myjobhunter.yml` are untouched. CI gates are separate workflows that run on PRs only; deploy stays a `push: main` event.
- No CODEOWNERS or branch-protection changes (those need admin scope, see manual step below).

## New required check names

Confirmed by the running CI on this PR — these are the exact strings GitHub uses (no workflow-name prefix):

- `backend-deps-resolve / mybookkeeper`
- `backend-tests / mybookkeeper`
- `frontend-build / mybookkeeper`
- `backend-deps-resolve / myjobhunter`
- `backend-tests / myjobhunter`
- `frontend-build / myjobhunter`

## Heads up: the gates are catching real preexisting bugs in `main`

CI on this PR turned up **four preexisting failures already on `main`** — the gates are doing exactly what they're supposed to do. None of these are introduced by this PR. The current run shows:

PASSING (5/9):
- `frontend-build / mybookkeeper` ✓
- `backend-deps-resolve / myjobhunter` ✓
- `Scan for committed secrets` (gitleaks) ✓
- `Analyze (CodeQL)` × 2 ✓
- `Review dependency changes` ✓

FAILING (4/9) — each one needs a separate follow-up PR:

| Failing job | Root cause | Out-of-scope follow-up |
|---|---|---|
| `backend-deps-resolve / mybookkeeper` | Real drift between `apps/mybookkeeper/backend/pyproject.toml` and `uv.lock` (this is the prod-deploy-breaking issue from today). | New PR: `fix(mybookkeeper): resync uv.lock with pyproject.toml` — run `uv lock` + `uv export --format requirements-txt --no-hashes --no-emit-project --output-file requirements.txt`, commit all three files together. |
| `backend-tests / mybookkeeper` | `app/db/session.py` passes Postgres-only pool kwargs (`pool_size`, `max_overflow`, `pool_timeout`) unconditionally; the test suite uses in-memory sqlite which rejects them. Tests have evidently been failing on this codebase since the standalone-repo migration. | New PR: make pool kwargs conditional on the dialect in `db/session.py`. |
| `backend-tests / myjobhunter` | `ModuleNotFoundError: platform_shared` — the shared package at `packages/shared-backend/` is imported as `platform_shared` but isn't on `sys.path` / installed in the test environment. | New PR: install `packages/shared-backend` in editable mode in CI (or convert imports to a relative path that doesn't depend on package install). |
| `frontend-build / myjobhunter` | `vitest.config.ts` plugin type mismatch — vite is resolved to two different paths (workspace-hoisted vs nested) so `Plugin<any>` types diverge between them. | New PR: align vite versions across the workspace, or hoist vite to the root, or cast the plugins array. |

**Decision needed**: this PR may be admin-merged with those four jobs failing — they fail because the gates work, not because the gates are broken. Alternatively, the four follow-up PRs above can land first so this PR goes fully green; happy to do either.

If we admin-merge with red, the gates will continue to fail on every subsequent PR touching those paths until the follow-ups land — which is the intended behavior of a gate.

### Note on `.gitleaksignore`

This branch's first commit landed CI dummy env values with entropy 3.9 that tripped the generic-api-key rule. The follow-up commit replaced them with low-entropy `change-me-*` / `placeholder` strings that hit the existing allowlist, but gitleaks scans the full PR diff and kept re-finding the now-superseded values. The third commit added a tiny `.gitleaksignore` with two fingerprints scoped to that one historical commit + the two affected lines. New commits introducing similar high-entropy patterns are NOT covered by this allowlist — gitleaks will fail anew, which is the intended behavior.

## MANUAL STEP for the user

Branch protection on `main` is configured manually and the `gh` token used to create this PR doesn't have admin scope. After this PR merges, please update branch protection settings to **require** the six check names above before merging to `main`. Without that step, the new gates will run on every PR but won't actually block merge.

GitHub UI path: Settings → Branches → `main` → Branch protection rule → Require status checks to pass before merging → search for and add the six check names listed above.

## Test plan

- [x] CI on this PR runs all three new MyBookkeeper jobs (path filter matches the workflow file itself)
- [x] CI on this PR runs all three new MyJobHunter jobs (path filter matches the workflow file itself)
- [x] Gitleaks no longer flags the CI dummy env values (allowlisted via `change-me-*` / `placeholder` stopword + `.gitleaksignore` for historical fingerprints)
- [x] `frontend-build / mybookkeeper` and `backend-deps-resolve / myjobhunter` pass — proves the workflow plumbing works on green app code
- [ ] After merge: open a follow-up no-op PR touching `apps/mybookkeeper/backend/` and confirm only the MyBookkeeper jobs trigger (not MyJobHunter)
- [ ] After merge: update branch protection rule per manual step above
- [ ] Follow-up PRs to fix the four preexisting failures listed in the table above

🤖 Generated with [Claude Code](https://claude.com/claude-code)