### PR TITLE
refactor(mybookkeeper/frontend): extract inline useState shapes to named types

### DIFF
--- a/apps/mybookkeeper/frontend/src/admin/pages/Admin.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/pages/Admin.tsx
@@ -13,6 +13,7 @@ import { useToast } from "@/shared/hooks/useToast";
 import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import type { Role } from "@/shared/types/user/role";
+import type { AdminConfirmAction } from "@/shared/types/admin/admin-confirm-action";
 import UsersTable from "@/admin/features/users/UsersTable";
 import StatsCards from "@/admin/features/users/StatsCards";
 import OrgsTable from "@/admin/features/organizations/OrgsTable";
@@ -37,11 +38,7 @@ export default function Admin() {
   const { showSuccess, showError } = useToast();
   const [activeTab, setActiveTab] = useState<Tab>("users");
   const [searchQuery, setSearchQuery] = useState("");
-  const [confirmAction, setConfirmAction] = useState<{
-    type: "deactivate" | "activate" | "superuser";
-    userId: string;
-    email: string;
-  } | null>(null);
+  const [confirmAction, setConfirmAction] = useState<AdminConfirmAction | null>(null);
 
   const filteredUsers = useMemo(() => {
     if (!users) return [];

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionForm.tsx
@@ -8,6 +8,7 @@ import type { Transaction } from "@/shared/types/transaction/transaction";
 import type { Property } from "@/shared/types/property/property";
 import type { TransactionFormValues } from "@/shared/types/transaction/transaction-form-values";
 import type { DuplicateTransaction } from "@/shared/types/transaction/duplicate";
+import type { SourcePreview } from "@/shared/types/transaction/source-preview";
 import FormField from "@/shared/components/ui/FormField";
 import Select from "@/shared/components/ui/Select";
 import TransactionDuplicateActions from "@/app/features/transactions/TransactionDuplicateActions";
@@ -39,7 +40,7 @@ export default function TransactionForm({
   onKeepDuplicate,
   onDismissDuplicate,
 }: Props) {
-  const [sourcePreview, setSourcePreview] = useState<{ url: string; type: string } | null>(null);
+  const [sourcePreview, setSourcePreview] = useState<SourcePreview | null>(null);
 
   const transactionType = watch("transaction_type");
   const categories = transactionType === "income" ? INCOME_CATEGORIES : EXPENSE_CATEGORY_LIST;

--- a/apps/mybookkeeper/frontend/src/shared/types/admin/admin-confirm-action-type.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/admin/admin-confirm-action-type.ts
@@ -1,0 +1,1 @@
+export type AdminConfirmActionType = "deactivate" | "activate" | "superuser";

--- a/apps/mybookkeeper/frontend/src/shared/types/admin/admin-confirm-action.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/admin/admin-confirm-action.ts
@@ -1,0 +1,7 @@
+import type { AdminConfirmActionType } from "./admin-confirm-action-type";
+
+export interface AdminConfirmAction {
+  type: AdminConfirmActionType;
+  userId: string;
+  email: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/transaction/source-preview-type.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/transaction/source-preview-type.ts
@@ -1,0 +1,1 @@
+export type SourcePreviewType = "pdf" | "image" | "other";

--- a/apps/mybookkeeper/frontend/src/shared/types/transaction/source-preview.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/transaction/source-preview.ts
@@ -1,0 +1,6 @@
+import type { SourcePreviewType } from "./source-preview-type";
+
+export interface SourcePreview {
+  url: string;
+  type: SourcePreviewType;
+}


### PR DESCRIPTION
Two inline anonymous useState shapes extracted to named types per the new global config rule. Tightens TransactionForm's preview type from 'string' to 'pdf' | 'image' | 'other' as a side benefit.