### PR TITLE
refactor(myjobhunter/frontend): rename bare `interface Props` to `<ComponentName>Props`

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
@@ -24,12 +24,12 @@ const REMOTE_OPTIONS: { value: FormValues["remote_type"]; label: string }[] = [
   { value: "onsite", label: "Onsite" },
 ];
 
-interface Props {
+export interface AddApplicationDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-export default function AddApplicationDialog({ open, onOpenChange }: Props) {
+export default function AddApplicationDialog({ open, onOpenChange }: AddApplicationDialogProps) {
   const { data: companiesData, isLoading: companiesLoading } = useListCompaniesQuery();
   const [createApplication, { isLoading: creatingApplication }] = useCreateApplicationMutation();
   const [createCompany, { isLoading: creatingCompany }] = useCreateCompanyMutation();

--- a/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
@@ -33,13 +33,13 @@ function defaultOccurredAt(): string {
   return local.toISOString().slice(0, 16);
 }
 
-interface Props {
+export interface LogEventDialogProps {
   applicationId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-export default function LogEventDialog({ applicationId, open, onOpenChange }: Props) {
+export default function LogEventDialog({ applicationId, open, onOpenChange }: LogEventDialogProps) {
   const [logEvent, { isLoading }] = useLogApplicationEventMutation();
 
   const {

--- a/apps/myjobhunter/frontend/src/features/companies/AddCompanyDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/companies/AddCompanyDialog.tsx
@@ -6,7 +6,7 @@ import type { Company } from "@/types/company";
 import type { CompanyCreateRequest } from "@/types/company-create-request";
 import CompanyForm from "./CompanyForm";
 
-interface Props {
+export interface AddCompanyDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /**
@@ -18,7 +18,7 @@ interface Props {
   onCreated?: (company: Company) => void;
 }
 
-export default function AddCompanyDialog({ open, onOpenChange, onCreated }: Props) {
+export default function AddCompanyDialog({ open, onOpenChange, onCreated }: AddCompanyDialogProps) {
   const [createCompany, { isLoading }] = useCreateCompanyMutation();
 
   const handleSubmit = async (request: CompanyCreateRequest) => {

--- a/apps/myjobhunter/frontend/src/features/companies/CompanyForm.tsx
+++ b/apps/myjobhunter/frontend/src/features/companies/CompanyForm.tsx
@@ -10,7 +10,7 @@ export interface CompanyFormValues {
   hq_location: string;
 }
 
-interface Props {
+export interface CompanyFormProps {
   onSubmit: (request: CompanyCreateRequest) => Promise<void>;
   onCancel: () => void;
   submitLabel?: string;
@@ -28,7 +28,7 @@ export default function CompanyForm({
   submitting = false,
   initialValues,
   autoFocus = true,
-}: Props) {
+}: CompanyFormProps) {
   // Use React's useId so IDs are unique even when the form renders multiple
   // times in the same page (e.g. AddApplicationDialog + AddCompanyDialog open
   // at the same time in tests).

--- a/apps/myjobhunter/frontend/src/features/profile/EducationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/EducationDialog.tsx
@@ -15,13 +15,13 @@ interface FormValues {
   gpa: string;
 }
 
-interface Props {
+export interface EducationDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   existing?: Education;
 }
 
-export default function EducationDialog({ open, onOpenChange, existing }: Props) {
+export default function EducationDialog({ open, onOpenChange, existing }: EducationDialogProps) {
   const [createEducation, { isLoading: isCreating }] = useCreateEducationMutation();
   const [updateEducation, { isLoading: isUpdating }] = useUpdateEducationMutation();
   const isLoading = isCreating || isUpdating;

--- a/apps/myjobhunter/frontend/src/features/profile/ProfileHeaderDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/ProfileHeaderDialog.tsx
@@ -23,13 +23,13 @@ const SENIORITY_OPTIONS = [
   { value: "exec", label: "Executive" },
 ];
 
-interface Props {
+export interface ProfileHeaderDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   profile: Profile;
 }
 
-export default function ProfileHeaderDialog({ open, onOpenChange, profile }: Props) {
+export default function ProfileHeaderDialog({ open, onOpenChange, profile }: ProfileHeaderDialogProps) {
   const [updateProfile, { isLoading }] = useUpdateProfileMutation();
 
   const { register, handleSubmit, reset } = useForm<FormValues>({

--- a/apps/myjobhunter/frontend/src/features/profile/ScreeningAnswerDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/ScreeningAnswerDialog.tsx
@@ -41,7 +41,7 @@ interface FormValues {
   answer: string;
 }
 
-interface Props {
+export interface ScreeningAnswerDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   existing?: ScreeningAnswer;
@@ -54,7 +54,7 @@ export default function ScreeningAnswerDialog({
   onOpenChange,
   existing,
   existingKeys = [],
-}: Props) {
+}: ScreeningAnswerDialogProps) {
   const [createAnswer, { isLoading: isCreating }] = useCreateScreeningAnswerMutation();
   const [updateAnswer, { isLoading: isUpdating }] = useUpdateScreeningAnswerMutation();
   const isLoading = isCreating || isUpdating;

--- a/apps/myjobhunter/frontend/src/features/profile/WorkHistoryDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/WorkHistoryDialog.tsx
@@ -17,7 +17,7 @@ interface FormValues {
   bullets: string;
 }
 
-interface Props {
+export interface WorkHistoryDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   /** When provided, dialog is in edit mode; otherwise add mode. */
@@ -35,7 +35,7 @@ function textToBullets(text: string): string[] {
     .filter(Boolean);
 }
 
-export default function WorkHistoryDialog({ open, onOpenChange, existing }: Props) {
+export default function WorkHistoryDialog({ open, onOpenChange, existing }: WorkHistoryDialogProps) {
   const [createWorkHistory, { isLoading: isCreating }] = useCreateWorkHistoryMutation();
   const [updateWorkHistory, { isLoading: isUpdating }] = useUpdateWorkHistoryMutation();
   const isLoading = isCreating || isUpdating;

--- a/apps/myjobhunter/frontend/src/features/security/DeleteAccountModal.tsx
+++ b/apps/myjobhunter/frontend/src/features/security/DeleteAccountModal.tsx
@@ -7,7 +7,7 @@ import { signOut } from "@/lib/auth";
 import { useDeleteAccountMutation } from "@/lib/accountApi";
 import { useGetCurrentUserQuery } from "@/lib/userApi";
 
-interface Props {
+export interface DeleteAccountModalProps {
   open: boolean;
   onClose: () => void;
 }
@@ -24,7 +24,7 @@ const TOTP_INPUT_MIN_LENGTH = 6;
  * On 204 the modal calls ``signOut()``, which clears the JWT and lets
  * ``RequireAuth`` redirect to ``/login``. No explicit navigate is needed.
  */
-export default function DeleteAccountModal({ open, onClose }: Props) {
+export default function DeleteAccountModal({ open, onClose }: DeleteAccountModalProps) {
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [totpCode, setTotpCode] = useState("");


### PR DESCRIPTION
## Summary

- Renames 9 bare `interface Props` declarations to domain-prefixed, exported interfaces across `apps/myjobhunter/frontend/src/`
- Adds `export` to each renamed interface so consumers can import the type if needed
- **Mechanical only** — no logic, styling, or behavioral changes

## Files changed (9)

| File | Old | New |
|---|---|---|
| `features/applications/AddApplicationDialog.tsx` | `interface Props` | `export interface AddApplicationDialogProps` |
| `features/applications/LogEventDialog.tsx` | `interface Props` | `export interface LogEventDialogProps` |
| `features/companies/AddCompanyDialog.tsx` | `interface Props` | `export interface AddCompanyDialogProps` |
| `features/companies/CompanyForm.tsx` | `interface Props` | `export interface CompanyFormProps` |
| `features/profile/EducationDialog.tsx` | `interface Props` | `export interface EducationDialogProps` |
| `features/profile/ProfileHeaderDialog.tsx` | `interface Props` | `export interface ProfileHeaderDialogProps` |
| `features/profile/ScreeningAnswerDialog.tsx` | `interface Props` | `export interface ScreeningAnswerDialogProps` |
| `features/profile/WorkHistoryDialog.tsx` | `interface Props` | `export interface WorkHistoryDialogProps` |
| `features/security/DeleteAccountModal.tsx` | `interface Props` | `export interface DeleteAccountModalProps` |

## Validation

- `npm run typecheck` passes clean (zero errors)
- Unit test suite has 115 pre-existing failures due to the React 18/19 two-copies issue (tracked in memory; unrelated to this PR — confirmed by running tests on unmodified main before this change)

## Why

Per `jkwon-claude-config` rule #92: props interfaces must be domain-prefixed and exported. Two bare `Props` types imported into the same file collide silently — the TypeScript compiler picks one and the other becomes unreachable without warning. Same sweep was done for MBK in PR #251.