### PR TITLE
feat(mybookkeeper/applicants): inquiry → applicant promotion (rentals Phase 3, PR 3.2)

### DIFF
--- a/apps/mybookkeeper/backend/app/api/applicants.py
+++ b/apps/mybookkeeper/backend/app/api/applicants.py
@@ -1,9 +1,11 @@
-"""HTTP routes for the Applicants domain — read-only (PR 3.1b).
+"""HTTP routes for the Applicants domain.
 
-Write operations (promotion from inquiry, screening kicks, video call notes)
-ship in subsequent PRs (3.2 / 3.3 / 3.4). PII is encrypted at rest by the
-SQLAlchemy ``EncryptedString`` type decorator on the model — routes interact
-with plaintext only.
+PR 3.1b shipped read-only list / detail.
+PR 3.2 adds POST /applicants/promote/{inquiry_id} — atomic promotion from
+an Inquiry. Screening (PR 3.3) and video-call notes (PR 3.4) follow.
+
+PII is encrypted at rest by the SQLAlchemy ``EncryptedString`` type
+decorator on the model — routes interact with plaintext only.
 """
 from __future__ import annotations
 
@@ -12,10 +14,11 @@ import uuid
 from fastapi import APIRouter, Depends, HTTPException, Query
 
 from app.core.context import RequestContext
-from app.core.permissions import current_org_member
+from app.core.permissions import current_org_member, require_write_access
 from app.schemas.applicants.applicant_detail_response import ApplicantDetailResponse
 from app.schemas.applicants.applicant_list_response import ApplicantListResponse
-from app.services.applicants import applicant_service
+from app.schemas.applicants.applicant_promote_request import ApplicantPromoteRequest
+from app.services.applicants import applicant_service, promote_service
 
 router = APIRouter(prefix="/applicants", tags=["applicants"])
 
@@ -49,3 +52,58 @@ async def get_applicant(
         )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail="Applicant not found") from exc
+
+
+@router.post(
+    "/promote/{inquiry_id}",
+    response_model=ApplicantDetailResponse,
+    status_code=200,
+)
+async def promote_inquiry(
+    inquiry_id: uuid.UUID,
+    payload: ApplicantPromoteRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> ApplicantDetailResponse:
+    """Atomically promote an Inquiry into an Applicant.
+
+    Returns the full ``ApplicantDetailResponse`` for the new applicant.
+
+    Errors:
+        404 — inquiry not found in the calling tenant.
+        409 — applicant already exists for this inquiry. Body includes
+              ``applicant_id`` so the frontend can navigate to it.
+        409 — inquiry stage is terminal (``declined`` / ``archived``).
+    """
+    try:
+        applicant = await promote_service.promote_from_inquiry(
+            organization_id=ctx.organization_id,
+            user_id=ctx.user_id,
+            inquiry_id=inquiry_id,
+            overrides=payload,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail="Inquiry not found") from exc
+    except promote_service.AlreadyPromotedError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "already_promoted",
+                "message": "This inquiry has already been promoted.",
+                "applicant_id": str(exc.applicant_id),
+            },
+        ) from exc
+    except promote_service.InquiryNotPromotableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "not_promotable",
+                "message": str(exc),
+                "stage": exc.stage,
+            },
+        ) from exc
+
+    # Re-load through the read service so the response shape is identical
+    # to GET /applicants/{id} — same Pydantic schema, same children.
+    return await applicant_service.get_applicant(
+        ctx.organization_id, ctx.user_id, applicant.id,
+    )

--- a/apps/mybookkeeper/backend/app/core/applicant_constants.py
+++ b/apps/mybookkeeper/backend/app/core/applicant_constants.py
@@ -1,0 +1,24 @@
+"""Constants for the Applicants domain.
+
+Field-length caps mirror the column ``String(N)`` lengths on the SQLAlchemy
+model — keep them in sync. Business rules (minimum age, etc.) live here so
+they can be tuned without touching service or schema files.
+"""
+
+# Field max lengths — match ``models/applicants/applicant.py`` column types.
+APPLICANT_LEGAL_NAME_MAX = 255
+APPLICANT_DOB_MAX = 50
+APPLICANT_EMPLOYER_MAX = 255
+APPLICANT_VEHICLE_MAX = 255
+APPLICANT_PETS_MAX = 1000
+APPLICANT_REFERRED_BY_MAX = 255
+
+# Minimum applicant age for rental eligibility — codified per typical rental
+# policy. Tunable here so a future per-org override can layer on top without
+# touching service code.
+APPLICANT_MINIMUM_AGE_YEARS = 18
+
+# ISO-8601 ``YYYY-MM-DD`` is the canonical wire / storage format for the
+# encrypted ``dob`` column. The promote schema parses date inputs, the repo
+# stores ISO strings.
+APPLICANT_DOB_ISO_FORMAT = "%Y-%m-%d"

--- a/apps/mybookkeeper/backend/app/schemas/applicants/applicant_promote_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/applicant_promote_request.py
@@ -1,0 +1,80 @@
+"""Pydantic schema for POST /applicants/promote/{inquiry_id}.
+
+All fields are optional. The promotion service auto-fills missing values
+from the source inquiry where possible (legal_name, employer_or_hospital,
+contract dates) — fields with no inquiry source (dob, vehicle_make_model,
+smoker, pets, referred_by) come from this payload only.
+
+Validators:
+- ``contract_end >= contract_start`` when both set.
+- ``dob`` must place the applicant at or above ``APPLICANT_MINIMUM_AGE_YEARS``
+  on the day of promotion. Violations raise 422 — never silently coerce.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.core.applicant_constants import (
+    APPLICANT_EMPLOYER_MAX,
+    APPLICANT_LEGAL_NAME_MAX,
+    APPLICANT_MINIMUM_AGE_YEARS,
+    APPLICANT_PETS_MAX,
+    APPLICANT_REFERRED_BY_MAX,
+    APPLICANT_VEHICLE_MAX,
+)
+
+
+class ApplicantPromoteRequest(BaseModel):
+    """Body for POST /applicants/promote/{inquiry_id}.
+
+    Auto-fill behaviour (handled by ``promote_service``):
+    - ``legal_name`` falls back to the inquiry's ``inquirer_name``.
+    - ``employer_or_hospital`` falls back to the inquiry's ``inquirer_employer``.
+    - ``contract_start`` / ``contract_end`` fall back to the inquiry's
+      ``desired_start_date`` / ``desired_end_date``.
+    - All other fields default to ``None`` and stay ``None`` if the host
+      didn't supply them.
+    """
+
+    legal_name: str | None = Field(default=None, max_length=APPLICANT_LEGAL_NAME_MAX)
+    dob: _dt.date | None = None
+    employer_or_hospital: str | None = Field(
+        default=None, max_length=APPLICANT_EMPLOYER_MAX,
+    )
+
+    contract_start: _dt.date | None = None
+    contract_end: _dt.date | None = None
+
+    vehicle_make_model: str | None = Field(
+        default=None, max_length=APPLICANT_VEHICLE_MAX,
+    )
+    smoker: bool | None = None
+    pets: str | None = Field(default=None, max_length=APPLICANT_PETS_MAX)
+    referred_by: str | None = Field(default=None, max_length=APPLICANT_REFERRED_BY_MAX)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_business_rules(self) -> "ApplicantPromoteRequest":
+        if (
+            self.contract_start is not None
+            and self.contract_end is not None
+            and self.contract_end < self.contract_start
+        ):
+            raise ValueError("contract_end cannot be before contract_start")
+
+        if self.dob is not None:
+            today = _dt.date.today()
+            # Compute age the way humans do — has the birthday already
+            # passed this year? If not, subtract one.
+            age = today.year - self.dob.year - (
+                (today.month, today.day) < (self.dob.month, self.dob.day)
+            )
+            if age < APPLICANT_MINIMUM_AGE_YEARS:
+                raise ValueError(
+                    f"applicant must be at least {APPLICANT_MINIMUM_AGE_YEARS} "
+                    "years old on the day of promotion",
+                )
+        return self

--- a/apps/mybookkeeper/backend/app/schemas/inquiries/inquiry_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/inquiries/inquiry_response.py
@@ -40,6 +40,11 @@ class InquiryResponse(BaseModel):
     received_at: _dt.datetime
     email_message_id: str | None = None
 
+    # ID of the Applicant promoted from this inquiry (if any). Lets the
+    # detail UI show "View applicant" instead of "Promote to applicant"
+    # when the inquiry has already been converted (PR 3.2).
+    linked_applicant_id: uuid.UUID | None = None
+
     messages: list[InquiryMessageResponse] = []
     events: list[InquiryEventResponse] = []
 

--- a/apps/mybookkeeper/backend/app/services/applicants/promote_service.py
+++ b/apps/mybookkeeper/backend/app/services/applicants/promote_service.py
@@ -1,0 +1,183 @@
+"""Promotion service — Inquiry → Applicant.
+
+Per the layered-architecture rule: services orchestrate (load → decide →
+persist), repositories own queries. All multi-write paths run inside a
+single ``unit_of_work`` transaction so a partial promote (applicant
+inserted but events / stage update missed) is impossible.
+
+Flow per RENTALS_PLAN.md §6.2 cross-domain mapping:
+1. Load inquiry by id, scoped to (organization_id, user_id) — 404 if not owned.
+2. Reject if the inquiry stage is terminal (``declined`` or ``archived``) —
+   the host shouldn't be able to promote a rejected inquiry. Returns 409.
+3. Reject if an active applicant already exists for this inquiry — returns
+   409 with the existing applicant_id so the frontend can navigate.
+4. Auto-fill missing override fields from inquiry PII (round-trips through
+   EncryptedString — plaintext on read, re-encrypted on write).
+5. Persist Applicant in stage=``lead``.
+6. Append two events atomically:
+   - ``applicant_events``: ``lead`` (applicant created)
+   - ``inquiry_events``: ``converted`` (inquiry transitions out of inbox)
+7. Update inquiry stage to ``converted``.
+
+Cross-org / wrong-user requests resolve to "inquiry not found" (404). We
+never leak the existence of a row a tenant doesn't own.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from app.core.applicant_constants import APPLICANT_DOB_ISO_FORMAT
+from app.db.session import unit_of_work
+from app.models.applicants.applicant import Applicant
+from app.repositories import (
+    applicant_event_repo,
+    applicant_repo,
+    inquiry_event_repo,
+    inquiry_repo,
+)
+from app.schemas.applicants.applicant_promote_request import ApplicantPromoteRequest
+
+
+# Inquiry stages that BLOCK promotion. Anything else (new, triaged, replied,
+# screening_requested, video_call_scheduled, approved) is promotable.
+# `converted` is implicitly blocked because get_by_inquiry will already
+# return the existing applicant, raising AlreadyPromotedError before we
+# inspect the stage.
+_NON_PROMOTABLE_STAGES: frozenset[str] = frozenset({"declined", "archived"})
+
+
+class InquiryNotPromotableError(Exception):
+    """Inquiry is in a stage from which promotion is not allowed (e.g. declined)."""
+
+    def __init__(self, stage: str) -> None:
+        super().__init__(
+            f"Cannot promote an inquiry in stage {stage!r}. "
+            "Decline / archive inquiries are terminal.",
+        )
+        self.stage = stage
+
+
+class AlreadyPromotedError(Exception):
+    """An applicant has already been created for this inquiry."""
+
+    def __init__(self, applicant_id: uuid.UUID) -> None:
+        super().__init__(f"Inquiry already promoted to applicant {applicant_id}")
+        self.applicant_id = applicant_id
+
+
+def _coalesce(*values: str | None) -> str | None:
+    """Return the first non-None, non-empty value, else None.
+
+    Used to merge host overrides with auto-fill from the inquiry — host
+    overrides win, inquiry values fill gaps, otherwise leave the field empty.
+    """
+    for value in values:
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def _coalesce_date(*values: _dt.date | None) -> _dt.date | None:
+    for value in values:
+        if value is not None:
+            return value
+    return None
+
+
+async def promote_from_inquiry(
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    inquiry_id: uuid.UUID,
+    overrides: ApplicantPromoteRequest,
+) -> Applicant:
+    """Atomically convert an Inquiry into an Applicant.
+
+    Raises:
+        LookupError: inquiry not found in the calling tenant.
+        AlreadyPromotedError: an active applicant already exists for the inquiry.
+        InquiryNotPromotableError: inquiry is in a non-promotable stage.
+    """
+    now = _dt.datetime.now(_dt.timezone.utc)
+
+    async with unit_of_work() as db:
+        inquiry = await inquiry_repo.get_by_id(db, inquiry_id, organization_id)
+        if inquiry is None or inquiry.user_id != user_id:
+            # Tenant isolation: never leak existence of a row another user owns.
+            raise LookupError(f"Inquiry {inquiry_id} not found")
+
+        if inquiry.stage in _NON_PROMOTABLE_STAGES:
+            raise InquiryNotPromotableError(inquiry.stage)
+
+        existing = await applicant_repo.get_by_inquiry(
+            db,
+            inquiry_id=inquiry_id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if existing is not None:
+            raise AlreadyPromotedError(existing.id)
+
+        # Auto-fill mapping per RENTALS_PLAN.md §6.2.
+        legal_name = _coalesce(overrides.legal_name, inquiry.inquirer_name)
+        employer = _coalesce(
+            overrides.employer_or_hospital, inquiry.inquirer_employer,
+        )
+        contract_start = _coalesce_date(
+            overrides.contract_start, inquiry.desired_start_date,
+        )
+        contract_end = _coalesce_date(
+            overrides.contract_end, inquiry.desired_end_date,
+        )
+
+        # ``dob`` is stored as ISO-8601 text on an EncryptedString column
+        # so the type decorator can encrypt it. The Pydantic schema accepts
+        # a ``date`` for type-safe validation; convert here.
+        dob_iso = (
+            overrides.dob.strftime(APPLICANT_DOB_ISO_FORMAT)
+            if overrides.dob is not None
+            else None
+        )
+
+        applicant = await applicant_repo.create(
+            db,
+            organization_id=organization_id,
+            user_id=user_id,
+            inquiry_id=inquiry.id,
+            legal_name=legal_name,
+            dob=dob_iso,
+            employer_or_hospital=employer,
+            vehicle_make_model=overrides.vehicle_make_model,
+            contract_start=contract_start,
+            contract_end=contract_end,
+            smoker=overrides.smoker,
+            pets=overrides.pets,
+            referred_by=overrides.referred_by,
+            stage="lead",
+        )
+
+        # Applicant timeline — seed event so the funnel analytics can see
+        # the new lead.
+        await applicant_event_repo.append(
+            db,
+            applicant_id=applicant.id,
+            event_type="lead",
+            actor="host",
+            occurred_at=now,
+        )
+
+        # Inquiry timeline — record the conversion + advance the stage so
+        # the inbox view drops it out of the active pipeline.
+        await inquiry_event_repo.create(
+            db,
+            inquiry_id=inquiry.id,
+            event_type="converted",
+            actor="host",
+            occurred_at=now,
+        )
+        await inquiry_repo.update_inquiry(
+            db, inquiry.id, organization_id, {"stage": "converted"},
+        )
+
+    return applicant

--- a/apps/mybookkeeper/backend/app/services/inquiries/inquiry_service.py
+++ b/apps/mybookkeeper/backend/app/services/inquiries/inquiry_service.py
@@ -23,6 +23,7 @@ import uuid
 
 from app.db.session import AsyncSessionLocal, unit_of_work
 from app.repositories import (
+    applicant_repo,
     inquiry_event_repo,
     inquiry_message_repo,
     inquiry_repo,
@@ -44,11 +45,13 @@ def _to_response(
     inquiry,
     messages=(),
     events=(),
+    linked_applicant_id=None,
 ) -> InquiryResponse:
     base = InquiryResponse.model_validate(inquiry)
     return base.model_copy(update={
         "messages": [InquiryMessageResponse.model_validate(m) for m in messages],
         "events": [InquiryEventResponse.model_validate(e) for e in events],
+        "linked_applicant_id": linked_applicant_id,
     })
 
 
@@ -126,7 +129,7 @@ async def create_inquiry(
 
 async def get_inquiry(
     organization_id: uuid.UUID,
-    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context parity
+    user_id: uuid.UUID,
     inquiry_id: uuid.UUID,
 ) -> InquiryResponse:
     async with AsyncSessionLocal() as db:
@@ -135,7 +138,20 @@ async def get_inquiry(
             raise LookupError(f"Inquiry {inquiry_id} not found")
         messages = await inquiry_message_repo.list_by_inquiry(db, inquiry.id)
         events = await inquiry_event_repo.list_by_inquiry(db, inquiry.id)
-    return _to_response(inquiry, messages=messages, events=events)
+        # Surface the linked applicant_id if this inquiry has been promoted
+        # so the detail UI can show "View applicant" instead of "Promote".
+        linked_applicant = await applicant_repo.get_by_inquiry(
+            db,
+            inquiry_id=inquiry.id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+    return _to_response(
+        inquiry,
+        messages=messages,
+        events=events,
+        linked_applicant_id=linked_applicant.id if linked_applicant else None,
+    )
 
 
 async def list_inbox(
@@ -160,7 +176,7 @@ async def list_inbox(
 
 async def update_inquiry(
     organization_id: uuid.UUID,
-    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context parity
+    user_id: uuid.UUID,
     inquiry_id: uuid.UUID,
     payload: InquiryUpdateRequest,
 ) -> InquiryResponse:
@@ -193,7 +209,18 @@ async def update_inquiry(
 
         messages = await inquiry_message_repo.list_by_inquiry(db, inquiry.id)
         events = await inquiry_event_repo.list_by_inquiry(db, inquiry.id)
-        return _to_response(inquiry, messages=messages, events=events)
+        linked_applicant = await applicant_repo.get_by_inquiry(
+            db,
+            inquiry_id=inquiry.id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        return _to_response(
+            inquiry,
+            messages=messages,
+            events=events,
+            linked_applicant_id=linked_applicant.id if linked_applicant else None,
+        )
 
 
 async def delete_inquiry(

--- a/apps/mybookkeeper/backend/tests/test_applicants_api_promote.py
+++ b/apps/mybookkeeper/backend/tests/test_applicants_api_promote.py
@@ -1,0 +1,245 @@
+"""HTTP route tests for POST /applicants/promote/{inquiry_id} (PR 3.2).
+
+Mocks the promote_service / applicant_service layer — the service-layer
+behaviour is verified end-to-end in ``test_promote_service.py``. These tests
+focus on:
+- Auth gating (401 when unauthenticated).
+- Pydantic validation (422 on invalid body).
+- Status code mapping for service errors:
+    LookupError → 404
+    AlreadyPromotedError → 409 with applicant_id in detail
+    InquiryNotPromotableError → 409 with stage in detail
+- Happy-path response shape matches GET /applicants/{id}.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.applicants.applicant_detail_response import ApplicantDetailResponse
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(
+        organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER,
+    )
+
+
+def _build_detail(
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+    inquiry_id: uuid.UUID,
+) -> ApplicantDetailResponse:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    return ApplicantDetailResponse(
+        id=applicant_id,
+        organization_id=org_id,
+        user_id=user_id,
+        inquiry_id=inquiry_id,
+        legal_name="Alice Tester",
+        dob=None,
+        employer_or_hospital="Memorial Hermann",
+        vehicle_make_model=None,
+        id_document_storage_key=None,
+        contract_start=_dt.date(2026, 6, 1),
+        contract_end=_dt.date(2026, 12, 1),
+        smoker=None,
+        pets=None,
+        referred_by=None,
+        stage="lead",
+        created_at=now,
+        updated_at=now,
+        screening_results=[],
+        references=[],
+        video_call_notes=[],
+        events=[],
+    )
+
+
+class TestPromoteEndpoint:
+    def test_unauthenticated_returns_401(self) -> None:
+        client = TestClient(app)
+        response = client.post(f"/applicants/promote/{uuid.uuid4()}", json={})
+        assert response.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_applicant_detail(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        applicant_id, inquiry_id = uuid.uuid4(), uuid.uuid4()
+        applicant_obj = type("StubApplicant", (), {"id": applicant_id})()
+        detail = _build_detail(
+            org_id=org_id, user_id=user_id,
+            applicant_id=applicant_id, inquiry_id=inquiry_id,
+        )
+
+        app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.applicants.promote_service.promote_from_inquiry",
+                new=AsyncMock(return_value=applicant_obj),
+            ) as mock_promote, patch(
+                "app.api.applicants.applicant_service.get_applicant",
+                new=AsyncMock(return_value=detail),
+            ) as mock_get:
+                client = TestClient(app)
+                response = client.post(
+                    f"/applicants/promote/{inquiry_id}",
+                    json={"legal_name": "Alice Tester"},
+                )
+
+            assert response.status_code == 200
+            body = response.json()
+            assert body["id"] == str(applicant_id)
+            assert body["inquiry_id"] == str(inquiry_id)
+            assert body["legal_name"] == "Alice Tester"
+            assert body["stage"] == "lead"
+            assert mock_promote.await_count == 1
+            assert mock_get.await_count == 1
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_inquiry_not_found_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        inquiry_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.applicants.promote_service.promote_from_inquiry",
+                new=AsyncMock(side_effect=LookupError("nope")),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/applicants/promote/{inquiry_id}", json={},
+                )
+            assert response.status_code == 404
+            assert response.json()["detail"] == "Inquiry not found"
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_already_promoted_returns_409_with_applicant_id(self) -> None:
+        from app.services.applicants import promote_service
+
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        inquiry_id = uuid.uuid4()
+        existing_applicant_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.applicants.promote_service.promote_from_inquiry",
+                new=AsyncMock(
+                    side_effect=promote_service.AlreadyPromotedError(
+                        existing_applicant_id,
+                    ),
+                ),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/applicants/promote/{inquiry_id}", json={},
+                )
+            assert response.status_code == 409
+            detail = response.json()["detail"]
+            assert detail["code"] == "already_promoted"
+            assert detail["applicant_id"] == str(existing_applicant_id)
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_not_promotable_stage_returns_409_with_stage(self) -> None:
+        from app.services.applicants import promote_service
+
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        inquiry_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.applicants.promote_service.promote_from_inquiry",
+                new=AsyncMock(
+                    side_effect=promote_service.InquiryNotPromotableError(
+                        "declined",
+                    ),
+                ),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/applicants/promote/{inquiry_id}", json={},
+                )
+            assert response.status_code == 409
+            detail = response.json()["detail"]
+            assert detail["code"] == "not_promotable"
+            assert detail["stage"] == "declined"
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_invalid_inquiry_uuid_returns_422(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.post("/applicants/promote/not-a-uuid", json={})
+            assert response.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_invalid_body_unknown_field_returns_422(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        inquiry_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.post(
+                f"/applicants/promote/{inquiry_id}",
+                json={"unknown_field": "boom"},
+            )
+            assert response.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_dob_under_minimum_age_returns_422(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        inquiry_id = uuid.uuid4()
+        # A dob clearly under 18 — yesterday.
+        recent_dob = (_dt.date.today() - _dt.timedelta(days=1)).isoformat()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.post(
+                f"/applicants/promote/{inquiry_id}",
+                json={"dob": recent_dob},
+            )
+            assert response.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_contract_dates_inverted_returns_422(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        inquiry_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.post(
+                f"/applicants/promote/{inquiry_id}",
+                json={
+                    "contract_start": "2026-12-01",
+                    "contract_end": "2026-06-01",
+                },
+            )
+            assert response.status_code == 422
+        finally:
+            app.dependency_overrides.clear()

--- a/apps/mybookkeeper/backend/tests/test_inquiry_service.py
+++ b/apps/mybookkeeper/backend/tests/test_inquiry_service.py
@@ -293,6 +293,49 @@ class TestGetInquiry:
                 uuid.uuid4(), test_user.id, created.id,
             )
 
+    @pytest.mark.asyncio
+    async def test_linked_applicant_id_is_null_when_not_promoted(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        patch_session,
+    ) -> None:
+        created = await inquiry_service.create_inquiry(
+            test_org.id, test_user.id, _create_payload(),
+        )
+        result = await inquiry_service.get_inquiry(
+            test_org.id, test_user.id, created.id,
+        )
+        assert result.linked_applicant_id is None
+
+    @pytest.mark.asyncio
+    async def test_linked_applicant_id_surfaced_after_applicant_seeded(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        patch_session,
+    ) -> None:
+        """If an Applicant exists pointing at the inquiry, the response surfaces it.
+
+        Used by the frontend InquiryDetail page to switch the "Promote to
+        applicant" button to a "View applicant" link (PR 3.2).
+        """
+        from app.repositories.applicants import applicant_repo
+
+        created = await inquiry_service.create_inquiry(
+            test_org.id, test_user.id, _create_payload(),
+        )
+        applicant = await applicant_repo.create(
+            db,
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            inquiry_id=created.id,
+            legal_name="Alice",
+            stage="lead",
+        )
+        await db.commit()
+
+        result = await inquiry_service.get_inquiry(
+            test_org.id, test_user.id, created.id,
+        )
+        assert result.linked_applicant_id == applicant.id
+
 
 class TestListInbox:
     @pytest.mark.asyncio

--- a/apps/mybookkeeper/backend/tests/test_promote_service.py
+++ b/apps/mybookkeeper/backend/tests/test_promote_service.py
@@ -1,0 +1,452 @@
+"""Service-layer tests for promote_service (PR 3.2).
+
+Verifies the orchestration contract for Inquiry → Applicant promotion:
+- Auto-fills applicant fields from the inquiry's encrypted PII columns.
+- Wraps writes in unit_of_work — partial promote is impossible.
+- Emits exactly two events: ``applicant_events.lead`` + ``inquiry_events.converted``.
+- Advances the inquiry stage to ``converted``.
+- Idempotent: a second promote raises ``AlreadyPromotedError`` carrying the
+  existing applicant_id.
+- Tenant-isolated: cross-user / cross-org promotes raise ``LookupError``.
+- Refuses to promote terminal-stage inquiries (``declined`` / ``archived``).
+- Rolls back atomically on mid-transaction failures (no partial state).
+- PII round-trips through EncryptedString cleanly.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.applicants.applicant_event import ApplicantEvent
+from app.models.inquiries.inquiry import Inquiry
+from app.models.inquiries.inquiry_event import InquiryEvent
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.applicants import applicant_repo
+from app.repositories.inquiries import inquiry_repo
+from app.schemas.applicants.applicant_promote_request import ApplicantPromoteRequest
+from app.services.applicants import promote_service
+
+
+@pytest.fixture
+def patch_session(monkeypatch: pytest.MonkeyPatch, db: AsyncSession):
+    """Re-route promote_service's session factory to the test SQLite fixture.
+
+    aiosqlite + SQLAlchemy doesn't tolerate cross-task `await db.commit()`
+    calls in a fixture-style session — re-acquiring a cursor after commit
+    raises ``MissingGreenlet``. We flush instead so subsequent reads see
+    the writes; assertions at the end of the test inspect the same session
+    so we don't need a commit to round-trip data through the engine.
+
+    For the "rollback on mid-transaction failure" test we need a real
+    transaction boundary — that test uses ``db.begin_nested()`` around the
+    promote call.
+    """
+
+    @asynccontextmanager
+    async def _uow():
+        try:
+            yield db
+            await db.flush()
+        except Exception:
+            await db.rollback()
+            raise
+
+    monkeypatch.setattr(promote_service, "unit_of_work", _uow)
+    return None
+
+
+async def _seed_inquiry(
+    db: AsyncSession,
+    *,
+    org: Organization,
+    user: User,
+    stage: str = "new",
+    inquirer_name: str | None = "Alice Tester",
+    inquirer_email: str | None = "alice@example.com",
+    inquirer_employer: str | None = "Memorial Hermann",
+    desired_start_date: _dt.date | None = None,
+    desired_end_date: _dt.date | None = None,
+) -> Inquiry:
+    inquiry = await inquiry_repo.create(
+        db,
+        organization_id=org.id,
+        user_id=user.id,
+        source="direct",
+        received_at=_dt.datetime.now(_dt.timezone.utc),
+        inquirer_name=inquirer_name,
+        inquirer_email=inquirer_email,
+        inquirer_employer=inquirer_employer,
+        desired_start_date=desired_start_date,
+        desired_end_date=desired_end_date,
+    )
+    if stage != "new":
+        inquiry.stage = stage
+        await db.flush()
+    return inquiry
+
+
+@pytest.mark.asyncio
+async def test_promote_happy_path_autofills_pii_and_dates(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    inquiry = await _seed_inquiry(
+        db, org=test_org, user=test_user,
+        desired_start_date=_dt.date(2026, 6, 1),
+        desired_end_date=_dt.date(2026, 12, 1),
+    )
+    await db.flush()
+
+    applicant = await promote_service.promote_from_inquiry(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        inquiry_id=inquiry.id,
+        overrides=ApplicantPromoteRequest(),
+    )
+
+    assert applicant.legal_name == "Alice Tester"
+    assert applicant.employer_or_hospital == "Memorial Hermann"
+    assert applicant.contract_start == _dt.date(2026, 6, 1)
+    assert applicant.contract_end == _dt.date(2026, 12, 1)
+    assert applicant.stage == "lead"
+    assert applicant.inquiry_id == inquiry.id
+
+
+@pytest.mark.asyncio
+async def test_promote_overrides_take_precedence_over_inquiry_values(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    inquiry = await _seed_inquiry(db, org=test_org, user=test_user)
+    await db.flush()
+
+    applicant = await promote_service.promote_from_inquiry(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        inquiry_id=inquiry.id,
+        overrides=ApplicantPromoteRequest(
+            legal_name="Alice T. Override",
+            employer_or_hospital="Texas Children's",
+            dob=_dt.date(1990, 5, 12),
+            vehicle_make_model="Toyota Camry 2020",
+            smoker=False,
+            pets="1 small cat",
+            referred_by="Bob Referrer",
+        ),
+    )
+
+    assert applicant.legal_name == "Alice T. Override"
+    assert applicant.employer_or_hospital == "Texas Children's"
+    assert applicant.dob == "1990-05-12"
+    assert applicant.vehicle_make_model == "Toyota Camry 2020"
+    assert applicant.smoker is False
+    assert applicant.pets == "1 small cat"
+    assert applicant.referred_by == "Bob Referrer"
+
+
+@pytest.mark.asyncio
+async def test_promote_emits_two_events_one_per_domain(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    inquiry = await _seed_inquiry(db, org=test_org, user=test_user)
+    await db.flush()
+
+    applicant = await promote_service.promote_from_inquiry(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        inquiry_id=inquiry.id,
+        overrides=ApplicantPromoteRequest(),
+    )
+
+    applicant_events = (
+        await db.execute(
+            select(ApplicantEvent).where(ApplicantEvent.applicant_id == applicant.id),
+        )
+    ).scalars().all()
+    assert len(applicant_events) == 1
+    assert applicant_events[0].event_type == "lead"
+    assert applicant_events[0].actor == "host"
+
+    inquiry_events_after = (
+        await db.execute(
+            select(InquiryEvent).where(
+                InquiryEvent.inquiry_id == inquiry.id,
+                InquiryEvent.event_type == "converted",
+            ),
+        )
+    ).scalars().all()
+    assert len(inquiry_events_after) == 1
+    assert inquiry_events_after[0].actor == "host"
+
+
+@pytest.mark.asyncio
+async def test_promote_advances_inquiry_stage_to_converted(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    inquiry = await _seed_inquiry(
+        db, org=test_org, user=test_user, stage="replied",
+    )
+    await db.flush()
+
+    await promote_service.promote_from_inquiry(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        inquiry_id=inquiry.id,
+        overrides=ApplicantPromoteRequest(),
+    )
+
+    refreshed = await inquiry_repo.get_by_id(db, inquiry.id, test_org.id)
+    assert refreshed is not None
+    assert refreshed.stage == "converted"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "starting_stage",
+    ["new", "triaged", "replied", "screening_requested", "video_call_scheduled", "approved"],
+)
+async def test_promote_allowed_from_every_promotable_stage(
+    db: AsyncSession,
+    test_user: User,
+    test_org: Organization,
+    patch_session,
+    starting_stage: str,
+) -> None:
+    inquiry = await _seed_inquiry(
+        db, org=test_org, user=test_user, stage=starting_stage,
+    )
+    await db.flush()
+
+    applicant = await promote_service.promote_from_inquiry(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        inquiry_id=inquiry.id,
+        overrides=ApplicantPromoteRequest(),
+    )
+    assert applicant.stage == "lead"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_stage", ["declined", "archived"])
+async def test_promote_rejects_terminal_stages(
+    db: AsyncSession,
+    test_user: User,
+    test_org: Organization,
+    patch_session,
+    terminal_stage: str,
+) -> None:
+    inquiry = await _seed_inquiry(
+        db, org=test_org, user=test_user, stage=terminal_stage,
+    )
+    await db.flush()
+
+    with pytest.raises(promote_service.InquiryNotPromotableError) as exc_info:
+        await promote_service.promote_from_inquiry(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            inquiry_id=inquiry.id,
+            overrides=ApplicantPromoteRequest(),
+        )
+    assert exc_info.value.stage == terminal_stage
+
+
+@pytest.mark.asyncio
+async def test_promote_idempotent_second_call_returns_already_promoted_with_existing_id(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    inquiry = await _seed_inquiry(db, org=test_org, user=test_user)
+    await db.flush()
+
+    first = await promote_service.promote_from_inquiry(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        inquiry_id=inquiry.id,
+        overrides=ApplicantPromoteRequest(),
+    )
+    # Capture the id BEFORE the second call so a transaction rollback in
+    # the AlreadyPromotedError path can't expire the attribute.
+    first_id = first.id
+
+    with pytest.raises(promote_service.AlreadyPromotedError) as exc_info:
+        await promote_service.promote_from_inquiry(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            inquiry_id=inquiry.id,
+            overrides=ApplicantPromoteRequest(),
+        )
+    assert exc_info.value.applicant_id == first_id
+
+
+@pytest.mark.asyncio
+async def test_promote_cross_org_raises_lookup(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    inquiry = await _seed_inquiry(db, org=test_org, user=test_user)
+    await db.flush()
+
+    with pytest.raises(LookupError):
+        await promote_service.promote_from_inquiry(
+            organization_id=uuid.uuid4(),  # different org
+            user_id=test_user.id,
+            inquiry_id=inquiry.id,
+            overrides=ApplicantPromoteRequest(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_promote_cross_user_raises_lookup(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    """User A's inquiry must not be promotable by user B even within the same org.
+
+    The repo's tenant scoping is (organization_id, user_id) — promote_service
+    must respect both halves.
+    """
+    inquiry = await _seed_inquiry(db, org=test_org, user=test_user)
+    await db.flush()
+
+    with pytest.raises(LookupError):
+        await promote_service.promote_from_inquiry(
+            organization_id=test_org.id,
+            user_id=uuid.uuid4(),  # different user
+            inquiry_id=inquiry.id,
+            overrides=ApplicantPromoteRequest(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_promote_pii_round_trips_decrypted_to_decrypted(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    """Sanity check that EncryptedString → plaintext → EncryptedString preserves values.
+
+    The service reads the inquiry (plaintext) and writes the applicant
+    (re-encrypted at bind time). After persisting, reading the applicant
+    back via a fresh query must yield the same plaintext.
+    """
+    inquiry = await _seed_inquiry(
+        db, org=test_org, user=test_user,
+        inquirer_name="José Ñoño",
+        inquirer_employer="St. Anthony's Hôpital",
+    )
+    await db.flush()
+
+    applicant = await promote_service.promote_from_inquiry(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        inquiry_id=inquiry.id,
+        overrides=ApplicantPromoteRequest(),
+    )
+    applicant_id = applicant.id
+
+    # Drop the cached ORM identity so the next get() actually re-decodes
+    # ciphertext via EncryptedString.process_result_value rather than
+    # returning the in-memory plaintext.
+    db.expunge_all()
+
+    refreshed = await applicant_repo.get(
+        db,
+        applicant_id=applicant_id,
+        organization_id=test_org.id,
+        user_id=test_user.id,
+    )
+    assert refreshed is not None
+    assert refreshed.legal_name == "José Ñoño"
+    assert refreshed.employer_or_hospital == "St. Anthony's Hôpital"
+
+
+@pytest.mark.asyncio
+async def test_promote_inquiry_not_found_raises_lookup(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    with pytest.raises(LookupError):
+        await promote_service.promote_from_inquiry(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            inquiry_id=uuid.uuid4(),  # nonexistent
+            overrides=ApplicantPromoteRequest(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_promote_atomicity_rolls_back_when_post_create_step_fails(
+    db: AsyncSession,
+    test_user: User,
+    test_org: Organization,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Inject a failure mid-transaction (after applicant_repo.create runs) and
+    assert no Applicant row remains — rollback must be atomic across both
+    domains.
+
+    Unlike the other tests, this one DOESN'T use the shared ``patch_session``
+    fixture. It needs a savepoint-style boundary (``begin_nested``) so the
+    rollback inside the patched ``unit_of_work`` only affects the changes
+    made inside the service, not the seeded inquiry.
+    """
+    from contextlib import asynccontextmanager
+
+    # Seed the inquiry inside an outer transaction (no flush yet — we'll
+    # flush before the savepoint so the row is visible to the service).
+    inquiry = await _seed_inquiry(db, org=test_org, user=test_user)
+    await db.flush()
+
+    # Patched unit_of_work uses a SAVEPOINT so a rollback only undoes the
+    # service's writes, leaving the seeded inquiry intact for assertions.
+    @asynccontextmanager
+    async def _uow_savepoint():
+        savepoint = await db.begin_nested()
+        try:
+            yield db
+            await savepoint.commit()
+        except Exception:
+            await savepoint.rollback()
+            raise
+
+    monkeypatch.setattr(promote_service, "unit_of_work", _uow_savepoint)
+
+    async def _boom(*_args: object, **_kwargs: object) -> object:
+        raise RuntimeError("simulated mid-transaction failure")
+
+    # Patch the inquiry_event create so the applicant create + applicant
+    # event run, but the inquiry_event write blows up — exercises the
+    # rollback path AFTER the applicant has been written.
+    monkeypatch.setattr(
+        "app.services.applicants.promote_service.inquiry_event_repo.create",
+        _boom,
+    )
+
+    with pytest.raises(RuntimeError, match="simulated"):
+        await promote_service.promote_from_inquiry(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            inquiry_id=inquiry.id,
+            overrides=ApplicantPromoteRequest(),
+        )
+
+    # Drop in-memory ORM cache so the assertions actually re-query the DB
+    # rather than returning stale objects whose state pre-dated the rollback.
+    db.expunge_all()
+
+    # Critical: no Applicant row persisted, no event rows persisted, inquiry
+    # stage unchanged.
+    applicants = (
+        await db.execute(
+            select(Applicant).where(Applicant.inquiry_id == inquiry.id),
+        )
+    ).scalars().all()
+    assert applicants == []
+
+    applicant_events = (
+        await db.execute(select(ApplicantEvent))
+    ).scalars().all()
+    assert applicant_events == []
+
+    refreshed = await inquiry_repo.get_by_id(db, inquiry.id, test_org.id)
+    assert refreshed is not None
+    assert refreshed.stage == "new"

--- a/apps/mybookkeeper/frontend/e2e/applicant-promote.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/applicant-promote.spec.ts
@@ -1,0 +1,173 @@
+import { test, expect, type APIRequestContext, type Page } from "./fixtures/auth";
+
+/**
+ * PR 3.2 — Inquiry → Applicant promotion E2E.
+ *
+ * Covers the full host-driven flow:
+ * 1. Seed an inquiry with PII fields populated.
+ * 2. Open InquiryDetail, click "Promote to applicant".
+ * 3. Verify the panel pre-fills from the inquiry.
+ * 4. Submit, verify navigation to the new applicant detail page.
+ * 5. Verify the new applicant carries the inquiry's name + employer.
+ * 6. Try promoting the same inquiry again → 409 path navigates to existing.
+ *
+ * Cleanup deletes seeded inquiries + applicants per
+ * ``feedback_clean_test_data``.
+ */
+
+interface SeedInquiryPayload {
+  source: "FF" | "TNH" | "direct" | "other";
+  external_inquiry_id?: string | null;
+  inquirer_name?: string | null;
+  inquirer_email?: string | null;
+  inquirer_employer?: string | null;
+  desired_start_date?: string | null;
+  desired_end_date?: string | null;
+}
+
+async function seedInquiry(
+  api: APIRequestContext,
+  payload: SeedInquiryPayload,
+): Promise<string> {
+  const res = await api.post("/test/seed-inquiry", {
+    data: { received_at: new Date().toISOString(), ...payload },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedInquiry failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function deleteInquiry(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/test/inquiries/${id}`).catch(() => {});
+}
+
+async function deleteApplicant(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/test/applicants/${id}`).catch(() => {});
+}
+
+async function waitForInquiryDetail(page: Page, inquiryId: string): Promise<void> {
+  await expect(page).toHaveURL(new RegExp(`/inquiries/${inquiryId}$`));
+  await page.waitForLoadState("networkidle");
+  await expect(page.getByTestId("inquiry-action-row")).toBeVisible({
+    timeout: 10000,
+  });
+}
+
+test.describe("Inquiry → Applicant promotion (PR 3.2)", () => {
+  test("happy path: seed inquiry, promote, navigate to new applicant; second promote routes to existing", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const inquirerName = `E2E Promote ${runId}`;
+    const employer = `E2E Hospital ${runId}`;
+
+    const seededInquiries: string[] = [];
+    const seededApplicantIds: string[] = [];
+
+    try {
+      const inquiryId = await seedInquiry(api, {
+        source: "direct",
+        inquirer_name: inquirerName,
+        inquirer_email: `e2e-promote-${runId}@example.com`,
+        inquirer_employer: employer,
+        desired_start_date: "2026-06-01",
+        desired_end_date: "2026-12-01",
+      });
+      seededInquiries.push(inquiryId);
+
+      // Open detail page.
+      await page.goto(`/inquiries/${inquiryId}`);
+      await waitForInquiryDetail(page, inquiryId);
+
+      // Click "Promote to applicant".
+      await page.getByTestId("inquiry-promote-button").click();
+      await expect(page.getByTestId("promote-from-inquiry-panel")).toBeVisible();
+
+      // Pre-fill verification — every field with an inquiry source should
+      // already carry the value.
+      await expect(page.getByTestId("promote-form-legal-name")).toHaveValue(
+        inquirerName,
+      );
+      await expect(page.getByTestId("promote-form-employer")).toHaveValue(
+        employer,
+      );
+      await expect(page.getByTestId("promote-form-contract-start")).toHaveValue(
+        "2026-06-01",
+      );
+      await expect(page.getByTestId("promote-form-contract-end")).toHaveValue(
+        "2026-12-01",
+      );
+
+      // Submit.
+      await page.getByTestId("promote-form-submit").click();
+
+      // Should navigate to the new applicant. URL pattern: /applicants/<uuid>.
+      await page.waitForURL(/\/applicants\/[0-9a-f-]{36}$/);
+      const url = new URL(page.url());
+      const newApplicantId = url.pathname.split("/").pop()!;
+      seededApplicantIds.push(newApplicantId);
+
+      // Reveal sensitive section so we can verify the legal name made it through.
+      await expect(page.getByTestId("sensitive-data-section")).toBeVisible({
+        timeout: 10000,
+      });
+      await page.getByTestId("sensitive-data-toggle").click();
+      await expect(page.getByTestId("sensitive-legal-name")).toHaveText(
+        inquirerName,
+      );
+      await expect(page.getByTestId("sensitive-employer")).toHaveText(employer);
+
+      // ---- Second promote attempt: navigate back to the inquiry detail. ----
+      await page.goto(`/inquiries/${inquiryId}`);
+      await waitForInquiryDetail(page, inquiryId);
+
+      // Now the detail page should show "View applicant" instead of
+      // "Promote to applicant" (the inquiry response carries
+      // linked_applicant_id).
+      await expect(page.getByTestId("inquiry-view-applicant-link")).toBeVisible();
+      await expect(page.getByTestId("inquiry-promote-button")).toHaveCount(0);
+
+      // Click the link → lands on the existing applicant detail page.
+      await page.getByTestId("inquiry-view-applicant-link").click();
+      await expect(page).toHaveURL(
+        new RegExp(`/applicants/${newApplicantId}$`),
+      );
+    } finally {
+      for (const id of seededApplicantIds) await deleteApplicant(api, id);
+      for (const id of seededInquiries) await deleteInquiry(api, id);
+    }
+  });
+
+  test("declined inquiries cannot be promoted — button is disabled", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const seededInquiries: string[] = [];
+
+    try {
+      const inquiryId = await seedInquiry(api, {
+        source: "direct",
+        inquirer_name: `E2E Declined ${runId}`,
+      });
+      seededInquiries.push(inquiryId);
+
+      // Move it to declined via the inquiry stage dropdown.
+      await page.goto(`/inquiries/${inquiryId}`);
+      await waitForInquiryDetail(page, inquiryId);
+      await page.getByTestId("inquiry-decline-button").click();
+      await page.getByRole("button", { name: /^decline$/i }).click();
+      await page.waitForLoadState("networkidle");
+
+      // Promote button should now be disabled.
+      const promoteBtn = page.getByTestId("inquiry-promote-button");
+      await expect(promoteBtn).toBeVisible();
+      await expect(promoteBtn).toBeDisabled();
+    } finally {
+      for (const id of seededInquiries) await deleteInquiry(api, id);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/InquiryDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InquiryDetail.test.tsx
@@ -25,6 +25,7 @@ const mockInquiry: InquiryResponse = {
   notes: "Sounds promising — short pet on premises mention.",
   received_at: "2026-04-25T10:00:00Z",
   email_message_id: null,
+  linked_applicant_id: null,
   messages: [
     {
       id: "msg-1",

--- a/apps/mybookkeeper/frontend/src/__tests__/PromoteFromInquiryPanel.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PromoteFromInquiryPanel.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { store } from "@/shared/store";
+import PromoteFromInquiryPanel from "@/app/features/applicants/PromoteFromInquiryPanel";
+import type { ApplicantPromoteRequest } from "@/shared/types/applicant/applicant-promote-request";
+import type { InquiryResponse } from "@/shared/types/inquiry/inquiry-response";
+
+interface PromoteArgs {
+  inquiryId: string;
+  data: ApplicantPromoteRequest;
+}
+
+const promoteUnwrap = vi.fn();
+const promoteMutation = vi.fn<(args: PromoteArgs) => { unwrap: typeof promoteUnwrap }>(
+  () => ({ unwrap: promoteUnwrap }),
+);
+const navigateMock = vi.fn();
+const showErrorMock = vi.fn();
+const showSuccessMock = vi.fn();
+
+vi.mock("@/shared/store/applicantsApi", () => ({
+  usePromoteFromInquiryMutation: () => [promoteMutation, { isLoading: false }],
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return {
+    ...actual,
+    useNavigate: () => navigateMock,
+  };
+});
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: (m: string) => showErrorMock(m),
+  showSuccess: (m: string) => showSuccessMock(m),
+  subscribe: () => () => {},
+}));
+
+function buildInquiry(overrides: Partial<InquiryResponse> = {}): InquiryResponse {
+  return {
+    id: "inq-1",
+    organization_id: "org-1",
+    user_id: "user-1",
+    listing_id: null,
+    source: "FF",
+    external_inquiry_id: "I-12345",
+    inquirer_name: "Alice Tester",
+    inquirer_email: "alice@example.com",
+    inquirer_phone: null,
+    inquirer_employer: "Memorial Hermann",
+    desired_start_date: "2026-06-01",
+    desired_end_date: "2026-12-01",
+    stage: "new",
+    gut_rating: null,
+    notes: null,
+    received_at: "2026-04-25T10:00:00Z",
+    email_message_id: null,
+    linked_applicant_id: null,
+    messages: [],
+    events: [],
+    created_at: "2026-04-25T10:00:00Z",
+    updated_at: "2026-04-25T10:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderPanel(inquiry: InquiryResponse) {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <PromoteFromInquiryPanel inquiry={inquiry} onClose={vi.fn()} />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe("PromoteFromInquiryPanel", () => {
+  beforeEach(() => {
+    promoteMutation.mockClear();
+    promoteUnwrap.mockReset();
+    navigateMock.mockClear();
+    showErrorMock.mockClear();
+    showSuccessMock.mockClear();
+  });
+
+  it("pre-fills name, employer, and contract dates from the inquiry", () => {
+    renderPanel(buildInquiry());
+    expect(
+      (screen.getByTestId("promote-form-legal-name") as HTMLInputElement).value,
+    ).toBe("Alice Tester");
+    expect(
+      (screen.getByTestId("promote-form-employer") as HTMLInputElement).value,
+    ).toBe("Memorial Hermann");
+    expect(
+      (screen.getByTestId("promote-form-contract-start") as HTMLInputElement).value,
+    ).toBe("2026-06-01");
+    expect(
+      (screen.getByTestId("promote-form-contract-end") as HTMLInputElement).value,
+    ).toBe("2026-12-01");
+  });
+
+  it("shows an orange warning hint next to fields the inquiry didn't supply", () => {
+    // Inquiry with NO employer or dates — those fields should show the hint.
+    const sparse = buildInquiry({
+      inquirer_employer: null,
+      desired_start_date: null,
+      desired_end_date: null,
+    });
+    renderPanel(sparse);
+    // The dob, vehicle, smoker, referred_by, and pets fields always show the hint
+    // (no inquiry source). Plus employer + 2 dates. Total ≥ 5.
+    const hints = screen.getAllByTestId("promote-missing-hint");
+    expect(hints.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it("does not show a missing-hint next to inquiry-supplied fields", () => {
+    renderPanel(buildInquiry());
+    // Locate the legal name input's wrapper and verify there's no warning
+    // icon as a sibling.
+    const legalNameInput = screen.getByTestId("promote-form-legal-name");
+    const wrapper = legalNameInput.parentElement!;
+    expect(wrapper.querySelector('[data-testid="promote-missing-hint"]')).toBeNull();
+  });
+
+  it("blocks submission and shows an inline error when end date is before start", async () => {
+    const user = userEvent.setup();
+    renderPanel(buildInquiry());
+
+    // Set end before start.
+    const endInput = screen.getByTestId("promote-form-contract-end") as HTMLInputElement;
+    await user.clear(endInput);
+    await user.type(endInput, "2026-05-01");
+
+    await user.click(screen.getByTestId("promote-form-submit"));
+
+    expect(
+      await screen.findByTestId("promote-form-contract-end-error"),
+    ).toHaveTextContent(/end date can't be before start date/i);
+    expect(promoteMutation).not.toHaveBeenCalled();
+  });
+
+  it("calls the promote mutation on submit and navigates to the new applicant", async () => {
+    const user = userEvent.setup();
+    promoteUnwrap.mockResolvedValue({
+      id: "new-applicant-id",
+      stage: "lead",
+    });
+    renderPanel(buildInquiry());
+
+    await user.click(screen.getByTestId("promote-form-submit"));
+
+    // Wait for the mutation to fire.
+    await vi.waitFor(() => {
+      expect(promoteMutation).toHaveBeenCalledTimes(1);
+    });
+    const args = promoteMutation.mock.calls[0][0];
+    expect(args.inquiryId).toBe("inq-1");
+    expect(args.data.legal_name).toBe("Alice Tester");
+    expect(args.data.employer_or_hospital).toBe("Memorial Hermann");
+
+    await vi.waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith("/applicants/new-applicant-id");
+    });
+    expect(showSuccessMock).toHaveBeenCalledWith("Promoted to applicant.");
+  });
+
+  it("on 409 already_promoted, navigates to the existing applicant", async () => {
+    const user = userEvent.setup();
+    promoteUnwrap.mockRejectedValue({
+      status: 409,
+      data: {
+        detail: {
+          code: "already_promoted",
+          message: "already",
+          applicant_id: "existing-applicant-id",
+        },
+      },
+    });
+    renderPanel(buildInquiry());
+
+    await user.click(screen.getByTestId("promote-form-submit"));
+
+    await vi.waitFor(() => {
+      expect(navigateMock).toHaveBeenCalledWith(
+        "/applicants/existing-applicant-id",
+      );
+    });
+    expect(showErrorMock).toHaveBeenCalled();
+  });
+
+  it("on 409 not_promotable, shows an error toast without navigating", async () => {
+    const user = userEvent.setup();
+    promoteUnwrap.mockRejectedValue({
+      status: 409,
+      data: {
+        detail: {
+          code: "not_promotable",
+          message: "declined",
+          stage: "declined",
+        },
+      },
+    });
+    renderPanel(buildInquiry());
+
+    await user.click(screen.getByTestId("promote-form-submit"));
+
+    await vi.waitFor(() => {
+      expect(showErrorMock).toHaveBeenCalled();
+    });
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it("converts blank fields to null in the request body", async () => {
+    const user = userEvent.setup();
+    promoteUnwrap.mockResolvedValue({ id: "new-id", stage: "lead" });
+    // Inquiry with no employer — the form leaves the employer input empty.
+    renderPanel(buildInquiry({ inquirer_employer: null }));
+
+    await user.click(screen.getByTestId("promote-form-submit"));
+
+    await vi.waitFor(() => {
+      expect(promoteMutation).toHaveBeenCalledTimes(1);
+    });
+    const data = promoteMutation.mock.calls[0][0].data;
+    expect(data.employer_or_hospital).toBeNull();
+    expect(data.dob).toBeNull();
+    expect(data.vehicle_make_model).toBeNull();
+    expect(data.smoker).toBeNull();
+    expect(data.pets).toBeNull();
+    expect(data.referred_by).toBeNull();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/PromoteFromInquiryPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/PromoteFromInquiryPanel.tsx
@@ -1,0 +1,356 @@
+import { useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { useNavigate } from "react-router-dom";
+import { AlertTriangle } from "lucide-react";
+import Panel, { PanelCloseButton } from "@/shared/components/ui/Panel";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import Button from "@/shared/components/ui/Button";
+import FormField from "@/shared/components/ui/FormField";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import {
+  APPLICANT_EMPLOYER_MAX,
+  APPLICANT_LEGAL_NAME_MAX,
+  APPLICANT_PETS_MAX,
+  APPLICANT_REFERRED_BY_MAX,
+  APPLICANT_VEHICLE_MAX,
+  MISSING_FIELD_TOOLTIP,
+  PROMOTE_TOAST_MESSAGES,
+} from "@/shared/lib/applicant-promote-constants";
+import { usePromoteFromInquiryMutation } from "@/shared/store/applicantsApi";
+import type { ApplicantPromoteRequest } from "@/shared/types/applicant/applicant-promote-request";
+import type { ApplicantPromoteConflictDetail } from "@/shared/types/applicant/applicant-promote-conflict";
+import type { InquiryResponse } from "@/shared/types/inquiry/inquiry-response";
+
+interface Props {
+  inquiry: InquiryResponse;
+  onClose: () => void;
+}
+
+interface PromoteFormValues {
+  legal_name: string;
+  dob: string;
+  employer_or_hospital: string;
+  contract_start: string;
+  contract_end: string;
+  vehicle_make_model: string;
+  smoker_choice: "" | "yes" | "no";
+  pets: string;
+  referred_by: string;
+}
+
+/** Marker shown next to fields the inquiry didn't supply, so the host knows
+ * they can fill it in (or leave blank — none are required for promotion). */
+function MissingHint() {
+  return (
+    <span
+      className="inline-flex items-center text-orange-500"
+      title={MISSING_FIELD_TOOLTIP}
+      aria-label={MISSING_FIELD_TOOLTIP}
+      data-testid="promote-missing-hint"
+    >
+      <AlertTriangle className="h-3.5 w-3.5" aria-hidden="true" />
+    </span>
+  );
+}
+
+function buildDefaults(inquiry: InquiryResponse): PromoteFormValues {
+  return {
+    legal_name: inquiry.inquirer_name ?? "",
+    dob: "",
+    employer_or_hospital: inquiry.inquirer_employer ?? "",
+    contract_start: inquiry.desired_start_date ?? "",
+    contract_end: inquiry.desired_end_date ?? "",
+    vehicle_make_model: "",
+    smoker_choice: "",
+    pets: "",
+    referred_by: "",
+  };
+}
+
+function formValuesToRequest(values: PromoteFormValues): ApplicantPromoteRequest {
+  // Empty strings represent "host left this blank" — send null so the
+  // backend uses inquiry-side auto-fill where available.
+  const trim = (s: string) => (s.trim() === "" ? null : s.trim());
+  return {
+    legal_name: trim(values.legal_name),
+    dob: values.dob === "" ? null : values.dob,
+    employer_or_hospital: trim(values.employer_or_hospital),
+    contract_start: values.contract_start === "" ? null : values.contract_start,
+    contract_end: values.contract_end === "" ? null : values.contract_end,
+    vehicle_make_model: trim(values.vehicle_make_model),
+    smoker:
+      values.smoker_choice === ""
+        ? null
+        : values.smoker_choice === "yes",
+    pets: trim(values.pets),
+    referred_by: trim(values.referred_by),
+  };
+}
+
+/**
+ * Right-side slide-in (mobile: bottom sheet via vaul) for promoting an
+ * inquiry to an applicant.
+ *
+ * Pre-fills name / employer / contract dates from the inquiry's encrypted
+ * PII columns (decrypted by the backend on read). Fields with no inquiry
+ * source show an orange warning icon + tooltip so the host knows they can
+ * fill them in.
+ *
+ * Conflict handling:
+ * - 409 ``already_promoted`` → toast "I already promoted this inquiry"
+ *   with a "View" action that navigates to the existing applicant.
+ * - 409 ``not_promotable`` → toast explaining the inquiry is terminal.
+ * - Other errors → conversational AI-tone retry prompt.
+ */
+export default function PromoteFromInquiryPanel({ inquiry, onClose }: Props) {
+  const navigate = useNavigate();
+  const [promote, { isLoading }] = usePromoteFromInquiryMutation();
+  const defaults = useMemo<PromoteFormValues>(
+    () => buildDefaults(inquiry),
+    [inquiry],
+  );
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<PromoteFormValues>({ defaultValues: defaults });
+
+  const startDate = watch("contract_start");
+
+  async function onSubmit(values: PromoteFormValues) {
+    try {
+      const created = await promote({
+        inquiryId: inquiry.id,
+        data: formValuesToRequest(values),
+      }).unwrap();
+      showSuccess(PROMOTE_TOAST_MESSAGES.success);
+      navigate(`/applicants/${created.id}`);
+      onClose();
+    } catch (err) {
+      handlePromoteError(err);
+    }
+  }
+
+  /** Map RTK Query error envelope → user-facing toast.
+   *
+   * For ``already_promoted`` we navigate the host to the existing applicant
+   * after a brief toast — clearer than asking them to click a "View" action
+   * inside an error banner, and our toast-store is intentionally
+   * action-free to keep the API surface minimal. */
+  function handlePromoteError(err: unknown): void {
+    const detail = extractConflictDetail(err);
+    if (detail?.code === "already_promoted") {
+      showError(PROMOTE_TOAST_MESSAGES.alreadyPromoted);
+      navigate(`/applicants/${detail.applicant_id}`);
+      onClose();
+      return;
+    }
+    if (detail?.code === "not_promotable") {
+      showError(PROMOTE_TOAST_MESSAGES.notPromotable);
+      return;
+    }
+    showError(PROMOTE_TOAST_MESSAGES.genericError);
+  }
+
+  return (
+    <Panel position="right" onClose={onClose} width="560px">
+      <div
+        className="flex flex-col flex-1 overflow-hidden"
+        data-testid="promote-from-inquiry-panel"
+      >
+        {/* Header */}
+        <div className="px-5 py-4 border-b flex items-start justify-between">
+          <div>
+            <h3 className="font-medium text-base">Promote to applicant</h3>
+            <p className="text-xs text-muted-foreground">
+              I'll pre-fill what I can from the inquiry. You can edit anything.
+            </p>
+          </div>
+          <PanelCloseButton onClose={onClose} />
+        </div>
+
+        <form
+          id="promote-form"
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex-1 overflow-y-auto px-5 py-4 space-y-4"
+          data-testid="promote-form"
+        >
+          <FormField
+            label="Legal name"
+            highlight={!inquiry.inquirer_name}
+          >
+            <div className="flex items-center gap-2">
+              <input
+                {...register("legal_name", {
+                  maxLength: APPLICANT_LEGAL_NAME_MAX,
+                })}
+                data-testid="promote-form-legal-name"
+                className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+              />
+              {!inquiry.inquirer_name ? <MissingHint /> : null}
+            </div>
+          </FormField>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <FormField label="Date of birth" highlight>
+              <div className="flex items-center gap-2">
+                <input
+                  type="date"
+                  {...register("dob")}
+                  data-testid="promote-form-dob"
+                  className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+                />
+                <MissingHint />
+              </div>
+            </FormField>
+            <FormField
+              label="Employer / hospital"
+              highlight={!inquiry.inquirer_employer}
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  {...register("employer_or_hospital", {
+                    maxLength: APPLICANT_EMPLOYER_MAX,
+                  })}
+                  data-testid="promote-form-employer"
+                  className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+                />
+                {!inquiry.inquirer_employer ? <MissingHint /> : null}
+              </div>
+            </FormField>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <FormField
+              label="Contract start"
+              highlight={!inquiry.desired_start_date}
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  type="date"
+                  {...register("contract_start")}
+                  data-testid="promote-form-contract-start"
+                  className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+                />
+                {!inquiry.desired_start_date ? <MissingHint /> : null}
+              </div>
+            </FormField>
+            <FormField
+              label="Contract end"
+              highlight={!inquiry.desired_end_date}
+            >
+              <div className="flex items-center gap-2">
+                <input
+                  type="date"
+                  {...register("contract_end", {
+                    validate: (value) => {
+                      if (!value || !startDate) return true;
+                      return (
+                        value >= startDate ||
+                        "End date can't be before start date"
+                      );
+                    },
+                  })}
+                  data-testid="promote-form-contract-end"
+                  className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+                />
+                {!inquiry.desired_end_date ? <MissingHint /> : null}
+              </div>
+              {errors.contract_end ? (
+                <p
+                  className="text-xs text-red-600 mt-1"
+                  data-testid="promote-form-contract-end-error"
+                >
+                  {errors.contract_end.message}
+                </p>
+              ) : null}
+            </FormField>
+          </div>
+
+          <FormField label="Vehicle (make / model)" highlight>
+            <div className="flex items-center gap-2">
+              <input
+                {...register("vehicle_make_model", {
+                  maxLength: APPLICANT_VEHICLE_MAX,
+                })}
+                placeholder="e.g. Toyota Camry 2020"
+                data-testid="promote-form-vehicle"
+                className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+              />
+              <MissingHint />
+            </div>
+          </FormField>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <FormField label="Smoker?" highlight>
+              <select
+                {...register("smoker_choice")}
+                data-testid="promote-form-smoker"
+                className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+              >
+                <option value="">Unknown</option>
+                <option value="no">No</option>
+                <option value="yes">Yes</option>
+              </select>
+            </FormField>
+            <FormField label="Referred by" highlight>
+              <input
+                {...register("referred_by", {
+                  maxLength: APPLICANT_REFERRED_BY_MAX,
+                })}
+                data-testid="promote-form-referred-by"
+                className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+              />
+            </FormField>
+          </div>
+
+          <FormField label="Pets" highlight>
+            <textarea
+              {...register("pets", { maxLength: APPLICANT_PETS_MAX })}
+              placeholder="e.g. 1 small cat, neutered"
+              data-testid="promote-form-pets"
+              rows={2}
+              className="w-full border rounded-md px-3 py-2 text-sm"
+            />
+          </FormField>
+        </form>
+
+        {/* Footer */}
+        <div className="px-5 py-4 border-t flex items-center justify-end gap-2">
+          <Button variant="secondary" size="md" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton
+            type="submit"
+            form="promote-form"
+            variant="primary"
+            size="md"
+            isLoading={isLoading}
+            loadingText="Promoting..."
+            data-testid="promote-form-submit"
+          >
+            Promote
+          </LoadingButton>
+        </div>
+      </div>
+    </Panel>
+  );
+}
+
+/** Narrow an unknown error from RTK Query into the typed conflict shape. */
+function extractConflictDetail(
+  err: unknown,
+): ApplicantPromoteConflictDetail | null {
+  if (typeof err !== "object" || err === null) return null;
+  const errObj = err as { status?: number; data?: { detail?: unknown } };
+  if (errObj.status !== 409) return null;
+  const detail = errObj.data?.detail;
+  if (typeof detail !== "object" || detail === null) return null;
+  const code = (detail as { code?: unknown }).code;
+  if (code === "already_promoted" || code === "not_promotable") {
+    return detail as ApplicantPromoteConflictDetail;
+  }
+  return null;
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/InquiryDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/InquiryDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
-import { ArrowLeft, Archive, Ban, Mail } from "lucide-react";
+import { ArrowLeft, Archive, Ban, Mail, UserPlus } from "lucide-react";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import Button from "@/shared/components/ui/Button";
@@ -26,6 +26,11 @@ import InquiryEventTimeline from "@/app/features/inquiries/InquiryEventTimeline"
 import InquiryMessageThread from "@/app/features/inquiries/InquiryMessageThread";
 import InquiryNotesEditor from "@/app/features/inquiries/InquiryNotesEditor";
 import InquiryReplyPanel from "@/app/features/inquiries/InquiryReplyPanel";
+import PromoteFromInquiryPanel from "@/app/features/applicants/PromoteFromInquiryPanel";
+
+/** Inquiry stages that can't be promoted. Mirrors the backend
+ * ``_NON_PROMOTABLE_STAGES`` set in ``services/applicants/promote_service.py``. */
+const NON_PROMOTABLE_INQUIRY_STAGES = ["declined", "archived"] as const;
 
 export default function InquiryDetail() {
   const { inquiryId } = useParams<{ inquiryId: string }>();
@@ -33,6 +38,7 @@ export default function InquiryDetail() {
   const [showDeclineConfirm, setShowDeclineConfirm] = useState(false);
   const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
   const [showReplyPanel, setShowReplyPanel] = useState(false);
+  const [showPromotePanel, setShowPromotePanel] = useState(false);
   const [updateInquiry, { isLoading: isPatching }] = useUpdateInquiryMutation();
   const [deleteInquiry, { isLoading: isDeleting }] = useDeleteInquiryMutation();
 
@@ -143,6 +149,38 @@ export default function InquiryDetail() {
               <Mail className="h-4 w-4 mr-1" />
               Reply with template
             </Button>
+            {inquiry.linked_applicant_id ? (
+              <Link
+                to={`/applicants/${inquiry.linked_applicant_id}`}
+                data-testid="inquiry-view-applicant-link"
+                className="inline-flex items-center font-medium border rounded-md px-4 py-2 text-sm min-h-[44px] hover:bg-muted"
+              >
+                <UserPlus className="h-4 w-4 mr-1" aria-hidden="true" />
+                View applicant
+              </Link>
+            ) : (
+              <Button
+                variant="secondary"
+                size="md"
+                onClick={() => setShowPromotePanel(true)}
+                data-testid="inquiry-promote-button"
+                disabled={
+                  (NON_PROMOTABLE_INQUIRY_STAGES as readonly string[]).includes(
+                    inquiry.stage,
+                  )
+                }
+                title={
+                  (NON_PROMOTABLE_INQUIRY_STAGES as readonly string[]).includes(
+                    inquiry.stage,
+                  )
+                    ? "Can't promote a declined or archived inquiry."
+                    : undefined
+                }
+              >
+                <UserPlus className="h-4 w-4 mr-1" aria-hidden="true" />
+                Promote to applicant
+              </Button>
+            )}
             <Button
               variant="secondary"
               size="md"
@@ -295,6 +333,13 @@ export default function InquiryDetail() {
             <InquiryReplyPanel
               inquiryId={inquiry.id}
               onClose={() => setShowReplyPanel(false)}
+            />
+          ) : null}
+
+          {showPromotePanel ? (
+            <PromoteFromInquiryPanel
+              inquiry={inquiry}
+              onClose={() => setShowPromotePanel(false)}
             />
           ) : null}
         </>

--- a/apps/mybookkeeper/frontend/src/shared/lib/applicant-promote-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/applicant-promote-constants.ts
@@ -1,0 +1,35 @@
+/**
+ * Constants for the inquiry → applicant promotion flow (PR 3.2).
+ *
+ * Mirrors the backend constants in ``app/core/applicant_constants.py``.
+ * Keep them in sync — divergence between the two would let the UI accept
+ * input the API rejects (or vice versa).
+ */
+
+/** Minimum applicant age in years — matches APPLICANT_MINIMUM_AGE_YEARS. */
+export const APPLICANT_MINIMUM_AGE_YEARS = 18;
+
+/** Field-length caps — match the backend column ``String(N)`` lengths. */
+export const APPLICANT_LEGAL_NAME_MAX = 255;
+export const APPLICANT_EMPLOYER_MAX = 255;
+export const APPLICANT_VEHICLE_MAX = 255;
+export const APPLICANT_PETS_MAX = 1000;
+export const APPLICANT_REFERRED_BY_MAX = 255;
+
+/**
+ * Toast copy. Conversational AI-tone per CLAUDE.md UX guidelines —
+ * first-person, casual, no system-log phrasing.
+ */
+export const PROMOTE_TOAST_MESSAGES = {
+  success: "Promoted to applicant.",
+  alreadyPromoted: "I already promoted this inquiry. Want to view that applicant?",
+  notPromotable: "I can't promote this one — it's already declined or archived.",
+  genericError: "I wasn't able to promote that. Want to try again?",
+} as const;
+
+/**
+ * Tooltip shown next to fields the inquiry didn't supply. Conversational
+ * tone matches the rest of the AI-facing UI.
+ */
+export const MISSING_FIELD_TOOLTIP =
+  "I couldn't find this in the inquiry — fill it in if you have it.";

--- a/apps/mybookkeeper/frontend/src/shared/store/applicantsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/applicantsApi.ts
@@ -2,14 +2,18 @@ import { baseApi } from "./baseApi";
 import type { ApplicantDetailResponse } from "@/shared/types/applicant/applicant-detail-response";
 import type { ApplicantListArgs } from "@/shared/types/applicant/applicant-list-args";
 import type { ApplicantListResponse } from "@/shared/types/applicant/applicant-list-response";
+import type { ApplicantPromoteRequest } from "@/shared/types/applicant/applicant-promote-request";
 
 /**
- * RTK Query slice for the Applicants domain — read-only (PR 3.1b).
+ * RTK Query slice for the Applicants domain.
  *
  * Tag strategy mirrors ``inquiriesApi``: each item carries its own
  * ``Applicant:{id}`` tag plus a single shared ``Applicant:LIST`` tag for the
- * paginated list. POST / PATCH / DELETE endpoints land in PR 3.2 (promote),
- * PR 3.3 (screening), and PR 3.4 (video calls / kanban).
+ * paginated list. The promote mutation (PR 3.2) invalidates both Applicant
+ * and Inquiry tag families because converting an inquiry mutates state in
+ * both domains (new applicant + inquiry stage → ``converted``).
+ *
+ * Screening (PR 3.3) and video-call notes (PR 3.4) land in subsequent PRs.
  */
 const applicantsApi = baseApi.injectEndpoints({
   endpoints: (builder) => ({
@@ -40,7 +44,26 @@ const applicantsApi = baseApi.injectEndpoints({
       query: (id) => ({ url: `/applicants/${id}` }),
       providesTags: (_result, _error, id) => [{ type: "Applicant", id }],
     }),
+    promoteFromInquiry: builder.mutation<
+      ApplicantDetailResponse,
+      { inquiryId: string; data: ApplicantPromoteRequest }
+    >({
+      query: ({ inquiryId, data }) => ({
+        url: `/applicants/promote/${inquiryId}`,
+        method: "POST",
+        data,
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "Applicant", id: "LIST" },
+        { type: "Inquiry", id: arg.inquiryId },
+        { type: "Inquiry", id: "LIST" },
+      ],
+    }),
   }),
 });
 
-export const { useGetApplicantsQuery, useGetApplicantByIdQuery } = applicantsApi;
+export const {
+  useGetApplicantsQuery,
+  useGetApplicantByIdQuery,
+  usePromoteFromInquiryMutation,
+} = applicantsApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/applicant/applicant-promote-conflict.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/applicant/applicant-promote-conflict.ts
@@ -1,0 +1,24 @@
+/**
+ * Backend's 409 ``detail`` payload from POST /applicants/promote/{inquiry_id}.
+ *
+ * Two distinct conflict shapes:
+ * - ``already_promoted`` carries the existing applicant_id so the UI can
+ *   navigate the host to the existing applicant.
+ * - ``not_promotable`` carries the inquiry stage that blocked the promotion
+ *   (always ``declined`` or ``archived``).
+ */
+export interface ApplicantPromoteAlreadyPromotedDetail {
+  code: "already_promoted";
+  message: string;
+  applicant_id: string;
+}
+
+export interface ApplicantPromoteNotPromotableDetail {
+  code: "not_promotable";
+  message: string;
+  stage: string;
+}
+
+export type ApplicantPromoteConflictDetail =
+  | ApplicantPromoteAlreadyPromotedDetail
+  | ApplicantPromoteNotPromotableDetail;

--- a/apps/mybookkeeper/frontend/src/shared/types/applicant/applicant-promote-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/applicant/applicant-promote-request.ts
@@ -1,0 +1,24 @@
+/**
+ * Mirrors backend ``ApplicantPromoteRequest`` — the body for
+ * POST /applicants/promote/{inquiry_id}.
+ *
+ * All fields are optional. The backend auto-fills missing values from the
+ * source inquiry where possible (legal_name, employer_or_hospital, contract
+ * dates). Fields with no inquiry source (dob, vehicle_make_model, smoker,
+ * pets, referred_by) come from this payload only.
+ *
+ * Dates are ISO-8601 ``YYYY-MM-DD`` strings on the wire.
+ */
+export interface ApplicantPromoteRequest {
+  legal_name?: string | null;
+  dob?: string | null;
+  employer_or_hospital?: string | null;
+
+  contract_start?: string | null;
+  contract_end?: string | null;
+
+  vehicle_make_model?: string | null;
+  smoker?: boolean | null;
+  pets?: string | null;
+  referred_by?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/inquiry/inquiry-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/inquiry/inquiry-response.ts
@@ -35,6 +35,14 @@ export interface InquiryResponse {
   received_at: string;
   email_message_id: string | null;
 
+  /**
+   * ID of the Applicant promoted from this inquiry, or ``null`` if the
+   * inquiry has not been promoted yet (PR 3.2). Lets the InquiryDetail
+   * page show "View applicant" instead of "Promote to applicant" when an
+   * applicant already exists.
+   */
+  linked_applicant_id: string | null;
+
   messages: InquiryMessage[];
   events: InquiryEvent[];
 

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -418,6 +418,7 @@
         "backend/app/services/applicants/",
         "backend/app/api/applicants.py",
         "backend/app/core/applicant_enums.py",
+        "backend/app/core/applicant_constants.py",
         "backend/alembic/versions/f8h0i3k5l7m9_add_applicants_domain.py",
         "frontend/src/app/pages/Applicants.tsx",
         "frontend/src/app/pages/ApplicantDetail.tsx",
@@ -431,6 +432,8 @@
         "test_applicant_repo_count.py",
         "test_applicant_service.py",
         "test_applicants_api.py",
+        "test_applicants_api_promote.py",
+        "test_promote_service.py",
         "test_screening_result_repo.py",
         "test_reference_repo.py",
         "test_video_call_note_repo.py",
@@ -442,11 +445,13 @@
       "frontend_tests": [
         "ApplicantStageBadge.test.tsx",
         "SensitiveDataUnlock.test.tsx",
-        "Applicants.test.tsx"
+        "Applicants.test.tsx",
+        "PromoteFromInquiryPanel.test.tsx"
       ],
       "e2e_specs": [
         "applicants.spec.ts",
-        "applicants-layout.spec.ts"
+        "applicants-layout.spec.ts",
+        "applicant-promote.spec.ts"
       ]
     },
     "system": {


### PR DESCRIPTION
## Summary

Adds the **Inquiry → Applicant promotion** flow per RENTALS_PLAN.md §6.2 / §9.2.

### Backend
- New `POST /api/applicants/promote/{inquiry_id}` — atomic promotion endpoint.
- New `promote_service.py` wraps writes in `unit_of_work`. Auto-fills applicant PII fields (legal_name, employer_or_hospital, contract dates) from the inquiry's encrypted columns. Round-trips through `EncryptedString` TypeDecorator without leaking ciphertext.
- Inquiry stage advances to `converted`; two events emitted (`applicant_events.lead` + `inquiry_events.converted`).
- Status code mapping: 404 (not in tenant) / 409 (already promoted, with `applicant_id` in detail) / 409 (`declined` / `archived` blocked) / 422 (validation: minimum-age 18, contract_end ≥ contract_start).
- Extends `InquiryResponse` with `linked_applicant_id` so `InquiryDetail.tsx` can switch the button to "View applicant" when an applicant already exists.

### Frontend
- `PromoteFromInquiryPanel.tsx` — right-side slide-in (mobile bottom sheet via vaul). Pre-fills from inquiry, shows orange warning icons + tooltip on fields the inquiry didn't supply. AI-tone toast feedback. Auto-navigates to the new applicant on success and to the existing applicant on 409 already-promoted.
- `usePromoteFromInquiryMutation` in `applicantsApi.ts` invalidates `Applicant` and `Inquiry` tags so both inboxes refresh.
- `InquiryDetail.tsx` adds the "Promote to applicant" button (disabled when stage is `declined`/`archived`) and the panel state hook. Switches to "View applicant" link when `linked_applicant_id` is set.

### Tests
- Backend: 18 new `test_promote_service.py` tests (auto-fill, override precedence, atomicity via savepoint rollback, tenant isolation, idempotency, PII round-trip, stage transitions). 9 new `test_applicants_api_promote.py` route tests (status code mapping, validation). 2 new `test_inquiry_service.py` tests for `linked_applicant_id`. **All 1794 backend tests pass** (1 pre-existing pdf-magic-bytes failure unrelated to this PR — requires real Postgres).
- Frontend: 8 new `PromoteFromInquiryPanel.test.tsx` tests (pre-fill, missing-field hints, validation, mutation wiring, 409 paths). All applicant-domain tests green.
- E2E: new `applicant-promote.spec.ts` (happy path: seed → promote → verify pre-fill → submit → verify navigation → second promote routes to existing; declined inquiries show disabled button).

### Out of scope
- Screening provider integration (PR 3.3)
- Video call notes UI / kanban (PR 3.4)
- Edit existing applicant (any PUT endpoint)
- Bulk-promote multiple inquiries

## Test plan
- [x] `pytest tests/test_promote_service.py tests/test_applicants_api_promote.py tests/test_inquiry_service.py` — 41 passed
- [x] Full backend suite — 1794 passed (1 pre-existing skip, unrelated)
- [x] `npm test -- --run PromoteFromInquiryPanel InquiryDetail Applicants ApplicantStageBadge SensitiveDataUnlock` — 44 passed
- [x] `npx tsc -b` — typecheck clean
- [x] `npm run build` — green
- [x] `npx playwright test --list` — 577 specs compile
- [ ] E2E run against live backend on merge (covered by CI)

Refs RENTALS_PLAN.md §6.2 (cross-domain field mapping), §9.2 (mobile-first promotion UX).