### PR TITLE
fix(integrations): close silent-fail gaps per audit (claude/gmail/turnstile)

### DIFF
--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -52,9 +52,31 @@ logging.basicConfig(
 logger = logging.getLogger("app")
 
 
+def _check_turnstile_configured() -> None:
+    """Fail loud at boot if Turnstile is not configured in a non-development environment.
+
+    Turnstile is the CAPTCHA gate on /auth/register and /auth/forgot-password.
+    Running without it in production is a credential-stuffing vulnerability.
+    In development/test the key is intentionally empty — the require_turnstile
+    dependency short-circuits when the key is absent, which is the desired CI/dev behaviour.
+
+    Raises:
+        RuntimeError: If ``ENVIRONMENT`` is not ``development`` or ``test`` and
+            ``TURNSTILE_SECRET_KEY`` is not set.
+    """
+    if settings.environment not in ("development", "test") and not settings.turnstile_secret_key:
+        raise RuntimeError(
+            "TURNSTILE_SECRET_KEY must be set in non-development environments. "
+            "Cloudflare Turnstile is the CAPTCHA gate on /auth/register and "
+            "/auth/forgot-password — running prod without it is a credential-stuffing "
+            "vulnerability. Set TURNSTILE_SECRET_KEY or set ENVIRONMENT=development."
+        )
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     init_sentry()
+    _check_turnstile_configured()
     register_audit_listeners()
     ensure_bucket()
     worker_task: asyncio.Task[None] | None = None

--- a/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
@@ -119,7 +119,11 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
                 )
                 raise GmailAuthExpiredError(str(exc)) from exc
             except Exception:
-                logger.warning("Failed to enumerate sources for email %s, skipping", message_id)
+                logger.warning(
+                    "Failed to enumerate sources for email %s, skipping",
+                    message_id,
+                    exc_info=True,
+                )
                 continue
 
             bounce_result = _detect_bounce(bounce_detector, sources_data)

--- a/apps/mybookkeeper/backend/app/services/email/gmail_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/gmail_service.py
@@ -121,11 +121,20 @@ def _resolve_label_id(service, label_name: str) -> str | None:
     """Resolve a Gmail label name to its ID."""
     try:
         results = service.users().labels().list(userId="me").execute()
-        for lbl in results.get("labels", []):
-            if lbl["name"].lower() == label_name.lower():
-                return lbl["id"]
     except Exception:
-        pass
+        logger.warning(
+            "Gmail label lookup failed for label=%r — falling back to no label filter",
+            label_name,
+            exc_info=True,
+        )
+        return None
+    for lbl in results.get("labels", []):
+        if lbl["name"].lower() == label_name.lower():
+            return lbl["id"]
+    logger.warning(
+        "Gmail label %r not found in user's label set — falling back to no label filter",
+        label_name,
+    )
     return None
 
 

--- a/apps/mybookkeeper/backend/app/services/extraction/claude_service.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/claude_service.py
@@ -118,7 +118,11 @@ async def _create_with_backoff(**kwargs) -> anthropic.types.Message:
                     {"wait_seconds": wait, "consecutive_429s": _throttle.consecutive_429s},
                 )
             except Exception:
-                pass
+                logger.warning(
+                    "Failed to record rate_limited event (consecutive=%d) — continuing backoff",
+                    _throttle.consecutive_429s,
+                    exc_info=True,
+                )
             if attempt == 4:
                 raise
             await asyncio.sleep(wait)

--- a/apps/mybookkeeper/backend/tests/test_silent_fail_audit_fixes.py
+++ b/apps/mybookkeeper/backend/tests/test_silent_fail_audit_fixes.py
@@ -1,0 +1,232 @@
+"""Tests for silent-fail audit fixes (PR: fix(integrations): close silent-fail gaps).
+
+Covers:
+- gmail_service._resolve_label_id logs warning + returns None on API error
+- gmail_service._resolve_label_id logs warning + returns None when label not found
+- gmail_service._resolve_label_id returns the id when label exists
+- email_discovery_service per-message warning includes exc_info
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.services.email.gmail_service import _resolve_label_id
+
+
+# ---------------------------------------------------------------------------
+# _resolve_label_id
+# ---------------------------------------------------------------------------
+
+class TestResolveLabelId:
+    def _make_service(self, labels: list[dict] | None = None, raise_exc: Exception | None = None) -> MagicMock:
+        """Build a minimal Gmail service mock for label list calls."""
+        service = MagicMock()
+        list_call = service.users.return_value.labels.return_value.list.return_value
+        if raise_exc is not None:
+            list_call.execute.side_effect = raise_exc
+        else:
+            list_call.execute.return_value = {"labels": labels or []}
+        return service
+
+    def test_returns_id_when_label_found(self) -> None:
+        service = self._make_service(labels=[
+            {"id": "Label_42", "name": "MyInvoices"},
+            {"id": "Label_99", "name": "Other"},
+        ])
+        result = _resolve_label_id(service, "MyInvoices")
+        assert result == "Label_42"
+
+    def test_case_insensitive_match(self) -> None:
+        service = self._make_service(labels=[{"id": "Label_42", "name": "MYINVOICES"}])
+        result = _resolve_label_id(service, "myinvoices")
+        assert result == "Label_42"
+
+    def test_returns_none_and_logs_warning_when_label_not_found(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        service = self._make_service(labels=[{"id": "Label_1", "name": "SomethingElse"}])
+        with caplog.at_level(logging.WARNING, logger="app.services.email.gmail_service"):
+            result = _resolve_label_id(service, "MissingLabel")
+
+        assert result is None
+        assert any("MissingLabel" in r.message for r in caplog.records), (
+            f"Expected warning mentioning 'MissingLabel'; got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_returns_none_when_label_list_empty(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        service = self._make_service(labels=[])
+        with caplog.at_level(logging.WARNING, logger="app.services.email.gmail_service"):
+            result = _resolve_label_id(service, "AnyLabel")
+
+        assert result is None
+
+    def test_returns_none_and_logs_warning_on_api_error(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        service = self._make_service(raise_exc=Exception("network timeout"))
+        with caplog.at_level(logging.WARNING, logger="app.services.email.gmail_service"):
+            result = _resolve_label_id(service, "MyLabel")
+
+        assert result is None
+        records = caplog.records
+        assert any(r.levelno == logging.WARNING for r in records), (
+            "Expected a WARNING log record when the Gmail API raises"
+        )
+
+    def test_api_error_log_includes_exc_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """exc_info=True means the log record carries the exception tuple."""
+        service = self._make_service(raise_exc=Exception("boom"))
+        with caplog.at_level(logging.WARNING, logger="app.services.email.gmail_service"):
+            _resolve_label_id(service, "MyLabel")
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warning_records, "Expected at least one WARNING record"
+        # When exc_info=True the record's exc_info is a 3-tuple (type, value, tb)
+        has_exc_info = any(
+            r.exc_info is not None and r.exc_info[0] is not None
+            for r in warning_records
+        )
+        assert has_exc_info, (
+            "Expected WARNING record to carry exc_info (exc_info=True not set on the logger.warning call)"
+        )
+
+    def test_not_found_log_does_not_carry_exc_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The 'label not found' warning is informational — no exception to attach."""
+        service = self._make_service(labels=[])
+        with caplog.at_level(logging.WARNING, logger="app.services.email.gmail_service"):
+            _resolve_label_id(service, "AnyLabel")
+
+        warning_records = [r for r in caplog.records if r.levelno == logging.WARNING]
+        # exc_info should be falsy (None or (None, None, None))
+        for r in warning_records:
+            assert not (r.exc_info and r.exc_info[0] is not None), (
+                "Not-found warning should not carry exc_info — no exception was raised"
+            )
+
+
+# ---------------------------------------------------------------------------
+# email_discovery_service — per-message warning includes exc_info
+# ---------------------------------------------------------------------------
+
+class TestEmailDiscoveryServiceExcInfo:
+    """Verify that the per-message 'skipping' warning carries exc_info=True.
+
+    We test this by importing the logger used inside email_discovery_service
+    and asserting the log record has exc_info attached when an exception
+    bubbles up from list_email_document_sources.
+    """
+
+    @pytest.mark.anyio
+    async def test_per_message_warning_carries_exc_info(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When list_email_document_sources raises a generic Exception,
+        the warning log should carry exc_info so the traceback is preserved."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        # Minimal stubs so discover_gmail_emails can be called without a real DB
+        mock_integration = MagicMock()
+        mock_integration.access_token = "token"
+        mock_integration.refresh_token = "refresh"
+
+        # Patch unit_of_work to yield a session that returns our stubs
+        mock_db = AsyncMock()
+
+        import asyncio
+        from contextlib import asynccontextmanager
+
+        @asynccontextmanager
+        async def _fake_uow():
+            yield mock_db
+
+        fake_service = MagicMock()
+        boom = Exception("fetch failed")
+
+        with (
+            patch("app.services.email.email_discovery_service.unit_of_work", _fake_uow),
+            patch(
+                "app.services.email.email_discovery_service.integration_repo.get_by_org_and_provider",
+                new=AsyncMock(return_value=mock_integration),
+            ),
+            patch(
+                "app.services.email.email_discovery_service.sync_log_repo.timeout_stuck",
+                new=AsyncMock(),
+            ),
+            patch(
+                "app.services.email.email_discovery_service.sync_log_repo.count_running",
+                new=AsyncMock(return_value=0),
+            ),
+            patch(
+                "app.services.email.email_discovery_service.email_queue_repo.reset_stuck",
+                new=AsyncMock(),
+            ),
+            patch(
+                "app.services.email.email_discovery_service.get_gmail_service",
+                return_value=fake_service,
+            ),
+            patch(
+                "app.services.email.email_discovery_service.email_queue_repo.get_message_ids",
+                new=AsyncMock(return_value=set()),
+            ),
+            patch(
+                "app.services.email.email_discovery_service.document_repo.get_email_message_ids",
+                new=AsyncMock(return_value=set()),
+            ),
+            # list_new_email_ids returns one new ID so we enter the per-message loop
+            patch(
+                "app.services.email.email_discovery_service.list_new_email_ids",
+                return_value=(["msg-001"], 1),
+            ),
+            # list_email_document_sources raises, triggering the warning
+            patch(
+                "app.services.email.email_discovery_service.list_email_document_sources",
+                side_effect=boom,
+            ),
+            patch(
+                "app.services.email.email_discovery_service.sync_log_repo.create",
+                new=AsyncMock(return_value=MagicMock(id=1)),
+            ),
+            patch(
+                "app.services.email.email_discovery_service.sync_log_repo.mark_completed",
+                new=AsyncMock(),
+            ),
+            patch(
+                "app.services.email.email_discovery_service.integration_repo.update_last_synced",
+                new=AsyncMock(),
+            ),
+        ):
+            from app.services.email.email_discovery_service import discover_gmail_emails
+            from app.core.context import worker_context
+            import uuid
+
+            ctx = worker_context(
+                organization_id=uuid.uuid4(),
+                user_id=uuid.uuid4(),
+            )
+
+            with caplog.at_level(logging.WARNING, logger="app.services.email.email_discovery_service"):
+                await discover_gmail_emails(ctx)
+
+        warning_records = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "msg-001" in r.message
+        ]
+        assert warning_records, (
+            f"Expected a WARNING about msg-001; got records: {[r.message for r in caplog.records]}"
+        )
+        has_exc_info = any(
+            r.exc_info is not None and r.exc_info[0] is not None
+            for r in warning_records
+        )
+        assert has_exc_info, (
+            "Per-message 'skipping' warning must carry exc_info=True so the traceback is preserved in logs"
+        )

--- a/apps/mybookkeeper/backend/tests/test_turnstile_boot_check.py
+++ b/apps/mybookkeeper/backend/tests/test_turnstile_boot_check.py
@@ -1,0 +1,83 @@
+"""Tests for Turnstile fail-loud boot check (app/main.py:_check_turnstile_configured).
+
+Covers:
+- environment=production + empty key → RuntimeError raised
+- environment=production + non-empty key → no error
+- environment=development + empty key → no error (preserves dev/CI no-op)
+- environment=test + empty key → no error (preserves CI no-op)
+- environment=staging + empty key → RuntimeError raised (staging is non-dev)
+
+Design mirrors test_observability.py: construct a settings-like namespace,
+patch app.main.settings, then call _check_turnstile_configured() directly.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.main import _check_turnstile_configured
+
+
+def _make_settings(*, environment: str, turnstile_secret_key: str) -> SimpleNamespace:
+    """Return a settings-like namespace for patching app.main.settings."""
+    return SimpleNamespace(environment=environment, turnstile_secret_key=turnstile_secret_key)
+
+
+class TestTurnstileBootCheckProduction:
+    """In production, a missing key must crash the process at boot."""
+
+    def test_raises_when_production_and_key_empty(self) -> None:
+        fake_settings = _make_settings(environment="production", turnstile_secret_key="")
+        with patch("app.main.settings", fake_settings):
+            with pytest.raises(RuntimeError, match="TURNSTILE_SECRET_KEY must be set"):
+                _check_turnstile_configured()
+
+    def test_does_not_raise_when_production_and_key_set(self) -> None:
+        fake_settings = _make_settings(
+            environment="production", turnstile_secret_key="real-secret-key-here"
+        )
+        with patch("app.main.settings", fake_settings):
+            _check_turnstile_configured()  # must not raise
+
+    def test_error_message_mentions_credential_stuffing(self) -> None:
+        """The error message must explain WHY this is enforced — not just that it is."""
+        fake_settings = _make_settings(environment="production", turnstile_secret_key="")
+        with patch("app.main.settings", fake_settings):
+            with pytest.raises(RuntimeError) as exc_info:
+                _check_turnstile_configured()
+        assert "credential-stuffing" in str(exc_info.value).lower()
+
+
+class TestTurnstileBootCheckDevelopment:
+    """In development/test, an empty key must be silently accepted."""
+
+    @pytest.mark.parametrize("env", ["development", "test"])
+    def test_does_not_raise_when_dev_or_test_and_key_empty(self, env: str) -> None:
+        fake_settings = _make_settings(environment=env, turnstile_secret_key="")
+        with patch("app.main.settings", fake_settings):
+            _check_turnstile_configured()  # must not raise
+
+    @pytest.mark.parametrize("env", ["development", "test"])
+    def test_does_not_raise_when_dev_or_test_and_key_set(self, env: str) -> None:
+        """Even if a key happens to be set in dev, it should not cause issues."""
+        fake_settings = _make_settings(environment=env, turnstile_secret_key="some-key")
+        with patch("app.main.settings", fake_settings):
+            _check_turnstile_configured()  # must not raise
+
+
+class TestTurnstileBootCheckNonDevEnvironments:
+    """Environments other than development/test should also enforce the key."""
+
+    @pytest.mark.parametrize("env", ["staging", "production", "prod", ""])
+    def test_raises_for_non_dev_environments_without_key(self, env: str) -> None:
+        fake_settings = _make_settings(environment=env, turnstile_secret_key="")
+        with patch("app.main.settings", fake_settings):
+            with pytest.raises(RuntimeError):
+                _check_turnstile_configured()
+
+    def test_does_not_raise_for_staging_with_key(self) -> None:
+        fake_settings = _make_settings(environment="staging", turnstile_secret_key="staging-key")
+        with patch("app.main.settings", fake_settings):
+            _check_turnstile_configured()  # must not raise

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -180,6 +180,7 @@
         "test_email_sync_worker.py",
         "test_gmail_auth_expired.py",
         "test_email_discovery_last_synced.py",
+        "test_silent_fail_audit_fixes.py",
         "services/email/test_bounce_detector.py",
         "services/email/test_discovery_bounce_filter.py"
       ],
@@ -934,7 +935,8 @@
         "frontend/src/shared/types/version/"
       ],
       "backend_tests": [
-        "test_version_endpoint.py"
+        "test_version_endpoint.py",
+        "test_turnstile_boot_check.py"
       ],
       "frontend_tests": [
         "VersionTag.test.tsx"


### PR DESCRIPTION
## Summary

Post-PR-#205 audit identified four remaining silent-fail patterns in the integrations layer. This PR closes all of them.

- **claude_service.py** — bare `except: pass` on rate-limit event recording replaced with `logger.warning(..., exc_info=True)`. Backoff loop behaviour is unchanged; failures are now visible in logs.
- **gmail_service._resolve_label_id** — split try/except so API errors get `exc_info=True` and "label not found" gets a distinct informational warning (no exc_info). Both paths return `None` and fall back to no-label-filter, same as before.
- **email_discovery_service** — added `exc_info=True` to the per-message "skipping" warning so tracebacks are preserved when `list_email_document_sources` raises.
- **main.py — Turnstile boot check** — added `_check_turnstile_configured()` in the lifespan next to `init_sentry()`, mirroring the PR #220 Sentry fail-loud pattern. Non-development environments (`environment != development|test`) without `TURNSTILE_SECRET_KEY` crash at boot rather than silently serving `/auth/register` and `/auth/forgot-password` without CAPTCHA. dev/test are explicitly exempted so CI and local dev are unaffected.

## Test plan

- [x] `test_silent_fail_audit_fixes.py` — 8 tests: `_resolve_label_id` happy path, case-insensitive match, not-found warning (no exc_info), API error warning (with exc_info), email_discovery per-message warning carries exc_info
- [x] `test_turnstile_boot_check.py` — 12 tests: production + empty key raises, production + key set passes, development/test + empty key passes, staging + empty key raises, staging + key set passes
- [x] All 20 new tests pass
- [x] 35 related existing tests pass with zero regressions (`test_gmail_service_send`, `test_gmail_auth_expired`, `test_observability`, `test_turnstile`)
- [x] `scripts/test-map.json` updated: `test_silent_fail_audit_fixes.py` → email domain; `test_turnstile_boot_check.py` → version domain

## Design decisions

- Turnstile boot check uses `settings.environment not in ("development", "test")` rather than `== "production"` to catch staging and any other non-dev environment — same gate Sentry uses after PR #220.
- `_resolve_label_id` "not found" case deliberately omits `exc_info` — there is no exception in scope, so attaching it would log `(None, None, None)` which is noise. The warning message includes the label name for debuggability.
- No new bare `except:` introduced anywhere in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)