### PR TITLE
refactor(shared-frontend): extract inline utility functions to @platform/ui/utils

### DIFF
--- a/apps/mybookkeeper/frontend/src/admin/features/organizations/OrgsTable.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/features/organizations/OrgsTable.tsx
@@ -1,6 +1,5 @@
 import Skeleton from "@/shared/components/ui/Skeleton";
-import { format } from "date-fns/format";
-import { parseISO } from "date-fns/parseISO";
+import { formatDate } from "@/shared/utils/date";
 
 interface OrgRow {
   id: string;
@@ -14,10 +13,6 @@ interface OrgRow {
 interface OrgsTableProps {
   orgs: OrgRow[];
   isLoading: boolean;
-}
-
-function formatDate(iso: string): string {
-  return format(parseISO(iso), "MMM d, yyyy");
 }
 
 export default function OrgsTable({ orgs, isLoading }: OrgsTableProps) {

--- a/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventAttachmentCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventAttachmentCard.tsx
@@ -1,15 +1,10 @@
 import { FileText, Paperclip, Trash2 } from "lucide-react";
 import type { ListingBlackoutAttachment } from "@/shared/types/listing/listing-blackout-attachment";
+import { formatFileSize } from "@/shared/utils/file-size";
 
 export interface CalendarEventAttachmentCardProps {
   attachment: ListingBlackoutAttachment;
   onDelete: () => void;
-}
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 export default function CalendarEventAttachmentCard({ attachment, onDelete }: CalendarEventAttachmentCardProps) {
@@ -54,7 +49,7 @@ export default function CalendarEventAttachmentCard({ attachment, onDelete }: Ca
           </span>
         )}
         <span className="text-xs text-muted-foreground">
-          {formatBytes(attachment.size_bytes)}
+          {formatFileSize(attachment.size_bytes)}
         </span>
       </div>
 

--- a/apps/mybookkeeper/frontend/src/shared/utils/file-size.ts
+++ b/apps/mybookkeeper/frontend/src/shared/utils/file-size.ts
@@ -1,0 +1,20 @@
+/**
+ * Formats a byte count into a human-readable file size string.
+ *
+ * - Returns "" for null/undefined (unknown size).
+ * - Returns "0 B" for exactly 0 bytes.
+ * - Uses 1-decimal precision for KB and MB.
+ *
+ * @example
+ * formatFileSize(null)       // ""
+ * formatFileSize(0)          // "0 B"
+ * formatFileSize(512)        // "512 B"
+ * formatFileSize(1536)       // "1.5 KB"
+ * formatFileSize(2097152)    // "2.0 MB"
+ */
+export function formatFileSize(bytes: number | null | undefined): string {
+  if (bytes == null) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/apps/myjobhunter/frontend/src/features/documents/DocumentList.tsx
+++ b/apps/myjobhunter/frontend/src/features/documents/DocumentList.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
 import { Download, Edit2, ExternalLink, Trash2 } from "lucide-react";
-import { Badge, EmptyState, Skeleton, showError, showSuccess, extractErrorMessage } from "@platform/ui";
+import { Badge, EmptyState, Skeleton, showError, showSuccess, extractErrorMessage, formatFileSize } from "@platform/ui";
 import DocumentKindBadge from "@/features/documents/DocumentKindBadge";
 import DocumentEditDialog from "@/features/documents/DocumentEditDialog";
 import type { Document } from "@/types/document/document";
@@ -18,13 +18,6 @@ export interface DocumentListProps {
   applicationId?: string;
   /** When true, the kind filter dropdown is hidden (parent controls it). */
   hideKindFilter?: boolean;
-}
-
-function formatBytes(bytes: number | null): string {
-  if (!bytes) return "";
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function formatDate(iso: string): string {
@@ -90,7 +83,7 @@ function DocumentRow({ doc, onEdit, onDelete }: DocumentRowProps) {
         <p className="text-sm font-medium truncate">{doc.title}</p>
         <div className="flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
           <span>{formatDate(doc.updated_at)}</span>
-          {doc.size_bytes ? <span>{formatBytes(doc.size_bytes)}</span> : null}
+          {doc.size_bytes ? <span>{formatFileSize(doc.size_bytes)}</span> : null}
           {doc.application_id ? (
             <Link
               to={`/applications/${doc.application_id}`}

--- a/apps/myjobhunter/frontend/src/features/profile/ResumeJobRow.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/ResumeJobRow.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { ChevronDown, ChevronUp, Download, FileText } from "lucide-react";
-import { Badge } from "@platform/ui";
+import { Badge, formatFileSize } from "@platform/ui";
 import type { ResumeUploadJob, ResumeUploadJobStatus } from "@/types/resume-upload-job/resume-upload-job";
 import ResumeJobParsedPanel from "@/features/profile/ResumeJobParsedPanel";
 
@@ -28,14 +28,6 @@ const STATUS_COLORS: Record<ResumeUploadJobStatus, BadgeColor> = {
   failed: "red",
   cancelled: "gray",
 };
-
-function formatFileSize(bytes: number | null): string {
-  // bytes is number | null; 0 is a valid distinct value (0-byte file) — keep === null
-  if (bytes === null) return "";
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 function formatTimestamp(iso: string): string {
   return new Date(iso).toLocaleDateString("en-US", {

--- a/packages/shared-frontend/src/__tests__/formatFileSize.test.ts
+++ b/packages/shared-frontend/src/__tests__/formatFileSize.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { formatFileSize } from "../utils/file-size";
+
+describe("formatFileSize", () => {
+  // ---- null / undefined ----
+  it("returns '' for null", () => {
+    expect(formatFileSize(null)).toBe("");
+  });
+
+  it("returns '' for undefined", () => {
+    expect(formatFileSize(undefined)).toBe("");
+  });
+
+  // ---- zero edge case ----
+  it("returns '0 B' for 0 bytes", () => {
+    expect(formatFileSize(0)).toBe("0 B");
+  });
+
+  // ---- bytes range ----
+  it("returns bytes with B suffix for values below 1024", () => {
+    expect(formatFileSize(1)).toBe("1 B");
+    expect(formatFileSize(512)).toBe("512 B");
+    expect(formatFileSize(1023)).toBe("1023 B");
+  });
+
+  // ---- kilobytes range ----
+  it("returns KB with 1 decimal for values in [1024, 1048576)", () => {
+    expect(formatFileSize(1024)).toBe("1.0 KB");
+    expect(formatFileSize(1536)).toBe("1.5 KB");
+    expect(formatFileSize(102400)).toBe("100.0 KB");
+    expect(formatFileSize(1048575)).toBe("1024.0 KB");
+  });
+
+  // ---- megabytes range ----
+  it("returns MB with 1 decimal for values >= 1048576", () => {
+    expect(formatFileSize(1048576)).toBe("1.0 MB");
+    expect(formatFileSize(2097152)).toBe("2.0 MB");
+    expect(formatFileSize(10 * 1024 * 1024)).toBe("10.0 MB");
+  });
+
+  // ---- rounding behavior ----
+  it("rounds to 1 decimal place for KB", () => {
+    // 1500 bytes = 1.46484375 KB → rounds to 1.5 KB
+    expect(formatFileSize(1500)).toBe("1.5 KB");
+  });
+
+  it("rounds to 1 decimal place for MB", () => {
+    // 1.55 MB = 1.55 * 1024 * 1024 = 1625292.8 bytes
+    expect(formatFileSize(1625293)).toBe("1.6 MB");
+  });
+
+  // ---- large files ----
+  it("handles large files (> 100 MB) without crashing", () => {
+    expect(formatFileSize(500 * 1024 * 1024)).toBe("500.0 MB");
+  });
+});

--- a/packages/shared-frontend/src/index.ts
+++ b/packages/shared-frontend/src/index.ts
@@ -11,6 +11,7 @@
 export { cn } from "./utils/cn";
 export { formatCurrency } from "./utils/currency";
 export { formatDate, timeAgo } from "./utils/date";
+export { formatFileSize } from "./utils/file-size";
 export { formatTag } from "./utils/tag";
 export { extractErrorMessage } from "./utils/errorMessage";
 export { showError, showSuccess, subscribe } from "./lib/toast-store";

--- a/packages/shared-frontend/src/utils/file-size.ts
+++ b/packages/shared-frontend/src/utils/file-size.ts
@@ -1,0 +1,21 @@
+/**
+ * Formats a byte count into a human-readable file size string.
+ *
+ * - Returns "" for null/undefined (unknown size).
+ * - Returns "0 B" for exactly 0 bytes.
+ * - Uses 1-decimal precision for KB and MB.
+ * - Does not go beyond MB (files in this app are capped at 10 MB).
+ *
+ * @example
+ * formatFileSize(null)       // ""
+ * formatFileSize(0)          // "0 B"
+ * formatFileSize(512)        // "512 B"
+ * formatFileSize(1536)       // "1.5 KB"
+ * formatFileSize(2097152)    // "2.0 MB"
+ */
+export function formatFileSize(bytes: number | null | undefined): string {
+  if (bytes == null) return "";
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}


### PR DESCRIPTION
## Summary

Consolidates inline byte-formatting utility functions that were duplicated across MBK and MJH component files into a single shared module. Also removes one identical `formatDate` inline redefinition in MBK that duplicated the existing shared utility.

## Audit Table

| File | Utility | Status | Action |
|---|---|---|---|
| `apps/mybookkeeper/frontend/src/app/features/calendar/CalendarEventAttachmentCard.tsx` | `formatBytes(bytes: number)` | Inline, duplicated | Moved to `@/shared/utils/file-size.ts` |
| `apps/myjobhunter/frontend/src/features/documents/DocumentList.tsx` | `formatBytes(bytes: number \| null)` | Inline, duplicated | Now imports `formatFileSize` from `@platform/ui` |
| `apps/myjobhunter/frontend/src/features/profile/ResumeJobRow.tsx` | `formatFileSize(bytes: number \| null)` | Inline, duplicated | Now imports `formatFileSize` from `@platform/ui` |
| `apps/mybookkeeper/frontend/src/admin/features/organizations/OrgsTable.tsx` | `formatDate(iso: string)` | Inline, identical to existing shared | Now imports `formatDate` from `@/shared/utils/date` |
| `packages/shared-frontend/src/utils/file-size.ts` | `formatFileSize` | **NEW** — canonical home | Exported from `@platform/ui` |
| `apps/mybookkeeper/frontend/src/shared/utils/file-size.ts` | `formatFileSize` | **NEW** — MBK-local copy | MBK can't import from `@platform/ui` until React 19 upgrade |

**Functions NOT extracted (domain-specific — stay where they are):**
- `formatEventType` (ApplicantTimelineList, InquiryEventTimeline) — depends on domain stage label maps
- `formatPeriodLabel` / `formatMonth` / `formatDisplayDate` — chart axis formatters, tightly coupled to chart data shapes
- `formatDate` variants with different output formats — intentionally distinct (MM/DD/YYYY vs MMM d, yyyy vs toLocaleString)
- `formatCoverage` — insurance-domain (cents, no decimals)
- `formatSalaryRange` / `formatDateRange` — job-hunt domain logic
- `formatHourlyRate` / `formatLastUsed` — vendor-domain, inconsistent fallback strings across files (intentional per context)
- `parseAmenities` / `parseStageParam` / `parseSpamParam` / etc. — domain URL param parsers
- `formatFieldValue` / `formatResolvedValue` / `formatIsoDate` — template renderer, tax form display logic

## Why MBK gets a local copy (not `@platform/ui`)

MBK is blocked from consuming `@platform/ui` directly until it upgrades from React 18 to 19 — two React copies crash the runtime. The local `shared/utils/file-size.ts` is a deliberate transitional file. When MBK upgrades React, delete it and re-point to `@platform/ui`.

## Test plan

- [x] 9 new unit tests for `formatFileSize` in `packages/shared-frontend/src/__tests__/formatFileSize.test.ts` — all pass
- [x] MBK `tsc -b && vite build` — 0 errors
- [x] MJH `npm run typecheck` — 0 errors
- [x] MBK `npm run lint` — 0 errors (9 pre-existing warnings unchanged)
- [x] MJH `npm run lint` — 3 pre-existing errors in unmodified files (DisplayNameSetting, DocumentEditDialog, ResumeUploadSection)
- [x] MBK CalendarEventDetail tests — 11/11 pass
- [x] Pre-existing MJH test failures confirmed identical before and after this PR (not caused by this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)