### PR TITLE
fix(mybookkeeper): merge cal260503 + totp260503 alembic heads

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/calttp260503_merge_heads.py
+++ b/apps/mybookkeeper/backend/alembic/versions/calttp260503_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge cal260503 + totp260503 heads
+
+Revision ID: calttp260503
+Revises: cal260503, totp260503
+Create Date: 2026-05-03 17:11:35.500091
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'calttp260503'
+down_revision: Union[str, None] = ('cal260503', 'totp260503')
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
Empty Alembic merge — both PR #191 and #195 branched off tenend260503, creating a multi-head state that fails 'alembic upgrade head' in the migrate container. Single head restored. Unblocks MBK prod deploy.