### PR TITLE
feat(myjobhunter): MinIO config + resume_upload_jobs metadata baseline

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/resup260504_resume_upload_metadata.py
+++ b/apps/myjobhunter/backend/alembic/versions/resup260504_resume_upload_metadata.py
@@ -1,0 +1,42 @@
+"""resume_upload_jobs: add file metadata columns
+
+The Phase 2 upload endpoint stores file bytes in MinIO and writes the
+object key to ``file_path``. We also surface filename / content type /
+size on the job row for the UI listing — saves a presigned-URL
+round-trip per row when displaying status.
+
+Revision ID: resup260504
+Revises: totp260503
+Create Date: 2026-05-04 22:30:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "resup260504"
+down_revision: Union[str, None] = "totp260503"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "resume_upload_jobs",
+        sa.Column("file_filename", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "resume_upload_jobs",
+        sa.Column("file_content_type", sa.String(100), nullable=True),
+    )
+    op.add_column(
+        "resume_upload_jobs",
+        sa.Column("file_size_bytes", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("resume_upload_jobs", "file_size_bytes")
+    op.drop_column("resume_upload_jobs", "file_content_type")
+    op.drop_column("resume_upload_jobs", "file_filename")

--- a/apps/myjobhunter/backend/app/core/config.py
+++ b/apps/myjobhunter/backend/app/core/config.py
@@ -65,6 +65,27 @@ class Settings(BaseSettings):
     totp_label: str = "MyJobHunter"
     totp_issuer: str = "MyJobHunter"
 
+    # MinIO object storage — mirrors MBK's setup so resumes / cover letters /
+    # tailored docs land in an encrypted bucket with presigned URL access.
+    # ``minio_endpoint`` is the docker-network endpoint the backend uses for
+    # put/get/delete; ``minio_public_endpoint`` is what the browser sees in
+    # presigned URLs. Empty values disable storage entirely (uploads return
+    # 503 — never silently swallowed).
+    minio_endpoint: str = ""
+    minio_public_endpoint: str = ""
+    minio_access_key: str = ""
+    minio_secret_key: str = ""
+    minio_bucket: str = "myjobhunter-files"
+    minio_secure: bool = False
+    # Skip the lifespan bucket-existence check (useful in unit tests where
+    # MinIO isn't available; production must leave this False so a missing
+    # bucket fails loudly at boot).
+    minio_skip_startup_check: bool = False
+
+    # Resume upload limits — generous for legitimate PDF/DOCX resumes,
+    # bounded to prevent storage abuse.
+    max_resume_upload_bytes: int = 25 * 1024 * 1024  # 25 MB
+
     model_config = {"env_file": ".env", "extra": "ignore"}
 
 

--- a/apps/myjobhunter/backend/app/models/jobs/resume_upload_job.py
+++ b/apps/myjobhunter/backend/app/models/jobs/resume_upload_job.py
@@ -33,7 +33,11 @@ class ResumeUploadJob(Base):
         index=True,
     )
 
+    # MinIO object key — set by the upload endpoint after the bytes land.
     file_path: Mapped[str] = mapped_column(Text, nullable=False)
+    file_filename: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    file_content_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    file_size_bytes: Mapped[int | None] = mapped_column(Integer, nullable=True)
     status: Mapped[str] = mapped_column(String(20), default="queued")
     retry_count: Mapped[int] = mapped_column(Integer, default=0)
     next_retry_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)


### PR DESCRIPTION
Schema + config baseline so the follow-up upload-endpoint PR has clean ground. No API surface yet — just MinIO settings, the file metadata migration, and model wiring.