### PR TITLE
fix(myjobhunter/ci): platform_shared install + smoke email TLD

### DIFF
--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -93,6 +93,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install -e ../../../packages/shared-backend
 
       - name: Run alembic migrations
         working-directory: apps/myjobhunter/backend

--- a/.github/workflows/integration-myjobhunter.yml
+++ b/.github/workflows/integration-myjobhunter.yml
@@ -83,7 +83,10 @@ jobs:
 
       - name: Smoke — register + login
         run: |
-          EMAIL="ci-$(date +%s)@myjobhunter-test.invalid"
+          # email-validator>=2 rejects RFC 6761 reserved TLDs (.invalid) when
+          # globally_deliverable=True, which fastapi-users' EmailStr enforces.
+          # Use example.com (RFC 2606 reserved, real public-suffix-list TLD).
+          EMAIL="ci-$(date +%s)@myjobhunter-ci.example.com"
           PASSWORD="integration_password_12_chars"
           REGISTER_RES=$(curl -fsS -X POST http://localhost:8092/api/auth/register \
             -H 'Content-Type: application/json' \


### PR DESCRIPTION
## Summary

Two CI fixes for MyJobHunter, both pre-existing failures on `main`:

1. **`backend-tests` job** — installs `platform_shared` so pytest can collect (`ModuleNotFoundError` blocked it).
2. **`integration` smoke test** — switches register+login email from `*.invalid` (rejected by `email-validator>=2` per RFC 6761 globally_deliverable check) to `*.example.com` (RFC 2606 reserved + accepted).

## Why

MJH backend imports `platform_shared.{db,core.security}`, but the CI workflow installed only `requirements.txt`. The smoke test email `*@myjobhunter-test.invalid` started 422-ing once email-validator was bumped past 2.0.

MJH backend-tests has been red on `main` since the regressions; this unblocks every MJH PR (incl. #112, #114).

## Test plan

- [x] `backend-tests / myjobhunter` passes on this PR
- [x] `Stack smoke (compose up + health + login)` passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)