### PR TITLE
fix(mbk/listings): Furnished Finder doesn't expose iCal — drop fake flags

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/ffcorr260502_correct_furnished_finder_ical_capabilities.py
+++ b/apps/mybookkeeper/backend/alembic/versions/ffcorr260502_correct_furnished_finder_ical_capabilities.py
@@ -1,0 +1,50 @@
+"""correct furnished finder ical capabilities
+
+Furnished Finder does not expose an iCal export, and only supports iCal
+import from Airbnb / VRBO (verified 2026-05-02 via FF support docs:
+support.furnishedfinder.com/hc/en-us/articles/35107733754779). The PR 1.4
+seed migration set both flags to True for the ``furnished_finder`` row;
+this migration corrects them to False so the UI can stop pretending an
+iCal feed is reachable.
+
+Existing ``channel_listings`` rows that point to furnished_finder with a
+non-null ``ical_import_url`` are left as-is — that URL is operator-entered
+and the column doesn't get cleared, but the polling worker already skips
+provider-incompatible feeds so no follow-up cleanup is required.
+
+Revision ID: ffcorr260502
+Revises: ffmerge260502
+Create Date: 2026-05-02 00:00:00.000000
+
+"""
+from typing import Union
+
+from alembic import op
+
+
+revision: str = "ffcorr260502"
+down_revision: Union[str, None] = "ffmerge260502"
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE channels
+           SET supports_ical_export = false,
+               supports_ical_import = false
+         WHERE id = 'furnished_finder'
+        """,
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE channels
+           SET supports_ical_export = true,
+               supports_ical_import = true
+         WHERE id = 'furnished_finder'
+        """,
+    )

--- a/apps/mybookkeeper/backend/alembic/versions/ffmerge260502_merge_heads_pre_ff_correction.py
+++ b/apps/mybookkeeper/backend/alembic/versions/ffmerge260502_merge_heads_pre_ff_correction.py
@@ -1,0 +1,37 @@
+"""merge heads pre ff correction
+
+Pre-existing two-head situation in main:
+  - ``z0a1b2c3d4e5`` (drop_user_sessions_and_user_activities) — head of
+    the OAuth-encryption chain
+  - ``b2c3d4e5f6a1`` (public_inquiry_form_t0) — head of the inquiry-form
+    chain landed via PR #130
+
+Both have been live in main without ever being merged. ``alembic upgrade
+head`` fails with "Multiple head revisions are present" until they are
+joined. This empty merge revision joins them so subsequent migrations have
+a single linear parent.
+
+Empty body — alembic merge revisions don't run DDL; they just unify the
+revision DAG. The FF capabilities correction lives in the next revision
+(``ffcorr260502``).
+
+Revision ID: ffmerge260502
+Revises: z0a1b2c3d4e5, b2c3d4e5f6a1
+Create Date: 2026-05-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+
+revision: str = "ffmerge260502"
+down_revision: Union[str, Sequence[str], None] = ("z0a1b2c3d4e5", "b2c3d4e5f6a1")
+branch_labels: Union[str, None] = None
+depends_on: Union[str, None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/apps/mybookkeeper/backend/app/core/channel_constants.py
+++ b/apps/mybookkeeper/backend/app/core/channel_constants.py
@@ -26,8 +26,12 @@ CHANNEL_SEEDS: tuple[ChannelSeed, ...] = (
     {
         "id": "furnished_finder",
         "name": "Furnished Finder",
-        "supports_ical_export": True,
-        "supports_ical_import": True,
+        # Furnished Finder does not expose an iCal export — verified via
+        # FF support docs (2026-05-02). Only iCal import is supported on
+        # FF's side, and only from Airbnb / VRBO. So an FF channel link
+        # in MBK is record-keeping (External URL) only.
+        "supports_ical_export": False,
+        "supports_ical_import": False,
     },
     {
         "id": "rotating_room",

--- a/apps/mybookkeeper/backend/tests/test_channel_constants.py
+++ b/apps/mybookkeeper/backend/tests/test_channel_constants.py
@@ -1,9 +1,16 @@
-"""Verify the migration's seed list matches ``CHANNEL_SEEDS``.
+"""Verify the migration chain produces the seed rows ``CHANNEL_SEEDS`` declares.
 
-Both must agree exactly — the migration is the source of truth for what
-ships in the DB at deploy time, but the constants module is the source of
-truth in code. Drift here means a re-run of the migration on a fresh DB
-would produce different rows than the live DB.
+The constants module is the source of truth in code; the migration chain is
+the source of truth at deploy time. They must agree exactly — drift here
+means a fresh DB rebuild would diverge from a long-running prod DB.
+
+We replay the chain in order:
+1. ``j2k4l6m8n0p2_add_channels_and_blackouts`` — initial seed (PR 1.4)
+2. ``a1b2c3d4e5f6_correct_furnished_finder_ical_capabilities`` — FF
+   correction (2026-05-02): FF doesn't expose iCal, only iCal import from
+   Airbnb/VRBO. Both flags flipped to False for ``furnished_finder``.
+
+If a future migration changes another channel's flags, add a step here.
 """
 from __future__ import annotations
 
@@ -13,46 +20,53 @@ from pathlib import Path
 from app.core.channel_constants import CHANNEL_SEEDS
 
 
-_MIGRATION_PATH = (
-    Path(__file__).resolve().parents[1]
-    / "alembic"
-    / "versions"
-    / "j2k4l6m8n0p2_add_channels_and_blackouts.py"
+_VERSIONS_DIR = (
+    Path(__file__).resolve().parents[1] / "alembic" / "versions"
+)
+_SEED_MIGRATION = _VERSIONS_DIR / "j2k4l6m8n0p2_add_channels_and_blackouts.py"
+_FF_CORRECTION_MIGRATION = (
+    _VERSIONS_DIR / "ffcorr260502_correct_furnished_finder_ical_capabilities.py"
 )
 
 
-def test_migration_seed_matches_constants() -> None:
-    text = _MIGRATION_PATH.read_text(encoding="utf-8")
-
-    # Extract every tuple from the migration's _CHANNEL_SEEDS literal.
-    # Format: ("airbnb", "Airbnb", True, True),
+def _replay_seed_migration() -> dict[str, dict[str, object]]:
+    """Parse the initial seed migration's ``_CHANNEL_SEEDS`` tuple."""
+    text = _SEED_MIGRATION.read_text(encoding="utf-8")
     pattern = re.compile(
         r'\("([\w_]+)",\s*"([^"]+)",\s*(True|False),\s*(True|False)\)',
     )
-    raw_matches = pattern.findall(text)
-    # Only keep the matches inside _CHANNEL_SEEDS — the file may contain
-    # other tuples elsewhere, but as of this PR there are none. Be safe:
-    # filter by the known channel slugs.
     expected_slugs = {seed["id"] for seed in CHANNEL_SEEDS}
-    matches = [m for m in raw_matches if m[0] in expected_slugs]
-
-    assert len(matches) == len(CHANNEL_SEEDS), (
-        f"Expected {len(CHANNEL_SEEDS)} channels in migration; saw {len(matches)}"
-    )
-
-    migration_seeds = [
-        {
+    matches = [m for m in pattern.findall(text) if m[0] in expected_slugs]
+    return {
+        cid: {
             "id": cid,
             "name": cname,
             "supports_ical_export": exp == "True",
             "supports_ical_import": imp == "True",
         }
         for cid, cname, exp, imp in matches
-    ]
+    }
 
-    # Compare in slug order (stable across re-runs).
+
+def _replay_ff_correction(state: dict[str, dict[str, object]]) -> None:
+    """Apply the FF capabilities correction in-place."""
+    state["furnished_finder"]["supports_ical_export"] = False
+    state["furnished_finder"]["supports_ical_import"] = False
+
+
+def test_migration_chain_matches_constants() -> None:
+    state = _replay_seed_migration()
+    _replay_ff_correction(state)
+
     by_slug_const = {s["id"]: s for s in CHANNEL_SEEDS}
-    by_slug_mig = {s["id"]: s for s in migration_seeds}
-    assert set(by_slug_const) == set(by_slug_mig)
+    assert set(by_slug_const) == set(state)
     for slug in by_slug_const:
-        assert by_slug_const[slug] == by_slug_mig[slug]
+        assert by_slug_const[slug] == state[slug]
+
+
+def test_ff_correction_migration_clears_both_flags() -> None:
+    """Guard against the FF row drifting back to True/True in the constants."""
+    text = _FF_CORRECTION_MIGRATION.read_text(encoding="utf-8")
+    assert "supports_ical_export = false" in text
+    assert "supports_ical_import = false" in text
+    assert "id = 'furnished_finder'" in text

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ChannelListingFormModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ChannelListingFormModal.tsx
@@ -60,6 +60,12 @@ export default function ChannelListingFormModal({
   );
   const [validationError, setValidationError] = useState<string | null>(null);
 
+  const selectedChannel = isEdit
+    ? existing?.channel
+    : availableChannels.find((c) => c.id === channelId);
+  const channelSupportsImport = selectedChannel?.supports_ical_import ?? true;
+  const channelSupportsExport = selectedChannel?.supports_ical_export ?? true;
+
   const [createChannel, { isLoading: isCreating }] = useCreateListingChannelMutation();
   const [updateChannel, { isLoading: isUpdating }] = useUpdateChannelListingMutation();
 
@@ -185,23 +191,31 @@ export default function ChannelListingFormModal({
               />
             </FormField>
 
-            <FormField label="Channel's calendar export URL (optional)">
-              <input
-                type="url"
-                value={icalImportUrl}
-                onChange={(e) => setIcalImportUrl(e.target.value)}
-                placeholder="https://.../calendar.ics"
-                maxLength={1000}
-                data-testid="channel-listing-form-ical-import-url"
-                className="w-full min-h-[44px] rounded border bg-background px-3 py-2 text-sm"
-              />
-              <p className="text-xs text-muted-foreground mt-1">
-                Paste the channel's iCal export URL here so bookings on that
-                channel come back into MBK every 15 minutes.
+            {channelSupportsImport ? (
+              <FormField label="Channel's calendar export URL (optional)">
+                <input
+                  type="url"
+                  value={icalImportUrl}
+                  onChange={(e) => setIcalImportUrl(e.target.value)}
+                  placeholder="https://.../calendar.ics"
+                  maxLength={1000}
+                  data-testid="channel-listing-form-ical-import-url"
+                  className="w-full min-h-[44px] rounded border bg-background px-3 py-2 text-sm"
+                />
+                <p className="text-xs text-muted-foreground mt-1">
+                  Paste the channel's iCal export URL here so bookings on that
+                  channel come back into MBK every 15 minutes.
+                </p>
+              </FormField>
+            ) : (
+              <p className="text-xs text-muted-foreground italic">
+                {selectedChannel?.name ?? "This channel"} doesn't expose a
+                calendar feed, so MBK can only store the listing link —
+                bookings won't sync automatically.
               </p>
-            </FormField>
+            )}
 
-            {isEdit && existing ? (
+            {isEdit && existing && channelSupportsExport ? (
               <div className="space-y-1">
                 <p className="text-xs font-medium">
                   Outbound iCal URL — paste this into the channel's import-calendar field:

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ChannelsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ChannelsSection.tsx
@@ -115,6 +115,7 @@ export default function ChannelsSection({ listingId }: Props) {
             size="sm"
             onClick={handleAdd}
             data-testid="channels-section-add-button"
+            className="whitespace-nowrap shrink-0"
           >
             <Plus className="h-3 w-3 mr-1" aria-hidden="true" />
             Add channel


### PR DESCRIPTION
## Summary

- Furnished Finder does **not** have an iCal export and only supports iCal import from Airbnb/VRBO. The PR 1.4 seed wrongly set `supports_ical_export=True, supports_ical_import=True`, making the UI imply a calendar feed could be wired up for FF. Verified 2026-05-02 via [FF support docs](https://support.furnishedfinder.com/hc/en-us/articles/35107733754779-Linking-Other-Calendars).
- Discovered + fixed a **pre-existing two-head Alembic state** in main (`z0a1b2c3d4e5` from the OAuth-encryption chain + `b2c3d4e5f6a1` from PR #130's inquiry form). `alembic upgrade head` would have failed on the next prod deploy. Empty merge migration `ffmerge260502` joins them.
- Frontend modal hides iCal fields when the selected channel can't sync, and shows an honest "channel doesn't expose a calendar feed" note instead of pretending bookings will sync.
- Small UX nit: "+ Add channel" button no longer wraps to two lines on narrow viewports.

## What changed

| File | Change |
|---|---|
| `backend/app/core/channel_constants.py` | FF flags → False/False |
| `backend/alembic/versions/ffmerge260502_*.py` | New: empty merge of pre-existing 2 heads |
| `backend/alembic/versions/ffcorr260502_*.py` | New: data migration flipping FF flags in DB |
| `backend/tests/test_channel_constants.py` | Rewritten to replay migration chain |
| `frontend/.../ChannelListingFormModal.tsx` | Hide iCal fields when channel doesn't support sync |
| `frontend/.../ChannelsSection.tsx` | `whitespace-nowrap shrink-0` on Add channel button |

## Test plan

- [x] `alembic upgrade head` succeeds locally — both new migrations applied cleanly
- [x] `channels` table query confirms FF row now reads `(false, false)`
- [x] Manual replay of `test_channel_constants` logic passes
- [ ] Frontend manual test: add an FF channel, confirm iCal field is hidden + warning text shows
- [ ] Frontend manual test: add an Airbnb channel, confirm iCal field still shows
- [ ] CI passes (full test suite + typecheck + lint)
- [ ] Prod deploy: confirm migration applies and FF channel UI hides the iCal field

🤖 Generated with [Claude Code](https://claude.com/claude-code)