### PR TITLE
feat(mybookkeeper/applicants): backend models, migration, PII encryption (rentals Phase 3, PR 3.1a)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/f8h0i3k5l7m9_add_applicants_domain.py
+++ b/apps/mybookkeeper/backend/alembic/versions/f8h0i3k5l7m9_add_applicants_domain.py
@@ -1,0 +1,318 @@
+"""add applicants domain (applicants, screening_results, applicant_references,
+video_call_notes, applicant_events)
+
+Revision ID: f8h0i3k5l7m9
+Revises: e7g9h2j4k6l8
+Create Date: 2026-04-27
+
+Phase 3 / PR 3.1a of the rentals expansion. See RENTALS_PLAN.md §5.3, §8.1-8.7.
+
+Conventions per RENTALS_PLAN.md §4.1 (mirrors the inquiries migration in
+``d6f8b1a2c4e5_add_inquiries_domain.py``):
+
+- String + CheckConstraint for stage / provider / status / actor /
+  relationship columns (not SAEnum).
+- Dual scope: ``organization_id + user_id`` on the parent (``applicants``);
+  child tables scope through their applicant FK.
+- Soft-delete via ``deleted_at`` on the parent only — children are
+  immutable / cascade-deleted.
+- ``DateTime(timezone=True)`` with ``server_default = func.now()``.
+- UUID primary keys (``uuid.uuid4`` Python-side default).
+- Append-only event log (``applicant_events``) has no ``updated_at``.
+- PII columns (``legal_name``, ``dob``, ``employer_or_hospital``,
+  ``vehicle_make_model``, ``reference_name``, ``reference_contact``,
+  ``video_call_notes.notes``) are stored as Fernet ciphertext via the
+  ``EncryptedString`` SQLAlchemy ``TypeDecorator``. The DB stores plain
+  TEXT — no DDL difference from any other String column.
+- ``key_version smallint`` lets future key rotation re-encrypt rows
+  non-destructively per RENTALS_PLAN.md §8.2.
+- Table name ``applicant_references`` (not ``references``) avoids the SQL
+  reserved keyword in dump/restore tooling and query logs.
+- ``applicants.inquiry_id`` is ``ON DELETE SET NULL`` — applicants outlive
+  inquiry purges. Other FKs are ``ON DELETE CASCADE``.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision: str = "f8h0i3k5l7m9"
+down_revision: Union[str, None] = "e7g9h2j4k6l8"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # applicants
+    # ------------------------------------------------------------------
+    op.create_table(
+        "applicants",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("inquiry_id", postgresql.UUID(as_uuid=True), nullable=True),
+        # PII — stored as TEXT, encrypted application-side via EncryptedString.
+        sa.Column("legal_name", sa.Text(), nullable=True),
+        sa.Column("dob", sa.Text(), nullable=True),
+        sa.Column("employer_or_hospital", sa.Text(), nullable=True),
+        sa.Column("vehicle_make_model", sa.Text(), nullable=True),
+        # Opaque MinIO key — NOT encrypted.
+        sa.Column("id_document_storage_key", sa.String(length=500), nullable=True),
+        sa.Column("contract_start", sa.Date(), nullable=True),
+        sa.Column("contract_end", sa.Date(), nullable=True),
+        sa.Column("smoker", sa.Boolean(), nullable=True),
+        sa.Column("pets", sa.Text(), nullable=True),
+        sa.Column("referred_by", sa.String(length=255), nullable=True),
+        sa.Column("stage", sa.String(length=40), nullable=False, server_default="lead"),
+        sa.Column("key_version", sa.SmallInteger(), nullable=False, server_default="1"),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("sensitive_purged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["organization_id"], ["organizations.id"], ondelete="CASCADE",
+            name="fk_applicants_organization_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], ondelete="CASCADE",
+            name="fk_applicants_user_id",
+        ),
+        sa.ForeignKeyConstraint(
+            ["inquiry_id"], ["inquiries.id"], ondelete="SET NULL",
+            name="fk_applicants_inquiry_id",
+        ),
+        sa.CheckConstraint(
+            "stage IN ('lead', 'screening_pending', 'screening_passed', "
+            "'screening_failed', 'video_call_done', 'approved', 'lease_sent', "
+            "'lease_signed', 'declined')",
+            name="chk_applicant_stage",
+        ),
+    )
+    op.create_index("ix_applicants_organization_id", "applicants", ["organization_id"])
+    op.create_index("ix_applicants_user_id", "applicants", ["user_id"])
+    op.create_index("ix_applicants_inquiry_id", "applicants", ["inquiry_id"])
+    op.create_index(
+        "ix_applicants_org_stage_active",
+        "applicants",
+        ["organization_id", "stage"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "ix_applicants_org_created_active",
+        "applicants",
+        ["organization_id", "created_at"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "ix_applicants_org_inquiry",
+        "applicants",
+        ["organization_id", "inquiry_id"],
+    )
+    # Retention purge worker scan (RENTALS_PLAN.md §6.6).
+    op.create_index(
+        "ix_applicants_user_pending_purge",
+        "applicants",
+        ["user_id", "deleted_at"],
+        postgresql_where=sa.text(
+            "deleted_at IS NOT NULL AND sensitive_purged_at IS NULL",
+        ),
+    )
+
+    # ------------------------------------------------------------------
+    # screening_results
+    # ------------------------------------------------------------------
+    op.create_table(
+        "screening_results",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("applicant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("provider", sa.String(length=20), nullable=False),
+        sa.Column("report_storage_key", sa.String(length=500), nullable=True),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("adverse_action_snippet", sa.Text(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("requested_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["applicant_id"], ["applicants.id"], ondelete="CASCADE",
+            name="fk_screening_results_applicant_id",
+        ),
+        sa.CheckConstraint(
+            "provider IN ('keycheck', 'rentspree', 'other')",
+            name="chk_screening_result_provider",
+        ),
+        sa.CheckConstraint(
+            "status IN ('pending', 'pass', 'fail', 'inconclusive')",
+            name="chk_screening_result_status",
+        ),
+    )
+    op.create_index(
+        "ix_screening_results_applicant_id", "screening_results", ["applicant_id"],
+    )
+    op.create_index(
+        "ix_screening_results_applicant_status",
+        "screening_results",
+        ["applicant_id", "status"],
+    )
+    # Partial UNIQUE: prevents two concurrent pending screenings for the same
+    # (applicant, provider). Once status moves off 'pending' a retry is allowed.
+    op.create_index(
+        "uq_screening_results_applicant_provider_pending",
+        "screening_results",
+        ["applicant_id", "provider"],
+        unique=True,
+        postgresql_where=sa.text("status = 'pending'"),
+    )
+
+    # ------------------------------------------------------------------
+    # applicant_references
+    # ------------------------------------------------------------------
+    op.create_table(
+        "applicant_references",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("applicant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("relationship", sa.String(length=40), nullable=False),
+        # PII — stored as TEXT, encrypted application-side.
+        sa.Column("reference_name", sa.Text(), nullable=False),
+        sa.Column("reference_contact", sa.Text(), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("contacted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("key_version", sa.SmallInteger(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["applicant_id"], ["applicants.id"], ondelete="CASCADE",
+            name="fk_applicant_references_applicant_id",
+        ),
+        sa.CheckConstraint(
+            "relationship IN ('landlord', 'employer', 'personal', "
+            "'professional', 'family', 'other')",
+            name="chk_applicant_reference_relationship",
+        ),
+    )
+    # FK index — matches the ``index=True`` declaration on the model column.
+    op.create_index(
+        "ix_applicant_references_applicant_id",
+        "applicant_references",
+        ["applicant_id"],
+    )
+
+    # ------------------------------------------------------------------
+    # video_call_notes
+    # ------------------------------------------------------------------
+    op.create_table(
+        "video_call_notes",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("applicant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("scheduled_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        # PII — stored as TEXT, encrypted application-side.
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("gut_rating", sa.SmallInteger(), nullable=True),
+        sa.Column("transcript_storage_key", sa.String(length=500), nullable=True),
+        sa.Column("key_version", sa.SmallInteger(), nullable=False, server_default="1"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["applicant_id"], ["applicants.id"], ondelete="CASCADE",
+            name="fk_video_call_notes_applicant_id",
+        ),
+        sa.CheckConstraint(
+            "gut_rating IS NULL OR (gut_rating BETWEEN 1 AND 5)",
+            name="chk_video_call_note_gut_rating",
+        ),
+    )
+    op.create_index(
+        "ix_video_call_notes_applicant_id", "video_call_notes", ["applicant_id"],
+    )
+    op.execute(
+        "CREATE INDEX ix_video_call_notes_applicant_scheduled "
+        "ON video_call_notes (applicant_id, scheduled_at DESC)",
+    )
+
+    # ------------------------------------------------------------------
+    # applicant_events  (append-only — no updated_at)
+    # ------------------------------------------------------------------
+    op.create_table(
+        "applicant_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("applicant_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("event_type", sa.String(length=40), nullable=False),
+        sa.Column("actor", sa.String(length=20), nullable=False),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False,
+                  server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(
+            ["applicant_id"], ["applicants.id"], ondelete="CASCADE",
+            name="fk_applicant_events_applicant_id",
+        ),
+        sa.CheckConstraint(
+            "event_type IN ('lead', 'screening_pending', 'screening_passed', "
+            "'screening_failed', 'video_call_done', 'approved', 'lease_sent', "
+            "'lease_signed', 'declined', 'note_added', 'screening_initiated', "
+            "'screening_completed', 'reference_contacted')",
+            name="chk_applicant_event_type",
+        ),
+        sa.CheckConstraint(
+            "actor IN ('host', 'system', 'applicant')",
+            name="chk_applicant_event_actor",
+        ),
+    )
+    op.create_index(
+        "ix_applicant_events_applicant_id", "applicant_events", ["applicant_id"],
+    )
+    op.execute(
+        "CREATE INDEX ix_applicant_events_applicant_occurred "
+        "ON applicant_events (applicant_id, occurred_at DESC)",
+    )
+    op.create_index(
+        "ix_applicant_events_type_occurred",
+        "applicant_events",
+        ["event_type", "occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    # Drop in reverse dependency order: children first, then parent.
+    op.drop_index("ix_applicant_events_type_occurred", table_name="applicant_events")
+    op.drop_index("ix_applicant_events_applicant_occurred", table_name="applicant_events")
+    op.drop_index("ix_applicant_events_applicant_id", table_name="applicant_events")
+    op.drop_table("applicant_events")
+
+    op.drop_index("ix_video_call_notes_applicant_scheduled", table_name="video_call_notes")
+    op.drop_index("ix_video_call_notes_applicant_id", table_name="video_call_notes")
+    op.drop_table("video_call_notes")
+
+    op.drop_index("ix_applicant_references_applicant_id", table_name="applicant_references")
+    op.drop_table("applicant_references")
+
+    op.drop_index(
+        "uq_screening_results_applicant_provider_pending",
+        table_name="screening_results",
+    )
+    op.drop_index(
+        "ix_screening_results_applicant_status", table_name="screening_results",
+    )
+    op.drop_index(
+        "ix_screening_results_applicant_id", table_name="screening_results",
+    )
+    op.drop_table("screening_results")
+
+    op.drop_index("ix_applicants_user_pending_purge", table_name="applicants")
+    op.drop_index("ix_applicants_org_inquiry", table_name="applicants")
+    op.drop_index("ix_applicants_org_created_active", table_name="applicants")
+    op.drop_index("ix_applicants_org_stage_active", table_name="applicants")
+    op.drop_index("ix_applicants_inquiry_id", table_name="applicants")
+    op.drop_index("ix_applicants_user_id", table_name="applicants")
+    op.drop_index("ix_applicants_organization_id", table_name="applicants")
+    op.drop_table("applicants")

--- a/apps/mybookkeeper/backend/app/core/applicant_enums.py
+++ b/apps/mybookkeeper/backend/app/core/applicant_enums.py
@@ -1,0 +1,64 @@
+"""Canonical string values for the Applicants domain (rentals Phase 3).
+
+Per RENTALS_PLAN.md §4.1: status / category columns use ``String(N)`` plus a
+``CheckConstraint``, never ``SQLAlchemy Enum``. These tuples are the single
+source of truth — referenced from both the SQLAlchemy model
+``CheckConstraint``s and the Alembic migration DDL.
+
+Mirrors ``app/core/inquiry_enums.py`` (Phase 2) for consistency.
+"""
+
+# Applicant pipeline stages. ``lead`` is the entry point (set when an
+# Inquiry is promoted to an Applicant via the PR 3.2 promotion service).
+APPLICANT_STAGES: tuple[str, ...] = (
+    "lead",
+    "screening_pending",
+    "screening_passed",
+    "screening_failed",
+    "video_call_done",
+    "approved",
+    "lease_sent",
+    "lease_signed",
+    "declined",
+)
+
+# Applicant timeline event types — superset of ``APPLICANT_STAGES`` plus
+# non-stage events that the host or system can record on the timeline.
+APPLICANT_EVENT_TYPES: tuple[str, ...] = APPLICANT_STAGES + (
+    "note_added",
+    "screening_initiated",
+    "screening_completed",
+    "reference_contacted",
+)
+
+APPLICANT_EVENT_ACTORS: tuple[str, ...] = ("host", "system", "applicant")
+
+# Screening provider identifiers. Keep this list minimal — every value here
+# corresponds to a code path in the (future) PR 3.3 screening integration.
+SCREENING_PROVIDERS: tuple[str, ...] = ("keycheck", "rentspree", "other")
+
+# Screening report status. ``inconclusive`` is a real provider response
+# (e.g. KeyCheck returns it when the applicant didn't complete consent).
+SCREENING_STATUSES: tuple[str, ...] = ("pending", "pass", "fail", "inconclusive")
+
+# Reference relationship to the applicant.
+REFERENCE_RELATIONSHIPS: tuple[str, ...] = (
+    "landlord",
+    "employer",
+    "personal",
+    "professional",
+    "family",
+    "other",
+)
+
+
+def _sql_in_list(values: tuple[str, ...]) -> str:
+    return "(" + ", ".join(f"'{v}'" for v in values) + ")"
+
+
+APPLICANT_STAGES_SQL = _sql_in_list(APPLICANT_STAGES)
+APPLICANT_EVENT_TYPES_SQL = _sql_in_list(APPLICANT_EVENT_TYPES)
+APPLICANT_EVENT_ACTORS_SQL = _sql_in_list(APPLICANT_EVENT_ACTORS)
+SCREENING_PROVIDERS_SQL = _sql_in_list(SCREENING_PROVIDERS)
+SCREENING_STATUSES_SQL = _sql_in_list(SCREENING_STATUSES)
+REFERENCE_RELATIONSHIPS_SQL = _sql_in_list(REFERENCE_RELATIONSHIPS)

--- a/apps/mybookkeeper/backend/app/core/audit.py
+++ b/apps/mybookkeeper/backend/app/core/audit.py
@@ -23,8 +23,22 @@ SENSITIVE_FIELDS = {
     "inquirer_employer",
     "from_address",
     "to_address",
+    # Applicants domain PII (RENTALS_PLAN.md §8.7, Phase 3 PR 3.1a) —
+    # encrypted at rest via EncryptedString. Field names are intentionally
+    # specific (``legal_name`` not ``name``, ``reference_name`` not ``name``)
+    # to avoid masking unrelated columns elsewhere in the schema (Property,
+    # Organization, User, ReplyTemplate all have plain ``name`` columns we
+    # MUST NOT mask in the audit log).
+    "legal_name",
+    "dob",
+    "employer_or_hospital",
+    "vehicle_make_model",
+    "reference_name",
+    "reference_contact",
     # Hosts may put sensitive context into freeform notes (medical info,
-    # personal references) — mask the column to be safe.
+    # personal references, candid character assessments) — mask the column
+    # to be safe. Applies to inquiries.notes, applicants.pets context,
+    # video_call_notes.notes, applicant_events.notes, etc.
     "notes",
 }
 SKIP_FIELDS = {"file_content"}  # large binary fields with no audit value

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -16,6 +16,11 @@ from app.models.inquiries.inquiry import Inquiry
 from app.models.inquiries.inquiry_message import InquiryMessage
 from app.models.inquiries.inquiry_event import InquiryEvent
 from app.models.inquiries.reply_template import ReplyTemplate
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.screening_result import ScreeningResult
+from app.models.applicants.reference import Reference
+from app.models.applicants.video_call_note import VideoCallNote
+from app.models.applicants.applicant_event import ApplicantEvent
 from app.models.documents.document import Document
 from app.models.extraction.extraction_prompt import ExtractionPrompt
 from app.models.extraction.extraction_types import ExtractionData, ExtractionResult

--- a/apps/mybookkeeper/backend/app/models/applicants/applicant.py
+++ b/apps/mybookkeeper/backend/app/models/applicants/applicant.py
@@ -1,0 +1,154 @@
+"""SQLAlchemy ORM model for ``applicants``.
+
+Per RENTALS_PLAN.md §5.3, §8.1-8.7:
+- PII columns (``legal_name``, ``dob``, ``employer_or_hospital``,
+  ``vehicle_make_model``) use ``EncryptedString`` so they're stored as Fernet
+  ciphertext and round-tripped to plaintext via the type decorator.
+- ``key_version`` records which key generation encrypted the row's PII —
+  required for non-destructive key rotation per §8.2.
+- ``inquiry_id`` is ``ON DELETE SET NULL``: applicants outlive the inquiry
+  they came from (the inquiry retention worker may purge older inquiries
+  while the applicant is still active in the screening / approval pipeline).
+- ``sensitive_purged_at`` is set by the future retention worker (§6.6) when
+  PII is NULL'd 1 year after a declined applicant — the row itself is kept
+  for funnel analytics, only the PII is purged.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    SmallInteger,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.applicant_enums import APPLICANT_STAGES_SQL
+from app.core.encrypted_string_type import EncryptedString
+from app.db.base import Base
+
+
+class Applicant(Base):
+    __tablename__ = "applicants"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    inquiry_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("inquiries.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+
+    # PII — encrypted at rest via EncryptedString TypeDecorator.
+    legal_name: Mapped[str | None] = mapped_column(EncryptedString(255), nullable=True)
+    # ``dob`` is stored as ISO-8601 date string so it can be encrypted as text.
+    # The repo / service layer is responsible for ISO formatting on write.
+    dob: Mapped[str | None] = mapped_column(EncryptedString(50), nullable=True)
+    employer_or_hospital: Mapped[str | None] = mapped_column(
+        EncryptedString(255), nullable=True,
+    )
+    vehicle_make_model: Mapped[str | None] = mapped_column(
+        EncryptedString(255), nullable=True,
+    )
+
+    # Opaque MinIO key — NOT encrypted (key reveals nothing about contents).
+    id_document_storage_key: Mapped[str | None] = mapped_column(
+        String(500), nullable=True,
+    )
+
+    contract_start: Mapped[_dt.date | None] = mapped_column(Date, nullable=True)
+    contract_end: Mapped[_dt.date | None] = mapped_column(Date, nullable=True)
+
+    smoker: Mapped[bool | None] = mapped_column(Boolean, nullable=True)
+    pets: Mapped[str | None] = mapped_column(Text, nullable=True)
+    referred_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    stage: Mapped[str] = mapped_column(
+        String(40), nullable=False, default="lead", server_default="lead",
+    )
+
+    key_version: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=1, server_default="1",
+    )
+
+    deleted_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    # Set by the retention worker (out of scope for PR 3.1a) once PII has been
+    # NULL'd post-decline. Lets us distinguish "soft-deleted but still has PII"
+    # from "soft-deleted and PII has been purged" without a separate flag.
+    sensitive_purged_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        onupdate=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"stage IN {APPLICANT_STAGES_SQL}",
+            name="chk_applicant_stage",
+        ),
+        # Pipeline stage filter — covers (org, stage) for active rows.
+        Index(
+            "ix_applicants_org_stage_active",
+            "organization_id", "stage",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        # Pipeline sort — newest first.
+        Index(
+            "ix_applicants_org_created_active",
+            "organization_id", "created_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        # "Find applicant from inquiry" lookup (used by promotion service).
+        Index(
+            "ix_applicants_org_inquiry",
+            "organization_id", "inquiry_id",
+        ),
+        # Retention purge worker scan (RENTALS_PLAN.md §6.6) — finds
+        # soft-deleted rows whose PII has not yet been purged.
+        Index(
+            "ix_applicants_user_pending_purge",
+            "user_id", "deleted_at",
+            postgresql_where=text(
+                "deleted_at IS NOT NULL AND sensitive_purged_at IS NULL",
+            ),
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/models/applicants/applicant_event.py
+++ b/apps/mybookkeeper/backend/app/models/applicants/applicant_event.py
@@ -1,0 +1,85 @@
+"""SQLAlchemy ORM model for ``applicant_events`` — append-only.
+
+Per RENTALS_PLAN.md §5.3: append-only stage / activity log for the applicant
+pipeline. No ``updated_at`` column — events are immutable timeline records
+that power funnel analytics (conversion rate, time-in-stage, etc.).
+
+The first event for every Applicant is typically ``event_type = 'lead'``
+with ``actor = 'system'`` (when promoted from an Inquiry by the PR 3.2
+service) or ``actor = 'host'`` (manual create). Subsequent events represent
+stage transitions and supplementary activity (notes, screening kicks,
+reference contacts).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.applicant_enums import (
+    APPLICANT_EVENT_ACTORS_SQL,
+    APPLICANT_EVENT_TYPES_SQL,
+)
+from app.db.base import Base
+
+
+class ApplicantEvent(Base):
+    __tablename__ = "applicant_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    applicant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("applicants.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    event_type: Mapped[str] = mapped_column(String(40), nullable=False)
+    actor: Mapped[str] = mapped_column(String(20), nullable=False)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    occurred_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"event_type IN {APPLICANT_EVENT_TYPES_SQL}",
+            name="chk_applicant_event_type",
+        ),
+        CheckConstraint(
+            f"actor IN {APPLICANT_EVENT_ACTORS_SQL}",
+            name="chk_applicant_event_actor",
+        ),
+        # Per-applicant timeline (chronological). Migration creates this with
+        # explicit ``occurred_at DESC`` via raw SQL — the ORM index here only
+        # needs to declare the columns so SQLite test fixtures can mirror.
+        Index(
+            "ix_applicant_events_applicant_occurred",
+            "applicant_id", "occurred_at",
+        ),
+        # Funnel aggregation by event type over time.
+        Index(
+            "ix_applicant_events_type_occurred",
+            "event_type", "occurred_at",
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/models/applicants/reference.py
+++ b/apps/mybookkeeper/backend/app/models/applicants/reference.py
@@ -1,0 +1,96 @@
+"""SQLAlchemy ORM model for ``applicant_references``.
+
+Per RENTALS_PLAN.md §5.3: contact references the applicant supplies (former
+landlords, employers, personal references). The host calls / emails them
+out-of-band and records the outcome in ``notes``.
+
+Table-name choice: SQL ``REFERENCES`` is a reserved keyword in many dialects
+(it's the FK declaration keyword). PostgreSQL would auto-quote a table named
+``references`` but Alembic's autogenerate, query logs, and external tooling
+(pgAdmin, dump/restore) all become harder to read. ``applicant_references``
+is unambiguous and parallels the inquiries → inquiry_messages naming.
+
+PII columns: ``reference_name`` and ``reference_contact`` are encrypted via
+``EncryptedString``. Naming uses the ``reference_*`` prefix (mirroring the
+``inquirer_*`` convention) so the audit-log SENSITIVE_FIELDS allowlist can
+mask them precisely without colliding with bare ``name``/``contact``
+columns elsewhere in the schema (Property, Organization, User all have
+plain ``name`` columns we DON'T want to mask).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    SmallInteger,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.applicant_enums import REFERENCE_RELATIONSHIPS_SQL
+from app.core.encrypted_string_type import EncryptedString
+from app.db.base import Base
+
+
+class Reference(Base):
+    __tablename__ = "applicant_references"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    applicant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("applicants.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    relationship: Mapped[str] = mapped_column(String(40), nullable=False)
+    # PII — encrypted at rest via EncryptedString TypeDecorator.
+    reference_name: Mapped[str] = mapped_column(
+        EncryptedString(255), nullable=False,
+    )
+    # ``reference_contact`` is freeform — email or phone, sometimes both.
+    reference_contact: Mapped[str] = mapped_column(
+        EncryptedString(255), nullable=False,
+    )
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    contacted_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    key_version: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=1, server_default="1",
+    )
+
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        onupdate=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"relationship IN {REFERENCE_RELATIONSHIPS_SQL}",
+            name="chk_applicant_reference_relationship",
+        ),
+        # Note: the FK ``applicant_id`` already gets ``ix_applicant_references_applicant_id``
+        # from the column-level ``index=True`` — no additional composite index
+        # needed here (lookups are always "list references for this applicant").
+    )

--- a/apps/mybookkeeper/backend/app/models/applicants/screening_result.py
+++ b/apps/mybookkeeper/backend/app/models/applicants/screening_result.py
@@ -1,0 +1,94 @@
+"""SQLAlchemy ORM model for ``screening_results``.
+
+Per RENTALS_PLAN.md §5.3: one row per (applicant, screening request). The
+partial UNIQUE on ``(applicant_id, provider) WHERE status = 'pending'``
+prevents the host from accidentally firing two concurrent screening requests
+to the same provider for the same applicant — once the first one completes
+(status moves off ``'pending'``) a re-run is allowed.
+
+``report_storage_key`` and ``adverse_action_snippet`` are NOT encrypted — the
+report blob is stored opaquely in MinIO (encrypted at the bucket level), and
+the adverse-action snippet is a regulator-facing summary the host needs to
+see and forward.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.applicant_enums import (
+    SCREENING_PROVIDERS_SQL,
+    SCREENING_STATUSES_SQL,
+)
+from app.db.base import Base
+
+
+class ScreeningResult(Base):
+    __tablename__ = "screening_results"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    applicant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("applicants.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    provider: Mapped[str] = mapped_column(String(20), nullable=False)
+    report_storage_key: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    adverse_action_snippet: Mapped[str | None] = mapped_column(Text, nullable=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    requested_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    completed_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"provider IN {SCREENING_PROVIDERS_SQL}",
+            name="chk_screening_result_provider",
+        ),
+        CheckConstraint(
+            f"status IN {SCREENING_STATUSES_SQL}",
+            name="chk_screening_result_status",
+        ),
+        # "What's pending / completed for this applicant" lookup.
+        Index(
+            "ix_screening_results_applicant_status",
+            "applicant_id", "status",
+        ),
+        # Partial UNIQUE: one in-flight screening request per (applicant, provider).
+        # Once the first request completes, status moves off 'pending' and the
+        # constraint no longer applies — a retry is allowed.
+        Index(
+            "uq_screening_results_applicant_provider_pending",
+            "applicant_id", "provider",
+            unique=True,
+            postgresql_where=text("status = 'pending'"),
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/models/applicants/video_call_note.py
+++ b/apps/mybookkeeper/backend/app/models/applicants/video_call_note.py
@@ -1,0 +1,91 @@
+"""SQLAlchemy ORM model for ``video_call_notes``.
+
+Per RENTALS_PLAN.md §5.3: notes captured during the host's video screening
+call with an applicant. ``notes`` is encrypted because freeform host
+observations are a defamation-risk surface (they often contain candid
+character assessments). ``transcript_storage_key`` references an opaque
+MinIO blob (encrypted at the bucket level).
+
+``gut_rating`` is 1-5 (5 = best); the CheckConstraint enforces the range
+when present.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    SmallInteger,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.encrypted_string_type import EncryptedString
+from app.db.base import Base
+
+
+class VideoCallNote(Base):
+    __tablename__ = "video_call_notes"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    applicant_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("applicants.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    scheduled_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    completed_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    # PII — encrypted at rest. 10000 chars is generous; long observation
+    # blocks are common after a 30-minute screening call.
+    notes: Mapped[str | None] = mapped_column(EncryptedString(10000), nullable=True)
+    gut_rating: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    transcript_storage_key: Mapped[str | None] = mapped_column(
+        String(500), nullable=True,
+    )
+
+    key_version: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=1, server_default="1",
+    )
+
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        onupdate=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "gut_rating IS NULL OR (gut_rating BETWEEN 1 AND 5)",
+            name="chk_video_call_note_gut_rating",
+        ),
+        # Per-applicant timeline. Migration creates this with explicit
+        # ``scheduled_at DESC`` via raw SQL — the ORM index here only needs
+        # to declare the columns so SQLite test fixtures can mirror the table.
+        Index(
+            "ix_video_call_notes_applicant_scheduled",
+            "applicant_id", "scheduled_at",
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/__init__.py
+++ b/apps/mybookkeeper/backend/app/repositories/__init__.py
@@ -37,6 +37,11 @@ from app.repositories.inquiries import inquiry_repo
 from app.repositories.inquiries import inquiry_message_repo
 from app.repositories.inquiries import inquiry_event_repo
 from app.repositories.inquiries import reply_template_repo
+from app.repositories.applicants import applicant_repo
+from app.repositories.applicants import screening_result_repo
+from app.repositories.applicants import reference_repo
+from app.repositories.applicants import video_call_note_repo
+from app.repositories.applicants import applicant_event_repo
 from app.repositories.user import user_repo
 from app.repositories.classification import classification_rule_repo
 from app.repositories.demo import demo_repo

--- a/apps/mybookkeeper/backend/app/repositories/applicants/applicant_event_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/applicants/applicant_event_repo.py
@@ -1,0 +1,71 @@
+"""Repository for ``applicant_events`` — append-only.
+
+No update or delete methods by design — events are immutable timeline
+records that power funnel analytics. Mutating the timeline would invalidate
+metrics (RENTALS_PLAN.md §7.1).
+
+Tenant scoping: rows have no ``organization_id`` or ``user_id`` — they're
+scoped through their parent ``Applicant`` via the FK.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import asc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.applicant_event import ApplicantEvent
+
+
+async def append(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    event_type: str,
+    actor: str,
+    occurred_at: _dt.datetime,
+    notes: str | None = None,
+) -> ApplicantEvent:
+    """Append an event to an applicant's timeline.
+
+    Caller is responsible for proving the applicant belongs to the calling
+    tenant via ``applicant_repo.get()`` BEFORE calling this — repos do not
+    double-check tenancy on creates.
+    """
+    event = ApplicantEvent(
+        applicant_id=applicant_id,
+        event_type=event_type,
+        actor=actor,
+        notes=notes,
+        occurred_at=occurred_at,
+    )
+    db.add(event)
+    await db.flush()
+    return event
+
+
+async def list_for_applicant(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> list[ApplicantEvent]:
+    """Return events for an applicant in chronological (occurred_at asc) order.
+
+    Tenant-scoped through Applicant — returns [] if the applicant doesn't
+    belong to (organization_id, user_id).
+    """
+    result = await db.execute(
+        select(ApplicantEvent)
+        .join(Applicant, Applicant.id == ApplicantEvent.applicant_id)
+        .where(
+            ApplicantEvent.applicant_id == applicant_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+        )
+        .order_by(asc(ApplicantEvent.occurred_at))
+    )
+    return list(result.scalars().all())

--- a/apps/mybookkeeper/backend/app/repositories/applicants/applicant_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/applicants/applicant_repo.py
@@ -1,0 +1,183 @@
+"""Repository for ``applicants`` — owns every query against the table.
+
+Per the layered-architecture rule: routes never touch the ORM, services
+orchestrate, repositories return ORM rows. All public functions filter by
+``organization_id`` AND ``user_id`` — the dual scope is mandatory per
+RENTALS_PLAN.md §8.1.
+
+PII columns are passed in plaintext; the ``EncryptedString`` TypeDecorator
+handles encryption at bind time. Equality lookups on PII columns are NOT
+supported (Fernet ciphertext is non-deterministic) — find applicants via
+``inquiry_id`` or by listing + iterating.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import desc, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    inquiry_id: uuid.UUID | None = None,
+    legal_name: str | None = None,
+    dob: str | None = None,
+    employer_or_hospital: str | None = None,
+    vehicle_make_model: str | None = None,
+    id_document_storage_key: str | None = None,
+    contract_start: _dt.date | None = None,
+    contract_end: _dt.date | None = None,
+    smoker: bool | None = None,
+    pets: str | None = None,
+    referred_by: str | None = None,
+    stage: str = "lead",
+) -> Applicant:
+    """Persist an Applicant. PII args are plaintext — encryption is automatic."""
+    applicant = Applicant(
+        organization_id=organization_id,
+        user_id=user_id,
+        inquiry_id=inquiry_id,
+        legal_name=legal_name,
+        dob=dob,
+        employer_or_hospital=employer_or_hospital,
+        vehicle_make_model=vehicle_make_model,
+        id_document_storage_key=id_document_storage_key,
+        contract_start=contract_start,
+        contract_end=contract_end,
+        smoker=smoker,
+        pets=pets,
+        referred_by=referred_by,
+        stage=stage,
+    )
+    db.add(applicant)
+    await db.flush()
+    return applicant
+
+
+async def get(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    include_deleted: bool = False,
+) -> Applicant | None:
+    """Return the applicant iff it belongs to (organization_id, user_id).
+
+    Defaults to skipping soft-deleted rows. Set ``include_deleted=True`` from
+    admin / retention contexts that need to see purged rows.
+    """
+    stmt = select(Applicant).where(
+        Applicant.id == applicant_id,
+        Applicant.organization_id == organization_id,
+        Applicant.user_id == user_id,
+    )
+    if not include_deleted:
+        stmt = stmt.where(Applicant.deleted_at.is_(None))
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_for_user(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    stage: str | None = None,
+    include_deleted: bool = False,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[Applicant]:
+    """List applicants for (organization_id, user_id). Newest first."""
+    stmt = select(Applicant).where(
+        Applicant.organization_id == organization_id,
+        Applicant.user_id == user_id,
+    )
+    if not include_deleted:
+        stmt = stmt.where(Applicant.deleted_at.is_(None))
+    if stage is not None:
+        stmt = stmt.where(Applicant.stage == stage)
+    stmt = stmt.order_by(desc(Applicant.created_at)).limit(limit).offset(offset)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_by_inquiry(
+    db: AsyncSession,
+    *,
+    inquiry_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> Applicant | None:
+    """Return the active Applicant promoted from the given Inquiry, if any.
+
+    Used by the (future) PR 3.2 promotion service to detect when an inquiry
+    has already been promoted. Skips soft-deleted rows by design — a previously
+    declined-then-purged applicant should not block a re-promotion.
+    """
+    result = await db.execute(
+        select(Applicant).where(
+            Applicant.inquiry_id == inquiry_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+            Applicant.deleted_at.is_(None),
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def soft_delete(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> bool:
+    """Soft-delete an applicant. Returns True iff a row was updated."""
+    result = await db.execute(
+        update(Applicant)
+        .where(
+            Applicant.id == applicant_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+            Applicant.deleted_at.is_(None),
+        )
+        .values(deleted_at=_dt.datetime.now(_dt.timezone.utc))
+    )
+    return (result.rowcount or 0) > 0
+
+
+async def list_pending_purge(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    older_than_days: int,
+) -> list[Applicant]:
+    """Return soft-deleted applicants whose PII has not yet been purged.
+
+    Used by the (future) retention worker (RENTALS_PLAN.md §6.6) to find
+    rows ready for the 1-year-post-decline PII purge. Scoped by ``user_id``
+    only because the worker iterates per-user.
+
+    Returns rows where:
+        deleted_at IS NOT NULL
+        AND sensitive_purged_at IS NULL
+        AND deleted_at < (now - older_than_days)
+    """
+    cutoff = _dt.datetime.now(_dt.timezone.utc) - _dt.timedelta(days=older_than_days)
+    result = await db.execute(
+        select(Applicant).where(
+            Applicant.user_id == user_id,
+            Applicant.deleted_at.is_not(None),
+            Applicant.sensitive_purged_at.is_(None),
+            Applicant.deleted_at < cutoff,
+        )
+    )
+    return list(result.scalars().all())

--- a/apps/mybookkeeper/backend/app/repositories/applicants/reference_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/applicants/reference_repo.py
@@ -1,0 +1,104 @@
+"""Repository for ``applicant_references``.
+
+Tenant scoping: ``Reference`` rows have no ``organization_id`` or
+``user_id`` of their own — they're scoped through their parent ``Applicant``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import asc, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.reference import Reference
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    relationship: str,
+    reference_name: str,
+    reference_contact: str,
+    notes: str | None = None,
+) -> Reference:
+    """Create a reference row. PII args are plaintext — encryption is automatic.
+
+    Caller is responsible for proving the applicant belongs to the calling
+    tenant via ``applicant_repo.get()`` BEFORE calling this.
+    """
+    ref = Reference(
+        applicant_id=applicant_id,
+        relationship=relationship,
+        reference_name=reference_name,
+        reference_contact=reference_contact,
+        notes=notes,
+    )
+    db.add(ref)
+    await db.flush()
+    return ref
+
+
+async def list_for_applicant(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> list[Reference]:
+    """List references for an applicant, scoped through the parent's tenancy.
+
+    Returns [] if the applicant doesn't belong to (organization_id, user_id).
+    Stable order: oldest-created first (mirrors when the host added them).
+    """
+    result = await db.execute(
+        select(Reference)
+        .join(Applicant, Applicant.id == Reference.applicant_id)
+        .where(
+            Reference.applicant_id == applicant_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+        )
+        .order_by(asc(Reference.created_at))
+    )
+    return list(result.scalars().all())
+
+
+async def mark_contacted(
+    db: AsyncSession,
+    *,
+    reference_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    contacted_at: _dt.datetime | None = None,
+    notes: str | None = None,
+) -> Reference | None:
+    """Mark a reference as contacted. Tenant-scoped through Applicant."""
+    found = await db.execute(
+        select(Reference)
+        .join(Applicant, Applicant.id == Reference.applicant_id)
+        .where(
+            Reference.id == reference_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+        )
+    )
+    ref = found.scalar_one_or_none()
+    if ref is None:
+        return None
+
+    when = contacted_at if contacted_at is not None else _dt.datetime.now(_dt.timezone.utc)
+    values: dict[str, object] = {"contacted_at": when}
+    if notes is not None:
+        values["notes"] = notes
+
+    await db.execute(
+        update(Reference)
+        .where(Reference.id == reference_id)
+        .values(**values)
+    )
+    await db.flush()
+    await db.refresh(ref)
+    return ref

--- a/apps/mybookkeeper/backend/app/repositories/applicants/screening_result_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/applicants/screening_result_repo.py
@@ -1,0 +1,116 @@
+"""Repository for ``screening_results``.
+
+Tenant scoping: ``ScreeningResult`` rows have no ``organization_id`` or
+``user_id`` of their own — they're scoped through their parent ``Applicant``.
+Every public function joins to ``applicants`` and filters by the caller's
+``(organization_id, user_id)`` to prevent cross-tenant access.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import desc, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.screening_result import ScreeningResult
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    provider: str,
+    requested_at: _dt.datetime,
+    status: str = "pending",
+    report_storage_key: str | None = None,
+    adverse_action_snippet: str | None = None,
+    notes: str | None = None,
+) -> ScreeningResult:
+    """Create a screening_result row. Caller is responsible for proving the
+    applicant belongs to the calling tenant via ``applicant_repo.get()``
+    BEFORE calling this — services compose, repos do not double-check."""
+    sr = ScreeningResult(
+        applicant_id=applicant_id,
+        provider=provider,
+        requested_at=requested_at,
+        status=status,
+        report_storage_key=report_storage_key,
+        adverse_action_snippet=adverse_action_snippet,
+        notes=notes,
+    )
+    db.add(sr)
+    await db.flush()
+    return sr
+
+
+async def list_for_applicant(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> list[ScreeningResult]:
+    """List screenings for an applicant, scoped through the parent's tenancy.
+
+    Returns [] if the applicant doesn't belong to (organization_id, user_id).
+    Newest-requested-first.
+    """
+    result = await db.execute(
+        select(ScreeningResult)
+        .join(Applicant, Applicant.id == ScreeningResult.applicant_id)
+        .where(
+            ScreeningResult.applicant_id == applicant_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+        )
+        .order_by(desc(ScreeningResult.requested_at))
+    )
+    return list(result.scalars().all())
+
+
+async def update_status(
+    db: AsyncSession,
+    *,
+    screening_result_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    status: str,
+    completed_at: _dt.datetime | None = None,
+    adverse_action_snippet: str | None = None,
+) -> ScreeningResult | None:
+    """Update status / completion of a screening_result.
+
+    Tenant-scoped: returns None if the parent applicant doesn't belong to
+    (organization_id, user_id) — prevents cross-tenant updates via a forged
+    screening_result_id.
+    """
+    # Look up the row through a tenant-scoped join first.
+    found = await db.execute(
+        select(ScreeningResult)
+        .join(Applicant, Applicant.id == ScreeningResult.applicant_id)
+        .where(
+            ScreeningResult.id == screening_result_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+        )
+    )
+    sr = found.scalar_one_or_none()
+    if sr is None:
+        return None
+
+    values: dict[str, object] = {"status": status}
+    if completed_at is not None:
+        values["completed_at"] = completed_at
+    if adverse_action_snippet is not None:
+        values["adverse_action_snippet"] = adverse_action_snippet
+
+    await db.execute(
+        update(ScreeningResult)
+        .where(ScreeningResult.id == screening_result_id)
+        .values(**values)
+    )
+    await db.flush()
+    await db.refresh(sr)
+    return sr

--- a/apps/mybookkeeper/backend/app/repositories/applicants/video_call_note_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/applicants/video_call_note_repo.py
@@ -1,0 +1,110 @@
+"""Repository for ``video_call_notes``.
+
+Tenant scoping: rows have no ``organization_id`` or ``user_id`` of their
+own — they're scoped through their parent ``Applicant``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import desc, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.video_call_note import VideoCallNote
+
+# Allowlist of fields updatable via ``update``. Excludes tenant-scoping
+# ``applicant_id`` and server-managed ``created_at`` / ``key_version``.
+_UPDATABLE_COLUMNS: frozenset[str] = frozenset({
+    "scheduled_at",
+    "completed_at",
+    "notes",
+    "gut_rating",
+    "transcript_storage_key",
+})
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    scheduled_at: _dt.datetime,
+    completed_at: _dt.datetime | None = None,
+    notes: str | None = None,
+    gut_rating: int | None = None,
+    transcript_storage_key: str | None = None,
+) -> VideoCallNote:
+    """Create a video_call_note row. ``notes`` is plaintext — encryption is automatic.
+
+    Caller is responsible for proving the applicant belongs to the calling
+    tenant via ``applicant_repo.get()`` BEFORE calling this.
+    """
+    note = VideoCallNote(
+        applicant_id=applicant_id,
+        scheduled_at=scheduled_at,
+        completed_at=completed_at,
+        notes=notes,
+        gut_rating=gut_rating,
+        transcript_storage_key=transcript_storage_key,
+    )
+    db.add(note)
+    await db.flush()
+    return note
+
+
+async def list_for_applicant(
+    db: AsyncSession,
+    *,
+    applicant_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> list[VideoCallNote]:
+    """List video call notes for an applicant, newest scheduled call first."""
+    result = await db.execute(
+        select(VideoCallNote)
+        .join(Applicant, Applicant.id == VideoCallNote.applicant_id)
+        .where(
+            VideoCallNote.applicant_id == applicant_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+        )
+        .order_by(desc(VideoCallNote.scheduled_at))
+    )
+    return list(result.scalars().all())
+
+
+async def update_note(
+    db: AsyncSession,
+    *,
+    video_call_note_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    fields: dict[str, object],
+) -> VideoCallNote | None:
+    """Apply allowlisted updates to a video call note. Tenant-scoped through Applicant."""
+    found = await db.execute(
+        select(VideoCallNote)
+        .join(Applicant, Applicant.id == VideoCallNote.applicant_id)
+        .where(
+            VideoCallNote.id == video_call_note_id,
+            Applicant.organization_id == organization_id,
+            Applicant.user_id == user_id,
+        )
+    )
+    note = found.scalar_one_or_none()
+    if note is None:
+        return None
+
+    safe = {k: v for k, v in fields.items() if k in _UPDATABLE_COLUMNS}
+    if not safe:
+        return note
+
+    await db.execute(
+        update(VideoCallNote)
+        .where(VideoCallNote.id == video_call_note_id)
+        .values(**safe)
+    )
+    await db.flush()
+    await db.refresh(note)
+    return note

--- a/apps/mybookkeeper/backend/app/schemas/applicants/applicant_event_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/applicant_event_response.py
@@ -1,0 +1,19 @@
+"""Pydantic schema for an ApplicantEvent response (read-only — append-only)."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ApplicantEventResponse(BaseModel):
+    id: uuid.UUID
+    applicant_id: uuid.UUID
+    event_type: str
+    actor: str
+    notes: str | None = None
+    occurred_at: _dt.datetime
+    created_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/applicants/applicant_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/applicant_response.py
@@ -1,0 +1,39 @@
+"""Pydantic schema for an Applicant response.
+
+PII fields (``legal_name`` etc.) are returned plaintext because the
+``EncryptedString`` TypeDecorator transparently decrypts on read. Routes
+that serialize this schema MUST be auth-protected (Phase 3 PR 3.2 / 3.3 /
+3.4 own the routes — none exist in PR 3.1a).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ApplicantResponse(BaseModel):
+    id: uuid.UUID
+    organization_id: uuid.UUID
+    user_id: uuid.UUID
+    inquiry_id: uuid.UUID | None = None
+
+    legal_name: str | None = None
+    dob: str | None = None
+    employer_or_hospital: str | None = None
+    vehicle_make_model: str | None = None
+    id_document_storage_key: str | None = None
+
+    contract_start: _dt.date | None = None
+    contract_end: _dt.date | None = None
+    smoker: bool | None = None
+    pets: str | None = None
+    referred_by: str | None = None
+
+    stage: str
+
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/applicants/reference_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/reference_response.py
@@ -1,0 +1,25 @@
+"""Pydantic schema for a Reference (applicant_references) response.
+
+PII fields (``reference_name``, ``reference_contact``) are returned plaintext
+via the ``EncryptedString`` TypeDecorator. Auth-protected at the route layer.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ReferenceResponse(BaseModel):
+    id: uuid.UUID
+    applicant_id: uuid.UUID
+    relationship: str
+    reference_name: str
+    reference_contact: str
+    notes: str | None = None
+    contacted_at: _dt.datetime | None = None
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/applicants/screening_result_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/screening_result_response.py
@@ -1,0 +1,22 @@
+"""Pydantic schema for a ScreeningResult response."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ScreeningResultResponse(BaseModel):
+    id: uuid.UUID
+    applicant_id: uuid.UUID
+    provider: str
+    status: str
+    report_storage_key: str | None = None
+    adverse_action_snippet: str | None = None
+    notes: str | None = None
+    requested_at: _dt.datetime
+    completed_at: _dt.datetime | None = None
+    created_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/applicants/video_call_note_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/video_call_note_response.py
@@ -1,0 +1,25 @@
+"""Pydantic schema for a VideoCallNote response.
+
+``notes`` is returned plaintext via ``EncryptedString`` decryption.
+Auth-protected at the route layer.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class VideoCallNoteResponse(BaseModel):
+    id: uuid.UUID
+    applicant_id: uuid.UUID
+    scheduled_at: _dt.datetime
+    completed_at: _dt.datetime | None = None
+    notes: str | None = None
+    gut_rating: int | None = None
+    transcript_storage_key: str | None = None
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/tests/test_applicant_audit_masking.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_audit_masking.py
@@ -1,0 +1,262 @@
+"""Verify the audit listener masks PII columns on the Applicants domain.
+
+Per RENTALS_PLAN.md §8.7: ``legal_name``, ``dob``, ``employer_or_hospital``,
+``vehicle_make_model``, ``reference_name``, ``reference_contact``, and
+freeform ``notes`` are sensitive — even after column-level encryption, the
+audit log must not capture decrypted PII (or the ciphertext, which leaks
+the existence of a value).
+
+This test catches the regression class where adding a new encrypted column
+without also adding it to ``SENSITIVE_FIELDS`` lets plaintext PII land in
+``audit_logs.new_value``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import register_audit_listeners
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.reference import Reference
+from app.models.applicants.video_call_note import VideoCallNote
+from app.models.organization.organization import Organization
+from app.models.system.audit_log import AuditLog
+from app.models.user.user import User
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _audit() -> None:
+    """Register audit listeners ONCE for the session.
+
+    The audit listener attaches to the global ``Session`` class — registering
+    per-test would stack listeners and produce duplicate audit_log rows.
+    """
+    register_audit_listeners()
+
+
+class TestApplicantAuditMasking:
+    @pytest.mark.asyncio
+    async def test_pii_fields_masked_on_insert(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        plaintext_name = "Jane Q Public"
+        plaintext_dob = "1985-07-22"
+        plaintext_employer = "Methodist Hospital"
+        plaintext_vehicle = "Honda Civic 2018"
+        a = Applicant(
+            id=uuid.uuid4(),
+            organization_id=test_org.id, user_id=test_user.id,
+            stage="lead",
+            legal_name=plaintext_name,
+            dob=plaintext_dob,
+            employer_or_hospital=plaintext_employer,
+            vehicle_make_model=plaintext_vehicle,
+            referred_by="public source",  # NON-PII — should NOT be masked
+        )
+        db.add(a)
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "applicants",
+                AuditLog.record_id == str(a.id),
+                AuditLog.operation == "INSERT",
+            ),
+        )).scalars().all()
+
+        masked = {r.field_name: r.new_value for r in rows}
+
+        # PII columns are masked.
+        for sensitive in (
+            "legal_name", "dob", "employer_or_hospital", "vehicle_make_model",
+        ):
+            assert masked.get(sensitive) == "***", (
+                f"audit log for {sensitive} must be masked, got {masked.get(sensitive)!r}"
+            )
+
+        # Non-PII columns are NOT masked — confirm we still capture them.
+        # ``referred_by`` is host-supplied marketing source (e.g. "Furnished Finder"),
+        # ``stage`` is the pipeline state — neither needs masking.
+        assert masked.get("stage") == "lead"
+        assert masked.get("referred_by") == "public source"
+
+        # Plaintext PII never leaks into ANY audit row for this record.
+        for r in rows:
+            if r.new_value is None:
+                continue
+            assert plaintext_name not in r.new_value
+            assert plaintext_dob not in r.new_value
+            assert plaintext_employer not in r.new_value
+            assert plaintext_vehicle not in r.new_value
+
+    @pytest.mark.asyncio
+    async def test_legal_name_update_masked(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = Applicant(
+            id=uuid.uuid4(),
+            organization_id=test_org.id, user_id=test_user.id,
+            stage="lead",
+            legal_name="Original Name",
+        )
+        db.add(a)
+        await db.commit()
+
+        a.legal_name = "Updated Name"
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "applicants",
+                AuditLog.record_id == str(a.id),
+                AuditLog.operation == "UPDATE",
+                AuditLog.field_name == "legal_name",
+            ),
+        )).scalars().all()
+
+        # Always at least one UPDATE row. Tolerate >1 in case other test files
+        # also register the audit listener (the listener is global on Session).
+        # The masking contract is what we're verifying — every row's old/new
+        # must be ``"***"`` regardless of how many were captured.
+        assert len(rows) >= 1
+        for r in rows:
+            assert r.old_value == "***"
+            assert r.new_value == "***"
+
+
+class TestReferenceAuditMasking:
+    @pytest.mark.asyncio
+    async def test_reference_pii_masked_on_insert(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = Applicant(
+            id=uuid.uuid4(),
+            organization_id=test_org.id, user_id=test_user.id,
+            stage="lead",
+        )
+        db.add(a)
+        await db.commit()
+
+        plaintext_name = "Bob T Landlord"
+        plaintext_contact = "bob.landlord@example.com"
+        plaintext_notes = "previous tenant 2019-2021, paid on time"
+        ref = Reference(
+            id=uuid.uuid4(),
+            applicant_id=a.id,
+            relationship="landlord",
+            reference_name=plaintext_name,
+            reference_contact=plaintext_contact,
+            notes=plaintext_notes,
+        )
+        db.add(ref)
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "applicant_references",
+                AuditLog.record_id == str(ref.id),
+                AuditLog.operation == "INSERT",
+            ),
+        )).scalars().all()
+
+        masked = {r.field_name: r.new_value for r in rows}
+        for sensitive in ("reference_name", "reference_contact", "notes"):
+            assert masked.get(sensitive) == "***", (
+                f"audit log for {sensitive} must be masked, got {masked.get(sensitive)!r}"
+            )
+        # ``relationship`` is enum-y, not PII — must remain captured.
+        assert masked.get("relationship") == "landlord"
+
+        # Plaintext PII never leaks anywhere.
+        for r in rows:
+            if r.new_value is None:
+                continue
+            assert plaintext_name not in r.new_value
+            assert plaintext_contact not in r.new_value
+            assert plaintext_notes not in r.new_value
+
+
+class TestVideoCallNoteAuditMasking:
+    @pytest.mark.asyncio
+    async def test_notes_masked_on_insert(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = Applicant(
+            id=uuid.uuid4(),
+            organization_id=test_org.id, user_id=test_user.id,
+            stage="lead",
+        )
+        db.add(a)
+        await db.commit()
+
+        plaintext = "Articulate but mentioned an active small-claims case."
+        note = VideoCallNote(
+            id=uuid.uuid4(),
+            applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            notes=plaintext,
+            gut_rating=3,
+        )
+        db.add(note)
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "video_call_notes",
+                AuditLog.record_id == str(note.id),
+                AuditLog.operation == "INSERT",
+                AuditLog.field_name == "notes",
+            ),
+        )).scalars().all()
+
+        assert len(rows) >= 1
+        for r in rows:
+            assert r.new_value == "***"
+            # And no plaintext leak.
+            if r.new_value is not None:
+                assert "small-claims" not in r.new_value
+
+        # gut_rating is non-PII numeric — must be captured.
+        gut_rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "video_call_notes",
+                AuditLog.record_id == str(note.id),
+                AuditLog.operation == "INSERT",
+                AuditLog.field_name == "gut_rating",
+            ),
+        )).scalars().all()
+        assert len(gut_rows) >= 1
+        for r in gut_rows:
+            assert r.new_value == "3"
+
+
+class TestAuditMaskingDoesNotMaskUnrelatedNameColumns:
+    """``name`` is on Property, Organization, Tenant, ReplyTemplate, etc. We
+    DO NOT add bare ``name`` to SENSITIVE_FIELDS — instead we use specific
+    names like ``legal_name`` and ``reference_name``. Confirm the unrelated
+    columns are still captured."""
+
+    @pytest.mark.asyncio
+    async def test_organization_name_not_masked(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        # test_org was created in the conftest fixture — find its INSERT log.
+        rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "organizations",
+                AuditLog.record_id == str(test_org.id),
+                AuditLog.field_name == "name",
+            ),
+        )).scalars().all()
+        # If the conftest creates the org before the audit listener is
+        # registered, this could be empty — that's also fine for the regression
+        # check (we just need to verify that when it IS captured, it is NOT masked).
+        for r in rows:
+            assert r.new_value != "***", (
+                "Organization.name must NOT be masked — adding bare 'name' to "
+                "SENSITIVE_FIELDS would break audit-log readability across the schema."
+            )

--- a/apps/mybookkeeper/backend/tests/test_applicant_encryption.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_encryption.py
@@ -1,0 +1,227 @@
+"""Verify every encrypted column on the Applicants domain round-trips
+plaintext → ciphertext → plaintext correctly, AND that the raw stored value
+is NOT plaintext.
+
+Per RENTALS_PLAN.md §8.7: PII columns must be encrypted at rest. The
+``EncryptedString`` TypeDecorator is exercised here against real ORM rows.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.reference import Reference
+from app.models.applicants.video_call_note import VideoCallNote
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+
+
+@pytest.fixture()
+async def applicant(
+    db: AsyncSession, test_user: User, test_org: Organization,
+) -> Applicant:
+    a = Applicant(
+        id=uuid.uuid4(),
+        organization_id=test_org.id, user_id=test_user.id,
+        stage="lead",
+    )
+    db.add(a)
+    await db.commit()
+    return a
+
+
+class TestApplicantPiiEncryption:
+    @pytest.mark.parametrize(
+        "field,plaintext",
+        [
+            ("legal_name", "Jane Q Public"),
+            ("dob", "1985-07-22"),
+            ("employer_or_hospital", "Methodist Hospital — Houston"),
+            ("vehicle_make_model", "Honda Civic 2018 — silver"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_round_trip_via_orm(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        field: str, plaintext: str,
+    ) -> None:
+        a = Applicant(
+            id=uuid.uuid4(),
+            organization_id=test_org.id, user_id=test_user.id,
+            stage="lead",
+            **{field: plaintext},
+        )
+        db.add(a)
+        await db.commit()
+        await db.refresh(a)
+        assert getattr(a, field) == plaintext
+
+    @pytest.mark.parametrize(
+        "field,plaintext",
+        [
+            ("legal_name", "Jane Q Public"),
+            ("dob", "1985-07-22"),
+            ("employer_or_hospital", "Methodist Hospital"),
+            ("vehicle_make_model", "Honda Civic 2018"),
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_db_stores_ciphertext_not_plaintext(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        field: str, plaintext: str,
+    ) -> None:
+        a = Applicant(
+            id=uuid.uuid4(),
+            organization_id=test_org.id, user_id=test_user.id,
+            stage="lead",
+            **{field: plaintext},
+        )
+        db.add(a)
+        await db.commit()
+
+        raw = await db.execute(text(f"SELECT {field} FROM applicants"))
+        stored = raw.scalar_one()
+        assert stored is not None
+        assert plaintext not in stored, (
+            f"plaintext {plaintext!r} found in raw stored {field!r} — "
+            f"encryption is not active"
+        )
+        assert stored.startswith("gAAAAA"), (
+            f"expected Fernet ciphertext for {field!r}, got {stored[:20]!r}"
+        )
+
+
+class TestReferencePiiEncryption:
+    @pytest.mark.asyncio
+    async def test_reference_name_round_trip(
+        self, db: AsyncSession, applicant: Applicant,
+    ) -> None:
+        plaintext = "Bob T Landlord"
+        ref = Reference(
+            id=uuid.uuid4(),
+            applicant_id=applicant.id,
+            relationship="landlord",
+            reference_name=plaintext,
+            reference_contact="other",
+        )
+        db.add(ref)
+        await db.commit()
+        await db.refresh(ref)
+        assert ref.reference_name == plaintext
+
+        raw = await db.execute(text("SELECT reference_name FROM applicant_references"))
+        stored = raw.scalar_one()
+        assert stored is not None
+        assert plaintext not in stored
+        assert stored.startswith("gAAAAA")
+
+    @pytest.mark.asyncio
+    async def test_reference_contact_round_trip(
+        self, db: AsyncSession, applicant: Applicant,
+    ) -> None:
+        plaintext = "bob.landlord@example.com"
+        ref = Reference(
+            id=uuid.uuid4(),
+            applicant_id=applicant.id,
+            relationship="landlord",
+            reference_name="other",
+            reference_contact=plaintext,
+        )
+        db.add(ref)
+        await db.commit()
+        await db.refresh(ref)
+        assert ref.reference_contact == plaintext
+
+        raw = await db.execute(text("SELECT reference_contact FROM applicant_references"))
+        stored = raw.scalar_one()
+        assert stored is not None
+        assert plaintext not in stored
+        assert stored.startswith("gAAAAA")
+
+
+class TestVideoCallNotePiiEncryption:
+    @pytest.mark.asyncio
+    async def test_notes_round_trip_and_ciphertext_at_rest(
+        self, db: AsyncSession, applicant: Applicant,
+    ) -> None:
+        plaintext = (
+            "Strong communicator. Minor concern: mentioned previous landlord "
+            "dispute over deposit return — referred to attorney."
+        )
+        note = VideoCallNote(
+            id=uuid.uuid4(),
+            applicant_id=applicant.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            notes=plaintext,
+        )
+        db.add(note)
+        await db.commit()
+        await db.refresh(note)
+        assert note.notes == plaintext
+
+        raw = await db.execute(text("SELECT notes FROM video_call_notes"))
+        stored = raw.scalar_one()
+        assert stored is not None
+        assert "previous landlord" not in stored
+        assert "deposit return" not in stored
+        assert stored.startswith("gAAAAA")
+
+    @pytest.mark.asyncio
+    async def test_long_notes_field_supports_10k_chars(
+        self, db: AsyncSession, applicant: Applicant,
+    ) -> None:
+        """The notes column is sized for long observation blocks."""
+        plaintext = "x" * 9000
+        note = VideoCallNote(
+            id=uuid.uuid4(),
+            applicant_id=applicant.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            notes=plaintext,
+        )
+        db.add(note)
+        await db.commit()
+        await db.refresh(note)
+        assert note.notes == plaintext
+
+
+class TestEncryptionKeyVersion:
+    @pytest.mark.asyncio
+    async def test_applicant_key_version_default_is_one(
+        self, db: AsyncSession, applicant: Applicant,
+    ) -> None:
+        await db.refresh(applicant)
+        assert applicant.key_version == 1
+
+    @pytest.mark.asyncio
+    async def test_reference_key_version_default_is_one(
+        self, db: AsyncSession, applicant: Applicant,
+    ) -> None:
+        ref = Reference(
+            id=uuid.uuid4(),
+            applicant_id=applicant.id,
+            relationship="personal",
+            reference_name="n", reference_contact="c",
+        )
+        db.add(ref)
+        await db.commit()
+        await db.refresh(ref)
+        assert ref.key_version == 1
+
+    @pytest.mark.asyncio
+    async def test_video_call_note_key_version_default_is_one(
+        self, db: AsyncSession, applicant: Applicant,
+    ) -> None:
+        note = VideoCallNote(
+            id=uuid.uuid4(),
+            applicant_id=applicant.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(note)
+        await db.commit()
+        await db.refresh(note)
+        assert note.key_version == 1

--- a/apps/mybookkeeper/backend/tests/test_applicant_event_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_event_repo.py
@@ -1,0 +1,195 @@
+"""Repository tests for ``applicant_event_repo``.
+
+Covers:
+- append / list_for_applicant
+- Tenant isolation through Applicant join
+- Chronological ordering
+- CheckConstraints: invalid event_type / actor rejected
+- Append-only: no update/delete methods exist
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.applicant_event import ApplicantEvent
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.applicants import applicant_event_repo
+
+
+def _make_applicant(
+    *, organization_id: uuid.UUID, user_id: uuid.UUID,
+) -> Applicant:
+    return Applicant(
+        id=uuid.uuid4(),
+        organization_id=organization_id, user_id=user_id,
+        stage="lead",
+    )
+
+
+class TestApplicantEventRepoAppend:
+    @pytest.mark.asyncio
+    async def test_append_persists(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        when = _dt.datetime.now(_dt.timezone.utc)
+        ev = await applicant_event_repo.append(
+            db, applicant_id=a.id,
+            event_type="lead", actor="system",
+            occurred_at=when, notes="auto-promoted from inquiry",
+        )
+        await db.commit()
+        assert ev.applicant_id == a.id
+        assert ev.event_type == "lead"
+        assert ev.actor == "system"
+        # SQLite drops tz info on read; compare naive parts.
+        assert ev.occurred_at.replace(tzinfo=None) == when.replace(tzinfo=None)
+
+
+class TestApplicantEventRepoList:
+    @pytest.mark.asyncio
+    async def test_list_returns_chronological(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        now = _dt.datetime.now(_dt.timezone.utc)
+        for i, etype in enumerate(("lead", "screening_pending", "screening_passed")):
+            await applicant_event_repo.append(
+                db, applicant_id=a.id,
+                event_type=etype, actor="system",
+                occurred_at=now + _dt.timedelta(seconds=i),
+            )
+        await db.commit()
+
+        results = await applicant_event_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert [e.event_type for e in results] == [
+            "lead", "screening_pending", "screening_passed",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_list_returns_empty_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await applicant_event_repo.append(
+            db, applicant_id=a.id,
+            event_type="lead", actor="system",
+            occurred_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        await db.commit()
+
+        results = await applicant_event_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+        )
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_list_returns_empty_for_other_user(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await applicant_event_repo.append(
+            db, applicant_id=a.id,
+            event_type="lead", actor="system",
+            occurred_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        await db.commit()
+
+        results = await applicant_event_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=uuid.uuid4(),
+        )
+        assert results == []
+
+
+class TestApplicantEventConstraints:
+    @pytest.mark.asyncio
+    async def test_invalid_event_type_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        bad = ApplicantEvent(
+            applicant_id=a.id,
+            event_type="banana_split",
+            actor="host",
+            occurred_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(bad)
+        with pytest.raises(IntegrityError):
+            await db.commit()
+        await db.rollback()
+
+    @pytest.mark.asyncio
+    async def test_invalid_actor_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        bad = ApplicantEvent(
+            applicant_id=a.id,
+            event_type="lead",
+            actor="alien",
+            occurred_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(bad)
+        with pytest.raises(IntegrityError):
+            await db.commit()
+        await db.rollback()
+
+    @pytest.mark.asyncio
+    async def test_supplementary_event_types_accepted(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """The applicant_events check constraint includes non-stage event
+        types: note_added, screening_initiated, screening_completed,
+        reference_contacted. Each must be insertable."""
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        for etype in (
+            "note_added", "screening_initiated",
+            "screening_completed", "reference_contacted",
+        ):
+            await applicant_event_repo.append(
+                db, applicant_id=a.id,
+                event_type=etype, actor="host",
+                occurred_at=_dt.datetime.now(_dt.timezone.utc),
+            )
+        await db.commit()
+
+    def test_repo_does_not_expose_update_or_delete(self) -> None:
+        """Append-only contract: this repo intentionally has no update/delete
+        helpers. Locking it in here so a future PR doesn't sneak one in."""
+        for forbidden in ("update", "delete", "remove", "modify", "edit"):
+            assert not hasattr(applicant_event_repo, forbidden), (
+                f"applicant_event_repo must not expose {forbidden!r} — events are immutable"
+            )

--- a/apps/mybookkeeper/backend/tests/test_applicant_indexes.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_indexes.py
@@ -1,0 +1,120 @@
+"""Regression guard for critical indexes on the Applicants domain.
+
+The partial index ``ix_applicants_user_pending_purge`` is required for the
+RENTALS_PLAN.md §6.6 retention worker to scan for purge-eligible rows
+without a sequential table scan. This test confirms the model declares the
+index AND the migration script creates it — losing either is a silent
+performance regression that won't show until production data volume grows.
+
+We verify against the SQLAlchemy metadata + raw migration source rather
+than ``pg_indexes`` because the test fixture uses SQLite (postgres-only
+partial-index syntax doesn't apply).
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.applicant_event import ApplicantEvent
+from app.models.applicants.reference import Reference
+from app.models.applicants.screening_result import ScreeningResult
+from app.models.applicants.video_call_note import VideoCallNote
+
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "alembic" / "versions"
+    / "f8h0i3k5l7m9_add_applicants_domain.py"
+)
+
+
+def _migration_source() -> str:
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def _model_index_names(model: type) -> set[str]:
+    return {ix.name for ix in model.__table__.indexes}
+
+
+def test_migration_file_exists() -> None:
+    assert MIGRATION_PATH.exists(), (
+        f"Expected applicants migration at {MIGRATION_PATH}. "
+        "PR 3.1a relies on this exact filename — renaming requires updating "
+        "test_applicant_indexes.py too."
+    )
+
+
+class TestApplicantIndexes:
+    def test_orm_declares_pipeline_stage_active_index(self) -> None:
+        assert "ix_applicants_org_stage_active" in _model_index_names(Applicant)
+
+    def test_orm_declares_pipeline_sort_index(self) -> None:
+        assert "ix_applicants_org_created_active" in _model_index_names(Applicant)
+
+    def test_orm_declares_org_inquiry_index(self) -> None:
+        assert "ix_applicants_org_inquiry" in _model_index_names(Applicant)
+
+    def test_orm_declares_purge_scan_index(self) -> None:
+        """Per RENTALS_PLAN.md §6.6 — without this, the retention worker
+        does a full-table scan every cycle."""
+        assert "ix_applicants_user_pending_purge" in _model_index_names(Applicant)
+
+    def test_migration_creates_purge_scan_index_with_correct_predicate(self) -> None:
+        """The partial index predicate is what makes the worker efficient.
+        Lock the predicate text in so a future migration edit can't widen it
+        (which would defeat the partial-index optimization)."""
+        source = _migration_source()
+        assert "ix_applicants_user_pending_purge" in source
+        # The WHERE clause must mention BOTH conditions — regression-prone.
+        assert re.search(
+            r'deleted_at IS NOT NULL\s+AND\s+sensitive_purged_at IS NULL',
+            source,
+        ), "purge-scan partial index must be predicated on (deleted_at IS NOT NULL AND sensitive_purged_at IS NULL)"
+
+
+class TestScreeningResultIndexes:
+    def test_orm_declares_pending_unique(self) -> None:
+        assert "uq_screening_results_applicant_provider_pending" in _model_index_names(ScreeningResult)
+
+    def test_migration_creates_pending_unique_predicate(self) -> None:
+        source = _migration_source()
+        assert "uq_screening_results_applicant_provider_pending" in source
+        assert "status = 'pending'" in source, (
+            "screening-results partial UNIQUE must be predicated on status='pending' "
+            "(allows re-runs once the first request completes)"
+        )
+
+
+class TestReferenceIndexes:
+    def test_table_name_is_applicant_references_not_reserved_word(self) -> None:
+        """The table is named ``applicant_references`` — using the SQL
+        reserved word ``references`` makes dump/restore tooling and query
+        logs harder to read. Locked here as a regression guard."""
+        assert Reference.__tablename__ == "applicant_references"
+
+
+class TestVideoCallNoteIndexes:
+    def test_orm_declares_applicant_scheduled_index(self) -> None:
+        assert "ix_video_call_notes_applicant_scheduled" in _model_index_names(VideoCallNote)
+
+    def test_migration_creates_descending_scheduled_index(self) -> None:
+        source = _migration_source()
+        # Migration uses raw SQL for DESC ordering.
+        assert "ix_video_call_notes_applicant_scheduled" in source
+        assert "scheduled_at DESC" in source, (
+            "video_call_notes timeline index must be DESC for newest-first ordering"
+        )
+
+
+class TestApplicantEventIndexes:
+    def test_orm_declares_applicant_timeline_index(self) -> None:
+        assert "ix_applicant_events_applicant_occurred" in _model_index_names(ApplicantEvent)
+
+    def test_orm_declares_funnel_aggregation_index(self) -> None:
+        assert "ix_applicant_events_type_occurred" in _model_index_names(ApplicantEvent)
+
+    def test_migration_creates_descending_occurred_index(self) -> None:
+        source = _migration_source()
+        assert "ix_applicant_events_applicant_occurred" in source
+        assert "occurred_at DESC" in source

--- a/apps/mybookkeeper/backend/tests/test_applicant_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_repo.py
@@ -1,0 +1,487 @@
+"""Repository tests for ``applicant_repo``.
+
+Covers:
+- create / get / list_for_user / get_by_inquiry / soft_delete / list_pending_purge
+- Tenant isolation: every function filters by (organization_id, user_id)
+- PII round-trip via EncryptedString
+- Soft-delete semantics: include_deleted flag, get_by_inquiry skips deleted
+- CheckConstraint: invalid stage rejected by DB
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.inquiries.inquiry import Inquiry
+from app.models.organization.organization import Organization
+from app.models.organization.organization_member import OrganizationMember
+from app.models.user.user import User
+from app.repositories.applicants import applicant_repo
+
+
+def _make_applicant(
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    inquiry_id: uuid.UUID | None = None,
+    legal_name: str | None = None,
+    stage: str = "lead",
+    deleted_at: _dt.datetime | None = None,
+    sensitive_purged_at: _dt.datetime | None = None,
+) -> Applicant:
+    return Applicant(
+        id=uuid.uuid4(),
+        organization_id=organization_id,
+        user_id=user_id,
+        inquiry_id=inquiry_id,
+        legal_name=legal_name,
+        stage=stage,
+        deleted_at=deleted_at,
+        sensitive_purged_at=sensitive_purged_at,
+    )
+
+
+async def _make_second_org(db: AsyncSession) -> tuple[User, Organization]:
+    user_b = User(
+        id=uuid.uuid4(), email="b@example.com", hashed_password="h",
+        is_active=True, is_superuser=False, is_verified=True,
+    )
+    org_b = Organization(id=uuid.uuid4(), name="B", created_by=user_b.id)
+    db.add_all([user_b, org_b])
+    await db.flush()
+    db.add(OrganizationMember(
+        organization_id=org_b.id, user_id=user_b.id, org_role="owner",
+    ))
+    await db.flush()
+    return user_b, org_b
+
+
+class TestApplicantRepoCreate:
+    @pytest.mark.asyncio
+    async def test_create_persists_with_pii_round_trip(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        created = await applicant_repo.create(
+            db,
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            legal_name="Jane Doe",
+            dob="1990-01-15",
+            employer_or_hospital="St Lukes Hospital",
+            vehicle_make_model="Toyota Camry 2020",
+            id_document_storage_key="docs/abc123.pdf",
+            smoker=False,
+            pets="1 small cat",
+        )
+        await db.commit()
+
+        fetched = await applicant_repo.get(
+            db,
+            applicant_id=created.id,
+            organization_id=test_org.id,
+            user_id=test_user.id,
+        )
+        assert fetched is not None
+        # PII columns round-trip via EncryptedString.
+        assert fetched.legal_name == "Jane Doe"
+        assert fetched.dob == "1990-01-15"
+        assert fetched.employer_or_hospital == "St Lukes Hospital"
+        assert fetched.vehicle_make_model == "Toyota Camry 2020"
+        # Non-encrypted columns stored as-is.
+        assert fetched.id_document_storage_key == "docs/abc123.pdf"
+        assert fetched.smoker is False
+        assert fetched.pets == "1 small cat"
+        assert fetched.stage == "lead"
+        assert fetched.key_version == 1
+
+
+class TestApplicantRepoGet:
+    @pytest.mark.asyncio
+    async def test_returns_applicant_when_owned(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            legal_name="Owned",
+        )
+        db.add(a)
+        await db.commit()
+
+        fetched = await applicant_repo.get(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert fetched is not None
+        assert fetched.id == a.id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        db.add(a)
+        await db.commit()
+
+        result = await applicant_repo.get(
+            db, applicant_id=a.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_other_user(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        db.add(a)
+        await db.commit()
+
+        result = await applicant_repo.get(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=uuid.uuid4(),
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_skips_soft_deleted_by_default(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            deleted_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(a)
+        await db.commit()
+
+        result = await applicant_repo.get(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_include_deleted_returns_soft_deleted(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            deleted_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(a)
+        await db.commit()
+
+        result = await applicant_repo.get(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+            include_deleted=True,
+        )
+        assert result is not None
+
+
+class TestApplicantRepoList:
+    @pytest.mark.asyncio
+    async def test_list_isolates_by_org_and_user(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        # Owned by test_user / test_org
+        db.add(_make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            legal_name="Mine",
+        ))
+        # Different org, same user_id (should NOT leak)
+        other_org_id = uuid.uuid4()
+        db.add(_make_applicant(
+            organization_id=other_org_id, user_id=test_user.id,
+            legal_name="OtherOrg",
+        ))
+        # Different user, same org (should NOT leak)
+        db.add(_make_applicant(
+            organization_id=test_org.id, user_id=uuid.uuid4(),
+            legal_name="OtherUser",
+        ))
+        await db.commit()
+
+        results = await applicant_repo.list_for_user(
+            db,
+            organization_id=test_org.id,
+            user_id=test_user.id,
+        )
+        assert {a.legal_name for a in results} == {"Mine"}
+
+    @pytest.mark.asyncio
+    async def test_list_filters_by_stage(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        for stage in ("lead", "lead", "approved"):
+            db.add(_make_applicant(
+                organization_id=test_org.id, user_id=test_user.id, stage=stage,
+            ))
+        await db.commit()
+
+        leads = await applicant_repo.list_for_user(
+            db, organization_id=test_org.id, user_id=test_user.id,
+            stage="lead",
+        )
+        assert len(leads) == 2
+
+    @pytest.mark.asyncio
+    async def test_list_excludes_soft_deleted_by_default(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        db.add(_make_applicant(
+            organization_id=test_org.id, user_id=test_user.id, legal_name="Live",
+        ))
+        db.add(_make_applicant(
+            organization_id=test_org.id, user_id=test_user.id, legal_name="Dead",
+            deleted_at=_dt.datetime.now(_dt.timezone.utc),
+        ))
+        await db.commit()
+
+        results = await applicant_repo.list_for_user(
+            db, organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert {a.legal_name for a in results} == {"Live"}
+
+
+class TestApplicantRepoGetByInquiry:
+    @pytest.mark.asyncio
+    async def test_returns_applicant_for_inquiry(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        inq = Inquiry(
+            id=uuid.uuid4(), organization_id=test_org.id, user_id=test_user.id,
+            source="direct", stage="new",
+            received_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(inq)
+        await db.flush()
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            inquiry_id=inq.id,
+        )
+        db.add(a)
+        await db.commit()
+
+        result = await applicant_repo.get_by_inquiry(
+            db, inquiry_id=inq.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert result is not None
+        assert result.id == a.id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        inq = Inquiry(
+            id=uuid.uuid4(), organization_id=test_org.id, user_id=test_user.id,
+            source="direct", stage="new",
+            received_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(inq)
+        await db.flush()
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            inquiry_id=inq.id,
+        )
+        db.add(a)
+        await db.commit()
+
+        result = await applicant_repo.get_by_inquiry(
+            db, inquiry_id=inq.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+        )
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_skips_soft_deleted(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        inq = Inquiry(
+            id=uuid.uuid4(), organization_id=test_org.id, user_id=test_user.id,
+            source="direct", stage="new",
+            received_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(inq)
+        await db.flush()
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            inquiry_id=inq.id,
+            deleted_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(a)
+        await db.commit()
+
+        result = await applicant_repo.get_by_inquiry(
+            db, inquiry_id=inq.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert result is None
+
+
+class TestApplicantRepoSoftDelete:
+    @pytest.mark.asyncio
+    async def test_soft_delete_sets_deleted_at(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        db.add(a)
+        await db.commit()
+
+        ok = await applicant_repo.soft_delete(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        await db.commit()
+        assert ok is True
+
+        # Subsequent get returns None.
+        assert await applicant_repo.get(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        ) is None
+
+    @pytest.mark.asyncio
+    async def test_soft_delete_returns_false_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        db.add(a)
+        await db.commit()
+
+        ok = await applicant_repo.soft_delete(
+            db, applicant_id=a.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+        )
+        assert ok is False
+
+    @pytest.mark.asyncio
+    async def test_soft_delete_returns_false_for_other_user(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        db.add(a)
+        await db.commit()
+
+        ok = await applicant_repo.soft_delete(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=uuid.uuid4(),
+        )
+        assert ok is False
+
+
+class TestApplicantRepoListPendingPurge:
+    @pytest.mark.asyncio
+    async def test_returns_old_soft_deleted_unpurged_rows(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        now = _dt.datetime.now(_dt.timezone.utc)
+        # Old, soft-deleted, not yet purged → should be returned.
+        old = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            legal_name="OLD",
+            deleted_at=now - _dt.timedelta(days=400),
+        )
+        # Old, soft-deleted, ALREADY purged → should NOT be returned.
+        purged = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            legal_name="PURGED",
+            deleted_at=now - _dt.timedelta(days=400),
+            sensitive_purged_at=now - _dt.timedelta(days=10),
+        )
+        # Recently soft-deleted → should NOT be returned (under cutoff).
+        recent = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            legal_name="RECENT",
+            deleted_at=now - _dt.timedelta(days=10),
+        )
+        # Not soft-deleted at all.
+        live = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            legal_name="LIVE",
+        )
+        db.add_all([old, purged, recent, live])
+        await db.commit()
+
+        results = await applicant_repo.list_pending_purge(
+            db, user_id=test_user.id, older_than_days=365,
+        )
+        assert {a.legal_name for a in results} == {"OLD"}
+
+    @pytest.mark.asyncio
+    async def test_isolates_by_user(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        now = _dt.datetime.now(_dt.timezone.utc)
+        old = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            legal_name="MINE",
+            deleted_at=now - _dt.timedelta(days=400),
+        )
+        db.add(old)
+        await db.commit()
+
+        # Different user — should not see it.
+        results = await applicant_repo.list_pending_purge(
+            db, user_id=uuid.uuid4(), older_than_days=365,
+        )
+        assert results == []
+
+
+class TestApplicantStageConstraint:
+    @pytest.mark.asyncio
+    async def test_invalid_stage_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        bad = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            stage="totally_invalid",
+        )
+        db.add(bad)
+        with pytest.raises(IntegrityError):
+            await db.commit()
+        await db.rollback()
+
+
+class TestApplicantInquiryFkSetNull:
+    @pytest.mark.asyncio
+    async def test_hard_delete_inquiry_nulls_applicant_inquiry_id(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Per RENTALS_PLAN.md §5.3: applicants outlive their inquiries.
+        Inquiry hard-delete (e.g. by retention worker) must set
+        applicant.inquiry_id to NULL, not cascade-delete the applicant."""
+        inq = Inquiry(
+            id=uuid.uuid4(), organization_id=test_org.id, user_id=test_user.id,
+            source="direct", stage="new",
+            received_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(inq)
+        await db.flush()
+        a = _make_applicant(
+            organization_id=test_org.id, user_id=test_user.id,
+            inquiry_id=inq.id, legal_name="Survives",
+        )
+        db.add(a)
+        await db.commit()
+
+        # SQLite test fixture has FKs OFF so cascade behavior won't fire.
+        # Verify the FK declaration via metadata as a structural regression.
+        fk_target = next(iter(Applicant.__table__.c.inquiry_id.foreign_keys))
+        assert fk_target.ondelete == "SET NULL"

--- a/apps/mybookkeeper/backend/tests/test_reference_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_reference_repo.py
@@ -1,0 +1,179 @@
+"""Repository tests for ``reference_repo`` (applicant_references).
+
+Covers:
+- create / list_for_applicant / mark_contacted
+- Tenant isolation through Applicant join
+- PII round-trip on reference_name / reference_contact via EncryptedString
+- CheckConstraint: invalid relationship rejected
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.reference import Reference
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.applicants import reference_repo
+
+
+def _make_applicant(
+    *, organization_id: uuid.UUID, user_id: uuid.UUID,
+) -> Applicant:
+    return Applicant(
+        id=uuid.uuid4(),
+        organization_id=organization_id, user_id=user_id,
+        stage="lead",
+    )
+
+
+class TestReferenceRepoCreate:
+    @pytest.mark.asyncio
+    async def test_create_persists_with_pii_round_trip(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        ref = await reference_repo.create(
+            db,
+            applicant_id=a.id,
+            relationship="landlord",
+            reference_name="John Q Landlord",
+            reference_contact="john@example.com",
+            notes="prev tenant for 2 years",
+        )
+        await db.commit()
+        await db.refresh(ref)
+
+        # PII round-trip via EncryptedString.
+        assert ref.reference_name == "John Q Landlord"
+        assert ref.reference_contact == "john@example.com"
+        assert ref.notes == "prev tenant for 2 years"
+        assert ref.key_version == 1
+
+
+class TestReferenceRepoList:
+    @pytest.mark.asyncio
+    async def test_list_returns_references_for_owned_applicant(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await reference_repo.create(
+            db, applicant_id=a.id, relationship="landlord",
+            reference_name="A", reference_contact="a@example.com",
+        )
+        await reference_repo.create(
+            db, applicant_id=a.id, relationship="employer",
+            reference_name="B", reference_contact="b@example.com",
+        )
+        await db.commit()
+
+        results = await reference_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert len(results) == 2
+        assert {r.relationship for r in results} == {"landlord", "employer"}
+
+    @pytest.mark.asyncio
+    async def test_list_returns_empty_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await reference_repo.create(
+            db, applicant_id=a.id, relationship="landlord",
+            reference_name="A", reference_contact="a@example.com",
+        )
+        await db.commit()
+
+        results = await reference_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+        )
+        assert results == []
+
+
+class TestReferenceRepoMarkContacted:
+    @pytest.mark.asyncio
+    async def test_mark_contacted_sets_timestamp(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+        ref = await reference_repo.create(
+            db, applicant_id=a.id, relationship="landlord",
+            reference_name="A", reference_contact="a@example.com",
+        )
+        await db.commit()
+
+        when = _dt.datetime.now(_dt.timezone.utc)
+        updated = await reference_repo.mark_contacted(
+            db, reference_id=ref.id,
+            organization_id=test_org.id, user_id=test_user.id,
+            contacted_at=when, notes="left voicemail",
+        )
+        await db.commit()
+        assert updated is not None
+        assert updated.contacted_at is not None
+        assert updated.contacted_at.replace(tzinfo=None) == when.replace(tzinfo=None)
+        assert updated.notes == "left voicemail"
+
+    @pytest.mark.asyncio
+    async def test_mark_contacted_returns_none_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+        ref = await reference_repo.create(
+            db, applicant_id=a.id, relationship="landlord",
+            reference_name="A", reference_contact="a@example.com",
+        )
+        await db.commit()
+
+        result = await reference_repo.mark_contacted(
+            db, reference_id=ref.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+        )
+        assert result is None
+
+
+class TestReferenceConstraints:
+    @pytest.mark.asyncio
+    async def test_invalid_relationship_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        bad = Reference(
+            applicant_id=a.id,
+            relationship="ufologist",
+            reference_name="X",
+            reference_contact="x@example.com",
+        )
+        db.add(bad)
+        with pytest.raises(IntegrityError):
+            await db.commit()
+        await db.rollback()
+
+
+class TestReferenceCascade:
+    def test_fk_declares_cascade(self) -> None:
+        fk = next(iter(Reference.__table__.c.applicant_id.foreign_keys))
+        assert fk.ondelete == "CASCADE"

--- a/apps/mybookkeeper/backend/tests/test_screening_result_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_screening_result_repo.py
@@ -1,0 +1,311 @@
+"""Repository tests for ``screening_result_repo``.
+
+Covers:
+- create / list_for_applicant / update_status
+- Tenant isolation through Applicant join
+- CheckConstraints: invalid provider / status rejected
+- Partial UNIQUE: two pending screenings for same (applicant, provider) rejected
+- Cascade delete: applicant hard-delete deletes screening_results
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy import delete, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.screening_result import ScreeningResult
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.applicants import screening_result_repo
+
+
+def _make_applicant(
+    *, organization_id: uuid.UUID, user_id: uuid.UUID,
+) -> Applicant:
+    return Applicant(
+        id=uuid.uuid4(),
+        organization_id=organization_id, user_id=user_id,
+        stage="lead",
+    )
+
+
+class TestScreeningResultRepoCreate:
+    @pytest.mark.asyncio
+    async def test_create_persists(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        sr = await screening_result_repo.create(
+            db,
+            applicant_id=a.id,
+            provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc),
+            status="pending",
+        )
+        await db.commit()
+        assert sr.applicant_id == a.id
+        assert sr.provider == "keycheck"
+        assert sr.status == "pending"
+
+
+class TestScreeningResultRepoList:
+    @pytest.mark.asyncio
+    async def test_list_returns_screenings_for_owned_applicant(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="pass",
+        )
+        await db.commit()
+
+        results = await screening_result_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert len(results) == 1
+        assert results[0].provider == "keycheck"
+
+    @pytest.mark.asyncio
+    async def test_list_returns_empty_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="pass",
+        )
+        await db.commit()
+
+        # Cross-org access returns empty even though applicant_id is real.
+        results = await screening_result_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+        )
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_list_returns_empty_for_other_user(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="pass",
+        )
+        await db.commit()
+
+        results = await screening_result_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=uuid.uuid4(),
+        )
+        assert results == []
+
+
+class TestScreeningResultRepoUpdate:
+    @pytest.mark.asyncio
+    async def test_update_status_persists(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        sr = await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="pending",
+        )
+        await db.commit()
+
+        completed = _dt.datetime.now(_dt.timezone.utc)
+        updated = await screening_result_repo.update_status(
+            db, screening_result_id=sr.id,
+            organization_id=test_org.id, user_id=test_user.id,
+            status="pass", completed_at=completed,
+        )
+        await db.commit()
+        assert updated is not None
+        assert updated.status == "pass"
+        # SQLite drops tz info on read; compare naive parts of the timestamp.
+        assert updated.completed_at is not None
+        assert updated.completed_at.replace(tzinfo=None) == completed.replace(tzinfo=None)
+
+    @pytest.mark.asyncio
+    async def test_update_returns_none_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+        sr = await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="pending",
+        )
+        await db.commit()
+
+        result = await screening_result_repo.update_status(
+            db, screening_result_id=sr.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+            status="pass",
+        )
+        assert result is None
+
+
+class TestScreeningResultConstraints:
+    @pytest.mark.asyncio
+    async def test_invalid_provider_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        bad = ScreeningResult(
+            applicant_id=a.id,
+            provider="bogus",
+            status="pending",
+            requested_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(bad)
+        with pytest.raises(IntegrityError):
+            await db.commit()
+        await db.rollback()
+
+    @pytest.mark.asyncio
+    async def test_invalid_status_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        bad = ScreeningResult(
+            applicant_id=a.id,
+            provider="keycheck",
+            status="never_heard_of_this",
+            requested_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        db.add(bad)
+        with pytest.raises(IntegrityError):
+            await db.commit()
+        await db.rollback()
+
+    @pytest.mark.asyncio
+    async def test_two_pending_for_same_provider_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Partial UNIQUE prevents concurrent in-flight screenings for the
+        same (applicant, provider) — once one completes, status moves off
+        'pending' and a re-run is allowed.
+
+        SQLite's partial-index implementation does not enforce the WHERE
+        predicate the same way Postgres does — it treats the index as a
+        full unique on (applicant_id, provider) regardless of status. The
+        migration source / index existence is verified separately in
+        ``test_applicant_indexes.py``; here we only verify the duplicate
+        is rejected (the correct behavior for the pending case)."""
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="pending",
+        )
+        await db.commit()
+
+        # The repository's ``create`` calls ``db.flush()`` which is where the
+        # UNIQUE violation surfaces — the IntegrityError fires before commit.
+        with pytest.raises(IntegrityError):
+            await screening_result_repo.create(
+                db, applicant_id=a.id, provider="keycheck",
+                requested_at=_dt.datetime.now(_dt.timezone.utc), status="pending",
+            )
+        await db.rollback()
+
+    @pytest.mark.asyncio
+    async def test_pending_and_completed_for_same_provider_allowed(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """Partial UNIQUE only applies to status='pending' on Postgres.
+
+        Skipped on SQLite because SQLite's partial-index implementation
+        does not enforce the WHERE predicate — the test_applicant_indexes
+        test verifies the migration source has the correct ``WHERE
+        status = 'pending'`` predicate for production behavior.
+        """
+        # This is a dialect-dependent behavior assertion. Read the dialect
+        # name from the bind to skip on SQLite without coupling to fixtures.
+        dialect_name = db.bind.dialect.name if db.bind is not None else "sqlite"
+        if dialect_name == "sqlite":
+            pytest.skip(
+                "SQLite ignores partial-index WHERE clauses — Postgres-only behavior. "
+                "Migration predicate verified in test_applicant_indexes.py.",
+            )
+
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="fail",
+        )
+        await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="pending",
+        )
+        await db.commit()
+
+
+class TestScreeningResultCascade:
+    @pytest.mark.asyncio
+    async def test_hard_delete_applicant_cascades_to_screening_results(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        """SQLite test fixture has FK enforcement OFF, so verify the FK
+        declaration says CASCADE rather than relying on runtime behavior."""
+        fk = next(iter(ScreeningResult.__table__.c.applicant_id.foreign_keys))
+        assert fk.ondelete == "CASCADE"
+
+        # Manual cleanup parity: delete the screening_result rows ourselves
+        # to mirror what CASCADE would do in Postgres, and confirm the rows
+        # are gone — ensures the test cleanup story works end-to-end.
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await screening_result_repo.create(
+            db, applicant_id=a.id, provider="keycheck",
+            requested_at=_dt.datetime.now(_dt.timezone.utc), status="pass",
+        )
+        await db.commit()
+
+        await db.execute(
+            delete(ScreeningResult).where(ScreeningResult.applicant_id == a.id),
+        )
+        await db.execute(delete(Applicant).where(Applicant.id == a.id))
+        await db.commit()
+
+        remaining = (await db.execute(
+            select(ScreeningResult).where(ScreeningResult.applicant_id == a.id),
+        )).all()
+        assert remaining == []

--- a/apps/mybookkeeper/backend/tests/test_video_call_note_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_video_call_note_repo.py
@@ -1,0 +1,234 @@
+"""Repository tests for ``video_call_note_repo``.
+
+Covers:
+- create / list_for_applicant / update_note
+- Tenant isolation through Applicant join
+- PII round-trip on notes via EncryptedString
+- CheckConstraint: gut_rating outside 1..5 rejected
+- Update allowlist: applicant_id NOT updatable
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.video_call_note import VideoCallNote
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.applicants import video_call_note_repo
+
+
+def _make_applicant(
+    *, organization_id: uuid.UUID, user_id: uuid.UUID,
+) -> Applicant:
+    return Applicant(
+        id=uuid.uuid4(),
+        organization_id=organization_id, user_id=user_id,
+        stage="lead",
+    )
+
+
+class TestVideoCallNoteRepoCreate:
+    @pytest.mark.asyncio
+    async def test_create_persists_with_pii_round_trip(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        note_text = "Strong candidate. Articulate, asked thoughtful questions."
+        scheduled = _dt.datetime.now(_dt.timezone.utc)
+        note = await video_call_note_repo.create(
+            db, applicant_id=a.id, scheduled_at=scheduled,
+            notes=note_text, gut_rating=4,
+        )
+        await db.commit()
+        await db.refresh(note)
+
+        assert note.notes == note_text  # PII round-trip
+        assert note.gut_rating == 4
+        # SQLite drops tz info on read; compare naive parts.
+        assert note.scheduled_at.replace(tzinfo=None) == scheduled.replace(tzinfo=None)
+
+
+class TestVideoCallNoteRepoList:
+    @pytest.mark.asyncio
+    async def test_list_returns_notes_for_owned_applicant(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await video_call_note_repo.create(
+            db, applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            notes="first",
+        )
+        await db.commit()
+
+        results = await video_call_note_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=test_user.id,
+        )
+        assert len(results) == 1
+        assert results[0].notes == "first"
+
+    @pytest.mark.asyncio
+    async def test_list_returns_empty_for_other_user(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        await video_call_note_repo.create(
+            db, applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            notes="first",
+        )
+        await db.commit()
+
+        results = await video_call_note_repo.list_for_applicant(
+            db, applicant_id=a.id,
+            organization_id=test_org.id, user_id=uuid.uuid4(),
+        )
+        assert results == []
+
+
+class TestVideoCallNoteRepoUpdate:
+    @pytest.mark.asyncio
+    async def test_update_applies_allowlisted_fields(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+        note = await video_call_note_repo.create(
+            db, applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            notes="initial",
+        )
+        await db.commit()
+
+        completed = _dt.datetime.now(_dt.timezone.utc)
+        updated = await video_call_note_repo.update_note(
+            db, video_call_note_id=note.id,
+            organization_id=test_org.id, user_id=test_user.id,
+            fields={"notes": "revised", "gut_rating": 5, "completed_at": completed},
+        )
+        await db.commit()
+        assert updated is not None
+        assert updated.notes == "revised"
+        assert updated.gut_rating == 5
+        assert updated.completed_at is not None
+        assert updated.completed_at.replace(tzinfo=None) == completed.replace(tzinfo=None)
+
+    @pytest.mark.asyncio
+    async def test_update_drops_protected_fields(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+        note = await video_call_note_repo.create(
+            db, applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            notes="initial",
+        )
+        await db.commit()
+        original_applicant_id = note.applicant_id
+
+        attacker_applicant_id = uuid.uuid4()
+        updated = await video_call_note_repo.update_note(
+            db, video_call_note_id=note.id,
+            organization_id=test_org.id, user_id=test_user.id,
+            fields={
+                "applicant_id": attacker_applicant_id,  # NOT in allowlist
+                "notes": "still updates",  # in allowlist
+            },
+        )
+        await db.commit()
+        assert updated is not None
+        assert updated.applicant_id == original_applicant_id
+        assert updated.notes == "still updates"
+
+    @pytest.mark.asyncio
+    async def test_update_returns_none_for_other_org(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+        note = await video_call_note_repo.create(
+            db, applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            notes="initial",
+        )
+        await db.commit()
+
+        result = await video_call_note_repo.update_note(
+            db, video_call_note_id=note.id,
+            organization_id=uuid.uuid4(), user_id=test_user.id,
+            fields={"notes": "x"},
+        )
+        assert result is None
+
+
+class TestVideoCallNoteConstraints:
+    @pytest.mark.asyncio
+    async def test_gut_rating_zero_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        bad = VideoCallNote(
+            applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            gut_rating=0,
+        )
+        db.add(bad)
+        with pytest.raises(IntegrityError):
+            await db.commit()
+        await db.rollback()
+
+    @pytest.mark.asyncio
+    async def test_gut_rating_six_rejected(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        bad = VideoCallNote(
+            applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+            gut_rating=6,
+        )
+        db.add(bad)
+        with pytest.raises(IntegrityError):
+            await db.commit()
+        await db.rollback()
+
+    @pytest.mark.asyncio
+    async def test_gut_rating_null_allowed(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        a = _make_applicant(organization_id=test_org.id, user_id=test_user.id)
+        db.add(a)
+        await db.commit()
+
+        # Just creating without gut_rating should succeed.
+        await video_call_note_repo.create(
+            db, applicant_id=a.id,
+            scheduled_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        await db.commit()

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -410,6 +410,27 @@
         "inquiry-reply.spec.ts"
       ]
     },
+    "applicants": {
+      "source_paths": [
+        "backend/app/models/applicants/",
+        "backend/app/repositories/applicants/",
+        "backend/app/schemas/applicants/",
+        "backend/app/core/applicant_enums.py",
+        "backend/alembic/versions/f8h0i3k5l7m9_add_applicants_domain.py"
+      ],
+      "backend_tests": [
+        "test_applicant_repo.py",
+        "test_screening_result_repo.py",
+        "test_reference_repo.py",
+        "test_video_call_note_repo.py",
+        "test_applicant_event_repo.py",
+        "test_applicant_encryption.py",
+        "test_applicant_audit_masking.py",
+        "test_applicant_indexes.py"
+      ],
+      "frontend_tests": [],
+      "e2e_specs": []
+    },
     "system": {
       "source_paths": [
         "backend/app/models/system/",


### PR DESCRIPTION
## Scope (PR 3.1a — backend foundation only)

Adds the SQLAlchemy ORM, Alembic migration, repositories, Pydantic response schemas, and tests for the new Applicants domain. Mirrors the Phase 2 Inquiries pattern.

**In scope:**
- 5 new tables: `applicants`, `screening_results`, `applicant_references`, `video_call_notes`, `applicant_events`
- Single Alembic migration `f8h0i3k5l7m9` (down_revision: `e7g9h2j4k6l8`)
- `core/applicant_enums.py` — canonical SQL value lists for CheckConstraints
- 5 repository modules (every public function dual-scoped on `organization_id` AND `user_id`)
- 5 Pydantic response schemas (one class per file)
- Audit `SENSITIVE_FIELDS` extension for the new PII columns
- 8 test files / 87 passing tests / 1 SQLite-skipped (verified via migration source)

**Out of scope (future PRs):**
- Frontend pages (PR 3.1b)
- Inquiry → Applicant promotion service (PR 3.2)
- Screening provider integration (PR 3.3)
- Video call notes UI / kanban (PR 3.4)

## Migration details

Single revision `f8h0i3k5l7m9_add_applicants_domain.py` written by hand (not autogenerate) for explicit naming control:
- All FKs named (`fk_*_*_id`)
- All indexes named (`ix_*` / `uq_*`)
- All CheckConstraints named (`chk_*`)
- Partial UNIQUE on `(applicant_id, provider) WHERE status='pending'` prevents concurrent in-flight screenings while allowing re-runs after completion
- Partial index `(user_id, deleted_at) WHERE deleted_at IS NOT NULL AND sensitive_purged_at IS NULL` powers the future retention worker scan (RENTALS_PLAN.md §6.6) without table scans
- `applicants.inquiry_id` is `ON DELETE SET NULL` (applicants outlive their inquiries); other FKs are `ON DELETE CASCADE`
- Reversible `downgrade()` drops in reverse order

Verified offline by generating the upgrade/downgrade SQL via `alembic upgrade --sql` against PostgreSQL dialect — clean syntax, all DDL valid.

## PII encryption

Reuses the existing `EncryptedString` `TypeDecorator` (no new crypto code):
- `applicants.legal_name`, `dob`, `employer_or_hospital`, `vehicle_make_model`
- `applicant_references.reference_name`, `reference_contact`
- `video_call_notes.notes` (sized 10000 chars for long observation blocks)

`key_version SmallInteger DEFAULT 1` on every PII-bearing table per RENTALS_PLAN.md §8.2 — required for non-destructive future key rotation.

## Tenant scoping

Per CLAUDE.md layered architecture:
- `applicant_repo` filters by `(organization_id, user_id)` directly
- Child repos (`screening_result_repo`, `reference_repo`, `video_call_note_repo`, `applicant_event_repo`) join through `applicants` to enforce the same scope — a forged `applicant_id` from a different tenant returns empty / `None`

No service or API code in this PR — every PR 3.2/3.3/3.4 will compose these repos.

## Audit masking — collision-aware design

PII column names intentionally chosen to be globally unique so they're safe to add to the flat `SENSITIVE_FIELDS` set in `core/audit.py`:
- `legal_name` (not bare `name` — would collide with Property, Organization, User, ReplyTemplate, Tenant, Plaid, etc.)
- `reference_name` / `reference_contact` (not bare `name` / `contact`)
- `dob`, `employer_or_hospital`, `vehicle_make_model` are unique to applicants

Tested in `test_applicant_audit_masking.py` including a regression guard verifying `Organization.name` is NOT masked.

## Table-name choice: `applicant_references` (not `references`)

`REFERENCES` is a SQL reserved keyword. PostgreSQL would auto-quote `references` but Alembic autogenerate, query logs, `pg_dump`, and external tooling (pgAdmin) become harder to read. `applicant_references` is unambiguous and parallels the inquiries → inquiry_messages naming. Locked in `test_applicant_indexes.py::test_table_name_is_applicant_references_not_reserved_word`.

## Test coverage

8 new test files, 87 passing tests, 1 SQLite-skipped (with explanation), 0 regressions to existing `test_inquiry_*` / `test_encrypted_string_type` / `test_alembic_chain`:

- `test_applicant_repo.py` — 19 tests: create/get/list/get_by_inquiry/soft_delete/list_pending_purge, tenant isolation (3 ways), soft-delete semantics, FK SET NULL declaration, stage CheckConstraint
- `test_screening_result_repo.py` — 11 tests: create/list/update_status, tenant isolation through Applicant join, provider/status CheckConstraints, partial UNIQUE on pending, FK CASCADE declaration
- `test_reference_repo.py` — 7 tests: create/list/mark_contacted, tenant isolation, PII round-trip, relationship CheckConstraint
- `test_video_call_note_repo.py` — 9 tests: create/list/update_note (allowlist), tenant isolation, gut_rating range CheckConstraint
- `test_applicant_event_repo.py` — 8 tests: append/list, tenant isolation, event_type/actor CheckConstraints, supplementary event types, append-only contract
- `test_applicant_encryption.py` — 15 tests: round-trip + ciphertext-at-rest for every encrypted column on every table, key_version defaults, long-text capacity
- `test_applicant_audit_masking.py` — 5 tests: PII masked on insert/update across applicants/references/video_call_notes, plaintext leak check, Organization.name NOT masked regression guard
- `test_applicant_indexes.py` — 14 tests: ORM model index declarations + migration source predicate verification (the partial index `WHERE` clauses lock in production behavior)

## References

- RENTALS_PLAN.md §5.3 (Applicants schema), §6.6 (retention worker), §8.1-8.7 (PII / encryption / audit), §11 (Migration 3) — operator-personal planning doc, not in repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)