### PR TITLE
fix(mybookkeeper/receipts): use user.name for landlord_name; add UI to set it

### DIFF
--- a/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
@@ -106,6 +106,24 @@ def _default_period(txn_date: _dt.date) -> tuple[_dt.date, _dt.date]:
     return first, last
 
 
+def _resolve_landlord_name(host_user) -> str:  # type: ignore[no-untyped-def]
+    """Pick the landlord display name for the receipt.
+
+    Prefers the host's configured ``user.name`` (legal name they entered
+    at registration or in profile settings). Falls back to the email
+    local-part only when the user hasn't set a name yet — that fallback
+    surfaces strings like 'jasonykwon91' on the receipt, which is wrong
+    for tenant-facing artifacts. The UI nudges the user to set their
+    name on the Security page so the fallback is short-lived.
+    """
+    name = (host_user.name or "").strip() if hasattr(host_user, "name") else ""
+    if name:
+        return name
+    if host_user.email:
+        return host_user.email.split("@")[0]
+    return "Landlord"
+
+
 async def _resolve_property_address(
     db: AsyncSession,
     *,
@@ -307,10 +325,10 @@ async def send_receipt(
             )
 
         host_user = await user_repo.get_by_id(db, user_id)
-        if host_user is None or not host_user.email:
+        if not host_user or not host_user.email:
             raise LookupError(f"User {user_id} not found or has no email")
 
-        landlord_name = host_user.email.split("@")[0]
+        landlord_name = _resolve_landlord_name(host_user)
         from_address = host_user.email
 
     # ── Phase 2: claim the receipt number (atomic DB op) ────────────────────
@@ -527,7 +545,7 @@ async def preview_receipt_pdf(
         )
 
         host_user = await user_repo.get_by_id(db, user_id)
-        landlord_name = host_user.email.split("@")[0] if host_user and host_user.email else "Landlord"
+        landlord_name = _resolve_landlord_name(host_user) if host_user else "Landlord"
 
     receipt_data = ReceiptData(
         receipt_number="R-PREVIEW",

--- a/apps/mybookkeeper/frontend/src/app/features/security/DisplayNameSetting.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/security/DisplayNameSetting.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import api from "@/shared/lib/api";
+
+interface CurrentUser {
+  id: string;
+  email: string;
+  name: string | null;
+}
+
+/**
+ * Lets the host set the display name that appears on rent receipts and
+ * outbound emails. Without this, the receipt PDF falls back to the
+ * email local-part (e.g. "jasonykwon91"), which is wrong for
+ * tenant-facing artifacts.
+ */
+export default function DisplayNameSetting() {
+  const [name, setName] = useState("");
+  const [originalName, setOriginalName] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .get<CurrentUser>("/users/me")
+      .then((res) => {
+        if (cancelled) return;
+        const current = res.data.name ?? "";
+        setName(current);
+        setOriginalName(current);
+      })
+      .catch(() => {
+        // non-fatal — user can still type a name and save
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      const trimmed = name.trim();
+      await api.patch("/users/me", { name: trimmed || null });
+      setOriginalName(trimmed);
+      showSuccess("Display name saved.");
+    } catch {
+      showError("Couldn't save your name. Try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  const dirty = name.trim() !== originalName;
+
+  return (
+    <div className="space-y-2">
+      <div>
+        <p className="text-sm font-medium">Display name</p>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Shown to tenants on rent receipts and outbound emails. Use the
+          legal name (or business name) you want tenants to see.
+        </p>
+      </div>
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="e.g. Jane Smith"
+          disabled={loading}
+          className="flex-1 px-3 py-2 text-sm border rounded-md disabled:opacity-50"
+          maxLength={120}
+        />
+        <button
+          type="button"
+          onClick={() => void handleSave()}
+          disabled={loading || saving || !dirty}
+          className="px-3 py-2 text-sm font-medium rounded-md border bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 min-h-[44px] sm:min-h-[36px]"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/Security.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Security.tsx
@@ -3,6 +3,7 @@ import { X, Download, Trash2 } from "lucide-react";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import TwoFactorSetup from "@/app/features/security/TwoFactorSetup";
 import DeleteAccountModal from "@/app/features/security/DeleteAccountModal";
+import DisplayNameSetting from "@/app/features/security/DisplayNameSetting";
 import { useDismissable } from "@/shared/hooks/useDismissable";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import api from "@/shared/lib/api";
@@ -50,6 +51,10 @@ export default function Security() {
           </button>
         </AlertBox>
       )}
+
+      <div className="bg-card border rounded-lg p-6">
+        <DisplayNameSetting />
+      </div>
 
       <div className="bg-card border rounded-lg p-6">
         <TwoFactorSetup />


### PR DESCRIPTION
Receipt was using email local-part as the landlord name. Fix routes through user.name, falls back to email only when name is unset. Adds a Display Name input on /security so the user can set it.