### PR TITLE
refactor(shared-backend): promote EncryptedString TypeDecorator + PII helpers to platform_shared (M2)

### DIFF
--- a/apps/mybookkeeper/backend/app/core/encrypted_string_type.py
+++ b/apps/mybookkeeper/backend/app/core/encrypted_string_type.py
@@ -1,12 +1,18 @@
 """SQLAlchemy ``TypeDecorator`` that transparently encrypts/decrypts string PII.
 
-Uses the existing Fernet-derived PII key from ``core/security.py:encrypt_pii``
-(HKDF info ``"mybookkeeper-pii-encryption"``, distinct from the OAuth-token
-key family used by the ``Integration`` model).
+Thin MBK-specific wrapper around
+:class:`platform_shared.core.encrypted_string_type.EncryptedString` — bakes in
+MBK's PII codec (``encrypt_pii`` / ``decrypt_pii`` from ``app.core.security``)
+so column declarations stay clean::
+
+    inquirer_email: Mapped[str | None] = mapped_column(EncryptedString(255), nullable=True)
+
+…with no per-column codec plumbing.
 
 Why this lives here rather than on each model:
-    - One implementation, reused for ``Inquiry`` (PR 2.1a) and Phase 3
-      ``Applicant`` / ``Reference`` / ``VideoCallNote`` columns.
+    - One implementation, reused for ``Inquiry`` (PR 2.1a), Phase 3
+      ``Applicant`` / ``Reference`` / ``VideoCallNote`` columns, and any
+      future PII-bearing tables.
     - Encrypt-on-bind / decrypt-on-result happens inside SQLAlchemy's type
       system, so callers (services, tests, audit) interact with plaintext only.
       This forces consistent treatment everywhere — no hand-rolled
@@ -17,64 +23,37 @@ Why this lives here rather than on each model:
       RENTALS_PLAN.md §8.2): a non-destructive background re-encryption worker
       will migrate v1 → v2 once a second key family is introduced.
 
-Tampered ciphertext raises ``cryptography.fernet.InvalidToken`` from
-``decrypt_pii`` — surfaced as a clear ``ValueError`` here so callers don't have
-to import ``cryptography`` to catch it.
+Tampered ciphertext raises ``cryptography.fernet.InvalidToken`` from the
+underlying Fernet library — surfaced as a clear ``ValueError`` by the shared
+TypeDecorator so callers don't have to import ``cryptography`` to catch it.
 """
 from __future__ import annotations
 
-from cryptography.fernet import InvalidToken
-from sqlalchemy import String
-from sqlalchemy.types import TypeDecorator
+from platform_shared.core.encrypted_string_type import (
+    EncryptedString as _SharedEncryptedString,
+    PIICodec,
+)
 
 from app.core.security import decrypt_pii, encrypt_pii
 
+# MBK's PII codec — closes over MBK settings via the wrappers in
+# ``app.core.security``. Constructed once at module import.
+_MBK_PII_CODEC = PIICodec(encrypt=encrypt_pii, decrypt=decrypt_pii)
 
-class EncryptedString(TypeDecorator):
-    """A ``String(N)`` column that encrypts on write and decrypts on read.
 
-    The ``length`` parameter is the **plaintext** size budget — the underlying
-    database column is sized large enough to hold the corresponding Fernet
-    ciphertext (which expands by ~80 bytes plus base64 overhead). ``Text``
-    backing avoids needing per-call length math.
+class EncryptedString(_SharedEncryptedString):
+    """MBK-specific :class:`EncryptedString` with the PII codec baked in.
+
+    Existing call sites use ``mapped_column(EncryptedString(255), ...)`` with
+    no codec arg — that continues to work because ``_codec`` is set at the
+    class level here.
     """
 
-    # Use Text-equivalent storage; ``String`` with no length is portable.
-    impl = String
+    # SQLAlchemy reads ``cache_ok`` per-class (it warns when a subclass of a
+    # ``TypeDecorator`` doesn't explicitly opt in, even if the parent did).
+    # Re-asserting it here avoids the warning and confirms intent: this type's
+    # cache key is fully determined by ``length`` (the codec is class-level
+    # state, identical across instances).
     cache_ok = True
 
-    def __init__(self, length: int | None = None, *args: object, **kwargs: object) -> None:
-        # Accept a `length` for documentation / Pydantic validation parity, but
-        # always store as unbounded string — Fernet ciphertext is much larger
-        # than the plaintext, and bounding the storage column risks truncating
-        # legitimate values.
-        super().__init__(*args, **kwargs)
-        self._plaintext_length = length
-
-    @property
-    def python_type(self) -> type[str]:
-        return str
-
-    def process_bind_param(self, value: object, dialect: object) -> str | None:
-        if value is None:
-            return None
-        if not isinstance(value, str):
-            raise TypeError(
-                f"EncryptedString expected str, got {type(value).__name__}",
-            )
-        return encrypt_pii(value)
-
-    def process_result_value(self, value: object, dialect: object) -> str | None:
-        if value is None:
-            return None
-        if not isinstance(value, str):
-            raise TypeError(
-                f"EncryptedString expected stored str, got {type(value).__name__}",
-            )
-        try:
-            return decrypt_pii(value)
-        except InvalidToken as exc:
-            raise ValueError(
-                "Failed to decrypt EncryptedString column — ciphertext is "
-                "corrupted, was encrypted with a different key, or was tampered with.",
-            ) from exc
+    _codec = _MBK_PII_CODEC

--- a/apps/mybookkeeper/backend/app/core/security.py
+++ b/apps/mybookkeeper/backend/app/core/security.py
@@ -4,9 +4,16 @@ from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives import hashes
 
+from platform_shared.core.security import FernetSuite, create_pii_suite
+
 from app.core.config import settings
 
 HKDF_SALT = b"mybookkeeper-v1"
+# HKDF info string for the PII key family — distinct from the OAuth-token
+# family below so leaking one set of ciphertexts does NOT compromise the
+# other. MUST stay byte-identical to what's baked into existing production
+# PII columns; changing it would silently make every PII row unreadable.
+_MBK_PII_INFO = b"mybookkeeper-pii-encryption"
 
 
 def _derive_fernet(salt: bytes | None, info: bytes = b"mybookkeeper-token-encryption") -> Fernet:
@@ -22,7 +29,7 @@ def _derive_fernet(salt: bytes | None, info: bytes = b"mybookkeeper-token-encryp
 
 _fernet = None
 _fernet_legacy = None
-_fernet_pii = None
+_pii_suite: FernetSuite | None = None
 
 
 def get_fernet() -> Fernet:
@@ -39,13 +46,6 @@ def _get_legacy_fernet() -> Fernet:
     return _fernet_legacy
 
 
-def _get_pii_fernet() -> Fernet:
-    global _fernet_pii
-    if _fernet_pii is None:
-        _fernet_pii = _derive_fernet(HKDF_SALT, info=b"mybookkeeper-pii-encryption")
-    return _fernet_pii
-
-
 def encrypt_token(token: str) -> str:
     return get_fernet().encrypt(token.encode()).decode()
 
@@ -57,9 +57,36 @@ def decrypt_token(token: str) -> str:
         return _get_legacy_fernet().decrypt(token.encode()).decode()
 
 
+def _get_pii_suite() -> FernetSuite:
+    """Lazily build (and cache) the MBK PII Fernet suite.
+
+    Caching matters here — PII columns are encrypted/decrypted on every
+    Inquiry / Applicant read & write. Re-deriving the HKDF key on each call
+    would be a measurable perf regression vs. the pre-promotion behaviour.
+    """
+    global _pii_suite
+    if _pii_suite is None:
+        _pii_suite = create_pii_suite(
+            settings.encryption_key,
+            salt=HKDF_SALT,
+            info=_MBK_PII_INFO,
+        )
+    return _pii_suite
+
+
 def encrypt_pii(value: str) -> str:
-    return _get_pii_fernet().encrypt(value.encode()).decode()
+    """Encrypt PII with MBK's PII key family.
+
+    Thin wrapper around the shared :class:`FernetSuite` from
+    ``platform_shared.core.security``. Same `(str) -> str` signature as
+    before — call sites are unchanged.
+    """
+    return _get_pii_suite().encrypt(value)
 
 
 def decrypt_pii(ciphertext: str) -> str:
-    return _get_pii_fernet().decrypt(ciphertext.encode()).decode()
+    """Decrypt PII produced by :func:`encrypt_pii`.
+
+    Same `(str) -> str` signature as before — call sites are unchanged.
+    """
+    return _get_pii_suite().decrypt(ciphertext)

--- a/packages/shared-backend/platform_shared/__init__.py
+++ b/packages/shared-backend/platform_shared/__init__.py
@@ -4,7 +4,8 @@ Modules:
     platform_shared.db.base                  — DeclarativeBase
     platform_shared.db.session               — create_session_factory()
     platform_shared.core.context             — RequestContext
-    platform_shared.core.security            — create_fernet_suite(), create_pii_suite()
+    platform_shared.core.security            — create_fernet_suite(), create_pii_suite(), encrypt_pii(), decrypt_pii()
+    platform_shared.core.encrypted_string_type — EncryptedString TypeDecorator, PIICodec
     platform_shared.core.storage             — StorageClient, get_storage()
     platform_shared.core.rate_limit          — RateLimiter, get_client_ip()
     platform_shared.core.audit               — register_audit_listeners(), current_user_id

--- a/packages/shared-backend/platform_shared/core/encrypted_string_type.py
+++ b/packages/shared-backend/platform_shared/core/encrypted_string_type.py
@@ -1,0 +1,123 @@
+"""SQLAlchemy ``TypeDecorator`` that transparently encrypts/decrypts string PII.
+
+This is the shared, app-agnostic implementation. Each app constructs its own
+codec with its own ``secret_key`` / ``salt`` / ``info`` constants and then
+either:
+
+1. Uses ``EncryptedString(length, codec=my_codec)`` directly at column-decl
+   sites, or
+2. Subclasses :class:`EncryptedString` to bake the codec in once::
+
+       class MyAppEncryptedString(EncryptedString):
+           _codec = my_app_codec
+
+   …and then declares columns with ``MyAppEncryptedString(length)`` so the
+   call sites stay byte-identical.
+
+Why a codec instead of importing ``encrypt_pii`` directly:
+    The shared package has no knowledge of app-specific settings (e.g.
+    ``app.core.config``), so the encryption key + HKDF salt + HKDF info must
+    be injected. Threading them through every column declaration is noisy —
+    a single :class:`PIICodec` value captures the trio.
+
+Tampered ciphertext raises ``cryptography.fernet.InvalidToken`` from the
+underlying Fernet library — surfaced as a clear ``ValueError`` here so callers
+don't have to import ``cryptography`` to catch it.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+from cryptography.fernet import InvalidToken
+from sqlalchemy import String
+from sqlalchemy.types import TypeDecorator
+
+
+@dataclass(frozen=True)
+class PIICodec:
+    """An encrypt/decrypt callable pair for a specific PII key family.
+
+    Both callables accept and return ``str | None`` and treat ``None`` as
+    a passthrough — matching the shape of
+    :func:`platform_shared.core.security.encrypt_pii` /
+    :func:`platform_shared.core.security.decrypt_pii`.
+    """
+
+    encrypt: Callable[[str | None], str | None]
+    decrypt: Callable[[str | None], str | None]
+
+
+class EncryptedString(TypeDecorator):
+    """A ``String(N)`` column that encrypts on write and decrypts on read.
+
+    The ``length`` parameter is the **plaintext** size budget — the underlying
+    database column is sized as unbounded ``String`` so the much-larger Fernet
+    ciphertext (plaintext + ~80 bytes of header + base64 overhead) always fits.
+
+    Args:
+        length: Documentary plaintext-size budget. Not enforced at the DB
+            level — bounding the column would risk truncating valid ciphertext.
+        codec: An :class:`PIICodec` providing encrypt/decrypt callables. May
+            be omitted if a subclass sets ``_codec`` as a class attribute
+            (the per-app convenience pattern).
+
+    A subclass-only declaration (no codec arg at instantiation) requires
+    ``_codec`` to be set on the subclass; otherwise instantiation raises
+    :class:`TypeError`.
+    """
+
+    impl = String
+    cache_ok = True
+
+    # Per-app subclasses set this to a PIICodec; instances may also override
+    # via the constructor.
+    _codec: PIICodec | None = None
+
+    def __init__(
+        self,
+        length: int | None = None,
+        *args: object,
+        codec: PIICodec | None = None,
+        **kwargs: object,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._plaintext_length = length
+        if codec is not None:
+            # Bind to the instance, shadowing the class attribute.
+            self._codec = codec
+        if self._codec is None:
+            raise TypeError(
+                "EncryptedString requires a `codec=` argument or a subclass "
+                "with a `_codec` class attribute set to a PIICodec instance.",
+            )
+
+    @property
+    def python_type(self) -> type[str]:
+        return str
+
+    def process_bind_param(self, value: object, dialect: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError(
+                f"EncryptedString expected str, got {type(value).__name__}",
+            )
+        assert self._codec is not None  # guaranteed by __init__
+        return self._codec.encrypt(value)
+
+    def process_result_value(self, value: object, dialect: object) -> str | None:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            raise TypeError(
+                f"EncryptedString expected stored str, got {type(value).__name__}",
+            )
+        assert self._codec is not None
+        try:
+            return self._codec.decrypt(value)
+        except InvalidToken as exc:
+            raise ValueError(
+                "Failed to decrypt EncryptedString column — ciphertext is "
+                "corrupted, was encrypted with a different key, or was tampered with.",
+            ) from exc

--- a/packages/shared-backend/platform_shared/core/security.py
+++ b/packages/shared-backend/platform_shared/core/security.py
@@ -4,10 +4,16 @@ Usage:
     suite = create_fernet_suite("my-secret-key", salt=b"myapp-v1", info=b"myapp-token-encryption")
     encrypted = suite.encrypt("secret-value")
     decrypted = suite.decrypt(encrypted)
+
+Per-app PII helpers:
+    ciphertext = encrypt_pii(plaintext, secret_key=..., salt=..., info=b"<app>-pii-encryption")
+    plaintext  = decrypt_pii(ciphertext, secret_key=..., salt=..., info=b"<app>-pii-encryption")
+
+Each app constructs its own ``info`` (e.g. ``b"mybookkeeper-pii-encryption"``)
+so PII key families stay isolated across apps even when they share a secret.
 """
 import base64
 from dataclasses import dataclass
-from typing import Callable
 
 from cryptography.fernet import Fernet, InvalidToken
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
@@ -80,3 +86,65 @@ def create_pii_suite(
     """Create a separate Fernet suite for PII encryption."""
     fernet = _derive_fernet(encryption_key, salt, info)
     return FernetSuite(_fernet=fernet, _legacy_fernet=None)
+
+
+# ---------------------------------------------------------------------------
+# Per-app PII helpers
+# ---------------------------------------------------------------------------
+#
+# Apps wrap these with their own ``secret_key`` / ``salt`` / ``info`` constants
+# (typically closing over their settings module) so callers in app code stay
+# free of cryptography concerns. The shared functions here are pure — they
+# take all key material as arguments and have no module-level state.
+
+def encrypt_pii(
+    plaintext: str | None,
+    *,
+    secret_key: str,
+    salt: bytes,
+    info: bytes,
+) -> str | None:
+    """Encrypt a PII string with a per-app-keyed Fernet suite.
+
+    ``None`` is returned unchanged so this is safe to call on optional
+    columns. The underlying Fernet ciphertext is non-deterministic — equality
+    lookups against the encrypted column will NOT match.
+
+    Args:
+        plaintext: The value to encrypt, or ``None``.
+        secret_key: The base secret (typically ``settings.encryption_key``).
+        salt: HKDF salt — must be byte-identical between encrypt and decrypt.
+        info: HKDF info, typically ``b"<app>-pii-encryption"`` to keep the
+            PII key family isolated from other key families derived from the
+            same secret (e.g. OAuth tokens).
+    """
+    if plaintext is None:
+        return None
+    fernet = _derive_fernet(secret_key, salt, info)
+    return fernet.encrypt(plaintext.encode()).decode()
+
+
+def decrypt_pii(
+    ciphertext: str | None,
+    *,
+    secret_key: str,
+    salt: bytes,
+    info: bytes,
+) -> str | None:
+    """Decrypt a PII ciphertext produced by :func:`encrypt_pii`.
+
+    ``None`` is returned unchanged so this is safe to call on optional
+    columns. Raises :class:`cryptography.fernet.InvalidToken` if ``ciphertext``
+    was encrypted with a different ``secret_key`` / ``salt`` / ``info``
+    combination, or if it has been tampered with.
+
+    Args:
+        ciphertext: The Fernet ciphertext to decrypt, or ``None``.
+        secret_key: The base secret used at encrypt time.
+        salt: The HKDF salt used at encrypt time — must be byte-identical.
+        info: The HKDF info used at encrypt time — must be byte-identical.
+    """
+    if ciphertext is None:
+        return None
+    fernet = _derive_fernet(secret_key, salt, info)
+    return fernet.decrypt(ciphertext.encode()).decode()

--- a/packages/shared-backend/tests/test_encrypted_string_type.py
+++ b/packages/shared-backend/tests/test_encrypted_string_type.py
@@ -1,0 +1,182 @@
+"""Unit tests for ``platform_shared.core.encrypted_string_type``.
+
+Covers:
+
+- :class:`PIICodec` is required (constructor or subclass)
+- ``process_bind_param`` encrypts strings and passes ``None`` through
+- ``process_bind_param`` rejects non-string bind values with ``TypeError``
+- ``process_result_value`` decrypts ciphertext and passes ``None`` through
+- ``process_result_value`` re-raises ``InvalidToken`` as ``ValueError`` so
+  callers don't have to import ``cryptography``
+- Subclass-with-``_codec`` pattern works for the per-app convenience case
+"""
+from __future__ import annotations
+
+import pytest
+
+from platform_shared.core.encrypted_string_type import (
+    EncryptedString,
+    PIICodec,
+)
+from platform_shared.core.security import decrypt_pii, encrypt_pii
+
+# Fixed parameters used for every test. Keep small + deterministic.
+_KEY = "encrypted-string-test-key"
+_SALT = b"est-salt"
+_INFO = b"est-pii"
+
+
+def _make_codec() -> PIICodec:
+    """Build a codec that closes over the fixed test parameters."""
+
+    def _enc(value: str | None) -> str | None:
+        return encrypt_pii(value, secret_key=_KEY, salt=_SALT, info=_INFO)
+
+    def _dec(value: str | None) -> str | None:
+        return decrypt_pii(value, secret_key=_KEY, salt=_SALT, info=_INFO)
+
+    return PIICodec(encrypt=_enc, decrypt=_dec)
+
+
+# ---------------------------------------------------------------------------
+# Codec wiring
+# ---------------------------------------------------------------------------
+
+
+class TestCodecRequirement:
+    def test_constructor_codec_is_used(self) -> None:
+        codec = _make_codec()
+        et = EncryptedString(255, codec=codec)
+        ct = et.process_bind_param("hello", dialect=None)
+        assert ct is not None
+        assert ct != "hello"
+        back = et.process_result_value(ct, dialect=None)
+        assert back == "hello"
+
+    def test_missing_codec_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="requires a `codec=` argument"):
+            EncryptedString(255)
+
+    def test_subclass_with_codec_class_attr_works(self) -> None:
+        codec = _make_codec()
+
+        class MyAppEncryptedString(EncryptedString):
+            _codec = codec
+
+        et = MyAppEncryptedString(255)
+        ct = et.process_bind_param("subclass-value", dialect=None)
+        assert ct is not None
+        back = et.process_result_value(ct, dialect=None)
+        assert back == "subclass-value"
+
+    def test_constructor_codec_overrides_subclass_class_attr(self) -> None:
+        """If both are set, the constructor arg wins. This is what lets a
+        per-app subclass be the default while ad-hoc instances can swap
+        codecs (useful in tests and rotation tooling)."""
+        codec_a = _make_codec()
+
+        def _alt_enc(v: str | None) -> str | None:
+            return f"ALT::{v}" if v is not None else None
+
+        def _alt_dec(v: str | None) -> str | None:
+            return v.removeprefix("ALT::") if v is not None else None
+
+        codec_alt = PIICodec(encrypt=_alt_enc, decrypt=_alt_dec)
+
+        class Sub(EncryptedString):
+            _codec = codec_a
+
+        # Default — class codec.
+        et_default = Sub(255)
+        ct_default = et_default.process_bind_param("x", dialect=None)
+        assert ct_default is not None
+        assert ct_default.startswith("gAAAAA")  # real Fernet ciphertext
+
+        # Override — instance codec.
+        et_alt = Sub(255, codec=codec_alt)
+        ct_alt = et_alt.process_bind_param("x", dialect=None)
+        assert ct_alt == "ALT::x"
+
+
+# ---------------------------------------------------------------------------
+# Bind/result behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestProcessBindParam:
+    def test_string_is_encrypted(self) -> None:
+        et = EncryptedString(255, codec=_make_codec())
+        ct = et.process_bind_param("hello", dialect=None)
+        assert ct is not None
+        assert ct != "hello"
+        assert ct.startswith("gAAAAA")
+
+    def test_none_passes_through(self) -> None:
+        et = EncryptedString(255, codec=_make_codec())
+        assert et.process_bind_param(None, dialect=None) is None
+
+    @pytest.mark.parametrize("bad", [12345, b"bytes", 1.0, ["list"], {"dict": 1}])
+    def test_non_string_raises_type_error(self, bad: object) -> None:
+        et = EncryptedString(255, codec=_make_codec())
+        with pytest.raises(TypeError, match="EncryptedString expected str"):
+            et.process_bind_param(bad, dialect=None)
+
+
+class TestProcessResultValue:
+    def test_ciphertext_round_trips_to_plaintext(self) -> None:
+        et = EncryptedString(255, codec=_make_codec())
+        for plaintext in ["a", "alice@example.com", "1234567890" * 30]:
+            ct = et.process_bind_param(plaintext, dialect=None)
+            assert ct is not None
+            back = et.process_result_value(ct, dialect=None)
+            assert back == plaintext
+
+    def test_none_passes_through(self) -> None:
+        et = EncryptedString(255, codec=_make_codec())
+        assert et.process_result_value(None, dialect=None) is None
+
+    def test_non_string_stored_value_raises_type_error(self) -> None:
+        et = EncryptedString(255, codec=_make_codec())
+        with pytest.raises(TypeError, match="EncryptedString expected stored str"):
+            et.process_result_value(12345, dialect=None)
+
+    def test_tampered_ciphertext_raises_value_error(self) -> None:
+        et = EncryptedString(255, codec=_make_codec())
+        good = et.process_bind_param("hello", dialect=None)
+        assert good is not None
+        bad = good[:-2] + ("A" if good[-2] != "A" else "B") + good[-1]
+        with pytest.raises(ValueError, match="Failed to decrypt EncryptedString"):
+            et.process_result_value(bad, dialect=None)
+
+    def test_decrypt_with_wrong_codec_raises_value_error(self) -> None:
+        """A ciphertext encrypted under codec A cannot be decrypted by
+        codec B (different key/salt/info). The TypeDecorator surfaces this
+        as ``ValueError`` (not bare ``InvalidToken``)."""
+        codec_a = _make_codec()
+        # codec_b uses a different info string — same shape, different key family.
+        def _enc_b(v: str | None) -> str | None:
+            return encrypt_pii(v, secret_key=_KEY, salt=_SALT, info=b"DIFFERENT")
+
+        def _dec_b(v: str | None) -> str | None:
+            return decrypt_pii(v, secret_key=_KEY, salt=_SALT, info=b"DIFFERENT")
+
+        codec_b = PIICodec(encrypt=_enc_b, decrypt=_dec_b)
+
+        et_a = EncryptedString(255, codec=codec_a)
+        et_b = EncryptedString(255, codec=codec_b)
+
+        ct = et_a.process_bind_param("isolated", dialect=None)
+        assert ct is not None
+        with pytest.raises(ValueError, match="Failed to decrypt EncryptedString"):
+            et_b.process_result_value(ct, dialect=None)
+
+
+# ---------------------------------------------------------------------------
+# Misc
+# ---------------------------------------------------------------------------
+
+
+class TestPythonType:
+    def test_python_type_is_str(self) -> None:
+        et = EncryptedString(255, codec=_make_codec())
+        assert et.python_type is str

--- a/packages/shared-backend/tests/test_pii_encryption.py
+++ b/packages/shared-backend/tests/test_pii_encryption.py
@@ -1,0 +1,250 @@
+"""Unit tests for ``platform_shared.core.security.encrypt_pii`` / ``decrypt_pii``.
+
+Covers:
+
+- Roundtrip: ``decrypt_pii(encrypt_pii(x)) == x``
+- ``None`` passthrough on both helpers
+- Fernet non-determinism (same plaintext + key+salt+info -> different ciphertext)
+- Key isolation: changing any of ``secret_key`` / ``salt`` / ``info`` makes
+  the ciphertext undecryptable with the original parameters
+- Stability fixture: a known-good ciphertext (fixed plaintext + key + salt +
+  info) decrypts to the expected plaintext. This is the regression contract
+  that guards every existing PII column in production from silent salt/info
+  drift in future refactors.
+"""
+from __future__ import annotations
+
+import pytest
+from cryptography.fernet import InvalidToken
+
+from platform_shared.core.security import decrypt_pii, encrypt_pii
+
+# A fixed (key, salt, info, plaintext, ciphertext) tuple used as a regression
+# guard. The ciphertext below was produced ONCE at refactor time using the
+# same parameters; future refactors that silently change HKDF derivation will
+# fail the ``test_known_ciphertext_still_decrypts`` test.
+_FIXED_KEY = "test-secret-stability-key"
+_FIXED_SALT = b"test-salt-v1"
+_FIXED_INFO = b"test-stability-pii-encryption"
+_FIXED_PLAINTEXT = "applicant.nurse@example.com"
+
+# ---------------------------------------------------------------------------
+# Roundtrip + null handling
+# ---------------------------------------------------------------------------
+
+
+class TestRoundtrip:
+    def test_basic_roundtrip(self) -> None:
+        ct = encrypt_pii(
+            _FIXED_PLAINTEXT,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert ct is not None
+        assert ct != _FIXED_PLAINTEXT
+        back = decrypt_pii(
+            ct,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert back == _FIXED_PLAINTEXT
+
+    @pytest.mark.parametrize("plaintext", ["", "x", "a@b.co", "1234567890" * 50])
+    def test_roundtrip_various_lengths(self, plaintext: str) -> None:
+        ct = encrypt_pii(
+            plaintext, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert ct is not None
+        back = decrypt_pii(
+            ct, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert back == plaintext
+
+    def test_roundtrip_unicode(self) -> None:
+        plaintext = "Héllo, wörld — 你好"
+        ct = encrypt_pii(
+            plaintext, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert ct is not None
+        back = decrypt_pii(
+            ct, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert back == plaintext
+
+
+class TestNoneHandling:
+    def test_encrypt_none_returns_none(self) -> None:
+        result = encrypt_pii(
+            None, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert result is None
+
+    def test_decrypt_none_returns_none(self) -> None:
+        result = decrypt_pii(
+            None, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Non-determinism
+# ---------------------------------------------------------------------------
+
+
+class TestNonDeterminism:
+    def test_same_inputs_produce_different_ciphertext(self) -> None:
+        """Fernet uses a random IV — same key+salt+info+plaintext should
+        yield different ciphertext on each call. Critical so equality
+        lookups against encrypted columns can't accidentally succeed."""
+        a = encrypt_pii(
+            _FIXED_PLAINTEXT,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        b = encrypt_pii(
+            _FIXED_PLAINTEXT,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert a != b
+        # …but both decrypt to the same plaintext.
+        assert decrypt_pii(
+            a, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        ) == _FIXED_PLAINTEXT
+        assert decrypt_pii(
+            b, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        ) == _FIXED_PLAINTEXT
+
+
+# ---------------------------------------------------------------------------
+# Key isolation — every parameter matters
+# ---------------------------------------------------------------------------
+
+
+class TestKeyIsolation:
+    """Changing any of ``secret_key``, ``salt``, or ``info`` MUST make the
+    ciphertext undecryptable with the original parameters. This is what
+    keeps app-level PII key families separated even when apps share a
+    secret."""
+
+    def test_different_info_does_not_decrypt(self) -> None:
+        ct = encrypt_pii(
+            _FIXED_PLAINTEXT,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=b"app-a-pii",
+        )
+        assert ct is not None
+        with pytest.raises(InvalidToken):
+            decrypt_pii(
+                ct,
+                secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=b"app-b-pii",
+            )
+
+    def test_different_salt_does_not_decrypt(self) -> None:
+        ct = encrypt_pii(
+            _FIXED_PLAINTEXT,
+            secret_key=_FIXED_KEY, salt=b"salt-v1", info=_FIXED_INFO,
+        )
+        assert ct is not None
+        with pytest.raises(InvalidToken):
+            decrypt_pii(
+                ct,
+                secret_key=_FIXED_KEY, salt=b"salt-v2", info=_FIXED_INFO,
+            )
+
+    def test_different_secret_does_not_decrypt(self) -> None:
+        ct = encrypt_pii(
+            _FIXED_PLAINTEXT,
+            secret_key="secret-a", salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert ct is not None
+        with pytest.raises(InvalidToken):
+            decrypt_pii(
+                ct,
+                secret_key="secret-b", salt=_FIXED_SALT, info=_FIXED_INFO,
+            )
+
+    def test_same_key_salt_info_different_plaintexts_isolated(self) -> None:
+        """Different plaintexts under the same key produce ciphertexts that
+        each only decrypt back to their own plaintext."""
+        ct_a = encrypt_pii(
+            "alpha", secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        ct_b = encrypt_pii(
+            "bravo", secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert ct_a != ct_b
+        assert decrypt_pii(
+            ct_a, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        ) == "alpha"
+        assert decrypt_pii(
+            ct_b, secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        ) == "bravo"
+
+
+# ---------------------------------------------------------------------------
+# Tamper detection
+# ---------------------------------------------------------------------------
+
+
+class TestTamperDetection:
+    def test_modified_ciphertext_fails(self) -> None:
+        ct = encrypt_pii(
+            _FIXED_PLAINTEXT,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert ct is not None
+        # Flip a character near the end.
+        bad = ct[:-2] + ("A" if ct[-2] != "A" else "B") + ct[-1]
+        with pytest.raises(InvalidToken):
+            decrypt_pii(
+                bad,
+                secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Stability — guards against silent HKDF derivation drift
+# ---------------------------------------------------------------------------
+
+
+# A literal ciphertext produced ONCE with the _FIXED_* parameters above.
+# This is the regression contract: any future change to HKDF derivation,
+# Fernet construction, or argument-order semantics that would silently
+# invalidate existing PII columns will fail to decrypt this fixture.
+# DO NOT regenerate this value casually — only at intentional, audited
+# key-format migrations (and then in lockstep with a re-encryption pass
+# over every PII row in production).
+_FIXED_KNOWN_CIPHERTEXT = (
+    "gAAAAABp8k81eepNSOopnH9NH77FwDSQEXT3x5pahWgicp2boMFWDgSZTAE8OnW-"
+    "C_x50kDxeqoT20JNazNxJudL7DImEl4_Ja5p6K_3nh8YogRG5cuJ53I="
+)
+
+
+class TestStabilityFixture:
+    """Pins a known-good ciphertext for a fixed (key, salt, info, plaintext).
+
+    Fernet ciphertext is non-deterministic (random IV + timestamp), so we
+    can't pin the encrypt side with a literal. But DECRYPTION of a literal
+    ciphertext is fully stable — and that's what protects production rows.
+    Future refactors that silently change the HKDF derivation will break
+    this test instead of the production database."""
+
+    def test_known_ciphertext_still_decrypts(self) -> None:
+        back = decrypt_pii(
+            _FIXED_KNOWN_CIPHERTEXT,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert back == _FIXED_PLAINTEXT
+
+    def test_freshly_encrypted_value_round_trips(self) -> None:
+        """Belt-and-suspenders: encrypt-then-decrypt with the same params
+        always works. Catches regressions that break encrypt without
+        breaking decrypt."""
+        ct = encrypt_pii(
+            _FIXED_PLAINTEXT,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert ct is not None
+        assert _FIXED_PLAINTEXT not in ct
+        assert ct.startswith("gAAAAA")
+        back = decrypt_pii(
+            ct,
+            secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
+        )
+        assert back == _FIXED_PLAINTEXT


### PR DESCRIPTION
PR M2 of the 14-PR auth-parity migration. Promotes the column-level PII encryption stack from apps/mybookkeeper into platform_shared so MyJobHunter and future apps consume the same implementation. Moved: EncryptedString TypeDecorator, PIICodec, and encrypt_pii/decrypt_pii helpers. The MBK wrappers at app.core.security.encrypt_pii/decrypt_pii preserve their (str) -> str signatures and cache via create_pii_suite (parity with pre-promotion behaviour). MBK call sites for both EncryptedString and encrypt_pii/decrypt_pii are unchanged because the in-MBK shim re-exports the shared type with the codec baked in. No production PII columns are re-encrypted by this change - same salt (mybookkeeper-v1) and info (mybookkeeper-pii-encryption) bytes are used; bidirectional parity verified locally. No new database migration. Tests: 16 new cases in tests/test_pii_encryption.py (roundtrip, None handling, non-determinism, key isolation across secret/salt/info, tamper detection, literal known-good ciphertext stability fixture); 17 new cases in tests/test_encrypted_string_type.py (codec wiring, bind/result behaviour, cross-codec isolation). All 127 existing MBK PII-touching tests pass. Do not auto-merge.