### PR TITLE
refactor(mybookkeeper/frontend): rename bare `interface Props` to `<ComponentName>Props` (mechanical sweep)

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -105,11 +105,8 @@
 
 ---
 
-### [Frontend] Bare `interface Props` across ~199 frontend component files
-**Effort:** M (mechanical sweep)
-**Location:** ~199 files across `apps/mybookkeeper/frontend/src/`
-**Problem:** Most component files declare their props as `interface Props` (un-prefixed). Per the new global config rule (jkwon-claude-config PR #92, merged 2026-05-04), props interfaces must be domain-prefixed (`<ComponentName>Props`) AND exported, otherwise importing two `Props` types into the same file collides and IDE rename refactors break. Props CAN stay co-located with the component (one allowed exception to "one type per file") but the bare name is no longer acceptable.
-**Recommendation:** Mechanical sweep — for each file, rename `interface Props` → `interface <ComponentName>Props` (matching the default-export name), add `export`, update local references. Type-check after the rename catches breakage. Ship as one PR (uniform change, TS catches all incorrect references). Defer until next time the codebase has natural quiet — bulk-touching 199 files mid-feature creates merge-conflict risk for in-flight branches.
+### ~~[Frontend] Bare `interface Props` across ~199 frontend component files~~ RESOLVED
+**Resolved:** PR refactor/jykwon91/mbk-props-rename (2026-05-04) — all 196 files renamed; `tsc --noEmit` clean.
 
 ---
 

--- a/apps/mybookkeeper/frontend/src/admin/features/demo/CreateDemoDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/features/demo/CreateDemoDialog.tsx
@@ -3,14 +3,14 @@ import * as Dialog from "@radix-ui/react-dialog";
 import Button from "@/shared/components/ui/Button";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 
-interface Props {
+export interface CreateDemoDialogProps {
   open: boolean;
   isLoading: boolean;
   onSubmit: (tag: string, recipientEmail?: string) => void;
   onCancel: () => void;
 }
 
-export default function CreateDemoDialog({ open, isLoading, onSubmit, onCancel }: Props) {
+export default function CreateDemoDialog({ open, isLoading, onSubmit, onCancel }: CreateDemoDialogProps) {
   const [tag, setTag] = useState("");
   const [recipientEmail, setRecipientEmail] = useState("");
 

--- a/apps/mybookkeeper/frontend/src/admin/features/demo/CredentialsModal.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/features/demo/CredentialsModal.tsx
@@ -3,14 +3,14 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { Check, Copy, AlertTriangle } from "lucide-react";
 import Button from "@/shared/components/ui/Button";
 
-interface Props {
+export interface CredentialsModalProps {
   open: boolean;
   email: string;
   password: string;
   onClose: () => void;
 }
 
-export default function CredentialsModal({ open, email, password, onClose }: Props) {
+export default function CredentialsModal({ open, email, password, onClose }: CredentialsModalProps) {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout>>();
 

--- a/apps/mybookkeeper/frontend/src/admin/features/demo/DemoCredentialsCard.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/features/demo/DemoCredentialsCard.tsx
@@ -2,11 +2,11 @@ import type { DemoCredentials } from "@/shared/types/demo/demo-status";
 import Card from "@/shared/components/ui/Card";
 import CopyField from "@/shared/components/ui/CopyField";
 
-interface Props {
+export interface DemoCredentialsCardProps {
   credentials: DemoCredentials;
 }
 
-export default function DemoCredentialsCard({ credentials }: Props) {
+export default function DemoCredentialsCard({ credentials }: DemoCredentialsCardProps) {
   return (
     <Card title="Demo Credentials">
       <div className="space-y-3">

--- a/apps/mybookkeeper/frontend/src/admin/features/demo/DemoUserTable.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/features/demo/DemoUserTable.tsx
@@ -2,13 +2,13 @@ import { RotateCcw, Trash2 } from "lucide-react";
 import type { DemoUser } from "@/shared/types/demo/demo-user";
 import { formatDate } from "@/shared/utils/date";
 
-interface Props {
+export interface DemoUserTableProps {
   users: DemoUser[];
   onReset: (userId: string) => void;
   onDelete: (userId: string) => void;
 }
 
-export default function DemoUserTable({ users, onReset, onDelete }: Props) {
+export default function DemoUserTable({ users, onReset, onDelete }: DemoUserTableProps) {
   if (users.length === 0) {
     return (
       <div className="border rounded-lg px-6 py-12 text-center">

--- a/apps/mybookkeeper/frontend/src/app/features/analytics/AnalyticsFilters.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/analytics/AnalyticsFilters.tsx
@@ -6,7 +6,7 @@ import type { Property } from "@/shared/types/property/property";
 
 type Granularity = "monthly" | "quarterly";
 
-interface Props {
+export interface AnalyticsFiltersProps {
   fromDate: string;
   toDate: string;
   granularity: Granularity;
@@ -32,7 +32,7 @@ export default function AnalyticsFilters({
   onPropertyIds,
   hasActiveFilters,
   onClear,
-}: Props) {
+}: AnalyticsFiltersProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   const filterContent = (

--- a/apps/mybookkeeper/frontend/src/app/features/analytics/UtilitySummaryCards.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/analytics/UtilitySummaryCards.tsx
@@ -2,7 +2,7 @@ import Card from "@/shared/components/ui/Card";
 import { formatCurrency } from "@/shared/utils/currency";
 import { UTILITY_SUB_CATEGORIES, UTILITY_SUB_CATEGORY_COLORS } from "@/shared/lib/constants";
 
-interface Props {
+export interface UtilitySummaryCardsProps {
   totalSpend: number;
   summary: Record<string, number>;
 }
@@ -11,7 +11,7 @@ function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
 }
 
-export default function UtilitySummaryCards({ totalSpend, summary }: Props) {
+export default function UtilitySummaryCards({ totalSpend, summary }: UtilitySummaryCardsProps) {
   return (
     <section
       className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-7 gap-3"

--- a/apps/mybookkeeper/frontend/src/app/features/analytics/UtilityTrendsChart.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/analytics/UtilityTrendsChart.tsx
@@ -52,13 +52,13 @@ function buildChartData(trends: UtilityTrendPoint[], granularity: Granularity): 
   );
 }
 
-interface Props {
+export interface UtilityTrendsChartProps {
   trends: UtilityTrendPoint[];
   granularity: Granularity;
   height?: number;
 }
 
-export default function UtilityTrendsChart({ trends, granularity, height = 350 }: Props) {
+export default function UtilityTrendsChart({ trends, granularity, height = 350 }: UtilityTrendsChartProps) {
   const presentCategories = UTILITY_SUB_CATEGORIES.filter((cat) =>
     trends.some((t) => t.sub_category === cat),
   );

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantCard.tsx
@@ -6,7 +6,7 @@ import {
 import type { ApplicantSummary } from "@/shared/types/applicant/applicant-summary";
 import ApplicantStageBadge from "./ApplicantStageBadge";
 
-interface Props {
+export interface ApplicantCardProps {
   applicant: ApplicantSummary;
   /**
    * When true (i.e., the list is in the "All" filter), render the stage
@@ -32,7 +32,7 @@ interface Props {
  *   - DOB, vehicle, ID document key (PII — detail page only, behind unlock)
  *   - screening status (detail page only — surfaced via ScreeningResultRow)
  */
-export default function ApplicantCard({ applicant, showStageBadge }: Props) {
+export default function ApplicantCard({ applicant, showStageBadge }: ApplicantCardProps) {
   const legalName = applicant.legal_name ?? "Unnamed applicant";
   const employer = applicant.employer_or_hospital ?? "—";
   const contractDates = formatDesiredDates(

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantRow.tsx
@@ -6,7 +6,7 @@ import {
 import type { ApplicantSummary } from "@/shared/types/applicant/applicant-summary";
 import ApplicantStageBadge from "./ApplicantStageBadge";
 
-interface Props {
+export interface ApplicantRowProps {
   applicant: ApplicantSummary;
 }
 
@@ -14,7 +14,7 @@ interface Props {
  * Desktop table row for the Applicants list. Click anywhere navigates to
  * the detail page.
  */
-export default function ApplicantRow({ applicant }: Props) {
+export default function ApplicantRow({ applicant }: ApplicantRowProps) {
   const navigate = useNavigate();
   const legalName = applicant.legal_name ?? "Unnamed applicant";
   const employer = applicant.employer_or_hospital ?? "—";

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantStageBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantStageBadge.tsx
@@ -15,7 +15,7 @@ const COLOR_CLASSES: Record<BadgeColor, string> = {
   purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
 };
 
-interface Props {
+export interface ApplicantStageBadgeProps {
   stage: ApplicantStage;
   className?: string;
 }
@@ -26,7 +26,7 @@ interface Props {
  * Hidden in stage-filtered list views (the chip already conveys the stage)
  * but shown on detail pages and the unfiltered "All" list.
  */
-export default function ApplicantStageBadge({ stage, className = "" }: Props) {
+export default function ApplicantStageBadge({ stage, className = "" }: ApplicantStageBadgeProps) {
   const color = APPLICANT_STAGE_BADGE_COLORS[stage];
   return (
     <span

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantStageFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantStageFilter.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/shared/lib/applicant-labels";
 import type { ApplicantStage } from "@/shared/types/applicant/applicant-stage";
 
-interface Props {
+export interface ApplicantStageFilterProps {
   value: ApplicantStage | null;
   onChange: (stage: ApplicantStage | null) => void;
 }
@@ -26,7 +26,7 @@ const CHIPS: Chip[] = [
  * mobile (``overflow-x-auto`` + ``flex-nowrap``), URL-state sync handled by
  * the parent page via ``useSearchParams``.
  */
-export default function ApplicantStageFilter({ value, onChange }: Props) {
+export default function ApplicantStageFilter({ value, onChange }: ApplicantStageFilterProps) {
   return (
     <div
       role="tablist"

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantStatusControl.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantStatusControl.tsx
@@ -25,7 +25,7 @@ const COLOR_CLASSES: Record<BadgeColor, string> = {
   purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
 };
 
-interface Props {
+export interface ApplicantStatusControlProps {
   applicantId: string;
   currentStage: ApplicantStage;
 }
@@ -36,7 +36,7 @@ interface Props {
  *
  * Read-only members see a plain non-interactive badge instead.
  */
-export default function ApplicantStatusControl({ applicantId, currentStage }: Props) {
+export default function ApplicantStatusControl({ applicantId, currentStage }: ApplicantStatusControlProps) {
   const canWrite = useCanWrite();
   const { showSuccess, showError } = useToast();
   const [transitionStage] = useTransitionApplicantStageMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantTimelineList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantTimelineList.tsx
@@ -28,7 +28,7 @@ const NON_STAGE_EVENT_LABELS: Record<string, string> = {
   reference_contacted: "Reference contacted",
 };
 
-interface Props {
+export interface ApplicantTimelineListProps {
   events: ApplicantEvent[];
   /**
    * Default-collapsed per RENTALS_PLAN.md §9.1 detail-page hierarchy — the
@@ -52,7 +52,7 @@ function formatEventType(eventType: string): string {
  * Read-only — the host-driven event sources (note_added, screening_*,
  * reference_contacted) ship in PR 3.3 / 3.4.
  */
-export default function ApplicantTimelineList({ events, defaultOpen = false }: Props) {
+export default function ApplicantTimelineList({ events, defaultOpen = false }: ApplicantTimelineListProps) {
   const [open, setOpen] = useState(defaultOpen);
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantsListSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantsListSkeleton.tsx
@@ -1,6 +1,6 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
 
-interface Props {
+export interface ApplicantsListSkeletonProps {
   count?: number;
 }
 
@@ -13,7 +13,7 @@ interface Props {
  *   - Desktop: same 5 columns (Name, Employer, Contract Dates, Promoted,
  *     Stage) and same number of skeleton rows.
  */
-export default function ApplicantsListSkeleton({ count = 4 }: Props) {
+export default function ApplicantsListSkeleton({ count = 4 }: ApplicantsListSkeletonProps) {
   const rows = Array.from({ length: count }, (_, i) => i);
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ContractDatesEditor.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ContractDatesEditor.tsx
@@ -7,7 +7,7 @@ import type { ApplicantStage } from "@/shared/types/applicant/applicant-stage";
 const DEBOUNCE_MS = 600;
 const LOCKED_STAGE: ApplicantStage = "lease_signed";
 
-interface Props {
+export interface ContractDatesEditorProps {
   applicantId: string;
   field: "contract_start" | "contract_end";
   value: string | null;
@@ -38,7 +38,7 @@ export default function ContractDatesEditor({
   value,
   stage,
   label,
-}: Props) {
+}: ContractDatesEditorProps) {
   const { showError, showSuccess } = useToast();
   const [updateDates, { isLoading }] = useUpdateApplicantContractDatesMutation();
 

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/PromoteFromInquiryPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/PromoteFromInquiryPanel.tsx
@@ -21,7 +21,7 @@ import type { ApplicantPromoteRequest } from "@/shared/types/applicant/applicant
 import type { ApplicantPromoteConflictDetail } from "@/shared/types/applicant/applicant-promote-conflict";
 import type { InquiryResponse } from "@/shared/types/inquiry/inquiry-response";
 
-interface Props {
+export interface PromoteFromInquiryPanelProps {
   inquiry: InquiryResponse;
   onClose: () => void;
 }
@@ -102,7 +102,7 @@ function formValuesToRequest(values: PromoteFormValues): ApplicantPromoteRequest
  * - 409 ``not_promotable`` → toast explaining the inquiry is terminal.
  * - Other errors → conversational AI-tone retry prompt.
  */
-export default function PromoteFromInquiryPanel({ inquiry, onClose }: Props) {
+export default function PromoteFromInquiryPanel({ inquiry, onClose }: PromoteFromInquiryPanelProps) {
   const navigate = useNavigate();
   const [promote, { isLoading }] = usePromoteFromInquiryMutation();
   const defaults = useMemo<PromoteFormValues>(

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ReferenceRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ReferenceRow.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/shared/lib/inquiry-date-format";
 import type { ApplicantReference } from "@/shared/types/applicant/applicant-reference";
 
-interface Props {
+export interface ReferenceRowProps {
   reference: ApplicantReference;
 }
 
@@ -25,7 +25,7 @@ const RELATIONSHIP_LABELS: Record<string, string> = {
  * Per RENTALS_PLAN.md §9.1: contacted_at is the actionable signal — the
  * host should know at a glance which references they've already chased.
  */
-export default function ReferenceRow({ reference }: Props) {
+export default function ReferenceRow({ reference }: ReferenceRowProps) {
   const relationship =
     RELATIONSHIP_LABELS[reference.relationship] ?? reference.relationship;
 

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/SensitiveDataUnlock.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/SensitiveDataUnlock.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Eye, EyeOff, ShieldAlert } from "lucide-react";
 
-interface Props {
+export interface SensitiveDataUnlockProps {
   children: React.ReactNode;
   /**
    * Optional override label for the toggle button. Defaults to a generic
@@ -24,7 +24,7 @@ export default function SensitiveDataUnlock({
   children,
   showLabel = "Show sensitive data",
   hideLabel = "Hide sensitive data",
-}: Props) {
+}: SensitiveDataUnlockProps) {
   const [revealed, setRevealed] = useState(false);
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/VideoCallNoteCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/VideoCallNoteCard.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/shared/lib/inquiry-date-format";
 import type { VideoCallNote } from "@/shared/types/applicant/video-call-note";
 
-interface Props {
+export interface VideoCallNoteCardProps {
   note: VideoCallNote;
 }
 
@@ -16,7 +16,7 @@ const MAX_RATING = 5;
  * gut_rating (1-5 stars), notes body. Read-only in PR 3.1b — editing UI
  * lands in PR 3.4 along with the kanban + create-note flow.
  */
-export default function VideoCallNoteCard({ note }: Props) {
+export default function VideoCallNoteCard({ note }: VideoCallNoteCardProps) {
   const isComplete = note.completed_at !== null;
   const stars = note.gut_rating ?? 0;
 

--- a/apps/mybookkeeper/frontend/src/app/features/attribution/AttributionReviewItem.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/attribution/AttributionReviewItem.tsx
@@ -9,11 +9,11 @@ import {
 } from "@/shared/store/attributionApi";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 
-interface Props {
+export interface AttributionReviewItemProps {
   item: ReviewItemType;
 }
 
-export default function AttributionReviewItem({ item }: Props) {
+export default function AttributionReviewItem({ item }: AttributionReviewItemProps) {
   const [confirmReview, { isLoading: isConfirming }] = useConfirmAttributionReviewMutation();
   const [rejectReview, { isLoading: isRejecting }] = useRejectAttributionReviewMutation();
   const [isActing, setIsActing] = useState(false);

--- a/apps/mybookkeeper/frontend/src/app/features/attribution/PnLDateRangeSelector.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/attribution/PnLDateRangeSelector.tsx
@@ -9,7 +9,7 @@ interface DateRange {
   until: string;
 }
 
-interface Props {
+export interface PnLDateRangeSelectorProps {
   value: DateRange;
   onChange: (range: DateRange) => void;
 }
@@ -48,7 +48,7 @@ const PRESETS: { key: Exclude<Preset, "custom">; label: string }[] = [
   { key: "ytd", label: "YTD" },
 ];
 
-export default function PnLDateRangeSelector({ value, onChange }: Props) {
+export default function PnLDateRangeSelector({ value, onChange }: PnLDateRangeSelectorProps) {
   const [showCustom, setShowCustom] = useState(false);
   const [customSince, setCustomSince] = useState(value.since);
   const [customUntil, setCustomUntil] = useState(value.until);

--- a/apps/mybookkeeper/frontend/src/app/features/attribution/PropertyPnLCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/attribution/PropertyPnLCard.tsx
@@ -5,14 +5,14 @@ import { formatCurrency } from "@/shared/utils/currency";
 import { formatTag } from "@/shared/utils/tag";
 import type { PropertyPnLEntry } from "@/shared/types/attribution/property-pnl";
 
-interface Props {
+export interface PropertyPnLCardProps {
   entry: PropertyPnLEntry;
   dateRange: { since: string; until: string };
 }
 
 const centsToAmount = (cents: number) => cents / 100;
 
-export default function PropertyPnLCard({ entry, dateRange }: Props) {
+export default function PropertyPnLCard({ entry, dateRange }: PropertyPnLCardProps) {
   const navigate = useNavigate();
   const isProfit = entry.net_cents >= 0;
 

--- a/apps/mybookkeeper/frontend/src/app/features/attribution/PropertyPnLGrid.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/attribution/PropertyPnLGrid.tsx
@@ -4,14 +4,14 @@ import { formatCurrency } from "@/shared/utils/currency";
 import { useGetPropertyPnlQuery } from "@/shared/store/attributionApi";
 import PropertyPnLCard from "./PropertyPnLCard";
 
-interface Props {
+export interface PropertyPnLGridProps {
   since: string;
   until: string;
 }
 
 const centsToAmount = (cents: number) => cents / 100;
 
-export default function PropertyPnLGrid({ since, until }: Props) {
+export default function PropertyPnLGrid({ since, until }: PropertyPnLGridProps) {
   const { data, isLoading } = useGetPropertyPnlQuery({ since, until });
 
   if (isLoading) {

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarAgendaList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarAgendaList.tsx
@@ -6,7 +6,7 @@ import {
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 import CalendarEventDetail from "@/app/features/calendar/CalendarEventDetail";
 
-interface Props {
+export interface CalendarAgendaListProps {
   events: readonly CalendarEvent[];
 }
 
@@ -18,7 +18,7 @@ interface Props {
  * unusable. Events are sorted by start date; events spanning multiple
  * days appear once at their start date with the date range visible.
  */
-export default function CalendarAgendaList({ events }: Props) {
+export default function CalendarAgendaList({ events }: CalendarAgendaListProps) {
   // Sort by start date, then end date (longer first for ties).
   const sorted = [...events].sort((a, b) => {
     if (a.starts_on !== b.starts_on) return a.starts_on.localeCompare(b.starts_on);

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventAttachmentCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventAttachmentCard.tsx
@@ -1,7 +1,7 @@
 import { FileText, Paperclip, Trash2 } from "lucide-react";
 import type { ListingBlackoutAttachment } from "@/shared/types/listing/listing-blackout-attachment";
 
-interface Props {
+export interface CalendarEventAttachmentCardProps {
   attachment: ListingBlackoutAttachment;
   onDelete: () => void;
 }
@@ -12,7 +12,7 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
-export default function CalendarEventAttachmentCard({ attachment, onDelete }: Props) {
+export default function CalendarEventAttachmentCard({ attachment, onDelete }: CalendarEventAttachmentCardProps) {
   const isImage = attachment.content_type.startsWith("image/");
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventAttachmentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventAttachmentsSection.tsx
@@ -21,11 +21,11 @@ const ALLOWED_MIME = [
   "text/plain",
 ];
 
-interface Props {
+export interface CalendarEventAttachmentsSectionProps {
   blackoutId: string;
 }
 
-export default function CalendarEventAttachmentsSection({ blackoutId }: Props) {
+export default function CalendarEventAttachmentsSection({ blackoutId }: CalendarEventAttachmentsSectionProps) {
   const { data: attachments, isLoading } = useGetBlackoutAttachmentsQuery(blackoutId);
   const [uploadAttachment, { isLoading: isUploading }] =
     useUploadBlackoutAttachmentMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventBar.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventBar.tsx
@@ -2,7 +2,7 @@ import { getSourceColor, getSourceLabel } from "@/shared/lib/calendar-constants"
 import { CALENDAR_DAY_CELL_PX } from "@/shared/lib/calendar-constants";
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 
-interface Props {
+export interface CalendarEventBarProps {
   event: CalendarEvent;
   startCol: number;
   span: number;
@@ -21,7 +21,7 @@ interface Props {
  * Top-right corner shows tiny indicators when the host has added notes
  * (📝) or file attachments (📎). Clicking still opens the detail dialog.
  */
-export default function CalendarEventBar({ event, startCol, span, onClick }: Props) {
+export default function CalendarEventBar({ event, startCol, span, onClick }: CalendarEventBarProps) {
   const isManual = event.source === "manual";
   const color = getSourceColor(event.source);
   const label = getSourceLabel(event.source);

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventDetail.tsx
@@ -3,7 +3,7 @@ import { X } from "lucide-react";
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 import CalendarEventDetailBody from "@/app/features/calendar/CalendarEventDetailBody";
 
-interface Props {
+export interface CalendarEventDetailProps {
   event: CalendarEvent | null;
   onClose: () => void;
 }
@@ -16,7 +16,7 @@ interface Props {
  * the content layout; CalendarEventNotesSection and
  * CalendarEventAttachmentsSection for the editable sections.
  */
-export default function CalendarEventDetail({ event, onClose }: Props) {
+export default function CalendarEventDetail({ event, onClose }: CalendarEventDetailProps) {
   const open = event !== null;
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventDetailBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventDetailBody.tsx
@@ -12,11 +12,11 @@ import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 import AttachmentsSection from "@/app/features/calendar/CalendarEventAttachmentsSection";
 import NotesSection from "@/app/features/calendar/CalendarEventNotesSection";
 
-interface Props {
+export interface CalendarEventDetailBodyProps {
   event: CalendarEvent;
 }
 
-export default function CalendarEventDetailBody({ event }: Props) {
+export default function CalendarEventDetailBody({ event }: CalendarEventDetailBodyProps) {
   const sourceLabel = getSourceLabel(event.source);
   const sourceColor = getSourceColor(event.source);
   const nights = Math.max(1, daysBetween(event.starts_on, event.ends_on));

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventNotesSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventNotesSection.tsx
@@ -6,12 +6,12 @@ import { useUpdateBlackoutMutation } from "@/shared/store/calendarApi";
 // Debounce delay for saving notes on blur (ms).
 const NOTES_SAVE_DELAY_MS = 600;
 
-interface Props {
+export interface CalendarEventNotesSectionProps {
   blackoutId: string;
   initialNotes: string | null;
 }
 
-export default function CalendarEventNotesSection({ blackoutId, initialNotes }: Props) {
+export default function CalendarEventNotesSection({ blackoutId, initialNotes }: CalendarEventNotesSectionProps) {
   const [notes, setNotes] = useState(initialNotes ?? "");
   const [isSaving, setIsSaving] = useState(false);
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarGrid.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarGrid.tsx
@@ -13,7 +13,7 @@ import CalendarGridHeader from "@/app/features/calendar/CalendarGridHeader";
 import CalendarListingRow from "@/app/features/calendar/CalendarListingRow";
 import CalendarEventDetail from "@/app/features/calendar/CalendarEventDetail";
 
-interface Props {
+export interface CalendarGridProps {
   events: readonly CalendarEvent[];
   fromIso: string;
   toIso: string;
@@ -31,7 +31,7 @@ interface Props {
  * license. A custom grid keeps the bundle small, the styling
  * predictable, and lets the skeleton match the loaded layout exactly.
  */
-export default function CalendarGrid({ events, fromIso, toIso }: Props) {
+export default function CalendarGrid({ events, fromIso, toIso }: CalendarGridProps) {
   const totalDays = daysBetween(fromIso, toIso);
   const rows = groupByListing(events);
   const groups = groupByProperty(rows);

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarGridHeader.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarGridHeader.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/shared/lib/calendar-constants";
 import { addDays, parseIsoDate } from "@/app/features/calendar/calendar-utils";
 
-interface Props {
+export interface CalendarGridHeaderProps {
   fromIso: string;
   totalDays: number;
 }
@@ -23,7 +23,7 @@ const SHORT_MONTH_NAMES = [
  * the first day of each month to anchor the view without a separate
  * row.
  */
-export default function CalendarGridHeader({ fromIso, totalDays }: Props) {
+export default function CalendarGridHeader({ fromIso, totalDays }: CalendarGridHeaderProps) {
   return (
     <div
       className="flex bg-muted/50 border-b sticky top-0 z-10"

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarLastSynced.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarLastSynced.tsx
@@ -1,7 +1,7 @@
 import { lastSyncedAt, relativeTime } from "@/app/features/calendar/calendar-utils";
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 
-interface Props {
+export interface CalendarLastSyncedProps {
   events: readonly CalendarEvent[];
 }
 
@@ -13,7 +13,7 @@ interface Props {
  * When there are no events, shows "—" so the indicator never lies
  * about staleness ("just now" with zero rows would be misleading).
  */
-export default function CalendarLastSynced({ events }: Props) {
+export default function CalendarLastSynced({ events }: CalendarLastSyncedProps) {
   const latest = lastSyncedAt(events);
   return (
     <div

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarListingRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarListingRow.tsx
@@ -11,7 +11,7 @@ import {
 import CalendarEventBar from "@/app/features/calendar/CalendarEventBar";
 import type { CalendarEvent } from "@/shared/types/calendar/calendar-event";
 
-interface Props {
+export interface CalendarListingRowProps {
   row: ListingRow;
   fromIso: string;
   toIso: string;
@@ -33,7 +33,7 @@ export default function CalendarListingRow({
   toIso,
   totalDays,
   onEventClick,
-}: Props) {
+}: CalendarListingRowProps) {
   return (
     <div
       className="flex border-t"

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarSkeleton.tsx
@@ -5,7 +5,7 @@ import {
   CALENDAR_ROW_HEIGHT_PX,
 } from "@/shared/lib/calendar-constants";
 
-interface Props {
+export interface CalendarSkeletonProps {
   rows?: number;
   days?: number;
 }
@@ -17,7 +17,7 @@ interface Props {
  * Per project rule: skeletons mirror loaded layout exactly to prevent
  * layout shift.
  */
-export default function CalendarSkeleton({ rows = 4, days = 30 }: Props) {
+export default function CalendarSkeleton({ rows = 4, days = 30 }: CalendarSkeletonProps) {
   return (
     <div data-testid="calendar-skeleton">
       {/* Mobile: agenda list skeleton */}

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarSourceFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarSourceFilter.tsx
@@ -7,7 +7,7 @@ import {
 } from "@/shared/lib/calendar-constants";
 import type { CalendarSource } from "@/shared/types/calendar/calendar-source";
 
-interface Props {
+export interface CalendarSourceFilterProps {
   selectedSources: readonly string[];
   onChange: (sources: string[]) => void;
 }
@@ -24,7 +24,7 @@ function getTriggerLabel(selected: readonly string[]): string {
  * Mirrors PropertyMultiSelect's UX so the page feels consistent.
  * Selecting nothing == "all sources" (no filter applied).
  */
-export default function CalendarSourceFilter({ selectedSources, onChange }: Props) {
+export default function CalendarSourceFilter({ selectedSources, onChange }: CalendarSourceFilterProps) {
   function handleCheck(source: CalendarSource, checked: boolean) {
     if (checked) {
       onChange([...selectedSources, source]);

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarWindowNav.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarWindowNav.tsx
@@ -6,7 +6,7 @@ import {
 import MonthYearJumper from "@/app/features/calendar/MonthYearJumper";
 import { CALENDAR_WINDOW_PRESETS } from "@/shared/lib/calendar-constants";
 
-interface Props {
+export interface CalendarWindowNavProps {
   fromIso: string;
   toIso: string;
   onChange: (fromIso: string, toIso: string) => void;
@@ -36,7 +36,7 @@ export default function CalendarWindowNav({
   toIso,
   onChange,
   onToday,
-}: Props) {
+}: CalendarWindowNavProps) {
   const stepDays = daysBetween(fromIso, toIso);
 
   function handlePrev() {

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/MonthYearJumper.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/MonthYearJumper.tsx
@@ -6,7 +6,7 @@ import {
   parseIsoDate,
 } from "@/app/features/calendar/calendar-utils";
 
-interface Props {
+export interface MonthYearJumperProps {
   fromIso: string;
   onJump: (newFromIso: string) => void;
 }
@@ -30,7 +30,7 @@ const YEAR_LOOKAHEAD = 5;
  * for a single small surface. Two `<select>` elements give us native
  * keyboard support and accessibility for free.
  */
-export default function MonthYearJumper({ fromIso, onJump }: Props) {
+export default function MonthYearJumper({ fromIso, onJump }: MonthYearJumperProps) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/ReviewQueueChannelBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/ReviewQueueChannelBadge.tsx
@@ -37,7 +37,7 @@ const FALLBACK_META = {
   Icon: Globe,
 };
 
-interface Props {
+export interface ReviewQueueChannelBadgeProps {
   channel: string;
 }
 
@@ -46,7 +46,7 @@ interface Props {
  * Distinct from SourceBadge (which is for inquiry sources) — the channel slug
  * format differs between the two domains.
  */
-export default function ReviewQueueChannelBadge({ channel }: Props) {
+export default function ReviewQueueChannelBadge({ channel }: ReviewQueueChannelBadgeProps) {
   const meta = CHANNEL_META[channel] ?? FALLBACK_META;
   const { Icon, label, colorClass } = meta;
 

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/ReviewQueueDrawer.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/ReviewQueueDrawer.tsx
@@ -5,7 +5,7 @@ import ReviewQueueSkeleton from "@/app/features/calendar/ReviewQueueSkeleton";
 import EmptyState from "@/shared/components/ui/EmptyState";
 import { useGetReviewQueueQuery } from "@/shared/store/calendarApi";
 
-interface Props {
+export interface ReviewQueueDrawerProps {
   isOpen: boolean;
   onClose: () => void;
 }
@@ -16,7 +16,7 @@ interface Props {
  * Rendered lazily — the queue is only fetched when the drawer opens so we
  * don't add a background poll to every Calendar page render.
  */
-export default function ReviewQueueDrawer({ isOpen, onClose }: Props) {
+export default function ReviewQueueDrawer({ isOpen, onClose }: ReviewQueueDrawerProps) {
   const { data: items, isLoading, isError } = useGetReviewQueueQuery(
     undefined,
     { skip: !isOpen },

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/ReviewQueueItem.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/ReviewQueueItem.tsx
@@ -11,7 +11,7 @@ import {
 import ReviewQueueChannelBadge from "@/app/features/calendar/ReviewQueueChannelBadge";
 import { useToast } from "@/shared/hooks/useToast";
 
-interface Props {
+export interface ReviewQueueItemProps {
   item: ReviewQueueItemType;
 }
 
@@ -45,7 +45,7 @@ function formatDate(isoDate: string | null): string {
  * The "Add to MBK" button expands the listing picker. "Ignore" adds the
  * listing to the blocklist and dismisses the item from the queue.
  */
-export default function ReviewQueueItem({ item }: Props) {
+export default function ReviewQueueItem({ item }: ReviewQueueItemProps) {
   const [isExpanded, setIsExpanded] = useState(false);
   const [selectedListingId, setSelectedListingId] = useState<string>("");
   const [error, setError] = useState<string | null>(null);

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/CategoryChart.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/CategoryChart.tsx
@@ -3,12 +3,12 @@ import { formatTag } from "@/shared/utils/tag";
 import { TAG_COLORS } from "@/shared/lib/constants";
 import CategoryChartTooltip from "@/app/features/dashboard/CategoryChartTooltip";
 
-interface Props {
+export interface CategoryChartProps {
   byCategory: Record<string, number>;
   onBarClick?: (category: string) => void;
 }
 
-export default function CategoryChart({ byCategory, onBarClick }: Props) {
+export default function CategoryChart({ byCategory, onBarClick }: CategoryChartProps) {
   const chartData = Object.entries(byCategory)
     .filter(([, amount]) => amount !== 0)
     .map(([key, amount]) => ({

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/DashboardFilterBar.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/DashboardFilterBar.tsx
@@ -7,7 +7,7 @@ import CategoryChip from "@/app/features/dashboard/CategoryChip";
 import type { CategoryFilterPreset, CategoryFilterState } from "@/shared/types/dashboard/category-filter";
 import type { Property } from "@/shared/types/property/property";
 
-interface Props {
+export interface DashboardFilterBarProps {
   filterState: CategoryFilterState;
   onToggleCategory: (category: string) => void;
   onSelectOnlyCategory: (category: string) => void;
@@ -35,7 +35,7 @@ export default function DashboardFilterBar({
   properties,
   selectedPropertyIds,
   onPropertyIdsChange,
-}: Props) {
+}: DashboardFilterBarProps) {
   const [expanded, setExpanded] = useState(false);
   const [touchedGroups, setTouchedGroups] = useState<Set<string>>(new Set());
   const { selectedCategories, preset } = filterState;

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/DrillDownPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/DrillDownPanel.tsx
@@ -11,12 +11,12 @@ import TransactionPanel from "@/app/features/transactions/TransactionPanel";
 import type { DrillDownFilter } from "@/shared/types/dashboard/drill-down-filter";
 import type { Transaction } from "@/shared/types/transaction/transaction";
 
-interface Props {
+export interface DrillDownPanelProps {
   filter: DrillDownFilter;
   onClose: () => void;
 }
 
-export default function DrillDownPanel({ filter, onClose }: Props) {
+export default function DrillDownPanel({ filter, onClose }: DrillDownPanelProps) {
   const { showSuccess } = useToast();
   const [selectedTxn, setSelectedTxn] = useState<Transaction | null>(null);
 

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/MonthlyAverageCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/MonthlyAverageCard.tsx
@@ -2,11 +2,11 @@ import { formatCurrency } from "@/shared/utils/currency";
 import Card from "@/shared/components/ui/Card";
 import type { MonthSummary } from "@/shared/types/summary/month-summary";
 
-interface Props {
+export interface MonthlyAverageCardProps {
   byMonth: MonthSummary[];
 }
 
-export default function MonthlyAverageCard({ byMonth }: Props) {
+export default function MonthlyAverageCard({ byMonth }: MonthlyAverageCardProps) {
   const activeMonths = byMonth.filter(
     (m) => m.revenue !== 0 || m.expenses !== 0,
   );

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/MonthlyChart.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/MonthlyChart.tsx
@@ -11,13 +11,13 @@ function formatMonth(month: string): string {
   return format(parse(month, "yyyy-MM", new Date()), "MMM yy");
 }
 
-interface Props {
+export interface MonthlyChartProps {
   data: MonthSummary[];
   height?: number;
   onBarClick?: (startDate: string, endDate: string, dataKey: string) => void;
 }
 
-export default function MonthlyChart({ data, height = 260, onBarClick }: Props) {
+export default function MonthlyChart({ data, height = 260, onBarClick }: MonthlyChartProps) {
   const chartData: ChartRow[] = data.map((row) => ({
     ...row,
     displayMonth: formatMonth(row.month),

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/SummaryCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/SummaryCard.tsx
@@ -1,13 +1,13 @@
 import { formatCurrency } from "@/shared/utils/currency";
 import Card from "@/shared/components/ui/Card";
 
-interface Props {
+export interface SummaryCardProps {
   label: string;
   amount: number;
   color: string;
 }
 
-export default function SummaryCard({ label, amount, color }: Props) {
+export default function SummaryCard({ label, amount, color }: SummaryCardProps) {
   return (
     <Card>
       <p className="text-sm text-muted-foreground">{label}</p>

--- a/apps/mybookkeeper/frontend/src/app/features/documents/DocumentTable.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/DocumentTable.tsx
@@ -18,14 +18,14 @@ interface FilterOptions {
   [columnId: string]: { value: string; label: string }[];
 }
 
-interface Props {
+export interface DocumentTableProps {
   table: Table<Document>;
   colCount: number;
   filterOptions: FilterOptions;
   onRowClick?: (doc: Document) => void;
 }
 
-export default function DocumentTable({ table, colCount, filterOptions, onRowClick }: Props) {
+export default function DocumentTable({ table, colCount, filterOptions, onRowClick }: DocumentTableProps) {
   const { pageIndex, pageSize } = table.getState().pagination;
   const totalRows = table.getFilteredRowModel().rows.length;
   const start = pageIndex * pageSize + 1;

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/GmailReconnectBanner.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/GmailReconnectBanner.tsx
@@ -1,7 +1,7 @@
 import { Link } from "react-router-dom";
 import AlertBox from "@/shared/components/ui/AlertBox";
 
-interface Props {
+export interface GmailReconnectBannerProps {
   reason: "missing-integration" | "missing-send-scope" | "reauth-required";
 }
 
@@ -14,7 +14,7 @@ interface Props {
  *
  * All cases link to Integrations where the host can connect or reconnect.
  */
-export default function GmailReconnectBanner({ reason }: Props) {
+export default function GmailReconnectBanner({ reason }: GmailReconnectBannerProps) {
   const message =
     reason === "missing-integration"
       ? "Connect Gmail to send replies. Your existing data stays untouched."

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiriesSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiriesSkeleton.tsx
@@ -1,6 +1,6 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
 
-interface Props {
+export interface InquiriesSkeletonProps {
   count?: number;
 }
 
@@ -12,7 +12,7 @@ interface Props {
  *     row structure (inquirer/badges, dates, employer/quality, listing/time).
  *   - Desktop: same 8 columns + same number of skeleton rows.
  */
-export default function InquiriesSkeleton({ count = 4 }: Props) {
+export default function InquiriesSkeleton({ count = 4 }: InquiriesSkeletonProps) {
   const rows = Array.from({ length: count }, (_, i) => i);
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryCard.tsx
@@ -8,7 +8,7 @@ import type { InquirySummary } from "@/shared/types/inquiry/inquiry-summary";
 import InquiryQualityBadge from "./InquiryQualityBadge";
 import InquiryStageBadge from "./InquiryStageBadge";
 
-interface Props {
+export interface InquiryCardProps {
   inquiry: InquirySummary;
   listingTitle: string | null;
   /**
@@ -37,7 +37,7 @@ interface Props {
  * ``showStageBadge``), notes preview, gut_rating at new/triaged stage.
  */
 
-export default function InquiryCard({ inquiry, listingTitle, showStageBadge }: Props) {
+export default function InquiryCard({ inquiry, listingTitle, showStageBadge }: InquiryCardProps) {
   const desiredDates = formatDesiredDates(
     inquiry.desired_start_date,
     inquiry.desired_end_date,

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryEventTimeline.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryEventTimeline.tsx
@@ -21,7 +21,7 @@ const ACTOR_LABELS: Record<InquiryEventActor, string> = {
   applicant: "Inquirer",
 };
 
-interface Props {
+export interface InquiryEventTimelineProps {
   events: InquiryEvent[];
   /**
    * Default-collapsed per RENTALS_PLAN.md §9.1 detail-page hierarchy — the
@@ -45,7 +45,7 @@ function formatEventType(eventType: string): string {
   return eventType.charAt(0).toUpperCase() + eventType.slice(1);
 }
 
-export default function InquiryEventTimeline({ events, defaultOpen = false }: Props) {
+export default function InquiryEventTimeline({ events, defaultOpen = false }: InquiryEventTimelineProps) {
   const [open, setOpen] = useState(defaultOpen);
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryForm.tsx
@@ -13,7 +13,7 @@ import type { InquiryResponse } from "@/shared/types/inquiry/inquiry-response";
 import type { InquirySource } from "@/shared/types/inquiry/inquiry-source";
 import type { ListingSummary } from "@/shared/types/listing/listing-summary";
 
-interface Props {
+export interface InquiryFormProps {
   listings: readonly ListingSummary[];
   onClose: () => void;
   onCreated?: (inquiry: InquiryResponse) => void;
@@ -70,7 +70,7 @@ function formValuesToCreateRequest(values: InquiryFormValues): InquiryCreateRequ
   };
 }
 
-export default function InquiryForm({ listings, onClose, onCreated }: Props) {
+export default function InquiryForm({ listings, onClose, onCreated }: InquiryFormProps) {
   const [createInquiry, { isLoading }] = useCreateInquiryMutation();
   const defaults = useMemo<InquiryFormValues>(() => buildEmptyDefaults(), []);
 

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryMessageThread.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryMessageThread.tsx
@@ -2,7 +2,7 @@ import { ChevronDown, ChevronUp } from "lucide-react";
 import { formatAbsoluteTime } from "@/shared/lib/inquiry-date-format";
 import type { InquiryMessage } from "@/shared/types/inquiry/inquiry-message";
 
-interface Props {
+export interface InquiryMessageThreadProps {
   messages: InquiryMessage[];
 }
 
@@ -21,7 +21,7 @@ const CHANNEL_LABELS: Record<string, string> = {
  * Manual inquiries created via this PR will normally have no messages at
  * all; PR 2.2 populates the thread for parsed FF/TNH emails.
  */
-export default function InquiryMessageThread({ messages }: Props) {
+export default function InquiryMessageThread({ messages }: InquiryMessageThreadProps) {
   if (messages.length === 0) {
     return (
       <p className="text-sm text-muted-foreground italic">

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryNotesEditor.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryNotesEditor.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useUpdateInquiryMutation } from "@/shared/store/inquiriesApi";
 
-interface Props {
+export interface InquiryNotesEditorProps {
   inquiryId: string;
   initialNotes: string | null;
 }
@@ -22,7 +22,7 @@ interface Props {
 const SAVED_TOAST = "Notes saved.";
 const ERROR_TOAST = "I couldn't save those notes. Want to try again?";
 
-export default function InquiryNotesEditor({ inquiryId, initialNotes }: Props) {
+export default function InquiryNotesEditor({ inquiryId, initialNotes }: InquiryNotesEditorProps) {
   const [value, setValue] = useState(initialNotes ?? "");
   const [savedValue, setSavedValue] = useState(initialNotes ?? "");
   const [updateInquiry, { isLoading }] = useUpdateInquiryMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryQualityBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryQualityBadge.tsx
@@ -5,7 +5,7 @@ import {
   type InquiryQualitySignals,
 } from "@/shared/lib/inquiry-quality";
 
-interface Props {
+export interface InquiryQualityBadgeProps {
   signals: InquiryQualitySignals;
   className?: string;
 }
@@ -23,7 +23,7 @@ interface Props {
  * badge competing for attention with the actually-important sparse / complete
  * signals defeats the purpose of the heuristic.
  */
-export default function InquiryQualityBadge({ signals, className = "" }: Props) {
+export default function InquiryQualityBadge({ signals, className = "" }: InquiryQualityBadgeProps) {
   const score = computeInquiryQualityScore(signals);
   const tier = getQualityTier(score);
 

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryQualityBreakdown.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryQualityBreakdown.tsx
@@ -4,7 +4,7 @@ import {
   type InquiryQualitySignals,
 } from "@/shared/lib/inquiry-quality";
 
-interface Props {
+export interface InquiryQualityBreakdownProps {
   signals: InquiryQualitySignals;
 }
 
@@ -22,7 +22,7 @@ const BODY_LENGTH_THRESHOLD = 100;
  * §9.1 detail-page hierarchy: "what's missing"). Mirrors the heuristic in
  * ``shared/lib/inquiry-quality.ts``.
  */
-export default function InquiryQualityBreakdown({ signals }: Props) {
+export default function InquiryQualityBreakdown({ signals }: InquiryQualityBreakdownProps) {
   const score = computeInquiryQualityScore(signals);
   const employerLen = signals.inquirer_employer?.trim().length ?? 0;
   const bodyLen = signals.last_message_body?.trim().length ?? 0;

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyPanel.tsx
@@ -14,7 +14,7 @@ import GmailReconnectBanner from "./GmailReconnectBanner";
 import RenderedReplyEditor from "./RenderedReplyEditor";
 import ReplyTemplatePicker from "./ReplyTemplatePicker";
 
-interface Props {
+export interface InquiryReplyPanelProps {
   inquiryId: string;
   onClose: () => void;
 }
@@ -37,7 +37,7 @@ type ReplyTab = "template" | "custom";
  *   5. On success: panel closes, toast confirms, inquiry refetches via
  *      RTK tag invalidation.
  */
-export default function InquiryReplyPanel({ inquiryId, onClose }: Props) {
+export default function InquiryReplyPanel({ inquiryId, onClose }: InquiryReplyPanelProps) {
   const [tab, setTab] = useState<ReplyTab>("template");
   const [selectedTemplateId, setSelectedTemplateId] = useState<string | null>(null);
   // Local overrides allow the user to edit the rendered template content.

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryRow.tsx
@@ -9,7 +9,7 @@ import InquiryQualityBadge from "./InquiryQualityBadge";
 import InquirySpamBadge from "./InquirySpamBadge";
 import InquiryStageBadge from "./InquiryStageBadge";
 
-interface Props {
+export interface InquiryRowProps {
   inquiry: InquirySummary;
   listingTitle: string | null;
 }
@@ -21,7 +21,7 @@ interface Props {
  *
  * Columns: Inquirer | Source | Desired Dates | Employer | Listing | Received | Stage | Quality.
  */
-export default function InquiryRow({ inquiry, listingTitle }: Props) {
+export default function InquiryRow({ inquiry, listingTitle }: InquiryRowProps) {
   const navigate = useNavigate();
   const goToDetail = () => navigate(`/inquiries/${inquiry.id}`);
 

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquirySpamTabFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquirySpamTabFilter.tsx
@@ -21,12 +21,12 @@ const TABS: ReadonlyArray<TabConfig> = [
   { key: "spam", label: "Spam", value: "spam" },
 ];
 
-interface Props {
+export interface InquirySpamTabFilterProps {
   value: InquirySpamStatus | null;
   onChange: (next: InquirySpamStatus | null) => void;
 }
 
-export default function InquirySpamTabFilter({ value, onChange }: Props) {
+export default function InquirySpamTabFilter({ value, onChange }: InquirySpamTabFilterProps) {
   return (
     <div
       className="flex flex-wrap gap-2 border-b pb-2"

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquirySpamTriagePanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquirySpamTriagePanel.tsx
@@ -10,7 +10,7 @@ import {
 import type { InquirySpamStatus } from "@/shared/types/inquiry/inquiry-spam-status";
 import InquirySpamBadge from "./InquirySpamBadge";
 
-interface Props {
+export interface InquirySpamTriagePanelProps {
   inquiryId: string;
   spamStatus: InquirySpamStatus;
   spamScore: number | null;
@@ -26,7 +26,7 @@ const ASSESSMENT_LABELS: Record<string, string> = {
   manual_override: "Manual override",
 };
 
-export default function InquirySpamTriagePanel({ inquiryId, spamStatus, spamScore }: Props) {
+export default function InquirySpamTriagePanel({ inquiryId, spamStatus, spamScore }: InquirySpamTriagePanelProps) {
   const [expanded, setExpanded] = useState(false);
   const { data: assessments = [], isLoading } = useGetInquirySpamAssessmentsQuery(
     inquiryId,

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryStageBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryStageBadge.tsx
@@ -15,7 +15,7 @@ const COLOR_CLASSES: Record<BadgeColor, string> = {
   purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
 };
 
-interface Props {
+export interface InquiryStageBadgeProps {
   stage: InquiryStage;
   className?: string;
 }
@@ -26,7 +26,7 @@ interface Props {
  * Hidden in stage-filtered list views (the chip already conveys that
  * information) but shown on detail pages and the unfiltered "All" inbox.
  */
-export default function InquiryStageBadge({ stage, className = "" }: Props) {
+export default function InquiryStageBadge({ stage, className = "" }: InquiryStageBadgeProps) {
   const color = INQUIRY_STAGE_BADGE_COLORS[stage];
   return (
     <span

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryStageDropdown.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryStageDropdown.tsx
@@ -4,7 +4,7 @@ import { useUpdateInquiryMutation } from "@/shared/store/inquiriesApi";
 import { INQUIRY_STAGES, INQUIRY_STAGE_LABELS } from "@/shared/lib/inquiry-labels";
 import type { InquiryStage } from "@/shared/types/inquiry/inquiry-stage";
 
-interface Props {
+export interface InquiryStageDropdownProps {
   inquiryId: string;
   currentStage: InquiryStage;
 }
@@ -17,7 +17,7 @@ interface Props {
  * inquiry tag + the list tag (see ``inquiriesApi``) so the inbox reflects
  * the change without a refetch dance.
  */
-export default function InquiryStageDropdown({ inquiryId, currentStage }: Props) {
+export default function InquiryStageDropdown({ inquiryId, currentStage }: InquiryStageDropdownProps) {
   const [updateInquiry] = useUpdateInquiryMutation();
   const [pending, setPending] = useState<InquiryStage | null>(null);
 

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryStageFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryStageFilter.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/shared/utils/cn";
 import { INQUIRY_STAGES, INQUIRY_STAGE_LABELS } from "@/shared/lib/inquiry-labels";
 import type { InquiryStage } from "@/shared/types/inquiry/inquiry-stage";
 
-interface Props {
+export interface InquiryStageFilterProps {
   value: InquiryStage | null;
   onChange: (stage: InquiryStage | null) => void;
 }
@@ -23,7 +23,7 @@ const CHIPS: Chip[] = [
  * mobile (``overflow-x-auto`` + ``flex-nowrap``), URL-state sync handled by
  * the parent page via ``useSearchParams``.
  */
-export default function InquiryStageFilter({ value, onChange }: Props) {
+export default function InquiryStageFilter({ value, onChange }: InquiryStageFilterProps) {
   return (
     <div
       role="tablist"

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/RenderedReplyEditor.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/RenderedReplyEditor.tsx
@@ -1,4 +1,4 @@
-interface Props {
+export interface RenderedReplyEditorProps {
   subject: string;
   body: string;
   onSubjectChange: (value: string) => void;
@@ -22,7 +22,7 @@ export default function RenderedReplyEditor({
   onSubjectChange,
   onBodyChange,
   disabled = false,
-}: Props) {
+}: RenderedReplyEditorProps) {
   return (
     <div className="space-y-3">
       <div>

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplateCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplateCard.tsx
@@ -1,6 +1,6 @@
 import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
 
-interface Props {
+export interface ReplyTemplateCardProps {
   template: ReplyTemplate;
   selected: boolean;
   onSelect: () => void;
@@ -16,7 +16,7 @@ export default function ReplyTemplateCard({
   template,
   selected,
   onSelect,
-}: Props) {
+}: ReplyTemplateCardProps) {
   const previewLines = template.body_template
     .split("\n")
     .filter((line) => line.trim().length > 0)

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplateForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplateForm.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/shared/store/inquiriesApi";
 import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
 
-interface Props {
+export interface ReplyTemplateFormProps {
   template: ReplyTemplate | null;
   onClose: () => void;
 }
@@ -30,7 +30,7 @@ const SUBJECT_MAX = 500;
 const BODY_MAX = 10000;
 
 /** Add / edit form for a reply template — slide-in panel. */
-export default function ReplyTemplateForm({ template, onClose }: Props) {
+export default function ReplyTemplateForm({ template, onClose }: ReplyTemplateFormProps) {
   const [name, setName] = useState(template?.name ?? "");
   const [subject, setSubject] = useState(template?.subject_template ?? "");
   const [body, setBody] = useState(template?.body_template ?? "");

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatePicker.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatePicker.tsx
@@ -1,7 +1,7 @@
 import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
 import ReplyTemplateCard from "./ReplyTemplateCard";
 
-interface Props {
+export interface ReplyTemplatePickerProps {
   templates: ReplyTemplate[];
   selectedTemplateId: string | null;
   onSelect: (template: ReplyTemplate) => void;
@@ -16,7 +16,7 @@ export default function ReplyTemplatePicker({
   templates,
   selectedTemplateId,
   onSelect,
-}: Props) {
+}: ReplyTemplatePickerProps) {
   if (templates.length === 0) {
     return (
       <div className="text-sm text-muted-foreground p-4">

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/AddInsurancePolicyDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/AddInsurancePolicyDialog.tsx
@@ -6,7 +6,7 @@ import Button from "@/shared/components/ui/Button";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useCreateInsurancePolicyMutation } from "@/shared/store/insurancePoliciesApi";
 
-interface Props {
+export interface AddInsurancePolicyDialogProps {
   listingId: string;
   onClose: () => void;
 }
@@ -14,7 +14,7 @@ interface Props {
 /**
  * Modal dialog for creating a new insurance policy on a listing.
  */
-export default function AddInsurancePolicyDialog({ listingId, onClose }: Props) {
+export default function AddInsurancePolicyDialog({ listingId, onClose }: AddInsurancePolicyDialogProps) {
   const [createPolicy, { isLoading }] = useCreateInsurancePolicyMutation();
 
   const [policyName, setPolicyName] = useState("");

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceExpirationBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsuranceExpirationBadge.tsx
@@ -1,6 +1,6 @@
 import { differenceInDays, parseISO } from "date-fns";
 
-interface Props {
+export interface InsuranceExpirationBadgeProps {
   expirationDate: string | null;
 }
 
@@ -12,7 +12,7 @@ interface Props {
  * - Within 90 days → yellow "Expires in N days"
  * - Beyond → nothing rendered
  */
-export default function InsuranceExpirationBadge({ expirationDate }: Props) {
+export default function InsuranceExpirationBadge({ expirationDate }: InsuranceExpirationBadgeProps) {
   if (!expirationDate) return null;
 
   const today = new Date();

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentRow.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/shared/types/insurance/insurance-attachment-kind";
 import type { InsurancePolicyAttachment } from "@/shared/types/insurance/insurance-policy-attachment";
 
-interface Props {
+export interface InsurancePolicyAttachmentRowProps {
   att: InsurancePolicyAttachment;
   canWrite: boolean;
   onPreview: () => void;
@@ -18,7 +18,7 @@ export default function InsurancePolicyAttachmentRow({
   canWrite,
   onPreview,
   onDelete,
-}: Props) {
+}: InsurancePolicyAttachmentRowProps) {
   const canPreview =
     att.presigned_url !== null &&
     (att.content_type === "application/pdf" || att.content_type.startsWith("image/"));

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentsSection.tsx
@@ -14,7 +14,7 @@ import type { InsurancePolicyAttachment } from "@/shared/types/insurance/insuran
 import AttachmentViewer from "@/app/features/leases/AttachmentViewer";
 import InsurancePolicyAttachmentRow from "@/app/features/insurance/InsurancePolicyAttachmentRow";
 
-interface Props {
+export interface InsurancePolicyAttachmentsSectionProps {
   policyId: string;
   attachments: InsurancePolicyAttachment[];
   canWrite: boolean;
@@ -32,7 +32,7 @@ export default function InsurancePolicyAttachmentsSection({
   policyId,
   attachments,
   canWrite,
-}: Props) {
+}: InsurancePolicyAttachmentsSectionProps) {
   const [uploadAttachment, { isLoading: isUploading }] =
     useUploadInsurancePolicyAttachmentMutation();
   const [deleteAttachment] = useDeleteInsurancePolicyAttachmentMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/ListingInsuranceSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/ListingInsuranceSection.tsx
@@ -6,7 +6,7 @@ import Button from "@/shared/components/ui/Button";
 import InsuranceExpirationBadge from "@/app/features/insurance/InsuranceExpirationBadge";
 import AddInsurancePolicyDialog from "@/app/features/insurance/AddInsurancePolicyDialog";
 
-interface Props {
+export interface ListingInsuranceSectionProps {
   listingId: string;
   canWrite: boolean;
 }
@@ -17,7 +17,7 @@ interface Props {
  * Shows a summary list of policies for this listing with expiration badges,
  * plus an "Add policy" button.
  */
-export default function ListingInsuranceSection({ listingId, canWrite }: Props) {
+export default function ListingInsuranceSection({ listingId, canWrite }: ListingInsuranceSectionProps) {
   const [showAddDialog, setShowAddDialog] = useState(false);
   const { data, isLoading, isError } = useGetInsurancePoliciesQuery({
     listing_id: listingId,

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/PlaidAccountMapping.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/PlaidAccountMapping.tsx
@@ -8,12 +8,12 @@ import { extractErrorMessage } from "@/shared/utils/errorMessage";
 import Select from "@/shared/components/ui/Select";
 import Skeleton from "@/shared/components/ui/Skeleton";
 
-interface Props {
+export interface PlaidAccountMappingProps {
   itemId: string;
   onError: (message: string) => void;
 }
 
-export default function PlaidAccountMapping({ itemId, onError }: Props) {
+export default function PlaidAccountMapping({ itemId, onError }: PlaidAccountMappingProps) {
   const { data: accounts = [], isLoading: accountsLoading } = useGetPlaidAccountsQuery(itemId);
   const { data: properties = [] } = useGetPropertiesQuery();
   const [updateProperty] = useUpdateAccountPropertyMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/PlaidConnect.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/PlaidConnect.tsx
@@ -7,12 +7,12 @@ import {
 import { extractErrorMessage } from "@/shared/utils/errorMessage";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 
-interface Props {
+export interface PlaidConnectProps {
   onSuccess: (institutionName: string) => void;
   onError: (message: string) => void;
 }
 
-export default function PlaidConnect({ onSuccess, onError }: Props) {
+export default function PlaidConnect({ onSuccess, onError }: PlaidConnectProps) {
   const [linkToken, setLinkToken] = useState<string | null>(null);
   const [createLinkToken, { isLoading: isCreating }] = useCreateLinkTokenMutation();
   const [exchangePublicToken, { isLoading: isExchanging }] = useExchangePublicTokenMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/PlaidItemList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/PlaidItemList.tsx
@@ -15,12 +15,12 @@ import PlaidAccountMapping from "./PlaidAccountMapping";
 import { PLAID_STATUS_BADGE } from "@/shared/lib/integration-config";
 import type { PlaidItem } from "@/shared/types/plaid/plaid-item";
 
-interface Props {
+export interface PlaidItemListProps {
   onSuccess: (message: string) => void;
   onError: (message: string) => void;
 }
 
-export default function PlaidItemList({ onSuccess, onError }: Props) {
+export default function PlaidItemList({ onSuccess, onError }: PlaidItemListProps) {
   const { data: items = [], isLoading } = useListPlaidItemsQuery();
   const [disconnectItem, { isLoading: isDisconnecting }] = useDisconnectPlaidItemMutation();
   const [syncItem] = useSyncPlaidItemMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/QueueItem.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/QueueItem.tsx
@@ -6,13 +6,13 @@ import Spinner from "@/shared/components/icons/Spinner";
 import RetryIcon from "@/shared/components/icons/RetryIcon";
 import { X } from "lucide-react";
 
-interface Props {
+export interface QueueItemProps {
   item: EmailQueueItem;
   onRetry: (id: string) => void;
   onDismiss: (id: string) => void;
 }
 
-export default function QueueItem({ item, onRetry, onDismiss }: Props) {
+export default function QueueItem({ item, onRetry, onDismiss }: QueueItemProps) {
   const badge = STATUS_BADGE[item.status];
   const [busy, setBusy] = useState<"retry" | "dismiss" | null>(null);
 

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/SyncLogRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/SyncLogRow.tsx
@@ -8,7 +8,7 @@ import ChevronDown from "@/shared/components/icons/ChevronDown";
 import ProgressBar from "./ProgressBar";
 import QueueItem from "./QueueItem";
 
-interface Props {
+export interface SyncLogRowProps {
   log: SyncLog;
   queueItems?: readonly EmailQueueItem[];
   onRetryItem?: (id: string) => void;
@@ -26,7 +26,7 @@ export default function SyncLogRow({
   onCancel,
   isCancelling = false,
   defaultOpen = false,
-}: Props) {
+}: SyncLogRowProps) {
   const [open, setOpen] = useState(defaultOpen);
   const toggle = useCallback(() => setOpen((prev) => !prev), []);
 

--- a/apps/mybookkeeper/frontend/src/app/features/leases/AISuggestionsPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/AISuggestionsPanel.tsx
@@ -4,7 +4,7 @@ import type { SuggestedPlaceholderItem } from "@/shared/types/lease/suggest-plac
 import { LEASE_PLACEHOLDER_INPUT_TYPE_LABELS } from "@/shared/lib/lease-labels";
 import type { LeasePlaceholderInputType } from "@/shared/types/lease/lease-placeholder-input-type";
 
-interface Props {
+export interface AISuggestionsPanelProps {
   suggestions: SuggestedPlaceholderItem[];
   truncated: boolean;
   pagesNote: string | null;
@@ -29,7 +29,7 @@ export default function AISuggestionsPanel({
   pagesNote,
   templatePlaceholderKeys,
   onDismiss,
-}: Props) {
+}: AISuggestionsPanelProps) {
   const [collapsed, setCollapsed] = useState(false);
 
   const newSuggestions = suggestions.filter(

--- a/apps/mybookkeeper/frontend/src/app/features/leases/ApplicantPicker.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/ApplicantPicker.tsx
@@ -17,7 +17,7 @@ import type { ApplicantStage } from "@/shared/types/applicant/applicant-stage";
  */
 const LEASE_ELIGIBLE_STAGES: ApplicantStage[] = ["approved", "lease_sent"];
 
-interface Props {
+export interface ApplicantPickerProps {
   selectedId: string | null;
   onSelect: (applicant: ApplicantSummary) => void;
 }
@@ -26,7 +26,7 @@ interface Props {
  * Renders a pick-list of applicants eligible for lease generation.
  * Filters to ``approved`` and ``lease_sent`` stages; excludes ``lease_signed``.
  */
-export default function ApplicantPicker({ selectedId, onSelect }: Props) {
+export default function ApplicantPicker({ selectedId, onSelect }: ApplicantPickerProps) {
   const { data, isLoading, isFetching, isError, refetch } =
     useGetApplicantsQuery();
   const allApplicants = data?.items ?? [];

--- a/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewer.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewer.tsx
@@ -1,7 +1,7 @@
 import { ExternalLink } from "lucide-react";
 import Panel, { PanelCloseButton } from "@/shared/components/ui/Panel";
 
-interface Props {
+export interface AttachmentViewerProps {
   url: string;
   filename: string;
   contentType: string;
@@ -17,7 +17,7 @@ interface Props {
  * - image/* → <img>
  * - anything else → download-only message (DOCX, etc.)
  */
-export default function AttachmentViewer({ url, filename, contentType, onClose }: Props) {
+export default function AttachmentViewer({ url, filename, contentType, onClose }: AttachmentViewerProps) {
   const isPdf = contentType === "application/pdf";
   const isImage = contentType.startsWith("image/");
 

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentRow.tsx
@@ -6,7 +6,7 @@ import {
 } from "@/shared/types/lease/lease-attachment-kind";
 import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
 
-interface Props {
+export interface LeaseAttachmentRowProps {
   att: SignedLeaseAttachment;
   canWrite: boolean;
   onPreview: () => void;
@@ -14,7 +14,7 @@ interface Props {
   onKindChange: (kind: LeaseAttachmentKind) => void;
 }
 
-export default function LeaseAttachmentRow({ att, canWrite, onPreview, onDelete, onKindChange }: Props) {
+export default function LeaseAttachmentRow({ att, canWrite, onPreview, onDelete, onKindChange }: LeaseAttachmentRowProps) {
   const canPreview =
     att.presigned_url !== null &&
     (att.content_type === "application/pdf" || att.content_type.startsWith("image/"));

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentsSection.tsx
@@ -16,7 +16,7 @@ import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-at
 import AttachmentViewer from "@/app/features/leases/AttachmentViewer";
 import LeaseAttachmentRow from "@/app/features/leases/LeaseAttachmentRow";
 
-interface Props {
+export interface LeaseAttachmentsSectionProps {
   leaseId: string;
   attachments: SignedLeaseAttachment[];
   canWrite: boolean;
@@ -30,7 +30,7 @@ const ALLOWED_MIME = [
   "image/webp",
 ];
 
-export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite }: Props) {
+export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite }: LeaseAttachmentsSectionProps) {
   const [uploadAttachment, { isLoading: isUploading }] =
     useUploadSignedLeaseAttachmentMutation();
   const [deleteAttachment] = useDeleteSignedLeaseAttachmentMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseGenerateForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseGenerateForm.tsx
@@ -8,7 +8,7 @@ import type { LeaseTemplateDetail } from "@/shared/types/lease/lease-template-de
 import type { PlaceholderProvenance } from "@/shared/types/lease/placeholder-provenance";
 import PlaceholderInput from "@/app/features/leases/PlaceholderInput";
 
-interface Props {
+export interface LeaseGenerateFormProps {
   template: LeaseTemplateDetail;
   applicantId: string;
   listingId?: string | null;
@@ -42,7 +42,7 @@ export default function LeaseGenerateForm({
   template,
   applicantId,
   listingId,
-}: Props) {
+}: LeaseGenerateFormProps) {
   const navigate = useNavigate();
   const [createLease, { isLoading: isCreating }] = useCreateSignedLeaseMutation();
 

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseImportDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseImportDialog.tsx
@@ -7,7 +7,7 @@ import { useGetApplicantsQuery } from "@/shared/store/applicantsApi";
 import { useGetListingsQuery } from "@/shared/store/listingsApi";
 import { useImportSignedLeaseMutation } from "@/shared/store/signedLeasesApi";
 
-interface Props {
+export interface LeaseImportDialogProps {
   onClose: () => void;
 }
 
@@ -19,7 +19,7 @@ interface Props {
  * subsequent files use a filename heuristic (move-in / move-out inspection →
  * appropriate kind, everything else → signed_addendum).
  */
-export default function LeaseImportDialog({ onClose }: Props) {
+export default function LeaseImportDialog({ onClose }: LeaseImportDialogProps) {
   const navigate = useNavigate();
   const [importLease, { isLoading }] = useImportSignedLeaseMutation();
   const { data: applicantsData } = useGetApplicantsQuery({ limit: 100 });

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseTemplateCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseTemplateCard.tsx
@@ -1,11 +1,11 @@
 import { Link, useNavigate } from "react-router-dom";
 import type { LeaseTemplateSummary } from "@/shared/types/lease/lease-template-summary";
 
-interface Props {
+export interface LeaseTemplateCardProps {
   template: LeaseTemplateSummary;
 }
 
-export default function LeaseTemplateCard({ template }: Props) {
+export default function LeaseTemplateCard({ template }: LeaseTemplateCardProps) {
   const navigate = useNavigate();
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseTemplateUploadDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseTemplateUploadDialog.tsx
@@ -10,7 +10,7 @@ import {
 import type { LeaseTemplateDetail } from "@/shared/types/lease/lease-template-detail";
 import type { SuggestPlaceholdersResponse } from "@/shared/types/lease/suggest-placeholders-response";
 
-interface Props {
+export interface LeaseTemplateUploadDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onCreated?: (
@@ -40,7 +40,7 @@ export default function LeaseTemplateUploadDialog({
   open,
   onOpenChange,
   onCreated,
-}: Props) {
+}: LeaseTemplateUploadDialogProps) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [files, setFiles] = useState<File[]>([]);

--- a/apps/mybookkeeper/frontend/src/app/features/leases/PlaceholderInput.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/PlaceholderInput.tsx
@@ -2,7 +2,7 @@ import type { LeaseTemplatePlaceholder } from "@/shared/types/lease/lease-templa
 import type { PlaceholderProvenance } from "@/shared/types/lease/placeholder-provenance";
 import ProvenanceBadge from "@/app/features/leases/ProvenanceBadge";
 
-interface Props {
+export interface PlaceholderInputProps {
   placeholder: LeaseTemplatePlaceholder;
   value: string;
   provenance: PlaceholderProvenance;
@@ -22,7 +22,7 @@ export default function PlaceholderInput({
   value,
   provenance,
   onChange,
-}: Props) {
+}: PlaceholderInputProps) {
   const inputType = (() => {
     switch (placeholder.input_type) {
       case "email":

--- a/apps/mybookkeeper/frontend/src/app/features/leases/PlaceholderSpecEditor.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/PlaceholderSpecEditor.tsx
@@ -1,7 +1,7 @@
 import PlaceholderSpecRow from "@/app/features/leases/PlaceholderSpecRow";
 import type { LeaseTemplatePlaceholder } from "@/shared/types/lease/lease-template-placeholder";
 
-interface Props {
+export interface PlaceholderSpecEditorProps {
   templateId: string;
   placeholders: LeaseTemplatePlaceholder[];
 }
@@ -12,7 +12,7 @@ interface Props {
  * ``computed_expr`` are editable here. ``key`` is read-only because it's the
  * identifier used by the substitution pipeline.
  */
-export default function PlaceholderSpecEditor({ templateId, placeholders }: Props) {
+export default function PlaceholderSpecEditor({ templateId, placeholders }: PlaceholderSpecEditorProps) {
   if (placeholders.length === 0) {
     return (
       <p className="text-sm text-muted-foreground" data-testid="placeholders-empty">

--- a/apps/mybookkeeper/frontend/src/app/features/leases/PlaceholderSpecRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/PlaceholderSpecRow.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/shared/types/lease/lease-placeholder-input-type";
 import type { LeaseTemplatePlaceholder } from "@/shared/types/lease/lease-template-placeholder";
 
-interface Props {
+export interface PlaceholderSpecRowProps {
   templateId: string;
   placeholder: LeaseTemplatePlaceholder;
 }
@@ -20,7 +20,7 @@ interface Props {
  * change via the update-placeholder mutation; the parent invalidates the
  * template cache tag automatically.
  */
-export default function PlaceholderSpecRow({ templateId, placeholder }: Props) {
+export default function PlaceholderSpecRow({ templateId, placeholder }: PlaceholderSpecRowProps) {
   const [updatePlaceholder] = useUpdateLeasePlaceholderMutation();
   const [draft, setDraft] = useState({
     display_label: placeholder.display_label,

--- a/apps/mybookkeeper/frontend/src/app/features/leases/ProvenanceBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/ProvenanceBadge.tsx
@@ -1,6 +1,6 @@
 import type { PlaceholderProvenance } from "@/shared/types/lease/placeholder-provenance";
 
-interface Props {
+export interface ProvenanceBadgeProps {
   provenance: PlaceholderProvenance;
 }
 
@@ -32,7 +32,7 @@ const BADGE_CONFIG: Record<
  * Renders nothing when ``provenance`` is ``null`` (no ``default_source`` on
  * the placeholder — manual entry only).
  */
-export default function ProvenanceBadge({ provenance }: Props) {
+export default function ProvenanceBadge({ provenance }: ProvenanceBadgeProps) {
   if (provenance === null) return null;
 
   const config = BADGE_CONFIG[provenance];

--- a/apps/mybookkeeper/frontend/src/app/features/leases/SignedLeaseStatusBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/SignedLeaseStatusBadge.tsx
@@ -15,7 +15,7 @@ const COLOR_CLASSES: Record<BadgeColor, string> = {
   purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
 };
 
-interface Props {
+export interface SignedLeaseStatusBadgeProps {
   status: SignedLeaseStatus;
   className?: string;
 }
@@ -23,7 +23,7 @@ interface Props {
 /**
  * Status badge for a signed lease. Mirrors the ApplicantStageBadge pattern.
  */
-export default function SignedLeaseStatusBadge({ status, className = "" }: Props) {
+export default function SignedLeaseStatusBadge({ status, className = "" }: SignedLeaseStatusBadgeProps) {
   const color = SIGNED_LEASE_STATUS_BADGE_COLORS[status];
   return (
     <span

--- a/apps/mybookkeeper/frontend/src/app/features/leases/TemplatePicker.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/TemplatePicker.tsx
@@ -4,7 +4,7 @@ import Skeleton from "@/shared/components/ui/Skeleton";
 import { useGetLeaseTemplatesQuery } from "@/shared/store/leaseTemplatesApi";
 import type { LeaseTemplateSummary } from "@/shared/types/lease/lease-template-summary";
 
-interface Props {
+export interface TemplatePickerProps {
   selectedId: string | null;
   onSelect: (template: LeaseTemplateSummary) => void;
 }
@@ -13,7 +13,7 @@ interface Props {
  * Renders a pick-list of lease templates. The selected item is highlighted.
  * Used on /leases/new when no template_id query param is present.
  */
-export default function TemplatePicker({ selectedId, onSelect }: Props) {
+export default function TemplatePicker({ selectedId, onSelect }: TemplatePickerProps) {
   const { data, isLoading, isFetching, isError, refetch } =
     useGetLeaseTemplatesQuery();
   const templates = data?.items ?? [];

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ChannelImportStatusBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ChannelImportStatusBadge.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/shared/lib/channel-labels";
 import type { ChannelListing } from "@/shared/types/listing/channel-listing";
 
-interface Props {
+export interface ChannelImportStatusBadgeProps {
   channelListing: ChannelListing;
 }
 
@@ -17,7 +17,7 @@ interface Props {
  * clicking into a row. Uses an icon AND color (never color alone) for
  * accessibility.
  */
-export default function ChannelImportStatusBadge({ channelListing }: Props) {
+export default function ChannelImportStatusBadge({ channelListing }: ChannelImportStatusBadgeProps) {
   const status = deriveImportStatus(channelListing);
 
   if (status === "pending") {

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ChannelListingFormModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ChannelListingFormModal.tsx
@@ -12,7 +12,7 @@ import {
 import type { Channel } from "@/shared/types/listing/channel";
 import type { ChannelListing } from "@/shared/types/listing/channel-listing";
 
-interface Props {
+export interface ChannelListingFormModalProps {
   open: boolean;
   listingId: string;
   /** Available channels (already filtered to exclude already-linked ones in create mode). */
@@ -48,7 +48,7 @@ export default function ChannelListingFormModal({
   availableChannels,
   existing,
   onClose,
-}: Props) {
+}: ChannelListingFormModalProps) {
   const isEdit = existing !== undefined;
   const initialChannelId = existing?.channel_id ?? availableChannels[0]?.id ?? "";
 

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ChannelListingRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ChannelListingRow.tsx
@@ -5,7 +5,7 @@ import { showSuccess } from "@/shared/lib/toast-store";
 import type { ChannelListing } from "@/shared/types/listing/channel-listing";
 import ChannelImportStatusBadge from "./ChannelImportStatusBadge";
 
-interface Props {
+export interface ChannelListingRowProps {
   channelListing: ChannelListing;
   onEdit: () => void;
   onRemove: () => void;
@@ -24,7 +24,7 @@ export default function ChannelListingRow({
   onEdit,
   onRemove,
   isRemoving,
-}: Props) {
+}: ChannelListingRowProps) {
   const [copied, setCopied] = useState(false);
   const channelName = channelListing.channel?.name ?? channelListing.channel_id;
 

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ChannelsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ChannelsSection.tsx
@@ -12,7 +12,7 @@ import type { ChannelListing } from "@/shared/types/listing/channel-listing";
 import ChannelListingRow from "./ChannelListingRow";
 import ChannelListingFormModal from "./ChannelListingFormModal";
 
-interface Props {
+export interface ChannelsSectionProps {
   listingId: string;
 }
 
@@ -29,7 +29,7 @@ type FormMode =
  * shows when there's at least one unlinked channel available. Empty
  * state pitches the operator on the first link.
  */
-export default function ChannelsSection({ listingId }: Props) {
+export default function ChannelsSection({ listingId }: ChannelsSectionProps) {
   const {
     data: channelListings = [],
     isLoading,

--- a/apps/mybookkeeper/frontend/src/app/features/listings/DeleteListingModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/DeleteListingModal.tsx
@@ -1,6 +1,6 @@
 import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
 
-interface Props {
+export interface DeleteListingModalProps {
   open: boolean;
   listingTitle: string;
   isLoading?: boolean;
@@ -14,7 +14,7 @@ export default function DeleteListingModal({
   isLoading,
   onConfirm,
   onCancel,
-}: Props) {
+}: DeleteListingModalProps) {
   return (
     <ConfirmDialog
       open={open}

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ExternalIdForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ExternalIdForm.tsx
@@ -18,7 +18,7 @@ import {
 import type { ListingExternalId } from "@/shared/types/listing/listing-external-id";
 import type { ListingSource } from "@/shared/types/listing/listing-source";
 
-interface Props {
+export interface ExternalIdFormProps {
   listingId: string;
   /** When undefined, the form is in create mode. */
   existing?: ListingExternalId;
@@ -45,7 +45,7 @@ export default function ExternalIdForm({
   linkedSources,
   onSuccess,
   onCancel,
-}: Props) {
+}: ExternalIdFormProps) {
   const isEdit = existing !== undefined;
   const availableSources = isEdit
     ? LISTING_SOURCES

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ExternalIdRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ExternalIdRow.tsx
@@ -4,7 +4,7 @@ import Button from "@/shared/components/ui/Button";
 import { LISTING_SOURCE_LABELS } from "@/shared/lib/listing-labels";
 import type { ListingExternalId } from "@/shared/types/listing/listing-external-id";
 
-interface Props {
+export interface ExternalIdRowProps {
   externalId: ListingExternalId;
   onEdit: () => void;
   onRemove: () => void;
@@ -24,7 +24,7 @@ export default function ExternalIdRow({
   onEdit,
   onRemove,
   isRemoving,
-}: Props) {
+}: ExternalIdRowProps) {
   const sourceLabel = LISTING_SOURCE_LABELS[externalId.source];
   return (
     <li

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ExternalIdSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ExternalIdSection.tsx
@@ -12,7 +12,7 @@ import type { ListingSource } from "@/shared/types/listing/listing-source";
 import ExternalIdForm from "./ExternalIdForm";
 import ExternalIdRow from "./ExternalIdRow";
 
-interface Props {
+export interface ExternalIdSectionProps {
   listingId: string;
   externalIds: readonly ListingExternalId[];
 }
@@ -32,7 +32,7 @@ type FormMode =
  *   - Empty state with prominent CTA
  *   - Toasts for success / failure (no alert(), no modal popups for ops)
  */
-export default function ExternalIdSection({ listingId, externalIds }: Props) {
+export default function ExternalIdSection({ listingId, externalIds }: ExternalIdSectionProps) {
   const [formMode, setFormMode] = useState<FormMode>({ kind: "closed" });
   const [removingId, setRemovingId] = useState<string | null>(null);
   const [deleteExternalId] = useDeleteListingExternalIdMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingAmenities.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingAmenities.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 
-interface Props {
+export interface ListingAmenitiesProps {
   amenities: string[];
 }
 
@@ -12,7 +12,7 @@ const COLLAPSE_THRESHOLD = 6;
  * compact. Desktop shows everything inline because vertical real estate is
  * cheaper there.
  */
-export default function ListingAmenities({ amenities }: Props) {
+export default function ListingAmenities({ amenities }: ListingAmenitiesProps) {
   const [expanded, setExpanded] = useState(false);
 
   if (amenities.length === 0) {

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingApplyUrlPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingApplyUrlPanel.tsx
@@ -4,7 +4,7 @@ import { QRCodeSVG } from "qrcode.react";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 
-interface Props {
+export interface ListingApplyUrlPanelProps {
   slug: string | null;
 }
 
@@ -16,7 +16,7 @@ interface Props {
  * than copying the URL, so we hide it behind a button to keep the panel
  * compact on small screens).
  */
-export default function ListingApplyUrlPanel({ slug }: Props) {
+export default function ListingApplyUrlPanel({ slug }: ListingApplyUrlPanelProps) {
   const [copied, setCopied] = useState(false);
   const [showQr, setShowQr] = useState(false);
 

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingCard.tsx
@@ -3,7 +3,7 @@ import ListingStatusBadge from "./ListingStatusBadge";
 import { LISTING_ROOM_TYPE_LABELS, formatRate } from "@/shared/lib/listing-labels";
 import type { ListingSummary } from "@/shared/types/listing/listing-summary";
 
-interface Props {
+export interface ListingCardProps {
   listing: ListingSummary;
   propertyName: string;
 }
@@ -17,7 +17,7 @@ interface Props {
  *   - room type (quick scan classifier)
  *   - monthly rate (primary money figure)
  */
-export default function ListingCard({ listing, propertyName }: Props) {
+export default function ListingCard({ listing, propertyName }: ListingCardProps) {
   return (
     <Link
       to={`/listings/${listing.id}`}

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingDetailRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingDetailRow.tsx
@@ -1,4 +1,4 @@
-interface Props {
+export interface ListingDetailRowProps {
   label: string;
   value: React.ReactNode;
 }
@@ -8,7 +8,7 @@ interface Props {
  * the listing detail page's Rates and Room details sections to keep
  * presentation consistent.
  */
-export default function ListingDetailRow({ label, value }: Props) {
+export default function ListingDetailRow({ label, value }: ListingDetailRowProps) {
   return (
     <div className="flex flex-col gap-0.5">
       <span className="text-xs uppercase tracking-wide text-muted-foreground">{label}</span>

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingForm.tsx
@@ -21,7 +21,7 @@ import type { ListingResponse } from "@/shared/types/listing/listing-response";
 import type { ListingUpdateRequest } from "@/shared/types/listing/listing-update-request";
 import type { Property } from "@/shared/types/property/property";
 
-interface Props {
+export interface ListingFormProps {
   listing?: ListingResponse;
   properties: readonly Property[];
   onClose: () => void;
@@ -130,7 +130,7 @@ export default function ListingForm({
   onClose,
   onCreated,
   onUpdated,
-}: Props) {
+}: ListingFormProps) {
   const [createListing, { isLoading: isCreating }] = useCreateListingMutation();
   const [updateListing, { isLoading: isUpdating }] = useUpdateListingMutation();
 

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoCard.tsx
@@ -3,12 +3,12 @@ import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, X } from "lucide-react";
 import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
 
-interface Props {
+export interface ListingPhotoCardProps {
   photo: ListingPhoto;
   onDelete: () => void;
 }
 
-export default function ListingPhotoCard({ photo, onDelete }: Props) {
+export default function ListingPhotoCard({ photo, onDelete }: ListingPhotoCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: photo.id });
 

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoManager.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoManager.tsx
@@ -27,7 +27,7 @@ import {
 import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
 import ListingPhotoCard from "@/app/features/listings/ListingPhotoCard";
 
-interface Props {
+export interface ListingPhotoManagerProps {
   listingId: string;
   photos: readonly ListingPhoto[];
 }
@@ -54,7 +54,7 @@ function clientSideValidate(files: File[]): { valid: File[]; rejected: string[] 
   return { valid, rejected };
 }
 
-export default function ListingPhotoManager({ listingId, photos }: Props) {
+export default function ListingPhotoManager({ listingId, photos }: ListingPhotoManagerProps) {
   const [uploadPhotos, { isLoading: isUploading }] = useUploadListingPhotosMutation();
   const [deletePhoto] = useDeleteListingPhotoMutation();
   const [updatePhoto] = useUpdateListingPhotoMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingStatusBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingStatusBadge.tsx
@@ -5,10 +5,10 @@ import {
 } from "@/shared/lib/listing-labels";
 import type { ListingStatus } from "@/shared/types/listing/listing-status";
 
-interface Props {
+export interface ListingStatusBadgeProps {
   status: ListingStatus;
 }
 
-export default function ListingStatusBadge({ status }: Props) {
+export default function ListingStatusBadge({ status }: ListingStatusBadgeProps) {
   return <Badge label={LISTING_STATUS_LABELS[status]} color={LISTING_STATUS_BADGE_COLORS[status]} />;
 }

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingStatusFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingStatusFilter.tsx
@@ -2,7 +2,7 @@ import { cn } from "@/shared/utils/cn";
 import { LISTING_STATUSES, LISTING_STATUS_LABELS } from "@/shared/lib/listing-labels";
 import type { ListingStatus } from "@/shared/types/listing/listing-status";
 
-interface Props {
+export interface ListingStatusFilterProps {
   value: ListingStatus | null;
   onChange: (status: ListingStatus | null) => void;
 }
@@ -22,7 +22,7 @@ const CHIPS: Chip[] = [
  * scrolls horizontally (overflow-x-auto, flex-nowrap) so all five chips remain
  * reachable without forcing a wrap. Touch targets are ≥ 44px tall.
  */
-export default function ListingStatusFilter({ value, onChange }: Props) {
+export default function ListingStatusFilter({ value, onChange }: ListingStatusFilterProps) {
   return (
     <div
       role="tablist"

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingTableRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingTableRow.tsx
@@ -3,7 +3,7 @@ import ListingStatusBadge from "./ListingStatusBadge";
 import { LISTING_ROOM_TYPE_LABELS, formatRate } from "@/shared/lib/listing-labels";
 import type { ListingSummary } from "@/shared/types/listing/listing-summary";
 
-interface Props {
+export interface ListingTableRowProps {
   listing: ListingSummary;
   propertyName: string;
 }
@@ -13,7 +13,7 @@ interface Props {
  * navigation) and exposes a keyboard-accessible button via tabIndex + key
  * handling.
  */
-export default function ListingTableRow({ listing, propertyName }: Props) {
+export default function ListingTableRow({ listing, propertyName }: ListingTableRowProps) {
   const navigate = useNavigate();
   const goToDetail = () => navigate(`/listings/${listing.id}`);
 

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingsSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingsSkeleton.tsx
@@ -1,6 +1,6 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
 
-interface Props {
+export interface ListingsSkeletonProps {
   count?: number;
 }
 
@@ -9,7 +9,7 @@ interface Props {
  * — same number of card slots on mobile, same column count in the desktop table —
  * to prevent layout shift and satisfy `feedback_skeletons_match_layout`.
  */
-export default function ListingsSkeleton({ count = 4 }: Props) {
+export default function ListingsSkeleton({ count = 4 }: ListingsSkeletonProps) {
   const rows = Array.from({ length: count }, (_, i) => i);
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/listings/PetDisclosureBanner.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/PetDisclosureBanner.tsx
@@ -1,6 +1,6 @@
 import { AlertTriangle } from "lucide-react";
 
-interface Props {
+export interface PetDisclosureBannerProps {
   largeDogDisclosure: string | null;
 }
 
@@ -13,7 +13,7 @@ interface Props {
  * Per RENTALS_PLAN §9.3 the host should never need to remember to mention
  * pets — the banner makes the disclosure the first thing a viewer sees.
  */
-export default function PetDisclosureBanner({ largeDogDisclosure }: Props) {
+export default function PetDisclosureBanner({ largeDogDisclosure }: PetDisclosureBannerProps) {
   return (
     <div
       role="note"

--- a/apps/mybookkeeper/frontend/src/app/features/onboarding/DependentsStep.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/onboarding/DependentsStep.tsx
@@ -1,12 +1,12 @@
 const MIN = 0;
 const MAX = 20;
 
-interface Props {
+export interface DependentsStepProps {
   value: number;
   onChange: (value: number) => void;
 }
 
-export default function DependentsStep({ value, onChange }: Props) {
+export default function DependentsStep({ value, onChange }: DependentsStepProps) {
   function decrement() {
     if (value > MIN) onChange(value - 1);
   }

--- a/apps/mybookkeeper/frontend/src/app/features/onboarding/FilingStatusStep.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/onboarding/FilingStatusStep.tsx
@@ -1,12 +1,12 @@
 import { cn } from "@/shared/utils/cn";
 import { FILING_STATUS_OPTIONS } from "@/shared/lib/tax-config";
 
-interface Props {
+export interface FilingStatusStepProps {
   value: string | null;
   onChange: (value: string) => void;
 }
 
-export default function FilingStatusStep({ value, onChange }: Props) {
+export default function FilingStatusStep({ value, onChange }: FilingStatusStepProps) {
   return (
     <div className="space-y-3">
       <p className="text-sm text-muted-foreground">

--- a/apps/mybookkeeper/frontend/src/app/features/onboarding/TaxSituationStep.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/onboarding/TaxSituationStep.tsx
@@ -1,12 +1,12 @@
 import { cn } from "@/shared/utils/cn";
 import { TAX_SITUATION_OPTIONS } from "@/shared/lib/tax-config";
 
-interface Props {
+export interface TaxSituationStepProps {
   value: string[];
   onChange: (value: string[]) => void;
 }
 
-export default function TaxSituationStep({ value, onChange }: Props) {
+export default function TaxSituationStep({ value, onChange }: TaxSituationStepProps) {
   function toggle(option: string) {
     if (value.includes(option)) {
       onChange(value.filter((v) => v !== option));

--- a/apps/mybookkeeper/frontend/src/app/features/organizations/InviteForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/organizations/InviteForm.tsx
@@ -7,12 +7,12 @@ import { INVITE_ROLE_OPTIONS } from "@/shared/lib/organization-config";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import Select from "@/shared/components/ui/Select";
 
-interface Props {
+export interface InviteFormProps {
   onError: (message: string) => void;
   onSuccess: (message: string) => void;
 }
 
-export default function InviteForm({ onError, onSuccess }: Props) {
+export default function InviteForm({ onError, onSuccess }: InviteFormProps) {
   const orgId = useActiveOrgId();
   const [email, setEmail] = useState("");
   const [role, setRole] = useState<OrgRole>("user");

--- a/apps/mybookkeeper/frontend/src/app/features/organizations/MemberList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/organizations/MemberList.tsx
@@ -11,12 +11,12 @@ import Select from "@/shared/components/ui/Select";
 import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
 import { ROLE_BADGE_COLORS, ROLE_OPTIONS } from "@/shared/lib/organization-config";
 
-interface Props {
+export interface MemberListProps {
   onError: (message: string) => void;
   onSuccess: (message: string) => void;
 }
 
-export default function MemberList({ onError, onSuccess }: Props) {
+export default function MemberList({ onError, onSuccess }: MemberListProps) {
   const orgId = useActiveOrgId();
   const { user } = useCurrentUser();
   const isAdmin = useIsOrgAdmin();

--- a/apps/mybookkeeper/frontend/src/app/features/organizations/PendingInvites.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/organizations/PendingInvites.tsx
@@ -5,12 +5,12 @@ import { X } from "lucide-react";
 import Badge from "@/shared/components/ui/Badge";
 import { INVITE_STATUS_COLORS } from "@/shared/lib/organization-config";
 
-interface Props {
+export interface PendingInvitesProps {
   onSuccess?: (message: string) => void;
   onError?: (message: string) => void;
 }
 
-export default function PendingInvites({ onSuccess, onError }: Props) {
+export default function PendingInvites({ onSuccess, onError }: PendingInvitesProps) {
   const orgId = useActiveOrgId();
   const { data: invites = [] } = useListInvitesQuery(orgId!, { skip: !orgId });
   const [cancelInvite] = useCancelInviteMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/properties/AddressInputs.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/properties/AddressInputs.tsx
@@ -1,12 +1,12 @@
 import type { AddressFields } from "@/shared/types/property/address-fields";
 import FormField from "@/shared/components/ui/FormField";
 
-interface Props {
+export interface AddressInputsProps {
   form: AddressFields;
   onChange: (field: keyof AddressFields, value: string) => void;
 }
 
-export default function AddressInputs({ form, onChange }: Props) {
+export default function AddressInputs({ form, onChange }: AddressInputsProps) {
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
       <div className="sm:col-span-2">

--- a/apps/mybookkeeper/frontend/src/app/features/properties/PropertyEditCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/properties/PropertyEditCard.tsx
@@ -12,12 +12,12 @@ import FormField from "@/shared/components/ui/FormField";
 import { fromProperty, toAddress, addressComplete } from "./propertyForm";
 import AddressInputs from "./AddressInputs";
 
-interface Props {
+export interface PropertyEditCardProps {
   property: Property;
   onDone: () => void;
 }
 
-export default function PropertyEditCard({ property, onDone }: Props) {
+export default function PropertyEditCard({ property, onDone }: PropertyEditCardProps) {
   const [form, setForm] = useState<PropertyForm>(() => fromProperty(property));
   const [updateProperty, { isLoading }] = useUpdatePropertyMutation();
 

--- a/apps/mybookkeeper/frontend/src/app/features/properties/PropertyListItem.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/properties/PropertyListItem.tsx
@@ -5,7 +5,7 @@ import { CLASSIFICATION_LABELS, TYPE_LABELS } from "@/shared/lib/property-labels
 import Button from "@/shared/components/ui/Button";
 import Badge from "@/shared/components/ui/Badge";
 
-interface Props {
+export interface PropertyListItemProps {
   property: Property;
   onEdit: () => void;
   onDelete: () => void;
@@ -13,7 +13,7 @@ interface Props {
   canWrite?: boolean;
 }
 
-export default function PropertyListItem({ property, onEdit, onDelete, onToggleActive, canWrite = true }: Props) {
+export default function PropertyListItem({ property, onEdit, onDelete, onToggleActive, canWrite = true }: PropertyListItemProps) {
   return (
     <div className={`border rounded-lg p-4 flex items-center justify-between ${!property.is_active ? "opacity-60" : ""}`}>
       <div>

--- a/apps/mybookkeeper/frontend/src/app/features/receipts/ReceiptSentBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/receipts/ReceiptSentBadge.tsx
@@ -2,12 +2,12 @@
  * Small pill shown on a transaction row when a receipt has been sent.
  * Links to the signed-lease attachments page for the tenant's lease.
  */
-interface Props {
+export interface ReceiptSentBadgeProps {
   /** If provided, the badge links to the lease detail page. */
   leaseId?: string | null;
 }
 
-export default function ReceiptSentBadge({ leaseId }: Props) {
+export default function ReceiptSentBadge({ leaseId }: ReceiptSentBadgeProps) {
   const content = (
     <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
       Receipt sent

--- a/apps/mybookkeeper/frontend/src/app/features/reconciliation/ReconciliationWizard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/reconciliation/ReconciliationWizard.tsx
@@ -18,12 +18,12 @@ import EmptyState from "@/shared/components/ui/EmptyState";
 import Skeleton from "@/shared/components/ui/Skeleton";
 
 
-interface Props {
+export interface ReconciliationWizardProps {
   onToast: (message: string, variant: "success" | "error") => void;
   canWrite?: boolean;
 }
 
-export default function ReconciliationWizard({ onToast, canWrite = true }: Props) {
+export default function ReconciliationWizard({ onToast, canWrite = true }: ReconciliationWizardProps) {
   const currentYear = getYear(new Date());
   const [taxYear, setTaxYear] = useState(currentYear - 1);
   const [step, setStep] = useState(0);

--- a/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningEligibilityGate.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningEligibilityGate.tsx
@@ -1,7 +1,7 @@
 import { AlertCircle } from "lucide-react";
 import type { ScreeningEligibilityResponse } from "@/shared/types/screening/screening-eligibility-response";
 
-interface Props {
+export interface ScreeningEligibilityGateProps {
   eligibility: ScreeningEligibilityResponse;
 }
 
@@ -13,7 +13,7 @@ interface Props {
  *
  * This component is only rendered when ``eligibility.eligible === false``.
  */
-export default function ScreeningEligibilityGate({ eligibility }: Props) {
+export default function ScreeningEligibilityGate({ eligibility }: ScreeningEligibilityGateProps) {
   const { missing_fields } = eligibility;
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningPendingPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningPendingPanel.tsx
@@ -3,7 +3,7 @@ import Button from "@/shared/components/ui/Button";
 import { formatRelativeTime } from "@/shared/lib/inquiry-date-format";
 import type { ScreeningResult } from "@/shared/types/applicant/screening-result";
 
-interface Props {
+export interface ScreeningPendingPanelProps {
   pendingResult: ScreeningResult;
   onUploadClick: () => void;
   canWrite: boolean;
@@ -16,7 +16,7 @@ interface Props {
  *
  * Uses AI-conversational tone per CLAUDE.md § UX: AI Interactions.
  */
-export default function ScreeningPendingPanel({ pendingResult, onUploadClick, canWrite }: Props) {
+export default function ScreeningPendingPanel({ pendingResult, onUploadClick, canWrite }: ScreeningPendingPanelProps) {
   return (
     <div
       data-testid="screening-pending-panel"

--- a/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningProviderCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningProviderCard.tsx
@@ -2,7 +2,7 @@ import { Clock, DollarSign, ExternalLink } from "lucide-react";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import type { ScreeningProviderInfo } from "@/shared/store/screeningApi";
 
-interface Props {
+export interface ScreeningProviderCardProps {
   provider: ScreeningProviderInfo;
   isLoading: boolean;
   onSelect: (providerName: string) => void;
@@ -17,7 +17,7 @@ interface Props {
  * ``isLoading`` disables all cards while any redirect fetch is in flight —
  * prevents double-clicks across different cards.
  */
-export default function ScreeningProviderCard({ provider, isLoading, onSelect }: Props) {
+export default function ScreeningProviderCard({ provider, isLoading, onSelect }: ScreeningProviderCardProps) {
   return (
     <div
       data-testid={`screening-provider-card-${provider.name}`}

--- a/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningProviderGrid.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningProviderGrid.tsx
@@ -4,7 +4,7 @@ import { showError } from "@/shared/lib/toast-store";
 import { useGetScreeningProvidersQuery, useLazyGetScreeningRedirectQuery } from "@/shared/store/screeningApi";
 import ScreeningProviderCard from "./ScreeningProviderCard";
 
-interface Props {
+export interface ScreeningProviderGridProps {
   applicantId: string;
   /** Override window.open — only used by tests. */
   openWindow?: (url: string) => void;
@@ -47,7 +47,7 @@ function ProviderGridSkeleton() {
  * All provider cards are disabled while any single redirect fetch is in
  * flight — prevents race conditions from rapid multi-clicks.
  */
-export default function ScreeningProviderGrid({ applicantId, openWindow }: Props) {
+export default function ScreeningProviderGrid({ applicantId, openWindow }: ScreeningProviderGridProps) {
   const [loadingProvider, setLoadingProvider] = useState<string | null>(null);
   const { data, isLoading, isError } = useGetScreeningProvidersQuery(applicantId);
   const [triggerRedirect] = useLazyGetScreeningRedirectQuery();

--- a/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningResultCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningResultCard.tsx
@@ -42,7 +42,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   other: "Other",
 };
 
-interface Props {
+export interface ScreeningResultCardProps {
   result: ScreeningResult;
 }
 
@@ -54,7 +54,7 @@ interface Props {
  *   expands it intentionally to read the reason for their records).
  * - Download link uses the per-row ``presigned_url`` minted by the backend.
  */
-export default function ScreeningResultCard({ result }: Props) {
+export default function ScreeningResultCard({ result }: ScreeningResultCardProps) {
   const [snippetOpen, setSnippetOpen] = useState(false);
   const meta = STATUS_META[result.status] ?? {
     label: result.status,

--- a/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningResultRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningResultRow.tsx
@@ -21,7 +21,7 @@ const PROVIDER_LABELS: Record<string, string> = {
   other: "Other",
 };
 
-interface Props {
+export interface ScreeningResultRowProps {
   result: ScreeningResult;
 }
 
@@ -34,7 +34,7 @@ interface Props {
  *   - Download link uses the per-row ``presigned_url`` minted by the
  *     screening response builder. Storage keys are never exposed.
  */
-export default function ScreeningResultRow({ result }: Props) {
+export default function ScreeningResultRow({ result }: ScreeningResultRowProps) {
   const [snippetOpen, setSnippetOpen] = useState(false);
   const statusMeta = STATUS_BADGE[result.status] ?? {
     label: result.status,

--- a/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningResultsList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningResultsList.tsx
@@ -2,7 +2,7 @@ import Skeleton from "@/shared/components/ui/Skeleton";
 import { useGetScreeningResultsQuery } from "@/shared/store/screeningApi";
 import ScreeningResultRow from "./ScreeningResultRow";
 
-interface Props {
+export interface ScreeningResultsListProps {
   applicantId: string;
 }
 
@@ -37,7 +37,7 @@ function ScreeningResultsSkeleton() {
  * convention — the parent ApplicantDetail already has a top-level error
  * banner so we keep this list-level error subtle.
  */
-export default function ScreeningResultsList({ applicantId }: Props) {
+export default function ScreeningResultsList({ applicantId }: ScreeningResultsListProps) {
   const { data, isLoading, isError, refetch, isFetching } =
     useGetScreeningResultsQuery(applicantId);
 

--- a/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/ScreeningSection.tsx
@@ -7,7 +7,7 @@ import ScreeningProviderGrid from "./ScreeningProviderGrid";
 import ScreeningResultCard from "./ScreeningResultCard";
 import UploadScreeningResultModal from "./UploadScreeningResultModal";
 
-interface Props {
+export interface ScreeningSectionProps {
   applicantId: string;
   canWrite: boolean;
   /** Override window.open — only used by tests. */
@@ -48,7 +48,7 @@ function ScreeningSectionSkeleton() {
  * Results list is always shown when results exist, regardless of current state.
  * This lets the host see historical results while a new one is pending.
  */
-export default function ScreeningSection({ applicantId, canWrite, openWindow }: Props) {
+export default function ScreeningSection({ applicantId, canWrite, openWindow }: ScreeningSectionProps) {
   const [uploadModalOpen, setUploadModalOpen] = useState(false);
 
   const {

--- a/apps/mybookkeeper/frontend/src/app/features/screening/UploadScreeningResultModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/screening/UploadScreeningResultModal.tsx
@@ -13,7 +13,7 @@ import {
   type ScreeningStatus,
 } from "@/shared/types/screening/screening-status";
 
-interface Props {
+export interface UploadScreeningResultModalProps {
   applicantId: string;
   open: boolean;
   onClose: () => void;
@@ -40,7 +40,7 @@ export default function UploadScreeningResultModal({
   applicantId,
   open,
   onClose,
-}: Props) {
+}: UploadScreeningResultModalProps) {
   const [file, setFile] = useState<File | null>(null);
   const [status, setStatus] = useState<ScreeningStatus | "">("");
   const [adverseSnippet, setAdverseSnippet] = useState<string>("");

--- a/apps/mybookkeeper/frontend/src/app/features/security/DeleteAccountModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/security/DeleteAccountModal.tsx
@@ -8,12 +8,12 @@ import { useGetTotpStatusQuery } from "@/shared/store/totpApi";
 import { logout } from "@/shared/lib/auth";
 import { showError } from "@/shared/lib/toast-store";
 
-interface Props {
+export interface DeleteAccountModalProps {
   open: boolean;
   onClose: () => void;
 }
 
-export default function DeleteAccountModal({ open, onClose }: Props) {
+export default function DeleteAccountModal({ open, onClose }: DeleteAccountModalProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [totpCode, setTotpCode] = useState("");

--- a/apps/mybookkeeper/frontend/src/app/features/tax-review/FormCompletenessCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax-review/FormCompletenessCard.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/shared/utils/cn";
 import { getFormLabel } from "@/shared/lib/tax-config";
 import type { FormCompleteness } from "@/shared/types/tax/tax-completeness";
 
-interface Props {
+export interface FormCompletenessCardProps {
   form: FormCompleteness;
 }
 
@@ -15,7 +15,7 @@ function completenessLabel(pct: number): string {
   return "Needs attention";
 }
 
-export default function FormCompletenessCard({ form }: Props) {
+export default function FormCompletenessCard({ form }: FormCompletenessCardProps) {
   const [expanded, setExpanded] = useState(false);
 
   const toggle = useCallback(() => {

--- a/apps/mybookkeeper/frontend/src/app/features/tax-review/ReviewSummary.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax-review/ReviewSummary.tsx
@@ -1,10 +1,10 @@
 import { Sparkles } from "lucide-react";
 
-interface Props {
+export interface ReviewSummaryProps {
   summary: string;
 }
 
-export default function ReviewSummary({ summary }: Props) {
+export default function ReviewSummary({ summary }: ReviewSummaryProps) {
   return (
     <div className="bg-card border rounded-lg p-5 sm:p-6">
       <div className="flex items-start gap-3">

--- a/apps/mybookkeeper/frontend/src/app/features/tax/FormFieldsTable.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/FormFieldsTable.tsx
@@ -6,7 +6,7 @@ import DocumentViewer from "@/app/features/documents/DocumentViewer";
 import type { TaxFormField, FieldValueType, SourceType } from "@/shared/types/tax/tax-form";
 import { VALIDATION_ICONS, SOURCE_BADGES, PII_FIELDS, SSN_REGEX } from "@/shared/lib/tax-form-config";
 
-interface Props {
+export interface FormFieldsTableProps {
   fields: TaxFormField[];
   instanceLabel: string | null;
   sourceType: SourceType;
@@ -29,7 +29,7 @@ function formatFieldValue(field: TaxFormField): string {
   return maskPii(field.field_id, String(field.value));
 }
 
-export default function FormFieldsTable({ fields, instanceLabel, sourceType, documentId, onOverride, isSaving }: Props) {
+export default function FormFieldsTable({ fields, instanceLabel, sourceType, documentId, onOverride, isSaving }: FormFieldsTableProps) {
   const [editingFieldId, setEditingFieldId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
   const [editReason, setEditReason] = useState("");

--- a/apps/mybookkeeper/frontend/src/app/features/tax/FormNameLabel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/FormNameLabel.tsx
@@ -1,10 +1,10 @@
 import { getFormLabel } from "@/shared/lib/tax-config";
 
-interface Props {
+export interface FormNameLabelProps {
   formName: string;
   className?: string;
 }
 
-export default function FormNameLabel({ formName, className }: Props) {
+export default function FormNameLabel({ formName, className }: FormNameLabelProps) {
   return <span className={className}>{getFormLabel(formName)}</span>;
 }

--- a/apps/mybookkeeper/frontend/src/app/features/tax/FormOverviewGrid.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/FormOverviewGrid.tsx
@@ -5,7 +5,7 @@ import type { BadgeColor } from "@/shared/components/ui/Badge";
 import type { ValidationResult } from "@/shared/types/tax/validation-result";
 import type { FormSummary } from "@/shared/types/tax/form-summary";
 
-interface Props {
+export interface FormOverviewGridProps {
   forms: FormSummary[];
   validationResults: ValidationResult[];
   onFormClick: (formName: string) => void;
@@ -23,7 +23,7 @@ function getStatusBadge(errors: number, warnings: number): { label: string; colo
   return { label: "Valid", color: "green" };
 }
 
-export default function FormOverviewGrid({ forms, validationResults, onFormClick }: Props) {
+export default function FormOverviewGrid({ forms, validationResults, onFormClick }: FormOverviewGridProps) {
   if (forms.length === 0) {
     return (
       <div className="text-center py-12 text-muted-foreground">

--- a/apps/mybookkeeper/frontend/src/app/features/tax/SourceDocumentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/SourceDocumentsSection.tsx
@@ -5,11 +5,11 @@ import SourceDocumentsSkeleton from "@/app/features/tax/SourceDocumentsSkeleton"
 import ReceivedDocumentsGrouped from "@/app/features/tax/ReceivedDocumentsGrouped";
 import CompletenessChecklist from "@/app/features/tax/CompletenessChecklist";
 
-interface Props {
+export interface SourceDocumentsSectionProps {
   taxReturnId: string;
 }
 
-export default function SourceDocumentsSection({ taxReturnId }: Props) {
+export default function SourceDocumentsSection({ taxReturnId }: SourceDocumentsSectionProps) {
   const [viewingDocId, setViewingDocId] = useState<string | null>(null);
 
   const { data, isLoading, isError } = useGetSourceDocumentsQuery(taxReturnId);

--- a/apps/mybookkeeper/frontend/src/app/features/tax/TaxAdvisorPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/TaxAdvisorPanel.tsx
@@ -9,12 +9,12 @@ import { SEVERITY_ORDER, SEVERITY_CONFIG } from "@/shared/lib/tax-advisor-config
 import SuggestionCard from "@/app/features/tax/SuggestionCard";
 import TaxAdvisorPanelSkeleton from "@/app/features/tax/TaxAdvisorPanelSkeleton";
 
-interface Props {
+export interface TaxAdvisorPanelProps {
   taxReturnId: string;
   formCount: number;
 }
 
-export default function TaxAdvisorPanel({ taxReturnId, formCount }: Props) {
+export default function TaxAdvisorPanel({ taxReturnId, formCount }: TaxAdvisorPanelProps) {
   const {
     data: cached,
     isLoading: isCacheLoading,

--- a/apps/mybookkeeper/frontend/src/app/features/tax/ValidationPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tax/ValidationPanel.tsx
@@ -3,12 +3,12 @@ import { formatCurrency } from "@/shared/utils/currency";
 import type { ValidationResult } from "@/shared/types/tax/validation-result";
 import { SEVERITY_ORDER, SEVERITY_CONFIG } from "@/shared/lib/validation-config";
 
-interface Props {
+export interface ValidationPanelProps {
   results: ValidationResult[];
   onNavigateToField: (formName: string, fieldId: string | null) => void;
 }
 
-export default function ValidationPanel({ results, onNavigateToField }: Props) {
+export default function ValidationPanel({ results, onNavigateToField }: ValidationPanelProps) {
   if (results.length === 0) {
     return (
       <div className="border rounded-lg p-6 text-center text-muted-foreground">

--- a/apps/mybookkeeper/frontend/src/app/features/tenants/EndTenancyDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tenants/EndTenancyDialog.tsx
@@ -6,7 +6,7 @@ import { useEndTenancyMutation } from "@/shared/store/applicantsApi";
 
 const REASON_MAX_LENGTH = 500;
 
-interface Props {
+export interface EndTenancyDialogProps {
   applicantId: string;
   tenantName: string;
   onClose: () => void;
@@ -16,7 +16,7 @@ interface Props {
  * Inline dialog to confirm ending a tenant's tenancy.
  * Posts PATCH /applicants/{id}/tenancy/end with an optional reason.
  */
-export default function EndTenancyDialog({ applicantId, tenantName, onClose }: Props) {
+export default function EndTenancyDialog({ applicantId, tenantName, onClose }: EndTenancyDialogProps) {
   const [reason, setReason] = useState("");
   const [endTenancy, { isLoading }] = useEndTenancyMutation();
   const reasonRef = useRef<HTMLTextAreaElement>(null);

--- a/apps/mybookkeeper/frontend/src/app/features/tenants/TenantCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tenants/TenantCard.tsx
@@ -3,14 +3,14 @@ import { formatDesiredDates, formatRelativeTime } from "@/shared/lib/inquiry-dat
 import type { ApplicantSummary } from "@/shared/types/applicant/applicant-summary";
 import TenantStatusBadge from "./TenantStatusBadge";
 
-interface Props {
+export interface TenantCardProps {
   tenant: ApplicantSummary;
 }
 
 /**
  * Mobile card for the Tenants list. Whole card is tappable (touch target ≥ 44px).
  */
-export default function TenantCard({ tenant }: Props) {
+export default function TenantCard({ tenant }: TenantCardProps) {
   const legalName = tenant.legal_name ?? "Unnamed tenant";
   const contractDates = formatDesiredDates(tenant.contract_start, tenant.contract_end);
   const created = formatRelativeTime(tenant.created_at);

--- a/apps/mybookkeeper/frontend/src/app/features/tenants/TenantRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tenants/TenantRow.tsx
@@ -3,7 +3,7 @@ import { formatDesiredDates, formatRelativeTime } from "@/shared/lib/inquiry-dat
 import type { ApplicantSummary } from "@/shared/types/applicant/applicant-summary";
 import TenantStatusBadge from "./TenantStatusBadge";
 
-interface Props {
+export interface TenantRowProps {
   tenant: ApplicantSummary;
 }
 
@@ -13,7 +13,7 @@ interface Props {
  * `/tenants/:id` so the breadcrumb context stays "tenant" rather than
  * jumping the user back to /applicants).
  */
-export default function TenantRow({ tenant }: Props) {
+export default function TenantRow({ tenant }: TenantRowProps) {
   const navigate = useNavigate();
   const legalName = tenant.legal_name ?? "Unnamed tenant";
   const contractDates = formatDesiredDates(tenant.contract_start, tenant.contract_end);

--- a/apps/mybookkeeper/frontend/src/app/features/tenants/TenantStatusBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tenants/TenantStatusBadge.tsx
@@ -1,6 +1,6 @@
 import type { ApplicantSummary } from "@/shared/types/applicant/applicant-summary";
 
-interface Props {
+export interface TenantStatusBadgeProps {
   tenant: ApplicantSummary;
   today?: string;
 }
@@ -12,7 +12,7 @@ interface Props {
  * - tenant_ended_at is set (manual end), OR
  * - contract_end is not null and is before today (contract expiry)
  */
-export default function TenantStatusBadge({ tenant, today }: Props) {
+export default function TenantStatusBadge({ tenant, today }: TenantStatusBadgeProps) {
   const todayStr = today ?? new Date().toISOString().slice(0, 10);
   const ended =
     tenant.tenant_ended_at !== null ||

--- a/apps/mybookkeeper/frontend/src/app/features/tenants/TenantsListSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/tenants/TenantsListSkeleton.tsx
@@ -1,6 +1,6 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
 
-interface Props {
+export interface TenantsListSkeletonProps {
   count?: number;
 }
 
@@ -11,7 +11,7 @@ interface Props {
  *   - Mobile: card slots with name + status badge, contract dates / created
  *   - Desktop: 4 columns (Name, Contract Dates, Since, Status)
  */
-export default function TenantsListSkeleton({ count = 4 }: Props) {
+export default function TenantsListSkeleton({ count = 4 }: TenantsListSkeletonProps) {
   const rows = Array.from({ length: count }, (_, i) => i);
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/AttributeTenantPicker.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/AttributeTenantPicker.tsx
@@ -12,7 +12,7 @@ import { useGetApplicantsQuery } from "@/shared/store/applicantsApi";
 import { useAttributeTransactionManuallyMutation } from "@/shared/store/attributionApi";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 
-interface Props {
+export interface AttributeTenantPickerProps {
   transactionId: string;
   currentApplicantId: string | null;
   currentAttributionSource: "auto_exact" | "auto_fuzzy_confirmed" | "manual" | null;
@@ -22,7 +22,7 @@ export default function AttributeTenantPicker({
   transactionId,
   currentApplicantId,
   currentAttributionSource,
-}: Props) {
+}: AttributeTenantPickerProps) {
   const [selectedId, setSelectedId] = useState<string>(currentApplicantId ?? "");
   const [attribute, { isLoading }] = useAttributeTransactionManuallyMutation();
 

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/BankStatementImport.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/BankStatementImport.tsx
@@ -6,14 +6,14 @@ import type { ImportResult } from "@/shared/types/transaction/import-result";
 import Button from "@/shared/components/ui/Button";
 import Select from "@/shared/components/ui/Select";
 
-interface Props {
+export interface BankStatementImportProps {
   properties: readonly Property[];
   onClose: () => void;
   onSuccess: (message: string) => void;
   onError: (message: string) => void;
 }
 
-export default function BankStatementImport({ properties, onClose, onSuccess, onError }: Props) {
+export default function BankStatementImport({ properties, onClose, onSuccess, onError }: BankStatementImportProps) {
   const fileRef = useRef<HTMLInputElement>(null);
   const [file, setFile] = useState<File | null>(null);
   const [propertyId, setPropertyId] = useState("");

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesPanel.tsx
@@ -10,11 +10,11 @@ import Panel from "@/shared/components/ui/Panel";
 import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
 import Spinner from "@/shared/components/icons/Spinner";
 
-interface Props {
+export interface ClassificationRulesPanelProps {
   onClose: () => void;
 }
 
-export default function ClassificationRulesPanel({ onClose }: Props) {
+export default function ClassificationRulesPanel({ onClose }: ClassificationRulesPanelProps) {
   const { data: rules = [], isLoading } = useListClassificationRulesQuery();
   const { data: properties = [] } = useGetPropertiesQuery();
   const [deleteRule] = useDeleteClassificationRuleMutation();

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/DuplicateCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/DuplicateCard.tsx
@@ -9,7 +9,7 @@ import MergePreview from "@/app/features/transactions/MergePreview";
 import DocumentViewer from "@/app/features/documents/DocumentViewer";
 import { computeDefaults, computeSurvivingId, type MergeableField } from "@/app/features/transactions/merge-defaults";
 
-interface Props {
+export interface DuplicateCardProps {
   pair: DuplicatePair;
   propertyMap: Map<string, string>;
   onMerge: (
@@ -44,7 +44,7 @@ function getConfidenceConfig(
   }
 }
 
-export default function DuplicateCard({ pair, propertyMap, onMerge, onDismiss }: Props) {
+export default function DuplicateCard({ pair, propertyMap, onMerge, onDismiss }: DuplicateCardProps) {
   const [busy, setBusy] = useState<"merge" | "dismiss" | null>(null);
   const [mergeOpen, setMergeOpen] = useState(false);
   const [viewingDocId, setViewingDocId] = useState<string | null>(null);

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/ManualEntryForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/ManualEntryForm.tsx
@@ -11,7 +11,7 @@ import Select from "@/shared/components/ui/Select";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import { useCreateTransactionMutation } from "@/shared/store/transactionsApi";
 
-interface Props {
+export interface ManualEntryFormProps {
   properties: readonly Property[];
   onClose: () => void;
   onSuccess: () => void;
@@ -38,7 +38,7 @@ function buildDefaults(): TransactionFormValues {
   };
 }
 
-export default function ManualEntryForm({ properties, onClose, onSuccess, onError }: Props) {
+export default function ManualEntryForm({ properties, onClose, onSuccess, onError }: ManualEntryFormProps) {
   const [createTransaction, { isLoading }] = useCreateTransactionMutation();
 
   const { register, handleSubmit, watch, setValue } = useForm<TransactionFormValues>({

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/MergeFieldPicker.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/MergeFieldPicker.tsx
@@ -34,7 +34,7 @@ function formatFieldValue(
   }
 }
 
-interface Props {
+export interface MergeFieldPickerProps {
   txnA: DuplicateTransaction;
   txnB: DuplicateTransaction;
   labelA: string;
@@ -52,7 +52,7 @@ export default function MergeFieldPicker({
   propertyMap,
   selections,
   onSelectionChange,
-}: Props) {
+}: MergeFieldPickerProps) {
   const allTags = [...new Set([...(txnA.tags ?? []), ...(txnB.tags ?? [])])];
 
   // Build rows — skip fields where both values are identical or both null

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/MergePreview.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/MergePreview.tsx
@@ -29,14 +29,14 @@ function formatResolvedValue(
   }
 }
 
-interface Props {
+export interface MergePreviewProps {
   txnA: DuplicateTransaction;
   txnB: DuplicateTransaction;
   selections: Record<MergeableField, MergeFieldSide>;
   propertyMap: Map<string, string>;
 }
 
-export default function MergePreview({ txnA, txnB, selections, propertyMap }: Props) {
+export default function MergePreview({ txnA, txnB, selections, propertyMap }: MergePreviewProps) {
   // Only show fields that have a conflict (were selectable)
   const conflictedFields = MERGEABLE_FIELDS.filter((field) => {
     const rawA = getRawValue(field, txnA);

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionBulkBar.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionBulkBar.tsx
@@ -1,7 +1,7 @@
 import { CheckCircle, Trash2 } from "lucide-react";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 
-interface Props {
+export interface TransactionBulkBarProps {
   selectedCount: number;
   hasApprovable: boolean;
   isApproving: boolean;
@@ -11,7 +11,7 @@ interface Props {
   onClearSelection: () => void;
 }
 
-export default function TransactionBulkBar({ selectedCount, hasApprovable, isApproving, isDeleting, onApprove, onDelete, onClearSelection }: Props) {
+export default function TransactionBulkBar({ selectedCount, hasApprovable, isApproving, isDeleting, onApprove, onDelete, onClearSelection }: TransactionBulkBarProps) {
   const busy = isApproving || isDeleting;
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionDuplicateActions.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionDuplicateActions.tsx
@@ -3,14 +3,14 @@ import { Copy, Check, XCircle } from "lucide-react";
 import { formatDate } from "@/shared/utils/date";
 import type { DuplicateTransaction } from "@/shared/types/transaction/duplicate";
 
-interface Props {
+export interface TransactionDuplicateActionsProps {
   transactionId: string;
   dupOther: DuplicateTransaction;
   onKeepDuplicate: (keepId: string, deleteIds: string[]) => Promise<void>;
   onDismissDuplicate: (transactionIds: string[]) => Promise<void>;
 }
 
-export default function TransactionDuplicateActions({ transactionId, dupOther, onKeepDuplicate, onDismissDuplicate }: Props) {
+export default function TransactionDuplicateActions({ transactionId, dupOther, onKeepDuplicate, onDismissDuplicate }: TransactionDuplicateActionsProps) {
   const [dupBusy, setDupBusy] = useState<"keep" | "dismiss" | null>(null);
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionFilterBar.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionFilterBar.tsx
@@ -7,13 +7,13 @@ import { STATUS_OPTIONS, TYPE_OPTIONS, ALL_CATEGORIES } from "@/shared/lib/trans
 import Select from "@/shared/components/ui/Select";
 import Badge from "@/shared/components/ui/Badge";
 
-interface Props {
+export interface TransactionFilterBarProps {
   filters: Filters;
   onChange: (filters: Filters) => void;
   properties: readonly Property[];
 }
 
-export default function TransactionFilterBar({ filters, onChange, properties }: Props) {
+export default function TransactionFilterBar({ filters, onChange, properties }: TransactionFilterBarProps) {
   const [mobileExpanded, setMobileExpanded] = useState(false);
 
   function update(field: keyof Filters, value: string) {

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionForm.tsx
@@ -14,7 +14,7 @@ import Select from "@/shared/components/ui/Select";
 import TransactionDuplicateActions from "@/app/features/transactions/TransactionDuplicateActions";
 import { useGetVendorsQuery } from "@/shared/store/vendorsApi";
 
-interface Props {
+export interface TransactionFormProps {
   transaction: Transaction;
   properties: readonly Property[];
   register: UseFormRegister<TransactionFormValues>;
@@ -39,7 +39,7 @@ export default function TransactionForm({
   dupOther,
   onKeepDuplicate,
   onDismissDuplicate,
-}: Props) {
+}: TransactionFormProps) {
   const [sourcePreview, setSourcePreview] = useState<SourcePreview | null>(null);
 
   const transactionType = watch("transaction_type");

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionPanel.tsx
@@ -15,7 +15,7 @@ import TransactionForm from "@/app/features/transactions/TransactionForm";
 import AttributeTenantPicker from "@/app/features/transactions/AttributeTenantPicker";
 import { useUpdateTransactionMutation, useDeleteTransactionMutation } from "@/shared/store/transactionsApi";
 
-interface Props {
+export interface TransactionPanelProps {
   transaction: Transaction;
   properties: readonly Property[];
   onClose: () => void;
@@ -52,7 +52,7 @@ function buildPayload(data: TransactionFormValues, dirty: Partial<Record<keyof T
   return payload;
 }
 
-export default function TransactionPanel({ transaction, properties, onClose, onVendorLearned, onDeleted, embedded, duplicatePair, onKeepDuplicate, onDismissDuplicate }: Props) {
+export default function TransactionPanel({ transaction, properties, onClose, onVendorLearned, onDeleted, embedded, duplicatePair, onKeepDuplicate, onDismissDuplicate }: TransactionPanelProps) {
   const [updateTransaction, { isLoading: isSaving }] = useUpdateTransactionMutation();
   const [deleteTransaction, { isLoading: isDeleting }] = useDeleteTransactionMutation();
   const [showDiscardDialog, setShowDiscardDialog] = useState(false);

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionSide.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionSide.tsx
@@ -4,14 +4,14 @@ import type { DuplicateTransaction } from "@/shared/types/transaction/duplicate"
 import Badge from "@/shared/components/ui/Badge";
 import { formatTag } from "@/shared/utils/tag";
 
-interface Props {
+export interface TransactionSideProps {
   txn: DuplicateTransaction;
   propertyMap: Map<string, string>;
   label: string;
   onViewSource?: (docId: string) => void;
 }
 
-export default function TransactionSide({ txn, propertyMap, label, onViewSource }: Props) {
+export default function TransactionSide({ txn, propertyMap, label, onViewSource }: TransactionSideProps) {
   const propertyName = txn.property_id ? propertyMap.get(txn.property_id) ?? "Unknown" : "No property";
   const sourceCount = (txn.linked_document_ids?.length ?? 0) + (txn.source_document_id ? 1 : 0);
 

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionTable.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionTable.tsx
@@ -17,7 +17,7 @@ import { formatDate } from "@/shared/utils/date";
 import { formatTag } from "@/shared/utils/tag";
 import { cn } from "@/shared/utils/cn";
 
-interface Props {
+export interface TransactionTableProps {
   table: Table<Transaction>;
   colCount: number;
   onRowClick: (transaction: Transaction) => void;
@@ -26,7 +26,7 @@ interface Props {
   propertyMap?: ReadonlyMap<string, string>;
 }
 
-export default function TransactionTable({ table, colCount, onRowClick, editingId, filterOptions, propertyMap }: Props) {
+export default function TransactionTable({ table, colCount, onRowClick, editingId, filterOptions, propertyMap }: TransactionTableProps) {
   const { pageIndex, pageSize } = table.getState().pagination;
   const totalRows = table.getFilteredRowModel().rows.length;
   const start = pageIndex * pageSize + 1;

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/DeleteVendorModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/DeleteVendorModal.tsx
@@ -1,6 +1,6 @@
 import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
 
-interface Props {
+export interface DeleteVendorModalProps {
   open: boolean;
   vendorName: string;
   isLoading?: boolean;
@@ -22,7 +22,7 @@ export default function DeleteVendorModal({
   isLoading,
   onConfirm,
   onCancel,
-}: Props) {
+}: DeleteVendorModalProps) {
   return (
     <ConfirmDialog
       open={open}

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCard.tsx
@@ -4,7 +4,7 @@ import { formatRelativeTime } from "@/shared/lib/inquiry-date-format";
 import type { VendorSummary } from "@/shared/types/vendor/vendor-summary";
 import VendorCategoryBadge from "./VendorCategoryBadge";
 
-interface Props {
+export interface VendorCardProps {
   vendor: VendorSummary;
   /**
    * When true (i.e. the list is in the "All" filter), render the category
@@ -40,7 +40,7 @@ function formatLastUsed(lastUsedAt: string | null): string {
  *   - phone, email, address (contact info)
  *   - flat_rate_notes, notes (free-form host notes)
  */
-export default function VendorCard({ vendor, showCategoryBadge }: Props) {
+export default function VendorCard({ vendor, showCategoryBadge }: VendorCardProps) {
   return (
     <Link
       to={`/vendors/${vendor.id}`}

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCategoryBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCategoryBadge.tsx
@@ -15,7 +15,7 @@ const COLOR_CLASSES: Record<BadgeColor, string> = {
   purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
 };
 
-interface Props {
+export interface VendorCategoryBadgeProps {
   category: VendorCategory;
   className?: string;
 }
@@ -26,7 +26,7 @@ interface Props {
  * Hidden in category-filtered list views (the active chip already conveys
  * the category) but shown on detail pages and the unfiltered "All" list.
  */
-export default function VendorCategoryBadge({ category, className = "" }: Props) {
+export default function VendorCategoryBadge({ category, className = "" }: VendorCategoryBadgeProps) {
   const color = VENDOR_CATEGORY_BADGE_COLORS[category];
   return (
     <span

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCategoryFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCategoryFilter.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/shared/lib/vendor-labels";
 import type { VendorCategory } from "@/shared/types/vendor/vendor-category";
 
-interface Props {
+export interface VendorCategoryFilterProps {
   value: VendorCategory | null;
   onChange: (category: VendorCategory | null) => void;
 }
@@ -26,7 +26,7 @@ const CHIPS: Chip[] = [
  * on mobile (``overflow-x-auto`` + ``flex-nowrap``), URL-state sync handled
  * by the parent page via ``useSearchParams``.
  */
-export default function VendorCategoryFilter({ value, onChange }: Props) {
+export default function VendorCategoryFilter({ value, onChange }: VendorCategoryFilterProps) {
   return (
     <div
       role="tablist"

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorForm.tsx
@@ -18,7 +18,7 @@ import type { VendorCreateRequest } from "@/shared/types/vendor/vendor-create-re
 import type { VendorResponse } from "@/shared/types/vendor/vendor-response";
 import type { VendorUpdateRequest } from "@/shared/types/vendor/vendor-update-request";
 
-interface Props {
+export interface VendorFormProps {
   /** When provided the form is in edit mode; absent = create. */
   vendor?: VendorResponse;
   onClose: () => void;
@@ -112,7 +112,7 @@ export default function VendorForm({
   onClose,
   onCreated,
   onUpdated,
-}: Props) {
+}: VendorFormProps) {
   const [createVendor, { isLoading: isCreating }] = useCreateVendorMutation();
   const [updateVendor, { isLoading: isUpdating }] = useUpdateVendorMutation();
 

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorPreferredToggle.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorPreferredToggle.tsx
@@ -1,7 +1,7 @@
 import { Star } from "lucide-react";
 import { cn } from "@/shared/utils/cn";
 
-interface Props {
+export interface VendorPreferredToggleProps {
   value: boolean;
   onChange: (next: boolean) => void;
 }
@@ -11,7 +11,7 @@ interface Props {
  * the same 44px touch target as the category chips so the two filters feel
  * paired. ``aria-pressed`` reflects state for screen readers.
  */
-export default function VendorPreferredToggle({ value, onChange }: Props) {
+export default function VendorPreferredToggle({ value, onChange }: VendorPreferredToggleProps) {
   return (
     <button
       type="button"

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorRow.tsx
@@ -4,7 +4,7 @@ import { formatRelativeTime } from "@/shared/lib/inquiry-date-format";
 import type { VendorSummary } from "@/shared/types/vendor/vendor-summary";
 import VendorCategoryBadge from "./VendorCategoryBadge";
 
-interface Props {
+export interface VendorRowProps {
   vendor: VendorSummary;
   showCategoryBadge: boolean;
 }
@@ -25,7 +25,7 @@ function formatLastUsed(lastUsedAt: string | null): string {
  * Desktop table row for the Vendors rolodex. Click anywhere navigates to
  * the detail page.
  */
-export default function VendorRow({ vendor, showCategoryBadge }: Props) {
+export default function VendorRow({ vendor, showCategoryBadge }: VendorRowProps) {
   const navigate = useNavigate();
 
   return (

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorsListSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorsListSkeleton.tsx
@@ -1,6 +1,6 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
 
-interface Props {
+export interface VendorsListSkeletonProps {
   count?: number;
 }
 
@@ -13,7 +13,7 @@ interface Props {
  *   - Desktop: same 4 columns (Name, Category, Hourly Rate, Last Used) and
  *     same number of skeleton rows.
  */
-export default function VendorsListSkeleton({ count = 4 }: Props) {
+export default function VendorsListSkeleton({ count = 4 }: VendorsListSkeletonProps) {
   const rows = Array.from({ length: count }, (_, i) => i);
 
   return (

--- a/apps/mybookkeeper/frontend/src/shared/components/ErrorBoundary.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 import { Component, type ReactNode } from "react";
 
-interface Props {
+export interface ErrorBoundaryProps {
   children: ReactNode;
 }
 
@@ -8,7 +8,7 @@ interface State {
   error: Error | null;
 }
 
-export default class ErrorBoundary extends Component<Props, State> {
+export default class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
   state: State = { error: null };
 
   static getDerivedStateFromError(error: Error): State {

--- a/apps/mybookkeeper/frontend/src/shared/components/HealthBanner.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/HealthBanner.tsx
@@ -2,11 +2,11 @@ import { Link } from "react-router-dom";
 import { AlertTriangle, AlertCircle } from "lucide-react";
 import type { HealthSummary } from "@/shared/types/health/health-summary";
 
-interface Props {
+export interface HealthBannerProps {
   status: Exclude<HealthSummary["status"], "healthy">;
 }
 
-export default function HealthBanner({ status }: Props) {
+export default function HealthBanner({ status }: HealthBannerProps) {
   const isDegraded = status === "degraded";
 
   return (

--- a/apps/mybookkeeper/frontend/src/shared/components/PageErrorBoundary.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/PageErrorBoundary.tsx
@@ -3,7 +3,7 @@ import { Coffee, ChevronDown, ChevronUp, Copy, Home, RotateCcw } from "lucide-re
 import Button from "@/shared/components/ui/Button";
 import api from "@/shared/lib/api";
 
-interface Props {
+export interface PageErrorBoundaryProps {
   children: ReactNode;
 }
 
@@ -90,7 +90,7 @@ function PageErrorFallback({
   );
 }
 
-export default class PageErrorBoundary extends Component<Props, State> {
+export default class PageErrorBoundary extends Component<PageErrorBoundaryProps, State> {
   state: State = { error: null };
 
   static getDerivedStateFromError(error: Error): State {

--- a/apps/mybookkeeper/frontend/src/shared/components/PropertyMultiSelect.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/PropertyMultiSelect.tsx
@@ -2,7 +2,7 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { ChevronDown } from "lucide-react";
 import type { Property } from "@/shared/types/property/property";
 
-interface Props {
+export interface PropertyMultiSelectProps {
   properties: Property[];
   selectedIds: string[];
   onChange: (ids: string[]) => void;
@@ -18,7 +18,7 @@ function getTriggerLabel(properties: Property[], selectedIds: string[]): string 
   return `${selectedIds.length} properties`;
 }
 
-export default function PropertyMultiSelect({ properties, selectedIds, onChange, maxSelected }: Props) {
+export default function PropertyMultiSelect({ properties, selectedIds, onChange, maxSelected }: PropertyMultiSelectProps) {
   function handleCheck(id: string, checked: boolean) {
     if (checked) {
       if (maxSelected !== undefined && selectedIds.length >= maxSelected) return;

--- a/apps/mybookkeeper/frontend/src/shared/components/RequireOrg.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/RequireOrg.tsx
@@ -10,11 +10,11 @@ import type { ApiError } from "@/shared/types/api-error";
 import Skeleton from "@/shared/components/ui/Skeleton";
 import CreateOrgPrompt from "@/app/features/organizations/CreateOrgPrompt";
 
-interface Props {
+export interface RequireOrgProps {
   children: React.ReactNode;
 }
 
-export default function RequireOrg({ children }: Props) {
+export default function RequireOrg({ children }: RequireOrgProps) {
   const dispatch = useDispatch<AppDispatch>();
   const {
     data: orgs,

--- a/apps/mybookkeeper/frontend/src/shared/components/RequireOrgRole.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/RequireOrgRole.tsx
@@ -2,12 +2,12 @@ import { Navigate } from "react-router-dom";
 import type { OrgRole } from "@/shared/types/organization/org-role";
 import { useOrgRole } from "@/shared/hooks/useOrgRole";
 
-interface Props {
+export interface RequireOrgRoleProps {
   roles: OrgRole[];
   children: React.ReactNode;
 }
 
-export default function RequireOrgRole({ roles, children }: Props) {
+export default function RequireOrgRole({ roles, children }: RequireOrgRoleProps) {
   const currentRole = useOrgRole();
 
   if (!currentRole) {

--- a/apps/mybookkeeper/frontend/src/shared/components/icons/ChevronDown.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/icons/ChevronDown.tsx
@@ -1,8 +1,8 @@
-interface Props {
+export interface ChevronDownProps {
   className?: string;
 }
 
-export default function ChevronDown({ className = "h-4 w-4" }: Props) {
+export default function ChevronDown({ className = "h-4 w-4" }: ChevronDownProps) {
   return (
     <svg
       className={className}

--- a/apps/mybookkeeper/frontend/src/shared/components/icons/ExternalLink.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/icons/ExternalLink.tsx
@@ -1,8 +1,8 @@
-interface Props {
+export interface ExternalLinkProps {
   className?: string;
 }
 
-export default function ExternalLink({ className = "h-3 w-3" }: Props) {
+export default function ExternalLink({ className = "h-3 w-3" }: ExternalLinkProps) {
   return (
     <svg
       className={className}

--- a/apps/mybookkeeper/frontend/src/shared/components/icons/RetryIcon.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/icons/RetryIcon.tsx
@@ -1,8 +1,8 @@
-interface Props {
+export interface RetryIconProps {
   className?: string;
 }
 
-export default function RetryIcon({ className = "h-4 w-4" }: Props) {
+export default function RetryIcon({ className = "h-4 w-4" }: RetryIconProps) {
   return (
     <svg
       className={className}

--- a/apps/mybookkeeper/frontend/src/shared/components/icons/Spinner.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/icons/Spinner.tsx
@@ -1,8 +1,8 @@
-interface Props {
+export interface SpinnerProps {
   className?: string;
 }
 
-export default function Spinner({ className = "h-4 w-4" }: Props) {
+export default function Spinner({ className = "h-4 w-4" }: SpinnerProps) {
   return (
     <svg className={`animate-spin ${className}`} viewBox="0 0 24 24" fill="none">
       <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />

--- a/apps/mybookkeeper/frontend/src/shared/components/table/ColumnFilter.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/table/ColumnFilter.tsx
@@ -2,13 +2,13 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { type Column } from "@tanstack/react-table";
 import { Filter, X } from "lucide-react";
 
-interface Props<TData = unknown> {
+export interface ColumnFilterProps<TData = unknown> {
   column: Column<TData, unknown>;
   options?: { value: string; label: string }[];
   enableDateRange?: boolean;
 }
 
-export default function ColumnFilter<TData = unknown>({ column, options, enableDateRange }: Props<TData>) {
+export default function ColumnFilter<TData = unknown>({ column, options, enableDateRange }: ColumnFilterProps<TData>) {
   if (enableDateRange) {
     return <DateRangeFilter column={column} />;
   }

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/Badge.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/Badge.tsx
@@ -1,6 +1,6 @@
 export type BadgeColor = "gray" | "blue" | "yellow" | "orange" | "green" | "red" | "purple";
 
-interface Props {
+export interface BadgeProps {
   label: string;
   color: BadgeColor;
 }
@@ -15,7 +15,7 @@ const COLOR_CLASSES: Record<BadgeColor, string> = {
   purple: "bg-purple-100 text-purple-700 dark:bg-purple-900 dark:text-purple-300",
 };
 
-export default function Badge({ label, color }: Props) {
+export default function Badge({ label, color }: BadgeProps) {
   return (
     <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${COLOR_CLASSES[color]}`}>
       {label}

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/Button.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/Button.tsx
@@ -3,14 +3,14 @@ import { cn } from "@/shared/utils/cn";
 type Variant = "primary" | "secondary" | "ghost" | "destructive" | "link";
 type Size = "md" | "sm";
 
-interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: Variant;
   size?: Size;
 }
 
 const isBlock = (v: Variant) => v === "primary" || v === "secondary";
 
-export default function Button({ variant = "primary", size = "md", className, ...props }: Props) {
+export default function Button({ variant = "primary", size = "md", className, ...props }: ButtonProps) {
   return (
     <button
       className={cn(

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/Card.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/Card.tsx
@@ -1,12 +1,12 @@
 import { cn } from "@/shared/utils/cn";
 
-interface Props {
+export interface CardProps {
   title?: string;
   children: React.ReactNode;
   className?: string;
 }
 
-export default function Card({ title, children, className }: Props) {
+export default function Card({ title, children, className }: CardProps) {
   return (
     <div className={cn("bg-card border rounded-lg p-6", className)}>
       {title ? <h2 className="text-base font-medium mb-4">{title}</h2> : null}

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/ConfirmDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/ConfirmDialog.tsx
@@ -1,7 +1,7 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import Button from "./Button";
 
-interface Props {
+export interface ConfirmDialogProps {
   open: boolean;
   title: string;
   description: string;
@@ -25,7 +25,7 @@ export default function ConfirmDialog({
   onConfirm,
   onCancel,
   children,
-}: Props) {
+}: ConfirmDialogProps) {
   return (
     <Dialog.Root open={open} onOpenChange={(isOpen) => { if (!isOpen) onCancel(); }}>
       <Dialog.Portal>

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/CopyField.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/CopyField.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
 import { Check, Copy } from "lucide-react";
 
-interface Props {
+export interface CopyFieldProps {
   label: string;
   value: string;
 }
 
-export default function CopyField({ label, value }: Props) {
+export default function CopyField({ label, value }: CopyFieldProps) {
   const [copied, setCopied] = useState(false);
 
   async function handleCopy() {

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/EmptyState.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/EmptyState.tsx
@@ -1,9 +1,9 @@
-interface Props {
+export interface EmptyStateProps {
   message: string;
   action?: { label: string; onClick: () => void };
 }
 
-export default function EmptyState({ message, action }: Props) {
+export default function EmptyState({ message, action }: EmptyStateProps) {
   return (
     <div className="text-center text-muted-foreground text-sm py-8">
       <p>{message}</p>

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/FormField.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/FormField.tsx
@@ -1,4 +1,4 @@
-interface Props {
+export interface FormFieldProps {
   label: string;
   required?: boolean;
   highlight?: boolean;
@@ -6,7 +6,7 @@ interface Props {
   children: React.ReactNode;
 }
 
-export default function FormField({ label, required, highlight, dirty, children }: Props) {
+export default function FormField({ label, required, highlight, dirty, children }: FormFieldProps) {
   return (
     <div>
       <label className="flex items-center gap-1.5 text-xs font-medium mb-1">

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/IndeterminateCheckbox.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/IndeterminateCheckbox.tsx
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from "react";
 
-interface Props {
+export interface IndeterminateCheckboxProps {
   checked: boolean;
   indeterminate?: boolean;
   onChange?: React.ChangeEventHandler<HTMLInputElement>;
@@ -8,7 +8,7 @@ interface Props {
   "aria-label"?: string;
 }
 
-export default function IndeterminateCheckbox({ checked, indeterminate, onChange, onClick, "aria-label": ariaLabel }: Props) {
+export default function IndeterminateCheckbox({ checked, indeterminate, onChange, onClick, "aria-label": ariaLabel }: IndeterminateCheckboxProps) {
   const ref = useRef<HTMLInputElement>(null);
   useEffect(() => {
     if (ref.current) ref.current.indeterminate = !!indeterminate;

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/LoadingButton.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/LoadingButton.tsx
@@ -1,7 +1,7 @@
 import Button from "@/shared/components/ui/Button";
 import Spinner from "@/shared/components/icons/Spinner";
 
-interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+export interface LoadingButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   isLoading?: boolean;
   loadingText?: string;
   variant?: "primary" | "secondary" | "ghost" | "destructive" | "link";
@@ -16,7 +16,7 @@ export default function LoadingButton({
   children,
   disabled,
   ...props
-}: Props) {
+}: LoadingButtonProps) {
   return (
     <Button variant={variant} size={size} disabled={disabled || isLoading} {...props}>
       {isLoading ? (

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/LoadingState.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/LoadingState.tsx
@@ -1,9 +1,9 @@
-interface Props {
+export interface LoadingStateProps {
   text?: string;
   fullHeight?: boolean;
 }
 
-export default function LoadingState({ text = "Loading...", fullHeight = false }: Props) {
+export default function LoadingState({ text = "Loading...", fullHeight = false }: LoadingStateProps) {
   if (fullHeight) {
     return (
       <div className="h-full flex items-center justify-center">

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/Panel.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/Panel.tsx
@@ -4,14 +4,14 @@ import { Drawer } from "vaul";
 import { useKeyboardClose } from "@/shared/hooks/useKeyboardClose";
 import { useMediaQuery } from "@/shared/hooks/useMediaQuery";
 
-interface Props {
+export interface PanelProps {
   position: "right" | "center";
   width?: string;
   onClose: () => void;
   children: React.ReactNode;
 }
 
-export default function Panel({ position, width, onClose, children }: Props) {
+export default function Panel({ position, width, onClose, children }: PanelProps) {
   useKeyboardClose(onClose);
   const isMobile = useMediaQuery("(max-width: 768px)");
 

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/SectionHeader.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/SectionHeader.tsx
@@ -1,10 +1,10 @@
-interface Props {
+export interface SectionHeaderProps {
   title: string;
   subtitle?: React.ReactNode;
   actions?: React.ReactNode;
 }
 
-export default function SectionHeader({ title, subtitle, actions }: Props) {
+export default function SectionHeader({ title, subtitle, actions }: SectionHeaderProps) {
   return (
     <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
       <div className="min-w-0">

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/Select.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/Select.tsx
@@ -1,11 +1,11 @@
 import { forwardRef } from "react";
 import { cn } from "@/shared/utils/cn";
 
-interface Props extends React.SelectHTMLAttributes<HTMLSelectElement> {
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {
   children: React.ReactNode;
 }
 
-const Select = forwardRef<HTMLSelectElement, Props>(
+const Select = forwardRef<HTMLSelectElement, SelectProps>(
   ({ className, children, ...props }, ref) => {
     return (
       <select

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/Skeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/Skeleton.tsx
@@ -1,8 +1,8 @@
-interface Props {
+export interface SkeletonProps {
   className?: string;
 }
 
-export default function Skeleton({ className = "h-4 w-full" }: Props) {
+export default function Skeleton({ className = "h-4 w-full" }: SkeletonProps) {
   return (
     <div className={`animate-pulse rounded bg-muted ${className}`} />
   );

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/SourceBadge.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/SourceBadge.tsx
@@ -66,7 +66,7 @@ const SOURCE_META: Record<Source, SourceMeta> = {
   },
 };
 
-interface Props {
+export interface SourceBadgeProps {
   source: Source;
   variant?: "full" | "short";
   className?: string;
@@ -76,7 +76,7 @@ interface Props {
  * Color + icon badge for inquiry/listing sources. Used across listings,
  * inquiries, and applicants per RENTALS_PLAN.md §9.2.
  */
-export default function SourceBadge({ source, variant = "full", className = "" }: Props) {
+export default function SourceBadge({ source, variant = "full", className = "" }: SourceBadgeProps) {
   const meta = SOURCE_META[source];
   const label = variant === "short" ? meta.shortLabel : meta.fullLabel;
   const Icon = meta.Icon;

--- a/apps/mybookkeeper/frontend/src/shared/components/ui/TilePicker.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/components/ui/TilePicker.tsx
@@ -6,14 +6,14 @@ export interface TileOption {
   description: string;
 }
 
-interface Props {
+export interface TilePickerProps {
   options: TileOption[];
   value: string;
   onChange: (value: string) => void;
   columns?: 1 | 2;
 }
 
-export default function TilePicker({ options, value, onChange, columns = 1 }: Props) {
+export default function TilePicker({ options, value, onChange, columns = 1 }: TilePickerProps) {
   return (
     <div className={cn("grid gap-3", columns === 2 ? "grid-cols-1 sm:grid-cols-2" : "grid-cols-1")}>
       {options.map((option) => {


### PR DESCRIPTION
## Summary

- **196 files** renamed in `apps/mybookkeeper/frontend/src/`
- Every `interface Props` → `export interface <ComponentName>Props` (component name matches the file's default export)
- Local usages updated in the same file (`: Props` → `: <ComponentName>Props`, generic `<Props>` usages, intersection types)
- No logic changes, no behavioral changes, no styling changes

## Why

Per the global config rule (jkwon-claude-config #92, merged 2026-05-04), props interfaces must be:
1. **Domain-prefixed** — two `Props` types imported into the same file collide silently
2. **Exported** — so consuming components/tests can reference the type without duplicating it

This was logged as a tech debt entry in `apps/mybookkeeper/TECH_DEBT.md`:
> "[Frontend] Bare `interface Props` across ~199 frontend component files"

## Scope

- `apps/mybookkeeper/frontend/src/**/*.tsx` and `*.ts`
- Skipped: `__tests__/`, `.d.ts`, `.stories.` files
- MJH (`apps/myjobhunter/`) was intentionally excluded

## Verification

- `tsc --noEmit` from `apps/mybookkeeper/frontend/` exits 0 (clean)
- Unit test suite: 44 failures / 1442 passes — identical to main (pre-existing failures unrelated to this change)
  - `useGetInviteInfoQuery` mock mismatch in members API tests — pre-existing
  - Tooltip `title` attribute assertions — pre-existing
- Zero remaining `^interface Props\b` declarations in scope

## Irregular files

None. All 196 files had a clear `export default function <Name>` or `export default <Name>` that was used as the component name. No anonymous exports, no files with multiple components.

## Tech debt

`apps/mybookkeeper/TECH_DEBT.md` entry marked as resolved in the follow-up commit on this branch.

## Merge conflict note

This PR touches 196 files. Any in-flight branch that also modified component files will have conflicts on the `interface Props` / `export interface <Name>Props` line. Conflicts are trivial to resolve (accept the new name from this PR). Recommend merging this before other in-flight feature PRs land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)