### PR TITLE
fix(myjobhunter/deploy): unbreak prod deploys (postgres healthcheck / shared-backend)

### DIFF
--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -1,0 +1,46 @@
+# Docker environment template — consumed by docker-compose.yml `env_file:` directive
+# for the migrate and api services. Copy to backend/.env.docker and fill in values:
+#   cp backend/.env.docker.example backend/.env.docker
+#
+# DATABASE_URL is set via docker-compose.yml `environment:` block — do NOT set it here.
+# DB_PASSWORD lives in apps/myjobhunter/.env (same dir as docker-compose.yml) — do NOT set it here.
+
+SECRET_KEY=change-me-to-random-64-chars
+ENCRYPTION_KEY=change-me-to-random-64-chars
+
+# Phase 2+ — required when AI extraction / company research lights up
+ANTHROPIC_API_KEY=
+TAVILY_API_KEY=
+GOOGLE_CLIENT_ID=
+GOOGLE_CLIENT_SECRET=
+
+# Frontend / CORS
+FRONTEND_URL=https://your-domain.com
+CORS_ORIGINS=["https://your-domain.com"]
+
+# JWT
+JWT_LIFETIME_SECONDS=1800
+LOG_LEVEL=INFO
+
+# HIBP compromised-password check — leave true in prod
+HIBP_ENABLED=true
+
+# Cloudflare Turnstile CAPTCHA — both must be set in prod
+TURNSTILE_SECRET_KEY=
+TURNSTILE_SITE_KEY=
+
+# Account-level login lockout
+LOCKOUT_THRESHOLD=5
+LOCKOUT_AUTORESET_HOURS=24
+
+# Per-IP login throttle
+LOGIN_RATE_LIMIT_THRESHOLD=10
+LOGIN_RATE_LIMIT_WINDOW_SECONDS=300
+
+# Email delivery — "console" prints to stdout (dev/CI); "smtp" uses SMTP_* below
+EMAIL_BACKEND=console
+EMAIL_FROM_NAME=MyJobHunter
+SMTP_HOST=
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=

--- a/apps/myjobhunter/docker-compose.yml
+++ b/apps/myjobhunter/docker-compose.yml
@@ -12,7 +12,12 @@ services:
       test: ["CMD-SHELL", "pg_isready -U myjobhunter"]
       interval: 5s
       timeout: 3s
-      retries: 5
+      retries: 10
+      # initdb on a cold start can take 10–20s; without start_period the early
+      # pg_isready failures count toward retries and Docker reports the
+      # container "unhealthy" before postgres has even bound the socket.
+      # Dependent services (migrate, api) bail out before postgres is ready.
+      start_period: 30s
 
   migrate:
     build:


### PR DESCRIPTION
## Summary

**MJH has never deployed successfully** — 30+ consecutive deploy failures going back to the very first MJH deploy on 2026-04-30. PR #196 fixed one layer (the `-e ../../../packages/shared-backend` editable-requirement error). This PR addresses what's underneath.

## Root cause analysis

After #196 fixed the build-time error, the latest run (25291817597) shows the container failing at the `up -d` step:

```
21:53:52.7843094Z  Container myjobhunter-postgres-1 Started
21:53:52.7843616Z  Container myjobhunter-postgres-1 Waiting
21:53:53.2865085Z  Container myjobhunter-postgres-1 Error dependency postgres failed to start  (~0.5s later)
dependency failed to start: container myjobhunter-postgres-1 is unhealthy
```

Half a second from "Started" to "Unhealthy" is **physically impossible** to be a timed-out healthcheck — the healthcheck `interval` is 5s. The container exited immediately on boot, and Docker reports an exited container as unhealthy on its dependents.

**Same exact pattern in the very first deploy on 2026-04-30** (run 25142131887). The MJH `pg_data` volume on the VPS is from a long chain of failed initdb attempts.

## What this PR changes

### 1. `apps/myjobhunter/docker-compose.yml` — postgres healthcheck hardening

Add `start_period: 30s` and bump `retries` from 5 to 10. Without `start_period`, healthcheck failures during the 5-15s initdb window count toward retries; postgres can be marked unhealthy before it has bound the socket. Aligns with postgres-alpine recommended practice. Strict improvement — never blocks faster than before.

### 2. `apps/myjobhunter/backend/.env.docker.example` — missing scaffold

The compose references `env_file: backend/.env.docker` but **MJH has never had a `.env.docker.example` template** (MBK has one, MJH never did). Without this, the operator has to know to create the file from scratch with the right shape. This template mirrors MBK's pattern and documents the env-var contract for migrate/api services.

## What this PR does NOT do

- Does not touch MBK config (per scope).
- Does not run any destructive VPS operation. No `docker volume rm` of `pg_data`.
- Does not change app code, schema, or migrations.
- Does not modify `.dockerignore` (MJH is missing one — separate concern, see follow-up below).

## Open questions for operator (verify on VPS BEFORE merging)

The healthcheck change alone may not be sufficient. The 0.5s container exit pattern is consistent with `POSTGRES_PASSWORD` being empty at boot — postgres-alpine refuses to initialize without one and exits immediately. **Please run these commands on the VPS** so we know what we're dealing with:

```bash
# 1. Does the MJH compose-level env file exist? Does it have DB_PASSWORD?
ls -la /srv/myfreeapps/apps/myjobhunter/.env 2>&1
grep -E '^DB_PASSWORD=' /srv/myfreeapps/apps/myjobhunter/.env 2>&1 | sed 's/=.*/=<value-redacted>/'

# 2. Does the backend env file the compose references exist?
ls -la /srv/myfreeapps/apps/myjobhunter/backend/.env.docker 2>&1

# 3. What is the actual container exit reason?
cd /srv/myfreeapps && docker compose -f apps/myjobhunter/docker-compose.yml up -d postgres
sleep 3
docker logs myjobhunter-postgres-1 2>&1 | head -40
docker inspect myjobhunter-postgres-1 --format '{{.State.ExitCode}} {{.State.Error}}'

# 4. Has the volume ever had successful data? (any actual postgres files vs empty/half-init?)
docker volume inspect myjobhunter_pg_data
docker run --rm -v myjobhunter_pg_data:/data alpine ls -la /data/ | head -20
```

### Possible outcomes

- **If `/srv/myfreeapps/apps/myjobhunter/.env` is missing or `DB_PASSWORD` is empty**: create the file (copy from `apps/myjobhunter/.env.example`), set a strong password, then redeploy. The healthcheck change in this PR plus this fix should resolve everything.
- **If the volume contains half-initialized data from prior failed boots**: since MJH has never had a successful deploy, **the volume contains no production data** — it can safely be recreated. **Do NOT do this without explicit confirmation in this thread**, but the procedure would be: `docker compose down`, `docker volume rm myjobhunter_pg_data`, then redeploy. I am flagging this rather than doing it because the rule is no destructive volume ops without explicit go-ahead.
- **If something else** (permission issue on the volume mount, host postgres binding port 5432 conflict, etc.): we'll see it in the `docker logs` and `docker inspect` output and triage from there.

## Test plan

- [ ] Operator runs the diagnostic commands above and posts results.
- [ ] If env-file gap confirmed, operator creates `/srv/myfreeapps/apps/myjobhunter/.env` (DB_PASSWORD + DOMAIN) and `/srv/myfreeapps/apps/myjobhunter/backend/.env.docker` (from new template, fill secrets).
- [ ] Merge PR — deploy CI runs.
- [ ] Verify deploy completes green: postgres healthy then migrate completes then api healthy then caddy serving frontend.
- [ ] `curl https://<mjh-domain>/health` returns 200.
- [ ] Frontend loads at `https://<mjh-domain>/`.

## Follow-ups (out of scope, separate PRs)

- **MJH is missing `.dockerignore`** — every build copies `.git`, `.venv`, `__pycache__` etc. into the docker context. MBK has one. Should add for parity (separate PR, low priority since builds work).
- **Add a CI guard that asserts every postgres healthcheck in the monorepo has `start_period`** — would have caught this. Could go into `g-pre-commit` style review.
- **Document the `/srv/myfreeapps/apps/<app>/.env` requirement** in MJH's CLAUDE.md Deployment section (MBK has this, MJH does not).

Generated with Claude Code
