### PR TITLE
feat(mybookkeeper/insurance): policy storage + attachments (Phase 1)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/insur260504_add_insurance_policy_tables.py
+++ b/apps/mybookkeeper/backend/alembic/versions/insur260504_add_insurance_policy_tables.py
@@ -1,0 +1,167 @@
+"""Add insurance_policies and insurance_policy_attachments tables.
+
+Phase 1: storage + CRUD only. AI extraction of policy details is Phase 2.
+
+Tables:
+  insurance_policies — one policy per listing (with optional PII-adjacent
+    policy_number encrypted via EncryptedString/Fernet).
+  insurance_policy_attachments — files attached to a policy (policy docs,
+    endorsements, binders, other).
+
+Storage key partition: insurance-policies/{policy_id}/{attachment_id}.
+
+Revision ID: insur260504
+Revises: calttp260503
+Create Date: 2026-05-04 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+
+revision: str = "insur260504"
+down_revision: Union[str, None] = "calttp260503"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # insurance_policies
+    # ------------------------------------------------------------------
+    op.create_table(
+        "insurance_policies",
+        sa.Column("id", PGUUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "user_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "organization_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("organizations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "listing_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("listings.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("policy_name", sa.String(255), nullable=False),
+        sa.Column("carrier", sa.String(255), nullable=True),
+        # Encrypted at rest via EncryptedString / Fernet.
+        sa.Column("policy_number", sa.Text(), nullable=True),
+        sa.Column("key_version", sa.BigInteger(), nullable=False, server_default="1"),
+        sa.Column("effective_date", sa.Date(), nullable=True),
+        sa.Column("expiration_date", sa.Date(), nullable=True),
+        sa.Column("coverage_amount_cents", sa.BigInteger(), nullable=True),
+        sa.Column("notes", sa.Text(), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "length(policy_name) > 0",
+            name="chk_insurance_policy_name_nonempty",
+        ),
+    )
+
+    # Indexes on insurance_policies.
+    op.create_index("ix_insurance_policies_user_id", "insurance_policies", ["user_id"])
+    op.create_index(
+        "ix_insurance_policies_organization_id",
+        "insurance_policies",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_insurance_policies_listing_id",
+        "insurance_policies",
+        ["listing_id"],
+    )
+    op.create_index(
+        "ix_insurance_policies_org_created_active",
+        "insurance_policies",
+        ["organization_id", "created_at"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "ix_insurance_policies_org_expiration_active",
+        "insurance_policies",
+        ["organization_id", "expiration_date"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+    # ------------------------------------------------------------------
+    # insurance_policy_attachments
+    # ------------------------------------------------------------------
+    op.create_table(
+        "insurance_policy_attachments",
+        sa.Column("id", PGUUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "policy_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("insurance_policies.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("storage_key", sa.String(500), nullable=False),
+        sa.Column("filename", sa.String(255), nullable=False),
+        sa.Column("content_type", sa.String(120), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column("kind", sa.String(40), nullable=False),
+        sa.Column(
+            "uploaded_by_user_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "uploaded_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.CheckConstraint(
+            "kind IN ('policy_document', 'endorsement', 'binder', 'other')",
+            name="chk_insurance_policy_attachment_kind",
+        ),
+    )
+
+    op.create_index(
+        "ix_insurance_policy_attachments_policy_id",
+        "insurance_policy_attachments",
+        ["policy_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("insurance_policy_attachments")
+
+    op.drop_index(
+        "ix_insurance_policies_org_expiration_active",
+        table_name="insurance_policies",
+    )
+    op.drop_index(
+        "ix_insurance_policies_org_created_active",
+        table_name="insurance_policies",
+    )
+    op.drop_index("ix_insurance_policies_listing_id", table_name="insurance_policies")
+    op.drop_index(
+        "ix_insurance_policies_organization_id",
+        table_name="insurance_policies",
+    )
+    op.drop_index("ix_insurance_policies_user_id", table_name="insurance_policies")
+
+    op.drop_table("insurance_policies")

--- a/apps/mybookkeeper/backend/app/api/insurance_policies.py
+++ b/apps/mybookkeeper/backend/app/api/insurance_policies.py
@@ -1,0 +1,186 @@
+"""HTTP routes for insurance policies.
+
+Route prefix: /insurance-policies.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from typing import Any
+
+from fastapi import APIRouter, Depends, File, Form, HTTPException, Query, Response, UploadFile
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.schemas.insurance.insurance_policy_attachment_response import (
+    InsurancePolicyAttachmentResponse,
+)
+from app.schemas.insurance.insurance_policy_create_request import (
+    InsurancePolicyCreateRequest,
+)
+from app.schemas.insurance.insurance_policy_list_response import (
+    InsurancePolicyListResponse,
+)
+from app.schemas.insurance.insurance_policy_response import InsurancePolicyResponse
+from app.schemas.insurance.insurance_policy_update_request import (
+    InsurancePolicyUpdateRequest,
+)
+from app.services.insurance import insurance_policy_service
+
+router = APIRouter(prefix="/insurance-policies", tags=["insurance-policies"])
+
+
+@router.post("", response_model=InsurancePolicyResponse, status_code=201)
+async def create_policy(
+    payload: InsurancePolicyCreateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> InsurancePolicyResponse:
+    return await insurance_policy_service.create_policy(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+        listing_id=payload.listing_id,
+        policy_name=payload.policy_name,
+        carrier=payload.carrier,
+        policy_number=payload.policy_number,
+        effective_date=payload.effective_date,
+        expiration_date=payload.expiration_date,
+        coverage_amount_cents=payload.coverage_amount_cents,
+        notes=payload.notes,
+    )
+
+
+@router.get("", response_model=InsurancePolicyListResponse)
+async def list_policies(
+    listing_id: uuid.UUID | None = Query(None),
+    expiring_before: _dt.date | None = Query(None),
+    limit: int = Query(50, ge=1, le=100),
+    offset: int = Query(0, ge=0),
+    ctx: RequestContext = Depends(current_org_member),
+) -> InsurancePolicyListResponse:
+    return await insurance_policy_service.list_policies(
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+        listing_id=listing_id,
+        expiring_before=expiring_before,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/{policy_id}", response_model=InsurancePolicyResponse)
+async def get_policy(
+    policy_id: uuid.UUID,
+    ctx: RequestContext = Depends(current_org_member),
+) -> InsurancePolicyResponse:
+    try:
+        return await insurance_policy_service.get_policy(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            policy_id=policy_id,
+        )
+    except insurance_policy_service.InsurancePolicyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Insurance policy not found") from exc
+
+
+@router.patch("/{policy_id}", response_model=InsurancePolicyResponse)
+async def update_policy(
+    policy_id: uuid.UUID,
+    payload: InsurancePolicyUpdateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> InsurancePolicyResponse:
+    # Build field dict from only the explicitly-provided fields.
+    # Using model_dump(exclude_unset=True) preserves the distinction between
+    # "field omitted" and "field set to null".
+    raw: dict[str, Any] = payload.model_dump(exclude_unset=True)
+    if not raw:
+        # Nothing to update — just return current state.
+        try:
+            return await insurance_policy_service.get_policy(
+                user_id=ctx.user_id,
+                organization_id=ctx.organization_id,
+                policy_id=policy_id,
+            )
+        except insurance_policy_service.InsurancePolicyNotFoundError as exc:
+            raise HTTPException(status_code=404, detail="Insurance policy not found") from exc
+
+    try:
+        return await insurance_policy_service.update_policy(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            policy_id=policy_id,
+            fields=raw,
+        )
+    except insurance_policy_service.InsurancePolicyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Insurance policy not found") from exc
+
+
+@router.delete("/{policy_id}", status_code=204)
+async def delete_policy(
+    policy_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    try:
+        await insurance_policy_service.soft_delete_policy(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            policy_id=policy_id,
+        )
+    except insurance_policy_service.InsurancePolicyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Insurance policy not found") from exc
+    return Response(status_code=204)
+
+
+@router.post(
+    "/{policy_id}/attachments",
+    response_model=InsurancePolicyAttachmentResponse,
+    status_code=201,
+)
+async def upload_attachment(
+    policy_id: uuid.UUID,
+    kind: str = Form(...),
+    file: UploadFile = File(...),
+    ctx: RequestContext = Depends(require_write_access),
+) -> InsurancePolicyAttachmentResponse:
+    content = await file.read()
+    try:
+        return await insurance_policy_service.upload_attachment(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            policy_id=policy_id,
+            content=content,
+            filename=file.filename or "",
+            declared_content_type=file.content_type,
+            kind=kind,
+        )
+    except insurance_policy_service.InsurancePolicyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Insurance policy not found") from exc
+    except insurance_policy_service.AttachmentTooLargeError as exc:
+        raise HTTPException(status_code=413, detail=str(exc)) from exc
+    except insurance_policy_service.AttachmentTypeRejectedError as exc:
+        raise HTTPException(status_code=415, detail=str(exc)) from exc
+    except insurance_policy_service.InvalidAttachmentKindError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.delete(
+    "/{policy_id}/attachments/{attachment_id}",
+    status_code=204,
+)
+async def delete_attachment(
+    policy_id: uuid.UUID,
+    attachment_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    try:
+        await insurance_policy_service.delete_attachment(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            policy_id=policy_id,
+            attachment_id=attachment_id,
+        )
+    except (
+        insurance_policy_service.InsurancePolicyNotFoundError,
+        insurance_policy_service.AttachmentNotFoundError,
+    ) as exc:
+        raise HTTPException(status_code=404, detail="Not found") from exc
+    return Response(status_code=204)

--- a/apps/mybookkeeper/backend/app/core/audit.py
+++ b/apps/mybookkeeper/backend/app/core/audit.py
@@ -40,6 +40,9 @@ MBK_SENSITIVE_FIELDS: frozenset[str] = frozenset({
     # Organization, User, ReplyTemplate all have plain ``name`` columns we
     # MUST NOT mask in the audit log).
     "legal_name",
+    # Insurance domain PII — policy numbers are PII-adjacent (can identify
+    # individuals with insurers), encrypted at rest via EncryptedString.
+    "policy_number",
     "dob",
     "employer_or_hospital",
     "vehicle_make_model",

--- a/apps/mybookkeeper/backend/app/core/insurance_enums.py
+++ b/apps/mybookkeeper/backend/app/core/insurance_enums.py
@@ -1,0 +1,22 @@
+"""Canonical string values for the Insurance domain.
+
+Per project convention (RENTALS_PLAN.md §4.1): status / category columns use
+``String(N)`` plus a ``CheckConstraint``, never ``SQLAlchemy Enum``. These
+tuples are the single source of truth — referenced from both the SQLAlchemy
+model ``CheckConstraint``s and the Alembic migration DDL.
+"""
+
+# File kinds for insurance policy attachments.
+INSURANCE_ATTACHMENT_KINDS: tuple[str, ...] = (
+    "policy_document",
+    "endorsement",
+    "binder",
+    "other",
+)
+
+
+def _sql_in_list(values: tuple[str, ...]) -> str:
+    return "(" + ", ".join(f"'{v}'" for v in values) + ")"
+
+
+INSURANCE_ATTACHMENT_KINDS_SQL = _sql_in_list(INSURANCE_ATTACHMENT_KINDS)

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -49,7 +49,7 @@ from app.db.session import AsyncSessionLocal
 from app.schemas.user.user import UserRead, UserCreate, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 from app.workers.upload_processor_worker import main as worker_main
-from app.api import account, activities, analytics, applicants, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, lease_templates, listings, properties, public_inquiries, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, plaid, vendors, webhooks, exports, imports, health_dashboard, totp, taxpayer_profiles
+from app.api import account, activities, analytics, applicants, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, properties, public_inquiries, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, plaid, vendors, webhooks, exports, imports, health_dashboard, totp, taxpayer_profiles
 
 logging.basicConfig(
     level=logging.INFO,
@@ -180,6 +180,7 @@ app.include_router(public_inquiries.router)
 app.include_router(applicants.router)
 app.include_router(lease_templates.router)
 app.include_router(signed_leases.router)
+app.include_router(insurance_policies.router)
 app.include_router(screening.router)
 app.include_router(vendors.router)
 app.include_router(reply_templates.router)

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -33,6 +33,8 @@ from app.models.leases.lease_template_file import LeaseTemplateFile
 from app.models.leases.lease_template_placeholder import LeaseTemplatePlaceholder
 from app.models.leases.signed_lease import SignedLease
 from app.models.leases.signed_lease_attachment import SignedLeaseAttachment
+from app.models.insurance.insurance_policy import InsurancePolicy
+from app.models.insurance.insurance_policy_attachment import InsurancePolicyAttachment
 from app.models.vendors.vendor import Vendor
 from app.models.documents.document import Document
 from app.models.extraction.extraction_prompt import ExtractionPrompt

--- a/apps/mybookkeeper/backend/app/models/insurance/insurance_policy.py
+++ b/apps/mybookkeeper/backend/app/models/insurance/insurance_policy.py
@@ -1,0 +1,113 @@
+"""Insurance policy record scoped to a listing.
+
+One policy per listing (e.g. "Landlord Insurance — 123 Main St"). Multiple
+attachments per policy (see ``insurance_policy_attachment.py``).
+
+Soft-deleted because insurance records are financial/legal documents and
+retention is recommended even after operational deletion.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    BigInteger,
+    CheckConstraint,
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.encrypted_string_type import EncryptedString
+from app.db.base import Base
+
+
+class InsurancePolicy(Base):
+    __tablename__ = "insurance_policies"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    organization_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("organizations.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+    listing_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("listings.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    policy_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    carrier: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    # PII-adjacent — policy numbers can identify individuals with insurers.
+    policy_number: Mapped[str | None] = mapped_column(
+        EncryptedString(255), nullable=True,
+    )
+    key_version: Mapped[int] = mapped_column(
+        BigInteger, nullable=False, default=1, server_default="1",
+    )
+
+    effective_date: Mapped[_dt.date | None] = mapped_column(Date, nullable=True)
+    expiration_date: Mapped[_dt.date | None] = mapped_column(Date, nullable=True)
+
+    # Stored as cents to avoid floating-point precision issues.
+    coverage_amount_cents: Mapped[int | None] = mapped_column(
+        BigInteger, nullable=True,
+    )
+
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    deleted_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        onupdate=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "length(policy_name) > 0",
+            name="chk_insurance_policy_name_nonempty",
+        ),
+        # List page: newest active first per org.
+        Index(
+            "ix_insurance_policies_org_created_active",
+            "organization_id", "created_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        # Expiration filter (expiring soon toggle).
+        Index(
+            "ix_insurance_policies_org_expiration_active",
+            "organization_id", "expiration_date",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/models/insurance/insurance_policy_attachment.py
+++ b/apps/mybookkeeper/backend/app/models/insurance/insurance_policy_attachment.py
@@ -1,0 +1,68 @@
+"""File attached to an insurance policy record.
+
+Mirrors the ``signed_lease_attachment`` shape:
+  storage_key + filename + content_type + size_bytes +
+  uploaded_by_user_id + uploaded_at + kind discriminator.
+
+Storage key partition: ``insurance-policies/{policy_id}/{attachment_id}``.
+CASCADE-deleted with the parent policy; storage cleanup is best-effort
+in the service layer.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.insurance_enums import INSURANCE_ATTACHMENT_KINDS_SQL
+from app.db.base import Base
+
+
+class InsurancePolicyAttachment(Base):
+    __tablename__ = "insurance_policy_attachments"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    policy_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("insurance_policies.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    storage_key: Mapped[str] = mapped_column(String(500), nullable=False)
+    filename: Mapped[str] = mapped_column(String(255), nullable=False)
+    content_type: Mapped[str] = mapped_column(String(120), nullable=False)
+    size_bytes: Mapped[int] = mapped_column(Integer, nullable=False)
+    kind: Mapped[str] = mapped_column(String(40), nullable=False)
+
+    uploaded_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+    uploaded_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"kind IN {INSURANCE_ATTACHMENT_KINDS_SQL}",
+            name="chk_insurance_policy_attachment_kind",
+        ),
+        Index("ix_insurance_policy_attachments_policy_id", "policy_id"),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/insurance/insurance_policy_attachment_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/insurance/insurance_policy_attachment_repo.py
@@ -1,0 +1,95 @@
+"""Repository for ``insurance_policy_attachments``.
+
+Mirrors ``signed_lease_attachment_repo`` — including the
+``delete_by_id_scoped_to_policy`` composite-WHERE pattern that prevents IDOR
+attacks (lesson from the calendar/blackout PR #172 fix).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import delete, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.insurance.insurance_policy_attachment import InsurancePolicyAttachment
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    policy_id: uuid.UUID,
+    storage_key: str,
+    filename: str,
+    content_type: str,
+    size_bytes: int,
+    kind: str,
+    uploaded_by_user_id: uuid.UUID,
+    uploaded_at: datetime,
+) -> InsurancePolicyAttachment:
+    row = InsurancePolicyAttachment(
+        policy_id=policy_id,
+        storage_key=storage_key,
+        filename=filename,
+        content_type=content_type,
+        size_bytes=size_bytes,
+        kind=kind,
+        uploaded_by_user_id=uploaded_by_user_id,
+        uploaded_at=uploaded_at,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def list_by_policy(
+    db: AsyncSession,
+    policy_id: uuid.UUID,
+) -> list[InsurancePolicyAttachment]:
+    result = await db.execute(
+        select(InsurancePolicyAttachment)
+        .where(InsurancePolicyAttachment.policy_id == policy_id)
+        .order_by(InsurancePolicyAttachment.uploaded_at.asc())
+    )
+    return list(result.scalars().all())
+
+
+async def get_by_id(
+    db: AsyncSession,
+    attachment_id: uuid.UUID,
+) -> InsurancePolicyAttachment | None:
+    result = await db.execute(
+        select(InsurancePolicyAttachment).where(
+            InsurancePolicyAttachment.id == attachment_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def delete_by_id_scoped_to_policy(
+    db: AsyncSession,
+    attachment_id: uuid.UUID,
+    policy_id: uuid.UUID,
+) -> InsurancePolicyAttachment | None:
+    """Delete a single attachment row scoped to its parent policy.
+
+    Both ``attachment_id`` AND ``policy_id`` must match — prevents an attacker
+    from pairing a valid own-org ``policy_id`` with a leaked ``attachment_id``
+    belonging to another tenant. Mirrors the blackout-attachment fix (PR #172).
+    """
+    result = await db.execute(
+        select(InsurancePolicyAttachment).where(
+            InsurancePolicyAttachment.id == attachment_id,
+            InsurancePolicyAttachment.policy_id == policy_id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    await db.execute(
+        delete(InsurancePolicyAttachment).where(
+            InsurancePolicyAttachment.id == attachment_id,
+            InsurancePolicyAttachment.policy_id == policy_id,
+        )
+    )
+    return row

--- a/apps/mybookkeeper/backend/app/repositories/insurance/insurance_policy_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/insurance/insurance_policy_repo.py
@@ -1,0 +1,158 @@
+"""Repository for ``insurance_policies``."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from typing import Any
+
+from sqlalchemy import desc, func, select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.insurance.insurance_policy import InsurancePolicy
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    listing_id: uuid.UUID,
+    policy_name: str,
+    carrier: str | None = None,
+    policy_number: str | None = None,
+    effective_date: _dt.date | None = None,
+    expiration_date: _dt.date | None = None,
+    coverage_amount_cents: int | None = None,
+    notes: str | None = None,
+) -> InsurancePolicy:
+    policy = InsurancePolicy(
+        user_id=user_id,
+        organization_id=organization_id,
+        listing_id=listing_id,
+        policy_name=policy_name,
+        carrier=carrier,
+        policy_number=policy_number,
+        effective_date=effective_date,
+        expiration_date=expiration_date,
+        coverage_amount_cents=coverage_amount_cents,
+        notes=notes,
+    )
+    db.add(policy)
+    await db.flush()
+    return policy
+
+
+async def get(
+    db: AsyncSession,
+    *,
+    policy_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    include_deleted: bool = False,
+) -> InsurancePolicy | None:
+    stmt = select(InsurancePolicy).where(
+        InsurancePolicy.id == policy_id,
+        InsurancePolicy.user_id == user_id,
+        InsurancePolicy.organization_id == organization_id,
+    )
+    if not include_deleted:
+        stmt = stmt.where(InsurancePolicy.deleted_at.is_(None))
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_for_org(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    listing_id: uuid.UUID | None = None,
+    expiring_before: _dt.date | None = None,
+    include_deleted: bool = False,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[InsurancePolicy]:
+    stmt = select(InsurancePolicy).where(
+        InsurancePolicy.user_id == user_id,
+        InsurancePolicy.organization_id == organization_id,
+    )
+    if not include_deleted:
+        stmt = stmt.where(InsurancePolicy.deleted_at.is_(None))
+    if listing_id is not None:
+        stmt = stmt.where(InsurancePolicy.listing_id == listing_id)
+    if expiring_before is not None:
+        stmt = stmt.where(
+            InsurancePolicy.expiration_date.isnot(None),
+            InsurancePolicy.expiration_date <= expiring_before,
+        )
+    stmt = stmt.order_by(desc(InsurancePolicy.created_at)).limit(limit).offset(offset)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def count_for_org(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    listing_id: uuid.UUID | None = None,
+    expiring_before: _dt.date | None = None,
+    include_deleted: bool = False,
+) -> int:
+    stmt = select(func.count()).select_from(InsurancePolicy).where(
+        InsurancePolicy.user_id == user_id,
+        InsurancePolicy.organization_id == organization_id,
+    )
+    if not include_deleted:
+        stmt = stmt.where(InsurancePolicy.deleted_at.is_(None))
+    if listing_id is not None:
+        stmt = stmt.where(InsurancePolicy.listing_id == listing_id)
+    if expiring_before is not None:
+        stmt = stmt.where(
+            InsurancePolicy.expiration_date.isnot(None),
+            InsurancePolicy.expiration_date <= expiring_before,
+        )
+    result = await db.execute(stmt)
+    return int(result.scalar_one())
+
+
+async def update_policy(
+    db: AsyncSession,
+    *,
+    policy_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> InsurancePolicy | None:
+    policy = await get(
+        db,
+        policy_id=policy_id,
+        user_id=user_id,
+        organization_id=organization_id,
+    )
+    if policy is None:
+        return None
+    for key, value in fields.items():
+        setattr(policy, key, value)
+    await db.flush()
+    return policy
+
+
+async def soft_delete(
+    db: AsyncSession,
+    *,
+    policy_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+) -> bool:
+    result = await db.execute(
+        update(InsurancePolicy)
+        .where(
+            InsurancePolicy.id == policy_id,
+            InsurancePolicy.user_id == user_id,
+            InsurancePolicy.organization_id == organization_id,
+            InsurancePolicy.deleted_at.is_(None),
+        )
+        .values(deleted_at=_dt.datetime.now(_dt.timezone.utc))
+    )
+    return (result.rowcount or 0) > 0

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_attachment_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_attachment_response.py
@@ -1,0 +1,22 @@
+"""Schema for a single attachment on an insurance policy."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class InsurancePolicyAttachmentResponse(BaseModel):
+    id: uuid.UUID
+    policy_id: uuid.UUID
+    filename: str
+    storage_key: str
+    content_type: str
+    size_bytes: int
+    kind: str
+    uploaded_by_user_id: uuid.UUID
+    uploaded_at: _dt.datetime
+    presigned_url: str | None = None
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_create_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_create_request.py
@@ -1,0 +1,20 @@
+"""Schema for POST /insurance-policies."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class InsurancePolicyCreateRequest(BaseModel):
+    listing_id: uuid.UUID
+    policy_name: str = Field(..., min_length=1, max_length=255)
+    carrier: str | None = Field(None, max_length=255)
+    policy_number: str | None = Field(None, max_length=255)
+    effective_date: _dt.date | None = None
+    expiration_date: _dt.date | None = None
+    coverage_amount_cents: int | None = Field(None, ge=0)
+    notes: str | None = Field(None, max_length=5000)
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_list_response.py
@@ -1,0 +1,14 @@
+"""Paginated list response for insurance policies."""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.insurance.insurance_policy_summary import InsurancePolicySummary
+
+
+class InsurancePolicyListResponse(BaseModel):
+    items: list[InsurancePolicySummary]
+    total: int
+    has_more: bool
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_response.py
@@ -1,0 +1,30 @@
+"""Schema for a single insurance policy (detail view with attachments)."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+from app.schemas.insurance.insurance_policy_attachment_response import (
+    InsurancePolicyAttachmentResponse,
+)
+
+
+class InsurancePolicyResponse(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID
+    organization_id: uuid.UUID
+    listing_id: uuid.UUID
+    policy_name: str
+    carrier: str | None = None
+    policy_number: str | None = None
+    effective_date: _dt.date | None = None
+    expiration_date: _dt.date | None = None
+    coverage_amount_cents: int | None = None
+    notes: str | None = None
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+    attachments: list[InsurancePolicyAttachmentResponse]
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_summary.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_summary.py
@@ -1,0 +1,21 @@
+"""Summary row for the insurance policy list view."""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class InsurancePolicySummary(BaseModel):
+    id: uuid.UUID
+    listing_id: uuid.UUID
+    policy_name: str
+    carrier: str | None = None
+    effective_date: _dt.date | None = None
+    expiration_date: _dt.date | None = None
+    coverage_amount_cents: int | None = None
+    created_at: _dt.datetime
+    updated_at: _dt.datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_update_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_update_request.py
@@ -1,0 +1,18 @@
+"""Schema for PATCH /insurance-policies/{id}."""
+from __future__ import annotations
+
+import datetime as _dt
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class InsurancePolicyUpdateRequest(BaseModel):
+    policy_name: str | None = Field(None, min_length=1, max_length=255)
+    carrier: str | None = Field(None, max_length=255)
+    policy_number: str | None = None
+    effective_date: _dt.date | None = None
+    expiration_date: _dt.date | None = None
+    coverage_amount_cents: int | None = Field(None, ge=0)
+    notes: str | None = Field(None, max_length=5000)
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/mybookkeeper/backend/app/services/insurance/attachment_response_builder.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/attachment_response_builder.py
@@ -1,0 +1,35 @@
+"""Inject per-request presigned URLs for insurance-domain attachments.
+
+The single-seam rule (CLAUDE.md): presigned URLs for any object in the
+insurance domain are minted ONLY through this module.
+
+Storage is a hard requirement (the lifespan refuses to boot if MinIO is
+unreachable). Per-request signing is purely cryptographic and cannot fail
+under normal operation; any exception bubbles up so the request returns 500
+with a real stack trace, surfacing the misconfiguration loudly.
+"""
+from __future__ import annotations
+
+from app.core.config import settings
+from app.core.storage import get_storage
+from app.schemas.insurance.insurance_policy_attachment_response import (
+    InsurancePolicyAttachmentResponse,
+)
+
+
+def attach_presigned_urls(
+    attachments: list[InsurancePolicyAttachmentResponse],
+) -> list[InsurancePolicyAttachmentResponse]:
+    if not attachments:
+        return attachments
+    storage = get_storage()
+    return [
+        a.model_copy(
+            update={
+                "presigned_url": storage.generate_presigned_url(
+                    a.storage_key, settings.presigned_url_ttl_seconds
+                )
+            }
+        )
+        for a in attachments
+    ]

--- a/apps/mybookkeeper/backend/app/services/insurance/insurance_policy_service.py
+++ b/apps/mybookkeeper/backend/app/services/insurance/insurance_policy_service.py
@@ -1,0 +1,376 @@
+"""Service layer for insurance policies.
+
+Handles CRUD + attachment upload/delete for the insurance domain.
+
+All data access is through repositories; never imports SQLAlchemy in this
+module.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import uuid
+from typing import Any
+
+from app.core.config import settings as _settings
+from app.core.insurance_enums import INSURANCE_ATTACHMENT_KINDS
+from app.core.storage import get_storage
+from app.db.session import unit_of_work
+from app.repositories.insurance import (
+    insurance_policy_attachment_repo,
+    insurance_policy_repo,
+)
+from app.schemas.insurance.insurance_policy_attachment_response import (
+    InsurancePolicyAttachmentResponse,
+)
+from app.schemas.insurance.insurance_policy_list_response import (
+    InsurancePolicyListResponse,
+)
+from app.schemas.insurance.insurance_policy_response import InsurancePolicyResponse
+from app.schemas.insurance.insurance_policy_summary import InsurancePolicySummary
+from app.services.insurance.attachment_response_builder import attach_presigned_urls
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+class InsurancePolicyNotFoundError(LookupError):
+    pass
+
+
+class AttachmentNotFoundError(LookupError):
+    pass
+
+
+class AttachmentTooLargeError(ValueError):
+    pass
+
+
+class AttachmentTypeRejectedError(ValueError):
+    pass
+
+
+class InvalidAttachmentKindError(ValueError):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Allowed MIME types for insurance attachments.
+# ---------------------------------------------------------------------------
+
+ALLOWED_ATTACHMENT_MIME_TYPES: frozenset[str] = frozenset({
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "image/jpeg",
+    "image/png",
+    "image/webp",
+})
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _attachment_responses(
+    rows: list,
+) -> list[InsurancePolicyAttachmentResponse]:
+    return attach_presigned_urls(
+        [InsurancePolicyAttachmentResponse.model_validate(r) for r in rows],
+    )
+
+
+def _to_detail(policy, attachments: list) -> InsurancePolicyResponse:
+    return InsurancePolicyResponse(
+        id=policy.id,
+        user_id=policy.user_id,
+        organization_id=policy.organization_id,
+        listing_id=policy.listing_id,
+        policy_name=policy.policy_name,
+        carrier=policy.carrier,
+        policy_number=policy.policy_number,
+        effective_date=policy.effective_date,
+        expiration_date=policy.expiration_date,
+        coverage_amount_cents=policy.coverage_amount_cents,
+        notes=policy.notes,
+        created_at=policy.created_at,
+        updated_at=policy.updated_at,
+        attachments=_attachment_responses(attachments),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create
+# ---------------------------------------------------------------------------
+
+async def create_policy(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    listing_id: uuid.UUID,
+    policy_name: str,
+    carrier: str | None,
+    policy_number: str | None,
+    effective_date: _dt.date | None,
+    expiration_date: _dt.date | None,
+    coverage_amount_cents: int | None,
+    notes: str | None,
+) -> InsurancePolicyResponse:
+    async with unit_of_work() as db:
+        policy = await insurance_policy_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            listing_id=listing_id,
+            policy_name=policy_name,
+            carrier=carrier,
+            policy_number=policy_number,
+            effective_date=effective_date,
+            expiration_date=expiration_date,
+            coverage_amount_cents=coverage_amount_cents,
+            notes=notes,
+        )
+    return _to_detail(policy, [])
+
+
+# ---------------------------------------------------------------------------
+# List + get
+# ---------------------------------------------------------------------------
+
+async def list_policies(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    listing_id: uuid.UUID | None = None,
+    expiring_before: _dt.date | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> InsurancePolicyListResponse:
+    async with unit_of_work() as db:
+        rows = await insurance_policy_repo.list_for_org(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            listing_id=listing_id,
+            expiring_before=expiring_before,
+            limit=limit,
+            offset=offset,
+        )
+        total = await insurance_policy_repo.count_for_org(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            listing_id=listing_id,
+            expiring_before=expiring_before,
+        )
+    items = [InsurancePolicySummary.model_validate(r) for r in rows]
+    return InsurancePolicyListResponse(
+        items=items, total=total, has_more=(offset + len(items)) < total,
+    )
+
+
+async def get_policy(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    policy_id: uuid.UUID,
+) -> InsurancePolicyResponse:
+    async with unit_of_work() as db:
+        policy = await insurance_policy_repo.get(
+            db,
+            policy_id=policy_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if policy is None:
+            raise InsurancePolicyNotFoundError(f"Policy {policy_id} not found")
+        attachments = await insurance_policy_attachment_repo.list_by_policy(
+            db, policy.id,
+        )
+    return _to_detail(policy, attachments)
+
+
+# ---------------------------------------------------------------------------
+# Update
+# ---------------------------------------------------------------------------
+
+async def update_policy(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    policy_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> InsurancePolicyResponse:
+    async with unit_of_work() as db:
+        policy = await insurance_policy_repo.update_policy(
+            db,
+            policy_id=policy_id,
+            user_id=user_id,
+            organization_id=organization_id,
+            fields=fields,
+        )
+        if policy is None:
+            raise InsurancePolicyNotFoundError(f"Policy {policy_id} not found")
+        attachments = await insurance_policy_attachment_repo.list_by_policy(
+            db, policy_id,
+        )
+        # Re-load policy so we return updated values.
+        policy = await insurance_policy_repo.get(
+            db,
+            policy_id=policy_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+    return _to_detail(policy, attachments)
+
+
+# ---------------------------------------------------------------------------
+# Soft-delete
+# ---------------------------------------------------------------------------
+
+async def soft_delete_policy(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    policy_id: uuid.UUID,
+) -> None:
+    async with unit_of_work() as db:
+        policy = await insurance_policy_repo.get(
+            db,
+            policy_id=policy_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if policy is None:
+            raise InsurancePolicyNotFoundError(f"Policy {policy_id} not found")
+        await insurance_policy_repo.soft_delete(
+            db,
+            policy_id=policy_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Attachments
+# ---------------------------------------------------------------------------
+
+def _resolve_content_type(
+    content: bytes, filename: str, declared: str | None,
+) -> str | None:
+    """Return a validated MIME type or None if not in the allowlist."""
+    if declared and declared in ALLOWED_ATTACHMENT_MIME_TYPES:
+        return declared
+    lower = filename.lower()
+    ext_map = {
+        ".pdf": "application/pdf",
+        ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".png": "image/png",
+        ".webp": "image/webp",
+    }
+    for ext, ct in ext_map.items():
+        if lower.endswith(ext):
+            return ct
+    return None
+
+
+async def upload_attachment(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    policy_id: uuid.UUID,
+    content: bytes,
+    filename: str,
+    declared_content_type: str | None,
+    kind: str,
+) -> InsurancePolicyAttachmentResponse:
+    storage = get_storage()
+
+    if kind not in INSURANCE_ATTACHMENT_KINDS:
+        raise InvalidAttachmentKindError(f"Invalid kind: {kind}")
+
+    if len(content) > _settings.max_blackout_attachment_size_bytes:
+        max_mb = _settings.max_blackout_attachment_size_bytes // (1024 * 1024)
+        raise AttachmentTooLargeError(f"File exceeds {max_mb}MB limit")
+
+    ct = _resolve_content_type(content, filename, declared_content_type)
+    if ct is None:
+        raise AttachmentTypeRejectedError(
+            "Unsupported file type. Allowed: pdf, docx, jpg, png, webp",
+        )
+
+    # Tenant scope — 404 if policy doesn't belong to this org/user.
+    async with unit_of_work() as db:
+        policy = await insurance_policy_repo.get(
+            db,
+            policy_id=policy_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if policy is None:
+            raise InsurancePolicyNotFoundError(f"Policy {policy_id} not found")
+
+    attachment_id = uuid.uuid4()
+    storage_key = f"insurance-policies/{policy_id}/{attachment_id}"
+    storage.upload_file(storage_key, content, ct)
+
+    try:
+        async with unit_of_work() as db:
+            row = await insurance_policy_attachment_repo.create(
+                db,
+                policy_id=policy_id,
+                storage_key=storage_key,
+                filename=filename or f"attachment-{attachment_id.hex}",
+                content_type=ct,
+                size_bytes=len(content),
+                kind=kind,
+                uploaded_by_user_id=user_id,
+                uploaded_at=_dt.datetime.now(_dt.timezone.utc),
+            )
+            response = InsurancePolicyAttachmentResponse.model_validate(row)
+    except Exception:
+        try:
+            storage.delete_file(storage_key)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to clean up orphan insurance attachment %s", storage_key,
+            )
+        raise
+
+    return attach_presigned_urls([response])[0]
+
+
+async def delete_attachment(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    policy_id: uuid.UUID,
+    attachment_id: uuid.UUID,
+) -> None:
+    async with unit_of_work() as db:
+        # Tenant scope — 404 if policy doesn't belong to this org/user.
+        policy = await insurance_policy_repo.get(
+            db,
+            policy_id=policy_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if policy is None:
+            raise InsurancePolicyNotFoundError(f"Policy {policy_id} not found")
+        deleted = await insurance_policy_attachment_repo.delete_by_id_scoped_to_policy(
+            db, attachment_id, policy_id,
+        )
+        if deleted is None:
+            raise AttachmentNotFoundError(f"Attachment {attachment_id} not found")
+        storage_key = deleted.storage_key
+
+    storage = get_storage()
+    try:
+        storage.delete_file(storage_key)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to delete insurance attachment object %s",
+            storage_key, exc_info=True,
+        )

--- a/apps/mybookkeeper/backend/tests/test_insurance_policies_api.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_policies_api.py
@@ -1,0 +1,452 @@
+"""Route-level tests for the insurance policies API.
+
+Tenant-isolation tests at the API layer: cross-tenant access must surface as
+404. Service layer is mocked — deeper repo/model coverage lives in
+``test_insurance_policy_repo.py``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from io import BytesIO
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(
+        organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER,
+    )
+
+
+def _ok_policy_response(policy_id: uuid.UUID, org_id: uuid.UUID, user_id: uuid.UUID) -> dict:
+    """Build a minimal policy response payload."""
+    from app.schemas.insurance.insurance_policy_response import InsurancePolicyResponse
+    return InsurancePolicyResponse(
+        id=policy_id,
+        user_id=user_id,
+        organization_id=org_id,
+        listing_id=uuid.uuid4(),
+        policy_name="Landlord Insurance",
+        carrier="State Farm",
+        policy_number=None,
+        effective_date=_dt.date(2025, 1, 1),
+        expiration_date=_dt.date(2026, 1, 1),
+        coverage_amount_cents=50000000,
+        notes=None,
+        created_at=_dt.datetime.now(_dt.timezone.utc),
+        updated_at=_dt.datetime.now(_dt.timezone.utc),
+        attachments=[],
+    )
+
+
+def _ok_list_response(policies: list) -> dict:
+    from app.schemas.insurance.insurance_policy_list_response import InsurancePolicyListResponse
+    from app.schemas.insurance.insurance_policy_summary import InsurancePolicySummary
+    items = [InsurancePolicySummary.model_validate(p) for p in policies]
+    return InsurancePolicyListResponse(items=items, total=len(items), has_more=False)
+
+
+# ---------------------------------------------------------------------------
+# POST /insurance-policies
+# ---------------------------------------------------------------------------
+
+class TestCreateInsurancePolicy:
+    def test_happy_path(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.create_policy",
+                return_value=_ok_policy_response(policy_id, org_id, user_id),
+            ):
+                client = TestClient(app)
+                resp = client.post(
+                    "/insurance-policies",
+                    json={
+                        "listing_id": str(uuid.uuid4()),
+                        "policy_name": "Landlord Insurance",
+                        "carrier": "State Farm",
+                        "expiration_date": "2026-01-01",
+                    },
+                )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["policy_name"] == "Landlord Insurance"
+            assert body["carrier"] == "State Farm"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_extra_field_rejected(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                "/insurance-policies",
+                json={
+                    "listing_id": str(uuid.uuid4()),
+                    "policy_name": "Test",
+                    "UNKNOWN_FIELD": "hax",
+                },
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_missing_policy_name_rejected(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                "/insurance-policies",
+                json={"listing_id": str(uuid.uuid4())},  # missing policy_name
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_empty_policy_name_rejected(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                "/insurance-policies",
+                json={"listing_id": str(uuid.uuid4()), "policy_name": ""},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /insurance-policies
+# ---------------------------------------------------------------------------
+
+class TestListInsurancePolicies:
+    def test_happy_path(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.list_policies",
+                return_value=_ok_list_response([]),
+            ):
+                client = TestClient(app)
+                resp = client.get("/insurance-policies")
+            assert resp.status_code == 200, resp.text
+            body = resp.json()
+            assert "items" in body
+            assert body["total"] == 0
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_filter_by_listing_id(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        listing_id = uuid.uuid4()
+        app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.list_policies",
+                return_value=_ok_list_response([]),
+            ) as mock_list:
+                client = TestClient(app)
+                resp = client.get(
+                    "/insurance-policies",
+                    params={"listing_id": str(listing_id)},
+                )
+            assert resp.status_code == 200, resp.text
+            # Ensure listing_id was forwarded to the service.
+            call_kwargs = mock_list.call_args.kwargs
+            assert str(call_kwargs["listing_id"]) == str(listing_id)
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# GET /insurance-policies/{policy_id}
+# ---------------------------------------------------------------------------
+
+class TestGetInsurancePolicy:
+    def test_happy_path(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.get_policy",
+                return_value=_ok_policy_response(policy_id, org_id, user_id),
+            ):
+                client = TestClient(app)
+                resp = client.get(f"/insurance-policies/{policy_id}")
+            assert resp.status_code == 200, resp.text
+            assert resp.json()["id"] == str(policy_id)
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_cross_tenant_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+        try:
+            from app.services.insurance.insurance_policy_service import InsurancePolicyNotFoundError
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.get_policy",
+                side_effect=InsurancePolicyNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.get(f"/insurance-policies/{policy_id}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# PATCH /insurance-policies/{policy_id}
+# ---------------------------------------------------------------------------
+
+class TestUpdateInsurancePolicy:
+    def test_happy_path(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.update_policy",
+                return_value=_ok_policy_response(policy_id, org_id, user_id),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/insurance-policies/{policy_id}",
+                    json={"carrier": "Allstate"},
+                )
+            assert resp.status_code == 200, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_extra_field_rejected(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            resp = client.patch(
+                f"/insurance-policies/{policy_id}",
+                json={"UNKNOWN_FIELD": "hax"},
+            )
+            assert resp.status_code == 422, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_cross_tenant_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            from app.services.insurance.insurance_policy_service import InsurancePolicyNotFoundError
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.update_policy",
+                side_effect=InsurancePolicyNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/insurance-policies/{policy_id}",
+                    json={"carrier": "Allstate"},
+                )
+            assert resp.status_code == 404, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /insurance-policies/{policy_id}
+# ---------------------------------------------------------------------------
+
+class TestDeleteInsurancePolicy:
+    def test_happy_path(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.soft_delete_policy",
+                return_value=None,
+            ):
+                client = TestClient(app)
+                resp = client.delete(f"/insurance-policies/{policy_id}")
+            assert resp.status_code == 204, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_cross_tenant_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            from app.services.insurance.insurance_policy_service import InsurancePolicyNotFoundError
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.soft_delete_policy",
+                side_effect=InsurancePolicyNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.delete(f"/insurance-policies/{policy_id}")
+            assert resp.status_code == 404, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# POST /insurance-policies/{policy_id}/attachments
+# ---------------------------------------------------------------------------
+
+class TestUploadInsurancePolicyAttachment:
+    def _ok_attachment_response(self, policy_id: uuid.UUID) -> dict:
+        from app.schemas.insurance.insurance_policy_attachment_response import (
+            InsurancePolicyAttachmentResponse,
+        )
+        return InsurancePolicyAttachmentResponse(
+            id=uuid.uuid4(),
+            policy_id=policy_id,
+            filename="policy.pdf",
+            storage_key=f"insurance-policies/{policy_id}/test-attachment",
+            content_type="application/pdf",
+            size_bytes=1024,
+            kind="policy_document",
+            uploaded_by_user_id=uuid.uuid4(),
+            uploaded_at=_dt.datetime.now(_dt.timezone.utc),
+            presigned_url="https://signed/test",
+        )
+
+    def test_happy_path(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.upload_attachment",
+                return_value=self._ok_attachment_response(policy_id),
+            ):
+                client = TestClient(app)
+                resp = client.post(
+                    f"/insurance-policies/{policy_id}/attachments",
+                    data={"kind": "policy_document"},
+                    files={"file": ("policy.pdf", BytesIO(b"%PDF test"), "application/pdf")},
+                )
+            assert resp.status_code == 201, resp.text
+            body = resp.json()
+            assert body["kind"] == "policy_document"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_cross_tenant_policy_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            from app.services.insurance.insurance_policy_service import InsurancePolicyNotFoundError
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.upload_attachment",
+                side_effect=InsurancePolicyNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.post(
+                    f"/insurance-policies/{policy_id}/attachments",
+                    data={"kind": "policy_document"},
+                    files={"file": ("policy.pdf", BytesIO(b"%PDF test"), "application/pdf")},
+                )
+            assert resp.status_code == 404, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_too_large_returns_413(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            from app.services.insurance.insurance_policy_service import AttachmentTooLargeError
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.upload_attachment",
+                side_effect=AttachmentTooLargeError("too large"),
+            ):
+                client = TestClient(app)
+                resp = client.post(
+                    f"/insurance-policies/{policy_id}/attachments",
+                    data={"kind": "policy_document"},
+                    files={"file": ("policy.pdf", BytesIO(b"%PDF test"), "application/pdf")},
+                )
+            assert resp.status_code == 413, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_unsupported_type_returns_415(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            from app.services.insurance.insurance_policy_service import AttachmentTypeRejectedError
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.upload_attachment",
+                side_effect=AttachmentTypeRejectedError("unsupported"),
+            ):
+                client = TestClient(app)
+                resp = client.post(
+                    f"/insurance-policies/{policy_id}/attachments",
+                    data={"kind": "policy_document"},
+                    files={"file": ("policy.exe", BytesIO(b"exec"), "application/octet-stream")},
+                )
+            assert resp.status_code == 415, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# DELETE /insurance-policies/{policy_id}/attachments/{attachment_id}
+# ---------------------------------------------------------------------------
+
+class TestDeleteInsurancePolicyAttachment:
+    def test_happy_path(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        attachment_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.delete_attachment",
+                return_value=None,
+            ):
+                client = TestClient(app)
+                resp = client.delete(
+                    f"/insurance-policies/{policy_id}/attachments/{attachment_id}",
+                )
+            assert resp.status_code == 204, resp.text
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_cross_tenant_attachment_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        policy_id = uuid.uuid4()
+        attachment_id = uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            from app.services.insurance.insurance_policy_service import AttachmentNotFoundError
+            with patch(
+                "app.api.insurance_policies.insurance_policy_service.delete_attachment",
+                side_effect=AttachmentNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.delete(
+                    f"/insurance-policies/{policy_id}/attachments/{attachment_id}",
+                )
+            assert resp.status_code == 404, resp.text
+        finally:
+            app.dependency_overrides.clear()

--- a/apps/mybookkeeper/backend/tests/test_insurance_policy_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_insurance_policy_repo.py
@@ -1,0 +1,363 @@
+"""Repository-level tests for insurance policies.
+
+Uses the in-memory SQLite fixture from conftest.py. Tests model field coverage,
+CRUD operations, soft-delete, IDOR-safe attachment delete, and filtering.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.organization.organization import Organization
+from app.models.organization.organization_member import OrganizationMember
+from app.models.user.user import User
+from app.models.listings.listing import Listing
+from app.repositories.insurance import (
+    insurance_policy_attachment_repo,
+    insurance_policy_repo,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+async def _make_listing(db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID | None = None) -> Listing:
+    """Create a minimal Listing row in the test database."""
+    listing = Listing(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id or uuid.uuid4(),  # FK not enforced in SQLite test env
+        property_id=uuid.uuid4(),  # FK not enforced in SQLite test env
+        title="Test Listing",
+        slug=f"test-listing-{uuid.uuid4().hex[:6]}",
+        status="active",
+        room_type="private_room",
+        monthly_rate=1500.00,
+    )
+    db.add(listing)
+    await db.flush()
+    return listing
+
+
+# ---------------------------------------------------------------------------
+# Tests — InsurancePolicy CRUD
+# ---------------------------------------------------------------------------
+
+class TestInsurancePolicyRepo:
+    @pytest.mark.asyncio
+    async def test_create_and_get(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        policy = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Landlord Insurance",
+            carrier="State Farm",
+            policy_number="POL-123456",
+            effective_date=_dt.date(2025, 1, 1),
+            expiration_date=_dt.date(2026, 1, 1),
+            coverage_amount_cents=50000000,
+            notes="Annual renewal",
+        )
+        await db.commit()
+
+        fetched = await insurance_policy_repo.get(
+            db,
+            policy_id=policy.id,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+        )
+        assert fetched is not None
+        assert fetched.policy_name == "Landlord Insurance"
+        assert fetched.carrier == "State Farm"
+        assert fetched.coverage_amount_cents == 50000000
+
+    @pytest.mark.asyncio
+    async def test_list_for_org(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Policy A",
+        )
+        await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Policy B",
+        )
+        await db.commit()
+
+        policies = await insurance_policy_repo.list_for_org(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+        )
+        assert len(policies) == 2
+
+    @pytest.mark.asyncio
+    async def test_filter_by_listing_id(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing_a = await _make_listing(db, test_org.id, test_user.id)
+        listing_b = await _make_listing(db, test_org.id, test_user.id)
+        await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing_a.id,
+            policy_name="Policy for A",
+        )
+        await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing_b.id,
+            policy_name="Policy for B",
+        )
+        await db.commit()
+
+        policies = await insurance_policy_repo.list_for_org(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing_a.id,
+        )
+        assert len(policies) == 1
+        assert policies[0].policy_name == "Policy for A"
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_returns_none(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        policy = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Test Policy",
+        )
+        await db.commit()
+
+        # Try to fetch with wrong org_id — should return None.
+        other_org_id = uuid.uuid4()
+        fetched = await insurance_policy_repo.get(
+            db,
+            policy_id=policy.id,
+            user_id=test_user.id,
+            organization_id=other_org_id,
+        )
+        assert fetched is None
+
+    @pytest.mark.asyncio
+    async def test_update_policy_fields(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        policy = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Original Name",
+        )
+        await db.commit()
+
+        updated = await insurance_policy_repo.update_policy(
+            db,
+            policy_id=policy.id,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            fields={"carrier": "Allstate", "policy_name": "Updated Name"},
+        )
+        assert updated is not None
+        assert updated.carrier == "Allstate"
+        assert updated.policy_name == "Updated Name"
+
+    @pytest.mark.asyncio
+    async def test_soft_delete(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        policy = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Policy to Delete",
+        )
+        await db.commit()
+
+        deleted = await insurance_policy_repo.soft_delete(
+            db,
+            policy_id=policy.id,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+        )
+        assert deleted is True
+
+        # Should not be visible after soft delete.
+        fetched = await insurance_policy_repo.get(
+            db,
+            policy_id=policy.id,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+        )
+        assert fetched is None
+
+        # But visible with include_deleted=True.
+        fetched_deleted = await insurance_policy_repo.get(
+            db,
+            policy_id=policy.id,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            include_deleted=True,
+        )
+        assert fetched_deleted is not None
+        assert fetched_deleted.deleted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_soft_delete_cross_tenant_no_effect(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        policy = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Protected Policy",
+        )
+        await db.commit()
+
+        # Try to soft-delete with a different org_id — should return False.
+        deleted = await insurance_policy_repo.soft_delete(
+            db,
+            policy_id=policy.id,
+            user_id=test_user.id,
+            organization_id=uuid.uuid4(),  # wrong org
+        )
+        assert deleted is False
+
+        # Verify the policy is still there.
+        fetched = await insurance_policy_repo.get(
+            db,
+            policy_id=policy.id,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+        )
+        assert fetched is not None
+
+
+# ---------------------------------------------------------------------------
+# Tests — InsurancePolicyAttachment
+# ---------------------------------------------------------------------------
+
+class TestInsurancePolicyAttachmentRepo:
+    @pytest.mark.asyncio
+    async def test_create_and_list(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        policy = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Test",
+        )
+        await db.flush()
+
+        att = await insurance_policy_attachment_repo.create(
+            db,
+            policy_id=policy.id,
+            storage_key=f"insurance-policies/{policy.id}/test-att",
+            filename="policy.pdf",
+            content_type="application/pdf",
+            size_bytes=1024,
+            kind="policy_document",
+            uploaded_by_user_id=test_user.id,
+            uploaded_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        await db.commit()
+
+        attachments = await insurance_policy_attachment_repo.list_by_policy(
+            db, policy.id,
+        )
+        assert len(attachments) == 1
+        assert attachments[0].id == att.id
+        assert attachments[0].kind == "policy_document"
+
+    @pytest.mark.asyncio
+    async def test_idor_safe_delete_correct_policy(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        policy = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Test",
+        )
+        await db.flush()
+
+        att = await insurance_policy_attachment_repo.create(
+            db,
+            policy_id=policy.id,
+            storage_key=f"insurance-policies/{policy.id}/test-att",
+            filename="policy.pdf",
+            content_type="application/pdf",
+            size_bytes=1024,
+            kind="policy_document",
+            uploaded_by_user_id=test_user.id,
+            uploaded_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        await db.flush()
+
+        deleted = await insurance_policy_attachment_repo.delete_by_id_scoped_to_policy(
+            db, att.id, policy.id,
+        )
+        assert deleted is not None
+        assert deleted.id == att.id
+
+        remaining = await insurance_policy_attachment_repo.list_by_policy(db, policy.id)
+        assert len(remaining) == 0
+
+    @pytest.mark.asyncio
+    async def test_idor_safe_delete_wrong_policy_returns_none(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        listing = await _make_listing(db, test_org.id, test_user.id)
+        policy_a = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Policy A",
+        )
+        policy_b = await insurance_policy_repo.create(
+            db,
+            user_id=test_user.id,
+            organization_id=test_org.id,
+            listing_id=listing.id,
+            policy_name="Policy B",
+        )
+        await db.flush()
+
+        att = await insurance_policy_attachment_repo.create(
+            db,
+            policy_id=policy_a.id,
+            storage_key=f"insurance-policies/{policy_a.id}/att",
+            filename="policy.pdf",
+            content_type="application/pdf",
+            size_bytes=1024,
+            kind="policy_document",
+            uploaded_by_user_id=test_user.id,
+            uploaded_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        await db.flush()
+
+        # Pair att.id with the WRONG policy_id — should return None (IDOR guard).
+        result = await insurance_policy_attachment_repo.delete_by_id_scoped_to_policy(
+            db, att.id, policy_b.id,  # wrong policy
+        )
+        assert result is None
+
+        # Attachment should still exist.
+        remaining = await insurance_policy_attachment_repo.list_by_policy(db, policy_a.id)
+        assert len(remaining) == 1

--- a/apps/mybookkeeper/frontend/src/App.tsx
+++ b/apps/mybookkeeper/frontend/src/App.tsx
@@ -34,6 +34,8 @@ import LeaseTemplateDetail from "@/app/pages/LeaseTemplateDetail";
 import Vendors from "@/app/pages/Vendors";
 import VendorDetail from "@/app/pages/VendorDetail";
 import ReplyTemplates from "@/app/pages/ReplyTemplates";
+import InsurancePolicies from "@/app/pages/InsurancePolicies";
+import InsurancePolicyDetail from "@/app/pages/InsurancePolicyDetail";
 import TaxReport from "@/app/pages/TaxReport";
 import Integrations from "@/app/pages/Integrations";
 import Members from "@/app/pages/Members";
@@ -123,6 +125,8 @@ export default function App() {
               <Route path="lease-templates/:templateId" element={<LeaseTemplateDetail />} />
               <Route path="vendors" element={<Vendors />} />
               <Route path="vendors/:vendorId" element={<VendorDetail />} />
+              <Route path="insurance-policies" element={<InsurancePolicies />} />
+              <Route path="insurance-policies/:policyId" element={<InsurancePolicyDetail />} />
               <Route path="reply-templates" element={<ReplyTemplates />} />
               <Route path="reconciliation" element={<Reconciliation />} />
               <Route path="tax" element={<TaxReport />} />

--- a/apps/mybookkeeper/frontend/src/__tests__/InsuranceExpirationBadge.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InsuranceExpirationBadge.test.tsx
@@ -1,0 +1,126 @@
+/**
+ * Unit tests for InsuranceExpirationBadge.
+ *
+ * Verifies all badge states:
+ * - null expirationDate → nothing rendered
+ * - Past date → red "Expired" badge
+ * - Within 30 days → orange "Expires in N days" badge
+ * - Within 90 days → yellow "Expires in N days" badge
+ * - Beyond 90 days → nothing rendered
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
+import InsuranceExpirationBadge from "@/app/features/insurance/InsuranceExpirationBadge";
+
+/**
+ * Return an ISO date string N days from today (negative for past).
+ * We pin "today" so tests are stable regardless of when they run.
+ */
+function isoDateDaysFromNow(days: number): string {
+  const d = new Date(2026, 4, 3); // 2026-05-03 (pinned)
+  d.setDate(d.getDate() + days);
+  return d.toISOString().split("T")[0];
+}
+
+// Pin Date.now so differenceInDays is deterministic.
+const PINNED_NOW = new Date(2026, 4, 3).getTime(); // 2026-05-03 00:00:00 local
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(PINNED_NOW);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("InsuranceExpirationBadge — null / no expiry", () => {
+  it("renders nothing when expirationDate is null", () => {
+    const { container } = render(<InsuranceExpirationBadge expirationDate={null} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});
+
+describe("InsuranceExpirationBadge — expired", () => {
+  it("shows 'Expired' badge for a date in the past", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(-1)} />);
+    expect(screen.getByTestId("expiration-badge-expired")).toBeInTheDocument();
+    expect(screen.getByText("Expired")).toBeInTheDocument();
+  });
+
+  it("shows 'Expired' badge for a date 30 days in the past", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(-30)} />);
+    expect(screen.getByTestId("expiration-badge-expired")).toBeInTheDocument();
+  });
+
+  it("'Expired' badge has destructive colour class", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(-1)} />);
+    const badge = screen.getByTestId("expiration-badge-expired");
+    expect(badge.className).toMatch(/bg-destructive/);
+    expect(badge.className).toMatch(/text-destructive/);
+  });
+});
+
+describe("InsuranceExpirationBadge — soon (≤30 days)", () => {
+  it("shows 'Expires in N days' badge for a date exactly 30 days away", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(30)} />);
+    expect(screen.getByTestId("expiration-badge-soon")).toBeInTheDocument();
+    expect(screen.getByText(/Expires in 30 days/)).toBeInTheDocument();
+  });
+
+  it("shows 'Expires in N days' badge for a date 15 days away", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(15)} />);
+    expect(screen.getByTestId("expiration-badge-soon")).toBeInTheDocument();
+    expect(screen.getByText(/Expires in 15 days/)).toBeInTheDocument();
+  });
+
+  it("shows singular 'day' when exactly 1 day away", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(1)} />);
+    expect(screen.getByTestId("expiration-badge-soon")).toBeInTheDocument();
+    expect(screen.getByText("Expires in 1 day")).toBeInTheDocument();
+  });
+
+  it("'soon' badge has orange colour classes", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(15)} />);
+    const badge = screen.getByTestId("expiration-badge-soon");
+    expect(badge.className).toMatch(/bg-orange-100/);
+    expect(badge.className).toMatch(/text-orange-700/);
+  });
+});
+
+describe("InsuranceExpirationBadge — upcoming (31–90 days)", () => {
+  it("shows 'Expires in N days' badge for a date 31 days away", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(31)} />);
+    expect(screen.getByTestId("expiration-badge-upcoming")).toBeInTheDocument();
+    expect(screen.getByText(/Expires in 31 days/)).toBeInTheDocument();
+  });
+
+  it("shows 'Expires in N days' badge for a date exactly 90 days away", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(90)} />);
+    expect(screen.getByTestId("expiration-badge-upcoming")).toBeInTheDocument();
+    expect(screen.getByText(/Expires in 90 days/)).toBeInTheDocument();
+  });
+
+  it("'upcoming' badge has yellow colour classes", () => {
+    render(<InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(60)} />);
+    const badge = screen.getByTestId("expiration-badge-upcoming");
+    expect(badge.className).toMatch(/bg-yellow-100/);
+    expect(badge.className).toMatch(/text-yellow-700/);
+  });
+});
+
+describe("InsuranceExpirationBadge — far future (>90 days)", () => {
+  it("renders nothing for a date 91 days away", () => {
+    const { container } = render(
+      <InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(91)} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing for a date 365 days away", () => {
+    const { container } = render(
+      <InsuranceExpirationBadge expirationDate={isoDateDaysFromNow(365)} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/InsurancePolicies.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InsurancePolicies.test.tsx
@@ -1,0 +1,218 @@
+/**
+ * Unit tests for the InsurancePolicies all-policies list page.
+ *
+ * Verifies:
+ * - Loading skeleton while query is in-flight
+ * - Error state with retry
+ * - Empty state (all policies)
+ * - Empty state (expiring-soon filter active)
+ * - Policy list renders names, carriers, expiration badge
+ * - "Show expiring soon" checkbox toggle changes query params
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { store } from "@/shared/store";
+import InsurancePolicies from "@/app/pages/InsurancePolicies";
+import type { InsurancePolicySummary } from "@/shared/types/insurance/insurance-policy-summary";
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockRefetch = vi.fn();
+let mockIsLoading = false;
+let mockIsError = false;
+let mockIsFetching = false;
+let mockPolicies: InsurancePolicySummary[] = [];
+
+vi.mock("@/shared/store/insurancePoliciesApi", () => ({
+  useGetInsurancePoliciesQuery: vi.fn(() => ({
+    data: { items: mockPolicies, total: mockPolicies.length, has_more: false },
+    isLoading: mockIsLoading,
+    isError: mockIsError,
+    isFetching: mockIsFetching,
+    refetch: mockRefetch,
+  })),
+}));
+
+vi.mock("@/shared/hooks/useOrgRole", () => ({
+  useCanWrite: vi.fn(() => true),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+const POLICY_A: InsurancePolicySummary = {
+  id: "pol-a",
+  listing_id: "listing-1",
+  policy_name: "Landlord Insurance",
+  carrier: "State Farm",
+  effective_date: "2025-01-01",
+  expiration_date: "2027-01-01",
+  coverage_amount_cents: 50000000,
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+const POLICY_B: InsurancePolicySummary = {
+  id: "pol-b",
+  listing_id: "listing-2",
+  policy_name: "Short-Term Rental Coverage",
+  carrier: "Allstate",
+  effective_date: "2024-06-01",
+  expiration_date: new Date(Date.now() + 10 * 86400000).toISOString().split("T")[0], // expiring in 10 days
+  coverage_amount_cents: null,
+  created_at: "2024-06-01T00:00:00Z",
+  updated_at: "2024-06-01T00:00:00Z",
+};
+
+// ── Render helper ────────────────────────────────────────────────────────────
+
+function renderPage() {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/insurance-policies"]}>
+        <Routes>
+          <Route path="/insurance-policies" element={<InsurancePolicies />} />
+          <Route path="/insurance-policies/:policyId" element={<div>Detail page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("InsurancePolicies page — loading state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = true;
+    mockIsError = false;
+    mockIsFetching = false;
+    mockPolicies = [];
+  });
+
+  it("renders a loading skeleton with aria-busy", () => {
+    renderPage();
+    expect(screen.getByTestId("insurance-policies-loading")).toBeInTheDocument();
+    expect(screen.getByTestId("insurance-policies-loading")).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("does not show the empty state or list during load", () => {
+    renderPage();
+    expect(screen.queryByTestId("insurance-policies-empty")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("insurance-policies-list")).not.toBeInTheDocument();
+  });
+});
+
+describe("InsurancePolicies page — error state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = true;
+    mockIsFetching = false;
+    mockPolicies = [];
+  });
+
+  it("renders an error alert with retry action", () => {
+    renderPage();
+    expect(screen.getByText(/couldn't load insurance policies/i)).toBeInTheDocument();
+    expect(screen.getByText(/retry/i)).toBeInTheDocument();
+  });
+
+  it("calls refetch on retry click", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByText(/retry/i));
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+});
+
+describe("InsurancePolicies page — empty state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockIsFetching = false;
+    mockPolicies = [];
+  });
+
+  it("renders the generic empty message when no filter is active", () => {
+    renderPage();
+    expect(screen.getByTestId("insurance-policies-empty")).toBeInTheDocument();
+    expect(screen.getByText(/no policies on this listing yet/i)).toBeInTheDocument();
+  });
+});
+
+describe("InsurancePolicies page — policy list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockIsFetching = false;
+    mockPolicies = [POLICY_A, POLICY_B];
+  });
+
+  it("renders all policy names", () => {
+    renderPage();
+    expect(screen.getByText("Landlord Insurance")).toBeInTheDocument();
+    expect(screen.getByText("Short-Term Rental Coverage")).toBeInTheDocument();
+  });
+
+  it("policy name links to the detail page", () => {
+    renderPage();
+    const link = screen.getByTestId("insurance-policy-item-pol-a");
+    expect(link).toHaveAttribute("href", "/insurance-policies/pol-a");
+  });
+
+  it("renders the carrier as secondary text", () => {
+    renderPage();
+    expect(screen.getByText("State Farm")).toBeInTheDocument();
+    expect(screen.getByText("Allstate")).toBeInTheDocument();
+  });
+
+  it("renders the expiration badge for a soon-expiring policy", () => {
+    renderPage();
+    // POLICY_B expires in 10 days → badge-soon
+    expect(screen.getByTestId("expiration-badge-soon")).toBeInTheDocument();
+  });
+});
+
+describe("InsurancePolicies page — expiring-soon toggle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockIsFetching = false;
+    mockPolicies = [];
+  });
+
+  it("renders the 'Show expiring within 30 days' checkbox unchecked by default", () => {
+    renderPage();
+    const checkbox = screen.getByTestId("expiring-soon-toggle");
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it("checkbox can be toggled on", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const checkbox = screen.getByTestId("expiring-soon-toggle");
+    await user.click(checkbox);
+    expect(checkbox).toBeChecked();
+  });
+
+  it("shows the 'no policies expiring within 30 days' message when filter is active and list is empty", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const checkbox = screen.getByTestId("expiring-soon-toggle");
+    await user.click(checkbox);
+    await waitFor(() => {
+      expect(screen.getByText(/no policies expiring within 30 days/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/InsurancePolicyDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InsurancePolicyDetail.test.tsx
@@ -1,0 +1,278 @@
+/**
+ * Unit tests for the InsurancePolicyDetail page.
+ *
+ * Verifies:
+ * - Skeleton rendered while loading
+ * - Error state with retry
+ * - Policy details display (policy number, coverage, dates, notes)
+ * - Expiration badge rendered
+ * - Delete button visibility gated on canWrite
+ * - Delete confirm dialog + successful delete navigates away
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { store } from "@/shared/store";
+import InsurancePolicyDetail from "@/app/pages/InsurancePolicyDetail";
+import type { InsurancePolicyDetail as PolicyDetailType } from "@/shared/types/insurance/insurance-policy-detail";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockRefetch = vi.fn();
+let mockIsLoading = false;
+let mockIsError = false;
+let mockIsFetching = false;
+let mockPolicy: PolicyDetailType | undefined;
+
+const deleteMock = vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) }));
+let mockIsDeleting = false;
+
+vi.mock("@/shared/store/insurancePoliciesApi", () => ({
+  useGetInsurancePolicyByIdQuery: vi.fn(() => ({
+    data: mockPolicy,
+    isLoading: mockIsLoading,
+    isError: mockIsError,
+    isFetching: mockIsFetching,
+    refetch: mockRefetch,
+  })),
+  useDeleteInsurancePolicyMutation: vi.fn(() => [deleteMock, { isLoading: mockIsDeleting }]),
+  useUploadInsurancePolicyAttachmentMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useDeleteInsurancePolicyAttachmentMutation: vi.fn(() => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })),
+    { isLoading: false },
+  ]),
+}));
+
+let mockCanWrite = true;
+vi.mock("@/shared/hooks/useOrgRole", () => ({
+  useCanWrite: vi.fn(() => mockCanWrite),
+}));
+
+const showSuccessMock = vi.fn();
+const showErrorMock = vi.fn();
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: (msg: string) => showErrorMock(msg),
+  showSuccess: (msg: string) => showSuccessMock(msg),
+}));
+
+// ── Test data ────────────────────────────────────────────────────────────────
+
+const POLICY: PolicyDetailType = {
+  id: "policy-abc",
+  user_id: "user-1",
+  organization_id: "org-1",
+  listing_id: "listing-1",
+  policy_name: "Landlord Insurance",
+  carrier: "State Farm",
+  policy_number: "POL-12345",
+  effective_date: "2025-01-01",
+  expiration_date: "2026-01-01",
+  coverage_amount_cents: 50000000,
+  notes: "Annual renewal reminder set.",
+  attachments: [],
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+// ── Render helper ─────────────────────────────────────────────────────────────
+
+function renderPage() {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/insurance-policies/policy-abc"]}>
+        <Routes>
+          <Route
+            path="/insurance-policies/:policyId"
+            element={<InsurancePolicyDetail />}
+          />
+          <Route
+            path="/insurance-policies"
+            element={<div data-testid="insurance-policies-page">All Policies</div>}
+          />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("InsurancePolicyDetail — loading state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = true;
+    mockIsError = false;
+    mockIsFetching = false;
+    mockPolicy = undefined;
+    mockCanWrite = true;
+  });
+
+  it("renders the skeleton while loading", () => {
+    renderPage();
+    expect(screen.getByTestId("insurance-policy-detail-skeleton")).toBeInTheDocument();
+  });
+
+  it("does not render policy details while loading", () => {
+    renderPage();
+    expect(screen.queryByTestId("insurance-policy-details")).not.toBeInTheDocument();
+  });
+});
+
+describe("InsurancePolicyDetail — error state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = true;
+    mockIsFetching = false;
+    mockPolicy = undefined;
+    mockCanWrite = true;
+  });
+
+  it("renders the error alert", () => {
+    renderPage();
+    expect(screen.getByText(/couldn't load this policy/i)).toBeInTheDocument();
+  });
+
+  it("retry button calls refetch", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+});
+
+describe("InsurancePolicyDetail — loaded state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockIsFetching = false;
+    mockPolicy = POLICY;
+    mockCanWrite = true;
+  });
+
+  it("renders the policy name as the page title", () => {
+    renderPage();
+    expect(screen.getByText("Landlord Insurance")).toBeInTheDocument();
+  });
+
+  it("renders the carrier name", () => {
+    renderPage();
+    expect(screen.getByText("State Farm")).toBeInTheDocument();
+  });
+
+  it("renders the policy number", () => {
+    renderPage();
+    expect(screen.getByTestId("insurance-policy-number")).toHaveTextContent("POL-12345");
+  });
+
+  it("formats coverage amount from cents to USD", () => {
+    renderPage();
+    // $500,000 from 50000000 cents
+    expect(screen.getByTestId("insurance-coverage-amount")).toHaveTextContent("$500,000");
+  });
+
+  it("formats effective and expiration dates as MM/DD/YYYY", () => {
+    renderPage();
+    expect(screen.getByTestId("insurance-effective-date")).toHaveTextContent("01/01/2025");
+    expect(screen.getByTestId("insurance-expiration-date")).toHaveTextContent("01/01/2026");
+  });
+
+  it("renders notes when present", () => {
+    renderPage();
+    expect(screen.getByTestId("insurance-notes")).toHaveTextContent(
+      "Annual renewal reminder set.",
+    );
+  });
+
+  it("renders 'Back to insurance policies' navigation link", () => {
+    renderPage();
+    const link = screen.getByRole("link", { name: /back to insurance policies/i });
+    expect(link).toHaveAttribute("href", "/insurance-policies");
+  });
+});
+
+describe("InsurancePolicyDetail — delete flow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockIsFetching = false;
+    mockPolicy = POLICY;
+    mockCanWrite = true;
+    mockIsDeleting = false;
+  });
+
+  it("shows the Delete button when canWrite=true", () => {
+    renderPage();
+    expect(screen.getByTestId("delete-insurance-policy-button")).toBeInTheDocument();
+  });
+
+  it("does not show the Delete button when canWrite=false", () => {
+    mockCanWrite = false;
+    renderPage();
+    expect(screen.queryByTestId("delete-insurance-policy-button")).not.toBeInTheDocument();
+  });
+
+  it("clicking Delete opens the confirm dialog", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByTestId("delete-insurance-policy-button"));
+    expect(screen.getByTestId("delete-insurance-policy-confirm")).toBeInTheDocument();
+  });
+
+  it("Cancel dismisses the confirm dialog without deleting", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByTestId("delete-insurance-policy-button"));
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(screen.queryByTestId("delete-insurance-policy-confirm")).not.toBeInTheDocument();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it("confirms delete, calls mutation, shows success toast, navigates to list", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    await user.click(screen.getByTestId("delete-insurance-policy-button"));
+    await user.click(screen.getByTestId("confirm-delete-insurance-policy"));
+    await waitFor(() => {
+      expect(deleteMock).toHaveBeenCalledWith("policy-abc");
+    });
+    await waitFor(() => {
+      expect(showSuccessMock).toHaveBeenCalledWith("Insurance policy deleted.");
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("insurance-policies-page")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("InsurancePolicyDetail — coverage edge cases", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockIsFetching = false;
+    mockCanWrite = true;
+  });
+
+  it("shows '—' when coverage_amount_cents is null", () => {
+    mockPolicy = { ...POLICY, coverage_amount_cents: null };
+    renderPage();
+    expect(screen.getByTestId("insurance-coverage-amount")).toHaveTextContent("—");
+  });
+
+  it("shows '—' for effective_date when null", () => {
+    mockPolicy = { ...POLICY, effective_date: null };
+    renderPage();
+    expect(screen.getByTestId("insurance-effective-date")).toHaveTextContent("—");
+  });
+
+  it("does not render notes section when notes is null", () => {
+    mockPolicy = { ...POLICY, notes: null };
+    renderPage();
+    expect(screen.queryByTestId("insurance-notes")).not.toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/ListingInsuranceSection.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/ListingInsuranceSection.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for ListingInsuranceSection.
+ *
+ * Verifies:
+ * - Loading skeleton while query is in-flight
+ * - Error state when query fails
+ * - Empty state when no policies exist for the listing
+ * - Policy list when data is returned
+ * - "Add policy" button shown only when canWrite=true
+ * - "Add policy" button hidden when canWrite=false
+ * - ExpiratingBadge is rendered for policies with expiration_date
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import ListingInsuranceSection from "@/app/features/insurance/ListingInsuranceSection";
+import type { InsurancePolicySummary } from "@/shared/types/insurance/insurance-policy-summary";
+
+// Mock the API hook
+let mockIsLoading = false;
+let mockIsError = false;
+let mockPolicies: InsurancePolicySummary[] = [];
+
+vi.mock("@/shared/store/insurancePoliciesApi", () => ({
+  useGetInsurancePoliciesQuery: vi.fn(() => ({
+    data: { items: mockPolicies, total: mockPolicies.length, has_more: false },
+    isLoading: mockIsLoading,
+    isError: mockIsError,
+  })),
+  useCreateInsurancePolicyMutation: vi.fn(() => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve({}) })),
+    { isLoading: false },
+  ]),
+}));
+
+const POLICY_ACTIVE: InsurancePolicySummary = {
+  id: "policy-1",
+  listing_id: "listing-1",
+  policy_name: "Landlord Insurance",
+  carrier: "State Farm",
+  effective_date: "2025-01-01",
+  expiration_date: "2026-12-31",
+  coverage_amount_cents: 50000000,
+  created_at: "2025-01-01T00:00:00Z",
+  updated_at: "2025-01-01T00:00:00Z",
+};
+
+const POLICY_EXPIRING_SOON: InsurancePolicySummary = {
+  id: "policy-2",
+  listing_id: "listing-1",
+  policy_name: "Short-Term Rental Coverage",
+  carrier: "Allstate",
+  effective_date: "2025-06-01",
+  expiration_date: new Date(Date.now() + 10 * 86400000).toISOString().split("T")[0],
+  coverage_amount_cents: null,
+  created_at: "2025-06-01T00:00:00Z",
+  updated_at: "2025-06-01T00:00:00Z",
+};
+
+function renderSection(overrides: { canWrite?: boolean } = {}) {
+  return render(
+    <MemoryRouter>
+      <ListingInsuranceSection
+        listingId="listing-1"
+        canWrite={overrides.canWrite ?? true}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("ListingInsuranceSection — loading state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = true;
+    mockIsError = false;
+    mockPolicies = [];
+  });
+
+  it("renders a loading skeleton with aria-busy", () => {
+    renderSection();
+    expect(screen.getByTestId("listing-insurance-loading")).toBeInTheDocument();
+    expect(screen.getByTestId("listing-insurance-loading")).toHaveAttribute("aria-busy", "true");
+  });
+
+  it("does not render the policy list or empty state while loading", () => {
+    renderSection();
+    expect(screen.queryByTestId("listing-insurance-list")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("listing-insurance-empty")).not.toBeInTheDocument();
+  });
+});
+
+describe("ListingInsuranceSection — error state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = true;
+    mockPolicies = [];
+  });
+
+  it("renders the error message", () => {
+    renderSection();
+    expect(screen.getByTestId("listing-insurance-error")).toBeInTheDocument();
+    expect(screen.getByText(/couldn't load insurance policies/i)).toBeInTheDocument();
+  });
+});
+
+describe("ListingInsuranceSection — empty state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockPolicies = [];
+  });
+
+  it("renders the empty state message when no policies", () => {
+    renderSection();
+    expect(screen.getByTestId("listing-insurance-empty")).toBeInTheDocument();
+    expect(screen.getByText(/no policies on this listing yet/i)).toBeInTheDocument();
+  });
+
+  it("does not render the list", () => {
+    renderSection();
+    expect(screen.queryByTestId("listing-insurance-list")).not.toBeInTheDocument();
+  });
+});
+
+describe("ListingInsuranceSection — policy list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockPolicies = [POLICY_ACTIVE, POLICY_EXPIRING_SOON];
+  });
+
+  it("renders all policy names", () => {
+    renderSection();
+    expect(screen.getByText("Landlord Insurance")).toBeInTheDocument();
+    expect(screen.getByText("Short-Term Rental Coverage")).toBeInTheDocument();
+  });
+
+  it("renders carrier names as secondary text", () => {
+    renderSection();
+    expect(screen.getByText("State Farm")).toBeInTheDocument();
+    expect(screen.getByText("Allstate")).toBeInTheDocument();
+  });
+
+  it("policy name is a link to the detail page", () => {
+    renderSection();
+    const link = screen.getByTestId("insurance-policy-link-policy-1");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/insurance-policies/policy-1");
+  });
+
+  it("renders the expiration badge for expiring-soon policy", () => {
+    renderSection();
+    // The expiring-soon policy has expiry within 10 days → badge-soon
+    expect(screen.getByTestId("expiration-badge-soon")).toBeInTheDocument();
+  });
+});
+
+describe("ListingInsuranceSection — Add policy button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockPolicies = [];
+  });
+
+  it("renders the 'Add policy' button when canWrite=true", () => {
+    renderSection({ canWrite: true });
+    expect(screen.getByTestId("add-insurance-policy-button")).toBeInTheDocument();
+  });
+
+  it("does not render the 'Add policy' button when canWrite=false", () => {
+    renderSection({ canWrite: false });
+    expect(screen.queryByTestId("add-insurance-policy-button")).not.toBeInTheDocument();
+  });
+
+  it("opens AddInsurancePolicyDialog on button click", async () => {
+    const user = userEvent.setup();
+    renderSection({ canWrite: true });
+    await user.click(screen.getByTestId("add-insurance-policy-button"));
+    // Dialog is rendered — look for a recognizable element inside it
+    await waitFor(() => {
+      expect(screen.getByTestId("add-insurance-policy-dialog")).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/AddInsurancePolicyDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/AddInsurancePolicyDialog.tsx
@@ -1,0 +1,180 @@
+import { useState } from "react";
+import { X } from "lucide-react";
+import FormField from "@/shared/components/ui/FormField";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import Button from "@/shared/components/ui/Button";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useCreateInsurancePolicyMutation } from "@/shared/store/insurancePoliciesApi";
+
+interface Props {
+  listingId: string;
+  onClose: () => void;
+}
+
+/**
+ * Modal dialog for creating a new insurance policy on a listing.
+ */
+export default function AddInsurancePolicyDialog({ listingId, onClose }: Props) {
+  const [createPolicy, { isLoading }] = useCreateInsurancePolicyMutation();
+
+  const [policyName, setPolicyName] = useState("");
+  const [carrier, setCarrier] = useState("");
+  const [policyNumber, setPolicyNumber] = useState("");
+  const [effectiveDate, setEffectiveDate] = useState("");
+  const [expirationDate, setExpirationDate] = useState("");
+  const [coverageDollars, setCoverageDollars] = useState("");
+  const [notes, setNotes] = useState("");
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!policyName.trim()) {
+      showError("Policy name is required.");
+      return;
+    }
+
+    const coverageCents =
+      coverageDollars !== "" && coverageDollars !== "0"
+        ? Math.round(parseFloat(coverageDollars) * 100)
+        : null;
+
+    try {
+      await createPolicy({
+        listing_id: listingId,
+        policy_name: policyName.trim(),
+        carrier: carrier.trim() || null,
+        policy_number: policyNumber.trim() || null,
+        effective_date: effectiveDate || null,
+        expiration_date: expirationDate || null,
+        coverage_amount_cents: coverageCents,
+        notes: notes.trim() || null,
+      }).unwrap();
+      showSuccess("Insurance policy added.");
+      onClose();
+    } catch {
+      showError("Couldn't save the policy. Please try again.");
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+      data-testid="add-insurance-policy-dialog"
+    >
+      <div className="bg-background rounded-lg shadow-lg w-full max-w-lg max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between px-5 pt-5 pb-3 border-b">
+          <h2 className="text-base font-semibold">Add insurance policy</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground min-h-[44px] min-w-[44px] flex items-center justify-center"
+            aria-label="Close"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={(e) => void handleSubmit(e)} className="p-5 space-y-4">
+          <FormField label="Policy name" required>
+            <input
+              type="text"
+              value={policyName}
+              onChange={(e) => setPolicyName(e.target.value)}
+              placeholder="e.g. Landlord Insurance — 123 Main St"
+              className="w-full px-3 py-2 text-sm border rounded-md"
+              maxLength={255}
+              required
+              data-testid="insurance-policy-name-input"
+            />
+          </FormField>
+
+          <FormField label="Carrier">
+            <input
+              type="text"
+              value={carrier}
+              onChange={(e) => setCarrier(e.target.value)}
+              placeholder="e.g. State Farm"
+              className="w-full px-3 py-2 text-sm border rounded-md"
+              maxLength={255}
+              data-testid="insurance-carrier-input"
+            />
+          </FormField>
+
+          <FormField label="Policy number">
+            <input
+              type="text"
+              value={policyNumber}
+              onChange={(e) => setPolicyNumber(e.target.value)}
+              placeholder="e.g. POL-123456"
+              className="w-full px-3 py-2 text-sm border rounded-md"
+              maxLength={255}
+              data-testid="insurance-policy-number-input"
+            />
+          </FormField>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <FormField label="Effective date">
+              <input
+                type="date"
+                value={effectiveDate}
+                onChange={(e) => setEffectiveDate(e.target.value)}
+                className="w-full px-3 py-2 text-sm border rounded-md"
+                data-testid="insurance-effective-date-input"
+              />
+            </FormField>
+
+            <FormField label="Expiration date">
+              <input
+                type="date"
+                value={expirationDate}
+                onChange={(e) => setExpirationDate(e.target.value)}
+                className="w-full px-3 py-2 text-sm border rounded-md"
+                data-testid="insurance-expiration-date-input"
+              />
+            </FormField>
+          </div>
+
+          <FormField label="Coverage amount (USD)">
+            <input
+              type="number"
+              value={coverageDollars}
+              onChange={(e) => setCoverageDollars(e.target.value)}
+              placeholder="e.g. 500000"
+              min="0"
+              step="1"
+              className="w-full px-3 py-2 text-sm border rounded-md"
+              data-testid="insurance-coverage-input"
+            />
+          </FormField>
+
+          <FormField label="Notes">
+            <textarea
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              placeholder="Any additional notes about this policy..."
+              className="w-full px-3 py-2 text-sm border rounded-md resize-none"
+              rows={3}
+              maxLength={5000}
+              data-testid="insurance-notes-input"
+            />
+          </FormField>
+
+          <div className="flex gap-3 pt-2 justify-end">
+            <Button type="button" variant="secondary" size="md" onClick={onClose}>
+              Cancel
+            </Button>
+            <LoadingButton
+              type="submit"
+              variant="primary"
+              size="md"
+              isLoading={isLoading}
+              loadingText="Saving..."
+              data-testid="insurance-policy-save-button"
+            >
+              Save policy
+            </LoadingButton>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceExpirationBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceExpirationBadge.tsx
@@ -1,0 +1,56 @@
+import { differenceInDays, parseISO } from "date-fns";
+
+interface Props {
+  expirationDate: string | null;
+}
+
+/**
+ * Badge that surfaces upcoming and past insurance policy expirations.
+ *
+ * - Past due → red "Expired"
+ * - Within 30 days → amber "Expires in N days"
+ * - Within 90 days → yellow "Expires in N days"
+ * - Beyond → nothing rendered
+ */
+export default function InsuranceExpirationBadge({ expirationDate }: Props) {
+  if (!expirationDate) return null;
+
+  const today = new Date();
+  const expiry = parseISO(expirationDate);
+  const daysUntil = differenceInDays(expiry, today);
+
+  if (daysUntil < 0) {
+    return (
+      <span
+        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-destructive/10 text-destructive"
+        data-testid="expiration-badge-expired"
+      >
+        Expired
+      </span>
+    );
+  }
+
+  if (daysUntil <= 30) {
+    return (
+      <span
+        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-orange-100 text-orange-700"
+        data-testid="expiration-badge-soon"
+      >
+        Expires in {daysUntil} day{daysUntil === 1 ? "" : "s"}
+      </span>
+    );
+  }
+
+  if (daysUntil <= 90) {
+    return (
+      <span
+        className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-yellow-100 text-yellow-700"
+        data-testid="expiration-badge-upcoming"
+      >
+        Expires in {daysUntil} days
+      </span>
+    );
+  }
+
+  return null;
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentRow.tsx
@@ -1,0 +1,80 @@
+import { Download, Trash2 } from "lucide-react";
+import {
+  INSURANCE_ATTACHMENT_KINDS,
+  INSURANCE_ATTACHMENT_KIND_LABELS,
+  type InsuranceAttachmentKind,
+} from "@/shared/types/insurance/insurance-attachment-kind";
+import type { InsurancePolicyAttachment } from "@/shared/types/insurance/insurance-policy-attachment";
+
+interface Props {
+  att: InsurancePolicyAttachment;
+  canWrite: boolean;
+  onPreview: () => void;
+  onDelete: () => void;
+}
+
+export default function InsurancePolicyAttachmentRow({
+  att,
+  canWrite,
+  onPreview,
+  onDelete,
+}: Props) {
+  const canPreview =
+    att.presigned_url !== null &&
+    (att.content_type === "application/pdf" || att.content_type.startsWith("image/"));
+
+  return (
+    <li
+      className="border rounded-md px-3 py-2 text-sm space-y-1"
+      data-testid={`insurance-attachment-${att.id}`}
+    >
+      <div className="flex items-center justify-between gap-2">
+        {canPreview ? (
+          <button
+            type="button"
+            onClick={onPreview}
+            className="truncate text-left text-primary hover:underline font-medium min-w-0"
+            data-testid={`insurance-attachment-preview-${att.id}`}
+            title={att.filename}
+          >
+            {att.filename}
+          </button>
+        ) : (
+          <span className="truncate text-muted-foreground min-w-0" title={att.filename}>
+            {att.filename}
+          </span>
+        )}
+
+        <div className="flex items-center gap-2 shrink-0">
+          {att.presigned_url ? (
+            <a
+              href={att.presigned_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-foreground"
+              aria-label={`Download ${att.filename}`}
+              data-testid={`insurance-attachment-download-${att.id}`}
+            >
+              <Download size={14} />
+            </a>
+          ) : null}
+          {canWrite ? (
+            <button
+              type="button"
+              onClick={onDelete}
+              className="text-muted-foreground hover:text-destructive min-h-[44px] min-w-[44px] flex items-center justify-center"
+              aria-label={`Delete ${att.filename}`}
+              data-testid={`insurance-attachment-delete-${att.id}`}
+            >
+              <Trash2 size={14} />
+            </button>
+          ) : null}
+        </div>
+      </div>
+
+      <span className="text-xs text-muted-foreground">
+        {INSURANCE_ATTACHMENT_KIND_LABELS[att.kind as InsuranceAttachmentKind] ?? att.kind}
+      </span>
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentsSection.tsx
@@ -1,0 +1,189 @@
+import { useRef, useState } from "react";
+import { Loader2, Upload } from "lucide-react";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import {
+  INSURANCE_ATTACHMENT_KINDS,
+  INSURANCE_ATTACHMENT_KIND_LABELS,
+  type InsuranceAttachmentKind,
+} from "@/shared/types/insurance/insurance-attachment-kind";
+import {
+  useDeleteInsurancePolicyAttachmentMutation,
+  useUploadInsurancePolicyAttachmentMutation,
+} from "@/shared/store/insurancePoliciesApi";
+import type { InsurancePolicyAttachment } from "@/shared/types/insurance/insurance-policy-attachment";
+import AttachmentViewer from "@/app/features/leases/AttachmentViewer";
+import InsurancePolicyAttachmentRow from "@/app/features/insurance/InsurancePolicyAttachmentRow";
+
+interface Props {
+  policyId: string;
+  attachments: InsurancePolicyAttachment[];
+  canWrite: boolean;
+}
+
+const ALLOWED_MIME = [
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+];
+
+export default function InsurancePolicyAttachmentsSection({
+  policyId,
+  attachments,
+  canWrite,
+}: Props) {
+  const [uploadAttachment, { isLoading: isUploading }] =
+    useUploadInsurancePolicyAttachmentMutation();
+  const [deleteAttachment] = useDeleteInsurancePolicyAttachmentMutation();
+
+  const [manualKind, setManualKind] = useState<InsuranceAttachmentKind>("policy_document");
+  const [isDragging, setIsDragging] = useState(false);
+  const [viewingAttachment, setViewingAttachment] =
+    useState<InsurancePolicyAttachment | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleFiles(files: File[]) {
+    const validFiles = files.filter((file) => {
+      if (file.type && !ALLOWED_MIME.includes(file.type)) {
+        showError(`${file.name}: unsupported file type.`);
+        return false;
+      }
+      return true;
+    });
+
+    if (validFiles.length === 0) return;
+
+    for (const file of validFiles) {
+      try {
+        await uploadAttachment({ policyId, file, kind: manualKind }).unwrap();
+        showSuccess(`${file.name} uploaded.`);
+      } catch (e: unknown) {
+        const status = (e as { status?: number }).status;
+        if (status === 413) showError(`${file.name} is too large.`);
+        else if (status === 415) showError(`${file.name}: unsupported file type.`);
+        else showError(`Couldn't upload ${file.name}.`);
+      }
+    }
+  }
+
+  async function handleDelete(att: InsurancePolicyAttachment) {
+    if (!window.confirm(`Remove ${att.filename}?`)) return;
+    try {
+      await deleteAttachment({ policyId, attachmentId: att.id }).unwrap();
+      showSuccess("Attachment removed.");
+    } catch {
+      showError("Couldn't remove that file.");
+    }
+  }
+
+  return (
+    <section className="space-y-3" data-testid="insurance-attachments-section">
+      {attachments.length === 0 ? (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="insurance-attachments-empty"
+        >
+          No attachments yet.
+        </p>
+      ) : (
+        <ul className="space-y-1" data-testid="insurance-attachments-list">
+          {attachments.map((att) => (
+            <InsurancePolicyAttachmentRow
+              key={att.id}
+              att={att}
+              canWrite={canWrite}
+              onPreview={() => setViewingAttachment(att)}
+              onDelete={() => void handleDelete(att)}
+            />
+          ))}
+        </ul>
+      )}
+
+      {canWrite ? (
+        <div className="space-y-2 pt-2 border-t">
+          <div className="flex items-center gap-2">
+            <label htmlFor="insurance-attachment-kind" className="text-xs font-medium">
+              Kind:
+            </label>
+            <select
+              id="insurance-attachment-kind"
+              value={manualKind}
+              onChange={(e) => setManualKind(e.target.value as InsuranceAttachmentKind)}
+              className="px-2 py-1 text-sm border rounded"
+              data-testid="insurance-attachment-kind-select"
+            >
+              {INSURANCE_ATTACHMENT_KINDS.map((k) => (
+                <option key={k} value={k}>
+                  {INSURANCE_ATTACHMENT_KIND_LABELS[k]}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div
+            onDragOver={(e) => {
+              e.preventDefault();
+              setIsDragging(true);
+            }}
+            onDragLeave={() => setIsDragging(false)}
+            onDrop={(e) => {
+              e.preventDefault();
+              setIsDragging(false);
+              const files = Array.from(e.dataTransfer.files);
+              if (files.length > 0) void handleFiles(files);
+            }}
+            className={`border-2 border-dashed rounded-lg p-4 text-center transition-colors ${
+              isDragging ? "border-primary bg-primary/5" : "border-border"
+            } ${isUploading ? "opacity-50 pointer-events-none" : ""}`}
+            data-testid="insurance-attachment-dropzone"
+          >
+            {isUploading ? (
+              <span className="inline-flex items-center gap-2 text-sm text-muted-foreground">
+                <Loader2 size={14} className="animate-spin" />
+                Uploading...
+              </span>
+            ) : (
+              <div>
+                <Upload size={16} className="mx-auto text-muted-foreground mb-1" />
+                <p className="text-xs text-muted-foreground">
+                  Drag & drop your policy document here, or{" "}
+                  <button
+                    type="button"
+                    onClick={() => fileInputRef.current?.click()}
+                    className="text-primary font-medium hover:underline"
+                  >
+                    browse
+                  </button>
+                </p>
+                <p className="text-xs text-muted-foreground/70 mt-1">
+                  PDF, DOCX, JPEG, PNG, WebP
+                </p>
+              </div>
+            )}
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              multiple
+              accept={ALLOWED_MIME.join(",")}
+              onChange={(e) => {
+                const files = Array.from(e.target.files ?? []);
+                if (files.length > 0) void handleFiles(files);
+                e.target.value = "";
+              }}
+            />
+          </div>
+        </div>
+      ) : null}
+
+      {viewingAttachment?.presigned_url ? (
+        <AttachmentViewer
+          url={viewingAttachment.presigned_url}
+          filename={viewingAttachment.filename}
+          contentType={viewingAttachment.content_type}
+          onClose={() => setViewingAttachment(null)}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyDetailSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyDetailSkeleton.tsx
@@ -1,0 +1,33 @@
+/**
+ * Skeleton loader for the InsurancePolicyDetail page.
+ * Mirrors the loaded page layout to prevent layout shift.
+ */
+export default function InsurancePolicyDetailSkeleton() {
+  return (
+    <div className="space-y-6 animate-pulse" data-testid="insurance-policy-detail-skeleton">
+      {/* Header */}
+      <div className="space-y-2">
+        <div className="h-6 bg-muted rounded w-1/2" />
+        <div className="h-4 bg-muted rounded w-1/4" />
+      </div>
+
+      {/* Details section */}
+      <div className="border rounded-lg p-4 space-y-3">
+        <div className="h-4 bg-muted rounded w-1/4" />
+        <div className="grid grid-cols-2 gap-3">
+          <div className="h-4 bg-muted rounded" />
+          <div className="h-4 bg-muted rounded" />
+          <div className="h-4 bg-muted rounded" />
+          <div className="h-4 bg-muted rounded" />
+        </div>
+      </div>
+
+      {/* Attachments section */}
+      <div className="border rounded-lg p-4 space-y-3">
+        <div className="h-4 bg-muted rounded w-1/4" />
+        <div className="h-4 bg-muted rounded w-3/4" />
+        <div className="h-4 bg-muted rounded w-1/2" />
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/ListingInsuranceSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/ListingInsuranceSection.tsx
@@ -1,0 +1,95 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Plus } from "lucide-react";
+import { useGetInsurancePoliciesQuery } from "@/shared/store/insurancePoliciesApi";
+import Button from "@/shared/components/ui/Button";
+import InsuranceExpirationBadge from "@/app/features/insurance/InsuranceExpirationBadge";
+import AddInsurancePolicyDialog from "@/app/features/insurance/AddInsurancePolicyDialog";
+
+interface Props {
+  listingId: string;
+  canWrite: boolean;
+}
+
+/**
+ * Insurance section embedded in the listing detail page.
+ *
+ * Shows a summary list of policies for this listing with expiration badges,
+ * plus an "Add policy" button.
+ */
+export default function ListingInsuranceSection({ listingId, canWrite }: Props) {
+  const [showAddDialog, setShowAddDialog] = useState(false);
+  const { data, isLoading, isError } = useGetInsurancePoliciesQuery({
+    listing_id: listingId,
+  });
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2" aria-busy="true" data-testid="listing-insurance-loading">
+        <div className="h-4 bg-muted rounded animate-pulse w-2/3" />
+        <div className="h-4 bg-muted rounded animate-pulse w-1/2" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-muted-foreground" data-testid="listing-insurance-error">
+        Couldn't load insurance policies.
+      </p>
+    );
+  }
+
+  const policies = data?.items ?? [];
+
+  return (
+    <div className="space-y-3" data-testid="listing-insurance-section">
+      {policies.length === 0 ? (
+        <p className="text-sm text-muted-foreground" data-testid="listing-insurance-empty">
+          No policies on this listing yet — add one to track coverage and expiration.
+        </p>
+      ) : (
+        <ul className="space-y-2" data-testid="listing-insurance-list">
+          {policies.map((policy) => (
+            <li key={policy.id} className="border rounded-md px-3 py-2 text-sm">
+              <div className="flex items-start justify-between gap-2">
+                <div className="min-w-0">
+                  <Link
+                    to={`/insurance-policies/${policy.id}`}
+                    className="font-medium text-primary hover:underline truncate block"
+                    data-testid={`insurance-policy-link-${policy.id}`}
+                  >
+                    {policy.policy_name}
+                  </Link>
+                  {policy.carrier ? (
+                    <p className="text-xs text-muted-foreground mt-0.5">{policy.carrier}</p>
+                  ) : null}
+                </div>
+                <InsuranceExpirationBadge expirationDate={policy.expiration_date} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {canWrite ? (
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={() => setShowAddDialog(true)}
+          data-testid="add-insurance-policy-button"
+        >
+          <Plus size={14} className="mr-1" />
+          Add policy
+        </Button>
+      ) : null}
+
+      {showAddDialog ? (
+        <AddInsurancePolicyDialog
+          listingId={listingId}
+          onClose={() => setShowAddDialog(false)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/lib/nav.ts
+++ b/apps/mybookkeeper/frontend/src/app/lib/nav.ts
@@ -16,6 +16,7 @@ export const NAV_GROUPS: readonly NavGroup[] = [
     items: [
       { to: "/properties", label: "Properties" },
       { to: "/listings", label: "Listings" },
+      { to: "/insurance-policies", label: "Insurance" },
       { to: "/calendar", label: "Calendar" },
     ],
   },

--- a/apps/mybookkeeper/frontend/src/app/pages/InsurancePolicies.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/InsurancePolicies.tsx
@@ -1,0 +1,114 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { addDays, format } from "date-fns";
+import { useGetInsurancePoliciesQuery } from "@/shared/store/insurancePoliciesApi";
+import { useCanWrite } from "@/shared/hooks/useOrgRole";
+import SectionHeader from "@/shared/components/ui/SectionHeader";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import InsuranceExpirationBadge from "@/app/features/insurance/InsuranceExpirationBadge";
+
+/**
+ * All-policies view: lists insurance policies across all listings.
+ * Includes an "expiring soon" toggle (within 30 days).
+ */
+export default function InsurancePolicies() {
+  const canWrite = useCanWrite();
+  const [showExpiringSoon, setShowExpiringSoon] = useState(false);
+
+  const expiringBefore = showExpiringSoon
+    ? format(addDays(new Date(), 30), "yyyy-MM-dd")
+    : undefined;
+
+  const { data, isLoading, isError, refetch, isFetching } = useGetInsurancePoliciesQuery(
+    expiringBefore ? { expiring_before: expiringBefore } : {},
+  );
+
+  const policies = data?.items ?? [];
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <SectionHeader
+        title="Insurance"
+        subtitle="Track coverage and expiration across all listings."
+      />
+
+      {isError ? (
+        <AlertBox variant="error" className="flex items-center justify-between gap-3">
+          <span>Couldn't load insurance policies.</span>
+          <button
+            type="button"
+            onClick={() => refetch()}
+            className="text-sm font-medium hover:underline"
+          >
+            {isFetching ? "Retrying..." : "Retry"}
+          </button>
+        </AlertBox>
+      ) : null}
+
+      {/* Expiring soon filter */}
+      <div className="flex items-center gap-3">
+        <label className="flex items-center gap-2 text-sm cursor-pointer">
+          <input
+            type="checkbox"
+            checked={showExpiringSoon}
+            onChange={(e) => setShowExpiringSoon(e.target.checked)}
+            className="rounded"
+            data-testid="expiring-soon-toggle"
+          />
+          Show expiring within 30 days only
+        </label>
+      </div>
+
+      {isLoading ? (
+        <div
+          className="space-y-2 animate-pulse"
+          aria-busy="true"
+          data-testid="insurance-policies-loading"
+        >
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="border rounded-lg p-4 space-y-2">
+              <div className="h-4 bg-muted rounded w-1/2" />
+              <div className="h-4 bg-muted rounded w-1/3" />
+            </div>
+          ))}
+        </div>
+      ) : policies.length === 0 ? (
+        <p
+          className="text-sm text-muted-foreground"
+          data-testid="insurance-policies-empty"
+        >
+          {showExpiringSoon
+            ? "No policies expiring within 30 days."
+            : "No policies on this listing yet — add one to track coverage and expiration."}
+        </p>
+      ) : (
+        <ul className="space-y-2" data-testid="insurance-policies-list">
+          {policies.map((policy) => (
+            <li key={policy.id} className="border rounded-lg px-4 py-3 text-sm">
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <Link
+                    to={`/insurance-policies/${policy.id}`}
+                    className="font-medium text-primary hover:underline block truncate"
+                    data-testid={`insurance-policy-item-${policy.id}`}
+                  >
+                    {policy.policy_name}
+                  </Link>
+                  {policy.carrier ? (
+                    <p className="text-xs text-muted-foreground mt-0.5">{policy.carrier}</p>
+                  ) : null}
+                  {policy.expiration_date ? (
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Expires {format(new Date(policy.expiration_date + "T00:00:00"), "MMM d, yyyy")}
+                    </p>
+                  ) : null}
+                </div>
+                <InsuranceExpirationBadge expirationDate={policy.expiration_date} />
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </main>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/InsurancePolicyDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/InsurancePolicyDetail.tsx
@@ -1,0 +1,195 @@
+import { useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Trash2 } from "lucide-react";
+import {
+  useDeleteInsurancePolicyMutation,
+  useGetInsurancePolicyByIdQuery,
+} from "@/shared/store/insurancePoliciesApi";
+import { useCanWrite } from "@/shared/hooks/useOrgRole";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import SectionHeader from "@/shared/components/ui/SectionHeader";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import Button from "@/shared/components/ui/Button";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import InsuranceExpirationBadge from "@/app/features/insurance/InsuranceExpirationBadge";
+import InsurancePolicyAttachmentsSection from "@/app/features/insurance/InsurancePolicyAttachmentsSection";
+import InsurancePolicyDetailSkeleton from "@/app/features/insurance/InsurancePolicyDetailSkeleton";
+
+function formatCoverage(cents: number | null): string {
+  if (cents === null) return "—";
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 0,
+  }).format(cents / 100);
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "—";
+  const [year, month, day] = iso.split("-");
+  return `${month}/${day}/${year}`;
+}
+
+export default function InsurancePolicyDetail() {
+  const { policyId } = useParams<{ policyId: string }>();
+  const navigate = useNavigate();
+  const canWrite = useCanWrite();
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [deletePolicy, { isLoading: isDeleting }] = useDeleteInsurancePolicyMutation();
+
+  const {
+    data: policy,
+    isLoading,
+    isFetching,
+    isError,
+    refetch,
+  } = useGetInsurancePolicyByIdQuery(policyId ?? "", { skip: !policyId });
+
+  async function handleDelete() {
+    if (!policy) return;
+    try {
+      await deletePolicy(policy.id).unwrap();
+      showSuccess("Insurance policy deleted.");
+      navigate("/insurance-policies");
+    } catch {
+      showError("Couldn't delete the policy. Please try again.");
+    }
+  }
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <Link
+        to="/insurance-policies"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground min-h-[44px]"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        Back to insurance policies
+      </Link>
+
+      {isError ? (
+        <AlertBox variant="error" className="flex items-center justify-between gap-3">
+          <span>I couldn't load this policy. Want me to try again?</span>
+          <LoadingButton
+            variant="secondary"
+            size="sm"
+            isLoading={isFetching}
+            loadingText="Retrying..."
+            onClick={() => refetch()}
+          >
+            Retry
+          </LoadingButton>
+        </AlertBox>
+      ) : null}
+
+      {isLoading || !policy ? (
+        !isError ? <InsurancePolicyDetailSkeleton /> : null
+      ) : (
+        <>
+          <SectionHeader
+            title={policy.policy_name}
+            subtitle={
+              <span className="inline-flex items-center gap-2 flex-wrap">
+                {policy.carrier ? (
+                  <span className="text-sm text-muted-foreground">{policy.carrier}</span>
+                ) : null}
+                <InsuranceExpirationBadge expirationDate={policy.expiration_date} />
+              </span>
+            }
+            actions={
+              canWrite ? (
+                <Button
+                  variant="secondary"
+                  size="md"
+                  onClick={() => setShowDeleteConfirm(true)}
+                  className="text-red-600 border-red-200 hover:bg-red-50"
+                  data-testid="delete-insurance-policy-button"
+                >
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  Delete
+                </Button>
+              ) : null
+            }
+          />
+
+          <section className="border rounded-lg p-4 space-y-3" data-testid="insurance-policy-details">
+            <h2 className="text-sm font-medium">Policy details</h2>
+            <dl className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
+              <div>
+                <dt className="text-xs text-muted-foreground">Policy number</dt>
+                <dd className="font-medium" data-testid="insurance-policy-number">
+                  {policy.policy_number ?? "—"}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Coverage amount</dt>
+                <dd className="font-medium" data-testid="insurance-coverage-amount">
+                  {formatCoverage(policy.coverage_amount_cents)}
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Effective date</dt>
+                <dd data-testid="insurance-effective-date">{formatDate(policy.effective_date)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">Expiration date</dt>
+                <dd data-testid="insurance-expiration-date">{formatDate(policy.expiration_date)}</dd>
+              </div>
+            </dl>
+            {policy.notes ? (
+              <div className="pt-2 border-t">
+                <p className="text-xs text-muted-foreground mb-1">Notes</p>
+                <p className="text-sm whitespace-pre-line" data-testid="insurance-notes">
+                  {policy.notes}
+                </p>
+              </div>
+            ) : null}
+          </section>
+
+          <section className="border rounded-lg p-4 space-y-3">
+            <h2 className="text-sm font-medium">Documents</h2>
+            <InsurancePolicyAttachmentsSection
+              policyId={policy.id}
+              attachments={policy.attachments}
+              canWrite={canWrite}
+            />
+          </section>
+
+          {showDeleteConfirm ? (
+            <div
+              className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4"
+              data-testid="delete-insurance-policy-confirm"
+            >
+              <div className="bg-background rounded-lg shadow-lg max-w-sm w-full p-6 space-y-4">
+                <h3 className="text-base font-semibold">Delete policy?</h3>
+                <p className="text-sm text-muted-foreground">
+                  This will permanently delete <strong>{policy.policy_name}</strong> and all
+                  attached documents. This action cannot be undone.
+                </p>
+                <div className="flex gap-3 justify-end">
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    onClick={() => setShowDeleteConfirm(false)}
+                  >
+                    Cancel
+                  </Button>
+                  <LoadingButton
+                    variant="primary"
+                    size="md"
+                    isLoading={isDeleting}
+                    loadingText="Deleting..."
+                    onClick={() => void handleDelete()}
+                    className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    data-testid="confirm-delete-insurance-policy"
+                  >
+                    Delete
+                  </LoadingButton>
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
+    </main>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/ListingDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/ListingDetail.tsx
@@ -26,6 +26,8 @@ import ListingForm from "@/app/features/listings/ListingForm";
 import ListingPhotoManager from "@/app/features/listings/ListingPhotoManager";
 import DeleteListingModal from "@/app/features/listings/DeleteListingModal";
 import ChannelsSection from "@/app/features/listings/ChannelsSection";
+import ListingInsuranceSection from "@/app/features/insurance/ListingInsuranceSection";
+import { useCanWrite } from "@/shared/hooks/useOrgRole";
 
 export default function ListingDetail() {
   const { listingId } = useParams<{ listingId: string }>();
@@ -33,6 +35,7 @@ export default function ListingDetail() {
   const [showEditForm, setShowEditForm] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [deleteListing, { isLoading: isDeleting }] = useDeleteListingMutation();
+  const canWrite = useCanWrite();
   const {
     data: listing,
     isLoading,
@@ -185,6 +188,11 @@ export default function ListingDetail() {
           <section className="border rounded-lg p-4 space-y-3">
             <h2 className="text-sm font-medium">Channels</h2>
             <ChannelsSection listingId={listing.id} />
+          </section>
+
+          <section className="border rounded-lg p-4 space-y-3" data-testid="listing-insurance-section-wrapper">
+            <h2 className="text-sm font-medium">Insurance</h2>
+            <ListingInsuranceSection listingId={listing.id} canWrite={canWrite} />
           </section>
 
           {showEditForm ? (

--- a/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
@@ -4,6 +4,6 @@ import { axiosBaseQuery } from "./baseQuery";
 export const baseApi = createApi({
   reducerPath: "api",
   baseQuery: axiosBaseQuery,
-  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "PlaidItem", "PlaidAccount", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue"],
+  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "PlaidItem", "PlaidAccount", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy"],
   endpoints: () => ({}),
 });

--- a/apps/mybookkeeper/frontend/src/shared/store/insurancePoliciesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/insurancePoliciesApi.ts
@@ -1,0 +1,125 @@
+import { baseApi } from "./baseApi";
+import type { InsuranceAttachmentKind } from "@/shared/types/insurance/insurance-attachment-kind";
+import type { InsurancePolicyAttachment } from "@/shared/types/insurance/insurance-policy-attachment";
+import type { InsurancePolicyCreateRequest } from "@/shared/types/insurance/insurance-policy-create-request";
+import type { InsurancePolicyDetail } from "@/shared/types/insurance/insurance-policy-detail";
+import type { InsurancePolicyListResponse } from "@/shared/types/insurance/insurance-policy-list-response";
+import type { InsurancePolicyUpdateRequest } from "@/shared/types/insurance/insurance-policy-update-request";
+
+export interface InsurancePolicyListArgs {
+  listing_id?: string;
+  expiring_before?: string;
+  limit?: number;
+  offset?: number;
+}
+
+/**
+ * RTK Query slice for the Insurance Policies domain.
+ *
+ * Tag strategy mirrors signedLeasesApi: per-id ``InsurancePolicy:{id}`` plus
+ * a shared ``InsurancePolicy:LIST``. Attachment upload/delete invalidate the
+ * parent policy tag.
+ */
+const insurancePoliciesApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getInsurancePolicies: builder.query<
+      InsurancePolicyListResponse,
+      InsurancePolicyListArgs | void
+    >({
+      query: (args) => ({
+        url: "/insurance-policies",
+        params: {
+          ...(args?.listing_id ? { listing_id: args.listing_id } : {}),
+          ...(args?.expiring_before ? { expiring_before: args.expiring_before } : {}),
+          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
+          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+        },
+      }),
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.items.map((p) => ({
+                type: "InsurancePolicy" as const,
+                id: p.id,
+              })),
+              { type: "InsurancePolicy" as const, id: "LIST" },
+            ]
+          : [{ type: "InsurancePolicy" as const, id: "LIST" }],
+    }),
+
+    getInsurancePolicyById: builder.query<InsurancePolicyDetail, string>({
+      query: (id) => ({ url: `/insurance-policies/${id}` }),
+      providesTags: (_r, _e, id) => [{ type: "InsurancePolicy", id }],
+    }),
+
+    createInsurancePolicy: builder.mutation<
+      InsurancePolicyDetail,
+      InsurancePolicyCreateRequest
+    >({
+      query: (data) => ({ url: "/insurance-policies", method: "POST", data }),
+      invalidatesTags: [{ type: "InsurancePolicy", id: "LIST" }],
+    }),
+
+    updateInsurancePolicy: builder.mutation<
+      InsurancePolicyDetail,
+      { policyId: string; data: InsurancePolicyUpdateRequest }
+    >({
+      query: ({ policyId, data }) => ({
+        url: `/insurance-policies/${policyId}`,
+        method: "PATCH",
+        data,
+      }),
+      invalidatesTags: (_r, _e, { policyId }) => [
+        { type: "InsurancePolicy", id: policyId },
+        { type: "InsurancePolicy", id: "LIST" },
+      ],
+    }),
+
+    deleteInsurancePolicy: builder.mutation<void, string>({
+      query: (id) => ({ url: `/insurance-policies/${id}`, method: "DELETE" }),
+      invalidatesTags: [{ type: "InsurancePolicy", id: "LIST" }],
+    }),
+
+    uploadInsurancePolicyAttachment: builder.mutation<
+      InsurancePolicyAttachment,
+      { policyId: string; file: File; kind: InsuranceAttachmentKind }
+    >({
+      query: ({ policyId, file, kind }) => {
+        const formData = new FormData();
+        formData.append("file", file);
+        formData.append("kind", kind);
+        return {
+          url: `/insurance-policies/${policyId}/attachments`,
+          method: "POST",
+          data: formData,
+        };
+      },
+      invalidatesTags: (_r, _e, { policyId }) => [
+        { type: "InsurancePolicy", id: policyId },
+      ],
+    }),
+
+    deleteInsurancePolicyAttachment: builder.mutation<
+      void,
+      { policyId: string; attachmentId: string }
+    >({
+      query: ({ policyId, attachmentId }) => ({
+        url: `/insurance-policies/${policyId}/attachments/${attachmentId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (_r, _e, { policyId }) => [
+        { type: "InsurancePolicy", id: policyId },
+      ],
+    }),
+  }),
+});
+
+export const {
+  useGetInsurancePoliciesQuery,
+  useGetInsurancePolicyByIdQuery,
+  useCreateInsurancePolicyMutation,
+  useUpdateInsurancePolicyMutation,
+  useDeleteInsurancePolicyMutation,
+  useUploadInsurancePolicyAttachmentMutation,
+  useDeleteInsurancePolicyAttachmentMutation,
+} = insurancePoliciesApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-attachment-kind.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-attachment-kind.ts
@@ -1,0 +1,25 @@
+/**
+ * Allowed kinds for an insurance policy attachment.
+ *
+ * Mirrors backend tuple ``INSURANCE_ATTACHMENT_KINDS`` in
+ * ``app/core/insurance_enums.py``.
+ */
+export type InsuranceAttachmentKind =
+  | "policy_document"
+  | "endorsement"
+  | "binder"
+  | "other";
+
+export const INSURANCE_ATTACHMENT_KINDS: readonly InsuranceAttachmentKind[] = [
+  "policy_document",
+  "endorsement",
+  "binder",
+  "other",
+] as const;
+
+export const INSURANCE_ATTACHMENT_KIND_LABELS: Record<InsuranceAttachmentKind, string> = {
+  policy_document: "Policy Document",
+  endorsement: "Endorsement",
+  binder: "Binder",
+  other: "Other",
+};

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-attachment.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-attachment.ts
@@ -1,0 +1,19 @@
+import type { InsuranceAttachmentKind } from "@/shared/types/insurance/insurance-attachment-kind";
+
+/**
+ * A file attached to an insurance policy.
+ *
+ * Mirrors ``schemas/insurance/insurance_policy_attachment_response.py``.
+ */
+export interface InsurancePolicyAttachment {
+  id: string;
+  policy_id: string;
+  filename: string;
+  storage_key: string;
+  content_type: string;
+  size_bytes: number;
+  kind: InsuranceAttachmentKind;
+  uploaded_by_user_id: string;
+  uploaded_at: string;
+  presigned_url: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-create-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-create-request.ts
@@ -1,0 +1,15 @@
+/**
+ * Request body for POST /insurance-policies.
+ *
+ * Mirrors ``schemas/insurance/insurance_policy_create_request.py``.
+ */
+export interface InsurancePolicyCreateRequest {
+  listing_id: string;
+  policy_name: string;
+  carrier?: string | null;
+  policy_number?: string | null;
+  effective_date?: string | null;
+  expiration_date?: string | null;
+  coverage_amount_cents?: number | null;
+  notes?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-detail.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-detail.ts
@@ -1,0 +1,23 @@
+import type { InsurancePolicyAttachment } from "@/shared/types/insurance/insurance-policy-attachment";
+
+/**
+ * Full insurance policy with attachments.
+ *
+ * Mirrors ``schemas/insurance/insurance_policy_response.py``.
+ */
+export interface InsurancePolicyDetail {
+  id: string;
+  user_id: string;
+  organization_id: string;
+  listing_id: string;
+  policy_name: string;
+  carrier: string | null;
+  policy_number: string | null;
+  effective_date: string | null;
+  expiration_date: string | null;
+  coverage_amount_cents: number | null;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+  attachments: InsurancePolicyAttachment[];
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-list-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-list-response.ts
@@ -1,0 +1,12 @@
+import type { InsurancePolicySummary } from "@/shared/types/insurance/insurance-policy-summary";
+
+/**
+ * Paginated list response for insurance policies.
+ *
+ * Mirrors ``schemas/insurance/insurance_policy_list_response.py``.
+ */
+export interface InsurancePolicyListResponse {
+  items: InsurancePolicySummary[];
+  total: number;
+  has_more: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-summary.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-summary.ts
@@ -1,0 +1,16 @@
+/**
+ * Summary row for the insurance policy list.
+ *
+ * Mirrors ``schemas/insurance/insurance_policy_summary.py``.
+ */
+export interface InsurancePolicySummary {
+  id: string;
+  listing_id: string;
+  policy_name: string;
+  carrier: string | null;
+  effective_date: string | null;
+  expiration_date: string | null;
+  coverage_amount_cents: number | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-update-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/insurance/insurance-policy-update-request.ts
@@ -1,0 +1,14 @@
+/**
+ * Request body for PATCH /insurance-policies/{id}.
+ *
+ * Mirrors ``schemas/insurance/insurance_policy_update_request.py``.
+ */
+export interface InsurancePolicyUpdateRequest {
+  policy_name?: string;
+  carrier?: string | null;
+  policy_number?: string | null;
+  effective_date?: string | null;
+  expiration_date?: string | null;
+  coverage_amount_cents?: number | null;
+  notes?: string | null;
+}

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -560,6 +560,35 @@
         "tenants.spec.ts"
       ]
     },
+    "insurance": {
+      "source_paths": [
+        "backend/app/models/insurance/",
+        "backend/app/repositories/insurance/",
+        "backend/app/schemas/insurance/",
+        "backend/app/services/insurance/",
+        "backend/app/api/insurance_policies.py",
+        "backend/app/core/insurance_enums.py",
+        "backend/alembic/versions/insur260504_add_insurance_policy_tables.py",
+        "frontend/src/app/pages/InsurancePolicies.tsx",
+        "frontend/src/app/pages/InsurancePolicyDetail.tsx",
+        "frontend/src/app/features/insurance/",
+        "frontend/src/shared/types/insurance/",
+        "frontend/src/shared/store/insurancePoliciesApi.ts"
+      ],
+      "backend_tests": [
+        "test_insurance_policies_api.py",
+        "test_insurance_policy_repo.py"
+      ],
+      "frontend_tests": [
+        "InsuranceExpirationBadge.test.tsx",
+        "ListingInsuranceSection.test.tsx",
+        "InsurancePolicies.test.tsx",
+        "InsurancePolicyDetail.test.tsx"
+      ],
+      "e2e_specs": [
+        "insurance-policies.spec.ts"
+      ]
+    },
     "leases": {
       "source_paths": [
         "backend/app/models/leases/",


### PR DESCRIPTION
## Summary

- **Backend**: Two new tables ( + ), 7 REST endpoints (CRUD policies + attachment upload/delete),  encrypted via  + added to , IDOR-safe composite WHERE on attachment delete, fail-loud presigned URL signing, Alembic migration 
- **Frontend**: All-policies list page at  with 30-day expiring-soon filter, detail page at  with skeleton loader,  embedded in listing detail,  (expired/≤30d/≤90d thresholds), , RTK Query slice, sidebar nav item under Property group
- **Tests**: 29 backend tests (19 API-level + 10 repo-level) + 56 frontend unit tests — all passing

## Out of scope (future phases)

- Phase 2: AI extraction from policy PDF documents
- Phase 3: Renewal reminder notifications
- Phase 4: Multi-policy comparison view

## Design decisions

-  encrypted with  (Fernet/HKDF, same key family as inquiry PII); added to  so audit log masks it
- Attachment delete uses composite C:\Program Files\Git\usr\bin\id.exe (IDOR guard — same pattern as signed lease attachments)
-  column with  for attachment kind (not SQLAlchemy Enum, per project convention)
- Soft delete on policies ( nullable) with partial index on 
- Coverage stored as  cents (no float rounding risk)
- Frontend coverage input is in dollars → converts to cents on submit

## Test plan

- [ ] Run  — 29 tests pass
- [ ] Run frontend tests for all 4 new test files — 56 tests pass
- [ ] Navigate to a listing detail page → Insurance section shows empty state + Add policy button
- [ ] Create a policy with carrier, policy number, dates, coverage, notes
- [ ] Verify policy number is masked in audit logs ()
- [ ] Upload a PDF attachment — verify it appears with presigned URL
- [ ] Delete attachment → verify IDOR guard (can''t delete attachment from wrong policy)
- [ ] Navigate to  → list shows all policies with expiration badges
- [ ] Toggle Show expiring within 30 days → filter activates
- [ ] Delete a policy → confirm dialog → success toast → navigates to list

🤖 Generated with [Claude Code](https://claude.com/claude-code)