### PR TITLE
chore(deps): bump lucide-react 0.447.0 → 1.14.0 in MJH frontend (replaces #138)

### DIFF
--- a/apps/myjobhunter/frontend/package.json
+++ b/apps/myjobhunter/frontend/package.json
@@ -23,7 +23,7 @@
     "axios": "^1.7.7",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
-    "lucide-react": "^0.447.0",
+    "lucide-react": "^1.14.0",
     "qrcode.react": "^4.2.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -80,7 +80,7 @@
         "axios": "^1.7.7",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
-        "lucide-react": "^0.447.0",
+        "lucide-react": "^1.14.0",
         "qrcode.react": "^4.2.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
@@ -151,14 +151,6 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
-      }
-    },
-    "apps/myjobhunter/frontend/node_modules/lucide-react": {
-      "version": "0.447.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.447.0.tgz",
-      "integrity": "sha512-SZ//hQmvi+kDKrNepArVkYK7/jfeZ5uFNEnYmd45RKZcbGD78KLnrcNXmgeg6m+xNHFvTG+CblszXCy4n6DN4w==",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
     "apps/myjobhunter/frontend/node_modules/react": {


### PR DESCRIPTION
## Summary

- Bumps `lucide-react` from `0.447.0` to `1.14.0` in `apps/myjobhunter/frontend`
- Replaces #138 (the Dependabot PR) — same change applied with manual verification

## Breaking changes audit

The v1 release has one breaking change: **brand icons removed** (GitHub, LinkedIn, Slack, Figma, etc.). MJH uses none of these. All 29 icons in the codebase were verified to exist in v1.14.0:

`AlertTriangle`, `Briefcase`, `Building2`, `Check`, `ChevronLeft`, `ChevronRight`, `Copy`, `Download`, `ExternalLink`, `FilePlus`, `Home`, `LayoutDashboard`, `Monitor`, `Moon`, `Pencil`, `Plus`, `Settings`, `Shield`, `ShieldCheck`, `ShieldOff`, `Sun`, `Trash2`, `UserCircle`, `X`, `GraduationCap`, `Code2`, `ClipboardList`, `DollarSign`, `MapPin`

No import changes needed.

## Validation

- `npm run build` — passes (TypeScript + Vite build clean)
- `npm test` — 12 failed | 4 passed, **identical to main** (pre-existing failures unrelated to this change)

## Files changed

- `apps/myjobhunter/frontend/package.json` — version bump
- `package-lock.json` — removes old pinned nested entry, resolves to v1.14.0

Replaces #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)