### PR TITLE
fix(@platform/ui): center button label by default

### DIFF
--- a/packages/shared-frontend/src/components/ui/Button.tsx
+++ b/packages/shared-frontend/src/components/ui/Button.tsx
@@ -14,7 +14,7 @@ export default function Button({ variant = "primary", size = "md", className, ..
   return (
     <button
       className={cn(
-        "inline-flex items-center font-medium disabled:opacity-50",
+        "inline-flex items-center justify-center font-medium disabled:opacity-50",
         variant === "primary" && "bg-primary text-primary-foreground hover:opacity-90",
         variant === "secondary" && "border hover:bg-muted",
         variant === "ghost" && "text-muted-foreground hover:underline px-2",


### PR DESCRIPTION
## Summary

Adds \`justify-center\` to the shared \`@platform/ui\` Button base classes.

## Why

Button had \`inline-flex items-center\` (vertical center only). Default flex justification is \`flex-start\`, so any button stretched with \`w-full\` rendered its label left-aligned. Surfaced by the C5 TOTP Verify button and C4 Resend verification button — both \`w-full\` and visibly off-center.

## Tradeoff

- Natural-width buttons (most of the codebase): render identically — content shrinks to fit children regardless.
- Full-width buttons: now center their label, matching universal UX expectation.

No code outside the shared package changes. Both MBK and MJH benefit immediately on next deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)