### PR TITLE
feat(mbk/listings): multi-select + bulk delete/download for photo grid

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/listings-photo-bulk.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/listings-photo-bulk.spec.ts
@@ -1,0 +1,168 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import fs from "fs";
+import { test, expect, type APIRequestContext, type Page } from "./fixtures/auth";
+import { createProperty, deleteProperty } from "./fixtures/seed-data";
+
+/**
+ * Photo bulk-actions E2E — multi-select + bulk delete.
+ *
+ * Seeds a listing with 3 photos, selects 2 via checkboxes, bulk deletes,
+ * and verifies the grid now shows 1 photo — both in the UI and via API.
+ *
+ * Each test tears down its own seed data in `finally` per project rules.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PHOTO = path.join(__dirname, "fixtures", "listings", "test-photo-with-gps.jpg");
+
+async function seedListingWithPhotos(
+  api: APIRequestContext,
+  propertyId: string,
+  runId: number,
+  photoCount: number,
+): Promise<string> {
+  const seedRes = await api.post("/test/seed-listing", {
+    data: {
+      property_id: propertyId,
+      title: `E2E Bulk Photo Listing ${runId}`,
+      monthly_rate: "1500.00",
+      room_type: "private_room",
+      status: "active",
+    },
+  });
+  expect(seedRes.ok()).toBeTruthy();
+  const { id: listingId } = (await seedRes.json()) as { id: string };
+
+  // Upload N photos to the listing.
+  const photoBytes = fs.readFileSync(FIXTURE_PHOTO);
+  for (let i = 0; i < photoCount; i++) {
+    const uploadRes = await api.post(`/listings/${listingId}/photos`, {
+      multipart: {
+        files: {
+          name: `test-photo-${i}.jpg`,
+          mimeType: "image/jpeg",
+          buffer: photoBytes,
+        },
+      },
+    });
+    expect(uploadRes.ok()).toBeTruthy();
+  }
+
+  return listingId;
+}
+
+async function deleteListingViaTestApi(
+  api: APIRequestContext,
+  listingId: string,
+): Promise<void> {
+  await api.delete(`/test/listings/${listingId}`).catch(() => {});
+}
+
+async function waitForPhotos(page: Page, count: number): Promise<void> {
+  await expect(page.getByTestId("listing-photo-card")).toHaveCount(count, {
+    timeout: 15000,
+  });
+}
+
+test.describe("Photo bulk actions (PR multi-select)", () => {
+  test.skip(!fs.existsSync(FIXTURE_PHOTO), "GPS-EXIF fixture missing — run scripts/build-listings-fixtures.py");
+
+  test("user can select 2 of 3 photos with checkboxes, bulk delete, and grid shows 1 remaining", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const property = await createProperty(api, { name: `E2E Bulk Delete Property ${runId}` });
+    let listingId: string | null = null;
+
+    try {
+      listingId = await seedListingWithPhotos(api, property.id, runId, 3);
+
+      await page.goto(`/listings/${listingId}`);
+      await expect(
+        page.getByRole("heading", { name: `E2E Bulk Photo Listing ${runId}` }),
+      ).toBeVisible({ timeout: 10000 });
+
+      // Wait for all 3 photos to render.
+      await waitForPhotos(page, 3);
+
+      // The toolbar should NOT be visible before any checkbox is clicked.
+      await expect(page.getByTestId("photo-selection-toolbar")).not.toBeVisible();
+
+      // Click the first two checkboxes to select photos 0 and 1.
+      const checkboxes = page.getByTestId("listing-photo-checkbox");
+      await checkboxes.nth(0).click();
+      await checkboxes.nth(1).click();
+
+      // Toolbar appears and shows "2 selected".
+      await expect(page.getByTestId("photo-selection-toolbar")).toBeVisible();
+      await expect(page.getByTestId("photo-selection-count")).toHaveText("2 selected");
+
+      // Click bulk delete — confirm dialog appears.
+      await page.getByTestId("photo-bulk-delete-button").click();
+      await expect(page.getByText(/Delete 2 photos\?/i)).toBeVisible();
+
+      // Confirm the delete.
+      await page.getByRole("button", { name: /Delete 2 photos/i }).click();
+
+      // Grid should now show 1 photo.
+      await waitForPhotos(page, 1);
+
+      // Toolbar should be gone (selection was cleared after delete).
+      await expect(page.getByTestId("photo-selection-toolbar")).not.toBeVisible();
+
+      // Verify via API.
+      const afterRes = await api.get(`/listings/${listingId}`);
+      expect(afterRes.ok()).toBeTruthy();
+      const afterBody = (await afterRes.json()) as { photos: unknown[] };
+      expect(afterBody.photos).toHaveLength(1);
+    } finally {
+      if (listingId) {
+        await deleteListingViaTestApi(api, listingId);
+      }
+      await deleteProperty(api, property.id);
+    }
+  });
+
+  test("Select all button selects all photos and count matches", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const property = await createProperty(api, { name: `E2E Select All Property ${runId}` });
+    let listingId: string | null = null;
+
+    try {
+      listingId = await seedListingWithPhotos(api, property.id, runId, 3);
+
+      await page.goto(`/listings/${listingId}`);
+      await expect(
+        page.getByRole("heading", { name: `E2E Bulk Photo Listing ${runId}` }),
+      ).toBeVisible({ timeout: 10000 });
+
+      await waitForPhotos(page, 3);
+
+      // Select one photo to bring the toolbar up.
+      const firstCheckbox = page.getByTestId("listing-photo-checkbox").first();
+      await firstCheckbox.click();
+      await expect(page.getByTestId("photo-selection-count")).toHaveText("1 selected");
+
+      // Click Select all.
+      await page.getByTestId("photo-select-all-button").click();
+      await expect(page.getByTestId("photo-selection-count")).toHaveText("3 selected");
+
+      // "Select all" button should disappear when all are selected.
+      await expect(page.getByTestId("photo-select-all-button")).not.toBeVisible();
+
+      // Clear deselects all and hides the toolbar.
+      await page.getByTestId("photo-clear-selection-button").click();
+      await expect(page.getByTestId("photo-selection-toolbar")).not.toBeVisible();
+    } finally {
+      if (listingId) {
+        await deleteListingViaTestApi(api, listingId);
+      }
+      await deleteProperty(api, property.id);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/package.json
+++ b/apps/mybookkeeper/frontend/package.json
@@ -29,6 +29,7 @@
     "axios": "^1.7.7",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^1.14.0",
     "posthog-js": "^1.372.6",
     "qrcode.react": "^4.2.0",

--- a/apps/mybookkeeper/frontend/src/__tests__/ListingPhotoManager.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/ListingPhotoManager.test.tsx
@@ -122,4 +122,72 @@ describe("ListingPhotoManager", () => {
     expect(cards[0]).toHaveAttribute("data-photo-id", "p1");
     expect(cards[1]).toHaveAttribute("data-photo-id", "p2");
   });
+
+  it("toolbar is hidden when nothing is selected", () => {
+    renderManager([
+      {
+        id: "p1", listing_id: "listing-1", storage_key: "k1",
+        caption: null, display_order: 0, created_at: "2026-01-01T00:00:00Z", presigned_url: null,
+      },
+    ]);
+    expect(screen.queryByTestId("photo-selection-toolbar")).not.toBeInTheDocument();
+  });
+
+  it("clicking a checkbox shows the toolbar with the correct count", async () => {
+    renderManager([
+      {
+        id: "p1", listing_id: "listing-1", storage_key: "k1",
+        caption: null, display_order: 0, created_at: "2026-01-01T00:00:00Z", presigned_url: null,
+      },
+      {
+        id: "p2", listing_id: "listing-1", storage_key: "k2",
+        caption: null, display_order: 1, created_at: "2026-01-01T00:00:00Z", presigned_url: null,
+      },
+    ]);
+    const user = userEvent.setup();
+    const checkboxes = screen.getAllByTestId("listing-photo-checkbox");
+    await user.click(checkboxes[0]);
+
+    expect(screen.getByTestId("photo-selection-toolbar")).toBeInTheDocument();
+    expect(screen.getByTestId("photo-selection-count")).toHaveTextContent("1 selected");
+  });
+
+  it("bulk delete opens a confirmation dialog and calls delete for each selected photo", async () => {
+    renderManager([
+      {
+        id: "p1", listing_id: "listing-1", storage_key: "k1",
+        caption: null, display_order: 0, created_at: "2026-01-01T00:00:00Z", presigned_url: null,
+      },
+      {
+        id: "p2", listing_id: "listing-1", storage_key: "k2",
+        caption: null, display_order: 1, created_at: "2026-01-01T00:00:00Z", presigned_url: null,
+      },
+    ]);
+    const user = userEvent.setup();
+    const checkboxes = screen.getAllByTestId("listing-photo-checkbox");
+    await user.click(checkboxes[0]);
+    await user.click(checkboxes[1]);
+
+    await user.click(screen.getByTestId("photo-bulk-delete-button"));
+    // Confirmation dialog appears
+    expect(screen.getByText(/Delete 2 photos\?/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Delete 2 photos/i }));
+
+    expect(deleteMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("Clear button hides the toolbar", async () => {
+    renderManager([
+      {
+        id: "p1", listing_id: "listing-1", storage_key: "k1",
+        caption: null, display_order: 0, created_at: "2026-01-01T00:00:00Z", presigned_url: null,
+      },
+    ]);
+    const user = userEvent.setup();
+    await user.click(screen.getByTestId("listing-photo-checkbox"));
+    expect(screen.getByTestId("photo-selection-toolbar")).toBeInTheDocument();
+
+    await user.click(screen.getByTestId("photo-clear-selection-button"));
+    expect(screen.queryByTestId("photo-selection-toolbar")).not.toBeInTheDocument();
+  });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/PhotoSelectionToolbar.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PhotoSelectionToolbar.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PhotoSelectionToolbar from "@/app/features/listings/PhotoSelectionToolbar";
+
+function renderToolbar(overrides: Partial<Parameters<typeof PhotoSelectionToolbar>[0]> = {}) {
+  const defaults = {
+    selectedCount: 2,
+    totalCount: 5,
+    onSelectAll: vi.fn(),
+    onClear: vi.fn(),
+    onBulkDelete: vi.fn(),
+    onBulkDownload: vi.fn(),
+    isBulkDeleting: false,
+    isBulkDownloading: false,
+  };
+  return { ...defaults, ...render(<PhotoSelectionToolbar {...defaults} {...overrides} />) };
+}
+
+describe("PhotoSelectionToolbar", () => {
+  it("renders the selection count", () => {
+    renderToolbar({ selectedCount: 3 });
+    expect(screen.getByTestId("photo-selection-count")).toHaveTextContent("3 selected");
+  });
+
+  it("shows Select all when not all are selected", () => {
+    renderToolbar({ selectedCount: 2, totalCount: 5 });
+    expect(screen.getByTestId("photo-select-all-button")).toBeInTheDocument();
+  });
+
+  it("hides Select all when all are selected", () => {
+    renderToolbar({ selectedCount: 5, totalCount: 5 });
+    expect(screen.queryByTestId("photo-select-all-button")).not.toBeInTheDocument();
+  });
+
+  it("calls onSelectAll when Select all is clicked", async () => {
+    const onSelectAll = vi.fn();
+    renderToolbar({ onSelectAll });
+    await userEvent.click(screen.getByTestId("photo-select-all-button"));
+    expect(onSelectAll).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClear when Clear is clicked", async () => {
+    const onClear = vi.fn();
+    renderToolbar({ onClear });
+    await userEvent.click(screen.getByTestId("photo-clear-selection-button"));
+    expect(onClear).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onBulkDelete when Delete is clicked", async () => {
+    const onBulkDelete = vi.fn();
+    renderToolbar({ onBulkDelete });
+    await userEvent.click(screen.getByTestId("photo-bulk-delete-button"));
+    expect(onBulkDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onBulkDownload when Download is clicked", async () => {
+    const onBulkDownload = vi.fn();
+    renderToolbar({ onBulkDownload });
+    await userEvent.click(screen.getByTestId("photo-bulk-download-button"));
+    expect(onBulkDownload).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables both action buttons while bulk deleting", () => {
+    renderToolbar({ isBulkDeleting: true });
+    expect(screen.getByTestId("photo-bulk-delete-button")).toBeDisabled();
+    expect(screen.getByTestId("photo-bulk-download-button")).toBeDisabled();
+  });
+
+  it("disables both action buttons while bulk downloading", () => {
+    renderToolbar({ isBulkDownloading: true });
+    expect(screen.getByTestId("photo-bulk-delete-button")).toBeDisabled();
+    expect(screen.getByTestId("photo-bulk-download-button")).toBeDisabled();
+  });
+
+  it("shows 'Deleting...' label while bulk deleting", () => {
+    renderToolbar({ isBulkDeleting: true });
+    expect(screen.getByTestId("photo-bulk-delete-button")).toHaveTextContent("Deleting...");
+  });
+
+  it("shows 'Downloading...' label while bulk downloading", () => {
+    renderToolbar({ isBulkDownloading: true });
+    expect(screen.getByTestId("photo-bulk-download-button")).toHaveTextContent("Downloading...");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/photo-bulk-download.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/photo-bulk-download.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
+
+// Mock jszip before importing the module under test.
+// vi.mock is hoisted, so spies must be declared with vi.hoisted.
+const { fileMock, generateMock } = vi.hoisted(() => ({
+  fileMock: vi.fn(),
+  generateMock: vi.fn().mockResolvedValue(new Blob(["zip"], { type: "application/zip" })),
+}));
+
+vi.mock("jszip", () => ({
+  default: vi.fn().mockImplementation(function () {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this as { file: typeof fileMock; generateAsync: typeof generateMock };
+    self.file = fileMock;
+    self.generateAsync = generateMock;
+  }),
+}));
+
+// Mock toast so we can assert on warning toasts.
+const showErrorMock = vi.fn();
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: (msg: string) => showErrorMock(msg),
+  showSuccess: vi.fn(),
+}));
+
+// Provide a minimal global fetch that returns an ok Blob response.
+const fetchMock = vi.fn();
+global.fetch = fetchMock as unknown as typeof fetch;
+
+// Suppress jsdom URL.createObjectURL / revokeObjectURL (not implemented in jsdom).
+global.URL.createObjectURL = vi.fn().mockReturnValue("blob:mock");
+global.URL.revokeObjectURL = vi.fn();
+
+// Capture anchor clicks so we can assert on the download trigger.
+const anchorClickSpy = vi.fn();
+
+import { downloadPhotosAsZip } from "@/app/features/listings/photo-bulk-download";
+
+function makePhoto(overrides: Partial<ListingPhoto> = {}): ListingPhoto {
+  return {
+    id: "photo-1",
+    listing_id: "listing-1",
+    storage_key: "listings/photo-1.jpg",
+    caption: null,
+    display_order: 0,
+    created_at: "2026-01-01T00:00:00Z",
+    presigned_url: "https://storage.example.com/photo-1.jpg",
+    ...overrides,
+  };
+}
+
+describe("downloadPhotosAsZip", () => {
+  beforeEach(() => {
+    fileMock.mockClear();
+    generateMock.mockClear();
+    showErrorMock.mockClear();
+    fetchMock.mockClear();
+    anchorClickSpy.mockClear();
+
+    // Default: fetch returns an ok response.
+    fetchMock.mockResolvedValue({
+      ok: true,
+      blob: async () => new Blob(["img"], { type: "image/jpeg" }),
+    });
+
+    // Intercept document.createElement so we can capture the anchor click.
+    const origCreate = document.createElement.bind(document);
+    vi.spyOn(document, "createElement").mockImplementation((tag: string) => {
+      if (tag === "a") {
+        const anchor = origCreate("a");
+        anchor.click = anchorClickSpy;
+        return anchor;
+      }
+      return origCreate(tag);
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches each photo and files it into the zip", async () => {
+    const photos = [makePhoto({ id: "p1" }), makePhoto({ id: "p2", display_order: 1 })];
+    await downloadPhotosAsZip(photos, "my-listing");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("zip filename matches <slug>-photos-<YYYY-MM-DD>.zip format", async () => {
+    const anchor = document.createElement("a");
+    const setSpy = vi.fn();
+    Object.defineProperty(anchor, "download", { set: setSpy, configurable: true });
+
+    await downloadPhotosAsZip([makePhoto()], "test-slug");
+    // The filename should match the pattern
+    expect(anchorClickSpy).toHaveBeenCalled();
+  });
+
+  it("skips a photo whose presigned_url is null and shows an error toast", async () => {
+    const photos = [makePhoto({ presigned_url: null })];
+    await downloadPhotosAsZip(photos, "my-listing");
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("1 photo couldn't be fetched"),
+    );
+    // The zip file call should not have been made for the skipped photo.
+    expect(fileMock).not.toHaveBeenCalled();
+  });
+
+  it("skips a photo whose fetch returns non-ok and shows an error toast", async () => {
+    fetchMock.mockResolvedValue({ ok: false });
+    const photos = [makePhoto(), makePhoto({ id: "p2", display_order: 1 })];
+    await downloadPhotosAsZip(photos, "my-listing");
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("2 photos couldn't be fetched"),
+    );
+    expect(fileMock).not.toHaveBeenCalled();
+  });
+
+  it("uses singular wording when exactly 1 photo is skipped", async () => {
+    fetchMock.mockResolvedValue({ ok: false });
+    await downloadPhotosAsZip([makePhoto()], "my-listing");
+    expect(showErrorMock).toHaveBeenCalledWith(
+      expect.stringContaining("1 photo couldn't be fetched"),
+    );
+  });
+
+  it("triggers a browser download by clicking an anchor", async () => {
+    await downloadPhotosAsZip([makePhoto()], "my-listing");
+    expect(anchorClickSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/usePhotoSelection.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/usePhotoSelection.test.tsx
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { usePhotoSelection } from "@/app/features/listings/usePhotoSelection";
+
+const ORDERED = ["a", "b", "c", "d", "e"];
+
+describe("usePhotoSelection", () => {
+  it("starts with nothing selected", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    expect(result.current.selection.selectedIds.size).toBe(0);
+    expect(result.current.selection.lastSelectedId).toBeNull();
+  });
+
+  it("toggles a single photo on (no shift)", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    act(() => {
+      result.current.toggleSelection("b", false, ORDERED);
+    });
+    expect(result.current.isSelected("b")).toBe(true);
+    expect(result.current.selection.lastSelectedId).toBe("b");
+  });
+
+  it("toggles a selected photo off", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    act(() => {
+      result.current.toggleSelection("b", false, ORDERED);
+    });
+    act(() => {
+      result.current.toggleSelection("b", false, ORDERED);
+    });
+    expect(result.current.isSelected("b")).toBe(false);
+  });
+
+  it("range-selects with shift from anchor to target", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    // Click "a" (anchor)
+    act(() => {
+      result.current.toggleSelection("a", false, ORDERED);
+    });
+    // Shift-click "c" → selects a, b, c
+    act(() => {
+      result.current.toggleSelection("c", true, ORDERED);
+    });
+    expect(result.current.isSelected("a")).toBe(true);
+    expect(result.current.isSelected("b")).toBe(true);
+    expect(result.current.isSelected("c")).toBe(true);
+    expect(result.current.isSelected("d")).toBe(false);
+  });
+
+  it("range-selects works when target is before anchor", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    // Click "d" (anchor)
+    act(() => {
+      result.current.toggleSelection("d", false, ORDERED);
+    });
+    // Shift-click "b" → selects b, c, d
+    act(() => {
+      result.current.toggleSelection("b", true, ORDERED);
+    });
+    expect(result.current.isSelected("b")).toBe(true);
+    expect(result.current.isSelected("c")).toBe(true);
+    expect(result.current.isSelected("d")).toBe(true);
+    expect(result.current.isSelected("a")).toBe(false);
+    expect(result.current.isSelected("e")).toBe(false);
+  });
+
+  it("shift-click with no prior selection falls back to single toggle", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    act(() => {
+      result.current.toggleSelection("c", true, ORDERED);
+    });
+    expect(result.current.isSelected("c")).toBe(true);
+    expect(result.current.selection.selectedIds.size).toBe(1);
+  });
+
+  it("selectAll selects every id and sets lastSelectedId to the last", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    act(() => {
+      result.current.selectAll(ORDERED);
+    });
+    for (const id of ORDERED) {
+      expect(result.current.isSelected(id)).toBe(true);
+    }
+    expect(result.current.selection.lastSelectedId).toBe("e");
+  });
+
+  it("clearSelection removes all selections", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    act(() => {
+      result.current.selectAll(ORDERED);
+    });
+    act(() => {
+      result.current.clearSelection();
+    });
+    expect(result.current.selection.selectedIds.size).toBe(0);
+  });
+
+  it("maintains previously-selected items when adding a range", () => {
+    const { result } = renderHook(() => usePhotoSelection());
+    // Select "e" independently
+    act(() => {
+      result.current.toggleSelection("e", false, ORDERED);
+    });
+    // Then click "a" (no shift, new anchor)
+    act(() => {
+      result.current.toggleSelection("a", false, ORDERED);
+    });
+    // Shift-click "c" → range a-c added; "e" was already selected so it stays
+    act(() => {
+      result.current.toggleSelection("c", true, ORDERED);
+    });
+    expect(result.current.isSelected("e")).toBe(true);
+    expect(result.current.isSelected("a")).toBe(true);
+    expect(result.current.isSelected("b")).toBe(true);
+    expect(result.current.isSelected("c")).toBe(true);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoCard.tsx
@@ -2,13 +2,23 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { GripVertical, X } from "lucide-react";
 import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
+import PhotoSelectionCheckbox from "@/app/features/listings/PhotoSelectionCheckbox";
 
 export interface ListingPhotoCardProps {
   photo: ListingPhoto;
   onDelete: () => void;
+  onOpenLightbox?: () => void;
+  selected: boolean;
+  onToggleSelection: (photoId: string, shiftKey: boolean) => void;
 }
 
-export default function ListingPhotoCard({ photo, onDelete }: ListingPhotoCardProps) {
+export default function ListingPhotoCard({
+  photo,
+  onDelete,
+  onOpenLightbox,
+  selected,
+  onToggleSelection,
+}: ListingPhotoCardProps) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } =
     useSortable({ id: photo.id });
 
@@ -18,14 +28,23 @@ export default function ListingPhotoCard({ photo, onDelete }: ListingPhotoCardPr
     opacity: isDragging ? 0.5 : 1,
   };
 
+  const selectedBorder = selected ? "border-2 border-primary" : "border";
+
   return (
     <li
       ref={setNodeRef}
       style={style}
-      className="relative border rounded-lg overflow-hidden bg-card group"
+      className={`relative ${selectedBorder} rounded-lg overflow-hidden bg-card group`}
       data-testid="listing-photo-card"
       data-photo-id={photo.id}
     >
+      <PhotoSelectionCheckbox
+        photoId={photo.id}
+        selected={selected}
+        onToggle={onToggleSelection}
+        photoIndex={photo.display_order}
+      />
+
       {/* Photo served via per-request presigned URL minted by the backend.
           Falls back to a labeled placeholder when storage is unavailable
           (e.g., MinIO outage) so the page still renders the layout. */}
@@ -34,13 +53,15 @@ export default function ListingPhotoCard({ photo, onDelete }: ListingPhotoCardPr
           src={photo.presigned_url}
           alt={photo.caption ?? `Photo ${photo.display_order + 1}`}
           loading="lazy"
-          className="aspect-square w-full object-cover bg-muted"
+          className="aspect-square w-full object-cover bg-muted cursor-pointer"
           data-testid="listing-photo-thumbnail"
+          onClick={onOpenLightbox}
         />
       ) : (
         <div
-          className="aspect-square bg-muted flex items-center justify-center text-xs text-muted-foreground"
+          className="aspect-square bg-muted flex items-center justify-center text-xs text-muted-foreground cursor-pointer"
           data-testid="listing-photo-thumbnail"
+          onClick={onOpenLightbox}
         >
           Photo {photo.display_order + 1}
         </div>
@@ -50,7 +71,7 @@ export default function ListingPhotoCard({ photo, onDelete }: ListingPhotoCardPr
         {...attributes}
         {...listeners}
         type="button"
-        className="absolute top-1 left-1 bg-card/80 hover:bg-card border rounded p-1 cursor-grab active:cursor-grabbing min-h-[32px] min-w-[32px] flex items-center justify-center"
+        className="absolute top-1 right-8 bg-card/80 hover:bg-card border rounded p-1 cursor-grab active:cursor-grabbing min-h-[32px] min-w-[32px] flex items-center justify-center"
         aria-label={`Drag to reorder photo ${photo.display_order + 1}`}
         data-testid="listing-photo-drag-handle"
       >

--- a/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoManager.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/ListingPhotoManager.tsx
@@ -26,9 +26,13 @@ import {
 } from "@/shared/store/listingsApi";
 import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
 import ListingPhotoCard from "@/app/features/listings/ListingPhotoCard";
+import PhotoSelectionToolbar from "@/app/features/listings/PhotoSelectionToolbar";
+import { usePhotoSelection } from "@/app/features/listings/usePhotoSelection";
+import { downloadPhotosAsZip } from "@/app/features/listings/photo-bulk-download";
 
 export interface ListingPhotoManagerProps {
   listingId: string;
+  listingSlug?: string;
   photos: readonly ListingPhoto[];
 }
 
@@ -54,13 +58,23 @@ function clientSideValidate(files: File[]): { valid: File[]; rejected: string[] 
   return { valid, rejected };
 }
 
-export default function ListingPhotoManager({ listingId, photos }: ListingPhotoManagerProps) {
+export default function ListingPhotoManager({
+  listingId,
+  listingSlug,
+  photos,
+}: ListingPhotoManagerProps) {
   const [uploadPhotos, { isLoading: isUploading }] = useUploadListingPhotosMutation();
   const [deletePhoto] = useDeleteListingPhotoMutation();
   const [updatePhoto] = useUpdateListingPhotoMutation();
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [confirmBulkDelete, setConfirmBulkDelete] = useState(false);
   const [orderedIds, setOrderedIds] = useState<string[] | null>(null);
+  const [isBulkDeleting, setIsBulkDeleting] = useState(false);
+  const [isBulkDownloading, setIsBulkDownloading] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const { selection, toggleSelection, selectAll, clearSelection, isSelected } =
+    usePhotoSelection();
 
   const sensors = useSensors(
     useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
@@ -71,6 +85,9 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
   const sortedPhotos = [...photos].sort((a, b) => a.display_order - b.display_order);
   const displayIds = orderedIds ?? sortedPhotos.map((p) => p.id);
   const photosById = new Map(sortedPhotos.map((p) => [p.id, p]));
+
+  const selectedCount = selection.selectedIds.size;
+  const hasSelection = selectedCount > 0;
 
   async function handleFiles(files: FileList | null) {
     if (!files || files.length === 0) return;
@@ -98,6 +115,44 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
       showSuccess("Photo removed.");
     } catch {
       showError("I couldn't remove that photo. Want to try again?");
+    }
+  }
+
+  async function handleBulkDelete() {
+    setConfirmBulkDelete(false);
+    setIsBulkDeleting(true);
+    const ids = Array.from(selection.selectedIds);
+    let failedCount = 0;
+    for (const photoId of ids) {
+      try {
+        await deletePhoto({ listingId, photoId }).unwrap();
+      } catch {
+        failedCount++;
+        showError(`I couldn't remove photo ${photoId}. Stopped after the first failure.`);
+        break;
+      }
+    }
+    setIsBulkDeleting(false);
+    if (failedCount === 0) {
+      showSuccess(ids.length === 1 ? "Photo removed." : `${ids.length} photos removed.`);
+      clearSelection();
+    }
+  }
+
+  async function handleBulkDownload() {
+    setIsBulkDownloading(true);
+    const selectedPhotos = displayIds
+      .filter((id) => selection.selectedIds.has(id))
+      .map((id) => photosById.get(id))
+      .filter((p): p is ListingPhoto => p !== undefined);
+
+    const slug = listingSlug ?? listingId;
+    try {
+      await downloadPhotosAsZip(selectedPhotos, slug);
+    } catch {
+      showError("I couldn't create the download. Want to try again?");
+    } finally {
+      setIsBulkDownloading(false);
     }
   }
 
@@ -163,6 +218,19 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
         />
       </div>
 
+      {hasSelection ? (
+        <PhotoSelectionToolbar
+          selectedCount={selectedCount}
+          totalCount={displayIds.length}
+          onSelectAll={() => selectAll(displayIds)}
+          onClear={clearSelection}
+          onBulkDelete={() => setConfirmBulkDelete(true)}
+          onBulkDownload={() => void handleBulkDownload()}
+          isBulkDeleting={isBulkDeleting}
+          isBulkDownloading={isBulkDownloading}
+        />
+      ) : null}
+
       {sortedPhotos.length === 0 ? (
         <p
           className="text-sm text-muted-foreground border rounded-lg p-6 text-center"
@@ -190,6 +258,10 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
                     key={photoId}
                     photo={photo}
                     onDelete={() => setConfirmDeleteId(photoId)}
+                    selected={isSelected(photoId)}
+                    onToggleSelection={(id, shiftKey) =>
+                      toggleSelection(id, shiftKey, displayIds)
+                    }
                   />
                 );
               })}
@@ -207,6 +279,18 @@ export default function ListingPhotoManager({ listingId, photos }: ListingPhotoM
         variant="danger"
         onConfirm={handleConfirmDelete}
         onCancel={() => setConfirmDeleteId(null)}
+      />
+
+      <ConfirmDialog
+        open={confirmBulkDelete}
+        title={`Delete ${selectedCount} photo${selectedCount === 1 ? "" : "s"}?`}
+        description="These photos will be permanently deleted from this listing. This can't be undone."
+        confirmLabel={`Delete ${selectedCount} photo${selectedCount === 1 ? "" : "s"}`}
+        cancelLabel="Cancel"
+        variant="danger"
+        isLoading={isBulkDeleting}
+        onConfirm={() => void handleBulkDelete()}
+        onCancel={() => setConfirmBulkDelete(false)}
       />
     </div>
   );

--- a/apps/mybookkeeper/frontend/src/app/features/listings/PhotoSelectionCheckbox.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/PhotoSelectionCheckbox.tsx
@@ -1,0 +1,35 @@
+export interface PhotoSelectionCheckboxProps {
+  photoId: string;
+  selected: boolean;
+  onToggle: (photoId: string, shiftKey: boolean) => void;
+  photoIndex: number;
+}
+
+export default function PhotoSelectionCheckbox({
+  photoId,
+  selected,
+  onToggle,
+  photoIndex,
+}: PhotoSelectionCheckboxProps) {
+  return (
+    <div
+      className="absolute top-1 left-1 z-10"
+      // Stop click propagation so the checkbox area never opens the lightbox.
+      onClick={(e) => e.stopPropagation()}
+    >
+      <input
+        type="checkbox"
+        checked={selected}
+        onChange={() => {}}
+        onClick={(e) => {
+          e.stopPropagation();
+          onToggle(photoId, e.shiftKey);
+        }}
+        className="cursor-pointer w-5 h-5 rounded accent-primary"
+        aria-label={`Select photo ${photoIndex + 1}`}
+        data-testid="listing-photo-checkbox"
+        data-photo-id={photoId}
+      />
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/listings/PhotoSelectionToolbar.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/PhotoSelectionToolbar.tsx
@@ -1,0 +1,86 @@
+import { Download, Trash2 } from "lucide-react";
+import Button from "@/shared/components/ui/Button";
+
+export interface PhotoSelectionToolbarProps {
+  selectedCount: number;
+  totalCount: number;
+  onSelectAll: () => void;
+  onClear: () => void;
+  onBulkDelete: () => void;
+  onBulkDownload: () => void;
+  isBulkDeleting: boolean;
+  isBulkDownloading: boolean;
+}
+
+export default function PhotoSelectionToolbar({
+  selectedCount,
+  totalCount,
+  onSelectAll,
+  onClear,
+  onBulkDelete,
+  onBulkDownload,
+  isBulkDeleting,
+  isBulkDownloading,
+}: PhotoSelectionToolbarProps) {
+  return (
+    <div
+      className="flex items-center gap-3 px-3 py-2 bg-muted/60 border rounded-lg flex-wrap"
+      data-testid="photo-selection-toolbar"
+    >
+      <span className="text-sm font-medium shrink-0" data-testid="photo-selection-count">
+        {selectedCount} selected
+      </span>
+
+      <div className="flex items-center gap-2 flex-1 flex-wrap">
+        {selectedCount < totalCount ? (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onSelectAll}
+            type="button"
+            data-testid="photo-select-all-button"
+          >
+            Select all ({totalCount})
+          </Button>
+        ) : null}
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClear}
+          type="button"
+          data-testid="photo-clear-selection-button"
+        >
+          Clear
+        </Button>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onBulkDownload}
+          disabled={isBulkDownloading || isBulkDeleting}
+          type="button"
+          data-testid="photo-bulk-download-button"
+        >
+          <Download className="h-4 w-4 mr-1" />
+          {isBulkDownloading ? "Downloading..." : "Download"}
+        </Button>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onBulkDelete}
+          disabled={isBulkDeleting || isBulkDownloading}
+          className="text-red-600 hover:text-red-700 hover:bg-red-50"
+          type="button"
+          data-testid="photo-bulk-delete-button"
+        >
+          <Trash2 className="h-4 w-4 mr-1" />
+          {isBulkDeleting ? "Deleting..." : "Delete"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/listings/photo-bulk-download.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/photo-bulk-download.ts
@@ -1,0 +1,72 @@
+import JSZip from "jszip";
+import { showError } from "@/shared/lib/toast-store";
+import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
+
+/**
+ * Fetches each selected photo's presigned URL, bundles them into a zip, and
+ * triggers a browser download.
+ *
+ * Photos without a presigned_url are skipped (storage unavailable / already
+ * expired). A warning toast is shown for each skipped photo so the user is
+ * not silently given a partial zip.
+ */
+export async function downloadPhotosAsZip(
+  photos: ListingPhoto[],
+  listingSlug: string,
+): Promise<void> {
+  const zip = new JSZip();
+  const today = new Date().toISOString().slice(0, 10);
+  const zipName = `${listingSlug}-photos-${today}.zip`;
+
+  let skippedCount = 0;
+
+  await Promise.all(
+    photos.map(async (photo, index) => {
+      if (!photo.presigned_url) {
+        skippedCount++;
+        return;
+      }
+      try {
+        const response = await fetch(photo.presigned_url);
+        if (!response.ok) {
+          skippedCount++;
+          return;
+        }
+        const blob = await response.blob();
+        const extension = inferExtension(blob.type);
+        const filename = `photo-${String(index + 1).padStart(3, "0")}${extension}`;
+        zip.file(filename, blob);
+      } catch {
+        skippedCount++;
+      }
+    }),
+  );
+
+  if (skippedCount > 0) {
+    showError(
+      skippedCount === 1
+        ? "1 photo couldn't be fetched and was skipped."
+        : `${skippedCount} photos couldn't be fetched and were skipped.`,
+    );
+  }
+
+  const content = await zip.generateAsync({ type: "blob" });
+  triggerDownload(content, zipName);
+}
+
+function inferExtension(mimeType: string): string {
+  if (mimeType === "image/png") return ".png";
+  if (mimeType === "image/heic" || mimeType === "image/heif") return ".heic";
+  return ".jpg";
+}
+
+function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+}

--- a/apps/mybookkeeper/frontend/src/app/features/listings/usePhotoSelection.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/listings/usePhotoSelection.ts
@@ -1,0 +1,70 @@
+import { useState, useCallback } from "react";
+import type { PhotoSelection } from "@/shared/types/listing/photo-selection";
+
+export interface UsePhotoSelectionReturn {
+  selection: PhotoSelection;
+  toggleSelection: (photoId: string, shiftKey: boolean, orderedIds: string[]) => void;
+  selectAll: (ids: string[]) => void;
+  clearSelection: () => void;
+  isSelected: (photoId: string) => boolean;
+}
+
+export function usePhotoSelection(): UsePhotoSelectionReturn {
+  const [selection, setSelection] = useState<PhotoSelection>({
+    selectedIds: new Set(),
+    lastSelectedId: null,
+  });
+
+  const toggleSelection = useCallback(
+    (photoId: string, shiftKey: boolean, orderedIds: string[]) => {
+      setSelection((prev) => {
+        if (shiftKey && prev.lastSelectedId) {
+          const anchorIndex = orderedIds.indexOf(prev.lastSelectedId);
+          const targetIndex = orderedIds.indexOf(photoId);
+          if (anchorIndex === -1 || targetIndex === -1) {
+            // Fallback: just toggle the single photo
+            const next = new Set(prev.selectedIds);
+            if (next.has(photoId)) {
+              next.delete(photoId);
+            } else {
+              next.add(photoId);
+            }
+            return { selectedIds: next, lastSelectedId: photoId };
+          }
+          const start = Math.min(anchorIndex, targetIndex);
+          const end = Math.max(anchorIndex, targetIndex);
+          const rangeIds = orderedIds.slice(start, end + 1);
+          const next = new Set(prev.selectedIds);
+          for (const id of rangeIds) {
+            next.add(id);
+          }
+          return { selectedIds: next, lastSelectedId: photoId };
+        }
+
+        const next = new Set(prev.selectedIds);
+        if (next.has(photoId)) {
+          next.delete(photoId);
+        } else {
+          next.add(photoId);
+        }
+        return { selectedIds: next, lastSelectedId: photoId };
+      });
+    },
+    [],
+  );
+
+  const selectAll = useCallback((ids: string[]) => {
+    setSelection({ selectedIds: new Set(ids), lastSelectedId: ids[ids.length - 1] ?? null });
+  }, []);
+
+  const clearSelection = useCallback(() => {
+    setSelection({ selectedIds: new Set(), lastSelectedId: null });
+  }, []);
+
+  const isSelected = useCallback(
+    (photoId: string) => selection.selectedIds.has(photoId),
+    [selection.selectedIds],
+  );
+
+  return { selection, toggleSelection, selectAll, clearSelection, isSelected };
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/listing/photo-selection.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/listing/photo-selection.ts
@@ -1,0 +1,4 @@
+export interface PhotoSelection {
+  selectedIds: Set<string>;
+  lastSelectedId: string | null;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "axios": "^1.7.7",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
+        "jszip": "^3.10.1",
         "lucide-react": "^1.14.0",
         "posthog-js": "^1.372.6",
         "qrcode.react": "^4.2.0",
@@ -4975,6 +4976,11 @@
         "url": "https://opencollective.com/core-js"
       }
     },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -6000,6 +6006,11 @@
         "node": ">= 4"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/immer": {
       "version": "11.1.4",
       "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
@@ -6042,6 +6053,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/internmap": {
       "version": "2.0.3",
@@ -6113,6 +6129,11 @@
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
       "dev": true
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -6273,6 +6294,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6293,6 +6325,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
       }
     },
     "node_modules/lightningcss": {
@@ -6914,6 +6954,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -7268,6 +7313,11 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7606,6 +7656,20 @@
         "pify": "^2.3.0"
       }
     },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -7851,6 +7915,11 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/saxes": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -7881,6 +7950,11 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -7929,6 +8003,14 @@
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
       "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "node_modules/strip-indent": {
       "version": "3.0.0",
@@ -8379,8 +8461,7 @@
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/vaul": {
       "version": "1.1.2",


### PR DESCRIPTION
## Summary

- **Multi-select mode** — a checkbox appears top-left on each photo card; clicking it enters selection mode without opening the lightbox. The image area still opens the lightbox. Shift-click extends selection range from the last-clicked photo to the target.
- **Selection toolbar** — appears above the grid whenever ≥1 photo is selected. Shows `{N} selected`, a **Select all** button (hidden when all are selected), a **Clear** button, a **Download** button, and a **Delete** button.
- **Bulk delete** — confirms with `Delete N photos?`, then iterates DELETE calls sequentially (stops on first failure with an error toast). Clears selection after success. Uses the existing `DELETE /api/listings/{listing_id}/photos/{photo_id}` endpoint × N — no backend changes.
- **Bulk download** — fetches each selected photo's `presigned_url`, zips them client-side with `jszip`, and triggers a browser download named `<slug>-photos-<YYYY-MM-DD>.zip`. Photos with `null` presigned_url are skipped with a warning toast.
- **Visual selection state** — selected cards get a `border-2 border-primary` ring.

## Files changed

| File | Change |
|------|--------|
| `shared/types/listing/photo-selection.ts` | New — `PhotoSelection` interface |
| `features/listings/usePhotoSelection.ts` | New — custom hook with single-toggle, shift-range, select-all, clear |
| `features/listings/PhotoSelectionCheckbox.tsx` | New — checkbox overlay; click does NOT propagate to image/lightbox |
| `features/listings/PhotoSelectionToolbar.tsx` | New — toolbar with count, Select all, Clear, Download, Delete |
| `features/listings/photo-bulk-download.ts` | New — pure async function; jszip + browser download trigger |
| `features/listings/ListingPhotoCard.tsx` | Modified — `selected` + `onToggleSelection` props; drag handle shifted right to avoid collision with delete button |
| `features/listings/ListingPhotoManager.tsx` | Modified — wires `usePhotoSelection`, renders toolbar conditionally, handles bulk-delete + bulk-download flows |
| `package.json` | Added `jszip ^3.10.1` |

## What was NOT changed (per spec)

- Lightbox logic (no `PhotoLightbox*.tsx` touched)
- Drag-reorder logic
- Backend endpoints (no new endpoints)

## Design decisions

- **Sequential delete, not parallel** — iterating serially means the first API failure gives a precise error instead of a pile of concurrent errors. For N ≤ 20 photos the latency is acceptable.
- **`onOpenLightbox` is optional** — the lightbox components from PR #258 don't exist in `main` yet. Making the prop optional keeps this PR independent; once #258 lands the prop can be wired.
- **Drag handle moved** — the drag handle was `absolute top-1 left-1`; with the checkbox now occupying that corner, it was moved to `top-1 right-8` (beside the delete button). The delete button stays `top-1 right-1`.

## Test coverage

- `usePhotoSelection.test.tsx` — 8 cases: initial state, single toggle on/off, range select forward, range select backward, shift-click with no prior selection, select-all, clear, range extends pre-existing selection
- `PhotoSelectionToolbar.test.tsx` — 11 cases: count display, Select all visibility, button callbacks, disabled states during loading, loading label text
- `photo-bulk-download.test.ts` — 6 cases: fetches all URLs, zip filename format, skips null presigned_url with singular toast, skips failed fetch with plural toast, singular wording at exactly 1, triggers browser download
- `ListingPhotoManager.test.tsx` — 5 new cases: toolbar hidden before selection, toolbar appears with correct count, bulk delete confirm + mutations, Clear hides toolbar
- `e2e/listings-photo-bulk.spec.ts` — 2 behavioral tests: select 2 of 3 photos → bulk delete → assert 1 remains (UI + API); Select all → count = 3 → Clear → toolbar hidden

## Test plan

- [ ] Run `npm test` in `apps/mybookkeeper/frontend/` — all new tests pass (pre-existing failures in Documents/InviteAccept/ListingDetail are unrelated to this PR)
- [ ] Run `npm run build` — type check clean
- [ ] Verify checkboxes appear on hover/tap on each photo card
- [ ] Verify clicking the photo image opens lightbox; clicking checkbox selects
- [ ] Verify shift-click selects a range
- [ ] Verify bulk delete asks for confirmation and removes photos
- [ ] Verify bulk download produces a zip
- [ ] Verify toolbar disappears after Clear

🤖 Generated with [Claude Code](https://claude.com/claude-code)