### PR TITLE
ci(mybookkeeper/deploy): auto-sync host Caddyfile + verify bundle freshness

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -54,4 +54,43 @@ jobs:
               sleep 2
             done
 
+            echo "--- Update host Caddyfile ---"
+            # The host Caddy (TLS termination + routing on the VPS itself,
+            # NOT the docker Caddy in the container) historically lived only
+            # on the VPS as /etc/caddy/Caddyfile. That meant changes to
+            # `apps/mybookkeeper/deploy/Caddyfile` in this repo never
+            # propagated automatically — every CSP / header / proxy fix
+            # required a manual `sudo cp + sudo caddy reload` on the VPS.
+            # That gap caused the 2026-05-01 incident where the host Caddy
+            # ran a stale config (wrong reverse_proxy port, double-stripping
+            # /api, no cache-control headers) for an unknown number of
+            # weeks. Sync it as part of every deploy now.
+            if ! diff -q apps/mybookkeeper/deploy/Caddyfile /etc/caddy/Caddyfile > /dev/null 2>&1; then
+              echo "Host Caddyfile differs from repo — updating"
+              sudo cp apps/mybookkeeper/deploy/Caddyfile /etc/caddy/Caddyfile
+              sudo caddy validate --config /etc/caddy/Caddyfile --adapter caddyfile
+              sudo caddy reload --config /etc/caddy/Caddyfile --adapter caddyfile
+              echo "Host Caddy reloaded with new config"
+            else
+              echo "Host Caddyfile already up to date"
+            fi
+
+            echo "--- Verify deployed frontend bundle is fresh ---"
+            # Catch the class of bug from 2026-05-01 where the deployed
+            # bundle was months stale despite many "successful" deploys.
+            # Fetch the live index.html, extract the asset hash it points
+            # at, then verify that exact file exists in the docker volume.
+            # If they don't match, the volume didn't get repopulated by
+            # the api container's entrypoint (volume staleness bug).
+            DEPLOYED_JS=$(curl -sS http://127.0.0.1:8094/ | grep -oE 'index-[A-Za-z0-9_-]+\.js' | head -1)
+            if [ -z "$DEPLOYED_JS" ]; then
+              echo "Could not extract deployed JS hash from index.html — frontend serving may be broken"
+              exit 1
+            fi
+            if ! docker compose -f apps/mybookkeeper/docker-compose.yml exec -T caddy test -f "/srv/frontend/$DEPLOYED_JS"; then
+              echo "Deployed bundle ($DEPLOYED_JS) is missing from /srv/frontend — volume is stale"
+              exit 1
+            fi
+            echo "Deployed bundle: $DEPLOYED_JS (verified present in volume)"
+
             echo "--- Done ---"


### PR DESCRIPTION
## Summary

Two safety nets added to the Deploy MyBookkeeper workflow to prevent the class of bugs that caused the 2026-05-01 outage.

## 1. Host Caddyfile auto-sync

The VPS-side `/etc/caddy/Caddyfile` was never part of any deploy pipeline. Changes to `apps/mybookkeeper/deploy/Caddyfile` in the repo required a manual `sudo cp + sudo caddy reload` on the VPS — which nobody did between PRs #150 and #151. That's how the host Caddy ended up serving stale config (wrong reverse_proxy port, double-stripping `/api`, missing `blob:` in `frame-src`, no cache-control headers) for an unknown number of weeks.

The deploy now:
1. Diffs the repo Caddyfile against the live one
2. If they differ: `sudo cp` + `caddy validate` + `caddy reload`
3. If identical: skips silently

## 2. Deployed-bundle freshness check

Fetches the live `index.html` from the running stack, extracts the hashed JS filename it references (`index-AbCd1234.js`), and verifies that exact file exists in the docker volume. If not, **the deploy fails**.

This catches the volume-staleness regression where the api container's entrypoint failed to repopulate the volume after a rebuild — the exact thing that left production running a months-old frontend bundle. Now the deploy fails loudly instead of silently no-op'ing.

## After this lands

No more manual VPS steps after merging Caddy/CSP/PWA fixes. Every deploy:
- Pulls latest code
- Rebuilds + restarts docker stack
- Runs migrations
- Health-checks the API
- Syncs the host Caddyfile
- Verifies the deployed frontend bundle is fresh

If any step fails, the deploy fails — instead of cascading into a quiet stale-prod situation that only the user notices days later.

## Test plan

- [ ] On first deploy after merge, the workflow logs should show \"Host Caddyfile differs from repo — updating\" then a successful caddy reload
- [ ] On subsequent deploys with no Caddyfile changes, should show \"Host Caddyfile already up to date\"
- [ ] Bundle freshness check should print the deployed JS hash for traceability
- [ ] Deliberately breaking the volume sync (e.g. `docker volume rm`) should make the next deploy fail at the freshness check instead of silently shipping stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)