### PR TITLE
fix(myjobhunter/backend): install platform_shared package in test env

### DIFF
--- a/apps/myjobhunter/backend/requirements.txt
+++ b/apps/myjobhunter/backend/requirements.txt
@@ -1,3 +1,6 @@
+# Local shared-backend package — path is relative to this requirements.txt file.
+# Pip resolves this to <repo>/packages/shared-backend when running from any directory.
+../../../packages/shared-backend
 fastapi==0.136.1
 uvicorn[standard]==0.46.0
 sqlalchemy==2.0.49

--- a/apps/myjobhunter/docker/backend.Dockerfile
+++ b/apps/myjobhunter/docker/backend.Dockerfile
@@ -10,11 +10,13 @@ COPY apps/myjobhunter/frontend ./apps/myjobhunter/frontend
 RUN npm run build --workspace=apps/myjobhunter/frontend
 
 # Stage 2: Install Python dependencies
+# Preserve the repo path layout so the relative path in requirements.txt
+# (../../../packages/shared-backend) resolves correctly under /repo.
 FROM python:3.12-slim AS backend-deps
-WORKDIR /deps
-COPY packages/shared-backend/ /deps/shared-backend/
-COPY apps/myjobhunter/backend/requirements.txt ./
-RUN pip install --no-cache-dir --prefix=/install /deps/shared-backend/ -r requirements.txt
+WORKDIR /repo
+COPY packages/shared-backend/ /repo/packages/shared-backend/
+COPY apps/myjobhunter/backend/requirements.txt /repo/apps/myjobhunter/backend/requirements.txt
+RUN pip install --no-cache-dir --prefix=/install -r /repo/apps/myjobhunter/backend/requirements.txt
 
 # Stage 3: Runtime
 FROM python:3.12-slim AS runtime


### PR DESCRIPTION
## Root cause

The myjobhunter backend imports `platform_shared` (from `packages/shared-backend/`) in three files:
- `app/core/security.py`
- `app/db/base.py`
- `app/db/session.py`

But `platform_shared` was **not declared** in `apps/myjobhunter/backend/requirements.txt`. Only the Dockerfile installed it, via a separate `pip install /deps/shared-backend/` step that ran before `pip install -r requirements.txt`.

This meant:
- `cd apps/myjobhunter/backend && pytest` failed locally with `ModuleNotFoundError: platform_shared`
- The new `backend-tests / myjobhunter` CI gate added in PR #91 (which only runs `pip install -r requirements.txt`) would fail the same way once that PR lands

## Fix

Declare the shared package in `requirements.txt` as a path-based entry:

```
../../../packages/shared-backend
```

Pip resolves relative paths in a `requirements.txt` relative to the requirements file's directory, so this resolves to `<repo>/packages/shared-backend` from any CWD.

The Dockerfile is adjusted to preserve the repo path layout under `/repo/` inside the build stage so the same relative path resolves correctly inside the container — net-zero functionality change, one fewer install step.

## Verification

Locally (Python 3.12 venv):
```
$ pip install -r requirements.txt
...
Successfully installed ... platform-shared-0.1.0 ...

$ python -c "from platform_shared.core.security import FernetSuite; from platform_shared.db.base import Base; from platform_shared.db.session import create_session_factory; print('ok')"
ok

$ pytest --collect-only
collected 14 items   # no ModuleNotFoundError
```

## Impact on PR #91

**No follow-up workflow change is needed.** PR #91's `ci-myjobhunter.yml` runs `pip install -r requirements.txt` and `pip install -r requirements.txt` again in the test job — both will now pull in `platform_shared` automatically. Once this PR lands and PR #91 rebases on main, the new CI gate will work as designed.

## Test plan

- [x] `pip install -r requirements.txt` installs `platform-shared-0.1.0`
- [x] All four `from platform_shared.*` imports referenced by myjobhunter resolve
- [x] `pytest --collect-only` collects 14 tests with no `ModuleNotFoundError`
- [ ] Once merged, PR #91's `backend-tests / myjobhunter` job advances past the import-error stage

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>