### PR TITLE
feat(myjobhunter): structural parity with MyBookkeeper

### DIFF
--- a/apps/myjobhunter/CLAUDE.md
+++ b/apps/myjobhunter/CLAUDE.md
@@ -214,6 +214,50 @@ docker compose -f apps/myjobhunter/docker-compose.yml exec postgres \
 **Phase 3:** Dramatiq workers, Gmail OAuth, Chrome extension integration
 **Phase 4:** Tavily company research, Claude JD parsing, cover letter generation
 
+## Parity rule
+
+MJH mirrors MBK by default. MBK is the canonical, battle-tested
+implementation; every MJH structural divergence is presumed to be a bug
+until justified.
+
+Before adding any of the following to MJH, **open the matching MBK file
+and copy its pattern**:
+
+- Settings classes / fields in `backend/app/core/config.py`
+- Lifespan steps in `backend/app/main.py` (Sentry init, Turnstile boot
+  guard, audit listeners, bucket initialisation, request-logging middleware,
+  `/version` + `/health` deploy-verification surfaces)
+- Env contract in `backend/.env.docker.example` — variables that must
+  exist in prod
+- Site-address syntax, header blocks, route ordering, and cache-control
+  policy in `docker/Caddyfile.docker` (`@no_cache_html` + `@hashed_assets`
+  — missing this on MBK in 2026-05-01 caused a stale-bundle outage)
+- Service definitions in `docker-compose.yml` (apart from the per-app
+  name and port — see "Port Offsets" above)
+- Deploy-workflow steps in `.github/workflows/deploy-myjobhunter.yml`
+  (env-file preflight, host-Caddyfile sync, frontend bundle freshness
+  tripwire)
+- Theme bootstrap script in `frontend/index.html`, AppShell layout in
+  `frontend/src/RootLayout.tsx`, semantic page wrappers in
+  `frontend/src/pages/*.tsx` (`<main className="p-4 sm:p-8 space-y-6 ...">`)
+
+**Divergence requires explicit justification.** Acceptable divergences:
+
+- The plural `users` table name (would require a migration; doesn't
+  warrant the disruption — documented in `apps/myjobhunter/backend/app/models/user/user.py`).
+- Port assignments (8002 / 8092 / 5174 vs MBK's 8000 / 8094) — by design.
+- Tighter CSP than MBK — MJH has fewer third-party integrations on the
+  page (no Plaid, no PostHog yet, no shared-storage subdomain). Widen
+  here when those land.
+- Tracing fewer routes than MBK (no `documents/`, `transactions/` etc.)
+  — MJH is earlier in its lifecycle.
+- `email_backend: str = "console"` default — appropriate while SMTP isn't
+  wired on the VPS. Operator flips to `smtp` in `.env.docker` when ready.
+- `restart: unless-stopped` (MJH) vs `restart: always` (MBK) — MJH's
+  choice is arguably better; both are valid.
+
+Anything NOT on the divergence list, presume MBK is right and copy.
+
 ## Known Follow-ups
 
 - GIN indexes on JSONB columns (add when actual query predicates exist)

--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -5,6 +5,16 @@
 # DATABASE_URL is set via docker-compose.yml `environment:` block — do NOT set it here.
 # DB_PASSWORD lives in apps/myjobhunter/.env (same dir as docker-compose.yml) — do NOT set it here.
 
+# Deployment environment — controls Sentry enforcement and the Turnstile boot guard.
+# Set to "production" in prod deployments; SENTRY_DSN and TURNSTILE_SECRET_KEY become REQUIRED.
+# Leave as "development" or "test" for local/CI environments.
+# Mirrors apps/mybookkeeper/backend/.env.docker.example.
+ENVIRONMENT=production
+
+# Sentry DSN — required when ENVIRONMENT=production. Boot fails loud if missing.
+# Project: mybookkeeper (Sentry org), look up the MJH-specific DSN in the dashboard.
+SENTRY_DSN=
+
 SECRET_KEY=change-me-to-random-64-chars
 ENCRYPTION_KEY=change-me-to-random-64-chars
 

--- a/apps/myjobhunter/backend/app/api/health.py
+++ b/apps/myjobhunter/backend/app/api/health.py
@@ -1,4 +1,5 @@
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
 from sqlalchemy import text
 
 from app.db.session import AsyncSessionLocal
@@ -7,10 +8,22 @@ router = APIRouter()
 
 
 @router.get("/health")
-async def health_check() -> dict:
+async def health_check():
+    """Health probe — DB connectivity + deploy version.
+
+    Returns the git commit short SHA so the deploy workflow can verify
+    the running container matches the expected revision without parsing
+    container logs. Mirrors apps/mybookkeeper/backend/app/main.py:/health.
+    """
+    # Lazy import to avoid a circular dep on app.main at module import time.
+    from app.main import GIT_COMMIT
+
     try:
         async with AsyncSessionLocal() as db:
             await db.execute(text("SELECT 1"))
-        return {"status": "ok", "db": "ok"}
-    except Exception as exc:
-        return {"status": "degraded", "db": str(exc)}
+        return {"status": "ok", "database": "connected", "version": GIT_COMMIT}
+    except Exception:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "degraded", "database": "unreachable", "version": GIT_COMMIT},
+        )

--- a/apps/myjobhunter/backend/app/core/config.py
+++ b/apps/myjobhunter/backend/app/core/config.py
@@ -89,6 +89,16 @@ class Settings(BaseSettings):
     # bounded to prevent storage abuse.
     max_resume_upload_bytes: int = 25 * 1024 * 1024  # 25 MB
 
+    # Deployment environment — controls Sentry enforcement.
+    # Set to "production" in prod deployments; SENTRY_DSN becomes REQUIRED.
+    # Leave as "development" or "test" for local/CI environments.
+    # Mirrors apps/mybookkeeper/backend/app/core/config.py.
+    environment: str = "development"
+
+    # Sentry DSN — fail-loud at boot when ENVIRONMENT=production and this is empty.
+    # Mirrors MBK's observability contract; see app/core/observability.py.
+    sentry_dsn: str = ""
+
     model_config = {"env_file": ".env", "extra": "ignore"}
 
 

--- a/apps/myjobhunter/backend/app/core/observability.py
+++ b/apps/myjobhunter/backend/app/core/observability.py
@@ -1,0 +1,73 @@
+"""Sentry initialisation with fail-loud production enforcement.
+
+In production (``ENVIRONMENT=production``), a missing ``SENTRY_DSN`` is a
+deployment-time fault — not a graceful degradation. The FastAPI lifespan
+calls ``init_sentry()`` at boot; if the DSN is absent in prod, it raises
+``SentryNotConfiguredError`` which crashes the lifespan, fails the
+healthcheck, and triggers a deploy rollback.
+
+In non-production environments (``development``, ``test``, etc.), Sentry is
+optional — ``init_sentry()`` exits silently when the DSN is empty.
+
+Mirrors apps/mybookkeeper/backend/app/core/observability.py — keep the two
+in sync.
+"""
+import logging
+
+import sentry_sdk
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+class SentryNotConfiguredError(RuntimeError):
+    """Raised at boot when ``SENTRY_DSN`` is missing in a production environment.
+
+    Distinct from a transient network outage: this is a deployment-time fault
+    that should crash the app immediately so the healthcheck catches it.
+    """
+
+
+def init_sentry() -> None:
+    """Initialise the Sentry SDK.
+
+    Raises:
+        SentryNotConfiguredError: If ``ENVIRONMENT=production`` and
+            ``SENTRY_DSN`` is not set.
+    """
+    if not settings.sentry_dsn:
+        if settings.environment == "production":
+            raise SentryNotConfiguredError(
+                "SENTRY_DSN is required in production. "
+                "Set the SENTRY_DSN environment variable or set "
+                "ENVIRONMENT to 'development' / 'test' to skip Sentry."
+            )
+        # Non-production: Sentry is optional — skip silently.
+        return
+
+    # LoggingIntegration: capture INFO+ as breadcrumbs (attached to any
+    # subsequent error event for context), and INFO+ as standalone events
+    # so diagnostic logs are visible in Sentry without exposing a debug API.
+    # The breadcrumb level controls what rides on errors; the event level
+    # controls what gets posted as its own Sentry event.
+    logging_integration = LoggingIntegration(
+        level=logging.INFO,
+        event_level=logging.INFO,
+    )
+
+    try:
+        sentry_sdk.init(
+            dsn=settings.sentry_dsn,
+            send_default_pii=False,
+            traces_sample_rate=0.1,
+            environment=settings.environment,
+            integrations=[logging_integration],
+        )
+    except Exception:
+        logger.warning(
+            "Sentry initialisation failed — error reporting will be unavailable.",
+            exc_info=True,
+        )
+        raise

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -1,5 +1,10 @@
+import logging
 import os
+import subprocess
+import time
+from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
+from datetime import datetime, timezone
 
 import jwt
 from fastapi import Depends, FastAPI, Request
@@ -10,6 +15,7 @@ from app.api import account, applications, companies, documents, health, integra
 from app.core.audit import current_user_id, register_audit_listeners
 from app.core.auth import auth_backend, fastapi_users
 from app.core.config import settings
+from app.core.observability import init_sentry
 from app.core.rate_limit import (
     check_account_not_locked,
     check_login_rate_limit,
@@ -19,8 +25,64 @@ from app.schemas.user import UserCreate, UserRead, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 
 
+def _resolve_git_commit() -> str:
+    """Resolve the deployed git commit short SHA.
+
+    Mirrors apps/mybookkeeper/backend/app/main.py — used by the deploy
+    workflow's freshness tripwire and by /api/version + /health for
+    deploy verification.
+    """
+    env_commit = os.environ.get("GIT_COMMIT", "").strip()
+    if env_commit:
+        return env_commit
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return "unknown"
+
+
+GIT_COMMIT = _resolve_git_commit()
+STARTUP_TIMESTAMP = datetime.now(timezone.utc).isoformat()
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    datefmt="%Y-%m-%dT%H:%M:%S",
+)
+logger = logging.getLogger("app")
+
+
+def _check_turnstile_configured() -> None:
+    """Fail loud at boot if Turnstile is not configured in a non-development environment.
+
+    Turnstile is the CAPTCHA gate on /auth/register and /auth/forgot-password.
+    Running without it in production is a credential-stuffing vulnerability.
+    In development/test the key is intentionally empty — the require_turnstile
+    dependency short-circuits when the key is absent, which is the desired CI/dev behaviour.
+
+    Mirrors apps/mybookkeeper/backend/app/main.py::_check_turnstile_configured.
+
+    Raises:
+        RuntimeError: If ``ENVIRONMENT`` is not ``development`` or ``test`` and
+            ``TURNSTILE_SECRET_KEY`` is not set.
+    """
+    if settings.environment not in ("development", "test") and not settings.turnstile_secret_key:
+        raise RuntimeError(
+            "TURNSTILE_SECRET_KEY must be set in non-development environments. "
+            "Cloudflare Turnstile is the CAPTCHA gate on /auth/register and "
+            "/auth/forgot-password — running prod without it is a credential-stuffing "
+            "vulnerability. Set TURNSTILE_SECRET_KEY or set ENVIRONMENT=development."
+        )
+
+
 @asynccontextmanager
-async def lifespan(app: FastAPI):
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    init_sentry()
+    _check_turnstile_configured()
     register_audit_listeners()
     ensure_bucket()
     yield
@@ -43,25 +105,43 @@ app.add_middleware(
 
 @app.middleware("http")
 async def set_audit_user(request: Request, call_next):
-    """Populate ``current_user_id`` ContextVar from the request's JWT."""
-    token = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
-    if not token:
-        return await call_next(request)
-    try:
-        payload = jwt.decode(
-            token,
-            settings.secret_key,
-            algorithms=["HS256"],
-            audience="fastapi-users:auth",
-        )
-    except JWTError:
-        return await call_next(request)
+    """Populate ``current_user_id`` ContextVar from the request's JWT and
+    emit a structured access log line for every request.
 
-    ctx_token = current_user_id.set(payload.get("sub"))
-    try:
-        return await call_next(request)
-    finally:
-        current_user_id.reset(ctx_token)
+    Mirrors apps/mybookkeeper/backend/app/main.py — the access log is the
+    primary triage surface in production, on top of Sentry. Without it,
+    debugging a slow / 5xx endpoint requires `docker logs api` parsing.
+    """
+    start = time.perf_counter()
+    token = request.headers.get("Authorization", "").removeprefix("Bearer ").strip()
+    user_id = None
+    if token:
+        try:
+            payload = jwt.decode(
+                token,
+                settings.secret_key,
+                algorithms=["HS256"],
+                audience="fastapi-users:auth",
+            )
+            user_id = payload.get("sub")
+            ctx_token = current_user_id.set(user_id)
+            try:
+                response = await call_next(request)
+            finally:
+                current_user_id.reset(ctx_token)
+        except JWTError:
+            response = await call_next(request)
+    else:
+        response = await call_next(request)
+
+    ms = (time.perf_counter() - start) * 1000
+    logger.info(
+        "%s %s %s %.0fms user=%s",
+        request.method, request.url.path, response.status_code, ms, user_id or "anonymous",
+    )
+    if response.status_code >= 500:
+        logger.error("5xx on %s %s", request.method, request.url.path)
+    return response
 
 
 # Auth routes — JWT login enforces email verification (returns
@@ -142,3 +222,12 @@ if os.environ.get("MYJOBHUNTER_ENABLE_TEST_HELPERS") == "1":
     from app.api import test_helpers
 
     app.include_router(test_helpers.router, tags=["_test"])
+
+
+# Deploy verification — exposes the git commit + boot timestamp so the
+# deploy workflow can confirm which commit is live without parsing logs.
+# Mirrors apps/mybookkeeper/backend/app/main.py:/api/version. Note that
+# this app uses ``root_path="/api"`` so the public path is /api/version.
+@app.get("/version")
+async def version() -> dict[str, str]:
+    return {"commit": GIT_COMMIT, "timestamp": STARTUP_TIMESTAMP}

--- a/apps/myjobhunter/backend/app/models/user/user.py
+++ b/apps/myjobhunter/backend/app/models/user/user.py
@@ -10,6 +10,13 @@ from app.db.base import Base
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):
+    # Intentional divergence from MBK (which uses singular ``user``): MJH was
+    # scaffolded with the plural form before the parity audit and migrating
+    # the table now would require a multi-step rename across every FK,
+    # index, RLS policy, and downstream system. The cost outweighs the
+    # benefit. Documented in apps/myjobhunter/CLAUDE.md "Parity rule" →
+    # divergences. New tables in MJH should follow the singular convention
+    # to minimise further drift.
     __tablename__ = "users"
 
     display_name: Mapped[str] = mapped_column(String(100), default="")

--- a/apps/myjobhunter/backend/pyproject.toml
+++ b/apps/myjobhunter/backend/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "anthropic>=0.49.0",
     "pypdf>=4.0.0",
     "mammoth>=1.7.0",
+    # Sentry — fail-loud production enforcement. See app/core/observability.py.
+    # Mirrors apps/mybookkeeper/backend/pyproject.toml.
+    "sentry-sdk[fastapi]==2.58.0",
 ]
 
 [tool.uv]

--- a/apps/myjobhunter/backend/requirements.txt
+++ b/apps/myjobhunter/backend/requirements.txt
@@ -36,6 +36,7 @@ certifi==2026.4.22
     #   httpcore
     #   httpx
     #   minio
+    #   sentry-sdk
 cffi==2.0.0
     # via
     #   argon2-cffi-bindings
@@ -70,6 +71,7 @@ fastapi==0.136.1
     #   fastapi-users
     #   myjobhunter-backend
     #   platform-shared
+    #   sentry-sdk
 fastapi-users==15.0.5
     # via
     #   fastapi-users-db-sqlalchemy
@@ -165,6 +167,8 @@ pyyaml==6.0.3
     # via uvicorn
 qrcode==8.2
     # via platform-shared
+sentry-sdk==2.58.0
+    # via myjobhunter-backend
 sniffio==1.3.1
     # via anthropic
 sqlalchemy==2.0.49
@@ -194,7 +198,9 @@ typing-inspection==0.4.2
     #   pydantic
     #   pydantic-settings
 urllib3==2.6.3
-    # via minio
+    # via
+    #   minio
+    #   sentry-sdk
 uvicorn==0.46.0
     # via myjobhunter-backend
 uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'

--- a/apps/myjobhunter/backend/tests/test_health.py
+++ b/apps/myjobhunter/backend/tests/test_health.py
@@ -1,4 +1,9 @@
-"""Smoke test: GET /health returns 200 with status ok."""
+"""Smoke test: GET /health returns 200 with status ok + database connectivity + version.
+
+Mirrors apps/mybookkeeper/backend/tests/test_health.py — health response must
+include a `version` field (git commit short SHA) so the deploy workflow can
+verify the running container matches the expected revision.
+"""
 import pytest
 from httpx import AsyncClient
 
@@ -9,4 +14,8 @@ async def test_health_returns_ok(client: AsyncClient) -> None:
     assert resp.status_code == 200
     body = resp.json()
     assert body["status"] == "ok"
-    assert body["db"] == "ok"
+    assert body["database"] == "connected"
+    # `version` is set from git rev-parse at module import; in test runs the
+    # repo is the worktree, so the value will be a short SHA or "unknown" — we
+    # assert presence rather than a specific value.
+    assert "version" in body

--- a/apps/myjobhunter/backend/tests/test_observability.py
+++ b/apps/myjobhunter/backend/tests/test_observability.py
@@ -1,0 +1,144 @@
+"""Tests for Sentry fail-loud initialisation (app/core/observability.py).
+
+Mirrors apps/mybookkeeper/backend/tests/test_observability.py — keep the two
+in sync. The contract is:
+
+- In production (ENVIRONMENT=production), SENTRY_DSN must be set.
+  A missing DSN raises SentryNotConfiguredError at boot — lifespan
+  crashes, healthcheck fails, deploy rolls back.
+- In non-production environments, an empty SENTRY_DSN is silently
+  accepted — Sentry is optional for local dev and CI.
+- When a DSN is present, sentry_sdk.init is called with the correct
+  environment tag (not a hardcoded "production" string).
+- When sentry_sdk.init raises, the exception is logged as a warning and
+  then re-raised so the lifespan still crashes rather than booting
+  with a broken Sentry connection.
+
+We construct a _local_ settings-like object for each test (never mutate
+the module-level singleton) and patch ``app.core.observability.settings``
+so ``init_sentry()`` sees the values we control.
+"""
+from __future__ import annotations
+
+import logging
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.core.observability import SentryNotConfiguredError, init_sentry
+
+
+def _make_settings(*, environment: str, sentry_dsn: str) -> SimpleNamespace:
+    """Return a settings-like namespace used to patch observability.settings."""
+    return SimpleNamespace(environment=environment, sentry_dsn=sentry_dsn)
+
+
+class TestSentryNotConfiguredError:
+    def test_is_runtime_error_subclass(self) -> None:
+        assert issubclass(SentryNotConfiguredError, RuntimeError)
+
+    def test_carries_message(self) -> None:
+        err = SentryNotConfiguredError("missing DSN")
+        assert "missing DSN" in str(err)
+
+
+class TestInitSentryProductionRequiresDsn:
+    """In production, a missing DSN must crash the process at boot."""
+
+    def test_raises_when_production_and_dsn_empty(self) -> None:
+        fake_settings = _make_settings(environment="production", sentry_dsn="")
+        with patch("app.core.observability.settings", fake_settings):
+            with pytest.raises(SentryNotConfiguredError, match="SENTRY_DSN is required"):
+                init_sentry()
+
+    def test_does_not_raise_when_production_and_dsn_set(self) -> None:
+        fake_settings = _make_settings(
+            environment="production", sentry_dsn="https://abc@sentry.io/123"
+        )
+        with patch("app.core.observability.settings", fake_settings):
+            with patch("app.core.observability.sentry_sdk.init"):
+                init_sentry()  # must not raise
+
+
+class TestInitSentryNonProductionAllowsEmptyDsn:
+    """In development / test, an empty DSN is silently skipped."""
+
+    @pytest.mark.parametrize("env", ["development", "test", "staging", ""])
+    def test_does_not_raise_when_non_production_and_dsn_empty(self, env: str) -> None:
+        fake_settings = _make_settings(environment=env, sentry_dsn="")
+        with patch("app.core.observability.settings", fake_settings):
+            init_sentry()  # must not raise
+
+    def test_does_not_call_sentry_init_when_dsn_empty(self) -> None:
+        fake_settings = _make_settings(environment="development", sentry_dsn="")
+        with patch("app.core.observability.settings", fake_settings):
+            with patch("app.core.observability.sentry_sdk.init") as mock_init:
+                init_sentry()
+        mock_init.assert_not_called()
+
+
+class TestInitSentryPassesEnvironmentTag:
+    """The environment tag passed to sentry_sdk.init must come from settings,
+    not from a hardcoded string."""
+
+    @pytest.mark.parametrize("env", ["production", "staging"])
+    def test_passes_environment_to_sentry(self, env: str) -> None:
+        fake_settings = _make_settings(
+            environment=env, sentry_dsn="https://abc@sentry.io/123"
+        )
+        with patch("app.core.observability.settings", fake_settings):
+            with patch("app.core.observability.sentry_sdk.init") as mock_init:
+                init_sentry()
+
+        mock_init.assert_called_once()
+        _, kwargs = mock_init.call_args
+        assert kwargs["environment"] == env, (
+            f"Expected environment={env!r} in sentry_sdk.init, got {kwargs.get('environment')!r}"
+        )
+
+    def test_passes_dsn_and_other_params(self) -> None:
+        dsn = "https://abc@sentry.io/999"
+        fake_settings = _make_settings(environment="production", sentry_dsn=dsn)
+        with patch("app.core.observability.settings", fake_settings):
+            with patch("app.core.observability.sentry_sdk.init") as mock_init:
+                init_sentry()
+
+        _, kwargs = mock_init.call_args
+        assert kwargs["dsn"] == dsn
+        assert kwargs["send_default_pii"] is False
+        assert "traces_sample_rate" in kwargs
+
+
+class TestInitSentryPropagatesInitFailure:
+    """If sentry_sdk.init raises (e.g. bad DSN format), the exception must be
+    logged as a warning and then re-raised so the lifespan still fails loudly."""
+
+    def test_reraises_when_sentry_init_throws(self) -> None:
+        fake_settings = _make_settings(
+            environment="production", sentry_dsn="https://abc@sentry.io/123"
+        )
+        with patch("app.core.observability.settings", fake_settings):
+            with patch(
+                "app.core.observability.sentry_sdk.init",
+                side_effect=RuntimeError("bad DSN"),
+            ):
+                with pytest.raises(RuntimeError, match="bad DSN"):
+                    init_sentry()
+
+    def test_logs_warning_before_reraising(self, caplog: pytest.LogCaptureFixture) -> None:
+        fake_settings = _make_settings(
+            environment="production", sentry_dsn="https://abc@sentry.io/123"
+        )
+        with patch("app.core.observability.settings", fake_settings):
+            with patch(
+                "app.core.observability.sentry_sdk.init",
+                side_effect=Exception("init error"),
+            ):
+                with caplog.at_level(logging.WARNING, logger="app.core.observability"):
+                    with pytest.raises(Exception):
+                        init_sentry()
+
+        assert any("unavailable" in r.message.lower() for r in caplog.records), (
+            f"Expected a warning about Sentry being unavailable; got: {[r.message for r in caplog.records]}"
+        )

--- a/apps/myjobhunter/backend/tests/test_turnstile_boot_check.py
+++ b/apps/myjobhunter/backend/tests/test_turnstile_boot_check.py
@@ -1,0 +1,82 @@
+"""Tests for Turnstile fail-loud boot check (app/main.py:_check_turnstile_configured).
+
+Mirrors apps/mybookkeeper/backend/tests/test_turnstile_boot_check.py — keep
+the two in sync. Covers:
+
+- environment=production + empty key → RuntimeError raised
+- environment=production + non-empty key → no error
+- environment=development + empty key → no error (preserves dev/CI no-op)
+- environment=test + empty key → no error (preserves CI no-op)
+- environment=staging + empty key → RuntimeError raised (staging is non-dev)
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.main import _check_turnstile_configured
+
+
+def _make_settings(*, environment: str, turnstile_secret_key: str) -> SimpleNamespace:
+    """Return a settings-like namespace for patching app.main.settings."""
+    return SimpleNamespace(environment=environment, turnstile_secret_key=turnstile_secret_key)
+
+
+class TestTurnstileBootCheckProduction:
+    """In production, a missing key must crash the process at boot."""
+
+    def test_raises_when_production_and_key_empty(self) -> None:
+        fake_settings = _make_settings(environment="production", turnstile_secret_key="")
+        with patch("app.main.settings", fake_settings):
+            with pytest.raises(RuntimeError, match="TURNSTILE_SECRET_KEY must be set"):
+                _check_turnstile_configured()
+
+    def test_does_not_raise_when_production_and_key_set(self) -> None:
+        fake_settings = _make_settings(
+            environment="production", turnstile_secret_key="real-secret-key-here"
+        )
+        with patch("app.main.settings", fake_settings):
+            _check_turnstile_configured()  # must not raise
+
+    def test_error_message_mentions_credential_stuffing(self) -> None:
+        """The error message must explain WHY this is enforced — not just that it is."""
+        fake_settings = _make_settings(environment="production", turnstile_secret_key="")
+        with patch("app.main.settings", fake_settings):
+            with pytest.raises(RuntimeError) as exc_info:
+                _check_turnstile_configured()
+        assert "credential-stuffing" in str(exc_info.value).lower()
+
+
+class TestTurnstileBootCheckDevelopment:
+    """In development/test, an empty key must be silently accepted."""
+
+    @pytest.mark.parametrize("env", ["development", "test"])
+    def test_does_not_raise_when_dev_or_test_and_key_empty(self, env: str) -> None:
+        fake_settings = _make_settings(environment=env, turnstile_secret_key="")
+        with patch("app.main.settings", fake_settings):
+            _check_turnstile_configured()  # must not raise
+
+    @pytest.mark.parametrize("env", ["development", "test"])
+    def test_does_not_raise_when_dev_or_test_and_key_set(self, env: str) -> None:
+        """Even if a key happens to be set in dev, it should not cause issues."""
+        fake_settings = _make_settings(environment=env, turnstile_secret_key="some-key")
+        with patch("app.main.settings", fake_settings):
+            _check_turnstile_configured()  # must not raise
+
+
+class TestTurnstileBootCheckNonDevEnvironments:
+    """Environments other than development/test should also enforce the key."""
+
+    @pytest.mark.parametrize("env", ["staging", "production", "prod", ""])
+    def test_raises_for_non_dev_environments_without_key(self, env: str) -> None:
+        fake_settings = _make_settings(environment=env, turnstile_secret_key="")
+        with patch("app.main.settings", fake_settings):
+            with pytest.raises(RuntimeError):
+                _check_turnstile_configured()
+
+    def test_does_not_raise_for_staging_with_key(self) -> None:
+        fake_settings = _make_settings(environment="staging", turnstile_secret_key="staging-key")
+        with patch("app.main.settings", fake_settings):
+            _check_turnstile_configured()  # must not raise

--- a/apps/myjobhunter/backend/tests/test_version_endpoint.py
+++ b/apps/myjobhunter/backend/tests/test_version_endpoint.py
@@ -1,0 +1,101 @@
+"""Tests for the deploy-verification surfaces — _resolve_git_commit, /version,
+and the version field on /health.
+
+Mirrors apps/mybookkeeper/backend/tests/test_version_endpoint.py — keep the
+two in sync. The contract is: the deploy workflow uses `/version` (or the
+`version` field on `/health`) to confirm which commit is live without
+parsing container logs. Breaking the response shape regresses that loop.
+
+Note that MJH mounts FastAPI with ``root_path="/api"``, so:
+- The `/version` route declared in app.main is reachable inside the test
+  client at the bare path `/version` (the test client does NOT prepend the
+  root_path — that's added by the upstream Caddy proxy in production).
+- The same applies to the `/health` route mounted via app/api/health.py.
+"""
+import os
+import subprocess  # noqa: F401 — used by patch path
+from datetime import datetime
+from unittest.mock import patch
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+
+def test_resolve_git_commit_from_env() -> None:
+    """When GIT_COMMIT env var is set, it takes precedence."""
+    with patch.dict(os.environ, {"GIT_COMMIT": "abc1234"}):
+        from app.main import _resolve_git_commit
+        assert _resolve_git_commit() == "abc1234"
+
+
+def test_resolve_git_commit_falls_back_to_git() -> None:
+    """When no env var, falls back to git rev-parse."""
+    with patch.dict(os.environ, {"GIT_COMMIT": ""}):
+        from app.main import _resolve_git_commit
+        result = _resolve_git_commit()
+        assert len(result) > 0
+        assert result != "unknown"
+
+
+def test_resolve_git_commit_returns_unknown_when_no_git() -> None:
+    """When both env var and git are unavailable, returns 'unknown'."""
+    with patch.dict(os.environ, {"GIT_COMMIT": ""}):
+        with patch("subprocess.check_output", side_effect=FileNotFoundError):
+            from app.main import _resolve_git_commit
+            assert _resolve_git_commit() == "unknown"
+
+
+def test_resolve_git_commit_strips_whitespace() -> None:
+    """Env var value is stripped of whitespace."""
+    with patch.dict(os.environ, {"GIT_COMMIT": "  abc1234  "}):
+        from app.main import _resolve_git_commit
+        assert _resolve_git_commit() == "abc1234"
+
+
+def test_git_commit_module_level_is_set() -> None:
+    """The module-level GIT_COMMIT is populated at import time."""
+    from app.main import GIT_COMMIT
+    assert isinstance(GIT_COMMIT, str)
+    assert len(GIT_COMMIT) > 0
+
+
+def test_startup_timestamp_is_iso_format() -> None:
+    """The module-level STARTUP_TIMESTAMP is a valid ISO timestamp."""
+    from app.main import STARTUP_TIMESTAMP
+    parsed = datetime.fromisoformat(STARTUP_TIMESTAMP)
+    assert parsed is not None
+
+
+@pytest.mark.asyncio
+async def test_version_endpoint_returns_commit_and_timestamp() -> None:
+    """GET /version returns commit and timestamp.
+
+    In production this endpoint is reachable at /api/version because Docker
+    Caddy strips the /api prefix before forwarding; FastAPI's root_path="/api"
+    handles the OpenAPI display. The ASGI test client bypasses the proxy,
+    so we hit the path FastAPI registered: /version.
+    """
+    from app.main import app, GIT_COMMIT, STARTUP_TIMESTAMP
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/version")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["commit"] == GIT_COMMIT
+    assert body["timestamp"] == STARTUP_TIMESTAMP
+
+
+@pytest.mark.asyncio
+async def test_health_endpoint_includes_version() -> None:
+    """GET /health includes the version field for deploy verification."""
+    from app.main import app, GIT_COMMIT
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        resp = await client.get("/health")
+
+    body = resp.json()
+    assert "version" in body
+    assert body["version"] == GIT_COMMIT

--- a/apps/myjobhunter/backend/uv.lock
+++ b/apps/myjobhunter/backend/uv.lock
@@ -550,6 +550,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt", extra = ["crypto"] },
     { name = "pypdf" },
+    { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -564,7 +565,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = "==1.18.4" },
-    { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "anthropic", specifier = ">=0.49.0" },
     { name = "anyio", specifier = "==4.13.0" },
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "cryptography", specifier = "==47.0.0" },
@@ -581,6 +582,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = "==2.14.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.12.1" },
     { name = "pypdf", specifier = ">=4.0.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.58.0" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.46.0" },
 ]
@@ -910,6 +912,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8f/b2/7fc2931bfae0af02d5f53b174e9cf701adbb35f39d69c2af63d4a39f81a9/qrcode-8.2.tar.gz", hash = "sha256:35c3f2a4172b33136ab9f6b3ef1c00260dd2f66f858f24d88418a015f446506c", size = 43317, upload-time = "2025-05-01T15:44:24.726Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/b8/d2d6d731733f51684bbf76bf34dab3b70a9148e8f2cef2bb544fccec681a/qrcode-8.2-py3-none-any.whl", hash = "sha256:16e64e0716c14960108e85d853062c9e8bba5ca8252c0b4d0231b9df4060ff4f", size = 45986, upload-time = "2025-05-01T15:44:22.781Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+]
+
+[package.optional-dependencies]
+fastapi = [
+    { name = "fastapi" },
 ]
 
 [[package]]

--- a/apps/myjobhunter/docker/Caddyfile.docker
+++ b/apps/myjobhunter/docker/Caddyfile.docker
@@ -83,6 +83,22 @@
 
     # SPA fallback for frontend
     handle {
+        # Cache strategy — mirrors apps/mybookkeeper/docker/Caddyfile.docker.
+        # - HTML and the service worker MUST never be cached. They are the
+        #   entry points that reference the latest asset bundles. If they
+        #   were cached, users would be stuck on old bundles forever after
+        #   a deploy (this happened to MBK on 2026-05-01 — clients kept
+        #   loading a pre-2FA bundle weeks after the new one shipped because
+        #   the SW precached it and `index.html` was cached too).
+        # - Hashed assets (Vite content-hashes filenames like
+        #   `index-AbCd1234.js`) ARE safe to cache forever because the
+        #   filename changes whenever content changes.
+        @no_cache_html path / /index.html /sw.js /workbox-*.js /manifest.webmanifest /registerSW.js
+        header @no_cache_html Cache-Control "no-cache, no-store, must-revalidate"
+
+        @hashed_assets path_regexp \.[A-Za-z0-9_-]{8,}\.(js|css|woff2)$
+        header @hashed_assets Cache-Control "public, max-age=31536000, immutable"
+
         root * /srv/frontend
         try_files {path} /index.html
         file_server

--- a/apps/myjobhunter/frontend/CLAUDE.md
+++ b/apps/myjobhunter/frontend/CLAUDE.md
@@ -175,3 +175,40 @@ See `packages/shared-frontend/src/index.ts` for the full export list. Key compon
 4. `notifyAuthChange()` from `@platform/ui` triggers `useIsAuthenticated` re-render
 5. `RequireAuth` in `RootLayout` redirects unauthenticated users to `/login`
 6. 401 responses handled by the shared axios interceptor in `@platform/ui/lib/api`
+
+## Parity rule
+
+MJH frontend mirrors MBK frontend by default. MBK is the canonical
+reference; before introducing a new layout pattern, dark-mode class,
+or theme variable, **open the matching MBK file and copy its pattern.**
+
+Files to mirror:
+
+- `frontend/index.html` — theme bootstrap script + iOS add-to-homescreen
+  meta tags (`apple-mobile-web-app-capable`, `apple-mobile-web-app-status-bar-style`)
+- `frontend/src/index.css` — Tailwind theme tokens. The CSS-variable
+  shadcn-style approach is the right choice — page components should
+  consume `bg-card`, `text-foreground`, `border-border` (which auto-flip
+  with `.dark`) and avoid handcrafted `dark:bg-...` overrides. Reach for
+  explicit `dark:` only when the token system can't express the variant
+  (rare — usually a sign the token system needs another variable).
+- **Page wrapper semantic + responsive padding:** every authenticated
+  page in MBK uses `<main className="p-4 sm:p-8 space-y-6 ...">` (not
+  `<div className="p-6 ...">`). The `sm:p-8` doubles the padding on
+  larger viewports, which makes the page feel less cramped on desktop;
+  `p-4` keeps mobile dense. Use `<main>` semantic — there should be
+  exactly one main landmark per route. Loaded / loading / error / empty
+  states all share the same wrapper element so the layout doesn't shift.
+- `RootLayout.tsx` consumes `@platform/ui`'s `AppShell` — sticky header
+  is the responsibility of the shell, not the route.
+
+Divergence requires explicit justification. Acceptable divergences:
+
+- MBK uses a custom `Layout.tsx` instead of `AppShell` because MBK
+  cannot migrate to `@platform/ui` until React 19 (two-React-copies
+  runtime crash). The two will reconverge once MBK upgrades.
+- Per-page `max-w-*` sizing is route-specific (Profile is `max-w-3xl`,
+  Settings is `max-w-2xl`). Mirror MBK's choice for the equivalent
+  page when one exists; otherwise pick what fits the data.
+
+Anything NOT on the divergence list, presume MBK is right and copy.

--- a/apps/myjobhunter/frontend/index.html
+++ b/apps/myjobhunter/frontend/index.html
@@ -2,16 +2,19 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#0f172a" />
+    <!-- iOS add-to-homescreen polish — mirrors apps/mybookkeeper/frontend/index.html. -->
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💼</text></svg>" />
+    <title>MyJobHunter</title>
     <script>
       // Apply dark/light theme BEFORE React hydrates to avoid a flash of the
       // wrong theme on first paint. Mirrors apps/mybookkeeper/frontend/index.html.
       // Storage key matches @platform/ui's useTheme() hook.
       (function(){var t=localStorage.getItem("v1_theme");var d=t==="dark"||(t!=="light"&&matchMedia("(prefers-color-scheme:dark)").matches);if(d)document.documentElement.classList.add("dark")})();
     </script>
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💼</text></svg>" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>MyJobHunter</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/myjobhunter/frontend/src/pages/ApplicationDetail.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ApplicationDetail.tsx
@@ -104,7 +104,7 @@ export default function ApplicationDetail() {
         ? (error as { status: number }).status
         : null;
     return (
-      <div className="p-6 flex flex-col items-center text-center gap-4 py-20">
+      <main className="p-4 sm:p-8 flex flex-col items-center text-center gap-4 py-20">
         <p className="text-4xl font-bold text-muted-foreground">{errorStatus ?? 404}</p>
         <h1 className="text-xl font-semibold">
           {/* errorStatus is number | null; null means no HTTP status extracted (e.g. network error) — treat same as 404 */}
@@ -124,7 +124,7 @@ export default function ApplicationDetail() {
           <ChevronLeft className="w-4 h-4" />
           Back to Applications
         </Link>
-      </div>
+      </main>
     );
   }
 
@@ -147,7 +147,7 @@ export default function ApplicationDetail() {
   }
 
   return (
-    <div className="p-6 max-w-3xl space-y-6">
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
       <Link
         to="/applications"
         className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
@@ -293,6 +293,6 @@ export default function ApplicationDetail() {
         open={logEventOpen}
         onOpenChange={setLogEventOpen}
       />
-    </div>
+    </main>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/Applications.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Applications.tsx
@@ -79,15 +79,15 @@ export default function Applications() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <main className="p-4 sm:p-8 space-y-6">
         <ApplicationsSkeleton />
-      </div>
+      </main>
     );
   }
 
   if (isError) {
     return (
-      <div className="p-6">
+      <main className="p-4 sm:p-8 space-y-6">
         <EmptyState
           icon={<FilePlus className="w-12 h-12 text-destructive" />}
           heading="Couldn't load applications"
@@ -97,7 +97,7 @@ export default function Applications() {
               : "Try refreshing the page."
           }
         />
-      </div>
+      </main>
     );
   }
 
@@ -106,21 +106,21 @@ export default function Applications() {
   if (items.length === 0) {
     return (
       <>
-        <div className="p-6">
+        <main className="p-4 sm:p-8 space-y-6">
           <EmptyState
             icon={<FilePlus className="w-12 h-12" />}
             heading={copy.heading}
             body={copy.body}
             action={{ label: copy.actionLabel, onClick: handleAddApplication }}
           />
-        </div>
+        </main>
         <AddApplicationDialog open={dialogOpen} onOpenChange={setDialogOpen} />
       </>
     );
   }
 
   return (
-    <div className="p-6 space-y-4">
+    <main className="p-4 sm:p-8 space-y-6">
       <header className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Applications</h1>
         <button
@@ -142,6 +142,6 @@ export default function Applications() {
         sorting={sorting}
         onSortingChange={setSorting}
       />
-    </div>
+    </main>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/Companies.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Companies.tsx
@@ -53,15 +53,15 @@ export default function Companies() {
 
   if (isLoading) {
     return (
-      <div className="p-6">
+      <main className="p-4 sm:p-8 space-y-6">
         <CompaniesSkeleton />
-      </div>
+      </main>
     );
   }
 
   if (isError) {
     return (
-      <div className="p-6">
+      <main className="p-4 sm:p-8 space-y-6">
         <EmptyState
           icon={<Building2 className="w-12 h-12 text-destructive" />}
           heading="Couldn't load companies"
@@ -71,7 +71,7 @@ export default function Companies() {
               : "Try refreshing the page."
           }
         />
-      </div>
+      </main>
     );
   }
 
@@ -80,21 +80,21 @@ export default function Companies() {
   if (items.length === 0) {
     return (
       <>
-        <div className="p-6">
+        <main className="p-4 sm:p-8 space-y-6">
           <EmptyState
             icon={<Building2 className="w-12 h-12" />}
             heading={copy.heading}
             body={copy.body}
             action={{ label: "Add a company", onClick: handleAddCompany }}
           />
-        </div>
+        </main>
         <AddCompanyDialog open={dialogOpen} onOpenChange={setDialogOpen} />
       </>
     );
   }
 
   return (
-    <div className="p-6 space-y-4">
+    <main className="p-4 sm:p-8 space-y-6">
       <header className="flex items-center justify-between">
         <h1 className="text-2xl font-semibold">Companies</h1>
         <button
@@ -114,6 +114,6 @@ export default function Companies() {
         getRowId={(row) => row.id}
         onRowClick={(row) => navigate(`/companies/${row.id}`)}
       />
-    </div>
+    </main>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/CompanyDetail.tsx
+++ b/apps/myjobhunter/frontend/src/pages/CompanyDetail.tsx
@@ -66,7 +66,7 @@ export default function CompanyDetail() {
   if (isError || !company) {
     const status = error && typeof error === "object" && "status" in error ? (error as { status: number }).status : null;
     return (
-      <div className="p-6 flex flex-col items-center text-center gap-4 py-20">
+      <main className="p-4 sm:p-8 flex flex-col items-center text-center gap-4 py-20">
         <p className="text-4xl font-bold text-muted-foreground">{status ?? 404}</p>
         <h1 className="text-xl font-semibold">
           {/* status is number | null; null means no HTTP status extracted (e.g. network error) — treat same as 404 */}
@@ -84,7 +84,7 @@ export default function CompanyDetail() {
           <ChevronLeft className="w-4 h-4" />
           Back to Companies
         </Link>
-      </div>
+      </main>
     );
   }
 
@@ -93,7 +93,7 @@ export default function CompanyDetail() {
   const applicationsForCompany = applicationsData?.items ?? [];
 
   return (
-    <div className="p-6 max-w-3xl space-y-6">
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
       <Link
         to="/companies"
         className="inline-flex items-center gap-1.5 text-sm font-medium text-muted-foreground hover:text-foreground"
@@ -170,7 +170,7 @@ export default function CompanyDetail() {
           />
         )}
       </section>
-    </div>
+    </main>
   );
 }
 

--- a/apps/myjobhunter/frontend/src/pages/Dashboard.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Dashboard.tsx
@@ -22,13 +22,13 @@ export default function Dashboard() {
   }
 
   return (
-    <div className="p-6">
+    <main className="p-4 sm:p-8 space-y-6">
       <EmptyState
         icon={<Briefcase className="w-12 h-12" />}
         heading={copy.heading}
         body={copy.body}
         action={{ label: copy.actionLabel, onClick: handleAddApplication }}
       />
-    </div>
+    </main>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/Documents.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Documents.tsx
@@ -7,7 +7,7 @@ export default function Documents() {
   const [uploadOpen, setUploadOpen] = useState(false);
 
   return (
-    <div className="p-6 max-w-3xl space-y-6">
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
       <header className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-semibold">Documents</h1>
@@ -30,6 +30,6 @@ export default function Documents() {
         open={uploadOpen}
         onOpenChange={setUploadOpen}
       />
-    </div>
+    </main>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/Profile.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Profile.tsx
@@ -111,9 +111,9 @@ export default function Profile() {
 
   if (profileError || !profile) {
     return (
-      <div className="p-6">
+      <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
         <p className="text-destructive">Couldn't load profile. Try refreshing.</p>
-      </div>
+      </main>
     );
   }
 
@@ -174,7 +174,7 @@ export default function Profile() {
   }
 
   return (
-    <div className="p-6 max-w-3xl space-y-6">
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
       {/* ------------------------------------------------------------------ */}
       {/* Header section */}
       {/* ------------------------------------------------------------------ */}
@@ -571,6 +571,6 @@ export default function Profile() {
         existing={screeningEditTarget}
         existingKeys={existingAnswerKeys}
       />
-    </div>
+    </main>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/Security.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Security.tsx
@@ -24,7 +24,7 @@ export default function Security() {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   return (
-    <div className="p-6 max-w-2xl space-y-6">
+    <main className="p-4 sm:p-8 space-y-6 max-w-2xl">
       <h1 className="text-2xl font-semibold">Security</h1>
 
       {!infoDismissed && (
@@ -96,6 +96,6 @@ export default function Security() {
         open={showDeleteModal}
         onClose={() => setShowDeleteModal(false)}
       />
-    </div>
+    </main>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/Settings.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Settings.tsx
@@ -4,7 +4,7 @@ import { Badge, Button, Card } from "@platform/ui";
 
 export default function Settings() {
   return (
-    <div className="p-6 max-w-2xl space-y-6">
+    <main className="p-4 sm:p-8 space-y-6 max-w-2xl">
       <div>
         <h1 className="text-xl font-semibold">Settings</h1>
         <p className="text-sm text-muted-foreground mt-1">
@@ -62,6 +62,6 @@ export default function Settings() {
           Account management options coming in a future phase.
         </p>
       </Card>
-    </div>
+    </main>
   );
 }


### PR DESCRIPTION
## Summary

This PR brings MyJobHunter into structural parity with MyBookkeeper on every dimension where they should be identical. Every MJH production bug this session traced back to MJH not mirroring MBK; this PR closes the audit by mechanically copying the patterns where they were missing and documenting the cases where divergence is intentional.

The earlier in-flight session fixes (#282 `database_url_sync` computed property, #283 Caddyfile `:80`) are already on `main`; this PR builds on top of them.

## Audit table

| # | Drift | Class | Right side | Patch |
|---|---|---|---|---|
| 1 | MJH `main.py` lacks Sentry init | **bug** | MBK | New `app/core/observability.py` mirroring MBK exactly; `init_sentry()` called from lifespan; `SENTRY_DSN` required in production (raises `SentryNotConfiguredError`); `sentry-sdk[fastapi]==2.58.0` added to `pyproject.toml`. |
| 2 | MJH `main.py` lacks Turnstile boot guard | **bug** | MBK | Added `_check_turnstile_configured()` mirroring MBK — fail-loud if `ENVIRONMENT` is not `development`/`test` and `TURNSTILE_SECRET_KEY` is empty. |
| 3 | MJH `main.py` lacks request-logging middleware | **bug** | MBK | Audit middleware now also logs `method path status ms user=...` per request, with 5xx surfaced at ERROR. Production triage no longer requires `docker logs api` parsing. |
| 4 | MJH `main.py` lacks `/version` route + `/health` version field | **bug** | MBK | Added `_resolve_git_commit()`, `GIT_COMMIT`, `STARTUP_TIMESTAMP`; new `/version` endpoint (reachable at `/api/version` via root_path); `/health` response shape now `{database: "connected", version: <sha>}` matching MBK. |
| 5 | MJH `config.py` lacks `environment` + `sentry_dsn` settings | **bug** | MBK | Added both to `Settings`; defaults `"development"` and `""` so dev/test boot is unchanged. |
| 6 | MJH `.env.docker.example` lacks `ENVIRONMENT` + `SENTRY_DSN` | **bug** | MBK | Added with comments explaining the prod requirement. Operator now knows to set them on the VPS. |
| 7 | MJH Caddyfile.docker lacks cache-control headers | **bug** | MBK | Added `@no_cache_html` (HTML/SW/manifest no-cache) + `@hashed_assets` (immutable, max-age 1y). Same class of failure as MBK's 2026-05-01 stale-bundle outage. |
| 8 | MJH pages use `<div className="p-6 ...">` instead of `<main className="p-4 sm:p-8 space-y-6 ...">` | cosmetic | MBK | All 9 pages updated (Dashboard, Profile, Companies, CompanyDetail, Applications, ApplicationDetail, Documents, Settings, Security). Loading / error / empty / loaded states all share the same wrapper to prevent layout shift. |
| 9 | MJH `index.html` missing iOS homescreen meta tags | cosmetic | MBK | Added `apple-mobile-web-app-capable` and `apple-mobile-web-app-status-bar-style`. |
| 10 | MJH `users` table is plural; MBK is singular | **intentional** | MBK | Documented in `app/models/user/user.py` as a known divergence — migration cost outweighs benefit. New tables follow MBK's singular convention. |
| 11 | MJH ports `8002/8092/5174` vs MBK `8000/8094` | **intentional** | both | By design — same VPS, different services. |
| 12 | MJH `email_backend: "console"` default | **intentional** | MJH | Appropriate while SMTP isn't wired on the VPS; operator flips to `smtp` in `.env.docker` when ready. |
| 13 | MJH `restart: unless-stopped` vs MBK `restart: always` | **intentional** | MJH | `unless-stopped` arguably better; both valid. |
| 14 | MJH CSP tighter than MBK | **intentional** | MJH | MJH has fewer 3rd-party integrations on the page (no Plaid, no PostHog yet). Already documented in MJH Caddyfile. |
| 15 | MJH AppShell already pinned-header + AppShell layout | already at parity | both | MJH uses `@platform/ui::AppShell` whose header is `shrink-0 h-14` + main is `overflow-y-auto` — header stays pinned by construction. MBK's custom `Layout.tsx` does the same with `pt-14 md:pt-0`. |
| 16 | Theme bootstrap script in `index.html` | already at parity | both | Both use `v1_theme` localStorage key + identical inline FOUC-prevention script. |
| 17 | Dark-mode classes | already at parity | both | Both apps use the same shadcn-style CSS-variable approach (`--background`, `--card`, `--foreground` swap in `.dark`). Explicit `dark:` overrides exist only where the token system can't express the variant — MBK has 20 occurrences, MJH 12. Not a structural drift. |

## Most surprising drift

**MJH's `Caddyfile.docker` had no cache-control directives at all.** The existing file set HSTS, X-Frame-Options, CSP, etc., but didn't tell browsers how to cache the SPA. The 2026-05-01 MBK stale-bundle outage — which led directly to the addition of those directives in `apps/mybookkeeper/docker/Caddyfile.docker` — never propagated. Without `@no_cache_html` + `@hashed_assets`, MJH would have hit the exact same outage on its first user-visible deploy: a deploy ships new content-hashed assets, but every browser still serves the old `index.html` from cache (which references the now-deleted old hashed bundle), so users get a blank page or wrong code. The fix is mechanical (16 lines), but the failure mode wouldn't have appeared until production. This is exactly the class of "MJH not mirroring MBK" bug the parity rule is designed to catch.

## Test plan

- [x] Backend type/import check (`python -c "import app.main"`) succeeds
- [x] Backend `pytest tests/test_observability.py tests/test_version_endpoint.py tests/test_health.py tests/test_turnstile_boot_check.py tests/test_turnstile.py` — 43 passed
- [x] Backend broader subset (`tests/test_audit.py tests/test_config_key_validation.py tests/test_jd_parsing_service.py tests/test_tavily_service.py tests/test_company_research_service.py`) — 100 passed total
- [x] Frontend `npm run typecheck` — clean
- [x] Frontend `npm test` — 194 passed / 14 pre-existing failures (already in TECH_DEBT.md as the React-18-hoist issue, unrelated to this PR — verified by running tests on `origin/main` and getting the identical 14/194 split)
- [x] Frontend `npm run lint` — 3 pre-existing errors in files this PR doesn't touch (`DocumentEditDialog.tsx`, `ResumeUploadSection.tsx`, `DisplayNameSetting.tsx`)
- [x] `uv lock --check` — clean

CI on this branch will run the full DB-dependent backend suite that I couldn't run locally (no PostgreSQL on the dev box). The lifespan-firing tests I did run (`test_health.py`, `test_turnstile.py`) all pass with the new lifespan steps in place.

## Next initiative (separate PR)

This PR is "make MJH match MBK by mechanical mirroring" — not "extract shared infrastructure." The natural follow-up is the platform extraction (a `BaseAppSettings`, a `create_app_lifespan`, an `infra/templates/` scaffolder, conformance tests) so future apps inherit parity by construction instead of by audit. That's substantially larger and belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)