### PR TITLE
fix(mybookkeeper/receipts): wire pending-receipt creation into attribution paths

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/recpbf260504_backfill_pending_rent_receipts.py
+++ b/apps/mybookkeeper/backend/alembic/versions/recpbf260504_backfill_pending_rent_receipts.py
@@ -1,0 +1,74 @@
+"""backfill pending_rent_receipts for already-attributed income transactions
+
+Until this PR, attribution_service.maybe_attribute_payment / confirm_review /
+attribute_manually all set transaction.applicant_id but NEVER created a
+pending_rent_receipts row, so the Receipts page was empty even when
+payments had been auto-attributed. The new code wires the receipt creation
+in-session for all three paths going forward; this migration retroactively
+creates rows for any historical attributed transactions that don't have one.
+
+The query is org-scoped and idempotent (NOT EXISTS guard against a real
+PendingRentReceipt row for the same transaction_id). Period defaults to
+the calendar month of the transaction_date — same convention as
+``receipt_service._default_period`` for new attributions.
+
+Revision ID: recpbf260504
+Revises: synfun260504
+Create Date: 2026-05-04 21:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "recpbf260504"
+down_revision: Union[str, None] = "synfun260504"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO pending_rent_receipts (
+            id, user_id, organization_id, transaction_id, applicant_id,
+            signed_lease_id, period_start_date, period_end_date, status,
+            created_at, updated_at
+        )
+        SELECT
+            gen_random_uuid(),
+            t.user_id,
+            t.organization_id,
+            t.id,
+            t.applicant_id,
+            (
+                SELECT sl.id FROM signed_leases sl
+                 WHERE sl.applicant_id    = t.applicant_id
+                   AND sl.organization_id = t.organization_id
+                   AND sl.deleted_at IS NULL
+                 ORDER BY sl.created_at DESC
+                 LIMIT 1
+            ),
+            DATE_TRUNC('month', t.transaction_date)::date,
+            (DATE_TRUNC('month', t.transaction_date) + INTERVAL '1 month - 1 day')::date,
+            'pending',
+            NOW(),
+            NOW()
+          FROM transactions t
+         WHERE t.applicant_id IS NOT NULL
+           AND t.transaction_type = 'income'
+           AND t.deleted_at IS NULL
+           AND NOT EXISTS (
+               SELECT 1 FROM pending_rent_receipts prr
+                WHERE prr.transaction_id  = t.id
+                  AND prr.organization_id = t.organization_id
+           );
+        """
+    )
+
+
+def downgrade() -> None:
+    # Conservative: leave backfilled rows in place. They are normal
+    # pending receipts at this point and indistinguishable from rows
+    # the application would have created on attribution.
+    pass

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
@@ -144,6 +144,55 @@ async def _resolve_property_address(
 # Public service functions
 # ---------------------------------------------------------------------------
 
+async def create_pending_receipt_in_session(
+    db: AsyncSession,
+    *,
+    transaction_id: uuid.UUID,
+    applicant_id: uuid.UUID,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    period_start_date: _dt.date | None = None,
+    period_end_date: _dt.date | None = None,
+) -> None:
+    """Path B — create a pending receipt row in the caller's session.
+
+    Idempotent on ``transaction_id`` — safe to call multiple times.
+    The caller owns the commit; the receipt insert is part of the same
+    transaction as the attribution that produced it. Used by
+    ``attribution_service`` so the receipt and the applicant_id mutation
+    land atomically.
+    """
+    txn = await transaction_repo.get_by_id(db, transaction_id, organization_id)
+    if not txn:
+        return  # transaction disappeared; nothing to do
+
+    leases = await signed_lease_repo.list_for_tenant(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+        applicant_id=applicant_id,
+        include_deleted=False,
+        limit=1,
+    )
+    signed_lease_id = leases[0].id if leases else None
+
+    if not period_start_date or not period_end_date:
+        start, end = _default_period(txn.transaction_date)
+    else:
+        start, end = period_start_date, period_end_date
+
+    await pending_rent_receipt_repo.create_idempotent(
+        db,
+        user_id=user_id,
+        organization_id=organization_id,
+        transaction_id=transaction_id,
+        applicant_id=applicant_id,
+        signed_lease_id=signed_lease_id,
+        period_start_date=start,
+        period_end_date=end,
+    )
+
+
 async def create_pending_receipt_from_attribution(
     *,
     transaction_id: uuid.UUID,
@@ -153,42 +202,22 @@ async def create_pending_receipt_from_attribution(
     period_start_date: _dt.date | None = None,
     period_end_date: _dt.date | None = None,
 ) -> None:
-    """Path B — create a pending receipt row when a transaction is attributed.
+    """Top-level wrapper — opens its own session.
 
-    Idempotent on ``transaction_id`` — safe to call multiple times.
-    Called from ``attribution_service.maybe_attribute_payment`` and
-    ``attribution_service.confirm_review``.
+    Used by test seeds that need to create a pending receipt outside any
+    existing transaction. Production attribution paths use
+    ``create_pending_receipt_in_session`` instead so the receipt creation
+    rides on the same commit as the applicant_id mutation.
     """
     async with unit_of_work() as db:
-        txn = await transaction_repo.get_by_id(db, transaction_id, organization_id)
-        if txn is None:
-            return  # transaction disappeared; nothing to do
-
-        # Resolve the signed lease for this applicant (for the receipt queue)
-        leases = await signed_lease_repo.list_for_tenant(
+        await create_pending_receipt_in_session(
             db,
-            user_id=user_id,
-            organization_id=organization_id,
-            applicant_id=applicant_id,
-            include_deleted=False,
-            limit=1,
-        )
-        signed_lease_id = leases[0].id if leases else None
-
-        if period_start_date is None or period_end_date is None:
-            start, end = _default_period(txn.transaction_date)
-        else:
-            start, end = period_start_date, period_end_date
-
-        await pending_rent_receipt_repo.create_idempotent(
-            db,
-            user_id=user_id,
-            organization_id=organization_id,
             transaction_id=transaction_id,
             applicant_id=applicant_id,
-            signed_lease_id=signed_lease_id,
-            period_start_date=start,
-            period_end_date=end,
+            user_id=user_id,
+            organization_id=organization_id,
+            period_start_date=period_start_date,
+            period_end_date=period_end_date,
         )
 
 

--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -24,6 +24,7 @@ from app.repositories.applicants import applicant_repo
 from app.repositories.leases import signed_lease_repo
 from app.repositories.listings import listing_repo
 from app.repositories import transaction_repo as txn_repo
+from app.services.leases import receipt_service
 
 logger = logging.getLogger(__name__)
 
@@ -187,6 +188,13 @@ async def maybe_attribute_payment(
             "Auto-attributed transaction %s to applicant %s (exact match)",
             txn.id, best.id,
         )
+        await receipt_service.create_pending_receipt_in_session(
+            db,
+            transaction_id=txn.id,
+            applicant_id=best.id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
         return
 
     # Queue for review — fuzzy or unmatched
@@ -326,6 +334,13 @@ async def confirm_review(
                 txn.property_id = property_id
 
         await attribution_repo.resolve(db, row, "confirmed")
+        await receipt_service.create_pending_receipt_in_session(
+            db,
+            transaction_id=txn.id,
+            applicant_id=applicant.id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
         return {"ok": True, "transaction_id": str(txn.id)}
 
 
@@ -376,4 +391,11 @@ async def attribute_manually(
             if property_id:
                 txn.property_id = property_id
 
+        await receipt_service.create_pending_receipt_in_session(
+            db,
+            transaction_id=txn.id,
+            applicant_id=applicant.id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
         return {"ok": True, "transaction_id": str(txn.id)}


### PR DESCRIPTION
Receipts page was empty after auto-attribution because no production path called the receipt creator. Wires all three attribution paths and backfills historical attributed transactions.