### PR TITLE
test(mybookkeeper/receipts): replace layout-only E2E with behavioral tests

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -171,8 +171,7 @@ jobs:
             e2e/two-factor-button-alignment.spec.ts \
             e2e/login-totp-button-text-centered.spec.ts \
             e2e/document-viewer-failure-modes.spec.ts \
-            e2e/caddy-headers-blob-iframe.spec.ts \
-            e2e/pending-receipts.spec.ts
+            e2e/caddy-headers-blob-iframe.spec.ts
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/apps/mybookkeeper/backend/app/api/test_utils.py
+++ b/apps/mybookkeeper/backend/app/api/test_utils.py
@@ -255,13 +255,21 @@ async def remove_gmail_integration(
 async def enable_mock_gmail_send(
     ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001 — gated by ctx
 ) -> None:
-    """Replace ``gmail_service.send_message`` with a stub that returns a fake
-    message-id. Used by E2E so tests don't hit the Gmail API.
+    """Replace ``gmail_service.send_message`` and ``send_message_with_attachment``
+    with stubs that return a fake message-id. Used by E2E so tests don't hit
+    the Gmail API.
 
-    The patch lives at module level — the next ``send_reply`` call sees the
-    stub. ``disable`` restores the original.
+    The attachment stub also captures send-call kwargs in the process-local
+    ``_last_gmail_attachment_send`` ring buffer so tests can assert recipient
+    and subject via ``GET /test/last-gmail-send``.
+
+    The patch lives at module level — the next send call sees the stub.
+    ``disable`` restores the originals.
     """
     _require_test_mode()
+    global _last_gmail_attachment_send
+    _last_gmail_attachment_send = None  # clear capture window on each enable
+
     if getattr(gmail_service, "_real_send_message", None) is None:
         gmail_service._real_send_message = gmail_service.send_message  # type: ignore[attr-defined]
 
@@ -270,17 +278,69 @@ async def enable_mock_gmail_send(
 
     gmail_service.send_message = _stub  # type: ignore[assignment]
 
+    if getattr(gmail_service, "_real_send_message_with_attachment", None) is None:
+        gmail_service._real_send_message_with_attachment = gmail_service.send_message_with_attachment  # type: ignore[attr-defined]
+
+    def _attachment_stub(*args: object, **kwargs: object) -> str:
+        global _last_gmail_attachment_send
+        _last_gmail_attachment_send = {
+            "to_address": kwargs.get("to_address"),
+            "subject": kwargs.get("subject"),
+            "attachment_filename": kwargs.get("attachment_filename"),
+        }
+        return f"<e2e-mock-att-{uuid.uuid4().hex[:12]}@mybookkeeper.app>"
+
+    gmail_service.send_message_with_attachment = _attachment_stub  # type: ignore[assignment]
+
+    # Also mock storage so receipt PDF upload succeeds without a real MinIO.
+    from app.core import storage as _storage_module
+
+    if getattr(_storage_module, "_real_get_storage", None) is None:
+        _storage_module._real_get_storage = _storage_module.get_storage  # type: ignore[attr-defined]
+
+    class _NoOpStorage:
+        bucket = "mock-bucket"
+
+        def upload_file(self, key: str, content: bytes, content_type: str) -> str:
+            return key
+
+        def delete_file(self, key: str) -> None:
+            pass
+
+        def ensure_bucket(self) -> None:
+            pass
+
+    _no_op = _NoOpStorage()
+
+    def _storage_stub() -> _NoOpStorage:
+        return _no_op
+
+    _storage_module.get_storage = _storage_stub  # type: ignore[assignment]
+
 
 @router.post("/mock-gmail-send/disable", status_code=204)
 async def disable_mock_gmail_send(
     ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001
 ) -> None:
-    """Restore the real ``gmail_service.send_message`` after E2E."""
+    """Restore the real ``gmail_service.send_message`` and
+    ``send_message_with_attachment`` after E2E."""
     _require_test_mode()
     real = getattr(gmail_service, "_real_send_message", None)
     if real is not None:
         gmail_service.send_message = real  # type: ignore[assignment]
         gmail_service._real_send_message = None  # type: ignore[attr-defined]
+
+    real_att = getattr(gmail_service, "_real_send_message_with_attachment", None)
+    if real_att is not None:
+        gmail_service.send_message_with_attachment = real_att  # type: ignore[assignment]
+        gmail_service._real_send_message_with_attachment = None  # type: ignore[attr-defined]
+
+    from app.core import storage as _storage_module
+
+    real_storage = getattr(_storage_module, "_real_get_storage", None)
+    if real_storage is not None:
+        _storage_module.get_storage = real_storage  # type: ignore[assignment]
+        _storage_module._real_get_storage = None  # type: ignore[attr-defined]
 
 
 class _SeedApplicantRequest(BaseModel):
@@ -797,3 +857,215 @@ async def hard_delete_review_queue_item(
                 CalendarEmailReviewQueue.organization_id == ctx.organization_id,
             )
         )
+
+
+# ---------------------------------------------------------------------------
+# Rent receipts — E2E seed + cleanup helpers
+# ---------------------------------------------------------------------------
+
+# Process-local ring buffer for capturing gmail send-with-attachment calls.
+# Populated by the mock stub installed via POST /test/mock-gmail-send/enable.
+# Cleared on each enable call so tests start with a clean capture window.
+_last_gmail_attachment_send: dict[str, object] | None = None
+
+
+class _SeedRentPaymentRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    tenant_legal_name: str
+    tenant_email: str
+    amount_cents: int
+    payer_name: str | None = None
+    contract_start: str | None = None
+    contract_end: str | None = None
+
+
+class _SeedRentPaymentResponse(BaseModel):
+    applicant_id: uuid.UUID
+    inquiry_id: uuid.UUID
+    signed_lease_id: uuid.UUID
+    transaction_id: uuid.UUID
+
+
+@router.post(
+    "/seed-rent-payment-attributed",
+    response_model=_SeedRentPaymentResponse,
+    status_code=201,
+)
+async def seed_rent_payment_attributed(
+    payload: _SeedRentPaymentRequest,
+    ctx: RequestContext = Depends(current_org_member),
+) -> _SeedRentPaymentResponse:
+    """Test-only: create a fully attributed rent payment fixture.
+
+    Creates:
+    - An Inquiry (provides the tenant email)
+    - An Applicant at ``lease_signed`` stage linked to that inquiry
+    - A SignedLease linked to the applicant
+    - A Transaction (category=rental_revenue, attribution_source=auto_exact,
+      applicant_id set)
+    - A PendingRentReceipt row via ``receipt_service.create_pending_receipt_from_attribution``
+
+    Returns IDs so the test can target specific rows and clean up afterwards.
+    Gated by ``ALLOW_TEST_ADMIN_PROMOTION``.
+    """
+    _require_test_mode()
+
+    from decimal import Decimal as _Decimal
+    from app.models.leases.signed_lease import SignedLease
+    from app.repositories.applicants import applicant_repo
+    from app.repositories.inquiries import inquiry_repo
+    from app.repositories.transactions import transaction_repo
+    from app.services.leases import receipt_service
+
+    amount = _Decimal(payload.amount_cents) / 100
+    now = _dt.datetime.now(_dt.timezone.utc)
+    today = now.date()
+
+    async with unit_of_work() as db:
+        # 1. Inquiry — provides tenant email for the receipt service lookup.
+        inquiry = await inquiry_repo.create(
+            db,
+            organization_id=ctx.organization_id,
+            user_id=ctx.user_id,
+            source="direct",
+            received_at=now,
+            inquirer_name=payload.tenant_legal_name,
+            inquirer_email=payload.tenant_email,
+        )
+
+        # 2. Applicant linked to the inquiry.
+        applicant = await applicant_repo.create(
+            db,
+            organization_id=ctx.organization_id,
+            user_id=ctx.user_id,
+            inquiry_id=inquiry.id,
+            legal_name=payload.tenant_legal_name,
+            stage="lease_signed",
+        )
+
+        # 3. Signed lease linked to the applicant.
+        contract_start = (
+            _dt.date.fromisoformat(payload.contract_start) if payload.contract_start else today
+        )
+        contract_end = (
+            _dt.date.fromisoformat(payload.contract_end)
+            if payload.contract_end
+            else today.replace(month=12, day=31) if today.month <= 12 else today
+        )
+        lease = SignedLease(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            template_id=None,
+            applicant_id=applicant.id,
+            listing_id=None,
+            kind="imported",
+            values={},
+            status="signed",
+            signed_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(lease)
+        await db.flush()
+
+        # 4. Transaction — attributed to the applicant.
+        txn = await transaction_repo.create_transaction(
+            db,
+            organization_id=ctx.organization_id,
+            user_id=ctx.user_id,
+            is_manual=True,
+            transaction_date=today,
+            tax_year=today.year,
+            vendor=payload.payer_name or payload.tenant_legal_name,
+            payer_name=payload.payer_name or payload.tenant_legal_name,
+            amount=amount,
+            transaction_type="income",
+            category="rental_revenue",
+            applicant_id=applicant.id,
+            attribution_source="auto_exact",
+            status="approved",
+        )
+
+        applicant_id = applicant.id
+        inquiry_id = inquiry.id
+        signed_lease_id = lease.id
+        transaction_id = txn.id
+
+    # 5. Create the pending receipt row (calls the real service — idempotent).
+    await receipt_service.create_pending_receipt_from_attribution(
+        transaction_id=transaction_id,
+        applicant_id=applicant_id,
+        user_id=ctx.user_id,
+        organization_id=ctx.organization_id,
+    )
+
+    return _SeedRentPaymentResponse(
+        applicant_id=applicant_id,
+        inquiry_id=inquiry_id,
+        signed_lease_id=signed_lease_id,
+        transaction_id=transaction_id,
+    )
+
+
+class _LastGmailSendResponse(BaseModel):
+    captured: bool
+    to_address: str | None = None
+    subject: str | None = None
+    has_attachment: bool = False
+    attachment_filename: str | None = None
+
+
+@router.get("/last-gmail-send", response_model=_LastGmailSendResponse)
+async def get_last_gmail_send(
+    ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001
+) -> _LastGmailSendResponse:
+    """Return the args of the most recent mock send_message_with_attachment call.
+
+    Only populated when the mock stub is active (POST /test/mock-gmail-send/enable).
+    Used by E2E tests to assert that a receipt email was dispatched with the
+    correct recipient and attachment without hitting the real Gmail API.
+    """
+    _require_test_mode()
+    captured = _last_gmail_attachment_send
+    if captured is None:
+        return _LastGmailSendResponse(captured=False)
+    return _LastGmailSendResponse(
+        captured=True,
+        to_address=captured.get("to_address"),  # type: ignore[arg-type]
+        subject=captured.get("subject"),  # type: ignore[arg-type]
+        has_attachment="attachment_filename" in captured,
+        attachment_filename=captured.get("attachment_filename"),  # type: ignore[arg-type]
+    )
+
+
+class _SeedNeedsReauthRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    needs_reauth: bool = True
+
+
+@router.post("/seed-integration-reauth-state", status_code=204)
+async def seed_integration_reauth_state(
+    payload: _SeedNeedsReauthRequest,
+    ctx: RequestContext = Depends(current_org_member),
+) -> None:
+    """Set ``needs_reauth`` on the org's Gmail integration. Test-only.
+
+    Used by E2E Test C to verify the dialog surfaces the reconnect-required
+    state rather than a generic error when Gmail tokens are expired.
+    """
+    _require_test_mode()
+    async with unit_of_work() as db:
+        integration = await integration_repo.get_by_org_and_provider(
+            db, ctx.organization_id, "gmail",
+        )
+        if integration is None:
+            raise HTTPException(status_code=404, detail="No Gmail integration found")
+        now = _dt.datetime.now(_dt.timezone.utc)
+        if payload.needs_reauth:
+            await integration_repo.mark_needs_reauth(
+                db, integration, "e2e-test-forced-reauth", now,
+            )
+        else:
+            await integration_repo.clear_reauth_state(db, integration)

--- a/apps/mybookkeeper/backend/app/core/config.py
+++ b/apps/mybookkeeper/backend/app/core/config.py
@@ -60,6 +60,11 @@ class Settings(BaseSettings):
     posthog_api_key: str = ""
 
     allow_test_admin_promotion: bool = False
+    # When true, skips the MinIO bucket-existence check at startup.
+    # Only effective when allow_test_admin_promotion is also true so this
+    # flag can never be accidentally set in production (which always has
+    # allow_test_admin_promotion=false).
+    minio_skip_startup_check: bool = False
 
     hibp_enabled: bool = True
 

--- a/apps/mybookkeeper/backend/app/services/email/gmail_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/gmail_service.py
@@ -271,6 +271,85 @@ def _collect_attachments(payload: _GmailPayload, service, message_id: str, resul
         _collect_attachments(part, service, message_id, result)
 
 
+def send_message_with_attachment(
+    integration,  # type: ignore[no-untyped-def] — app.models.integrations.Integration, avoid circular import
+    *,
+    from_address: str,
+    to_address: str,
+    subject: str,
+    body: str,
+    attachment_bytes: bytes,
+    attachment_filename: str,
+    attachment_content_type: str,
+) -> str:
+    """Send an email with a single binary attachment via Gmail API.
+
+    Builds a MIME multipart/mixed message, encodes the attachment inline, and
+    POSTs to ``users.messages.send``.  Returns the Gmail-issued message ID.
+
+    Raises the same GmailReauthRequiredError / GmailSendScopeError /
+    GmailSendError hierarchy as ``send_message`` so callers can handle errors
+    uniformly.
+    """
+    if not integration.access_token:
+        raise GmailSendScopeError("Gmail integration has no access token")
+
+    from email.mime.application import MIMEApplication
+    from email.mime.multipart import MIMEMultipart
+    from email.mime.text import MIMEText
+
+    msg = MIMEMultipart()
+    msg["From"] = from_address
+    msg["To"] = to_address
+    msg["Subject"] = subject
+    msg["Message-ID"] = make_msgid(domain="mybookkeeper.app")
+    msg.attach(MIMEText(body, "plain"))
+
+    attachment_part = MIMEApplication(attachment_bytes, _subtype="octet-stream")
+    attachment_part.add_header(
+        "Content-Disposition", "attachment", filename=attachment_filename
+    )
+    attachment_part.add_header("Content-Type", attachment_content_type)
+    msg.attach(attachment_part)
+
+    raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
+
+    service = get_gmail_service(integration.access_token, integration.refresh_token)
+    try:
+        sent = service.users().messages().send(
+            userId="me", body={"raw": raw},
+        ).execute()
+    except RefreshError as exc:
+        logger.warning("Gmail send rejected — refresh token invalid: %s", exc)
+        raise GmailReauthRequiredError(
+            "Gmail token expired. Reconnect Gmail to send receipts."
+        ) from exc
+    except HttpError as exc:
+        status = getattr(getattr(exc, "resp", None), "status", None)
+        if status == 401:
+            logger.warning("Gmail send rejected with 401 — token rejected by Google")
+            raise GmailReauthRequiredError(
+                "Gmail token rejected (401). Reconnect Gmail to send receipts."
+            ) from exc
+        if status == 403:
+            logger.warning(
+                "Gmail send rejected with 403 — likely missing gmail.send scope",
+            )
+            raise GmailSendScopeError(
+                "Gmail send permission missing. Reconnect Gmail to enable receipts.",
+            ) from exc
+        logger.warning("Gmail send failed: status=%s", status)
+        raise GmailSendError(f"Gmail rejected the message (status {status})") from exc
+    except Exception as exc:
+        logger.warning("Gmail send raised an unexpected error", exc_info=True)
+        raise GmailSendError("Gmail send failed unexpectedly") from exc
+
+    sent_id = sent.get("id")
+    if not isinstance(sent_id, str) or not sent_id:
+        raise GmailSendError("Gmail did not return a message id")
+    return sent_id
+
+
 def send_message(
     integration,  # type: ignore[no-untyped-def] — app.models.integrations.Integration, avoid circular import
     *,

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
@@ -51,7 +51,7 @@ from app.services.email.exceptions import (
 )
 from app.services.integrations import integration_service
 from app.services.leases.receipt_pdf_service import ReceiptData, generate_receipt_pdf
-from app.core.storage import get_storage
+from app.core import storage as _storage_module
 
 logger = logging.getLogger(__name__)
 
@@ -320,7 +320,7 @@ async def send_receipt(
     pdf_filename = f"receipt-{receipt_number}.pdf"
 
     # ── Phase 4: upload to MinIO ──────────────────────────────────────────────
-    storage = get_storage()
+    storage = _storage_module.get_storage()
     storage_key = f"signed-leases/{signed_lease_id or 'unlinked'}/{uuid.uuid4()}/{pdf_filename}"
     storage.upload_file(storage_key, pdf_bytes, "application/pdf")
 

--- a/apps/mybookkeeper/backend/app/services/storage/bucket_initializer.py
+++ b/apps/mybookkeeper/backend/app/services/storage/bucket_initializer.py
@@ -9,12 +9,20 @@ Previous behavior (graceful degradation) hid environmental
 misconfiguration as `presigned_url=null` in API responses, with no
 visible error path — see the postmortem after PRs #201–#204 for the
 two-week trail of bugs that pattern caused.
+
+Exception: when ``allow_test_admin_promotion=true`` AND
+``minio_skip_startup_check=true`` both appear in the environment the
+bucket check is skipped so E2E test suites can run against a backend
+that has no local MinIO. Storage is still mocked at the route level via
+``POST /test/mock-gmail-send/enable`` for any test that exercises the
+receipt-send path.
 """
 from __future__ import annotations
 
 import logging
 
-from app.core.storage import get_storage
+from app.core.config import settings
+from app.core.storage import StorageNotConfiguredError, get_storage
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +34,20 @@ def ensure_bucket() -> None:
     vars missing, etc.) or `bucket_exists()` raises (MinIO unreachable),
     the exception propagates and FastAPI startup fails. The deploy
     healthcheck catches this and rolls back.
+
+    The check is intentionally skipped when both
+    ``ALLOW_TEST_ADMIN_PROMOTION=true`` and
+    ``MINIO_SKIP_STARTUP_CHECK=true`` are set — test-only escape hatch.
     """
-    storage = get_storage()
+    if settings.allow_test_admin_promotion and settings.minio_skip_startup_check:
+        logger.warning(
+            "MinIO startup check skipped (MINIO_SKIP_STARTUP_CHECK=true in test mode)"
+        )
+        return
+
+    try:
+        storage = get_storage()
+    except StorageNotConfiguredError:
+        raise
     storage.ensure_bucket()
     logger.info("MinIO bucket %s ready", storage.bucket)

--- a/apps/mybookkeeper/frontend/e2e/pending-receipts.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/pending-receipts.spec.ts
@@ -1,242 +1,359 @@
+import { test, expect } from "./fixtures/auth";
+
 /**
- * Layout E2E tests for the Pending Receipts page.
+ * Behavioral E2E tests for the rent-receipt send chain.
  *
- * Mocks the API surface so the test runs without a backend.
+ * Each test creates real data via the seed API, performs the user action,
+ * asserts the outcome via the API, and cleans up.
  *
- * Covers:
- * 1. The /receipts route renders without crashing (page header visible).
- * 2. The Receipts nav item is visible in the Tenancy sidebar section.
- * 3. The empty state is shown when the API returns no pending receipts.
- * 4. Pending receipt rows are shown when the API returns items.
- * 5. The SendReceiptDialog opens when "Review & send" is clicked.
- * 6. The skeleton loader appears while the page loads.
+ * Replaces the layout-only suite from PR #215 which only checked element
+ * visibility with mocked API responses.
+ *
+ * Three scenarios:
+ *   A. Seed payment → open /receipts → click "Review & send" → Send → assert
+ *      Gmail stub captured the send + lease attachment created.
+ *   B. Same flow as A but verifies the pending-receipts list entry disappears
+ *      after the receipt is marked sent.
+ *   C. Gmail reauth gating — expired token → send button shows toast error
+ *      about reconnecting Gmail, not a generic failure.
  */
-import { test, expect } from "@playwright/test";
 
-function plantValidJwtAndOrgInLocalStorage(page: import("@playwright/test").Page): Promise<void> {
-  return page.addInitScript(() => {
-    const futureExp = Math.floor(Date.now() / 1000) + 3600;
-    const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
-    const payload = btoa(JSON.stringify({ sub: "test-user", exp: futureExp }));
-    window.localStorage.setItem("token", `${header}.${payload}.fake-signature`);
-    window.localStorage.setItem("v1_activeOrgId", "00000000-0000-0000-0000-000000000010");
-  });
+// ---------------------------------------------------------------------------
+// Seed / cleanup helpers
+// ---------------------------------------------------------------------------
+
+interface SeedRentPaymentPayload {
+  tenant_legal_name: string;
+  tenant_email: string;
+  amount_cents: number;
+  payer_name?: string;
 }
 
-async function stubCommonRoutes(page: import("@playwright/test").Page): Promise<void> {
-  await page.route("**/api/users/me", (route) => {
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({
-        id: "00000000-0000-0000-0000-000000000001",
-        email: "host@example.com",
-        name: "Host User",
-        is_active: true,
-        is_superuser: false,
-        is_verified: true,
-        role: "owner",
-      }),
-    });
-  });
-  await page.route("**/api/organizations", (route) => {
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify([
-        { id: "00000000-0000-0000-0000-000000000010", name: "Test Workspace", role: "owner" },
-      ]),
-    });
-  });
-  await page.route("**/api/version", (route) => {
-    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) });
-  });
-  await page.route("**/api/tax-profile", (route) => {
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ onboarding_completed: true, tax_situations: [], filing_status: null, dependents_count: 0 }),
-    });
-  });
-  // Attribution review queue badge
-  await page.route("**/transactions/attribution-review-queue**", (route) => {
-    route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify({ items: [], total: 0, pending_count: 0 }),
-    });
-  });
+interface SeedRentPaymentResult {
+  applicant_id: string;
+  inquiry_id: string;
+  signed_lease_id: string;
+  transaction_id: string;
 }
 
-const MOCK_TRANSACTION = {
-  id: "00000000-0000-0000-0000-000000000aaa",
-  transaction_date: "2026-05-15",
-  amount: "1500.00",
-  vendor: "Chase Bank",
-  payer_name: "Alice Johnson",
-  description: "Rent payment",
-  category: "income",
-  transaction_type: "income",
-  tax_relevant: false,
-  payment_method: "check",
-  property_id: null,
-  applicant_id: "00000000-0000-0000-0000-000000000bbb",
-  attribution_source: "auto_exact",
-  channel: null,
-  tax_year: 2026,
-  status: "approved",
-  is_manual: false,
-  created_at: "2026-05-15T10:00:00Z",
-  updated_at: "2026-05-15T10:00:00Z",
-  vendor_id: null,
-};
+async function seedRentPayment(
+  api: import("@playwright/test").APIRequestContext,
+  payload: SeedRentPaymentPayload,
+): Promise<SeedRentPaymentResult> {
+  const res = await api.post("/test/seed-rent-payment-attributed", {
+    data: payload,
+  });
+  if (!res.ok()) {
+    throw new Error(`seedRentPayment failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json() as Promise<SeedRentPaymentResult>;
+}
 
-const MOCK_PENDING_RECEIPT = {
-  id: "00000000-0000-0000-0000-000000000ccc",
-  user_id: "00000000-0000-0000-0000-000000000001",
-  organization_id: "00000000-0000-0000-0000-000000000010",
-  transaction_id: MOCK_TRANSACTION.id,
-  applicant_id: "00000000-0000-0000-0000-000000000bbb",
-  signed_lease_id: null,
-  period_start_date: "2026-05-01",
-  period_end_date: "2026-05-31",
-  status: "pending",
-  sent_at: null,
-  sent_via_attachment_id: null,
-  created_at: "2026-05-15T10:00:00Z",
-  updated_at: "2026-05-15T10:00:00Z",
-  deleted_at: null,
-};
+async function cleanupRentPayment(
+  api: import("@playwright/test").APIRequestContext,
+  seed: SeedRentPaymentResult,
+): Promise<void> {
+  // Deleting the applicant cascades to signed leases and pending receipts.
+  // Deleting the inquiry separately ensures the email address is gone.
+  // Transaction's applicant_id goes to NULL via ON DELETE SET NULL.
+  await api.delete(`/test/applicants/${seed.applicant_id}`).catch(() => {});
+  await api.delete(`/test/inquiries/${seed.inquiry_id}`).catch(() => {});
+}
 
-test.describe("Pending Receipts page — empty", () => {
-  test.beforeEach(async ({ page }) => {
-    await plantValidJwtAndOrgInLocalStorage(page);
-    await stubCommonRoutes(page);
-    await page.route("**/api/rent-receipts/pending**", (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ items: [], total: 0, pending_count: 0 }),
-      });
+async function seedGmailIntegration(
+  api: import("@playwright/test").APIRequestContext,
+  opts: { hasSendScope: boolean } = { hasSendScope: true },
+): Promise<void> {
+  const res = await api.post("/test/seed-gmail-integration", {
+    data: { has_send_scope: opts.hasSendScope },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedGmailIntegration failed: ${res.status()} ${await res.text()}`);
+  }
+}
+
+async function removeGmailIntegration(
+  api: import("@playwright/test").APIRequestContext,
+): Promise<void> {
+  await api.delete("/test/seed-gmail-integration").catch(() => {});
+}
+
+async function enableMockGmailSend(
+  api: import("@playwright/test").APIRequestContext,
+): Promise<void> {
+  const res = await api.post("/test/mock-gmail-send/enable");
+  if (!res.ok()) {
+    throw new Error(`enableMockGmailSend failed: ${res.status()} ${await res.text()}`);
+  }
+}
+
+async function disableMockGmailSend(
+  api: import("@playwright/test").APIRequestContext,
+): Promise<void> {
+  await api.post("/test/mock-gmail-send/disable").catch(() => {});
+}
+
+async function setGmailReauthState(
+  api: import("@playwright/test").APIRequestContext,
+  needsReauth: boolean,
+): Promise<void> {
+  const res = await api.post("/test/seed-integration-reauth-state", {
+    data: { needs_reauth: needsReauth },
+  });
+  if (!res.ok()) {
+    throw new Error(`setGmailReauthState failed: ${res.status()} ${await res.text()}`);
+  }
+}
+
+interface LastGmailSendResult {
+  captured: boolean;
+  to_address?: string;
+  subject?: string;
+  has_attachment?: boolean;
+  attachment_filename?: string;
+}
+
+async function getLastGmailSend(
+  api: import("@playwright/test").APIRequestContext,
+): Promise<LastGmailSendResult> {
+  const res = await api.get("/test/last-gmail-send");
+  if (!res.ok()) {
+    throw new Error(`getLastGmailSend failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json() as Promise<LastGmailSendResult>;
+}
+
+interface LeaseAttachment {
+  id: string;
+  kind: string;
+  filename: string;
+}
+
+async function getLeaseAttachments(
+  api: import("@playwright/test").APIRequestContext,
+  leaseId: string,
+): Promise<LeaseAttachment[]> {
+  const res = await api.get(`/signed-leases/${leaseId}/attachments`);
+  if (!res.ok()) return [];
+  const data = await res.json() as LeaseAttachment[] | { items?: LeaseAttachment[] };
+  // The endpoint returns a plain array, not a paginated envelope.
+  return Array.isArray(data) ? data : (data.items ?? []);
+}
+
+// ---------------------------------------------------------------------------
+// Test A — Send from Pending Receipts page: receipt email dispatched + lease
+//           attachment created
+// ---------------------------------------------------------------------------
+
+// Serial execution is required because all three tests share process-level
+// state (the mock Gmail ring buffer and the org's Gmail integration row).
+// Parallel runs would stomp on each other's integration state mid-test.
+test.describe.serial("Pending Receipts — behavioral: send receipt chain", () => {
+  test("A: send receipt → Gmail stub captures send, lease gets rent_receipt attachment", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const seed = await seedRentPayment(api, {
+      tenant_legal_name: `E2E Tenant ${runId}`,
+      tenant_email: `e2e-receipt-${runId}@example.com`,
+      amount_cents: 150000,
+      payer_name: `E2E Tenant ${runId}`,
     });
+
+    try {
+      await seedGmailIntegration(api, { hasSendScope: true });
+      await enableMockGmailSend(api);
+
+      // Navigate to pending receipts page and find the row.
+      await page.goto("/receipts");
+      await expect(
+        page.getByTestId("pending-receipt-row").first(),
+      ).toBeVisible({ timeout: 15000 });
+
+      // Open the send dialog for our seeded row.
+      // Use the row that matches our payer name.
+      const row = page.getByText(`E2E Tenant ${runId}`).first();
+      await expect(row).toBeVisible({ timeout: 10000 });
+      // Click the "Review & send" button in the same row container.
+      const sendBtn = page
+        .locator('[data-testid="pending-receipt-row"]')
+        .filter({ hasText: `E2E Tenant ${runId}` })
+        .getByTestId("pending-receipt-send-btn");
+      await sendBtn.click();
+
+      // Dialog opens with pre-filled period dates.
+      await expect(page.getByTestId("send-receipt-dialog")).toBeVisible({ timeout: 5000 });
+      const periodStart = await page.getByTestId("receipt-period-start").inputValue();
+      expect(periodStart).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+
+      // Click Send and wait for the response.
+      const sendResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/rent-receipts/${seed.transaction_id}/send`) &&
+          r.request().method() === "POST",
+      );
+      await page.getByTestId("receipt-send-btn").click();
+      const resp = await sendResponse;
+      expect(resp.ok()).toBeTruthy();
+
+      // Dialog should close on success.
+      await expect(page.getByTestId("send-receipt-dialog")).not.toBeVisible({ timeout: 5000 });
+
+      // Assert Gmail mock captured the send with correct recipient.
+      const gmailCapture = await getLastGmailSend(api);
+      expect(gmailCapture.captured).toBe(true);
+      expect(gmailCapture.to_address).toBe(`e2e-receipt-${runId}@example.com`);
+      expect(gmailCapture.subject).toContain("Rent receipt");
+      expect(gmailCapture.has_attachment).toBe(true);
+      expect(gmailCapture.attachment_filename).toMatch(/^receipt-R-/);
+
+      // Assert a rent_receipt attachment was saved to the signed lease.
+      const attachments = await getLeaseAttachments(api, seed.signed_lease_id);
+      const receiptAttachment = attachments.find((a) => a.kind === "rent_receipt");
+      expect(receiptAttachment).toBeDefined();
+      expect(receiptAttachment?.filename).toMatch(/^receipt-R-/);
+    } finally {
+      await disableMockGmailSend(api);
+      await removeGmailIntegration(api);
+      await cleanupRentPayment(api, seed);
+    }
   });
 
-  test("renders page header", async ({ page }) => {
-    await page.goto("/receipts");
-    await expect(page.getByRole("heading", { name: /pending receipts/i })).toBeVisible({ timeout: 10000 });
-  });
+  // -------------------------------------------------------------------------
+  // Test B — After sending, the pending row is marked sent (disappears from
+  //           the pending list)
+  // -------------------------------------------------------------------------
 
-  test("shows empty state message", async ({ page }) => {
-    await page.goto("/receipts");
-    await page.waitForLoadState("networkidle");
-    await expect(page.getByText(/queue a receipt here/i)).toBeVisible({ timeout: 10000 });
-  });
-
-  test("Receipts nav item navigates here", async ({ page }) => {
-    await page.goto("/");
-    await page.waitForLoadState("domcontentloaded");
-    // Stub the API for the receipts page before clicking nav
-    await page.route("**/api/rent-receipts/pending**", (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ items: [], total: 0, pending_count: 0 }),
-      });
+  test("B: after send, pending receipt row is removed from the pending list", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const seed = await seedRentPayment(api, {
+      tenant_legal_name: `E2E Tenant B ${runId}`,
+      tenant_email: `e2e-receipt-b-${runId}@example.com`,
+      amount_cents: 120000,
     });
-    await expect(page.getByRole("link", { name: "Receipts" })).toBeVisible({ timeout: 10000 });
-    await page.getByRole("link", { name: "Receipts" }).click();
-    await expect(page).toHaveURL(/\/receipts/);
-    await expect(page.getByRole("heading", { name: /pending receipts/i })).toBeVisible({ timeout: 10000 });
-  });
-});
 
-test.describe("Pending Receipts page — with items", () => {
-  test.beforeEach(async ({ page }) => {
-    await plantValidJwtAndOrgInLocalStorage(page);
-    await stubCommonRoutes(page);
-    await page.route("**/api/rent-receipts/pending**", (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({
-          items: [MOCK_PENDING_RECEIPT],
-          total: 1,
-          pending_count: 1,
+    try {
+      await seedGmailIntegration(api, { hasSendScope: true });
+      await enableMockGmailSend(api);
+
+      // Verify the pending row appears via the API before navigating.
+      const pendingRes = await api.get("/rent-receipts/pending");
+      expect(pendingRes.ok()).toBeTruthy();
+      const pendingData = await pendingRes.json() as { items: { transaction_id: string }[] };
+      const pendingRow = pendingData.items.find(
+        (item) => item.transaction_id === seed.transaction_id,
+      );
+      expect(pendingRow).toBeDefined();
+
+      // Navigate and send.
+      await page.goto("/receipts");
+      await expect(
+        page.locator('[data-testid="pending-receipt-row"]').filter({
+          hasText: `E2E Tenant B ${runId}`,
         }),
-      });
-    });
-    await page.route(`**/api/transactions/${MOCK_TRANSACTION.id}`, (route) => {
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify(MOCK_TRANSACTION),
-      });
-    });
+      ).toBeVisible({ timeout: 15000 });
+
+      await page
+        .locator('[data-testid="pending-receipt-row"]')
+        .filter({ hasText: `E2E Tenant B ${runId}` })
+        .getByTestId("pending-receipt-send-btn")
+        .click();
+
+      await expect(page.getByTestId("send-receipt-dialog")).toBeVisible({ timeout: 5000 });
+
+      const sendResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/rent-receipts/${seed.transaction_id}/send`) &&
+          r.request().method() === "POST",
+      );
+      await page.getByTestId("receipt-send-btn").click();
+      await sendResponse;
+
+      // After sending, our row should disappear from the pending list.
+      await expect(
+        page.locator('[data-testid="pending-receipt-row"]').filter({
+          hasText: `E2E Tenant B ${runId}`,
+        }),
+      ).not.toBeVisible({ timeout: 10000 });
+
+      // Confirm via API that the receipt is now in "sent" state.
+      const afterRes = await api.get("/rent-receipts/pending");
+      expect(afterRes.ok()).toBeTruthy();
+      const afterData = await afterRes.json() as { items: { transaction_id: string }[] };
+      const stillPending = afterData.items.find(
+        (item) => item.transaction_id === seed.transaction_id,
+      );
+      expect(stillPending).toBeUndefined();
+    } finally {
+      await disableMockGmailSend(api);
+      await removeGmailIntegration(api);
+      await cleanupRentPayment(api, seed);
+    }
   });
 
-  test("shows pending count in subtitle", async ({ page }) => {
-    await page.goto("/receipts");
-    await page.waitForLoadState("networkidle");
-    await expect(page.getByText(/1 receipt ready to send/i)).toBeVisible({ timeout: 10000 });
-  });
+  // -------------------------------------------------------------------------
+  // Test C — Gmail reauth gating: expired token surfaces reconnect toast
+  // -------------------------------------------------------------------------
 
-  test("shows pending receipt row with dismiss and send buttons", async ({ page }) => {
-    await page.goto("/receipts");
-    await page.waitForLoadState("networkidle");
-    await expect(page.getByTestId("pending-receipt-row")).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId("pending-receipt-dismiss-btn")).toBeVisible();
-    await expect(page.getByTestId("pending-receipt-send-btn")).toBeVisible();
-  });
-
-  test("send receipt dialog opens when Review & send is clicked", async ({ page }) => {
-    await page.goto("/receipts");
-    await page.waitForLoadState("networkidle");
-
-    // Wait for the row to appear (requires transaction data to load)
-    await expect(page.getByTestId("pending-receipt-send-btn")).toBeVisible({ timeout: 10000 });
-    await page.getByTestId("pending-receipt-send-btn").click();
-
-    // Dialog should appear
-    await expect(page.getByTestId("send-receipt-dialog")).toBeVisible({ timeout: 5000 });
-    // Dialog has period start/end inputs
-    await expect(page.getByTestId("receipt-period-start")).toBeVisible();
-    await expect(page.getByTestId("receipt-period-end")).toBeVisible();
-    // Dialog has send and cancel buttons
-    await expect(page.getByTestId("receipt-send-btn")).toBeVisible();
-    await expect(page.getByTestId("receipt-cancel-btn")).toBeVisible();
-  });
-
-  test("send receipt dialog closes when cancel is clicked", async ({ page }) => {
-    await page.goto("/receipts");
-    await page.waitForLoadState("networkidle");
-    await expect(page.getByTestId("pending-receipt-send-btn")).toBeVisible({ timeout: 10000 });
-    await page.getByTestId("pending-receipt-send-btn").click();
-
-    await expect(page.getByTestId("send-receipt-dialog")).toBeVisible({ timeout: 5000 });
-    await page.getByTestId("receipt-cancel-btn").click();
-    await expect(page.getByTestId("send-receipt-dialog")).not.toBeVisible();
-  });
-});
-
-test.describe("Pending Receipts page — skeleton loading", () => {
-  test("shows skeleton rows while loading", async ({ page }) => {
-    await plantValidJwtAndOrgInLocalStorage(page);
-    await stubCommonRoutes(page);
-
-    // Delay the pending receipts API response to see skeleton
-    await page.route("**/api/rent-receipts/pending**", async (route) => {
-      await new Promise((resolve) => setTimeout(resolve, 500));
-      route.fulfill({
-        status: 200,
-        contentType: "application/json",
-        body: JSON.stringify({ items: [], total: 0, pending_count: 0 }),
-      });
+  test("C: expired Gmail token → send shows reconnect-Gmail error, not generic failure", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const seed = await seedRentPayment(api, {
+      tenant_legal_name: `E2E Tenant C ${runId}`,
+      tenant_email: `e2e-receipt-c-${runId}@example.com`,
+      amount_cents: 90000,
     });
 
-    await page.goto("/receipts");
+    try {
+      // Seed integration with send scope but force needs_reauth=true.
+      await seedGmailIntegration(api, { hasSendScope: true });
+      await setGmailReauthState(api, true);
 
-    // The skeleton should appear briefly before the data loads
-    // We just verify the page eventually loads correctly without crashing
-    await expect(page.getByRole("heading", { name: /pending receipts/i })).toBeVisible({ timeout: 15000 });
+      // Navigate and open the dialog.
+      await page.goto("/receipts");
+      await expect(
+        page.locator('[data-testid="pending-receipt-row"]').filter({
+          hasText: `E2E Tenant C ${runId}`,
+        }),
+      ).toBeVisible({ timeout: 15000 });
+
+      await page
+        .locator('[data-testid="pending-receipt-row"]')
+        .filter({ hasText: `E2E Tenant C ${runId}` })
+        .getByTestId("pending-receipt-send-btn")
+        .click();
+
+      await expect(page.getByTestId("send-receipt-dialog")).toBeVisible({ timeout: 5000 });
+
+      // Click send — the backend returns 503 with gmail_reauth_required.
+      const sendResponse = page.waitForResponse(
+        (r) =>
+          r.url().includes(`/api/rent-receipts/${seed.transaction_id}/send`) &&
+          r.request().method() === "POST",
+      );
+      await page.getByTestId("receipt-send-btn").click();
+      const resp = await sendResponse;
+      // Backend returns 503 for gmail_reauth_required.
+      expect(resp.status()).toBe(503);
+
+      // The frontend should show a reconnect-specific toast, not a generic error.
+      await expect(
+        page.getByText(/reconnect gmail/i),
+      ).toBeVisible({ timeout: 5000 });
+
+      // Dialog stays open so the user can cancel or retry.
+      await expect(page.getByTestId("send-receipt-dialog")).toBeVisible();
+    } finally {
+      // Reset reauth state before cleanup so the integration deletion succeeds.
+      await setGmailReauthState(api, false).catch(() => {});
+      await removeGmailIntegration(api);
+      await cleanupRentPayment(api, seed);
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replaces 8 element-visibility tests in `pending-receipts.spec.ts` with 3 behavioral tests that exercise the full receipt-send chain end-to-end (seed → navigate → send → assert Gmail captured + attachment created)
- Adds 3 new test-utils seed endpoints to support the behavioral tests: `POST /test/seed-rent-payment-attributed`, `GET /test/last-gmail-send`, `POST /test/seed-integration-reauth-state`
- Fixes two real bugs uncovered during implementation: `gmail_service.send_message_with_attachment` was missing entirely (PR #215 gap), and `receipt_service.py` used a direct `from ... import get_storage` that made the E2E mock invisible to the service

## What changed

**New behavioral tests (3):**
- **A**: Seed attributed rent payment → navigate to `/receipts` → click Send → assert Gmail mock captured send (correct recipient, subject, attachment filename) → assert `rent_receipt` attachment row created on the signed lease
- **B**: Same flow → assert pending row disappears from the UI and the `/rent-receipts/pending` API after send completes
- **C**: Gmail reauth gating — set `needs_reauth=true` → send returns 503 → frontend shows "reconnect Gmail" toast, not a generic error

**Backend additions:**
- `POST /test/seed-rent-payment-attributed` — creates the full attributed payment fixture chain (inquiry → applicant → signed lease → transaction → pending receipt) in one call
- `GET /test/last-gmail-send` — returns args from the most recent mock `send_message_with_attachment` call
- `POST /test/seed-integration-reauth-state` — sets `needs_reauth` on the org's Gmail integration
- Extended `POST /test/mock-gmail-send/enable` to also patch `get_storage` with a `_NoOpStorage` so PDF uploads succeed without MinIO

**Bug fixes:**
- `gmail_service.py`: implemented `send_message_with_attachment` (was missing; `receipt_service.py` called it but it didn't exist)
- `receipt_service.py`: changed from `from app.core.storage import get_storage` (captures original reference at import time, invisible to runtime mock) to `from app.core import storage as _storage_module` and calling `_storage_module.get_storage()` (picks up the runtime patch)
- `bucket_initializer.py` + `config.py`: added `MINIO_SKIP_STARTUP_CHECK` flag so the backend can start in test environments without a real MinIO bucket (only effective when `ALLOW_TEST_ADMIN_PROMOTION=true`)

**CI:**
- Removed `pending-receipts.spec.ts` from the `frontend-layout-e2e` job — it now requires a real backend and belongs in the full behavioral E2E suite

## Test plan

- [x] All 3 new behavioral tests pass locally (`3 passed (10.1s)`)
- [x] Test B and C previously passed; Test A had two bugs fixed (missing function + storage mock not applied)
- [x] Manual API verification: mock enable → seed Gmail → seed payment → send → `last-gmail-send` returns correct to_address, subject, attachment_filename
- [x] CI: `frontend-layout-e2e` job no longer includes `pending-receipts.spec.ts` (it would fail without a backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)