### PR TITLE
fix(mybookkeeper/tests): restore SQLite skip on tax-summary PDF test deleted in #92

### DIFF
--- a/apps/mybookkeeper/backend/tests/test_export_service.py
+++ b/apps/mybookkeeper/backend/tests/test_export_service.py
@@ -183,6 +183,10 @@ class TestExportScheduleE:
 
 class TestExportTaxSummary:
     @pytest.mark.asyncio
+    @pytest.mark.skipif(
+        "sqlite" in __import__("os").environ.get("DATABASE_URL", ""),
+        reason="Tax summary export uses Postgres-specific SQL (`tax_relevant IS 1`); requires real Postgres in test env",
+    )
     async def test_tax_summary_pdf_starts_with_magic_bytes(self, db: AsyncSession) -> None:
         user, org_id, prop = await _setup(db)
         db.add(_make_txn(org_id, user.id, prop.id))


### PR DESCRIPTION
## Summary

Re-applies the `@pytest.mark.skipif` decorator that #97 originally added and #92 silently deleted. Without it, `backend-tests / mybookkeeper` fails on every PR with `sqlite3.OperationalError: no such table: transactions` because the Postgres-specific \`tax_relevant IS 1\` SQL fails under aiosqlite. Verbatim restoration of the decorator from #97's diff.

This is the third regression introduced by #92 (alongside the deleted CI workflows + the engine pool-config bug, both fixed in #102). The CI gate that should have caught all three was the same one that was deleted in #92 — circular invisibility.

## Test plan

- [ ] CI runs `backend-tests / mybookkeeper` and the test is now skipped instead of failing
- [ ] No other tests change behavior

## Note on merge mechanics

Will need admin merge — myjobhunter required checks (#103, #104) are still red as accepted-risk per #102's PR comment.