### PR TITLE
fix(mybookkeeper/integrations): support new 'skipped' email_queue status in UI

### DIFF
--- a/apps/mybookkeeper/frontend/src/shared/lib/constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/constants.ts
@@ -229,6 +229,7 @@ export const STATUS_BADGE: Readonly<Record<EmailQueueStatus, { label: string; co
   fetched: { label: "Fetched", color: "blue" },
   extracting: { label: "Extracting", color: "yellow" },
   done: { label: "Done", color: "green" },
+  skipped: { label: "Skipped", color: "gray" },
   failed: { label: "Failed", color: "red" },
 };
 

--- a/apps/mybookkeeper/frontend/src/shared/types/integration/email-queue.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/integration/email-queue.ts
@@ -1,4 +1,10 @@
-export type EmailQueueStatus = "pending" | "fetched" | "extracting" | "done" | "failed";
+export type EmailQueueStatus =
+  | "pending"
+  | "fetched"
+  | "extracting"
+  | "done"
+  | "skipped"
+  | "failed";
 
 export interface EmailQueueItem {
   id: string;


### PR DESCRIPTION
Adds the 'skipped' status (introduced in backend PR #229) to the frontend EmailQueueStatus type and STATUS_BADGE map. Without this the Integrations page crashes when the queue contains any row with the new status.