### PR TITLE
infra: shared MinIO compose stack at monorepo root

### DIFF
--- a/infra/MIGRATION.md
+++ b/infra/MIGRATION.md
@@ -1,0 +1,95 @@
+# MinIO migration: per-app → shared infra stack
+
+This is a one-time, operator-driven migration. After it lands, MBK and
+MJH (and future apps) all consume `myfreeapps-minio` from
+`infra/docker-compose.yml` instead of each spinning up their own.
+
+## Pre-migration checks
+
+- [ ] Verify a recent MBK MinIO backup exists (the data migration
+      below is rsync-equivalent and reversible, but a backup is
+      cheap insurance).
+- [ ] Note the current MBK MinIO root user + root password. They
+      must be re-used in `infra/.env` so existing object keys remain
+      accessible.
+
+## Steps (run on the VPS as root)
+
+```bash
+cd /srv/myfreeapps
+
+# 1. Build /srv/myfreeapps/infra/.env by copying the existing values
+#    out of MBK's compose env — MUST reuse the same MINIO_ROOT_USER /
+#    PASSWORD / KMS_SECRET_KEY so the existing data + signing keys
+#    decode correctly under the new container.
+cat > infra/.env <<EOF
+MINIO_ROOT_USER=$(grep '^MINIO_ROOT_USER=' apps/mybookkeeper/.env | cut -d= -f2-)
+MINIO_ROOT_PASSWORD=$(grep '^MINIO_ROOT_PASSWORD=' apps/mybookkeeper/.env | cut -d= -f2-)
+MINIO_KMS_SECRET_KEY=$(grep '^MINIO_KMS_SECRET_KEY=' apps/mybookkeeper/.env | cut -d= -f2-)
+MINIO_BROWSER_URL=http://localhost:9001
+EOF
+chmod 600 infra/.env
+
+# 2. Stop MBK so its MinIO container releases the volume.
+docker compose -f apps/mybookkeeper/docker-compose.yml down
+
+# 3. Copy the existing volume's contents into the new shared volume.
+#    Both volumes are named docker volumes; addressed by name regardless
+#    of which compose project owns them.
+docker volume create myfreeapps_minio_data
+docker run --rm \
+  -v mybookkeeper_minio_data:/old:ro \
+  -v myfreeapps_minio_data:/new \
+  alpine sh -c "cp -a /old/. /new/ && echo 'copy complete'"
+
+# 4. Bring up the shared infra stack.
+docker compose -f infra/docker-compose.yml --env-file infra/.env up -d
+
+# 5. Verify the data made it across.
+docker exec myfreeapps-minio mc alias set local http://127.0.0.1:9000 \
+  "$(grep MINIO_ROOT_USER infra/.env | cut -d= -f2-)" \
+  "$(grep MINIO_ROOT_PASSWORD infra/.env | cut -d= -f2-)"
+docker exec myfreeapps-minio mc ls local/mybookkeeper-files | head -10
+
+# 6. Bring MBK back up — it now joins the shared myfreeapps network
+#    and reaches the new minio at myfreeapps-minio:9000.
+#    (Requires the matching MBK compose update — PR B.)
+docker compose -f apps/mybookkeeper/docker-compose.yml up -d
+
+# 7. Smoke-test MBK end-to-end:
+#    - Open the app, view a property's listing photos (existing data)
+#    - Upload a new listing photo (verify the write path through the new endpoint)
+#    - Open a tenant's lease and view a signed-lease attachment
+#    - Send a rent receipt and verify the PDF generates + uploads
+
+# 8. After ~24 hours of stable operation, drop the old volume.
+#    The data has been copied, not moved — the original is still
+#    intact until you do this.
+docker volume rm mybookkeeper_minio_data
+```
+
+## Rollback
+
+If anything goes wrong before step 8:
+
+```bash
+# Stop the new shared stack
+docker compose -f infra/docker-compose.yml down
+
+# Bring MBK back up against its OLD compose (which still references
+# mybookkeeper_minio_data — the original volume is intact).
+git revert <PR-B-merge-sha>
+docker compose -f apps/mybookkeeper/docker-compose.yml up -d
+```
+
+After step 8 (volume removal) the rollback path is restore-from-backup.
+
+## What changes for new apps after this lands
+
+Adding a new app to the monorepo means: declare a bucket name (e.g.
+`myrestaurantreviews-files`) in the app's config, set MINIO_*
+environment variables to point at the shared service, join the
+`myfreeapps` external network in the app's compose. The lifespan
+bucket-initializer (each app already has one) creates the bucket
+idempotently on boot. No new container, no new volume, no key
+rotation — the shared service handles all of that.

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -1,0 +1,68 @@
+# Shared infrastructure stack for the MyFreeApps monorepo.
+#
+# Currently runs the MinIO object-storage service that every app in the
+# monorepo consumes. Each app gets its own bucket (mybookkeeper-files,
+# myjobhunter-files, ...) on a single MinIO cluster, with its own access
+# key + secret key — bucket-level isolation, not container-level.
+#
+# Why this lives at the monorepo root rather than per-app: a single
+# MinIO is the right shape for the operator running multiple apps on
+# one VPS. One key-rotation cycle, one backup target, one
+# encryption-at-rest config. Per-app MinIO would mean N times the
+# memory + N times the operations cost for no isolation gain.
+#
+# Deploy: bring this stack up FIRST on the VPS, then the per-app stacks
+# (apps/mybookkeeper/docker-compose.yml, apps/myjobhunter/docker-compose.yml)
+# will join the shared `myfreeapps` network and reach minio at
+# myfreeapps-minio:9000.
+#
+# Run from the monorepo root on the VPS:
+#   sudo docker compose -f infra/docker-compose.yml up -d
+#
+services:
+  minio:
+    # SHA-pinned via tag — verified against Docker Hub on 2026-04-26.
+    # Tag check: gh api hub.docker.com/v2/repositories/minio/minio/tags/<tag>
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    container_name: myfreeapps-minio
+    restart: unless-stopped
+    ports:
+      # Bind only to localhost — apps reach the API via the docker
+      # network; public access for downloads goes through the per-app
+      # caddy reverse-proxy (storage.<app-domain>).
+      - "127.0.0.1:9000:9000"
+      - "127.0.0.1:9001:9001"
+    volumes:
+      - minio_data:/data
+    environment:
+      # Dev defaults — production OVERRIDES these via /srv/myfreeapps/infra/.env.
+      # Never use these credentials in production: see deploy/MINIO_SETUP.md
+      # in apps/mybookkeeper/ for the production setup procedure.
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
+      MINIO_KMS_AUTO_ENCRYPTION: "on"
+      MINIO_KMS_SECRET_KEY: ${MINIO_KMS_SECRET_KEY:-key1:V0VBSyBERVYgS0VZIC0gUkVQTEFDRSBJTiBQUk9EICAgIA==}
+      MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_URL:-http://localhost:9001}
+    command: server /data --console-address ":9001"
+    healthcheck:
+      test: ["CMD-SHELL", "mc ready local || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+    networks:
+      - myfreeapps
+
+volumes:
+  # Named volume holding object data. The migration from MBK's own
+  # `mybookkeeper_minio_data` volume to this one is operator-driven
+  # (one-time `docker run --rm -v old:/old -v new:/new alpine cp -a /old/. /new/`)
+  # documented in infra/MIGRATION.md.
+  minio_data:
+
+networks:
+  # Shared external network. Per-app compose stacks join it via
+  # `networks: myfreeapps: external: true`.
+  myfreeapps:
+    name: myfreeapps
+    driver: bridge

--- a/infra/migrate-to-shared-minio.sh
+++ b/infra/migrate-to-shared-minio.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# One-time VPS migration: per-app MinIO → shared infra/ MinIO.
+#
+# Run from /srv/myfreeapps as root:
+#   sudo bash infra/migrate-to-shared-minio.sh
+#
+# Safe to re-run after a partial failure — every step is idempotent or
+# guarded by a precondition check. If anything fails, the script exits
+# with the failing command's exit code and prints a rollback hint.
+#
+# What this script does:
+#   1. Pre-flight checks (compose installed, MBK env present, MBK
+#      currently running, etc.)
+#   2. Builds infra/.env by reusing MBK's MinIO root user / password /
+#      KMS key — required so existing object data + signing keys
+#      remain valid under the new container.
+#   3. Stops MBK (releases the existing minio_data volume).
+#   4. Copies mybookkeeper_minio_data → myfreeapps_minio_data.
+#   5. Brings up the shared infra stack.
+#   6. Verifies data made it across.
+#   7. Brings MBK back up (it joins the shared myfreeapps network and
+#      reaches minio at myfreeapps-minio:9000 — requires the matching
+#      MBK compose update to have landed in main).
+#   8. Smoke-tests connectivity from the MBK api container.
+#   9. Prompts before deleting the old mybookkeeper_minio_data volume.
+#      Default is to keep it for 24h; pass --drop-old-volume to remove
+#      immediately.
+#
+# Rollback if step 7 or 8 fails: run with --rollback. Restores the old
+# MBK compose-only setup and brings MBK back up against
+# mybookkeeper_minio_data.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INFRA_DIR="$REPO_ROOT/infra"
+MBK_DIR="$REPO_ROOT/apps/mybookkeeper"
+MBK_COMPOSE="$MBK_DIR/docker-compose.yml"
+INFRA_COMPOSE="$INFRA_DIR/docker-compose.yml"
+INFRA_ENV="$INFRA_DIR/.env"
+MBK_ENV_FILE="$MBK_DIR/.env"
+
+OLD_VOLUME="mybookkeeper_minio_data"
+NEW_VOLUME="myfreeapps_minio_data"
+NEW_NETWORK="myfreeapps"
+NEW_CONTAINER="myfreeapps-minio"
+
+DROP_OLD=0
+ROLLBACK=0
+for arg in "$@"; do
+  case "$arg" in
+    --drop-old-volume) DROP_OLD=1 ;;
+    --rollback) ROLLBACK=1 ;;
+    -h|--help)
+      sed -n '1,/^set -euo/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      echo "see --help" >&2
+      exit 2
+      ;;
+  esac
+done
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+blue()   { printf '\033[34m%s\033[0m\n' "$*"; }
+
+require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || { red "missing: $1"; exit 1; }
+}
+
+# ──────────────────────────────────────────────────────────────────────────
+# Rollback path
+# ──────────────────────────────────────────────────────────────────────────
+if [[ "$ROLLBACK" == "1" ]]; then
+  yellow "Rolling back to per-app MinIO."
+  blue "Step 1/3: bringing down shared infra stack"
+  if [[ -f "$INFRA_COMPOSE" ]]; then
+    docker compose -f "$INFRA_COMPOSE" down || true
+  fi
+  blue "Step 2/3: bringing MBK back up against original volume"
+  docker compose -f "$MBK_COMPOSE" up -d
+  blue "Step 3/3: verifying MBK is healthy"
+  sleep 5
+  docker compose -f "$MBK_COMPOSE" ps
+  green "Rollback complete. ${OLD_VOLUME} is intact and serving MBK again."
+  exit 0
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pre-flight
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 0/9: pre-flight checks"
+require_cmd docker
+require_cmd grep
+require_cmd cut
+
+if ! docker compose version >/dev/null 2>&1; then
+  red "docker compose v2 not available. Install via 'apt install docker-compose-plugin'."
+  exit 1
+fi
+
+if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  red "Run as root: sudo bash $0"
+  exit 1
+fi
+
+[[ -f "$INFRA_COMPOSE" ]] || { red "missing: $INFRA_COMPOSE"; exit 1; }
+[[ -f "$MBK_COMPOSE" ]]   || { red "missing: $MBK_COMPOSE"; exit 1; }
+[[ -f "$MBK_ENV_FILE" ]]  || { red "missing: $MBK_ENV_FILE — needed to copy MinIO credentials"; exit 1; }
+
+# Required env keys must exist in MBK env so we can copy them.
+for key in MINIO_ROOT_USER MINIO_ROOT_PASSWORD MINIO_KMS_SECRET_KEY; do
+  if ! grep -q "^${key}=" "$MBK_ENV_FILE"; then
+    red "MBK env $MBK_ENV_FILE missing required key $key"
+    exit 1
+  fi
+done
+
+# Detect whether the migration has already been done (idempotency).
+already_migrated=0
+if docker volume inspect "$NEW_VOLUME" >/dev/null 2>&1 \
+   && docker ps --format '{{.Names}}' | grep -q "^${NEW_CONTAINER}\$"; then
+  already_migrated=1
+  yellow "Detected existing ${NEW_VOLUME} + running ${NEW_CONTAINER}."
+  yellow "Re-running will skip already-completed steps."
+fi
+
+green "Pre-flight passed."
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 1/9: write infra/.env
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 1/9: building $INFRA_ENV from MBK env"
+if [[ -f "$INFRA_ENV" ]]; then
+  yellow "  $INFRA_ENV already exists — keeping. (Delete it manually if you need to re-derive.)"
+else
+  {
+    echo "MINIO_ROOT_USER=$(grep '^MINIO_ROOT_USER=' "$MBK_ENV_FILE" | cut -d= -f2-)"
+    echo "MINIO_ROOT_PASSWORD=$(grep '^MINIO_ROOT_PASSWORD=' "$MBK_ENV_FILE" | cut -d= -f2-)"
+    echo "MINIO_KMS_SECRET_KEY=$(grep '^MINIO_KMS_SECRET_KEY=' "$MBK_ENV_FILE" | cut -d= -f2-)"
+    echo "MINIO_BROWSER_URL=http://localhost:9001"
+  } > "$INFRA_ENV"
+  chmod 600 "$INFRA_ENV"
+  chown root:root "$INFRA_ENV"
+  green "  wrote $INFRA_ENV (mode 600, root:root)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 2/9: stop MBK so the volume can be copied
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 2/9: stopping MBK"
+if [[ "$already_migrated" == "1" ]]; then
+  yellow "  already migrated — skipping"
+else
+  docker compose -f "$MBK_COMPOSE" down
+  green "  MBK stopped"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 3/9: copy old volume → new volume
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 3/9: copying $OLD_VOLUME → $NEW_VOLUME"
+if docker volume inspect "$NEW_VOLUME" >/dev/null 2>&1; then
+  yellow "  $NEW_VOLUME already exists — assuming previous copy succeeded. Skipping."
+else
+  if ! docker volume inspect "$OLD_VOLUME" >/dev/null 2>&1; then
+    red "  $OLD_VOLUME does not exist — nothing to migrate from."
+    red "  This is unexpected unless this is a fresh VPS. Aborting."
+    exit 1
+  fi
+  docker volume create "$NEW_VOLUME" >/dev/null
+  docker run --rm \
+    -v "${OLD_VOLUME}:/old:ro" \
+    -v "${NEW_VOLUME}:/new" \
+    alpine sh -c "cp -a /old/. /new/ && echo 'copied'"
+  green "  copy complete"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 4/9: bring up the shared infra stack
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 4/9: starting shared MinIO"
+docker compose -f "$INFRA_COMPOSE" --env-file "$INFRA_ENV" up -d
+sleep 6
+if ! docker ps --format '{{.Names}}' | grep -q "^${NEW_CONTAINER}\$"; then
+  red "  ${NEW_CONTAINER} did not come up. Check 'docker compose -f $INFRA_COMPOSE logs minio'."
+  exit 1
+fi
+green "  ${NEW_CONTAINER} is running"
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 5/9: verify data is readable from the new container
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 5/9: verifying data accessibility"
+ROOT_USER="$(grep '^MINIO_ROOT_USER=' "$INFRA_ENV" | cut -d= -f2-)"
+ROOT_PASS="$(grep '^MINIO_ROOT_PASSWORD=' "$INFRA_ENV" | cut -d= -f2-)"
+docker exec "$NEW_CONTAINER" mc alias set local \
+  http://127.0.0.1:9000 "$ROOT_USER" "$ROOT_PASS" >/dev/null
+if docker exec "$NEW_CONTAINER" mc ls local/ 2>/dev/null | grep -q .; then
+  green "  buckets found:"
+  docker exec "$NEW_CONTAINER" mc ls local/ | sed 's/^/    /'
+else
+  yellow "  no buckets visible. If this is the first migration, that's unexpected."
+  yellow "  If only myjobhunter-files is missing, that's fine — it's created on MJH boot."
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 6/9: bring MBK back up — it will join the shared network + reach
+# minio at myfreeapps-minio:9000 (requires PR B to have landed)
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 6/9: bringing MBK back up"
+docker compose -f "$MBK_COMPOSE" up -d
+sleep 8
+green "  MBK started"
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 7/9: smoke-test MBK → MinIO connectivity from the api container
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 7/9: smoke-testing MBK api → MinIO connectivity"
+api_container="$(docker ps --format '{{.Names}}' | grep -E '^mybookkeeper-api(-1)?$' | head -1)"
+if [[ -z "$api_container" ]]; then
+  red "  could not locate the MBK api container by name. Skipping smoke test."
+  red "  Check 'docker ps' and verify yourself."
+elif docker exec "$api_container" sh -c \
+       "wget -q -O - http://${NEW_CONTAINER}:9000/minio/health/live >/dev/null 2>&1 \
+        || curl -sf http://${NEW_CONTAINER}:9000/minio/health/live >/dev/null 2>&1"; then
+  green "  ${api_container} can reach ${NEW_CONTAINER}:9000 ✓"
+else
+  red "  ${api_container} CANNOT reach ${NEW_CONTAINER}:9000."
+  red "  This usually means PR B (MBK compose joining the shared myfreeapps network)"
+  red "  has not landed yet. Check: docker network inspect ${NEW_NETWORK}"
+  red "  Rollback: sudo bash $0 --rollback"
+  exit 1
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 8/9: prompt about old volume (default keep)
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 8/9: old volume cleanup"
+if [[ "$DROP_OLD" == "1" ]]; then
+  yellow "  --drop-old-volume passed; removing $OLD_VOLUME now"
+  docker volume rm "$OLD_VOLUME" || red "  failed to remove $OLD_VOLUME (may already be gone)"
+  green "  removed"
+else
+  yellow "  $OLD_VOLUME left in place for 24h safety net."
+  yellow "  Re-run with --drop-old-volume after MBK has been verified working,"
+  yellow "  or remove manually with: docker volume rm $OLD_VOLUME"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Step 9/9: summary
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 9/9: summary"
+green "Migration complete."
+green ""
+green "  Shared infra stack:    docker compose -f $INFRA_COMPOSE ps"
+green "  MBK status:            docker compose -f $MBK_COMPOSE ps"
+green "  Data volume:           $NEW_VOLUME"
+green "  Network:               $NEW_NETWORK"
+green ""
+yellow "Next steps:"
+yellow "  1. Open MBK in a browser; verify listing photos / lease attachments load."
+yellow "  2. Send a test rent receipt; verify the PDF generates + uploads."
+yellow "  3. After 24h of stable operation, remove $OLD_VOLUME"
+yellow "     (or pass --drop-old-volume on the next run)."


### PR DESCRIPTION
Adds infra/docker-compose.yml + shared external docker network. Operator runbook in infra/MIGRATION.md. MBK + MJH compose refactors come in follow-up PRs (B + C).