### PR TITLE
chore(myjobhunter): deploy hardening — .dockerignore, CLAUDE.md deploy section, env-file preflight

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -33,6 +33,20 @@ jobs:
             echo "--- Pull latest code ---"
             git pull --ff-only
 
+            echo "--- Preflight: verify required env files exist ---"
+            # These files must be created manually on first VPS setup (via setup.sh
+            # or equivalent). Without them docker compose starts with no secrets and
+            # the app fails at runtime. Same class of failure as PR #206 RCA for MJH.
+            test -f /srv/myfreeapps/apps/mybookkeeper/.env || {
+              echo "::error::Missing /srv/myfreeapps/apps/mybookkeeper/.env — run setup.sh or create env files manually first"
+              exit 1
+            }
+            test -f /srv/myfreeapps/apps/mybookkeeper/backend/.env.docker || {
+              echo "::error::Missing /srv/myfreeapps/apps/mybookkeeper/backend/.env.docker — run setup.sh or create env files manually first"
+              exit 1
+            }
+            echo "Env files present — proceeding"
+
             echo "--- Build and deploy with Docker ---"
             docker compose -f apps/mybookkeeper/docker-compose.yml build
             docker compose -f apps/mybookkeeper/docker-compose.yml up -d --remove-orphans

--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -33,6 +33,21 @@ jobs:
             echo "--- Pull latest code ---"
             git pull --ff-only
 
+            echo "--- Preflight: verify required env files exist ---"
+            # These files must be created manually on first VPS setup via:
+            #   sudo bash apps/myjobhunter/scripts/seed-env-from-mbk.sh
+            # Without them docker compose silently starts with no secrets and
+            # postgres reports "unhealthy" for 30+ deploys (PR #206 RCA).
+            test -f /srv/myfreeapps/apps/myjobhunter/.env || {
+              echo "::error::Missing /srv/myfreeapps/apps/myjobhunter/.env — run apps/myjobhunter/scripts/seed-env-from-mbk.sh on the VPS first"
+              exit 1
+            }
+            test -f /srv/myfreeapps/apps/myjobhunter/backend/.env.docker || {
+              echo "::error::Missing /srv/myfreeapps/apps/myjobhunter/backend/.env.docker — run apps/myjobhunter/scripts/seed-env-from-mbk.sh on the VPS first"
+              exit 1
+            }
+            echo "Env files present — proceeding"
+
             echo "--- Build and deploy with Docker ---"
             docker compose -f apps/myjobhunter/docker-compose.yml build
             docker compose -f apps/myjobhunter/docker-compose.yml up -d --remove-orphans

--- a/apps/myjobhunter/.dockerignore
+++ b/apps/myjobhunter/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.github
+*.md
+!requirements.txt
+frontend/node_modules
+frontend/dist
+backend/.venv
+backend/__pycache__
+backend/.pytest_cache
+**/__pycache__
+**/*.pyc
+.env
+*.log
+e2e/
+playwright-report/
+test-results/
+.claude/

--- a/apps/myjobhunter/CLAUDE.md
+++ b/apps/myjobhunter/CLAUDE.md
@@ -155,6 +155,58 @@ uv lock --check
 - Hard-delete users in teardown to prevent cross-session contamination
 - Tenant isolation tests in `test_tenant_isolation.py`
 
+## Deployment
+
+**VPS path:** `/srv/myfreeapps/apps/myjobhunter`
+
+**Required env files (must exist on VPS before first deploy):**
+
+| File | What it is |
+|---|---|
+| `apps/myjobhunter/.env` | Compose-level — only `DB_PASSWORD` |
+| `apps/myjobhunter/backend/.env.docker` | App-level — all other secrets; see `backend/.env.docker.example` |
+
+**First-time setup** (new VPS only — run once from `/srv/myfreeapps`):
+```bash
+sudo bash apps/myjobhunter/scripts/seed-env-from-mbk.sh
+# Then fill in the MJH-specific blanks:
+vim apps/myjobhunter/backend/.env.docker
+# Required: GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, TURNSTILE_SECRET_KEY, TURNSTILE_SITE_KEY
+# Optional: TAVILY_API_KEY (Phase 4), SMTP_* (currently uses console backend)
+```
+
+The seed script reads safe-to-reuse keys from MBK's running config (Anthropic API key, lockout
+tunables, log level) and generates fresh secrets for per-app values (SECRET_KEY, ENCRYPTION_KEY,
+DB_PASSWORD). FRONTEND_URL and CORS_ORIGINS are pre-filled with the sslip.io domain.
+
+**Day-to-day deploys:** Push to main or merge a PR — GitHub Actions deploys automatically.
+
+**Routing:**
+- Domain: `myjobhunter.165-245-134-251.sslip.io`
+- Host Caddy (TLS termination at `/etc/caddy/Caddyfile`) proxies to docker Caddy on `127.0.0.1:8092`
+- Docker Caddy (baked into caddy image) owns routing, security headers, CSP, SPA fallback, and `/api/*` → backend proxy
+
+**Health check:**
+```bash
+curl http://127.0.0.1:8092/health    # from VPS (bypasses host Caddy)
+curl https://myjobhunter.165-245-134-251.sslip.io/health  # public
+```
+
+**Database backup/restore:**
+MJH does not yet have automated backup scripts (MBK has `deploy/backup.sh` + systemd timer;
+MJH should mirror this — see TECH_DEBT.md). For now, manual backup:
+```bash
+# On VPS:
+docker compose -f apps/myjobhunter/docker-compose.yml exec postgres \
+  pg_dump -U myjobhunter myjobhunter | gzip > /tmp/mjh-$(date +%Y%m%d).sql.gz
+```
+
+**When to SSH into the server:**
+- First-time env file setup (seed-env-from-mbk.sh)
+- Restore from backup
+- Check logs: `docker compose -f apps/myjobhunter/docker-compose.yml logs api --tail=50`
+- Debug production issues
+
 ## Phase 1 Scope
 
 **Implemented:** models, migrations, auth endpoints, 6 smoke read endpoints, tests, Docker, CI


### PR DESCRIPTION
## Summary

Three hardening changes that fell out of the [#206 RCA](https://github.com/jykwon91/MyFreeApps/pull/206) — 30 failed deploys caused by missing env files producing a cryptic postgres-unhealthy failure instead of a clear error.

### 1. `apps/myjobhunter/.dockerignore`

MJH was missing a `.dockerignore`. Every Docker build used the full monorepo root as context, including `.git`, `node_modules`, `__pycache__`, `.venv`, test artifacts, and `.claude/`. This bloats build context, slows every build, and in the worst case leaks dev files into images.

Mirrors `apps/mybookkeeper/.dockerignore` exactly (same exclusion list, adjusted for MJH paths).

### 2. `apps/myjobhunter/CLAUDE.md` — Deployment section

The MJH CLAUDE.md had no Deployment section. A future operator (or Claude session) had no in-repo source of truth for:
- VPS path
- Which env files are required and how to create them
- The routing topology (host Caddy → docker Caddy on 127.0.0.1:8092)
- Health check commands

Added a Deployment section mirroring the MBK shape with MJH-specific values. Includes a note that automated DB backups are not yet wired (matches what's in TECH_DEBT.md).

### 3. Env-file preflight in both deploy workflows

`deploy-myjobhunter.yml` and `deploy-mybookkeeper.yml` now assert that both required env files exist on the VPS **before** `docker compose up`. If either is missing, the deploy fails immediately with:

```
::error::Missing /srv/myfreeapps/apps/myjobhunter/.env — run apps/myjobhunter/scripts/seed-env-from-mbk.sh on the VPS first
```

This turns the #206 failure mode (cryptic postgres-unhealthy after 10 min) into a clear 5-second error with an actionable fix. MBK gets the same check — same risk class.

## Test plan

- [x] Bash syntax check (`bash -n`) on the preflight script block — passes clean
- [x] `git diff --stat` confirms only the four expected files changed
- [ ] Verify on next MJH deploy: if `.env` is present, deploy proceeds normally; if absent, deploy fails at the preflight step with the expected `::error::` annotation