### PR TITLE
feat(mybookkeeper/leases): inline viewer + per-attachment kind picker + filename heuristic

### DIFF
--- a/apps/mybookkeeper/backend/app/api/signed_leases.py
+++ b/apps/mybookkeeper/backend/app/api/signed_leases.py
@@ -17,6 +17,9 @@ from app.core.permissions import current_org_member, require_write_access
 from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
+from app.schemas.leases.signed_lease_attachment_update_request import (
+    SignedLeaseAttachmentUpdateRequest,
+)
 from app.schemas.leases.signed_lease_create_request import (
     SignedLeaseCreateRequest,
 )
@@ -243,6 +246,33 @@ async def list_attachments(
         )
     except signed_lease_service.SignedLeaseNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Lease not found") from exc
+
+
+@router.patch(
+    "/{lease_id}/attachments/{attachment_id}",
+    response_model=SignedLeaseAttachmentResponse,
+)
+async def update_attachment(
+    lease_id: uuid.UUID,
+    attachment_id: uuid.UUID,
+    payload: SignedLeaseAttachmentUpdateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> SignedLeaseAttachmentResponse:
+    try:
+        return await signed_lease_service.update_attachment_kind(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            lease_id=lease_id,
+            attachment_id=attachment_id,
+            kind=payload.kind,
+        )
+    except (
+        signed_lease_service.SignedLeaseNotFoundError,
+        signed_lease_service.AttachmentNotFoundError,
+    ) as exc:
+        raise HTTPException(status_code=404, detail="Not found") from exc
+    except signed_lease_service.InvalidAttachmentKindError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
 
 @router.delete(

--- a/apps/mybookkeeper/backend/app/api/test_utils.py
+++ b/apps/mybookkeeper/backend/app/api/test_utils.py
@@ -610,31 +610,46 @@ async def hard_delete_lease_template(
         await db.execute(_sa_delete(LeaseTemplate).where(LeaseTemplate.id == template_id))
 
 
-class _SeedSignedLeasePayload(BaseModel):
-    applicant_id: uuid.UUID
+class _SeedAttachmentSpec(BaseModel):
+    filename: str = "seeded-lease.pdf"
+    kind: str = "signed_lease"
+    content_type: str = "application/pdf"
+
+
+class _SeedSignedLeaseRequest(BaseModel):
+    applicant_id: uuid.UUID | None = None
     kind: str = "imported"
     status: str = "signed"
+    attachments: list[_SeedAttachmentSpec] = []
 
 
 class _SeedSignedLeaseResponse(BaseModel):
     id: uuid.UUID
-    attachment_id: uuid.UUID
+    attachment_ids: list[uuid.UUID] = []
 
 
 @router.post("/seed-signed-lease", response_model=_SeedSignedLeaseResponse, status_code=201)
 async def seed_signed_lease(
-    payload: _SeedSignedLeasePayload,
+    payload: _SeedSignedLeaseRequest,
     ctx: RequestContext = Depends(current_org_member),
 ) -> _SeedSignedLeaseResponse:
-    """Seed a signed lease with one fake attachment record (no MinIO upload). Test-only."""
+    """Test-only: create a signed lease (status=signed) with optional fake attachments.
+
+    Bypasses MinIO — attachment storage_keys are fake paths. Suitable for
+    testing import / attachment UX (kind picker, viewer links, PATCH kind
+    endpoint) without requiring a real storage bucket.
+    """
     _require_test_mode()
-    import datetime as _dt2
     from app.models.leases.signed_lease import SignedLease
     from app.models.leases.signed_lease_attachment import SignedLeaseAttachment
 
+    now = _dt.datetime.now(_dt.timezone.utc)
+    lease_id = uuid.uuid4()
+    attachment_ids: list[uuid.UUID] = []
+
     async with unit_of_work() as db:
         lease = SignedLease(
-            id=uuid.uuid4(),
+            id=lease_id,
             user_id=ctx.user_id,
             organization_id=ctx.organization_id,
             template_id=None,
@@ -643,24 +658,33 @@ async def seed_signed_lease(
             kind=payload.kind,
             values={},
             status=payload.status,
-            signed_at=_dt2.datetime.now(_dt2.timezone.utc),
+            signed_at=now,
+            created_at=now,
+            updated_at=now,
         )
         db.add(lease)
         await db.flush()
 
-        attachment = SignedLeaseAttachment(
-            id=uuid.uuid4(),
-            lease_id=lease.id,
-            storage_key=f"signed-leases/{lease.id}/seed-attachment",
-            filename="seeded-lease.pdf",
-            content_type="application/pdf",
-            size_bytes=1024,
-            kind="signed_lease",
-            uploaded_by_user_id=ctx.user_id,
-        )
-        db.add(attachment)
+        specs = payload.attachments or [_SeedAttachmentSpec()]
+        for spec in specs:
+            att_id = uuid.uuid4()
+            att = SignedLeaseAttachment(
+                id=att_id,
+                lease_id=lease_id,
+                storage_key=f"signed-leases/{lease_id}/{att_id}",
+                filename=spec.filename,
+                content_type=spec.content_type,
+                size_bytes=1024,
+                kind=spec.kind,
+                uploaded_by_user_id=ctx.user_id,
+                uploaded_at=now,
+            )
+            db.add(att)
+            attachment_ids.append(att_id)
 
-    return _SeedSignedLeaseResponse(id=lease.id, attachment_id=attachment.id)
+        await db.flush()
+
+    return _SeedSignedLeaseResponse(id=lease_id, attachment_ids=attachment_ids)
 
 
 @router.delete("/signed-leases/{lease_id}", status_code=204)

--- a/apps/mybookkeeper/backend/app/repositories/leases/signed_lease_attachment_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/leases/signed_lease_attachment_repo.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime
 
-from sqlalchemy import delete, select
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.leases.signed_lease_attachment import SignedLeaseAttachment
@@ -64,6 +64,38 @@ async def get_by_id(
         )
     )
     return result.scalar_one_or_none()
+
+
+async def update_kind_scoped_to_lease(
+    db: AsyncSession,
+    attachment_id: uuid.UUID,
+    lease_id: uuid.UUID,
+    kind: str,
+) -> SignedLeaseAttachment | None:
+    """Update the kind of an attachment, scoped to its parent lease.
+
+    Both ``attachment_id`` AND ``lease_id`` must match — prevents IDOR.
+    Returns the updated row, or None if the composite key does not match.
+    """
+    result = await db.execute(
+        select(SignedLeaseAttachment).where(
+            SignedLeaseAttachment.id == attachment_id,
+            SignedLeaseAttachment.lease_id == lease_id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    await db.execute(
+        update(SignedLeaseAttachment)
+        .where(
+            SignedLeaseAttachment.id == attachment_id,
+            SignedLeaseAttachment.lease_id == lease_id,
+        )
+        .values(kind=kind)
+    )
+    await db.refresh(row)
+    return row
 
 
 async def delete_by_id_scoped_to_lease(

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_attachment_update_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_attachment_update_request.py
@@ -1,0 +1,10 @@
+"""Request body for PATCH /signed-leases/{lease_id}/attachments/{attachment_id}."""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SignedLeaseAttachmentUpdateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    kind: str

--- a/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
@@ -16,7 +16,7 @@ import logging
 import uuid
 from typing import Any
 
-from app.core.lease_enums import SIGNED_LEASE_STATUSES
+from app.core.lease_enums import LEASE_ATTACHMENT_KINDS, SIGNED_LEASE_STATUSES
 from app.core.storage import get_storage
 from app.db.session import unit_of_work
 from app.repositories.applicants import applicant_repo
@@ -89,6 +89,10 @@ class AttachmentTypeRejectedError(ValueError):
     pass
 
 
+class InvalidAttachmentKindError(ValueError):
+    pass
+
+
 # ---------------------------------------------------------------------------
 # Allowlist for signed-lease attachment uploads.
 # ---------------------------------------------------------------------------
@@ -112,6 +116,46 @@ _ALLOWED_TRANSITIONS: dict[str, set[str]] = {
     "ended": {"ended"},
     "terminated": {"terminated"},
 }
+
+
+def infer_kind_from_filename(filename: str) -> str:
+    """Infer the attachment kind from a filename using pattern matching.
+
+    Order of evaluation (case-insensitive):
+    1. "move-in inspection" / "move in inspection" → move_in_inspection
+    2. "move-out inspection" / "move out inspection" → move_out_inspection
+    3. "lease agreement" / "master lease" / "rental agreement" → signed_lease
+    4. "inspection" (without "move") → move_in_inspection (default to in if ambiguous)
+    5. "insurance" → insurance_proof
+    6. Everything else → signed_addendum
+    """
+    lower = filename.lower()
+
+    if "move-in inspection" in lower or "move in inspection" in lower:
+        return "move_in_inspection"
+    if "move-out inspection" in lower or "move out inspection" in lower:
+        return "move_out_inspection"
+    if "lease agreement" in lower or "master lease" in lower or "rental agreement" in lower:
+        return "signed_lease"
+    if "inspection" in lower:
+        return "move_in_inspection"
+    if "insurance" in lower:
+        return "insurance_proof"
+    return "signed_addendum"
+
+
+def infer_kinds_for_files(filenames: list[str]) -> list[str]:
+    """Infer a kind for each filename in a batch.
+
+    Applies ``infer_kind_from_filename`` to each file. If none of the
+    inferred kinds is ``signed_lease``, the first file is promoted to
+    ``signed_lease`` as a last-resort fallback so every batch has at
+    least one main lease.
+    """
+    kinds = [infer_kind_from_filename(name) for name in filenames]
+    if "signed_lease" not in kinds and filenames:
+        kinds[0] = "signed_lease"
+    return kinds
 
 
 def _validate_status_transition(current: str, target: str) -> None:
@@ -748,7 +792,6 @@ async def upload_attachment(
         raise StorageNotConfiguredError("Object storage is not configured")
 
     from app.core.config import settings as _settings
-    from app.core.lease_enums import LEASE_ATTACHMENT_KINDS
 
     if kind not in LEASE_ATTACHMENT_KINDS:
         raise AttachmentTypeRejectedError(f"Invalid kind: {kind}")
@@ -837,6 +880,47 @@ async def list_attachments(
             raise SignedLeaseNotFoundError(f"Lease {lease_id} not found")
         rows = await signed_lease_attachment_repo.list_by_lease(db, lease_id)
     return _attachment_responses(rows)
+
+
+async def update_attachment_kind(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    lease_id: uuid.UUID,
+    attachment_id: uuid.UUID,
+    kind: str,
+) -> SignedLeaseAttachmentResponse:
+    """Change the kind of an existing attachment.
+
+    Validates the kind is in ``LEASE_ATTACHMENT_KINDS``, then applies a
+    composite-WHERE update (attachment_id + lease_id) to prevent IDOR.
+    """
+    if kind not in LEASE_ATTACHMENT_KINDS:
+        raise InvalidAttachmentKindError(f"Invalid kind: {kind}")
+
+    async with unit_of_work() as db:
+        # Tenant scope — 404 if lease doesn't belong to this org/user.
+        lease = await signed_lease_repo.get(
+            db,
+            lease_id=lease_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if lease is None:
+            raise SignedLeaseNotFoundError(f"Lease {lease_id} not found")
+
+        row = await signed_lease_attachment_repo.update_kind_scoped_to_lease(
+            db,
+            attachment_id=attachment_id,
+            lease_id=lease_id,
+            kind=kind,
+        )
+        if row is None:
+            raise AttachmentNotFoundError(f"Attachment {attachment_id} not found")
+
+        response = SignedLeaseAttachmentResponse.model_validate(row)
+
+    return attach_presigned_urls_to_attachments([response])[0]
 
 
 async def delete_attachment(

--- a/apps/mybookkeeper/backend/tests/test_lease_attachment_kind.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_attachment_kind.py
@@ -1,0 +1,213 @@
+"""Tests for the lease attachment kind heuristic and the PATCH kind endpoint.
+
+Coverage:
+  - infer_kind_from_filename / infer_kinds_for_files: one test per heuristic
+    branch + the fallback case.
+  - PATCH /signed-leases/{lease_id}/attachments/{attachment_id}: happy path,
+    cross-tenant 404, invalid kind 422, composite-filter IDOR guard.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.services.leases.signed_lease_service import (
+    infer_kind_from_filename,
+    infer_kinds_for_files,
+)
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(
+        organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER,
+    )
+
+
+def _attachment_response(kind: str = "signed_lease") -> dict:
+    """Build a minimal SignedLeaseAttachmentResponse payload."""
+    from app.schemas.leases.signed_lease_attachment_response import (
+        SignedLeaseAttachmentResponse,
+    )
+
+    return SignedLeaseAttachmentResponse(
+        id=uuid.uuid4(),
+        lease_id=uuid.uuid4(),
+        filename="lease.pdf",
+        storage_key="signed-leases/x/y",
+        content_type="application/pdf",
+        size_bytes=1024,
+        kind=kind,
+        uploaded_by_user_id=uuid.uuid4(),
+        uploaded_at=_dt.datetime.now(_dt.timezone.utc),
+        presigned_url=None,
+    ).model_dump(mode="json")
+
+
+# ---------------------------------------------------------------------------
+# infer_kind_from_filename — unit tests (one per heuristic branch)
+# ---------------------------------------------------------------------------
+
+class TestInferKindFromFilename:
+    def test_move_in_inspection_hyphen(self) -> None:
+        assert infer_kind_from_filename("Move-In Inspection.pdf") == "move_in_inspection"
+
+    def test_move_in_inspection_space(self) -> None:
+        assert infer_kind_from_filename("move in inspection report.pdf") == "move_in_inspection"
+
+    def test_move_out_inspection_hyphen(self) -> None:
+        assert infer_kind_from_filename("Move-Out Inspection.pdf") == "move_out_inspection"
+
+    def test_move_out_inspection_space(self) -> None:
+        assert infer_kind_from_filename("move out inspection 2026.pdf") == "move_out_inspection"
+
+    def test_lease_agreement(self) -> None:
+        assert infer_kind_from_filename("Lease Agreement.pdf") == "signed_lease"
+
+    def test_master_lease(self) -> None:
+        assert infer_kind_from_filename("master lease - unit 3.pdf") == "signed_lease"
+
+    def test_rental_agreement(self) -> None:
+        assert infer_kind_from_filename("Rental Agreement Signed.pdf") == "signed_lease"
+
+    def test_generic_inspection(self) -> None:
+        assert infer_kind_from_filename("Property Inspection.pdf") == "move_in_inspection"
+
+    def test_insurance(self) -> None:
+        assert infer_kind_from_filename("Tenant Insurance.pdf") == "insurance_proof"
+
+    def test_unknown_filename_default(self) -> None:
+        assert infer_kind_from_filename("House Rules.pdf") == "signed_addendum"
+
+
+class TestInferKindsForFiles:
+    def test_named_files_infer_correctly(self) -> None:
+        filenames = [
+            "Lease Agreement.pdf",
+            "House Rules.pdf",
+            "Pet Disclosure.pdf",
+        ]
+        kinds = infer_kinds_for_files(filenames)
+        assert kinds == ["signed_lease", "signed_addendum", "signed_addendum"]
+
+    def test_fallback_promotes_first_when_no_signed_lease(self) -> None:
+        filenames = ["House Rules.pdf", "Pet Disclosure.pdf", "Addendum.pdf"]
+        kinds = infer_kinds_for_files(filenames)
+        assert kinds[0] == "signed_lease"
+        assert kinds[1] == "signed_addendum"
+        assert kinds[2] == "signed_addendum"
+
+    def test_empty_list_returns_empty(self) -> None:
+        assert infer_kinds_for_files([]) == []
+
+    def test_inspection_files_detected(self) -> None:
+        filenames = [
+            "Move-In Inspection.pdf",
+            "Move-Out Inspection.pdf",
+        ]
+        kinds = infer_kinds_for_files(filenames)
+        # Neither matches signed_lease → first is promoted.
+        assert kinds[0] == "signed_lease"
+        assert kinds[1] == "move_out_inspection"
+
+    def test_existing_signed_lease_prevents_fallback_promotion(self) -> None:
+        filenames = ["Lease Agreement.pdf", "House Rules.pdf"]
+        kinds = infer_kinds_for_files(filenames)
+        assert kinds == ["signed_lease", "signed_addendum"]
+
+
+# ---------------------------------------------------------------------------
+# PATCH /signed-leases/{lease_id}/attachments/{attachment_id}
+# ---------------------------------------------------------------------------
+
+class TestUpdateAttachmentKind:
+    def test_happy_path_returns_200(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.signed_lease_service.update_attachment_kind",
+                return_value=_attachment_response("signed_addendum"),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/signed-leases/{lease_id}/attachments/{attachment_id}",
+                    json={"kind": "signed_addendum"},
+                )
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["kind"] == "signed_addendum"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_cross_tenant_returns_404(self) -> None:
+        """User A cannot patch User B's attachment."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.services.leases.signed_lease_service import SignedLeaseNotFoundError
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.signed_lease_service.update_attachment_kind",
+                side_effect=SignedLeaseNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/signed-leases/{lease_id}/attachments/{attachment_id}",
+                    json={"kind": "signed_addendum"},
+                )
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_invalid_kind_returns_422(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.services.leases.signed_lease_service import InvalidAttachmentKindError
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.signed_lease_service.update_attachment_kind",
+                side_effect=InvalidAttachmentKindError("bad kind"),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/signed-leases/{lease_id}/attachments/{attachment_id}",
+                    json={"kind": "not_a_real_kind"},
+                )
+            assert resp.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_composite_filter_foreign_attachment_returns_404(self) -> None:
+        """Pairing a valid own lease_id with a foreign attachment_id must 404."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.services.leases.signed_lease_service import AttachmentNotFoundError
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.signed_lease_service.update_attachment_kind",
+                side_effect=AttachmentNotFoundError("foreign attachment"),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/signed-leases/{lease_id}/attachments/{attachment_id}",
+                    json={"kind": "signed_addendum"},
+                )
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()

--- a/apps/mybookkeeper/frontend/src/__tests__/AttachmentViewer.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/AttachmentViewer.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for AttachmentViewer.
+ *
+ * Verifies:
+ * - PDF shows iframe + "Open in new tab" link.
+ * - Image shows <img> element.
+ * - Other content type (DOCX) shows the download fallback.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import AttachmentViewer from "@/app/features/leases/AttachmentViewer";
+
+const BASE_PROPS = {
+  url: "https://storage.example.com/presigned/test.pdf",
+  filename: "lease.pdf",
+  onClose: () => {},
+};
+
+// Panel uses createPortal which jsdom handles correctly when document.body exists.
+
+describe("AttachmentViewer — PDF", () => {
+  it("renders an iframe for application/pdf", () => {
+    render(
+      <AttachmentViewer
+        {...BASE_PROPS}
+        filename="lease.pdf"
+        contentType="application/pdf"
+      />,
+    );
+
+    const iframe = screen.getByTestId("attachment-viewer-iframe");
+    expect(iframe).toBeInTheDocument();
+    expect(iframe.getAttribute("src")).toBe(BASE_PROPS.url);
+
+    const link = screen.getByTestId("attachment-viewer-open-in-new-tab");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe(BASE_PROPS.url);
+    expect(link.getAttribute("target")).toBe("_blank");
+
+    expect(screen.queryByTestId("attachment-viewer-img")).toBeNull();
+    expect(screen.queryByTestId("attachment-viewer-download-fallback")).toBeNull();
+  });
+});
+
+describe("AttachmentViewer — image", () => {
+  it("renders an img for image/jpeg", () => {
+    render(
+      <AttachmentViewer
+        {...BASE_PROPS}
+        url="https://storage.example.com/presigned/photo.jpg"
+        filename="photo.jpg"
+        contentType="image/jpeg"
+      />,
+    );
+
+    const img = screen.getByTestId("attachment-viewer-img");
+    expect(img).toBeInTheDocument();
+    expect(img.getAttribute("src")).toBe("https://storage.example.com/presigned/photo.jpg");
+
+    expect(screen.queryByTestId("attachment-viewer-iframe")).toBeNull();
+    expect(screen.queryByTestId("attachment-viewer-download-fallback")).toBeNull();
+  });
+
+  it("renders an img for image/png", () => {
+    render(
+      <AttachmentViewer
+        {...BASE_PROPS}
+        url="https://storage.example.com/presigned/scan.png"
+        filename="scan.png"
+        contentType="image/png"
+      />,
+    );
+
+    expect(screen.getByTestId("attachment-viewer-img")).toBeInTheDocument();
+  });
+});
+
+describe("AttachmentViewer — DOCX fallback", () => {
+  it("shows download fallback for non-previewable content type", () => {
+    render(
+      <AttachmentViewer
+        {...BASE_PROPS}
+        url="https://storage.example.com/presigned/lease.docx"
+        filename="lease.docx"
+        contentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      />,
+    );
+
+    const fallback = screen.getByTestId("attachment-viewer-download-fallback");
+    expect(fallback).toBeInTheDocument();
+    expect(fallback.textContent).toMatch(/cannot be previewed/i);
+
+    expect(screen.queryByTestId("attachment-viewer-iframe")).toBeNull();
+    expect(screen.queryByTestId("attachment-viewer-img")).toBeNull();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAttachmentKind.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAttachmentKind.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for:
+ * - inferKindFromFilename / inferKindsForFiles heuristics (frontend mirror of backend logic)
+ * - LeaseAttachmentsSection kind picker: change calls updateLeaseAttachment mutation
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import { inferKindFromFilename, inferKindsForFiles } from "@/shared/lib/infer-attachment-kind";
+import LeaseAttachmentsSection from "@/app/features/leases/LeaseAttachmentsSection";
+import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
+
+// ---------------------------------------------------------------------------
+// inferKindFromFilename unit tests
+// ---------------------------------------------------------------------------
+
+describe("inferKindFromFilename", () => {
+  it("returns move_in_inspection for 'move-in inspection'", () => {
+    expect(inferKindFromFilename("Move-In Inspection.pdf")).toBe("move_in_inspection");
+  });
+
+  it("returns move_in_inspection for 'move in inspection'", () => {
+    expect(inferKindFromFilename("move in inspection.pdf")).toBe("move_in_inspection");
+  });
+
+  it("returns move_out_inspection for 'move-out inspection'", () => {
+    expect(inferKindFromFilename("Move-Out Inspection.pdf")).toBe("move_out_inspection");
+  });
+
+  it("returns signed_lease for 'lease agreement'", () => {
+    expect(inferKindFromFilename("Lease Agreement.pdf")).toBe("signed_lease");
+  });
+
+  it("returns signed_lease for 'rental agreement'", () => {
+    expect(inferKindFromFilename("Rental Agreement.pdf")).toBe("signed_lease");
+  });
+
+  it("returns move_in_inspection for generic 'inspection'", () => {
+    expect(inferKindFromFilename("Property Inspection.pdf")).toBe("move_in_inspection");
+  });
+
+  it("returns insurance_proof for 'insurance'", () => {
+    expect(inferKindFromFilename("Tenant Insurance.pdf")).toBe("insurance_proof");
+  });
+
+  it("returns signed_addendum for unknown filename", () => {
+    expect(inferKindFromFilename("House Rules.pdf")).toBe("signed_addendum");
+  });
+});
+
+describe("inferKindsForFiles", () => {
+  it("promotes first file to signed_lease if none match", () => {
+    const kinds = inferKindsForFiles(["House Rules.pdf", "Pet Disclosure.pdf"]);
+    expect(kinds[0]).toBe("signed_lease");
+    expect(kinds[1]).toBe("signed_addendum");
+  });
+
+  it("does not promote if signed_lease already detected", () => {
+    const kinds = inferKindsForFiles(["Lease Agreement.pdf", "House Rules.pdf"]);
+    expect(kinds).toEqual(["signed_lease", "signed_addendum"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(inferKindsForFiles([])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LeaseAttachmentsSection — kind picker calls mutation
+// ---------------------------------------------------------------------------
+
+const updateMock = vi.fn();
+const deleteMock = vi.fn();
+const uploadMock = vi.fn();
+
+vi.mock("@/shared/store/signedLeasesApi", () => ({
+  useUploadSignedLeaseAttachmentMutation: () => [uploadMock, { isLoading: false }],
+  useDeleteSignedLeaseAttachmentMutation: () => [deleteMock, {}],
+  useUpdateLeaseAttachmentMutation: () => [updateMock, {}],
+}));
+
+// Suppress toast errors in tests.
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+const ATTACHMENT: SignedLeaseAttachment = {
+  id: "att-1",
+  lease_id: "lease-1",
+  filename: "lease.pdf",
+  storage_key: "signed-leases/lease-1/att-1",
+  content_type: "application/pdf",
+  size_bytes: 1024,
+  kind: "signed_addendum",
+  uploaded_by_user_id: "user-1",
+  uploaded_at: "2026-05-01T10:00:00Z",
+  presigned_url: "https://storage.example.com/presigned/lease.pdf",
+};
+
+describe("LeaseAttachmentsSection — kind picker", () => {
+  beforeEach(() => {
+    updateMock.mockReset();
+    updateMock.mockReturnValue({ unwrap: () => Promise.resolve({ ...ATTACHMENT, kind: "signed_lease" }) });
+  });
+
+  function renderSection() {
+    return render(
+      <Provider store={store}>
+        <LeaseAttachmentsSection
+          leaseId="lease-1"
+          attachments={[ATTACHMENT]}
+          canWrite
+        />
+      </Provider>,
+    );
+  }
+
+  it("shows the current kind in the dropdown", () => {
+    renderSection();
+    const picker = screen.getByTestId(`lease-attachment-kind-picker-${ATTACHMENT.id}`);
+    expect((picker as HTMLSelectElement).value).toBe("signed_addendum");
+  });
+
+  it("calls updateLeaseAttachment when kind changes", async () => {
+    renderSection();
+    const picker = screen.getByTestId(`lease-attachment-kind-picker-${ATTACHMENT.id}`);
+    fireEvent.change(picker, { target: { value: "signed_lease" } });
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith({
+        leaseId: "lease-1",
+        attachmentId: ATTACHMENT.id,
+        kind: "signed_lease",
+      });
+    });
+  });
+
+  it("makes the filename clickable for previewable content types", () => {
+    renderSection();
+    const previewButton = screen.getByTestId(`lease-attachment-preview-${ATTACHMENT.id}`);
+    expect(previewButton).toBeInTheDocument();
+  });
+
+  it("hides the kind picker when canWrite is false", () => {
+    render(
+      <Provider store={store}>
+        <LeaseAttachmentsSection
+          leaseId="lease-1"
+          attachments={[ATTACHMENT]}
+          canWrite={false}
+        />
+      </Provider>,
+    );
+    expect(screen.queryByTestId(`lease-attachment-kind-picker-${ATTACHMENT.id}`)).toBeNull();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewer.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewer.tsx
@@ -1,0 +1,81 @@
+import { ExternalLink } from "lucide-react";
+import Panel, { PanelCloseButton } from "@/shared/components/ui/Panel";
+
+interface Props {
+  url: string;
+  filename: string;
+  contentType: string;
+  onClose: () => void;
+}
+
+/**
+ * Generic inline viewer for lease attachments.
+ *
+ * Takes a presigned URL directly (no API fetch needed — the URL is already
+ * available from the attachment list response). Renders:
+ * - PDF → iframe
+ * - image/* → <img>
+ * - anything else → download-only message (DOCX, etc.)
+ */
+export default function AttachmentViewer({ url, filename, contentType, onClose }: Props) {
+  const isPdf = contentType === "application/pdf";
+  const isImage = contentType.startsWith("image/");
+
+  return (
+    <Panel position="center" onClose={onClose}>
+      <header className="flex items-center justify-between px-4 py-2 border-b shrink-0 bg-card">
+        <div className="flex items-center gap-3 min-w-0">
+          <span className="text-sm font-medium text-muted-foreground truncate max-w-xs" title={filename}>
+            {filename}
+          </span>
+          <a
+            href={url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-primary hover:underline inline-flex items-center gap-1 shrink-0"
+            data-testid="attachment-viewer-open-in-new-tab"
+          >
+            <ExternalLink size={12} />
+            Open in new tab
+          </a>
+        </div>
+        <PanelCloseButton onClose={onClose} label="Close viewer" />
+      </header>
+
+      <div className="flex-1 min-h-0 overflow-auto bg-muted/50" data-testid="attachment-viewer-body">
+        {isPdf ? (
+          <div className="h-full bg-white rounded-b-lg">
+            <iframe
+              src={url}
+              className="w-full h-full"
+              title={filename}
+              data-testid="attachment-viewer-iframe"
+            />
+          </div>
+        ) : isImage ? (
+          <div className="flex items-center justify-center h-full p-4">
+            <img
+              src={url}
+              alt={filename}
+              className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
+              data-testid="attachment-viewer-img"
+            />
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center h-full gap-3 px-4 text-center" data-testid="attachment-viewer-download-fallback">
+            <p className="text-sm text-muted-foreground">
+              This file type cannot be previewed in the browser.
+            </p>
+            <a
+              href={url}
+              download={filename}
+              className="text-sm text-primary hover:underline font-medium"
+            >
+              Download {filename}
+            </a>
+          </div>
+        )}
+      </div>
+    </Panel>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentRow.tsx
@@ -1,0 +1,93 @@
+import { Download, Trash2 } from "lucide-react";
+import { LEASE_ATTACHMENT_KIND_LABELS } from "@/shared/lib/lease-labels";
+import {
+  LEASE_ATTACHMENT_KINDS,
+  type LeaseAttachmentKind,
+} from "@/shared/types/lease/lease-attachment-kind";
+import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
+
+interface Props {
+  att: SignedLeaseAttachment;
+  canWrite: boolean;
+  onPreview: () => void;
+  onDelete: () => void;
+  onKindChange: (kind: LeaseAttachmentKind) => void;
+}
+
+export default function LeaseAttachmentRow({ att, canWrite, onPreview, onDelete, onKindChange }: Props) {
+  const canPreview =
+    att.presigned_url !== null &&
+    (att.content_type === "application/pdf" || att.content_type.startsWith("image/"));
+
+  return (
+    <li
+      className="border rounded-md px-3 py-2 text-sm space-y-1"
+      data-testid={`lease-attachment-${att.id}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        {canPreview ? (
+          <button
+            type="button"
+            onClick={onPreview}
+            className="truncate text-left text-primary hover:underline font-medium min-w-0"
+            data-testid={`lease-attachment-preview-${att.id}`}
+            title={att.filename}
+          >
+            {att.filename}
+          </button>
+        ) : (
+          <span className="truncate text-muted-foreground min-w-0" title={att.filename}>
+            {att.filename}
+          </span>
+        )}
+
+        <div className="flex items-center gap-2 shrink-0">
+          {att.presigned_url ? (
+            <a
+              href={att.presigned_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-foreground"
+              aria-label={`Download ${att.filename}`}
+              data-testid={`lease-attachment-download-${att.id}`}
+            >
+              <Download size={14} />
+            </a>
+          ) : null}
+          {canWrite ? (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="text-muted-foreground hover:text-destructive min-h-[44px] min-w-[44px] flex items-center justify-center"
+              aria-label={`Delete ${att.filename}`}
+            >
+              <Trash2 size={14} />
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2">
+        {canWrite ? (
+          <select
+            value={att.kind}
+            onChange={(e) => onKindChange(e.target.value as LeaseAttachmentKind)}
+            className="px-2 py-0.5 text-xs border rounded text-muted-foreground bg-background"
+            aria-label={`Kind for ${att.filename}`}
+            data-testid={`lease-attachment-kind-picker-${att.id}`}
+          >
+            {LEASE_ATTACHMENT_KINDS.map((k) => (
+              <option key={k} value={k}>
+                {LEASE_ATTACHMENT_KIND_LABELS[k]}
+              </option>
+            ))}
+          </select>
+        ) : (
+          <span className="text-xs text-muted-foreground">
+            {LEASE_ATTACHMENT_KIND_LABELS[att.kind as LeaseAttachmentKind]}
+          </span>
+        )}
+      </div>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentsSection.tsx
@@ -1,18 +1,20 @@
 import { useRef, useState } from "react";
-import { Download, Loader2, Trash2, Upload } from "lucide-react";
+import { Loader2, Upload } from "lucide-react";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
-import {
-  LEASE_ATTACHMENT_KIND_LABELS,
-} from "@/shared/lib/lease-labels";
+import { LEASE_ATTACHMENT_KIND_LABELS } from "@/shared/lib/lease-labels";
 import {
   LEASE_ATTACHMENT_KINDS,
   type LeaseAttachmentKind,
 } from "@/shared/types/lease/lease-attachment-kind";
 import {
   useDeleteSignedLeaseAttachmentMutation,
+  useUpdateLeaseAttachmentMutation,
   useUploadSignedLeaseAttachmentMutation,
 } from "@/shared/store/signedLeasesApi";
+import { inferKindsForFiles } from "@/shared/lib/infer-attachment-kind";
 import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
+import AttachmentViewer from "@/app/features/leases/AttachmentViewer";
+import LeaseAttachmentRow from "@/app/features/leases/LeaseAttachmentRow";
 
 interface Props {
   leaseId: string;
@@ -32,22 +34,34 @@ export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite
   const [uploadAttachment, { isLoading: isUploading }] =
     useUploadSignedLeaseAttachmentMutation();
   const [deleteAttachment] = useDeleteSignedLeaseAttachmentMutation();
-  const [kind, setKind] = useState<LeaseAttachmentKind>("signed_lease");
+  const [updateAttachment] = useUpdateLeaseAttachmentMutation();
+
+  const [manualKind, setManualKind] = useState<LeaseAttachmentKind>("signed_lease");
   const [isDragging, setIsDragging] = useState(false);
+  const [viewingAttachment, setViewingAttachment] = useState<SignedLeaseAttachment | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Group attachments by kind for display.
-  const groups: Record<string, SignedLeaseAttachment[]> = {};
-  for (const att of attachments) {
-    (groups[att.kind] ??= []).push(att);
-  }
-
   async function handleFiles(files: File[]) {
-    for (const file of files) {
+    const validFiles = files.filter((file) => {
       if (file.type && !ALLOWED_MIME.includes(file.type)) {
         showError(`${file.name}: unsupported file type.`);
-        continue;
+        return false;
       }
+      return true;
+    });
+
+    if (validFiles.length === 0) return;
+
+    // When multiple files are dropped, use the filename heuristic.
+    // For a single file, fall back to the manual kind picker.
+    const kinds: LeaseAttachmentKind[] =
+      validFiles.length > 1
+        ? inferKindsForFiles(validFiles.map((f) => f.name))
+        : [manualKind];
+
+    for (let i = 0; i < validFiles.length; i++) {
+      const file = validFiles[i];
+      const kind = kinds[i];
       try {
         await uploadAttachment({ leaseId, file, kind }).unwrap();
         showSuccess(`${file.name} uploaded.`);
@@ -70,66 +84,46 @@ export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite
     }
   }
 
+  async function handleKindChange(att: SignedLeaseAttachment, kind: LeaseAttachmentKind) {
+    try {
+      await updateAttachment({ leaseId, attachmentId: att.id, kind }).unwrap();
+      showSuccess("Kind updated.");
+    } catch {
+      showError("Couldn't update the kind.");
+    }
+  }
+
   return (
     <section className="space-y-3">
-      {Object.keys(groups).length === 0 ? (
+      {attachments.length === 0 ? (
         <p className="text-sm text-muted-foreground" data-testid="lease-attachments-empty">
           No attachments yet.
         </p>
       ) : (
-        Object.entries(groups).map(([groupKind, items]) => (
-          <div key={groupKind} className="space-y-1">
-            <h3 className="text-xs font-semibold uppercase text-muted-foreground">
-              {LEASE_ATTACHMENT_KIND_LABELS[groupKind as LeaseAttachmentKind]}
-            </h3>
-            <ul className="space-y-1">
-              {items.map((att) => (
-                <li
-                  key={att.id}
-                  className="flex items-center justify-between border rounded-md px-3 py-2 text-sm"
-                  data-testid={`lease-attachment-${att.id}`}
-                >
-                  <span className="truncate">{att.filename}</span>
-                  <div className="flex items-center gap-3">
-                    {att.presigned_url ? (
-                      <a
-                        href={att.presigned_url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:underline inline-flex items-center gap-1 text-xs"
-                      >
-                        <Download size={14} />
-                        Download
-                      </a>
-                    ) : null}
-                    {canWrite ? (
-                      <button
-                        type="button"
-                        onClick={() => void handleDelete(att)}
-                        className="text-muted-foreground hover:text-destructive"
-                        aria-label={`Delete ${att.filename}`}
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    ) : null}
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-        ))
+        <ul className="space-y-1">
+          {attachments.map((att) => (
+            <LeaseAttachmentRow
+              key={att.id}
+              att={att}
+              canWrite={canWrite}
+              onPreview={() => setViewingAttachment(att)}
+              onDelete={() => void handleDelete(att)}
+              onKindChange={(kind) => void handleKindChange(att, kind)}
+            />
+          ))}
+        </ul>
       )}
 
       {canWrite ? (
         <div className="space-y-2 pt-2 border-t">
           <div className="flex items-center gap-2">
             <label htmlFor="attachment-kind" className="text-xs font-medium">
-              Kind:
+              Kind (single file):
             </label>
             <select
               id="attachment-kind"
-              value={kind}
-              onChange={(e) => setKind(e.target.value as LeaseAttachmentKind)}
+              value={manualKind}
+              onChange={(e) => setManualKind(e.target.value as LeaseAttachmentKind)}
               className="px-2 py-1 text-sm border rounded"
               data-testid="lease-attachment-kind-select"
             >
@@ -140,6 +134,9 @@ export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite
               ))}
             </select>
           </div>
+          <p className="text-xs text-muted-foreground/70">
+            Dropping multiple files auto-detects kind from filename.
+          </p>
           <div
             onDragOver={(e) => {
               e.preventDefault();
@@ -184,6 +181,7 @@ export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite
               ref={fileInputRef}
               type="file"
               className="hidden"
+              multiple
               accept={ALLOWED_MIME.join(",")}
               onChange={(e) => {
                 const files = Array.from(e.target.files ?? []);
@@ -194,6 +192,16 @@ export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite
           </div>
         </div>
       ) : null}
+
+      {viewingAttachment?.presigned_url ? (
+        <AttachmentViewer
+          url={viewingAttachment.presigned_url}
+          filename={viewingAttachment.filename}
+          contentType={viewingAttachment.content_type}
+          onClose={() => setViewingAttachment(null)}
+        />
+      ) : null}
     </section>
   );
 }
+

--- a/apps/mybookkeeper/frontend/src/shared/lib/infer-attachment-kind.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/infer-attachment-kind.ts
@@ -1,0 +1,56 @@
+import type { LeaseAttachmentKind } from "@/shared/types/lease/lease-attachment-kind";
+
+/**
+ * Infers a lease attachment kind from a filename.
+ *
+ * Mirrors the backend logic in ``signed_lease_service.infer_kind_from_filename``.
+ * Keep both in sync when changing heuristics.
+ *
+ * Order of evaluation (case-insensitive):
+ * 1. "move-in inspection" / "move in inspection" → move_in_inspection
+ * 2. "move-out inspection" / "move out inspection" → move_out_inspection
+ * 3. "lease agreement" / "master lease" / "rental agreement" → signed_lease
+ * 4. "inspection" (without "move") → move_in_inspection
+ * 5. "insurance" → insurance_proof
+ * 6. Everything else → signed_addendum
+ */
+export function inferKindFromFilename(filename: string): LeaseAttachmentKind {
+  const lower = filename.toLowerCase();
+
+  if (lower.includes("move-in inspection") || lower.includes("move in inspection")) {
+    return "move_in_inspection";
+  }
+  if (lower.includes("move-out inspection") || lower.includes("move out inspection")) {
+    return "move_out_inspection";
+  }
+  if (
+    lower.includes("lease agreement") ||
+    lower.includes("master lease") ||
+    lower.includes("rental agreement")
+  ) {
+    return "signed_lease";
+  }
+  if (lower.includes("inspection")) {
+    return "move_in_inspection";
+  }
+  if (lower.includes("insurance")) {
+    return "insurance_proof";
+  }
+
+  return "signed_addendum";
+}
+
+/**
+ * Infers kinds for a batch of files.
+ *
+ * If none of the filenames pattern-match to ``signed_lease``, the first file
+ * is promoted to ``signed_lease`` as a last-resort fallback — at least one
+ * file must be the main lease.
+ */
+export function inferKindsForFiles(filenames: string[]): LeaseAttachmentKind[] {
+  const kinds = filenames.map((name) => inferKindFromFilename(name));
+  if (!kinds.includes("signed_lease") && kinds.length > 0) {
+    kinds[0] = "signed_lease";
+  }
+  return kinds;
+}

--- a/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
@@ -133,6 +133,20 @@ const signedLeasesApi = baseApi.injectEndpoints({
       },
       invalidatesTags: [{ type: "SignedLease", id: "LIST" }],
     }),
+
+    updateLeaseAttachment: builder.mutation<
+      SignedLeaseAttachment,
+      { leaseId: string; attachmentId: string; kind: LeaseAttachmentKind }
+    >({
+      query: ({ leaseId, attachmentId, kind }) => ({
+        url: `/signed-leases/${leaseId}/attachments/${attachmentId}`,
+        method: "PATCH",
+        data: { kind },
+      }),
+      invalidatesTags: (_r, _e, { leaseId }) => [
+        { type: "SignedLease", id: leaseId },
+      ],
+    }),
   }),
 });
 
@@ -146,4 +160,5 @@ export const {
   useUploadSignedLeaseAttachmentMutation,
   useDeleteSignedLeaseAttachmentMutation,
   useImportSignedLeaseMutation,
+  useUpdateLeaseAttachmentMutation,
 } = signedLeasesApi;


### PR DESCRIPTION
## Summary

Polish for the lease attachments UX after import-signed-lease (#182) shipped without download/preview affordances.

- **Inline viewer**: click an attachment filename to open `AttachmentViewer` (PDF iframe / image / download fallback for unsupported types)
- **Per-attachment kind picker**: inline dropdown on each row → `PATCH /signed-leases/{id}/attachments/{aid}` (composite-WHERE IDOR-safe per PR #172 pattern)
- **Smart import heuristic**: when multiple files are dropped, kind is auto-detected from filename (\"Lease Agreement\" → signed_lease, \"Move-In Inspection\" → move_in_inspection, etc.). If no file pattern-matches signed_lease, the first file is promoted so every batch has a main lease.
- **Test seam**: \`/test/seed-signed-lease\` helper to E2E without MinIO

## Test plan

- [x] Backend: 19 new tests pass (heuristic branches + happy path + cross-tenant 404 + invalid kind 422 + composite-filter IDOR guard)
- [x] Backend: full lease test suite green (57/57)
- [x] Frontend: 19 new tests pass (heuristic mirror + kind picker behavior + viewer)
- [x] Frontend: SignedLease tests green (15/15); pre-existing 44 dual-React failures unchanged from baseline
- [ ] Prod smoke: open imported lease at `/leases/<id>`, click filename → preview opens; change kind dropdown → status persists on reload