### PR TITLE
feat(mybookkeeper/tenants): split receipts into their own section on tenant detail

### DIFF
--- a/apps/mybookkeeper/backend/app/core/lease_enums.py
+++ b/apps/mybookkeeper/backend/app/core/lease_enums.py
@@ -48,6 +48,7 @@ LEASE_ATTACHMENT_KINDS: tuple[str, ...] = (
     "insurance_proof",
     "amendment",
     "notice",
+    "rent_receipt",
     "other",
 )
 

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/LeaseReceiptsRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/LeaseReceiptsRow.tsx
@@ -1,0 +1,67 @@
+import { Download, FileText } from "lucide-react";
+import { useGetSignedLeaseByIdQuery } from "@/shared/store/signedLeasesApi";
+import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
+
+export interface LeaseReceiptsRowProps {
+  leaseId: string;
+  onPreview: (attachment: SignedLeaseAttachment) => void;
+}
+
+const RECEIPT_KIND = "rent_receipt";
+
+/**
+ * Fetches a single lease's attachments and renders only the
+ * ``rent_receipt`` ones as inline list items. Used by
+ * ``LinkedLeaseReceipts`` once per linked lease so receipts from a
+ * renewed lease appear alongside originals.
+ */
+export default function LeaseReceiptsRow({ leaseId, onPreview }: LeaseReceiptsRowProps) {
+  const { data: detail, isLoading } = useGetSignedLeaseByIdQuery(leaseId);
+  const receipts = (detail?.attachments ?? []).filter((a) => a.kind === RECEIPT_KIND);
+
+  if (isLoading) {
+    return <li className="text-xs text-muted-foreground">Loading receipts…</li>;
+  }
+  if (!receipts.length) return null;
+
+  return (
+    <>
+      {receipts.map((att) => (
+        <li
+          key={att.id}
+          className="border rounded-md px-3 py-2 text-sm flex items-center justify-between gap-2"
+          data-testid={`receipt-attachment-${att.id}`}
+        >
+          <div className="flex items-center gap-2 min-w-0">
+            <FileText className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
+            {att.presigned_url ? (
+              <button
+                type="button"
+                onClick={() => onPreview(att)}
+                className="text-left text-primary hover:underline font-medium truncate"
+                title={att.filename}
+              >
+                {att.filename}
+              </button>
+            ) : (
+              <span className="truncate text-muted-foreground" title={att.filename}>
+                {att.filename}
+              </span>
+            )}
+          </div>
+          {att.presigned_url ? (
+            <a
+              href={att.presigned_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-muted-foreground hover:text-foreground shrink-0"
+              aria-label={`Download ${att.filename}`}
+            >
+              <Download size={14} />
+            </a>
+          ) : null}
+        </li>
+      ))}
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocuments.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocuments.tsx
@@ -9,17 +9,20 @@ import SignedLeaseStatusBadge from "@/app/features/leases/SignedLeaseStatusBadge
 import AttachmentViewer from "@/app/features/leases/AttachmentViewer";
 import { formatLongDate } from "@/shared/lib/inquiry-date-format";
 
-interface Props {
+export interface LinkedLeaseDocumentsProps {
   lease: SignedLeaseSummary;
 }
 
+const RECEIPT_KIND = "rent_receipt";
+
 /**
- * Lists a single linked lease's attachments inline on the applicant/tenant
- * detail page. Click a filename to open the document via ``AttachmentViewer``
- * — the same per-document preview pattern the rest of MBK uses. No drilling
- * away from the parent profile.
+ * Lists a single linked lease's NON-RECEIPT attachments inline on the
+ * applicant/tenant detail page. Receipts render in a separate section
+ * via ``LinkedLeaseReceipts`` so the Leases group only shows the lease
+ * agreement + addenda + amendments. Click a filename to open the
+ * document via ``AttachmentViewer``.
  */
-export default function LinkedLeaseDocuments({ lease }: Props) {
+export default function LinkedLeaseDocuments({ lease }: LinkedLeaseDocumentsProps) {
   const { data: detail, isLoading } = useGetSignedLeaseByIdQuery(lease.id);
   const [viewing, setViewing] = useState<SignedLeaseAttachment | null>(null);
 
@@ -29,7 +32,9 @@ export default function LinkedLeaseDocuments({ lease }: Props) {
           lease.ends_on ? formatLongDate(lease.ends_on) : "—"
         }`
       : null;
-  const attachments = detail?.attachments ?? [];
+  const attachments = (detail?.attachments ?? []).filter(
+    (att) => att.kind !== RECEIPT_KIND,
+  );
 
   return (
     <div className="space-y-2" data-testid={`linked-lease-${lease.id}`}>

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseReceipts.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseReceipts.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
+import type { SignedLeaseSummary } from "@/shared/types/lease/signed-lease-summary";
+import AttachmentViewer from "@/app/features/leases/AttachmentViewer";
+import LeaseReceiptsRow from "./LeaseReceiptsRow";
+
+export interface LinkedLeaseReceiptsProps {
+  leases: readonly SignedLeaseSummary[];
+}
+
+/**
+ * Receipts section on the tenant detail page. Aggregates
+ * ``rent_receipt`` attachments across every lease linked to the tenant
+ * so renewals don't fragment the receipt history. Lives in its own
+ * section so receipts don't clutter the Leases group — the user
+ * explicitly asked for this split on 2026-05-04.
+ */
+export default function LinkedLeaseReceipts({ leases }: LinkedLeaseReceiptsProps) {
+  const [viewing, setViewing] = useState<SignedLeaseAttachment | null>(null);
+  if (!leases.length) return null;
+  return (
+    <section
+      className="border rounded-lg p-4 space-y-2"
+      data-testid="linked-receipts-section"
+    >
+      <h2 className="text-sm font-medium">Receipts</h2>
+      <ul className="space-y-1">
+        {leases.map((lease) => (
+          <LeaseReceiptsRow key={lease.id} leaseId={lease.id} onPreview={setViewing} />
+        ))}
+      </ul>
+      {viewing?.presigned_url ? (
+        <AttachmentViewer
+          url={viewing.presigned_url}
+          filename={viewing.filename}
+          contentType={viewing.content_type}
+          onClose={() => setViewing(null)}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/ApplicantDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/ApplicantDetail.tsx
@@ -2,6 +2,7 @@ import { Link, useLocation, useNavigate, useParams } from "react-router-dom";
 import { ArrowLeft, ExternalLink } from "lucide-react";
 import { useGetSignedLeasesQuery } from "@/shared/store/signedLeasesApi";
 import LinkedLeaseDocuments from "@/app/features/applicants/LinkedLeaseDocuments";
+import LinkedLeaseReceipts from "@/app/features/applicants/LinkedLeaseReceipts";
 import EndTenancyDialog from "@/app/features/tenants/EndTenancyDialog";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import AlertBox from "@/shared/components/ui/AlertBox";
@@ -193,6 +194,8 @@ export default function ApplicantDetail() {
               </div>
             </section>
           ) : null}
+
+          <LinkedLeaseReceipts leases={linkedLeases} />
 
           {/* Contract dates */}
           <section

--- a/apps/mybookkeeper/frontend/src/shared/lib/lease-labels.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/lease-labels.ts
@@ -39,6 +39,7 @@ export const LEASE_ATTACHMENT_KIND_LABELS: Record<LeaseAttachmentKind, string> =
   insurance_proof: "Insurance proof",
   amendment: "Amendment",
   notice: "Notice",
+  rent_receipt: "Rent receipt",
   other: "Other",
 };
 

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/lease-attachment-kind.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/lease-attachment-kind.ts
@@ -13,6 +13,7 @@ export type LeaseAttachmentKind =
   | "insurance_proof"
   | "amendment"
   | "notice"
+  | "rent_receipt"
   | "other";
 
 export const LEASE_ATTACHMENT_KINDS: readonly LeaseAttachmentKind[] = [
@@ -24,5 +25,6 @@ export const LEASE_ATTACHMENT_KINDS: readonly LeaseAttachmentKind[] = [
   "insurance_proof",
   "amendment",
   "notice",
+  "rent_receipt",
   "other",
 ] as const;


### PR DESCRIPTION
Receipts now render in a dedicated Receipts section on the tenant page, separate from the Leases group. Also brings backend/frontend enums in sync with the rent_receipt kind that was already in the DB.