### PR TITLE
infra: MBK consumes shared MinIO from infra/ (PR B)

### DIFF
--- a/apps/mybookkeeper/backend/.env.docker.example
+++ b/apps/mybookkeeper/backend/.env.docker.example
@@ -19,8 +19,10 @@ OAUTH_REDIRECT_URI=https://your-domain.com/api/integrations/gmail/callback
 GOOGLE_OAUTH_REDIRECT_URI=https://your-domain.com/api/integrations/gmail/callback
 RUN_UPLOAD_WORKER=false
 
-# MinIO storage — see deploy/MINIO_SETUP.md
-MINIO_ENDPOINT=minio:9000
+# MinIO storage — points at the SHARED infra/ stack's container.
+# Bring up the infra stack first: docker compose -f infra/docker-compose.yml up -d
+# See infra/MIGRATION.md for the migration runbook.
+MINIO_ENDPOINT=myfreeapps-minio:9000
 MINIO_PUBLIC_ENDPOINT=https://storage.your-domain.com
 MINIO_ACCESS_KEY=
 MINIO_SECRET_KEY=

--- a/apps/mybookkeeper/docker-compose.yml
+++ b/apps/mybookkeeper/docker-compose.yml
@@ -14,35 +14,6 @@ services:
       timeout: 3s
       retries: 5
 
-  minio:
-    # SHA-pinned via tag — verified against Docker Hub on 2026-04-26.
-    # Tag check: gh api hub.docker.com/v2/repositories/minio/minio/tags/<tag>
-    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-    container_name: mybookkeeper-minio
-    restart: unless-stopped
-    ports:
-      # Bind only to localhost — the docker-network Caddy is the single
-      # public route to the storage subdomain. SSH tunnel for the console.
-      - "127.0.0.1:9000:9000"
-      - "127.0.0.1:9001:9001"
-    volumes:
-      - minio_data:/data
-    environment:
-      # Dev defaults — production OVERRIDES these via /srv/myfreeapps/.env.
-      # Never use these credentials in production: see deploy/MINIO_SETUP.md.
-      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
-      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
-      MINIO_KMS_AUTO_ENCRYPTION: "on"
-      MINIO_KMS_SECRET_KEY: ${MINIO_KMS_SECRET_KEY:-key1:V0VBSyBERVYgS0VZIC0gUkVQTEFDRSBJTiBQUk9EICAgIA==}
-      MINIO_BROWSER_REDIRECT_URL: ${MINIO_BROWSER_URL:-http://localhost:9001}
-    command: server /data --console-address ":9001"
-    healthcheck:
-      test: ["CMD-SHELL", "mc ready local || exit 1"]
-      interval: 30s
-      timeout: 10s
-      retries: 3
-      start_period: 30s
-
   migrate:
     build:
       # Build context is the monorepo root so the image can pull in
@@ -70,7 +41,12 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
       RUN_UPLOAD_WORKER: "false"
-      # MinIO connection — sourced from root .env (same place the minio service reads from)
+      # MinIO connection — points at the shared infra/ stack's
+      # ``myfreeapps-minio`` container reachable via the shared
+      # ``myfreeapps`` external network. ``MINIO_ENDPOINT`` should be
+      # ``myfreeapps-minio:9000`` (set in /srv/myfreeapps/apps/mybookkeeper/.env
+      # on the VPS); ``MINIO_PUBLIC_ENDPOINT`` is the public URL the
+      # browser uses for presigned downloads.
       MINIO_ENDPOINT: ${MINIO_ENDPOINT}
       MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-${MINIO_ROOT_USER}}
@@ -80,8 +56,9 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
-      minio:
-        condition: service_healthy
+    networks:
+      - default
+      - myfreeapps
     healthcheck:
       test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
       interval: 10s
@@ -103,6 +80,9 @@ services:
     depends_on:
       migrate:
         condition: service_completed_successfully
+    networks:
+      - default
+      - myfreeapps
 
   scheduler:
     build:
@@ -141,9 +121,20 @@ services:
     depends_on:
       api:
         condition: service_healthy
+    networks:
+      - default
+      - myfreeapps
 
 volumes:
   pg_data:
   caddy_data:
   caddy_config:
-  minio_data:
+
+networks:
+  # Per-app default network for postgres + migrate + workers.
+  default:
+  # Shared external network owned by infra/docker-compose.yml — joined
+  # by services that need to reach myfreeapps-minio. Bring up the infra
+  # stack first or compose-up will fail with "network myfreeapps not found".
+  myfreeapps:
+    external: true

--- a/infra/migrate-to-shared-minio.sh
+++ b/infra/migrate-to-shared-minio.sh
@@ -76,14 +76,45 @@ require_cmd() {
 # ──────────────────────────────────────────────────────────────────────────
 if [[ "$ROLLBACK" == "1" ]]; then
   yellow "Rolling back to per-app MinIO."
-  blue "Step 1/3: bringing down shared infra stack"
+
+  # Step 1: bring down the shared infra stack (frees port 9000 + the
+  # myfreeapps network).
+  blue "Step 1/5: bringing down shared infra stack"
   if [[ -f "$INFRA_COMPOSE" ]]; then
-    docker compose -f "$INFRA_COMPOSE" down || true
+    docker compose -f "$INFRA_COMPOSE" down --remove-orphans || true
   fi
-  blue "Step 2/3: bringing MBK back up against original volume"
+
+  # Step 2: bring MBK FULLY down. Without --remove-orphans, the
+  # ``mybookkeeper-minio`` container can survive from a previous partial
+  # run while the api / caddy / etc are recreated on a fresh
+  # ``mybookkeeper_default`` network — the new api then can't resolve
+  # the hostname ``minio``. We hit this exact failure on 2026-05-04.
+  blue "Step 2/5: bringing MBK fully down (clears stale networks + containers)"
+  docker compose -f "$MBK_COMPOSE" down --remove-orphans || true
+
+  # Step 3: restore MINIO_ENDPOINT in the env file if a forward run
+  # had rewritten it (idempotent — does nothing if already on the
+  # original value).
+  blue "Step 3/5: restoring MBK env if needed"
+  if [[ -f "$MBK_ENV_FILE" ]]; then
+    if [[ -f "${MBK_ENV_FILE}.bak" ]]; then
+      mv "${MBK_ENV_FILE}.bak" "$MBK_ENV_FILE"
+      green "  restored from ${MBK_ENV_FILE}.bak"
+    elif grep -q "^MINIO_ENDPOINT=myfreeapps-minio:9000$" "$MBK_ENV_FILE"; then
+      sed -i 's|^MINIO_ENDPOINT=myfreeapps-minio:9000$|MINIO_ENDPOINT=minio:9000|' "$MBK_ENV_FILE"
+      green "  reverted MINIO_ENDPOINT to minio:9000"
+    else
+      yellow "  no env rewrite to undo"
+    fi
+  fi
+
+  # Step 4: clean restart — every container joins the same fresh network.
+  blue "Step 4/5: bringing MBK back up against original volume"
   docker compose -f "$MBK_COMPOSE" up -d
-  blue "Step 3/3: verifying MBK is healthy"
-  sleep 5
+
+  # Step 5: wait for health.
+  blue "Step 5/5: verifying MBK is healthy"
+  sleep 15
   docker compose -f "$MBK_COMPOSE" ps
   green "Rollback complete. ${OLD_VOLUME} is intact and serving MBK again."
   exit 0

--- a/infra/migrate-to-shared-minio.sh
+++ b/infra/migrate-to-shared-minio.sh
@@ -192,6 +192,41 @@ fi
 green "  ${NEW_CONTAINER} is running"
 
 # ──────────────────────────────────────────────────────────────────────────
+# Pre-flight for step 6: MBK's compose MUST already point at
+# myfreeapps-minio (PR B). If MBK's compose still has its own minio
+# service, step 6 fails on a port-9000 collision (we hit this on
+# 2026-05-04 — see PR-B description). Detect early and refuse to proceed.
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 4.5/9: verifying MBK compose has been refactored to consume shared MinIO"
+if grep -qE "^[[:space:]]*minio:" "$MBK_COMPOSE"; then
+  red "  $MBK_COMPOSE still defines its own 'minio:' service."
+  red "  This means PR B (MBK consume shared MinIO) hasn't landed yet."
+  red "  Bringing MBK back up here would collide on port 9000 with the shared service."
+  red ""
+  red "  Recover with:  sudo bash $0 --rollback"
+  red "  Then merge the matching MBK-compose-refactor PR before re-running migration."
+  exit 1
+fi
+if ! grep -qE "myfreeapps:[[:space:]]*$" "$MBK_COMPOSE" && \
+   ! grep -qE "^networks:[[:space:]]*$" "$MBK_COMPOSE"; then
+  yellow "  warning: MBK compose may not be wired to the shared 'myfreeapps' network."
+  yellow "  api will fail to resolve myfreeapps-minio if so. Continuing — step 7 will catch it."
+fi
+green "  MBK compose looks refactored ✓"
+
+# Update MBK env to point at the shared service (idempotent — overwrites
+# the value if present, otherwise no-op).
+if [[ -f "$MBK_ENV_FILE" ]] && ! grep -q "^MINIO_ENDPOINT=myfreeapps-minio:9000$" "$MBK_ENV_FILE"; then
+  if grep -q "^MINIO_ENDPOINT=" "$MBK_ENV_FILE"; then
+    sed -i.bak 's|^MINIO_ENDPOINT=.*|MINIO_ENDPOINT=myfreeapps-minio:9000|' "$MBK_ENV_FILE"
+    green "  updated MINIO_ENDPOINT in $MBK_ENV_FILE (backup at ${MBK_ENV_FILE}.bak)"
+  else
+    echo "MINIO_ENDPOINT=myfreeapps-minio:9000" >> "$MBK_ENV_FILE"
+    green "  appended MINIO_ENDPOINT to $MBK_ENV_FILE"
+  fi
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
 # Step 5/9: verify data is readable from the new container
 # ──────────────────────────────────────────────────────────────────────────
 blue "Step 5/9: verifying data accessibility"


### PR DESCRIPTION
Required follow-up to PR #250. Without this, the migration script collides on port 9000 (we hit this on 2026-05-04). Migration script now refuses to proceed past step 4.5 if MBK compose still declares its own minio service. PR C (MJH joins shared network) ships next.