### PR TITLE
feat(myjobhunter/backend): application_events list + log endpoints

### DIFF
--- a/apps/myjobhunter/backend/app/api/applications.py
+++ b/apps/myjobhunter/backend/app/api/applications.py
@@ -28,6 +28,8 @@ from app.core.auth import current_active_user
 from app.db.session import get_db
 from app.models.user.user import User
 from app.schemas.application.application_create_request import ApplicationCreateRequest
+from app.schemas.application.application_event_create_request import ApplicationEventCreateRequest
+from app.schemas.application.application_event_response import ApplicationEventResponse
 from app.schemas.application.application_response import ApplicationResponse
 from app.schemas.application.application_update_request import ApplicationUpdateRequest
 from app.services.application import application_service
@@ -139,3 +141,53 @@ async def delete_application(
     if not deleted:
         raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
     return Response(status_code=204)
+
+
+@router.get("/applications/{application_id}/events")
+async def list_application_events(
+    application_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> dict:
+    """Return events for an application, newest first.
+
+    Returns 404 if the application is missing or belongs to another user
+    (no existence leak — same response as a genuine miss). Response
+    shape mirrors the list endpoints: ``{"items": [...], "total": int}``.
+    """
+    events = await application_service.list_application_events(db, user.id, application_id)
+    if events is None:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
+    return {
+        "items": [
+            ApplicationEventResponse.model_validate(e).model_dump(mode="json") for e in events
+        ],
+        "total": len(events),
+    }
+
+
+@router.post(
+    "/applications/{application_id}/events",
+    response_model=ApplicationEventResponse,
+    status_code=201,
+)
+async def create_application_event(
+    application_id: uuid.UUID,
+    payload: ApplicationEventCreateRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> ApplicationEventResponse:
+    """Log a new event against an application.
+
+    Returns 404 if the application is missing or belongs to another user.
+    422 on schema violations (event_type not in enum, source not in enum,
+    extra fields). Idempotency for sync-imported events lives on the
+    UNIQUE(user_id, email_message_id) constraint — manual events
+    intentionally don't carry email_message_id and so always insert.
+    """
+    event = await application_service.log_application_event(
+        db, user.id, application_id, payload,
+    )
+    if event is None:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
+    return ApplicationEventResponse.model_validate(event)

--- a/apps/myjobhunter/backend/app/repositories/application/application_event_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/application/application_event_repository.py
@@ -1,0 +1,57 @@
+"""Repository for ``application_events`` — the immutable event log per
+application.
+
+Per the data model: events are an INSERT-only table with no soft delete.
+Status is computed by lateral join on (application_id, occurred_at DESC) —
+NEVER stored as a column on applications.
+
+Tenant scoping is mandatory — every public function takes ``user_id`` and
+filters by it. Events also carry their own ``user_id`` (denormalized from
+the parent application) so tenant filters short-circuit without a join
+back to applications.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application.application_event import ApplicationEvent
+
+
+async def list_by_application(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+) -> list[ApplicationEvent]:
+    """Return events for an application, newest first.
+
+    Filters by both ``user_id`` and ``application_id`` so a malicious
+    caller passing another user's application_id sees an empty list (the
+    route layer's existence check on the parent application is the
+    canonical no-leak boundary; this is defense in depth).
+    """
+    result = await db.execute(
+        select(ApplicationEvent)
+        .where(
+            ApplicationEvent.user_id == user_id,
+            ApplicationEvent.application_id == application_id,
+        )
+        .order_by(ApplicationEvent.occurred_at.desc()),
+    )
+    return list(result.scalars().all())
+
+
+async def create(db: AsyncSession, event: ApplicationEvent) -> ApplicationEvent:
+    """Persist a new ``ApplicationEvent``.
+
+    The caller (service layer) sets ``user_id``, ``application_id``,
+    ``event_type``, ``occurred_at``, ``source`` from the validated request
+    context. The repo intentionally takes a fully-constructed ORM
+    instance — keeps field validation in one place (schema + service).
+    """
+    db.add(event)
+    await db.flush()
+    await db.refresh(event)
+    return event

--- a/apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py
@@ -1,0 +1,45 @@
+"""Pydantic schema for POST /applications/{id}/events request body.
+
+Mirrors the writable columns on ``ApplicationEvent``. ``user_id``,
+``application_id``, ``email_message_id`` (Gmail-sync only),
+``raw_payload`` (Gmail-sync only) are NOT accepted via the manual-log
+route — they're set by the service layer from request context or by
+background sync workers. ``extra='forbid'`` rejects attempts to inject
+them.
+
+``event_type`` and ``source`` are validated against the enum allowlists
+in ``app.core.enums`` to match the DB CHECK constraints.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from app.core.enums import EventType, EventSource
+
+_EVENT_TYPE_MAX_LEN = 30
+_SOURCE_MAX_LEN = 20
+
+
+class ApplicationEventCreateRequest(BaseModel):
+    """Body for POST /applications/{application_id}/events."""
+
+    event_type: str = Field(min_length=1, max_length=_EVENT_TYPE_MAX_LEN)
+    occurred_at: _dt.datetime
+    source: str = Field(default=EventSource.MANUAL, max_length=_SOURCE_MAX_LEN)
+    note: str | None = None
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_enums(self) -> "ApplicationEventCreateRequest":
+        if self.event_type not in EventType.ALL:
+            raise ValueError(
+                f"event_type must be one of {EventType.ALL}, got {self.event_type!r}",
+            )
+        if self.source not in EventSource.ALL:
+            raise ValueError(
+                f"source must be one of {EventSource.ALL}, got {self.source!r}",
+            )
+        return self

--- a/apps/myjobhunter/backend/app/schemas/application/application_event_response.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_event_response.py
@@ -1,0 +1,29 @@
+"""Pydantic schema for an ApplicationEvent response.
+
+Used by GET /applications/{id}/events and POST /applications/{id}/events.
+``raw_payload`` and ``email_message_id`` are exposed read-only — they
+only get populated by Gmail sync workers, never by manual log entries.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ApplicationEventResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    application_id: uuid.UUID
+
+    event_type: str
+    occurred_at: _dt.datetime
+    source: str
+    email_message_id: str | None = None
+    raw_payload: dict | None = None
+    note: str | None = None
+
+    created_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/myjobhunter/backend/app/services/application/application_service.py
+++ b/apps/myjobhunter/backend/app/services/application/application_service.py
@@ -21,9 +21,11 @@ import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.application.application import Application
-from app.repositories.application import application_repository
+from app.models.application.application_event import ApplicationEvent
+from app.repositories.application import application_repository, application_event_repository
 from app.repositories.company import company_repository
 from app.schemas.application.application_create_request import ApplicationCreateRequest
+from app.schemas.application.application_event_create_request import ApplicationEventCreateRequest
 from app.schemas.application.application_update_request import ApplicationUpdateRequest
 
 
@@ -136,3 +138,52 @@ async def soft_delete_application(
     await application_repository.soft_delete(db, application)
     await db.commit()
     return True
+
+
+async def list_application_events(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+) -> list[ApplicationEvent] | None:
+    """Return events for ``application_id`` ordered newest-first.
+
+    Returns ``None`` if the application does not exist under ``user_id``
+    so the route layer can map to HTTP 404 with no existence leak. Soft-
+    deleted applications also return ``None`` — events are not visible
+    after the parent application is deleted.
+    """
+    application = await application_repository.get_by_id(db, application_id, user_id)
+    if application is None:
+        return None
+    return await application_event_repository.list_by_application(db, user_id, application_id)
+
+
+async def log_application_event(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+    request: ApplicationEventCreateRequest,
+) -> ApplicationEvent | None:
+    """Persist a new event against an application.
+
+    Returns ``None`` if the application does not exist under ``user_id``
+    (route layer maps to 404). The event's ``user_id`` is denormalized
+    from the parent application; the route never trusts a body-provided
+    ``user_id`` (the schema's ``extra='forbid'`` rejects it anyway).
+
+    Commits at the end so the write survives the request lifecycle.
+    """
+    application = await application_repository.get_by_id(db, application_id, user_id)
+    if application is None:
+        return None
+    event = ApplicationEvent(
+        user_id=user_id,
+        application_id=application_id,
+        event_type=request.event_type,
+        occurred_at=request.occurred_at,
+        source=request.source,
+        note=request.note,
+    )
+    event = await application_event_repository.create(db, event)
+    await db.commit()
+    return event

--- a/apps/myjobhunter/backend/tests/test_application_events.py
+++ b/apps/myjobhunter/backend/tests/test_application_events.py
@@ -1,0 +1,215 @@
+"""Tests for ``application_events`` routes (Phase 3).
+
+Covers:
+- POST /applications/{id}/events: happy path 201 + payload, schema
+  validation (422), unauthenticated (401), cross-tenant (404).
+- GET /applications/{id}/events: returns newest-first events scoped to
+  the caller, no events leaked across tenants, 404 for cross-tenant.
+
+Mirrors the conftest fixture pattern from test_application_writes.py.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.company.company import Company
+
+
+async def _create_company(db: AsyncSession, user_id: uuid.UUID, name: str) -> Company:
+    company = Company(user_id=user_id, name=name, primary_domain=f"{name.lower().replace(' ', '-')}.example.com")
+    db.add(company)
+    await db.commit()
+    await db.refresh(company)
+    return company
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+
+def _app_payload(company_id: uuid.UUID) -> dict:
+    return {
+        "company_id": str(company_id),
+        "role_title": "Senior Backend Engineer",
+        "source": "linkedin",
+        "remote_type": "remote",
+    }
+
+
+def _event_payload(event_type: str = "applied", **overrides) -> dict:
+    payload: dict = {
+        "event_type": event_type,
+        "occurred_at": _now_iso(),
+        "source": "manual",
+    }
+    payload.update(overrides)
+    return payload
+
+
+# ---------------------------------------------------------------------------
+# POST /applications/{id}/events
+# ---------------------------------------------------------------------------
+
+
+class TestCreateEvent:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_201(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            assert create_app.status_code == 201
+            app_id = create_app.json()["id"]
+
+            resp = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload("applied", note="Submitted via website"),
+            )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["application_id"] == app_id
+        assert body["event_type"] == "applied"
+        assert body["source"] == "manual"
+        assert body["note"] == "Submitted via website"
+        assert body["email_message_id"] is None
+
+    @pytest.mark.asyncio
+    async def test_invalid_event_type_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            resp = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload("not_a_real_type"),
+            )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_extra_field_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+            # Try to inject email_message_id (only sync workers should set this).
+            payload = _event_payload("applied")
+            payload["email_message_id"] = "<gmail-id-123>"
+
+            resp = await authed.post(f"/applications/{app_id}/events", json=payload)
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_returns_404(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        owner = await user_factory()
+        attacker = await user_factory()
+        company = await _create_company(db, uuid.UUID(owner["id"]), "Acme")
+
+        async with await as_user(owner) as authed_owner:
+            create_app = await authed_owner.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+        async with await as_user(attacker) as authed_attacker:
+            resp = await authed_attacker.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload("applied"),
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        resp = await client.post(
+            f"/applications/{uuid.uuid4()}/events",
+            json=_event_payload("applied"),
+        )
+        assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# GET /applications/{id}/events
+# ---------------------------------------------------------------------------
+
+
+class TestListEvents:
+    @pytest.mark.asyncio
+    async def test_returns_newest_first(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+            old = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload(
+                    "applied",
+                    occurred_at=_dt.datetime(2026, 1, 1, tzinfo=_dt.timezone.utc).isoformat(),
+                ),
+            )
+            assert old.status_code == 201
+
+            new = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload(
+                    "interview_scheduled",
+                    occurred_at=_dt.datetime(2026, 2, 1, tzinfo=_dt.timezone.utc).isoformat(),
+                ),
+            )
+            assert new.status_code == 201
+
+            list_resp = await authed.get(f"/applications/{app_id}/events")
+
+        assert list_resp.status_code == 200
+        body = list_resp.json()
+        assert body["total"] == 2
+        # Newest first.
+        assert body["items"][0]["event_type"] == "interview_scheduled"
+        assert body["items"][1]["event_type"] == "applied"
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_returns_404(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        owner = await user_factory()
+        attacker = await user_factory()
+        company = await _create_company(db, uuid.UUID(owner["id"]), "Acme")
+
+        async with await as_user(owner) as authed_owner:
+            create_app = await authed_owner.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            await authed_owner.post(f"/applications/{app_id}/events", json=_event_payload("applied"))
+
+        async with await as_user(attacker) as authed_attacker:
+            resp = await authed_attacker.get(f"/applications/{app_id}/events")
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        resp = await client.get(f"/applications/{uuid.uuid4()}/events")
+        assert resp.status_code == 401


### PR DESCRIPTION
## Summary

Phase 3 backend — adds the event-log surface that will drive the application status timeline on the frontend.

Per the data model (`apps/myjobhunter/CLAUDE.md`): events are an INSERT-only audit log; status is computed by lateral join on `(application_id, occurred_at DESC)`. We do NOT store status as a column on `applications`.

## Endpoints

- `GET /applications/{id}/events` — newest first, scoped to caller. 404 if the parent application is missing or cross-tenant (no leak).
- `POST /applications/{id}/events` — manual log entry. `event_type` + `source` validated against the enum allowlists. `extra='forbid'` on the schema rejects `email_message_id` / `raw_payload` injection from manual clients (those columns are only set by Gmail sync workers).

## Files

- `repositories/application/application_event_repository.py` — list + create.
- `schemas/application/application_event_create_request.py` — body validator with enum gates.
- `schemas/application/application_event_response.py` — read shape.
- `services/application/application_service.py` — `list_application_events` + `log_application_event` (both check parent ownership first).
- `tests/test_application_events.py` — happy path, 422 on bad enum / extra field, 404 cross-tenant, 401 unauth, newest-first ordering.

## Test plan

- [x] Routes import + register cleanly
- [ ] Backend pytest passes in CI

## Next

Frontend wiring (separate PR): `applicationEventsApi` slice + Timeline section on `ApplicationDetail` + `LogEventDialog`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)