### PR TITLE
refactor(shared-backend): promote AuditLog model + listener to platform_shared (M3)

### DIFF
--- a/apps/mybookkeeper/CLAUDE.md
+++ b/apps/mybookkeeper/CLAUDE.md
@@ -251,8 +251,8 @@ All AI-facing UI (extraction feedback, status messages, error states) should fee
 - Underlying ciphertext is Fernet, derived from the same `ENCRYPTION_KEY` master via HKDF but with a distinct `info=b"mybookkeeper-pii-encryption"` so the PII key family is isolated from the OAuth-token key family — leaking one set of ciphertexts does NOT compromise the other
 - Ciphertext is non-deterministic — equality lookups on encrypted columns will NOT match (each write produces a different ciphertext for the same plaintext). Dedup must use non-PII keys (e.g. `email_message_id`, `external_inquiry_id`)
 - Add a sibling `key_version: SmallInteger` column on every PII-bearing table per RENTALS_PLAN.md §8.2 — required for non-destructive future key rotation
-- Add encrypted-column field names to `SENSITIVE_FIELDS` in `core/audit.py` so the audit log masks them as `***` (the audit listener captures values BEFORE the bind-time encryption hook fires, so without masking it would leak plaintext into audit_logs)
-- Phase 3 (Applicants) reuses the same `EncryptedString` type — do NOT re-implement; extend the SENSITIVE_FIELDS allowlist instead
+- Add encrypted-column field names to `MBK_SENSITIVE_FIELDS` in `app/core/audit.py` so the audit log masks them as `***` (the audit listener captures values BEFORE the bind-time encryption hook fires, so without masking it would leak plaintext into audit_logs). The wrapper calls `platform_shared.core.audit.register_sensitive_fields()` at import time — listener + model now live in `platform_shared` (PR M3).
+- Phase 3 (Applicants) reuses the same `EncryptedString` type — do NOT re-implement; extend the `MBK_SENSITIVE_FIELDS` allowlist instead
 
 ## Commands
 

--- a/apps/mybookkeeper/backend/app/core/audit.py
+++ b/apps/mybookkeeper/backend/app/core/audit.py
@@ -1,15 +1,25 @@
-from contextvars import ContextVar
-from datetime import datetime, timezone
-from sqlalchemy import event, inspect
-from sqlalchemy.orm import Session
-from sqlalchemy.orm.attributes import NO_VALUE
-from sqlalchemy.orm.base import NEVER_SET
+"""MBK audit listener — thin wrapper over :mod:`platform_shared.core.audit`.
 
-from app.models.system.audit_log import AuditLog
+Registers MBK-specific sensitive-field column names + skip-tables at import
+time so the shared listener masks PII the moment it attaches. Re-exports
+``current_user_id`` and ``register_audit_listeners`` so the rest of MBK
+(``app.main`` lifespan + middleware) keeps importing from the same path.
 
-current_user_id: ContextVar[str | None] = ContextVar("current_user_id", default=None)
+PII column names are app-specific — MBK's are documented in CLAUDE.md under
+"PII encryption (column-level)" and RENTALS_PLAN.md §8.7.
+"""
+from platform_shared.core.audit import (
+    current_user_id,
+    register_audit_listeners,
+    register_sensitive_fields,
+    register_skip_fields,
+    register_skip_tables,
+)
 
-SENSITIVE_FIELDS = {
+# MBK-specific sensitive-field allowlist. Edit this list when adding a new
+# PII-bearing column. The shared listener masks any value attached to a column
+# in this set as ``"***"`` BEFORE it lands in the audit_logs table.
+MBK_SENSITIVE_FIELDS: frozenset[str] = frozenset({
     "hashed_password",
     "access_token",
     "refresh_token",
@@ -40,85 +50,43 @@ SENSITIVE_FIELDS = {
     # to be safe. Applies to inquiries.notes, applicants.pets context,
     # video_call_notes.notes, applicant_events.notes, etc.
     "notes",
-}
-SKIP_FIELDS = {"file_content"}  # large binary fields with no audit value
-SKIP_TABLES = {"audit_logs", "auth_events", "processed_emails", "usage_logs", "sync_logs"}
+})
+
+# MBK skip-tables — high-volume / secret-bearing tables we don't audit.
+# (``audit_logs`` itself is added by platform_shared as a recursion guard.)
+MBK_SKIP_TABLES: frozenset[str] = frozenset({
+    "auth_events",
+    "processed_emails",
+    "usage_logs",
+    "sync_logs",
+})
+
+# Large-binary columns where neither the value nor a masked stub is useful.
+MBK_SKIP_FIELDS: frozenset[str] = frozenset({"file_content"})
 
 
-def _get_record_id(target) -> str:
-    pk = inspect(target.__class__).primary_key
-    return ",".join(str(getattr(target, col.name, "")) for col in pk)
+# Register at IMPORT time — not lazily — so the listener (registered later in
+# the FastAPI lifespan) never fires without these sets populated. Importing
+# ``app.core.audit`` anywhere during app startup is sufficient; ``app.main``
+# already imports it before the lifespan runs.
+register_sensitive_fields(MBK_SENSITIVE_FIELDS)
+register_skip_tables(MBK_SKIP_TABLES)
+register_skip_fields(MBK_SKIP_FIELDS)
 
 
-def _serialize(value) -> str | None:
-    return None if value is None else str(value)
+# Backwards-compatible re-exports — older MBK code referenced these as
+# module-level names on app.core.audit. Keep them working.
+SENSITIVE_FIELDS: frozenset[str] = MBK_SENSITIVE_FIELDS
+SKIP_TABLES: frozenset[str] = MBK_SKIP_TABLES
+SKIP_FIELDS: frozenset[str] = MBK_SKIP_FIELDS
 
-
-def _create_log(session, table_name, record_id, operation, field_name, old_value, new_value):
-    session.add(AuditLog(
-        table_name=table_name,
-        record_id=record_id,
-        operation=operation,
-        field_name=field_name,
-        old_value=old_value,
-        new_value=new_value,
-        changed_by=current_user_id.get(),
-    ))
-
-
-def _is_loaded(attr) -> bool:
-    """Return False for deferred/expired attributes to avoid triggering a lazy load."""
-    return attr.loaded_value not in (NEVER_SET, NO_VALUE)
-
-
-def _handle_insert(session, target):
-    if target.__tablename__ in SKIP_TABLES:
-        return
-    record_id = _get_record_id(target)
-    for attr in inspect(target).attrs:
-        if attr.key in SKIP_FIELDS or not _is_loaded(attr):
-            continue
-        new_val = "***" if attr.key in SENSITIVE_FIELDS else _serialize(attr.value)
-        _create_log(session, target.__tablename__, record_id, "INSERT", attr.key, None, new_val)
-
-
-def _handle_update(session, target):
-    if target.__tablename__ in SKIP_TABLES:
-        return
-    record_id = _get_record_id(target)
-    for attr in inspect(target).attrs:
-        if attr.key in SKIP_FIELDS:
-            continue
-        hist = attr.history
-        if not hist.has_changes():
-            continue
-        old = hist.deleted[0] if hist.deleted else None
-        new = hist.added[0] if hist.added else None
-        if attr.key in SENSITIVE_FIELDS:
-            old_val = "***" if old is not None else None
-            new_val = "***" if new is not None else None
-        else:
-            old_val, new_val = _serialize(old), _serialize(new)
-        _create_log(session, target.__tablename__, record_id, "UPDATE", attr.key, old_val, new_val)
-
-
-def _handle_delete(session, target):
-    if target.__tablename__ in SKIP_TABLES:
-        return
-    record_id = _get_record_id(target)
-    for attr in inspect(target).attrs:
-        if attr.key in SKIP_FIELDS or not _is_loaded(attr):
-            continue
-        old_val = "***" if attr.key in SENSITIVE_FIELDS else _serialize(attr.value)
-        _create_log(session, target.__tablename__, record_id, "DELETE", attr.key, old_val, None)
-
-
-def register_audit_listeners():
-    @event.listens_for(Session, "after_flush")
-    def after_flush(session, flush_context):
-        for target in list(session.new):
-            _handle_insert(session, target)
-        for target in list(session.dirty):
-            _handle_update(session, target)
-        for target in list(session.deleted):
-            _handle_delete(session, target)
+__all__ = [
+    "current_user_id",
+    "register_audit_listeners",
+    "MBK_SENSITIVE_FIELDS",
+    "MBK_SKIP_TABLES",
+    "MBK_SKIP_FIELDS",
+    "SENSITIVE_FIELDS",
+    "SKIP_TABLES",
+    "SKIP_FIELDS",
+]

--- a/apps/mybookkeeper/backend/app/db/base.py
+++ b/apps/mybookkeeper/backend/app/db/base.py
@@ -1,5 +1,11 @@
-from sqlalchemy.orm import DeclarativeBase
+"""MBK's ``Base`` is the shared :class:`platform_shared.db.base.Base`.
 
+Re-exported so the 50+ existing ``from app.db.base import Base`` imports keep
+working unchanged. Models registered against this Base land in
+``platform_shared.db.base.Base.metadata`` — the same metadata the shared
+:class:`platform_shared.db.models.audit_log.AuditLog` uses, so alembic's
+``target_metadata`` sees both MBK-defined and shared tables in one pass.
+"""
+from platform_shared.db.base import Base
 
-class Base(DeclarativeBase):
-    pass
+__all__ = ["Base"]

--- a/apps/mybookkeeper/backend/app/models/system/audit_log.py
+++ b/apps/mybookkeeper/backend/app/models/system/audit_log.py
@@ -1,25 +1,9 @@
-from datetime import datetime, timezone
+"""MBK re-exports the shared :class:`AuditLog`.
 
-from sqlalchemy import Index, String, DateTime, Text, Integer, text
-from sqlalchemy.orm import Mapped, mapped_column
+The model lives in :mod:`platform_shared.db.models.audit_log`. Keeping the
+``app.models.system.audit_log`` module path means ~20 callsites elsewhere in
+MBK (services, repositories, API routes, tests) continue to import unchanged.
+"""
+from platform_shared.db.models.audit_log import AuditLog
 
-from app.db.base import Base
-
-
-class AuditLog(Base):
-    __tablename__ = "audit_logs"
-
-    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
-    table_name: Mapped[str] = mapped_column(String(100))
-    record_id: Mapped[str] = mapped_column(String(255))
-    operation: Mapped[str] = mapped_column(String(10))
-    field_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    old_value: Mapped[str | None] = mapped_column(Text, nullable=True)
-    new_value: Mapped[str | None] = mapped_column(Text, nullable=True)
-    changed_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
-    changed_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
-
-    __table_args__ = (
-        Index("ix_audit_table_record", "table_name", "record_id"),
-        Index("ix_audit_changed_at", text("changed_at DESC")),
-    )
+__all__ = ["AuditLog"]

--- a/apps/mybookkeeper/backend/tests/test_audit_registration.py
+++ b/apps/mybookkeeper/backend/tests/test_audit_registration.py
@@ -1,0 +1,86 @@
+"""Verify MBK's import-time registration of sensitive-field column names.
+
+After PR M3 the audit listener + AuditLog model live in ``platform_shared``.
+MBK's ``app/core/audit.py`` is now a thin wrapper that calls the shared
+``register_sensitive_fields`` / ``register_skip_tables`` / ``register_skip_fields``
+at import time. If that wiring ever breaks (e.g. someone refactors away the
+top-level ``register_*`` calls), the listener would still attach but produce
+audit rows with PII plaintext leaked into ``new_value`` — a silent security
+regression.
+
+This test is the safety net: if it fails, the listener is no longer protecting
+PII columns.
+"""
+from __future__ import annotations
+
+# Importing ``app.core.audit`` runs the module body, which calls
+# ``register_sensitive_fields(MBK_SENSITIVE_FIELDS)`` etc. We rely on that side
+# effect — do NOT defer the import inside the tests.
+from app.core.audit import (  # noqa: F401 — import side-effect populates registry
+    MBK_SENSITIVE_FIELDS,
+    MBK_SKIP_FIELDS,
+    MBK_SKIP_TABLES,
+)
+from platform_shared.core.audit import (
+    get_sensitive_fields,
+    get_skip_tables,
+)
+
+
+class TestMBKAuditRegistration:
+    def test_inquiries_pii_columns_are_registered(self) -> None:
+        registered = get_sensitive_fields()
+        for field in (
+            "inquirer_name",
+            "inquirer_email",
+            "inquirer_phone",
+            "inquirer_employer",
+            "from_address",
+            "to_address",
+            "notes",
+        ):
+            assert field in registered, (
+                f"{field!r} must be registered as sensitive — adding a new "
+                "encrypted PII column without registering it leaks plaintext "
+                "into audit_logs.new_value."
+            )
+
+    def test_applicants_pii_columns_are_registered(self) -> None:
+        registered = get_sensitive_fields()
+        for field in (
+            "legal_name",
+            "dob",
+            "employer_or_hospital",
+            "vehicle_make_model",
+            "reference_name",
+            "reference_contact",
+        ):
+            assert field in registered, f"{field!r} must be registered as sensitive."
+
+    def test_secrets_are_registered(self) -> None:
+        registered = get_sensitive_fields()
+        for field in ("hashed_password", "access_token", "refresh_token"):
+            assert field in registered
+
+    def test_default_audit_logs_skip_table_is_present(self) -> None:
+        # platform_shared seeds this — without it the listener would recurse
+        # infinitely on every flush.
+        assert "audit_logs" in get_skip_tables()
+
+    def test_mbk_high_volume_skip_tables_are_registered(self) -> None:
+        registered = get_skip_tables()
+        for table in ("auth_events", "processed_emails", "usage_logs", "sync_logs"):
+            assert table in registered
+
+    def test_mbk_constants_match_registered_state(self) -> None:
+        # The exported MBK_SENSITIVE_FIELDS constant is the documentation
+        # surface — every entry must actually have been pushed into the
+        # shared registry.
+        for field in MBK_SENSITIVE_FIELDS:
+            assert field in get_sensitive_fields()
+        for table in MBK_SKIP_TABLES:
+            assert table in get_skip_tables()
+        # MBK_SKIP_FIELDS is registered separately — assert non-empty + present.
+        from platform_shared.core import audit as audit_module
+        for field in MBK_SKIP_FIELDS:
+            assert field in audit_module._skip_fields

--- a/packages/shared-backend/platform_shared/__init__.py
+++ b/packages/shared-backend/platform_shared/__init__.py
@@ -3,11 +3,16 @@
 Modules:
     platform_shared.db.base                  — DeclarativeBase
     platform_shared.db.session               — create_session_factory()
+    platform_shared.db.models.audit_log      — AuditLog ORM model
     platform_shared.core.context             — RequestContext
     platform_shared.core.security            — create_fernet_suite(), create_pii_suite()
     platform_shared.core.storage             — StorageClient, get_storage()
     platform_shared.core.rate_limit          — RateLimiter, get_client_ip()
-    platform_shared.core.audit               — register_audit_listeners(), current_user_id
+    platform_shared.core.audit               — register_audit_listeners(),
+                                                register_sensitive_fields(),
+                                                register_skip_tables(),
+                                                register_skip_fields(),
+                                                current_user_id
     platform_shared.core.auth_events         — AuthEventType
     platform_shared.core.auth_messages       — RATE_LIMIT_GENERIC_DETAIL
     platform_shared.services.email_service   — EmailService

--- a/packages/shared-backend/platform_shared/core/audit.py
+++ b/packages/shared-backend/platform_shared/core/audit.py
@@ -1,13 +1,37 @@
 """SQLAlchemy audit logging via event listeners.
 
-Usage:
-    register_audit_listeners(
-        audit_log_model=AuditLog,
-        skip_tables={"audit_logs", "usage_logs"},
-        sensitive_fields={"hashed_password", "access_token"},
-        skip_fields={"file_content"},
+This module captures INSERT / UPDATE / DELETE events on every flush and writes
+per-field rows into the shared ``audit_logs`` table. Each consuming app
+contributes its own list of column names that should be masked as ``"***"``
+(PII, secrets, tokens) and any additional tables that should be skipped from
+auditing entirely.
+
+Usage (in the consuming app's ``main.py`` lifespan or core/audit.py wrapper)::
+
+    from platform_shared.core.audit import (
+        register_audit_listeners,
+        register_sensitive_fields,
+        register_skip_tables,
+        register_skip_fields,
     )
+
+    register_sensitive_fields([
+        "hashed_password",
+        "access_token",
+        "inquirer_email",
+        # ...all PII / secret column names for this app
+    ])
+    register_skip_tables(["usage_logs", "auth_events"])
+    register_audit_listeners()  # idempotent — safe across reloader restarts
+
+The ``audit_logs`` table itself is skipped by default to prevent recursion.
+The listener writes ``changed_by`` from the ``current_user_id`` ContextVar by
+default; pass ``get_actor`` to override (e.g. for workers that read from a
+different request-context source).
 """
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
 from contextvars import ContextVar
 from typing import Any
 
@@ -16,7 +40,77 @@ from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import NO_VALUE
 from sqlalchemy.orm.base import NEVER_SET
 
+from platform_shared.db.models.audit_log import AuditLog
+
+# Per-request actor identifier for the ``changed_by`` column. Apps' middleware
+# is responsible for setting + resetting this on each request.
 current_user_id: ContextVar[str | None] = ContextVar("current_user_id", default=None)
+
+# Module-level state — apps populate at import time so the listener never fires
+# without the masking sets being correct.
+_sensitive_fields: set[str] = set()
+_skip_tables: set[str] = {"audit_logs"}  # default: never recurse into ourselves
+_skip_fields: set[str] = set()
+_listeners_registered: bool = False
+# Hold a reference to the SQLAlchemy listener function for ``reset_registry``
+# (test-only) to detach. Production code never reads this.
+_attached_listener: Any | None = None
+
+
+def register_sensitive_fields(field_names: Iterable[str]) -> None:
+    """Add column names whose values should be masked as ``"***"`` in audit log entries."""
+    _sensitive_fields.update(field_names)
+
+
+def register_skip_tables(table_names: Iterable[str]) -> None:
+    """Add table names that the listener should ignore entirely.
+
+    The shared default already includes ``audit_logs`` (recursion guard); apps
+    typically add their high-volume / secret-bearing tables here (e.g.
+    ``auth_events``, ``usage_logs``, ``processed_emails``, ``sync_logs``).
+    """
+    _skip_tables.update(table_names)
+
+
+def register_skip_fields(field_names: Iterable[str]) -> None:
+    """Add column names that should be omitted from audit rows entirely.
+
+    Use for large binary blobs (``file_content``) where neither the value nor a
+    masked stub is useful and storing per-field rows would bloat the table.
+    """
+    _skip_fields.update(field_names)
+
+
+def get_sensitive_fields() -> frozenset[str]:
+    """Read-only view of the registered sensitive fields (for assertions / tests)."""
+    return frozenset(_sensitive_fields)
+
+
+def get_skip_tables() -> frozenset[str]:
+    """Read-only view of the registered skip-tables (for assertions / tests)."""
+    return frozenset(_skip_tables)
+
+
+def reset_registry() -> None:
+    """Clear all registrations + reset to seed defaults. Test-only.
+
+    Production code must never call this — it removes the masking guarantee for
+    every subsequent flush. Also detaches the SQLAlchemy event listener so a
+    subsequent ``register_audit_listeners()`` call attaches a fresh one (the
+    SQLAlchemy event registry is a process-global, not session-scoped).
+    """
+    global _listeners_registered, _attached_listener
+    _sensitive_fields.clear()
+    _skip_fields.clear()
+    _skip_tables.clear()
+    _skip_tables.add("audit_logs")
+    if _attached_listener is not None:
+        try:
+            event.remove(Session, "after_flush", _attached_listener)
+        except Exception:  # pragma: no cover — defensive only; tests never hit it
+            pass
+        _attached_listener = None
+    _listeners_registered = False
 
 
 def _get_record_id(target: Any) -> str:
@@ -29,31 +123,47 @@ def _serialize(value: Any) -> str | None:
 
 
 def _is_loaded(attr: Any) -> bool:
+    """Return False for deferred / expired attributes to avoid lazy-load on flush."""
     return attr.loaded_value not in (NEVER_SET, NO_VALUE)
 
 
 def register_audit_listeners(
     *,
-    audit_log_model: type,
-    skip_tables: set[str] | None = None,
-    sensitive_fields: set[str] | None = None,
-    skip_fields: set[str] | None = None,
+    audit_log_model: type = AuditLog,
+    get_actor: Callable[[], str | None] | None = None,
 ) -> None:
-    """Register SQLAlchemy after_flush listeners for audit logging.
+    """Attach the after_flush listener that writes audit rows.
 
     Args:
-        audit_log_model: The ORM model class for audit logs. Must accept kwargs:
-            table_name, record_id, operation, field_name, old_value, new_value, changed_by
-        skip_tables: Table names to exclude from auditing.
-        sensitive_fields: Field names to mask with "***".
-        skip_fields: Field names to skip entirely (e.g., large binary fields).
-    """
-    _skip_tables = skip_tables or set()
-    _sensitive = sensitive_fields or set()
-    _skip_fields = skip_fields or set()
+        audit_log_model: ORM class to use for audit rows. Defaults to the shared
+            :class:`platform_shared.db.models.audit_log.AuditLog`. Apps that
+            need a custom audit table shape can pass their own model — the
+            listener constructs it via the same kwargs (``table_name``,
+            ``record_id``, ``operation``, ``field_name``, ``old_value``,
+            ``new_value``, ``changed_by``).
+        get_actor: Callable returning the current actor's user-id string for
+            the ``changed_by`` column. Defaults to reading
+            :data:`current_user_id`. Pass a different callable when the app
+            populates a different request-context store.
 
-    def _create_log(session: Session, table_name: str, record_id: str,
-                    operation: str, field_name: str, old_value: str | None, new_value: str | None) -> None:
+    Idempotent — calling more than once (e.g. across uvicorn reloader restarts
+    or pytest sessions that reuse the process) is a no-op.
+    """
+    global _listeners_registered, _attached_listener
+    if _listeners_registered:
+        return
+
+    actor: Callable[[], str | None] = get_actor or (lambda: current_user_id.get())
+
+    def _create_log(
+        session: Session,
+        table_name: str,
+        record_id: str,
+        operation: str,
+        field_name: str,
+        old_value: str | None,
+        new_value: str | None,
+    ) -> None:
         session.add(audit_log_model(
             table_name=table_name,
             record_id=record_id,
@@ -61,7 +171,7 @@ def register_audit_listeners(
             field_name=field_name,
             old_value=old_value,
             new_value=new_value,
-            changed_by=current_user_id.get(),
+            changed_by=actor(),
         ))
 
     def _handle_insert(session: Session, target: Any) -> None:
@@ -71,7 +181,7 @@ def register_audit_listeners(
         for attr in inspect(target).attrs:
             if attr.key in _skip_fields or not _is_loaded(attr):
                 continue
-            new_val = "***" if attr.key in _sensitive else _serialize(attr.value)
+            new_val = "***" if attr.key in _sensitive_fields else _serialize(attr.value)
             _create_log(session, target.__tablename__, record_id, "INSERT", attr.key, None, new_val)
 
     def _handle_update(session: Session, target: Any) -> None:
@@ -86,7 +196,7 @@ def register_audit_listeners(
                 continue
             old = hist.deleted[0] if hist.deleted else None
             new = hist.added[0] if hist.added else None
-            if attr.key in _sensitive:
+            if attr.key in _sensitive_fields:
                 old_val = "***" if old is not None else None
                 new_val = "***" if new is not None else None
             else:
@@ -100,14 +210,17 @@ def register_audit_listeners(
         for attr in inspect(target).attrs:
             if attr.key in _skip_fields or not _is_loaded(attr):
                 continue
-            old_val = "***" if attr.key in _sensitive else _serialize(attr.value)
+            old_val = "***" if attr.key in _sensitive_fields else _serialize(attr.value)
             _create_log(session, target.__tablename__, record_id, "DELETE", attr.key, old_val, None)
 
-    @event.listens_for(Session, "after_flush")
-    def after_flush(session: Session, flush_context: Any) -> None:
+    def _after_flush(session: Session, _flush_context: Any) -> None:
         for target in list(session.new):
             _handle_insert(session, target)
         for target in list(session.dirty):
             _handle_update(session, target)
         for target in list(session.deleted):
             _handle_delete(session, target)
+
+    event.listen(Session, "after_flush", _after_flush)
+    _attached_listener = _after_flush
+    _listeners_registered = True

--- a/packages/shared-backend/platform_shared/db/models/__init__.py
+++ b/packages/shared-backend/platform_shared/db/models/__init__.py
@@ -1,0 +1,9 @@
+"""Shared SQLAlchemy ORM models that ship with platform_shared.
+
+Importing this package registers every model class with
+``platform_shared.db.base.Base.metadata`` so consumer apps that include
+``Base.metadata`` in their alembic ``target_metadata`` see the schema.
+"""
+from platform_shared.db.models.audit_log import AuditLog
+
+__all__ = ["AuditLog"]

--- a/packages/shared-backend/platform_shared/db/models/audit_log.py
+++ b/packages/shared-backend/platform_shared/db/models/audit_log.py
@@ -1,0 +1,41 @@
+"""Shared AuditLog model.
+
+Append-only, per-field change log written by ``platform_shared.core.audit``'s
+SQLAlchemy event listener. Schema is identical to MyBookkeeper's pre-promotion
+``audit_logs`` table — no migration is required when an app first picks up the
+shared model, only when an app first introduces the table.
+
+Notes:
+    * ``user_id``/``changed_by`` is a free-form string, not a FK to ``users`` —
+      audit rows must survive user deletion.
+    * ``record_id`` is a comma-joined PK string so composite-keyed tables are
+      representable without a per-table audit table shape.
+"""
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Index, Integer, String, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from platform_shared.db.base import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_logs"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    table_name: Mapped[str] = mapped_column(String(100))
+    record_id: Mapped[str] = mapped_column(String(255))
+    operation: Mapped[str] = mapped_column(String(10))
+    field_name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    old_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    new_value: Mapped[str | None] = mapped_column(Text, nullable=True)
+    changed_by: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    changed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index("ix_audit_table_record", "table_name", "record_id"),
+        Index("ix_audit_changed_at", text("changed_at DESC")),
+    )

--- a/packages/shared-backend/pyproject.toml
+++ b/packages/shared-backend/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
+    "aiosqlite>=0.20.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/packages/shared-backend/tests/test_audit.py
+++ b/packages/shared-backend/tests/test_audit.py
@@ -1,0 +1,398 @@
+"""Tests for platform_shared.core.audit.
+
+Exercises the registration API and the SQLAlchemy after_flush listener against
+a fresh in-memory SQLite database — no MBK / MJH fixtures referenced. The
+shared module is the contract; consumer apps add their own PII column lists
+on top.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator, Callable
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import Integer, String, select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Mapped, mapped_column
+
+from platform_shared.core import audit as audit_module
+from platform_shared.core.audit import (
+    current_user_id,
+    get_sensitive_fields,
+    get_skip_tables,
+    register_audit_listeners,
+    register_sensitive_fields,
+    register_skip_fields,
+    register_skip_tables,
+    reset_registry,
+)
+from platform_shared.db.base import Base
+from platform_shared.db.models.audit_log import AuditLog
+
+
+class _Widget(Base):
+    """Minimal table used to drive the listener in isolation."""
+    __tablename__ = "test_widgets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    password: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    secret_token: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    file_content: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+
+class _SecretBag(Base):
+    """A second table used to test the skip-table behaviour."""
+    __tablename__ = "test_secret_bag"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
+    payload: Mapped[str] = mapped_column(String(100))
+
+
+@pytest.fixture(autouse=True)
+def _reset() -> None:
+    """Each test starts with a clean registry — module state is global."""
+    reset_registry()
+
+
+@pytest_asyncio.fixture()
+async def db() -> AsyncIterator[AsyncSession]:
+    """In-memory SQLite session with shared Base + AuditLog metadata."""
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+    async with sessionmaker() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture()
+async def listener_attached() -> None:
+    """Register the listener once for the test. Reset_registry already cleared
+    ``_listeners_registered`` so the registration takes effect."""
+    register_audit_listeners()
+
+
+class TestRegistrationAPI:
+    def test_default_skip_tables_includes_audit_logs(self) -> None:
+        # Recursion guard ships by default — apps don't need to opt in.
+        assert "audit_logs" in get_skip_tables()
+
+    def test_default_sensitive_fields_is_empty(self) -> None:
+        # Apps populate this — shared has no PII opinions.
+        assert get_sensitive_fields() == frozenset()
+
+    def test_register_sensitive_fields_accumulates(self) -> None:
+        register_sensitive_fields(["password"])
+        register_sensitive_fields(["secret_token"])
+        assert "password" in get_sensitive_fields()
+        assert "secret_token" in get_sensitive_fields()
+
+    def test_register_sensitive_fields_accepts_set_or_list(self) -> None:
+        register_sensitive_fields({"a", "b"})
+        register_sensitive_fields(["c"])
+        register_sensitive_fields(("d",))
+        assert {"a", "b", "c", "d"}.issubset(get_sensitive_fields())
+
+    def test_register_skip_tables_extends_default(self) -> None:
+        register_skip_tables(["usage_logs", "auth_events"])
+        skip = get_skip_tables()
+        assert "audit_logs" in skip
+        assert "usage_logs" in skip
+        assert "auth_events" in skip
+
+    def test_reset_registry_restores_seed_defaults(self) -> None:
+        register_sensitive_fields(["password"])
+        register_skip_tables(["foo"])
+        reset_registry()
+        assert get_sensitive_fields() == frozenset()
+        assert get_skip_tables() == frozenset({"audit_logs"})
+
+    def test_register_audit_listeners_is_idempotent(self) -> None:
+        register_audit_listeners()
+        register_audit_listeners()
+        register_audit_listeners()
+        # No exception, no duplicate listener attachment — the second + third
+        # calls are no-ops by design.
+        assert audit_module._listeners_registered is True
+
+
+class TestListenerInsert:
+    @pytest.mark.asyncio
+    async def test_insert_writes_per_field_rows(
+        self, db: AsyncSession, listener_attached: None,
+    ) -> None:
+        w = _Widget(name="hello", password="hunter2")
+        db.add(w)
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(AuditLog.table_name == "test_widgets"),
+        )).scalars().all()
+
+        # One row per non-skipped, loaded attribute.
+        by_field = {r.field_name: r for r in rows}
+        assert "name" in by_field
+        assert "password" in by_field
+        assert all(r.operation == "INSERT" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_password_masked_when_registered(
+        self, db: AsyncSession,
+    ) -> None:
+        # The masking contract: registering "password" causes a write of
+        # password="hunter2" to log as password="***" — the regression test
+        # called out in the task spec.
+        register_sensitive_fields(["password"])
+        register_audit_listeners()
+
+        w = _Widget(name="hello", password="hunter2")
+        db.add(w)
+        await db.commit()
+
+        password_row = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "test_widgets",
+                AuditLog.field_name == "password",
+            ),
+        )).scalar_one()
+
+        assert password_row.new_value == "***"
+        assert password_row.old_value is None
+
+        # And the un-registered ``name`` column remains plaintext — masking
+        # must not bleed across columns.
+        name_row = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "test_widgets",
+                AuditLog.field_name == "name",
+            ),
+        )).scalar_one()
+        assert name_row.new_value == "hello"
+
+    @pytest.mark.asyncio
+    async def test_skip_field_omits_row(
+        self, db: AsyncSession,
+    ) -> None:
+        register_skip_fields(["file_content"])
+        register_audit_listeners()
+
+        w = _Widget(name="x", file_content="big-binary-blob")
+        db.add(w)
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "test_widgets",
+                AuditLog.field_name == "file_content",
+            ),
+        )).scalars().all()
+        assert rows == []
+
+
+class TestListenerUpdate:
+    @pytest.mark.asyncio
+    async def test_update_captures_old_and_new_values(
+        self, db: AsyncSession, listener_attached: None,
+    ) -> None:
+        w = _Widget(name="before")
+        db.add(w)
+        await db.commit()
+
+        w.name = "after"
+        await db.commit()
+
+        update_rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "test_widgets",
+                AuditLog.operation == "UPDATE",
+                AuditLog.field_name == "name",
+            ),
+        )).scalars().all()
+        assert len(update_rows) == 1
+        assert update_rows[0].old_value == "before"
+        assert update_rows[0].new_value == "after"
+
+    @pytest.mark.asyncio
+    async def test_update_to_sensitive_field_masks_both_sides(
+        self, db: AsyncSession,
+    ) -> None:
+        register_sensitive_fields(["password"])
+        register_audit_listeners()
+
+        w = _Widget(name="x", password="oldpass")
+        db.add(w)
+        await db.commit()
+
+        w.password = "newpass"
+        await db.commit()
+
+        update_row = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "test_widgets",
+                AuditLog.operation == "UPDATE",
+                AuditLog.field_name == "password",
+            ),
+        )).scalar_one()
+        assert update_row.old_value == "***"
+        assert update_row.new_value == "***"
+        # Plaintext must never leak.
+        assert "oldpass" not in (update_row.old_value or "")
+        assert "newpass" not in (update_row.new_value or "")
+
+
+class TestListenerDelete:
+    @pytest.mark.asyncio
+    async def test_delete_logs_old_values(
+        self, db: AsyncSession, listener_attached: None,
+    ) -> None:
+        w = _Widget(name="doomed")
+        db.add(w)
+        await db.commit()
+
+        await db.delete(w)
+        await db.commit()
+
+        delete_rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "test_widgets",
+                AuditLog.operation == "DELETE",
+                AuditLog.field_name == "name",
+            ),
+        )).scalars().all()
+        assert len(delete_rows) == 1
+        assert delete_rows[0].old_value == "doomed"
+        assert delete_rows[0].new_value is None
+
+
+class TestSkipTables:
+    @pytest.mark.asyncio
+    async def test_audit_logs_table_does_not_recurse(
+        self, db: AsyncSession, listener_attached: None,
+    ) -> None:
+        # Inserting an AuditLog directly must not generate audit rows for the
+        # audit_logs table itself — the seed default ``audit_logs`` skip-table
+        # entry is the recursion guard.
+        log = AuditLog(
+            table_name="test_widgets",
+            record_id="1",
+            operation="INSERT",
+            field_name="name",
+            old_value=None,
+            new_value="manual",
+        )
+        db.add(log)
+        await db.commit()
+
+        recursive_rows = (await db.execute(
+            select(AuditLog).where(AuditLog.table_name == "audit_logs"),
+        )).scalars().all()
+        assert recursive_rows == []
+
+    @pytest.mark.asyncio
+    async def test_registered_skip_table_is_ignored(
+        self, db: AsyncSession,
+    ) -> None:
+        register_skip_tables(["test_secret_bag"])
+        register_audit_listeners()
+
+        bag = _SecretBag(payload="don't-audit-me")
+        db.add(bag)
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(AuditLog.table_name == "test_secret_bag"),
+        )).scalars().all()
+        assert rows == []
+
+
+class TestActorAttribution:
+    @pytest.mark.asyncio
+    async def test_changed_by_reads_default_contextvar(
+        self, db: AsyncSession,
+    ) -> None:
+        register_audit_listeners()
+
+        token = current_user_id.set("user-abc")
+        try:
+            db.add(_Widget(name="x"))
+            await db.commit()
+        finally:
+            current_user_id.reset(token)
+
+        rows = (await db.execute(
+            select(AuditLog).where(AuditLog.table_name == "test_widgets"),
+        )).scalars().all()
+        assert rows
+        assert all(r.changed_by == "user-abc" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_changed_by_uses_custom_get_actor_callable(
+        self, db: AsyncSession,
+    ) -> None:
+        # Decoupling check: workers / non-HTTP entry points may not have a
+        # request ContextVar populated. Passing ``get_actor`` lets the
+        # consumer inject its own actor source without touching the shared
+        # listener body.
+        actor_calls: list[None] = []
+
+        def custom_actor() -> str | None:
+            actor_calls.append(None)
+            return "worker-task-42"
+
+        register_audit_listeners(get_actor=custom_actor)
+
+        db.add(_Widget(name="y"))
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(AuditLog.table_name == "test_widgets"),
+        )).scalars().all()
+        assert rows
+        assert all(r.changed_by == "worker-task-42" for r in rows)
+        # The actor callable was invoked once per audit row written.
+        assert len(actor_calls) == len(rows)
+
+
+class TestCustomAuditLogModel:
+    """Apps with a non-shared audit table can pass ``audit_log_model``."""
+
+    @pytest.mark.asyncio
+    async def test_custom_model_receives_writes(
+        self, db: AsyncSession,
+    ) -> None:
+        # Use the shared AuditLog as the "custom" type — proves the kwarg path
+        # is wired without needing to define a second table in this test file.
+        register_audit_listeners(audit_log_model=AuditLog)
+
+        db.add(_Widget(name="z"))
+        await db.commit()
+
+        rows = (await db.execute(select(AuditLog))).scalars().all()
+        assert any(r.table_name == "test_widgets" for r in rows)
+
+
+class TestRegistrationHappensBeforeListener:
+    """Regression: the registration API must accumulate state SHARED with the
+    listener — not a private copy taken at register_audit_listeners() time."""
+
+    @pytest.mark.asyncio
+    async def test_late_registration_still_masks(
+        self, db: AsyncSession,
+    ) -> None:
+        # Listener attached BEFORE the field is registered.
+        register_audit_listeners()
+        # Now an app or test registers a field after the listener is live.
+        register_sensitive_fields(["password"])
+
+        db.add(_Widget(name="x", password="leaked"))
+        await db.commit()
+
+        password_row = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "test_widgets",
+                AuditLog.field_name == "password",
+            ),
+        )).scalar_one()
+        assert password_row.new_value == "***"


### PR DESCRIPTION
PR M3 of the 14-PR migration plan. Promotes the audit-log infrastructure from MyBookkeeper into platform_shared so MyJobHunter and future apps can reuse it.

No schema change — alembic check passes. The shared AuditLog model is registered on the same Base.metadata that MBK's app.db.base.Base now re-exports, so MBK's alembic env.py continues to discover the audit_logs table through app.models.

## Modules moved

- apps/mybookkeeper/backend/app/models/system/audit_log.py -> packages/shared-backend/platform_shared/db/models/audit_log.py
- apps/mybookkeeper/backend/app/core/audit.py (listener body) -> packages/shared-backend/platform_shared/core/audit.py

The MBK paths remain as thin re-exports / wrappers so the ~20 callsites that import the AuditLog model and the ~3 callsites that import register_audit_listeners keep working unchanged.

## Registration API

The hardcoded SENSITIVE_FIELDS set is replaced with:

```python
register_sensitive_fields(["hashed_password", "inquirer_email", ...])
register_skip_tables(["usage_logs", "auth_events"])
register_skip_fields(["file_content"])
register_audit_listeners()  # idempotent
```

The shared default _skip_tables = {"audit_logs"} ships as a recursion guard. The listener also accepts a get_actor callable so workers can inject their own actor source instead of reading the request ContextVar.

## MBK wiring

- app/db/base.py re-exports platform_shared.db.base.Base (matching MJH). All 57 imports unchanged.
- app/models/system/audit_log.py re-exports shared AuditLog.
- app/core/audit.py is a thin wrapper that registers MBK_SENSITIVE_FIELDS at import time. Backwards-compat constants preserved.

## MJH side

Deferred per the migration plan. MJH starts cleanly without register_sensitive_fields — the default audit_logs skip-table prevents recursion. C2 will attach the listener.

## Tests

- packages/shared-backend/tests/test_audit.py — 19 new tests for the registration API, listener insert/update/delete with masking, skip-table, custom get_actor and audit_log_model, idempotency, late-registration regression
- apps/mybookkeeper/backend/tests/test_audit_registration.py — 6 new tests verifying MBK's import-time registration covers every PII column
- Existing test_inquiry_audit_masking.py and test_applicant_audit_masking.py pass unchanged

The required regression test (registering password masks 'hunter2' as '***') is in TestListenerInsert::test_password_masked_when_registered.

## Test plan

- [x] pytest packages/shared-backend/tests/ — 43/43 pass
- [x] pytest apps/mybookkeeper/backend/tests/ audit-related tests — 12/12 pass
- [x] pytest MBK representative slice (alembic chain, applicant repo/encryption/service, auth events, account lockout, admin routes, account deletion, applicants API, data export, inquiry/listing repos, demo security) — 211/211 pass
- [x] AuditLog in app.db.base.Base.metadata after import app.models — 9 columns + 2 indexes match migration
- [x] MJH app.main imports cleanly — empty sensitive fields, only audit_logs in skip-tables
- [ ] alembic check against real Postgres in CI
- [ ] Wait for CI green before merge

## Out of scope (deliberately not touched)

- M2 encrypted_string_type.py (parallel PR)
- M4 auth_event model (parallel PR)
- The applicants-kanban worktree
- MJH wiring (C2 will register MJH's sensitive fields)

DO NOT auto-merge.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>