### PR TITLE
feat(mybookkeeper/email): comprehensive P2P payment support (Zelle/Venmo/Cash App/PayPal/etc.)

### DIFF
--- a/apps/mybookkeeper/backend/app/core/config.py
+++ b/apps/mybookkeeper/backend/app/core/config.py
@@ -33,15 +33,32 @@ class Settings(BaseSettings):
     # universe MBK can react to:
     #   - Document-extractor patterns (invoice/receipt/billing/etc.)
     #   - Airbnb host payouts (subject:payout)
-    #   - Peer-to-peer rent payments (Zelle/Venmo/Cash App/Chase Zelle alerts)
+    #   - Peer-to-peer rent payments (Zelle/Venmo/Cash App/PayPal/Apple Pay)
+    #     across multiple banks (Chase, BoA, Wells, Citi, Capital One, etc.)
     gmail_search_query: str = (
+        # --- Document-extractor patterns ------------------------------------
         "subject:invoice OR subject:receipt OR subject:payment OR subject:payout OR "
         "subject:billing OR subject:statement OR subject:booking OR subject:report OR "
         "subject:financial OR has:attachment OR "
-        # Rent-attribution catches — peer-to-peer payment notifications
+        # --- Peer-to-peer payment subjects ----------------------------------
+        # Platform-named subjects
         "subject:zelle OR subject:venmo OR subject:\"cash app\" OR "
+        "subject:cashapp OR subject:paypal OR subject:\"apple pay\" OR "
+        # Generic money-movement phrases — catches forwarded subjects too
+        # ("Fwd: ..." prefix doesn't break Gmail subject token matching)
         "subject:\"received money\" OR subject:\"sent you money\" OR "
-        "from:no.reply.alerts@chase.com OR from:venmo@venmo.com OR from:cash@square.com"
+        "subject:\"sent you\" OR subject:\"paid you\" OR "
+        "subject:\"you received\" OR subject:\"you got paid\" OR "
+        "subject:\"deposit alert\" OR subject:\"transfer received\" OR "
+        # --- Peer-to-peer payment senders -----------------------------------
+        # Standalone platforms
+        "from:zellepay.com OR from:venmo.com OR from:cash.app OR "
+        "from:paypal.com OR from:square.com OR "
+        # Bank-routed Zelle / deposit alerts (major US issuers)
+        "from:no.reply.alerts@chase.com OR from:alerts.chase.com OR "
+        "from:ealerts.bankofamerica.com OR from:notify.wellsfargo.com OR "
+        "from:notification.capitalone.com OR from:alerts.citibank.com OR "
+        "from:usaa.com OR from:alerts.usbank.com OR from:pncalerts.com"
     )
     max_uploads_per_user_per_day: int = 50
     max_upload_size_bytes: int = 100 * 1024 * 1024  # 100MB (supports zip uploads)

--- a/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
@@ -75,8 +75,14 @@ async def save_email_extraction(
     records_added = 0
     ext_record: Extraction | None = None
 
-    # Payment confirmations: skip entirely — they duplicate the original invoice
-    if ext_doc_type == "payment_confirmation" or _is_payment_confirmation(documents_data):
+    # Payment confirmations: skip entirely — they duplicate the original invoice.
+    # Carve-out: peer-to-peer transfers (Zelle/Venmo/Cash App/PayPal etc.) ARE
+    # the source of truth for rent income, not duplicates. If any document in
+    # the batch looks like a P2P payment, we must not short-circuit here.
+    has_p2p = any(_looks_like_p2p_payment(d) for d in documents_data)
+    if not has_p2p and (
+        ext_doc_type == "payment_confirmation" or _is_payment_confirmation(documents_data)
+    ):
         logger.info(
             "Skipping payment confirmation email (message_id=%s, subject=%r)",
             message_id, subject,
@@ -238,14 +244,46 @@ _PAYMENT_CONFIRMATION_PATTERNS = re.compile(
     re.IGNORECASE,
 )
 
+# Peer-to-peer money transfer notifications. These emails ARE the source of
+# truth for rent income — they must NEVER be silently dropped as
+# "payment_confirmation duplicates of an invoice", because there is no
+# invoice. Defense-in-depth: even if Claude mis-classifies, the presence of
+# a payer_name + non-zero amount + a P2P-platform vendor short-circuits the
+# skip.
+_P2P_PLATFORM_VENDORS = frozenset({
+    "zelle", "venmo", "cash app", "cashapp", "paypal", "apple pay", "google pay",
+})
+
+
+def _looks_like_p2p_payment(data: dict) -> bool:
+    """Return True if the extraction looks like a peer-to-peer transfer.
+
+    P2P payments have a real payer (not the host) AND a real amount AND a
+    P2P-platform vendor. They must bypass the payment_confirmation skip path.
+    """
+    payer = (data.get("payer_name") or "").strip()
+    if not payer:
+        return False
+    amount_raw = data.get("amount")
+    try:
+        if amount_raw is None or float(str(amount_raw)) <= 0:
+            return False
+    except (TypeError, ValueError):
+        return False
+    vendor = (data.get("vendor") or "").strip().lower()
+    return any(platform in vendor for platform in _P2P_PLATFORM_VENDORS)
+
 
 def _is_payment_confirmation(documents_data: list) -> bool:
     """Detect payment confirmations from extraction data as a fallback.
 
     Checks if any extracted item has a document_type of 'payment_confirmation'
     or if the description/vendor text matches common payment confirmation patterns.
+    Peer-to-peer transfers are explicitly excluded — see _looks_like_p2p_payment.
     """
     for data in documents_data:
+        if _looks_like_p2p_payment(data):
+            continue
         if data.get("document_type") == "payment_confirmation":
             return True
         desc = data.get("description") or ""

--- a/apps/mybookkeeper/backend/app/services/extraction/prompts/base_prompt.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/prompts/base_prompt.py
@@ -38,6 +38,16 @@ Always return this structure (documents is always an array, even for a single re
   - Bill-ready notifications: "Your bill is ready to view", "Your statement is available", "View your bill online", "Bill reminder"
   - Any email that notifies about a bill or payment but does NOT contain the actual bill/invoice document itself
   When you detect any of these, return a single document entry with document_type "payment_confirmation", the vendor name, a description, amount null, and category "uncategorized" — do NOT extract transaction amounts, as these duplicate the original invoice or bill
+
+  CRITICAL EXCEPTION — peer-to-peer money transfer emails are NEVER "payment_confirmation". They ARE the source of truth for the income, not a duplicate of any invoice. This includes ALL of:
+    - Zelle ("You received money with Zelle", "FN LN sent you $X with Zelle")
+    - Venmo ("FN LN paid you $X", "Venmo: ... sent you $X")
+    - Cash App ("FN LN sent you $X", "$X from FN")
+    - PayPal ("You received $X from FN LN")
+    - Apple Pay Cash, Google Pay, direct ACH/wire deposit alerts
+    - Any bank deposit alert showing a person-to-person transfer (e.g. Chase Zelle, Bank of America Zelle, Wells Fargo Zelle)
+    - Forwarded ("Fwd:") versions of any of the above
+  For all of these, set document_type "invoice", transaction_type "income", category "rental_revenue", and extract: amount, date, payer_name (the sender), vendor (the platform — "Zelle", "Venmo", "Cash App", "PayPal"), and payment_method "bank_transfer" (or "platform_payout" for Venmo/Cash App/PayPal).
 - "statement" — billing statements, account statements, property management billing periods
 - "lease" — lease agreements, rental contracts, renewals/amendments
 - "insurance_policy" — insurance policies, declarations pages, certificates of insurance
@@ -296,4 +306,13 @@ Mortgage statement with interest and principal breakdown:
 
 Airbnb payout:
 {"documents": [{"document_type": "statement", "date": "2025-09-20", "vendor": "Airbnb", "amount": "850.00", "description": "Payout for reservation HM12345", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": "airbnb", "address": "6738 Peerless St Houston TX", "confidence": "high", "line_items": null}]}
+
+Zelle payment ("You received money with Zelle" — Sonu King sent $701.20):
+{"documents": [{"document_type": "invoice", "date": "2026-05-03", "vendor": "Zelle", "payer_name": "Sonu King", "amount": "701.20", "description": "Zelle from Sonu King", "transaction_type": "income", "category": "rental_revenue", "payment_method": "bank_transfer", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
+
+Venmo payment ("John Doe paid you $1500.00"):
+{"documents": [{"document_type": "invoice", "date": "2026-05-01", "vendor": "Venmo", "payer_name": "John Doe", "amount": "1500.00", "description": "Venmo from John Doe", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
+
+Cash App payment ("$800.00 from Jane Smith"):
+{"documents": [{"document_type": "invoice", "date": "2026-05-02", "vendor": "Cash App", "payer_name": "Jane Smith", "amount": "800.00", "description": "Cash App from Jane Smith", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
 """

--- a/apps/mybookkeeper/backend/tests/test_p2p_payment_carveout.py
+++ b/apps/mybookkeeper/backend/tests/test_p2p_payment_carveout.py
@@ -1,0 +1,162 @@
+"""Peer-to-peer payment carve-out from the payment_confirmation skip path.
+
+Zelle, Venmo, Cash App, PayPal, Apple Pay, Google Pay, and bank-routed
+deposit alerts are the SOURCE OF TRUTH for rent income — there is no
+underlying invoice they could duplicate. They must NEVER be silently
+dropped by the payment_confirmation skip filter.
+
+These tests pin two layers:
+1. ``_looks_like_p2p_payment`` correctly identifies P2P transfers.
+2. ``_is_payment_confirmation`` returns False for batches containing P2P
+   transfers, even when the description text contains "payment received".
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.extraction.extraction_persistence import (
+    _is_payment_confirmation,
+    _looks_like_p2p_payment,
+)
+
+
+class TestLooksLikeP2PPayment:
+    """Detection of peer-to-peer transfer extractions."""
+
+    def test_zelle_payment_with_payer_and_amount(self) -> None:
+        data = {
+            "vendor": "Zelle",
+            "payer_name": "Sonu King",
+            "amount": "701.20",
+            "document_type": "invoice",
+        }
+        assert _looks_like_p2p_payment(data) is True
+
+    def test_venmo_payment(self) -> None:
+        data = {
+            "vendor": "Venmo",
+            "payer_name": "John Doe",
+            "amount": "1500.00",
+        }
+        assert _looks_like_p2p_payment(data) is True
+
+    def test_cash_app_payment(self) -> None:
+        data = {
+            "vendor": "Cash App",
+            "payer_name": "Jane Smith",
+            "amount": "800.00",
+        }
+        assert _looks_like_p2p_payment(data) is True
+
+    def test_paypal_payment(self) -> None:
+        data = {
+            "vendor": "PayPal",
+            "payer_name": "Pat Roe",
+            "amount": "300.00",
+        }
+        assert _looks_like_p2p_payment(data) is True
+
+    def test_vendor_substring_match_is_case_insensitive(self) -> None:
+        # Claude may return "Zelle (Chase)" — substring match should still hit
+        data = {
+            "vendor": "Zelle (Chase)",
+            "payer_name": "Sonu King",
+            "amount": "701.20",
+        }
+        assert _looks_like_p2p_payment(data) is True
+
+    def test_missing_payer_name_disqualifies(self) -> None:
+        # Without a payer, we can't attribute — treat as a generic payment_confirmation
+        data = {"vendor": "Zelle", "payer_name": None, "amount": "100.00"}
+        assert _looks_like_p2p_payment(data) is False
+
+    def test_zero_amount_disqualifies(self) -> None:
+        data = {"vendor": "Zelle", "payer_name": "Sonu King", "amount": "0"}
+        assert _looks_like_p2p_payment(data) is False
+
+    def test_negative_amount_disqualifies(self) -> None:
+        # A negative amount means "you sent money" — not income
+        data = {"vendor": "Venmo", "payer_name": "John Doe", "amount": "-50.00"}
+        assert _looks_like_p2p_payment(data) is False
+
+    def test_unrecognized_vendor_disqualifies(self) -> None:
+        data = {"vendor": "Comcast", "payer_name": "Sonu King", "amount": "75.00"}
+        assert _looks_like_p2p_payment(data) is False
+
+    def test_non_numeric_amount_disqualifies(self) -> None:
+        data = {"vendor": "Zelle", "payer_name": "Sonu King", "amount": "foo"}
+        assert _looks_like_p2p_payment(data) is False
+
+    def test_empty_payer_name_string_disqualifies(self) -> None:
+        data = {"vendor": "Zelle", "payer_name": "", "amount": "100.00"}
+        assert _looks_like_p2p_payment(data) is False
+
+    def test_whitespace_only_payer_name_disqualifies(self) -> None:
+        data = {"vendor": "Zelle", "payer_name": "   ", "amount": "100.00"}
+        assert _looks_like_p2p_payment(data) is False
+
+
+class TestIsPaymentConfirmationP2PCarveout:
+    """The skip filter must NOT trigger on P2P payment batches."""
+
+    def test_p2p_payment_with_received_in_description_is_not_skipped(self) -> None:
+        # Description text "payment received" would normally match the
+        # payment_confirmation regex and skip the email — but a Zelle has
+        # a payer + amount, so it must still come through.
+        documents = [{
+            "vendor": "Zelle",
+            "payer_name": "Sonu King",
+            "amount": "701.20",
+            "description": "Payment received from Sonu King",
+        }]
+        assert _is_payment_confirmation(documents) is False
+
+    def test_p2p_payment_with_explicit_doctype_is_not_skipped(self) -> None:
+        # Even if Claude mis-labels the doc as payment_confirmation, the
+        # P2P shape rescues it.
+        documents = [{
+            "vendor": "Venmo",
+            "payer_name": "John Doe",
+            "amount": "1500.00",
+            "description": "Venmo payment",
+            "document_type": "payment_confirmation",
+        }]
+        assert _is_payment_confirmation(documents) is False
+
+    def test_real_payment_confirmation_still_skipped(self) -> None:
+        # A genuine "your bill payment was processed" notification
+        # (no payer, no amount) MUST still skip.
+        documents = [{
+            "vendor": "Constellation",
+            "amount": None,
+            "description": "Thank you for your payment",
+            "document_type": "payment_confirmation",
+        }]
+        assert _is_payment_confirmation(documents) is True
+
+    def test_mixed_batch_with_p2p_is_not_skipped(self) -> None:
+        # If the batch contains a P2P AND a payment_confirmation, we must
+        # process the batch — the carve-out trumps the skip.
+        documents = [
+            {
+                "vendor": "Zelle",
+                "payer_name": "Sonu King",
+                "amount": "701.20",
+            },
+            {
+                "vendor": "Constellation",
+                "description": "Payment received",
+                "document_type": "payment_confirmation",
+            },
+        ]
+        # The persistence path checks `_is_payment_confirmation` after a
+        # `has_p2p` short-circuit. We pin the helper directly: with a P2P
+        # in the batch, the helper returns False (P2P bypasses the loop)
+        # and the bill-payment row falls through to the regex, which DOES
+        # match — but that's fine because the persistence path uses the
+        # `has_p2p` short-circuit, not this helper, for the skip decision.
+        # The helper still needs to return True for the bill row alone.
+        assert _is_payment_confirmation(documents[1:]) is True
+
+    def test_empty_batch_is_not_a_payment_confirmation(self) -> None:
+        assert _is_payment_confirmation([]) is False


### PR DESCRIPTION
Three coordinated changes so peer-to-peer rent payments actually flow end-to-end into the rent-attribution pipeline: (1) broaden Gmail search query to every major US P2P platform + bank deposit alert; (2) Claude prompt carve-out so P2P transfers aren't misclassified as 'payment_confirmation'; (3) persistence-layer defense-in-depth + 17 unit tests pinning the behavior.