### PR TITLE
fix(myjobhunter/frontend): use vitest/config defineConfig to avoid dual vite type instance

### DIFF
--- a/apps/myjobhunter/frontend/vitest.config.ts
+++ b/apps/myjobhunter/frontend/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, type Plugin } from "vitest/config";
 import react from "@vitejs/plugin-react";
 import path from "path";
 
@@ -8,7 +8,12 @@ const sharedFrontend = path.resolve(
 );
 
 export default defineConfig({
-  plugins: [react()],
+  // npm-workspaces resolves @vitejs/plugin-react against the app-local vite 8
+  // copy while vitest/config pulls vite 7 from the workspace root, producing
+  // two distinct (but structurally compatible) Plugin type instances. Cast via
+  // unknown to paper over the dual-instance mismatch without weakening typing
+  // anywhere else in the config.
+  plugins: [react() as unknown as Plugin],
   test: {
     environment: "jsdom",
     globals: true,


### PR DESCRIPTION
## Summary

- Unblocks the new `frontend-build / myjobhunter` CI gate (PR #91) which was failing with TS2769 in `apps/myjobhunter/frontend/vitest.config.ts`.
- Root cause: npm-workspaces installs two vite copies — vite 8 under `apps/myjobhunter/frontend/node_modules` (the app's `^8.0.10` pin) and vite 7 at the workspace root (matching mybookkeeper + vitest 4). `@vitejs/plugin-react` resolves vite 8, `vitest/config` resolves vite 7, so the `Plugin<any>` types diverge structurally on the rolldown-vs-rollup `hotUpdate` hook.
- Fix: cast the `react()` plugin via `unknown` to the `Plugin` type re-exported from `vitest/config`. Single, local cast — typing elsewhere in the config is unchanged. No version bumps (per the do-not-touch-package.json constraint).
- mybookkeeper is unaffected: its `vite ^7.3.2` dedupes against the workspace root. Verified locally.

## Diff

```diff
-import { defineConfig } from "vitest/config";
+import { defineConfig, type Plugin } from "vitest/config";
 ...
-  plugins: [react()],
+  plugins: [react() as unknown as Plugin],
```

(plus a short explanatory comment)

## Test plan

- [x] `cd apps/myjobhunter/frontend && npm run build` succeeds with zero TS errors locally
- [x] `npm test` confirms the config still loads at runtime (jsdom env, alias resolution, plugin transform — all working). Pre-existing test failures in `Login.test.tsx` are unrelated React 19 issues.
- [x] mybookkeeper build verified clean — no preemptive fix required there.
- [ ] CI `frontend-build / myjobhunter` job goes green on this PR

## Follow-up note (not in this PR)

`apps/myjobhunter/frontend/` accumulates `vite.config.{js,d.ts}` and `vitest.config.{js,d.ts}` artifacts from `tsc -b` that are not gitignored. Worth adding to a `.gitignore` in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)