### PR TITLE
fix(mybookkeeper/csp): allow storage subdomain in connect-src

### DIFF
--- a/apps/mybookkeeper/docker/Caddyfile.docker
+++ b/apps/mybookkeeper/docker/Caddyfile.docker
@@ -32,7 +32,7 @@
             X-Content-Type-Options "nosniff"
             Referrer-Policy "strict-origin-when-cross-origin"
             Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=(), browsing-topics=()"
-            Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https://*.plaid.com https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://cdn.plaid.com https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+            Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://*.plaid.com https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://cdn.plaid.com https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
             -Server
         }
 


### PR DESCRIPTION
## Summary

- Source-document viewing was still blocked after #131 added `blob:` to `frame-src`. The browser flow is: fetch presigned URL on `storage.<DOMAIN>` → convert response to `blob:` → render iframe `src={blob.url}`.
- The `fetch()` step is governed by `connect-src`, which did not include the storage origin. The blob was never created → the iframe rendered "blocked content".
- Add `https://storage.{$DOMAIN}` to the `connect-src` directive.

## Test plan

- [ ] After deploy, open a transaction with a source document and confirm the PDF/image renders inline.
- [ ] Verify no CSP violations are reported in browser devtools console.
- [ ] Existing CSP behaviors unchanged: app subdomain still blocks unrelated origins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)