### PR TITLE
refactor(transactions): replace 3-way ternary chains with discriminated-union dispatch

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/useClassificationRulesPanelMode.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/useClassificationRulesPanelMode.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { useClassificationRulesPanelMode } from "@/app/features/transactions/useClassificationRulesPanelMode";
+import type { ClassificationRule } from "@/shared/types/classification-rule/classification-rule";
+
+function makeRule(override?: Partial<ClassificationRule>): ClassificationRule {
+  return {
+    id: "rule-1",
+    organization_id: "org-1",
+    match_type: "contains",
+    match_pattern: "Home Depot",
+    match_context: null,
+    category: "repairs",
+    property_id: null,
+    activity_id: null,
+    source: "user",
+    priority: 1,
+    times_applied: 3,
+    is_active: true,
+    created_at: "2025-01-01T00:00:00Z",
+    ...override,
+  };
+}
+
+describe("useClassificationRulesPanelMode", () => {
+  it("returns 'loading' when isLoading is true regardless of rules", () => {
+    expect(useClassificationRulesPanelMode({ isLoading: true, rules: [] })).toBe("loading");
+    expect(useClassificationRulesPanelMode({ isLoading: true, rules: [makeRule()] })).toBe("loading");
+  });
+
+  it("returns 'empty' when not loading and rules array is empty", () => {
+    expect(useClassificationRulesPanelMode({ isLoading: false, rules: [] })).toBe("empty");
+  });
+
+  it("returns 'list' when not loading and rules exist", () => {
+    expect(useClassificationRulesPanelMode({ isLoading: false, rules: [makeRule()] })).toBe("list");
+    expect(
+      useClassificationRulesPanelMode({ isLoading: false, rules: [makeRule(), makeRule({ id: "rule-2" })] }),
+    ).toBe("list");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/useMergeFieldPickerMode.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/useMergeFieldPickerMode.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { useMergeFieldPickerMode } from "@/app/features/transactions/useMergeFieldPickerMode";
+import type { MergeableField } from "@/app/features/transactions/merge-defaults";
+
+describe("useMergeFieldPickerMode", () => {
+  it("returns 'no-conflicts' when visibleFields is empty", () => {
+    expect(useMergeFieldPickerMode({ visibleFields: [] })).toBe("no-conflicts");
+  });
+
+  it("returns 'date-only' when only transaction_date differs", () => {
+    const fields: MergeableField[] = ["transaction_date"];
+    expect(useMergeFieldPickerMode({ visibleFields: fields })).toBe("date-only");
+  });
+
+  it("returns 'conflicts' when multiple fields differ", () => {
+    const fields: MergeableField[] = ["transaction_date", "vendor"];
+    expect(useMergeFieldPickerMode({ visibleFields: fields })).toBe("conflicts");
+  });
+
+  it("returns 'conflicts' when a single non-date field differs", () => {
+    const fields: MergeableField[] = ["vendor"];
+    expect(useMergeFieldPickerMode({ visibleFields: fields })).toBe("conflicts");
+  });
+
+  it("returns 'conflicts' when amount and vendor differ", () => {
+    const fields: MergeableField[] = ["amount", "vendor"];
+    expect(useMergeFieldPickerMode({ visibleFields: fields })).toBe("conflicts");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesEmptyState.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesEmptyState.tsx
@@ -1,0 +1,8 @@
+export default function ClassificationRulesEmptyState() {
+  return (
+    <div className="px-5 py-12 text-center text-muted-foreground text-sm">
+      <p>No classification rules yet.</p>
+      <p className="mt-1">When you correct a transaction's category, I'll remember the vendor and apply it automatically next time.</p>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesList.tsx
@@ -1,0 +1,63 @@
+import { Trash2 } from "lucide-react";
+import { formatTag } from "@/shared/utils/tag";
+import type { ClassificationRule } from "@/shared/types/classification-rule/classification-rule";
+
+export interface ClassificationRulesListProps {
+  rules: readonly ClassificationRule[];
+  propertyMap: ReadonlyMap<string, string>;
+  deletingId: string | null;
+  onDeleteClick: (ruleId: string) => void;
+}
+
+export default function ClassificationRulesList({
+  rules,
+  propertyMap,
+  deletingId,
+  onDeleteClick,
+}: ClassificationRulesListProps) {
+  return (
+    <table className="w-full text-sm">
+      <thead>
+        <tr className="border-b text-left text-muted-foreground">
+          <th className="px-5 py-2.5 font-medium">Pattern</th>
+          <th className="px-3 py-2.5 font-medium">Category</th>
+          <th className="px-3 py-2.5 font-medium text-right">Used</th>
+          <th className="px-3 py-2.5 w-10" />
+        </tr>
+      </thead>
+      <tbody>
+        {rules.map((rule) => (
+          <tr key={rule.id} className="border-b last:border-0 hover:bg-muted/50">
+            <td className="px-5 py-2.5">
+              <div className="font-medium">{rule.match_pattern}</div>
+              <div className="text-xs text-muted-foreground mt-0.5 flex gap-2">
+                <span className="capitalize">{rule.match_type}</span>
+                {rule.property_id ? (
+                  <span>| {propertyMap.get(rule.property_id) ?? "Unknown property"}</span>
+                ) : null}
+              </div>
+            </td>
+            <td className="px-3 py-2.5">
+              <span className="inline-block bg-muted text-xs px-2 py-0.5 rounded">
+                {formatTag(rule.category)}
+              </span>
+            </td>
+            <td className="px-3 py-2.5 text-right text-muted-foreground">
+              {rule.times_applied}x
+            </td>
+            <td className="px-3 py-2.5">
+              <button
+                onClick={() => onDeleteClick(rule.id)}
+                disabled={deletingId === rule.id}
+                className="text-muted-foreground hover:text-destructive p-1 rounded disabled:opacity-50"
+                aria-label={`Delete rule for ${rule.match_pattern}`}
+              >
+                <Trash2 size={14} />
+              </button>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesLoadingState.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesLoadingState.tsx
@@ -1,0 +1,9 @@
+import Spinner from "@/shared/components/icons/Spinner";
+
+export default function ClassificationRulesLoadingState() {
+  return (
+    <div className="flex items-center justify-center py-12">
+      <Spinner />
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesPanel.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
-import { X, Trash2 } from "lucide-react";
+import { X } from "lucide-react";
 import {
   useListClassificationRulesQuery,
   useDeleteClassificationRuleMutation,
 } from "@/shared/store/classificationRulesApi";
 import { useGetPropertiesQuery } from "@/shared/store/propertiesApi";
-import { formatTag } from "@/shared/utils/tag";
 import Panel from "@/shared/components/ui/Panel";
 import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
-import Spinner from "@/shared/components/icons/Spinner";
+import { useClassificationRulesPanelMode } from "./useClassificationRulesPanelMode";
+import ClassificationRulesPanelBody from "./ClassificationRulesPanelBody";
 
 export interface ClassificationRulesPanelProps {
   onClose: () => void;
@@ -36,6 +36,8 @@ export default function ClassificationRulesPanel({ onClose }: ClassificationRule
 
   const deleteTarget = confirmDeleteId ? rules.find((r) => r.id === confirmDeleteId) : null;
 
+  const mode = useClassificationRulesPanelMode({ isLoading, rules });
+
   return (
     <Panel position="right" onClose={onClose} width="520px">
       <div className="px-5 py-4 border-b flex items-center justify-between">
@@ -51,60 +53,13 @@ export default function ClassificationRulesPanel({ onClose }: ClassificationRule
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {isLoading ? (
-          <div className="flex items-center justify-center py-12">
-            <Spinner />
-          </div>
-        ) : rules.length === 0 ? (
-          <div className="px-5 py-12 text-center text-muted-foreground text-sm">
-            <p>No classification rules yet.</p>
-            <p className="mt-1">When you correct a transaction's category, I'll remember the vendor and apply it automatically next time.</p>
-          </div>
-        ) : (
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b text-left text-muted-foreground">
-                <th className="px-5 py-2.5 font-medium">Pattern</th>
-                <th className="px-3 py-2.5 font-medium">Category</th>
-                <th className="px-3 py-2.5 font-medium text-right">Used</th>
-                <th className="px-3 py-2.5 w-10" />
-              </tr>
-            </thead>
-            <tbody>
-              {rules.map((rule) => (
-                <tr key={rule.id} className="border-b last:border-0 hover:bg-muted/50">
-                  <td className="px-5 py-2.5">
-                    <div className="font-medium">{rule.match_pattern}</div>
-                    <div className="text-xs text-muted-foreground mt-0.5 flex gap-2">
-                      <span className="capitalize">{rule.match_type}</span>
-                      {rule.property_id ? (
-                        <span>| {propertyMap.get(rule.property_id) ?? "Unknown property"}</span>
-                      ) : null}
-                    </div>
-                  </td>
-                  <td className="px-3 py-2.5">
-                    <span className="inline-block bg-muted text-xs px-2 py-0.5 rounded">
-                      {formatTag(rule.category)}
-                    </span>
-                  </td>
-                  <td className="px-3 py-2.5 text-right text-muted-foreground">
-                    {rule.times_applied}x
-                  </td>
-                  <td className="px-3 py-2.5">
-                    <button
-                      onClick={() => setConfirmDeleteId(rule.id)}
-                      disabled={deletingId === rule.id}
-                      className="text-muted-foreground hover:text-destructive p-1 rounded disabled:opacity-50"
-                      aria-label={`Delete rule for ${rule.match_pattern}`}
-                    >
-                      <Trash2 size={14} />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
+        <ClassificationRulesPanelBody
+          mode={mode}
+          rules={rules}
+          propertyMap={propertyMap}
+          deletingId={deletingId}
+          onDeleteClick={setConfirmDeleteId}
+        />
       </div>
 
       <div className="px-5 py-3 border-t text-xs text-muted-foreground">

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesPanelBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/ClassificationRulesPanelBody.tsx
@@ -1,0 +1,37 @@
+import type { ClassificationRulesPanelMode } from "@/shared/types/transaction/classification-rules-panel-mode";
+import type { ClassificationRule } from "@/shared/types/classification-rule/classification-rule";
+import ClassificationRulesLoadingState from "./ClassificationRulesLoadingState";
+import ClassificationRulesEmptyState from "./ClassificationRulesEmptyState";
+import ClassificationRulesList from "./ClassificationRulesList";
+
+export interface ClassificationRulesPanelBodyProps {
+  mode: ClassificationRulesPanelMode;
+  rules: readonly ClassificationRule[];
+  propertyMap: ReadonlyMap<string, string>;
+  deletingId: string | null;
+  onDeleteClick: (ruleId: string) => void;
+}
+
+export default function ClassificationRulesPanelBody({
+  mode,
+  rules,
+  propertyMap,
+  deletingId,
+  onDeleteClick,
+}: ClassificationRulesPanelBodyProps) {
+  switch (mode) {
+    case "loading":
+      return <ClassificationRulesLoadingState />;
+    case "empty":
+      return <ClassificationRulesEmptyState />;
+    case "list":
+      return (
+        <ClassificationRulesList
+          rules={rules}
+          propertyMap={propertyMap}
+          deletingId={deletingId}
+          onDeleteClick={onDeleteClick}
+        />
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/MergeConflictsState.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/MergeConflictsState.tsx
@@ -1,0 +1,49 @@
+import type { DuplicateTransaction, MergeFieldSide } from "@/shared/types/transaction/duplicate";
+import type { MergeableField } from "./merge-defaults";
+import MergeFieldRow from "./MergeFieldRow";
+
+export interface MergeConflictsStateProps {
+  visibleFields: readonly MergeableField[];
+  labelA: string;
+  labelB: string;
+  txnA: DuplicateTransaction;
+  txnB: DuplicateTransaction;
+  selections: Record<MergeableField, MergeFieldSide>;
+  formatFieldValue: (field: MergeableField, txn: DuplicateTransaction) => string | null;
+  onSelectionChange: (field: MergeableField, side: MergeFieldSide) => void;
+}
+
+export default function MergeConflictsState({
+  visibleFields,
+  labelA,
+  labelB,
+  txnA,
+  txnB,
+  selections,
+  formatFieldValue,
+  onSelectionChange,
+}: MergeConflictsStateProps) {
+  return (
+    <div className="rounded-md border divide-y overflow-hidden">
+      {visibleFields.map((field) => {
+        const valueA = formatFieldValue(field, txnA);
+        const valueB = formatFieldValue(field, txnB);
+        const showAmountWarning = field === "amount" && txnA.amount !== txnB.amount;
+
+        return (
+          <MergeFieldRow
+            key={field}
+            field={field}
+            labelA={labelA}
+            labelB={labelB}
+            valueA={valueA}
+            valueB={valueB}
+            selected={selections[field]}
+            onSelect={(side) => onSelectionChange(field, side)}
+            showAmountWarning={showAmountWarning}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/MergeDateOnlyState.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/MergeDateOnlyState.tsx
@@ -1,0 +1,50 @@
+import { Info } from "lucide-react";
+import type { DuplicateTransaction, MergeFieldSide } from "@/shared/types/transaction/duplicate";
+import type { MergeableField } from "./merge-defaults";
+import MergeFieldRow from "./MergeFieldRow";
+
+export interface MergeDateOnlyStateProps {
+  visibleFields: readonly MergeableField[];
+  labelA: string;
+  labelB: string;
+  txnA: DuplicateTransaction;
+  txnB: DuplicateTransaction;
+  propertyMap: ReadonlyMap<string, string>;
+  selections: Record<MergeableField, MergeFieldSide>;
+  formatFieldValue: (field: MergeableField, txn: DuplicateTransaction) => string | null;
+  onSelectionChange: (field: MergeableField, side: MergeFieldSide) => void;
+}
+
+export default function MergeDateOnlyState({
+  visibleFields,
+  labelA,
+  labelB,
+  txnA,
+  txnB,
+  selections,
+  formatFieldValue,
+  onSelectionChange,
+}: MergeDateOnlyStateProps) {
+  return (
+    <>
+      <div className="flex items-center gap-2 px-3 py-2.5 rounded-md bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 text-sm">
+        <Info size={14} className="shrink-0" />
+        These look like the same expense from different dates. Which date is correct?
+      </div>
+      <div className="rounded-md border divide-y overflow-hidden mt-2">
+        {visibleFields.map((field) => (
+          <MergeFieldRow
+            key={field}
+            field={field}
+            labelA={labelA}
+            labelB={labelB}
+            valueA={formatFieldValue(field, txnA)}
+            valueB={formatFieldValue(field, txnB)}
+            selected={selections[field]}
+            onSelect={(side) => onSelectionChange(field, side)}
+          />
+        ))}
+      </div>
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/MergeFieldPicker.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/MergeFieldPicker.tsx
@@ -7,12 +7,13 @@ import {
   getRawValue,
   type MergeableField,
 } from "@/app/features/transactions/merge-defaults";
-import MergeFieldRow from "@/app/features/transactions/MergeFieldRow";
+import { useMergeFieldPickerMode } from "./useMergeFieldPickerMode";
+import MergeFieldPickerBody from "./MergeFieldPickerBody";
 
 function formatFieldValue(
   field: MergeableField,
   txn: DuplicateTransaction,
-  propertyMap: Map<string, string>,
+  propertyMap: ReadonlyMap<string, string>,
 ): string | null {
   switch (field) {
     case "transaction_date":
@@ -39,7 +40,7 @@ export interface MergeFieldPickerProps {
   txnB: DuplicateTransaction;
   labelA: string;
   labelB: string;
-  propertyMap: Map<string, string>;
+  propertyMap: ReadonlyMap<string, string>;
   selections: Record<MergeableField, MergeFieldSide>;
   onSelectionChange: (field: MergeableField, side: MergeFieldSide) => void;
 }
@@ -64,60 +65,22 @@ export default function MergeFieldPicker({
     return true;
   });
 
-  const allConflictsMatch = visibleFields.length === 0;
-  const onlyDateDiffers = visibleFields.length === 1 && visibleFields[0] === "transaction_date";
+  const mode = useMergeFieldPickerMode({ visibleFields });
 
   return (
     <div className="space-y-0">
-      {allConflictsMatch ? (
-        <div className="flex items-center gap-2 px-3 py-2.5 rounded-md bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 text-sm">
-          <Info size={14} className="shrink-0" />
-          No conflicts found — all fields match. Ready to merge.
-        </div>
-      ) : onlyDateDiffers ? (
-        <>
-          <div className="flex items-center gap-2 px-3 py-2.5 rounded-md bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-300 text-sm">
-            <Info size={14} className="shrink-0" />
-            These look like the same expense from different dates. Which date is correct?
-          </div>
-          <div className="rounded-md border divide-y overflow-hidden mt-2">
-            {visibleFields.map((field) => (
-              <MergeFieldRow
-                key={field}
-                field={field}
-                labelA={labelA}
-                labelB={labelB}
-                valueA={formatFieldValue(field, txnA, propertyMap)}
-                valueB={formatFieldValue(field, txnB, propertyMap)}
-                selected={selections[field]}
-                onSelect={(side) => onSelectionChange(field, side)}
-              />
-            ))}
-          </div>
-        </>
-      ) : (
-        <div className="rounded-md border divide-y overflow-hidden">
-          {visibleFields.map((field) => {
-            const valueA = formatFieldValue(field, txnA, propertyMap);
-            const valueB = formatFieldValue(field, txnB, propertyMap);
-            const showAmountWarning = field === "amount" && txnA.amount !== txnB.amount;
-
-            return (
-              <MergeFieldRow
-                key={field}
-                field={field}
-                labelA={labelA}
-                labelB={labelB}
-                valueA={valueA}
-                valueB={valueB}
-                selected={selections[field]}
-                onSelect={(side) => onSelectionChange(field, side)}
-                showAmountWarning={showAmountWarning}
-              />
-            );
-          })}
-        </div>
-      )}
+      <MergeFieldPickerBody
+        mode={mode}
+        visibleFields={visibleFields}
+        labelA={labelA}
+        labelB={labelB}
+        txnA={txnA}
+        txnB={txnB}
+        propertyMap={propertyMap}
+        selections={selections}
+        formatFieldValue={(field, txn) => formatFieldValue(field, txn, propertyMap)}
+        onSelectionChange={onSelectionChange}
+      />
 
       {allTags.length > 0 && (
         <div className="flex items-center gap-2 pt-3 text-sm text-muted-foreground">

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/MergeFieldPickerBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/MergeFieldPickerBody.tsx
@@ -1,0 +1,64 @@
+import type { MergeFieldPickerMode } from "@/shared/types/transaction/merge-field-picker-mode";
+import type { DuplicateTransaction, MergeFieldSide } from "@/shared/types/transaction/duplicate";
+import type { MergeableField } from "./merge-defaults";
+import MergeNoConflictsState from "./MergeNoConflictsState";
+import MergeDateOnlyState from "./MergeDateOnlyState";
+import MergeConflictsState from "./MergeConflictsState";
+
+export interface MergeFieldPickerBodyProps {
+  mode: MergeFieldPickerMode;
+  visibleFields: readonly MergeableField[];
+  labelA: string;
+  labelB: string;
+  txnA: DuplicateTransaction;
+  txnB: DuplicateTransaction;
+  propertyMap: ReadonlyMap<string, string>;
+  selections: Record<MergeableField, MergeFieldSide>;
+  formatFieldValue: (field: MergeableField, txn: DuplicateTransaction) => string | null;
+  onSelectionChange: (field: MergeableField, side: MergeFieldSide) => void;
+}
+
+export default function MergeFieldPickerBody({
+  mode,
+  visibleFields,
+  labelA,
+  labelB,
+  txnA,
+  txnB,
+  propertyMap,
+  selections,
+  formatFieldValue,
+  onSelectionChange,
+}: MergeFieldPickerBodyProps) {
+  switch (mode) {
+    case "no-conflicts":
+      return <MergeNoConflictsState />;
+    case "date-only":
+      return (
+        <MergeDateOnlyState
+          visibleFields={visibleFields}
+          labelA={labelA}
+          labelB={labelB}
+          txnA={txnA}
+          txnB={txnB}
+          propertyMap={propertyMap}
+          selections={selections}
+          formatFieldValue={formatFieldValue}
+          onSelectionChange={onSelectionChange}
+        />
+      );
+    case "conflicts":
+      return (
+        <MergeConflictsState
+          visibleFields={visibleFields}
+          labelA={labelA}
+          labelB={labelB}
+          txnA={txnA}
+          txnB={txnB}
+          selections={selections}
+          formatFieldValue={formatFieldValue}
+          onSelectionChange={onSelectionChange}
+        />
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/MergeNoConflictsState.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/MergeNoConflictsState.tsx
@@ -1,0 +1,10 @@
+import { Info } from "lucide-react";
+
+export default function MergeNoConflictsState() {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2.5 rounded-md bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 text-sm">
+      <Info size={14} className="shrink-0" />
+      No conflicts found — all fields match. Ready to merge.
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/SourcePreviewBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/SourcePreviewBody.tsx
@@ -1,0 +1,24 @@
+import type { SourcePreviewType } from "@/shared/types/transaction/source-preview-type";
+
+export interface SourcePreviewBodyProps {
+  mode: SourcePreviewType;
+  url: string;
+  fileName: string | null;
+}
+
+export default function SourcePreviewBody({ mode, url, fileName }: SourcePreviewBodyProps) {
+  switch (mode) {
+    case "pdf":
+      return <iframe src={url} className="w-full h-[70vh]" title="Source document" />;
+    case "image":
+      return <img src={url} alt="Source document" className="max-w-full max-h-[70vh] object-contain" />;
+    case "other":
+      return (
+        <div className="p-4 text-sm text-muted-foreground">
+          <a href={url} download={fileName} className="text-primary hover:underline">
+            Download {fileName}
+          </a>
+        </div>
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/TransactionForm.tsx
@@ -13,6 +13,7 @@ import FormField from "@/shared/components/ui/FormField";
 import Select from "@/shared/components/ui/Select";
 import TransactionDuplicateActions from "@/app/features/transactions/TransactionDuplicateActions";
 import { useGetVendorsQuery } from "@/shared/store/vendorsApi";
+import SourcePreviewBody from "./SourcePreviewBody";
 
 export interface TransactionFormProps {
   transaction: Transaction;
@@ -136,17 +137,11 @@ export default function TransactionForm({
               </button>
             </div>
             <div className="overflow-auto max-h-[calc(80vh-3rem)] flex items-center justify-center">
-              {sourcePreview.type === "pdf" ? (
-                <iframe src={sourcePreview.url} className="w-full h-[70vh]" title="Source document" />
-              ) : sourcePreview.type === "image" ? (
-                <img src={sourcePreview.url} alt="Source document" className="max-w-full max-h-[70vh] object-contain" />
-              ) : (
-                <div className="p-4 text-sm text-muted-foreground">
-                  <a href={sourcePreview.url} download={transaction.source_file_name} className="text-primary hover:underline">
-                    Download {transaction.source_file_name}
-                  </a>
-                </div>
-              )}
+              <SourcePreviewBody
+                mode={sourcePreview.type}
+                url={sourcePreview.url}
+                fileName={transaction.source_file_name}
+              />
             </div>
           </div>
         </div>

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/useClassificationRulesPanelMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/useClassificationRulesPanelMode.ts
@@ -1,0 +1,21 @@
+import type { ClassificationRulesPanelMode } from "@/shared/types/transaction/classification-rules-panel-mode";
+import type { ClassificationRule } from "@/shared/types/classification-rule/classification-rule";
+
+interface UseClassificationRulesPanelModeArgs {
+  isLoading: boolean;
+  rules: readonly ClassificationRule[];
+}
+
+/**
+ * Resolves the panel's render mode from the loaded state. Single source of
+ * truth so the body component is a flat switch instead of a tower of
+ * conditionals.
+ */
+export function useClassificationRulesPanelMode({
+  isLoading,
+  rules,
+}: UseClassificationRulesPanelModeArgs): ClassificationRulesPanelMode {
+  if (isLoading) return "loading";
+  if (rules.length === 0) return "empty";
+  return "list";
+}

--- a/apps/mybookkeeper/frontend/src/app/features/transactions/useMergeFieldPickerMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/transactions/useMergeFieldPickerMode.ts
@@ -1,0 +1,19 @@
+import type { MergeFieldPickerMode } from "@/shared/types/transaction/merge-field-picker-mode";
+import type { MergeableField } from "./merge-defaults";
+
+interface UseMergeFieldPickerModeArgs {
+  visibleFields: readonly MergeableField[];
+}
+
+/**
+ * Resolves the picker's render mode from the set of conflicting fields.
+ * Single source of truth so the body component is a flat switch instead
+ * of a tower of conditionals.
+ */
+export function useMergeFieldPickerMode({
+  visibleFields,
+}: UseMergeFieldPickerModeArgs): MergeFieldPickerMode {
+  if (visibleFields.length === 0) return "no-conflicts";
+  if (visibleFields.length === 1 && visibleFields[0] === "transaction_date") return "date-only";
+  return "conflicts";
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/transaction/classification-rules-panel-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/transaction/classification-rules-panel-mode.ts
@@ -1,0 +1,5 @@
+/**
+ * Discriminated union for what ClassificationRulesPanel body should render.
+ * Replaces a chain of nested ternaries with a single switch.
+ */
+export type ClassificationRulesPanelMode = "loading" | "empty" | "list";

--- a/apps/mybookkeeper/frontend/src/shared/types/transaction/merge-field-picker-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/transaction/merge-field-picker-mode.ts
@@ -1,0 +1,5 @@
+/**
+ * Discriminated union for what MergeFieldPicker body should render.
+ * Replaces a chain of nested ternaries with a single switch.
+ */
+export type MergeFieldPickerMode = "no-conflicts" | "date-only" | "conflicts";


### PR DESCRIPTION
## Summary

Per jkwon-claude-config #92: nested ternaries past 2 levels are unreadable. Three files in `apps/mybookkeeper/frontend/src/app/features/transactions/` had JSX expressions with ≥3 stacked ternaries. Each was refactored to the canonical `useXxxMode` hook + flat `switch` body dispatch pattern, matching the `DocumentViewer` reference implementation.

## Refactored files

| File | Discriminated union introduced |
|---|---|
| `ClassificationRulesPanel.tsx` | `ClassificationRulesPanelMode = 'loading' \| 'empty' \| 'list'` |
| `MergeFieldPicker.tsx` | `MergeFieldPickerMode = 'no-conflicts' \| 'date-only' \| 'conflicts'` |
| `TransactionForm.tsx` (source preview modal) | Uses existing `SourcePreviewType` — new `SourcePreviewBody` dispatches via switch |

## New files

**Hooks (one per refactored component):**
- `useClassificationRulesPanelMode.ts` — derives mode from `isLoading` + `rules.length`
- `useMergeFieldPickerMode.ts` — derives mode from `visibleFields.length` + whether only date differs

**Body dispatchers (flat switch, one component per file):**
- `ClassificationRulesPanelBody.tsx`
- `MergeFieldPickerBody.tsx`
- `SourcePreviewBody.tsx`

**Per-state subcomponents:**
- `ClassificationRulesLoadingState.tsx`, `ClassificationRulesEmptyState.tsx`, `ClassificationRulesList.tsx`
- `MergeNoConflictsState.tsx`, `MergeDateOnlyState.tsx`, `MergeConflictsState.tsx`

**Types:**
- `shared/types/transaction/classification-rules-panel-mode.ts`
- `shared/types/transaction/merge-field-picker-mode.ts`

## Test coverage

- `useClassificationRulesPanelMode.test.ts` — 3 cases (loading priority, empty, list)
- `useMergeFieldPickerMode.test.ts` — 5 cases (no-conflicts, date-only, single date conflict, conflicts with multiple fields, conflicts with single non-date field)
- Pre-existing regression tests: `DuplicateReview`, `DuplicateTab`, `MergeFieldRow`, `ExportDropdown` — all 30 pass
- Type check clean: `npx tsc --noEmit` exits 0

## Scope

Strictly limited to `apps/mybookkeeper/frontend/src/app/features/transactions/`. No behavior or styling changes — same render output as before. No backend changes.

## Pre-existing test failures (not introduced by this PR)

6 test files had failures on `main` before this branch was cut: `Documents`, `InviteAccept`, `ListingDetail`, `PendingInvites`, `TaxDocuments`, `Transactions` (tooltip + info banner tests). Confirmed pre-existing by running the full suite on `main` first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)