### PR TITLE
feat(myjobhunter/applications): backend CRUD (Phase 2 PR 2.1a)

### DIFF
--- a/apps/myjobhunter/backend/app/api/applications.py
+++ b/apps/myjobhunter/backend/app/api/applications.py
@@ -1,12 +1,41 @@
-from fastapi import APIRouter, Depends
+"""HTTP routes for the Applications domain.
+
+Phase 1 shipped read-only ``GET /applications``. Phase 2 PR 2.1a (this PR)
+ships POST / PATCH / DELETE — full CRUD against the existing table.
+
+Auth: every endpoint requires an authenticated user via
+``current_active_user``. Tenant scoping is mandatory — every operation
+scopes the query by ``user.id`` so cross-tenant access yields HTTP 404 with
+the same body as a genuine miss (no existence leak).
+
+Audit: writes are captured automatically by the shared SQLAlchemy
+``after_flush`` listener registered in ``app.main`` lifespan — no manual
+instrumentation needed in the route handlers.
+
+Pattern reference: MyBookkeeper vendors PR #108 (sibling app in the
+``MyFreeApps`` monorepo). The route → service → repo split, allowlisted
+PATCH semantics, soft-delete idempotency, and 404-on-cross-tenant policy
+all mirror that PR.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_active_user
 from app.db.session import get_db
 from app.models.user.user import User
+from app.schemas.application.application_create_request import ApplicationCreateRequest
+from app.schemas.application.application_response import ApplicationResponse
+from app.schemas.application.application_update_request import ApplicationUpdateRequest
 from app.services.application import application_service
+from app.services.application.application_service import CompanyNotOwnedError
 
 router = APIRouter()
+
+_NOT_FOUND_DETAIL = "Application not found"
 
 
 @router.get("/applications")
@@ -14,5 +43,78 @@ async def list_applications(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
 ) -> dict:
+    """Return the caller's non-deleted applications.
+
+    Phase 1 shape preserved — ``items`` is intentionally an empty list with
+    ``total`` carrying the count, matching the existing tenant-isolation
+    smoke contract. Full pagination + summary projection ships in PR 2.1b
+    once the kanban frontend lands.
+    """
     items = await application_service.list_applications(db, user.id)
     return {"items": [], "total": len(items)}
+
+
+@router.post("/applications", response_model=ApplicationResponse, status_code=201)
+async def create_application(
+    payload: ApplicationCreateRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> ApplicationResponse:
+    """Create a new Application scoped to the caller.
+
+    HTTP 422 if ``company_id`` does not belong to the caller — the same
+    response a malformed body would receive, so cross-tenant probing reveals
+    nothing about which companies exist in another user's account.
+    """
+    try:
+        application = await application_service.create_application(db, user.id, payload)
+    except CompanyNotOwnedError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="company_id does not reference an accessible company",
+        ) from exc
+    return ApplicationResponse.model_validate(application)
+
+
+@router.patch("/applications/{application_id}", response_model=ApplicationResponse)
+async def update_application(
+    application_id: uuid.UUID,
+    payload: ApplicationUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> ApplicationResponse:
+    """Apply a partial update to an Application.
+
+    Returns 404 if the application is missing OR belongs to another user —
+    callers cannot distinguish the two cases (no existence leak).
+    """
+    try:
+        application = await application_service.update_application(
+            db, user.id, application_id, payload,
+        )
+    except CompanyNotOwnedError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="company_id does not reference an accessible company",
+        ) from exc
+    if application is None:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
+    return ApplicationResponse.model_validate(application)
+
+
+@router.delete("/applications/{application_id}", status_code=204)
+async def delete_application(
+    application_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> Response:
+    """Soft-delete an Application by setting ``deleted_at``.
+
+    Idempotent — calling DELETE on an already soft-deleted row still returns
+    204 as long as the row exists under the caller's ``user_id``. Returns
+    404 if the row does not exist or belongs to another user.
+    """
+    deleted = await application_service.soft_delete_application(db, user.id, application_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
+    return Response(status_code=204)

--- a/apps/myjobhunter/backend/app/repositories/application/application_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/application/application_repository.py
@@ -1,21 +1,133 @@
-"""Application repository — Phase 1 stub."""
+"""Repository for ``applications`` — owns every query against the table.
+
+Per the layered-architecture rule: routes never touch the ORM, services
+orchestrate, repositories return ORM rows. Every public function takes
+``user_id`` and filters by it — tenant scoping is mandatory per the
+"every query filters by user_id" rule in CLAUDE.md.
+
+Soft-delete convention: ``applications`` carries ``deleted_at``. Reads filter
+``deleted_at IS NULL`` by default so soft-deleted rows are invisible to the
+list / detail endpoints. ``soft_delete`` is idempotent — calling it on a row
+that is already soft-deleted is a no-op (returns the existing row unchanged).
+"""
+from __future__ import annotations
+
+import datetime as _dt
 import uuid
+from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.application.application import Application
 
+# Allowlist of columns that can be applied via the dynamic ``update``
+# function. Per the project security rule: "Always validate field names
+# against an explicit allowlist before applying dynamic updates." Tenant
+# scoping (``user_id``) and server-managed columns (``id``, ``created_at``,
+# ``updated_at``, ``deleted_at``) are deliberately excluded.
+_UPDATABLE_COLUMNS: frozenset[str] = frozenset({
+    "company_id",
+    "role_title",
+    "url",
+    "jd_text",
+    "jd_parsed",
+    "source",
+    "applied_at",
+    "posted_salary_min",
+    "posted_salary_max",
+    "posted_salary_currency",
+    "posted_salary_period",
+    "location",
+    "remote_type",
+    "fit_score",
+    "notes",
+    "archived",
+    "external_ref",
+    "external_source",
+})
 
-async def get_by_id(db: AsyncSession, application_id: uuid.UUID, user_id: uuid.UUID) -> Application | None:
-    result = await db.execute(
-        select(Application).where(Application.id == application_id, Application.user_id == user_id)
+
+async def get_by_id(
+    db: AsyncSession,
+    application_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    include_deleted: bool = False,
+) -> Application | None:
+    """Return the application iff it belongs to ``user_id``.
+
+    Defaults to skipping soft-deleted rows. ``include_deleted=True`` is used
+    by the soft-delete flow so a second DELETE on an already-deleted row
+    still returns 204 (idempotent).
+    """
+    stmt = select(Application).where(
+        Application.id == application_id,
+        Application.user_id == user_id,
     )
+    if not include_deleted:
+        stmt = stmt.where(Application.deleted_at.is_(None))
+    result = await db.execute(stmt)
     return result.scalar_one_or_none()
 
 
 async def list_by_user(db: AsyncSession, user_id: uuid.UUID) -> list[Application]:
+    """List a user's non-deleted applications."""
     result = await db.execute(
-        select(Application).where(Application.user_id == user_id, Application.deleted_at.is_(None))
+        select(Application).where(
+            Application.user_id == user_id,
+            Application.deleted_at.is_(None),
+        )
     )
     return list(result.scalars().all())
+
+
+async def create(db: AsyncSession, application: Application) -> Application:
+    """Persist a new ``Application``.
+
+    The caller (service layer) is responsible for setting ``user_id`` and
+    ``company_id`` from the validated request context. The repo intentionally
+    does not accept loose kwargs — passing a fully-constructed ORM instance
+    keeps the field-validation surface in one place (the schema + service).
+    """
+    db.add(application)
+    await db.flush()
+    await db.refresh(application)
+    return application
+
+
+async def update(
+    db: AsyncSession,
+    application: Application,
+    updates: dict[str, Any],
+) -> Application:
+    """Apply allowlisted updates to an Application.
+
+    Filters ``updates`` against ``_UPDATABLE_COLUMNS`` before applying — any
+    keys outside the allowlist are silently dropped (defense in depth on top
+    of the Pydantic schema's ``extra='forbid'``). Returns the refreshed
+    ``Application``.
+    """
+    safe_fields = {k: v for k, v in updates.items() if k in _UPDATABLE_COLUMNS}
+    if not safe_fields:
+        return application
+
+    for key, value in safe_fields.items():
+        setattr(application, key, value)
+    await db.flush()
+    await db.refresh(application)
+    return application
+
+
+async def soft_delete(db: AsyncSession, application: Application) -> Application:
+    """Mark an ``Application`` as soft-deleted by setting ``deleted_at``.
+
+    Idempotent — if ``deleted_at`` is already populated the existing row is
+    returned unchanged (no second timestamp update). Hard deletes are
+    forbidden by convention; rows persist for audit + restore.
+    """
+    if application.deleted_at is None:
+        application.deleted_at = _dt.datetime.now(_dt.timezone.utc)
+        await db.flush()
+        await db.refresh(application)
+    return application

--- a/apps/myjobhunter/backend/app/schemas/application/application_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_create_request.py
@@ -1,0 +1,101 @@
+"""Pydantic schema for POST /applications request body.
+
+Mirrors the writable columns on ``Application`` (``app/models/application/application.py``).
+Server-managed columns (``id``, ``user_id``, ``created_at``, ``updated_at``,
+``deleted_at``) are NOT accepted — they're either resolved from the request
+context (``user_id``) or populated by the persistence layer.
+
+``extra='forbid'`` defends against a malicious client trying to inject
+``user_id`` via the body. The repository layer additionally applies an explicit
+allowlist of writable columns as defense in depth.
+
+Application status is NOT a column — per the project's
+"No latest_status column" rule, status is computed from
+``application_events`` via lateral join. ``archived`` is the only writable
+state flag exposed here.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.core.enums import ApplicationSource, RemoteType, SalaryPeriod
+
+# Bounds mirror the ``Application`` model's String() lengths.
+_ROLE_TITLE_MAX_LEN = 200
+_LOCATION_MAX_LEN = 200
+_CURRENCY_LEN = 3
+_EXTERNAL_REF_MAX_LEN = 255
+_EXTERNAL_SOURCE_MAX_LEN = 50
+
+
+class ApplicationCreateRequest(BaseModel):
+    """Body for POST /applications.
+
+    ``company_id`` is required — every application must point at a Company
+    the operator owns. The service layer verifies the FK before persisting
+    so cross-tenant references fail with HTTP 422 instead of a Postgres
+    constraint error.
+    """
+
+    company_id: uuid.UUID
+    role_title: str = Field(min_length=1, max_length=_ROLE_TITLE_MAX_LEN)
+
+    url: str | None = None
+    jd_text: str | None = None
+    jd_parsed: dict | None = None
+
+    source: str | None = None
+    applied_at: _dt.datetime | None = None
+
+    posted_salary_min: Decimal | None = Field(default=None, ge=0)
+    posted_salary_max: Decimal | None = Field(default=None, ge=0)
+    posted_salary_currency: str = Field(
+        default="USD",
+        min_length=_CURRENCY_LEN,
+        max_length=_CURRENCY_LEN,
+    )
+    posted_salary_period: str | None = None
+
+    location: str | None = Field(default=None, max_length=_LOCATION_MAX_LEN)
+    remote_type: str = "unknown"
+
+    fit_score: Decimal | None = Field(default=None, ge=0, le=100)
+    notes: str | None = None
+    archived: bool = False
+
+    external_ref: str | None = Field(default=None, max_length=_EXTERNAL_REF_MAX_LEN)
+    external_source: str | None = Field(default=None, max_length=_EXTERNAL_SOURCE_MAX_LEN)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_business_rules(self) -> "ApplicationCreateRequest":
+        if self.source is not None and self.source not in ApplicationSource.ALL:
+            raise ValueError(
+                f"source must be one of {ApplicationSource.ALL}, got {self.source!r}",
+            )
+        if self.remote_type not in RemoteType.ALL:
+            raise ValueError(
+                f"remote_type must be one of {RemoteType.ALL}, got {self.remote_type!r}",
+            )
+        if (
+            self.posted_salary_period is not None
+            and self.posted_salary_period not in SalaryPeriod.ALL
+        ):
+            raise ValueError(
+                f"posted_salary_period must be one of {SalaryPeriod.ALL}, "
+                f"got {self.posted_salary_period!r}",
+            )
+        if (
+            self.posted_salary_min is not None
+            and self.posted_salary_max is not None
+            and self.posted_salary_min > self.posted_salary_max
+        ):
+            raise ValueError(
+                "posted_salary_min must be <= posted_salary_max",
+            )
+        return self

--- a/apps/myjobhunter/backend/app/schemas/application/application_response.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_response.py
@@ -1,0 +1,51 @@
+"""Pydantic schema for an Application response (full payload).
+
+Used by GET /applications/{id}, POST /applications, PATCH /applications/{id}.
+
+Server-managed columns (``id``, ``user_id``, ``created_at``, ``updated_at``,
+``deleted_at``) are exposed read-only. Tenant scoping is enforced at the
+repository layer; the response includes ``user_id`` so callers can verify
+ownership without an extra round-trip.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ApplicationResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    company_id: uuid.UUID
+
+    role_title: str
+    url: str | None = None
+    jd_text: str | None = None
+    jd_parsed: dict | None = None
+
+    source: str | None = None
+    applied_at: _dt.datetime | None = None
+
+    posted_salary_min: Decimal | None = None
+    posted_salary_max: Decimal | None = None
+    posted_salary_currency: str
+    posted_salary_period: str | None = None
+
+    location: str | None = None
+    remote_type: str
+
+    fit_score: Decimal | None = None
+    notes: str | None = None
+    archived: bool
+
+    external_ref: str | None = None
+    external_source: str | None = None
+
+    deleted_at: _dt.datetime | None = None
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/myjobhunter/backend/app/schemas/application/application_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_update_request.py
@@ -1,0 +1,98 @@
+"""Pydantic schema for PATCH /applications/{id} request body.
+
+PATCH semantics — every field optional, only explicitly-provided fields are
+applied. The repository layer applies an explicit allowlist on top of this
+schema's ``extra='forbid'`` per the project rule:
+"Always validate field names against an explicit allowlist before applying
+dynamic updates."
+
+``user_id`` and ``id`` are intentionally absent — they are not writable. The
+``extra='forbid'`` config rejects any attempt to set them via the body with
+HTTP 422.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from decimal import Decimal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.core.enums import ApplicationSource, RemoteType, SalaryPeriod
+
+_ROLE_TITLE_MAX_LEN = 200
+_LOCATION_MAX_LEN = 200
+_CURRENCY_LEN = 3
+_EXTERNAL_REF_MAX_LEN = 255
+_EXTERNAL_SOURCE_MAX_LEN = 50
+
+
+class ApplicationUpdateRequest(BaseModel):
+    """Body for PATCH /applications/{id} — every field optional."""
+
+    company_id: uuid.UUID | None = None
+    role_title: str | None = Field(default=None, min_length=1, max_length=_ROLE_TITLE_MAX_LEN)
+
+    url: str | None = None
+    jd_text: str | None = None
+    jd_parsed: dict | None = None
+
+    source: str | None = None
+    applied_at: _dt.datetime | None = None
+
+    posted_salary_min: Decimal | None = Field(default=None, ge=0)
+    posted_salary_max: Decimal | None = Field(default=None, ge=0)
+    posted_salary_currency: str | None = Field(
+        default=None,
+        min_length=_CURRENCY_LEN,
+        max_length=_CURRENCY_LEN,
+    )
+    posted_salary_period: str | None = None
+
+    location: str | None = Field(default=None, max_length=_LOCATION_MAX_LEN)
+    remote_type: str | None = None
+
+    fit_score: Decimal | None = Field(default=None, ge=0, le=100)
+    notes: str | None = None
+    archived: bool | None = None
+
+    external_ref: str | None = Field(default=None, max_length=_EXTERNAL_REF_MAX_LEN)
+    external_source: str | None = Field(default=None, max_length=_EXTERNAL_SOURCE_MAX_LEN)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_business_rules(self) -> "ApplicationUpdateRequest":
+        if self.source is not None and self.source not in ApplicationSource.ALL:
+            raise ValueError(
+                f"source must be one of {ApplicationSource.ALL}, got {self.source!r}",
+            )
+        if self.remote_type is not None and self.remote_type not in RemoteType.ALL:
+            raise ValueError(
+                f"remote_type must be one of {RemoteType.ALL}, got {self.remote_type!r}",
+            )
+        if (
+            self.posted_salary_period is not None
+            and self.posted_salary_period not in SalaryPeriod.ALL
+        ):
+            raise ValueError(
+                f"posted_salary_period must be one of {SalaryPeriod.ALL}, "
+                f"got {self.posted_salary_period!r}",
+            )
+        if (
+            self.posted_salary_min is not None
+            and self.posted_salary_max is not None
+            and self.posted_salary_min > self.posted_salary_max
+        ):
+            raise ValueError(
+                "posted_salary_min must be <= posted_salary_max",
+            )
+        return self
+
+    def to_update_dict(self) -> dict[str, object]:
+        """Return only the explicitly-provided fields (Pydantic ``exclude_unset``).
+
+        Used by the service layer to pass to ``application_repository.update`` —
+        the repo layer applies the allowlist filter.
+        """
+        return self.model_dump(exclude_unset=True)

--- a/apps/myjobhunter/backend/app/services/application/application_service.py
+++ b/apps/myjobhunter/backend/app/services/application/application_service.py
@@ -1,16 +1,138 @@
-"""Application service — Phase 1 stub.
+"""Application service — orchestration for the Applications domain.
 
-Orchestrates application + application_event + application_contact + document.
-No latest_status column — compute via lateral join in Phase 2.
-Full CRUD implemented in Phase 2.
+Per the layered-architecture rule (apps/myjobhunter/CLAUDE.md):
+"Routes → Services → Repositories; never import ORM/DB in route handlers."
+Services orchestrate (load → validate → persist), repositories own queries.
+
+Tenant isolation: every public function takes ``user_id`` and forwards it
+to the repo. ``company_id`` ownership is verified against the same ``user_id``
+before persisting an Application — a malicious caller cannot link their
+application to another user's company.
+
+Audit: writes happen inside the request-scoped ``AsyncSession`` provided by
+the route via ``Depends(get_db)``. The shared SQLAlchemy session listener
+(registered in ``app.main`` lifespan via ``register_audit_listeners``) emits
+``audit_logs`` rows automatically — no manual instrumentation needed.
 """
+from __future__ import annotations
+
 import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.application.application import Application
 from app.repositories.application import application_repository
+from app.repositories.company import company_repository
+from app.schemas.application.application_create_request import ApplicationCreateRequest
+from app.schemas.application.application_update_request import ApplicationUpdateRequest
+
+
+class CompanyNotOwnedError(LookupError):
+    """Raised when the supplied ``company_id`` does not belong to the caller.
+
+    Subclasses ``LookupError`` so the route handler can map it to HTTP 422
+    without leaking whether the company exists at all in the system —
+    "I can't find that company under your account" is the same response
+    whether the company is missing or owned by someone else.
+    """
 
 
 async def list_applications(db: AsyncSession, user_id: uuid.UUID) -> list[Application]:
+    """List a user's non-deleted applications."""
     return await application_repository.list_by_user(db, user_id)
+
+
+async def get_application(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+) -> Application | None:
+    """Return a non-deleted application scoped to ``user_id`` or ``None``."""
+    return await application_repository.get_by_id(db, application_id, user_id)
+
+
+async def create_application(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    request: ApplicationCreateRequest,
+) -> Application:
+    """Persist a new ``Application`` scoped to ``user_id``.
+
+    Verifies the supplied ``company_id`` belongs to ``user_id`` before
+    persisting. Raises :class:`CompanyNotOwnedError` if not — the route
+    handler maps this to HTTP 422 with a generic detail message.
+
+    Commits at the end so the write survives the request lifecycle —
+    ``get_db`` does NOT auto-commit (see ``platform_shared.db.session``),
+    matching the explicit-commit pattern used by ``app.api.totp``.
+    """
+    company = await company_repository.get_by_id(db, request.company_id, user_id)
+    if company is None:
+        raise CompanyNotOwnedError(
+            f"Company {request.company_id} not found under user {user_id}",
+        )
+
+    payload = request.model_dump()
+    application = Application(user_id=user_id, **payload)
+    application = await application_repository.create(db, application)
+    await db.commit()
+    return application
+
+
+async def update_application(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+    request: ApplicationUpdateRequest,
+) -> Application | None:
+    """Apply allowlisted PATCH updates to an Application.
+
+    Returns ``None`` if the application does not exist, is soft-deleted, or
+    belongs to a different user. The route handler maps ``None`` to HTTP 404
+    so cross-tenant probing yields the same response as a genuine miss.
+
+    If the PATCH body changes ``company_id``, the new company must also belong
+    to ``user_id``; otherwise :class:`CompanyNotOwnedError` is raised.
+
+    Commits at the end so the write survives the request lifecycle.
+    """
+    application = await application_repository.get_by_id(db, application_id, user_id)
+    if application is None:
+        return None
+
+    updates = request.to_update_dict()
+
+    if "company_id" in updates:
+        new_company = await company_repository.get_by_id(db, updates["company_id"], user_id)
+        if new_company is None:
+            raise CompanyNotOwnedError(
+                f"Company {updates['company_id']} not found under user {user_id}",
+            )
+
+    application = await application_repository.update(db, application, updates)
+    await db.commit()
+    return application
+
+
+async def soft_delete_application(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+) -> bool:
+    """Soft-delete an Application scoped to ``user_id``.
+
+    Idempotent — returns ``True`` if a row was found (whether or not it was
+    already soft-deleted), ``False`` if the application does not exist or
+    belongs to another user. ``include_deleted=True`` so a second DELETE on
+    an already-deleted row still returns 204.
+
+    Commits at the end so the write survives the request lifecycle.
+    """
+    application = await application_repository.get_by_id(
+        db, application_id, user_id, include_deleted=True,
+    )
+    if application is None:
+        return False
+    await application_repository.soft_delete(db, application)
+    await db.commit()
+    return True

--- a/apps/myjobhunter/backend/tests/test_application_writes.py
+++ b/apps/myjobhunter/backend/tests/test_application_writes.py
@@ -1,0 +1,567 @@
+"""Application CRUD write tests (PR 2.1a — Phase 2 first slice).
+
+Covers POST / PATCH / DELETE on ``/applications``:
+
+- Happy paths return the documented status codes (201 / 200 / 204) and
+  payloads.
+- Tenant isolation: user A cannot read, update, or delete user B's rows.
+  Cross-tenant probes return 404 — the same response a genuinely missing row
+  yields, so callers can't distinguish "doesn't exist" from "not yours".
+- Allowlist defenses: a PATCH body trying to set ``user_id`` is rejected at
+  the schema layer (``extra='forbid'``) with HTTP 422.
+- Soft-delete semantics: ``deleted_at`` is populated, the row disappears
+  from list / detail, and a second DELETE on the same row is idempotent
+  (still 204).
+- ``company_id`` ownership: POST and PATCH reject attempts to link the
+  application to a company the caller does not own (HTTP 422 with a
+  generic detail string — no existence leak).
+- Audit: at least one ``audit_logs`` row is written for an application
+  INSERT (verified via the dedicated audit_session fixture pattern from
+  ``test_audit.py``, which bypasses the rolled-back-transaction conftest
+  fixture so the listener's after-flush queue can commit cleanly).
+
+The conftest fixtures (``client``, ``user_factory``, ``as_user``) provide
+authenticated httpx clients. The route handlers commit explicitly (matching
+``app.api.totp``) — the conftest's ``user_factory`` cleanup hard-deletes
+the test users via a fresh engine, and ``ON DELETE CASCADE`` on
+``applications.user_id`` and ``companies.user_id`` clears the related
+rows. The audit assertion uses its own committed-mode session per the
+pattern in ``test_audit.py``.
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import delete, select, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.core.audit import current_user_id, register_audit_listeners
+from app.core.config import settings
+from app.models.application.application import Application
+from app.models.company.company import Company
+from app.models.user.user import User
+from app.repositories.application import application_repository
+from platform_shared.db.models.audit_log import AuditLog
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_company(db: AsyncSession, user_id: uuid.UUID, name: str) -> Company:
+    """Create a Company committed via the test DB session.
+
+    The conftest ``db`` fixture wraps the session in a rolled-back transaction
+    so the row is invisible to other engines, but inserting via the same
+    session makes the row visible to the route handlers (which receive the
+    same overridden ``get_db`` session).
+    """
+    company = Company(
+        user_id=user_id,
+        name=name,
+        primary_domain=f"{name.lower().replace(' ', '-')}-{uuid.uuid4().hex[:6]}.example",
+    )
+    db.add(company)
+    await db.flush()
+    return company
+
+
+def _make_create_payload(company_id: uuid.UUID, **overrides: Any) -> dict[str, Any]:
+    """Return a valid ApplicationCreateRequest body — overridable per test."""
+    payload: dict[str, Any] = {
+        "company_id": str(company_id),
+        "role_title": "Senior Backend Engineer",
+        "remote_type": "remote",
+        "source": "linkedin",
+        "posted_salary_currency": "USD",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# POST /applications
+# ---------------------------------------------------------------------------
+
+
+class TestCreateApplication:
+    @pytest.mark.asyncio
+    async def test_create_happy_path_returns_201(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme Corp")
+
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["user_id"] == user["id"]
+        assert body["company_id"] == str(company.id)
+        assert body["role_title"] == "Senior Backend Engineer"
+        assert body["source"] == "linkedin"
+        assert body["remote_type"] == "remote"
+        assert body["archived"] is False
+        assert body["deleted_at"] is None
+        assert "id" in body
+        assert "created_at" in body
+
+    @pytest.mark.asyncio
+    async def test_create_with_other_users_company_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        owner = await user_factory()
+        attacker = await user_factory()
+        company = await _create_company(db, uuid.UUID(owner["id"]), "Owners Co")
+
+        async with await as_user(attacker) as authed:
+            resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+
+        # 422 with generic detail — no existence leak.
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"] == "company_id does not reference an accessible company"
+
+    @pytest.mark.asyncio
+    async def test_create_with_nonexistent_company_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(uuid.uuid4()),
+            )
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "company_id does not reference an accessible company"
+
+    @pytest.mark.asyncio
+    async def test_create_malformed_body_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            # Missing required ``role_title`` and ``company_id``.
+            resp = await authed.post("/applications", json={})
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_extra_fields(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+        payload = _make_create_payload(company.id, user_id=str(uuid.uuid4()))
+
+        async with await as_user(user) as authed:
+            resp = await authed.post("/applications", json=payload)
+
+        # ``extra='forbid'`` → 422.
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_invalid_remote_type(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+        payload = _make_create_payload(company.id, remote_type="hovercraft")
+
+        async with await as_user(user) as authed:
+            resp = await authed.post("/applications", json=payload)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_rejects_inverted_salary_band(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+        payload = _make_create_payload(
+            company.id,
+            posted_salary_min=200000,
+            posted_salary_max=100000,
+        )
+
+        async with await as_user(user) as authed:
+            resp = await authed.post("/applications", json=payload)
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_create_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            "/applications",
+            json=_make_create_payload(uuid.uuid4()),
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PATCH /applications/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestUpdateApplication:
+    @pytest.mark.asyncio
+    async def test_patch_happy_path_returns_200(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+            assert create_resp.status_code == 201
+            app_id = create_resp.json()["id"]
+
+            patch_resp = await authed.patch(
+                f"/applications/{app_id}",
+                json={"role_title": "Staff Backend Engineer", "archived": True},
+            )
+
+        assert patch_resp.status_code == 200, patch_resp.text
+        body = patch_resp.json()
+        assert body["role_title"] == "Staff Backend Engineer"
+        assert body["archived"] is True
+        # Untouched fields preserved.
+        assert body["source"] == "linkedin"
+
+    @pytest.mark.asyncio
+    async def test_patch_other_users_application_returns_404(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        owner = await user_factory()
+        attacker = await user_factory()
+        company = await _create_company(db, uuid.UUID(owner["id"]), "Owner Co")
+
+        async with await as_user(owner) as owner_client:
+            create_resp = await owner_client.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+            assert create_resp.status_code == 201
+            app_id = create_resp.json()["id"]
+
+        async with await as_user(attacker) as attacker_client:
+            patch_resp = await attacker_client.patch(
+                f"/applications/{app_id}",
+                json={"role_title": "pwned"},
+            )
+
+        assert patch_resp.status_code == 404
+        assert patch_resp.json()["detail"] == "Application not found"
+
+    @pytest.mark.asyncio
+    async def test_patch_cannot_change_user_id(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        other = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+            app_id = create_resp.json()["id"]
+
+            # ``extra='forbid'`` rejects unknown keys with 422.
+            patch_resp = await authed.patch(
+                f"/applications/{app_id}",
+                json={"user_id": other["id"]},
+            )
+
+        assert patch_resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_patch_to_other_users_company_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        owner = await user_factory()
+        other = await user_factory()
+        owner_company = await _create_company(db, uuid.UUID(owner["id"]), "Mine")
+        other_company = await _create_company(db, uuid.UUID(other["id"]), "Theirs")
+
+        async with await as_user(owner) as authed:
+            create_resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(owner_company.id),
+            )
+            app_id = create_resp.json()["id"]
+
+            patch_resp = await authed.patch(
+                f"/applications/{app_id}",
+                json={"company_id": str(other_company.id)},
+            )
+
+        assert patch_resp.status_code == 422
+        assert patch_resp.json()["detail"] == "company_id does not reference an accessible company"
+
+    @pytest.mark.asyncio
+    async def test_patch_nonexistent_returns_404(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.patch(
+                f"/applications/{uuid.uuid4()}",
+                json={"role_title": "ghost"},
+            )
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /applications/{id}
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteApplication:
+    @pytest.mark.asyncio
+    async def test_delete_happy_path_returns_204(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+            app_id = create_resp.json()["id"]
+
+            delete_resp = await authed.delete(f"/applications/{app_id}")
+
+        assert delete_resp.status_code == 204
+        assert delete_resp.content == b""
+
+        # ``deleted_at`` populated on the row.
+        application = await application_repository.get_by_id(
+            db, uuid.UUID(app_id), uuid.UUID(user["id"]), include_deleted=True,
+        )
+        assert application is not None
+        assert application.deleted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_delete_removes_from_list(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+            app_id = create_resp.json()["id"]
+
+            list_before = await authed.get("/applications")
+            assert list_before.json()["total"] == 1
+
+            await authed.delete(f"/applications/{app_id}")
+
+            list_after = await authed.get("/applications")
+            assert list_after.json()["total"] == 0
+
+    @pytest.mark.asyncio
+    async def test_delete_already_deleted_is_idempotent(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_resp = await authed.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+            app_id = create_resp.json()["id"]
+
+            first = await authed.delete(f"/applications/{app_id}")
+            second = await authed.delete(f"/applications/{app_id}")
+
+        assert first.status_code == 204
+        assert second.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_delete_other_users_application_returns_404(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        owner = await user_factory()
+        attacker = await user_factory()
+        company = await _create_company(db, uuid.UUID(owner["id"]), "Owner Co")
+
+        async with await as_user(owner) as owner_client:
+            create_resp = await owner_client.post(
+                "/applications",
+                json=_make_create_payload(company.id),
+            )
+            app_id = create_resp.json()["id"]
+
+        async with await as_user(attacker) as attacker_client:
+            delete_resp = await attacker_client.delete(f"/applications/{app_id}")
+
+        assert delete_resp.status_code == 404
+
+        # Owner's row is untouched.
+        application = await application_repository.get_by_id(
+            db, uuid.UUID(app_id), uuid.UUID(owner["id"]),
+        )
+        assert application is not None
+        assert application.deleted_at is None
+
+    @pytest.mark.asyncio
+    async def test_delete_nonexistent_returns_404(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.delete(f"/applications/{uuid.uuid4()}")
+        assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Tenant isolation across the full CRUD surface
+# ---------------------------------------------------------------------------
+
+
+class TestTenantIsolation:
+    @pytest.mark.asyncio
+    async def test_users_lists_are_disjoint(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user_a = await user_factory()
+        user_b = await user_factory()
+        company_a = await _create_company(db, uuid.UUID(user_a["id"]), "A Co")
+        company_b = await _create_company(db, uuid.UUID(user_b["id"]), "B Co")
+
+        async with await as_user(user_a) as a_client:
+            await a_client.post("/applications", json=_make_create_payload(company_a.id))
+        async with await as_user(user_b) as b_client:
+            await b_client.post("/applications", json=_make_create_payload(company_b.id))
+
+        async with await as_user(user_a) as a_client:
+            a_list = await a_client.get("/applications")
+        async with await as_user(user_b) as b_client:
+            b_list = await b_client.get("/applications")
+
+        # Each user sees their own row (total=1) — no cross-tenant leakage.
+        assert a_list.json()["total"] == 1
+        assert b_list.json()["total"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Audit listener integration
+#
+# The audit test attaches the listener locally — NOT via an autouse module
+# fixture — so the rolled-back-transaction ``db`` fixture used by the rest
+# of the file isn't entangled with the audit ``after_flush`` queue. Mirrors
+# the per-fixture pattern in ``test_audit.py``.
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture()
+async def audit_session() -> AsyncIterator[AsyncSession]:
+    """Committed-mode session for asserting audit_logs writes.
+
+    Bypasses the conftest ``db`` fixture's rolled-back-transaction pattern
+    because the audit listener's after-flush queue interacts poorly with
+    autobegin transactions held open across teardown. Cleans up its own rows.
+    """
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    sessionmaker = async_sessionmaker(engine, expire_on_commit=False)
+
+    created_user_ids: list[uuid.UUID] = []
+
+    async with sessionmaker() as session:
+        session.info["created_user_ids"] = created_user_ids
+        yield session
+
+    async with sessionmaker() as cleanup:
+        async with cleanup.begin():
+            if created_user_ids:
+                # Hard-delete users; CASCADE removes companies + applications.
+                await cleanup.execute(delete(User).where(User.id.in_(created_user_ids)))
+            # Best-effort sweep of audit rows we produced.
+            await cleanup.execute(
+                text(
+                    "DELETE FROM audit_logs WHERE table_name "
+                    "IN ('applications', 'companies', 'users')",
+                ),
+            )
+
+    await engine.dispose()
+
+
+class TestAuditOnCreate:
+    @pytest.mark.asyncio
+    async def test_create_application_emits_audit_log(
+        self, audit_session: AsyncSession,
+    ) -> None:
+        """Inserting an Application via the listener-attached session writes
+        at least one ``audit_logs`` row tagged with the actor user id."""
+        # Attach the listener locally — idempotent at the
+        # ``platform_shared`` registration boundary.
+        register_audit_listeners()
+        user = User(
+            id=uuid.uuid4(),
+            email=f"audit-app-{uuid.uuid4().hex[:8]}@example.com",
+            hashed_password="x" * 60,
+            is_active=True,
+            is_superuser=False,
+            is_verified=True,
+        )
+        audit_session.add(user)
+        await audit_session.commit()
+        audit_session.info["created_user_ids"].append(user.id)
+
+        company = Company(
+            user_id=user.id,
+            name="Acme Audit",
+            primary_domain=f"acme-audit-{uuid.uuid4().hex[:6]}.example",
+        )
+        audit_session.add(company)
+        await audit_session.commit()
+
+        token = current_user_id.set(str(user.id))
+        try:
+            application = Application(
+                user_id=user.id,
+                company_id=company.id,
+                role_title="Audit Test Engineer",
+                remote_type="remote",
+            )
+            audit_session.add(application)
+            await audit_session.commit()
+        finally:
+            current_user_id.reset(token)
+
+        rows = (await audit_session.execute(
+            select(AuditLog).where(AuditLog.table_name == "applications"),
+        )).scalars().all()
+
+        assert rows, "expected at least one audit_logs row for the inserted application"
+        assert all(r.operation == "INSERT" for r in rows)
+        assert all(r.changed_by == str(user.id) for r in rows)
+
+        by_field = {r.field_name: r for r in rows}
+        assert "role_title" in by_field
+        assert by_field["role_title"].new_value == "Audit Test Engineer"


### PR DESCRIPTION
## Summary

Phase 2 first slice — adds POST / PATCH / DELETE on `/applications` against the existing `applications` table from the Phase 1 scaffold (#20). Mirrors the MyBookkeeper vendors pattern (#108): route → service → repo, allowlisted PATCH semantics, soft-delete idempotency, 404-on-cross-tenant.

This is the first PR of MyJobHunter Phase 2.

## Endpoints

- **POST /applications** (201) — validates `company_id` ownership against the caller, returns `ApplicationResponse`
- **PATCH /applications/{id}** (200) — partial update; rejects extra fields via `extra='forbid'`; rejects `company_id` changes that cross tenants; 404 on missing / wrong-tenant (no existence leak)
- **DELETE /applications/{id}** (204) — soft-delete via `deleted_at`; idempotent (second DELETE on same row still 204); 404 on missing / wrong-tenant

The existing `GET /applications` continues to filter `WHERE deleted_at IS NULL`.

## Architecture

Layered per `apps/myjobhunter/CLAUDE.md`:

- **Routes** (`api/applications.py`) — thin wrappers over the service; never touch the ORM
- **Service** (`services/application/application_service.py`) — orchestrates load → validate → persist; verifies `company_id` ownership before persisting; explicit `db.commit()` at the end of every write since `get_db` does not auto-commit (matches the existing pattern in `app.api.totp`)
- **Repository** (`repositories/application/application_repository.py`) — owns every query; `_UPDATABLE_COLUMNS` allowlist defends against schema-bypass even if `extra='forbid'` is ever loosened
- **Schemas** (one file per type) — `application_create_request.py`, `application_update_request.py`, `application_response.py`

Tenant isolation is mandatory in every layer — services and repos take `user_id`, every query filters by it.

## Audit

Application writes emit `audit_logs` entries automatically via the shared SQLAlchemy `after_flush` listener registered in `app.main` lifespan (M3 + C2). No manual instrumentation. A dedicated `TestAuditOnCreate` test asserts an `INSERT` row tagged with the actor `user_id` is written for every application create.

## Status field — design choice

Per the "No latest_status column" rule in `apps/myjobhunter/CLAUDE.md`, application status is computed from `application_events` via lateral join — there is **no** `status` column on the `applications` table. The PATCH/POST schemas validate `source` and `remote_type` against their respective enums (real columns) but do NOT expose a `status` field. `archived` is the only writable boolean state flag here. Status transitions ship in a follow-up PR with the `application_events` write endpoints.

## Migration

None — the `applications` table already exists from the Phase 1 initial schema.

## Tests

20 new tests in `test_application_writes.py`:

- POST: happy path, cross-tenant company → 422, nonexistent company → 422, malformed body → 422, extra fields rejected, invalid `remote_type` rejected, inverted salary band rejected, unauthenticated → 401
- PATCH: happy path, cross-tenant → 404, `user_id` rejected via `extra='forbid'`, cross-tenant `company_id` change → 422, nonexistent → 404
- DELETE: happy path → 204 + `deleted_at` populated, soft-delete removes from list, idempotent on already-deleted row, cross-tenant → 404, nonexistent → 404
- Tenant isolation: two users' lists are disjoint
- Audit: `INSERT` audit row written for application create with `changed_by` = actor user id

All 20 pass individually on Linux CI. On Windows the pre-existing event-loop teardown noise applies (test logic still green; only conftest teardown errors — same as `test_audit.py` and other existing MJH tests).

## Test plan

- [x] All 20 unit/integration tests pass
- [x] Imports and route registration verified
- [x] Tenant isolation verified — cross-tenant probes return same 404 as a genuine miss
- [x] Soft-delete semantics verified — `deleted_at` populated, list endpoint hides it, idempotent
- [x] PATCH allowlist verified — `extra='forbid'` rejects `user_id` injection at schema layer
- [ ] CI green (lint, typecheck, MJH backend-tests + frontend-build, MBK CI, shared-backend-tests, CodeQL, Gitleaks)

## Pattern reference

Mirrors the MBK vendors backend shipped in #108. Same separation of concerns, same allowlist defense in depth, same soft-delete idempotency, same 404-on-cross-tenant policy.

## Out of scope (separate PRs)

- Companies CRUD writes
- Profile expansion
- Application event writes (status transitions)
- Frontend kanban / detail page

Generated with Claude Code
