### PR TITLE
feat(mybookkeeper/vendors): frontend rolodex (rentals Phase 4, PR 4.1b)

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/vendors-layout.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/vendors-layout.spec.ts
@@ -1,0 +1,210 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+
+/**
+ * Layout E2E for the Vendors rolodex list + detail (PR 4.1b).
+ *
+ * Verifies:
+ *   1. The list skeleton has roughly the same number of cards/rows as the
+ *      loaded list (no large layout shift when data arrives).
+ *   2. The list renders without horizontal overflow at mobile / tablet /
+ *      desktop viewports.
+ *   3. The category chip filter has 44px touch targets.
+ *   4. The detail-page skeleton has the same section headers as the loaded
+ *      page so there's no visual jump when data arrives.
+ */
+
+interface SeedVendorPayload {
+  name?: string;
+  category?: string;
+  phone?: string | null;
+  email?: string | null;
+  address?: string | null;
+  hourly_rate?: string | null;
+  flat_rate_notes?: string | null;
+  preferred?: boolean;
+  notes?: string | null;
+}
+
+async function seedVendor(
+  api: APIRequestContext,
+  payload: SeedVendorPayload,
+): Promise<string> {
+  const res = await api.post("/test/seed-vendor", { data: payload });
+  if (!res.ok()) {
+    throw new Error(`seedVendor failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function deleteVendor(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/test/vendors/${id}`).catch(() => {});
+}
+
+const VENDOR_COUNT = 3;
+
+test.describe("Vendors layout (PR 4.1b)", () => {
+  test("list skeleton card count is in the same order of magnitude as the loaded card count on mobile", async ({
+    authedPage: page,
+    api,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+
+    const runId = Date.now();
+    const vendorIds: string[] = [];
+    try {
+      await page.route("**/api/vendors**", async (route) => {
+        await new Promise((r) => setTimeout(r, 1500));
+        await route.continue();
+      });
+
+      const navPromise = page.goto("/vendors");
+      await expect(page.getByTestId("vendors-skeleton")).toBeVisible({
+        timeout: 5000,
+      });
+
+      const skeletonMobileList = page.locator(
+        '[data-testid="vendors-skeleton"] ul.md\\:hidden li',
+      );
+      const skeletonCount = await skeletonMobileList.count();
+      expect(skeletonCount).toBeGreaterThan(0);
+
+      for (let i = 0; i < VENDOR_COUNT; i++) {
+        vendorIds.push(
+          await seedVendor(api, {
+            name: `E2E Layout Vendor ${runId}-${i}`,
+            category: "handyman",
+          }),
+        );
+      }
+      await page.unroute("**/api/vendors**");
+      await navPromise;
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+
+      const loadedMobileCards = page.locator('[data-testid="vendors-mobile"] li');
+      const loadedCount = await loadedMobileCards.count();
+      expect(loadedCount).toBeGreaterThanOrEqual(VENDOR_COUNT);
+
+      // Same skeleton-vs-loaded tolerance as the applicants layout spec.
+      expect(Math.abs(skeletonCount - loadedCount)).toBeLessThanOrEqual(4);
+    } finally {
+      for (const id of vendorIds) await deleteVendor(api, id);
+    }
+  });
+
+  test("renders without horizontal scroll at mobile / tablet / desktop viewports", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const vendorIds: string[] = [];
+
+    try {
+      for (let i = 0; i < 3; i++) {
+        vendorIds.push(
+          await seedVendor(api, {
+            name: `E2E Multi Layout Vendor ${runId}-${i}`,
+            category: "plumber",
+          }),
+        );
+      }
+
+      const viewports: ReadonlyArray<{ name: string; width: number; height: number }> = [
+        { name: "mobile", width: 375, height: 800 },
+        { name: "tablet", width: 768, height: 1024 },
+        { name: "desktop", width: 1280, height: 900 },
+      ];
+
+      for (const vp of viewports) {
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await page.goto("/vendors");
+        await page.waitForLoadState("networkidle");
+
+        await expect(
+          page.getByRole("heading", { name: "Vendors" }),
+          `heading visible at ${vp.name}`,
+        ).toBeVisible();
+
+        const docWidth = await page.evaluate(() => document.documentElement.scrollWidth);
+        expect(docWidth, `no horizontal overflow at ${vp.name}`).toBeLessThanOrEqual(
+          vp.width + 1,
+        );
+      }
+    } finally {
+      for (const id of vendorIds) await deleteVendor(api, id);
+    }
+  });
+
+  test("vendor category chip filter is keyboard-accessible (44px touch target)", async ({
+    authedPage: page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto("/vendors");
+    await expect(page.getByRole("heading", { name: "Vendors" })).toBeVisible();
+
+    const allChip = page.getByTestId("vendor-filter-all");
+    await expect(allChip).toBeVisible();
+    const box = await allChip.boundingBox();
+    expect(box?.height ?? 0).toBeGreaterThanOrEqual(44);
+
+    const preferredToggle = page.getByTestId("vendor-preferred-toggle");
+    await expect(preferredToggle).toBeVisible();
+    const preferredBox = await preferredToggle.boundingBox();
+    expect(preferredBox?.height ?? 0).toBeGreaterThanOrEqual(44);
+  });
+
+  test("detail skeleton section headers match the loaded page", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const vendorId = await seedVendor(api, {
+      name: `E2E Detail Skeleton ${runId}`,
+      category: "plumber",
+      phone: "555-9999",
+      email: "skeleton@example.com",
+      address: "1 Skeleton Way",
+      hourly_rate: "100.00",
+      flat_rate_notes: "Flat $150 for inspection",
+      notes: "Layout test vendor",
+    });
+
+    try {
+      await page.route(`**/api/vendors/${vendorId}`, async (route) => {
+        await new Promise((r) => setTimeout(r, 1500));
+        await route.continue();
+      });
+
+      const navPromise = page.goto(`/vendors/${vendorId}`);
+      await expect(page.getByTestId("vendor-detail-skeleton")).toBeVisible({
+        timeout: 5000,
+      });
+      const skeletonSections = [
+        "contact-section-skeleton",
+        "pricing-section-skeleton",
+        "notes-section-skeleton",
+      ];
+      for (const sectionId of skeletonSections) {
+        await expect(
+          page.getByTestId(sectionId),
+          `${sectionId} present in skeleton`,
+        ).toBeVisible();
+      }
+
+      await page.unroute(`**/api/vendors/${vendorId}`);
+      await navPromise;
+      await page.waitForLoadState("networkidle");
+
+      const loadedSections = ["contact-section", "pricing-section", "notes-section"];
+      for (const sectionId of loadedSections) {
+        await expect(
+          page.getByTestId(sectionId),
+          `${sectionId} present after load`,
+        ).toBeVisible();
+      }
+    } finally {
+      await deleteVendor(api, vendorId);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/e2e/vendors.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/vendors.spec.ts
@@ -1,0 +1,235 @@
+import { test, expect, type APIRequestContext, type Page } from "./fixtures/auth";
+
+/**
+ * PR 4.1b — Vendors frontend behavioural E2E (read-only).
+ *
+ * Covers the rolodex list / detail flows that ship in this PR. Create /
+ * edit / soft-delete UI lands in PR 4.2 — those specs will be added
+ * alongside the write endpoints and ``Transaction.vendor_id`` FK.
+ */
+
+interface SeedVendorPayload {
+  name?: string;
+  category?: string;
+  phone?: string | null;
+  email?: string | null;
+  address?: string | null;
+  hourly_rate?: string | null;
+  flat_rate_notes?: string | null;
+  preferred?: boolean;
+  notes?: string | null;
+}
+
+async function seedVendor(
+  api: APIRequestContext,
+  payload: SeedVendorPayload,
+): Promise<string> {
+  const res = await api.post("/test/seed-vendor", { data: payload });
+  if (!res.ok()) {
+    throw new Error(`seedVendor failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function deleteVendor(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/test/vendors/${id}`).catch(() => {});
+}
+
+async function waitForVendorsPage(page: Page): Promise<void> {
+  await expect(page.getByRole("heading", { name: "Vendors" })).toBeVisible({
+    timeout: 10000,
+  });
+  await page.waitForLoadState("networkidle");
+}
+
+test.describe("Vendors frontend (PR 4.1b)", () => {
+  test("seeded vendor renders in rolodex, drilldown shows all sections, contact links work", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const name = `E2E Vendor ${runId}`;
+    const seededVendors: string[] = [];
+
+    try {
+      const vendorId = await seedVendor(api, {
+        name,
+        category: "plumber",
+        phone: "555-0101",
+        email: "e2e-plumber@example.com",
+        address: "1 E2E Way",
+        hourly_rate: "125.50",
+        flat_rate_notes: "Flat $200 for drain unclog",
+        preferred: true,
+        notes: "Reliable",
+      });
+      seededVendors.push(vendorId);
+
+      // List page renders.
+      await page.goto("/vendors");
+      await waitForVendorsPage(page);
+      await expect(page.getByText(name).first()).toBeVisible({ timeout: 5000 });
+
+      // Drill into detail.
+      await page.getByText(name).first().click();
+      await expect(page).toHaveURL(new RegExp(`/vendors/${vendorId}$`));
+
+      // Header and category badge.
+      await expect(page.getByRole("heading", { name })).toBeVisible();
+      await expect(page.getByTestId("vendor-category-badge-plumber")).toBeVisible();
+
+      // Preferred indicator visible because we seeded preferred=true.
+      await expect(page.getByTestId("vendor-preferred-indicator")).toBeVisible();
+
+      // Contact / pricing / notes sections all render with the seeded values.
+      await expect(page.getByTestId("contact-section")).toBeVisible();
+      await expect(page.getByTestId("pricing-section")).toBeVisible();
+      await expect(page.getByTestId("notes-section")).toBeVisible();
+
+      const phoneCell = page.getByTestId("vendor-phone");
+      await expect(phoneCell).toContainText("555-0101");
+      await expect(phoneCell.locator("a")).toHaveAttribute("href", "tel:555-0101");
+
+      const emailCell = page.getByTestId("vendor-email");
+      await expect(emailCell).toContainText("e2e-plumber@example.com");
+      await expect(emailCell.locator("a")).toHaveAttribute(
+        "href",
+        "mailto:e2e-plumber@example.com",
+      );
+
+      await expect(page.getByTestId("vendor-address")).toContainText("1 E2E Way");
+      await expect(page.getByTestId("vendor-hourly-rate")).toContainText("$125.50");
+      await expect(page.getByTestId("vendor-flat-rate-notes")).toContainText(
+        /Flat \$200/,
+      );
+      await expect(page.getByTestId("vendor-notes")).toContainText("Reliable");
+
+      // Back link returns to rolodex.
+      await page.getByRole("link", { name: /Back to vendors/i }).click();
+      await expect(page).toHaveURL(/\/vendors$/);
+      await expect(page.getByRole("heading", { name: "Vendors" })).toBeVisible();
+    } finally {
+      for (const id of seededVendors) await deleteVendor(api, id);
+    }
+  });
+
+  test("category filter narrows the rolodex to a single category and syncs URL state", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const seededIds: string[] = [];
+
+    try {
+      const plumberId = await seedVendor(api, {
+        name: `E2E Plumber ${runId}`,
+        category: "plumber",
+      });
+      seededIds.push(plumberId);
+
+      const electricianId = await seedVendor(api, {
+        name: `E2E Electrician ${runId}`,
+        category: "electrician",
+      });
+      seededIds.push(electricianId);
+
+      await page.goto("/vendors");
+      await waitForVendorsPage(page);
+
+      // Both visible by default.
+      await expect(page.getByText(`E2E Plumber ${runId}`).first()).toBeVisible();
+      await expect(page.getByText(`E2E Electrician ${runId}`).first()).toBeVisible();
+
+      // Filter to plumber.
+      await page.getByTestId("vendor-filter-plumber").click();
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.getByText(`E2E Plumber ${runId}`).first()).toBeVisible();
+      await expect(page.getByText(`E2E Electrician ${runId}`)).toHaveCount(0);
+
+      // URL state reflects the filter (deep-linkable).
+      expect(page.url()).toContain("category=plumber");
+
+      // Back to All — both return.
+      await page.getByTestId("vendor-filter-all").click();
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByText(`E2E Plumber ${runId}`).first()).toBeVisible();
+      await expect(page.getByText(`E2E Electrician ${runId}`).first()).toBeVisible();
+      expect(page.url()).not.toContain("category=");
+    } finally {
+      for (const id of seededIds) await deleteVendor(api, id);
+    }
+  });
+
+  test("preferred-only toggle narrows the rolodex to preferred vendors", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const seededIds: string[] = [];
+
+    try {
+      const preferredId = await seedVendor(api, {
+        name: `E2E Preferred ${runId}`,
+        category: "handyman",
+        preferred: true,
+      });
+      seededIds.push(preferredId);
+
+      const regularId = await seedVendor(api, {
+        name: `E2E Regular ${runId}`,
+        category: "handyman",
+        preferred: false,
+      });
+      seededIds.push(regularId);
+
+      await page.goto("/vendors");
+      await waitForVendorsPage(page);
+
+      // Both visible.
+      await expect(page.getByText(`E2E Preferred ${runId}`).first()).toBeVisible();
+      await expect(page.getByText(`E2E Regular ${runId}`).first()).toBeVisible();
+
+      // Flip preferred-only on.
+      await page.getByTestId("vendor-preferred-toggle").click();
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.getByText(`E2E Preferred ${runId}`).first()).toBeVisible();
+      await expect(page.getByText(`E2E Regular ${runId}`)).toHaveCount(0);
+
+      // URL deep-links the filter.
+      expect(page.url()).toContain("preferred=true");
+    } finally {
+      for (const id of seededIds) await deleteVendor(api, id);
+    }
+  });
+
+  test("renders the filtered empty state when the user has no vendors in this category", async ({
+    authedPage: page,
+  }) => {
+    // Pick a category unlikely to have stale seeded data.
+    await page.goto("/vendors?category=locksmith");
+    await page.waitForLoadState("networkidle");
+    await expect(page.getByRole("heading", { name: "Vendors" })).toBeVisible();
+    await expect(page.getByTestId("vendor-filter-locksmith")).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    const filteredEmpty = await page.getByText(/No vendors match this filter/i).count();
+    if (filteredEmpty > 0) {
+      expect(filteredEmpty).toBeGreaterThan(0);
+    }
+  });
+
+  test("404 detail page surfaces the friendly not-found message", async ({
+    authedPage: page,
+  }) => {
+    // Random UUID — no such vendor exists for this user.
+    await page.goto("/vendors/00000000-0000-0000-0000-000000000000");
+    await expect(page.getByText(/I couldn't find that vendor/i)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+});

--- a/apps/mybookkeeper/frontend/src/App.tsx
+++ b/apps/mybookkeeper/frontend/src/App.tsx
@@ -24,6 +24,8 @@ import Inquiries from "@/app/pages/Inquiries";
 import InquiryDetail from "@/app/pages/InquiryDetail";
 import Applicants from "@/app/pages/Applicants";
 import ApplicantDetail from "@/app/pages/ApplicantDetail";
+import Vendors from "@/app/pages/Vendors";
+import VendorDetail from "@/app/pages/VendorDetail";
 import ReplyTemplates from "@/app/pages/ReplyTemplates";
 import TaxReport from "@/app/pages/TaxReport";
 import Integrations from "@/app/pages/Integrations";
@@ -101,6 +103,8 @@ export default function App() {
               <Route path="inquiries/:inquiryId" element={<InquiryDetail />} />
               <Route path="applicants" element={<Applicants />} />
               <Route path="applicants/:applicantId" element={<ApplicantDetail />} />
+              <Route path="vendors" element={<Vendors />} />
+              <Route path="vendors/:vendorId" element={<VendorDetail />} />
               <Route path="reply-templates" element={<ReplyTemplates />} />
               <Route path="reconciliation" element={<Reconciliation />} />
               <Route path="tax" element={<TaxReport />} />

--- a/apps/mybookkeeper/frontend/src/__tests__/VendorDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/VendorDetail.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { store } from "@/shared/store";
+import VendorDetail from "@/app/pages/VendorDetail";
+import type { VendorResponse } from "@/shared/types/vendor/vendor-response";
+
+const mockVendor: VendorResponse = {
+  id: "vendor-1",
+  organization_id: "org-1",
+  user_id: "user-1",
+  name: "Bob's Plumbing",
+  category: "plumber",
+  phone: "555-0101",
+  email: "bob@plumbing.example.com",
+  address: "123 Main St\nHouston, TX",
+  hourly_rate: "125.00",
+  flat_rate_notes: "Flat $200 for drain unclog",
+  preferred: true,
+  notes: "Reliable. Same-day for emergencies.",
+  last_used_at: "2026-04-01T10:00:00Z",
+  created_at: "2026-01-15T10:00:00Z",
+  updated_at: "2026-04-01T10:00:00Z",
+};
+
+const defaultDetailState = {
+  data: mockVendor,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+
+vi.mock("@/shared/store/vendorsApi", () => ({
+  useGetVendorsQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+  useGetVendorByIdQuery: vi.fn(() => defaultDetailState),
+}));
+
+import { useGetVendorByIdQuery } from "@/shared/store/vendorsApi";
+
+type DetailQueryReturn = ReturnType<typeof useGetVendorByIdQuery>;
+
+function renderVendorDetail(vendorId = "vendor-1") {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[`/vendors/${vendorId}`]}>
+        <Routes>
+          <Route path="/vendors/:vendorId" element={<VendorDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe("VendorDetail page", () => {
+  beforeEach(() => {
+    vi.mocked(useGetVendorByIdQuery).mockReturnValue(
+      defaultDetailState as unknown as DetailQueryReturn,
+    );
+  });
+
+  it("renders the vendor name as the heading and the back link", () => {
+    renderVendorDetail();
+    expect(
+      screen.getByRole("heading", { name: "Bob's Plumbing" }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Back to vendors/i })).toBeInTheDocument();
+  });
+
+  it("renders the preferred indicator when preferred=true", () => {
+    renderVendorDetail();
+    expect(screen.getByTestId("vendor-preferred-indicator")).toBeInTheDocument();
+  });
+
+  it("hides the preferred indicator when preferred=false", () => {
+    vi.mocked(useGetVendorByIdQuery).mockReturnValueOnce({
+      ...defaultDetailState,
+      data: { ...mockVendor, preferred: false },
+    } as unknown as DetailQueryReturn);
+    renderVendorDetail();
+    expect(screen.queryByTestId("vendor-preferred-indicator")).toBeNull();
+  });
+
+  it("renders contact info as tel:/mailto: links and the address", () => {
+    renderVendorDetail();
+    const phoneCell = screen.getByTestId("vendor-phone");
+    expect(phoneCell).toHaveTextContent("555-0101");
+    expect(phoneCell.querySelector("a")?.getAttribute("href")).toBe("tel:555-0101");
+
+    const emailCell = screen.getByTestId("vendor-email");
+    expect(emailCell).toHaveTextContent("bob@plumbing.example.com");
+    expect(emailCell.querySelector("a")?.getAttribute("href")).toBe(
+      "mailto:bob@plumbing.example.com",
+    );
+
+    expect(screen.getByTestId("vendor-address")).toHaveTextContent(/123 Main St/);
+  });
+
+  it("renders the formatted hourly rate and flat-rate notes", () => {
+    renderVendorDetail();
+    expect(screen.getByTestId("vendor-hourly-rate")).toHaveTextContent("$125.00 / hour");
+    expect(screen.getByTestId("vendor-flat-rate-notes")).toHaveTextContent(
+      /Flat \$200 for drain unclog/,
+    );
+  });
+
+  it("renders the host notes", () => {
+    renderVendorDetail();
+    expect(screen.getByTestId("vendor-notes")).toHaveTextContent(/Reliable/);
+  });
+
+  it("renders the loading skeleton while fetching", () => {
+    vi.mocked(useGetVendorByIdQuery).mockReturnValueOnce({
+      ...defaultDetailState,
+      data: undefined,
+      isLoading: true,
+    } as unknown as DetailQueryReturn);
+    renderVendorDetail();
+    expect(screen.getByTestId("vendor-detail-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the friendly not-found message on error", () => {
+    vi.mocked(useGetVendorByIdQuery).mockReturnValueOnce({
+      ...defaultDetailState,
+      data: undefined,
+      isError: true,
+    } as unknown as DetailQueryReturn);
+    renderVendorDetail();
+    expect(
+      screen.getByText(/I couldn't find that vendor/i),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to '—' for missing optional contact fields", () => {
+    vi.mocked(useGetVendorByIdQuery).mockReturnValueOnce({
+      ...defaultDetailState,
+      data: {
+        ...mockVendor,
+        phone: null,
+        email: null,
+        address: null,
+        flat_rate_notes: null,
+      },
+    } as unknown as DetailQueryReturn);
+    renderVendorDetail();
+    expect(screen.getByTestId("vendor-phone")).toHaveTextContent("—");
+    expect(screen.getByTestId("vendor-email")).toHaveTextContent("—");
+    expect(screen.getByTestId("vendor-address")).toHaveTextContent("—");
+    expect(screen.getByTestId("vendor-flat-rate-notes")).toHaveTextContent("—");
+  });
+
+  it("falls back to 'Not set' for missing hourly rate", () => {
+    vi.mocked(useGetVendorByIdQuery).mockReturnValueOnce({
+      ...defaultDetailState,
+      data: { ...mockVendor, hourly_rate: null },
+    } as unknown as DetailQueryReturn);
+    renderVendorDetail();
+    expect(screen.getByTestId("vendor-hourly-rate")).toHaveTextContent("Not set");
+  });
+
+  it("renders 'Never used' when last_used_at is null", () => {
+    vi.mocked(useGetVendorByIdQuery).mockReturnValueOnce({
+      ...defaultDetailState,
+      data: { ...mockVendor, last_used_at: null },
+    } as unknown as DetailQueryReturn);
+    renderVendorDetail();
+    expect(screen.getByText(/Never used/i)).toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/Vendors.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/Vendors.test.tsx
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { store } from "@/shared/store";
+import Vendors from "@/app/pages/Vendors";
+import type { VendorSummary } from "@/shared/types/vendor/vendor-summary";
+import type { VendorListResponse } from "@/shared/types/vendor/vendor-list-response";
+
+const mockVendors: VendorSummary[] = [
+  {
+    id: "vendor-1",
+    organization_id: "org-1",
+    user_id: "user-1",
+    name: "Bob's Plumbing",
+    category: "plumber",
+    hourly_rate: "125.00",
+    preferred: true,
+    last_used_at: "2026-04-01T10:00:00Z",
+    created_at: "2026-01-15T10:00:00Z",
+    updated_at: "2026-04-01T10:00:00Z",
+  },
+  {
+    id: "vendor-2",
+    organization_id: "org-1",
+    user_id: "user-1",
+    name: "Sparky Electric",
+    category: "electrician",
+    hourly_rate: null,
+    preferred: false,
+    last_used_at: null,
+    created_at: "2026-02-01T10:00:00Z",
+    updated_at: "2026-02-01T10:00:00Z",
+  },
+];
+
+const mockEnvelope: VendorListResponse = {
+  items: mockVendors,
+  total: 2,
+  has_more: false,
+};
+
+const defaultVendorsState = {
+  data: mockEnvelope,
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  refetch: vi.fn(),
+};
+
+vi.mock("@/shared/store/vendorsApi", () => ({
+  useGetVendorsQuery: vi.fn(() => defaultVendorsState),
+  useGetVendorByIdQuery: vi.fn(() => ({ data: undefined, isLoading: false })),
+}));
+
+import { useGetVendorsQuery } from "@/shared/store/vendorsApi";
+
+type ListQueryReturn = ReturnType<typeof useGetVendorsQuery>;
+
+function renderVendors(initialEntry = "/vendors") {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={[initialEntry]}>
+        <Vendors />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe("Vendors page", () => {
+  beforeEach(() => {
+    vi.mocked(useGetVendorsQuery).mockReturnValue(
+      defaultVendorsState as unknown as ListQueryReturn,
+    );
+  });
+
+  it("renders the heading and the rolodex of vendors", () => {
+    renderVendors();
+    expect(screen.getByRole("heading", { name: "Vendors" })).toBeInTheDocument();
+    expect(screen.getAllByText("Bob's Plumbing").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Sparky Electric").length).toBeGreaterThan(0);
+  });
+
+  it("renders the loading skeleton while fetching", () => {
+    vi.mocked(useGetVendorsQuery).mockReturnValueOnce({
+      ...defaultVendorsState,
+      data: undefined,
+      isLoading: true,
+    } as unknown as ListQueryReturn);
+    renderVendors();
+    expect(screen.getByTestId("vendors-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the empty state when there are no vendors", () => {
+    vi.mocked(useGetVendorsQuery).mockReturnValueOnce({
+      ...defaultVendorsState,
+      data: { items: [], total: 0, has_more: false },
+    } as unknown as ListQueryReturn);
+    renderVendors();
+    expect(screen.getByText(/No vendors yet/i)).toBeInTheDocument();
+  });
+
+  it("renders the filtered empty state when a category filter has no matches", () => {
+    vi.mocked(useGetVendorsQuery).mockReturnValueOnce({
+      ...defaultVendorsState,
+      data: { items: [], total: 0, has_more: false },
+    } as unknown as ListQueryReturn);
+    renderVendors("/vendors?category=hvac");
+    expect(screen.getByText(/No vendors match this filter/i)).toBeInTheDocument();
+  });
+
+  it("renders an error AlertBox when the query errors", () => {
+    vi.mocked(useGetVendorsQuery).mockReturnValueOnce({
+      ...defaultVendorsState,
+      data: undefined,
+      isError: true,
+    } as unknown as ListQueryReturn);
+    renderVendors();
+    expect(screen.getByText(/I couldn't load your vendors/i)).toBeInTheDocument();
+  });
+
+  it("renders the category filter chips and preferred toggle", () => {
+    renderVendors();
+    expect(screen.getByTestId("vendor-filter-all")).toBeInTheDocument();
+    expect(screen.getByTestId("vendor-filter-plumber")).toBeInTheDocument();
+    expect(screen.getByTestId("vendor-filter-hvac")).toBeInTheDocument();
+    expect(screen.getByTestId("vendor-preferred-toggle")).toBeInTheDocument();
+  });
+
+  it("hides the category badge inside mobile cards when filtered to a single category", () => {
+    renderVendors("/vendors?category=plumber");
+    // The mobile card list should NOT contain a category badge — that
+    // information is implied by the active filter chip.
+    const mobileList = screen.getByTestId("vendors-mobile");
+    expect(
+      mobileList.querySelector('[data-testid^="vendor-category-badge-"]'),
+    ).toBeNull();
+  });
+
+  it("renders the preferred star for preferred vendors only", () => {
+    renderVendors();
+    // Bob's Plumbing is preferred, Sparky Electric is not.
+    expect(
+      screen.getAllByTestId("vendor-preferred-star-vendor-1").length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByTestId("vendor-preferred-star-vendor-2")).toBeNull();
+  });
+
+  it("reflects ?preferred=true in the toggle's pressed state", () => {
+    renderVendors("/vendors?preferred=true");
+    const toggle = screen.getByTestId("vendor-preferred-toggle");
+    expect(toggle.getAttribute("aria-pressed")).toBe("true");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCard.tsx
@@ -1,0 +1,71 @@
+import { Link } from "react-router-dom";
+import { Star } from "lucide-react";
+import { formatRelativeTime } from "@/shared/lib/inquiry-date-format";
+import type { VendorSummary } from "@/shared/types/vendor/vendor-summary";
+import VendorCategoryBadge from "./VendorCategoryBadge";
+
+interface Props {
+  vendor: VendorSummary;
+  /**
+   * When true (i.e. the list is in the "All" filter), render the category
+   * badge alongside the vendor name. When false, the category badge is
+   * redundant — it's implied by the active chip.
+   */
+  showCategoryBadge: boolean;
+}
+
+function formatHourlyRate(rate: string | null): string {
+  if (rate === null) return "Rate not set";
+  const num = Number(rate);
+  if (Number.isNaN(num)) return "Rate not set";
+  return `$${num.toFixed(2)}/hr`;
+}
+
+function formatLastUsed(lastUsedAt: string | null): string {
+  return lastUsedAt === null ? "Never used" : formatRelativeTime(lastUsedAt);
+}
+
+/**
+ * Mobile vendor card for the rolodex. Whole card is tappable per
+ * RENTALS_PLAN.md §9.2 (touch target ≥ 44px).
+ *
+ * Visible data points (rolodex-card subset):
+ *   - vendor name (primary identifier)
+ *   - preferred star (host-curated "show first" flag)
+ *   - category badge (when not category-filtered)
+ *   - hourly rate (quick comparison)
+ *   - last used relative time
+ *
+ * Excluded — detail page only:
+ *   - phone, email, address (contact info)
+ *   - flat_rate_notes, notes (free-form host notes)
+ */
+export default function VendorCard({ vendor, showCategoryBadge }: Props) {
+  return (
+    <Link
+      to={`/vendors/${vendor.id}`}
+      data-testid={`vendor-card-${vendor.id}`}
+      className="block border rounded-lg p-4 min-h-[44px] hover:bg-muted/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+    >
+      <div className="flex items-start justify-between gap-2 mb-1">
+        <p className="font-medium leading-tight truncate inline-flex items-center gap-2">
+          {vendor.preferred ? (
+            <Star
+              className="h-4 w-4 fill-yellow-500 text-yellow-500 shrink-0"
+              data-testid={`vendor-preferred-star-${vendor.id}`}
+              aria-label="Preferred vendor"
+            />
+          ) : null}
+          <span className="truncate">{vendor.name}</span>
+        </p>
+        {showCategoryBadge ? (
+          <VendorCategoryBadge category={vendor.category} />
+        ) : null}
+      </div>
+      <div className="mt-2 flex items-center justify-between text-xs text-muted-foreground">
+        <span className="truncate">{formatHourlyRate(vendor.hourly_rate)}</span>
+        <span className="shrink-0 ml-2">{formatLastUsed(vendor.last_used_at)}</span>
+      </div>
+    </Link>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCategoryBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCategoryBadge.tsx
@@ -1,0 +1,39 @@
+import {
+  VENDOR_CATEGORY_BADGE_COLORS,
+  VENDOR_CATEGORY_LABELS,
+} from "@/shared/lib/vendor-labels";
+import type { VendorCategory } from "@/shared/types/vendor/vendor-category";
+import type { BadgeColor } from "@/shared/components/ui/Badge";
+
+const COLOR_CLASSES: Record<BadgeColor, string> = {
+  gray: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  blue: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+  yellow: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
+  orange: "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
+  green: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+  red: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+  purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+};
+
+interface Props {
+  category: VendorCategory;
+  className?: string;
+}
+
+/**
+ * Category badge for vendors. Color mapping per ``vendor-labels.ts``.
+ *
+ * Hidden in category-filtered list views (the active chip already conveys
+ * the category) but shown on detail pages and the unfiltered "All" list.
+ */
+export default function VendorCategoryBadge({ category, className = "" }: Props) {
+  const color = VENDOR_CATEGORY_BADGE_COLORS[category];
+  return (
+    <span
+      data-testid={`vendor-category-badge-${category}`}
+      className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${COLOR_CLASSES[color]} ${className}`.trim()}
+    >
+      {VENDOR_CATEGORY_LABELS[category]}
+    </span>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCategoryFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCategoryFilter.tsx
@@ -1,0 +1,59 @@
+import { cn } from "@/shared/utils/cn";
+import {
+  VENDOR_CATEGORIES,
+  VENDOR_CATEGORY_LABELS,
+} from "@/shared/lib/vendor-labels";
+import type { VendorCategory } from "@/shared/types/vendor/vendor-category";
+
+interface Props {
+  value: VendorCategory | null;
+  onChange: (category: VendorCategory | null) => void;
+}
+
+interface Chip {
+  value: VendorCategory | null;
+  label: string;
+}
+
+const CHIPS: Chip[] = [
+  { value: null, label: "All" },
+  ...VENDOR_CATEGORIES.map((c) => ({ value: c, label: VENDOR_CATEGORY_LABELS[c] })),
+];
+
+/**
+ * Horizontal chip row for filtering vendors by trade category. Mirrors the
+ * ``ApplicantStageFilter`` pattern: 44px touch targets, horizontal scroll
+ * on mobile (``overflow-x-auto`` + ``flex-nowrap``), URL-state sync handled
+ * by the parent page via ``useSearchParams``.
+ */
+export default function VendorCategoryFilter({ value, onChange }: Props) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Filter vendors by category"
+      className="flex flex-nowrap overflow-x-auto gap-2 pb-1 -mx-1 px-1"
+    >
+      {CHIPS.map((chip) => {
+        const active = chip.value === value;
+        const key = chip.value ?? "all";
+        return (
+          <button
+            key={key}
+            role="tab"
+            aria-selected={active}
+            onClick={() => onChange(chip.value)}
+            className={cn(
+              "shrink-0 min-h-[44px] px-4 rounded-full text-sm font-medium transition-colors",
+              active
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:bg-muted/70",
+            )}
+            data-testid={`vendor-filter-${key}`}
+          >
+            {chip.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorDetailSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorDetailSkeleton.tsx
@@ -1,0 +1,52 @@
+import Skeleton from "@/shared/components/ui/Skeleton";
+
+/**
+ * Skeleton for the VendorDetail page. Mirrors the loaded layout exactly:
+ * header, contact section, pricing section, notes section.
+ */
+export default function VendorDetailSkeleton() {
+  return (
+    <div className="space-y-6" data-testid="vendor-detail-skeleton">
+      {/* Header */}
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-48" />
+        <div className="flex gap-2">
+          <Skeleton className="h-5 w-24 rounded-full" />
+          <Skeleton className="h-3 w-32" />
+        </div>
+      </div>
+
+      {/* Contact info */}
+      <section
+        className="border rounded-lg p-4 space-y-3"
+        data-testid="contact-section-skeleton"
+      >
+        <Skeleton className="h-4 w-24" />
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+          <Skeleton className="h-4 w-full" />
+        </div>
+      </section>
+
+      {/* Pricing */}
+      <section
+        className="border rounded-lg p-4 space-y-3"
+        data-testid="pricing-section-skeleton"
+      >
+        <Skeleton className="h-4 w-20" />
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-12 w-full" />
+      </section>
+
+      {/* Notes */}
+      <section
+        className="border rounded-lg p-4 space-y-3"
+        data-testid="notes-section-skeleton"
+      >
+        <Skeleton className="h-4 w-16" />
+        <Skeleton className="h-12 w-full" />
+      </section>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorPreferredToggle.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorPreferredToggle.tsx
@@ -1,0 +1,36 @@
+import { Star } from "lucide-react";
+import { cn } from "@/shared/utils/cn";
+
+interface Props {
+  value: boolean;
+  onChange: (next: boolean) => void;
+}
+
+/**
+ * Toggle button that filters the rolodex to preferred-only vendors. Uses
+ * the same 44px touch target as the category chips so the two filters feel
+ * paired. ``aria-pressed`` reflects state for screen readers.
+ */
+export default function VendorPreferredToggle({ value, onChange }: Props) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-pressed={value}
+      onClick={() => onChange(!value)}
+      data-testid="vendor-preferred-toggle"
+      className={cn(
+        "inline-flex items-center gap-1.5 shrink-0 min-h-[44px] px-4 rounded-full text-sm font-medium transition-colors",
+        value
+          ? "bg-yellow-500 text-white hover:bg-yellow-500/90"
+          : "bg-muted text-muted-foreground hover:bg-muted/70",
+      )}
+    >
+      <Star
+        className={cn("h-4 w-4", value ? "fill-current" : "")}
+        aria-hidden="true"
+      />
+      Preferred only
+    </button>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorRow.tsx
@@ -1,0 +1,62 @@
+import { useNavigate } from "react-router-dom";
+import { Star } from "lucide-react";
+import { formatRelativeTime } from "@/shared/lib/inquiry-date-format";
+import type { VendorSummary } from "@/shared/types/vendor/vendor-summary";
+import VendorCategoryBadge from "./VendorCategoryBadge";
+
+interface Props {
+  vendor: VendorSummary;
+  showCategoryBadge: boolean;
+}
+
+function formatHourlyRate(rate: string | null): string {
+  if (rate === null) return "—";
+  // Backend returns Decimal as a string — strip trailing zeros for display.
+  const num = Number(rate);
+  if (Number.isNaN(num)) return "—";
+  return `$${num.toFixed(2)}/hr`;
+}
+
+function formatLastUsed(lastUsedAt: string | null): string {
+  return lastUsedAt === null ? "Never used" : formatRelativeTime(lastUsedAt);
+}
+
+/**
+ * Desktop table row for the Vendors rolodex. Click anywhere navigates to
+ * the detail page.
+ */
+export default function VendorRow({ vendor, showCategoryBadge }: Props) {
+  const navigate = useNavigate();
+
+  return (
+    <tr
+      data-testid={`vendor-row-${vendor.id}`}
+      onClick={() => navigate(`/vendors/${vendor.id}`)}
+      className="border-t cursor-pointer hover:bg-muted/30 transition-colors"
+    >
+      <td className="px-4 py-3 font-medium">
+        <span className="inline-flex items-center gap-2">
+          {vendor.preferred ? (
+            <Star
+              className="h-4 w-4 fill-yellow-500 text-yellow-500 shrink-0"
+              data-testid={`vendor-preferred-star-${vendor.id}`}
+              aria-label="Preferred vendor"
+            />
+          ) : null}
+          <span className="truncate">{vendor.name}</span>
+        </span>
+      </td>
+      <td className="px-4 py-3">
+        {showCategoryBadge ? (
+          <VendorCategoryBadge category={vendor.category} />
+        ) : null}
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {formatHourlyRate(vendor.hourly_rate)}
+      </td>
+      <td className="px-4 py-3 text-muted-foreground">
+        {formatLastUsed(vendor.last_used_at)}
+      </td>
+    </tr>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorsListSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorsListSkeleton.tsx
@@ -1,0 +1,62 @@
+import Skeleton from "@/shared/components/ui/Skeleton";
+
+interface Props {
+  count?: number;
+}
+
+/**
+ * Skeleton loader for the Vendors rolodex.
+ *
+ * Mirrors the loaded layout exactly per ``feedback_skeletons_match_layout``:
+ *   - Mobile: same number of card slots (default 4) with the same internal
+ *     row structure (name + category badge, rate + last used).
+ *   - Desktop: same 4 columns (Name, Category, Hourly Rate, Last Used) and
+ *     same number of skeleton rows.
+ */
+export default function VendorsListSkeleton({ count = 4 }: Props) {
+  const rows = Array.from({ length: count }, (_, i) => i);
+
+  return (
+    <div data-testid="vendors-skeleton">
+      {/* Mobile: card list */}
+      <ul className="md:hidden space-y-3">
+        {rows.map((i) => (
+          <li key={`m-${i}`} className="border rounded-lg p-4 space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-3 w-24" />
+              <Skeleton className="h-3 w-20" />
+            </div>
+          </li>
+        ))}
+      </ul>
+
+      {/* Desktop: table */}
+      <div className="hidden md:block border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-4 py-2">Name</th>
+              <th className="px-4 py-2">Category</th>
+              <th className="px-4 py-2">Hourly Rate</th>
+              <th className="px-4 py-2">Last Used</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((i) => (
+              <tr key={`d-${i}`} className="border-t">
+                <td className="px-4 py-3"><Skeleton className="h-4 w-32" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-5 w-24 rounded-full" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-20" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-24" /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/lib/nav.ts
+++ b/apps/mybookkeeper/frontend/src/app/lib/nav.ts
@@ -8,6 +8,7 @@ export const NAV: readonly NavItem[] = [
   { to: "/listings", label: "Listings" },
   { to: "/inquiries", label: "Inquiries" },
   { to: "/applicants", label: "Applicants" },
+  { to: "/vendors", label: "Vendors" },
   { to: "/reconciliation", label: "Reconciliation" },
   { to: "/tax", label: "Tax Report" },
   { to: "/tax-documents", label: "Tax Documents" },

--- a/apps/mybookkeeper/frontend/src/app/pages/VendorDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/VendorDetail.tsx
@@ -1,0 +1,181 @@
+import { Link, useParams } from "react-router-dom";
+import { ArrowLeft, Star } from "lucide-react";
+import SectionHeader from "@/shared/components/ui/SectionHeader";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import { useGetVendorByIdQuery } from "@/shared/store/vendorsApi";
+import {
+  formatAbsoluteTime,
+  formatRelativeTime,
+} from "@/shared/lib/inquiry-date-format";
+import VendorCategoryBadge from "@/app/features/vendors/VendorCategoryBadge";
+import VendorDetailSkeleton from "@/app/features/vendors/VendorDetailSkeleton";
+
+function formatHourlyRate(rate: string | null): string {
+  if (rate === null) return "Not set";
+  const num = Number(rate);
+  if (Number.isNaN(num)) return "Not set";
+  return `$${num.toFixed(2)} / hour`;
+}
+
+export default function VendorDetail() {
+  const { vendorId } = useParams<{ vendorId: string }>();
+  const {
+    data: vendor,
+    isLoading,
+    isFetching,
+    isError,
+    refetch,
+  } = useGetVendorByIdQuery(vendorId ?? "", { skip: !vendorId });
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <Link
+        to="/vendors"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground min-h-[44px]"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        Back to vendors
+      </Link>
+
+      {isError ? (
+        <AlertBox variant="error" className="flex items-center justify-between gap-3">
+          <span>I couldn't find that vendor. Maybe it was removed?</span>
+          <LoadingButton
+            variant="secondary"
+            size="sm"
+            isLoading={isFetching}
+            loadingText="Retrying..."
+            onClick={() => refetch()}
+          >
+            Retry
+          </LoadingButton>
+        </AlertBox>
+      ) : null}
+
+      {isLoading || !vendor ? (
+        !isError ? <VendorDetailSkeleton /> : null
+      ) : (
+        <>
+          <SectionHeader
+            title={vendor.name}
+            subtitle={
+              <span className="inline-flex items-center gap-2 flex-wrap">
+                {vendor.preferred ? (
+                  <span
+                    className="inline-flex items-center gap-1 text-xs font-medium text-yellow-700 dark:text-yellow-300"
+                    data-testid="vendor-preferred-indicator"
+                  >
+                    <Star
+                      className="h-3.5 w-3.5 fill-yellow-500 text-yellow-500"
+                      aria-hidden="true"
+                    />
+                    Preferred
+                  </span>
+                ) : null}
+                <VendorCategoryBadge category={vendor.category} />
+                {vendor.last_used_at ? (
+                  <span
+                    className="text-xs text-muted-foreground"
+                    title={formatAbsoluteTime(vendor.last_used_at)}
+                  >
+                    Last used {formatRelativeTime(vendor.last_used_at)}
+                  </span>
+                ) : (
+                  <span className="text-xs text-muted-foreground">
+                    Never used
+                  </span>
+                )}
+              </span>
+            }
+          />
+
+          {/* Contact info */}
+          <section
+            className="border rounded-lg p-4 space-y-3"
+            data-testid="contact-section"
+          >
+            <h2 className="text-sm font-medium">Contact</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 text-sm">
+              <div>
+                <dt className="text-xs text-muted-foreground">Phone</dt>
+                <dd data-testid="vendor-phone">
+                  {vendor.phone ? (
+                    <a
+                      href={`tel:${vendor.phone}`}
+                      className="text-primary hover:underline"
+                    >
+                      {vendor.phone}
+                    </a>
+                  ) : (
+                    "—"
+                  )}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Email</dt>
+                <dd data-testid="vendor-email">
+                  {vendor.email ? (
+                    <a
+                      href={`mailto:${vendor.email}`}
+                      className="text-primary hover:underline break-all"
+                    >
+                      {vendor.email}
+                    </a>
+                  ) : (
+                    "—"
+                  )}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Address</dt>
+                <dd data-testid="vendor-address" className="whitespace-pre-line">
+                  {vendor.address ?? "—"}
+                </dd>
+              </div>
+            </div>
+          </section>
+
+          {/* Pricing */}
+          <section
+            className="border rounded-lg p-4 space-y-3"
+            data-testid="pricing-section"
+          >
+            <h2 className="text-sm font-medium">Pricing</h2>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+              <div>
+                <dt className="text-xs text-muted-foreground">Hourly rate</dt>
+                <dd data-testid="vendor-hourly-rate">
+                  {formatHourlyRate(vendor.hourly_rate)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Flat-rate notes</dt>
+                <dd
+                  data-testid="vendor-flat-rate-notes"
+                  className="whitespace-pre-line"
+                >
+                  {vendor.flat_rate_notes ?? "—"}
+                </dd>
+              </div>
+            </div>
+          </section>
+
+          {/* Notes */}
+          <section
+            className="border rounded-lg p-4 space-y-3"
+            data-testid="notes-section"
+          >
+            <h2 className="text-sm font-medium">Notes</h2>
+            <p
+              data-testid="vendor-notes"
+              className="text-sm text-muted-foreground whitespace-pre-line"
+            >
+              {vendor.notes ?? "No notes yet."}
+            </p>
+          </section>
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/Vendors.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Vendors.tsx
@@ -1,0 +1,179 @@
+import { useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import SectionHeader from "@/shared/components/ui/SectionHeader";
+import EmptyState from "@/shared/components/ui/EmptyState";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import { useGetVendorsQuery } from "@/shared/store/vendorsApi";
+import {
+  VENDOR_CATEGORIES,
+  VENDOR_PAGE_SIZE,
+} from "@/shared/lib/vendor-labels";
+import type { VendorCategory } from "@/shared/types/vendor/vendor-category";
+import VendorsListSkeleton from "@/app/features/vendors/VendorsListSkeleton";
+import VendorCategoryFilter from "@/app/features/vendors/VendorCategoryFilter";
+import VendorPreferredToggle from "@/app/features/vendors/VendorPreferredToggle";
+import VendorCard from "@/app/features/vendors/VendorCard";
+import VendorRow from "@/app/features/vendors/VendorRow";
+
+const CATEGORY_PARAM = "category";
+const PREFERRED_PARAM = "preferred";
+
+function parseCategoryParam(value: string | null): VendorCategory | null {
+  if (value === null) return null;
+  return (VENDOR_CATEGORIES as readonly string[]).includes(value)
+    ? (value as VendorCategory)
+    : null;
+}
+
+function parsePreferredParam(value: string | null): boolean {
+  return value === "true";
+}
+
+export default function Vendors() {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const category = parseCategoryParam(searchParams.get(CATEGORY_PARAM));
+  const preferredOnly = parsePreferredParam(searchParams.get(PREFERRED_PARAM));
+  const [pageCount, setPageCount] = useState(1);
+
+  const queryArgs = useMemo(
+    () => ({
+      ...(category ? { category } : {}),
+      ...(preferredOnly ? { preferred: true } : {}),
+      limit: VENDOR_PAGE_SIZE * pageCount,
+      offset: 0,
+    }),
+    [category, preferredOnly, pageCount],
+  );
+
+  const { data, isLoading, isFetching, isError, refetch } =
+    useGetVendorsQuery(queryArgs);
+
+  const vendors = data?.items ?? [];
+  const hasMore = data?.has_more ?? false;
+  const isFiltered = category !== null || preferredOnly;
+  const showCategoryBadge = category === null;
+
+  function handleCategoryChange(next: VendorCategory | null) {
+    const params = new URLSearchParams(searchParams);
+    if (next) {
+      params.set(CATEGORY_PARAM, next);
+    } else {
+      params.delete(CATEGORY_PARAM);
+    }
+    setSearchParams(params, { replace: true });
+    setPageCount(1);
+  }
+
+  function handlePreferredChange(next: boolean) {
+    const params = new URLSearchParams(searchParams);
+    if (next) {
+      params.set(PREFERRED_PARAM, "true");
+    } else {
+      params.delete(PREFERRED_PARAM);
+    }
+    setSearchParams(params, { replace: true });
+    setPageCount(1);
+  }
+
+  function handleLoadMore() {
+    setPageCount((prev) => prev + 1);
+  }
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6">
+      <SectionHeader
+        title="Vendors"
+        subtitle="Your rolodex of trusted handymen, plumbers, cleaners, and other trades."
+      />
+
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <VendorCategoryFilter value={category} onChange={handleCategoryChange} />
+        <VendorPreferredToggle
+          value={preferredOnly}
+          onChange={handlePreferredChange}
+        />
+      </div>
+
+      {isError ? (
+        <AlertBox variant="error" className="flex items-center justify-between gap-3">
+          <span>I couldn't load your vendors. Want me to try again?</span>
+          <LoadingButton
+            variant="secondary"
+            size="sm"
+            isLoading={isFetching}
+            loadingText="Retrying..."
+            onClick={() => refetch()}
+          >
+            Retry
+          </LoadingButton>
+        </AlertBox>
+      ) : null}
+
+      {isLoading ? (
+        <VendorsListSkeleton />
+      ) : vendors.length === 0 && !isError ? (
+        <EmptyState
+          message={
+            isFiltered
+              ? "No vendors match this filter. Try a different category or clear preferred-only."
+              : "No vendors yet — your rolodex is empty. Adding vendors is coming soon."
+          }
+        />
+      ) : (
+        <>
+          {/* Mobile: cards */}
+          <ul className="md:hidden space-y-3" data-testid="vendors-mobile">
+            {vendors.map((vendor) => (
+              <li key={vendor.id}>
+                <VendorCard
+                  vendor={vendor}
+                  showCategoryBadge={showCategoryBadge}
+                />
+              </li>
+            ))}
+          </ul>
+
+          {/* Desktop: table */}
+          <div
+            className="hidden md:block border rounded-lg overflow-hidden"
+            data-testid="vendors-desktop"
+          >
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Name</th>
+                  <th className="px-4 py-2 font-medium">Category</th>
+                  <th className="px-4 py-2 font-medium">Hourly Rate</th>
+                  <th className="px-4 py-2 font-medium">Last Used</th>
+                </tr>
+              </thead>
+              <tbody>
+                {vendors.map((vendor) => (
+                  <VendorRow
+                    key={vendor.id}
+                    vendor={vendor}
+                    showCategoryBadge={showCategoryBadge}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {hasMore ? (
+            <div className="flex justify-center">
+              <LoadingButton
+                variant="secondary"
+                onClick={handleLoadMore}
+                isLoading={isFetching}
+                loadingText="Loading..."
+              >
+                Load more
+              </LoadingButton>
+            </div>
+          ) : null}
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/vendor-labels.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/vendor-labels.ts
@@ -1,0 +1,54 @@
+import type { BadgeColor } from "@/shared/components/ui/Badge";
+import type { VendorCategory } from "@/shared/types/vendor/vendor-category";
+
+/**
+ * Category label & color tables for the Vendors domain.
+ *
+ * Mirrors backend tuples in ``app/core/vendor_enums.py`` — keep both in
+ * sync when categories are added (canonical source of truth is the backend
+ * ``CheckConstraint`` per RENTALS_PLAN.md §4.1).
+ */
+
+export const VENDOR_CATEGORIES: readonly VendorCategory[] = [
+  "handyman",
+  "plumber",
+  "electrician",
+  "hvac",
+  "locksmith",
+  "cleaner",
+  "pest",
+  "landscaper",
+  "general_contractor",
+] as const;
+
+export const VENDOR_CATEGORY_LABELS: Record<VendorCategory, string> = {
+  handyman: "Handyman",
+  plumber: "Plumber",
+  electrician: "Electrician",
+  hvac: "HVAC",
+  locksmith: "Locksmith",
+  cleaner: "Cleaner",
+  pest: "Pest Control",
+  landscaper: "Landscaper",
+  general_contractor: "General Contractor",
+};
+
+/**
+ * Category badge colors. Visually grouped by trade family so scanning a
+ * mixed rolodex feels coherent — building systems (plumber/electrician/hvac)
+ * are blue, exterior trades green, mechanical/security (locksmith/handyman)
+ * gray, miscellaneous in warm hues.
+ */
+export const VENDOR_CATEGORY_BADGE_COLORS: Record<VendorCategory, BadgeColor> = {
+  handyman: "gray",
+  plumber: "blue",
+  electrician: "blue",
+  hvac: "blue",
+  locksmith: "gray",
+  cleaner: "purple",
+  pest: "orange",
+  landscaper: "green",
+  general_contractor: "yellow",
+};
+
+export const VENDOR_PAGE_SIZE = 25;

--- a/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
@@ -4,6 +4,6 @@ import { axiosBaseQuery } from "./baseQuery";
 export const baseApi = createApi({
   reducerPath: "api",
   baseQuery: axiosBaseQuery,
-  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "Reservation", "Reconciliation", "TaxReturn", "PlaidItem", "PlaidAccount", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant"],
+  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "Reservation", "Reconciliation", "TaxReturn", "PlaidItem", "PlaidAccount", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor"],
   endpoints: () => ({}),
 });

--- a/apps/mybookkeeper/frontend/src/shared/store/vendorsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/vendorsApi.ts
@@ -1,0 +1,47 @@
+import { baseApi } from "./baseApi";
+import type { VendorListArgs } from "@/shared/types/vendor/vendor-list-args";
+import type { VendorListResponse } from "@/shared/types/vendor/vendor-list-response";
+import type { VendorResponse } from "@/shared/types/vendor/vendor-response";
+
+/**
+ * RTK Query slice for the Vendors domain (rentals Phase 4).
+ *
+ * Tag strategy mirrors ``applicantsApi``: each item carries its own
+ * ``Vendor:{id}`` tag plus a single shared ``Vendor:LIST`` tag for the
+ * paginated list. Write endpoints (create / update / soft-delete) land in
+ * PR 4.2; this PR ships read-only queries.
+ */
+const vendorsApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getVendors: builder.query<VendorListResponse, VendorListArgs | void>({
+      query: (args) => ({
+        url: "/vendors",
+        params: {
+          ...(args?.category ? { category: args.category } : {}),
+          ...(args?.preferred !== undefined ? { preferred: args.preferred } : {}),
+          ...(args?.include_deleted !== undefined
+            ? { include_deleted: args.include_deleted }
+            : {}),
+          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
+          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+        },
+      }),
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.items.map((vendor) => ({
+                type: "Vendor" as const,
+                id: vendor.id,
+              })),
+              { type: "Vendor" as const, id: "LIST" },
+            ]
+          : [{ type: "Vendor" as const, id: "LIST" }],
+    }),
+    getVendorById: builder.query<VendorResponse, string>({
+      query: (id) => ({ url: `/vendors/${id}` }),
+      providesTags: (_result, _error, id) => [{ type: "Vendor", id }],
+    }),
+  }),
+});
+
+export const { useGetVendorsQuery, useGetVendorByIdQuery } = vendorsApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-category.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-category.ts
@@ -1,0 +1,17 @@
+/**
+ * Trade categories a vendor can be tagged with.
+ *
+ * Mirrors backend ``VENDOR_CATEGORIES`` in ``app/core/vendor_enums.py``. Keep
+ * both in sync — the canonical source of truth is the backend
+ * ``CheckConstraint`` per RENTALS_PLAN.md §4.1.
+ */
+export type VendorCategory =
+  | "handyman"
+  | "plumber"
+  | "electrician"
+  | "hvac"
+  | "locksmith"
+  | "cleaner"
+  | "pest"
+  | "landscaper"
+  | "general_contractor";

--- a/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-list-args.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-list-args.ts
@@ -1,0 +1,14 @@
+import type { VendorCategory } from "./vendor-category";
+
+/**
+ * Query args for the GET /vendors hook. ``category`` omitted means "all
+ * categories"; ``preferred`` omitted means "all vendors regardless of
+ * preferred flag".
+ */
+export interface VendorListArgs {
+  category?: VendorCategory;
+  preferred?: boolean;
+  include_deleted?: boolean;
+  limit?: number;
+  offset?: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-list-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-list-response.ts
@@ -1,0 +1,12 @@
+import type { VendorSummary } from "./vendor-summary";
+
+/**
+ * Paginated envelope returned by GET /vendors — same shape as
+ * ``ApplicantListResponse``. ``has_more`` lets the frontend hide the
+ * "Load more" button on the last page.
+ */
+export interface VendorListResponse {
+  items: VendorSummary[];
+  total: number;
+  has_more: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-response.ts
@@ -1,0 +1,32 @@
+import type { VendorCategory } from "./vendor-category";
+
+/**
+ * Mirrors backend ``VendorResponse`` Pydantic schema — the full payload
+ * returned by GET /vendors/{id}. Includes business contact info, pricing
+ * notes, and host notes that are excluded from the rolodex list view.
+ *
+ * Numeric fields are serialised as strings by FastAPI (Decimal → str) so
+ * the frontend treats ``hourly_rate`` as ``string | null``.
+ */
+export interface VendorResponse {
+  id: string;
+  organization_id: string;
+  user_id: string;
+
+  name: string;
+  category: VendorCategory;
+
+  phone: string | null;
+  email: string | null;
+  address: string | null;
+
+  hourly_rate: string | null;
+  flat_rate_notes: string | null;
+
+  preferred: boolean;
+  notes: string | null;
+
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-summary.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/vendor/vendor-summary.ts
@@ -1,0 +1,24 @@
+import type { VendorCategory } from "./vendor-category";
+
+/**
+ * Mirrors backend ``VendorSummary`` Pydantic schema — the rolodex-card shape
+ * returned by GET /vendors.
+ *
+ * Excludes phone / email / address / flat_rate_notes / notes per
+ * RENTALS_PLAN.md §5.4 information hierarchy — those live on the detail
+ * page only.
+ */
+export interface VendorSummary {
+  id: string;
+  organization_id: string;
+  user_id: string;
+
+  name: string;
+  category: VendorCategory;
+  hourly_rate: string | null;
+  preferred: boolean;
+
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -462,16 +462,27 @@
         "backend/app/services/vendors/",
         "backend/app/api/vendors.py",
         "backend/app/core/vendor_enums.py",
-        "backend/alembic/versions/g9i1j4l6m8n0_add_vendors_domain.py"
+        "backend/alembic/versions/g9i1j4l6m8n0_add_vendors_domain.py",
+        "frontend/src/app/pages/Vendors.tsx",
+        "frontend/src/app/pages/VendorDetail.tsx",
+        "frontend/src/app/features/vendors/",
+        "frontend/src/shared/types/vendor/",
+        "frontend/src/shared/store/vendorsApi.ts",
+        "frontend/src/shared/lib/vendor-labels.ts"
       ],
       "backend_tests": [
         "test_vendor_repo.py",
         "test_vendor_service.py",
         "test_vendor_routes.py"
       ],
-      "frontend_tests": [],
+      "frontend_tests": [
+        "Vendors.test.tsx",
+        "VendorDetail.test.tsx"
+      ],
       "e2e_specs": [
-        "vendors-api.spec.ts"
+        "vendors-api.spec.ts",
+        "vendors.spec.ts",
+        "vendors-layout.spec.ts"
       ]
     },
     "system": {


### PR DESCRIPTION
## Summary

Read-only Vendors rolodex frontend (rentals Phase 4, PR 4.1b). Consumes the
`GET /vendors` and `GET /vendors/{id}` endpoints shipped in PR 4.1a (#108).
Mirrors the Applicants frontend pattern (PR 3.1b, #106) for consistency.

This PR is intentionally narrow: list page + detail page, no writes. The
public `POST /vendors`, edit/soft-delete UI, and the `Transaction.vendor_id`
FK come later in PR 4.2.

## Deliverables

**Pages**
- `apps/mybookkeeper/frontend/src/app/pages/Vendors.tsx` — list view with
  category chip filter and a preferred-only toggle. Both filters
  URL-state-synced via `useSearchParams` so deep links and the back button
  work. Mobile cards / desktop table responsive split.
- `apps/mybookkeeper/frontend/src/app/pages/VendorDetail.tsx` — header (name
  + preferred indicator + category badge + last-used timestamp), Contact /
  Pricing / Notes sections, `tel:` and `mailto:` links.

**Feature components** (`apps/mybookkeeper/frontend/src/app/features/vendors/`)
- `VendorCard`, `VendorRow` — mobile / desktop list rows
- `VendorCategoryBadge`, `VendorCategoryFilter`
- `VendorPreferredToggle` — yellow star, `role="switch"`, 44px touch target
- `VendorsListSkeleton`, `VendorDetailSkeleton` — mirror loaded layout

**Shared**
- `shared/store/vendorsApi.ts` — RTK Query slice with `getVendors` and
  `getVendorById`; `Vendor` tag added to `baseApi.tagTypes`.
- `shared/types/vendor/*.ts` — strict per-file types matching backend
  Pydantic schemas (`VendorSummary`, `VendorResponse`, list args /
  response, `VendorCategory` literal union).
- `shared/lib/vendor-labels.ts` — category labels, badge colors, page size.

**Routing & nav**
- `/vendors` and `/vendors/:vendorId` added to `App.tsx`
- "Vendors" nav entry added to `app/lib/nav.ts` between Applicants and
  Reconciliation

**Tests**
- `frontend/src/__tests__/Vendors.test.tsx` — 9 unit tests
- `frontend/src/__tests__/VendorDetail.test.tsx` — 11 unit tests
- `frontend/e2e/vendors-layout.spec.ts` — 4 layout tests (mirrors
  `applicants-layout.spec.ts`): skeleton-vs-loaded card count, no
  horizontal overflow at mobile/tablet/desktop, 44px touch targets,
  detail-skeleton sections match loaded sections.
- `frontend/e2e/vendors.spec.ts` — 5 behavioural tests: rolodex render +
  drilldown + contact links, category filter URL-state sync, preferred
  toggle, filtered empty state, 404 detail.
- `scripts/test-map.json` — vendors entry expanded with frontend sources,
  unit tests, and new E2E specs so the targeted runner picks them up.

## Information hierarchy (per the page spec)

| Data point | Where | Why |
|---|---|---|
| Vendor name | List + detail | Primary identifier |
| Category badge | List (when "All") + detail | Trade context |
| Preferred star | List + detail | Host-curated "show first" flag |
| Hourly rate | List + detail | Quick comparison |
| Last used (relative) | List + detail | Recall who was used recently |
| Phone, email, address | Detail only | Action context, not scan context |
| Flat-rate notes, host notes | Detail only | Free-form, doesn't fit a row |

## Excluded by design (out of scope)

- No create / edit / soft-delete UI — PR 4.2.
- No "assign vendor" affordance on transactions — PR 4.2 (lands with the
  `Transaction.vendor_id` FK migration).
- No KeyCheck / screening button — that's PR 3.3, separate scope.

## Test plan

- [x] `npm run build` — clean (TypeScript + Vite)
- [x] `npm run lint` (vendor files only) — clean
- [x] `vitest run` for vendor + applicant tests — 27/27 pass
- [x] `playwright test --list e2e/vendors-layout.spec.ts e2e/vendors.spec.ts` —
      9 specs discovered
- [ ] CI: full E2E run against backend (lint, typecheck, unit, E2E,
      CodeQL, Gitleaks)
- [ ] Manual: verify rolodex renders against a live backend with seeded
      vendors

## Notes

- Worktree-developed in `MyFreeApps-worktrees/vendors-frontend` per
  multi-session-safety. No screenshot included because the worktree has
  no Python venv / Postgres — the dev server starts cleanly on `:5174`
  but a backend isn't running to render data. CI will validate end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
