### PR TITLE
fix(mybookkeeper/deploy/Caddyfile): scope XFO + CSP frame-ancestors to SPA

### DIFF
--- a/apps/mybookkeeper/deploy/Caddyfile
+++ b/apps/mybookkeeper/deploy/Caddyfile
@@ -1,10 +1,14 @@
 165-245-134-251.sslip.io {
+    # Headers safe + useful on every response (HTML, JSON, binary).
+    # X-Frame-Options and CSP `frame-ancestors` are intentionally NOT here —
+    # they propagate to /api/* responses, and Chrome enforces the framing
+    # restrictions on blob URLs synthesized from those Responses, which
+    # blocks DocumentViewer's in-app PDF iframe in production. See the SPA
+    # handler below — the HTML document is the right place for those.
     header {
         Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
-        X-Frame-Options "DENY"
         X-Content-Type-Options "nosniff"
         Referrer-Policy "strict-origin-when-cross-origin"
-        Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://*.plaid.com https://us.i.posthog.com https://*.posthog.com; frame-src 'self' https://cdn.plaid.com https://us.posthog.com; frame-ancestors 'none'"
         -Server
     }
 
@@ -33,14 +37,22 @@
         reverse_proxy 127.0.0.1:8000
     }
 
-    # Proxy all other API requests to FastAPI
+    # Proxy all other API requests to FastAPI. API responses MUST NOT carry
+    # `X-Frame-Options: DENY` or CSP `frame-ancestors 'none'` — see the
+    # comment on the top-level header block above.
     handle /api/* {
         uri strip_prefix /api
         reverse_proxy 127.0.0.1:8000
     }
 
-    # Serve React frontend with SPA fallback
+    # Serve React frontend with SPA fallback. XFO + CSP `frame-ancestors`
+    # belong on the HTML document — that is the surface clickjacking attacks
+    # target. Same anti-clickjacking protection, scoped to the right place.
     handle {
+        header {
+            X-Frame-Options "DENY"
+            Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://*.plaid.com https://us.i.posthog.com https://*.posthog.com; frame-src 'self' https://cdn.plaid.com https://us.posthog.com; frame-ancestors 'none'"
+        }
         root * /srv/mybookkeeper/frontend/dist
         try_files {path} /index.html
         file_server


### PR DESCRIPTION
## Summary

PR #150 fixed the docker Caddyfile but production response headers still showed `X-Frame-Options: DENY` and CSP `frame-ancestors 'none'` on `/api/*` responses (visible as `Via: 1.1 Caddy` appearing twice). The HOST Caddy on the VPS — which sits in front of the docker Caddy — was independently re-adding those headers, so #150 alone didn't unblock the iframe.

This PR applies the same scoping fix to `apps/mybookkeeper/deploy/Caddyfile` (the host Caddy config). Same shape: XFO + `frame-ancestors` move to the SPA HTML handler; nosniff/HSTS/Referrer-Policy stay global.

## ⚠️ Manual VPS step required

This Caddyfile is **not** in any deploy workflow today. After merge, you need to run:

```bash
ssh <vps>
sudo cp /srv/myfreeapps/apps/mybookkeeper/deploy/Caddyfile /etc/caddy/Caddyfile
sudo systemctl reload caddy
```

(Or whatever your VPS's host Caddy config path actually is — `/etc/caddy/Caddyfile` is the standard Caddy install location.)

A follow-up PR should fold the host Caddyfile into the deploy workflow so this can't drift again.

## Verification after VPS reload

```bash
curl -sSI https://<your-domain>/api/health | grep -iE 'x-frame|frame-ancestors'
```

Expected: empty output (no XFO, no frame-ancestors). Before this PR the same command shows both directives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)