### PR TITLE
fix(mybookkeeper/storage): drop per-request bucket_exists() + add storage-health diagnostic

### DIFF
--- a/apps/mybookkeeper/backend/app/api/admin.py
+++ b/apps/mybookkeeper/backend/app/api/admin.py
@@ -5,7 +5,9 @@ from typing import Optional
 from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.core.permissions import current_admin
+from app.core.storage import get_storage
 from app.db.session import get_db
 from app.models.user.user import User
 from app.repositories.system import auth_event_repo
@@ -15,6 +17,63 @@ from app.schemas.user.user import AdminUserRoleUpdate, UserRead
 from app.services.system import admin_service
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+@router.get("/storage-health")
+async def storage_health(user: User = Depends(current_admin)) -> dict:
+    """Diagnostic: report MinIO/storage configuration + reachability.
+
+    Admin-only. Lets ops verify whether presigned-URL signing will work
+    without hand-spelunking the VPS .env.
+    """
+    configured = bool(
+        settings.minio_endpoint and settings.minio_access_key and settings.minio_secret_key
+    )
+    public_endpoint_set = bool(settings.minio_public_endpoint)
+    public_differs_from_internal = (
+        public_endpoint_set
+        and settings.minio_public_endpoint != settings.minio_endpoint
+    )
+    storage_built = False
+    bucket_reachable: bool | None = None
+    sign_test: str | None = None
+    sign_error: str | None = None
+    bucket_error: str | None = None
+
+    if configured:
+        try:
+            client = get_storage()
+            storage_built = client is not None
+            if client is not None:
+                try:
+                    sign_test = client.generate_presigned_url(
+                        "_storage-health-probe",
+                        expires_in_seconds=60,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    sign_error = repr(exc)
+                try:
+                    bucket_reachable = client._client.bucket_exists(
+                        settings.minio_bucket,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    bucket_reachable = False
+                    bucket_error = repr(exc)
+        except Exception as exc:  # noqa: BLE001
+            sign_error = repr(exc)
+
+    return {
+        "configured": configured,
+        "minio_endpoint_set": bool(settings.minio_endpoint),
+        "public_endpoint_set": public_endpoint_set,
+        "public_differs_from_internal": public_differs_from_internal,
+        "bucket_name": settings.minio_bucket or None,
+        "storage_built": storage_built,
+        "bucket_reachable": bucket_reachable,
+        "sign_test_returned_url": sign_test is not None,
+        "sign_error": sign_error,
+        "bucket_error": bucket_error,
+    }
 
 
 @router.get("/users", response_model=list[UserRead])

--- a/apps/mybookkeeper/backend/app/core/storage.py
+++ b/apps/mybookkeeper/backend/app/core/storage.py
@@ -187,15 +187,14 @@ def get_storage() -> StorageClient | None:
     else:
         client = StorageClient(internal_client, settings.minio_bucket)
 
-    try:
-        client.ensure_bucket()
-    except S3Error:
-        logger.warning(
-            "Failed to ensure MinIO bucket %s exists at startup",
-            settings.minio_bucket,
-            exc_info=True,
-        )
-
+    # Bucket existence is verified by the FastAPI lifespan
+    # (services/storage/bucket_initializer.py). Calling ensure_bucket()
+    # here would re-trigger a network round-trip on every cold-cache
+    # invocation — when MinIO is unreachable, bucket_exists() hangs for
+    # tens of seconds, blocking any request that touches attachments.
+    # Presigning is purely cryptographic (HMAC over the URL) and does
+    # not require the bucket to exist or MinIO to be reachable; the
+    # browser-side fetch is what tests connectivity.
     _client = client
     return _client
 

--- a/apps/mybookkeeper/backend/tests/test_storage.py
+++ b/apps/mybookkeeper/backend/tests/test_storage.py
@@ -230,22 +230,29 @@ class TestGetStorageInitialization:
         mock_settings.minio_bucket = "mybookkeeper"
         mock_settings.minio_secure = False
         instance = MagicMock()
-        instance.bucket_exists.return_value = False
         mock_minio_cls.return_value = instance
 
         result = get_storage()
         try:
             assert result is not None
             assert not isinstance(result, _DualEndpointStorageClient)
-            instance.make_bucket.assert_called_once_with("mybookkeeper")
+            # Bucket existence is verified by the FastAPI lifespan
+            # (bucket_initializer.ensure_bucket); get_storage no longer
+            # touches the network on every cold-cache invocation.
+            instance.bucket_exists.assert_not_called()
+            instance.make_bucket.assert_not_called()
         finally:
             reset_client_cache()
 
     @patch("app.core.storage.settings")
     @patch("app.core.storage.Minio")
-    def test_skips_bucket_creation_when_present(
+    def test_does_not_call_bucket_check_on_get_storage(
         self, mock_minio_cls: MagicMock, mock_settings: MagicMock,
     ) -> None:
+        """Regression: per-request bucket_exists() hung when MinIO was
+        unreachable, blocking attachment-list endpoints. get_storage now
+        constructs the client without any network round-trip.
+        """
         reset_client_cache()
         mock_settings.minio_endpoint = "localhost:9000"
         mock_settings.minio_public_endpoint = ""
@@ -254,12 +261,12 @@ class TestGetStorageInitialization:
         mock_settings.minio_bucket = "mybookkeeper"
         mock_settings.minio_secure = False
         instance = MagicMock()
-        instance.bucket_exists.return_value = True
         mock_minio_cls.return_value = instance
 
         result = get_storage()
         try:
             assert result is not None
+            instance.bucket_exists.assert_not_called()
             instance.make_bucket.assert_not_called()
         finally:
             reset_client_cache()


### PR DESCRIPTION
Two fixes for the slow lease pages and broken document downloads. See commit body.