### PR TITLE
docs(myjobhunter): correct stale 'Known Follow-ups' — HIBP and TOTP both shipped

### DIFF
--- a/apps/myjobhunter/CLAUDE.md
+++ b/apps/myjobhunter/CLAUDE.md
@@ -209,13 +209,11 @@ docker compose -f apps/myjobhunter/docker-compose.yml exec postgres \
 
 ## Phase 1 Scope
 
-**Implemented:** models, migrations, auth endpoints, 6 smoke read endpoints, tests, Docker, CI
+**Implemented:** models, migrations, auth endpoints, 6 smoke read endpoints, tests, Docker, CI, HIBP password-breach check at registration / reset (`platform_shared.services.hibp_service`, fail-open on outage), TOTP 2FA enrollment + login challenge + disable + status (`backend/app/api/totp.py`, frontend `features/security/TwoFactorSetup.tsx`)
 **Phase 2:** Full CRUD for all domains, file upload, resume parse trigger
 **Phase 3:** Dramatiq workers, Gmail OAuth, Chrome extension integration
 **Phase 4:** Tavily company research, Claude JD parsing, cover letter generation
 
 ## Known Follow-ups
 
-- HIBP password breach check (deferred from Phase 1 password validator)
 - GIN indexes on JSONB columns (add when actual query predicates exist)
-- 2FA TOTP setup endpoint (model columns exist, endpoint deferred to Phase 2)


### PR DESCRIPTION
Audit found that both items listed as 'deferred' in MJH's CLAUDE.md are fully shipped. Correcting the doc so future security audits don't keep treating them as gaps.