### PR TITLE
refactor(mybookkeeper/documents): flatten DocumentViewer + extract inline types

### DIFF
--- a/apps/mybookkeeper/frontend/src/app/features/applicants/TenantPayments.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/TenantPayments.tsx
@@ -4,6 +4,8 @@ import Skeleton from "@/shared/components/ui/Skeleton";
 import { formatCurrency } from "@/shared/utils/currency";
 import { useListTransactionsQuery } from "@/shared/store/transactionsApi";
 import DocumentViewer from "@/app/features/documents/DocumentViewer";
+import type { DocumentViewTarget } from "@/shared/types/document/document-view-target";
+import type { Transaction } from "@/shared/types/transaction/transaction";
 
 interface Props {
   applicantId: string;
@@ -14,79 +16,29 @@ export default function TenantPayments({ applicantId }: Props) {
     { applicant_id: applicantId, transaction_type: "income" },
     { skip: !applicantId },
   );
-  const [viewing, setViewing] = useState<{ documentId: string; txnId: string } | null>(null);
-  const viewingTransaction = viewing ? transactions.find((t) => t.id === viewing.txnId) : undefined;
+  const [viewing, setViewing] = useState<DocumentViewTarget | null>(null);
+
+  if (isLoading) return <PaymentsSkeleton />;
+  if (transactions.length === 0) return <PaymentsEmpty />;
 
   const total = transactions.reduce(
     (sum, txn) => sum + parseFloat(txn.amount),
     0,
   );
-
-  if (isLoading) {
-    return (
-      <div className="space-y-2">
-        <Skeleton className="h-5 w-32" />
-        {[1, 2, 3].map((i) => (
-          <div key={i} className="flex justify-between">
-            <Skeleton className="h-4 w-28" />
-            <Skeleton className="h-4 w-16" />
-          </div>
-        ))}
-      </div>
-    );
-  }
-
-  if (transactions.length === 0) {
-    return (
-      <p className="text-xs text-muted-foreground italic">
-        No attributed payments yet.
-      </p>
-    );
-  }
+  const viewingTransaction =
+    viewing === null
+      ? undefined
+      : transactions.find((t) => t.id === viewing.transactionId);
 
   return (
     <div className="space-y-3">
-      <div className="flex items-center gap-2">
-        <DollarSign className="h-4 w-4 text-green-600" aria-hidden="true" />
-        <span className="text-sm font-medium text-green-600">
-          Total received: {formatCurrency(total)}
-        </span>
-      </div>
+      <PaymentsHeader total={total} />
       <ul className="divide-y text-sm" data-testid="tenant-payments-list">
-        {transactions.map((txn) => {
-          const docId = txn.source_document_id;
-          return (
-            <li key={txn.id} className="flex items-center justify-between py-2 gap-3">
-              <div className="min-w-0 flex items-center gap-2">
-                {docId ? (
-                  <button
-                    type="button"
-                    onClick={() => setViewing({ documentId: docId, txnId: txn.id })}
-                    className="text-muted-foreground hover:text-primary shrink-0"
-                    title="Open source document"
-                    aria-label="Open source document"
-                  >
-                    <FileText className="h-3.5 w-3.5" />
-                  </button>
-                ) : null}
-                <div className="min-w-0">
-                  <p className="truncate">{txn.payer_name ?? txn.vendor ?? "Payment"}</p>
-                  <p className="text-xs text-muted-foreground">
-                    {new Date(txn.transaction_date).toLocaleDateString()}
-                    {txn.attribution_source === "manual" && (
-                      <span className="ml-1 text-muted-foreground">(manual)</span>
-                    )}
-                  </p>
-                </div>
-              </div>
-              <span className="shrink-0 font-medium text-green-600">
-                {formatCurrency(parseFloat(txn.amount))}
-              </span>
-            </li>
-          );
-        })}
+        {transactions.map((txn) => (
+          <PaymentRow key={txn.id} transaction={txn} onOpenDocument={setViewing} />
+        ))}
       </ul>
-      {viewing ? (
+      {viewing !== null ? (
         <DocumentViewer
           documentId={viewing.documentId}
           transaction={viewingTransaction}
@@ -94,5 +46,92 @@ export default function TenantPayments({ applicantId }: Props) {
         />
       ) : null}
     </div>
+  );
+}
+
+function PaymentsSkeleton() {
+  return (
+    <div className="space-y-2">
+      <Skeleton className="h-5 w-32" />
+      {[1, 2, 3].map((i) => (
+        <div key={i} className="flex justify-between">
+          <Skeleton className="h-4 w-28" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PaymentsEmpty() {
+  return (
+    <p className="text-xs text-muted-foreground italic">No attributed payments yet.</p>
+  );
+}
+
+interface PaymentsHeaderProps {
+  total: number;
+}
+
+function PaymentsHeader({ total }: PaymentsHeaderProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <DollarSign className="h-4 w-4 text-green-600" aria-hidden="true" />
+      <span className="text-sm font-medium text-green-600">
+        Total received: {formatCurrency(total)}
+      </span>
+    </div>
+  );
+}
+
+interface PaymentRowProps {
+  transaction: Transaction;
+  onOpenDocument: (target: DocumentViewTarget) => void;
+}
+
+function PaymentRow({ transaction, onOpenDocument }: PaymentRowProps) {
+  const docId = transaction.source_document_id;
+  const label = transaction.payer_name ?? transaction.vendor ?? "Payment";
+  const dateLabel = new Date(transaction.transaction_date).toLocaleDateString();
+  const isManual = transaction.attribution_source === "manual";
+
+  return (
+    <li className="flex items-center justify-between py-2 gap-3">
+      <div className="min-w-0 flex items-center gap-2">
+        {docId !== null ? (
+          <OpenSourceButton
+            onClick={() => onOpenDocument({ documentId: docId, transactionId: transaction.id })}
+          />
+        ) : null}
+        <div className="min-w-0">
+          <p className="truncate">{label}</p>
+          <p className="text-xs text-muted-foreground">
+            {dateLabel}
+            {isManual ? <span className="ml-1 text-muted-foreground">(manual)</span> : null}
+          </p>
+        </div>
+      </div>
+      <span className="shrink-0 font-medium text-green-600">
+        {formatCurrency(parseFloat(transaction.amount))}
+      </span>
+    </li>
+  );
+}
+
+interface OpenSourceButtonProps {
+  onClick: () => void;
+}
+
+function OpenSourceButton({ onClick }: OpenSourceButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-muted-foreground hover:text-primary shrink-0"
+      title="Open source document"
+      aria-label="Open source document"
+    >
+      <FileText className="h-3.5 w-3.5" />
+    </button>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewer.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewer.tsx
@@ -1,19 +1,27 @@
 import { useEffect, useState } from "react";
-import { Loader2, ExternalLink } from "lucide-react";
+import { ExternalLink } from "lucide-react";
 import { fetchDocumentBlob, type DocumentBlob } from "@/shared/services/documentService";
 import Panel, { PanelCloseButton } from "@/shared/components/ui/Panel";
 import type { Transaction } from "@/shared/types/transaction/transaction";
-import PaymentDocumentCard, { isPaymentTransaction } from "./PaymentDocumentCard";
+import { isPaymentTransaction } from "./PaymentDocumentCard";
+import PaymentDocumentBody from "./PaymentDocumentBody";
+import {
+  EmptyState,
+  ErrorState,
+  GenericBlobBody,
+  ImageBody,
+  LoadingState,
+  PdfBody,
+} from "./DocumentViewerStates";
+import { useDocumentViewMode } from "./useDocumentViewMode";
 
 interface Props {
   documentId: string;
   onClose: () => void;
   /**
-   * When provided AND the transaction looks like a P2P / platform payment
-   * (Zelle, Venmo, Cash App, PayPal, Airbnb payout, etc.), the viewer
-   * renders a structured card with the extracted fields instead of
-   * dumping the raw forwarded email body. The original email is still
-   * accessible via the "Show original email" disclosure.
+   * When provided AND the transaction looks like a P2P / platform payment,
+   * the viewer renders a structured card with the extracted fields. The
+   * original email is accessible via "Show original email".
    */
   transaction?: Transaction;
 }
@@ -22,17 +30,24 @@ export default function DocumentViewer({ documentId, onClose, transaction }: Pro
   const [blob, setBlob] = useState<DocumentBlob | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [showSource, setShowSource] = useState(false);
+
   const renderAsPayment = transaction !== undefined && isPaymentTransaction(transaction);
 
   useEffect(() => {
-    // For payment transactions we lazy-load the blob — only fetch when the
-    // user clicks "Show original email". Saves a network round-trip on the
-    // common path where the structured card is enough.
+    // Payment view lazy-loads the blob — only when the user expands the
+    // "Show original email" disclosure. Saves a network round-trip when
+    // the structured card is sufficient.
     if (renderAsPayment && !showSource) return;
+
     let revoked = false;
     fetchDocumentBlob(documentId)
-      .then((result) => { if (!revoked) setBlob(result); })
-      .catch((e: Error) => { if (!revoked) setError(e.message); });
+      .then((result) => {
+        if (!revoked) setBlob(result);
+      })
+      .catch((e: Error) => {
+        if (!revoked) setError(e.message);
+      });
+
     return () => {
       revoked = true;
       setBlob((prev) => {
@@ -42,93 +57,99 @@ export default function DocumentViewer({ documentId, onClose, transaction }: Pro
     };
   }, [documentId, renderAsPayment, showSource]);
 
-  const isImage = blob?.contentType.startsWith("image/");
-  const isPdf = blob?.contentType === "application/pdf";
-  const isEmpty = blob !== null && blob.size === 0;
+  const mode = useDocumentViewMode({ renderAsPayment, error, blob });
 
   return (
     <Panel position="center" onClose={onClose}>
-      <header className="flex items-center justify-between px-4 py-2 border-b shrink-0 bg-card">
-        <div className="flex items-center gap-3 min-w-0">
-          <span className="text-sm font-medium text-muted-foreground">Source document</span>
-          {blob && !isEmpty ? (
-            <a
-              href={blob.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-xs text-primary hover:underline inline-flex items-center gap-1"
-              data-testid="document-open-in-new-tab"
-            >
-              <ExternalLink size={12} />
-              Open in new tab
-            </a>
-          ) : null}
-        </div>
-        <PanelCloseButton onClose={onClose} label="Close viewer" />
-      </header>
-
+      <ViewerHeader blob={blob} mode={mode} onClose={onClose} />
       <div className="flex-1 min-h-0 overflow-auto bg-muted/50">
-        {renderAsPayment && transaction ? (
-          <div className="p-6 space-y-4">
-            <PaymentDocumentCard transaction={transaction} />
-            <button
-              type="button"
-              onClick={() => setShowSource((v) => !v)}
-              className="text-xs text-primary hover:underline"
-            >
-              {showSource ? "Hide original email" : "Show original email"}
-            </button>
-            {showSource ? (
-              <div className="border rounded-md bg-card overflow-hidden">
-                {blob && !isEmpty ? (
-                  <iframe src={blob.url} className="w-full h-[40vh]" title="Original email" />
-                ) : blob && isEmpty ? (
-                  <p className="p-3 text-xs text-muted-foreground italic">
-                    The original email is no longer available.
-                  </p>
-                ) : (
-                  <div className="flex items-center gap-2 p-3 text-xs text-muted-foreground">
-                    <Loader2 size={14} className="animate-spin" />
-                    Loading source...
-                  </div>
-                )}
-              </div>
-            ) : null}
-          </div>
-        ) : error ? (
-          <p className="flex items-center justify-center h-full text-sm text-destructive px-4 text-center" data-testid="document-error">
-            {error}
-          </p>
-        ) : isEmpty ? (
-          <div className="flex flex-col items-center justify-center h-full gap-2 px-4 text-center" data-testid="document-empty">
-            <p className="text-sm text-destructive">This document has no content available.</p>
-            <p className="text-xs text-muted-foreground">
-              The file may have been removed from storage. Try re-uploading the document.
-            </p>
-          </div>
-        ) : blob ? (
-          isImage ? (
-            <div className="flex items-center justify-center h-full p-4">
-              <img
-                src={blob.url}
-                alt="Source document"
-                className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
-              />
-            </div>
-          ) : isPdf ? (
-            <div className="h-full bg-white rounded-b-lg">
-              <iframe src={blob.url} className="w-full h-full" title="Source document" />
-            </div>
-          ) : (
-            <iframe src={blob.url} className="w-full h-full rounded-b-lg" title="Source document" />
-          )
-        ) : (
-          <div className="flex flex-col items-center justify-center h-full gap-3 text-foreground">
-            <Loader2 size={32} className="animate-spin text-primary" />
-            <p className="text-sm">Loading document...</p>
-          </div>
-        )}
+        <ViewerBody
+          mode={mode}
+          blob={blob}
+          error={error}
+          transaction={transaction}
+          showSource={showSource}
+          onToggleSource={() => setShowSource((v) => !v)}
+        />
       </div>
     </Panel>
   );
+}
+
+interface ViewerHeaderProps {
+  blob: DocumentBlob | null;
+  mode: ReturnType<typeof useDocumentViewMode>;
+  onClose: () => void;
+}
+
+function ViewerHeader({ blob, mode, onClose }: ViewerHeaderProps) {
+  const showOpenInNewTab = blob !== null && blob.size > 0 && mode !== "payment";
+  return (
+    <header className="flex items-center justify-between px-4 py-2 border-b shrink-0 bg-card">
+      <div className="flex items-center gap-3 min-w-0">
+        <span className="text-sm font-medium text-muted-foreground">Source document</span>
+        {showOpenInNewTab ? <OpenInNewTabLink url={blob!.url} /> : null}
+      </div>
+      <PanelCloseButton onClose={onClose} label="Close viewer" />
+    </header>
+  );
+}
+
+function OpenInNewTabLink({ url }: { url: string }) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-xs text-primary hover:underline inline-flex items-center gap-1"
+      data-testid="document-open-in-new-tab"
+    >
+      <ExternalLink size={12} />
+      Open in new tab
+    </a>
+  );
+}
+
+interface ViewerBodyProps {
+  mode: ReturnType<typeof useDocumentViewMode>;
+  blob: DocumentBlob | null;
+  error: string | null;
+  transaction: Transaction | undefined;
+  showSource: boolean;
+  onToggleSource: () => void;
+}
+
+function ViewerBody({
+  mode,
+  blob,
+  error,
+  transaction,
+  showSource,
+  onToggleSource,
+}: ViewerBodyProps) {
+  switch (mode) {
+    case "payment":
+      // ``renderAsPayment`` only resolves to "payment" when transaction is
+      // defined; the assertion is sound.
+      return (
+        <PaymentDocumentBody
+          transaction={transaction!}
+          blob={blob}
+          showSource={showSource}
+          onToggleSource={onToggleSource}
+        />
+      );
+    case "loading":
+      return <LoadingState />;
+    case "error":
+      return <ErrorState message={error ?? "Unknown error"} />;
+    case "empty":
+      return <EmptyState />;
+    case "image":
+      return <ImageBody blob={blob!} />;
+    case "pdf":
+      return <PdfBody blob={blob!} />;
+    case "generic":
+      return <GenericBlobBody blob={blob!} />;
+  }
 }

--- a/apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewerStates.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewerStates.tsx
@@ -1,0 +1,78 @@
+import { Loader2 } from "lucide-react";
+import type { DocumentBlob } from "@/shared/services/documentService";
+
+export function LoadingState() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-full gap-3 text-foreground"
+    >
+      <Loader2 size={32} className="animate-spin text-primary" />
+      <p className="text-sm">Loading document...</p>
+    </div>
+  );
+}
+
+interface ErrorStateProps {
+  message: string;
+}
+
+export function ErrorState({ message }: ErrorStateProps) {
+  return (
+    <p
+      className="flex items-center justify-center h-full text-sm text-destructive px-4 text-center"
+      data-testid="document-error"
+    >
+      {message}
+    </p>
+  );
+}
+
+export function EmptyState() {
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-full gap-2 px-4 text-center"
+      data-testid="document-empty"
+    >
+      <p className="text-sm text-destructive">
+        This document has no content available.
+      </p>
+      <p className="text-xs text-muted-foreground">
+        The file may have been removed from storage. Try re-uploading the document.
+      </p>
+    </div>
+  );
+}
+
+interface BlobBodyProps {
+  blob: DocumentBlob;
+}
+
+export function ImageBody({ blob }: BlobBodyProps) {
+  return (
+    <div className="flex items-center justify-center h-full p-4">
+      <img
+        src={blob.url}
+        alt="Source document"
+        className="max-w-full max-h-full object-contain rounded-lg shadow-lg"
+      />
+    </div>
+  );
+}
+
+export function PdfBody({ blob }: BlobBodyProps) {
+  return (
+    <div className="h-full bg-white rounded-b-lg">
+      <iframe src={blob.url} className="w-full h-full" title="Source document" />
+    </div>
+  );
+}
+
+export function GenericBlobBody({ blob }: BlobBodyProps) {
+  return (
+    <iframe
+      src={blob.url}
+      className="w-full h-full rounded-b-lg"
+      title="Source document"
+    />
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/documents/PaymentDocumentBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/PaymentDocumentBody.tsx
@@ -1,0 +1,67 @@
+import { Loader2 } from "lucide-react";
+import type { Transaction } from "@/shared/types/transaction/transaction";
+import type { DocumentBlob } from "@/shared/services/documentService";
+import PaymentDocumentCard from "./PaymentDocumentCard";
+
+interface Props {
+  transaction: Transaction;
+  blob: DocumentBlob | null;
+  showSource: boolean;
+  onToggleSource: () => void;
+}
+
+export default function PaymentDocumentBody({
+  transaction,
+  blob,
+  showSource,
+  onToggleSource,
+}: Props) {
+  return (
+    <div className="p-6 space-y-4">
+      <PaymentDocumentCard transaction={transaction} />
+      <button
+        type="button"
+        onClick={onToggleSource}
+        className="text-xs text-primary hover:underline"
+      >
+        {showSource ? "Hide original email" : "Show original email"}
+      </button>
+      {showSource ? (
+        <SourceEmailFrame blob={blob} />
+      ) : null}
+    </div>
+  );
+}
+
+interface SourceEmailFrameProps {
+  blob: DocumentBlob | null;
+}
+
+function SourceEmailFrame({ blob }: SourceEmailFrameProps) {
+  if (blob === null) {
+    return (
+      <div className="border rounded-md bg-card overflow-hidden">
+        <div className="flex items-center gap-2 p-3 text-xs text-muted-foreground">
+          <Loader2 size={14} className="animate-spin" />
+          Loading source...
+        </div>
+      </div>
+    );
+  }
+
+  if (blob.size === 0) {
+    return (
+      <div className="border rounded-md bg-card overflow-hidden">
+        <p className="p-3 text-xs text-muted-foreground italic">
+          The original email is no longer available.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border rounded-md bg-card overflow-hidden">
+      <iframe src={blob.url} className="w-full h-[40vh]" title="Original email" />
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/documents/useDocumentViewMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/useDocumentViewMode.ts
@@ -1,0 +1,23 @@
+import type { DocumentBlob } from "@/shared/services/documentService";
+import type { DocumentViewMode } from "@/shared/types/document/document-view-mode";
+
+interface Args {
+  renderAsPayment: boolean;
+  error: string | null;
+  blob: DocumentBlob | null;
+}
+
+/**
+ * Resolves the viewer's current render mode from the loaded state.
+ * Single source of truth — keeps the body of DocumentViewer free of
+ * cascading conditionals.
+ */
+export function useDocumentViewMode({ renderAsPayment, error, blob }: Args): DocumentViewMode {
+  if (renderAsPayment) return "payment";
+  if (error !== null) return "error";
+  if (blob === null) return "loading";
+  if (blob.size === 0) return "empty";
+  if (blob.contentType.startsWith("image/")) return "image";
+  if (blob.contentType === "application/pdf") return "pdf";
+  return "generic";
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/document/document-view-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/document/document-view-mode.ts
@@ -1,0 +1,12 @@
+/**
+ * Discriminated union for what the DocumentViewer body should render at any
+ * given moment. Replaces a chain of nested ternaries with a single switch.
+ */
+export type DocumentViewMode =
+  | "payment"
+  | "loading"
+  | "error"
+  | "empty"
+  | "image"
+  | "pdf"
+  | "generic";

--- a/apps/mybookkeeper/frontend/src/shared/types/document/document-view-target.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/document/document-view-target.ts
@@ -1,0 +1,10 @@
+/**
+ * Identifies which document the user is currently viewing in a modal.
+ * Used by callers (e.g. TenantPayments) that need to remember both the
+ * Document id (to fetch the source blob) and the Transaction id (to render
+ * the structured payment card from the Transaction's extracted fields).
+ */
+export interface DocumentViewTarget {
+  documentId: string;
+  transactionId: string;
+}


### PR DESCRIPTION
Addresses PR #236 review feedback: nested ternaries → mode-dispatch + subcomponents; inline state shapes → named DocumentViewTarget / DocumentViewMode types in shared/types/document/.