### PR TITLE
fix(mybookkeeper/csp): allow blob: in frame-src

### DIFF
--- a/apps/mybookkeeper/docker/Caddyfile.docker
+++ b/apps/mybookkeeper/docker/Caddyfile.docker
@@ -32,7 +32,7 @@
             X-Content-Type-Options "nosniff"
             Referrer-Policy "strict-origin-when-cross-origin"
             Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=(), browsing-topics=()"
-            Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https://*.plaid.com https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' https://cdn.plaid.com https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+            Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https://*.plaid.com https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://cdn.plaid.com https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
             -Server
         }
 


### PR DESCRIPTION
## Summary

- Adds `blob:` to the `frame-src` CSP directive in MyBookkeeper's Caddy config

## Why

`DocumentViewer.tsx` renders source documents via `<iframe src={blob.url}>` where `blob.url` is a `blob:` URL created from a fetch of the presigned MinIO URL. The CSP didn't include `blob:` in `frame-src`, so the browser blocked the iframe and showed:

> This content is blocked. Contact the site owner to fix the issue.

User-reported regression. Hit when clicking a source document in the Documents page.

## Test plan

- [ ] Click on a source document in /documents — iframe renders the PDF
- [ ] Other CSP-protected paths still work (Plaid Link, PostHog, Turnstile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)