### PR TITLE
fix(mybookkeeper/observability): Sentry fail-loud + log OAuth exception class before propagating

### DIFF
--- a/apps/mybookkeeper/backend/.env.docker.example
+++ b/apps/mybookkeeper/backend/.env.docker.example
@@ -3,6 +3,11 @@
 #   cp backend/.env.docker.example backend/.env.docker
 # DATABASE_URL is set via docker-compose.yml environment, not here.
 
+# Deployment environment — controls Sentry enforcement.
+# Set to "production" in prod deployments; Sentry DSN becomes REQUIRED.
+# Leave as "development" or "test" for local/CI environments.
+ENVIRONMENT=production
+
 SECRET_KEY=change-me-to-random-64-chars
 ENCRYPTION_KEY=change-me-to-random-64-chars
 ANTHROPIC_API_KEY=

--- a/apps/mybookkeeper/backend/.env.example
+++ b/apps/mybookkeeper/backend/.env.example
@@ -10,6 +10,10 @@ JWT_LIFETIME_SECONDS=86400
 GMAIL_POLL_INTERVAL_MINUTES=15
 MAX_UPLOADS_PER_USER_PER_DAY=50
 MAX_UPLOAD_SIZE_BYTES=10485760
+# Deployment environment — controls Sentry enforcement.
+# Set to "production" in prod deployments; SENTRY_DSN becomes REQUIRED.
+# Use "development" or "test" locally/in CI to allow an empty SENTRY_DSN.
+ENVIRONMENT=development
 SENTRY_DSN=
 POSTHOG_API_KEY=
 

--- a/apps/mybookkeeper/backend/app/api/integrations.py
+++ b/apps/mybookkeeper/backend/app/api/integrations.py
@@ -49,6 +49,9 @@ async def gmail_callback(
         await integration_service.handle_gmail_callback(code, state)
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        logger.exception("Gmail OAuth callback failed — exception class and traceback above")
+        raise
     return RedirectResponse(url=f"{settings.frontend_url}/oauth-callback")
 
 

--- a/apps/mybookkeeper/backend/app/core/config.py
+++ b/apps/mybookkeeper/backend/app/core/config.py
@@ -56,6 +56,7 @@ class Settings(BaseSettings):
 
     gmail_label: str = ""
 
+    environment: str = "development"
     sentry_dsn: str = ""
     posthog_api_key: str = ""
 

--- a/apps/mybookkeeper/backend/app/core/observability.py
+++ b/apps/mybookkeeper/backend/app/core/observability.py
@@ -1,0 +1,58 @@
+"""Sentry initialisation with fail-loud production enforcement.
+
+In production (``ENVIRONMENT=production``), a missing ``SENTRY_DSN`` is a
+deployment-time fault — not a graceful degradation. The FastAPI lifespan
+calls ``init_sentry()`` at boot; if the DSN is absent in prod, it raises
+``SentryNotConfiguredError`` which crashes the lifespan, fails the
+healthcheck, and triggers a deploy rollback.
+
+In non-production environments (``development``, ``test``, etc.), Sentry is
+optional — ``init_sentry()`` exits silently when the DSN is empty.
+"""
+import logging
+
+import sentry_sdk
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class SentryNotConfiguredError(RuntimeError):
+    """Raised at boot when ``SENTRY_DSN`` is missing in a production environment.
+
+    Distinct from a transient network outage: this is a deployment-time fault
+    that should crash the app immediately so the healthcheck catches it.
+    """
+
+
+def init_sentry() -> None:
+    """Initialise the Sentry SDK.
+
+    Raises:
+        SentryNotConfiguredError: If ``ENVIRONMENT=production`` and
+            ``SENTRY_DSN`` is not set.
+    """
+    if not settings.sentry_dsn:
+        if settings.environment == "production":
+            raise SentryNotConfiguredError(
+                "SENTRY_DSN is required in production. "
+                "Set the SENTRY_DSN environment variable or set "
+                "ENVIRONMENT to 'development' / 'test' to skip Sentry."
+            )
+        # Non-production: Sentry is optional — skip silently.
+        return
+
+    try:
+        sentry_sdk.init(
+            dsn=settings.sentry_dsn,
+            send_default_pii=False,
+            traces_sample_rate=0.1,
+            environment=settings.environment,
+        )
+    except Exception:
+        logger.warning(
+            "Sentry initialisation failed — error reporting will be unavailable.",
+            exc_info=True,
+        )
+        raise

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -7,7 +7,6 @@ from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 
-import sentry_sdk
 from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
@@ -17,6 +16,7 @@ from sqlalchemy import text
 
 from app.core.auth import fastapi_users, auth_backend
 from app.core.config import settings
+from app.core.observability import init_sentry
 
 
 def _resolve_git_commit() -> str:
@@ -36,13 +36,6 @@ def _resolve_git_commit() -> str:
 GIT_COMMIT = _resolve_git_commit()
 STARTUP_TIMESTAMP = datetime.now(timezone.utc).isoformat()
 
-if settings.sentry_dsn:
-    sentry_sdk.init(
-        dsn=settings.sentry_dsn,
-        send_default_pii=False,
-        traces_sample_rate=0.1,
-        environment="production",
-    )
 from app.core.audit import current_user_id, register_audit_listeners
 from app.core.rate_limit import check_account_not_locked, check_login_rate_limit, check_password_reset_rate_limit, check_register_rate_limit, require_turnstile
 from app.db.session import AsyncSessionLocal
@@ -61,6 +54,7 @@ logger = logging.getLogger("app")
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    init_sentry()
     register_audit_listeners()
     ensure_bucket()
     worker_task: asyncio.Task[None] | None = None

--- a/apps/mybookkeeper/backend/app/services/integrations/integration_service.py
+++ b/apps/mybookkeeper/backend/app/services/integrations/integration_service.py
@@ -1,3 +1,4 @@
+import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -16,6 +17,8 @@ from app.models.responses.retry_result import RetryResult
 from app.models.responses.sync_log_info import SyncLogInfo
 from app.repositories import email_queue_repo, integration_repo, sync_log_repo
 from app.services.system.auth_event_service import log_auth_event
+
+logger = logging.getLogger(__name__)
 
 GMAIL_READONLY_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
 GMAIL_SEND_SCOPE = "https://www.googleapis.com/auth/gmail.send"
@@ -96,7 +99,11 @@ async def handle_gmail_callback(code: str, state: str) -> None:
     user_id_str, org_id_str = _verify_oauth_state(state)
 
     flow = _get_flow()
-    flow.fetch_token(code=code)
+    try:
+        flow.fetch_token(code=code)
+    except Exception:
+        logger.exception("Gmail OAuth token exchange failed (fetch_token)")
+        raise
     creds = flow.credentials
     expiry = creds.expiry or datetime.now(timezone.utc) + timedelta(seconds=3600)
 
@@ -105,26 +112,30 @@ async def handle_gmail_callback(code: str, state: str) -> None:
     # missing send-scope without a Google round-trip.
     granted_scopes = list(creds.scopes) if creds.scopes else []
 
-    async with unit_of_work() as db:
-        integration = await integration_repo.upsert_gmail(
-            db,
-            organization_id=uuid.UUID(org_id_str),
-            user_id=uuid.UUID(user_id_str),
-            access_token=creds.token,
-            refresh_token=creds.refresh_token,
-            token_expiry=expiry,
-            scopes=granted_scopes,
-        )
-        # A successful re-auth clears any stale reauth state so the UI
-        # reconnect banner goes away immediately after the OAuth popup closes.
-        await integration_repo.clear_reauth_state(db, integration)
-        await log_auth_event(
-            db,
-            event_type=AuthEventType.OAUTH_CONNECT,
-            user_id=uuid.UUID(user_id_str),
-            succeeded=True,
-            metadata={"provider": "gmail"},
-        )
+    try:
+        async with unit_of_work() as db:
+            integration = await integration_repo.upsert_gmail(
+                db,
+                organization_id=uuid.UUID(org_id_str),
+                user_id=uuid.UUID(user_id_str),
+                access_token=creds.token,
+                refresh_token=creds.refresh_token,
+                token_expiry=expiry,
+                scopes=granted_scopes,
+            )
+            # A successful re-auth clears any stale reauth state so the UI
+            # reconnect banner goes away immediately after the OAuth popup closes.
+            await integration_repo.clear_reauth_state(db, integration)
+            await log_auth_event(
+                db,
+                event_type=AuthEventType.OAUTH_CONNECT,
+                user_id=uuid.UUID(user_id_str),
+                succeeded=True,
+                metadata={"provider": "gmail"},
+            )
+    except Exception:
+        logger.exception("Gmail OAuth upsert failed (upsert_gmail / clear_reauth_state)")
+        raise
 
 
 async def list_integrations(

--- a/apps/mybookkeeper/backend/tests/conftest.py
+++ b/apps/mybookkeeper/backend/tests/conftest.py
@@ -13,6 +13,10 @@ import pytest
 # ensures the guard fires before any test module is collected.
 os.environ.setdefault("MAGIC_DISABLED", "1")
 
+# Environment tag — set to "test" so init_sentry() does not require SENTRY_DSN.
+# Must be set before settings is imported.
+os.environ.setdefault("ENVIRONMENT", "test")
+
 # Storage env vars — set before settings is imported so ``get_storage()``
 # doesn't raise StorageNotConfiguredError when the lifespan or any
 # service touches it. The ``_patch_storage_for_tests`` autouse fixture

--- a/apps/mybookkeeper/backend/tests/test_oauth_callback_logging.py
+++ b/apps/mybookkeeper/backend/tests/test_oauth_callback_logging.py
@@ -1,0 +1,201 @@
+"""Tests for Gmail OAuth callback exception logging.
+
+The route ``GET /integrations/gmail/callback`` must log the full traceback
+(including exception class) to stdout/docker-logs before propagating any
+non-ValueError exception. This guarantees that production failures are
+visible in ``docker logs mybookkeeper-api-1`` even when Sentry is not yet
+configured.
+
+Two layers are covered:
+1. The route handler (``app/api/integrations.py``) — catches ``Exception``,
+   calls ``logger.exception()``, then re-raises.
+2. The service layer (``app/services/integrations/integration_service.py``) —
+   ``fetch_token`` and ``upsert_gmail`` failure points each call
+   ``logger.exception()`` before propagating.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+# ---------------------------------------------------------------------------
+# Route-layer tests
+# ---------------------------------------------------------------------------
+class TestGmailCallbackRouteLogging:
+    """The route handler must log unexpected exceptions before re-raising."""
+
+    def _make_client(self) -> TestClient:
+        from app.main import app
+        # raise_server_exceptions=False so the TestClient returns a 500 response
+        # instead of re-raising the exception in the test process.
+        return TestClient(app, raise_server_exceptions=False)
+
+    def test_logs_and_returns_500_on_unexpected_exception(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When handle_gmail_callback raises a non-ValueError, the route logs
+        the full traceback (logger.exception) and returns HTTP 500."""
+        from app.api import integrations as integrations_module
+
+        class _FakeOAuthError(Exception):
+            pass
+
+        with patch.object(
+            integrations_module.integration_service,
+            "handle_gmail_callback",
+            new=AsyncMock(side_effect=_FakeOAuthError("token exchange failed")),
+        ):
+            with caplog.at_level(logging.ERROR, logger="app.api.integrations"):
+                client = self._make_client()
+                response = client.get(
+                    "/integrations/gmail/callback",
+                    params={"code": "fake-code", "state": "fake-state"},
+                    follow_redirects=False,
+                )
+
+        assert response.status_code == 500
+        # The logger.exception call emits at ERROR level with exc_info=True.
+        error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("Gmail OAuth callback failed" in m for m in error_messages), (
+            f"Expected 'Gmail OAuth callback failed' in logs; got: {error_messages}"
+        )
+
+    def test_still_returns_400_for_value_error(self) -> None:
+        """ValueError (bad state token) continues to return HTTP 400, not 500."""
+        from app.api import integrations as integrations_module
+
+        with patch.object(
+            integrations_module.integration_service,
+            "handle_gmail_callback",
+            new=AsyncMock(side_effect=ValueError("Invalid OAuth state")),
+        ):
+            client = self._make_client()
+            response = client.get(
+                "/integrations/gmail/callback",
+                params={"code": "fake-code", "state": "bad-state"},
+                follow_redirects=False,
+            )
+
+        assert response.status_code == 400
+
+    def test_does_not_log_for_value_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """ValueError must NOT trigger the logger.exception path."""
+        from app.api import integrations as integrations_module
+
+        with patch.object(
+            integrations_module.integration_service,
+            "handle_gmail_callback",
+            new=AsyncMock(side_effect=ValueError("bad state")),
+        ):
+            with caplog.at_level(logging.ERROR, logger="app.api.integrations"):
+                client = self._make_client()
+                client.get(
+                    "/integrations/gmail/callback",
+                    params={"code": "fake-code", "state": "bad-state"},
+                    follow_redirects=False,
+                )
+
+        error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        # ValueError should be handled as 400 without logging the full trace
+        assert not any("Gmail OAuth callback failed" in m for m in error_messages), (
+            "ValueError should not trigger the exception logger; "
+            f"got unexpected log messages: {error_messages}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Service-layer tests
+# ---------------------------------------------------------------------------
+class TestHandleGmailCallbackServiceLogging:
+    """handle_gmail_callback must log at the failure site before re-raising."""
+
+    @pytest.mark.asyncio
+    async def test_logs_fetch_token_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """fetch_token() raising triggers logger.exception in the service layer."""
+        from app.services.integrations import integration_service
+
+        class _TokenError(Exception):
+            pass
+
+        fake_flow = MagicMock()
+        fake_flow.fetch_token.side_effect = _TokenError("network timeout")
+
+        with patch.object(integration_service, "_get_flow", return_value=fake_flow):
+            with patch.object(
+                integration_service,
+                "_verify_oauth_state",
+                return_value=(str(uuid.uuid4()), str(uuid.uuid4())),
+            ):
+                with caplog.at_level(
+                    logging.ERROR,
+                    logger="app.services.integrations.integration_service",
+                ):
+                    with pytest.raises(_TokenError):
+                        await integration_service.handle_gmail_callback(
+                            code="code", state="state"
+                        )
+
+        error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("fetch_token" in m for m in error_messages), (
+            f"Expected fetch_token failure log; got: {error_messages}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_logs_upsert_failure(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """upsert_gmail() raising triggers logger.exception in the service layer."""
+        from app.services.integrations import integration_service
+
+        class _DbError(Exception):
+            pass
+
+        fake_creds = MagicMock()
+        fake_creds.token = "access-token"
+        fake_creds.refresh_token = "refresh-token"
+        fake_creds.expiry = None
+        fake_creds.scopes = []
+
+        fake_flow = MagicMock()
+        fake_flow.credentials = fake_creds
+
+        with patch.object(integration_service, "_get_flow", return_value=fake_flow):
+            with patch.object(
+                integration_service,
+                "_verify_oauth_state",
+                return_value=(str(uuid.uuid4()), str(uuid.uuid4())),
+            ):
+                with patch.object(
+                    integration_service.integration_repo,
+                    "upsert_gmail",
+                    new=AsyncMock(side_effect=_DbError("db unavailable")),
+                ):
+                    with patch(
+                        "app.services.integrations.integration_service.unit_of_work"
+                    ) as mock_uow:
+                        mock_db = AsyncMock()
+                        mock_uow.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+                        mock_uow.return_value.__aexit__ = AsyncMock(return_value=False)
+
+                        with caplog.at_level(
+                            logging.ERROR,
+                            logger="app.services.integrations.integration_service",
+                        ):
+                            with pytest.raises(_DbError):
+                                await integration_service.handle_gmail_callback(
+                                    code="code", state="state"
+                                )
+
+        error_messages = [r.message for r in caplog.records if r.levelno >= logging.ERROR]
+        assert any("upsert" in m.lower() for m in error_messages), (
+            f"Expected upsert failure log; got: {error_messages}"
+        )

--- a/apps/mybookkeeper/backend/tests/test_observability.py
+++ b/apps/mybookkeeper/backend/tests/test_observability.py
@@ -1,0 +1,142 @@
+"""Tests for Sentry fail-loud initialisation (app/core/observability.py).
+
+Design:
+- In production (ENVIRONMENT=production), SENTRY_DSN must be set.
+  A missing DSN raises SentryNotConfiguredError at boot — lifespan
+  crashes, healthcheck fails, deploy rolls back.
+- In non-production environments, an empty SENTRY_DSN is silently
+  accepted — Sentry is optional for local dev and CI.
+- When a DSN is present, sentry_sdk.init is called with the correct
+  environment tag (not a hardcoded "production" string).
+- When sentry_sdk.init raises, the exception is logged as a warning and
+  then re-raised so the lifespan still crashes rather than booting
+  with a broken Sentry connection.
+
+We construct a _local_ settings-like object for each test (never mutate
+the module-level singleton) and patch ``app.core.observability.settings``
+so ``init_sentry()`` sees the values we control.
+"""
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from app.core.observability import SentryNotConfiguredError, init_sentry
+
+
+def _make_settings(*, environment: str, sentry_dsn: str) -> SimpleNamespace:
+    """Return a settings-like namespace used to patch observability.settings."""
+    return SimpleNamespace(environment=environment, sentry_dsn=sentry_dsn)
+
+
+class TestSentryNotConfiguredError:
+    def test_is_runtime_error_subclass(self) -> None:
+        assert issubclass(SentryNotConfiguredError, RuntimeError)
+
+    def test_carries_message(self) -> None:
+        err = SentryNotConfiguredError("missing DSN")
+        assert "missing DSN" in str(err)
+
+
+class TestInitSentryProductionRequiresDsn:
+    """In production, a missing DSN must crash the process at boot."""
+
+    def test_raises_when_production_and_dsn_empty(self) -> None:
+        fake_settings = _make_settings(environment="production", sentry_dsn="")
+        with patch("app.core.observability.settings", fake_settings):
+            with pytest.raises(SentryNotConfiguredError, match="SENTRY_DSN is required"):
+                init_sentry()
+
+    def test_does_not_raise_when_production_and_dsn_set(self) -> None:
+        fake_settings = _make_settings(
+            environment="production", sentry_dsn="https://abc@sentry.io/123"
+        )
+        with patch("app.core.observability.settings", fake_settings):
+            with patch("app.core.observability.sentry_sdk.init"):
+                init_sentry()  # must not raise
+
+
+class TestInitSentryNonProductionAllowsEmptyDsn:
+    """In development / test, an empty DSN is silently skipped."""
+
+    @pytest.mark.parametrize("env", ["development", "test", "staging", ""])
+    def test_does_not_raise_when_non_production_and_dsn_empty(self, env: str) -> None:
+        fake_settings = _make_settings(environment=env, sentry_dsn="")
+        with patch("app.core.observability.settings", fake_settings):
+            init_sentry()  # must not raise
+
+    def test_does_not_call_sentry_init_when_dsn_empty(self) -> None:
+        fake_settings = _make_settings(environment="development", sentry_dsn="")
+        with patch("app.core.observability.settings", fake_settings):
+            with patch("app.core.observability.sentry_sdk.init") as mock_init:
+                init_sentry()
+        mock_init.assert_not_called()
+
+
+class TestInitSentryPassesEnvironmentTag:
+    """The environment tag passed to sentry_sdk.init must come from settings,
+    not from a hardcoded string."""
+
+    @pytest.mark.parametrize("env", ["production", "staging"])
+    def test_passes_environment_to_sentry(self, env: str) -> None:
+        fake_settings = _make_settings(
+            environment=env, sentry_dsn="https://abc@sentry.io/123"
+        )
+        with patch("app.core.observability.settings", fake_settings):
+            with patch("app.core.observability.sentry_sdk.init") as mock_init:
+                init_sentry()
+
+        mock_init.assert_called_once()
+        _, kwargs = mock_init.call_args
+        assert kwargs["environment"] == env, (
+            f"Expected environment={env!r} in sentry_sdk.init, got {kwargs.get('environment')!r}"
+        )
+
+    def test_passes_dsn_and_other_params(self) -> None:
+        dsn = "https://abc@sentry.io/999"
+        fake_settings = _make_settings(environment="production", sentry_dsn=dsn)
+        with patch("app.core.observability.settings", fake_settings):
+            with patch("app.core.observability.sentry_sdk.init") as mock_init:
+                init_sentry()
+
+        _, kwargs = mock_init.call_args
+        assert kwargs["dsn"] == dsn
+        assert kwargs["send_default_pii"] is False
+        assert "traces_sample_rate" in kwargs
+
+
+class TestInitSentryPropagatesInitFailure:
+    """If sentry_sdk.init raises (e.g. bad DSN format), the exception must be
+    logged as a warning and then re-raised so the lifespan still fails loudly."""
+
+    def test_reraises_when_sentry_init_throws(self) -> None:
+        fake_settings = _make_settings(
+            environment="production", sentry_dsn="https://abc@sentry.io/123"
+        )
+        with patch("app.core.observability.settings", fake_settings):
+            with patch(
+                "app.core.observability.sentry_sdk.init",
+                side_effect=RuntimeError("bad DSN"),
+            ):
+                with pytest.raises(RuntimeError, match="bad DSN"):
+                    init_sentry()
+
+    def test_logs_warning_before_reraising(self, caplog: pytest.LogCaptureFixture) -> None:
+        fake_settings = _make_settings(
+            environment="production", sentry_dsn="https://abc@sentry.io/123"
+        )
+        with patch("app.core.observability.settings", fake_settings):
+            with patch(
+                "app.core.observability.sentry_sdk.init",
+                side_effect=Exception("init error"),
+            ):
+                with caplog.at_level(logging.WARNING, logger="app.core.observability"):
+                    with pytest.raises(Exception):
+                        init_sentry()
+
+        assert any("unavailable" in r.message.lower() for r in caplog.records), (
+            f"Expected a warning about Sentry being unavailable; got: {[r.message for r in caplog.records]}"
+        )


### PR DESCRIPTION
## Summary

- **Part A — Sentry fail-loud**: Rips out the silent `if settings.sentry_dsn: sentry_sdk.init(...)` pattern that was silently disabling error reporting in production when `SENTRY_DSN` was unset. Mirrors the same fail-loud approach introduced for storage in PR #205. A missing `SENTRY_DSN` in `ENVIRONMENT=production` now raises `SentryNotConfiguredError` inside the FastAPI lifespan — the app refuses to boot, the healthcheck fails, and the deploy rolls back. Non-production environments (`development`, `test`) allow an empty DSN and skip Sentry silently, so local dev and CI are unaffected.

- **Part B — OAuth callback logging**: The user is hitting a 500 on `GET /integrations/gmail/callback` in production but can't see the actual exception class because (a) Sentry was silently disabled (fixed by Part A) and (b) the route swallowed non-`ValueError` exceptions as bare 500s with no trace in docker logs. Added `except Exception: logger.exception(...); raise` in the route handler, plus targeted `logger.exception()` calls at `flow.fetch_token(code=code)` and `upsert_gmail()` in the service layer. The next time the OAuth flow fails, `docker logs mybookkeeper-api-1` will show the actual exception class and full traceback.

## Files changed

- `app/core/observability.py` — new module with `SentryNotConfiguredError` + `init_sentry()`
- `app/core/config.py` — adds `environment: str = "development"` field to `Settings`
- `app/main.py` — removes inline sentry init block; calls `init_sentry()` in lifespan
- `app/api/integrations.py` — adds `except Exception` with `logger.exception()` before re-raise
- `app/services/integrations/integration_service.py` — adds `logger` + `logger.exception()` at `fetch_token` and `upsert_gmail` failure sites
- `tests/conftest.py` — sets `ENVIRONMENT=test` so test suite never requires a DSN
- `backend/.env.example` — documents `ENVIRONMENT=development`
- `backend/.env.docker.example` — documents `ENVIRONMENT=production` (required in prod)
- `tests/test_observability.py` — 14 new unit tests
- `tests/test_oauth_callback_logging.py` — 5 new tests

## Test results

19 new tests, all passing. Full regression run on the related test modules: 94/94 pass.

## Deployment note

After merging, add `ENVIRONMENT=production` to the VPS `.env.docker` (or confirm it's already there via `docker exec mybookkeeper-api-1 env | grep ENVIRONMENT`). The app will boot without it (defaults to `development`, which skips the DSN check) — but the fail-loud protection only kicks in once you explicitly set `production`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)