### PR TITLE
refactor(mbk/inquiries): ternary dispatch — hook + switch for InquiryReplyPanel, InquirySpamTriagePanel, ReplyTemplatesManager (#92)

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/useInquiryAuditTrailMode.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/useInquiryAuditTrailMode.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { useInquiryAuditTrailMode } from "@/app/features/inquiries/useInquiryAuditTrailMode";
+import type { InquirySpamAssessment } from "@/shared/types/inquiry/inquiry-spam-assessment";
+
+const ASSESSMENT: InquirySpamAssessment = {
+  id: "a-1",
+  inquiry_id: "inq-1",
+  assessment_type: "claude_score",
+  passed: true,
+  score: 95,
+  flags: null,
+  details_json: null,
+  created_at: "2026-05-04T10:00:00Z",
+};
+
+describe("useInquiryAuditTrailMode", () => {
+  it("returns 'collapsed' when not expanded, regardless of loading state", () => {
+    expect(
+      useInquiryAuditTrailMode({ expanded: false, isLoading: true, assessments: [] }),
+    ).toBe("collapsed");
+    expect(
+      useInquiryAuditTrailMode({ expanded: false, isLoading: false, assessments: [] }),
+    ).toBe("collapsed");
+    expect(
+      useInquiryAuditTrailMode({ expanded: false, isLoading: false, assessments: [ASSESSMENT] }),
+    ).toBe("collapsed");
+  });
+
+  it("returns 'loading' when expanded and loading", () => {
+    expect(
+      useInquiryAuditTrailMode({ expanded: true, isLoading: true, assessments: [] }),
+    ).toBe("loading");
+  });
+
+  it("returns 'empty' when expanded, loaded, and no assessments", () => {
+    expect(
+      useInquiryAuditTrailMode({ expanded: true, isLoading: false, assessments: [] }),
+    ).toBe("empty");
+  });
+
+  it("returns 'list' when expanded, loaded, and assessments present", () => {
+    expect(
+      useInquiryAuditTrailMode({ expanded: true, isLoading: false, assessments: [ASSESSMENT] }),
+    ).toBe("list");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/useInquiryReplyMode.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/useInquiryReplyMode.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { useInquiryReplyMode } from "@/app/features/inquiries/useInquiryReplyMode";
+
+describe("useInquiryReplyMode", () => {
+  it("returns 'reconnect' when reconnectReason is missing-integration", () => {
+    expect(
+      useInquiryReplyMode({ reconnectReason: "missing-integration", tab: "template" }),
+    ).toBe("reconnect");
+  });
+
+  it("returns 'reconnect' when reconnectReason is missing-send-scope", () => {
+    expect(
+      useInquiryReplyMode({ reconnectReason: "missing-send-scope", tab: "custom" }),
+    ).toBe("reconnect");
+  });
+
+  it("returns 'reconnect' when reconnectReason is reauth-required", () => {
+    expect(
+      useInquiryReplyMode({ reconnectReason: "reauth-required", tab: "template" }),
+    ).toBe("reconnect");
+  });
+
+  it("returns 'template' when gmail is healthy and template tab active", () => {
+    expect(
+      useInquiryReplyMode({ reconnectReason: null, tab: "template" }),
+    ).toBe("template");
+  });
+
+  it("returns 'custom' when gmail is healthy and custom tab active", () => {
+    expect(
+      useInquiryReplyMode({ reconnectReason: null, tab: "custom" }),
+    ).toBe("custom");
+  });
+
+  it("returns 'template' while integrations still loading (reconnectReason is null)", () => {
+    // While loading, reconnectReason is null, so we render the normal tab view.
+    expect(
+      useInquiryReplyMode({ reconnectReason: null, tab: "template" }),
+    ).toBe("template");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/useReplyTemplatesListMode.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/useReplyTemplatesListMode.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { useReplyTemplatesListMode } from "@/app/features/inquiries/useReplyTemplatesListMode";
+import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
+
+const TEMPLATE: ReplyTemplate = {
+  id: "tpl-1",
+  organization_id: "org-1",
+  user_id: "user-1",
+  name: "Initial inquiry reply",
+  subject_template: "Re: $listing",
+  body_template: "Hi $name",
+  is_archived: false,
+  display_order: 0,
+  created_at: "2026-05-04T10:00:00Z",
+  updated_at: "2026-05-04T10:00:00Z",
+};
+
+describe("useReplyTemplatesListMode", () => {
+  it("returns 'loading' while fetching regardless of templates list", () => {
+    expect(
+      useReplyTemplatesListMode({ isLoading: true, templates: [] }),
+    ).toBe("loading");
+    expect(
+      useReplyTemplatesListMode({ isLoading: true, templates: [TEMPLATE] }),
+    ).toBe("loading");
+  });
+
+  it("returns 'empty' when loaded and templates list is empty", () => {
+    expect(
+      useReplyTemplatesListMode({ isLoading: false, templates: [] }),
+    ).toBe("empty");
+  });
+
+  it("returns 'list' when loaded and templates are present", () => {
+    expect(
+      useReplyTemplatesListMode({ isLoading: false, templates: [TEMPLATE] }),
+    ).toBe("list");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryAuditTrailBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryAuditTrailBody.tsx
@@ -1,0 +1,26 @@
+import type { InquirySpamAssessment } from "@/shared/types/inquiry/inquiry-spam-assessment";
+import type { InquiryAuditTrailMode } from "@/shared/types/inquiry/inquiry-audit-trail-mode";
+import InquiryAuditTrailEmpty from "./InquiryAuditTrailEmpty";
+import InquiryAuditTrailList from "./InquiryAuditTrailList";
+import InquiryAuditTrailLoading from "./InquiryAuditTrailLoading";
+
+export interface InquiryAuditTrailBodyProps {
+  mode: InquiryAuditTrailMode;
+  assessments: readonly InquirySpamAssessment[];
+}
+
+export default function InquiryAuditTrailBody({
+  mode,
+  assessments,
+}: InquiryAuditTrailBodyProps) {
+  switch (mode) {
+    case "collapsed":
+      return null;
+    case "loading":
+      return <InquiryAuditTrailLoading />;
+    case "empty":
+      return <InquiryAuditTrailEmpty />;
+    case "list":
+      return <InquiryAuditTrailList assessments={assessments} />;
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryAuditTrailEmpty.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryAuditTrailEmpty.tsx
@@ -1,0 +1,7 @@
+export default function InquiryAuditTrailEmpty() {
+  return (
+    <p className="text-xs text-muted-foreground">
+      No spam assessments recorded for this inquiry.
+    </p>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryAuditTrailList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryAuditTrailList.tsx
@@ -1,0 +1,54 @@
+import type { InquirySpamAssessment } from "@/shared/types/inquiry/inquiry-spam-assessment";
+
+export interface InquiryAuditTrailListProps {
+  assessments: readonly InquirySpamAssessment[];
+}
+
+const ASSESSMENT_LABELS: Record<string, string> = {
+  turnstile: "Captcha",
+  honeypot: "Honeypot",
+  submit_timing: "Submit timing",
+  disposable_email: "Disposable email",
+  rate_limit: "Rate limit",
+  claude_score: "AI score",
+  manual_override: "Manual override",
+};
+
+export default function InquiryAuditTrailList({ assessments }: InquiryAuditTrailListProps) {
+  return (
+    <ul className="space-y-2 text-xs" data-testid="spam-assessments-list">
+      {assessments.map((a) => {
+        const label = ASSESSMENT_LABELS[a.assessment_type] ?? a.assessment_type;
+        const passLabel =
+          a.passed === null ? "—" : a.passed ? "passed" : "tripped";
+        return (
+          <li
+            key={a.id}
+            className="border rounded-md p-2 bg-muted/40"
+            data-testid={`spam-assessment-${a.assessment_type}`}
+          >
+            <div className="flex items-center justify-between gap-2">
+              <div>
+                <span className="font-medium">{label}</span>
+                <span className="text-muted-foreground ml-2">{passLabel}</span>
+                {a.score !== null ? (
+                  <span className="text-muted-foreground ml-2">
+                    score {Math.round(a.score)}
+                  </span>
+                ) : null}
+              </div>
+              <span className="text-muted-foreground">
+                {new Date(a.created_at).toLocaleString()}
+              </span>
+            </div>
+            {a.flags && a.flags.length > 0 ? (
+              <p className="mt-1 text-muted-foreground">
+                Flags: {a.flags.join(", ")}
+              </p>
+            ) : null}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryAuditTrailLoading.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryAuditTrailLoading.tsx
@@ -1,0 +1,5 @@
+export default function InquiryAuditTrailLoading() {
+  return (
+    <p className="text-xs text-muted-foreground">Loading audit trail...</p>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyCustomBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyCustomBody.tsx
@@ -1,0 +1,27 @@
+import RenderedReplyEditor from "./RenderedReplyEditor";
+
+export interface InquiryReplyCustomBodyProps {
+  subject: string;
+  body: string;
+  isSending: boolean;
+  onSubjectChange: (value: string) => void;
+  onBodyChange: (value: string) => void;
+}
+
+export default function InquiryReplyCustomBody({
+  subject,
+  body,
+  isSending,
+  onSubjectChange,
+  onBodyChange,
+}: InquiryReplyCustomBodyProps) {
+  return (
+    <RenderedReplyEditor
+      subject={subject}
+      body={body}
+      onSubjectChange={onSubjectChange}
+      onBodyChange={onBodyChange}
+      disabled={isSending}
+    />
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyPanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyPanel.tsx
@@ -10,9 +10,8 @@ import {
   useSendInquiryReplyMutation,
 } from "@/shared/store/inquiriesApi";
 import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
-import GmailReconnectBanner from "./GmailReconnectBanner";
-import RenderedReplyEditor from "./RenderedReplyEditor";
-import ReplyTemplatePicker from "./ReplyTemplatePicker";
+import InquiryReplyPanelBody from "./InquiryReplyPanelBody";
+import { useInquiryReplyMode } from "./useInquiryReplyMode";
 
 export interface InquiryReplyPanelProps {
   inquiryId: string;
@@ -20,6 +19,23 @@ export interface InquiryReplyPanelProps {
 }
 
 type ReplyTab = "template" | "custom";
+
+type ReconnectReason =
+  | "missing-integration"
+  | "missing-send-scope"
+  | "reauth-required"
+  | null;
+
+function deriveReconnectReason(
+  integrationsLoading: boolean,
+  gmail: { needs_reauth?: boolean; has_send_scope?: boolean } | undefined,
+): ReconnectReason {
+  if (integrationsLoading) return null;
+  if (!gmail) return "missing-integration";
+  if (gmail.needs_reauth) return "reauth-required";
+  if (gmail.has_send_scope === false) return "missing-send-scope";
+  return null;
+}
 
 /**
  * Right-side slide-in (mobile: bottom sheet) for composing a templated
@@ -53,27 +69,19 @@ export default function InquiryReplyPanel({ inquiryId, onClose }: InquiryReplyPa
   const [sendReply, { isLoading: isSending }] = useSendInquiryReplyMutation();
 
   const gmail = integrations.find((i) => i.provider === "gmail");
-  const reconnectReason: "missing-integration" | "missing-send-scope" | "reauth-required" | null =
-    integrationsLoading
-      ? null
-      : !gmail
-        ? "missing-integration"
-        : gmail.needs_reauth
-          ? "reauth-required"
-          : gmail.has_send_scope === false
-            ? "missing-send-scope"
-            : null;
+  const reconnectReason = deriveReconnectReason(integrationsLoading, gmail);
+  const mode = useInquiryReplyMode({ reconnectReason, tab });
 
   // Derive subject/body: prefer local override (user edits), fall back to
   // server-rendered template data, then empty string.
   const subject = subjectOverride ?? renderState.data?.subject ?? "";
   const body = bodyOverride ?? renderState.data?.body ?? "";
 
-  function setSubject(value: string) {
+  function handleSubjectChange(value: string) {
     setSubjectOverride(value);
   }
 
-  function setBody(value: string) {
+  function handleBodyChange(value: string) {
     setBodyOverride(value);
   }
 
@@ -173,62 +181,20 @@ export default function InquiryReplyPanel({ inquiryId, onClose }: InquiryReplyPa
 
         {/* Body */}
         <div className="flex-1 overflow-y-auto p-5 space-y-4">
-          {reconnectReason !== null ? (
-            <GmailReconnectBanner reason={reconnectReason} />
-          ) : null}
-
-          {tab === "template" && reconnectReason === null ? (
-            <>
-              <div>
-                <h4 className="text-sm font-medium mb-2">Choose a template</h4>
-                {templatesLoading ? (
-                  <div
-                    className="text-sm text-muted-foreground"
-                    data-testid="reply-templates-loading"
-                  >
-                    Loading templates...
-                  </div>
-                ) : (
-                  <ReplyTemplatePicker
-                    templates={templates}
-                    selectedTemplateId={selectedTemplateId}
-                    onSelect={handleSelectTemplate}
-                  />
-                )}
-              </div>
-              {selectedTemplateId !== null ? (
-                <div className="border-t pt-4">
-                  <h4 className="text-sm font-medium mb-2">Preview &amp; edit</h4>
-                  {renderState.isFetching ? (
-                    <div
-                      className="text-sm text-muted-foreground"
-                      data-testid="reply-render-loading"
-                    >
-                      Hmm, let me build that for you...
-                    </div>
-                  ) : (
-                    <RenderedReplyEditor
-                      subject={subject}
-                      body={body}
-                      onSubjectChange={setSubject}
-                      onBodyChange={setBody}
-                      disabled={isSending}
-                    />
-                  )}
-                </div>
-              ) : null}
-            </>
-          ) : null}
-
-          {tab === "custom" && reconnectReason === null ? (
-            <RenderedReplyEditor
-              subject={subject}
-              body={body}
-              onSubjectChange={setSubject}
-              onBodyChange={setBody}
-              disabled={isSending}
-            />
-          ) : null}
+          <InquiryReplyPanelBody
+            mode={mode}
+            reconnectReason={reconnectReason}
+            templates={templates}
+            templatesLoading={templatesLoading}
+            selectedTemplateId={selectedTemplateId}
+            isRenderFetching={renderState.isFetching}
+            isSending={isSending}
+            subject={subject}
+            body={body}
+            onSelectTemplate={handleSelectTemplate}
+            onSubjectChange={handleSubjectChange}
+            onBodyChange={handleBodyChange}
+          />
         </div>
 
         {/* Footer */}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyPanelBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyPanelBody.tsx
@@ -1,0 +1,67 @@
+import type { InquiryReplyMode } from "@/shared/types/inquiry/inquiry-reply-mode";
+import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
+import type { GmailReconnectBannerProps } from "./GmailReconnectBanner";
+import InquiryReplyCustomBody from "./InquiryReplyCustomBody";
+import InquiryReplyReconnectBody from "./InquiryReplyReconnectBody";
+import InquiryReplyTemplateBody from "./InquiryReplyTemplateBody";
+
+export interface InquiryReplyPanelBodyProps {
+  mode: InquiryReplyMode;
+  reconnectReason: GmailReconnectBannerProps["reason"] | null;
+  templates: ReplyTemplate[];
+  templatesLoading: boolean;
+  selectedTemplateId: string | null;
+  isRenderFetching: boolean;
+  isSending: boolean;
+  subject: string;
+  body: string;
+  onSelectTemplate: (template: ReplyTemplate) => void;
+  onSubjectChange: (value: string) => void;
+  onBodyChange: (value: string) => void;
+}
+
+export default function InquiryReplyPanelBody({
+  mode,
+  reconnectReason,
+  templates,
+  templatesLoading,
+  selectedTemplateId,
+  isRenderFetching,
+  isSending,
+  subject,
+  body,
+  onSelectTemplate,
+  onSubjectChange,
+  onBodyChange,
+}: InquiryReplyPanelBodyProps) {
+  switch (mode) {
+    case "reconnect":
+      // reconnectReason is always non-null when mode === "reconnect"
+      return <InquiryReplyReconnectBody reason={reconnectReason!} />;
+    case "template":
+      return (
+        <InquiryReplyTemplateBody
+          templates={templates}
+          templatesLoading={templatesLoading}
+          selectedTemplateId={selectedTemplateId}
+          isRenderFetching={isRenderFetching}
+          isSending={isSending}
+          subject={subject}
+          body={body}
+          onSelectTemplate={onSelectTemplate}
+          onSubjectChange={onSubjectChange}
+          onBodyChange={onBodyChange}
+        />
+      );
+    case "custom":
+      return (
+        <InquiryReplyCustomBody
+          subject={subject}
+          body={body}
+          isSending={isSending}
+          onSubjectChange={onSubjectChange}
+          onBodyChange={onBodyChange}
+        />
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyReconnectBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyReconnectBody.tsx
@@ -1,0 +1,12 @@
+import type { GmailReconnectBannerProps } from "./GmailReconnectBanner";
+import GmailReconnectBanner from "./GmailReconnectBanner";
+
+export interface InquiryReplyReconnectBodyProps {
+  reason: GmailReconnectBannerProps["reason"];
+}
+
+export default function InquiryReplyReconnectBody({
+  reason,
+}: InquiryReplyReconnectBodyProps) {
+  return <GmailReconnectBanner reason={reason} />;
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyTemplateBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquiryReplyTemplateBody.tsx
@@ -1,0 +1,72 @@
+import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
+import RenderedReplyEditor from "./RenderedReplyEditor";
+import ReplyTemplatePicker from "./ReplyTemplatePicker";
+
+export interface InquiryReplyTemplateBodyProps {
+  templates: ReplyTemplate[];
+  templatesLoading: boolean;
+  selectedTemplateId: string | null;
+  isRenderFetching: boolean;
+  isSending: boolean;
+  subject: string;
+  body: string;
+  onSelectTemplate: (template: ReplyTemplate) => void;
+  onSubjectChange: (value: string) => void;
+  onBodyChange: (value: string) => void;
+}
+
+export default function InquiryReplyTemplateBody({
+  templates,
+  templatesLoading,
+  selectedTemplateId,
+  isRenderFetching,
+  isSending,
+  subject,
+  body,
+  onSelectTemplate,
+  onSubjectChange,
+  onBodyChange,
+}: InquiryReplyTemplateBodyProps) {
+  return (
+    <>
+      <div>
+        <h4 className="text-sm font-medium mb-2">Choose a template</h4>
+        {templatesLoading ? (
+          <div
+            className="text-sm text-muted-foreground"
+            data-testid="reply-templates-loading"
+          >
+            Loading templates...
+          </div>
+        ) : (
+          <ReplyTemplatePicker
+            templates={templates}
+            selectedTemplateId={selectedTemplateId}
+            onSelect={onSelectTemplate}
+          />
+        )}
+      </div>
+      {selectedTemplateId !== null ? (
+        <div className="border-t pt-4">
+          <h4 className="text-sm font-medium mb-2">Preview &amp; edit</h4>
+          {isRenderFetching ? (
+            <div
+              className="text-sm text-muted-foreground"
+              data-testid="reply-render-loading"
+            >
+              Hmm, let me build that for you...
+            </div>
+          ) : (
+            <RenderedReplyEditor
+              subject={subject}
+              body={body}
+              onSubjectChange={onSubjectChange}
+              onBodyChange={onBodyChange}
+              disabled={isSending}
+            />
+          )}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/InquirySpamTriagePanel.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/InquirySpamTriagePanel.tsx
@@ -9,22 +9,14 @@ import {
 } from "@/shared/store/inquiriesApi";
 import type { InquirySpamStatus } from "@/shared/types/inquiry/inquiry-spam-status";
 import InquirySpamBadge from "./InquirySpamBadge";
+import InquiryAuditTrailBody from "./InquiryAuditTrailBody";
+import { useInquiryAuditTrailMode } from "./useInquiryAuditTrailMode";
 
 export interface InquirySpamTriagePanelProps {
   inquiryId: string;
   spamStatus: InquirySpamStatus;
   spamScore: number | null;
 }
-
-const ASSESSMENT_LABELS: Record<string, string> = {
-  turnstile: "Captcha",
-  honeypot: "Honeypot",
-  submit_timing: "Submit timing",
-  disposable_email: "Disposable email",
-  rate_limit: "Rate limit",
-  claude_score: "AI score",
-  manual_override: "Manual override",
-};
 
 export default function InquirySpamTriagePanel({ inquiryId, spamStatus, spamScore }: InquirySpamTriagePanelProps) {
   const [expanded, setExpanded] = useState(false);
@@ -35,6 +27,8 @@ export default function InquirySpamTriagePanel({ inquiryId, spamStatus, spamScor
   const [markNotSpam, { isLoading: isMarkingNotSpam }] =
     useMarkInquiryNotSpamMutation();
   const [markSpam, { isLoading: isMarkingSpam }] = useMarkInquirySpamMutation();
+
+  const auditTrailMode = useInquiryAuditTrailMode({ expanded, isLoading, assessments });
 
   async function handleMarkNotSpam() {
     try {
@@ -110,53 +104,7 @@ export default function InquirySpamTriagePanel({ inquiryId, spamStatus, spamScor
         {expanded ? "Hide" : "Show"} audit trail
       </button>
 
-      {expanded ? (
-        isLoading ? (
-          <p className="text-xs text-muted-foreground">Loading audit trail...</p>
-        ) : assessments.length === 0 ? (
-          <p className="text-xs text-muted-foreground">
-            No spam assessments recorded for this inquiry.
-          </p>
-        ) : (
-          <ul
-            className="space-y-2 text-xs"
-            data-testid="spam-assessments-list"
-          >
-            {assessments.map((a) => {
-              const label = ASSESSMENT_LABELS[a.assessment_type] ?? a.assessment_type;
-              const passLabel =
-                a.passed === null ? "—" : a.passed ? "passed" : "tripped";
-              return (
-                <li
-                  key={a.id}
-                  className="border rounded-md p-2 bg-muted/40"
-                  data-testid={`spam-assessment-${a.assessment_type}`}
-                >
-                  <div className="flex items-center justify-between gap-2">
-                    <div>
-                      <span className="font-medium">{label}</span>
-                      <span className="text-muted-foreground ml-2">{passLabel}</span>
-                      {a.score !== null ? (
-                        <span className="text-muted-foreground ml-2">
-                          score {Math.round(a.score)}
-                        </span>
-                      ) : null}
-                    </div>
-                    <span className="text-muted-foreground">
-                      {new Date(a.created_at).toLocaleString()}
-                    </span>
-                  </div>
-                  {a.flags && a.flags.length > 0 ? (
-                    <p className="mt-1 text-muted-foreground">
-                      Flags: {a.flags.join(", ")}
-                    </p>
-                  ) : null}
-                </li>
-              );
-            })}
-          </ul>
-        )
-      ) : null}
+      <InquiryAuditTrailBody mode={auditTrailMode} assessments={assessments} />
     </section>
   );
 }

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesEmpty.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesEmpty.tsx
@@ -1,0 +1,7 @@
+import EmptyState from "@/shared/components/ui/EmptyState";
+
+export default function ReplyTemplatesEmpty() {
+  return (
+    <EmptyState message="No templates yet. Create your first to speed up replies." />
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesList.tsx
@@ -1,0 +1,54 @@
+import { Pencil, Archive } from "lucide-react";
+import Button from "@/shared/components/ui/Button";
+import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
+
+export interface ReplyTemplatesListProps {
+  templates: readonly ReplyTemplate[];
+  onEdit: (template: ReplyTemplate) => void;
+  onArchive: (template: ReplyTemplate) => void;
+}
+
+export default function ReplyTemplatesList({
+  templates,
+  onEdit,
+  onArchive,
+}: ReplyTemplatesListProps) {
+  return (
+    <ul className="divide-y border rounded-md">
+      {templates.map((template) => (
+        <li
+          key={template.id}
+          className="flex items-center justify-between p-3"
+          data-testid={`reply-template-row-${template.id}`}
+        >
+          <div className="min-w-0 flex-1 pr-3">
+            <div className="font-medium text-sm truncate">{template.name}</div>
+            <div className="text-xs text-muted-foreground truncate">
+              {template.subject_template}
+            </div>
+          </div>
+          <div className="flex gap-1">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => onEdit(template)}
+              data-testid={`reply-template-edit-${template.id}`}
+              aria-label={`Edit ${template.name}`}
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => onArchive(template)}
+              data-testid={`reply-template-archive-${template.id}`}
+              aria-label={`Archive ${template.name}`}
+            >
+              <Archive className="h-4 w-4" />
+            </Button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesListBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesListBody.tsx
@@ -1,0 +1,34 @@
+import type { ReplyTemplatesListMode } from "@/shared/types/inquiry/reply-templates-list-mode";
+import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
+import ReplyTemplatesEmpty from "./ReplyTemplatesEmpty";
+import ReplyTemplatesList from "./ReplyTemplatesList";
+import ReplyTemplatesLoading from "./ReplyTemplatesLoading";
+
+export interface ReplyTemplatesListBodyProps {
+  mode: ReplyTemplatesListMode;
+  templates: readonly ReplyTemplate[];
+  onEdit: (template: ReplyTemplate) => void;
+  onArchive: (template: ReplyTemplate) => void;
+}
+
+export default function ReplyTemplatesListBody({
+  mode,
+  templates,
+  onEdit,
+  onArchive,
+}: ReplyTemplatesListBodyProps) {
+  switch (mode) {
+    case "loading":
+      return <ReplyTemplatesLoading />;
+    case "empty":
+      return <ReplyTemplatesEmpty />;
+    case "list":
+      return (
+        <ReplyTemplatesList
+          templates={templates}
+          onEdit={onEdit}
+          onArchive={onArchive}
+        />
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesLoading.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesLoading.tsx
@@ -1,0 +1,5 @@
+export default function ReplyTemplatesLoading() {
+  return (
+    <div className="text-sm text-muted-foreground">Loading templates...</div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesManager.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/ReplyTemplatesManager.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
-import { Plus, Pencil, Archive } from "lucide-react";
+import { Plus } from "lucide-react";
 import Button from "@/shared/components/ui/Button";
-import EmptyState from "@/shared/components/ui/EmptyState";
 import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import {
@@ -10,6 +9,8 @@ import {
 } from "@/shared/store/inquiriesApi";
 import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
 import ReplyTemplateForm from "./ReplyTemplateForm";
+import ReplyTemplatesListBody from "./ReplyTemplatesListBody";
+import { useReplyTemplatesListMode } from "./useReplyTemplatesListMode";
 
 export default function ReplyTemplatesManager() {
   const { data: templates = [], isLoading } = useGetReplyTemplatesQuery();
@@ -22,6 +23,8 @@ export default function ReplyTemplatesManager() {
   const [archiveCandidate, setArchiveCandidate] = useState<ReplyTemplate | null>(
     null,
   );
+
+  const listMode = useReplyTemplatesListMode({ isLoading, templates });
 
   function handleNew() {
     setEditingTemplate(null);
@@ -67,48 +70,12 @@ export default function ReplyTemplatesManager() {
         </Button>
       </div>
 
-      {isLoading ? (
-        <div className="text-sm text-muted-foreground">Loading templates...</div>
-      ) : templates.length === 0 ? (
-        <EmptyState message="No templates yet. Create your first to speed up replies." />
-      ) : (
-        <ul className="divide-y border rounded-md">
-          {templates.map((template) => (
-            <li
-              key={template.id}
-              className="flex items-center justify-between p-3"
-              data-testid={`reply-template-row-${template.id}`}
-            >
-              <div className="min-w-0 flex-1 pr-3">
-                <div className="font-medium text-sm truncate">{template.name}</div>
-                <div className="text-xs text-muted-foreground truncate">
-                  {template.subject_template}
-                </div>
-              </div>
-              <div className="flex gap-1">
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => handleEdit(template)}
-                  data-testid={`reply-template-edit-${template.id}`}
-                  aria-label={`Edit ${template.name}`}
-                >
-                  <Pencil className="h-4 w-4" />
-                </Button>
-                <Button
-                  variant="secondary"
-                  size="sm"
-                  onClick={() => setArchiveCandidate(template)}
-                  data-testid={`reply-template-archive-${template.id}`}
-                  aria-label={`Archive ${template.name}`}
-                >
-                  <Archive className="h-4 w-4" />
-                </Button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
+      <ReplyTemplatesListBody
+        mode={listMode}
+        templates={templates}
+        onEdit={handleEdit}
+        onArchive={setArchiveCandidate}
+      />
 
       {showForm ? (
         <ReplyTemplateForm

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/useInquiryAuditTrailMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/useInquiryAuditTrailMode.ts
@@ -1,0 +1,24 @@
+import type { InquirySpamAssessment } from "@/shared/types/inquiry/inquiry-spam-assessment";
+import type { InquiryAuditTrailMode } from "@/shared/types/inquiry/inquiry-audit-trail-mode";
+
+interface UseInquiryAuditTrailModeArgs {
+  expanded: boolean;
+  isLoading: boolean;
+  assessments: readonly InquirySpamAssessment[];
+}
+
+/**
+ * Resolves the audit trail's render mode from the current expanded/loaded
+ * state. Single source of truth so the body component is a flat switch
+ * instead of a tower of conditionals.
+ */
+export function useInquiryAuditTrailMode({
+  expanded,
+  isLoading,
+  assessments,
+}: UseInquiryAuditTrailModeArgs): InquiryAuditTrailMode {
+  if (!expanded) return "collapsed";
+  if (isLoading) return "loading";
+  if (assessments.length === 0) return "empty";
+  return "list";
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/useInquiryReplyMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/useInquiryReplyMode.ts
@@ -1,0 +1,31 @@
+import type { InquiryReplyMode } from "@/shared/types/inquiry/inquiry-reply-mode";
+
+type ReconnectReason =
+  | "missing-integration"
+  | "missing-send-scope"
+  | "reauth-required"
+  | null;
+
+type ReplyTab = "template" | "custom";
+
+interface UseInquiryReplyModeArgs {
+  reconnectReason: ReconnectReason;
+  tab: ReplyTab;
+}
+
+/**
+ * Resolves the reply panel body's render mode. Single source of truth so the
+ * body component is a flat switch instead of a tower of conditionals.
+ *
+ * While integrations load, the caller passes reconnectReason=null so the
+ * normal tab flow renders — the reconnect banner only appears once Gmail
+ * status is known to be broken.
+ */
+export function useInquiryReplyMode({
+  reconnectReason,
+  tab,
+}: UseInquiryReplyModeArgs): InquiryReplyMode {
+  if (reconnectReason !== null) return "reconnect";
+  if (tab === "template") return "template";
+  return "custom";
+}

--- a/apps/mybookkeeper/frontend/src/app/features/inquiries/useReplyTemplatesListMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/inquiries/useReplyTemplatesListMode.ts
@@ -1,0 +1,21 @@
+import type { ReplyTemplatesListMode } from "@/shared/types/inquiry/reply-templates-list-mode";
+import type { ReplyTemplate } from "@/shared/types/inquiry/reply-template";
+
+interface UseReplyTemplatesListModeArgs {
+  isLoading: boolean;
+  templates: readonly ReplyTemplate[];
+}
+
+/**
+ * Resolves the templates list render mode from the loaded state. Single
+ * source of truth so the body component is a flat switch instead of a tower
+ * of conditionals.
+ */
+export function useReplyTemplatesListMode({
+  isLoading,
+  templates,
+}: UseReplyTemplatesListModeArgs): ReplyTemplatesListMode {
+  if (isLoading) return "loading";
+  if (templates.length === 0) return "empty";
+  return "list";
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/inquiry/inquiry-audit-trail-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/inquiry/inquiry-audit-trail-mode.ts
@@ -1,0 +1,5 @@
+/**
+ * Discriminated union for what InquirySpamTriagePanel's audit trail should
+ * render. Replaces a chain of nested ternaries with a single switch.
+ */
+export type InquiryAuditTrailMode = "collapsed" | "loading" | "empty" | "list";

--- a/apps/mybookkeeper/frontend/src/shared/types/inquiry/inquiry-reply-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/inquiry/inquiry-reply-mode.ts
@@ -1,0 +1,9 @@
+/**
+ * Discriminated union for what InquiryReplyPanel's body section should
+ * render. Replaces a chain of nested ternaries with a single switch.
+ *
+ * - "reconnect": Gmail is missing, expired, or lacks send scope — show banner
+ * - "template":  template tab is active and Gmail is healthy
+ * - "custom":    custom tab is active and Gmail is healthy
+ */
+export type InquiryReplyMode = "reconnect" | "template" | "custom";

--- a/apps/mybookkeeper/frontend/src/shared/types/inquiry/reply-templates-list-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/inquiry/reply-templates-list-mode.ts
@@ -1,0 +1,5 @@
+/**
+ * Discriminated union for what ReplyTemplatesManager's list section should
+ * render. Replaces a chain of nested ternaries with a single switch.
+ */
+export type ReplyTemplatesListMode = "loading" | "empty" | "list";


### PR DESCRIPTION
## Summary

Replaces all JSX expressions with ≥3 stacked ternaries in `apps/mybookkeeper/frontend/src/app/features/inquiries/` using the `useXxxMode` hook → discriminated union → flat `switch` body pattern from PR #237/#238 (DocumentViewer reference).

Three components refactored:

### 1. `InquirySpamTriagePanel` — `InquiryAuditTrailMode`

Discriminated union: `"collapsed" | "loading" | "empty" | "list"`

Before (lines 113-158, 3-deep chain inside JSX):
```tsx
{expanded ? (
  isLoading ? (
    <p>Loading...</p>
  ) : assessments.length === 0 ? (
    <p>No assessments...</p>
  ) : (
    <ul>...</ul>
  )
) : null}
```

After:
- `shared/types/inquiry/inquiry-audit-trail-mode.ts` — union type
- `useInquiryAuditTrailMode.ts` — hook, pure resolver
- `InquiryAuditTrailBody.tsx` — flat `switch` dispatcher
- `InquiryAuditTrailLoading.tsx`, `InquiryAuditTrailEmpty.tsx`, `InquiryAuditTrailList.tsx` — per-state sub-components
- `ASSESSMENT_LABELS` map moved from the panel into `InquiryAuditTrailList` (its only consumer)

### 2. `ReplyTemplatesManager` — `ReplyTemplatesListMode`

Discriminated union: `"loading" | "empty" | "list"`

Before (lines 70-111, 3-way chain):
```tsx
{isLoading ? (
  <div>Loading...</div>
) : templates.length === 0 ? (
  <EmptyState />
) : (
  <ul>...</ul>
)}
```

After:
- `shared/types/inquiry/reply-templates-list-mode.ts` — union type
- `useReplyTemplatesListMode.ts` — hook, pure resolver
- `ReplyTemplatesListBody.tsx` — flat `switch` dispatcher
- `ReplyTemplatesLoading.tsx`, `ReplyTemplatesEmpty.tsx`, `ReplyTemplatesList.tsx` — per-state sub-components
- `Pencil`/`Archive` icon imports moved from manager into `ReplyTemplatesList` (their only consumer)

### 3. `InquiryReplyPanel` — `InquiryReplyMode`

Discriminated union: `"reconnect" | "template" | "custom"`

Before (lines 56-65, 4-deep computed ternary + 3-branch body):
```tsx
const reconnectReason = integrationsLoading
  ? null
  : !gmail
    ? "missing-integration"
    : gmail.needs_reauth
      ? "reauth-required"
      : gmail.has_send_scope === false
        ? "missing-send-scope"
        : null;
```

After:
- `shared/types/inquiry/inquiry-reply-mode.ts` — union type
- `deriveReconnectReason()` — pure function (4-deep chain → 4 early-return `if`s)
- `useInquiryReplyMode.ts` — hook, flat resolver consuming `reconnectReason`
- `InquiryReplyPanelBody.tsx` — flat `switch` dispatcher
- `InquiryReplyReconnectBody.tsx`, `InquiryReplyTemplateBody.tsx`, `InquiryReplyCustomBody.tsx` — per-state sub-components

## Scope

- Only `apps/mybookkeeper/frontend/src/app/features/inquiries/` (TSX + TS)
- Zero behavior or styling changes — pure structural refactor

## Test coverage

- 3 new hook unit-test files (`useInquiryAuditTrailMode`, `useReplyTemplatesListMode`, `useInquiryReplyMode`) — 13 cases total
- All 9 existing `InquiryReplyPanel` tests pass unchanged
- All 6 existing `ReplyTemplatesManager` tests pass unchanged
- `tsc --noEmit` clean

## Files changed

**Modified (3):**
- `InquiryReplyPanel.tsx` — uses `deriveReconnectReason` + `useInquiryReplyMode` + `InquiryReplyPanelBody`
- `InquirySpamTriagePanel.tsx` — uses `useInquiryAuditTrailMode` + `InquiryAuditTrailBody`
- `ReplyTemplatesManager.tsx` — uses `useReplyTemplatesListMode` + `ReplyTemplatesListBody`

**New (21):**
- `shared/types/inquiry/inquiry-audit-trail-mode.ts`
- `shared/types/inquiry/reply-templates-list-mode.ts`
- `shared/types/inquiry/inquiry-reply-mode.ts`
- `useInquiryAuditTrailMode.ts`
- `useReplyTemplatesListMode.ts`
- `useInquiryReplyMode.ts`
- `InquiryAuditTrailBody.tsx`
- `InquiryAuditTrailLoading.tsx`
- `InquiryAuditTrailEmpty.tsx`
- `InquiryAuditTrailList.tsx`
- `ReplyTemplatesListBody.tsx`
- `ReplyTemplatesLoading.tsx`
- `ReplyTemplatesEmpty.tsx`
- `ReplyTemplatesList.tsx`
- `InquiryReplyPanelBody.tsx`
- `InquiryReplyReconnectBody.tsx`
- `InquiryReplyTemplateBody.tsx`
- `InquiryReplyCustomBody.tsx`
- `src/__tests__/useInquiryAuditTrailMode.test.ts`
- `src/__tests__/useReplyTemplatesListMode.test.ts`
- `src/__tests__/useInquiryReplyMode.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)