### PR TITLE
feat(myjobhunter): event timeline + log dialog on ApplicationDetail

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
@@ -1,0 +1,157 @@
+import { useEffect } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { useForm, type SubmitHandler } from "react-hook-form";
+import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
+import { X } from "lucide-react";
+import { useLogApplicationEventMutation } from "@/lib/applicationsApi";
+import type { ApplicationEventType } from "@/types/application-event";
+
+const EVENT_TYPE_OPTIONS: { value: ApplicationEventType; label: string }[] = [
+  { value: "applied", label: "Applied" },
+  { value: "interview_scheduled", label: "Interview scheduled" },
+  { value: "interview_completed", label: "Interview completed" },
+  { value: "offer_received", label: "Offer received" },
+  { value: "rejected", label: "Rejected" },
+  { value: "withdrawn", label: "Withdrawn" },
+  { value: "ghosted", label: "Ghosted" },
+  { value: "note_added", label: "Note added" },
+  // `email_received` intentionally omitted from manual logging — that's
+  // the Gmail sync worker's lane.
+];
+
+interface FormValues {
+  event_type: ApplicationEventType;
+  occurred_at: string;
+  note: string;
+}
+
+function defaultOccurredAt(): string {
+  // datetime-local input expects YYYY-MM-DDTHH:mm without timezone.
+  const now = new Date();
+  const tzOffsetMs = now.getTimezoneOffset() * 60_000;
+  const local = new Date(now.getTime() - tzOffsetMs);
+  return local.toISOString().slice(0, 16);
+}
+
+interface Props {
+  applicationId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function LogEventDialog({ applicationId, open, onOpenChange }: Props) {
+  const [logEvent, { isLoading }] = useLogApplicationEventMutation();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormValues>({
+    defaultValues: {
+      event_type: "applied",
+      occurred_at: defaultOccurredAt(),
+      note: "",
+    },
+  });
+
+  useEffect(() => {
+    if (!open) reset({ event_type: "applied", occurred_at: defaultOccurredAt(), note: "" });
+  }, [open, reset]);
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    try {
+      // datetime-local is naive; promote to UTC ISO so the backend stores
+      // a tz-aware datetime.
+      const occurredIso = new Date(values.occurred_at).toISOString();
+      await logEvent({
+        applicationId,
+        body: {
+          event_type: values.event_type,
+          occurred_at: occurredIso,
+          source: "manual",
+          note: values.note.trim() || null,
+        },
+      }).unwrap();
+      showSuccess("Event logged");
+      onOpenChange(false);
+    } catch (err) {
+      showError(`Couldn't log event: ${extractErrorMessage(err)}`);
+    }
+  };
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md max-h-[90vh] overflow-y-auto bg-card border rounded-lg shadow-lg z-50 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <Dialog.Title className="text-lg font-semibold">Log event</Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                aria-label="Close"
+                className="text-muted-foreground hover:text-foreground"
+              >
+                <X size={18} />
+              </button>
+            </Dialog.Close>
+          </div>
+
+          <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Event <span className="text-destructive">*</span>
+              </label>
+              <select
+                {...register("event_type", { required: true })}
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+              >
+                {EVENT_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                When <span className="text-destructive">*</span>
+              </label>
+              <input
+                type="datetime-local"
+                {...register("occurred_at", { required: "Date is required" })}
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+              />
+              {errors.occurred_at ? (
+                <p className="text-xs text-destructive mt-1">{errors.occurred_at.message}</p>
+              ) : null}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Note</label>
+              <textarea
+                {...register("note")}
+                rows={3}
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+                placeholder="Anything to remember about this event..."
+              />
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <Dialog.Close asChild>
+                <button
+                  type="button"
+                  className="px-4 py-2 text-sm border rounded-md hover:bg-muted"
+                >
+                  Cancel
+                </button>
+              </Dialog.Close>
+              <LoadingButton type="submit" isLoading={isLoading} loadingText="Logging...">
+                Log event
+              </LoadingButton>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/myjobhunter/frontend/src/lib/applicationsApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/applicationsApi.ts
@@ -2,10 +2,16 @@ import { baseApi } from "@platform/ui";
 import type { Application } from "@/types/application";
 import type { ApplicationListResponse } from "@/types/application-list-response";
 import type { ApplicationCreateRequest } from "@/types/application-create-request";
+import type { ApplicationEvent } from "@/types/application-event";
+import type { ApplicationEventCreateRequest } from "@/types/application-event-create-request";
+import type { ApplicationEventListResponse } from "@/types/application-event-list-response";
 
 const APPLICATIONS_TAG = "Applications";
+const APPLICATION_EVENTS_TAG = "ApplicationEvents";
 
-const applicationsApi = baseApi.enhanceEndpoints({ addTagTypes: [APPLICATIONS_TAG] }).injectEndpoints({
+const applicationsApi = baseApi.enhanceEndpoints({
+  addTagTypes: [APPLICATIONS_TAG, APPLICATION_EVENTS_TAG],
+}).injectEndpoints({
   endpoints: (build) => ({
     listApplications: build.query<ApplicationListResponse, void>({
       query: () => ({ url: "/applications", method: "GET" }),
@@ -46,6 +52,30 @@ const applicationsApi = baseApi.enhanceEndpoints({ addTagTypes: [APPLICATIONS_TA
         { type: APPLICATIONS_TAG, id: "LIST" },
       ],
     }),
+
+    listApplicationEvents: build.query<ApplicationEventListResponse, string>({
+      query: (applicationId) => ({
+        url: `/applications/${applicationId}/events`,
+        method: "GET",
+      }),
+      providesTags: (_result, _err, applicationId) => [
+        { type: APPLICATION_EVENTS_TAG, id: applicationId },
+      ],
+    }),
+
+    logApplicationEvent: build.mutation<
+      ApplicationEvent,
+      { applicationId: string; body: ApplicationEventCreateRequest }
+    >({
+      query: ({ applicationId, body }) => ({
+        url: `/applications/${applicationId}/events`,
+        method: "POST",
+        data: body,
+      }),
+      invalidatesTags: (_result, _err, { applicationId }) => [
+        { type: APPLICATION_EVENTS_TAG, id: applicationId },
+      ],
+    }),
   }),
 });
 
@@ -55,4 +85,6 @@ export const {
   useCreateApplicationMutation,
   useUpdateApplicationMutation,
   useDeleteApplicationMutation,
+  useListApplicationEventsQuery,
+  useLogApplicationEventMutation,
 } = applicationsApi;

--- a/apps/myjobhunter/frontend/src/pages/ApplicationDetail.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ApplicationDetail.tsx
@@ -1,9 +1,47 @@
+import { useState } from "react";
 import { useParams, Link, useNavigate } from "react-router-dom";
-import { ChevronLeft, Trash2, ExternalLink as ExternalLinkIcon } from "lucide-react";
+import { ChevronLeft, Trash2, ExternalLink as ExternalLinkIcon, Plus } from "lucide-react";
 import { Badge, showSuccess, showError, extractErrorMessage } from "@platform/ui";
 import ApplicationDetailSkeleton from "@/features/applications/ApplicationDetailSkeleton";
-import { useGetApplicationQuery, useDeleteApplicationMutation } from "@/lib/applicationsApi";
+import LogEventDialog from "@/features/applications/LogEventDialog";
+import {
+  useGetApplicationQuery,
+  useDeleteApplicationMutation,
+  useListApplicationEventsQuery,
+} from "@/lib/applicationsApi";
 import { useGetCompanyQuery } from "@/lib/companiesApi";
+import type { ApplicationEvent, ApplicationEventType } from "@/types/application-event";
+
+const EVENT_LABELS: Record<ApplicationEventType, string> = {
+  applied: "Applied",
+  email_received: "Email received",
+  interview_scheduled: "Interview scheduled",
+  interview_completed: "Interview completed",
+  rejected: "Rejected",
+  offer_received: "Offer received",
+  withdrawn: "Withdrawn",
+  ghosted: "Ghosted",
+  note_added: "Note",
+};
+
+const EVENT_BADGE_COLOR: Record<ApplicationEventType, "gray" | "blue" | "yellow" | "green" | "red" | "purple"> = {
+  applied: "blue",
+  email_received: "gray",
+  interview_scheduled: "yellow",
+  interview_completed: "yellow",
+  rejected: "red",
+  offer_received: "green",
+  withdrawn: "gray",
+  ghosted: "gray",
+  note_added: "purple",
+};
+
+function deriveStatus(events: ApplicationEvent[] | undefined): ApplicationEventType | null {
+  if (!events || events.length === 0) return null;
+  // Events come back newest-first; the latest non-note event drives status.
+  const meaningful = events.find((e) => e.event_type !== "note_added");
+  return meaningful?.event_type ?? null;
+}
 
 function formatDate(iso: string | null): string {
   if (!iso) return "—";
@@ -30,7 +68,12 @@ export default function ApplicationDetail() {
   const { data: company } = useGetCompanyQuery(app?.company_id ?? "", {
     skip: !app?.company_id,
   });
+  const { data: eventsData } = useListApplicationEventsQuery(id ?? "", { skip: !id });
   const [deleteApplication, { isLoading: deleting }] = useDeleteApplicationMutation();
+  const [logEventOpen, setLogEventOpen] = useState(false);
+
+  const events = eventsData?.items ?? [];
+  const status = deriveStatus(events);
 
   if (isLoading) {
     return <ApplicationDetailSkeleton />;
@@ -92,6 +135,9 @@ export default function ApplicationDetail() {
             {app.location ? ` · ${app.location}` : ""}
           </p>
           <div className="flex items-center gap-2 pt-1 flex-wrap">
+            {status ? (
+              <Badge label={EVENT_LABELS[status]} color={EVENT_BADGE_COLOR[status]} />
+            ) : null}
             {app.archived ? <Badge label="Archived" color="gray" /> : null}
             {app.remote_type !== "unknown" ? <Badge label={app.remote_type} color="blue" /> : null}
             {app.source ? <Badge label={app.source} color="purple" /> : null}
@@ -146,6 +192,60 @@ export default function ApplicationDetail() {
           </p>
         </section>
       ) : null}
+
+      <section>
+        <header className="flex items-center justify-between mb-3">
+          <h2 className="text-sm font-medium">
+            Timeline{" "}
+            <span className="text-muted-foreground font-normal">({events.length})</span>
+          </h2>
+          <button
+            onClick={() => setLogEventOpen(true)}
+            className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs border rounded-md hover:bg-muted"
+          >
+            <Plus size={12} />
+            Log event
+          </button>
+        </header>
+        {events.length === 0 ? (
+          <p className="text-sm text-muted-foreground border rounded-lg p-3 bg-muted/30">
+            No events yet. Log the first one to start tracking this application's status.
+          </p>
+        ) : (
+          <ol className="space-y-2">
+            {events.map((event) => (
+              <li
+                key={event.id}
+                className="border rounded-lg p-3 bg-muted/20"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <Badge
+                    label={EVENT_LABELS[event.event_type]}
+                    color={EVENT_BADGE_COLOR[event.event_type]}
+                  />
+                  <span className="text-xs text-muted-foreground">
+                    {formatDate(event.occurred_at)}
+                  </span>
+                </div>
+                {event.note ? (
+                  <p className="text-sm mt-2 whitespace-pre-wrap">{event.note}</p>
+                ) : null}
+                {event.source !== "manual" ? (
+                  <p className="text-xs text-muted-foreground mt-1">
+                    via {event.source}
+                  </p>
+                ) : null}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+
+      <LogEventDialog
+        applicationId={app.id}
+        open={logEventOpen}
+        onOpenChange={setLogEventOpen}
+      />
     </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/types/application-event-create-request.ts
+++ b/apps/myjobhunter/frontend/src/types/application-event-create-request.ts
@@ -1,0 +1,12 @@
+import type { ApplicationEventType, ApplicationEventSource } from "./application-event";
+
+/**
+ * Body for POST /applications/{id}/events. Mirrors `ApplicationEventCreateRequest`
+ * in apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py.
+ */
+export interface ApplicationEventCreateRequest {
+  event_type: ApplicationEventType;
+  occurred_at: string;
+  source?: ApplicationEventSource;
+  note?: string | null;
+}

--- a/apps/myjobhunter/frontend/src/types/application-event-list-response.ts
+++ b/apps/myjobhunter/frontend/src/types/application-event-list-response.ts
@@ -1,0 +1,10 @@
+import type { ApplicationEvent } from "./application-event";
+
+/**
+ * Shape of `GET /applications/{id}/events`. Same `{items, total}` envelope
+ * as `/applications` and `/companies` for consistency.
+ */
+export interface ApplicationEventListResponse {
+  items: ApplicationEvent[];
+  total: number;
+}

--- a/apps/myjobhunter/frontend/src/types/application-event.ts
+++ b/apps/myjobhunter/frontend/src/types/application-event.ts
@@ -1,0 +1,35 @@
+/**
+ * TypeScript model for an ApplicationEvent as returned by the MJH backend.
+ * Mirrors `ApplicationEventResponse` in
+ * apps/myjobhunter/backend/app/schemas/application/application_event_response.py.
+ */
+export type ApplicationEventType =
+  | "applied"
+  | "email_received"
+  | "interview_scheduled"
+  | "interview_completed"
+  | "rejected"
+  | "offer_received"
+  | "withdrawn"
+  | "ghosted"
+  | "note_added";
+
+export type ApplicationEventSource =
+  | "manual"
+  | "gmail"
+  | "calendar"
+  | "extension"
+  | "system";
+
+export interface ApplicationEvent {
+  id: string;
+  user_id: string;
+  application_id: string;
+  event_type: ApplicationEventType;
+  occurred_at: string;
+  source: ApplicationEventSource;
+  email_message_id: string | null;
+  raw_payload: Record<string, unknown> | null;
+  note: string | null;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

Phase 3 frontend — drives the \"what's happened on this application\" timeline off the backend's `application_events` log shipped in #162.

## What ships

- **Types**: ApplicationEvent, ApplicationEventCreateRequest, ApplicationEventListResponse + the ApplicationEventType / ApplicationEventSource string-literal unions.
- **applicationsApi** gains `listApplicationEvents` + `logApplicationEvent` endpoints under a new `ApplicationEvents` cache tag (separate from `Applications` so logging an event doesn't refetch the whole list).
- **LogEventDialog** — Radix Dialog + React Hook Form. `datetime-local` input promoted to UTC ISO at submit. `event_type` select restricted to 8 manually-loggable types (`email_received` intentionally omitted — that's Gmail sync's lane).
- **ApplicationDetail** picks up:
  - Status badge in the header derived from the latest non-note event
  - \"Timeline\" section: per-event cards with badge, occurred_at, optional note, source attribution when not \"manual\"
  - \"+ Log event\" button to open the dialog
  - Empty timeline copy when no events yet

## End-to-end Phase 3 flow

1. Open an application → see empty timeline
2. Click \"Log event\" → dialog → pick \"Applied\", set datetime, note
3. Submit → toast → row appears in timeline
4. Header status badge updates to match the latest event

## Test plan

- [x] `npm run build --workspace=myjobhunter-frontend` clean
- [ ] CI frontend-build green
- [ ] Manual: full happy-path flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)