### PR TITLE
chore(lint): clear pre-existing eslint debt across all 3 frontend workspaces

### DIFF
--- a/apps/mybookkeeper/frontend/public/sw.js
+++ b/apps/mybookkeeper/frontend/public/sw.js
@@ -1,3 +1,4 @@
+/* global self, caches */
 // Kill-switch service worker.
 //
 // vite-plugin-pwa was removed 2026-05-01 (see vite.config.ts comment for

--- a/apps/mybookkeeper/frontend/src/__tests__/ColumnFilter.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/ColumnFilter.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import ColumnFilter from "@/shared/components/table/ColumnFilter";

--- a/apps/mybookkeeper/frontend/src/__tests__/InviteAccept.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InviteAccept.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, act } from "@testing-library/react";
+import { render, screen, act } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import InviteAccept from "@/app/pages/InviteAccept";
 

--- a/apps/mybookkeeper/frontend/src/__tests__/SourceDocumentsSection.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/SourceDocumentsSection.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { Provider } from "react-redux";
 import { MemoryRouter } from "react-router-dom";
 import { store } from "@/shared/store";

--- a/apps/mybookkeeper/frontend/src/admin/features/costs/ThresholdSettings.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/features/costs/ThresholdSettings.tsx
@@ -1,11 +1,14 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useGetCostThresholdsQuery, useUpdateCostThresholdsMutation } from "@/shared/store/costsApi";
+import type { CostThresholds } from "@/shared/types/admin/cost";
 import { useToast } from "@/shared/hooks/useToast";
 import Card from "@/shared/components/ui/Card";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 
+type ThresholdKey = keyof CostThresholds;
+
 interface ThresholdField {
-  key: string;
+  key: ThresholdKey;
   label: string;
   prefix?: string;
   suffix?: string;
@@ -25,31 +28,25 @@ export default function ThresholdSettings({ onSaved }: { onSaved?: () => void } 
   const { data: thresholds } = useGetCostThresholdsQuery();
   const [updateThresholds, { isLoading }] = useUpdateCostThresholdsMutation();
   const { showSuccess, showError } = useToast();
-  const [values, setValues] = useState<Record<string, string>>({});
-  const [dirty, setDirty] = useState(false);
+  // Track user edits as partial overrides; fall back to server values for unedited fields.
+  const [overrides, setOverrides] = useState<Record<string, string>>({});
+  const dirty = Object.keys(overrides).length > 0;
 
-  useEffect(() => {
-    if (thresholds) {
-      setValues({
-        daily_budget: String(thresholds.daily_budget),
-        monthly_budget: String(thresholds.monthly_budget),
-        per_user_daily_alert: String(thresholds.per_user_daily_alert),
-        input_rate_per_million: String(thresholds.input_rate_per_million),
-        output_rate_per_million: String(thresholds.output_rate_per_million),
-      });
-      setDirty(false);
-    }
-  }, [thresholds]);
+  // Merge server data with user overrides to get the current displayed values.
+  function getValue(key: ThresholdKey): string {
+    if (key in overrides) return overrides[key];
+    if (!thresholds) return "";
+    return String(thresholds[key]);
+  }
 
-  function handleChange(key: string, val: string) {
-    setValues((prev) => ({ ...prev, [key]: val }));
-    setDirty(true);
+  function handleChange(key: ThresholdKey, val: string) {
+    setOverrides((prev) => ({ ...prev, [key]: val }));
   }
 
   async function handleSave() {
-    const updates: Record<string, number> = {};
+    const updates: Partial<CostThresholds> = {};
     for (const field of FIELDS) {
-      const val = parseFloat(values[field.key] ?? "0");
+      const val = parseFloat(getValue(field.key));
       if (!isNaN(val) && val >= 0) {
         updates[field.key] = val;
       }
@@ -57,7 +54,7 @@ export default function ThresholdSettings({ onSaved }: { onSaved?: () => void } 
     try {
       await updateThresholds(updates).unwrap();
       showSuccess("Thresholds updated");
-      setDirty(false);
+      setOverrides({});
       onSaved?.();
     } catch {
       showError("Couldn't update thresholds");
@@ -82,7 +79,7 @@ export default function ThresholdSettings({ onSaved }: { onSaved?: () => void } 
                 min="0"
                 max={field.max}
                 step={field.step}
-                value={values[field.key] ?? ""}
+                value={getValue(field.key)}
                 onChange={(e) => handleChange(field.key, e.target.value)}
                 className="w-24 border rounded-md px-2 py-1.5 text-sm bg-background"
               />
@@ -93,7 +90,7 @@ export default function ThresholdSettings({ onSaved }: { onSaved?: () => void } 
               min="0"
               max={field.max}
               step={field.step}
-              value={parseFloat(values[field.key] ?? "0") || 0}
+              value={parseFloat(getValue(field.key)) || 0}
               onChange={(e) => handleChange(field.key, e.target.value)}
               className="w-full mt-2 accent-primary"
               aria-label={`${field.label} slider`}

--- a/apps/mybookkeeper/frontend/src/admin/features/demo/CreateDemoDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/features/demo/CreateDemoDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import Button from "@/shared/components/ui/Button";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
@@ -13,13 +13,6 @@ interface Props {
 export default function CreateDemoDialog({ open, isLoading, onSubmit, onCancel }: Props) {
   const [tag, setTag] = useState("");
   const [recipientEmail, setRecipientEmail] = useState("");
-
-  useEffect(() => {
-    if (open) {
-      setTag("");
-      setRecipientEmail("");
-    }
-  }, [open]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Panel, { PanelCloseButton } from "@/shared/components/ui/Panel";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import Button from "@/shared/components/ui/Button";
@@ -40,8 +40,10 @@ type ReplyTab = "template" | "custom";
 export default function InquiryReplyPanel({ inquiryId, onClose }: Props) {
   const [tab, setTab] = useState<ReplyTab>("template");
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
-  const [subject, setSubject] = useState("");
-  const [body, setBody] = useState("");
+  // Local overrides allow the user to edit the rendered template content.
+  // When a new render arrives, the overrides reset (via key change below).
+  const [subjectOverride, setSubjectOverride] = useState<string | null>(null);
+  const [bodyOverride, setBodyOverride] = useState<string | null>(null);
 
   const { data: templates = [], isLoading: templatesLoading } =
     useGetReplyTemplatesQuery();
@@ -60,19 +62,24 @@ export default function InquiryReplyPanel({ inquiryId, onClose }: Props) {
           ? "missing-send-scope"
           : null;
 
-  // Pull the server-rendered subject/body into the editor whenever a new
-  // (template,inquiry) render returns. Synchronizing local state to a remote
-  // resource is exactly the use-case useEffect was designed for.
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => {
-    if (renderState.data) {
-      setSubject(renderState.data.subject);
-      setBody(renderState.data.body);
-    }
-  }, [renderState.data]);
+  // Derive subject/body: prefer local override (user edits), fall back to
+  // server-rendered template data, then empty string.
+  const subject = subjectOverride ?? renderState.data?.subject ?? "";
+  const body = bodyOverride ?? renderState.data?.body ?? "";
+
+  function setSubject(value: string) {
+    setSubjectOverride(value);
+  }
+
+  function setBody(value: string) {
+    setBodyOverride(value);
+  }
 
   function handleSelectTemplate(template: ReplyTemplate) {
     setSelectedTemplateId(template.id);
+    // Clear local overrides so the newly-rendered template fills the editor.
+    setSubjectOverride(null);
+    setBodyOverride(null);
     void triggerRender({ inquiryId, templateId: template.id });
   }
 
@@ -80,6 +87,8 @@ export default function InquiryReplyPanel({ inquiryId, onClose }: Props) {
     setTab(next);
     if (next === "custom") {
       setSelectedTemplateId(null);
+      setSubjectOverride(null);
+      setBodyOverride(null);
     }
   }
 

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplateForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplateForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import Panel, { PanelCloseButton } from "@/shared/components/ui/Panel";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import Button from "@/shared/components/ui/Button";
@@ -39,15 +39,18 @@ export default function ReplyTemplateForm({ template, onClose }: Props) {
   const [updateTemplate, { isLoading: isUpdating }] =
     useUpdateReplyTemplateMutation();
 
-  // If the parent swaps the ``template`` prop (e.g., the manager opens edit
-  // for a different template after first opening another), refresh the local
-  // form state. This is the documented React idiom for syncing form fields
-  // to a prop change.
-  // eslint-disable-next-line react-hooks/set-state-in-effect
+  // When the parent swaps the template prop (e.g., the manager opens edit for
+  // a different template after first opening another), refresh local form state.
+  // Tracking the previously-seen template id avoids re-setting on every render
+  // while still responding to genuine prop changes.
+  const prevTemplateIdRef = useRef(template?.id);
   useEffect(() => {
-    setName(template?.name ?? "");
-    setSubject(template?.subject_template ?? "");
-    setBody(template?.body_template ?? "");
+    if (template?.id !== prevTemplateIdRef.current) {
+      prevTemplateIdRef.current = template?.id;
+      setName(template?.name ?? "");
+      setSubject(template?.subject_template ?? "");
+      setBody(template?.body_template ?? "");
+    }
   }, [template]);
 
   const isEdit = template !== null;

--- a/apps/mybookkeeper/frontend/src/app/features/onboarding/DependentsStep.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/onboarding/DependentsStep.tsx
@@ -1,5 +1,3 @@
-import Button from "@/shared/components/ui/Button";
-
 const MIN = 0;
 const MAX = 20;
 

--- a/apps/mybookkeeper/frontend/src/app/features/tax-review/FormCompletenessCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax-review/FormCompletenessCard.tsx
@@ -1,7 +1,7 @@
 import { useState, useCallback } from "react";
 import { ChevronDown, ChevronUp, AlertTriangle, CheckCircle } from "lucide-react";
 import { cn } from "@/shared/utils/cn";
-import { getFormLabel } from "@/app/features/tax/FormNameLabel";
+import { getFormLabel } from "@/shared/lib/tax-config";
 import type { FormCompleteness } from "@/shared/types/tax/tax-completeness";
 
 interface Props {

--- a/apps/mybookkeeper/frontend/src/app/features/tax/FormNameLabel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/FormNameLabel.tsx
@@ -1,7 +1,5 @@
 import { getFormLabel } from "@/shared/lib/tax-config";
 
-export { getFormLabel };
-
 interface Props {
   formName: string;
   className?: string;

--- a/apps/mybookkeeper/frontend/src/app/features/tax/FormOverviewGrid.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/FormOverviewGrid.tsx
@@ -1,5 +1,5 @@
 import { FileText, AlertTriangle, CheckCircle2, AlertCircle } from "lucide-react";
-import { getFormLabel } from "@/app/features/tax/FormNameLabel";
+import { getFormLabel } from "@/shared/lib/tax-config";
 import Badge from "@/shared/components/ui/Badge";
 import type { BadgeColor } from "@/shared/components/ui/Badge";
 import type { ValidationResult } from "@/shared/types/tax/validation-result";
@@ -21,24 +21,6 @@ function getStatusBadge(errors: number, warnings: number): { label: string; colo
   if (errors > 0) return { label: `${errors} error${errors > 1 ? "s" : ""}`, color: "red" };
   if (warnings > 0) return { label: `${warnings} warning${warnings > 1 ? "s" : ""}`, color: "yellow" };
   return { label: "Valid", color: "green" };
-}
-
-export function buildFormSummaries(
-  formNames: string[],
-  instanceCounts: Record<string, number>,
-  fieldCounts: Record<string, number>,
-  validationResults: ValidationResult[],
-): FormSummary[] {
-  return formNames.map((form_name) => {
-    const formResults = validationResults.filter((v) => v.form_name === form_name);
-    return {
-      form_name,
-      instance_count: instanceCounts[form_name] ?? 0,
-      field_count: fieldCounts[form_name] ?? 0,
-      error_count: formResults.filter((v) => v.severity === "error").length,
-      warning_count: formResults.filter((v) => v.severity === "warning").length,
-    };
-  });
 }
 
 export default function FormOverviewGrid({ forms, validationResults, onFormClick }: Props) {

--- a/apps/mybookkeeper/frontend/src/app/features/tax/TaxDocumentChecklist.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/TaxDocumentChecklist.tsx
@@ -1,6 +1,6 @@
 import { CheckCircle2, AlertCircle, Upload } from "lucide-react";
 import { Link } from "react-router-dom";
-import { getFormLabel } from "@/app/features/tax/FormNameLabel";
+import { getFormLabel } from "@/shared/lib/tax-config";
 import Badge from "@/shared/components/ui/Badge";
 import type { ChecklistItem } from "@/shared/types/tax/source-document";
 

--- a/apps/mybookkeeper/frontend/src/app/features/tax/ValidationPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/ValidationPanel.tsx
@@ -1,4 +1,4 @@
-import { getFormLabel } from "@/app/features/tax/FormNameLabel";
+import { getFormLabel } from "@/shared/lib/tax-config";
 import { formatCurrency } from "@/shared/utils/currency";
 import type { ValidationResult } from "@/shared/types/tax/validation-result";
 import { SEVERITY_ORDER, SEVERITY_CONFIG } from "@/shared/lib/validation-config";

--- a/apps/mybookkeeper/frontend/src/app/features/tax/form-summaries.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/form-summaries.ts
@@ -1,0 +1,20 @@
+import type { ValidationResult } from "@/shared/types/tax/validation-result";
+import type { FormSummary } from "@/shared/types/tax/form-summary";
+
+export function buildFormSummaries(
+  formNames: string[],
+  instanceCounts: Record<string, number>,
+  fieldCounts: Record<string, number>,
+  validationResults: ValidationResult[],
+): FormSummary[] {
+  return formNames.map((form_name) => {
+    const formResults = validationResults.filter((v) => v.form_name === form_name);
+    return {
+      form_name,
+      instance_count: instanceCounts[form_name] ?? 0,
+      field_count: fieldCounts[form_name] ?? 0,
+      error_count: formResults.filter((v) => v.severity === "error").length,
+      warning_count: formResults.filter((v) => v.severity === "warning").length,
+    };
+  });
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/BankStatementImport.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/BankStatementImport.tsx
@@ -2,7 +2,6 @@ import { useCallback, useRef, useState } from "react";
 import { Upload, FileSpreadsheet, X, Loader2 } from "lucide-react";
 import api from "@/shared/lib/api";
 import type { Property } from "@/shared/types/property/property";
-import type { TransactionPreview } from "@/shared/types/transaction/transaction-preview";
 import type { ImportResult } from "@/shared/types/transaction/import-result";
 import Button from "@/shared/components/ui/Button";
 import Select from "@/shared/components/ui/Select";

--- a/apps/mybookkeeper/frontend/src/app/pages/Integrations.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Integrations.tsx
@@ -58,15 +58,13 @@ export default function Integrations() {
   const isSyncing = latestLog?.status === "running";
 
   const savedLabel = (gmail?.metadata as Record<string, unknown> | null)?.gmail_label;
-  const [labelInput, setLabelInput] = useState("");
-  const [labelInitialized, setLabelInitialized] = useState(false);
+  // Track user edits as an override; fall back to the server value before any edit.
+  const [labelOverride, setLabelOverride] = useState<string | null>(null);
+  const labelInput = labelOverride ?? (typeof savedLabel === "string" ? savedLabel : "");
 
-  useEffect(() => {
-    if (!labelInitialized && gmail) {
-      setLabelInput(typeof savedLabel === "string" ? savedLabel : "");
-      setLabelInitialized(true);
-    }
-  }, [gmail, savedLabel, labelInitialized]);
+  function setLabelInput(value: string) {
+    setLabelOverride(value);
+  }
 
   const queueBySession = useMemo(() => {
     const map = new Map<number, EmailQueueItem[]>();
@@ -158,12 +156,12 @@ export default function Integrations() {
     [dismissItem, showError],
   );
 
-  const handleSaveLabel = useCallback(() => {
+  function handleSaveLabel() {
     updateGmailLabel({ label: labelInput.trim() })
       .unwrap()
       .then(() => showSuccess(labelInput.trim() ? `Got it, I'll only sync emails with the "${labelInput.trim()}" label` : "Label filter cleared - I'll sync all emails now"))
       .catch((err) => showError(`Couldn't save label: ${extractErrorMessage(err)}`));
-  }, [updateGmailLabel, labelInput, showSuccess, showError]);
+  }
 
   return (
     <main className="p-4 sm:p-8 space-y-6">

--- a/apps/mybookkeeper/frontend/src/app/pages/InviteAccept.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/InviteAccept.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { useAcceptInviteMutation, useGetInviteInfoQuery } from "@/shared/store/membersApi";
-import { isAuthenticated, login, notifyAuthChange } from "@/shared/lib/auth";
+import { login, notifyAuthChange } from "@/shared/lib/auth";
 import { useCurrentUser } from "@/shared/hooks/useCurrentUser";
 import { extractErrorMessage } from "@/shared/utils/errorMessage";
 import LoadingButton from "@/shared/components/ui/LoadingButton";

--- a/apps/mybookkeeper/frontend/src/app/pages/ResetPassword.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/ResetPassword.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useSearchParams, Link, useNavigate } from "react-router-dom";
 import api from "@/shared/lib/api";
 import { extractErrorMessage } from "@/shared/utils/errorMessage";
@@ -9,8 +9,10 @@ const MIN_PASSWORD_LENGTH = 12;
 export default function ResetPassword() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const tokenRef = useRef(searchParams.get("token"));
-  const token = tokenRef.current;
+  // Capture the token from the URL once on mount using useState lazy initializer.
+  // window.history.replaceState below removes the token from the URL without
+  // triggering a re-render, so searchParams stays stable after the initial read.
+  const [token] = useState(() => searchParams.get("token"));
 
   // Clear token from URL to prevent leaking in browser history/referer
   useEffect(() => {

--- a/apps/mybookkeeper/frontend/src/app/pages/TaxReturnDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/TaxReturnDetail.tsx
@@ -16,12 +16,13 @@ import Button from "@/shared/components/ui/Button";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import Badge from "@/shared/components/ui/Badge";
 import TaxReturnSkeleton from "@/app/features/tax/TaxReturnSkeleton";
-import FormOverviewGrid, { buildFormSummaries } from "@/app/features/tax/FormOverviewGrid";
+import FormOverviewGrid from "@/app/features/tax/FormOverviewGrid";
+import { buildFormSummaries } from "@/app/features/tax/form-summaries";
 import FormFieldsTable from "@/app/features/tax/FormFieldsTable";
 import ValidationPanel from "@/app/features/tax/ValidationPanel";
 import SourceDocumentsSection from "@/app/features/tax/SourceDocumentsSection";
 import TaxAdvisorPanel from "@/app/features/tax/TaxAdvisorPanel";
-import { getFormLabel } from "@/app/features/tax/FormNameLabel";
+import { getFormLabel } from "@/shared/lib/tax-config";
 import type { FieldValueType } from "@/shared/types/tax/tax-form";
 import { STATUS_BADGE } from "@/shared/lib/tax-return-config";
 

--- a/apps/mybookkeeper/frontend/src/app/pages/VerifyEmail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/VerifyEmail.tsx
@@ -5,19 +5,19 @@ import { extractErrorMessage } from "@/shared/utils/errorMessage";
 
 type VerifyState = "verifying" | "success" | "error";
 
+const NO_TOKEN_MESSAGE =
+  "No verification token found in the link. Please check your email and try again.";
+
 export default function VerifyEmail() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token");
 
-  const [state, setState] = useState<VerifyState>("verifying");
-  const [errorMessage, setErrorMessage] = useState("");
+  // Initialize directly from token presence — avoids calling setState inside an effect.
+  const [state, setState] = useState<VerifyState>(token ? "verifying" : "error");
+  const [errorMessage, setErrorMessage] = useState(token ? "" : NO_TOKEN_MESSAGE);
 
   useEffect(() => {
-    if (!token) {
-      setState("error");
-      setErrorMessage("No verification token found in the link. Please check your email and try again.");
-      return;
-    }
+    if (!token) return;
 
     api
       .post("/auth/verify", { token })

--- a/apps/mybookkeeper/frontend/src/shared/components/table/ColumnFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/table/ColumnFilter.tsx
@@ -1,16 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 import { type Column } from "@tanstack/react-table";
 import { Filter, X } from "lucide-react";
 
-interface Props {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  column: Column<any, unknown>;
+interface Props<TData = unknown> {
+  column: Column<TData, unknown>;
   options?: { value: string; label: string }[];
   enableDateRange?: boolean;
 }
 
-export default function ColumnFilter({ column, options, enableDateRange }: Props) {
+export default function ColumnFilter<TData = unknown>({ column, options, enableDateRange }: Props<TData>) {
   if (enableDateRange) {
     return <DateRangeFilter column={column} />;
   }
@@ -22,8 +20,7 @@ export default function ColumnFilter({ column, options, enableDateRange }: Props
   return null;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function DateRangeFilter({ column }: { column: Column<any, unknown> }) {
+function DateRangeFilter<TData = unknown>({ column }: { column: Column<TData, unknown> }) {
   const value = (column.getFilterValue() as [string, string] | undefined) ?? ["", ""];
 
   return (
@@ -46,12 +43,11 @@ function DateRangeFilter({ column }: { column: Column<any, unknown> }) {
   );
 }
 
-function MultiSelectFilter({
+function MultiSelectFilter<TData = unknown>({
   column,
   options,
 }: {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  column: Column<any, unknown>;
+  column: Column<TData, unknown>;
   options: { value: string; label: string }[];
 }) {
   const [open, setOpen] = useState(false);

--- a/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
@@ -54,12 +54,13 @@ export default function AddApplicationDialog({ open, onOpenChange }: Props) {
   });
 
   // Reset form + inline panel when the dialog closes so a re-open starts fresh.
-  useEffect(() => {
-    if (!open) {
+  function handleOpenChange(next: boolean) {
+    if (!next) {
       reset();
       setShowNewCompany(false);
     }
-  }, [open, reset]);
+    onOpenChange(next);
+  }
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     try {
@@ -94,7 +95,7 @@ export default function AddApplicationDialog({ open, onOpenChange }: Props) {
   const hasCompanies = companies.length > 0;
 
   return (
-    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40" />
         <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-lg max-h-[90vh] overflow-y-auto bg-card border rounded-lg shadow-lg z-50 p-6">

--- a/apps/myjobhunter/frontend/src/features/security/__tests__/DeleteAccountModal.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/security/__tests__/DeleteAccountModal.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@platform/ui", async (importOriginal) => {
     extractErrorMessage: vi.fn((err: unknown) =>
       err instanceof Error ? err.message : "Something went wrong",
     ),
-  };
+  } as typeof import("@platform/ui");
 });
 
 import DeleteAccountModal from "@/features/security/DeleteAccountModal";
@@ -42,15 +42,16 @@ interface DeleteMutationFn {
 
 function setupMutation(unwrapImpl: () => Promise<void>) {
   const trigger = vi.fn(() => ({ unwrap: unwrapImpl }) as DeleteMutationFn);
-  // Cast to any: RTK Query's mutation tuple is complex and the test only
-  // exercises the trigger + isLoading slot we use in the component.
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  mockUseDeleteAccountMutation.mockReturnValue([trigger, { isLoading: false }] as any);
+  // RTK Query's mutation tuple is complex; cast to the expected return type via
+  // unknown to avoid using `any` while still bypassing the full generic signature
+  // that the test doesn't need to exercise.
+  mockUseDeleteAccountMutation.mockReturnValue(
+    [trigger, { isLoading: false }] as unknown as ReturnType<typeof useDeleteAccountMutation>,
+  );
   return trigger;
 }
 
 function setupCurrentUser(totp_enabled: boolean) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   mockUseGetCurrentUserQuery.mockReturnValue({
     data: {
       id: "user-1",
@@ -64,7 +65,7 @@ function setupCurrentUser(totp_enabled: boolean) {
     isSuccess: true,
     isError: false,
     refetch: vi.fn(),
-  } as any);
+  } as unknown as ReturnType<typeof useGetCurrentUserQuery>);
 }
 
 describe("DeleteAccountModal", () => {

--- a/apps/myjobhunter/frontend/src/pages/VerifyEmail.tsx
+++ b/apps/myjobhunter/frontend/src/pages/VerifyEmail.tsx
@@ -5,21 +5,19 @@ import api from "@/lib/api";
 
 type VerifyState = "verifying" | "success" | "error";
 
+const NO_TOKEN_MESSAGE =
+  "No verification token found in the link. Please check your email and try again.";
+
 export default function VerifyEmail() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token");
 
-  const [state, setState] = useState<VerifyState>("verifying");
-  const [errorMessage, setErrorMessage] = useState("");
+  // Initialize directly from token presence — avoids calling setState inside an effect.
+  const [state, setState] = useState<VerifyState>(token ? "verifying" : "error");
+  const [errorMessage, setErrorMessage] = useState(token ? "" : NO_TOKEN_MESSAGE);
 
   useEffect(() => {
-    if (!token) {
-      setState("error");
-      setErrorMessage(
-        "No verification token found in the link. Please check your email and try again.",
-      );
-      return;
-    }
+    if (!token) return;
 
     api
       .post("/auth/verify", { token })


### PR DESCRIPTION
## Summary

Clears all ESLint errors that accumulated in MBK frontend and MJH frontend since PR #173 enabled project-wide ESLint enforcement. No files modified in PRs #171–#182 are touched.

**Before / after:**
| Workspace | Before (errors) | After (errors) |
|---|---|---|
| apps/mybookkeeper/frontend | 22 errors, 13 warnings | 0 errors, 8 warnings |
| apps/myjobhunter/frontend | 3 errors, 1 warning | 0 errors, 0 warnings |
| packages/shared-frontend | no lint script | no lint script |

## Fixes by rule

**react-hooks/set-state-in-effect (7 violations in 7 files)**
- ThresholdSettings.tsx — user edits tracked as overrides, server value as fallback; no useEffect needed
- CreateDemoDialog.tsx — removed effect entirely; handleOpenChange already resets state on close
- InquiryReplyPanel.tsx — replaced state mirror of renderState.data with derived subject/body (server data as fallback, local overrides on user edit); removed stale eslint-disable comment
- ReplyTemplateForm.tsx — replaced plain effect with useRef prev-id guard; removed stale eslint-disable comment
- Integrations.tsx — label input tracks user edits as labelOverride; derives displayed value from server data until user edits
- VerifyEmail.tsx (MBK + MJH, same fix) — initialized state directly from token presence in useState call instead of setting inside effect

**@typescript-eslint/no-unused-vars (6 removals in 5 files)**
Removed unused imports: beforeEach, waitFor, userEvent, Button, TransactionPreview, isAuthenticated.

**react-hooks/refs (1 violation — ResetPassword.tsx)**
useRef read during render replaced with useState lazy initializer.

**react-refresh/only-export-components (2 violations in 2 files)**
- FormNameLabel.tsx — removed re-export of getFormLabel; 5 consumers updated to import from tax-config directly
- FormOverviewGrid.tsx — extracted buildFormSummaries to new form-summaries.ts sibling

**no-undef (7 violations — sw.js)**
Added /* global self, caches */ comment (eslint-env serviceworker deprecated in flat-config ESLint v9).

**@typescript-eslint/no-explicit-any (1 violation — DeleteAccountModal.test.tsx)**
Replaced two `as any` casts with `as unknown as ReturnType<typeof ...>` pattern.

## Files changed

apps/mybookkeeper/frontend: 23 files (public/sw.js; 3 test files; ThresholdSettings, CreateDemoDialog, InquiryReplyPanel, ReplyTemplateForm, DependentsStep, FormNameLabel, FormOverviewGrid, form-summaries.ts (new), TaxDocumentChecklist, ValidationPanel, FormCompletenessCard, BankStatementImport, Integrations, InviteAccept, ResetPassword, TaxReturnDetail, VerifyEmail, ColumnFilter)

apps/myjobhunter/frontend: 3 files (AddApplicationDialog, DeleteAccountModal.test.tsx, VerifyEmail)

No files from PRs #171-#182 are touched.

## Remaining warnings (not errors)

MBK retains 8 warnings (severity warn, not error):
- 7x react-hooks/incompatible-library — TanStack useReactTable; pre-existing
- 1x react-hooks/exhaustive-deps in ColumnFilter.tsx — pre-existing

## Test plan

- [x] npm run lint MBK frontend: 0 errors (8 pre-existing warnings)
- [x] npm run lint MJH frontend: 0 errors, 0 warnings
- [x] npm run build MBK: clean (tsc + vite)
- [x] npm run build MJH: clean
- [x] npm run typecheck shared-frontend: clean
- [x] npm run typecheck MJH: clean
- [x] npm test MBK: 44 failures (pre-existing dual-React, unchanged from baseline)
- [x] npm test MJH: 88 failures (pre-existing dual-React, unchanged from baseline)
- [x] npm test shared-frontend: 43 failures (pre-existing dual-React, unchanged from baseline)

Generated with Claude Code