### PR TITLE
fix(myjobhunter/frontend): vitest dual-vite-types regression via mergeConfig

### DIFF
--- a/apps/myjobhunter/frontend/vitest.config.ts
+++ b/apps/myjobhunter/frontend/vitest.config.ts
@@ -1,35 +1,14 @@
-import { defineConfig } from "vitest/config";
-import react from "@vitejs/plugin-react";
-import path from "path";
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config";
 
-const sharedFrontend = path.resolve(
-  __dirname,
-  "../../../packages/shared-frontend/src"
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      globals: true,
+      setupFiles: ["./src/test-setup.ts"],
+      exclude: ["e2e/**", "**/node_modules/**"],
+    },
+  }),
 );
-
-export default defineConfig({
-  plugins: [react()],
-  test: {
-    environment: "jsdom",
-    globals: true,
-    setupFiles: ["./src/test-setup.ts"],
-    exclude: ["e2e/**", "**/node_modules/**"],
-  },
-  resolve: {
-    alias: [
-      // More specific aliases must come before the generic "@" catch-all.
-      {
-        find: "@/shared",
-        replacement: sharedFrontend,
-      },
-      {
-        find: "@platform/ui",
-        replacement: sharedFrontend,
-      },
-      {
-        find: "@",
-        replacement: path.resolve(__dirname, "./src"),
-      },
-    ],
-  },
-});


### PR DESCRIPTION
## Summary

- Refactors `apps/myjobhunter/frontend/vitest.config.ts` to use `mergeConfig` over `./vite.config` (MBK's existing pattern) so the React plugin is constructed once inside `vite.config.ts` and never re-typechecked against `vitest/config`'s `defineConfig`.

## Why

`tsc -b` has been failing every MJH stack-smoke run with TS2769 — `Plugin<any>` from `apps/myjobhunter/frontend/node_modules/vite` is not assignable to `Plugin<any>` from `/node_modules/vite`. Two vite copies exist because MBK pins `vite ^7` and MJH pins `vite ^8` — npm hoists one and nests the other, and the plugin's return type comes from a different `vite` than `vitest/config`'s `defineConfig` parameter type.

The previous fix in #93 swapped to `vitest/config`'s `defineConfig` but kept passing the plugin inline, so the type collision came right back as soon as the lockfile rebalanced.

## Test plan

- [x] CI's stack-smoke `tsc -b && vite build` step passes
- [x] `npm test --workspace=apps/myjobhunter/frontend` resolves vitest config without TS errors
- [x] No runtime change — same plugins, same aliases, same test setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)