### PR TITLE
feat(mybookkeeper/applicants): manual stage transitions from UI (approve/decline/reset)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/a1b2c3d4e5f6_add_payload_to_applicant_events_add_stage_changed.py
+++ b/apps/mybookkeeper/backend/alembic/versions/a1b2c3d4e5f6_add_payload_to_applicant_events_add_stage_changed.py
@@ -1,0 +1,59 @@
+"""add payload JSONB to applicant_events; add stage_changed event type
+
+The manual stage-transition feature (PR manual-stage) writes a
+``stage_changed`` event with a JSONB payload ``{from, to, note}`` so the
+host's approval history is auditable without querying the applicant row
+history.
+
+Revision ID: a1b2c3d4e5f6
+Revises: z0a1b2c3d4e5
+Create Date: 2026-05-02 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "a1b2c3d4e5f6"
+down_revision: Union[str, None] = "z0a1b2c3d4e5"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # 1. Add nullable JSONB payload column to applicant_events.
+    op.add_column(
+        "applicant_events",
+        sa.Column("payload", postgresql.JSONB(astext_type=sa.Text()), nullable=True),
+    )
+
+    # 2. Extend the event_type CheckConstraint to include "stage_changed".
+    #    DROP the old constraint, re-create it with the expanded value list.
+    op.drop_constraint(
+        "chk_applicant_event_type", "applicant_events", type_="check",
+    )
+    op.create_check_constraint(
+        "chk_applicant_event_type",
+        "applicant_events",
+        "event_type IN ('lead', 'screening_pending', 'screening_passed', "
+        "'screening_failed', 'video_call_done', 'approved', 'lease_sent', "
+        "'lease_signed', 'declined', 'note_added', 'screening_initiated', "
+        "'screening_completed', 'reference_contacted', 'stage_changed')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "chk_applicant_event_type", "applicant_events", type_="check",
+    )
+    op.create_check_constraint(
+        "chk_applicant_event_type",
+        "applicant_events",
+        "event_type IN ('lead', 'screening_pending', 'screening_passed', "
+        "'screening_failed', 'video_call_done', 'approved', 'lease_sent', "
+        "'lease_signed', 'declined', 'note_added', 'screening_initiated', "
+        "'screening_completed', 'reference_contacted')",
+    )
+    op.drop_column("applicant_events", "payload")

--- a/apps/mybookkeeper/backend/alembic/versions/stage260502_add_payload_to_applicant_events_add_stage_changed.py
+++ b/apps/mybookkeeper/backend/alembic/versions/stage260502_add_payload_to_applicant_events_add_stage_changed.py
@@ -5,8 +5,8 @@ The manual stage-transition feature (PR manual-stage) writes a
 host's approval history is auditable without querying the applicant row
 history.
 
-Revision ID: a1b2c3d4e5f6
-Revises: z0a1b2c3d4e5
+Revision ID: stage260502
+Revises: mbk260502
 Create Date: 2026-05-02 00:00:00.000000
 
 """
@@ -16,8 +16,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "a1b2c3d4e5f6"
-down_revision: Union[str, None] = "z0a1b2c3d4e5"
+revision: str = "stage260502"
+down_revision: Union[str, None] = "mbk260502"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/apps/mybookkeeper/backend/app/api/applicants.py
+++ b/apps/mybookkeeper/backend/app/api/applicants.py
@@ -18,7 +18,8 @@ from app.core.permissions import current_org_member, require_write_access
 from app.schemas.applicants.applicant_detail_response import ApplicantDetailResponse
 from app.schemas.applicants.applicant_list_response import ApplicantListResponse
 from app.schemas.applicants.applicant_promote_request import ApplicantPromoteRequest
-from app.services.applicants import applicant_service, promote_service
+from app.schemas.applicants.stage_transition_request import StageTransitionRequest
+from app.services.applicants import applicant_service, applicant_stage_service, promote_service
 
 router = APIRouter(prefix="/applicants", tags=["applicants"])
 
@@ -52,6 +53,43 @@ async def get_applicant(
         )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail="Applicant not found") from exc
+
+
+@router.patch(
+    "/{applicant_id}/stage",
+    response_model=ApplicantDetailResponse,
+)
+async def transition_stage(
+    applicant_id: uuid.UUID,
+    payload: StageTransitionRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> ApplicantDetailResponse:
+    """Manually transition an applicant to a new stage.
+
+    The host can approve, decline, or reset an applicant without uploading
+    a screening report. An ``applicant_events`` row with ``event_type =
+    "stage_changed"`` is appended atomically alongside the stage update.
+
+    Errors:
+        404 — applicant not found in the calling tenant.
+        422 — new_stage is not a known stage, transition is not allowed from
+              the current stage, or note exceeds 500 characters.
+    """
+    try:
+        return await applicant_stage_service.transition_stage(
+            organization_id=ctx.organization_id,
+            user_id=ctx.user_id,
+            applicant_id=applicant_id,
+            new_stage=payload.new_stage,
+            note=payload.note,
+        )
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail="Applicant not found") from exc
+    except (
+        applicant_stage_service.InvalidStageError,
+        applicant_stage_service.InvalidTransitionError,
+    ) as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.post(

--- a/apps/mybookkeeper/backend/app/core/applicant_enums.py
+++ b/apps/mybookkeeper/backend/app/core/applicant_enums.py
@@ -29,6 +29,7 @@ APPLICANT_EVENT_TYPES: tuple[str, ...] = APPLICANT_STAGES + (
     "screening_initiated",
     "screening_completed",
     "reference_contacted",
+    "stage_changed",
 )
 
 APPLICANT_EVENT_ACTORS: tuple[str, ...] = ("host", "system", "applicant")

--- a/apps/mybookkeeper/backend/app/models/applicants/applicant_event.py
+++ b/apps/mybookkeeper/backend/app/models/applicants/applicant_event.py
@@ -24,7 +24,7 @@ from sqlalchemy import (
     Text,
     func,
 )
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import JSONB, UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
 from app.core.applicant_enums import (
@@ -50,6 +50,9 @@ class ApplicantEvent(Base):
     event_type: Mapped[str] = mapped_column(String(40), nullable=False)
     actor: Mapped[str] = mapped_column(String(20), nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Structured metadata for stage_changed events: {from, to, note}.
+    # NULL for non-stage events (note_added, screening_initiated, etc.).
+    payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
 
     occurred_at: Mapped[_dt.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False,

--- a/apps/mybookkeeper/backend/app/repositories/applicants/applicant_event_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/applicants/applicant_event_repo.py
@@ -27,6 +27,7 @@ async def append(
     actor: str,
     occurred_at: _dt.datetime,
     notes: str | None = None,
+    payload: dict | None = None,
 ) -> ApplicantEvent:
     """Append an event to an applicant's timeline.
 
@@ -39,6 +40,7 @@ async def append(
         event_type=event_type,
         actor=actor,
         notes=notes,
+        payload=payload,
         occurred_at=occurred_at,
     )
     db.add(event)

--- a/apps/mybookkeeper/backend/app/repositories/applicants/applicant_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/applicants/applicant_repo.py
@@ -175,6 +175,23 @@ async def soft_delete(
     return (result.rowcount or 0) > 0
 
 
+async def update_stage(
+    db: AsyncSession,
+    *,
+    applicant: Applicant,
+    new_stage: str,
+    now: _dt.datetime,
+) -> None:
+    """Update the stage and updated_at on an already-loaded Applicant row.
+
+    Caller is responsible for verifying tenant scope before calling (via
+    ``applicant_repo.get()``). The ``update`` path uses an ORM attribute
+    assignment so SQLAlchemy tracks the dirty column — no raw UPDATE needed.
+    """
+    applicant.stage = new_stage
+    applicant.updated_at = now
+
+
 async def list_pending_purge(
     db: AsyncSession,
     *,

--- a/apps/mybookkeeper/backend/app/schemas/applicants/applicant_event_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/applicant_event_response.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import datetime as _dt
 import uuid
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -13,6 +14,7 @@ class ApplicantEventResponse(BaseModel):
     event_type: str
     actor: str
     notes: str | None = None
+    payload: dict[str, Any] | None = None
     occurred_at: _dt.datetime
     created_at: _dt.datetime
 

--- a/apps/mybookkeeper/backend/app/schemas/applicants/stage_transition_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/stage_transition_request.py
@@ -1,0 +1,15 @@
+"""Pydantic schema for PATCH /applicants/{id}/stage."""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class StageTransitionRequest(BaseModel):
+    new_stage: str = Field(..., description="Target stage from APPLICANT_STAGES")
+    note: str | None = Field(
+        None,
+        max_length=500,
+        description="Optional free-text note for the transition record",
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/mybookkeeper/backend/app/services/applicants/applicant_stage_service.py
+++ b/apps/mybookkeeper/backend/app/services/applicants/applicant_stage_service.py
@@ -1,0 +1,119 @@
+"""Service for manual applicant stage transitions.
+
+Hosts can approve/decline/reset an applicant without uploading a screening
+report. The future screening rebuild will repurpose this UI to write a
+``screening_decision`` column instead of ``stage`` — a ~5-line frontend
+change at that time.
+
+Transition rules intentionally allow host overrides (e.g. ``screening_failed``
+→ ``approved``) for the common case where the host has done manual checks.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from app.core.applicant_enums import APPLICANT_STAGES
+from app.db.session import unit_of_work
+from app.repositories.applicants import applicant_event_repo, applicant_repo
+from app.schemas.applicants.applicant_detail_response import ApplicantDetailResponse
+from app.services.applicants import applicant_service
+
+# Allowed transitions per stage. ``set()`` means no forward transitions
+# (terminal state). The service enforces this before writing any rows.
+ALLOWED_TRANSITIONS: dict[str, set[str]] = {
+    "lead": {"screening_pending", "approved", "declined"},
+    "screening_pending": {"screening_passed", "screening_failed", "approved", "declined"},
+    "screening_passed": {"video_call_done", "approved", "declined"},
+    "screening_failed": {"declined", "approved"},
+    "video_call_done": {"approved", "declined"},
+    "approved": {"lease_sent", "declined"},
+    "lease_sent": {"lease_signed", "declined"},
+    "lease_signed": set(),
+    "declined": {"lead"},
+}
+
+
+class InvalidStageError(ValueError):
+    """The requested new_stage is not a known APPLICANT_STAGE."""
+
+
+class InvalidTransitionError(ValueError):
+    """The requested transition is not allowed from the current stage."""
+
+
+def _validate_new_stage(new_stage: str) -> None:
+    if new_stage not in APPLICANT_STAGES:
+        raise InvalidStageError(
+            f"Unknown stage {new_stage!r}. "
+            f"Valid stages: {', '.join(APPLICANT_STAGES)}",
+        )
+
+
+def _validate_transition(current_stage: str, new_stage: str) -> None:
+    allowed = ALLOWED_TRANSITIONS.get(current_stage, set())
+    if new_stage not in allowed:
+        if not allowed:
+            raise InvalidTransitionError(
+                f"Stage {current_stage!r} is terminal — no further transitions are allowed.",
+            )
+        raise InvalidTransitionError(
+            f"Cannot transition from {current_stage!r} to {new_stage!r}. "
+            f"Allowed next stages: {', '.join(sorted(allowed))}",
+        )
+
+
+async def transition_stage(
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+    new_stage: str,
+    note: str | None,
+) -> ApplicantDetailResponse:
+    """Transition an applicant's stage and record it in the event timeline.
+
+    Raises:
+        LookupError: applicant not found in the calling tenant.
+        InvalidStageError: new_stage is not a known APPLICANT_STAGE.
+        InvalidTransitionError: the transition is not allowed from the
+            current stage.
+    """
+    _validate_new_stage(new_stage)
+
+    now = _dt.datetime.now(_dt.timezone.utc)
+
+    async with unit_of_work() as db:
+        applicant = await applicant_repo.get(
+            db,
+            applicant_id=applicant_id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if applicant is None:
+            raise LookupError(f"Applicant {applicant_id} not found")
+
+        old_stage = applicant.stage
+        _validate_transition(old_stage, new_stage)
+
+        await applicant_repo.update_stage(
+            db,
+            applicant=applicant,
+            new_stage=new_stage,
+            now=now,
+        )
+
+        await applicant_event_repo.append(
+            db,
+            applicant_id=applicant.id,
+            event_type="stage_changed",
+            actor="host",
+            occurred_at=now,
+            payload={"from": old_stage, "to": new_stage, "note": note},
+        )
+
+    # Re-load via the read service so the response shape is identical to
+    # GET /applicants/{id} — same schema, same nested children.
+    return await applicant_service.get_applicant(
+        organization_id, user_id, applicant_id,
+    )

--- a/apps/mybookkeeper/backend/tests/test_applicant_stage_service.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_stage_service.py
@@ -1,0 +1,76 @@
+"""Unit tests for applicant_stage_service.
+
+Tests:
+- _validate_new_stage: valid stage passes, invalid raises InvalidStageError
+- _validate_transition: allowed transitions pass; invalid transitions raise
+  InvalidTransitionError; terminal stage (lease_signed) raises
+- ALLOWED_TRANSITIONS completeness: every APPLICANT_STAGE has an entry
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.core.applicant_enums import APPLICANT_STAGES
+from app.services.applicants.applicant_stage_service import (
+    ALLOWED_TRANSITIONS,
+    InvalidStageError,
+    InvalidTransitionError,
+    _validate_new_stage,
+    _validate_transition,
+)
+
+
+class TestValidateNewStage:
+    def test_all_known_stages_pass(self) -> None:
+        for stage in APPLICANT_STAGES:
+            _validate_new_stage(stage)  # must not raise
+
+    def test_unknown_stage_raises(self) -> None:
+        with pytest.raises(InvalidStageError, match="Unknown stage"):
+            _validate_new_stage("banana_split")
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(InvalidStageError):
+            _validate_new_stage("")
+
+
+class TestValidateTransition:
+    def test_lead_to_approved(self) -> None:
+        _validate_transition("lead", "approved")
+
+    def test_lead_to_declined(self) -> None:
+        _validate_transition("lead", "declined")
+
+    def test_declined_to_lead(self) -> None:
+        """Un-decline is explicitly allowed."""
+        _validate_transition("declined", "lead")
+
+    def test_screening_failed_to_approved(self) -> None:
+        """Host override: bypass failed screening."""
+        _validate_transition("screening_failed", "approved")
+
+    def test_lease_signed_is_terminal(self) -> None:
+        with pytest.raises(InvalidTransitionError, match="terminal"):
+            _validate_transition("lease_signed", "lead")
+
+    def test_invalid_pair_raises(self) -> None:
+        with pytest.raises(InvalidTransitionError, match="Cannot transition"):
+            _validate_transition("lead", "lease_signed")
+
+    def test_same_stage_is_invalid(self) -> None:
+        with pytest.raises(InvalidTransitionError):
+            _validate_transition("approved", "approved")
+
+
+class TestAllowedTransitionsCompleteness:
+    def test_every_stage_has_an_entry(self) -> None:
+        missing = [s for s in APPLICANT_STAGES if s not in ALLOWED_TRANSITIONS]
+        assert not missing, f"Missing entries in ALLOWED_TRANSITIONS: {missing}"
+
+    def test_all_target_stages_are_valid(self) -> None:
+        valid = set(APPLICANT_STAGES)
+        for src, targets in ALLOWED_TRANSITIONS.items():
+            for tgt in targets:
+                assert tgt in valid, (
+                    f"ALLOWED_TRANSITIONS[{src!r}] references unknown stage {tgt!r}"
+                )

--- a/apps/mybookkeeper/backend/tests/test_applicant_stage_transition_api.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_stage_transition_api.py
@@ -1,0 +1,250 @@
+"""HTTP route tests for PATCH /applicants/{id}/stage.
+
+Tests:
+- Happy path: transition with + without a note
+- Tenant isolation: other user/org gets 404
+- Invalid transition (terminal stage, bad pair)
+- Unknown stage value: 422
+- Note length cap: 501 chars → 422, 500 chars OK, null note OK
+- Read-only viewer gets 403 (require_write_access)
+- Unauthenticated gets 401
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.applicants.applicant_detail_response import ApplicantDetailResponse
+
+
+def _ctx(
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    role: OrgRole = OrgRole.OWNER,
+) -> RequestContext:
+    return RequestContext(organization_id=org_id, user_id=user_id, org_role=role)
+
+
+def _build_detail(
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+    stage: str = "approved",
+) -> ApplicantDetailResponse:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    return ApplicantDetailResponse(
+        id=applicant_id,
+        organization_id=org_id,
+        user_id=user_id,
+        inquiry_id=None,
+        legal_name="Prince Kapoor",
+        stage=stage,
+        created_at=now,
+        updated_at=now,
+    )
+
+
+class TestStageTransitionEndpoint:
+    @pytest.mark.asyncio
+    async def test_happy_path_with_note(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        applicant_id = uuid.uuid4()
+        detail = _build_detail(
+            org_id=org_id, user_id=user_id, applicant_id=applicant_id, stage="approved",
+        )
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+        with patch(
+            "app.api.applicants.applicant_stage_service.transition_stage",
+            new_callable=AsyncMock,
+            return_value=detail,
+        ) as mock_svc:
+            client = TestClient(app)
+            response = client.patch(
+                f"/applicants/{applicant_id}/stage",
+                json={"new_stage": "approved", "note": "References checked separately"},
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["stage"] == "approved"
+        assert body["id"] == str(applicant_id)
+        kwargs = mock_svc.call_args.kwargs
+        assert kwargs["new_stage"] == "approved"
+        assert kwargs["note"] == "References checked separately"
+        assert kwargs["organization_id"] == org_id
+        assert kwargs["user_id"] == user_id
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_happy_path_no_note(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        applicant_id = uuid.uuid4()
+        detail = _build_detail(
+            org_id=org_id, user_id=user_id, applicant_id=applicant_id, stage="declined",
+        )
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+        with patch(
+            "app.api.applicants.applicant_stage_service.transition_stage",
+            new_callable=AsyncMock,
+            return_value=detail,
+        ):
+            client = TestClient(app)
+            response = client.patch(
+                f"/applicants/{applicant_id}/stage",
+                json={"new_stage": "declined"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["stage"] == "declined"
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_tenant_isolation_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+        with patch(
+            "app.api.applicants.applicant_stage_service.transition_stage",
+            new_callable=AsyncMock,
+            side_effect=LookupError("not found"),
+        ):
+            client = TestClient(app)
+            response = client.patch(
+                f"/applicants/{uuid.uuid4()}/stage",
+                json={"new_stage": "approved"},
+            )
+
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Applicant not found"
+        app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_invalid_transition_returns_422(self) -> None:
+        from app.services.applicants.applicant_stage_service import InvalidTransitionError
+
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+        with patch(
+            "app.api.applicants.applicant_stage_service.transition_stage",
+            new_callable=AsyncMock,
+            side_effect=InvalidTransitionError(
+                "Cannot transition from 'lease_signed' to 'lead'.",
+            ),
+        ):
+            client = TestClient(app)
+            response = client.patch(
+                f"/applicants/{uuid.uuid4()}/stage",
+                json={"new_stage": "lead"},
+            )
+
+        assert response.status_code == 422
+        assert "lease_signed" in response.json()["detail"] or "Cannot" in response.json()["detail"]
+        app.dependency_overrides.clear()
+
+    def test_unknown_stage_value_returns_422(self) -> None:
+        from app.services.applicants.applicant_stage_service import InvalidStageError
+
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+        with patch(
+            "app.api.applicants.applicant_stage_service.transition_stage",
+            new_callable=AsyncMock,
+            side_effect=InvalidStageError("Unknown stage 'banana'"),
+        ):
+            try:
+                client = TestClient(app)
+                response = client.patch(
+                    f"/applicants/{uuid.uuid4()}/stage",
+                    json={"new_stage": "banana"},
+                )
+                assert response.status_code == 422
+            finally:
+                app.dependency_overrides.clear()
+
+    def test_note_too_long_returns_422(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.patch(
+                f"/applicants/{uuid.uuid4()}/stage",
+                json={"new_stage": "approved", "note": "x" * 501},
+            )
+            assert response.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    @pytest.mark.asyncio
+    async def test_note_at_max_length_is_accepted(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        applicant_id = uuid.uuid4()
+        detail = _build_detail(
+            org_id=org_id, user_id=user_id, applicant_id=applicant_id,
+        )
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+        with patch(
+            "app.api.applicants.applicant_stage_service.transition_stage",
+            new_callable=AsyncMock,
+            return_value=detail,
+        ):
+            client = TestClient(app)
+            response = client.patch(
+                f"/applicants/{applicant_id}/stage",
+                json={"new_stage": "approved", "note": "x" * 500},
+            )
+
+        assert response.status_code == 200
+        app.dependency_overrides.clear()
+
+    def test_extra_fields_rejected(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            response = client.patch(
+                f"/applicants/{uuid.uuid4()}/stage",
+                json={"new_stage": "approved", "evil_field": "injection"},
+            )
+            assert response.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_viewer_gets_403(self) -> None:
+        app.dependency_overrides[require_write_access] = lambda: (
+            (_ for _ in ()).throw(
+                __import__("fastapi").HTTPException(
+                    status_code=403, detail="Viewers have read-only access",
+                )
+            )
+        )
+        try:
+            client = TestClient(app)
+            response = client.patch(
+                f"/applicants/{uuid.uuid4()}/stage",
+                json={"new_stage": "approved"},
+            )
+            assert response.status_code == 403
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_unauthenticated_returns_401(self) -> None:
+        client = TestClient(app)
+        response = client.patch(
+            f"/applicants/{uuid.uuid4()}/stage",
+            json={"new_stage": "approved"},
+        )
+        assert response.status_code == 401

--- a/apps/mybookkeeper/frontend/e2e/applicant-stage-transition.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/applicant-stage-transition.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+
+/**
+ * PR: manual-applicant-stage-transition
+ *
+ * Covers:
+ * 1. Happy path: create applicant in "lead" → approve via UI → badge updates
+ *    + applicant_events row exists with stage_changed payload.
+ * 2. Note flows through to the event payload.
+ * 3. Terminal stage (lease_signed) shows "no further transitions" in the popover.
+ * 4. Layout: ApplicantStatusControl renders in the detail page header without
+ *    breaking the existing layout (stage badge still visible, sections intact).
+ */
+
+async function seedApplicant(
+  api: APIRequestContext,
+  stage: string = "lead",
+  legalName?: string,
+): Promise<string> {
+  const res = await api.post("/test/seed-applicant", {
+    data: { stage, legal_name: legalName ?? `E2E Stage Test ${Date.now()}`, seed_event: true },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedApplicant failed: ${res.status()} ${await res.text()}`);
+  }
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function deleteApplicant(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/test/applicants/${id}`).catch(() => {});
+}
+
+async function getApplicantEvents(
+  api: APIRequestContext,
+  applicantId: string,
+): Promise<Array<{ event_type: string; actor: string; payload: Record<string, unknown> | null }>> {
+  const res = await api.get(`/applicants/${applicantId}`);
+  if (!res.ok()) return [];
+  const body = (await res.json()) as { events: Array<{ event_type: string; actor: string; payload: unknown }> };
+  return body.events as Array<{ event_type: string; actor: string; payload: Record<string, unknown> | null }>;
+}
+
+test.describe("Manual applicant stage transition (PR manual-stage)", () => {
+  test("approve a lead applicant via status control — badge updates and event is written", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const legalName = `E2E Stage Approve ${runId}`;
+    let applicantId = "";
+
+    try {
+      applicantId = await seedApplicant(api, "lead", legalName);
+
+      await page.goto(`/applicants/${applicantId}`);
+      await page.waitForLoadState("networkidle");
+
+      // Stage badge renders as "Lead" initially.
+      await expect(page.getByTestId("applicant-stage-badge-lead")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Open status control popover.
+      await page.getByTestId("applicant-status-control-trigger").click();
+      await expect(page.getByTestId("applicant-status-popover")).toBeVisible();
+
+      // "Approved" must be an option for a lead applicant.
+      const select = page.getByTestId("applicant-status-stage-select");
+      await expect(select).toBeVisible();
+      await select.selectOption("approved");
+
+      // Enter a note.
+      await page.getByTestId("applicant-status-note").fill("References checked separately");
+
+      // Confirm is now enabled — click it.
+      const confirmBtn = page.getByTestId("applicant-status-confirm");
+      await expect(confirmBtn).not.toBeDisabled();
+      await confirmBtn.click();
+
+      // Popover should close and badge should update to "Approved".
+      await expect(page.getByTestId("applicant-status-popover")).toHaveCount(0, {
+        timeout: 5000,
+      });
+      await expect(page.getByTestId("applicant-stage-badge-approved")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Verify the applicant_events row in the DB via API.
+      const events = await getApplicantEvents(api, applicantId);
+      const changeEvent = events.find((e) => e.event_type === "stage_changed");
+      expect(changeEvent).toBeDefined();
+      expect(changeEvent?.actor).toBe("host");
+      expect(changeEvent?.payload?.from).toBe("lead");
+      expect(changeEvent?.payload?.to).toBe("approved");
+      expect(changeEvent?.payload?.note).toBe("References checked separately");
+    } finally {
+      if (applicantId) await deleteApplicant(api, applicantId);
+    }
+  });
+
+  test("decline then un-decline (reset to lead) — two stage_changed events written", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const legalName = `E2E Stage Decline ${runId}`;
+    let applicantId = "";
+
+    try {
+      applicantId = await seedApplicant(api, "lead", legalName);
+
+      await page.goto(`/applicants/${applicantId}`);
+      await page.waitForLoadState("networkidle");
+
+      // Decline first.
+      await page.getByTestId("applicant-status-control-trigger").click();
+      await page.getByTestId("applicant-status-stage-select").selectOption("declined");
+      await page.getByTestId("applicant-status-confirm").click();
+      await expect(page.getByTestId("applicant-stage-badge-declined")).toBeVisible({
+        timeout: 10000,
+      });
+
+      // Now un-decline: declined → lead.
+      await page.getByTestId("applicant-status-control-trigger").click();
+      await page.getByTestId("applicant-status-stage-select").selectOption("lead");
+      await page.getByTestId("applicant-status-confirm").click();
+      await expect(page.getByTestId("applicant-stage-badge-lead")).toBeVisible({
+        timeout: 10000,
+      });
+
+      const events = await getApplicantEvents(api, applicantId);
+      const changeEvents = events.filter((e) => e.event_type === "stage_changed");
+      expect(changeEvents.length).toBeGreaterThanOrEqual(2);
+    } finally {
+      if (applicantId) await deleteApplicant(api, applicantId);
+    }
+  });
+
+  test("terminal stage (lease_signed) shows no-transitions message", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    let applicantId = "";
+
+    try {
+      applicantId = await seedApplicant(api, "lease_signed", `E2E Terminal ${runId}`);
+
+      await page.goto(`/applicants/${applicantId}`);
+      await page.waitForLoadState("networkidle");
+
+      await expect(page.getByTestId("applicant-stage-badge-lease_signed")).toBeVisible({
+        timeout: 10000,
+      });
+
+      await page.getByTestId("applicant-status-control-trigger").click();
+      await expect(page.getByTestId("applicant-status-popover")).toBeVisible();
+      await expect(
+        page.getByText(/No further transitions available/i),
+      ).toBeVisible();
+      // No stage select should be rendered.
+      await expect(page.getByTestId("applicant-status-stage-select")).toHaveCount(0);
+    } finally {
+      if (applicantId) await deleteApplicant(api, applicantId);
+    }
+  });
+
+  test("layout: detail page sections remain intact after adding status control", async ({
+    authedPage: page,
+    api,
+  }) => {
+    let applicantId = "";
+
+    try {
+      applicantId = await seedApplicant(api, "lead", `E2E Layout ${Date.now()}`);
+
+      await page.goto(`/applicants/${applicantId}`);
+      await page.waitForLoadState("networkidle");
+
+      // All existing sections should still be visible.
+      await expect(page.getByTestId("contract-section")).toBeVisible();
+      await expect(page.getByTestId("sensitive-data-section")).toBeVisible();
+      await expect(page.getByTestId("screening-section")).toBeVisible();
+      await expect(page.getByTestId("references-section")).toBeVisible();
+      await expect(page.getByTestId("notes-section")).toBeVisible();
+      await expect(page.getByTestId("applicant-timeline")).toBeVisible();
+
+      // The status control trigger must be visible in the header area.
+      await expect(page.getByTestId("applicant-status-control-trigger")).toBeVisible();
+    } finally {
+      if (applicantId) await deleteApplicant(api, applicantId);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/ApplicantStatusControl.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/ApplicantStatusControl.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import ApplicantStatusControl from "@/app/features/applicants/ApplicantStatusControl";
+import { APPLICANT_STAGE_LABELS } from "@/shared/lib/applicant-labels";
+import { getAllowedTransitions } from "@/shared/lib/applicant-stage-transitions";
+import type { ApplicantStage } from "@/shared/types/applicant/applicant-stage";
+
+// --- mocks ---
+
+vi.mock("@/shared/hooks/useOrgRole", () => ({
+  useCanWrite: vi.fn(() => true),
+}));
+
+const mockTransitionStage = vi.fn();
+vi.mock("@/shared/store/applicantsApi", () => ({
+  useTransitionApplicantStageMutation: vi.fn(() => [mockTransitionStage, { isLoading: false }]),
+}));
+
+vi.mock("@/shared/hooks/useToast", () => ({
+  useToast: vi.fn(() => ({
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+  })),
+}));
+
+import { useCanWrite } from "@/shared/hooks/useOrgRole";
+
+function renderControl(stage: ApplicantStage = "lead") {
+  return render(
+    <Provider store={store}>
+      <ApplicantStatusControl applicantId="app-123" currentStage={stage} />
+    </Provider>,
+  );
+}
+
+describe("ApplicantStatusControl", () => {
+  beforeEach(() => {
+    vi.mocked(useCanWrite).mockReturnValue(true);
+    mockTransitionStage.mockReset();
+  });
+
+  it("renders the current stage label", () => {
+    renderControl("lead");
+    expect(screen.getByTestId("applicant-stage-badge-lead")).toBeInTheDocument();
+    expect(screen.getByText(APPLICANT_STAGE_LABELS.lead)).toBeInTheDocument();
+  });
+
+  it("opens the popover on trigger click", () => {
+    renderControl("lead");
+    expect(screen.queryByTestId("applicant-status-popover")).toBeNull();
+    fireEvent.click(screen.getByTestId("applicant-status-control-trigger"));
+    expect(screen.getByTestId("applicant-status-popover")).toBeInTheDocument();
+  });
+
+  it("only shows allowed transitions for the current stage", () => {
+    renderControl("lead");
+    fireEvent.click(screen.getByTestId("applicant-status-control-trigger"));
+    const select = screen.getByTestId("applicant-status-stage-select") as HTMLSelectElement;
+    const options = Array.from(select.options)
+      .filter((o) => o.value !== "")
+      .map((o) => o.value);
+    expect(options.sort()).toEqual([...getAllowedTransitions("lead")].sort());
+  });
+
+  it("closes the popover on Cancel click", () => {
+    renderControl("lead");
+    fireEvent.click(screen.getByTestId("applicant-status-control-trigger"));
+    expect(screen.getByTestId("applicant-status-popover")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("applicant-status-cancel"));
+    expect(screen.queryByTestId("applicant-status-popover")).toBeNull();
+  });
+
+  it("confirm is disabled until a stage is selected", () => {
+    renderControl("lead");
+    fireEvent.click(screen.getByTestId("applicant-status-control-trigger"));
+    const confirm = screen.getByTestId("applicant-status-confirm") as HTMLButtonElement;
+    expect(confirm).toBeDisabled();
+  });
+
+  it("calls the mutation with the selected stage and note on confirm", async () => {
+    mockTransitionStage.mockResolvedValueOnce({ data: { stage: "approved" }, unwrap: () => Promise.resolve({ stage: "approved" }) });
+    renderControl("lead");
+    fireEvent.click(screen.getByTestId("applicant-status-control-trigger"));
+
+    const select = screen.getByTestId("applicant-status-stage-select");
+    fireEvent.change(select, { target: { value: "approved" } });
+
+    const noteArea = screen.getByTestId("applicant-status-note");
+    fireEvent.change(noteArea, { target: { value: "Test note" } });
+
+    fireEvent.click(screen.getByTestId("applicant-status-confirm"));
+
+    await waitFor(() => {
+      expect(mockTransitionStage).toHaveBeenCalledWith({
+        applicantId: "app-123",
+        data: { new_stage: "approved", note: "Test note" },
+      });
+    });
+  });
+
+  it("shows no transitions and no select for terminal stage (lease_signed)", () => {
+    renderControl("lease_signed");
+    fireEvent.click(screen.getByTestId("applicant-status-control-trigger"));
+    expect(screen.queryByTestId("applicant-status-stage-select")).toBeNull();
+    expect(screen.getByText(/No further transitions/i)).toBeInTheDocument();
+  });
+
+  it("renders a plain non-interactive badge for read-only viewers", () => {
+    vi.mocked(useCanWrite).mockReturnValue(false);
+    renderControl("approved");
+    expect(screen.queryByTestId("applicant-status-control-trigger")).toBeNull();
+    expect(screen.getByTestId("applicant-stage-badge-approved")).toBeInTheDocument();
+  });
+
+  it("trims empty note to null before calling the mutation", async () => {
+    mockTransitionStage.mockReturnValueOnce({
+      unwrap: () => Promise.resolve({ stage: "approved" }),
+    });
+    renderControl("lead");
+    fireEvent.click(screen.getByTestId("applicant-status-control-trigger"));
+    fireEvent.change(screen.getByTestId("applicant-status-stage-select"), {
+      target: { value: "approved" },
+    });
+    // Do NOT type in note field — leave blank
+    fireEvent.click(screen.getByTestId("applicant-status-confirm"));
+
+    await waitFor(() => {
+      expect(mockTransitionStage).toHaveBeenCalledWith({
+        applicantId: "app-123",
+        data: { new_stage: "approved", note: null },
+      });
+    });
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantStatusControl.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantStatusControl.tsx
@@ -1,0 +1,203 @@
+import { useEffect, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import {
+  APPLICANT_STAGE_BADGE_COLORS,
+  APPLICANT_STAGE_LABELS,
+} from "@/shared/lib/applicant-labels";
+import { getAllowedTransitions } from "@/shared/lib/applicant-stage-transitions";
+import type { ApplicantStage } from "@/shared/types/applicant/applicant-stage";
+import type { BadgeColor } from "@/shared/components/ui/Badge";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import Button from "@/shared/components/ui/Button";
+import { useToast } from "@/shared/hooks/useToast";
+import { useTransitionApplicantStageMutation } from "@/shared/store/applicantsApi";
+import { useCanWrite } from "@/shared/hooks/useOrgRole";
+
+const NOTE_MAX_LENGTH = 500;
+
+const COLOR_CLASSES: Record<BadgeColor, string> = {
+  gray: "bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300",
+  blue: "bg-blue-100 text-blue-700 dark:bg-blue-900 dark:text-blue-300",
+  yellow: "bg-yellow-100 text-yellow-700 dark:bg-yellow-900 dark:text-yellow-300",
+  orange: "bg-orange-100 text-orange-700 dark:bg-orange-900 dark:text-orange-300",
+  green: "bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300",
+  red: "bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300",
+  purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
+};
+
+interface Props {
+  applicantId: string;
+  currentStage: ApplicantStage;
+}
+
+/**
+ * Renders the current stage as a clickable badge that opens a popover for
+ * manual stage transitions (approve / decline / reset).
+ *
+ * Read-only members see a plain non-interactive badge instead.
+ */
+export default function ApplicantStatusControl({ applicantId, currentStage }: Props) {
+  const canWrite = useCanWrite();
+  const { showSuccess, showError } = useToast();
+  const [transitionStage] = useTransitionApplicantStageMutation();
+
+  const [open, setOpen] = useState(false);
+  const [selectedStage, setSelectedStage] = useState<ApplicantStage | "">("");
+  const [note, setNote] = useState("");
+  const ref = useRef<HTMLDivElement>(null);
+
+  const allowedNextStages = getAllowedTransitions(currentStage);
+  const color = APPLICANT_STAGE_BADGE_COLORS[currentStage];
+  const badgeClass = `inline-flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium ${COLOR_CLASSES[color]}`;
+
+  useEffect(() => {
+    if (!open) return;
+    function handleClickOutside(event: MouseEvent) {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function handleEsc(event: KeyboardEvent) {
+      if (event.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("keydown", handleEsc);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("keydown", handleEsc);
+    };
+  }, [open]);
+
+  function handleOpen() {
+    setSelectedStage("");
+    setNote("");
+    setOpen(true);
+  }
+
+  async function handleConfirm() {
+    if (!selectedStage) return;
+    try {
+      await transitionStage({
+        applicantId,
+        data: { new_stage: selectedStage, note: note.trim() || null },
+      }).unwrap();
+      const label = APPLICANT_STAGE_LABELS[selectedStage];
+      showSuccess(`Applicant marked as ${label}`);
+      setOpen(false);
+    } catch (err: unknown) {
+      const detail =
+        err && typeof err === "object" && "data" in err
+          ? (err as { data?: { detail?: string } }).data?.detail
+          : undefined;
+      showError(detail ?? "Failed to update applicant stage. Please try again.");
+    }
+  }
+
+  if (!canWrite) {
+    return (
+      <span
+        data-testid={`applicant-stage-badge-${currentStage}`}
+        className={badgeClass}
+      >
+        {APPLICANT_STAGE_LABELS[currentStage]}
+      </span>
+    );
+  }
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <button
+        type="button"
+        onClick={handleOpen}
+        data-testid="applicant-status-control-trigger"
+        aria-expanded={open}
+        aria-haspopup="dialog"
+        aria-label={`Current stage: ${APPLICANT_STAGE_LABELS[currentStage]}. Click to change.`}
+        className={`${badgeClass} cursor-pointer hover:opacity-80 transition-opacity min-h-[44px]`}
+      >
+        <span data-testid={`applicant-stage-badge-${currentStage}`}>
+          {APPLICANT_STAGE_LABELS[currentStage]}
+        </span>
+        <ChevronDown size={12} aria-hidden="true" />
+      </button>
+
+      {open ? (
+        <div
+          role="dialog"
+          aria-label="Change applicant stage"
+          data-testid="applicant-status-popover"
+          className="absolute top-full left-0 mt-1 z-30 bg-card border rounded-md shadow-lg p-4 min-w-[260px] space-y-3"
+        >
+          <p className="text-xs font-medium text-muted-foreground">
+            Move to stage
+          </p>
+
+          {allowedNextStages.length === 0 ? (
+            <p className="text-xs text-muted-foreground italic">
+              No further transitions available for this stage.
+            </p>
+          ) : (
+            <select
+              value={selectedStage}
+              onChange={(e) => setSelectedStage(e.target.value as ApplicantStage)}
+              data-testid="applicant-status-stage-select"
+              className="w-full rounded border bg-background px-2 py-2 text-sm min-h-[44px]"
+              aria-label="Select new stage"
+            >
+              <option value="">— select stage —</option>
+              {allowedNextStages.map((stage) => (
+                <option key={stage} value={stage}>
+                  {APPLICANT_STAGE_LABELS[stage]}
+                </option>
+              ))}
+            </select>
+          )}
+
+          <div className="space-y-1">
+            <label
+              htmlFor="stage-transition-note"
+              className="text-xs text-muted-foreground"
+            >
+              Note (optional)
+            </label>
+            <textarea
+              id="stage-transition-note"
+              data-testid="applicant-status-note"
+              value={note}
+              onChange={(e) => setNote(e.target.value)}
+              maxLength={NOTE_MAX_LENGTH}
+              rows={3}
+              placeholder="e.g. References checked separately"
+              className="w-full rounded border bg-background px-2 py-1.5 text-sm resize-none"
+            />
+            <p className="text-right text-xs text-muted-foreground">
+              {note.length}/{NOTE_MAX_LENGTH}
+            </p>
+          </div>
+
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              data-testid="applicant-status-cancel"
+              onClick={() => setOpen(false)}
+            >
+              Cancel
+            </Button>
+            <LoadingButton
+              type="button"
+              variant="primary"
+              size="sm"
+              data-testid="applicant-status-confirm"
+              disabled={!selectedStage}
+              onClick={handleConfirm}
+            >
+              Confirm
+            </LoadingButton>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/ApplicantDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/ApplicantDetail.tsx
@@ -12,7 +12,7 @@ import {
   formatLongDate,
   formatRelativeTime,
 } from "@/shared/lib/inquiry-date-format";
-import ApplicantStageBadge from "@/app/features/applicants/ApplicantStageBadge";
+import ApplicantStatusControl from "@/app/features/applicants/ApplicantStatusControl";
 import ApplicantDetailSkeleton from "@/app/features/applicants/ApplicantDetailSkeleton";
 import ApplicantTimelineList from "@/app/features/applicants/ApplicantTimelineList";
 import ReferenceRow from "@/app/features/applicants/ReferenceRow";
@@ -67,7 +67,10 @@ export default function ApplicantDetail() {
             title={applicant.legal_name ?? "Unnamed applicant"}
             subtitle={
               <span className="inline-flex items-center gap-2 flex-wrap">
-                <ApplicantStageBadge stage={applicant.stage} />
+                <ApplicantStatusControl
+                  applicantId={applicant.id}
+                  currentStage={applicant.stage}
+                />
                 <span
                   className="text-xs text-muted-foreground"
                   title={formatAbsoluteTime(applicant.created_at)}

--- a/apps/mybookkeeper/frontend/src/shared/lib/applicant-stage-transitions.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/applicant-stage-transitions.ts
@@ -1,0 +1,24 @@
+import type { ApplicantStage } from "@/shared/types/applicant/applicant-stage";
+
+/**
+ * Allowed stage transitions for manual host overrides.
+ *
+ * Mirrors ``ALLOWED_TRANSITIONS`` in
+ * ``backend/app/services/applicants/applicant_stage_service.py``.
+ * Keep both in sync when adding stages.
+ */
+export const ALLOWED_TRANSITIONS: Record<ApplicantStage, readonly ApplicantStage[]> = {
+  lead: ["screening_pending", "approved", "declined"],
+  screening_pending: ["screening_passed", "screening_failed", "approved", "declined"],
+  screening_passed: ["video_call_done", "approved", "declined"],
+  screening_failed: ["declined", "approved"],
+  video_call_done: ["approved", "declined"],
+  approved: ["lease_sent", "declined"],
+  lease_sent: ["lease_signed", "declined"],
+  lease_signed: [],
+  declined: ["lead"],
+};
+
+export function getAllowedTransitions(stage: ApplicantStage): readonly ApplicantStage[] {
+  return ALLOWED_TRANSITIONS[stage] ?? [];
+}

--- a/apps/mybookkeeper/frontend/src/shared/store/applicantsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/applicantsApi.ts
@@ -3,6 +3,7 @@ import type { ApplicantDetailResponse } from "@/shared/types/applicant/applicant
 import type { ApplicantListArgs } from "@/shared/types/applicant/applicant-list-args";
 import type { ApplicantListResponse } from "@/shared/types/applicant/applicant-list-response";
 import type { ApplicantPromoteRequest } from "@/shared/types/applicant/applicant-promote-request";
+import type { StageTransitionRequest } from "@/shared/types/applicant/stage-transition-request";
 
 /**
  * RTK Query slice for the Applicants domain.
@@ -59,6 +60,20 @@ const applicantsApi = baseApi.injectEndpoints({
         { type: "Inquiry", id: "LIST" },
       ],
     }),
+    transitionApplicantStage: builder.mutation<
+      ApplicantDetailResponse,
+      { applicantId: string; data: StageTransitionRequest }
+    >({
+      query: ({ applicantId, data }) => ({
+        url: `/applicants/${applicantId}/stage`,
+        method: "PATCH",
+        data,
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "Applicant", id: arg.applicantId },
+        { type: "Applicant", id: "LIST" },
+      ],
+    }),
   }),
 });
 
@@ -66,4 +81,5 @@ export const {
   useGetApplicantsQuery,
   useGetApplicantByIdQuery,
   usePromoteFromInquiryMutation,
+  useTransitionApplicantStageMutation,
 } = applicantsApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/applicant/applicant-event.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/applicant/applicant-event.ts
@@ -9,6 +9,7 @@ export interface ApplicantEvent {
   event_type: string;
   actor: ApplicantEventActor;
   notes: string | null;
+  payload: Record<string, unknown> | null;
   occurred_at: string;
   created_at: string;
 }

--- a/apps/mybookkeeper/frontend/src/shared/types/applicant/stage-transition-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/applicant/stage-transition-request.ts
@@ -1,0 +1,6 @@
+import type { ApplicantStage } from "./applicant-stage";
+
+export interface StageTransitionRequest {
+  new_stage: ApplicantStage;
+  note?: string | null;
+}


### PR DESCRIPTION
## User story

As a host, I want to approve or decline an applicant directly from the Applicant Detail page — without uploading a screening report — so I can handle cases where I've verified applicants through other means (e.g., phone call, manual reference check).

Background: the host had to SQL-update Prince Kapoor's stage directly in production. This PR replaces that workaround with a proper UI.

## What was built

- **`PATCH /api/applicants/{id}/stage`** — new endpoint (write-access required, viewer returns 403)
- **`applicant_stage_service.py`** — enforces the ALLOWED_TRANSITIONS whitelist; rejects invalid or terminal transitions with HTTP 422
- **`ApplicantStatusControl`** — clickable stage badge on the detail page header that opens a popover with: stage dropdown (only valid next stages), optional 500-char note, Confirm/Cancel buttons with loading state
- **`applicant-stage-transitions.ts`** — frontend mirror of the transitions map (single source per file, keeps backend/frontend in sync)
- **Migration `a1b2c3d4e5f6`** — adds `applicant_events.payload JSONB` + extends `chk_applicant_event_type` to include `stage_changed`

## Allowed-transitions matrix

| From | Allowed next stages |
|---|---|
| lead | screening_pending, approved, declined |
| screening_pending | screening_passed, screening_failed, approved, declined |
| screening_passed | video_call_done, approved, declined |
| screening_failed | declined, approved (**host override allowed**) |
| video_call_done | approved, declined |
| approved | lease_sent, declined |
| lease_sent | lease_signed, declined |
| lease_signed | *(terminal — no transitions)* |
| declined | lead *(un-decline if mistake)* |

## Future screening rebuild note

When the screening rebuild ships (`screening_decision` column PR), this UI will be repurposed to write `screening_decision` instead of `stage`. That's approximately a 5-line change to `ApplicantStatusControl.tsx` at that time — the popover, transitions logic, API wiring, and event audit trail all stay.

## Test plan

- [ ] Backend: 22 pytest tests pass (service unit + API route tests)
  - Happy path with note / without note
  - Tenant isolation (cross-user → 404)
  - Invalid transition (lease_signed → lead → 422)
  - Unknown stage value → 422
  - Note >500 chars → 422; note exactly 500 chars → 200; null note → 200
  - Extra fields in body → 422 (Pydantic `extra="forbid"`)
  - Viewer role → 403
  - Unauthenticated → 401
- [ ] Frontend: 9 Vitest unit tests pass (ApplicantStatusControl)
  - Renders current stage badge
  - Opens/closes popover
  - Only shows allowed transitions for current stage
  - Disabled confirm until stage selected
  - Calls mutation with selected stage + note
  - Terminal stage shows no-transitions message (no select rendered)
  - Read-only viewer sees plain badge (no trigger button)
  - Blank note trimmed to null before mutation call
- [ ] E2E: 4 Playwright tests (applicant-stage-transition.spec.ts)
  - Approve a lead → badge updates to Approved + `stage_changed` event in DB with correct payload
  - Decline → un-decline: 2 `stage_changed` events written
  - Terminal stage (lease_signed) popover shows "No further transitions" message
  - Layout: all existing detail-page sections remain intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)