### PR TITLE
fix(myjobhunter/config): make database_url_sync a computed property

### DIFF
--- a/apps/myjobhunter/backend/.env.example
+++ b/apps/myjobhunter/backend/.env.example
@@ -1,5 +1,5 @@
 DATABASE_URL=postgresql+asyncpg://myjobhunter:password@localhost/myjobhunter
-DATABASE_URL_SYNC=postgresql+psycopg2://myjobhunter:password@localhost/myjobhunter
+# database_url_sync is computed automatically from DATABASE_URL — do not set.
 SECRET_KEY=change-me-to-a-64-hex-char-random-string
 ENCRYPTION_KEY=change-me-to-a-32-byte-base64-key
 

--- a/apps/myjobhunter/backend/app/core/config.py
+++ b/apps/myjobhunter/backend/app/core/config.py
@@ -6,9 +6,12 @@ _MIN_KEY_LENGTH = 32
 
 class Settings(BaseSettings):
     database_url: str
-    database_url_sync: str
     secret_key: str
     encryption_key: str
+
+    @property
+    def database_url_sync(self) -> str:
+        return self.database_url.replace("+asyncpg", "")
 
     @field_validator("secret_key", "encryption_key")
     @classmethod


### PR DESCRIPTION
## Summary
\`Settings.database_url_sync\` was a required str field with no default and no env source — Pydantic crashed at boot every MJH migrate run with \`Field required\`, blocking every MJH deploy from reaching the api/caddy steps.

## Fix
Mirror MBK's pattern (\`apps/mybookkeeper/backend/app/core/config.py:153\`): compute \`database_url_sync\` from \`database_url\` by stripping \`+asyncpg\`. The field is dead in MJH (never referenced anywhere outside the declaration), so this turns a hard requirement into a derived helper.

Also dropped \`DATABASE_URL_SYNC\` from \`.env.example\` since it's now computed, replaced with a comment.

## Test plan
- [ ] CI deploy succeeds (migrate container completes 0)
- [ ] \`https://myjobhunter.165-245-134-251.sslip.io/health\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)