### PR TITLE
fix(mybookkeeper/storage): rip out silent-fail handlers — fail loud on env misconfig

### DIFF
--- a/apps/mybookkeeper/backend/app/core/storage.py
+++ b/apps/mybookkeeper/backend/app/core/storage.py
@@ -7,9 +7,13 @@ must be signed against the *public* hostname so the user's browser can fetch
 the object directly. The `_DualEndpointStorageClient` keeps these two
 endpoints distinct.
 
-When MinIO is not configured, `get_storage()` returns `None` and callers fall
-back to the appropriate degraded path (e.g., `presigned_url=None`, or a 503
-on photo upload).
+Storage is a HARD REQUIREMENT. Listing photos, lease attachments, and
+applicant documents all depend on it. ``get_storage()`` raises
+``StorageNotConfiguredError`` on missing env vars; the FastAPI lifespan
+verifies bucket reachability at startup and refuses to boot on failure.
+Per-request paths therefore never see ``None`` — silent degradation
+(``presigned_url=None`` placeholders) is gone. See the
+PR #201–#204 postmortem for the bug trail this pattern caused.
 """
 import io
 import logging
@@ -26,6 +30,14 @@ from app.core.config import settings
 logger = logging.getLogger(__name__)
 
 _client: "StorageClient | None" = None
+
+
+class StorageNotConfiguredError(RuntimeError):
+    """Raised when MinIO env vars are missing or incomplete.
+
+    Distinct from a transient outage: this is a *deployment-time* fault
+    that should crash the app at boot, not a per-request degradation.
+    """
 
 
 def _parse_endpoint(url: str) -> tuple[str, bool]:
@@ -147,10 +159,6 @@ class _DualEndpointStorageClient(StorageClient):
         )
 
 
-def _is_configured() -> bool:
-    return bool(settings.minio_endpoint and settings.minio_access_key and settings.minio_secret_key)
-
-
 def _build_client(host: str, secure: bool) -> Minio:
     # Pin region to "us-east-1" so the minio-py client never calls
     # GetBucketLocation to discover it. Without this, presign triggers
@@ -169,8 +177,13 @@ def _build_client(host: str, secure: bool) -> Minio:
     )
 
 
-def get_storage() -> StorageClient | None:
-    """Return the MinIO storage client, or None if not configured.
+def get_storage() -> StorageClient:
+    """Return the MinIO storage client.
+
+    Raises ``StorageNotConfiguredError`` if the required env vars
+    (MINIO_ENDPOINT / MINIO_ACCESS_KEY / MINIO_SECRET_KEY / MINIO_BUCKET)
+    are missing. The lifespan calls this at startup so misconfiguration
+    crashes the app at boot rather than per-request.
 
     When `minio_public_endpoint` is set and differs from `minio_endpoint`,
     a `_DualEndpointStorageClient` is returned so presigned URLs are signed
@@ -178,8 +191,18 @@ def get_storage() -> StorageClient | None:
     internal one.
     """
     global _client
-    if not _is_configured():
-        return None
+    missing = [
+        name for name, value in (
+            ("MINIO_ENDPOINT", settings.minio_endpoint),
+            ("MINIO_ACCESS_KEY", settings.minio_access_key),
+            ("MINIO_SECRET_KEY", settings.minio_secret_key),
+            ("MINIO_BUCKET", settings.minio_bucket),
+        ) if not value
+    ]
+    if missing:
+        raise StorageNotConfiguredError(
+            f"MinIO storage is required but the following env vars are unset: {', '.join(missing)}",
+        )
     if _client is not None:
         return _client
 

--- a/apps/mybookkeeper/backend/app/services/leases/attachment_response_builder.py
+++ b/apps/mybookkeeper/backend/app/services/leases/attachment_response_builder.py
@@ -5,12 +5,15 @@ lease domain are minted ONLY through this module. Two helpers — one for
 ``LeaseTemplateFileResponse`` rows, one for ``SignedLeaseAttachmentResponse``
 rows — share the same signing helper.
 
-Graceful degradation: if storage is unavailable, every row gets
-``presigned_url=None`` so the frontend can show a placeholder.
+Storage is a hard requirement (the lifespan refuses to boot if MinIO is
+unreachable). Per-request signing is purely cryptographic and cannot
+fail under normal operation; any exception bubbles up so the request
+returns 500 with a real stack trace, surfacing the misconfiguration
+loudly. Silent ``presigned_url=None`` placeholders were the source of
+the PR #201–#204 outage trail and are no longer permitted on this path.
 """
 from __future__ import annotations
 
-import logging
 from typing import TypeVar
 
 from app.core.config import settings
@@ -22,25 +25,17 @@ from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
 
-logger = logging.getLogger(__name__)
-
 _T = TypeVar("_T", LeaseTemplateFileResponse, SignedLeaseAttachmentResponse)
 
 
-def _sign_one(storage: StorageClient, key: str) -> str | None:
-    try:
-        return storage.generate_presigned_url(key, settings.presigned_url_ttl_seconds)
-    except Exception:  # noqa: BLE001
-        logger.warning("Failed to sign presigned URL for %s", key, exc_info=True)
-        return None
+def _sign_one(storage: StorageClient, key: str) -> str:
+    return storage.generate_presigned_url(key, settings.presigned_url_ttl_seconds)
 
 
 def _attach(rows: list[_T]) -> list[_T]:
     if not rows:
         return rows
     storage = get_storage()
-    if storage is None:
-        return [r.model_copy(update={"presigned_url": None}) for r in rows]
     return [
         r.model_copy(update={"presigned_url": _sign_one(storage, r.storage_key)})
         for r in rows

--- a/apps/mybookkeeper/backend/app/services/listings/photo_response_builder.py
+++ b/apps/mybookkeeper/backend/app/services/listings/photo_response_builder.py
@@ -8,50 +8,32 @@ than a public bucket so that:
 
 This module is the single seam where presigned URLs are minted on read paths.
 Centralising it here keeps `core/storage.py` a pure transport layer (no
-schema awareness) and avoids each call site re-implementing the
-graceful-degradation fallback.
+schema awareness).
 
-Graceful degradation: if storage is not configured (local dev without MinIO,
-broken connection, etc.) the response is still returned with
-`presigned_url=None`. The frontend treats `None` as "no URL available, render
-a placeholder" — listing reads must never crash on a storage outage.
+Storage is a hard requirement (the lifespan refuses to boot if MinIO is
+unreachable). Per-request signing is purely cryptographic and any
+exception bubbles up so the request returns 500 with a real stack
+trace. Silent ``presigned_url=None`` placeholders are no longer
+permitted on this path — see PR #201–#204 postmortem.
 """
 from __future__ import annotations
-
-import logging
 
 from app.core.config import settings
 from app.core.storage import StorageClient, get_storage
 from app.schemas.listings.listing_photo_response import ListingPhotoResponse
 
-logger = logging.getLogger(__name__)
 
-
-def _sign_one(storage: StorageClient, key: str) -> str | None:
-    """Sign a single key. Returns None on failure so a single broken object
-    doesn't poison the entire listing response."""
-    try:
-        return storage.generate_presigned_url(key, settings.presigned_url_ttl_seconds)
-    except Exception:  # noqa: BLE001 — defensive; storage transport errors must degrade gracefully
-        logger.warning("Failed to sign presigned URL for %s", key, exc_info=True)
-        return None
+def _sign_one(storage: StorageClient, key: str) -> str:
+    return storage.generate_presigned_url(key, settings.presigned_url_ttl_seconds)
 
 
 def attach_presigned_urls(
     photos: list[ListingPhotoResponse],
 ) -> list[ListingPhotoResponse]:
-    """Return the same photos with `presigned_url` populated.
-
-    Mutates a copy — input list is not modified. When storage is unavailable,
-    every photo gets `presigned_url=None`.
-    """
+    """Return the same photos with `presigned_url` populated."""
     if not photos:
         return photos
-
     storage = get_storage()
-    if storage is None:
-        return [p.model_copy(update={"presigned_url": None}) for p in photos]
-
     return [
         p.model_copy(update={"presigned_url": _sign_one(storage, p.storage_key)})
         for p in photos

--- a/apps/mybookkeeper/backend/app/services/storage/bucket_initializer.py
+++ b/apps/mybookkeeper/backend/app/services/storage/bucket_initializer.py
@@ -1,12 +1,14 @@
-"""Idempotent bucket setup, called from FastAPI lifespan.
+"""Eager bucket setup, called from FastAPI lifespan.
 
-The MinIO container starts fresh on first deploy, and Docker volumes survive
-restarts but not destroy/recreate cycles. Calling this on every backend boot
-ensures the bucket exists without any hand-coded provisioning step.
+Storage is a hard requirement for this app — listing photos, lease
+attachments, and applicant documents all depend on MinIO. If env vars
+are missing or MinIO is unreachable at boot, the app MUST refuse to
+start so the deploy healthcheck fails and the rollout aborts.
 
-When MinIO is not configured or unreachable, this function logs a warning
-and returns — the backend must keep starting. Callers that actually need
-storage (photo upload) handle the missing-storage case separately.
+Previous behavior (graceful degradation) hid environmental
+misconfiguration as `presigned_url=null` in API responses, with no
+visible error path — see the postmortem after PRs #201–#204 for the
+two-week trail of bugs that pattern caused.
 """
 from __future__ import annotations
 
@@ -18,34 +20,13 @@ logger = logging.getLogger(__name__)
 
 
 def ensure_bucket() -> None:
-    """Ensure the configured bucket exists. Safe to call repeatedly.
+    """Ensure the configured bucket exists. Raises on any error.
 
-    Returns silently on every error path so a misconfigured or temporarily
-    unavailable MinIO never blocks app startup. Storage-dependent endpoints
-    (photo upload) surface the misconfiguration to the caller as a 503.
+    The lifespan calls this at startup. If `get_storage()` raises (env
+    vars missing, etc.) or `bucket_exists()` raises (MinIO unreachable),
+    the exception propagates and FastAPI startup fails. The deploy
+    healthcheck catches this and rolls back.
     """
-    try:
-        storage = get_storage()
-    except Exception:  # noqa: BLE001 — startup must be defensive
-        logger.warning(
-            "Storage initialization raised; bucket setup skipped",
-            exc_info=True,
-        )
-        return
-
-    if storage is None:
-        logger.info(
-            "MinIO not configured — skipping bucket initialization. "
-            "Set minio_endpoint/access_key/secret_key to enable.",
-        )
-        return
-
-    try:
-        storage.ensure_bucket()
-        logger.info("MinIO bucket %s ready", storage.bucket)
-    except Exception:  # noqa: BLE001 — startup must be defensive
-        logger.warning(
-            "Failed to ensure MinIO bucket %s exists; storage may be unavailable",
-            storage.bucket,
-            exc_info=True,
-        )
+    storage = get_storage()
+    storage.ensure_bucket()
+    logger.info("MinIO bucket %s ready", storage.bucket)

--- a/apps/mybookkeeper/backend/tests/conftest.py
+++ b/apps/mybookkeeper/backend/tests/conftest.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from collections.abc import AsyncGenerator
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -12,6 +12,17 @@ import pytest
 # the report-processor unit tests.  Setting this at conftest import time
 # ensures the guard fires before any test module is collected.
 os.environ.setdefault("MAGIC_DISABLED", "1")
+
+# Storage env vars — set before settings is imported so ``get_storage()``
+# doesn't raise StorageNotConfiguredError when the lifespan or any
+# service touches it. The ``_patch_storage_for_tests`` autouse fixture
+# replaces the cached client with a MagicMock so no real network call
+# is ever attempted.
+os.environ.setdefault("MINIO_ENDPOINT", "test-minio:9000")
+os.environ.setdefault("MINIO_ACCESS_KEY", "test-access-key")
+os.environ.setdefault("MINIO_SECRET_KEY", "test-secret-key")
+os.environ.setdefault("MINIO_BUCKET", "test-bucket")
+os.environ.setdefault("MINIO_PUBLIC_ENDPOINT", "test-minio:9000")
 import pytest_asyncio
 from sqlalchemy import event, JSON, String
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
@@ -27,6 +38,34 @@ from app.models.user.user import User
 @pytest.fixture(scope="session")
 def anyio_backend() -> str:
     return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _patch_storage_for_tests(monkeypatch):
+    """Replace the cached storage client with an in-memory MagicMock so
+    every importer of ``get_storage`` sees a working storage without
+    actually touching the network.
+
+    Storage is now a hard requirement (the FastAPI lifespan refuses to
+    boot on misconfig). Tests don't have a real MinIO, so we (a) ensure
+    env vars are set above so the get_storage missing-vars check passes,
+    then (b) inject a fake into ``_client`` so the function returns it
+    without ever constructing a real Minio() client. Tests that want to
+    assert misconfig behavior override by patching ``get_storage`` on
+    the importing module directly.
+    """
+    fake = MagicMock()
+    fake.bucket = "test-bucket"
+    fake.generate_presigned_url.side_effect = lambda key, ttl: f"https://signed/{key}"
+    fake.ensure_bucket.return_value = None
+    # ``generate_key`` is the storage key generator used by upload paths;
+    # returning a MagicMock from it would fail downstream INSERTs that
+    # bind the value as a string column.
+    fake.generate_key.side_effect = lambda org_id, filename: f"{org_id}/test/{filename}"
+    fake.upload_file.side_effect = lambda key, content, content_type: key
+
+    from app.core import storage
+    monkeypatch.setattr(storage, "_client", fake)
 
 
 def _patch_metadata_for_sqlite() -> None:

--- a/apps/mybookkeeper/backend/tests/test_bucket_initializer.py
+++ b/apps/mybookkeeper/backend/tests/test_bucket_initializer.py
@@ -1,27 +1,19 @@
 """Tests for `services/storage/bucket_initializer.py`.
 
-The initializer runs at FastAPI startup. It must:
-- Be idempotent (calling twice is fine).
-- Never raise — startup must succeed even if MinIO is misconfigured or
-  unreachable.
-- Skip silently when storage is not configured (local dev).
+The initializer runs at FastAPI startup. It MUST raise on any failure
+so the deploy healthcheck catches misconfigured or unreachable MinIO
+immediately. Silent degradation here was the source of PR #201–#204.
 """
 from __future__ import annotations
 
+import pytest
 from unittest.mock import MagicMock, patch
 
+from app.core.storage import StorageNotConfiguredError
 from app.services.storage.bucket_initializer import ensure_bucket
 
 
 class TestEnsureBucket:
-    def test_no_op_when_storage_not_configured(self) -> None:
-        with patch(
-            "app.services.storage.bucket_initializer.get_storage",
-            return_value=None,
-        ):
-            # Must not raise.
-            ensure_bucket()
-
     def test_calls_ensure_bucket_when_configured(self) -> None:
         storage = MagicMock()
         storage.bucket = "test-bucket"
@@ -32,7 +24,15 @@ class TestEnsureBucket:
             ensure_bucket()
         storage.ensure_bucket.assert_called_once()
 
-    def test_swallows_storage_errors(self) -> None:
+    def test_propagates_get_storage_misconfig(self) -> None:
+        with patch(
+            "app.services.storage.bucket_initializer.get_storage",
+            side_effect=StorageNotConfiguredError("MINIO_ENDPOINT unset"),
+        ):
+            with pytest.raises(StorageNotConfiguredError):
+                ensure_bucket()
+
+    def test_propagates_bucket_runtime_error(self) -> None:
         storage = MagicMock()
         storage.bucket = "test-bucket"
         storage.ensure_bucket.side_effect = RuntimeError("MinIO unreachable")
@@ -40,15 +40,8 @@ class TestEnsureBucket:
             "app.services.storage.bucket_initializer.get_storage",
             return_value=storage,
         ):
-            # Must not raise — startup must succeed.
-            ensure_bucket()
-
-    def test_swallows_get_storage_exceptions(self) -> None:
-        with patch(
-            "app.services.storage.bucket_initializer.get_storage",
-            side_effect=RuntimeError("config exploded"),
-        ):
-            ensure_bucket()  # must not raise
+            with pytest.raises(RuntimeError, match="MinIO unreachable"):
+                ensure_bucket()
 
     def test_is_idempotent(self) -> None:
         storage = MagicMock()
@@ -59,6 +52,4 @@ class TestEnsureBucket:
         ):
             ensure_bucket()
             ensure_bucket()
-        # Each call to ensure_bucket dispatches a single make_bucket attempt;
-        # safe to call repeatedly.
         assert storage.ensure_bucket.call_count == 2

--- a/apps/mybookkeeper/backend/tests/test_listing_photo_service.py
+++ b/apps/mybookkeeper/backend/tests/test_listing_photo_service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import io
 import uuid
 from contextlib import asynccontextmanager
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image
@@ -26,18 +26,21 @@ from app.services.storage.image_processor import ImageRejected
 
 
 @pytest.fixture(autouse=True)
-def _patch_builder_storage_to_none(monkeypatch):
-    """Default the photo_response_builder's storage to None so the existing
-    tests (which patch only `listing_photo_service.get_storage`) keep
-    working — `presigned_url` simply comes back as None on the responses,
-    which the assertions don't inspect.
+def _patch_builder_storage(monkeypatch):
+    """Provide a working storage stub to ``photo_response_builder.get_storage``
+    so per-request signing succeeds in the read path. Storage is now a
+    hard requirement (the lifespan refuses to boot without it), so any
+    test exercising read paths must inject a real or fake storage —
+    silent ``presigned_url=None`` is no longer permitted.
 
-    Tests that want a real storage client mocked into the builder should
-    `monkeypatch.setattr(photo_response_builder, "get_storage", ...)`
-    themselves to override this default.
+    Tests that want to assert misconfig-propagation should override this
+    fixture by patching ``photo_response_builder.get_storage`` to raise.
     """
     from app.services.listings import photo_response_builder
-    monkeypatch.setattr(photo_response_builder, "get_storage", lambda: None)
+
+    fake = MagicMock()
+    fake.generate_presigned_url.side_effect = lambda key, ttl: f"https://signed/{key}"
+    monkeypatch.setattr(photo_response_builder, "get_storage", lambda: fake)
 
 
 class _FakeStorage:

--- a/apps/mybookkeeper/backend/tests/test_photo_response_builder.py
+++ b/apps/mybookkeeper/backend/tests/test_photo_response_builder.py
@@ -1,11 +1,9 @@
 """Tests for `services/listings/photo_response_builder.py`.
 
-Covers:
-- presigned URL injection happy path
-- graceful degradation when storage is unavailable (returns None for url)
-- per-row resilience: a single signing failure doesn't poison the batch
-- empty input is a no-op
-- input is not mutated
+Storage is a hard requirement (lifespan refuses to boot if MinIO is
+unreachable). Per-request signing is purely cryptographic — failures
+must propagate so the request returns 500 rather than silently degrade
+to ``presigned_url=None`` placeholders.
 """
 from __future__ import annotations
 
@@ -13,6 +11,9 @@ import uuid
 from datetime import datetime, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
+
+from app.core.storage import StorageNotConfiguredError
 from app.schemas.listings.listing_photo_response import ListingPhotoResponse
 from app.services.listings.photo_response_builder import attach_presigned_urls
 
@@ -34,16 +35,14 @@ class TestAttachPresignedUrls:
         result = attach_presigned_urls([])
         assert result == []
 
-    def test_returns_none_url_when_storage_not_configured(self) -> None:
-        photos = [_make_response(), _make_response()]
+    def test_propagates_storage_misconfig(self) -> None:
+        photos = [_make_response()]
         with patch(
             "app.services.listings.photo_response_builder.get_storage",
-            return_value=None,
+            side_effect=StorageNotConfiguredError("MINIO_ENDPOINT unset"),
         ):
-            result = attach_presigned_urls(photos)
-        assert all(p.presigned_url is None for p in result)
-        # Original input is not mutated.
-        assert all(p.presigned_url is None for p in photos)
+            with pytest.raises(StorageNotConfiguredError):
+                attach_presigned_urls(photos)
 
     def test_signs_each_photo_when_storage_configured(self) -> None:
         photos = [_make_response("a"), _make_response("b")]
@@ -57,33 +56,31 @@ class TestAttachPresignedUrls:
 
         assert result[0].presigned_url == "https://signed/a"
         assert result[1].presigned_url == "https://signed/b"
-        # TTL passed through from settings.
         assert storage.generate_presigned_url.call_count == 2
 
-    def test_per_row_failure_does_not_poison_batch(self) -> None:
+    def test_per_row_signing_error_propagates(self) -> None:
+        """A signing exception is never swallowed. The request returns 500
+        with the real stack trace; silent ``presigned_url=None`` is gone."""
         photos = [_make_response("a"), _make_response("b")]
         storage = MagicMock()
-        storage.generate_presigned_url.side_effect = [
-            RuntimeError("transient failure"),
-            "https://signed/b",
-        ]
+        storage.generate_presigned_url.side_effect = RuntimeError("signing exploded")
         with patch(
             "app.services.listings.photo_response_builder.get_storage",
             return_value=storage,
         ):
-            result = attach_presigned_urls(photos)
-
-        assert result[0].presigned_url is None
-        assert result[1].presigned_url == "https://signed/b"
+            with pytest.raises(RuntimeError, match="signing exploded"):
+                attach_presigned_urls(photos)
 
     def test_does_not_mutate_input(self) -> None:
         photo = _make_response("k")
         original_id = photo.id
+        storage = MagicMock()
+        storage.generate_presigned_url.return_value = "https://signed/k"
         with patch(
             "app.services.listings.photo_response_builder.get_storage",
-            return_value=None,
+            return_value=storage,
         ):
             attach_presigned_urls([photo])
-        # Same object, unchanged.
+        # Original object unchanged (model_copy returns a new instance).
         assert photo.id == original_id
         assert photo.presigned_url is None

--- a/apps/mybookkeeper/backend/tests/test_storage.py
+++ b/apps/mybookkeeper/backend/tests/test_storage.py
@@ -7,8 +7,8 @@ import pytest
 
 from app.core.storage import (
     StorageClient,
+    StorageNotConfiguredError,
     _DualEndpointStorageClient,
-    _is_configured,
     _parse_endpoint,
     get_storage,
     reset_client_cache,
@@ -51,35 +51,66 @@ class TestParseEndpoint:
         assert secure is False
 
 
-class TestFallbackWhenNotConfigured:
+class TestRaisesWhenNotConfigured:
+    """Storage is a hard requirement; missing env vars must crash, not
+    return None. The lifespan calls get_storage() at boot so the deploy
+    healthcheck catches misconfiguration immediately.
+    """
+
     @patch("app.core.storage.settings")
-    def test_get_storage_returns_none_when_not_configured(self, mock_settings: MagicMock) -> None:
+    def test_get_storage_raises_when_endpoint_empty(self, mock_settings: MagicMock) -> None:
+        reset_client_cache()
+        mock_settings.minio_endpoint = ""
+        mock_settings.minio_access_key = "key"
+        mock_settings.minio_secret_key = "secret"
+        mock_settings.minio_bucket = "bucket"
+        with pytest.raises(StorageNotConfiguredError, match="MINIO_ENDPOINT"):
+            get_storage()
+
+    @patch("app.core.storage.settings")
+    def test_get_storage_raises_when_access_key_empty(self, mock_settings: MagicMock) -> None:
+        reset_client_cache()
+        mock_settings.minio_endpoint = "localhost:9000"
+        mock_settings.minio_access_key = ""
+        mock_settings.minio_secret_key = "secret"
+        mock_settings.minio_bucket = "bucket"
+        with pytest.raises(StorageNotConfiguredError, match="MINIO_ACCESS_KEY"):
+            get_storage()
+
+    @patch("app.core.storage.settings")
+    def test_get_storage_raises_when_secret_key_empty(self, mock_settings: MagicMock) -> None:
+        reset_client_cache()
+        mock_settings.minio_endpoint = "localhost:9000"
+        mock_settings.minio_access_key = "key"
+        mock_settings.minio_secret_key = ""
+        mock_settings.minio_bucket = "bucket"
+        with pytest.raises(StorageNotConfiguredError, match="MINIO_SECRET_KEY"):
+            get_storage()
+
+    @patch("app.core.storage.settings")
+    def test_get_storage_raises_when_bucket_empty(self, mock_settings: MagicMock) -> None:
+        reset_client_cache()
+        mock_settings.minio_endpoint = "localhost:9000"
+        mock_settings.minio_access_key = "key"
+        mock_settings.minio_secret_key = "secret"
+        mock_settings.minio_bucket = ""
+        with pytest.raises(StorageNotConfiguredError, match="MINIO_BUCKET"):
+            get_storage()
+
+    @patch("app.core.storage.settings")
+    def test_error_lists_all_missing_vars(self, mock_settings: MagicMock) -> None:
         reset_client_cache()
         mock_settings.minio_endpoint = ""
         mock_settings.minio_access_key = ""
         mock_settings.minio_secret_key = ""
-        assert get_storage() is None
-
-    @patch("app.core.storage.settings")
-    def test_is_configured_false_when_endpoint_empty(self, mock_settings: MagicMock) -> None:
-        mock_settings.minio_endpoint = ""
-        mock_settings.minio_access_key = "key"
-        mock_settings.minio_secret_key = "secret"
-        assert _is_configured() is False
-
-    @patch("app.core.storage.settings")
-    def test_is_configured_false_when_access_key_empty(self, mock_settings: MagicMock) -> None:
-        mock_settings.minio_endpoint = "localhost:9000"
-        mock_settings.minio_access_key = ""
-        mock_settings.minio_secret_key = "secret"
-        assert _is_configured() is False
-
-    @patch("app.core.storage.settings")
-    def test_is_configured_false_when_secret_key_empty(self, mock_settings: MagicMock) -> None:
-        mock_settings.minio_endpoint = "localhost:9000"
-        mock_settings.minio_access_key = "key"
-        mock_settings.minio_secret_key = ""
-        assert _is_configured() is False
+        mock_settings.minio_bucket = ""
+        with pytest.raises(StorageNotConfiguredError) as exc:
+            get_storage()
+        msg = str(exc.value)
+        assert "MINIO_ENDPOINT" in msg
+        assert "MINIO_ACCESS_KEY" in msg
+        assert "MINIO_SECRET_KEY" in msg
+        assert "MINIO_BUCKET" in msg
 
 
 class TestStorageClientMethods:


### PR DESCRIPTION
Removes graceful-degradation patterns from MBK storage path. See commit body for details and rationale (postmortem of PRs #201–#204).