### PR TITLE
fix(security): commit auth events before raise — silent audit-row rollback (audit follow-up)

### DIFF
--- a/apps/mybookkeeper/backend/app/api/totp.py
+++ b/apps/mybookkeeper/backend/app/api/totp.py
@@ -126,6 +126,7 @@ async def totp_login(
             succeeded=False,
             metadata={"reason": "bad_credentials"},
         )
+        await db.commit()
         raise HTTPException(status_code=400, detail="LOGIN_BAD_CREDENTIALS")
 
     if not user.is_active:
@@ -137,6 +138,7 @@ async def totp_login(
             succeeded=False,
             metadata={"reason": "account_inactive"},
         )
+        await db.commit()
         raise HTTPException(status_code=400, detail="LOGIN_BAD_CREDENTIALS")
 
     if not user.is_verified:
@@ -147,6 +149,7 @@ async def totp_login(
             request=request,
             succeeded=False,
         )
+        await db.commit()
         raise HTTPException(status_code=400, detail="LOGIN_USER_NOT_VERIFIED")
 
     # TOTP gate: if user has 2FA enabled, require the code

--- a/apps/mybookkeeper/backend/tests/test_email_verification.py
+++ b/apps/mybookkeeper/backend/tests/test_email_verification.py
@@ -313,6 +313,7 @@ class TestTotpLoginUnverified:
         try:
             with (
                 patch("app.api.totp.UserManager.authenticate_password", new=AsyncMock(return_value=unverified_user)),
+                patch("app.api.totp.log_auth_event", new=AsyncMock(return_value=None)),
             ):
                 async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
                     resp = await client.post(

--- a/apps/myjobhunter/backend/app/api/totp.py
+++ b/apps/myjobhunter/backend/app/api/totp.py
@@ -196,6 +196,14 @@ async def totp_login(
     # standard /auth/jwt/login route. The TOTP login path must enforce this too
     # or unverified users can obtain a JWT via this endpoint.
     if not user.is_verified:
+        await log_auth_event(
+            db,
+            event_type=AuthEventType.LOGIN_BLOCKED_UNVERIFIED,
+            user_id=user.id,
+            request=request,
+            succeeded=False,
+        )
+        await db.commit()
         raise HTTPException(status_code=400, detail="LOGIN_USER_NOT_VERIFIED")
 
     # TOTP gate: if the user has 2FA enabled, require the code before issuing JWT.


### PR DESCRIPTION
## Summary

Two distinct bugs of the same class, both surfaced during PR #179 inline review:

**MBK** — `apps/mybookkeeper/backend/app/api/totp.py`
- Three `log_auth_event` calls (bad_credentials, account_inactive, LOGIN_BLOCKED_UNVERIFIED) followed by `raise HTTPException` with no `await db.commit()` in between
- The implicit transaction rolls back on raise → every audit row on failed-login paths has been **silently dropped** since email-verify shipped
- Fix: add `await db.commit()` after each `log_auth_event` before `raise`

**MJH** — `apps/myjobhunter/backend/app/api/totp.py`
- The unverified-user path raised HTTPException with NO `log_auth_event` call at all
- `LOGIN_BLOCKED_UNVERIFIED` event has been **entirely absent** from MJH's audit_events table since launch
- Fix: add the missing `log_auth_event(LOGIN_BLOCKED_UNVERIFIED) + commit` before the raise

## Test plan

- [ ] MBK: trigger TOTP login with bad credentials → assert `auth_events` has the row (was being rolled back)
- [ ] MBK: trigger TOTP login with inactive account → assert `auth_events` has the row
- [ ] MBK: trigger TOTP login with unverified user → assert `auth_events` has the row
- [ ] MJH: trigger TOTP login with unverified user → assert `auth_events` has a `LOGIN_BLOCKED_UNVERIFIED` row (currently missing entirely)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)