### PR TITLE
fix(mybookkeeper/email): revert over-aggressive 'skipped' refetch behavior from #229

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/skp260504r_revert_aggressive_skipped_flip.py
+++ b/apps/mybookkeeper/backend/alembic/versions/skp260504r_revert_aggressive_skipped_flip.py
@@ -1,0 +1,60 @@
+"""revert the over-aggressive 'skipped' flip from skp260504
+
+The skp260504 migration flipped every 'done' email_queue row that had
+no matching Document to 'skipped' so they would be re-fetched. Intent
+was to give a previously-mis-skipped Zelle email another chance with
+the new P2P prompt — but the side effect was to also re-fetch every
+legitimate 0-document case (dedup-identified duplicates, low-confidence
+extractions, real payment-confirmation notifications). Each sync now
+burned Claude tokens re-extracting them.
+
+This migration reverts that flip — only rows whose error column matches
+the marker that skp260504 wrote are flipped back to 'done', so manual
+'skipped' marks (none yet, but possible in the future) are preserved.
+
+Going forward, the application code (email_extraction_service) marks
+0-document extractions as 'done' regardless, so the lockout is
+restored to its pre-skp260504 behavior.
+
+Revision ID: skp260504r
+Revises: skp260504
+Create Date: 2026-05-04 19:55:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "skp260504r"
+down_revision: Union[str, None] = "skp260504"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE email_queue
+           SET status = 'done',
+               error  = NULL
+         WHERE status = 'skipped'
+           AND error  = 'auto-marked skipped: no Document linked at migration time';
+        """
+    )
+
+
+def downgrade() -> None:
+    # Re-apply the flip (matches skp260504.upgrade's behavior).
+    op.execute(
+        """
+        UPDATE email_queue eq
+           SET status = 'skipped',
+               error  = 'auto-marked skipped: no Document linked at migration time'
+         WHERE eq.status = 'done'
+           AND NOT EXISTS (
+               SELECT 1 FROM documents d
+                WHERE d.email_message_id = eq.message_id
+                  AND d.organization_id  = eq.organization_id
+           );
+        """
+    )

--- a/apps/mybookkeeper/backend/app/services/email/email_extraction_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_extraction_service.py
@@ -152,18 +152,15 @@ async def _extract_next_fetched(ctx: RequestContext) -> ExtractResult:
 
             item_ref = await email_queue_repo.get_by_id(db, item_id)
             if item_ref:
-                # Distinguish 'extraction succeeded and produced documents' (done)
-                # from 'extraction succeeded but produced no documents' (skipped —
-                # e.g. payment-confirmation duplicate). Skipped rows are
-                # re-fetchable on the next sync so a future prompt improvement
-                # can give the email another chance — see
-                # email_queue_repo.get_message_ids for the dedup rule.
-                if records_added > 0:
-                    await email_queue_repo.mark_done(db, item_ref)
-                else:
-                    await email_queue_repo.mark_skipped(
-                        db, item_ref, reason="extraction returned 0 documents",
-                    )
+                # Mark 'done' regardless of records_added. Reason: many
+                # legitimate skip paths (dedup hit on a duplicate, low-
+                # confidence + uncategorized, payment-confirmation
+                # notification) all produce 0 documents — re-fetching them
+                # on every sync wastes Claude tokens for no value. The
+                # ``skipped`` status remains available for explicit use
+                # (e.g. an admin-triggered 're-process this email' flow)
+                # but is NOT applied automatically.
+                await email_queue_repo.mark_done(db, item_ref)
 
             log = await sync_log_repo.get_by_id(db, sync_log_id)
             if log:

--- a/apps/mybookkeeper/backend/tests/test_email_queue_split.py
+++ b/apps/mybookkeeper/backend/tests/test_email_queue_split.py
@@ -177,11 +177,11 @@ class TestDrainClaudeExtraction:
 
         assert result.status == "done"
         await db.refresh(item)
-        # Extraction returned an empty data array (zero documents extracted),
-        # so the queue row is now ``skipped`` rather than ``done``. This
-        # distinction lets a future sync re-fetch the message if the prompt
-        # later improves — see email_queue_repo.get_message_ids dedup rule.
-        assert item.status == "skipped"
+        # Extraction returned an empty data array (legitimate skip — dedup
+        # hit, payment confirmation, low confidence, etc.). We mark 'done'
+        # to lock the message_id out of re-fetch — re-extracting on every
+        # sync would burn Claude tokens for no value.
+        assert item.status == "done"
         # raw_content is deferred — query it explicitly to avoid greenlet issues
         from sqlalchemy.orm import undefer
         row = await db.execute(


### PR DESCRIPTION
Sync was re-extracting every legitimately-skipped email (Vello duplicates, payment confirmations) on every run, costing Claude tokens. Reverts the 0-doc → skipped rule and provides a migration to flip the affected rows back to 'done'.