### PR TITLE
fix(mybookkeeper): never serve stale frontend bundles after deploy

### DIFF
--- a/apps/mybookkeeper/deploy/Caddyfile
+++ b/apps/mybookkeeper/deploy/Caddyfile
@@ -12,7 +12,11 @@
         -Server
     }
 
-    # Protect /api/docs and /api/openapi.json — IP + basic auth
+    # Protect /api/docs and /api/openapi.json — IP + basic auth.
+    # Forwards to docker Caddy on :8094 which then strips /api before
+    # forwarding to FastAPI. Do NOT strip /api here — double-stripping
+    # caused /api/* to fall through to docker Caddy's SPA handler and
+    # serve HTML instead of API responses (caught 2026-05-01).
     handle /api/docs* {
         @blocked not remote_ip {$ADMIN_ALLOWED_IP:127.0.0.1}
         respond @blocked 403
@@ -21,8 +25,7 @@
             admin $2b$12$cwJJJdX7H5h8n141BI4JKO92RbBcVYdQd6N7GAlTyTfJzCPCG3OJS
         }
 
-        uri strip_prefix /api
-        reverse_proxy 127.0.0.1:8000
+        reverse_proxy 127.0.0.1:8094
     }
 
     handle /api/openapi.json {
@@ -33,16 +36,14 @@
             admin $2b$12$cwJJJdX7H5h8n141BI4JKO92RbBcVYdQd6N7GAlTyTfJzCPCG3OJS
         }
 
-        uri strip_prefix /api
-        reverse_proxy 127.0.0.1:8000
+        reverse_proxy 127.0.0.1:8094
     }
 
-    # Proxy all other API requests to FastAPI. API responses MUST NOT carry
-    # `X-Frame-Options: DENY` or CSP `frame-ancestors 'none'` — see the
-    # comment on the top-level header block above.
+    # Proxy all other API requests to docker Caddy. API responses MUST NOT
+    # carry `X-Frame-Options: DENY` or CSP `frame-ancestors 'none'` — see
+    # the comment on the top-level header block above.
     handle /api/* {
-        uri strip_prefix /api
-        reverse_proxy 127.0.0.1:8000
+        reverse_proxy 127.0.0.1:8094
     }
 
     # Serve React frontend with SPA fallback. XFO + CSP `frame-ancestors`
@@ -51,8 +52,21 @@
     handle {
         header {
             X-Frame-Options "DENY"
-            Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://*.plaid.com https://us.i.posthog.com https://*.posthog.com; frame-src 'self' https://cdn.plaid.com https://us.posthog.com; frame-ancestors 'none'"
+            Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://*.plaid.com https://us.i.posthog.com https://*.posthog.com; frame-src 'self' blob: https://cdn.plaid.com https://us.posthog.com; frame-ancestors 'none'"
         }
+
+        # Cache strategy: never cache HTML / service worker (entry points
+        # that reference the latest asset bundles); cache content-hashed
+        # assets forever (Vite hashes the filename so it changes when
+        # content changes, making aggressive caching safe). Without this,
+        # browsers served stale bundles for weeks after each deploy —
+        # caught 2026-05-01 when prod was still running pre-2FA frontend.
+        @no_cache_html path / /index.html /sw.js /workbox-*.js /manifest.webmanifest /registerSW.js
+        header @no_cache_html Cache-Control "no-cache, no-store, must-revalidate"
+
+        @hashed_assets path_regexp \.[A-Za-z0-9_-]{8,}\.(js|css|woff2)$
+        header @hashed_assets Cache-Control "public, max-age=31536000, immutable"
+
         root * /srv/mybookkeeper/frontend/dist
         try_files {path} /index.html
         file_server

--- a/apps/mybookkeeper/docker/Caddyfile.docker
+++ b/apps/mybookkeeper/docker/Caddyfile.docker
@@ -66,6 +66,23 @@
                 X-Frame-Options "DENY"
                 Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://*.plaid.com https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://cdn.plaid.com https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
             }
+
+            # Cache strategy:
+            # - HTML and the service worker MUST never be cached. They are the
+            #   entry points that reference the latest asset bundles. If they
+            #   were cached, users would be stuck on old bundles forever after
+            #   a deploy (this happened 2026-05-01 — clients kept loading a
+            #   pre-2FA bundle weeks after the new one shipped because the SW
+            #   precached it and `index.html` was cached too).
+            # - Hashed assets (Vite content-hashes filenames like
+            #   `index-AbCd1234.js`) ARE safe to cache forever because the
+            #   filename changes whenever content changes.
+            @no_cache_html path / /index.html /sw.js /workbox-*.js /manifest.webmanifest /registerSW.js
+            header @no_cache_html Cache-Control "no-cache, no-store, must-revalidate"
+
+            @hashed_assets path_regexp \.[A-Za-z0-9_-]{8,}\.(js|css|woff2)$
+            header @hashed_assets Cache-Control "public, max-age=31536000, immutable"
+
             root * /srv/frontend
             try_files {path} /index.html
             file_server

--- a/apps/mybookkeeper/frontend/vite.config.ts
+++ b/apps/mybookkeeper/frontend/vite.config.ts
@@ -25,7 +25,23 @@ export default defineConfig({
         ],
       },
       workbox: {
-        globPatterns: ["**/*.{js,css,html,ico,png,svg,woff2}"],
+        // skipWaiting + clientsClaim: when a new service worker is installed,
+        // activate it immediately and take over open tabs instead of leaving
+        // the old SW serving stale precached assets until the user closes all
+        // tabs of the site. Without these, users can be stuck on a months-old
+        // bundle even after dozens of deploys (this is exactly what happened
+        // 2026-05-01 — the deployed `auth.ts` was so old it still posted to
+        // `/auth/jwt/login` instead of `/auth/totp/login`).
+        skipWaiting: true,
+        clientsClaim: true,
+        // Remove precaches from previous SW versions so old hashed bundles
+        // don't accumulate in the SW cache forever.
+        cleanupOutdatedCaches: true,
+        // Exclude index.html from precache. The HTML must always be fetched
+        // fresh so it points at the latest hashed asset bundles. Hashed
+        // assets are immutable (their content determines their filename) so
+        // they're safe to precache aggressively.
+        globPatterns: ["**/*.{js,css,ico,png,svg,woff2}"],
         runtimeCaching: [
           {
             urlPattern: /^https?:\/\/.*\/api\//,
@@ -33,6 +49,18 @@ export default defineConfig({
             options: {
               cacheName: "api-cache",
               expiration: { maxAgeSeconds: 300 },
+            },
+          },
+          {
+            // Always fetch index.html (and any document navigation) from the
+            // network so a fresh deploy is picked up on the next page load
+            // without requiring any client-side cache clear.
+            urlPattern: ({ request }) => request.mode === "navigate",
+            handler: "NetworkFirst",
+            options: {
+              cacheName: "html-cache",
+              networkTimeoutSeconds: 5,
+              expiration: { maxAgeSeconds: 0 },
             },
           },
         ],


### PR DESCRIPTION
## Summary

Root cause for the 2026-05-01 \"i can't login\" outage: production was serving a months-old frontend bundle that posted to `/auth/jwt/login` instead of `/auth/totp/login` (TOTP was added long ago). The underlying issue is **three failure modes stacked**:

1. The PWA service worker precached the old bundle and kept serving it — `skipWaiting`/`clientsClaim` were not enabled, so a new SW would install but never activate while any tab of the site was open
2. `index.html` had no `Cache-Control` headers, so browsers cached it indefinitely → users kept loading old hashed asset bundles even after dozens of deploys
3. CI never caught any of this because it doesn't probe the deployed bundle

**You were the canary.** That's not acceptable.

## What this changes

### Service worker auto-updates (`vite.config.ts`)
- `skipWaiting: true` + `clientsClaim: true` — new SW activates immediately and takes over open tabs
- `cleanupOutdatedCaches: true` — removes precaches from previous SW versions
- Drop `html` from precache + `NetworkFirst` for navigation requests — index.html is always fetched fresh

### Caddy cache headers (both `Caddyfile.docker` and `deploy/Caddyfile`)
- HTML / SW / manifest: `Cache-Control: no-cache, no-store, must-revalidate`
- Content-hashed assets: `Cache-Control: public, max-age=31536000, immutable`

### Host Caddyfile architecture sync (`deploy/Caddyfile`)
- Removed `uri strip_prefix /api` from all three /api handlers (was double-stripping with docker Caddy → /api/* served HTML instead of JSON)
- Updated `reverse_proxy` targets from `:8000` (pre-docker direct-to-FastAPI) to `:8094` (docker Caddy)
- Added `blob:` to `frame-src` to match docker Caddyfile

## Manual VPS step after merge

Same as PR #151 — host Caddyfile isn't in the deploy workflow yet:

```bash
sudo cp /srv/myfreeapps/apps/mybookkeeper/deploy/Caddyfile /etc/caddy/Caddyfile
sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
```

Plus rebuild the docker stack to pick up the new `Caddyfile.docker`:

```bash
docker compose -f /srv/myfreeapps/apps/mybookkeeper/docker-compose.yml restart caddy
```

## Verification after deploy

```bash
curl -sSI https://165-245-134-251.sslip.io/ | grep -i cache-control
# Expected: cache-control: no-cache, no-store, must-revalidate

curl -sSI https://165-245-134-251.sslip.io/$(curl -sS https://165-245-134-251.sslip.io/ | grep -oE 'index-[A-Za-z0-9_-]+\.js' | head -1) | grep -i cache-control
# Expected: cache-control: public, max-age=31536000, immutable
```

## Follow-ups (separate PRs)

- Fold host Caddyfile into the deploy workflow so `/etc/caddy/Caddyfile` on the VPS can't drift from source again
- Post-deploy smoke test: fetch `index.html`, extract hashed asset filenames, download the JS, assert it contains a known-recent string. Fails the deploy if the prod bundle is stale
- Cron job: weekly check that hashes of prod assets match the hashes from the latest main build artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)