### PR TITLE
fix(mybookkeeper/receipts): preview PDF fetch + payment-method inference for known vendors

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/SendReceiptDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/SendReceiptDialog.test.tsx
@@ -17,6 +17,11 @@ vi.mock("@/shared/lib/toast-store", () => ({
   showError: vi.fn(),
 }));
 
+const mockApiGet = vi.fn();
+vi.mock("@/shared/lib/api", () => ({
+  default: { get: (...args: unknown[]) => mockApiGet(...args) },
+}));
+
 import { showSuccess, showError } from "@/shared/lib/toast-store";
 
 const mockTransaction = {
@@ -144,7 +149,13 @@ describe("SendReceiptDialog", () => {
     });
   });
 
-  it("sets preview iframe src after clicking Preview PDF", async () => {
+  it("fetches the preview PDF via the authenticated API and renders it as a blob URL", async () => {
+    const fakeBlob = new Blob(["%PDF-1.4 fake"], { type: "application/pdf" });
+    mockApiGet.mockResolvedValueOnce({ data: fakeBlob });
+    const objectUrlSpy = vi
+      .spyOn(URL, "createObjectURL")
+      .mockReturnValue("blob:fake-pdf-url");
+
     renderDialog();
     fireEvent.click(screen.getByTestId("receipt-preview-btn"));
 
@@ -152,9 +163,28 @@ describe("SendReceiptDialog", () => {
       expect(screen.getByTestId("receipt-preview-iframe")).toBeInTheDocument();
     });
 
+    expect(mockApiGet).toHaveBeenCalledWith(
+      expect.stringContaining("/rent-receipts/preview/txn-123"),
+      expect.objectContaining({ responseType: "blob" }),
+    );
+    const calledUrl = mockApiGet.mock.calls[0][0] as string;
+    expect(calledUrl).toContain("period_start=2026-05-01");
+    expect(calledUrl).toContain("period_end=2026-05-31");
+
     const iframe = screen.getByTestId("receipt-preview-iframe") as HTMLIFrameElement;
-    expect(iframe.src).toContain("/api/rent-receipts/preview/txn-123");
-    expect(iframe.src).toContain("period_start=2026-05-01");
-    expect(iframe.src).toContain("period_end=2026-05-31");
+    expect(iframe.src).toBe("blob:fake-pdf-url");
+
+    objectUrlSpy.mockRestore();
+  });
+
+  it("surfaces a preview error when the API fails", async () => {
+    mockApiGet.mockRejectedValueOnce(new Error("net err"));
+    renderDialog();
+    fireEvent.click(screen.getByTestId("receipt-preview-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("receipt-preview-error")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("receipt-preview-iframe")).not.toBeInTheDocument();
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/receipts/ReceiptPreviewPane.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/receipts/ReceiptPreviewPane.tsx
@@ -1,0 +1,30 @@
+export interface ReceiptPreviewPaneProps {
+  url: string | null;
+  error: string | null;
+}
+
+export default function ReceiptPreviewPane({ url, error }: ReceiptPreviewPaneProps) {
+  if (error) {
+    return (
+      <p className="text-sm text-destructive p-6 text-center" data-testid="receipt-preview-error">
+        {error}
+      </p>
+    );
+  }
+  if (url) {
+    return (
+      <iframe
+        src={url}
+        title="Receipt preview"
+        data-testid="receipt-preview-iframe"
+        className="w-full h-full min-h-64 bg-white"
+        style={{ border: "none", colorScheme: "light" }}
+      />
+    );
+  }
+  return (
+    <p className="text-sm text-muted-foreground p-6 text-center">
+      Click "Preview PDF" to see what the tenant will receive.
+    </p>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/receipts/SendReceiptDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/receipts/SendReceiptDialog.tsx
@@ -1,11 +1,14 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Button from "@/shared/components/ui/Button";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useSendReceiptMutation } from "@/shared/store/rentReceiptsApi";
+import api from "@/shared/lib/api";
 import type { Transaction } from "@/shared/types/transaction/transaction";
+import { inferPaymentMethod } from "./inferPaymentMethod";
+import ReceiptPreviewPane from "./ReceiptPreviewPane";
 
-interface Props {
+export interface SendReceiptDialogProps {
   transaction: Transaction;
   onClose: (receiptNumber?: string) => void;
 }
@@ -35,28 +38,50 @@ function defaultPeriod(transactionDate: string): { start: string; end: string } 
  * Modal dialog to review and send a rent receipt PDF to the tenant.
  * Path A — triggered from a transaction row or the pending receipts page.
  */
-export default function SendReceiptDialog({ transaction, onClose }: Props) {
+export default function SendReceiptDialog({ transaction, onClose }: SendReceiptDialogProps) {
   const period = defaultPeriod(transaction.transaction_date);
   const [periodStart, setPeriodStart] = useState(period.start);
   const [periodEnd, setPeriodEnd] = useState(period.end);
-  const [paymentMethod, setPaymentMethod] = useState<string>(
-    transaction.payment_method ?? "",
+  const [paymentMethod, setPaymentMethod] = useState<string>(() =>
+    inferPaymentMethod(transaction),
   );
   const [previewLoading, setPreviewLoading] = useState(false);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [previewError, setPreviewError] = useState<string | null>(null);
 
   const [sendReceipt, { isLoading: isSending }] = useSendReceiptMutation();
 
+  // Free the blob URL when it changes or the dialog unmounts. Iframes don't
+  // release blob: URLs on src change, so leaks accumulate without this.
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
   async function handlePreview() {
     setPreviewLoading(true);
-    const params = new URLSearchParams({
-      period_start: periodStart,
-      period_end: periodEnd,
-      ...(paymentMethod ? { payment_method: paymentMethod } : {}),
-    });
-    const url = `/api/rent-receipts/preview/${transaction.id}?${params.toString()}`;
-    setPreviewUrl(url);
-    setPreviewLoading(false);
+    setPreviewError(null);
+    try {
+      // Iframes don't carry the JWT Authorization header — fetch the PDF as
+      // a blob via the authenticated axios client, then point the iframe at
+      // a blob: URL we control.
+      const params = new URLSearchParams({
+        period_start: periodStart,
+        period_end: periodEnd,
+      });
+      if (paymentMethod) params.append("payment_method", paymentMethod);
+      const res = await api.get(
+        `/rent-receipts/preview/${transaction.id}?${params.toString()}`,
+        { responseType: "blob" },
+      );
+      const blobUrl = URL.createObjectURL(res.data as Blob);
+      setPreviewUrl(blobUrl);
+    } catch {
+      setPreviewError("Couldn't load preview. Try again.");
+    } finally {
+      setPreviewLoading(false);
+    }
   }
 
   async function handleSend() {
@@ -183,19 +208,7 @@ export default function SendReceiptDialog({ transaction, onClose }: Props) {
 
           {/* Right: PDF preview */}
           <div className="flex-1 bg-muted/20 border-t md:border-t-0 md:border-l flex items-center justify-center min-h-64">
-            {previewUrl ? (
-              <iframe
-                src={previewUrl}
-                title="Receipt preview"
-                data-testid="receipt-preview-iframe"
-                className="w-full h-full min-h-64"
-                style={{ border: "none" }}
-              />
-            ) : (
-              <p className="text-sm text-muted-foreground p-6 text-center">
-                Click "Preview PDF" to see what the tenant will receive.
-              </p>
-            )}
+            <ReceiptPreviewPane url={previewUrl} error={previewError} />
           </div>
         </div>
 

--- a/apps/mybookkeeper/frontend/src/app/features/receipts/inferPaymentMethod.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/receipts/inferPaymentMethod.ts
@@ -1,0 +1,42 @@
+import type { Transaction } from "@/shared/types/transaction/transaction";
+
+/**
+ * Best-effort inference of a receipt's payment method when the
+ * extraction didn't fill ``transaction.payment_method``. Maps known
+ * P2P / platform vendors to the value that the receipt PDF would
+ * print anyway. Returns ``""`` when no confident default can be made
+ * (caller falls back to the manual select).
+ */
+export function inferPaymentMethod(transaction: Transaction): string {
+  if (transaction.payment_method) return transaction.payment_method;
+
+  const vendor = (transaction.vendor ?? "").toLowerCase();
+  if (!vendor) return "";
+
+  if (
+    vendor.includes("zelle") ||
+    vendor.includes("ach") ||
+    vendor.includes("bank transfer") ||
+    vendor.includes("wire") ||
+    vendor.includes("direct deposit")
+  ) {
+    return "bank_transfer";
+  }
+  if (
+    vendor.includes("venmo") ||
+    vendor.includes("cash app") ||
+    vendor.includes("cashapp") ||
+    vendor.includes("paypal") ||
+    vendor.includes("apple pay") ||
+    vendor.includes("google pay")
+  ) {
+    return "platform_payout";
+  }
+  if (vendor.includes("airbnb") || vendor.includes("vrbo") || vendor.includes("booking.com")) {
+    return "platform_payout";
+  }
+  if (vendor.includes("check")) return "check";
+  if (vendor.includes("cash")) return "cash";
+
+  return "";
+}


### PR DESCRIPTION
Preview iframe loaded the URL directly (no JWT) so it rendered the 401 body as raw text. Fixed by fetching as a blob via the authenticated api client. Also auto-infers payment_method (bank_transfer / platform_payout) from the vendor when the transaction itself doesn't have one.