### PR TITLE
feat(mybookkeeper/listings): click-to-expand photo lightbox on listing detail page

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/listings-photo-lightbox.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/listings-photo-lightbox.spec.ts
@@ -1,0 +1,194 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * E2E tests for the photo lightbox on the Listing detail page.
+ *
+ * Strategy: seed a real listing via the test endpoint, then intercept the
+ * GET /api/listings/:id response to inject synthetic photo objects with
+ * data-URL presigned_urls (1×1 red pixel PNG). This avoids needing MinIO
+ * to be populated with real objects while still exercising the full lightbox
+ * UI flow in the browser.
+ */
+
+// 1×1 red pixel PNG as a data URL — stable across runs.
+const RED_PIXEL_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg==";
+const BLUE_PIXEL_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+interface SeedListingPayload {
+  property_id: string;
+  title?: string;
+  monthly_rate?: string;
+  status?: "active" | "paused" | "draft" | "archived";
+}
+
+async function seedListing(api: APIRequestContext, payload: SeedListingPayload): Promise<string> {
+  const res = await api.post("/test/seed-listing", { data: payload });
+  if (!res.ok()) {
+    throw new Error(`seedListing failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as { id: string };
+  return body.id;
+}
+
+async function deleteListing(api: APIRequestContext, listingId: string): Promise<void> {
+  await api.delete(`/test/listings/${listingId}`).catch(() => {});
+}
+
+test.describe("Photo lightbox (PR listings-photo-lightbox)", () => {
+  test("clicking a thumbnail opens the lightbox, arrows navigate, Escape closes", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const property = await createProperty(api, { name: `E2E Lightbox Property ${runId}` });
+    let listingId: string | null = null;
+
+    try {
+      listingId = await seedListing(api, {
+        property_id: property.id,
+        title: `E2E Lightbox Listing ${runId}`,
+        status: "active",
+      });
+
+      // Intercept the listing detail API response and inject two synthetic photos.
+      await page.route(`**/api/listings/${listingId}`, async (route) => {
+        const original = await route.fetch();
+        const body = (await original.json()) as Record<string, unknown>;
+
+        const fakePhotos = [
+          {
+            id: "fake-photo-1",
+            listing_id: listingId,
+            storage_key: "listings/fake/1.png",
+            caption: null,
+            display_order: 0,
+            created_at: new Date().toISOString(),
+            presigned_url: RED_PIXEL_PNG,
+          },
+          {
+            id: "fake-photo-2",
+            listing_id: listingId,
+            storage_key: "listings/fake/2.png",
+            caption: null,
+            display_order: 1,
+            created_at: new Date().toISOString(),
+            presigned_url: BLUE_PIXEL_PNG,
+          },
+        ];
+
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({ ...body, photos: fakePhotos }),
+        });
+      });
+
+      await page.goto(`/listings/${listingId}`);
+      await expect(page.getByRole("heading", { name: `E2E Lightbox Listing ${runId}` })).toBeVisible({
+        timeout: 10000,
+      });
+      await page.waitForLoadState("networkidle");
+
+      // The photo grid should show two cards.
+      const openButtons = page.getByTestId("listing-photo-open-button");
+      await expect(openButtons).toHaveCount(2);
+
+      // --- Open the lightbox on the first photo ---
+      await openButtons.first().click();
+      const backdrop = page.getByTestId("photo-lightbox-backdrop");
+      await expect(backdrop).toBeVisible();
+
+      // Lightbox shows the first image.
+      const img = page.getByTestId("photo-lightbox-image");
+      await expect(img).toBeVisible();
+      await expect(img).toHaveAttribute("src", RED_PIXEL_PNG);
+
+      // Counter shows 1 / 2.
+      await expect(page.getByTestId("photo-lightbox-counter")).toHaveText("1 / 2");
+
+      // No previous arrow on the first photo.
+      await expect(page.getByTestId("photo-lightbox-prev")).not.toBeVisible();
+      await expect(page.getByTestId("photo-lightbox-next")).toBeVisible();
+
+      // --- Navigate right with the arrow button ---
+      await page.getByTestId("photo-lightbox-next").click();
+      await expect(img).toHaveAttribute("src", BLUE_PIXEL_PNG);
+      await expect(page.getByTestId("photo-lightbox-counter")).toHaveText("2 / 2");
+
+      // Now on the last photo: no next arrow.
+      await expect(page.getByTestId("photo-lightbox-next")).not.toBeVisible();
+      await expect(page.getByTestId("photo-lightbox-prev")).toBeVisible();
+
+      // --- Navigate back with the keyboard arrow key ---
+      await page.keyboard.press("ArrowLeft");
+      await expect(img).toHaveAttribute("src", RED_PIXEL_PNG);
+      await expect(page.getByTestId("photo-lightbox-counter")).toHaveText("1 / 2");
+
+      // --- Close with Escape ---
+      await page.keyboard.press("Escape");
+      await expect(backdrop).not.toBeVisible();
+    } finally {
+      if (listingId) await deleteListing(api, listingId);
+      await deleteProperty(api, property.id);
+    }
+  });
+
+  test("clicking outside the image closes the lightbox", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const property = await createProperty(api, { name: `E2E Lightbox Click-Out ${runId}` });
+    let listingId: string | null = null;
+
+    try {
+      listingId = await seedListing(api, {
+        property_id: property.id,
+        title: `E2E Lightbox Click-Out Listing ${runId}`,
+        status: "active",
+      });
+
+      await page.route(`**/api/listings/${listingId}`, async (route) => {
+        const original = await route.fetch();
+        const body = (await original.json()) as Record<string, unknown>;
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            ...body,
+            photos: [
+              {
+                id: "fake-photo-only",
+                listing_id: listingId,
+                storage_key: "listings/fake/only.png",
+                caption: null,
+                display_order: 0,
+                created_at: new Date().toISOString(),
+                presigned_url: RED_PIXEL_PNG,
+              },
+            ],
+          }),
+        });
+      });
+
+      await page.goto(`/listings/${listingId}`);
+      await expect(page.getByRole("heading", { name: `E2E Lightbox Click-Out Listing ${runId}` })).toBeVisible({
+        timeout: 10000,
+      });
+      await page.waitForLoadState("networkidle");
+
+      await page.getByTestId("listing-photo-open-button").first().click();
+      await expect(page.getByTestId("photo-lightbox-backdrop")).toBeVisible();
+
+      // Click in the top-left corner of the backdrop (outside the centred image).
+      await page.mouse.click(5, 5);
+      await expect(page.getByTestId("photo-lightbox-backdrop")).not.toBeVisible();
+    } finally {
+      if (listingId) await deleteListing(api, listingId);
+      await deleteProperty(api, property.id);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/PhotoLightbox.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PhotoLightbox.test.tsx
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import PhotoLightbox from "@/app/features/listings/PhotoLightbox";
+import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
+
+function makePhoto(
+  id: string,
+  displayOrder: number,
+  presignedUrl: string | null = `https://storage.example.com/photo-${id}.jpg`,
+): ListingPhoto {
+  return {
+    id,
+    listing_id: "listing-1",
+    storage_key: `listings/listing-1/${id}.jpg`,
+    caption: null,
+    display_order: displayOrder,
+    created_at: "2026-01-01T00:00:00Z",
+    presigned_url: presignedUrl,
+  };
+}
+
+const THREE_PHOTOS: ListingPhoto[] = [
+  makePhoto("p1", 0),
+  makePhoto("p2", 1),
+  makePhoto("p3", 2),
+];
+
+describe("PhotoLightbox", () => {
+  let onClose: ReturnType<typeof vi.fn>;
+  let onNavigate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onClose = vi.fn();
+    onNavigate = vi.fn();
+  });
+
+  it("renders with the correct photo when opened at index 0", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    const img = screen.getByTestId("photo-lightbox-image");
+    expect(img).toHaveAttribute("src", "https://storage.example.com/photo-p1.jpg");
+    expect(screen.getByTestId("photo-lightbox-counter")).toHaveTextContent("1 / 3");
+  });
+
+  it("renders the counter correctly for middle photo", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={1}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(screen.getByTestId("photo-lightbox-counter")).toHaveTextContent("2 / 3");
+    const img = screen.getByTestId("photo-lightbox-image");
+    expect(img).toHaveAttribute("src", "https://storage.example.com/photo-p2.jpg");
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("photo-lightbox-close"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when clicking the backdrop outside the image", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("photo-lightbox-backdrop"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when Escape key is pressed", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={1}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onNavigate with next index when right arrow key is pressed", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    expect(onNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it("calls onNavigate with prev index when left arrow key is pressed", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={2}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "ArrowLeft" });
+    expect(onNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it("does not call onNavigate when pressing left on the first photo", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "ArrowLeft" });
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not call onNavigate when pressing right on the last photo", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={2}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("calls onNavigate when the next arrow button is clicked", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("photo-lightbox-next"));
+    expect(onNavigate).toHaveBeenCalledWith(1);
+  });
+
+  it("calls onNavigate when the prev arrow button is clicked", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={1}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId("photo-lightbox-prev"));
+    expect(onNavigate).toHaveBeenCalledWith(0);
+  });
+
+  it("hides the prev button on the first photo", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(screen.queryByTestId("photo-lightbox-prev")).not.toBeInTheDocument();
+    expect(screen.getByTestId("photo-lightbox-next")).toBeInTheDocument();
+  });
+
+  it("hides the next button on the last photo", () => {
+    render(
+      <PhotoLightbox
+        photos={THREE_PHOTOS}
+        currentIndex={2}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(screen.queryByTestId("photo-lightbox-next")).not.toBeInTheDocument();
+    expect(screen.getByTestId("photo-lightbox-prev")).toBeInTheDocument();
+  });
+
+  it("shows the unavailable state when presigned_url is null", () => {
+    const photos = [makePhoto("p1", 0, null)];
+    render(
+      <PhotoLightbox
+        photos={photos}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(screen.getByTestId("photo-lightbox-unavailable")).toBeInTheDocument();
+    expect(screen.queryByTestId("photo-lightbox-image")).not.toBeInTheDocument();
+  });
+
+  it("renders only one arrow when there are exactly 2 photos", () => {
+    const twoPhotos = [makePhoto("a", 0), makePhoto("b", 1)];
+    render(
+      <PhotoLightbox
+        photos={twoPhotos}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(screen.queryByTestId("photo-lightbox-prev")).not.toBeInTheDocument();
+    expect(screen.getByTestId("photo-lightbox-next")).toBeInTheDocument();
+  });
+
+  it("shows no arrows for a single photo", () => {
+    const singlePhoto = [makePhoto("only", 0)];
+    render(
+      <PhotoLightbox
+        photos={singlePhoto}
+        currentIndex={0}
+        onClose={onClose}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    expect(screen.queryByTestId("photo-lightbox-prev")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("photo-lightbox-next")).not.toBeInTheDocument();
+    expect(screen.getByTestId("photo-lightbox-counter")).toHaveTextContent("1 / 1");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoCard.tsx
@@ -6,9 +6,10 @@ import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
 export interface ListingPhotoCardProps {
   photo: ListingPhoto;
   onDelete: () => void;
+  onOpen: () => void;
 }
 
-export default function ListingPhotoCard({ photo, onDelete }: ListingPhotoCardProps) {
+export default function ListingPhotoCard({ photo, onDelete, onOpen }: ListingPhotoCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: photo.id });
 
@@ -28,15 +29,24 @@ export default function ListingPhotoCard({ photo, onDelete }: ListingPhotoCardPr
     >
       {/* Photo served via per-request presigned URL minted by the backend.
           Falls back to a labeled placeholder when storage is unavailable
-          (e.g., MinIO outage) so the page still renders the layout. */}
+          (e.g., MinIO outage) so the page still renders the layout.
+          Clicking opens the full-size lightbox viewer. */}
       {photo.presigned_url ? (
-        <img
-          src={photo.presigned_url}
-          alt={photo.caption ?? `Photo ${photo.display_order + 1}`}
-          loading="lazy"
-          className="aspect-square w-full object-cover bg-muted"
-          data-testid="listing-photo-thumbnail"
-        />
+        <button
+          type="button"
+          onClick={onOpen}
+          className="block w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`View photo ${photo.display_order + 1} full size`}
+          data-testid="listing-photo-open-button"
+        >
+          <img
+            src={photo.presigned_url}
+            alt={photo.caption ?? `Photo ${photo.display_order + 1}`}
+            loading="lazy"
+            className="aspect-square w-full object-cover bg-muted hover:opacity-90 transition-opacity"
+            data-testid="listing-photo-thumbnail"
+          />
+        </button>
       ) : (
         <div
           className="aspect-square bg-muted flex items-center justify-center text-xs text-muted-foreground"

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoManager.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoManager.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import {
   DndContext,
   closestCenter,
@@ -25,7 +25,9 @@ import {
   useUploadListingPhotosMutation,
 } from "@/shared/store/listingsApi";
 import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
+import type { PhotoLightboxTarget } from "@/shared/types/listing/photo-lightbox-target";
 import ListingPhotoCard from "@/app/features/listings/ListingPhotoCard";
+import PhotoLightbox from "@/app/features/listings/PhotoLightbox";
 
 export interface ListingPhotoManagerProps {
   listingId: string;
@@ -60,7 +62,12 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
   const [updatePhoto] = useUpdateListingPhotoMutation();
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [orderedIds, setOrderedIds] = useState<string[] | null>(null);
+  const [lightboxTarget, setLightboxTarget] = useState<PhotoLightboxTarget | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleLightboxNavigate = useCallback((nextIndex: number) => {
+    setLightboxTarget({ listingId, index: nextIndex });
+  }, [listingId]);
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -182,7 +189,7 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
               className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3"
               data-testid="listing-photo-grid"
             >
-              {displayIds.map((photoId) => {
+              {displayIds.map((photoId, index) => {
                 const photo = photosById.get(photoId);
                 if (!photo) return null;
                 return (
@@ -190,6 +197,7 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
                     key={photoId}
                     photo={photo}
                     onDelete={() => setConfirmDeleteId(photoId)}
+                    onOpen={() => setLightboxTarget({ listingId, index })}
                   />
                 );
               })}
@@ -208,6 +216,15 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
         onConfirm={handleConfirmDelete}
         onCancel={() => setConfirmDeleteId(null)}
       />
+
+      {lightboxTarget && (
+        <PhotoLightbox
+          photos={displayIds.map((id) => photosById.get(id)).filter((p): p is ListingPhoto => p !== undefined)}
+          currentIndex={lightboxTarget.index}
+          onClose={() => setLightboxTarget(null)}
+          onNavigate={handleLightboxNavigate}
+        />
+      )}
     </div>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/listings/PhotoLightbox.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/PhotoLightbox.tsx
@@ -1,0 +1,90 @@
+import { useCallback, useEffect } from "react";
+import { createPortal } from "react-dom";
+import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
+import PhotoLightboxImage from "./PhotoLightboxImage";
+import PhotoLightboxControls from "./PhotoLightboxControls";
+import { usePhotoLightboxMode } from "./usePhotoLightboxMode";
+
+export interface PhotoLightboxProps {
+  photos: readonly ListingPhoto[];
+  /** Index into `photos` of the currently displayed photo. */
+  currentIndex: number;
+  onClose: () => void;
+  onNavigate: (nextIndex: number) => void;
+}
+
+export default function PhotoLightbox({
+  photos,
+  currentIndex,
+  onClose,
+  onNavigate,
+}: PhotoLightboxProps) {
+  const photo = photos[currentIndex];
+  const mode = usePhotoLightboxMode({ presignedUrl: photo?.presigned_url });
+
+  const handlePrev = useCallback(() => {
+    if (currentIndex > 0) onNavigate(currentIndex - 1);
+  }, [currentIndex, onNavigate]);
+
+  const handleNext = useCallback(() => {
+    if (currentIndex < photos.length - 1) onNavigate(currentIndex + 1);
+  }, [currentIndex, photos.length, onNavigate]);
+
+  // Keyboard navigation: Escape closes, arrow keys navigate.
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.key === "Escape") {
+        onClose();
+      } else if (e.key === "ArrowLeft") {
+        handlePrev();
+      } else if (e.key === "ArrowRight") {
+        handleNext();
+      }
+    }
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [onClose, handlePrev, handleNext]);
+
+  if (!photo) return null;
+
+  const alt = photo.caption ?? `Photo ${currentIndex + 1}`;
+
+  return createPortal(
+    // Full-viewport dark backdrop — click outside the image to close.
+    <div
+      className="fixed inset-0 z-[70] bg-black/90 flex items-center justify-center"
+      onClick={onClose}
+      data-testid="photo-lightbox-backdrop"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Photo viewer"
+    >
+      {/* Content container — stops click propagation so clicking the image
+          itself does not close the modal. */}
+      <div
+        className="relative flex items-center justify-center"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {mode === "image" ? (
+          <PhotoLightboxImage src={photo.presigned_url!} alt={alt} />
+        ) : (
+          <div
+            className="text-white text-sm bg-black/60 rounded px-4 py-3"
+            data-testid="photo-lightbox-unavailable"
+          >
+            Photo unavailable
+          </div>
+        )}
+
+        <PhotoLightboxControls
+          currentIndex={currentIndex}
+          total={photos.length}
+          onClose={onClose}
+          onPrev={handlePrev}
+          onNext={handleNext}
+        />
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/listings/PhotoLightboxControls.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/PhotoLightboxControls.tsx
@@ -1,0 +1,71 @@
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+
+export interface PhotoLightboxControlsProps {
+  currentIndex: number;
+  total: number;
+  onClose: () => void;
+  onPrev: () => void;
+  onNext: () => void;
+}
+
+export default function PhotoLightboxControls({
+  currentIndex,
+  total,
+  onClose,
+  onPrev,
+  onNext,
+}: PhotoLightboxControlsProps) {
+  const hasPrev = currentIndex > 0;
+  const hasNext = currentIndex < total - 1;
+
+  return (
+    <>
+      {/* Close button — top-right */}
+      <button
+        type="button"
+        onClick={onClose}
+        className="absolute top-3 right-3 z-10 flex items-center justify-center rounded-full bg-black/60 hover:bg-black/80 text-white min-h-[44px] min-w-[44px] transition-colors"
+        aria-label="Close photo viewer"
+        data-testid="photo-lightbox-close"
+      >
+        <X size={20} />
+      </button>
+
+      {/* Image counter — bottom-center */}
+      <div
+        className="absolute bottom-3 left-1/2 -translate-x-1/2 z-10 rounded-full bg-black/60 text-white text-sm px-3 py-1 tabular-nums"
+        data-testid="photo-lightbox-counter"
+        aria-live="polite"
+        aria-label={`Photo ${currentIndex + 1} of ${total}`}
+      >
+        {currentIndex + 1} / {total}
+      </div>
+
+      {/* Prev arrow */}
+      {hasPrev && (
+        <button
+          type="button"
+          onClick={onPrev}
+          className="absolute left-3 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center rounded-full bg-black/60 hover:bg-black/80 text-white min-h-[44px] min-w-[44px] transition-colors"
+          aria-label="Previous photo"
+          data-testid="photo-lightbox-prev"
+        >
+          <ChevronLeft size={24} />
+        </button>
+      )}
+
+      {/* Next arrow */}
+      {hasNext && (
+        <button
+          type="button"
+          onClick={onNext}
+          className="absolute right-3 top-1/2 -translate-y-1/2 z-10 flex items-center justify-center rounded-full bg-black/60 hover:bg-black/80 text-white min-h-[44px] min-w-[44px] transition-colors"
+          aria-label="Next photo"
+          data-testid="photo-lightbox-next"
+        >
+          <ChevronRight size={24} />
+        </button>
+      )}
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/listings/PhotoLightboxImage.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/PhotoLightboxImage.tsx
@@ -1,0 +1,16 @@
+export interface PhotoLightboxImageProps {
+  src: string;
+  alt: string;
+}
+
+export default function PhotoLightboxImage({ src, alt }: PhotoLightboxImageProps) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className="max-w-[90vw] max-h-[90vh] object-contain select-none"
+      draggable={false}
+      data-testid="photo-lightbox-image"
+    />
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/listings/usePhotoLightboxMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/usePhotoLightboxMode.ts
@@ -1,0 +1,18 @@
+/**
+ * Discriminated union for the lightbox's current render state.
+ * Mirrors the DocumentViewMode pattern used in DocumentViewer.
+ */
+export type PhotoLightboxMode = "image" | "unavailable";
+
+export interface UsePhotoLightboxModeArgs {
+  presignedUrl: string | null | undefined;
+}
+
+/**
+ * Resolves the lightbox's render mode from the current photo's presigned URL.
+ * Separates the state-derivation logic from the rendering components.
+ */
+export function usePhotoLightboxMode({ presignedUrl }: UsePhotoLightboxModeArgs): PhotoLightboxMode {
+  if (!presignedUrl) return "unavailable";
+  return "image";
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/listing/photo-lightbox-target.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/listing/photo-lightbox-target.ts
@@ -1,0 +1,4 @@
+export interface PhotoLightboxTarget {
+  listingId: string;
+  index: number;
+}


### PR DESCRIPTION
## Summary

- Click any listing photo thumbnail → full-screen dark-backdrop lightbox opens with the full-size image
- Left/right arrow buttons (and keyboard arrow keys) navigate through the listing's photos in display order
- Image counter (e.g. \"3 / 12\") shown bottom-centre; close via X button, Escape key, or click outside the image
- Navigation index stays consistent with any drag-reorder the host applied in the same session
- Photos without a presigned URL (MinIO outage) gracefully show an \"unavailable\" state rather than crashing

## File layout (one component per file rule)

| File | Purpose |
|------|---------|
| `PhotoLightbox.tsx` | Top-level modal — `createPortal`, keyboard listener, mode dispatch |
| `PhotoLightboxImage.tsx` | `<img>` element with `max-w-[90vw] max-h-[90vh] object-contain` |
| `PhotoLightboxControls.tsx` | Close button + prev/next arrows + counter overlay |
| `usePhotoLightboxMode.ts` | Discriminated-union hook (`image \| unavailable`) — mirrors `useDocumentViewMode` pattern |
| `photo-lightbox-target.ts` | `PhotoLightboxTarget` interface — `{ listingId, index }` |
| `ListingPhotoCard.tsx` | +`onOpen` prop; wraps `<img>` in a `<button>` when `presigned_url` present |
| `ListingPhotoManager.tsx` | Wires `lightboxTarget` state; passes display-order-stable photo array to `PhotoLightbox` |

## Design notes

- Uses `createPortal` directly (not `Panel position="center"`) so the dark full-viewport overlay (`bg-black/90`) and absolutely-positioned arrow buttons work correctly without the Panel's white rounded-box constraints
- Navigation source of truth is `displayIds` (post-drag order) — not `sortedPhotos` — so the lightbox sequence matches what the host sees in the grid after reordering

## Test coverage

- **16 unit tests** (`PhotoLightbox.test.tsx`): opens at correct index, counter text, close button, click-backdrop, Escape key, ArrowLeft/ArrowRight keys, arrow button clicks, boundary clamping (no nav past first/last), unavailable state, edge cases (1 photo, 2 photos)
- **2 E2E tests** (`listings-photo-lightbox.spec.ts`): seeds real listing via test endpoint, intercepts `GET /api/listings/:id` to inject synthetic photos (data-URL PNGs — no MinIO required), then asserts: thumbnail clickable → lightbox opens → image src correct → counter correct → right arrow navigates → ArrowLeft key navigates back → Escape closes; second test asserts click-outside-closes

## What was NOT changed

- Backend: zero changes
- Photo upload / delete logic: unchanged
- Zoom / pinch / rotate: out of scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)