### PR TITLE
ci(myjobhunter): split backend-tests into 3 parallel shards

### DIFF
--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -48,9 +48,38 @@ jobs:
           pip install -r requirements.txt
 
   backend-tests:
-    name: backend-tests / myjobhunter
+    name: backend-tests / myjobhunter / ${{ matrix.shard.name }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
+
+    strategy:
+      fail-fast: false
+      matrix:
+        shard:
+          # The auth suite is dominated by Argon2 password hashing — the slow
+          # tests are the ones that issue many login attempts (account
+          # lockout, per-IP rate limit, account deletion re-auth, data
+          # export login). Splitting by file across three shards keeps any
+          # single shard inside the 10-min timeout and lets them run in
+          # parallel.
+          - name: fast
+            paths: >-
+              tests/test_health.py
+              tests/test_auth.py
+              tests/test_hibp_validation.py
+              tests/test_turnstile.py
+              tests/test_tenant_isolation.py
+              tests/test_audit.py
+          - name: login-heavy
+            paths: >-
+              tests/test_account_lockout.py
+              tests/test_login_ip_rate_limit.py
+              tests/test_account_deletion.py
+              tests/test_data_export.py
+          - name: totp
+            paths: >-
+              tests/test_totp_login.py
+              tests/test_totp_setup.py
 
     services:
       postgres:
@@ -99,9 +128,9 @@ jobs:
         working-directory: apps/myjobhunter/backend
         run: PYTHONPATH=. alembic upgrade head
 
-      - name: Run pytest
+      - name: Run pytest (${{ matrix.shard.name }})
         working-directory: apps/myjobhunter/backend
-        run: python -m pytest -q
+        run: python -m pytest -q ${{ matrix.shard.paths }}
 
   frontend-build:
     name: frontend-build / myjobhunter


### PR DESCRIPTION
## Summary

- The auth test suite is dominated by Argon2 password hashing. Tests that issue many login attempts (account lockout, per-IP rate limit, account deletion re-auth, data export login) push the single-job `backend-tests` run past its 10-min timeout under load.
- Convert `backend-tests` into a matrix with three parallel shards, each with its own postgres service and a 10-min timeout:
  - **fast** — health, auth, hibp, turnstile, tenant_isolation, audit (6 files)
  - **login-heavy** — account_lockout, login_ip_rate_limit, account_deletion, data_export (4 files)
  - **totp** — totp_login, totp_setup (2 files)
- `fail-fast: false` so all three reports come back even when one fails — easier triage than an ambiguous single-job timeout.

## Test plan

- [ ] Verify all three matrix legs report status on this PR.
- [ ] Confirm wall-clock CI time matches the slowest shard rather than the sum of all tests.
- [ ] After merge, rebase #126 (email verification) onto main and confirm the previously-timing-out suite now passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)