### PR TITLE
fix(deploy): unbreak MBK + MJH prod deploys (lockfile + requirements.txt)

### DIFF
--- a/apps/mybookkeeper/docker/backend.Dockerfile
+++ b/apps/mybookkeeper/docker/backend.Dockerfile
@@ -10,7 +10,12 @@ FROM python:3.12-slim AS backend-deps
 WORKDIR /deps
 COPY packages/shared-backend/ /deps/shared-backend/
 COPY apps/mybookkeeper/backend/requirements.txt ./
-RUN pip install --no-cache-dir --prefix=/install /deps/shared-backend/ -r requirements.txt
+# Strip the editable workspace dep line — uv export emits `-e ../../../packages/shared-backend`
+# which only resolves in the monorepo working tree, not in the Docker /deps context. The package
+# is installed via the positional /deps/shared-backend/ arg below; the -e line in requirements
+# is for local dev only.
+RUN sed -i '/^-e \.\.\/\.\.\/\.\.\/packages\/shared-backend/d' requirements.txt \
+    && pip install --no-cache-dir --prefix=/install /deps/shared-backend/ -r requirements.txt
 
 # Stage 2: Runtime
 FROM python:3.12-slim AS runtime

--- a/apps/mybookkeeper/frontend/package-lock.json
+++ b/apps/mybookkeeper/frontend/package-lock.json
@@ -3123,13 +3123,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3139,7 +3139,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4723,23 +4723,6 @@
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/fflate": {
@@ -6782,6 +6765,23 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
@@ -7139,6 +7139,23 @@
           "optional": true
         },
         "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
           "optional": true
         }
       }

--- a/apps/myjobhunter/docker/backend.Dockerfile
+++ b/apps/myjobhunter/docker/backend.Dockerfile
@@ -3,7 +3,12 @@ FROM python:3.12-slim AS backend-deps
 WORKDIR /deps
 COPY packages/shared-backend/ /deps/shared-backend/
 COPY apps/myjobhunter/backend/requirements.txt ./
-RUN pip install --no-cache-dir --prefix=/install /deps/shared-backend/ -r requirements.txt
+# Strip the editable workspace dep line — uv export emits `-e ../../../packages/shared-backend`
+# which only resolves in the monorepo working tree, not in the Docker /deps context. The package
+# is installed via the positional /deps/shared-backend/ arg below; the -e line in requirements
+# is for local dev only.
+RUN sed -i '/^-e \.\.\/\.\.\/\.\.\/packages\/shared-backend/d' requirements.txt \
+    && pip install --no-cache-dir --prefix=/install /deps/shared-backend/ -r requirements.txt
 
 # Stage 2: Runtime
 FROM python:3.12-slim AS runtime


### PR DESCRIPTION
## Summary

**Every MBK and MJH deploy since #188/#189/#190 has failed silently.** Operator just noticed in prod (the /tenants page from #187 was missing — turned out it was never deployed, along with #186, #188-#195, #190, #191, #192, #193, #194, #195).

Two unrelated build breakages introduced by this session's dep-refresh PRs:

### 1. MBK frontend `package-lock.json` out of sync
- `npm ci` in `apps/mybookkeeper/docker/caddy.Dockerfile` fails: \`Invalid: lock file's picomatch@2.3.2 does not satisfy picomatch@4.0.4\`
- Root cause: per-app lockfile regenerated under workspace context in #189 and #193, producing a workspace-aware lockfile that's not standalone-valid for the Docker per-app `npm ci`
- Fix: regenerated `apps/mybookkeeper/frontend/package-lock.json` outside the workspace (in /tmp) so it's self-contained

### 2. Both backend Dockerfiles broken by new `-e ../../../packages/shared-backend` line
- `uv export` adds an editable line for the workspace `platform-shared` dep
- The relative path \`../../../packages/shared-backend\` doesn't resolve from Docker's `/deps` working dir
- Added by #188 (MBK pip bundle) and #190 (MJH uv setup)
- Fix: `sed -i` to strip the line before `pip install` in both Dockerfiles. shared-backend is already installed via the positional `/deps/shared-backend/` arg, so this is a no-op functionally — just removes the broken redundant install attempt
- Local dev still works because the line stays in requirements.txt

## Test plan

- [x] MBK frontend `npm ci` works in isolation (verified locally with /tmp copy)
- [ ] MBK deploy succeeds on this PR (CI gate)
- [ ] MJH deploy succeeds on this PR (CI gate)
- [ ] Prod /tenants page renders after merge