### PR TITLE
fix(mybookkeeper/inquiries): public form 404 — wrong /api router prefix

### DIFF
--- a/apps/mybookkeeper/backend/app/api/public_inquiries.py
+++ b/apps/mybookkeeper/backend/app/api/public_inquiries.py
@@ -13,6 +13,8 @@ doesn't require a logged-in user. Defense-in-depth lives in the service layer
 """
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 
 from app.core.config import settings
@@ -39,12 +41,23 @@ public_inquiry_limiter = RateLimiter(
     window_seconds=settings.inquiry_public_rate_limit_window_seconds,
 )
 
+logger = logging.getLogger(__name__)
+
 # Generic message returned on EVERY filter failure except the friendly
 # "tell us more" gate. Keeps anti-spam intel out of the response so an
 # attacker probing the form can't tell which check tripped.
 _GENERIC_REJECTION = "Something went wrong, please try again."
 
-router = APIRouter(prefix="/api", tags=["public-inquiries"])
+# NO ``prefix`` here. The frontend hits ``/api/listings/public/{slug}`` and
+# ``/api/inquiries/public``, but both production Caddy (``uri strip_prefix
+# /api``) and the Vite dev proxy (``rewrite: p.replace(/^\/api/, "")``) drop
+# the ``/api`` segment before the request reaches FastAPI. If we declared a
+# ``prefix="/api"`` on this router, the routes would resolve to
+# ``/api/listings/public/...`` inside the app, which the stripped requests
+# would never match — yielding the FastAPI default ``{"detail":"Not Found"}``
+# 404. (Bug shipped in PR #130; the original tests used TestClient and did
+# not exercise the strip-prefix, so the regression went undetected.)
+router = APIRouter(tags=["public-inquiries"])
 
 
 @router.get("/listings/public/{slug}", response_model=PublicListingResponse)
@@ -54,10 +67,25 @@ async def get_public_listing(slug: str) -> PublicListingResponse:
     Anyone with the slug can read the basic listing fields. Returns 404 for
     unknown / soft-deleted slugs — operators rotate slugs by archiving the
     listing, which automatically takes the form down.
+
+    On 404, logs a WARNING with the slug AND whether the slug exists in an
+    archived state. This lets the operator distinguish "host pasted a typo'd
+    URL into Airbnb" (slug never existed) from "host archived a listing whose
+    URL is still live in external descriptions" (slug exists but archived) —
+    without SSHing into the DB to triage every public-form 404.
     """
     async with AsyncSessionLocal() as db:
         listing = await listing_repo.get_by_slug(db, slug)
+        if listing is None:
+            archived_match = await listing_repo.slug_exists_including_archived(
+                db, slug,
+            )
     if listing is None:
+        logger.warning(
+            "public_listing.not_found slug=%r archived_match=%s",
+            slug,
+            archived_match,
+        )
         raise HTTPException(status_code=404, detail="Listing not found")
     return PublicListingResponse.model_validate(listing)
 

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -158,9 +158,10 @@ app.include_router(listings.router)
 app.include_router(listings.channels_router)
 app.include_router(listings.channel_listings_router)
 app.include_router(blackouts.router)
-# Calendar router declares its own ``/api`` prefix because the outbound
-# iCal URL must be unauthenticated and follow a stable channel-facing
-# path that does not depend on auth-router ordering.
+# Public iCal feed — unauthenticated, follows a stable channel-facing
+# path (``/calendar/{token}.ics``). Mounted separately from the
+# authenticated calendar viewer below so the two have independent
+# dependency stacks.
 app.include_router(calendar.router)
 # Authenticated unified calendar viewer — declared separately because it
 # has different auth/rate-limit needs from the public iCal feed above.
@@ -168,8 +169,10 @@ app.include_router(calendar.events_router)
 # Phase 2 — Gmail booking review queue.
 app.include_router(calendar.review_queue_router)
 app.include_router(inquiries.router)
-# Public inquiry form (T0) — unauthenticated; lives under /api so the Vite
-# dev proxy + Caddy production reverse proxy both forward it correctly.
+# Public inquiry form (T0) — unauthenticated. The router declares no prefix
+# because production Caddy (``uri strip_prefix /api``) and the Vite dev proxy
+# already drop the ``/api`` segment before requests reach FastAPI. See the
+# detailed comment in ``api/public_inquiries.py``.
 app.include_router(public_inquiries.router)
 app.include_router(applicants.router)
 app.include_router(lease_templates.router)

--- a/apps/mybookkeeper/backend/app/repositories/listings/listing_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/listings/listing_repo.py
@@ -69,6 +69,20 @@ async def get_by_slug(db: AsyncSession, slug: str) -> Listing | None:
     return result.scalar_one_or_none()
 
 
+async def slug_exists_including_archived(db: AsyncSession, slug: str) -> bool:
+    """Return True iff a listing with this slug exists (active OR soft-deleted).
+
+    Operator-diagnostic helper used by the public-inquiry route to log the
+    *reason* a 404 fired: was the slug typo'd into a never-existed value,
+    or did the host archive a still-published external link? Without this
+    distinction the operator has to SSH into the DB to triage every 404.
+    """
+    result = await db.execute(
+        select(Listing.id).where(Listing.slug == slug).limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
 async def list_by_organization(
     db: AsyncSession,
     organization_id: uuid.UUID,

--- a/apps/mybookkeeper/backend/tests/test_listing_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_listing_repo.py
@@ -623,6 +623,100 @@ class TestListingRepoSoftDelete:
         assert await listing_repo.get_by_id(db, listing.id, test_org.id) is not None
 
 
+class TestListingRepoGetBySlug:
+    """Cover the public-form lookup path. The slug itself is the capability —
+    no organization scope on this lookup."""
+
+    @pytest.mark.asyncio
+    async def test_returns_listing_for_active_slug(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _seed_property(db, test_org, test_user)
+        listing = _make_listing(
+            organization_id=test_org.id, user_id=test_user.id, property_id=prop.id,
+        )
+        listing.slug = "master-bedroom-abc123"
+        db.add(listing)
+        await db.commit()
+
+        result = await listing_repo.get_by_slug(db, "master-bedroom-abc123")
+        assert result is not None
+        assert result.id == listing.id
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_unknown_slug(
+        self, db: AsyncSession,
+    ) -> None:
+        result = await listing_repo.get_by_slug(db, "never-existed-zzz999")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_soft_deleted_slug(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _seed_property(db, test_org, test_user)
+        listing = _make_listing(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            deleted_at=datetime.now(timezone.utc),
+        )
+        listing.slug = "archived-listing-xyz789"
+        db.add(listing)
+        await db.commit()
+
+        result = await listing_repo.get_by_slug(db, "archived-listing-xyz789")
+        assert result is None
+
+
+class TestListingRepoSlugExistsIncludingArchived:
+    """The operator-diagnostic helper that lets the public route distinguish
+    'slug never existed' from 'slug archived' for log triage."""
+
+    @pytest.mark.asyncio
+    async def test_active_slug_returns_true(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _seed_property(db, test_org, test_user)
+        listing = _make_listing(
+            organization_id=test_org.id, user_id=test_user.id, property_id=prop.id,
+        )
+        listing.slug = "active-listing-aaa111"
+        db.add(listing)
+        await db.commit()
+
+        assert await listing_repo.slug_exists_including_archived(
+            db, "active-listing-aaa111",
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_archived_slug_returns_true(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        prop = await _seed_property(db, test_org, test_user)
+        listing = _make_listing(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            property_id=prop.id,
+            deleted_at=datetime.now(timezone.utc),
+        )
+        listing.slug = "archived-listing-bbb222"
+        db.add(listing)
+        await db.commit()
+
+        assert await listing_repo.slug_exists_including_archived(
+            db, "archived-listing-bbb222",
+        ) is True
+
+    @pytest.mark.asyncio
+    async def test_unknown_slug_returns_false(
+        self, db: AsyncSession,
+    ) -> None:
+        assert await listing_repo.slug_exists_including_archived(
+            db, "never-existed-ccc333",
+        ) is False
+
+
 class TestListingRepoCount:
     @pytest.mark.asyncio
     async def test_count_excludes_soft_deleted(

--- a/apps/mybookkeeper/backend/tests/test_public_inquiries_api.py
+++ b/apps/mybookkeeper/backend/tests/test_public_inquiries_api.py
@@ -1,11 +1,20 @@
 """HTTP route tests for the public inquiry form (T0).
 
+The browser-visible URLs are ``/api/listings/public/{slug}`` and
+``/api/inquiries/public``. The ``/api`` segment is stripped by Caddy /
+Vite *before* requests reach FastAPI, so the test client (which talks to
+FastAPI directly) hits the post-strip paths ``/listings/public/{slug}``
+and ``/inquiries/public``. This mirrors what the backend actually
+receives — see PR #<this-fix> for the prefix bug that motivated the
+URL change.
+
 Covers:
-- GET /api/listings/public/{slug} happy path + 404
-- POST /api/inquiries/public happy path returns generic 200 envelope
+- GET /listings/public/{slug} happy path + 404
+- POST /inquiries/public happy path returns generic 200 envelope
 - POST returns 400 on schema-validated invalid email
 - POST returns 400 with friendly message on short why_this_room
 - Honeypot fills returns 200 (fake success) — bot doesn't learn it was caught
+- Routes are NOT mounted under /api (regression guard for PR #<this-fix>)
 """
 from __future__ import annotations
 
@@ -50,12 +59,76 @@ def _valid_body(slug: str = "abc-123") -> dict:
 class TestPublicListingLookup:
     def test_unknown_slug_returns_404(self) -> None:
         client = TestClient(app)
-        with patch(
-            "app.api.public_inquiries.listing_repo.get_by_slug",
-            return_value=None,
+        with (
+            patch(
+                "app.api.public_inquiries.listing_repo.get_by_slug",
+                return_value=None,
+            ),
+            patch(
+                "app.api.public_inquiries.listing_repo.slug_exists_including_archived",
+                return_value=False,
+            ),
         ):
-            r = client.get("/api/listings/public/no-such-slug")
+            r = client.get("/listings/public/no-such-slug")
         assert r.status_code == 404
+        assert r.json() == {"detail": "Listing not found"}
+
+    def test_archived_slug_logs_archived_match_and_404s(
+        self,
+        caplog,
+    ) -> None:
+        # When the slug exists but the listing is soft-deleted, the route
+        # must still 404 (no leak of archived state to the public) but
+        # must log a WARNING so the operator can tell the host their
+        # external link is stale.
+        import logging
+        client = TestClient(app)
+        with (
+            patch(
+                "app.api.public_inquiries.listing_repo.get_by_slug",
+                return_value=None,
+            ),
+            patch(
+                "app.api.public_inquiries.listing_repo.slug_exists_including_archived",
+                return_value=True,
+            ),
+            caplog.at_level(logging.WARNING, logger="app.api.public_inquiries"),
+        ):
+            r = client.get("/listings/public/archived-slug-abc123")
+        assert r.status_code == 404
+        assert r.json() == {"detail": "Listing not found"}
+        # Operator-visibility log must say archived_match=True
+        assert any(
+            "public_listing.not_found" in rec.message
+            and "archived_match=True" in rec.message
+            and "archived-slug-abc123" in rec.message
+            for rec in caplog.records
+        ), f"Expected archived-slug warning; got: {[r.message for r in caplog.records]}"
+
+    def test_unknown_slug_logs_archived_match_false(
+        self,
+        caplog,
+    ) -> None:
+        import logging
+        client = TestClient(app)
+        with (
+            patch(
+                "app.api.public_inquiries.listing_repo.get_by_slug",
+                return_value=None,
+            ),
+            patch(
+                "app.api.public_inquiries.listing_repo.slug_exists_including_archived",
+                return_value=False,
+            ),
+            caplog.at_level(logging.WARNING, logger="app.api.public_inquiries"),
+        ):
+            r = client.get("/listings/public/never-existed")
+        assert r.status_code == 404
+        assert any(
+            "public_listing.not_found" in rec.message
+            and "archived_match=False" in rec.message
+            for rec in caplog.records
+        )
 
     def test_known_slug_returns_listing(self) -> None:
         from decimal import Decimal
@@ -83,7 +156,7 @@ class TestPublicListingLookup:
             "app.api.public_inquiries.listing_repo.get_by_slug",
             return_value=listing,
         ):
-            r = client.get("/api/listings/public/master-bedroom-abc123")
+            r = client.get("/listings/public/master-bedroom-abc123")
         assert r.status_code == 200
         body = r.json()
         assert body["title"] == "Master Bedroom"
@@ -108,7 +181,7 @@ class TestPublicInquirySubmission:
         with patch.object(
             public_inquiry_service, "submit_public_inquiry", side_effect=fake_submit,
         ):
-            r = client.post("/api/inquiries/public", json=_valid_body())
+            r = client.post("/inquiries/public", json=_valid_body())
         assert r.status_code == 200
         assert r.json() == {"status": "received"}
 
@@ -116,7 +189,7 @@ class TestPublicInquirySubmission:
         body = _valid_body()
         body["email"] = "not-a-real-email"
         client = TestClient(app)
-        r = client.post("/api/inquiries/public", json=body)
+        r = client.post("/inquiries/public", json=body)
         # Pydantic validation surfaces as 422; either way it's a hard rejection
         assert r.status_code in (400, 422)
 
@@ -128,7 +201,7 @@ class TestPublicInquirySubmission:
         with patch.object(
             public_inquiry_service, "submit_public_inquiry", side_effect=fake_submit,
         ):
-            r = client.post("/api/inquiries/public", json=_valid_body())
+            r = client.post("/inquiries/public", json=_valid_body())
         assert r.status_code == 404
 
     def test_short_why_returns_friendly_400(self) -> None:
@@ -139,7 +212,7 @@ class TestPublicInquirySubmission:
         with patch.object(
             public_inquiry_service, "submit_public_inquiry", side_effect=fake_submit,
         ):
-            r = client.post("/api/inquiries/public", json=_valid_body())
+            r = client.post("/inquiries/public", json=_valid_body())
         assert r.status_code == 400
         assert "tell us a bit more" in r.json()["detail"].lower()
 
@@ -151,7 +224,65 @@ class TestPublicInquirySubmission:
         with patch.object(
             public_inquiry_service, "submit_public_inquiry", side_effect=fake_submit,
         ):
-            r = client.post("/api/inquiries/public", json=_valid_body())
+            r = client.post("/inquiries/public", json=_valid_body())
         assert r.status_code == 400
         # Generic message — no anti-spam intel leaks
         assert r.json()["detail"] == "Something went wrong, please try again."
+
+
+class TestPublicInquiryRouting:
+    """Regression guard for the ``prefix="/api"`` bug shipped in PR #130.
+
+    Caddy / Vite strip ``/api`` from inbound URLs before they reach FastAPI.
+    If this router were declared with ``prefix="/api"``, the actual mounted
+    routes would live under ``/api/listings/public/...`` and ``/api/
+    inquiries/public`` — which the stripped requests would never match,
+    yielding the FastAPI default ``{"detail":"Not Found"}`` 404 in
+    production. These tests fail loudly if the prefix sneaks back in.
+    """
+
+    def test_router_has_no_api_prefix(self) -> None:
+        # Inspect the registered router directly — independent of ordering
+        # in main.py. If someone re-adds ``prefix="/api"`` here, this catches it.
+        for route in public_inquiries.router.routes:
+            path = getattr(route, "path", "")
+            assert not path.startswith("/api"), (
+                f"public_inquiries router must not declare a /api prefix; "
+                f"Caddy and the Vite proxy strip /api before requests reach "
+                f"FastAPI. Found offending route: {path}"
+            )
+
+    def test_listing_lookup_not_mounted_under_api_prefix(self) -> None:
+        # Sanity-check via the full app — confirms that hitting the route
+        # WITHOUT the /api prefix (i.e. what the backend actually receives
+        # in production) returns the application 404 message, while hitting
+        # WITH the /api prefix returns FastAPI's default unmatched-route 404.
+        client = TestClient(app)
+        with (
+            patch(
+                "app.api.public_inquiries.listing_repo.get_by_slug",
+                return_value=None,
+            ),
+            patch(
+                "app.api.public_inquiries.listing_repo.slug_exists_including_archived",
+                return_value=False,
+            ),
+        ):
+            unprefixed = client.get("/listings/public/anything")
+        prefixed = client.get("/api/listings/public/anything")
+        # Post-strip path resolves to the application route (custom message)
+        assert unprefixed.status_code == 404
+        assert unprefixed.json() == {"detail": "Listing not found"}
+        # Pre-strip path is genuinely unmounted (FastAPI default message)
+        assert prefixed.status_code == 404
+        assert prefixed.json() == {"detail": "Not Found"}
+
+    def test_inquiry_submit_not_mounted_under_api_prefix(self) -> None:
+        client = TestClient(app)
+        # POST /api/inquiries/public must NOT be a registered route.
+        # An unrelated route ``GET /inquiries/{inquiry_id}`` also exists
+        # (under ``inquiries.router``) — the request path here doesn't
+        # match it (different prefix), so we expect a hard 404 not a 405.
+        prefixed = client.post("/api/inquiries/public", json=_valid_body())
+        assert prefixed.status_code == 404
+        assert prefixed.json() == {"detail": "Not Found"}

--- a/apps/mybookkeeper/frontend/src/__tests__/PublicInquiryForm.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PublicInquiryForm.test.tsx
@@ -78,6 +78,17 @@ describe("PublicInquiryForm — listing rendering", () => {
     renderForm("does-not-exist");
     expect(await screen.findByText(/Listing not found/)).toBeInTheDocument();
   });
+
+  it("requests the public listing endpoint with the slug from the URL", async () => {
+    // Regression guard: the axios baseURL is "/api", so the frontend must
+    // call `/listings/public/<slug>` (NOT `/api/listings/public/<slug>`).
+    // Caddy strips the leading `/api` segment before requests reach the
+    // backend; re-introducing `/api/` here would 404 in production.
+    (api.get as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ data: mockListing });
+    renderForm("master-bedroom-abc123");
+    await screen.findByText(/Master Bedroom in Houston/);
+    expect(api.get).toHaveBeenCalledWith("/listings/public/master-bedroom-abc123");
+  });
 });
 
 describe("PublicInquiryForm — honeypot", () => {


### PR DESCRIPTION
## Summary

The public inquiry form at `/apply/<slug>` always returned "Listing not found" in production because `GET /api/listings/public/<slug>` returned `{"detail":"Not Found"}` (capital N, F — FastAPI default 404, distinct from the application's `Listing not found` message).

**Root cause:** `api/public_inquiries.py` declared its router with `APIRouter(prefix="/api", ...)`. Both production Caddy (`uri strip_prefix /api`) and the Vite dev proxy (`rewrite: p.replace(/^\/api/, "")`) strip the leading `/api` before requests reach FastAPI. With the prefix on the router, the actual mounted routes were `/api/listings/public/{slug}` and `/api/inquiries/public` — never matched by the post-strip requests.

The bug also broke `POST /inquiries/public` (form submission) — it returned 405 against `inquiries.router`'s `GET /inquiries/{inquiry_id}` instead of resolving correctly. So the form was unusable end-to-end since PR #130 shipped.

The original tests used FastAPI TestClient (which does not exercise the strip-prefix), so they passed green against the broken prefix.

**Fix:**
- Drop `prefix="/api"` from `public_inquiries.router`
- Update test URLs to match what the backend actually receives in production
- Add `TestPublicInquiryRouting` regression class — inspects the registered routes directly AND asserts the prefixed paths return FastAPI's default 404
- Add operator-diagnostic logging on every public 404 (`archived_match=True/False`) so the operator can distinguish typo'd slugs from archived listings without SSHing into the DB
- Add frontend regression assertion on the URL the axios call uses
- Boy Scout: also fix the stale `main.py` comment that claimed the calendar router declares an `/api` prefix (verified: neither calendar router does)

## Verification

```bash
# Confirms the listing exists and the route works once /api/api is bypassed:
curl https://165-245-134-251.sslip.io/api/api/listings/public/<slug>  # 200 with full listing payload
curl https://165-245-134-251.sslip.io/api/listings/public/<slug>      # 404 {"detail":"Not Found"} (FastAPI default — proves route not mounted)
```

After this fix deploys, the second curl will return the listing.

## Test plan

- [x] Backend: full suite passes (2478 tests + 12 new — listings/repo + public inquiries route + regression guards)
- [x] Backend: temporarily re-introduced `prefix="/api"` to confirm all 3 regression tests in `TestPublicInquiryRouting` fail loudly
- [x] Frontend: `PublicInquiryForm.test.tsx` passes with new URL-shape assertion
- [x] Logs: 404 for unknown slug logs `archived_match=False`; 404 for soft-deleted listing logs `archived_match=True`
- [ ] Manual smoke after deploy: visit `/apply/5-min-to-tmc-brand-new-gated-townhome-all-incl-b8w8iy`, confirm form loads with listing header
- [ ] Manual smoke after deploy: submit a real inquiry end-to-end and confirm the POST returns 200 (not 405)

🤖 Generated with [Claude Code](https://claude.com/claude-code)