### PR TITLE
fix(mybookkeeper/email): unstuck the silent-skip lockout (Zelle re-fetch)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/skp260504_email_queue_skipped_status.py
+++ b/apps/mybookkeeper/backend/alembic/versions/skp260504_email_queue_skipped_status.py
@@ -1,0 +1,59 @@
+"""mark orphan 'done' email_queue rows as 'skipped'
+
+Backstop for the silent-skip lockout: prior to PR introducing
+``EmailQueue.status='skipped'``, any email that was fetched but
+classified as a payment_confirmation duplicate (or otherwise produced
+zero Documents) was marked ``done`` even though no Document survived.
+The discovery filter then permanently excluded the message_id from
+re-fetch, so a future prompt improvement could never give the email
+another chance.
+
+This migration converts every ``done`` queue row that has NO matching
+Document (joined on ``email_message_id``) to ``skipped`` so the
+discovery filter (now status-aware) re-fetches them on the next sync.
+
+Revision ID: skp260504
+Revises: rcpt260504
+Create Date: 2026-05-04 19:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "skp260504"
+down_revision: Union[str, None] = "rcpt260504"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Convert done-with-no-document rows to skipped. raw_content is not
+    # touched (skipped rows already have raw_content cleared at mark_done
+    # time, so the column is null for these rows).
+    op.execute(
+        """
+        UPDATE email_queue eq
+           SET status = 'skipped',
+               error  = COALESCE(eq.error, 'auto-marked skipped: no Document linked at migration time')
+         WHERE eq.status = 'done'
+           AND NOT EXISTS (
+               SELECT 1 FROM documents d
+                WHERE d.email_message_id = eq.message_id
+                  AND d.organization_id  = eq.organization_id
+           );
+        """
+    )
+
+
+def downgrade() -> None:
+    # Revert is conservative — only flip rows we marked in upgrade.
+    op.execute(
+        """
+        UPDATE email_queue
+           SET status = 'done',
+               error  = NULL
+         WHERE status = 'skipped'
+           AND error  = 'auto-marked skipped: no Document linked at migration time';
+        """
+    )

--- a/apps/mybookkeeper/backend/app/repositories/email/email_queue_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/email/email_queue_repo.py
@@ -32,8 +32,29 @@ async def get_with_content(
 
 
 async def get_message_ids(db: AsyncSession, organization_id: uuid.UUID) -> set[str]:
+    """Return message_ids that should be EXCLUDED from re-fetch.
+
+    Excludes:
+      - Rows currently in flight (``fetched``, ``extracting``)
+      - Rows that successfully produced a Document (``done``)
+
+    Does NOT exclude:
+      - ``failed`` rows — let them be retried
+      - ``skipped`` rows — re-fetch so the current prompt gets another chance
+        (these are emails the extractor classified as duplicates/no-op; if the
+        prompt has improved since, we want a re-run. Token cost is bounded
+        because legit duplicates re-skip quickly.)
+
+    The status filter here is the systemic fix for the
+    'fetched-once-locked-forever' lockout: if an email was previously fetched
+    but no Document survived (silent skip / extraction error), the message is
+    eligible for re-fetch on the next sync.
+    """
     result = await db.execute(
-        select(EmailQueue.message_id).where(EmailQueue.organization_id == organization_id)
+        select(EmailQueue.message_id).where(
+            EmailQueue.organization_id == organization_id,
+            EmailQueue.status.in_(("fetched", "extracting", "done")),
+        )
     )
     return {row[0] for row in result.all()}
 
@@ -141,6 +162,18 @@ async def mark_done(db: AsyncSession, item: EmailQueue) -> None:
     item.status = "done"
     item.raw_content = None
     item.error = None
+
+
+async def mark_skipped(db: AsyncSession, item: EmailQueue, *, reason: str | None = None) -> None:
+    """Mark a queue row as skipped — extraction succeeded but produced no
+    Document (e.g. classified as a payment-confirmation duplicate).
+
+    Distinct from ``done`` so a future sync (with a possibly-improved prompt)
+    can re-fetch and re-extract — see ``get_message_ids`` for the dedup rule.
+    """
+    item.status = "skipped"
+    item.raw_content = None
+    item.error = reason[:1000] if reason else None
 
 
 async def count_by_status(

--- a/apps/mybookkeeper/backend/app/services/email/email_extraction_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_extraction_service.py
@@ -152,7 +152,18 @@ async def _extract_next_fetched(ctx: RequestContext) -> ExtractResult:
 
             item_ref = await email_queue_repo.get_by_id(db, item_id)
             if item_ref:
-                await email_queue_repo.mark_done(db, item_ref)
+                # Distinguish 'extraction succeeded and produced documents' (done)
+                # from 'extraction succeeded but produced no documents' (skipped —
+                # e.g. payment-confirmation duplicate). Skipped rows are
+                # re-fetchable on the next sync so a future prompt improvement
+                # can give the email another chance — see
+                # email_queue_repo.get_message_ids for the dedup rule.
+                if records_added > 0:
+                    await email_queue_repo.mark_done(db, item_ref)
+                else:
+                    await email_queue_repo.mark_skipped(
+                        db, item_ref, reason="extraction returned 0 documents",
+                    )
 
             log = await sync_log_repo.get_by_id(db, sync_log_id)
             if log:

--- a/apps/mybookkeeper/backend/tests/test_email_queue_dedup_filter.py
+++ b/apps/mybookkeeper/backend/tests/test_email_queue_dedup_filter.py
@@ -1,0 +1,164 @@
+"""email_queue_repo.get_message_ids — status-aware dedup filter.
+
+Regression coverage for the silent-skip lockout. Before the fix, ANY queue
+row would lock its message_id out of re-fetch forever — even rows whose
+extraction silently produced zero Documents (e.g. payment-confirmation
+duplicates that were misclassified). After the fix, only rows that are
+in-flight (``fetched``, ``extracting``) or successfully produced a Document
+(``done``) lock the message_id. ``skipped`` and ``failed`` rows are
+re-fetchable.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.email.email_queue import EmailQueue
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.email import email_queue_repo
+
+
+async def _insert_queue_row(
+    db: AsyncSession,
+    *,
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    message_id: str,
+    status: str,
+) -> None:
+    row = EmailQueue(
+        organization_id=org_id,
+        user_id=user_id,
+        message_id=message_id,
+        attachment_id="body",
+        status=status,
+        sync_log_id=1,
+        created_at=datetime.now(timezone.utc),
+    )
+    # Need a sync_logs row for the FK
+    from app.models.integrations.sync_log import SyncLog
+    from sqlalchemy import select
+    existing = await db.execute(select(SyncLog).where(SyncLog.id == 1))
+    if existing.scalar_one_or_none() is None:
+        db.add(SyncLog(
+            id=1,
+            organization_id=org_id,
+            user_id=user_id,
+            provider="gmail",
+            status="success",
+        ))
+        await db.flush()
+    db.add(row)
+    await db.flush()
+
+
+class TestGetMessageIdsStatusFilter:
+    @pytest.mark.asyncio
+    async def test_done_rows_are_locked_out(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-done", status="done",
+        )
+        ids = await email_queue_repo.get_message_ids(db, test_org.id)
+        assert "msg-done" in ids
+
+    @pytest.mark.asyncio
+    async def test_in_flight_rows_are_locked_out(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-fetched", status="fetched",
+        )
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-extracting", status="extracting",
+        )
+        ids = await email_queue_repo.get_message_ids(db, test_org.id)
+        assert "msg-fetched" in ids
+        assert "msg-extracting" in ids
+
+    @pytest.mark.asyncio
+    async def test_skipped_rows_are_refetchable(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        # The whole point of the fix: skipped rows must NOT lock the
+        # message_id, so a future sync with a better prompt can re-fetch.
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-skipped", status="skipped",
+        )
+        ids = await email_queue_repo.get_message_ids(db, test_org.id)
+        assert "msg-skipped" not in ids
+
+    @pytest.mark.asyncio
+    async def test_failed_rows_are_refetchable(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-failed", status="failed",
+        )
+        ids = await email_queue_repo.get_message_ids(db, test_org.id)
+        assert "msg-failed" not in ids
+
+    @pytest.mark.asyncio
+    async def test_org_isolation(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        # Pin org-scoping: a row in test_org must not be returned when
+        # we query a *different* org (synthesised via uuid4).
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="my-org-msg", status="done",
+        )
+        other_org_id = uuid.uuid4()
+        ids = await email_queue_repo.get_message_ids(db, other_org_id)
+        assert "my-org-msg" not in ids
+
+
+class TestMarkSkipped:
+    @pytest.mark.asyncio
+    async def test_mark_skipped_sets_status_and_clears_content(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-x", status="extracting",
+        )
+        from sqlalchemy import select
+        result = await db.execute(
+            select(EmailQueue).where(EmailQueue.message_id == "msg-x")
+        )
+        item = result.scalar_one()
+        await email_queue_repo.mark_skipped(db, item, reason="payment confirmation")
+        await db.flush()
+        assert item.status == "skipped"
+        assert item.error == "payment confirmation"
+
+    @pytest.mark.asyncio
+    async def test_mark_skipped_truncates_long_reasons(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-long", status="extracting",
+        )
+        from sqlalchemy import select
+        result = await db.execute(
+            select(EmailQueue).where(EmailQueue.message_id == "msg-long")
+        )
+        item = result.scalar_one()
+        long_reason = "x" * 2000
+        await email_queue_repo.mark_skipped(db, item, reason=long_reason)
+        await db.flush()
+        await db.refresh(item)
+        assert item.status == "skipped"
+        assert item.error is not None
+        assert len(item.error) == 1000

--- a/apps/mybookkeeper/backend/tests/test_email_queue_split.py
+++ b/apps/mybookkeeper/backend/tests/test_email_queue_split.py
@@ -177,7 +177,11 @@ class TestDrainClaudeExtraction:
 
         assert result.status == "done"
         await db.refresh(item)
-        assert item.status == "done"
+        # Extraction returned an empty data array (zero documents extracted),
+        # so the queue row is now ``skipped`` rather than ``done``. This
+        # distinction lets a future sync re-fetch the message if the prompt
+        # later improves — see email_queue_repo.get_message_ids dedup rule.
+        assert item.status == "skipped"
         # raw_content is deferred — query it explicitly to avoid greenlet issues
         from sqlalchemy.orm import undefer
         row = await db.execute(


### PR DESCRIPTION
Root cause of why the Zelle still wasn't picked up after #224/#226: prior syncs silently classified P2P emails as payment_confirmation, marked the queue row 'done' with no Document, and the discovery filter then permanently locked the message_id out of re-fetch. New 'skipped' status + status-aware dedup filter + one-time data migration to flip orphan 'done' rows. 7 new tests pin behavior.