### PR TITLE
fix(security): harden input validation — URL schemes, length caps, extra=forbid (audit 2026-05-02)

### DIFF
--- a/apps/mybookkeeper/backend/app/schemas/applicants/screening_upload_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/screening_upload_request.py
@@ -13,7 +13,7 @@ an auditable business decision.
 """
 from __future__ import annotations
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from app.core.applicant_enums import SCREENING_STATUSES
 
@@ -29,6 +29,8 @@ class ScreeningUploadRequest(BaseModel):
             "outcomes can trigger an adverse action."
         ),
     )
+
+    model_config = ConfigDict(extra="forbid")
 
     @model_validator(mode="after")
     def _validate_status(self) -> "ScreeningUploadRequest":

--- a/apps/mybookkeeper/backend/app/schemas/listings/blackout_update_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/listings/blackout_update_request.py
@@ -1,7 +1,9 @@
 """PATCH /listings/blackouts/{blackout_id} request body."""
 from __future__ import annotations
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, Field
+
+_HOST_NOTES_MAX_LEN = 10000
 
 
 class BlackoutUpdateRequest(BaseModel):
@@ -11,4 +13,6 @@ class BlackoutUpdateRequest(BaseModel):
     label) slot in here without changing the endpoint shape.
     """
 
-    host_notes: str | None = None
+    host_notes: str | None = Field(default=None, max_length=_HOST_NOTES_MAX_LEN)
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/mybookkeeper/backend/tests/test_input_validation_hardening.py
+++ b/apps/mybookkeeper/backend/tests/test_input_validation_hardening.py
@@ -1,0 +1,90 @@
+"""Schema-level input validation tests — audit 2026-05-02.
+
+MBK scope:
+1. BlackoutUpdateRequest — host_notes max_length cap + extra="forbid" (Cat 2 + Cat 3).
+2. ScreeningUploadRequest — extra="forbid" (Cat 3).
+
+These are pure unit tests against Pydantic schema construction — no DB or
+HTTP calls needed.
+"""
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.listings.blackout_update_request import BlackoutUpdateRequest
+from app.schemas.applicants.screening_upload_request import ScreeningUploadRequest
+
+
+# ===========================================================================
+# BlackoutUpdateRequest — host_notes length cap + extra="forbid"
+# ===========================================================================
+
+
+class TestBlackoutUpdateRequestLengthCap:
+    """host_notes is capped at 10 000 characters."""
+
+    def test_accepts_notes_at_limit(self) -> None:
+        req = BlackoutUpdateRequest(host_notes="x" * 10000)
+        assert req.host_notes is not None
+
+    def test_rejects_notes_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            BlackoutUpdateRequest(host_notes="x" * 10001)
+
+    def test_accepts_none_notes(self) -> None:
+        req = BlackoutUpdateRequest(host_notes=None)
+        assert req.host_notes is None
+
+    def test_accepts_empty_string(self) -> None:
+        req = BlackoutUpdateRequest(host_notes="")
+        assert req.host_notes == ""
+
+    def test_accepts_normal_notes(self) -> None:
+        req = BlackoutUpdateRequest(host_notes="Closed for maintenance")
+        assert req.host_notes == "Closed for maintenance"
+
+
+class TestBlackoutUpdateRequestExtraForbid:
+    """BlackoutUpdateRequest rejects extra fields (mass-assignment guard)."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            BlackoutUpdateRequest(host_notes="Valid notes", injected_field="bad")
+
+    def test_rejects_user_id_injection(self) -> None:
+        with pytest.raises(ValidationError):
+            BlackoutUpdateRequest(host_notes="Valid notes", user_id="some-id")
+
+
+# ===========================================================================
+# ScreeningUploadRequest — extra="forbid"
+# ===========================================================================
+
+
+class TestScreeningUploadRequestExtraForbid:
+    """ScreeningUploadRequest rejects extra fields (mass-assignment guard)."""
+
+    def test_accepts_valid_pass_status(self) -> None:
+        req = ScreeningUploadRequest(status="pass")
+        assert req.status == "pass"
+
+    def test_accepts_valid_fail_status_with_snippet(self) -> None:
+        req = ScreeningUploadRequest(
+            status="fail",
+            adverse_action_snippet="Credit score below threshold",
+        )
+        assert req.adverse_action_snippet == "Credit score below threshold"
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            ScreeningUploadRequest(status="pass", injected_field="bad")
+
+    def test_rejects_unknown_status_field(self) -> None:
+        """Regression: extra=forbid must not swallow the status validator."""
+        with pytest.raises(ValidationError):
+            ScreeningUploadRequest(status="pass", extra_key="sneaky")
+
+    def test_happy_path_no_extra_is_clean(self) -> None:
+        req = ScreeningUploadRequest(status="inconclusive")
+        assert req.adverse_action_snippet is None

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -399,7 +399,8 @@
         "test_calendar_service.py",
         "test_calendar_events_route.py",
         "test_calendar_route.py",
-        "test_blackout_notes_attachments.py"
+        "test_blackout_notes_attachments.py",
+        "test_input_validation_hardening.py"
       ],
       "frontend_tests": [
         "Calendar.test.tsx",
@@ -538,7 +539,8 @@
       ],
       "backend_tests": [
         "test_screening.py",
-        "test_screening_result_repo.py"
+        "test_screening_result_repo.py",
+        "test_input_validation_hardening.py"
       ],
       "frontend_tests": [
         "RunScreeningButton.test.tsx",

--- a/apps/myjobhunter/backend/app/schemas/application/application_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_create_request.py
@@ -20,7 +20,7 @@ import datetime as _dt
 import uuid
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_serializer, model_validator
 
 from app.core.enums import ApplicationSource, RemoteType, SalaryPeriod
 
@@ -30,6 +30,9 @@ _LOCATION_MAX_LEN = 200
 _CURRENCY_LEN = 3
 _EXTERNAL_REF_MAX_LEN = 255
 _EXTERNAL_SOURCE_MAX_LEN = 50
+_URL_MAX_LEN = 2048
+_JD_TEXT_MAX_LEN = 50000
+_NOTES_MAX_LEN = 5000
 
 
 class ApplicationCreateRequest(BaseModel):
@@ -44,8 +47,8 @@ class ApplicationCreateRequest(BaseModel):
     company_id: uuid.UUID
     role_title: str = Field(min_length=1, max_length=_ROLE_TITLE_MAX_LEN)
 
-    url: str | None = None
-    jd_text: str | None = None
+    url: AnyHttpUrl | None = None
+    jd_text: str | None = Field(default=None, max_length=_JD_TEXT_MAX_LEN)
     jd_parsed: dict | None = None
 
     source: str | None = None
@@ -64,13 +67,18 @@ class ApplicationCreateRequest(BaseModel):
     remote_type: str = "unknown"
 
     fit_score: Decimal | None = Field(default=None, ge=0, le=100)
-    notes: str | None = None
+    notes: str | None = Field(default=None, max_length=_NOTES_MAX_LEN)
     archived: bool = False
 
     external_ref: str | None = Field(default=None, max_length=_EXTERNAL_REF_MAX_LEN)
     external_source: str | None = Field(default=None, max_length=_EXTERNAL_SOURCE_MAX_LEN)
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_serializer("url")
+    def _serialize_url(self, value: AnyHttpUrl | None) -> str | None:
+        """Coerce AnyHttpUrl to plain string for DB storage."""
+        return str(value) if value is not None else None
 
     @model_validator(mode="after")
     def _validate_business_rules(self) -> "ApplicationCreateRequest":

--- a/apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py
@@ -20,6 +20,7 @@ from app.core.enums import EventType, EventSource
 
 _EVENT_TYPE_MAX_LEN = 30
 _SOURCE_MAX_LEN = 20
+_NOTE_MAX_LEN = 5000
 
 
 class ApplicationEventCreateRequest(BaseModel):
@@ -28,7 +29,7 @@ class ApplicationEventCreateRequest(BaseModel):
     event_type: str = Field(min_length=1, max_length=_EVENT_TYPE_MAX_LEN)
     occurred_at: _dt.datetime
     source: str = Field(default=EventSource.MANUAL, max_length=_SOURCE_MAX_LEN)
-    note: str | None = None
+    note: str | None = Field(default=None, max_length=_NOTE_MAX_LEN)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/apps/myjobhunter/backend/app/schemas/application/application_event_response.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_event_response.py
@@ -1,8 +1,14 @@
 """Pydantic schema for an ApplicationEvent response.
 
 Used by GET /applications/{id}/events and POST /applications/{id}/events.
-``raw_payload`` and ``email_message_id`` are exposed read-only — they
-only get populated by Gmail sync workers, never by manual log entries.
+``email_message_id`` is exposed read-only — it is only populated by Gmail
+sync workers, never by manual log entries.
+
+``raw_payload`` was removed from this response schema (audit 2026-05-02,
+CWE-200). The field is always null in Phase 1-2 and exposing it in the public
+API response is a forward-looking data-exposure risk. If Phase 3 Gmail
+sync workers need to surface parsed email artifacts, introduce a separate
+admin-only response schema at that time.
 """
 from __future__ import annotations
 
@@ -21,7 +27,6 @@ class ApplicationEventResponse(BaseModel):
     occurred_at: _dt.datetime
     source: str
     email_message_id: str | None = None
-    raw_payload: dict | None = None
     note: str | None = None
 
     created_at: _dt.datetime

--- a/apps/myjobhunter/backend/app/schemas/application/application_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_update_request.py
@@ -16,7 +16,7 @@ import datetime as _dt
 import uuid
 from decimal import Decimal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_serializer, model_validator
 
 from app.core.enums import ApplicationSource, RemoteType, SalaryPeriod
 
@@ -25,6 +25,9 @@ _LOCATION_MAX_LEN = 200
 _CURRENCY_LEN = 3
 _EXTERNAL_REF_MAX_LEN = 255
 _EXTERNAL_SOURCE_MAX_LEN = 50
+_URL_MAX_LEN = 2048
+_JD_TEXT_MAX_LEN = 50000
+_NOTES_MAX_LEN = 5000
 
 
 class ApplicationUpdateRequest(BaseModel):
@@ -33,8 +36,8 @@ class ApplicationUpdateRequest(BaseModel):
     company_id: uuid.UUID | None = None
     role_title: str | None = Field(default=None, min_length=1, max_length=_ROLE_TITLE_MAX_LEN)
 
-    url: str | None = None
-    jd_text: str | None = None
+    url: AnyHttpUrl | None = None
+    jd_text: str | None = Field(default=None, max_length=_JD_TEXT_MAX_LEN)
     jd_parsed: dict | None = None
 
     source: str | None = None
@@ -53,13 +56,18 @@ class ApplicationUpdateRequest(BaseModel):
     remote_type: str | None = None
 
     fit_score: Decimal | None = Field(default=None, ge=0, le=100)
-    notes: str | None = None
+    notes: str | None = Field(default=None, max_length=_NOTES_MAX_LEN)
     archived: bool | None = None
 
     external_ref: str | None = Field(default=None, max_length=_EXTERNAL_REF_MAX_LEN)
     external_source: str | None = Field(default=None, max_length=_EXTERNAL_SOURCE_MAX_LEN)
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_serializer("url")
+    def _serialize_url(self, value: AnyHttpUrl | None) -> str | None:
+        """Coerce AnyHttpUrl to plain string for DB storage."""
+        return str(value) if value is not None else None
 
     @model_validator(mode="after")
     def _validate_business_rules(self) -> "ApplicationUpdateRequest":

--- a/apps/myjobhunter/backend/app/schemas/company/company_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/company/company_create_request.py
@@ -11,7 +11,7 @@ explicit allowlist of writable columns as defense in depth.
 """
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_serializer
 
 # Bounds mirror the ``Company`` model's String() lengths.
 _NAME_MAX_LEN = 200
@@ -22,6 +22,8 @@ _HQ_MAX_LEN = 200
 _EXTERNAL_REF_MAX_LEN = 255
 _EXTERNAL_SOURCE_MAX_LEN = 50
 _CRUNCHBASE_MAX_LEN = 50
+_LOGO_URL_MAX_LEN = 2048
+_DESCRIPTION_MAX_LEN = 5000
 
 
 class CompanyCreateRequest(BaseModel):
@@ -30,13 +32,18 @@ class CompanyCreateRequest(BaseModel):
     name: str = Field(min_length=1, max_length=_NAME_MAX_LEN)
 
     primary_domain: str | None = Field(default=None, max_length=_DOMAIN_MAX_LEN)
-    logo_url: str | None = None
+    logo_url: AnyHttpUrl | None = None
     industry: str | None = Field(default=None, max_length=_INDUSTRY_MAX_LEN)
     size_range: str | None = Field(default=None, max_length=_SIZE_RANGE_MAX_LEN)
     hq_location: str | None = Field(default=None, max_length=_HQ_MAX_LEN)
-    description: str | None = None
+    description: str | None = Field(default=None, max_length=_DESCRIPTION_MAX_LEN)
     external_ref: str | None = Field(default=None, max_length=_EXTERNAL_REF_MAX_LEN)
     external_source: str | None = Field(default=None, max_length=_EXTERNAL_SOURCE_MAX_LEN)
     crunchbase_id: str | None = Field(default=None, max_length=_CRUNCHBASE_MAX_LEN)
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_serializer("logo_url")
+    def _serialize_logo_url(self, value: AnyHttpUrl | None) -> str | None:
+        """Coerce AnyHttpUrl to plain string for DB storage."""
+        return str(value) if value is not None else None

--- a/apps/myjobhunter/backend/app/schemas/company/company_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/company/company_update_request.py
@@ -12,7 +12,7 @@ HTTP 422.
 """
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, Field, field_serializer
 
 # Bounds mirror the ``Company`` model's String() lengths.
 _NAME_MAX_LEN = 200
@@ -23,6 +23,8 @@ _HQ_MAX_LEN = 200
 _EXTERNAL_REF_MAX_LEN = 255
 _EXTERNAL_SOURCE_MAX_LEN = 50
 _CRUNCHBASE_MAX_LEN = 50
+_LOGO_URL_MAX_LEN = 2048
+_DESCRIPTION_MAX_LEN = 5000
 
 _ALLOWED_SIZE_RANGES = frozenset({"1-10", "11-50", "51-200", "201-1000", "1001-5000", "5000+"})
 
@@ -32,16 +34,21 @@ class CompanyUpdateRequest(BaseModel):
 
     name: str | None = Field(default=None, min_length=1, max_length=_NAME_MAX_LEN)
     primary_domain: str | None = Field(default=None, max_length=_DOMAIN_MAX_LEN)
-    logo_url: str | None = None
+    logo_url: AnyHttpUrl | None = None
     industry: str | None = Field(default=None, max_length=_INDUSTRY_MAX_LEN)
     size_range: str | None = Field(default=None, max_length=_SIZE_RANGE_MAX_LEN)
     hq_location: str | None = Field(default=None, max_length=_HQ_MAX_LEN)
-    description: str | None = None
+    description: str | None = Field(default=None, max_length=_DESCRIPTION_MAX_LEN)
     external_ref: str | None = Field(default=None, max_length=_EXTERNAL_REF_MAX_LEN)
     external_source: str | None = Field(default=None, max_length=_EXTERNAL_SOURCE_MAX_LEN)
     crunchbase_id: str | None = Field(default=None, max_length=_CRUNCHBASE_MAX_LEN)
 
     model_config = ConfigDict(extra="forbid")
+
+    @field_serializer("logo_url")
+    def _serialize_logo_url(self, value: AnyHttpUrl | None) -> str | None:
+        """Coerce AnyHttpUrl to plain string for DB storage."""
+        return str(value) if value is not None else None
 
     def to_update_dict(self) -> dict[str, object]:
         """Return only the explicitly-provided fields (Pydantic ``exclude_unset``).

--- a/apps/myjobhunter/backend/app/schemas/profile/screening_answer_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/screening_answer_create_request.py
@@ -8,9 +8,11 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+_ANSWER_MAX_LEN = 5000
+
 
 class ScreeningAnswerCreateRequest(BaseModel):
     question_key: str = Field(min_length=1, max_length=80)
-    answer: str | None = None
+    answer: str | None = Field(default=None, max_length=_ANSWER_MAX_LEN)
 
     model_config = ConfigDict(extra="forbid")

--- a/apps/myjobhunter/backend/app/schemas/profile/screening_answer_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/screening_answer_update_request.py
@@ -5,11 +5,13 @@ after creation.
 """
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
+
+_ANSWER_MAX_LEN = 5000
 
 
 class ScreeningAnswerUpdateRequest(BaseModel):
-    answer: str | None = None
+    answer: str | None = Field(default=None, max_length=_ANSWER_MAX_LEN)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/apps/myjobhunter/backend/app/schemas/profile/work_history_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/work_history_create_request.py
@@ -2,8 +2,15 @@
 from __future__ import annotations
 
 from datetime import date
+from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
+
+_BULLET_MAX_LEN = 2000
+_BULLETS_MAX_COUNT = 30
+
+# Annotated item type so each bullet is length-capped.
+BulletItem = Annotated[str, Field(min_length=1, max_length=_BULLET_MAX_LEN)]
 
 
 class WorkHistoryCreateRequest(BaseModel):
@@ -11,6 +18,6 @@ class WorkHistoryCreateRequest(BaseModel):
     title: str = Field(min_length=1, max_length=200)
     start_date: date
     end_date: date | None = None
-    bullets: list[str] = Field(default_factory=list, max_length=30)
+    bullets: list[BulletItem] = Field(default_factory=list, max_length=_BULLETS_MAX_COUNT)
 
     model_config = ConfigDict(extra="forbid")

--- a/apps/myjobhunter/backend/app/schemas/profile/work_history_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/work_history_update_request.py
@@ -2,8 +2,15 @@
 from __future__ import annotations
 
 from datetime import date
+from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field
+
+_BULLET_MAX_LEN = 2000
+_BULLETS_MAX_COUNT = 30
+
+# Annotated item type so each bullet is length-capped.
+BulletItem = Annotated[str, Field(min_length=1, max_length=_BULLET_MAX_LEN)]
 
 
 class WorkHistoryUpdateRequest(BaseModel):
@@ -11,7 +18,7 @@ class WorkHistoryUpdateRequest(BaseModel):
     title: str | None = Field(default=None, min_length=1, max_length=200)
     start_date: date | None = None
     end_date: date | None = None
-    bullets: list[str] | None = Field(default=None, max_length=30)
+    bullets: list[BulletItem] | None = Field(default=None, max_length=_BULLETS_MAX_COUNT)
 
     model_config = ConfigDict(extra="forbid")
 

--- a/apps/myjobhunter/backend/tests/test_input_validation_hardening.py
+++ b/apps/myjobhunter/backend/tests/test_input_validation_hardening.py
@@ -1,0 +1,369 @@
+"""Schema-level input validation tests — audit 2026-05-02.
+
+Covers four categories of hardening:
+1. URL fields reject ``javascript:`` and other non-http/https schemes (CWE-79).
+2. Unbounded Text columns now have length caps (CWE-400).
+3. Write-side schemas enforce ``extra="forbid"`` (mass-assignment guard).
+4. ``ApplicationEventResponse`` no longer exposes ``raw_payload`` (CWE-200).
+
+These are pure unit tests against Pydantic schema construction — no DB or
+HTTP calls needed. Each test class maps to one schema or one category.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from pydantic import ValidationError
+
+from app.schemas.application.application_create_request import ApplicationCreateRequest
+from app.schemas.application.application_event_create_request import ApplicationEventCreateRequest
+from app.schemas.application.application_event_response import ApplicationEventResponse
+from app.schemas.application.application_update_request import ApplicationUpdateRequest
+from app.schemas.company.company_create_request import CompanyCreateRequest
+from app.schemas.company.company_update_request import CompanyUpdateRequest
+from app.schemas.profile.screening_answer_create_request import ScreeningAnswerCreateRequest
+from app.schemas.profile.screening_answer_update_request import ScreeningAnswerUpdateRequest
+from app.schemas.profile.work_history_create_request import WorkHistoryCreateRequest
+from app.schemas.profile.work_history_update_request import WorkHistoryUpdateRequest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COMPANY_ID = str(uuid.uuid4())
+_APP_BASE = {
+    "company_id": _COMPANY_ID,
+    "role_title": "Engineer",
+    "remote_type": "remote",
+    "posted_salary_currency": "USD",
+}
+
+
+# ===========================================================================
+# Category 1 — URL fields reject non-http/https schemes (CWE-79)
+# ===========================================================================
+
+
+class TestApplicationUrlValidation:
+    """ApplicationCreateRequest / ApplicationUpdateRequest — url field."""
+
+    def test_create_accepts_https_url(self) -> None:
+        req = ApplicationCreateRequest(**_APP_BASE, url="https://jobs.example.com/apply/123")
+        assert req.url is not None
+
+    def test_create_accepts_http_url(self) -> None:
+        req = ApplicationCreateRequest(**_APP_BASE, url="http://jobs.example.com/apply/123")
+        assert req.url is not None
+
+    def test_create_accepts_none_url(self) -> None:
+        req = ApplicationCreateRequest(**_APP_BASE, url=None)
+        assert req.url is None
+
+    def test_create_rejects_javascript_scheme(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationCreateRequest(**_APP_BASE, url="javascript:alert(1)")
+
+    def test_create_rejects_data_scheme(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationCreateRequest(**_APP_BASE, url="data:text/html,<script>alert(1)</script>")
+
+    def test_create_rejects_bare_string(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationCreateRequest(**_APP_BASE, url="not-a-url")
+
+    def test_update_accepts_https_url(self) -> None:
+        req = ApplicationUpdateRequest(url="https://example.com/job")
+        assert req.url is not None
+
+    def test_update_rejects_javascript_scheme(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationUpdateRequest(url="javascript:void(0)")
+
+    def test_url_serializes_to_str(self) -> None:
+        """AnyHttpUrl must round-trip as a plain str so DB column stays String."""
+        req = ApplicationCreateRequest(**_APP_BASE, url="https://example.com/job")
+        dumped = req.model_dump()
+        assert isinstance(dumped["url"], str)
+
+    def test_update_url_serializes_to_str(self) -> None:
+        req = ApplicationUpdateRequest(url="https://example.com/job")
+        dumped = req.to_update_dict()
+        assert isinstance(dumped["url"], str)
+
+
+class TestCompanyLogoUrlValidation:
+    """CompanyCreateRequest / CompanyUpdateRequest — logo_url field."""
+
+    def test_create_accepts_https_logo_url(self) -> None:
+        req = CompanyCreateRequest(name="Acme", logo_url="https://cdn.example.com/logo.png")
+        assert req.logo_url is not None
+
+    def test_create_accepts_http_logo_url(self) -> None:
+        req = CompanyCreateRequest(name="Acme", logo_url="http://cdn.example.com/logo.png")
+        assert req.logo_url is not None
+
+    def test_create_accepts_none_logo_url(self) -> None:
+        req = CompanyCreateRequest(name="Acme", logo_url=None)
+        assert req.logo_url is None
+
+    def test_create_rejects_javascript_scheme(self) -> None:
+        with pytest.raises(ValidationError):
+            CompanyCreateRequest(name="Acme", logo_url="javascript:alert('xss')")
+
+    def test_create_rejects_bare_string(self) -> None:
+        with pytest.raises(ValidationError):
+            CompanyCreateRequest(name="Acme", logo_url="not-a-url")
+
+    def test_update_rejects_javascript_scheme(self) -> None:
+        with pytest.raises(ValidationError):
+            CompanyUpdateRequest(logo_url="javascript:void(0)")
+
+    def test_logo_url_serializes_to_str(self) -> None:
+        req = CompanyCreateRequest(name="Acme", logo_url="https://cdn.example.com/logo.png")
+        dumped = req.model_dump()
+        assert isinstance(dumped["logo_url"], str)
+
+    def test_update_logo_url_serializes_to_str(self) -> None:
+        req = CompanyUpdateRequest(logo_url="https://cdn.example.com/logo.png")
+        dumped = req.to_update_dict()
+        assert isinstance(dumped["logo_url"], str)
+
+
+# ===========================================================================
+# Category 2 — Length caps (CWE-400)
+# ===========================================================================
+
+
+class TestApplicationLengthCaps:
+    """ApplicationCreateRequest / ApplicationUpdateRequest — text length caps."""
+
+    def test_create_accepts_notes_at_limit(self) -> None:
+        req = ApplicationCreateRequest(**_APP_BASE, notes="x" * 5000)
+        assert req.notes is not None
+
+    def test_create_rejects_notes_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationCreateRequest(**_APP_BASE, notes="x" * 5001)
+
+    def test_update_rejects_notes_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationUpdateRequest(notes="y" * 5001)
+
+    def test_create_accepts_jd_text_at_limit(self) -> None:
+        req = ApplicationCreateRequest(**_APP_BASE, jd_text="x" * 50000)
+        assert req.jd_text is not None
+
+    def test_create_rejects_jd_text_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationCreateRequest(**_APP_BASE, jd_text="x" * 50001)
+
+    def test_update_rejects_jd_text_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationUpdateRequest(jd_text="x" * 50001)
+
+
+class TestScreeningAnswerLengthCaps:
+    """ScreeningAnswerCreateRequest / ScreeningAnswerUpdateRequest."""
+
+    def test_create_accepts_answer_at_limit(self) -> None:
+        req = ScreeningAnswerCreateRequest(question_key="work_auth", answer="a" * 5000)
+        assert req.answer is not None
+
+    def test_create_rejects_answer_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            ScreeningAnswerCreateRequest(question_key="work_auth", answer="a" * 5001)
+
+    def test_update_accepts_answer_at_limit(self) -> None:
+        req = ScreeningAnswerUpdateRequest(answer="a" * 5000)
+        assert req.answer is not None
+
+    def test_update_rejects_answer_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            ScreeningAnswerUpdateRequest(answer="a" * 5001)
+
+
+class TestApplicationEventNoteLengthCap:
+    """ApplicationEventCreateRequest — note field."""
+
+    def test_accepts_note_at_limit(self) -> None:
+        req = ApplicationEventCreateRequest(
+            event_type="applied",
+            occurred_at="2025-01-01T00:00:00Z",
+            note="n" * 5000,
+        )
+        assert req.note is not None
+
+    def test_rejects_note_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationEventCreateRequest(
+                event_type="applied",
+                occurred_at="2025-01-01T00:00:00Z",
+                note="n" * 5001,
+            )
+
+
+class TestWorkHistoryBulletCaps:
+    """WorkHistoryCreateRequest / WorkHistoryUpdateRequest — per-item bullet cap."""
+
+    _BASE_WORK = {
+        "company_name": "Acme",
+        "title": "Engineer",
+        "start_date": "2020-01-01",
+    }
+
+    def test_create_accepts_bullet_at_limit(self) -> None:
+        req = WorkHistoryCreateRequest(**self._BASE_WORK, bullets=["x" * 2000])
+        assert len(req.bullets) == 1
+
+    def test_create_rejects_bullet_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkHistoryCreateRequest(**self._BASE_WORK, bullets=["x" * 2001])
+
+    def test_create_rejects_too_many_bullets(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkHistoryCreateRequest(**self._BASE_WORK, bullets=["bullet"] * 31)
+
+    def test_update_rejects_bullet_over_limit(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkHistoryUpdateRequest(bullets=["x" * 2001])
+
+    def test_update_rejects_too_many_bullets(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkHistoryUpdateRequest(bullets=["bullet"] * 31)
+
+    def test_create_accepts_empty_bullets(self) -> None:
+        req = WorkHistoryCreateRequest(**self._BASE_WORK, bullets=[])
+        assert req.bullets == []
+
+    def test_update_accepts_valid_bullets(self) -> None:
+        req = WorkHistoryUpdateRequest(bullets=["Led team of 5", "Shipped feature X"])
+        assert len(req.bullets) == 2
+
+
+# ===========================================================================
+# Category 3 — extra="forbid" audit
+# ===========================================================================
+
+
+class TestExtraForbidApplicationCreate:
+    """ApplicationCreateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationCreateRequest(**_APP_BASE, malicious_field="injected")
+
+    def test_rejects_user_id_injection(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationCreateRequest(**_APP_BASE, user_id=str(uuid.uuid4()))
+
+
+class TestExtraForbidApplicationUpdate:
+    """ApplicationUpdateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationUpdateRequest(role_title="Engineer", unknown_key="bad")
+
+
+class TestExtraForbidCompanyCreate:
+    """CompanyCreateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            CompanyCreateRequest(name="Acme", injected_field="bad")
+
+
+class TestExtraForbidCompanyUpdate:
+    """CompanyUpdateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            CompanyUpdateRequest(name="Acme", injected_field="bad")
+
+
+class TestExtraForbidScreeningAnswerCreate:
+    """ScreeningAnswerCreateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            ScreeningAnswerCreateRequest(
+                question_key="work_auth", answer="citizen", extra_key="bad",
+            )
+
+
+class TestExtraForbidScreeningAnswerUpdate:
+    """ScreeningAnswerUpdateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            ScreeningAnswerUpdateRequest(answer="citizen", is_eeoc=True)
+
+
+class TestExtraForbidApplicationEventCreate:
+    """ApplicationEventCreateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            ApplicationEventCreateRequest(
+                event_type="applied",
+                occurred_at="2025-01-01T00:00:00Z",
+                raw_payload={"sneaky": "injection"},
+            )
+
+
+class TestExtraForbidWorkHistoryCreate:
+    """WorkHistoryCreateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkHistoryCreateRequest(
+                company_name="Acme",
+                title="Eng",
+                start_date="2020-01-01",
+                extra_field="bad",
+            )
+
+
+class TestExtraForbidWorkHistoryUpdate:
+    """WorkHistoryUpdateRequest rejects unknown keys."""
+
+    def test_rejects_extra_field(self) -> None:
+        with pytest.raises(ValidationError):
+            WorkHistoryUpdateRequest(title="Eng", extra_field="bad")
+
+
+# ===========================================================================
+# Category 4 — raw_payload removed from ApplicationEventResponse (CWE-200)
+# ===========================================================================
+
+
+class TestApplicationEventResponseNoRawPayload:
+    """ApplicationEventResponse must not expose raw_payload."""
+
+    def test_raw_payload_not_in_schema_fields(self) -> None:
+        assert "raw_payload" not in ApplicationEventResponse.model_fields
+
+    def test_response_excludes_raw_payload_from_serialized_output(self) -> None:
+        resp = ApplicationEventResponse(
+            id=uuid.uuid4(),
+            user_id=uuid.uuid4(),
+            application_id=uuid.uuid4(),
+            event_type="applied",
+            occurred_at="2025-01-01T00:00:00Z",
+            source="manual",
+            created_at="2025-01-01T00:00:00Z",
+        )
+        dumped = resp.model_dump()
+        assert "raw_payload" not in dumped
+
+    def test_response_still_has_expected_fields(self) -> None:
+        """Regression guard — confirm the remaining fields are intact."""
+        fields = set(ApplicationEventResponse.model_fields.keys())
+        expected = {
+            "id", "user_id", "application_id",
+            "event_type", "occurred_at", "source",
+            "email_message_id", "note", "created_at",
+        }
+        assert expected.issubset(fields)


### PR DESCRIPTION
## Summary

Addresses all four input-validation High findings from the 2026-05-02 security audit. Pure schema-layer hardening — no migrations, no service-layer changes, no API contract breaks for consumers sending valid data.

---

## Cat 1 — URL fields reject `javascript:` URIs (CWE-79 stored XSS) — 4 files

| File | Field | Before | After |
|------|-------|--------|-------|
| MJH `application_create_request.py` | `url` | `str \| None` | `AnyHttpUrl \| None` |
| MJH `application_update_request.py` | `url` | `str \| None` | `AnyHttpUrl \| None` |
| MJH `company_create_request.py` | `logo_url` | `str \| None` | `AnyHttpUrl \| None` |
| MJH `company_update_request.py` | `logo_url` | `str \| None` | `AnyHttpUrl \| None` |

Each gets a `@field_serializer` that coerces `AnyHttpUrl → str` so DB columns (plain `String`) receive a string, not a Pydantic `AnyHttpUrl` object. Pattern mirrors existing MBK listings schemas (`ChannelListingCreateRequest`, `ListingExternalIdCreateRequest`).

`javascript:`, `data:`, and bare strings all → 422. `http://` and `https://` pass. `None` passes.

**Note re: `description` fields:** `CompanyCreateRequest.description` and `CompanyUpdateRequest.description` were also unbounded `str | None`. Added `max_length=5000` while in these files (Cat 2 overlap).

---

## Cat 2 — Unbounded Text columns get length caps (CWE-400 DoS) — 8 files

| File | Field | Cap |
|------|-------|-----|
| MBK `blackout_update_request.py` | `host_notes` | 10 000 |
| MJH `application_create_request.py` | `notes` | 5 000 |
| MJH `application_create_request.py` | `jd_text` | 50 000 |
| MJH `application_update_request.py` | `notes` | 5 000 |
| MJH `application_update_request.py` | `jd_text` | 50 000 |
| MJH `screening_answer_create_request.py` | `answer` | 5 000 |
| MJH `screening_answer_update_request.py` | `answer` | 5 000 |
| MJH `application_event_create_request.py` | `note` | 5 000 |
| MJH `work_history_create_request.py` | `bullets` items | 2 000 each |
| MJH `work_history_update_request.py` | `bullets` items | 2 000 each |

Bullet item cap uses `Annotated[str, Field(min_length=1, max_length=2000)]` as the list item type — list-level count cap (`max_length=30`) preserved.

---

## Cat 3 — `extra="forbid"` stragglers — 2 files

| File | Before | After |
|------|--------|-------|
| MBK `blackout_update_request.py` | no `model_config` | `ConfigDict(extra="forbid")` |
| MBK `screening_upload_request.py` | no `model_config` | `ConfigDict(extra="forbid")` |

All MJH write schemas already had `extra="forbid"`.

---

## Cat 4 — `raw_payload` removed from `ApplicationEventResponse` (CWE-200) — 1 file

`ApplicationEventResponse.raw_payload: dict | None = None` removed from the public response schema. The column still exists on the ORM model (correct — Phase 3 Gmail sync workers write to it). Pydantic's `from_attributes=True` simply ignores unmapped columns.

**Phase 3 note:** If the Gmail sync worker needs to surface `raw_payload` in an API response, introduce a separate admin-only or internal response schema at that time. Do NOT re-add to the public response schema.

---

## Test plan

- [x] `test_input_validation_hardening.py` (MJH) — 50 tests, all green
  - `javascript:` scheme → 422 (application url, company logo_url)
  - `data:` scheme → 422
  - bare string → 422
  - `http://` and `https://` → accepted
  - `None` → accepted
  - URL serializes as `str` in `model_dump()` / `to_update_dict()`
  - notes > 5000 chars → 422
  - jd_text > 50000 chars → 422
  - screening answer > 5000 chars → 422
  - event note > 5000 chars → 422
  - single bullet > 2000 chars → 422
  - > 30 bullets → 422
  - extra fields → 422 (all write schemas)
  - `raw_payload` absent from `ApplicationEventResponse.model_fields`
  - `raw_payload` absent from `model_dump()` output
  - remaining expected fields intact
- [x] `test_input_validation_hardening.py` (MBK) — 12 tests, all green
  - `host_notes` > 10000 chars → 422
  - `host_notes = None` → accepted
  - extra field on `BlackoutUpdateRequest` → 422
  - extra field on `ScreeningUploadRequest` → 422
- [x] No regressions in `test_schema_cleanup.py`, `test_transaction_schema.py` (MBK)

## Out of scope (separate PRs)

- TOTP SHA-256 KDF migration
- Screening rebuild
- Audit log gap fixes
- Performance fixes