### PR TITLE
feat(myjobhunter): wire Companies list + detail pages

### DIFF
--- a/apps/myjobhunter/frontend/src/features/companies/AddCompanyDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/companies/AddCompanyDialog.tsx
@@ -1,0 +1,147 @@
+import { useEffect } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
+import { X } from "lucide-react";
+import { useCreateCompanyMutation } from "@/lib/companiesApi";
+import type { Company } from "@/types/company";
+
+interface FormValues {
+  name: string;
+  primary_domain: string;
+  industry: string;
+  hq_location: string;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /**
+   * Optional callback fired after a successful create. Useful for e.g.
+   * `AddApplicationDialog` to capture the new company id and pre-select
+   * it without re-opening the dialog. The standalone Companies page
+   * doesn't need this — the cache invalidation handles list refresh.
+   */
+  onCreated?: (company: Company) => void;
+}
+
+export default function AddCompanyDialog({ open, onOpenChange, onCreated }: Props) {
+  const [createCompany, { isLoading }] = useCreateCompanyMutation();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormValues>({
+    defaultValues: { name: "", primary_domain: "", industry: "", hq_location: "" },
+  });
+
+  // Reset on close so re-open starts fresh.
+  useEffect(() => {
+    if (!open) reset();
+  }, [open, reset]);
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    try {
+      const created = await createCompany({
+        name: values.name.trim(),
+        primary_domain: values.primary_domain.trim() || null,
+        industry: values.industry.trim() || null,
+        hq_location: values.hq_location.trim() || null,
+      }).unwrap();
+      showSuccess(`Company "${created.name}" added`);
+      onCreated?.(created);
+      onOpenChange(false);
+    } catch (err) {
+      showError(`Couldn't create company: ${extractErrorMessage(err)}`);
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md max-h-[90vh] overflow-y-auto bg-card border rounded-lg shadow-lg z-50 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <Dialog.Title className="text-lg font-semibold">Add company</Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Close"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Name <span className="text-destructive">*</span>
+              </label>
+              <input
+                type="text"
+                {...register("name", { required: "Name is required", minLength: 1 })}
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+                placeholder="e.g. Acme Corp"
+                autoFocus
+              />
+              {errors.name ? (
+                <p className="text-xs text-destructive mt-1">{errors.name.message}</p>
+              ) : null}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Domain</label>
+              <input
+                type="text"
+                {...register("primary_domain")}
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+                placeholder="acme.com"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Optional — must be unique across your companies if set.
+              </p>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium mb-1">Industry</label>
+                <input
+                  type="text"
+                  {...register("industry")}
+                  className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+                  placeholder="e.g. SaaS"
+                />
+              </div>
+              <div>
+                <label className="block text-sm font-medium mb-1">HQ location</label>
+                <input
+                  type="text"
+                  {...register("hq_location")}
+                  className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+                  placeholder="e.g. SF, NYC"
+                />
+              </div>
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="px-4 py-2 text-sm border rounded-md hover:bg-muted"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <LoadingButton type="submit" isLoading={isLoading} loadingText="Adding...">
+                Add company
+              </LoadingButton>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/myjobhunter/frontend/src/pages/Companies.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Companies.tsx
@@ -1,30 +1,118 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Building2 } from "lucide-react";
-import { EmptyState } from "@platform/ui";
+import { Building2, Plus } from "lucide-react";
+import { DataTable, EmptyState, type ColumnDef } from "@platform/ui";
 import CompaniesSkeleton from "@/features/companies/CompaniesSkeleton";
+import AddCompanyDialog from "@/features/companies/AddCompanyDialog";
+import { useListCompaniesQuery } from "@/lib/companiesApi";
 import { EMPTY_STATES } from "@/constants/empty-states";
+import type { Company } from "@/types/company";
 
-// Phase 1: no data yet — simulate instant load then show empty state
-const IS_LOADING = false;
+const COLUMNS: ColumnDef<Company>[] = [
+  {
+    id: "name",
+    header: "Name",
+    accessorKey: "name",
+    cell: ({ getValue }) => <span className="font-medium">{getValue<string>()}</span>,
+  },
+  {
+    id: "primary_domain",
+    header: "Domain",
+    accessorFn: (row) => row.primary_domain ?? "—",
+    cell: ({ getValue }) => (
+      <span className="text-sm text-muted-foreground">{getValue<string>()}</span>
+    ),
+  },
+  {
+    id: "industry",
+    header: "Industry",
+    accessorFn: (row) => row.industry ?? "—",
+    cell: ({ getValue }) => (
+      <span className="text-sm text-muted-foreground">{getValue<string>()}</span>
+    ),
+  },
+  {
+    id: "hq_location",
+    header: "HQ",
+    accessorFn: (row) => row.hq_location ?? "—",
+    cell: ({ getValue }) => (
+      <span className="text-sm text-muted-foreground">{getValue<string>()}</span>
+    ),
+  },
+];
 
 export default function Companies() {
   const navigate = useNavigate();
+  const { data, isLoading, isError, error } = useListCompaniesQuery();
+  const [dialogOpen, setDialogOpen] = useState(false);
   const copy = EMPTY_STATES.companies;
 
-  if (IS_LOADING) {
-    return <CompaniesSkeleton />;
+  function handleAddCompany() {
+    setDialogOpen(true);
+  }
+
+  if (isLoading) {
+    return (
+      <div className="p-6">
+        <CompaniesSkeleton />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="p-6">
+        <EmptyState
+          icon={<Building2 className="w-12 h-12 text-destructive" />}
+          heading="Couldn't load companies"
+          body={
+            error && typeof error === "object" && "status" in error
+              ? `The server returned ${(error as { status: number }).status}. Try refreshing.`
+              : "Try refreshing the page."
+          }
+        />
+      </div>
+    );
+  }
+
+  const items = data?.items ?? [];
+
+  if (items.length === 0) {
+    return (
+      <>
+        <div className="p-6">
+          <EmptyState
+            icon={<Building2 className="w-12 h-12" />}
+            heading={copy.heading}
+            body={copy.body}
+            action={{ label: "Add a company", onClick: handleAddCompany }}
+          />
+        </div>
+        <AddCompanyDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+      </>
+    );
   }
 
   return (
-    <div className="p-6">
-      <EmptyState
-        icon={<Building2 className="w-12 h-12" />}
-        heading={copy.heading}
-        body={copy.body}
-        action={{
-          label: copy.actionLabel,
-          onClick: () => navigate("/applications"),
-        }}
+    <div className="p-6 space-y-4">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Companies</h1>
+        <button
+          onClick={handleAddCompany}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 min-h-[44px]"
+        >
+          <Plus size={16} />
+          Add company
+        </button>
+      </header>
+
+      <AddCompanyDialog open={dialogOpen} onOpenChange={setDialogOpen} />
+
+      <DataTable<Company>
+        data={items}
+        columns={COLUMNS}
+        getRowId={(row) => row.id}
+        onRowClick={(row) => navigate(`/companies/${row.id}`)}
       />
     </div>
   );

--- a/apps/myjobhunter/frontend/src/pages/CompanyDetail.tsx
+++ b/apps/myjobhunter/frontend/src/pages/CompanyDetail.tsx
@@ -1,33 +1,154 @@
-import { useParams, Link } from "react-router-dom";
-import { ChevronLeft } from "lucide-react";
+import { useParams, Link, useNavigate } from "react-router-dom";
+import { ChevronLeft, ExternalLink as ExternalLinkIcon } from "lucide-react";
+import { Badge, DataTable, type ColumnDef } from "@platform/ui";
 import CompanyDetailSkeleton from "@/features/companies/CompanyDetailSkeleton";
+import { useGetCompanyQuery } from "@/lib/companiesApi";
+import { useListApplicationsQuery } from "@/lib/applicationsApi";
+import type { Application } from "@/types/application";
 
-// Phase 1: no real data — always shows 404 for any id
-const IS_LOADING = false;
+const APPLICATION_COLUMNS: ColumnDef<Application>[] = [
+  {
+    id: "role_title",
+    header: "Role",
+    accessorKey: "role_title",
+    cell: ({ getValue }) => <span className="font-medium">{getValue<string>()}</span>,
+  },
+  {
+    id: "location",
+    header: "Location",
+    accessorFn: (row) => row.location ?? "—",
+  },
+  {
+    id: "remote_type",
+    header: "Remote",
+    accessorKey: "remote_type",
+    cell: ({ getValue }) => {
+      const v = getValue<string>();
+      return <span className="text-sm text-muted-foreground">{v === "unknown" ? "—" : v}</span>;
+    },
+  },
+  {
+    id: "applied_at",
+    header: "Applied",
+    accessorFn: (row) => (row.applied_at ? new Date(row.applied_at).toLocaleDateString() : "—"),
+  },
+];
 
 export default function CompanyDetail() {
   const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data: company, isLoading, isError, error } = useGetCompanyQuery(id ?? "", { skip: !id });
+  const { data: applicationsData } = useListApplicationsQuery();
 
-  if (IS_LOADING) {
+  if (isLoading) {
     return <CompanyDetailSkeleton />;
   }
 
+  if (isError || !company) {
+    const status = error && typeof error === "object" && "status" in error ? (error as { status: number }).status : null;
+    return (
+      <div className="p-6 flex flex-col items-center text-center gap-4 py-20">
+        <p className="text-4xl font-bold text-muted-foreground">{status ?? 404}</p>
+        <h1 className="text-xl font-semibold">
+          {status === 404 || status === null
+            ? "I couldn't find that company — it may have been removed."
+            : "Couldn't load that company."}
+        </h1>
+        <p className="text-sm text-muted-foreground max-w-sm">
+          The company with id <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">{id}</code> isn&apos;t available.
+        </p>
+        <Link
+          to="/companies"
+          className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline mt-2"
+        >
+          <ChevronLeft className="w-4 h-4" />
+          Back to Companies
+        </Link>
+      </div>
+    );
+  }
+
+  // Filter applications that belong to this company (client-side; backend
+  // doesn't yet support ?company_id= filter on /applications).
+  const applicationsForCompany = (applicationsData?.items ?? []).filter(
+    (a) => a.company_id === company.id,
+  );
+
   return (
-    <div className="p-6 flex flex-col items-center text-center gap-4 py-20">
-      <p className="text-4xl font-bold text-muted-foreground">404</p>
-      <h1 className="text-xl font-semibold">
-        I couldn&apos;t find that company — it may have been removed.
-      </h1>
-      <p className="text-sm text-muted-foreground max-w-sm">
-        The company with id <code className="font-mono text-xs bg-muted px-1 py-0.5 rounded">{id}</code> doesn&apos;t exist.
-      </p>
+    <div className="p-6 max-w-3xl space-y-6">
       <Link
         to="/companies"
-        className="inline-flex items-center gap-1.5 text-sm font-medium text-primary hover:underline mt-2"
+        className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
       >
         <ChevronLeft className="w-4 h-4" />
         Back to Companies
       </Link>
+
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">{company.name}</h1>
+        {company.primary_domain ? (
+          <a
+            href={`https://${company.primary_domain}`}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm text-primary hover:underline"
+          >
+            <ExternalLinkIcon size={14} />
+            {company.primary_domain}
+          </a>
+        ) : null}
+        <div className="flex items-center gap-2 pt-1 flex-wrap">
+          {company.industry ? <Badge label={company.industry} color="blue" /> : null}
+          {company.size_range ? <Badge label={company.size_range} color="gray" /> : null}
+        </div>
+      </header>
+
+      <section className="border rounded-lg p-4 grid grid-cols-1 md:grid-cols-2 gap-3 text-sm">
+        <Field label="HQ" value={company.hq_location ?? "—"} />
+        <Field
+          label="Created"
+          value={new Date(company.created_at).toLocaleDateString()}
+        />
+        <Field label="Domain" value={company.primary_domain ?? "—"} />
+        <Field label="Industry" value={company.industry ?? "—"} />
+      </section>
+
+      {company.description ? (
+        <section>
+          <h2 className="text-sm font-medium mb-2">Description</h2>
+          <p className="text-sm whitespace-pre-wrap text-muted-foreground border rounded-lg p-3 bg-muted/30">
+            {company.description}
+          </p>
+        </section>
+      ) : null}
+
+      <section>
+        <h2 className="text-sm font-medium mb-2">
+          Applications at {company.name}{" "}
+          <span className="text-muted-foreground font-normal">({applicationsForCompany.length})</span>
+        </h2>
+        {applicationsForCompany.length === 0 ? (
+          <p className="text-sm text-muted-foreground border rounded-lg p-3 bg-muted/30">
+            No applications at this company yet.
+          </p>
+        ) : (
+          <DataTable<Application>
+            data={applicationsForCompany}
+            columns={APPLICATION_COLUMNS}
+            getRowId={(row) => row.id}
+            onRowClick={(row) => navigate(`/applications/${row.id}`)}
+          />
+        )}
+      </section>
+    </div>
+  );
+}
+
+function Field({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <p className="text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className="font-medium">{value}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Phase 3 — first slice of the Companies domain. Mirrors the Phase 2 Applications wiring exactly.

## What ships

- **`pages/Companies.tsx`** — replaces Phase 1 empty-state stub with `useListCompaniesQuery` + `DataTable` + skeleton / empty / error branches. Add Company button on both branches.
- **`pages/CompanyDetail.tsx`** — `useGetCompanyQuery` driven detail page. Header, fields grid, description, plus an \"Applications at {company}\" section that filters the existing applications list client-side. Row click navigates to ApplicationDetail.
- **`features/companies/AddCompanyDialog.tsx`** — standalone Radix Dialog + React Hook Form for company creation. Used by the Companies page now; can later replace the inline new-company panel inside `AddApplicationDialog` (left in place to keep this PR focused).

## End-to-end flow

1. Companies page → empty → \"Add a company\"
2. Dialog → fill name → submit → row appears in DataTable
3. Click row → CompanyDetail → see header + applications-at-company list
4. Click application row → ApplicationDetail (existing)

## Test plan

- [x] `npm run build --workspace=myjobhunter-frontend` clean
- [ ] CI frontend-build green
- [ ] Manual: full happy-path flow (above)
- [ ] Manual: empty state → add → list state transition

## Future cleanup (separate PR)

Refactor `AddApplicationDialog`'s inline \"+ New company\" panel to use this `AddCompanyDialog` component for consistency. Functional today, just duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)