### PR TITLE
feat(myjobhunter/deploy): add HTTP security headers to Caddy (C7)

### DIFF
--- a/.github/workflows/integration-myjobhunter.yml
+++ b/.github/workflows/integration-myjobhunter.yml
@@ -81,6 +81,48 @@ jobs:
           grep -q "<html" /tmp/index.html
           echo "Frontend HTML served correctly"
 
+      - name: Verify security response headers
+        # Asserts apps/myjobhunter/docker/Caddyfile.docker is emitting the
+        # five security headers required for parity with MyBookkeeper.
+        # Header lookups are case-insensitive (curl -I lower-cases names).
+        run: |
+          set -e
+          HEADERS=$(curl -fsSI http://localhost:8092/ | tr -d '\r')
+          echo "$HEADERS"
+
+          echo "$HEADERS" | grep -i '^Strict-Transport-Security:' \
+            | grep -q 'max-age=63072000' \
+            || (echo "Missing or wrong HSTS header" && exit 1)
+
+          echo "$HEADERS" | grep -iq '^X-Frame-Options:.*DENY' \
+            || (echo "Missing or wrong X-Frame-Options header" && exit 1)
+
+          echo "$HEADERS" | grep -iq '^X-Content-Type-Options:.*nosniff' \
+            || (echo "Missing or wrong X-Content-Type-Options header" && exit 1)
+
+          echo "$HEADERS" | grep -iq '^Referrer-Policy:.*strict-origin-when-cross-origin' \
+            || (echo "Missing or wrong Referrer-Policy header" && exit 1)
+
+          echo "$HEADERS" | grep -iq "^Content-Security-Policy:.*default-src 'self'" \
+            || (echo "Missing or wrong Content-Security-Policy header" && exit 1)
+
+          # Phase 1 CSP must NOT contain 'unsafe-inline' for scripts.
+          # If this ever fires, someone added a third-party script integration
+          # without splitting the script-src directive — fail loud.
+          if echo "$HEADERS" | grep -i '^Content-Security-Policy:' \
+              | grep -Eq "script-src[^;]*'unsafe-inline'"; then
+            echo "CSP regression: script-src must never contain 'unsafe-inline'" >&2
+            exit 1
+          fi
+
+          # Server header should be stripped.
+          if echo "$HEADERS" | grep -iq '^Server:'; then
+            echo "Server header was not stripped" >&2
+            exit 1
+          fi
+
+          echo "All security headers present and correctly configured."
+
       - name: Smoke — register + login
         run: |
           EMAIL="ci-$(date +%s)@myjobhunter-test.invalid"

--- a/apps/myjobhunter/docker/Caddyfile.docker
+++ b/apps/myjobhunter/docker/Caddyfile.docker
@@ -1,9 +1,84 @@
+# Trust X-Forwarded-For headers from host Caddy (runs on the same machine,
+# bridges to this container). This ensures real client IPs appear in app logs
+# rather than the Docker bridge IP.
+{
+    servers {
+        trusted_proxies static private_ranges
+        client_ip_headers X-Forwarded-For
+    }
+}
+
+# HTTP-only on :80 — TLS is terminated by host Caddy before traffic reaches
+# this container. The host Caddy must reverse-proxy the app domain to this
+# container with the original Host header preserved.
 {$DOMAIN:localhost} {
+    # ----------------------------------------------------------------------
+    # Security response headers — applied to every response (API + SPA).
+    #
+    # `defer` lets these headers also override anything the upstream FastAPI
+    # process might emit, so we never accidentally regress on a stricter
+    # policy because the API set a looser one.
+    #
+    # Mirrors apps/mybookkeeper/docker/Caddyfile.docker; CSP is intentionally
+    # tighter — see the per-directive justification under Content-Security-Policy.
+    # ----------------------------------------------------------------------
+    header {
+        defer
+
+        # HSTS — instructs browsers to only ever talk to this origin over HTTPS.
+        # Effective once the outer host Caddy is terminating TLS for the domain;
+        # harmless to set early. Two years + preload list eligibility, matching MBK.
+        Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+
+        # Forbid framing entirely — MJH never embeds itself in another site.
+        X-Frame-Options "DENY"
+
+        # Don't let browsers MIME-sniff responses past the declared Content-Type.
+        X-Content-Type-Options "nosniff"
+
+        # Send the origin (no path or query) on cross-origin nav; full referrer same-origin.
+        Referrer-Policy "strict-origin-when-cross-origin"
+
+        # Disable browser features MJH does not use. Matches MBK's exhaustive list
+        # so we don't have to revisit it as features get standardized.
+        Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=(), browsing-topics=()"
+
+        # Content-Security-Policy — tighter than MBK because MJH Phase 1 has no
+        # third-party integrations on the page (no Plaid, no PostHog, no Sentry,
+        # no Cloudflare embeds). Each directive justified:
+        #
+        #   default-src 'self'         — fallback: only same-origin assets
+        #   script-src 'self'          — bundled JS only; NEVER add 'unsafe-inline'
+        #   style-src 'self' 'unsafe-inline' — Tailwind/Vite emit inline styles for
+        #                                runtime theme variables; acceptable for
+        #                                styles, never for scripts
+        #   img-src 'self' data: blob: — data: for inline SVG icons, blob: for any
+        #                                client-built images (e.g. avatar previews)
+        #   font-src 'self'            — bundled fonts only
+        #   connect-src 'self'         — XHR/fetch only to the same origin (the API
+        #                                lives at /api/* under the same host).
+        #                                Widen here when Phase 4 adds Anthropic /
+        #                                Tavily / Google OAuth callbacks.
+        #   frame-src 'none'           — MJH does not embed any iframes today.
+        #                                Add Cloudflare Turnstile here when C1 ships.
+        #   frame-ancestors 'none'     — backstop for X-Frame-Options on modern browsers
+        #   base-uri 'self'            — block <base href="..."> hijacks
+        #   form-action 'self'         — forms can only submit back to the app
+        #   object-src 'none'          — no Flash/Java/legacy plugin embeds
+        #   upgrade-insecure-requests  — auto-upgrade any stray http:// reference
+        Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self'; frame-src 'none'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+
+        # Don't advertise the server software in the response headers.
+        -Server
+    }
+
+    # API proxy (strip /api prefix)
     handle /api/* {
         uri strip_prefix /api
         reverse_proxy api:8002
     }
 
+    # SPA fallback for frontend
     handle {
         root * /srv/frontend
         try_files {path} /index.html


### PR DESCRIPTION
## Summary

PR C7 of the 14-PR plan to bring MyJobHunter to security-header parity with MyBookkeeper. Pure config + CI change — no app code, no DB, no Python.

## What changes

**`apps/myjobhunter/docker/Caddyfile.docker`** — adds a site-block-level \`header { defer ... }\` directive emitting the same security headers MBK already serves:

| Header | Value | Source of truth |
|---|---|---|
| Strict-Transport-Security | \`max-age=63072000; includeSubDomains; preload\` | mirrored from MBK |
| X-Frame-Options | \`DENY\` | mirrored from MBK |
| X-Content-Type-Options | \`nosniff\` | mirrored from MBK |
| Referrer-Policy | \`strict-origin-when-cross-origin\` | mirrored from MBK |
| Permissions-Policy | exhaustive disable list | mirrored from MBK |
| Content-Security-Policy | tighter Phase 1 policy | **MJH-specific (see below)** |
| Server | stripped (\`-Server\`) | mirrored from MBK |

Also adds the \`servers { trusted_proxies static private_ranges; client_ip_headers X-Forwarded-For }\` block so real client IPs reach the app — same pattern MBK uses now that traffic comes through host Caddy.

## Where MJH's CSP is tighter than MBK's

MBK integrates with Plaid, PostHog, Sentry, and Cloudflare-fronted endpoints, so its CSP allows those origins on \`script-src\`, \`connect-src\`, \`frame-src\`, etc. MJH Phase 1 has **no** third-party browser integrations, so its CSP locks down to:

- \`default-src 'self'\`
- \`script-src 'self'\` — bundled JS only; never \`'unsafe-inline'\`
- \`style-src 'self' 'unsafe-inline'\` — Tailwind/Vite emit inline styles for theme variables; acceptable for styles only
- \`img-src 'self' data: blob:\`
- \`font-src 'self'\`
- \`connect-src 'self'\` — XHR/fetch only to the same origin (\`/api/*\` lives under the same host)
- \`frame-src 'none'\` — no embeds today
- \`frame-ancestors 'none'\`, \`base-uri 'self'\`, \`form-action 'self'\`, \`object-src 'none'\`, \`upgrade-insecure-requests\`

The Caddyfile has each directive justified inline so the next person knows where to widen it when Phase 2-4 adds Anthropic, Tavily, Google OAuth, and Cloudflare Turnstile.

## Test plan

**\`.github/workflows/integration-myjobhunter.yml\`** — extended the existing Stack Smoke job to \`curl -I http://localhost:8092/\` against the live docker-compose stack and assert every required header is present. The workflow already builds + runs the full Caddy + API + Postgres stack on every PR touching MJH; a Caddyfile syntax error or missing header now fails CI.

The new step also:
- Confirms HSTS includes \`max-age=63072000\` (catches an MBK regression)
- Regression-checks that \`script-src\` never contains \`'unsafe-inline'\`
- Confirms \`Server:\` is stripped

## Things checked

- [x] Caddyfile structure mirrors \`apps/mybookkeeper/docker/Caddyfile.docker\` (known-working in MBK production)
- [x] \`header\` directive uses \`defer\` so it overrides any FastAPI-emitted headers — same pattern as MBK
- [x] CSP \`script-src\` does NOT contain \`'unsafe-inline'\`
- [x] HSTS value matches MBK exactly (\`max-age=63072000; includeSubDomains; preload\`)
- [x] CI assertion runs against the actual Caddy container (\`:8092\`) not the dev Vite server (\`:5174\`) — Vite doesn't proxy these headers
- [x] No \`/api/docs\` block (MBK 404s prod docs; MJH still exposes them in Phase 1 — separate PR)
- [x] No storage subdomain block (MJH has no MinIO yet)

## Manual validation

Did not run \`caddy validate\` locally — Docker/Caddy not available on the dev box. The integration CI job validates parse-correctness on every PR (a syntax error fails \`Wait for api health\`, which goes through Caddy). Adding native local validation is a follow-up.

## Pre-existing CI failure (unrelated)

Recent runs of \`MyJobHunter Integration\` on \`main\` are failing during the Docker build with a \`vitest.config.ts\` TS2769 error — \`Plugin<any>\` from the local frontend's vite vs the workspace root's vite. PR #93 attempted a fix but the error has resurfaced. **This is pre-existing, not introduced by C7**, but it will block this PR's CI from reaching the new header-verification step. Fixing the dual-vite-types issue should be a separate follow-up PR (likely a clean cherry-pick of #93's intent applied to the current Docker build context).

## What this is NOT

- Not a TLS change — outer host Caddy still terminates TLS (PR S4)
- Not a docs-protection change — \`/api/docs\` exposure is a separate PR
- Not a CSP-allow widening — Phase 1 surface only

🤖 Generated with [Claude Code](https://claude.com/claude-code)