### PR TITLE
perf(mybookkeeper/leases): fix N+1 on lease list applicant-name lookup

### DIFF
--- a/apps/mybookkeeper/backend/app/repositories/applicants/applicant_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/applicants/applicant_repo.py
@@ -117,6 +117,34 @@ async def list_for_user(
     return list(result.scalars().all())
 
 
+async def list_by_ids(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    applicant_ids: list[uuid.UUID],
+    include_deleted: bool = True,
+) -> list[Applicant]:
+    """Bulk-fetch applicants by IDs in a single query, scoped to the tenant.
+
+    Used by the lease list page to avoid N+1 round-trips when joining
+    applicant.legal_name onto each lease row. Pass ``include_deleted=True``
+    by default so soft-deleted applicants still surface their name on the
+    historical lease (matches prior per-id ``applicant_repo.get`` behavior).
+    """
+    if not applicant_ids:
+        return []
+    stmt = select(Applicant).where(
+        Applicant.organization_id == organization_id,
+        Applicant.user_id == user_id,
+        Applicant.id.in_(applicant_ids),
+    )
+    if not include_deleted:
+        stmt = stmt.where(Applicant.deleted_at.is_(None))
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
 async def count_for_user(
     db: AsyncSession,
     *,

--- a/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
@@ -335,18 +335,18 @@ async def list_leases(
         )
 
         # Bulk-load applicant names for the tenant name column on the list page.
-        # The EncryptedString TypeDecorator decrypts transparently on load.
-        applicant_ids = list({r.applicant_id for r in rows})
-        applicant_names: dict[uuid.UUID, str | None] = {}
-        for aid in applicant_ids:
-            applicant = await applicant_repo.get(
-                db,
-                applicant_id=aid,
-                organization_id=organization_id,
-                user_id=user_id,
-                include_deleted=True,
-            )
-            applicant_names[aid] = applicant.legal_name if applicant else None
+        # Single IN-list query; the EncryptedString TypeDecorator decrypts
+        # transparently on load.
+        applicant_ids = [aid for aid in {r.applicant_id for r in rows} if aid is not None]
+        applicants = await applicant_repo.list_by_ids(
+            db,
+            organization_id=organization_id,
+            user_id=user_id,
+            applicant_ids=applicant_ids,
+        )
+        applicant_names: dict[uuid.UUID, str | None] = {
+            a.id: a.legal_name for a in applicants
+        }
 
     items = [_build_summary(r, applicant_names) for r in rows]
     return SignedLeaseListResponse(


### PR DESCRIPTION
PR #187 said "bulk-load" but was actually a per-id loop. Replaced with single IN-list query. Verified by running 99 lease+applicant_repo tests.