### PR TITLE
feat(mybookkeeper/tenants): clickable source-document icon on tenant payment rows

### DIFF
--- a/apps/mybookkeeper/frontend/src/app/features/applicants/TenantPayments.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/TenantPayments.tsx
@@ -1,7 +1,9 @@
-import { DollarSign } from "lucide-react";
+import { useState } from "react";
+import { DollarSign, FileText } from "lucide-react";
 import Skeleton from "@/shared/components/ui/Skeleton";
 import { formatCurrency } from "@/shared/utils/currency";
 import { useListTransactionsQuery } from "@/shared/store/transactionsApi";
+import DocumentViewer from "@/app/features/documents/DocumentViewer";
 
 interface Props {
   applicantId: string;
@@ -12,6 +14,7 @@ export default function TenantPayments({ applicantId }: Props) {
     { applicant_id: applicantId, transaction_type: "income" },
     { skip: !applicantId },
   );
+  const [viewingDocumentId, setViewingDocumentId] = useState<string | null>(null);
 
   const total = transactions.reduce(
     (sum, txn) => sum + parseFloat(txn.amount),
@@ -49,23 +52,45 @@ export default function TenantPayments({ applicantId }: Props) {
         </span>
       </div>
       <ul className="divide-y text-sm" data-testid="tenant-payments-list">
-        {transactions.map((txn) => (
-          <li key={txn.id} className="flex items-center justify-between py-2 gap-3">
-            <div className="min-w-0">
-              <p className="truncate">{txn.payer_name ?? txn.vendor ?? "Payment"}</p>
-              <p className="text-xs text-muted-foreground">
-                {new Date(txn.transaction_date).toLocaleDateString()}
-                {txn.attribution_source === "manual" && (
-                  <span className="ml-1 text-muted-foreground">(manual)</span>
-                )}
-              </p>
-            </div>
-            <span className="shrink-0 font-medium text-green-600">
-              {formatCurrency(parseFloat(txn.amount))}
-            </span>
-          </li>
-        ))}
+        {transactions.map((txn) => {
+          const docId = txn.source_document_id;
+          return (
+            <li key={txn.id} className="flex items-center justify-between py-2 gap-3">
+              <div className="min-w-0 flex items-center gap-2">
+                {docId ? (
+                  <button
+                    type="button"
+                    onClick={() => setViewingDocumentId(docId)}
+                    className="text-muted-foreground hover:text-primary shrink-0"
+                    title="Open source document"
+                    aria-label="Open source document"
+                  >
+                    <FileText className="h-3.5 w-3.5" />
+                  </button>
+                ) : null}
+                <div className="min-w-0">
+                  <p className="truncate">{txn.payer_name ?? txn.vendor ?? "Payment"}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {new Date(txn.transaction_date).toLocaleDateString()}
+                    {txn.attribution_source === "manual" && (
+                      <span className="ml-1 text-muted-foreground">(manual)</span>
+                    )}
+                  </p>
+                </div>
+              </div>
+              <span className="shrink-0 font-medium text-green-600">
+                {formatCurrency(parseFloat(txn.amount))}
+              </span>
+            </li>
+          );
+        })}
       </ul>
+      {viewingDocumentId ? (
+        <DocumentViewer
+          documentId={viewingDocumentId}
+          onClose={() => setViewingDocumentId(null)}
+        />
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Adds a small file icon next to each payment row on the Tenant detail page. Click opens the existing DocumentViewer modal for the linked source document. Works for all payment forms — Zelle, Venmo, Cash App, PayPal, Airbnb payouts, etc. — not just one provider.