### PR TITLE
feat(mybookkeeper/integrations): full sync funnel — Gmail matches → new → fetched → extracted → added

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/synfun260504_sync_log_gmail_matches_total.py
+++ b/apps/mybookkeeper/backend/alembic/versions/synfun260504_sync_log_gmail_matches_total.py
@@ -1,0 +1,36 @@
+"""add sync_logs.gmail_matches_total
+
+Lets the UI distinguish 'Gmail returned 0 matches' from 'Gmail returned
+N matches that were all already processed' — both currently surface as
+'0 documents added' with no further detail.
+
+Revision ID: synfun260504
+Revises: p2punlock260504
+Create Date: 2026-05-04 20:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "synfun260504"
+down_revision: Union[str, None] = "p2punlock260504"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "sync_logs",
+        sa.Column(
+            "gmail_matches_total",
+            sa.Integer(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("sync_logs", "gmail_matches_total")

--- a/apps/mybookkeeper/backend/app/models/integrations/sync_log.py
+++ b/apps/mybookkeeper/backend/app/models/integrations/sync_log.py
@@ -18,6 +18,12 @@ class SyncLog(Base):
     status: Mapped[str] = mapped_column(String(20))
     records_added: Mapped[int] = mapped_column(default=0)
     total_items: Mapped[int] = mapped_column(Integer, default=0)
+    # Pre-dedup count of message IDs Gmail returned for the configured search
+    # query. Lets the UI surface the full funnel (matched → new → fetched →
+    # extracted → added) so a "0 documents" sync is no longer ambiguous —
+    # operator can see whether Gmail returned 0 matches or 100 matches that
+    # were all already processed.
+    gmail_matches_total: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     error: Mapped[str | None] = mapped_column(String(1000), nullable=True)
     started_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)

--- a/apps/mybookkeeper/backend/app/models/responses/sync_log_info.py
+++ b/apps/mybookkeeper/backend/app/models/responses/sync_log_info.py
@@ -14,3 +14,4 @@ class SyncLogInfo(TypedDict):
     emails_total: int
     emails_done: int
     emails_fetched: int
+    gmail_matches_total: int

--- a/apps/mybookkeeper/backend/app/models/responses/sync_log_response.py
+++ b/apps/mybookkeeper/backend/app/models/responses/sync_log_response.py
@@ -14,3 +14,4 @@ class SyncLogResponse(TypedDict):
     emails_total: int
     emails_done: int
     emails_fetched: int
+    gmail_matches_total: int

--- a/apps/mybookkeeper/backend/app/repositories/email/sync_log_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/email/sync_log_repo.py
@@ -59,6 +59,7 @@ async def create(
     records_added: int = 0,
     started_at: datetime | None = None,
     completed_at: datetime | None = None,
+    gmail_matches_total: int = 0,
 ) -> SyncLog:
     log = SyncLog(
         organization_id=organization_id,
@@ -68,6 +69,7 @@ async def create(
         records_added=records_added,
         started_at=started_at or datetime.now(timezone.utc),
         completed_at=completed_at,
+        gmail_matches_total=gmail_matches_total,
     )
     db.add(log)
     await db.flush()

--- a/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
@@ -64,7 +64,7 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
 
         label = settings.gmail_label or None
         try:
-            new_ids: list[str] = await asyncio.to_thread(
+            new_ids, gmail_matches_total = await asyncio.to_thread(
                 list_new_email_ids, service, processed_ids, label=label
             )
         except RefreshError as exc:
@@ -77,7 +77,10 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
                 org_id, ctx.user_id, exc,
             )
             raise GmailAuthExpiredError(str(exc)) from exc
-        logger.info("Gmail discovery: %d new emails found (skipped %d)", len(new_ids), len(processed_ids))
+        logger.info(
+            "Gmail discovery: matched=%d new=%d (skipped %d already-processed)",
+            gmail_matches_total, len(new_ids), gmail_matches_total - len(new_ids),
+        )
 
         if not new_ids:
             await sync_log_repo.create(
@@ -85,11 +88,16 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
                 records_added=0,
                 started_at=now,
                 completed_at=now,
+                gmail_matches_total=gmail_matches_total,
             )
             await integration_repo.update_last_synced(db, integration, now)
             return DiscoverResult("nothing_new")
 
-        log = await sync_log_repo.create(db, org_id, ctx.user_id, "gmail", "running", started_at=now)
+        log = await sync_log_repo.create(
+            db, org_id, ctx.user_id, "gmail", "running",
+            started_at=now,
+            gmail_matches_total=gmail_matches_total,
+        )
 
         bounce_detector = BounceDetector()
         total_sources = 0

--- a/apps/mybookkeeper/backend/app/services/email/gmail_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/gmail_service.py
@@ -69,7 +69,14 @@ def get_gmail_service(access_token: str, refresh_token: str | None = None):
 
 def list_new_email_ids(
     service, processed_ids: set[str], *, label: str | None = None,
-) -> list[str]:
+) -> tuple[list[str], int]:
+    """Return (new_ids, total_matched).
+
+    ``new_ids`` excludes any message already in ``processed_ids`` (the dedup
+    set built from email_queue + documents). ``total_matched`` is the
+    pre-dedup count Gmail returned for the configured query — surfaced to
+    the UI so '0 documents added' isn't ambiguous.
+    """
     query = settings.gmail_search_query
     label_ids: list[str] | None = None
 
@@ -106,7 +113,8 @@ def list_new_email_ids(
         except Exception:
             logger.debug("Failed to fetch metadata for diagnostic log", exc_info=True)
 
-    return [msg["id"] for msg in messages if msg["id"] not in processed_ids]
+    new_ids = [msg["id"] for msg in messages if msg["id"] not in processed_ids]
+    return new_ids, len(messages)
 
 
 def _resolve_label_id(service, label_name: str) -> str | None:

--- a/apps/mybookkeeper/backend/app/services/integrations/integration_service.py
+++ b/apps/mybookkeeper/backend/app/services/integrations/integration_service.py
@@ -297,6 +297,7 @@ async def get_sync_logs(
                 emails_total=emails_total,
                 emails_done=emails_done,
                 emails_fetched=emails_fetched,
+                gmail_matches_total=log.gmail_matches_total,
             ))
         return response
 

--- a/apps/mybookkeeper/backend/tests/services/email/test_discovery_bounce_filter.py
+++ b/apps/mybookkeeper/backend/tests/services/email/test_discovery_bounce_filter.py
@@ -100,7 +100,7 @@ async def test_discovery_filters_bounce_and_logs_it(
         patch("app.services.email.email_discovery_service.get_gmail_service") as mock_gmail,
         patch(
             "app.services.email.email_discovery_service.list_new_email_ids",
-            return_value=[bounce_msg_id],
+            return_value=([bounce_msg_id], 1),
         ),
         patch(
             "app.services.email.email_discovery_service.list_email_document_sources",
@@ -157,7 +157,7 @@ async def test_discovery_queues_legit_email_alongside_filtered_bounce(
         patch("app.services.email.email_discovery_service.get_gmail_service") as mock_gmail,
         patch(
             "app.services.email.email_discovery_service.list_new_email_ids",
-            return_value=[bounce_msg_id, legit_msg_id],
+            return_value=([bounce_msg_id, legit_msg_id], 2),
         ),
         patch(
             "app.services.email.email_discovery_service.list_email_document_sources",
@@ -207,7 +207,7 @@ async def test_discovery_does_not_call_extraction_for_filtered_bounce(
         patch("app.services.email.email_discovery_service.get_gmail_service") as mock_gmail,
         patch(
             "app.services.email.email_discovery_service.list_new_email_ids",
-            return_value=[bounce_msg_id],
+            return_value=([bounce_msg_id], 1),
         ),
         patch(
             "app.services.email.email_discovery_service.list_email_document_sources",

--- a/apps/mybookkeeper/backend/tests/test_email_discovery_last_synced.py
+++ b/apps/mybookkeeper/backend/tests/test_email_discovery_last_synced.py
@@ -109,7 +109,7 @@ def _patch_discovery_dependencies(
         patches.append(
             patch(
                 "app.services.email.email_discovery_service.list_new_email_ids",
-                return_value=new_ids,
+                return_value=(new_ids, len(new_ids)),
             )
         )
 

--- a/apps/mybookkeeper/frontend/src/__tests__/Integrations.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/Integrations.test.tsx
@@ -36,6 +36,7 @@ const mockSyncLog: SyncLog = {
   emails_total: 10,
   emails_done: 10,
   emails_fetched: 5,
+  gmail_matches_total: 10,
 };
 
 const mockRunningSyncLog: SyncLog = {

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/SyncLogRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/SyncLogRow.tsx
@@ -69,7 +69,25 @@ export default function SyncLogRow({
                   <span>{formatDate(log.completed_at)}</span>
                 </>
               ) : null}
-              {log.emails_total > 0 ? (
+              {/* Funnel — render whenever Gmail returned at least one match */}
+              {/* (lets the user see "100 matched, 100 already processed, 0 new") */}
+              {log.gmail_matches_total > 0 ? (
+                <>
+                  <span>Gmail matches</span>
+                  <span>{log.gmail_matches_total}</span>
+                  <span>New (after dedup)</span>
+                  <span>{log.emails_total}</span>
+                  {log.emails_total > 0 ? (
+                    <>
+                      <span>Fetched from Gmail</span>
+                      <span>{log.emails_fetched}</span>
+                      <span>Extracted by Claude</span>
+                      <span>{log.emails_done}</span>
+                    </>
+                  ) : null}
+                </>
+              ) : log.emails_total > 0 ? (
+                /* Legacy sync_logs (pre-#235) without gmail_matches_total */
                 <>
                   <span>Emails found</span>
                   <span>{log.emails_total}</span>

--- a/apps/mybookkeeper/frontend/src/shared/types/integration/sync-log.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/integration/sync-log.ts
@@ -10,4 +10,5 @@ export interface SyncLog {
   emails_total: number;
   emails_done: number;
   emails_fetched: number;
+  gmail_matches_total: number;
 }


### PR DESCRIPTION
Adds sync_logs.gmail_matches_total + UI surfacing the full funnel so a '0 documents added' sync is no longer ambiguous.