### PR TITLE
fix(myjobhunter/caddy): use :80 site address to disable auto-HTTPS redirect

### DIFF
--- a/apps/myjobhunter/docker/Caddyfile.docker
+++ b/apps/myjobhunter/docker/Caddyfile.docker
@@ -9,9 +9,12 @@
 }
 
 # HTTP-only on :80 — TLS is terminated by host Caddy before traffic reaches
-# this container. The host Caddy must reverse-proxy the app domain to this
-# container with the original Host header preserved.
-{$DOMAIN:localhost} {
+# this container. Using a port-only address (`:80`) instead of a hostname
+# disables Caddy's auto-HTTPS behaviour: with `{$DOMAIN}` Caddy issues a
+# 308 redirect from HTTP→HTTPS, but host Caddy proxies plain HTTP into
+# this container, so the redirect bounces back to the same URL → infinite
+# loop. Mirrors apps/mybookkeeper/docker/Caddyfile.docker.
+:80 {
     # ----------------------------------------------------------------------
     # Security response headers — applied to every response (API + SPA).
     #


### PR DESCRIPTION
## Summary
MJH was unreachable in browsers ("The page isn't redirecting properly") because the docker Caddyfile used \`{\$DOMAIN:localhost}\` as the site address, triggering Caddy's auto-HTTPS 308 redirect. Host Caddy proxies plain HTTP into this container, so each redirect bounced back → infinite loop.

## Fix
Use \`:80\` (port-only) like MBK. Caddy treats port-only addresses as HTTP-only and skips auto-HTTPS. Host Caddy is the TLS terminator.

## Test plan
After merge + deploy:
- [ ] \`curl https://myjobhunter.165-245-134-251.sslip.io/health\` returns 200 (not 308)
- [ ] Browser loads \`https://myjobhunter.165-245-134-251.sslip.io/\` to the SPA shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)