### PR TITLE
fix(mybookkeeper/documents): surface viewer failure modes + open-in-new-tab fallback

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/document-viewer-failure-modes.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/document-viewer-failure-modes.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * Layout E2E for DocumentViewer's failure-mode UX. Mirrors the user-visible
+ * scenarios that produced the 2026-04-30 "i still can't see the source documents"
+ * report. Mocks the API surface so the test runs without a backend.
+ */
+import { test, expect } from "@playwright/test";
+
+function plantValidJwtAndOrgInLocalStorage(page: import("@playwright/test").Page): Promise<void> {
+  return page.addInitScript(() => {
+    const futureExp = Math.floor(Date.now() / 1000) + 3600;
+    const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const payload = btoa(JSON.stringify({ sub: "test-user", exp: futureExp }));
+    window.localStorage.setItem("token", `${header}.${payload}.fake-signature`);
+    window.localStorage.setItem("v1_activeOrgId", "00000000-0000-0000-0000-000000000010");
+  });
+}
+
+async function stubAuthAndOrg(page: import("@playwright/test").Page): Promise<void> {
+  await page.route("**/api/users/me", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "00000000-0000-0000-0000-000000000001",
+        email: "test@example.com",
+        name: "Test User",
+        is_active: true,
+        is_superuser: false,
+        is_verified: true,
+        role: "owner",
+      }),
+    });
+  });
+  await page.route("**/api/organizations", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([
+        { id: "00000000-0000-0000-0000-000000000010", name: "Test Workspace", role: "owner" },
+      ]),
+    });
+  });
+  await page.route("**/api/version", (route) => {
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) });
+  });
+  await page.route("**/api/tax-profile", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ onboarding_completed: true, tax_situations: [], filing_status: null, dependents_count: 0 }),
+    });
+  });
+}
+
+const DOC_ID = "00000000-0000-0000-0000-000000000aaa";
+
+async function stubDocumentList(page: import("@playwright/test").Page): Promise<void> {
+  // The Documents page calls /api/documents (RTK Query) — return one PDF row.
+  await page.route("**/api/documents*", (route, request) => {
+    if (request.method() === "GET") {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([
+          {
+            id: DOC_ID,
+            file_name: "empty-test.pdf",
+            file_mime_type: "application/pdf",
+            status: "completed",
+            document_type: "Invoice",
+            source: "manual",
+            created_at: "2026-05-01T00:00:00Z",
+            user_id: "00000000-0000-0000-0000-000000000001",
+            organization_id: "00000000-0000-0000-0000-000000000010",
+            invoice_id: null,
+          },
+        ]),
+      });
+      return;
+    }
+    route.continue();
+  });
+}
+
+test.describe("DocumentViewer — failure modes surface to user", () => {
+  test("zero-byte download response shows the empty-state message, not a blank iframe", async ({ page }) => {
+    await plantValidJwtAndOrgInLocalStorage(page);
+    await stubAuthAndOrg(page);
+    await stubDocumentList(page);
+
+    // Critical mock: the download endpoint returns 200 with an empty body.
+    // This is the silent-failure mode the previous wrong fixes (#131/#134) did
+    // not address — the iframe stayed blank with no error visible to the user.
+    await page.route(`**/api/documents/${DOC_ID}/download`, (route) => {
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/pdf", "Content-Length": "0" },
+        body: Buffer.alloc(0),
+      });
+    });
+
+    await page.goto("/documents");
+
+    // Wait for the table to render
+    await expect(page.locator("table")).toBeVisible({ timeout: 15000 });
+    const row = page.locator("tbody tr", { hasText: "empty-test.pdf" }).first();
+    await expect(row).toBeVisible();
+    await row.click();
+
+    // Header should appear (existing tests stop here — but that's not enough)
+    await expect(page.getByText("Source document").first()).toBeVisible({ timeout: 10000 });
+
+    // BEHAVIORAL ASSERTION — empty state is rendered, NOT a blank iframe.
+    await expect(page.getByTestId("document-empty")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("document-empty")).toContainText(/no content available/i);
+
+    // The iframe must NOT render for an empty blob.
+    await expect(page.locator('iframe[title="Source document"]')).toHaveCount(0);
+  });
+
+  test("successful PDF download shows iframe AND an 'Open in new tab' fallback link", async ({ page }) => {
+    await plantValidJwtAndOrgInLocalStorage(page);
+    await stubAuthAndOrg(page);
+    await stubDocumentList(page);
+
+    // Minimal valid PDF bytes (PDF header + EOF marker — enough for size > 0)
+    const pdfBytes = Buffer.from(
+      "%PDF-1.4\n1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n2 0 obj<</Type/Pages/Count 0/Kids[]>>endobj\nxref\n0 3\n0000000000 65535 f\n0000000009 00000 n\n0000000054 00000 n\ntrailer<</Size 3/Root 1 0 R>>\nstartxref\n98\n%%EOF\n",
+      "utf-8"
+    );
+
+    await page.route(`**/api/documents/${DOC_ID}/download`, (route) => {
+      route.fulfill({
+        status: 200,
+        headers: { "Content-Type": "application/pdf" },
+        body: pdfBytes,
+      });
+    });
+
+    await page.goto("/documents");
+    await expect(page.locator("table")).toBeVisible({ timeout: 15000 });
+    await page.locator("tbody tr", { hasText: "empty-test.pdf" }).first().click();
+
+    await expect(page.getByText("Source document").first()).toBeVisible({ timeout: 10000 });
+
+    // Iframe rendered with a blob: URL.
+    const iframe = page.locator('iframe[title="Source document"]');
+    await expect(iframe).toBeVisible({ timeout: 10000 });
+    const src = await iframe.getAttribute("src");
+    expect(src?.startsWith("blob:"), `iframe src should be a blob URL, got ${src}`).toBe(true);
+
+    // Open-in-new-tab fallback is visible and points at the same blob URL.
+    const fallback = page.getByTestId("document-open-in-new-tab");
+    await expect(fallback).toBeVisible();
+    expect(await fallback.getAttribute("href")).toBe(src);
+    expect(await fallback.getAttribute("target")).toBe("_blank");
+
+    // No empty-state, no error.
+    await expect(page.getByTestId("document-empty")).toHaveCount(0);
+    await expect(page.getByTestId("document-error")).toHaveCount(0);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/DocumentViewer.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/DocumentViewer.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Unit tests for DocumentViewer covering the failure modes that the
+ * 2026-04-30 user report ("i still can't see the source documents")
+ * went undiagnosed for. Earlier E2E coverage stopped at the panel header
+ * being visible, which passed even when the iframe content was blank.
+ *
+ * These tests verify that:
+ * - A successful PDF load shows the iframe + an "Open in new tab" link.
+ * - A 0-byte response shows a clear empty-state message (the most likely
+ *   failure mode where the backend returns 200 with no content).
+ * - A request error surfaces the underlying error message.
+ */
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import DocumentViewer from "@/app/features/documents/DocumentViewer";
+
+const fetchDocumentBlobMock = vi.fn();
+
+vi.mock("@/shared/services/documentService", () => ({
+  fetchDocumentBlob: (id: string) => fetchDocumentBlobMock(id),
+}));
+
+// jsdom doesn't implement createObjectURL/revokeObjectURL.
+beforeEach(() => {
+  // Each test sets its own resolved/rejected mock value.
+  fetchDocumentBlobMock.mockReset();
+  if (!("createObjectURL" in URL)) {
+    Object.defineProperty(URL, "createObjectURL", {
+      writable: true,
+      value: vi.fn(() => "blob:mock-url"),
+    });
+  }
+  if (!("revokeObjectURL" in URL)) {
+    Object.defineProperty(URL, "revokeObjectURL", {
+      writable: true,
+      value: vi.fn(),
+    });
+  }
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DocumentViewer — successful PDF render", () => {
+  it("shows the iframe and an 'Open in new tab' link when the blob has content", async () => {
+    fetchDocumentBlobMock.mockResolvedValue({
+      url: "blob:abc",
+      contentType: "application/pdf",
+      size: 1989,
+    });
+
+    render(<DocumentViewer documentId="doc-1" onClose={() => {}} />);
+
+    const iframe = await screen.findByTitle("Source document");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.getAttribute("src")).toBe("blob:abc");
+
+    const link = screen.getByTestId("document-open-in-new-tab");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("blob:abc");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+
+    expect(screen.queryByTestId("document-empty")).toBeNull();
+    expect(screen.queryByTestId("document-error")).toBeNull();
+  });
+});
+
+describe("DocumentViewer — empty response (size === 0)", () => {
+  it("shows the empty-state message when the backend returns a zero-byte body", async () => {
+    fetchDocumentBlobMock.mockResolvedValue({
+      url: "blob:empty",
+      contentType: "application/pdf",
+      size: 0,
+    });
+
+    render(<DocumentViewer documentId="doc-empty" onClose={() => {}} />);
+
+    const empty = await screen.findByTestId("document-empty");
+    expect(empty).toBeInTheDocument();
+    expect(empty.textContent).toMatch(/no content available/i);
+    expect(empty.textContent).toMatch(/re-uploading/i);
+
+    // The iframe MUST NOT render for an empty blob — that was the silent
+    // failure mode users were seeing in production.
+    expect(screen.queryByTitle("Source document")).toBeNull();
+
+    // No "Open in new tab" link for an empty document.
+    expect(screen.queryByTestId("document-open-in-new-tab")).toBeNull();
+  });
+});
+
+describe("DocumentViewer — request error", () => {
+  it("surfaces the error message when the download request fails", async () => {
+    fetchDocumentBlobMock.mockRejectedValue(new Error("Request failed with status code 404"));
+
+    render(<DocumentViewer documentId="doc-missing" onClose={() => {}} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("document-error")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("document-error").textContent).toMatch(/404/);
+
+    // No iframe, no fallback link.
+    expect(screen.queryByTitle("Source document")).toBeNull();
+    expect(screen.queryByTestId("document-open-in-new-tab")).toBeNull();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewer.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewer.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Loader2 } from "lucide-react";
+import { Loader2, ExternalLink } from "lucide-react";
 import { fetchDocumentBlob, type DocumentBlob } from "@/shared/services/documentService";
 import Panel, { PanelCloseButton } from "@/shared/components/ui/Panel";
 
@@ -28,17 +28,41 @@ export default function DocumentViewer({ documentId, onClose }: Props) {
 
   const isImage = blob?.contentType.startsWith("image/");
   const isPdf = blob?.contentType === "application/pdf";
+  const isEmpty = blob !== null && blob.size === 0;
 
   return (
     <Panel position="center" onClose={onClose}>
       <header className="flex items-center justify-between px-4 py-2 border-b shrink-0 bg-card">
-        <span className="text-sm font-medium text-muted-foreground">Source document</span>
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="text-sm font-medium text-muted-foreground">Source document</span>
+          {blob && !isEmpty ? (
+            <a
+              href={blob.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+              data-testid="document-open-in-new-tab"
+            >
+              <ExternalLink size={12} />
+              Open in new tab
+            </a>
+          ) : null}
+        </div>
         <PanelCloseButton onClose={onClose} label="Close viewer" />
       </header>
 
       <div className="flex-1 min-h-0 overflow-auto bg-muted/50">
         {error ? (
-          <p className="flex items-center justify-center h-full text-sm text-destructive">{error}</p>
+          <p className="flex items-center justify-center h-full text-sm text-destructive px-4 text-center" data-testid="document-error">
+            {error}
+          </p>
+        ) : isEmpty ? (
+          <div className="flex flex-col items-center justify-center h-full gap-2 px-4 text-center" data-testid="document-empty">
+            <p className="text-sm text-destructive">This document has no content available.</p>
+            <p className="text-xs text-muted-foreground">
+              The file may have been removed from storage. Try re-uploading the document.
+            </p>
+          </div>
         ) : blob ? (
           isImage ? (
             <div className="flex items-center justify-center h-full p-4">

--- a/apps/mybookkeeper/frontend/src/shared/services/documentService.ts
+++ b/apps/mybookkeeper/frontend/src/shared/services/documentService.ts
@@ -3,11 +3,12 @@ import api from "@/shared/lib/api";
 export interface DocumentBlob {
   url: string;
   contentType: string;
+  size: number;
 }
 
 /**
  * Fetches the source document for a given document ID and returns a
- * temporary blob URL and content type.
+ * temporary blob URL, content type, and size.
  * The caller is responsible for calling URL.revokeObjectURL() when done.
  */
 export async function fetchDocumentBlob(documentId: string): Promise<DocumentBlob> {
@@ -18,5 +19,6 @@ export async function fetchDocumentBlob(documentId: string): Promise<DocumentBlo
   return {
     url: URL.createObjectURL(blob),
     contentType: blob.type,
+    size: blob.size,
   };
 }


### PR DESCRIPTION
## Summary

Investigation of the 2026-04-30 user report (\"i still can't see the source documents\") with real headed Chrome under the production CSP showed that PDF rendering works fine — `object-src 'none'` does NOT block Chrome's built-in PDF viewer in iframes. PRs #131 and #134 were treating a phantom CSP problem.

What actually goes wrong: the existing UI silently rendered a blank iframe whenever the download response was zero bytes. The previous tests stopped at \"panel header is visible,\" which passed even when the user saw nothing.

## What this changes

- `DocumentBlob` carries `size` so the viewer can detect empty responses.
- When `blob.size === 0`, the viewer renders an explicit empty-state message instead of a blank iframe.
- An \"Open in new tab\" link is added in the panel header for non-empty blobs — a working fallback for any browser-specific PDF rendering edge case we haven't identified yet, and a useful affordance regardless.

## What this does NOT change

- No CSP changes. Production CSP was verified to allow PDF iframe rendering correctly in real Chrome.
- No backend changes. If the user's specific documents return empty bodies in production, that's a separate backend issue (file_content NULL or MinIO file missing) — this PR makes it visible to the user instead of silent.

## Test plan

- [x] Unit tests (3): successful render, empty response, request error — all green
- [x] Layout E2E (2): full `/documents` → click row → viewer flow for empty-blob and successful-PDF paths — both green
- [x] Verified the open-in-new-tab link href matches the iframe's blob URL
- [x] `npm run build --workspace=mybookkeeper-frontend` succeeds
- [ ] User-side: open a document on prod after deploy. Expected outcomes:
  - If you see content → PR #131/#134 didn't matter, content was there all along (suggests transient backend issue or browser cache)
  - If you see the empty-state message → backend is returning 0 bytes for that doc; we know to look at storage/DB
  - If you see content via \"Open in new tab\" but iframe still blank → browser-specific iframe rendering issue we'd then have a clear repro for

## Investigation notes

Wrote a Playwright test against real Chrome (not headless-shell, which lacks the PDF viewer plugin) loading the plumber-invoice fixture under the verbatim production CSP including `object-src 'none'`. Screenshot: PDF rendered perfectly with toolbar, page navigation, content. So the CSP `object-src` hypothesis from the prior session was wrong.

The flawed reproduction test was deleted from this branch — keeping only contracts that match real behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)