### PR TITLE
feat(myjobhunter/ui): briefcase favicon + dark mode theming

### DIFF
--- a/apps/myjobhunter/frontend/index.html
+++ b/apps/myjobhunter/frontend/index.html
@@ -2,7 +2,14 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="theme-color" content="#0f172a" />
+    <script>
+      // Apply dark/light theme BEFORE React hydrates to avoid a flash of the
+      // wrong theme on first paint. Mirrors apps/mybookkeeper/frontend/index.html.
+      // Storage key matches @platform/ui's useTheme() hook.
+      (function(){var t=localStorage.getItem("v1_theme");var d=t==="dark"||(t!=="light"&&matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")})();
+    </script>
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💼</text></svg>" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>MyJobHunter</title>
   </head>

--- a/apps/myjobhunter/frontend/src/RootLayout.tsx
+++ b/apps/myjobhunter/frontend/src/RootLayout.tsx
@@ -10,6 +10,7 @@ import {
 import { AppShell, RequireAuth, Toaster, useIsAuthenticated } from "@platform/ui";
 import { buildNav, buildBottomNav } from "@/constants/nav";
 import { signOut } from "@/lib/auth";
+import ThemeToggle from "@/components/ThemeToggle";
 
 // Decode basic user info from JWT for display in the shell's user menu.
 // This is display-only — no security decisions are made from client-side decode.
@@ -70,6 +71,7 @@ export default function RootLayout() {
         user={user}
         onSignOut={signOut}
         searchPlaceholder="Search applications, companies..."
+        headerActions={<ThemeToggle />}
       >
         <Outlet />
       </AppShell>

--- a/apps/myjobhunter/frontend/src/components/ThemeToggle.tsx
+++ b/apps/myjobhunter/frontend/src/components/ThemeToggle.tsx
@@ -1,0 +1,32 @@
+import { Sun, Moon, Monitor } from "lucide-react";
+import { useTheme } from "@platform/ui";
+
+const OPTIONS = [
+  { value: "light" as const, icon: Sun, label: "Light" },
+  { value: "dark" as const, icon: Moon, label: "Dark" },
+  { value: "system" as const, icon: Monitor, label: "System" },
+];
+
+export default function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  return (
+    <div className="flex items-center gap-0.5 rounded-md border p-0.5">
+      {OPTIONS.map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          onClick={() => setTheme(value)}
+          title={label}
+          aria-label={label}
+          className={`p-1.5 rounded transition-colors ${
+            theme === value
+              ? "bg-muted text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <Icon size={14} />
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Brings MJH visual chrome up to parity with MBK.

- **Favicon**: data-URL inline SVG of the briefcase emoji 💼 (was the Vite default `/vite.svg`, which didn't even exist in `public/`)
- **Dark mode**: boot script in `index.html` applies the `dark` class before React hydrates so there's no flash of light theme on first paint. Reads `v1_theme` from localStorage with `prefers-color-scheme` fallback. Storage key matches MBK / `@platform/ui`'s `useTheme`.
- **ThemeToggle**: 3-state Light/Dark/System toggle in the `AppShell` header (Sun/Moon/Monitor icons), wired via the existing `headerActions` prop. Uses the shared `useTheme` hook from `@platform/ui`.

CSS variables for the dark palette were already defined in `index.css` — this just adds the boot script + the UI to toggle them.

## Test plan

- [x] `npm run build` clean
- [ ] Browser: visit `/login` (or any page) — favicon shows briefcase
- [ ] Click Moon — dark mode applies; reload still dark
- [ ] Click Sun — light mode applies; reload still light
- [ ] Click Monitor — follows OS preference; toggle OS theme to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)