### PR TITLE
chore(deps): bump icalendar 6.1.3 → 7.1.0 in MBK backend (replaces #145)

### DIFF
--- a/apps/mybookkeeper/backend/pyproject.toml
+++ b/apps/mybookkeeper/backend/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     # 5545 line folding, escaping, DATE vs DATETIME VALUE parameters, and
     # timezone propagation — all of which are fiddly enough that hand-rolling
     # is a bug factory. Used by both outbound serializer and inbound parser.
-    "icalendar==6.1.3",
+    "icalendar==7.1.0",
     # Lease Templates Phase 1 — DOCX rendering with placeholder substitution.
     # PDF rendering uses the existing ``reportlab`` dep (low-fidelity for v1;
     # weasyprint deferred per Phase 1 stop conditions due to Windows install

--- a/apps/mybookkeeper/backend/requirements.txt
+++ b/apps/mybookkeeper/backend/requirements.txt
@@ -131,7 +131,7 @@ httpx==0.28.1
     #   anthropic
     #   mybookkeeper-backend
     #   platform-shared
-icalendar==6.1.3
+icalendar==7.1.0
     # via mybookkeeper-backend
 idna==3.13
     # via
@@ -276,6 +276,7 @@ typing-extensions==4.15.0
     #   anthropic
     #   anyio
     #   fastapi
+    #   icalendar
     #   minio
     #   pydantic
     #   pydantic-core

--- a/apps/mybookkeeper/backend/uv.lock
+++ b/apps/mybookkeeper/backend/uv.lock
@@ -576,15 +576,16 @@ wheels = [
 
 [[package]]
 name = "icalendar"
-version = "6.1.3"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "python-dateutil" },
+    { name = "typing-extensions" },
     { name = "tzdata" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/3b/6532b45eef165c32fad5db2ce9b2a5669a4faeff232ab0bf0be2c576e9f5/icalendar-6.1.3.tar.gz", hash = "sha256:4aef710ff205925b3947fe69ed00f4e142c6a49b5533fca6cc2fdde5a6f62e66", size = 152131, upload-time = "2025-03-28T10:08:38.872Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/4c/ea2ca8ea012a2bf486657ebc5704d97bd9628e1cb85130b3f5298ac08f60/icalendar-7.1.0.tar.gz", hash = "sha256:10cd223c792fcc43bee4c3ebe3149d4cf32406c85cfef146624df5a0d414260f", size = 467258, upload-time = "2026-04-30T23:25:20.282Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/55/37/b1d557e0d2fbe80e47d02c319e1f3cb5921e7f70ca145352e3c4f2a37892/icalendar-6.1.3-py3-none-any.whl", hash = "sha256:11eb5d21a1a9e119a6efc0f9e38f2cf1622ef97777cd25fb0dd7074d393a2a8d", size = 208380, upload-time = "2025-03-28T10:08:37.128Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/df/68d5aa80188ad0880f12e2fc60d5df10fc831fdb11ef1d91e417e24ef4ee/icalendar-7.1.0-py3-none-any.whl", hash = "sha256:6de875370d22fc4aff172ad7c439b39fb109dc2eab9ce358fcb95e8689ad7b56", size = 471220, upload-time = "2026-04-30T23:25:18.584Z" },
 ]
 
 [[package]]
@@ -793,7 +794,7 @@ requires-dist = [
     { name = "google-auth-httplib2", specifier = "==0.3.1" },
     { name = "google-auth-oauthlib", specifier = "==1.3.1" },
     { name = "httpx", specifier = "==0.28.1" },
-    { name = "icalendar", specifier = "==6.1.3" },
+    { name = "icalendar", specifier = "==7.1.0" },
     { name = "mammoth", specifier = "==1.12.0" },
     { name = "minio", specifier = "==7.2.20" },
     { name = "openpyxl", specifier = "==3.1.5" },


### PR DESCRIPTION
Replaces #145

## What changed

Bumps `icalendar` from 6.1.3 to 7.1.0 in the MyBookkeeper backend. Updates `pyproject.toml`, `uv.lock`, and the generated `requirements.txt`.

## Breaking-change audit (v7.0.0 release notes)

| Breaking change | Impact on our code |
|---|---|
| `DURATION_REGEX` moved to `icalendar.prop.dt.duration` | Not imported anywhere |
| `WEEKDAY_RULE` moved to `icalendar.prop.recur.weekday` | Not imported anywhere |
| `tzid_from_dt` / `tzid_from_tzinfo` removed from `icalendar.prop` | Not used (were in `icalendar.timezone` anyway) |
| `Component.decoded()` returns `str` for text props (was `bytes`) | Not called in our code |
| `FOLD`, `NAME`, `NEWLINE`, etc. removed from `icalendar.parser` | Not imported |
| Python 3.8/3.9 dropped | We run Python 3.12 |

No source-code changes were required. Our code uses only the stable core API:
- `Calendar.from_ical()`, `cal.walk()`, `component.get()`, `.dt`
- `Calendar()`, `Event()`, `cal.add()`, `cal.to_ical()`

None of these changed between v6 and v7.

## Test results

```
tests/test_calendar_route.py::TestCalendarRoute::test_invalid_token_returns_404 PASSED
tests/test_calendar_route.py::TestCalendarRoute::test_valid_token_returns_parseable_ical PASSED
tests/test_ical_serializer.py::TestSerializeBlackouts::test_emits_valid_ical_with_one_event PASSED
tests/test_ical_serializer.py::TestSerializeBlackouts::test_emits_empty_calendar_when_no_blackouts PASSED
tests/test_ical_serializer.py::TestSerializeBlackouts::test_emits_one_vevent_per_blackout PASSED
tests/test_ical_serializer.py::TestSerializeBlackouts::test_dtstamp_is_now_in_utc PASSED

6 passed in 7.86s
```

Full backend suite: 1175 passed (pre-existing DB-dependent errors unchanged from before this bump).