### PR TITLE
refactor(shared-backend): promote rate_limit + login throttle to platform_shared (M6)

### DIFF
--- a/apps/mybookkeeper/backend/app/core/rate_limit.py
+++ b/apps/mybookkeeper/backend/app/core/rate_limit.py
@@ -1,10 +1,25 @@
-"""In-memory rate limiter for auth and API endpoints.
+"""MBK rate-limit + login-throttle wrapper over :mod:`platform_shared.core.rate_limit`.
 
-Uses a simple dict with TTL cleanup. Suitable for single-server deployments.
+After PR M6 the pure token-bucket implementation, the per-IP login
+throttle, the registration / password-reset / Turnstile gates, and the
+account-lockout dependency all live in ``platform_shared``. This module
+keeps the parts that legitimately depend on MBK config + MBK's user
+repository:
+
+  * pre-instantiated ``RateLimiter`` instances at MBK's policy thresholds
+    (``login``: 10 / 5 min, ``register``: 5 / 1 h, etc.)
+  * thin dependency bodies that close over MBK-local symbols
+    (``login_limiter``, ``verify_turnstile_token``, ``get_user_by_email``)
+    so existing tests can keep monkeypatching them via
+    ``patch("app.core.rate_limit.<symbol>", ...)``
+  * ``settings.turnstile_secret_key`` lookup is lazy so
+    ``patch.object(settings, "turnstile_secret_key", "...")`` still
+    works during a single request.
+
+Existing call sites inside MBK (``app.main``, ``app.api.totp``, route
+gates, tests) keep their imports — every public name from before M6
+still resolves here.
 """
-import time
-import threading
-from dataclasses import dataclass, field
 from datetime import datetime, timezone
 
 from fastapi import Depends, HTTPException, Request
@@ -13,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from platform_shared.core.auth_events import AuthEventType
 from platform_shared.core.auth_messages import RATE_LIMIT_GENERIC_DETAIL
+from platform_shared.core.rate_limit import RateLimiter, email_domain_from_request
 from platform_shared.services.turnstile_service import verify_turnstile_token
 
 from app.core.config import settings
@@ -22,52 +38,29 @@ from app.repositories.user.user_repo import get_by_email as get_user_by_email
 from app.services.system.auth_event_service import log_auth_event
 
 
-@dataclass(slots=True)
-class _BucketConfig:
-    max_attempts: int
-    window_seconds: int
+__all__ = [
+    "RateLimiter",
+    "RATE_LIMIT_GENERIC_DETAIL",
+    "verify_turnstile_token",
+    "get_user_by_email",
+    "login_limiter",
+    "totp_limiter",
+    "register_limiter",
+    "password_reset_limiter",
+    "export_limiter",
+    "frontend_error_limiter",
+    "require_turnstile",
+    "check_login_rate_limit",
+    "check_totp_rate_limit",
+    "check_password_reset_rate_limit",
+    "check_register_rate_limit",
+    "check_account_not_locked",
+]
 
 
-@dataclass
-class _Bucket:
-    timestamps: list[float] = field(default_factory=list)
-
-
-class RateLimiter:
-    def __init__(self, max_attempts: int, window_seconds: int) -> None:
-        self._config = _BucketConfig(max_attempts, window_seconds)
-        self._buckets: dict[str, _Bucket] = {}
-        self._lock = threading.Lock()
-
-    def _cleanup_bucket(self, bucket: _Bucket, now: float) -> None:
-        cutoff = now - self._config.window_seconds
-        bucket.timestamps = [t for t in bucket.timestamps if t > cutoff]
-
-    def check(self, key: str) -> None:
-        """Record an attempt and raise 429 if over limit."""
-        now = time.monotonic()
-        with self._lock:
-            bucket = self._buckets.get(key)
-            if bucket is None:
-                bucket = _Bucket()
-                self._buckets[key] = bucket
-            self._cleanup_bucket(bucket, now)
-            if len(bucket.timestamps) >= self._config.max_attempts:
-                raise HTTPException(
-                    status_code=429,
-                    detail=RATE_LIMIT_GENERIC_DETAIL,
-                )
-            bucket.timestamps.append(now)
-
-            # Periodic cleanup of stale keys (every 100th call)
-            if len(self._buckets) > 100:
-                stale_keys = [
-                    k for k, b in self._buckets.items()
-                    if not b.timestamps or b.timestamps[-1] < now - self._config.window_seconds
-                ]
-                for k in stale_keys:
-                    del self._buckets[k]
-
+# ---------------------------------------------------------------------------
+# MBK rate-limit policy — pre-instantiated limiters
+# ---------------------------------------------------------------------------
 
 login_limiter = RateLimiter(max_attempts=10, window_seconds=300)
 totp_limiter = RateLimiter(max_attempts=20, window_seconds=300)
@@ -77,21 +70,17 @@ export_limiter = RateLimiter(max_attempts=20, window_seconds=3600)
 frontend_error_limiter = RateLimiter(max_attempts=50, window_seconds=3600)
 
 
-def _email_domain_from_request(request: Request) -> str | None:
-    """Best-effort read of the submitted email domain from a login request.
-
-    Pulled from ``request.state.login_email`` if a higher layer (e.g. an
-    upstream dependency) chose to stash it there. Returns ``None`` when
-    nothing is available — we never parse the body here, because the
-    dependency runs before FastAPI binds the route's body parameters and
-    consuming the stream would leave the route handler with an empty body.
-
-    Never returns the full email — only the domain — so this stays PII-safe.
-    """
-    raw = getattr(request.state, "login_email", None)
-    if not isinstance(raw, str) or "@" not in raw:
-        return None
-    return raw.split("@", 1)[-1].lower() or None
+# ---------------------------------------------------------------------------
+# FastAPI dependencies
+#
+# Each dependency body deliberately references the *module-level* symbols
+# (``login_limiter``, ``verify_turnstile_token``, ``get_user_by_email``,
+# ``settings``) so that existing tests using
+# ``patch("app.core.rate_limit.<symbol>", …)`` still influence the
+# dependency's behaviour. Calling the shared ``make_*`` factories at
+# import time would close over the values present at startup and make
+# those patches no-ops.
+# ---------------------------------------------------------------------------
 
 
 async def check_login_rate_limit(
@@ -110,7 +99,7 @@ async def check_login_rate_limit(
         login_limiter.check(ip)
     except HTTPException:
         metadata: dict[str, str] = {"ip": ip}
-        domain = _email_domain_from_request(request)
+        domain = email_domain_from_request(request)
         if domain is not None:
             metadata["email_domain"] = domain
         await log_auth_event(
@@ -136,8 +125,7 @@ async def check_password_reset_rate_limit(request: Request) -> None:
 async def require_turnstile(request: Request) -> None:
     """FastAPI dependency that enforces Turnstile CAPTCHA verification.
 
-    No-op when ``settings.turnstile_secret_key`` is empty (dev/CI mode),
-    matching the behaviour of the registration flow.
+    No-op when ``settings.turnstile_secret_key`` is empty (dev/CI mode).
     """
     if not settings.turnstile_secret_key:
         return

--- a/packages/shared-backend/platform_shared/__init__.py
+++ b/packages/shared-backend/platform_shared/__init__.py
@@ -8,7 +8,10 @@ Modules:
     platform_shared.core.security            — create_fernet_suite(), create_pii_suite(), encrypt_pii(), decrypt_pii()
     platform_shared.core.encrypted_string_type — EncryptedString TypeDecorator, PIICodec
     platform_shared.core.storage             — StorageClient, get_storage()
-    platform_shared.core.rate_limit          — RateLimiter, get_client_ip()
+    platform_shared.core.rate_limit          — RateLimiter, email_domain_from_request,
+                                                make_require_turnstile,
+                                                make_check_login_ip_limit,
+                                                make_check_account_not_locked
     platform_shared.core.audit               — register_audit_listeners(),
                                                 register_sensitive_fields(),
                                                 register_skip_tables(),

--- a/packages/shared-backend/platform_shared/core/rate_limit.py
+++ b/packages/shared-backend/platform_shared/core/rate_limit.py
@@ -1,17 +1,44 @@
-"""In-memory rate limiter for auth and API endpoints.
+"""In-memory rate limiter and login-throttle factories.
 
-Uses a simple dict with TTL cleanup. Suitable for single-server deployments.
+Two layers live here:
 
-Usage:
-    limiter = RateLimiter(max_attempts=10, window_seconds=300)
-    limiter.check("user-ip-or-key")  # raises HTTPException(429) if over limit
+1. ``RateLimiter`` — a pure token-bucket implementation (no settings, no DB,
+   no logger). The 429 it raises uses the shared ``RATE_LIMIT_GENERIC_DETAIL``
+   so per-IP, account-lockout, and registration-rate gates all return a
+   byte-identical response body. Any divergence would let an attacker
+   probe whether a target account is currently locked.
+
+2. ``make_*`` factories — return FastAPI dependencies. Each app provides
+   its own thresholds, secret key, user-lookup callable, and (where
+   applicable) auth-event logger when wiring the factory into its own
+   thin ``app/core/rate_limit.py`` wrapper. The shared module deliberately
+   does NOT import any app's ``settings``, repositories, or session
+   factory.
+
+In-process state — ``_buckets`` is a module-local dict on each
+``RateLimiter`` instance, so the limiter is per-worker. Multi-worker /
+multi-host coordination (Redis backend) is intentionally out of scope.
 """
 import time
 import threading
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Callable, Optional
 
 from fastapi import HTTPException, Request
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from platform_shared.core.auth_events import AuthEventType
+from platform_shared.core.auth_messages import RATE_LIMIT_GENERIC_DETAIL
+from platform_shared.core.request_utils import get_client_ip
+from platform_shared.services.auth_event_service import log_auth_event
+from platform_shared.services.turnstile_service import verify_turnstile_token
+
+
+# ---------------------------------------------------------------------------
+# RateLimiter — pure token bucket, no app-specific deps
+# ---------------------------------------------------------------------------
 
 @dataclass(slots=True)
 class _BucketConfig:
@@ -25,6 +52,18 @@ class _Bucket:
 
 
 class RateLimiter:
+    """Per-key sliding-window rate limiter.
+
+    Usage::
+
+        limiter = RateLimiter(max_attempts=10, window_seconds=300)
+        limiter.check("client-ip-or-key")  # raises HTTPException(429) on over-limit
+
+    The 429 ``detail`` is intentionally generic
+    (``RATE_LIMIT_GENERIC_DETAIL``) so callers cannot distinguish which
+    gate fired.
+    """
+
     def __init__(self, max_attempts: int, window_seconds: int) -> None:
         self._config = _BucketConfig(max_attempts, window_seconds)
         self._buckets: dict[str, _Bucket] = {}
@@ -46,10 +85,11 @@ class RateLimiter:
             if len(bucket.timestamps) >= self._config.max_attempts:
                 raise HTTPException(
                     status_code=429,
-                    detail="Too many requests. Please try again later.",
+                    detail=RATE_LIMIT_GENERIC_DETAIL,
                 )
             bucket.timestamps.append(now)
 
+            # Periodic cleanup of stale keys to bound memory.
             if len(self._buckets) > 100:
                 stale_keys = [
                     k for k, b in self._buckets.items()
@@ -59,9 +99,156 @@ class RateLimiter:
                     del self._buckets[k]
 
 
-def get_client_ip(request: Request) -> str:
-    """Extract client IP from request, respecting X-Forwarded-For."""
-    forwarded = request.headers.get("x-forwarded-for")
-    if forwarded:
-        return forwarded.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
+# ---------------------------------------------------------------------------
+# PII-safe email domain extractor
+# ---------------------------------------------------------------------------
+
+def email_domain_from_request(request: Request) -> Optional[str]:
+    """Best-effort read of the submitted email domain from a login request.
+
+    Pulled from ``request.state.login_email`` if a higher layer (e.g. an
+    upstream dependency) chose to stash it there. Returns ``None`` when
+    nothing is available — we never parse the body here, because the
+    dependency runs before FastAPI binds the route's body parameters and
+    consuming the stream would leave the route handler with an empty body.
+
+    Never returns the full email — only the domain — so this stays PII-safe.
+    """
+    raw = getattr(request.state, "login_email", None)
+    if not isinstance(raw, str) or "@" not in raw:
+        return None
+    return raw.split("@", 1)[-1].lower() or None
+
+
+# ---------------------------------------------------------------------------
+# Type aliases for factory parameters
+# ---------------------------------------------------------------------------
+
+# Lazy provider so callers can dynamically swap their secret-key value
+# (e.g. ``patch.object(settings, "turnstile_secret_key", "...")`` in tests).
+SecretKeyProvider = Callable[[], str]
+
+# (db, email) -> User-like row or None. Returning Any means the shared
+# module doesn't depend on any app's User model — it just reads
+# ``locked_until`` off the result.
+UserLookup = Callable[[AsyncSession, str], Awaitable[Any]]
+
+
+# ---------------------------------------------------------------------------
+# Turnstile factory
+# ---------------------------------------------------------------------------
+
+def make_require_turnstile(
+    secret_key_provider: SecretKeyProvider,
+    *,
+    verify: Callable[..., Awaitable[bool]] = verify_turnstile_token,
+) -> Callable[[Request], Awaitable[None]]:
+    """Build a FastAPI dependency that enforces Turnstile CAPTCHA.
+
+    The returned dependency is a no-op when ``secret_key_provider()`` is
+    empty (dev / CI mode), matching MyBookkeeper's pre-PR-M6 behaviour.
+    """
+
+    async def _require_turnstile(request: Request) -> None:
+        secret_key = secret_key_provider()
+        if not secret_key:
+            return
+        token = request.headers.get("X-Turnstile-Token", "")
+        if not token:
+            raise HTTPException(status_code=400, detail="Captcha token required")
+        valid = await verify(
+            token,
+            get_client_ip(request),
+            secret_key=secret_key,
+        )
+        if not valid:
+            raise HTTPException(status_code=400, detail="Captcha verification failed")
+
+    return _require_turnstile
+
+
+# ---------------------------------------------------------------------------
+# Per-IP login throttle factory (with auth-event audit on block)
+# ---------------------------------------------------------------------------
+
+def make_check_login_ip_limit(
+    limiter: RateLimiter,
+    *,
+    log_event: Callable[..., Awaitable[None]] = log_auth_event,
+) -> Callable[[Request, AsyncSession], Awaitable[None]]:
+    """Build the per-IP login dependency that audits every block.
+
+    The returned dependency reads the client IP, hits ``limiter.check``,
+    and on block writes a ``LOGIN_BLOCKED_RATE_LIMIT`` row to
+    ``auth_events`` (via ``log_event``) before re-raising the 429. This
+    means SOC / admin tooling can spot credential-stuffing patterns.
+
+    The 429 body is the shared ``RATE_LIMIT_GENERIC_DETAIL`` — identical
+    to the account-lockout body, so a caller cannot infer which gate
+    fired.
+    """
+
+    async def _check_login_ip_limit(
+        request: Request,
+        db: AsyncSession,
+    ) -> None:
+        ip = get_client_ip(request)
+        try:
+            limiter.check(ip)
+        except HTTPException:
+            metadata: dict[str, str] = {"ip": ip}
+            domain = email_domain_from_request(request)
+            if domain is not None:
+                metadata["email_domain"] = domain
+            await log_event(
+                db,
+                event_type=AuthEventType.LOGIN_BLOCKED_RATE_LIMIT,
+                user_id=None,
+                request=request,
+                succeeded=False,
+                metadata=metadata,
+            )
+            await db.commit()
+            raise
+
+    return _check_login_ip_limit
+
+
+# ---------------------------------------------------------------------------
+# Account-lockout factory (early-reject before password check)
+# ---------------------------------------------------------------------------
+
+def make_check_account_not_locked(
+    user_lookup: UserLookup,
+) -> Callable[[OAuth2PasswordRequestForm, AsyncSession], Awaitable[None]]:
+    """Build the account-lockout dependency.
+
+    Runs BEFORE the password check so a locked account is rejected
+    without revealing password correctness, and without further
+    incrementing the failure counter (the counter is only incremented
+    inside ``UserManager.authenticate`` on a real password failure).
+
+    ``user_lookup`` is the app's own repository function — typically
+    ``user_repo.get_by_email`` — passed in to avoid coupling this
+    module to any app's User model.
+
+    On block, raises 429 with the shared ``RATE_LIMIT_GENERIC_DETAIL``
+    so the response is byte-identical to per-IP and registration gates.
+    """
+
+    async def _check_account_not_locked(
+        credentials: OAuth2PasswordRequestForm,
+        db: AsyncSession,
+    ) -> None:
+        user = await user_lookup(db, credentials.username)
+        if user is None:
+            # Unknown email — let the normal auth flow handle it (timing-safe).
+            return
+        locked_until = getattr(user, "locked_until", None)
+        if locked_until and locked_until > datetime.now(tz=timezone.utc):
+            raise HTTPException(
+                status_code=429,
+                detail=RATE_LIMIT_GENERIC_DETAIL,
+            )
+
+    return _check_account_not_locked

--- a/packages/shared-backend/tests/test_rate_limit.py
+++ b/packages/shared-backend/tests/test_rate_limit.py
@@ -1,0 +1,423 @@
+"""Unit tests for ``platform_shared.core.rate_limit``.
+
+These tests cover the pure / app-agnostic surface promoted in PR M6:
+
+  * ``RateLimiter`` token-bucket math, time-window expiry, generic 429
+    body
+  * ``email_domain_from_request`` PII-safe parsing
+  * ``make_require_turnstile`` factory
+  * ``make_check_login_ip_limit`` factory — including the
+    ``LOGIN_BLOCKED_RATE_LIMIT`` audit event written on block
+  * ``make_check_account_not_locked`` factory
+
+App-level integration (the bound dependencies under MBK's
+``app.core.rate_limit`` namespace, FastAPI router wiring, and the
+fastapi-users glue) stays in MBK — those tests need MBK's User model,
+auth backend, and audit listener.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException, Request
+from fastapi.datastructures import Headers
+from fastapi.security import OAuth2PasswordRequestForm
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.core.auth_events import AuthEventType
+from platform_shared.core.auth_messages import RATE_LIMIT_GENERIC_DETAIL
+from platform_shared.core.rate_limit import (
+    RateLimiter,
+    email_domain_from_request,
+    make_check_account_not_locked,
+    make_check_login_ip_limit,
+    make_require_turnstile,
+)
+from platform_shared.db.models.auth_event import AuthEvent
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_request(
+    *,
+    ip: str = "1.2.3.4",
+    headers: dict[str, str] | None = None,
+    login_email: str | None = None,
+) -> MagicMock:
+    """Build a minimal MagicMock that satisfies the bits of ``Request`` we
+    introspect (``headers``, ``client.host``, ``state.login_email``).
+
+    Uses a real :class:`fastapi.datastructures.Headers` so case-insensitive
+    lookups (``X-Turnstile-Token`` vs ``x-turnstile-token``) behave like
+    a real request.
+    """
+    request = MagicMock(spec=Request)
+    request.headers = Headers({"user-agent": "TestAgent/1.0", **(headers or {})})
+    request.client = MagicMock()
+    request.client.host = ip
+    request.state = MagicMock(spec=[])
+    if login_email is not None:
+        request.state.login_email = login_email
+    return request
+
+
+def _make_credentials(email: str, password: str = "anything") -> OAuth2PasswordRequestForm:
+    form = MagicMock(spec=OAuth2PasswordRequestForm)
+    form.username = email
+    form.password = password
+    return form
+
+
+async def _events(db: AsyncSession) -> list[AuthEvent]:
+    return list((await db.execute(select(AuthEvent))).scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# RateLimiter — pure token-bucket math
+# ---------------------------------------------------------------------------
+
+class TestRateLimiter:
+    def test_allows_up_to_max(self) -> None:
+        limiter = RateLimiter(max_attempts=3, window_seconds=60)
+        for _ in range(3):
+            limiter.check("ip1")
+
+    def test_blocks_after_max(self) -> None:
+        limiter = RateLimiter(max_attempts=3, window_seconds=60)
+        for _ in range(3):
+            limiter.check("ip1")
+        with pytest.raises(HTTPException) as exc_info:
+            limiter.check("ip1")
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail == RATE_LIMIT_GENERIC_DETAIL
+
+    def test_independent_keys(self) -> None:
+        limiter = RateLimiter(max_attempts=2, window_seconds=60)
+        limiter.check("ip1")
+        limiter.check("ip1")
+        # ip2 should still be allowed
+        limiter.check("ip2")
+
+    def test_single_attempt_limit(self) -> None:
+        limiter = RateLimiter(max_attempts=1, window_seconds=60)
+        limiter.check("ip1")
+        with pytest.raises(HTTPException) as exc_info:
+            limiter.check("ip1")
+        assert exc_info.value.status_code == 429
+
+    def test_zero_window_expires_immediately(self) -> None:
+        """With ``window_seconds=0`` every entry is stale by the next check."""
+        limiter = RateLimiter(max_attempts=1, window_seconds=0)
+        limiter.check("ip1")
+        # Next call succeeds because the window already passed.
+        limiter.check("ip1")
+
+    def test_blocked_response_uses_generic_detail(self) -> None:
+        """The 429 body must be the shared generic string — no info leak.
+
+        If this string ever diverges across gates, an attacker can probe
+        which gate fired and therefore whether their target account is
+        currently locked.
+        """
+        limiter = RateLimiter(max_attempts=1, window_seconds=60)
+        limiter.check("ip1")
+        with pytest.raises(HTTPException) as exc_info:
+            limiter.check("ip1")
+        assert exc_info.value.detail == RATE_LIMIT_GENERIC_DETAIL
+
+
+# ---------------------------------------------------------------------------
+# email_domain_from_request — PII-safe parsing
+# ---------------------------------------------------------------------------
+
+class TestEmailDomainFromRequest:
+    def test_returns_none_when_state_has_no_login_email(self) -> None:
+        request = _make_request()
+        assert email_domain_from_request(request) is None
+
+    def test_returns_none_for_non_string_login_email(self) -> None:
+        request = _make_request()
+        request.state.login_email = 12345  # not a string
+        assert email_domain_from_request(request) is None
+
+    def test_returns_none_when_no_at_sign(self) -> None:
+        request = _make_request(login_email="not-an-email")
+        assert email_domain_from_request(request) is None
+
+    def test_returns_lowercased_domain(self) -> None:
+        request = _make_request(login_email="User@Example.COM")
+        assert email_domain_from_request(request) == "example.com"
+
+    def test_never_returns_full_email(self) -> None:
+        """Helper must NEVER leak the local part — only the domain."""
+        request = _make_request(login_email="alice.smith@bigcorp.test")
+        domain = email_domain_from_request(request)
+        assert domain == "bigcorp.test"
+        assert "alice" not in (domain or "")
+
+
+# ---------------------------------------------------------------------------
+# make_require_turnstile factory
+# ---------------------------------------------------------------------------
+
+class TestMakeRequireTurnstile:
+    @pytest.mark.anyio
+    async def test_dev_mode_passes_without_token(self) -> None:
+        """Empty secret_key (dev / CI) skips the check entirely."""
+        verify = AsyncMock(return_value=True)
+        dep = make_require_turnstile(lambda: "", verify=verify)
+
+        request = _make_request()
+        await dep(request)  # must not raise
+        verify.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_missing_token_header_raises_400(self) -> None:
+        verify = AsyncMock(return_value=True)
+        dep = make_require_turnstile(lambda: "secret", verify=verify)
+
+        request = _make_request()
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request)
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Captcha token required"
+        verify.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_invalid_token_raises_400(self) -> None:
+        verify = AsyncMock(return_value=False)
+        dep = make_require_turnstile(lambda: "secret", verify=verify)
+
+        request = _make_request(headers={"x-turnstile-token": "bad"})
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request)
+        assert exc_info.value.status_code == 400
+        assert exc_info.value.detail == "Captcha verification failed"
+
+    @pytest.mark.anyio
+    async def test_valid_token_passes(self) -> None:
+        verify = AsyncMock(return_value=True)
+        dep = make_require_turnstile(lambda: "secret", verify=verify)
+
+        request = _make_request(headers={"x-turnstile-token": "good"})
+        await dep(request)  # must not raise
+        verify.assert_awaited_once_with(
+            "good", "1.2.3.4", secret_key="secret",
+        )
+
+    @pytest.mark.anyio
+    async def test_secret_key_provider_is_called_per_request(self) -> None:
+        """The provider is read on every request so callers can dynamically
+        toggle Turnstile (e.g. tests that ``patch.object(settings, …)``)."""
+        provider_calls = 0
+
+        def _provider() -> str:
+            nonlocal provider_calls
+            provider_calls += 1
+            return ""  # stays in dev mode
+
+        verify = AsyncMock(return_value=True)
+        dep = make_require_turnstile(_provider, verify=verify)
+
+        request = _make_request()
+        await dep(request)
+        await dep(request)
+        await dep(request)
+
+        assert provider_calls == 3
+
+    @pytest.mark.anyio
+    async def test_uses_x_forwarded_for_as_remote_ip(self) -> None:
+        """Reverse-proxy deployments rely on ``X-Forwarded-For`` for the
+        real caller IP — that's what gets sent to Cloudflare."""
+        verify = AsyncMock(return_value=True)
+        dep = make_require_turnstile(lambda: "secret", verify=verify)
+
+        request = _make_request(
+            headers={
+                "x-turnstile-token": "good",
+                "x-forwarded-for": "203.0.113.5, 10.0.0.1",
+            },
+        )
+        await dep(request)
+        verify.assert_awaited_once_with(
+            "good", "203.0.113.5", secret_key="secret",
+        )
+
+
+# ---------------------------------------------------------------------------
+# make_check_login_ip_limit factory
+# ---------------------------------------------------------------------------
+
+class TestMakeCheckLoginIpLimit:
+    @pytest.mark.anyio
+    async def test_under_limit_does_not_block_or_log(self, db: AsyncSession) -> None:
+        log_event = AsyncMock()
+        limiter = RateLimiter(max_attempts=5, window_seconds=60)
+        dep = make_check_login_ip_limit(limiter, log_event=log_event)
+
+        request = _make_request(ip="1.2.3.4")
+        await dep(request, db)
+
+        log_event.assert_not_awaited()
+        assert (await _events(db)) == []
+
+    @pytest.mark.anyio
+    async def test_over_limit_raises_429_with_generic_detail(self, db: AsyncSession) -> None:
+        log_event = AsyncMock()
+        limiter = RateLimiter(max_attempts=1, window_seconds=60)
+        dep = make_check_login_ip_limit(limiter, log_event=log_event)
+
+        request = _make_request(ip="9.9.9.9")
+        await dep(request, db)  # seeds the bucket
+
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(request, db)
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail == RATE_LIMIT_GENERIC_DETAIL
+
+    @pytest.mark.anyio
+    async def test_block_writes_audit_event_with_ip_metadata(self, db: AsyncSession) -> None:
+        """Using the real ``log_auth_event`` (default seam) — verifies the
+        full row shape, including the ``LOGIN_BLOCKED_RATE_LIMIT`` event
+        type, ``user_id=None``, and ``ip`` in metadata.
+        """
+        limiter = RateLimiter(max_attempts=1, window_seconds=60)
+        dep = make_check_login_ip_limit(limiter)
+
+        request = _make_request(ip="203.0.113.42")
+        await dep(request, db)  # seed
+        with pytest.raises(HTTPException):
+            await dep(request, db)  # block → writes event + commits
+
+        rows = await _events(db)
+        rate_limit_rows = [
+            r for r in rows
+            if r.event_type == AuthEventType.LOGIN_BLOCKED_RATE_LIMIT
+        ]
+        assert len(rate_limit_rows) == 1
+        ev = rate_limit_rows[0]
+        assert ev.user_id is None
+        assert ev.succeeded is False
+        assert ev.ip_address == "203.0.113.42"
+        assert ev.event_metadata.get("ip") == "203.0.113.42"
+        # Anonymous block — no email_domain unless caller stashed one.
+        assert "email_domain" not in ev.event_metadata
+        # Full email must NEVER reach the audit row (PII guard).
+        assert "email" not in ev.event_metadata
+        assert "password" not in ev.event_metadata
+
+    @pytest.mark.anyio
+    async def test_block_includes_email_domain_when_stashed(self, db: AsyncSession) -> None:
+        limiter = RateLimiter(max_attempts=1, window_seconds=60)
+        dep = make_check_login_ip_limit(limiter)
+
+        request = _make_request(ip="198.51.100.7", login_email="user@example.com")
+        await dep(request, db)  # seed
+        with pytest.raises(HTTPException):
+            await dep(request, db)
+
+        rows = await _events(db)
+        ev = next(r for r in rows if r.event_type == AuthEventType.LOGIN_BLOCKED_RATE_LIMIT)
+        assert ev.event_metadata.get("email_domain") == "example.com"
+        assert ev.event_metadata.get("ip") == "198.51.100.7"
+
+
+# ---------------------------------------------------------------------------
+# make_check_account_not_locked factory
+# ---------------------------------------------------------------------------
+
+class _FakeUser:
+    """Minimal ``UserLike`` — only ``locked_until`` is read."""
+
+    def __init__(self, locked_until: datetime | None) -> None:
+        self.id = uuid.uuid4()
+        self.locked_until = locked_until
+
+
+class TestMakeCheckAccountNotLocked:
+    @pytest.mark.anyio
+    async def test_locked_account_raises_429(self) -> None:
+        future = datetime.now(tz=timezone.utc) + timedelta(minutes=5)
+        locked_user = _FakeUser(locked_until=future)
+        lookup = AsyncMock(return_value=locked_user)
+        dep = make_check_account_not_locked(lookup)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await dep(_make_credentials("user@example.com"), MagicMock())
+        assert exc_info.value.status_code == 429
+        assert exc_info.value.detail == RATE_LIMIT_GENERIC_DETAIL
+
+    @pytest.mark.anyio
+    async def test_unlocked_account_does_not_raise(self) -> None:
+        unlocked = _FakeUser(locked_until=None)
+        lookup = AsyncMock(return_value=unlocked)
+        dep = make_check_account_not_locked(lookup)
+
+        await dep(_make_credentials("user@example.com"), MagicMock())  # must not raise
+
+    @pytest.mark.anyio
+    async def test_unknown_email_does_not_raise(self) -> None:
+        """Unknown email must not raise — leaves it to the auth flow so
+        the response is timing-safe with the 'wrong password' branch."""
+        lookup = AsyncMock(return_value=None)
+        dep = make_check_account_not_locked(lookup)
+
+        await dep(_make_credentials("ghost@example.com"), MagicMock())  # must not raise
+
+    @pytest.mark.anyio
+    async def test_expired_lock_does_not_raise(self) -> None:
+        past = datetime.now(tz=timezone.utc) - timedelta(seconds=1)
+        user = _FakeUser(locked_until=past)
+        lookup = AsyncMock(return_value=user)
+        dep = make_check_account_not_locked(lookup)
+
+        await dep(_make_credentials("user@example.com"), MagicMock())  # must not raise
+
+    @pytest.mark.anyio
+    async def test_user_lookup_called_with_session_and_username(self) -> None:
+        unlocked = _FakeUser(locked_until=None)
+        lookup = AsyncMock(return_value=unlocked)
+        dep = make_check_account_not_locked(lookup)
+
+        fake_db = MagicMock()
+        await dep(_make_credentials("user@example.com"), fake_db)
+
+        lookup.assert_awaited_once_with(fake_db, "user@example.com")
+
+
+# ---------------------------------------------------------------------------
+# Regression guard — shared module never imports any app code
+# ---------------------------------------------------------------------------
+
+class TestSharedModuleHasNoAppImports:
+    def test_rate_limit_module_does_not_import_app(self) -> None:
+        """``platform_shared.core.rate_limit`` must stay app-agnostic.
+
+        If a future change re-introduces ``from app.core.config import
+        settings`` (or any other ``app.*`` import) the shared package
+        will only work inside MyBookkeeper — every other consumer
+        breaks at import time. This regression guard fails loudly.
+        """
+        import platform_shared.core.rate_limit as mod
+
+        source: str = ""
+        if mod.__file__:
+            with open(mod.__file__, encoding="utf-8") as fh:
+                source = fh.read()
+
+        offending = [
+            line for line in source.splitlines()
+            if line.strip().startswith(("from app.", "import app."))
+        ]
+        assert offending == [], (
+            "platform_shared.core.rate_limit must not import from `app.*`; "
+            f"found: {offending}"
+        )


### PR DESCRIPTION
## Summary

PR **M6 of 14** in the platform_shared migration plan (M1-M5 already landed).

Promotes MyBookkeeper's rate-limiting + login-throttle infrastructure to `platform_shared` so MyJobHunter and future apps consume the same primitives. **MBK behaviour is unchanged** — every existing call site keeps working without modification.

## What moved into `platform_shared.core.rate_limit`

- `RateLimiter` — pure token-bucket. Raises 429 with `RATE_LIMIT_GENERIC_DETAIL` (M1) on over-limit.
- `email_domain_from_request` — PII-safe domain extractor for the audited per-IP throttle.
- `make_require_turnstile(secret_key_provider, *, verify=…)` — factory returning the FastAPI dependency. Lazy `secret_key_provider` callable preserves the test contract that toggles `settings.turnstile_secret_key` per-request.
- `make_check_login_ip_limit(limiter, *, log_event=…)` — factory for the per-IP login throttle. On block writes a `LOGIN_BLOCKED_RATE_LIMIT` (M1) auth event via `log_auth_event` (M4) with `metadata={"ip", "email_domain"}`.
- `make_check_account_not_locked(user_lookup)` — factory accepting the caller's user-lookup callable. Reads `user.locked_until` off the result; never imports any app's `User` model.

The shared module deliberately does **NOT** import `app.core.config`, `app.repositories.*`, `app.db.session`, or `app.models.*` — a regression-guard test (`TestSharedModuleHasNoAppImports`) fails the build if a future change re-introduces an `app.…` import.

The pre-existing partial `rate_limit.py` in `platform_shared` carried only the bare `RateLimiter` class plus a duplicate `get_client_ip` helper. `get_client_ip` already lives in `platform_shared.core.request_utils` (M1), so this PR drops it from the rate_limit module entirely.

## What stayed in MyBookkeeper

`apps/mybookkeeper/backend/app/core/rate_limit.py` is now a thin wrapper that:

- re-exports `RateLimiter` plus the pre-instantiated MBK limiters (`login_limiter` 10/5 min, `register_limiter` 5/1 h, etc.) at their existing paths, so every call site in MBK (`app.main`, `app.api.totp`, route gates) keeps working unchanged;
- re-exports `verify_turnstile_token` and `get_user_by_email` so the existing monkey-patch contract (`patch("app.core.rate_limit.verify_turnstile_token", …)` / `patch("app.core.rate_limit.get_user_by_email", …)`) keeps working;
- keeps each FastAPI dependency body resolved inside the wrapper (not via the shared `make_*` factories) so monkey-patches of `login_limiter` / `settings.turnstile_secret_key` continue to influence the live dependency. The shared `make_*` factories are the new public API for consumers without that monkey-patch contract (MyJobHunter, future apps).

## MBK behaviour unchanged

- Same lockout policy (`LOCKOUT_THRESHOLD=5`, exponential schedule 1 m -> 5 m -> 15 m -> 1 h -> 24 h, 24 h auto-reset).
- Same per-IP login limit (10 req / 5 min).
- Same registration / password-reset / TOTP / export / frontend-error limiters at their pre-PR thresholds.
- Same generic 429 body (`RATE_LIMIT_GENERIC_DETAIL`) for per-IP, account-lockout, and registration gates — callers cannot distinguish which gate fired.
- Same `LOGIN_BLOCKED_RATE_LIMIT` audit event payload (`user_id=None`, `metadata={"ip", "email_domain"}`, `succeeded=False`).
- Anonymous failed-login: full email never reaches `auth_events` — only the domain.

## Test plan

- [x] 27 new shared unit tests in `packages/shared-backend/tests/test_rate_limit.py` covering: token-bucket math, time-window expiry, generic 429 detail, `email_domain_from_request` PII safety, all three `make_*` factories (including the audit-event row shape on per-IP block), and the no-app-imports regression guard.
- [x] Full shared-backend suite: **149 passed** locally.
- [x] All MBK rate-limit-affected tests pass unchanged: `test_rate_limit.py`, `test_login_ip_rate_limit.py`, `test_account_lockout.py`, `test_turnstile.py`, `test_password_reset.py`, `test_frontend_errors.py`, `test_auth_events_integration.py`, `test_totp_routes.py`, `test_auth_events_admin.py` — **158 passed**.
- [x] Wider MBK alphabet sweeps (a-i, l/m/o/p, r, t/u/v): **1676 passed** locally on Windows. Tests under `test_s*.py` blocked by a pre-existing Windows-only `python-magic` libmagic.dll loading flake (unrelated to this PR; CI on Ubuntu runs them fine).
- [ ] CI: backend-tests / mybookkeeper, backend-tests / myjobhunter, shared-backend-tests, frontend-build, CodeQL, Gitleaks, Stack smoke.

## Things to watch

- **Generic 429 body invariant**: per-IP, account-lockout, and registration gates all return the same `RATE_LIMIT_GENERIC_DETAIL` from M1. The new shared module pins this; if a future change diverges the strings, `test_per_ip_429_body_matches_account_lockout_429_body` in MBK fails.
- **In-process bucket state**: unchanged. `_buckets` is per-worker in-memory. Redis-backed shared state is out of scope for this PR.
- **Lockout schedule** (1 m -> 5 m -> 15 m -> 1 h -> 24 h) is unchanged — the shared factory does not know about MBK's exponential schedule, that lives in `app.core.auth._lock_duration_for` and stays where it is.

## Scope discipline

One feature per PR — no unrelated cleanup. The 24 pre-existing frontend test failures and the libmagic Windows flake are untouched.

Generated with [Claude Code](https://claude.com/claude-code)
