### PR TITLE
feat(mybookkeeper/leases): auto-pull placeholder values from applicant + inquiry fallback

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -41,11 +41,20 @@
 
 ---
 
+<<<<<<< HEAD
 ### [Contract dates] Partial-update cannot explicitly null a date field
 **Effort:** S
 **Location:** `apps/mybookkeeper/backend/app/services/applicants/applicant_contract_service.py` — `update_contract_dates()`, comment at line 84-91; `apps/mybookkeeper/backend/app/schemas/applicants/applicant_update_request.py`
 **Problem:** The PATCH schema uses `None` as the default for both `contract_start` and `contract_end`, making it impossible to distinguish "field not sent" from "field explicitly set to null". The service treats `None` as "keep existing value", which is the correct UX for the inline date picker (users rarely want to null a date). However, if a future UX needs a "clear date" action, the API cannot express it without a schema change (e.g., using `UNSET` sentinel or a separate `clear_contract_start: bool` field).
 **Recommendation:** When a "clear date" UX is needed, extend the request schema to use `Annotated[date | None, Field(default=UNSET)]` with a custom sentinel, or add a separate `clear_fields: list[str]` parameter. Document this limitation in the schema docstring until then.
+=======
+### [Leases] LeaseGenerateForm not yet integrated into any app route
+
+**Effort:** M
+**Location:** `apps/mybookkeeper/frontend/src/app/features/leases/LeaseGenerateForm.tsx`
+**Problem:** `LeaseGenerateForm` (originally from PR #175, enhanced in PR #185) is a standalone component with no consuming page route. The `GET /lease-templates/{id}/generate-defaults` endpoint exists and is tested, but the end-to-end flow (applicant selector + template picker + form) has no UI entry point yet. E2E tests cover the API layer only; UI-level E2E tests are blocked until the page is wired up.
+**Recommendation:** In the follow-up lease-generate-page PR: mount `LeaseGenerateForm` inside a `/leases/new?template_id=&applicant_id=` route, add an applicant dropdown, and add Playwright E2E tests for the full UI flow including provenance badge rendering and the "Pull from source" confirmation.
+>>>>>>> aabb3b1 (chore(mybookkeeper): log tech debt from lease-template-source-pull (PR #185))
 
 ---
 

--- a/apps/mybookkeeper/backend/app/api/lease_templates.py
+++ b/apps/mybookkeeper/backend/app/api/lease_templates.py
@@ -15,6 +15,7 @@ from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Respon
 
 from app.core.context import RequestContext
 from app.core.permissions import current_org_member, require_write_access
+from app.schemas.leases.generate_defaults_response import GenerateDefaultsResponse
 from app.schemas.leases.lease_template_list_response import (
     LeaseTemplateListResponse,
 )
@@ -132,6 +133,41 @@ async def update_placeholder(
         raise HTTPException(status_code=404, detail="Placeholder not found") from exc
     except lease_template_service.InvalidComputedExprError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except lease_template_service.InvalidDefaultSourceError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.get(
+    "/{template_id}/generate-defaults",
+    response_model=GenerateDefaultsResponse,
+)
+async def get_generate_defaults(
+    template_id: uuid.UUID,
+    applicant_id: uuid.UUID = Query(...),
+    ctx: RequestContext = Depends(current_org_member),
+) -> GenerateDefaultsResponse:
+    """Return resolved default values for each placeholder given an applicant.
+
+    Evaluates each placeholder's ``default_source`` spec against the applicant
+    and (if linked) the applicant's inquiry. Returns the resolved value and
+    provenance so the frontend can pre-fill the generate form and show
+    provenance badges.
+    """
+    try:
+        defaults = await lease_template_service.generate_defaults(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            template_id=template_id,
+            applicant_id=applicant_id,
+        )
+        from app.schemas.leases.generate_defaults_response import PlaceholderDefault
+        return GenerateDefaultsResponse(
+            defaults=[PlaceholderDefault(**d) for d in defaults]
+        )
+    except lease_template_service.TemplateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Template not found") from exc
+    except lease_template_service.ApplicantNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Applicant not found") from exc
 
 
 @router.delete("/{template_id}", status_code=204)

--- a/apps/mybookkeeper/backend/app/repositories/inquiries/inquiry_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/inquiries/inquiry_repo.py
@@ -363,3 +363,26 @@ async def find_by_source_and_external_id(
         )
     )
     return result.scalar_one_or_none()
+
+
+async def get_by_applicant_inquiry_id(
+    db: AsyncSession,
+    inquiry_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> Inquiry | None:
+    """Return the inquiry linked from an applicant's ``inquiry_id``.
+
+    Scoped by both ``organization_id`` and ``user_id`` — dual tenant check
+    per the project's multi-tenant isolation pattern. Returns ``None`` if the
+    inquiry is soft-deleted or belongs to a different tenant.
+    """
+    result = await db.execute(
+        select(Inquiry).where(
+            Inquiry.id == inquiry_id,
+            Inquiry.organization_id == organization_id,
+            Inquiry.user_id == user_id,
+            Inquiry.deleted_at.is_(None),
+        )
+    )
+    return result.scalar_one_or_none()

--- a/apps/mybookkeeper/backend/app/schemas/leases/generate_defaults_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/generate_defaults_response.py
@@ -1,0 +1,28 @@
+"""Response schema for GET /lease-templates/{id}/generate-defaults.
+
+Returns the resolved default value and provenance for each placeholder that
+has a ``default_source`` spec. Placeholders without a ``default_source`` are
+omitted — they're manual-entry only.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class PlaceholderDefault(BaseModel):
+    """Resolved default for a single placeholder key."""
+
+    key: str
+    value: str | None
+    # "applicant" | "inquiry" | "today" | None (when nothing resolved)
+    provenance: str | None
+
+    model_config = ConfigDict(from_attributes=False)
+
+
+class GenerateDefaultsResponse(BaseModel):
+    """Resolved defaults for all placeholders in a template."""
+
+    defaults: list[PlaceholderDefault]
+
+    model_config = ConfigDict(from_attributes=False)

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
@@ -6,24 +6,36 @@ can pre-populate ``default_source`` and ``input_type`` so the host doesn't
 have to fill them in by hand. The host can always override.
 
 The keys are matched after normalisation (whitespace collapsed, uppercased).
+
+``default_source`` values follow the resolver syntax defined in
+``services/leases/default_source_resolver.py``:
+- Single path: ``applicant.legal_name``, ``today``
+- Fallback chain: ``applicant.legal_name || inquiry.inquirer_name``
+  (first non-None, non-empty value wins)
+
+NOTE: Applicant has no ``email`` or ``phone`` columns — those PII fields
+live only on the Inquiry model (``inquirer_email``, ``inquirer_phone``).
+For those fields the inquiry is the primary source with no applicant fallback.
 """
 from __future__ import annotations
 
 # (input_type, default_source) — None means "no default".
 DEFAULT_SOURCE_MAP: dict[str, tuple[str, str | None]] = {
-    # Tenant identity
-    "TENANT FULL NAME": ("text", "applicant.legal_name"),
-    "TENANT NAME": ("text", "applicant.legal_name"),
-    "TENANT EMAIL": ("email", "applicant.email"),
-    "TENANT PHONE": ("phone", "applicant.phone"),
-    "TENANT EMPLOYER": ("text", "applicant.employer_or_hospital"),
-    # Dates
-    "MOVE-IN DATE": ("date", "applicant.contract_start"),
-    "MOVE_IN_DATE": ("date", "applicant.contract_start"),
-    "MOVE IN DATE": ("date", "applicant.contract_start"),
-    "MOVE-OUT DATE": ("date", "applicant.contract_end"),
-    "MOVE_OUT_DATE": ("date", "applicant.contract_end"),
-    "MOVE OUT DATE": ("date", "applicant.contract_end"),
+    # Tenant identity — applicant-primary where the field exists, inquiry fallback otherwise.
+    "TENANT FULL NAME": ("text", "applicant.legal_name || inquiry.inquirer_name"),
+    "TENANT NAME": ("text", "applicant.legal_name || inquiry.inquirer_name"),
+    # Email and phone only exist on Inquiry — no applicant fallback.
+    "TENANT EMAIL": ("email", "inquiry.inquirer_email"),
+    "TENANT PHONE": ("phone", "inquiry.inquirer_phone"),
+    "TENANT EMPLOYER": ("text", "applicant.employer_or_hospital || inquiry.inquirer_employer"),
+    "EMPLOYER": ("text", "applicant.employer_or_hospital || inquiry.inquirer_employer"),
+    # Dates — applicant-primary (contract dates), inquiry fallback (desired dates).
+    "MOVE-IN DATE": ("date", "applicant.contract_start || inquiry.desired_start_date"),
+    "MOVE_IN_DATE": ("date", "applicant.contract_start || inquiry.desired_start_date"),
+    "MOVE IN DATE": ("date", "applicant.contract_start || inquiry.desired_start_date"),
+    "MOVE-OUT DATE": ("date", "applicant.contract_end || inquiry.desired_end_date"),
+    "MOVE_OUT_DATE": ("date", "applicant.contract_end || inquiry.desired_end_date"),
+    "MOVE OUT DATE": ("date", "applicant.contract_end || inquiry.desired_end_date"),
     "EFFECTIVE DATE": ("date", "today"),
     "DATE": ("date", "today"),
     # Computed

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_resolver.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_resolver.py
@@ -1,0 +1,175 @@
+"""Resolver for ``default_source`` placeholder specs.
+
+Supports single dotted paths (``applicant.legal_name``, ``today``) and
+``||``-separated fallback chains (``applicant.legal_name || inquiry.inquirer_name``).
+The chain is evaluated left-to-right; the first non-None, non-empty value wins.
+
+Usage::
+
+    from app.services.leases.default_source_resolver import (
+        resolve_default_source,
+        validate_default_source_spec,
+    )
+
+    # Validate at write time — raises ValueError on bad specs.
+    validate_default_source_spec("applicant.legal_name || inquiry.inquirer_name")
+
+    # Resolve at read/generate time — returns plaintext or None.
+    value = resolve_default_source(
+        spec="applicant.legal_name || inquiry.inquirer_name",
+        applicant=applicant_orm_row,
+        inquiry=inquiry_orm_row,  # or None
+    )
+"""
+from __future__ import annotations
+
+import datetime
+import re
+from typing import Any
+
+from app.models.applicants.applicant import Applicant
+from app.models.inquiries.inquiry import Inquiry
+
+# ---------------------------------------------------------------------------
+# Allowed namespace prefixes and their attribute allowlists
+# ---------------------------------------------------------------------------
+
+_APPLICANT_ATTRS: frozenset[str] = frozenset({
+    "legal_name",
+    "employer_or_hospital",
+    "contract_start",
+    "contract_end",
+    "dob",
+    "vehicle_make_model",
+    "stage",
+    "referred_by",
+    "pets",
+})
+
+_INQUIRY_ATTRS: frozenset[str] = frozenset({
+    "inquirer_name",
+    "inquirer_email",
+    "inquirer_phone",
+    "inquirer_employer",
+    "desired_start_date",
+    "desired_end_date",
+})
+
+_SPECIAL_SOURCES: frozenset[str] = frozenset({"today"})
+
+# A valid single segment: "today", "applicant.<attr>", or "inquiry.<attr>".
+_SEGMENT_RE = re.compile(
+    r"^(?:today|applicant\.\w+|inquiry\.\w+)$"
+)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+def validate_default_source_spec(spec: str) -> None:
+    """Raise ``ValueError`` if ``spec`` is not a valid default_source value.
+
+    Valid forms:
+    - A single segment: ``today``, ``applicant.legal_name``, ``inquiry.inquirer_email``
+    - A ``||``-separated chain of exactly 2 segments (no N>2 chains per spec)
+
+    Raises ``ValueError`` with a human-readable message on invalid input.
+    """
+    if not spec or not spec.strip():
+        raise ValueError("default_source must not be blank")
+
+    segments = [s.strip() for s in spec.split("||")]
+    if len(segments) > 2:
+        raise ValueError(
+            "default_source supports at most one '||' fallback "
+            f"(got {len(segments)} segments). Example: 'applicant.legal_name || inquiry.inquirer_name'"
+        )
+
+    for segment in segments:
+        _validate_segment(segment, spec)
+
+
+def _validate_segment(segment: str, full_spec: str) -> None:
+    if not _SEGMENT_RE.match(segment):
+        raise ValueError(
+            f"Invalid default_source segment '{segment}' in '{full_spec}'. "
+            "Expected 'today', 'applicant.<field>', or 'inquiry.<field>'."
+        )
+
+    if segment == "today":
+        return
+
+    namespace, attr = segment.split(".", 1)
+    if namespace == "applicant" and attr not in _APPLICANT_ATTRS:
+        raise ValueError(
+            f"Unknown applicant field '{attr}' in '{full_spec}'. "
+            f"Allowed: {sorted(_APPLICANT_ATTRS)}"
+        )
+    if namespace == "inquiry" and attr not in _INQUIRY_ATTRS:
+        raise ValueError(
+            f"Unknown inquiry field '{attr}' in '{full_spec}'. "
+            f"Allowed: {sorted(_INQUIRY_ATTRS)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Resolution
+# ---------------------------------------------------------------------------
+
+ProvenanceLabel = str  # "applicant" | "inquiry" | "today"
+
+
+def resolve_default_source(
+    spec: str,
+    applicant: Applicant,
+    inquiry: Inquiry | None,
+) -> tuple[Any | None, ProvenanceLabel | None]:
+    """Evaluate a ``default_source`` spec against live ORM rows.
+
+    Returns ``(value, provenance)`` where:
+    - ``value`` is the resolved plaintext (or ``None`` if nothing resolved).
+    - ``provenance`` is ``"applicant"``, ``"inquiry"``, or ``"today"`` indicating
+      which segment produced the value, or ``None`` if nothing resolved.
+
+    PII is decrypted automatically by the ``EncryptedString`` TypeDecorator —
+    callers receive plaintext.
+
+    Dates are returned as ISO-8601 strings (``YYYY-MM-DD``) for consistency
+    with the frontend ``<input type="date">`` format.
+    """
+    segments = [s.strip() for s in spec.split("||")]
+
+    for segment in segments:
+        value = _evaluate_segment(segment, applicant, inquiry)
+        if value is not None and value != "":
+            provenance = _segment_provenance(segment)
+            if isinstance(value, datetime.date):
+                return value.isoformat(), provenance
+            return str(value), provenance
+
+    return None, None
+
+
+def _evaluate_segment(
+    segment: str,
+    applicant: Applicant,
+    inquiry: Inquiry | None,
+) -> Any | None:
+    if segment == "today":
+        return datetime.date.today()
+
+    namespace, attr = segment.split(".", 1)
+    if namespace == "applicant":
+        return getattr(applicant, attr, None)
+    if namespace == "inquiry":
+        if inquiry is None:
+            return None
+        return getattr(inquiry, attr, None)
+    return None
+
+
+def _segment_provenance(segment: str) -> ProvenanceLabel:
+    if segment == "today":
+        return "today"
+    return segment.split(".", 1)[0]

--- a/apps/mybookkeeper/backend/app/services/leases/lease_template_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_template_service.py
@@ -21,6 +21,8 @@ import uuid
 from app.core.config import settings
 from app.core.storage import StorageClient, get_storage
 from app.db.session import unit_of_work
+from app.repositories.applicants import applicant_repo
+from app.repositories.inquiries.inquiry_repo import get_by_applicant_inquiry_id
 from app.repositories.leases import (
     lease_template_file_repo,
     lease_template_placeholder_repo,
@@ -45,6 +47,10 @@ from app.services.leases.computed import ComputedExprError, validate_expr
 from app.services.leases.default_source_map import (
     guess_display_label,
     guess_input_type_and_default,
+)
+from app.services.leases.default_source_resolver import (
+    resolve_default_source,
+    validate_default_source_spec,
 )
 from app.services.leases.placeholder_extractor import (
     extract_placeholders_across_files,
@@ -94,7 +100,15 @@ class InvalidComputedExprError(ValueError):
     pass
 
 
+class InvalidDefaultSourceError(ValueError):
+    pass
+
+
 class PlaceholderNotFoundError(LookupError):
+    pass
+
+
+class ApplicantNotFoundError(LookupError):
     pass
 
 
@@ -371,6 +385,81 @@ async def get_template(
 
 
 # ---------------------------------------------------------------------------
+# Resolve generate-defaults for a template + applicant pair
+# ---------------------------------------------------------------------------
+
+async def generate_defaults(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    template_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+) -> list[dict]:
+    """Return resolved default values for each placeholder in a template.
+
+    For each placeholder with a ``default_source`` spec, evaluates the spec
+    against the applicant row and (if the applicant has a linked inquiry) the
+    inquiry row. Returns a list of dicts with ``key``, ``value``, and
+    ``provenance`` fields.
+
+    Placeholders without ``default_source`` are included with ``value=None``
+    and ``provenance=None`` so the frontend can render all fields in one pass.
+    """
+    async with unit_of_work() as db:
+        # Validate template belongs to caller.
+        template = await lease_template_repo.get(
+            db,
+            template_id=template_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if template is None:
+            raise TemplateNotFoundError(f"Template {template_id} not found")
+
+        # Validate applicant belongs to caller.
+        applicant = await applicant_repo.get(
+            db,
+            applicant_id=applicant_id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        if applicant is None:
+            raise ApplicantNotFoundError(f"Applicant {applicant_id} not found")
+
+        # Load linked inquiry if present.
+        inquiry = None
+        if applicant.inquiry_id is not None:
+            inquiry = await get_by_applicant_inquiry_id(
+                db,
+                inquiry_id=applicant.inquiry_id,
+                organization_id=organization_id,
+                user_id=user_id,
+            )
+
+        placeholders = await lease_template_placeholder_repo.list_for_template(
+            db, template_id=template_id,
+        )
+
+    defaults: list[dict] = []
+    for p in placeholders:
+        if p.input_type in ("signature", "computed"):
+            continue
+        if p.default_source:
+            value, provenance = resolve_default_source(
+                p.default_source, applicant, inquiry,
+            )
+        else:
+            value, provenance = None, None
+        defaults.append({
+            "key": p.key,
+            "value": value,
+            "provenance": provenance,
+        })
+
+    return defaults
+
+
+# ---------------------------------------------------------------------------
 # Update template metadata (name / description)
 # ---------------------------------------------------------------------------
 
@@ -456,7 +545,13 @@ async def update_placeholder(
         if "required" in fields and fields["required"] is not None:
             update_payload["required"] = bool(fields["required"])
         if "default_source" in fields:
-            update_payload["default_source"] = fields["default_source"]
+            ds = fields["default_source"]
+            if ds is not None and ds != "":
+                try:
+                    validate_default_source_spec(ds)  # type: ignore[arg-type]
+                except ValueError as exc:
+                    raise InvalidDefaultSourceError(str(exc)) from exc
+            update_payload["default_source"] = ds
         if "display_order" in fields and fields["display_order"] is not None:
             update_payload["display_order"] = int(fields["display_order"])  # type: ignore[arg-type]
 

--- a/apps/mybookkeeper/backend/tests/test_default_source_resolver.py
+++ b/apps/mybookkeeper/backend/tests/test_default_source_resolver.py
@@ -1,0 +1,209 @@
+"""Unit tests for the default_source_resolver module.
+
+Tests cover:
+- resolve_default_source: applicant-only, inquiry fallback, both null,
+  single-source (no ||), "today", date formatting
+- validate_default_source_spec: valid chains accepted, arbitrary strings
+  rejected, && rejected (only || supported), N>2 chain rejected
+"""
+from __future__ import annotations
+
+import datetime
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.leases.default_source_resolver import (
+    resolve_default_source,
+    validate_default_source_spec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal mock objects matching ORM column names
+# ---------------------------------------------------------------------------
+
+def _make_applicant(
+    legal_name: str | None = None,
+    employer_or_hospital: str | None = None,
+    contract_start: datetime.date | None = None,
+    contract_end: datetime.date | None = None,
+) -> MagicMock:
+    a = MagicMock()
+    a.legal_name = legal_name
+    a.employer_or_hospital = employer_or_hospital
+    a.contract_start = contract_start
+    a.contract_end = contract_end
+    a.dob = None
+    a.vehicle_make_model = None
+    a.stage = "lead"
+    a.referred_by = None
+    a.pets = None
+    return a
+
+
+def _make_inquiry(
+    inquirer_name: str | None = None,
+    inquirer_email: str | None = None,
+    inquirer_phone: str | None = None,
+    inquirer_employer: str | None = None,
+    desired_start_date: datetime.date | None = None,
+    desired_end_date: datetime.date | None = None,
+) -> MagicMock:
+    i = MagicMock()
+    i.inquirer_name = inquirer_name
+    i.inquirer_email = inquirer_email
+    i.inquirer_phone = inquirer_phone
+    i.inquirer_employer = inquirer_employer
+    i.desired_start_date = desired_start_date
+    i.desired_end_date = desired_end_date
+    return i
+
+
+# ---------------------------------------------------------------------------
+# resolve_default_source
+# ---------------------------------------------------------------------------
+
+class TestResolveDefaultSource:
+    def test_single_applicant_source_returns_value_and_provenance(self) -> None:
+        applicant = _make_applicant(legal_name="Jane Doe")
+        value, prov = resolve_default_source("applicant.legal_name", applicant, None)
+        assert value == "Jane Doe"
+        assert prov == "applicant"
+
+    def test_single_applicant_source_none_returns_none(self) -> None:
+        applicant = _make_applicant(legal_name=None)
+        value, prov = resolve_default_source("applicant.legal_name", applicant, None)
+        assert value is None
+        assert prov is None
+
+    def test_inquiry_fallback_used_when_applicant_field_is_none(self) -> None:
+        applicant = _make_applicant(legal_name=None)
+        inquiry = _make_inquiry(inquirer_name="John Smith")
+        value, prov = resolve_default_source(
+            "applicant.legal_name || inquiry.inquirer_name", applicant, inquiry
+        )
+        assert value == "John Smith"
+        assert prov == "inquiry"
+
+    def test_applicant_wins_over_inquiry_when_both_present(self) -> None:
+        applicant = _make_applicant(legal_name="Jane Doe")
+        inquiry = _make_inquiry(inquirer_name="John Smith")
+        value, prov = resolve_default_source(
+            "applicant.legal_name || inquiry.inquirer_name", applicant, inquiry
+        )
+        assert value == "Jane Doe"
+        assert prov == "applicant"
+
+    def test_both_null_returns_none(self) -> None:
+        applicant = _make_applicant(legal_name=None)
+        inquiry = _make_inquiry(inquirer_name=None)
+        value, prov = resolve_default_source(
+            "applicant.legal_name || inquiry.inquirer_name", applicant, inquiry
+        )
+        assert value is None
+        assert prov is None
+
+    def test_inquiry_none_with_fallback_chain_returns_none(self) -> None:
+        applicant = _make_applicant(legal_name=None)
+        value, prov = resolve_default_source(
+            "applicant.legal_name || inquiry.inquirer_name", applicant, None
+        )
+        assert value is None
+        assert prov is None
+
+    def test_today_returns_todays_date_as_iso_string(self) -> None:
+        applicant = _make_applicant()
+        value, prov = resolve_default_source("today", applicant, None)
+        assert value == datetime.date.today().isoformat()
+        assert prov == "today"
+
+    def test_date_field_returned_as_iso_string(self) -> None:
+        target_date = datetime.date(2026, 3, 1)
+        applicant = _make_applicant(contract_start=target_date)
+        value, prov = resolve_default_source("applicant.contract_start", applicant, None)
+        assert value == "2026-03-01"
+        assert prov == "applicant"
+
+    def test_inquiry_email_no_applicant_field(self) -> None:
+        """Email only exists on Inquiry — single inquiry source."""
+        applicant = _make_applicant()
+        inquiry = _make_inquiry(inquirer_email="tenant@example.com")
+        value, prov = resolve_default_source("inquiry.inquirer_email", applicant, inquiry)
+        assert value == "tenant@example.com"
+        assert prov == "inquiry"
+
+    def test_empty_string_treated_as_none_falls_through_to_fallback(self) -> None:
+        applicant = _make_applicant(legal_name="")
+        inquiry = _make_inquiry(inquirer_name="John Smith")
+        value, prov = resolve_default_source(
+            "applicant.legal_name || inquiry.inquirer_name", applicant, inquiry
+        )
+        assert value == "John Smith"
+        assert prov == "inquiry"
+
+    def test_date_fallback_to_inquiry_desired_start(self) -> None:
+        target = datetime.date(2026, 6, 1)
+        applicant = _make_applicant(contract_start=None)
+        inquiry = _make_inquiry(desired_start_date=target)
+        value, prov = resolve_default_source(
+            "applicant.contract_start || inquiry.desired_start_date", applicant, inquiry
+        )
+        assert value == "2026-06-01"
+        assert prov == "inquiry"
+
+
+# ---------------------------------------------------------------------------
+# validate_default_source_spec
+# ---------------------------------------------------------------------------
+
+class TestValidateDefaultSourceSpec:
+    def test_valid_single_applicant_path(self) -> None:
+        validate_default_source_spec("applicant.legal_name")  # must not raise
+
+    def test_valid_single_inquiry_path(self) -> None:
+        validate_default_source_spec("inquiry.inquirer_email")  # must not raise
+
+    def test_valid_today(self) -> None:
+        validate_default_source_spec("today")  # must not raise
+
+    def test_valid_chain_with_spaces(self) -> None:
+        validate_default_source_spec(
+            "applicant.legal_name || inquiry.inquirer_name"
+        )  # must not raise
+
+    def test_valid_chain_without_spaces(self) -> None:
+        validate_default_source_spec(
+            "applicant.legal_name||inquiry.inquirer_name"
+        )  # must not raise
+
+    def test_n_greater_than_2_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="at most one"):
+            validate_default_source_spec(
+                "applicant.legal_name || inquiry.inquirer_name || today"
+            )
+
+    def test_arbitrary_string_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            validate_default_source_spec("some.random.path")
+
+    def test_and_and_operator_raises_value_error(self) -> None:
+        """&& is not supported — only ||."""
+        with pytest.raises(ValueError):
+            validate_default_source_spec("applicant.legal_name && inquiry.inquirer_name")
+
+    def test_unknown_applicant_field_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown applicant field"):
+            validate_default_source_spec("applicant.nonexistent_field")
+
+    def test_unknown_inquiry_field_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown inquiry field"):
+            validate_default_source_spec("inquiry.nonexistent_field")
+
+    def test_blank_spec_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            validate_default_source_spec("")
+
+    def test_whitespace_only_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            validate_default_source_spec("   ")

--- a/apps/mybookkeeper/backend/tests/test_lease_templates_api.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_templates_api.py
@@ -202,6 +202,158 @@ class TestUpdatePlaceholder:
         finally:
             app.dependency_overrides.clear()
 
+    def test_invalid_default_source_returns_422(self) -> None:
+        """An arbitrary default_source string must be rejected with 422."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        template_id, placeholder_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.services.leases.lease_template_service import (
+            InvalidDefaultSourceError,
+        )
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.lease_templates.lease_template_service.update_placeholder",
+                side_effect=InvalidDefaultSourceError(
+                    "Invalid default_source segment 'foo.bar'",
+                ),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/lease-templates/{template_id}/placeholders/{placeholder_id}",
+                    json={"default_source": "foo.bar"},
+                )
+            assert resp.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_valid_pipe_chain_default_source_accepted(self) -> None:
+        """A valid || chain must reach the service (no early rejection)."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        template_id, placeholder_id = uuid.uuid4(), uuid.uuid4()
+
+        import datetime as _dt
+        from app.schemas.leases.lease_template_placeholder_response import (
+            LeaseTemplatePlaceholderResponse,
+        )
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            mock_resp = LeaseTemplatePlaceholderResponse(
+                id=placeholder_id,
+                template_id=template_id,
+                key="TENANT FULL NAME",
+                display_label="Tenant full name",
+                input_type="text",
+                required=True,
+                default_source="applicant.legal_name || inquiry.inquirer_name",
+                computed_expr=None,
+                display_order=0,
+                created_at=_dt.datetime.now(_dt.timezone.utc),
+                updated_at=_dt.datetime.now(_dt.timezone.utc),
+            )
+            with patch(
+                "app.api.lease_templates.lease_template_service.update_placeholder",
+                return_value=mock_resp,
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/lease-templates/{template_id}/placeholders/{placeholder_id}",
+                    json={
+                        "default_source": "applicant.legal_name || inquiry.inquirer_name"
+                    },
+                )
+            assert resp.status_code == 200
+            assert (
+                resp.json()["default_source"]
+                == "applicant.legal_name || inquiry.inquirer_name"
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /lease-templates/{id}/generate-defaults
+# ---------------------------------------------------------------------------
+
+class TestGetGenerateDefaults:
+    def test_happy_path_returns_defaults_list(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        template_id, applicant_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.schemas.leases.generate_defaults_response import (
+            GenerateDefaultsResponse,
+            PlaceholderDefault,
+        )
+
+        app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+        try:
+            mock_defaults = [
+                {"key": "TENANT FULL NAME", "value": "Jane Doe", "provenance": "applicant"},
+                {"key": "TENANT EMAIL", "value": None, "provenance": None},
+            ]
+            with patch(
+                "app.api.lease_templates.lease_template_service.generate_defaults",
+                return_value=mock_defaults,
+            ):
+                client = TestClient(app)
+                resp = client.get(
+                    f"/lease-templates/{template_id}/generate-defaults",
+                    params={"applicant_id": str(applicant_id)},
+                )
+            assert resp.status_code == 200
+            body = resp.json()
+            assert len(body["defaults"]) == 2
+            assert body["defaults"][0]["key"] == "TENANT FULL NAME"
+            assert body["defaults"][0]["value"] == "Jane Doe"
+            assert body["defaults"][0]["provenance"] == "applicant"
+            assert body["defaults"][1]["value"] is None
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_template_not_found_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        template_id, applicant_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.services.leases.lease_template_service import TemplateNotFoundError
+
+        app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.lease_templates.lease_template_service.generate_defaults",
+                side_effect=TemplateNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.get(
+                    f"/lease-templates/{template_id}/generate-defaults",
+                    params={"applicant_id": str(applicant_id)},
+                )
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_applicant_not_found_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        template_id, applicant_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.services.leases.lease_template_service import ApplicantNotFoundError
+
+        app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.lease_templates.lease_template_service.generate_defaults",
+                side_effect=ApplicantNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.get(
+                    f"/lease-templates/{template_id}/generate-defaults",
+                    params={"applicant_id": str(applicant_id)},
+                )
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+
 
 # ---------------------------------------------------------------------------
 # POST /signed-leases/{id}/generate

--- a/apps/mybookkeeper/frontend/e2e/lease-generate-defaults.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/lease-generate-defaults.spec.ts
@@ -1,0 +1,324 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+
+/**
+ * E2E tests for the lease-template-source-pull enhancements:
+ *
+ * - Backend: ``GET /lease-templates/{id}/generate-defaults?applicant_id=``
+ *   correctly resolves defaults with inquiry fallback.
+ *
+ * NOTE: ``LeaseGenerateForm`` is a component built in PR #175 but not yet
+ * integrated into any app route (the consuming page is a future PR). These
+ * E2E tests therefore cover the backend API layer directly — the component
+ * behavior (provenance badges, applicant switch re-pull, Pull-from-source) is
+ * fully covered by ``LeaseGenerateForm.test.tsx`` Vitest unit tests.
+ */
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function seedTemplate(
+  api: APIRequestContext,
+  payload: { name?: string; source_text?: string } = {},
+): Promise<string> {
+  const res = await api.post("/test/seed-lease-template", { data: payload });
+  if (!res.ok()) {
+    throw new Error(`seedTemplate failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function deleteTemplate(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/test/lease-templates/${id}`).catch(() => {});
+}
+
+async function seedInquiry(
+  api: APIRequestContext,
+  payload: {
+    source?: string;
+    inquirer_name?: string | null;
+    inquirer_email?: string | null;
+    inquirer_phone?: string | null;
+    inquirer_employer?: string | null;
+    desired_start_date?: string | null;
+    desired_end_date?: string | null;
+  } = {},
+): Promise<string> {
+  const res = await api.post("/test/seed-inquiry", {
+    data: {
+      source: "direct",
+      received_at: new Date().toISOString(),
+      ...payload,
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedInquiry failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function deleteInquiry(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/test/inquiries/${id}`).catch(() => {});
+}
+
+async function seedApplicant(
+  api: APIRequestContext,
+  payload: {
+    inquiry_id?: string | null;
+    legal_name?: string | null;
+    employer_or_hospital?: string | null;
+    contract_start?: string | null;
+    contract_end?: string | null;
+    stage?: string;
+  } = {},
+): Promise<string> {
+  const res = await api.post("/test/seed-applicant", {
+    data: { stage: "lead", seed_event: false, ...payload },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedApplicant failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function deleteApplicant(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/test/applicants/${id}`).catch(() => {});
+}
+
+async function getGenerateDefaults(
+  api: APIRequestContext,
+  templateId: string,
+  applicantId: string,
+) {
+  const res = await api.get(
+    `/lease-templates/${templateId}/generate-defaults?applicant_id=${applicantId}`,
+  );
+  return { status: res.status(), body: await res.json() };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("generate-defaults API (lease-template-source-pull)", () => {
+  test(
+    "applicant with full data — name resolves from applicant, provenance=applicant",
+    async ({ api }) => {
+      const runId = Date.now();
+      const seededTemplates: string[] = [];
+      const seededApplicants: string[] = [];
+      const seededInquiries: string[] = [];
+
+      try {
+        const templateId = await seedTemplate(api, {
+          name: `E2E Defaults Full ${runId}`,
+        });
+        seededTemplates.push(templateId);
+
+        const applicantId = await seedApplicant(api, {
+          legal_name: "Jane Full Doe",
+          stage: "lead",
+        });
+        seededApplicants.push(applicantId);
+
+        const { status, body } = await getGenerateDefaults(
+          api, templateId, applicantId,
+        );
+        expect(status).toBe(200);
+
+        const nameDefault = (body.defaults as Array<{
+          key: string;
+          value: string | null;
+          provenance: string | null;
+        }>).find((d) => d.key === "TENANT FULL NAME");
+
+        expect(nameDefault).toBeDefined();
+        expect(nameDefault?.value).toBe("Jane Full Doe");
+        expect(nameDefault?.provenance).toBe("applicant");
+      } finally {
+        for (const id of seededTemplates) await deleteTemplate(api, id);
+        for (const id of seededApplicants) await deleteApplicant(api, id);
+        for (const id of seededInquiries) await deleteInquiry(api, id);
+      }
+    },
+  );
+
+  test(
+    "sparse applicant + inquiry with full data — name falls back to inquiry, provenance=inquiry",
+    async ({ api }) => {
+      const runId = Date.now();
+      const seededTemplates: string[] = [];
+      const seededApplicants: string[] = [];
+      const seededInquiries: string[] = [];
+
+      try {
+        const templateId = await seedTemplate(api, {
+          name: `E2E Defaults Fallback ${runId}`,
+        });
+        seededTemplates.push(templateId);
+
+        // Seed inquiry with full PII data.
+        const inquiryId = await seedInquiry(api, {
+          inquirer_name: "Inquiry Tenant Name",
+          inquirer_email: "tenant@example.com",
+          inquirer_phone: "555-0100",
+          inquirer_employer: "Inquiry Employer",
+          desired_start_date: "2026-07-01",
+          desired_end_date: "2027-06-30",
+        });
+        seededInquiries.push(inquiryId);
+
+        // Sparse applicant: no legal_name, no employer, no contract dates.
+        // Linked to the inquiry so the fallback chain fires.
+        const applicantId = await seedApplicant(api, {
+          inquiry_id: inquiryId,
+          legal_name: null,
+          employer_or_hospital: null,
+          contract_start: null,
+          contract_end: null,
+        });
+        seededApplicants.push(applicantId);
+
+        const { status, body } = await getGenerateDefaults(
+          api, templateId, applicantId,
+        );
+        expect(status).toBe(200);
+
+        const defaults = body.defaults as Array<{
+          key: string;
+          value: string | null;
+          provenance: string | null;
+        }>;
+
+        // Name should fall back to inquiry.
+        const nameDefault = defaults.find((d) => d.key === "TENANT FULL NAME");
+        expect(nameDefault?.value).toBe("Inquiry Tenant Name");
+        expect(nameDefault?.provenance).toBe("inquiry");
+
+        // Email — only on inquiry (applicant has no email field).
+        const emailDefault = defaults.find((d) => d.key === "TENANT EMAIL");
+        expect(emailDefault?.value).toBe("tenant@example.com");
+        expect(emailDefault?.provenance).toBe("inquiry");
+
+        // Move-in date falls back to inquiry.desired_start_date.
+        const moveInDefault = defaults.find((d) => d.key === "MOVE-IN DATE");
+        expect(moveInDefault?.value).toBe("2026-07-01");
+        expect(moveInDefault?.provenance).toBe("inquiry");
+      } finally {
+        for (const id of seededTemplates) await deleteTemplate(api, id);
+        for (const id of seededApplicants) await deleteApplicant(api, id);
+        for (const id of seededInquiries) await deleteInquiry(api, id);
+      }
+    },
+  );
+
+  test(
+    "applicant with no linked inquiry — email and phone resolve to null",
+    async ({ api }) => {
+      const runId = Date.now();
+      const seededTemplates: string[] = [];
+      const seededApplicants: string[] = [];
+
+      try {
+        const templateId = await seedTemplate(api, {
+          name: `E2E Defaults No Inquiry ${runId}`,
+        });
+        seededTemplates.push(templateId);
+
+        const applicantId = await seedApplicant(api, {
+          inquiry_id: null,
+          legal_name: "No Inquiry Tenant",
+        });
+        seededApplicants.push(applicantId);
+
+        const { status, body } = await getGenerateDefaults(
+          api, templateId, applicantId,
+        );
+        expect(status).toBe(200);
+
+        const defaults = body.defaults as Array<{
+          key: string;
+          value: string | null;
+          provenance: string | null;
+        }>;
+
+        // Email only exists on inquiry — with no inquiry, should be null.
+        const emailDefault = defaults.find((d) => d.key === "TENANT EMAIL");
+        expect(emailDefault?.value).toBeNull();
+        expect(emailDefault?.provenance).toBeNull();
+
+        // Name resolves from applicant.
+        const nameDefault = defaults.find((d) => d.key === "TENANT FULL NAME");
+        expect(nameDefault?.value).toBe("No Inquiry Tenant");
+        expect(nameDefault?.provenance).toBe("applicant");
+      } finally {
+        for (const id of seededTemplates) await deleteTemplate(api, id);
+        for (const id of seededApplicants) await deleteApplicant(api, id);
+      }
+    },
+  );
+
+  test(
+    "today placeholder resolves to today's date, provenance=today",
+    async ({ api }) => {
+      const runId = Date.now();
+      const seededTemplates: string[] = [];
+      const seededApplicants: string[] = [];
+
+      try {
+        const templateId = await seedTemplate(api, {
+          name: `E2E Defaults Today ${runId}`,
+        });
+        seededTemplates.push(templateId);
+
+        const applicantId = await seedApplicant(api, { legal_name: "Test Tenant" });
+        seededApplicants.push(applicantId);
+
+        const { status, body } = await getGenerateDefaults(
+          api, templateId, applicantId,
+        );
+        expect(status).toBe(200);
+
+        const effectiveDateDefault = (body.defaults as Array<{
+          key: string;
+          value: string | null;
+          provenance: string | null;
+        }>).find((d) => d.key === "EFFECTIVE DATE");
+
+        const todayIso = new Date().toISOString().slice(0, 10);
+        expect(effectiveDateDefault?.value).toBe(todayIso);
+        expect(effectiveDateDefault?.provenance).toBe("today");
+      } finally {
+        for (const id of seededTemplates) await deleteTemplate(api, id);
+        for (const id of seededApplicants) await deleteApplicant(api, id);
+      }
+    },
+  );
+
+  test(
+    "cross-tenant applicant returns 404",
+    async ({ api }) => {
+      const runId = Date.now();
+      const seededTemplates: string[] = [];
+
+      try {
+        const templateId = await seedTemplate(api, {
+          name: `E2E Defaults Cross-Tenant ${runId}`,
+        });
+        seededTemplates.push(templateId);
+
+        // Use a random UUID that definitely doesn't belong to this tenant.
+        const fakeApplicantId = "00000000-0000-4000-8000-000000000001";
+        const { status } = await getGenerateDefaults(
+          api, templateId, fakeApplicantId,
+        );
+        expect(status).toBe(404);
+      } finally {
+        for (const id of seededTemplates) await deleteTemplate(api, id);
+      }
+    },
+  );
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseGenerateForm.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseGenerateForm.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Unit tests for LeaseGenerateForm — enhancements from lease-template-source-pull:
+ *
+ * 1. Auto-pull on applicant change (via useGetGenerateDefaultsQuery re-fetch)
+ * 2. Provenance badge transitions to "manually edited" on keystroke
+ * 3. "Pull from source" button overwrites fields + resets provenance
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import LeaseGenerateForm from "@/app/features/leases/LeaseGenerateForm";
+import type { LeaseTemplateDetail } from "@/shared/types/lease/lease-template-detail";
+
+// ---------------------------------------------------------------------------
+// Mock RTK Query hooks
+// ---------------------------------------------------------------------------
+
+const mockUseGetGenerateDefaultsQuery = vi.fn();
+const mockUseCreateSignedLeaseMutation = vi.fn();
+
+vi.mock("@/shared/store/leaseTemplatesApi", () => ({
+  useGetGenerateDefaultsQuery: (args: unknown, opts: unknown) =>
+    mockUseGetGenerateDefaultsQuery(args, opts),
+}));
+
+vi.mock("@/shared/store/signedLeasesApi", () => ({
+  useCreateSignedLeaseMutation: () => mockUseCreateSignedLeaseMutation(),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+const TEMPLATE: LeaseTemplateDetail = {
+  id: "tpl-1",
+  user_id: "user-1",
+  organization_id: "org-1",
+  name: "Standard Lease",
+  description: null,
+  version: 1,
+  files: [],
+  placeholders: [
+    {
+      id: "ph-1",
+      template_id: "tpl-1",
+      key: "TENANT FULL NAME",
+      display_label: "Tenant full name",
+      input_type: "text",
+      required: true,
+      default_source: "applicant.legal_name || inquiry.inquirer_name",
+      computed_expr: null,
+      display_order: 0,
+      created_at: "2026-05-02T00:00:00Z",
+      updated_at: "2026-05-02T00:00:00Z",
+    },
+    {
+      id: "ph-2",
+      template_id: "tpl-1",
+      key: "TENANT EMAIL",
+      display_label: "Tenant email",
+      input_type: "email",
+      required: false,
+      default_source: "inquiry.inquirer_email",
+      computed_expr: null,
+      display_order: 1,
+      created_at: "2026-05-02T00:00:00Z",
+      updated_at: "2026-05-02T00:00:00Z",
+    },
+  ],
+  created_at: "2026-05-02T00:00:00Z",
+  updated_at: "2026-05-02T00:00:00Z",
+};
+
+const DEFAULTS_FROM_APPLICANT = {
+  data: {
+    defaults: [
+      { key: "TENANT FULL NAME", value: "Jane Doe", provenance: "applicant" },
+      { key: "TENANT EMAIL", value: null, provenance: null },
+    ],
+  },
+  isLoading: false,
+  isFetching: false,
+};
+
+const DEFAULTS_FROM_INQUIRY = {
+  data: {
+    defaults: [
+      { key: "TENANT FULL NAME", value: "John Smith", provenance: "inquiry" },
+      { key: "TENANT EMAIL", value: "john@example.com", provenance: "inquiry" },
+    ],
+  },
+  isLoading: false,
+  isFetching: false,
+};
+
+function renderForm(applicantId: string) {
+  return render(
+    <MemoryRouter>
+      <Provider store={store}>
+        <LeaseGenerateForm template={TEMPLATE} applicantId={applicantId} />
+      </Provider>
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LeaseGenerateForm", () => {
+  beforeEach(() => {
+    mockUseCreateSignedLeaseMutation.mockReturnValue([vi.fn(), { isLoading: false }]);
+  });
+
+  it("pre-fills fields from resolved defaults on mount", () => {
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_APPLICANT);
+    renderForm("applicant-1");
+
+    const nameInput = screen.getByTestId("generate-field-TENANT FULL NAME")
+      .querySelector("input")!;
+    expect(nameInput.value).toBe("Jane Doe");
+  });
+
+  it("shows 'from applicant' provenance badge when value came from applicant", () => {
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_APPLICANT);
+    renderForm("applicant-1");
+
+    expect(screen.getByTestId("provenance-badge-applicant")).toBeInTheDocument();
+  });
+
+  it("shows 'from inquiry' provenance badge when value came from inquiry fallback", () => {
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_INQUIRY);
+    renderForm("applicant-1");
+
+    const badges = screen.getAllByTestId("provenance-badge-inquiry");
+    expect(badges.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("transitions badge to 'manually edited' when user edits a pre-filled field", () => {
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_APPLICANT);
+    renderForm("applicant-1");
+
+    const nameInput = screen.getByTestId("generate-field-TENANT FULL NAME")
+      .querySelector("input")!;
+
+    fireEvent.change(nameInput, { target: { value: "Edited Name" } });
+
+    expect(screen.getByTestId("provenance-badge-manual")).toBeInTheDocument();
+  });
+
+  it("re-pulls fields when defaults data changes (simulates applicant switch)", async () => {
+    // First render: applicant-1 with Jane Doe
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_APPLICANT);
+    const { rerender } = renderForm("applicant-1");
+
+    let nameInput = screen.getByTestId("generate-field-TENANT FULL NAME")
+      .querySelector("input")!;
+    expect(nameInput.value).toBe("Jane Doe");
+
+    // Switch to applicant-2 (different defaults from inquiry)
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_INQUIRY);
+    await act(async () => {
+      rerender(
+        <MemoryRouter>
+          <Provider store={store}>
+            <LeaseGenerateForm template={TEMPLATE} applicantId="applicant-2" />
+          </Provider>
+        </MemoryRouter>,
+      );
+    });
+
+    nameInput = screen.getByTestId("generate-field-TENANT FULL NAME")
+      .querySelector("input")!;
+    expect(nameInput.value).toBe("John Smith");
+  });
+
+  it("shows Pull from source button", () => {
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_APPLICANT);
+    renderForm("applicant-1");
+
+    expect(screen.getByTestId("pull-from-source-button")).toBeInTheDocument();
+  });
+
+  it("shows inline confirmation when Pull from source is clicked", () => {
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_APPLICANT);
+    renderForm("applicant-1");
+
+    fireEvent.click(screen.getByTestId("pull-from-source-button"));
+
+    expect(screen.getByTestId("pull-from-source-confirm")).toBeInTheDocument();
+  });
+
+  it("overwrites fields and resets provenance when Pull from source is confirmed", () => {
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_APPLICANT);
+    renderForm("applicant-1");
+
+    const nameInput = screen.getByTestId("generate-field-TENANT FULL NAME")
+      .querySelector("input")!;
+
+    // Edit the field manually
+    fireEvent.change(nameInput, { target: { value: "Manually Edited" } });
+    expect(screen.getByTestId("provenance-badge-manual")).toBeInTheDocument();
+
+    // Click Pull from source → confirm
+    fireEvent.click(screen.getByTestId("pull-from-source-button"));
+    fireEvent.click(screen.getByTestId("pull-from-source-confirm-yes"));
+
+    // Value and provenance should be reset to defaults
+    expect(nameInput.value).toBe("Jane Doe");
+    expect(screen.getByTestId("provenance-badge-applicant")).toBeInTheDocument();
+  });
+
+  it("dismisses confirmation without changing values when Cancel is clicked", () => {
+    mockUseGetGenerateDefaultsQuery.mockReturnValue(DEFAULTS_FROM_APPLICANT);
+    renderForm("applicant-1");
+
+    const nameInput = screen.getByTestId("generate-field-TENANT FULL NAME")
+      .querySelector("input")!;
+    fireEvent.change(nameInput, { target: { value: "Manually Edited" } });
+
+    // Click Pull from source → cancel
+    fireEvent.click(screen.getByTestId("pull-from-source-button"));
+    fireEvent.click(screen.getByTestId("pull-from-source-confirm-no"));
+
+    // Value preserved, confirmation gone
+    expect(nameInput.value).toBe("Manually Edited");
+    expect(screen.queryByTestId("pull-from-source-confirm")).not.toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseGenerateForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseGenerateForm.tsx
@@ -1,53 +1,56 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useCreateSignedLeaseMutation } from "@/shared/store/signedLeasesApi";
+import { useGetGenerateDefaultsQuery } from "@/shared/store/leaseTemplatesApi";
 import type { LeaseTemplateDetail } from "@/shared/types/lease/lease-template-detail";
+import type { PlaceholderProvenance } from "@/shared/types/lease/placeholder-provenance";
 import PlaceholderInput from "@/app/features/leases/PlaceholderInput";
 
 interface Props {
   template: LeaseTemplateDetail;
   applicantId: string;
   listingId?: string | null;
-  /**
-   * Optional initial values pre-populated from applicant fields. Keys must
-   * match the template's placeholder ``key`` strings.
-   */
-  initialValues?: Record<string, string>;
 }
+
+type ProvenanceMap = Record<string, PlaceholderProvenance>;
+type ValuesMap = Record<string, string>;
 
 /**
  * Form for filling in a template's placeholders to generate a draft lease.
  *
- * Computed placeholders are NOT user-editable — they're shown as previewed
- * values that update live as their dependencies change.
+ * Three enhancements over PR #175:
  *
- * Required placeholders block submission until filled. Signature placeholders
- * are filled at signing time so they're hidden in this form.
+ * 1. **Auto-pull on applicant change** — when ``applicantId`` changes, all
+ *    fields with a ``default_source`` re-pull from the new applicant + linked
+ *    inquiry. Manual edits are overwritten by design.
+ *
+ * 2. **Inquiry fallback** — ``default_source`` chains (``applicant.X ||
+ *    inquiry.Y``) are evaluated server-side; the resolved value and provenance
+ *    are returned by ``GET /lease-templates/{id}/generate-defaults``.
+ *
+ * 3. **Provenance badges** — each field shows where its value came from
+ *    (applicant / inquiry / manually edited). Editing a field transitions its
+ *    badge to "manually edited". A "Pull from source" button re-runs the
+ *    resolution and overwrites all fields.
+ *
+ * Computed and signature placeholders are hidden in this form — they're
+ * resolved at generate / signing time.
  */
 export default function LeaseGenerateForm({
   template,
   applicantId,
   listingId,
-  initialValues = {},
 }: Props) {
   const navigate = useNavigate();
-  const [createLease, { isLoading }] = useCreateSignedLeaseMutation();
+  const [createLease, { isLoading: isCreating }] = useCreateSignedLeaseMutation();
 
-  // Initial seed comes from ``initialValues`` filtered to the template's
-  // user-fillable placeholder keys. Computed by ``useState``'s initialiser
-  // function — runs once on mount per (template, applicantId) — see the
-  // ``key`` prop on the parent LeaseDetail / generate route to remount this
-  // component when the user picks a different template.
-  const [values, setValues] = useState<Record<string, string>>(() => {
-    const seed: Record<string, string> = {};
-    for (const p of template.placeholders) {
-      if (p.input_type === "signature" || p.input_type === "computed") continue;
-      if (initialValues[p.key]) seed[p.key] = initialValues[p.key];
-    }
-    return seed;
-  });
+  const [values, setValues] = useState<ValuesMap>({});
+  const [provenance, setProvenance] = useState<ProvenanceMap>({});
+
+  // Track whether we're showing the "Pull from source" confirmation inline.
+  const [showPullConfirm, setShowPullConfirm] = useState(false);
 
   const editablePlaceholders = useMemo(
     () =>
@@ -58,10 +61,60 @@ export default function LeaseGenerateForm({
   );
 
   const computedPlaceholders = useMemo(
-    () =>
-      template.placeholders.filter((p) => p.input_type === "computed"),
+    () => template.placeholders.filter((p) => p.input_type === "computed"),
     [template.placeholders],
   );
+
+  // Fetch resolved defaults for the current applicant.
+  const {
+    data: defaultsData,
+    isLoading: isLoadingDefaults,
+    isFetching: isFetchingDefaults,
+  } = useGetGenerateDefaultsQuery(
+    { templateId: template.id, applicantId },
+    { skip: !applicantId },
+  );
+
+  // Re-pull all fields whenever the resolved defaults change (i.e., applicantId
+  // changed and a fresh fetch completed). This covers both the initial mount
+  // and subsequent applicant switches.
+  useEffect(() => {
+    if (!defaultsData) return;
+    applyDefaults(defaultsData.defaults);
+  }, [defaultsData]); // applyDefaults uses only setState dispatch calls — stable, safe to omit
+
+  function applyDefaults(
+    defaults: Array<{ key: string; value: string | null; provenance: PlaceholderProvenance }>,
+  ): void {
+    const nextValues: ValuesMap = {};
+    const nextProvenance: ProvenanceMap = {};
+
+    for (const d of defaults) {
+      nextValues[d.key] = d.value ?? "";
+      nextProvenance[d.key] = d.provenance;
+    }
+
+    setValues(nextValues);
+    setProvenance(nextProvenance);
+  }
+
+  function handleFieldChange(key: string, next: string): void {
+    setValues((prev) => ({ ...prev, [key]: next }));
+    // Any keystroke transitions provenance → "manual" if a source had populated it.
+    setProvenance((prev) => {
+      const current = prev[key];
+      if (current === null || current === "manual") return prev;
+      return { ...prev, [key]: "manual" };
+    });
+  }
+
+  function handlePullFromSource(): void {
+    // Re-apply the latest resolved defaults, overwriting all current values.
+    if (defaultsData) {
+      applyDefaults(defaultsData.defaults);
+    }
+    setShowPullConfirm(false);
+  }
 
   const missingRequired = useMemo(
     () =>
@@ -71,7 +124,7 @@ export default function LeaseGenerateForm({
     [editablePlaceholders, values],
   );
 
-  async function handleSubmit(e: React.FormEvent) {
+  async function handleSubmit(e: React.FormEvent): Promise<void> {
     e.preventDefault();
     if (missingRequired.length > 0) {
       showError(`Missing: ${missingRequired.map((p) => p.display_label).join(", ")}`);
@@ -93,15 +146,61 @@ export default function LeaseGenerateForm({
     }
   }
 
+  const isPulling = isLoadingDefaults || isFetchingDefaults;
+
   return (
     <form onSubmit={handleSubmit} className="space-y-4" data-testid="lease-generate-form">
+      {/* Pull from source button + inline confirmation */}
+      <div className="flex items-start justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          Fields marked with a badge are auto-filled from the applicant or inquiry.
+        </p>
+        {showPullConfirm ? (
+          <div
+            className="flex items-center gap-2 rounded-md border bg-muted px-3 py-2 text-xs"
+            data-testid="pull-from-source-confirm"
+          >
+            <span>This will replace your edits. Continue?</span>
+            <button
+              type="button"
+              onClick={handlePullFromSource}
+              className="font-medium text-primary hover:underline"
+              data-testid="pull-from-source-confirm-yes"
+            >
+              Yes, pull
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowPullConfirm(false)}
+              className="text-muted-foreground hover:text-foreground"
+              data-testid="pull-from-source-confirm-no"
+            >
+              Cancel
+            </button>
+          </div>
+        ) : (
+          <LoadingButton
+            type="button"
+            variant="secondary"
+            size="sm"
+            isLoading={isPulling}
+            loadingText="Pulling..."
+            onClick={() => setShowPullConfirm(true)}
+            data-testid="pull-from-source-button"
+          >
+            Pull from source
+          </LoadingButton>
+        )}
+      </div>
+
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         {editablePlaceholders.map((p) => (
           <PlaceholderInput
             key={p.id}
             placeholder={p}
             value={values[p.key] ?? ""}
-            onChange={(v) => setValues((prev) => ({ ...prev, [p.key]: v }))}
+            provenance={provenance[p.key] ?? null}
+            onChange={(v) => handleFieldChange(p.key, v)}
           />
         ))}
       </div>
@@ -120,7 +219,7 @@ export default function LeaseGenerateForm({
       <div className="flex justify-end">
         <LoadingButton
           type="submit"
-          isLoading={isLoading}
+          isLoading={isCreating}
           loadingText="Creating draft..."
           disabled={missingRequired.length > 0}
           data-testid="lease-generate-submit"

--- a/apps/mybookkeeper/frontend/src/app/features/leases/PlaceholderInput.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/PlaceholderInput.tsx
@@ -1,8 +1,11 @@
 import type { LeaseTemplatePlaceholder } from "@/shared/types/lease/lease-template-placeholder";
+import type { PlaceholderProvenance } from "@/shared/types/lease/placeholder-provenance";
+import ProvenanceBadge from "@/app/features/leases/ProvenanceBadge";
 
 interface Props {
   placeholder: LeaseTemplatePlaceholder;
   value: string;
+  provenance: PlaceholderProvenance;
   onChange: (next: string) => void;
 }
 
@@ -10,8 +13,16 @@ interface Props {
  * Single placeholder input field used by ``LeaseGenerateForm``. The HTML
  * input type is derived from the placeholder's ``input_type`` so the right
  * mobile keyboard / picker shows up.
+ *
+ * Shows a provenance badge below the input indicating where the value came
+ * from (applicant, inquiry, or manually edited).
  */
-export default function PlaceholderInput({ placeholder, value, onChange }: Props) {
+export default function PlaceholderInput({
+  placeholder,
+  value,
+  provenance,
+  onChange,
+}: Props) {
   const inputType = (() => {
     switch (placeholder.input_type) {
       case "email":
@@ -40,9 +51,12 @@ export default function PlaceholderInput({ placeholder, value, onChange }: Props
         className="w-full px-3 py-2 text-sm border rounded-md"
         placeholder={placeholder.default_source ?? ""}
       />
-      <p className="text-xs text-muted-foreground mt-0.5 font-mono">
-        [{placeholder.key}]
-      </p>
+      <div className="flex items-center gap-2 mt-0.5">
+        <p className="text-xs text-muted-foreground font-mono">
+          [{placeholder.key}]
+        </p>
+        <ProvenanceBadge provenance={provenance} />
+      </div>
     </div>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/leases/ProvenanceBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/ProvenanceBadge.tsx
@@ -1,0 +1,49 @@
+import type { PlaceholderProvenance } from "@/shared/types/lease/placeholder-provenance";
+
+interface Props {
+  provenance: PlaceholderProvenance;
+}
+
+const BADGE_CONFIG: Record<
+  NonNullable<Exclude<PlaceholderProvenance, null>>,
+  { label: string; className: string }
+> = {
+  applicant: {
+    label: "from applicant",
+    className: "bg-muted text-muted-foreground border border-border",
+  },
+  inquiry: {
+    label: "from inquiry",
+    className: "bg-purple-100 text-purple-700 border border-purple-200",
+  },
+  today: {
+    label: "today's date",
+    className: "bg-muted text-muted-foreground border border-border",
+  },
+  manual: {
+    label: "manually edited",
+    className: "bg-yellow-100 text-yellow-700 border border-yellow-200",
+  },
+};
+
+/**
+ * Small inline badge indicating where a placeholder value came from.
+ *
+ * Renders nothing when ``provenance`` is ``null`` (no ``default_source`` on
+ * the placeholder — manual entry only).
+ */
+export default function ProvenanceBadge({ provenance }: Props) {
+  if (provenance === null) return null;
+
+  const config = BADGE_CONFIG[provenance];
+  if (!config) return null;
+
+  return (
+    <span
+      className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${config.className}`}
+      data-testid={`provenance-badge-${provenance}`}
+    >
+      {config.label}
+    </span>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/store/leaseTemplatesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/leaseTemplatesApi.ts
@@ -1,4 +1,5 @@
 import { baseApi } from "./baseApi";
+import type { GenerateDefaultsResponse } from "@/shared/types/lease/generate-defaults-response";
 import type { LeasePlaceholderUpdateRequest } from "@/shared/types/lease/lease-placeholder-update-request";
 import type { LeaseTemplateDetail } from "@/shared/types/lease/lease-template-detail";
 import type { LeaseTemplateListResponse } from "@/shared/types/lease/lease-template-list-response";
@@ -96,6 +97,17 @@ const leaseTemplatesApi = baseApi.injectEndpoints({
       ],
     }),
 
+    getGenerateDefaults: builder.query<
+      GenerateDefaultsResponse,
+      { templateId: string; applicantId: string }
+    >({
+      query: ({ templateId, applicantId }) => ({
+        url: `/lease-templates/${templateId}/generate-defaults`,
+        params: { applicant_id: applicantId },
+      }),
+      // No cache tag — always fetch fresh when applicant changes.
+    }),
+
     deleteLeaseTemplate: builder.mutation<void, string>({
       query: (id) => ({ url: `/lease-templates/${id}`, method: "DELETE" }),
       invalidatesTags: [{ type: "LeaseTemplate", id: "LIST" }],
@@ -125,6 +137,7 @@ const leaseTemplatesApi = baseApi.injectEndpoints({
 export const {
   useGetLeaseTemplatesQuery,
   useGetLeaseTemplateByIdQuery,
+  useGetGenerateDefaultsQuery,
   useCreateLeaseTemplateMutation,
   useUpdateLeaseTemplateMutation,
   useUpdateLeasePlaceholderMutation,

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/generate-defaults-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/generate-defaults-response.ts
@@ -1,0 +1,19 @@
+import type { PlaceholderProvenance } from "@/shared/types/lease/placeholder-provenance";
+
+/**
+ * Resolved default for a single placeholder key.
+ * Mirrors backend ``PlaceholderDefault``.
+ */
+export interface PlaceholderDefault {
+  key: string;
+  value: string | null;
+  provenance: PlaceholderProvenance;
+}
+
+/**
+ * Response from ``GET /lease-templates/{id}/generate-defaults``.
+ * Mirrors backend ``GenerateDefaultsResponse``.
+ */
+export interface GenerateDefaultsResponse {
+  defaults: PlaceholderDefault[];
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/placeholder-provenance.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/placeholder-provenance.ts
@@ -1,0 +1,15 @@
+/**
+ * Where a placeholder value came from during auto-fill.
+ *
+ * - ``"applicant"`` — resolved from the applicant row
+ * - ``"inquiry"`` — resolved from the linked inquiry (fallback)
+ * - ``"today"`` — resolved from today's date
+ * - ``"manual"`` — host typed or edited the value
+ * - ``null`` — field has no default_source; manual-entry only
+ */
+export type PlaceholderProvenance =
+  | "applicant"
+  | "inquiry"
+  | "today"
+  | "manual"
+  | null;

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -551,17 +551,29 @@
         "test_lease_renderer.py",
         "test_lease_template_repo.py",
         "test_lease_templates_api.py",
+<<<<<<< HEAD
         "test_lease_import_api.py",
         "test_lease_import_heuristic.py"
+=======
+        "test_default_source_resolver.py"
+>>>>>>> a18f113 (feat(mybookkeeper/leases): auto-pull placeholder values from applicant + inquiry fallback)
       ],
       "frontend_tests": [
         "SignedLeaseStatusBadge.test.tsx",
         "PlaceholderSpecEditor.test.tsx",
+<<<<<<< HEAD
         "LeaseImportDialog.test.tsx"
       ],
       "e2e_specs": [
         "lease-templates.spec.ts",
         "lease-import.spec.ts"
+=======
+        "LeaseGenerateForm.test.tsx"
+      ],
+      "e2e_specs": [
+        "lease-templates.spec.ts",
+        "lease-generate-defaults.spec.ts"
+>>>>>>> a18f113 (feat(mybookkeeper/leases): auto-pull placeholder values from applicant + inquiry fallback)
       ]
     },
     "screening": {


### PR DESCRIPTION
## User story

When generating a draft lease, property managers need fields to auto-populate from the selected applicant (and their linked inquiry as a fallback) — without manual copy-paste. If they switch applicants, fields should refresh automatically. Fields they edit manually should stay until they explicitly pull fresh data.

## What this PR adds

### Enhancement 1 — Auto-pull on applicant change

LeaseGenerateForm watches the RTK Query result for GET /lease-templates/{id}/generate-defaults. When applicantId prop changes, the query re-fetches and a useEffect on defaultsData calls applyDefaults(), overwriting all field values and provenance state with the new applicant resolved defaults. No user interaction needed.

### Enhancement 2 — Inquiry fallback (pipe syntax in default_source)

Extends default_source to support pipe-separated fallback chains evaluated server-side:

- TENANT FULL NAME: applicant.legal_name || inquiry.inquirer_name
- TENANT EMAIL: inquiry.inquirer_email (inquiry-primary; Applicant model has no email column)
- TENANT PHONE: inquiry.inquirer_phone (inquiry-primary; Applicant model has no phone column)
- TENANT EMPLOYER: applicant.employer_or_hospital || inquiry.inquirer_employer
- MOVE-IN DATE: applicant.contract_start || inquiry.desired_start_date
- MOVE-OUT DATE: applicant.contract_end || inquiry.desired_end_date
- EFFECTIVE DATE: today

Data model gap found during implementation: the original spec assumed applicant.email and applicant.phone exist. The actual Applicant ORM model has no email or phone columns — those fields only exist on Inquiry. Mappings updated to reflect reality.

New endpoint: GET /lease-templates/{id}/generate-defaults?applicant_id={id} returns { defaults: [{ key, value, provenance }] }.

default_source validation: Updating a placeholder with an invalid default_source string now returns 422.

### Enhancement 3 — Provenance badges

Each form field displays where its value came from:
- Gray badge: from applicant (provenance = applicant or today)
- Purple badge: from inquiry (provenance = inquiry)
- Yellow badge: manually edited (provenance = manual)
- No badge: field has no default_source

Any keystroke transitions the badge to manually edited. A Pull from source button shows inline confirmation before overwriting all fields with the latest resolved defaults.

## Files changed

Backend:
- app/services/leases/default_source_resolver.py (NEW) — pure resolver + validator
- app/services/leases/default_source_map.py — updated all mappings with correct column names + fallback chains
- app/services/leases/lease_template_service.py — added generate_defaults(), default_source validation on placeholder update
- app/schemas/leases/generate_defaults_response.py (NEW) — response schema
- app/api/lease_templates.py — new GET /{id}/generate-defaults endpoint + 422 handler
- app/repositories/inquiries/inquiry_repo.py — added get_by_applicant_inquiry_id()

Frontend:
- src/shared/types/lease/placeholder-provenance.ts (NEW) — PlaceholderProvenance type
- src/shared/types/lease/generate-defaults-response.ts (NEW) — response interface
- src/shared/store/leaseTemplatesApi.ts — added getGenerateDefaults query
- src/app/features/leases/ProvenanceBadge.tsx (NEW) — colored badge component
- src/app/features/leases/PlaceholderInput.tsx — added provenance prop + badge render
- src/app/features/leases/LeaseGenerateForm.tsx — rewrite: API-driven auto-fill, provenance state, pull-from-source flow

Tests:
- backend/tests/test_default_source_resolver.py (NEW) — 23 unit tests (pure resolver, no DB)
- backend/tests/test_lease_templates_api.py — 3 new API tests for generate-defaults + 2 for default_source validation
- frontend/src/__tests__/LeaseGenerateForm.test.tsx (NEW) — 9 Vitest component tests
- frontend/e2e/lease-generate-defaults.spec.ts (NEW) — 5 Playwright API-level E2E tests

## Test plan

- [x] test_default_source_resolver.py — 23 unit tests pass
- [x] test_lease_templates_api.py — all 15 API tests pass (includes TestGetGenerateDefaults, invalid/valid default_source tests)
- [x] LeaseGenerateForm.test.tsx — 9 Vitest tests pass
- [x] lease-generate-defaults.spec.ts — 5 Playwright E2E tests covering API contract
- [x] TypeScript build clean
- [x] ESLint clean

Note: LeaseGenerateForm E2E tests cover the backend API layer directly. The component itself is not yet wired into any app route (built as an isolated component in PR #175). Component behavior is fully covered by the Vitest unit tests. Route integration is a follow-up PR.

## Out of scope (follow-up PRs)

- Integrating LeaseGenerateForm into an app route/page
- Multiple applicant selector in the generate flow
- Bulk lease generation

Generated with Claude Code