### PR TITLE
fix(mybookkeeper/backend): conditional pool kwargs in db session for sqlite test fixture

### DIFF
--- a/apps/mybookkeeper/backend/app/db/session.py
+++ b/apps/mybookkeeper/backend/app/db/session.py
@@ -1,18 +1,24 @@
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.core.config import settings
 
-engine = create_async_engine(
-    settings.database_url,
-    echo=False,
-    pool_size=10,
-    max_overflow=20,
-    pool_timeout=30,
-    pool_recycle=1800,
-)
+# Pool kwargs are valid for QueuePool (Postgres asyncpg) but rejected by sqlite's
+# default pool. The test suite uses an in-memory sqlite URL, so apply pool kwargs
+# only when the configured database is not sqlite.
+engine_kwargs: dict[str, Any] = {"echo": False}
+if not settings.database_url.startswith("sqlite"):
+    engine_kwargs.update(
+        pool_size=10,
+        max_overflow=20,
+        pool_timeout=30,
+        pool_recycle=1800,
+    )
+
+engine = create_async_engine(settings.database_url, **engine_kwargs)
 AsyncSessionLocal = async_sessionmaker(engine, expire_on_commit=False)
 
 

--- a/apps/mybookkeeper/backend/tests/test_db_session_engine.py
+++ b/apps/mybookkeeper/backend/tests/test_db_session_engine.py
@@ -1,0 +1,59 @@
+"""Regression tests for app.db.session engine kwarg construction.
+
+PR #91 surfaced a bug: pool kwargs (pool_size, max_overflow, pool_timeout,
+pool_recycle) were passed unconditionally to create_async_engine. SQLAlchemy's
+sqlite dialect rejects these, breaking the test suite which uses an in-memory
+sqlite URL. The fix builds engine kwargs conditionally on the URL dialect.
+"""
+import importlib
+import sys
+from typing import Any
+from unittest.mock import patch
+
+
+def _reload_session_with_url(url: str) -> dict[str, Any]:
+    """Reload app.db.session with a patched DATABASE_URL and return the engine kwargs
+    captured from create_async_engine."""
+    captured: dict[str, Any] = {}
+
+    def _capture(database_url: str, **kwargs: Any) -> Any:
+        captured["url"] = database_url
+        captured["kwargs"] = kwargs
+
+        # Return a stub object that async_sessionmaker can wrap without erroring.
+        class _StubEngine:
+            sync_engine = object()
+
+        return _StubEngine()
+
+    sys.modules.pop("app.db.session", None)
+    with patch("app.core.config.settings.database_url", url), patch(
+        "sqlalchemy.ext.asyncio.create_async_engine", side_effect=_capture
+    ):
+        importlib.import_module("app.db.session")
+
+    # Drop the patched module so subsequent tests get a fresh, correctly-built engine.
+    sys.modules.pop("app.db.session", None)
+    return captured
+
+
+def test_sqlite_url_omits_pool_kwargs() -> None:
+    captured = _reload_session_with_url("sqlite+aiosqlite:///:memory:")
+    kwargs = captured["kwargs"]
+    assert "pool_size" not in kwargs
+    assert "max_overflow" not in kwargs
+    assert "pool_timeout" not in kwargs
+    assert "pool_recycle" not in kwargs
+    assert kwargs.get("echo") is False
+
+
+def test_postgres_url_includes_pool_kwargs() -> None:
+    captured = _reload_session_with_url(
+        "postgresql+asyncpg://user:pw@localhost:5432/mybookkeeper"
+    )
+    kwargs = captured["kwargs"]
+    assert kwargs["pool_size"] == 10
+    assert kwargs["max_overflow"] == 20
+    assert kwargs["pool_timeout"] == 30
+    assert kwargs["pool_recycle"] == 1800
+    assert kwargs["echo"] is False


### PR DESCRIPTION
## Root cause

PR #91 introduced a `backend-tests / mybookkeeper` CI gate that runs pytest with `DATABASE_URL=sqlite+aiosqlite:///:memory:`. The gate fails at module-import time because `apps/mybookkeeper/backend/app/db/session.py` passes `pool_size`, `max_overflow`, `pool_timeout`, and `pool_recycle` unconditionally to `create_async_engine`. SQLAlchemy's sqlite `StaticPool` rejects these kwargs:

```
TypeError: Invalid argument(s) 'pool_size','max_overflow','pool_timeout' sent to create_engine(), using configuration SQLiteDialect_aiosqlite/StaticPool/Engine.
```

Many test files (`test_auth_events_admin.py`, `test_data_export.py`, `test_login_ip_rate_limit.py`, `test_totp_routes.py`, etc.) `from app.db.session import get_db`, which triggers this at collection time.

## Fix

Build engine kwargs conditionally on the URL dialect. Postgres prod/dev behavior is unchanged — same four pool kwargs as before. Sqlite test paths now use SQLAlchemy defaults.

```python
engine_kwargs: dict[str, Any] = {"echo": False}
if not settings.database_url.startswith("sqlite"):
    engine_kwargs.update(
        pool_size=10,
        max_overflow=20,
        pool_timeout=30,
        pool_recycle=1800,
    )
engine = create_async_engine(settings.database_url, **engine_kwargs)
```

## Verification

- `pytest --collect-only` against the worktree with `DATABASE_URL=sqlite+aiosqlite:///:memory:` collects all **1645 tests** with no import errors (was previously failing at import time).
- New regression test `tests/test_db_session_engine.py` asserts both branches:
  - `test_sqlite_url_omits_pool_kwargs` — sqlite URL produces no pool kwargs
  - `test_postgres_url_includes_pool_kwargs` — postgres URL produces all four pool kwargs at the original values
- Both regression tests pass: `2 passed in 0.04s`.
- Reverted the fix locally to reproduce the original `TypeError` against sqlite — confirmed bug, then re-applied the fix.

## Scope

- Modifies only `apps/mybookkeeper/backend/app/db/session.py` and adds the regression test. Does not touch `pyproject.toml` / `uv.lock` (separate follow-up PR per the PR #91 plan).
- Diff is 22 lines in `session.py` (under the requested <30 line cap).

## Test plan

- [x] CI `backend-tests / mybookkeeper` should pass (was failing before this PR).
- [x] Regression test prevents the same kwarg-construction mistake from coming back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)