### PR TITLE
feat(mybookkeeper/documents): structured payment-document card replaces raw email body

### DIFF
--- a/apps/mybookkeeper/frontend/src/app/features/applicants/TenantPayments.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/TenantPayments.tsx
@@ -14,7 +14,8 @@ export default function TenantPayments({ applicantId }: Props) {
     { applicant_id: applicantId, transaction_type: "income" },
     { skip: !applicantId },
   );
-  const [viewingDocumentId, setViewingDocumentId] = useState<string | null>(null);
+  const [viewing, setViewing] = useState<{ documentId: string; txnId: string } | null>(null);
+  const viewingTransaction = viewing ? transactions.find((t) => t.id === viewing.txnId) : undefined;
 
   const total = transactions.reduce(
     (sum, txn) => sum + parseFloat(txn.amount),
@@ -60,7 +61,7 @@ export default function TenantPayments({ applicantId }: Props) {
                 {docId ? (
                   <button
                     type="button"
-                    onClick={() => setViewingDocumentId(docId)}
+                    onClick={() => setViewing({ documentId: docId, txnId: txn.id })}
                     className="text-muted-foreground hover:text-primary shrink-0"
                     title="Open source document"
                     aria-label="Open source document"
@@ -85,10 +86,11 @@ export default function TenantPayments({ applicantId }: Props) {
           );
         })}
       </ul>
-      {viewingDocumentId ? (
+      {viewing ? (
         <DocumentViewer
-          documentId={viewingDocumentId}
-          onClose={() => setViewingDocumentId(null)}
+          documentId={viewing.documentId}
+          transaction={viewingTransaction}
+          onClose={() => setViewing(null)}
         />
       ) : null}
     </div>

--- a/apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewer.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewer.tsx
@@ -2,17 +2,33 @@ import { useEffect, useState } from "react";
 import { Loader2, ExternalLink } from "lucide-react";
 import { fetchDocumentBlob, type DocumentBlob } from "@/shared/services/documentService";
 import Panel, { PanelCloseButton } from "@/shared/components/ui/Panel";
+import type { Transaction } from "@/shared/types/transaction/transaction";
+import PaymentDocumentCard, { isPaymentTransaction } from "./PaymentDocumentCard";
 
 interface Props {
   documentId: string;
   onClose: () => void;
+  /**
+   * When provided AND the transaction looks like a P2P / platform payment
+   * (Zelle, Venmo, Cash App, PayPal, Airbnb payout, etc.), the viewer
+   * renders a structured card with the extracted fields instead of
+   * dumping the raw forwarded email body. The original email is still
+   * accessible via the "Show original email" disclosure.
+   */
+  transaction?: Transaction;
 }
 
-export default function DocumentViewer({ documentId, onClose }: Props) {
+export default function DocumentViewer({ documentId, onClose, transaction }: Props) {
   const [blob, setBlob] = useState<DocumentBlob | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [showSource, setShowSource] = useState(false);
+  const renderAsPayment = transaction !== undefined && isPaymentTransaction(transaction);
 
   useEffect(() => {
+    // For payment transactions we lazy-load the blob — only fetch when the
+    // user clicks "Show original email". Saves a network round-trip on the
+    // common path where the structured card is enough.
+    if (renderAsPayment && !showSource) return;
     let revoked = false;
     fetchDocumentBlob(documentId)
       .then((result) => { if (!revoked) setBlob(result); })
@@ -24,7 +40,7 @@ export default function DocumentViewer({ documentId, onClose }: Props) {
         return null;
       });
     };
-  }, [documentId]);
+  }, [documentId, renderAsPayment, showSource]);
 
   const isImage = blob?.contentType.startsWith("image/");
   const isPdf = blob?.contentType === "application/pdf";
@@ -52,7 +68,34 @@ export default function DocumentViewer({ documentId, onClose }: Props) {
       </header>
 
       <div className="flex-1 min-h-0 overflow-auto bg-muted/50">
-        {error ? (
+        {renderAsPayment && transaction ? (
+          <div className="p-6 space-y-4">
+            <PaymentDocumentCard transaction={transaction} />
+            <button
+              type="button"
+              onClick={() => setShowSource((v) => !v)}
+              className="text-xs text-primary hover:underline"
+            >
+              {showSource ? "Hide original email" : "Show original email"}
+            </button>
+            {showSource ? (
+              <div className="border rounded-md bg-card overflow-hidden">
+                {blob && !isEmpty ? (
+                  <iframe src={blob.url} className="w-full h-[40vh]" title="Original email" />
+                ) : blob && isEmpty ? (
+                  <p className="p-3 text-xs text-muted-foreground italic">
+                    The original email is no longer available.
+                  </p>
+                ) : (
+                  <div className="flex items-center gap-2 p-3 text-xs text-muted-foreground">
+                    <Loader2 size={14} className="animate-spin" />
+                    Loading source...
+                  </div>
+                )}
+              </div>
+            ) : null}
+          </div>
+        ) : error ? (
           <p className="flex items-center justify-center h-full text-sm text-destructive px-4 text-center" data-testid="document-error">
             {error}
           </p>

--- a/apps/mybookkeeper/frontend/src/app/features/documents/PaymentDocumentCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/PaymentDocumentCard.tsx
@@ -1,0 +1,77 @@
+import { DollarSign } from "lucide-react";
+import type { Transaction } from "@/shared/types/transaction/transaction";
+import { formatCurrency } from "@/shared/utils/currency";
+
+interface Props {
+  transaction: Transaction;
+}
+
+const PAYMENT_VENDOR_PATTERNS = [
+  "zelle",
+  "venmo",
+  "cash app",
+  "cashapp",
+  "paypal",
+  "apple pay",
+  "google pay",
+  "airbnb",
+  "vrbo",
+];
+
+export function isPaymentTransaction(txn: Transaction): boolean {
+  if (txn.transaction_type !== "income") return false;
+  if (txn.amount === null || parseFloat(txn.amount) <= 0) return false;
+  const vendor = (txn.vendor ?? "").toLowerCase();
+  if (!vendor) return false;
+  return PAYMENT_VENDOR_PATTERNS.some((p) => vendor.includes(p));
+}
+
+export default function PaymentDocumentCard({ transaction }: Props) {
+  const amount = parseFloat(transaction.amount);
+  const date = new Date(transaction.transaction_date);
+  return (
+    <div className="rounded-lg border bg-card overflow-hidden">
+      <div className="flex items-center justify-between px-4 py-3 border-b bg-muted/40">
+        <div className="flex items-center gap-2 min-w-0">
+          <DollarSign className="h-4 w-4 text-green-600 shrink-0" aria-hidden="true" />
+          <span className="text-sm font-medium truncate">
+            {transaction.vendor ?? "Payment"}
+          </span>
+        </div>
+        <span className="text-base font-semibold text-green-600 shrink-0">
+          {formatCurrency(amount)}
+        </span>
+      </div>
+      <dl className="px-4 py-3 grid grid-cols-[max-content_1fr] gap-x-4 gap-y-2 text-sm">
+        {transaction.payer_name ? (
+          <>
+            <dt className="text-muted-foreground">Payer</dt>
+            <dd className="font-medium truncate">{transaction.payer_name}</dd>
+          </>
+        ) : null}
+        <dt className="text-muted-foreground">Date</dt>
+        <dd>{date.toLocaleDateString()}</dd>
+        {transaction.payment_method ? (
+          <>
+            <dt className="text-muted-foreground">Method</dt>
+            <dd className="capitalize">
+              {transaction.payment_method.replace(/_/g, " ")}
+            </dd>
+          </>
+        ) : null}
+        {transaction.description ? (
+          <>
+            <dt className="text-muted-foreground">Memo</dt>
+            <dd className="truncate">{transaction.description}</dd>
+          </>
+        ) : null}
+        {transaction.address ? (
+          <>
+            <dt className="text-muted-foreground">Property</dt>
+            <dd className="truncate">{transaction.address}</dd>
+          </>
+        ) : null}
+      </dl>
+    </div>
+  );
+}


### PR DESCRIPTION
When opening a P2P payment document (Zelle/Venmo/Cash App/PayPal/Airbnb), the viewer now shows a clean card with extracted fields. Raw email body is hidden behind a 'Show original email' disclosure.