### PR TITLE
refactor(shared-backend): promote AuthEvent model + service to platform_shared (M4)

### DIFF
--- a/apps/mybookkeeper/backend/app/core/request_utils.py
+++ b/apps/mybookkeeper/backend/app/core/request_utils.py
@@ -1,21 +1,7 @@
-"""Request introspection helpers shared across core modules.
+"""Thin re-export of the shared request introspection helpers.
 
-Lives in its own module so that auth_event logging can read the client IP
-without importing from rate_limit (which itself needs to log auth events on
-per-IP login blocks). Keeping this here avoids the
-rate_limit <-> auth_event_service circular import.
+The implementation lives in ``platform_shared.core.request_utils``. Existing
+MyBookkeeper call sites keep importing from ``app.core.request_utils`` — they
+reach the same function either way.
 """
-from fastapi import Request
-
-
-def get_client_ip(request: Request) -> str:
-    """Return the originating client IP for ``request``.
-
-    Honours ``X-Forwarded-For`` (first hop) when present so that requests
-    arriving via a reverse proxy (Caddy in production) are attributed to the
-    real caller, not the proxy.
-    """
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+from platform_shared.core.request_utils import get_client_ip  # noqa: F401

--- a/apps/mybookkeeper/backend/app/db/base.py
+++ b/apps/mybookkeeper/backend/app/db/base.py
@@ -1,5 +1,9 @@
-from sqlalchemy.orm import DeclarativeBase
+"""Re-export the shared SQLAlchemy declarative base.
 
-
-class Base(DeclarativeBase):
-    pass
+A single ``Base`` is shared with ``platform_shared`` so models defined in the
+shared package (e.g. ``platform_shared.db.models.auth_event.AuthEvent``)
+register with the same ``Base.metadata`` MyBookkeeper's Alembic migrations
+target. Without this unification, autogenerate would see the shared model as
+a "missing" table and try to create it on every revision.
+"""
+from platform_shared.db.base import Base  # noqa: F401

--- a/apps/mybookkeeper/backend/app/models/system/auth_event.py
+++ b/apps/mybookkeeper/backend/app/models/system/auth_event.py
@@ -1,36 +1,7 @@
-import uuid
-from datetime import datetime, timezone
+"""Thin re-export of the shared AuthEvent model.
 
-from sqlalchemy import Boolean, DateTime, Index, String, text
-from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import Mapped, mapped_column
-
-from app.db.base import Base
-
-
-class AuthEvent(Base):
-    __tablename__ = "auth_events"
-
-    id: Mapped[uuid.UUID] = mapped_column(
-        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
-    )
-    # Nullable — some events (failed login for unknown email) don't tie to a user
-    user_id: Mapped[uuid.UUID | None] = mapped_column(
-        UUID(as_uuid=True), nullable=True, index=True,
-    )
-    event_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
-    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)  # IPv6 max
-    user_agent: Mapped[str | None] = mapped_column(String(500), nullable=True)
-    event_metadata: Mapped[dict] = mapped_column("metadata", JSONB, nullable=False, default=dict, server_default="{}")
-    succeeded: Mapped[bool] = mapped_column(Boolean, nullable=False)
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True),
-        nullable=False,
-        default=lambda: datetime.now(timezone.utc),
-        index=True,
-    )
-
-    __table_args__ = (
-        Index("ix_auth_events_user_event_time", "user_id", "event_type", "created_at"),
-        Index("ix_auth_events_ip_time", "ip_address", "created_at"),
-    )
+The implementation lives in ``platform_shared.db.models.auth_event``. Existing
+MyBookkeeper call sites (services, repositories, tests) keep importing from
+``app.models.system.auth_event`` — they reach the same class either way.
+"""
+from platform_shared.db.models.auth_event import AuthEvent  # noqa: F401

--- a/apps/mybookkeeper/backend/app/services/system/auth_event_service.py
+++ b/apps/mybookkeeper/backend/app/services/system/auth_event_service.py
@@ -1,41 +1,8 @@
-import uuid
-from typing import Optional
+"""Thin re-export of the shared auth-event write helper.
 
-from fastapi import Request
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.core.request_utils import get_client_ip
-from app.models.system.auth_event import AuthEvent
-
-
-async def log_auth_event(
-    db: AsyncSession,
-    *,
-    event_type: str,
-    user_id: Optional[uuid.UUID] = None,
-    request: Optional[Request] = None,
-    succeeded: bool = True,
-    metadata: Optional[dict] = None,
-) -> None:
-    """Append an auth event row to the session.
-
-    Deliberately does not flush — the caller's transaction will commit.
-    Never log sensitive values (passwords, tokens) in metadata.
-    """
-    ip: Optional[str] = None
-    ua: Optional[str] = None
-    if request is not None:
-        ip = get_client_ip(request)
-        raw_ua = request.headers.get("user-agent")
-        if raw_ua:
-            ua = raw_ua[:500]
-
-    event = AuthEvent(
-        user_id=user_id,
-        event_type=event_type,
-        ip_address=ip,
-        user_agent=ua,
-        succeeded=succeeded,
-        event_metadata=metadata or {},
-    )
-    db.add(event)
+The implementation lives in ``platform_shared.services.auth_event_service``.
+Existing MyBookkeeper call sites keep importing from
+``app.services.system.auth_event_service`` — they reach the same function
+either way.
+"""
+from platform_shared.services.auth_event_service import log_auth_event  # noqa: F401

--- a/packages/shared-backend/platform_shared/core/request_utils.py
+++ b/packages/shared-backend/platform_shared/core/request_utils.py
@@ -1,0 +1,21 @@
+"""Request introspection helpers shared across core modules.
+
+Lives in its own module so that auth_event logging can read the client IP
+without importing from rate_limit (which itself needs to log auth events on
+per-IP login blocks). Keeping this here avoids the
+rate_limit <-> auth_event_service circular import.
+"""
+from fastapi import Request
+
+
+def get_client_ip(request: Request) -> str:
+    """Return the originating client IP for ``request``.
+
+    Honours ``X-Forwarded-For`` (first hop) when present so that requests
+    arriving via a reverse proxy (Caddy in production) are attributed to the
+    real caller, not the proxy.
+    """
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"

--- a/packages/shared-backend/platform_shared/db/models/auth_event.py
+++ b/packages/shared-backend/platform_shared/db/models/auth_event.py
@@ -1,0 +1,57 @@
+"""Shared AuthEvent model.
+
+Audit row for security-relevant authentication events (login, register,
+password reset, TOTP, OAuth connect/disconnect, account deletion, data export).
+Schema is consumed by every app that imports this model into its
+``app.models`` package — the table is provisioned by each app's own Alembic
+migrations.
+
+Notes
+-----
+- ``user_id`` deliberately has NO foreign key to ``users.id`` so event rows
+  survive account deletion. The ``ACCOUNT_DELETED`` event is written BEFORE
+  the cascade delete runs.
+- ``event_metadata`` is mapped to the SQL column ``metadata`` (renamed to
+  avoid collision with SQLAlchemy's ``DeclarativeBase.metadata`` attribute).
+- Anonymous failed-login rows are written with ``user_id=NULL`` and only
+  ``metadata.email_domain`` — never the full email. The scrubbing happens
+  at the service layer (see ``platform_shared.services.auth_event_service``).
+"""
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Boolean, DateTime, Index, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from platform_shared.db.base import Base
+
+
+class AuthEvent(Base):
+    __tablename__ = "auth_events"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    # Nullable — some events (failed login for unknown email) don't tie to a user
+    user_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True), nullable=True, index=True,
+    )
+    event_type: Mapped[str] = mapped_column(String(50), nullable=False, index=True)
+    ip_address: Mapped[str | None] = mapped_column(String(45), nullable=True)  # IPv6 max
+    user_agent: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    event_metadata: Mapped[dict] = mapped_column(
+        "metadata", JSONB, nullable=False, default=dict, server_default="{}",
+    )
+    succeeded: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        index=True,
+    )
+
+    __table_args__ = (
+        Index("ix_auth_events_user_event_time", "user_id", "event_type", "created_at"),
+        Index("ix_auth_events_ip_time", "ip_address", "created_at"),
+    )

--- a/packages/shared-backend/platform_shared/services/auth_event_service.py
+++ b/packages/shared-backend/platform_shared/services/auth_event_service.py
@@ -1,0 +1,51 @@
+"""Shared write helper for the ``auth_events`` audit table.
+
+Caller passes in the SQLAlchemy session — this helper is decoupled from any
+app-specific session factory. It deliberately does not flush; the caller's
+transaction commits.
+
+Never log sensitive values (passwords, tokens, full email addresses for
+unknown users) in metadata. For anonymous failed-login attempts, write
+``user_id=None`` and only ``metadata.email_domain`` — never the full email.
+"""
+import uuid
+from typing import Optional
+
+from fastapi import Request
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.core.request_utils import get_client_ip
+from platform_shared.db.models.auth_event import AuthEvent
+
+
+async def log_auth_event(
+    db: AsyncSession,
+    *,
+    event_type: str,
+    user_id: Optional[uuid.UUID] = None,
+    request: Optional[Request] = None,
+    succeeded: bool = True,
+    metadata: Optional[dict] = None,
+) -> None:
+    """Append an auth event row to the session.
+
+    Deliberately does not flush — the caller's transaction will commit.
+    Never log sensitive values (passwords, tokens) in metadata.
+    """
+    ip: Optional[str] = None
+    ua: Optional[str] = None
+    if request is not None:
+        ip = get_client_ip(request)
+        raw_ua = request.headers.get("user-agent")
+        if raw_ua:
+            ua = raw_ua[:500]
+
+    event = AuthEvent(
+        user_id=user_id,
+        event_type=event_type,
+        ip_address=ip,
+        user_agent=ua,
+        succeeded=succeeded,
+        event_metadata=metadata or {},
+    )
+    db.add(event)

--- a/packages/shared-backend/pyproject.toml
+++ b/packages/shared-backend/pyproject.toml
@@ -24,7 +24,11 @@ dependencies = [
 dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.24",
+    "aiosqlite>=0.20",
 ]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
 
 [tool.setuptools.packages.find]
 include = ["platform_shared*"]

--- a/packages/shared-backend/tests/conftest.py
+++ b/packages/shared-backend/tests/conftest.py
@@ -29,6 +29,24 @@ def _patch_metadata_for_sqlite() -> None:
                 column.type = JSON()
 
 
+@pytest.fixture(autouse=True, scope="session")
+def _patch_jsonb_for_sqlite_session() -> None:
+    """Apply the JSONB→JSON patch once per test session.
+
+    Any test that calls ``Base.metadata.create_all`` against SQLite (including
+    tests that define their own ``db`` fixture, like ``test_audit.py``) needs
+    this. Runs at session scope so it's idempotent and applies before any
+    test-local fixtures touch metadata.
+    """
+    # Force-import every shared model so its table is registered with
+    # ``Base.metadata`` before we walk it. Lazy importers would otherwise
+    # leave the metadata empty until their tests run.
+    from platform_shared.db.models.audit_log import AuditLog  # noqa: F401
+    from platform_shared.db.models.auth_event import AuthEvent  # noqa: F401
+
+    _patch_metadata_for_sqlite()
+
+
 @pytest_asyncio.fixture()
 async def db() -> AsyncGenerator[AsyncSession, None]:
     """Yield an in-memory SQLite async session with the shared schema applied.

--- a/packages/shared-backend/tests/conftest.py
+++ b/packages/shared-backend/tests/conftest.py
@@ -1,8 +1,59 @@
-"""Shared-backend test config — registers asyncio mode for pytest-asyncio."""
+"""Shared-backend test config — registers asyncio mode and a fresh in-memory DB."""
+from collections.abc import AsyncGenerator
+
 import pytest
+import pytest_asyncio
+from sqlalchemy import JSON, event
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from platform_shared.db.base import Base
 
 
 @pytest.fixture
 def anyio_backend() -> str:
     """Force ``anyio``-marked tests onto asyncio (no Trio in our test deps)."""
     return "asyncio"
+
+
+def _patch_metadata_for_sqlite() -> None:
+    """Make PostgreSQL-specific DDL compatible with SQLite for tests.
+
+    Replaces JSONB columns with JSON so ``Base.metadata.create_all`` succeeds
+    against SQLite. Mirrors the same patch in MyBookkeeper's test conftest.
+    """
+    for table in Base.metadata.tables.values():
+        for column in table.columns:
+            if isinstance(column.type, JSONB):
+                column.type = JSON()
+
+
+@pytest_asyncio.fixture()
+async def db() -> AsyncGenerator[AsyncSession, None]:
+    """Yield an in-memory SQLite async session with the shared schema applied.
+
+    Each test gets a fresh engine + database. The shared ``Base.metadata``
+    is the registry — any model imported before the fixture runs will have
+    its table created.
+    """
+    # Importing here ensures the AuthEvent table is registered with
+    # Base.metadata before create_all runs, regardless of test discovery order.
+    from platform_shared.db.models.auth_event import AuthEvent  # noqa: F401
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    @event.listens_for(engine.sync_engine, "connect")
+    def _disable_fk(dbapi_conn, _rec):  # type: ignore[no-untyped-def]
+        dbapi_conn.execute("PRAGMA foreign_keys=OFF")
+
+    _patch_metadata_for_sqlite()
+
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    async_session = sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with async_session() as session:
+        yield session
+
+    await engine.dispose()

--- a/packages/shared-backend/tests/test_auth_event_service.py
+++ b/packages/shared-backend/tests/test_auth_event_service.py
@@ -1,4 +1,4 @@
-"""Unit tests for auth_event_service.log_auth_event."""
+"""Unit tests for ``platform_shared.services.auth_event_service.log_auth_event``."""
 import uuid
 from unittest.mock import MagicMock
 
@@ -7,9 +7,8 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from platform_shared.core.auth_events import AuthEventType
-
-from app.models.system.auth_event import AuthEvent
-from app.services.system.auth_event_service import log_auth_event
+from platform_shared.db.models.auth_event import AuthEvent
+from platform_shared.services.auth_event_service import log_auth_event
 
 
 def _make_request(
@@ -113,7 +112,11 @@ async def test_log_auth_event_extracts_real_ip_from_forwarded_for(db: AsyncSessi
 
 @pytest.mark.anyio
 async def test_log_auth_event_no_user_id(db: AsyncSession) -> None:
-    """Events for unknown-user attempts are allowed with user_id=None."""
+    """Events for unknown-user attempts are allowed with user_id=None.
+
+    Anonymous failed-login rows store only ``metadata.email_domain`` —
+    never the full email — to keep PII out of the audit log.
+    """
     await log_auth_event(
         db,
         event_type=AuthEventType.LOGIN_FAILURE,
@@ -126,3 +129,18 @@ async def test_log_auth_event_no_user_id(db: AsyncSession) -> None:
     ev = (await db.execute(select(AuthEvent))).scalars().one()
     assert ev.user_id is None
     assert ev.event_metadata["email_domain"] == "example.com"
+
+
+@pytest.mark.anyio
+async def test_log_auth_event_does_not_flush(db: AsyncSession) -> None:
+    """The helper adds the row but never flushes — caller's tx commits."""
+    await log_auth_event(
+        db,
+        event_type=AuthEventType.LOGIN_SUCCESS,
+        user_id=uuid.uuid4(),
+        succeeded=True,
+    )
+
+    # Row should be staged in the session but not yet visible without flush.
+    pending = [obj for obj in db.new if isinstance(obj, AuthEvent)]
+    assert len(pending) == 1

--- a/packages/shared-backend/tests/test_pii_encryption.py
+++ b/packages/shared-backend/tests/test_pii_encryption.py
@@ -189,8 +189,11 @@ class TestTamperDetection:
             secret_key=_FIXED_KEY, salt=_FIXED_SALT, info=_FIXED_INFO,
         )
         assert ct is not None
-        # Flip a character near the end.
-        bad = ct[:-2] + ("A" if ct[-2] != "A" else "B") + ct[-1]
+        # Flip a character in the middle of the token so we don't land in the
+        # trailing base64 padding bytes (which a lenient decoder may discard,
+        # leaving the underlying bytes — and the Fernet HMAC — unchanged).
+        mid = len(ct) // 2
+        bad = ct[:mid] + ("A" if ct[mid] != "A" else "B") + ct[mid + 1:]
         with pytest.raises(InvalidToken):
             decrypt_pii(
                 bad,

--- a/packages/shared-backend/tests/test_request_utils.py
+++ b/packages/shared-backend/tests/test_request_utils.py
@@ -1,0 +1,53 @@
+"""Unit tests for ``platform_shared.core.request_utils.get_client_ip``."""
+from unittest.mock import MagicMock
+
+from platform_shared.core.request_utils import get_client_ip
+
+
+def _make_request(
+    *,
+    client_host: str | None = "1.2.3.4",
+    forwarded_for: str | None = None,
+) -> MagicMock:
+    request = MagicMock()
+    headers: dict[str, str] = {}
+    if forwarded_for is not None:
+        headers["x-forwarded-for"] = forwarded_for
+    request.headers = headers
+    if client_host is None:
+        request.client = None
+    else:
+        request.client = MagicMock()
+        request.client.host = client_host
+    return request
+
+
+class TestGetClientIp:
+    def test_returns_client_host_when_no_forwarded_header(self) -> None:
+        req = _make_request(client_host="10.0.0.5")
+        assert get_client_ip(req) == "10.0.0.5"
+
+    def test_prefers_x_forwarded_for_first_hop(self) -> None:
+        req = _make_request(
+            client_host="172.16.0.1",  # proxy
+            forwarded_for="203.0.113.5, 10.0.0.1",
+        )
+        assert get_client_ip(req) == "203.0.113.5"
+
+    def test_strips_whitespace_from_forwarded_for(self) -> None:
+        req = _make_request(
+            client_host="172.16.0.1",
+            forwarded_for="  198.51.100.7  , 10.0.0.1",
+        )
+        assert get_client_ip(req) == "198.51.100.7"
+
+    def test_single_value_forwarded_for(self) -> None:
+        req = _make_request(
+            client_host="172.16.0.1",
+            forwarded_for="198.51.100.42",
+        )
+        assert get_client_ip(req) == "198.51.100.42"
+
+    def test_returns_unknown_when_no_client(self) -> None:
+        req = _make_request(client_host=None)
+        assert get_client_ip(req) == "unknown"


### PR DESCRIPTION
## Summary

PR M4 of the 14-PR migration to make `platform_shared` the source of truth for cross-app security infrastructure. Pure refactor — promotes the auth-event audit infrastructure from MyBookkeeper into `platform_shared` so MyJobHunter (PR C2) and future apps consume the same implementation. **No new features. No schema change. No new user-facing functionality.**

### Moved modules

| From (MBK) | To (platform_shared) |
|---|---|
| `app.models.system.auth_event:AuthEvent` | `platform_shared.db.models.auth_event:AuthEvent` |
| `app.services.system.auth_event_service:log_auth_event` | `platform_shared.services.auth_event_service:log_auth_event` |
| `app.core.request_utils:get_client_ip` | `platform_shared.core.request_utils:get_client_ip` |

The three MBK modules become thin re-exports. All 14 MBK call sites (8 source + 6 test imports) keep working unchanged.

### M1 reminder

The `AuthEventType` constants enum was already promoted in M1 (#114) to `platform_shared.core.auth_events`. M4 does not touch it; the new shared service imports it from there.

### Base unification

`apps/mybookkeeper/backend/app/db/base.py` is now a thin re-export of `platform_shared.db.base.Base` (matching how MJH already does it). Required so the shared model registers on the same `Base.metadata` MBK's Alembic migrations target — without this, autogenerate would see `auth_events` as missing.

After unification, `Base.metadata.tables['auth_events']` matches the existing `e3bc2531d23e_add_auth_events_table.py` migration exactly:
- 8 columns, 5 indexes, all types, nullability, PK identical
- `event_metadata` Python attribute → SQL column `metadata` (avoids `DeclarativeBase.metadata` collision)
- `auth_events.user_id` deliberately has NO foreign key to `users.id` — preserved

**No schema change — alembic check passes.**

### MJH side

MJH's `app.models.__init__.py` does NOT import `auth_event`, so MJH's `Base.metadata.tables` does NOT contain `auth_events` (verified: 16 tables, no auth_events). MJH starts cleanly without the table existing — C2 wires this up explicitly later.

### Constraints honored

- Schema unchanged
- Anonymous failed-login PII scrubbing preserved: rows with `user_id=NULL` and only `metadata.email_domain` (never the full email)
- `ACCOUNT_DELETED` is written before cascade delete — call site in MBK's `account_service.py` is preserved (M7's scope, not this PR's)
- M2's `encrypted_string_type.py` and M3's `audit_log.py` not touched (they run in parallel; both end up needing the same `app/db/base.py` re-export change — git's natural merge handles it)

### Quality gate notes

This PR adds no new user-facing features, no new pages, no new API endpoints, no new frontend components. It is a pure module relocation with re-exports for backwards compatibility. The 6 standard quality checks therefore find:

- **E2E tests for new features**: N/A — no new features. Existing MBK integration tests (`test_auth_events_admin.py`, `test_auth_events_integration.py`, `test_login_ip_rate_limit.py`) cover the auth-event flows end-to-end and all pass unchanged.
- **No ORM in services**: The shared `log_auth_event` calls `db.add(event)` — this matches the pre-existing MBK code being moved (same single-line writer pattern as the original `app.services.system.auth_event_service`). Audit-log writers are a recognized exception in MBK; the function is one line and trivially testable.
- **No inline components**: N/A — no frontend changes.
- **Strict typing**: All new code uses strict types; no `any` introduced.
- **Pre-commit review**: One refactor commit; reviewed against M1 patterns.

## Test plan

- [x] `packages/shared-backend` pytest passes — 35 tests (24 prior + 6 new `test_auth_event_service.py` + 5 new `test_request_utils.py`)
- [x] MBK auth/event/totp/lockout/deletion tests: 70 passed
- [x] Shared `Base.metadata.tables['auth_events']` matches existing migration exactly (column types, nullability, PK, all 5 indexes)
- [x] `from app.models.system.auth_event import AuthEvent` is the same class as `from platform_shared.db.models.auth_event import AuthEvent` (verified by `is`)
- [x] MJH `Base.metadata` has 16 tables, no `auth_events`
- [x] Anonymous failed-login row test (`test_log_auth_event_no_user_id`) — `user_id=None`, `metadata.email_domain` set, no full email
- [ ] CI green (shared-backend + mybookkeeper workflows on push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)