### PR TITLE
fix(mybookkeeper/csp): allow storage.<domain> in frame-src + img-src

### DIFF
--- a/apps/mybookkeeper/docker/Caddyfile.docker
+++ b/apps/mybookkeeper/docker/Caddyfile.docker
@@ -64,7 +64,7 @@
             header {
                 defer
                 X-Frame-Options "DENY"
-                Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://*.plaid.com https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://cdn.plaid.com https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+                Content-Security-Policy "default-src 'self'; script-src 'self' https://cdn.plaid.com https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.{$DOMAIN} https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://*.plaid.com https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://storage.{$DOMAIN} https://cdn.plaid.com https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
             }
 
             # Cache strategy:


### PR DESCRIPTION
Allows AttachmentViewer iframe to load presigned PDF URLs from storage subdomain. Without this CSP allowance, browser blocks the iframe even though the URL itself is fetchable.