### PR TITLE
refactor(shared-backend): promote TOTP service to platform_shared (M5)

### DIFF
--- a/apps/mybookkeeper/backend/app/services/user/totp_service.py
+++ b/apps/mybookkeeper/backend/app/services/user/totp_service.py
@@ -1,61 +1,113 @@
-import base64
-import hashlib
-import secrets
+"""MBK TOTP orchestration — thin wrapper over :mod:`platform_shared.services.totp_service`.
+
+After PR M5 the pure crypto / OTP helpers live in ``platform_shared`` (see
+``packages/shared-backend/platform_shared/services/totp_service.py``). This
+module keeps the DB-coupled coordinators that load the user row, encrypt
+the secret with MBK's master ``encryption_key``, and persist the result —
+the parts that legitimately depend on ``app.core.config``,
+``app.db.session``, and ``app.repositories.user_repo``.
+
+The wire format / on-disk format is unchanged from before M5 — production
+users keep generating valid codes against the secrets stored on their
+``users.totp_secret`` column.
+
+Re-exports preserve the pre-M5 import shape so the ~6 in-app call sites
+and the integration tests don't have to change:
+
+    from app.services.user import totp_service
+    totp_service.generate_secret()
+    totp_service.verify_code(secret, code)
+    totp_service._encrypt(value, user_id)        # private alias kept for tests
+    totp_service._decrypt(value, user_id)        # private alias kept for tests
+    await totp_service.setup_totp(user.id)       # DB coordinator (this module)
+"""
 import uuid
 
-import pyotp
-from cryptography.fernet import Fernet
+from platform_shared.services.totp_service import (
+    decrypt_for_user,
+    encrypt_for_user,
+    generate_recovery_codes,
+    generate_secret,
+    get_provisioning_uri as _shared_get_provisioning_uri,
+    verify_code,
+    verify_recovery_code,
+)
 
 from app.core.config import settings
 from app.db.session import AsyncSessionLocal, unit_of_work
 from app.repositories import user_repo
 
-
-def _fernet(user_id: uuid.UUID) -> Fernet:
-    key = hashlib.sha256(
-        settings.encryption_key.encode() + str(user_id).encode(),
-    ).digest()
-    return Fernet(base64.urlsafe_b64encode(key))
+# MBK's authenticator brand. Centralised here so every call site in the app
+# (setup, login, recovery) uses the same string and we don't ship a mix of
+# "MyBookkeeper" / "Mybookkeeper" / "MyBookKeeper" to authenticator apps.
+_TOTP_ISSUER = "MyBookkeeper"
 
 
-def _encrypt(value: str, user_id: uuid.UUID) -> str:
-    return _fernet(user_id).encrypt(value.encode()).decode()
+# ---------------------------------------------------------------------------
+# Re-exports — pure helpers from platform_shared
+# ---------------------------------------------------------------------------
 
-
-def _decrypt(value: str, user_id: uuid.UUID) -> str:
-    return _fernet(user_id).decrypt(value.encode()).decode()
-
-
-def generate_secret() -> str:
-    return pyotp.random_base32()
+# The shared `generate_secret`, `verify_code`, `verify_recovery_code`, and
+# `generate_recovery_codes` take no app-specific args, so we re-export them
+# verbatim. Aliasing here (rather than a `from … import *`) lets tests
+# patch `app.services.user.totp_service.generate_secret` without polluting
+# the shared module.
+__all__ = [
+    "generate_secret",
+    "get_provisioning_uri",
+    "verify_code",
+    "verify_recovery_code",
+    "generate_recovery_codes",
+    "setup_totp",
+    "confirm_totp",
+    "disable_totp",
+    "validate_totp_for_login",
+    "is_totp_required",
+]
 
 
 def get_provisioning_uri(secret: str, email: str) -> str:
-    totp = pyotp.TOTP(secret)
-    return totp.provisioning_uri(name=email, issuer_name="MyBookkeeper")
+    """MBK-issuer-bound wrapper over the shared provisioning-URI builder.
+
+    Pre-M5 callers passed ``(secret, email)`` and the issuer was hardcoded
+    inside the function. Keep that signature so existing call sites and
+    tests keep working — the shared helper is what actually builds the
+    URI, with ``issuer`` always set to MBK's brand string.
+    """
+    return _shared_get_provisioning_uri(secret, email, issuer=_TOTP_ISSUER)
 
 
-def verify_code(secret: str, code: str) -> bool:
-    totp = pyotp.TOTP(secret)
-    return totp.verify(code, valid_window=1)
+# ---------------------------------------------------------------------------
+# Encryption helpers — bind MBK's master key into the per-user Fernet
+# ---------------------------------------------------------------------------
+
+def _encrypt(value: str, user_id: uuid.UUID) -> str:
+    """Encrypt ``value`` for ``user_id`` using MBK's configured master key.
+
+    Underscore-prefixed name kept for backwards compatibility with the
+    pre-M5 test suite (``test_totp_service.py``, ``test_totp_routes.py``,
+    ``test_auth_events_integration.py``) that patches / imports this
+    symbol directly. New code should call the shared helper directly.
+    """
+    return encrypt_for_user(value, settings.encryption_key, user_id)
 
 
-def generate_recovery_codes(count: int = 8) -> list[str]:
-    return [secrets.token_hex(4).upper() for _ in range(count)]
+def _decrypt(value: str, user_id: uuid.UUID) -> str:
+    """Decrypt a token produced by :func:`_encrypt`. Raises ``InvalidToken`` on key mismatch."""
+    return decrypt_for_user(value, settings.encryption_key, user_id)
 
 
-def verify_recovery_code(stored_codes_str: str | None, code: str) -> tuple[bool, str | None]:
-    if not stored_codes_str:
-        return False, None
-    codes = stored_codes_str.split(",")
-    normalized = code.strip().upper()
-    if normalized in codes:
-        codes.remove(normalized)
-        return True, ",".join(codes) if codes else None
-    return False, stored_codes_str
-
+# ---------------------------------------------------------------------------
+# DB-coupled coordinators
+# ---------------------------------------------------------------------------
 
 async def setup_totp(user_id: uuid.UUID) -> tuple[str, str]:
+    """Generate a fresh TOTP secret for a user and return ``(secret, provisioning_uri)``.
+
+    The plaintext secret is encrypted onto ``users.totp_secret`` but
+    ``totp_enabled`` stays False — the user still has to confirm a code
+    via :func:`confirm_totp` before 2FA actually gates their login.
+    """
     async with unit_of_work() as db:
         user = await user_repo.get_by_id(db, user_id)
         if user is None:
@@ -67,6 +119,11 @@ async def setup_totp(user_id: uuid.UUID) -> tuple[str, str]:
 
 
 async def confirm_totp(user_id: uuid.UUID, code: str) -> tuple[bool, list[str]]:
+    """Verify a TOTP ``code`` and, on success, enable 2FA + issue recovery codes.
+
+    Returns ``(verified, recovery_codes)``. On failure or unknown user,
+    returns ``(False, [])`` and leaves all flags unchanged.
+    """
     async with unit_of_work() as db:
         user = await user_repo.get_by_id(db, user_id)
         if user is None or not user.totp_secret:
@@ -81,6 +138,7 @@ async def confirm_totp(user_id: uuid.UUID, code: str) -> tuple[bool, list[str]]:
 
 
 async def disable_totp(user_id: uuid.UUID, code: str) -> bool:
+    """Disable 2FA after verifying a current TOTP ``code``. Clears all TOTP fields on success."""
     async with unit_of_work() as db:
         user = await user_repo.get_by_id(db, user_id)
         if user is None or not user.totp_enabled or not user.totp_secret:
@@ -95,9 +153,12 @@ async def disable_totp(user_id: uuid.UUID, code: str) -> bool:
 
 
 async def validate_totp_for_login(email: str, code: str) -> tuple[bool, bool]:
-    """Validate a TOTP or recovery code.
+    """Validate a TOTP code OR a recovery code for the login flow.
 
-    Returns (valid, used_recovery_code).
+    Returns ``(valid, used_recovery_code)``. A successful recovery-code
+    consumption rewrites the encrypted recovery-codes column with the
+    matched code removed (or clears the column entirely if it was the
+    last one).
     """
     async with unit_of_work() as db:
         user = await user_repo.get_by_email(db, email)
@@ -112,12 +173,15 @@ async def validate_totp_for_login(email: str, code: str) -> tuple[bool, bool]:
             recovery_str = _decrypt(user.totp_recovery_codes, user.id)
             valid, remaining = verify_recovery_code(recovery_str, code)
             if valid:
-                user.totp_recovery_codes = _encrypt(remaining, user.id) if remaining else None
+                user.totp_recovery_codes = (
+                    _encrypt(remaining, user.id) if remaining else None
+                )
                 return True, True
 
         return False, False
 
 
 async def is_totp_required(email: str) -> bool:
+    """Return True if the user with ``email`` has 2FA enabled (cheap selectinload)."""
     async with AsyncSessionLocal() as db:
         return await user_repo.get_totp_enabled(db, email)

--- a/packages/shared-backend/platform_shared/services/totp_service.py
+++ b/packages/shared-backend/platform_shared/services/totp_service.py
@@ -1,52 +1,157 @@
-"""TOTP (2FA) utilities — secret generation, verification, recovery codes.
+"""TOTP (RFC 6238) helpers — pure functions, no database, no app config.
 
-Pure functions only — no database access. App-level services handle persistence.
+Promoted from MyBookkeeper's ``app.services.user.totp_service`` (PR M5 of the
+shared-backend migration). The MBK version mixed pure crypto/OTP helpers with
+DB-coupled coordinators (``setup_totp``, ``confirm_totp``, ``disable_totp``,
+``validate_totp_for_login``); the DB-coupled half stayed in MBK as a thin
+orchestration layer. Only the pure helpers live here.
 
-Usage:
-    secret = generate_secret()
-    uri = get_provisioning_uri(secret, "user@example.com", issuer="MyApp")
-    is_valid = verify_code(secret, "123456")
+The caller is responsible for:
+  * persisting the returned ``secret`` and ``recovery_codes`` (typically on
+    a ``users`` row, transparently encrypted-at-rest via the M2
+    :class:`platform_shared.core.encrypted_string_type.EncryptedString`
+    TypeDecorator using the caller's own PII codec)
+  * supplying the ``label`` (usually the user's email) and ``issuer`` (the
+    app brand shown in Google Authenticator / 1Password) on enrollment
+
+Wire format / on-disk format is preserved verbatim from the MBK production
+copy so existing TOTP-enrolled users keep generating valid codes:
+  * secrets are ``pyotp.random_base32()`` (default 32-char base32 alphabet)
+  * recovery codes are ``secrets.token_hex(4).upper()`` (8 uppercase hex chars)
+  * the otpauth URI is ``pyotp.TOTP(secret).provisioning_uri(name=label,
+    issuer_name=issuer)`` — RFC 6238 + Google Authenticator key-uri spec
+  * verification window is ±1 30-second step (``valid_window=1``)
+
+Per-user Fernet derivation (``make_user_fernet``, ``encrypt_for_user``,
+``decrypt_for_user``) is also pure: callers pass their own
+``encryption_key`` master and ``user_id``; the function never reads global
+config. MBK uses these to encrypt the TOTP secret + comma-separated recovery
+codes onto the user row; we keep the helpers here so any future app can use
+the same scheme without copy-paste.
+
+Cross-app key isolation is automatic: the Fernet key is
+``sha256(encryption_key || str(user_id))``, so two apps running with
+different ``encryption_key`` masters cannot decrypt each other's stored
+secrets, even for users sharing the same UUID.
 """
 import base64
 import hashlib
 import secrets
 import uuid
+from typing import Final
 
 import pyotp
 from cryptography.fernet import Fernet
 
+# Default to RFC 6238's 30-second step + ±1 step drift, matching what MBK
+# shipped to production. Bumping ``VERIFY_WINDOW`` widens the window the
+# user has to type the code; tightening it would invalidate codes typed
+# with mild clock skew. Constant lives at module scope so callers (and
+# tests) can reference the production value without magic numbers.
+VERIFY_WINDOW: Final[int] = 1
+
+# 8 alphanumeric (hex) recovery codes, 8 chars each. Format must NOT change
+# without a data migration — production users have these stored on their
+# user row; changing the format invalidates every existing code.
+DEFAULT_RECOVERY_CODE_COUNT: Final[int] = 8
+RECOVERY_CODE_BYTES: Final[int] = 4  # token_hex(4) -> 8 hex chars uppercased
+
+
+# ---------------------------------------------------------------------------
+# Pure crypto / OTP helpers
+# ---------------------------------------------------------------------------
 
 def generate_secret() -> str:
+    """Return a fresh base32 TOTP secret (RFC 6238 / Google Authenticator compatible)."""
     return pyotp.random_base32()
 
 
-def get_provisioning_uri(secret: str, email: str, *, issuer: str) -> str:
-    totp = pyotp.TOTP(secret)
-    return totp.provisioning_uri(name=email, issuer_name=issuer)
+def get_provisioning_uri(secret: str, label: str, *, issuer: str) -> str:
+    """Build the ``otpauth://`` URI consumed by authenticator apps.
+
+    ``label`` is typically the user's email; ``issuer`` is the app brand
+    shown in Google Authenticator / 1Password. Both are caller-supplied so
+    no app-specific config leaks into this module.
+    """
+    return pyotp.TOTP(secret).provisioning_uri(name=label, issuer_name=issuer)
 
 
 def verify_code(secret: str, code: str) -> bool:
-    totp = pyotp.TOTP(secret)
-    return totp.verify(code, valid_window=1)
+    """Return True if ``code`` is the current TOTP for ``secret`` (±1 step)."""
+    if not code:
+        return False
+    return pyotp.TOTP(secret).verify(code, valid_window=VERIFY_WINDOW)
 
 
-def generate_recovery_codes(count: int = 8) -> list[str]:
-    return [secrets.token_hex(4).upper() for _ in range(count)]
+def generate_recovery_codes(count: int = DEFAULT_RECOVERY_CODE_COUNT) -> list[str]:
+    """Return ``count`` fresh recovery codes (8 uppercase hex chars each).
+
+    Format matches MBK production exactly — must not change without
+    migrating existing user rows.
+    """
+    return [secrets.token_hex(RECOVERY_CODE_BYTES).upper() for _ in range(count)]
 
 
-def verify_recovery_code(stored_codes_str: str | None, code: str) -> tuple[bool, str | None]:
+def verify_recovery_code(
+    stored_codes_str: str | None,
+    candidate: str,
+) -> tuple[bool, str | None]:
+    """Consume a recovery code from a comma-separated stored string.
+
+    Returns ``(valid, remaining_codes_str)``. If valid, ``remaining`` has the
+    matched code removed. If the last code was consumed, ``remaining`` is
+    ``None`` (so the caller can clear the column entirely). If invalid,
+    ``remaining`` is the original ``stored_codes_str`` unchanged.
+
+    Match is case-insensitive and tolerates leading/trailing whitespace —
+    users typing recovery codes on a phone are forgiving cases worth
+    handling.
+    """
     if not stored_codes_str:
         return False, None
     codes = stored_codes_str.split(",")
-    normalized = code.strip().upper()
+    normalized = candidate.strip().upper()
     if normalized in codes:
         codes.remove(normalized)
         return True, ",".join(codes) if codes else None
     return False, stored_codes_str
 
 
+def enroll_totp(
+    *,
+    label: str,
+    issuer: str,
+    recovery_code_count: int = DEFAULT_RECOVERY_CODE_COUNT,
+) -> tuple[str, str, list[str]]:
+    """Generate a fresh TOTP enrollment bundle.
+
+    Returns ``(secret, provisioning_uri, recovery_codes)``. The caller is
+    responsible for persisting all three values (typically on the user row,
+    encrypted at rest via the M2 ``EncryptedString`` TypeDecorator).
+
+    This is a thin convenience wrapper over :func:`generate_secret`,
+    :func:`get_provisioning_uri`, and :func:`generate_recovery_codes` so
+    apps don't have to call all three in sequence.
+    """
+    secret = generate_secret()
+    uri = get_provisioning_uri(secret, label, issuer=issuer)
+    recovery_codes = generate_recovery_codes(count=recovery_code_count)
+    return secret, uri, recovery_codes
+
+
+# ---------------------------------------------------------------------------
+# Per-user Fernet helpers (pure — caller supplies the master key)
+# ---------------------------------------------------------------------------
+
 def make_user_fernet(encryption_key: str, user_id: uuid.UUID) -> Fernet:
-    """Create a user-specific Fernet cipher for encrypting TOTP secrets."""
+    """Build a per-user :class:`Fernet` cipher.
+
+    The derivation is intentionally simple — ``sha256(master || user_id)``
+    — because it has been in production at MBK since the original 2FA
+    rollout and changing it would require re-encrypting every existing
+    ``users.totp_secret`` value. If a future app needs HKDF or a stronger
+    KDF, define a sibling helper rather than mutating this one.
+    """
     key = hashlib.sha256(
         encryption_key.encode() + str(user_id).encode(),
     ).digest()
@@ -54,8 +159,14 @@ def make_user_fernet(encryption_key: str, user_id: uuid.UUID) -> Fernet:
 
 
 def encrypt_for_user(value: str, encryption_key: str, user_id: uuid.UUID) -> str:
+    """Encrypt ``value`` under the per-user Fernet key. Returns urlsafe-base64 token."""
     return make_user_fernet(encryption_key, user_id).encrypt(value.encode()).decode()
 
 
 def decrypt_for_user(value: str, encryption_key: str, user_id: uuid.UUID) -> str:
+    """Decrypt a token previously produced by :func:`encrypt_for_user`.
+
+    Raises :class:`cryptography.fernet.InvalidToken` if the key/user pair
+    doesn't match the one that produced ``value``.
+    """
     return make_user_fernet(encryption_key, user_id).decrypt(value.encode()).decode()

--- a/packages/shared-backend/tests/test_totp_service.py
+++ b/packages/shared-backend/tests/test_totp_service.py
@@ -1,0 +1,349 @@
+"""Tests for ``platform_shared.services.totp_service``.
+
+The module is pure functions — no database, no app config — so these
+tests exercise the real ``pyotp`` and ``cryptography.fernet`` libraries
+directly. No mocks for either: a TOTP code rejection from a faked clock
+is exactly the bug we want to catch.
+
+What's covered:
+  * RFC-6238 secret format (base32, sufficient entropy)
+  * provisioning URI matches the Google Authenticator key-uri spec
+  * verify accepts the current code, rejects empty / wrong / cross-secret codes
+  * recovery codes: format (8 uppercase hex chars), uniqueness, custom count
+  * recovery-code consumption: case-insensitive, whitespace-tolerant, single-use
+  * ``enroll_totp`` returns a self-consistent triple (secret -> URI -> codes)
+  * per-user Fernet roundtrip + cross-user isolation
+  * cross-app key isolation: codes generated under master key A do NOT
+    decrypt under master key B (the reason this service is decoupled
+    from any single app's config)
+"""
+import secrets as _secrets
+import uuid
+
+import pyotp
+import pytest
+from cryptography.fernet import InvalidToken
+
+from platform_shared.services import totp_service
+from platform_shared.services.totp_service import (
+    DEFAULT_RECOVERY_CODE_COUNT,
+    decrypt_for_user,
+    encrypt_for_user,
+    enroll_totp,
+    generate_recovery_codes,
+    generate_secret,
+    get_provisioning_uri,
+    make_user_fernet,
+    verify_code,
+    verify_recovery_code,
+)
+
+
+# ---------------------------------------------------------------------------
+# generate_secret
+# ---------------------------------------------------------------------------
+
+class TestGenerateSecret:
+    def test_returns_base32_string(self) -> None:
+        secret = generate_secret()
+        assert isinstance(secret, str)
+        # ``pyotp.random_base32()`` defaults to a 32-char alphabet, but the
+        # contract is ≥16 chars (RFC 4226 §4 recommends ≥128 bits ≈ 26 b32 chars).
+        assert len(secret) >= 16
+        # Every character must be in the base32 alphabet.
+        assert set(secret).issubset(set("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"))
+
+    def test_each_call_returns_unique_secret(self) -> None:
+        secrets_seen = {generate_secret() for _ in range(20)}
+        assert len(secrets_seen) == 20  # collision probability ≈ 0
+
+
+# ---------------------------------------------------------------------------
+# get_provisioning_uri
+# ---------------------------------------------------------------------------
+
+class TestGetProvisioningUri:
+    def test_otpauth_scheme(self) -> None:
+        uri = get_provisioning_uri(generate_secret(), "alice@example.com", issuer="MyApp")
+        assert uri.startswith("otpauth://totp/")
+
+    def test_contains_label_and_issuer(self) -> None:
+        uri = get_provisioning_uri(generate_secret(), "alice@example.com", issuer="MyApp")
+        assert "alice%40example.com" in uri or "alice@example.com" in uri
+        assert "MyApp" in uri
+
+    def test_issuer_kwarg_is_required(self) -> None:
+        with pytest.raises(TypeError):
+            get_provisioning_uri(generate_secret(), "alice@example.com")  # type: ignore[call-arg]
+
+    def test_different_issuers_produce_different_uris(self) -> None:
+        secret = generate_secret()
+        uri_a = get_provisioning_uri(secret, "alice@example.com", issuer="AppA")
+        uri_b = get_provisioning_uri(secret, "alice@example.com", issuer="AppB")
+        assert uri_a != uri_b
+        assert "AppA" in uri_a and "AppA" not in uri_b
+
+
+# ---------------------------------------------------------------------------
+# verify_code
+# ---------------------------------------------------------------------------
+
+class TestVerifyCode:
+    def test_current_code_is_valid(self) -> None:
+        secret = generate_secret()
+        code = pyotp.TOTP(secret).now()
+        assert verify_code(secret, code) is True
+
+    def test_wrong_code_is_invalid(self) -> None:
+        assert verify_code(generate_secret(), "000000") is False
+
+    def test_empty_code_is_invalid(self) -> None:
+        # Important: pyotp will raise on empty input if we forward it, so
+        # the wrapper short-circuits to False instead.
+        assert verify_code(generate_secret(), "") is False
+
+    def test_wrong_secret_rejects_valid_code(self) -> None:
+        secret_a = generate_secret()
+        secret_b = generate_secret()
+        code = pyotp.TOTP(secret_a).now()
+        assert verify_code(secret_b, code) is False
+
+    def test_non_numeric_code_is_invalid(self) -> None:
+        assert verify_code(generate_secret(), "abcdef") is False
+
+
+# ---------------------------------------------------------------------------
+# generate_recovery_codes
+# ---------------------------------------------------------------------------
+
+class TestGenerateRecoveryCodes:
+    def test_default_count_matches_constant(self) -> None:
+        codes = generate_recovery_codes()
+        assert len(codes) == DEFAULT_RECOVERY_CODE_COUNT == 8
+
+    def test_custom_count(self) -> None:
+        codes = generate_recovery_codes(count=4)
+        assert len(codes) == 4
+
+    def test_codes_are_eight_uppercase_hex_chars(self) -> None:
+        for code in generate_recovery_codes():
+            assert len(code) == 8
+            assert code == code.upper()
+            assert all(c in "0123456789ABCDEF" for c in code)
+
+    def test_codes_are_unique_within_a_batch(self) -> None:
+        codes = generate_recovery_codes(count=8)
+        assert len(set(codes)) == 8
+
+    def test_zero_count_returns_empty_list(self) -> None:
+        # Edge case: a caller with a custom recovery-code count of 0 should
+        # get an empty list, not an error. This is unusual but valid.
+        assert generate_recovery_codes(count=0) == []
+
+
+# ---------------------------------------------------------------------------
+# verify_recovery_code
+# ---------------------------------------------------------------------------
+
+class TestVerifyRecoveryCode:
+    def test_valid_code_returns_true_and_removes_code(self) -> None:
+        stored = "AABBCCDD,11223344,DEADBEEF"
+        valid, remaining = verify_recovery_code(stored, "AABBCCDD")
+        assert valid is True
+        assert "AABBCCDD" not in (remaining or "").split(",")
+
+    def test_invalid_code_returns_false_and_preserves_all_codes(self) -> None:
+        stored = "AABBCCDD,11223344"
+        valid, remaining = verify_recovery_code(stored, "XXXXXXXX")
+        assert valid is False
+        assert remaining == stored
+
+    def test_none_stored_returns_false(self) -> None:
+        valid, remaining = verify_recovery_code(None, "AABBCCDD")
+        assert valid is False
+        assert remaining is None
+
+    def test_empty_stored_returns_false(self) -> None:
+        valid, _ = verify_recovery_code("", "AABBCCDD")
+        assert valid is False
+
+    def test_case_insensitive(self) -> None:
+        valid, _ = verify_recovery_code("AABBCCDD", "aabbccdd")
+        assert valid is True
+
+    def test_strips_whitespace(self) -> None:
+        valid, _ = verify_recovery_code("AABBCCDD", "  AABBCCDD  ")
+        assert valid is True
+
+    def test_last_code_consumed_returns_none(self) -> None:
+        valid, remaining = verify_recovery_code("AABBCCDD", "AABBCCDD")
+        assert valid is True
+        assert remaining is None
+
+    def test_second_use_of_same_code_fails(self) -> None:
+        stored = "AABBCCDD,11223344"
+        _, remaining = verify_recovery_code(stored, "AABBCCDD")
+        valid, _ = verify_recovery_code(remaining, "AABBCCDD")
+        assert valid is False
+
+
+# ---------------------------------------------------------------------------
+# enroll_totp — bundle convenience
+# ---------------------------------------------------------------------------
+
+class TestEnrollTotp:
+    def test_returns_self_consistent_triple(self) -> None:
+        secret, uri, recovery_codes = enroll_totp(label="user@example.com", issuer="MyApp")
+        # Secret round-trips through the URI.
+        assert secret in uri
+        # Issuer round-trips through the URI.
+        assert "MyApp" in uri
+        # The current code for the returned secret verifies.
+        code = pyotp.TOTP(secret).now()
+        assert verify_code(secret, code) is True
+        # Default count.
+        assert len(recovery_codes) == DEFAULT_RECOVERY_CODE_COUNT
+
+    def test_custom_recovery_code_count(self) -> None:
+        _, _, recovery_codes = enroll_totp(
+            label="user@example.com",
+            issuer="MyApp",
+            recovery_code_count=3,
+        )
+        assert len(recovery_codes) == 3
+
+    def test_each_enrollment_is_independent(self) -> None:
+        s1, u1, r1 = enroll_totp(label="a@example.com", issuer="MyApp")
+        s2, u2, r2 = enroll_totp(label="a@example.com", issuer="MyApp")
+        assert s1 != s2
+        assert u1 != u2
+        # Recovery codes should also be unique across enrollments (16 hex
+        # chars of entropy each — collision is astronomically unlikely).
+        assert set(r1).isdisjoint(set(r2))
+
+
+# ---------------------------------------------------------------------------
+# Per-user Fernet roundtrip
+# ---------------------------------------------------------------------------
+
+class TestPerUserFernet:
+    def test_roundtrip_preserves_value(self) -> None:
+        master = _secrets.token_urlsafe(32)
+        user_id = uuid.uuid4()
+        plaintext = "MYSECRET123"
+        encrypted = encrypt_for_user(plaintext, master, user_id)
+        assert encrypted != plaintext  # ciphertext, not plaintext
+        assert decrypt_for_user(encrypted, master, user_id) == plaintext
+
+    def test_different_users_produce_different_ciphertext(self) -> None:
+        master = _secrets.token_urlsafe(32)
+        plaintext = "SAME_SECRET"
+        enc_a = encrypt_for_user(plaintext, master, uuid.uuid4())
+        enc_b = encrypt_for_user(plaintext, master, uuid.uuid4())
+        assert enc_a != enc_b
+
+    def test_wrong_user_id_cannot_decrypt(self) -> None:
+        master = _secrets.token_urlsafe(32)
+        uid_a = uuid.uuid4()
+        uid_b = uuid.uuid4()
+        encrypted = encrypt_for_user("SECRET", master, uid_a)
+        with pytest.raises(InvalidToken):
+            decrypt_for_user(encrypted, master, uid_b)
+
+    def test_make_user_fernet_is_deterministic(self) -> None:
+        master = _secrets.token_urlsafe(32)
+        user_id = uuid.uuid4()
+        f1 = make_user_fernet(master, user_id)
+        f2 = make_user_fernet(master, user_id)
+        # Two Fernet instances with the same derived key must round-trip
+        # each other's ciphertext.
+        token = f1.encrypt(b"hello")
+        assert f2.decrypt(token) == b"hello"
+
+
+# ---------------------------------------------------------------------------
+# Cross-app key isolation
+# ---------------------------------------------------------------------------
+
+class TestCrossAppKeyIsolation:
+    """The whole point of decoupling this service from app config is so two
+    apps deployed side-by-side cannot read each other's TOTP secrets, even
+    if a UUID happens to collide (which it shouldn't, but defense in depth)."""
+
+    def test_app_a_cannot_decrypt_app_bs_ciphertext(self) -> None:
+        master_a = _secrets.token_urlsafe(32)
+        master_b = _secrets.token_urlsafe(32)
+        # Same user UUID across both apps — the attack scenario. Decrypt
+        # must still fail because the master key is different.
+        user_id = uuid.uuid4()
+        encrypted_under_a = encrypt_for_user("SECRET-FROM-APP-A", master_a, user_id)
+        with pytest.raises(InvalidToken):
+            decrypt_for_user(encrypted_under_a, master_b, user_id)
+
+    def test_recovery_codes_generated_for_one_app_dont_match_anothers_store(self) -> None:
+        """The pure API has no shared global state — recovery codes
+        generated for AppA's user don't appear in AppB's store unless
+        AppB explicitly persists them. This is structural, not behavioral,
+        but we assert it explicitly so a future regression that introduces
+        any module-level cache fails fast."""
+        codes_a = generate_recovery_codes()
+        codes_b = generate_recovery_codes()
+        # Two batches drawn from os.urandom — overlap probability is
+        # negligible (each code is 32 bits of entropy; with 8 codes each,
+        # collision prob ≈ 64 / 2^32).
+        assert set(codes_a).isdisjoint(set(codes_b))
+
+
+# ---------------------------------------------------------------------------
+# Module surface
+# ---------------------------------------------------------------------------
+
+class TestModuleSurface:
+    """The public API contract. Removing any of these symbols breaks the
+    M5 promotion guarantees — bump a major version + migrate every caller."""
+
+    def test_exports_required_public_symbols(self) -> None:
+        for name in (
+            "generate_secret",
+            "get_provisioning_uri",
+            "verify_code",
+            "verify_recovery_code",
+            "generate_recovery_codes",
+            "enroll_totp",
+            "make_user_fernet",
+            "encrypt_for_user",
+            "decrypt_for_user",
+            "VERIFY_WINDOW",
+            "DEFAULT_RECOVERY_CODE_COUNT",
+        ):
+            assert hasattr(totp_service, name), f"missing public symbol: {name}"
+
+    def test_does_not_import_app_specific_modules(self) -> None:
+        """Regression guard: the shared module must NEVER pull in app config.
+
+        If this fails, the shared service has been recoupled to a single
+        app's settings and the M5 decoupling has regressed.
+        """
+        import sys
+
+        # Reload the module fresh to avoid contamination from other tests.
+        # (In practice this always passes since the module is loaded once
+        # at session start, but we want a deterministic check.)
+        forbidden_prefixes = ("app.", "mybookkeeper", "myjobhunter")
+        module_globals = vars(totp_service)
+        for value in module_globals.values():
+            module = getattr(value, "__module__", None)
+            if module is None:
+                continue
+            for prefix in forbidden_prefixes:
+                assert not module.startswith(prefix), (
+                    f"shared totp_service must not depend on app-specific "
+                    f"module {module}"
+                )
+        # Also verify no app.* modules are imported in sys.modules as a
+        # side-effect of loading totp_service. (We can't undo a stray
+        # import after the fact, but if the module is already loaded with
+        # a stray import, this catches it.)
+        for mod_name in list(sys.modules):
+            if mod_name.startswith("app.") and "totp" in mod_name:
+                pytest.fail(f"app-specific module leaked into sys.modules: {mod_name}")


### PR DESCRIPTION
## Summary

Promotes the **pure-function half** of MyBookkeeper's TOTP service into `platform_shared` so MyJobHunter (PR C5) and future apps consume the same RFC-6238 implementation. PR **M5** of the 14-PR shared-backend migration plan (M1-M4 already merged).

## Step 0 — Reconciliation

A pre-existing `platform_shared.services.totp_service` was in place from the initial monorepo extraction. Its pure helpers were close to MBK's production copy, but two things were inconsistent — resolved here:

| Concern | Pre-existing shared | MBK production | Resolved by going with |
|---|---|---|---|
| `get_provisioning_uri` issuer | `issuer` kwarg-only (decoupled) | hardcoded `"MyBookkeeper"` | Kept shared's kwarg shape — that's the decoupled API the migration aims for. The MBK-issuer hardcode now lives only in the MBK wrapper. |
| `enroll_totp` bundle | absent | absent | **Added new** per the PR spec — returns `(secret, provisioning_uri, recovery_codes)` so apps don't have to call three helpers in sequence. |
| `verify_code` empty-code handling | crashes if `pyotp` ever changes its empty-input behavior | relied on pyotp returning False | Added defensive `if not code: return False` early return — safer against `None`. |
| Encryption helper names | `encrypt_for_user` / `decrypt_for_user` | `_encrypt` / `_decrypt` | Kept shared's public names. The MBK wrapper aliases them as `_encrypt` / `_decrypt` to preserve the test-side imports without changes. |

## What moved

**Pure helpers — now in `platform_shared`:**
- `generate_secret()`
- `get_provisioning_uri(secret, label, *, issuer)`
- `verify_code(secret, code)` — ±1 30-second step
- `generate_recovery_codes(count=8)` — 8 uppercase hex chars
- `verify_recovery_code(stored, candidate)` — case-insensitive, whitespace-tolerant, single-use consumption
- `enroll_totp(*, label, issuer)` — bundle convenience: returns `(secret, uri, recovery_codes)`
- `make_user_fernet`, `encrypt_for_user`, `decrypt_for_user` — per-user Fernet helpers (caller supplies master key)
- Module-level constants: `VERIFY_WINDOW = 1`, `DEFAULT_RECOVERY_CODE_COUNT = 8`

**DB-coupled coordinators — stay in MBK** (legitimately need `app.core.config`, `app.db.session`, `app.repositories.user_repo`):
- `setup_totp(user_id)`
- `confirm_totp(user_id, code)`
- `disable_totp(user_id, code)`
- `validate_totp_for_login(email, code)`
- `is_totp_required(email)`

## On-disk format preserved verbatim

Production users keep working — the wire format is unchanged:
- secrets: `pyotp.random_base32()` (same as before)
- recovery codes: `secrets.token_hex(4).upper()`, comma-separated, Fernet-encrypted with `sha256(encryption_key || str(user_id))`
- otpauth URI: `pyotp.TOTP(secret).provisioning_uri(name=label, issuer_name=issuer)`
- verification window: `valid_window=1`

QR codes already scanned into Google Authenticator / 1Password keep generating valid codes.

## MBK wiring

`apps/mybookkeeper/backend/app/services/user/totp_service.py` is now a **thin orchestration wrapper**:
- re-exports the pure helpers from `platform_shared` (so `from app.services.user import totp_service; totp_service.verify_code(...)` still works)
- keeps the 5 DB coordinators
- preserves the `_encrypt` / `_decrypt` private aliases — this matters because `test_totp_routes.py`, `test_totp_service.py`, and `test_auth_events_integration.py` all `patch("app.services.user.totp_service.unit_of_work", …)` and `from app.services.user.totp_service import _encrypt`. **Zero test-side changes needed.**
- centralises `_TOTP_ISSUER = "MyBookkeeper"` so every authenticator URI uses the same brand string

Importer count check: only 3 in-app sites (`api/totp.py`, `api/account.py`, `core/auth.py` references via the model) plus 4 test files. Well under the 10-importer threshold for a delete-and-rewrite, but rewriting all those imports would have churned the integration tests for no benefit, so I kept the wrapper.

## Decoupling guarantees

The shared service does **NOT** import any `app.*` module. A regression-guard test (`TestModuleSurface::test_does_not_import_app_specific_modules`) fails fast if a future change recouples it. MJH backend can import + use the shared service cleanly — verified locally:

```
otpauth://totp/MyJobHunter:user%40example.com?secret=YF4PWBT…  (8 recovery codes)
```

## Test coverage

- **`packages/shared-backend/tests/test_totp_service.py`** (NEW, 35 tests) — RFC-6238 secret format, otpauth URI format, verify ±1 step window, recovery-code format/uniqueness/consumption, `enroll_totp` triple consistency, per-user Fernet roundtrip, **cross-app key isolation** (master-key A's ciphertext does NOT decrypt under master-key B even with the same UUID), module-surface regression guards.
- **`apps/mybookkeeper/backend/tests/test_totp_service.py`** (48 tests) — pass unchanged via the wrapper.
- **`apps/mybookkeeper/backend/tests/test_totp_routes.py`** (19 tests) — pass unchanged.
- **`apps/mybookkeeper/backend/tests/test_auth_events_integration.py`** (8 tests) — pass unchanged.
- **155 auth-adjacent MBK tests** pass collectively (TOTP routes, login, password change, account deletion, audit registration, PII).

Total: 35 new shared tests, 0 MBK test changes, 155+ MBK tests verified.

## Test plan

- [ ] CI green: lint, typecheck, MBK backend-tests + frontend-build, MJH backend-tests + frontend-build, shared-backend-tests, CodeQL, Gitleaks, Stack smoke
- [ ] No live-user disruption: secrets/recovery-codes already on prod user rows keep validating (wire format unchanged)
- [ ] `grep -rn "from app.services.user.totp_service" apps/mybookkeeper/` resolves to the in-MBK wrapper which delegates to shared
- [ ] The shared TOTP service does NOT import `app.*` anywhere (regression-guarded by `TestModuleSurface`)
- [ ] MJH still imports cleanly (no TOTP routes added — that's C5)

## Out of scope (intentionally untouched)

- Pre-existing 24 frontend test failures and 16 lint errors stay untouched per spec
- MJH TOTP routes / model wiring — that's PR C5
- Applicants-kanban worktree — another session's work

🤖 Generated with [Claude Code](https://claude.com/claude-code)
