### PR TITLE
fix(mbk/frontend): typecheck errors blocking deploy

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/PhotoLightbox.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PhotoLightbox.test.tsx
@@ -26,12 +26,12 @@ const THREE_PHOTOS: ListingPhoto[] = [
 ];
 
 describe("PhotoLightbox", () => {
-  let onClose: ReturnType<typeof vi.fn>;
-  let onNavigate: ReturnType<typeof vi.fn>;
+  let onClose: ReturnType<typeof vi.fn<() => void>>;
+  let onNavigate: ReturnType<typeof vi.fn<(nextIndex: number) => void>>;
 
   beforeEach(() => {
-    onClose = vi.fn();
-    onNavigate = vi.fn();
+    onClose = vi.fn<() => void>();
+    onNavigate = vi.fn<(nextIndex: number) => void>();
   });
 
   it("renders with the correct photo when opened at index 0", () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/photo-bulk-download.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/photo-bulk-download.test.ts
@@ -9,11 +9,9 @@ const { fileMock, generateMock } = vi.hoisted(() => ({
 }));
 
 vi.mock("jszip", () => ({
-  default: vi.fn().mockImplementation(function () {
-    // eslint-disable-next-line @typescript-eslint/no-this-alias
-    const self = this as { file: typeof fileMock; generateAsync: typeof generateMock };
-    self.file = fileMock;
-    self.generateAsync = generateMock;
+  default: vi.fn().mockImplementation(function (this: { file: typeof fileMock; generateAsync: typeof generateMock }) {
+    this.file = fileMock;
+    this.generateAsync = generateMock;
   }),
 }));
 

--- a/apps/mybookkeeper/frontend/src/__tests__/useLinkedLeaseDocumentsMode.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/useLinkedLeaseDocumentsMode.test.ts
@@ -4,9 +4,14 @@ import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-at
 
 const mockAttachment: SignedLeaseAttachment = {
   id: "att-1",
+  lease_id: "lease-1",
   filename: "lease.pdf",
+  storage_key: "leases/lease-1/lease.pdf",
   content_type: "application/pdf",
-  kind: "lease_agreement",
+  size_bytes: 12345,
+  kind: "signed_lease",
+  uploaded_by_user_id: "user-1",
+  uploaded_at: "2026-01-01T00:00:00Z",
   presigned_url: "https://example.com/lease.pdf",
 };
 


### PR DESCRIPTION
## Summary
After PR #276 unblocked npm ci, three test files revealed latent TS errors that were silently allowed when the build was failing earlier in the pipeline. Deploy still 0/N until these are fixed.

- PhotoLightbox.test.tsx — vi.fn() needs explicit signature to be assignable to typed callbacks
- photo-bulk-download.test.ts — implicit any on \`this\` inside a function() body
- useLinkedLeaseDocumentsMode.test.ts — used kind \"lease_agreement\" which isn't a LeaseAttachmentKind, plus missing 5 required SignedLeaseAttachment fields

## Test plan
- [x] \`tsc -b\` passes locally
- [ ] CI deploy goes green
- [ ] Smoke: lightbox + multi-select + public inquiry slug pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)