### PR TITLE
fix(frontend): explicit cursor:pointer parity for MBK + MJH

### DIFF
--- a/apps/mybookkeeper/frontend/src/index.css
+++ b/apps/mybookkeeper/frontend/src/index.css
@@ -43,4 +43,17 @@
   input, textarea, select {
     @apply bg-background text-foreground;
   }
+
+  button:not(:disabled),
+  [role="button"]:not(:disabled),
+  [role="tab"],
+  [role="menuitem"],
+  summary {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"] {
+    cursor: not-allowed;
+  }
 }

--- a/apps/myjobhunter/frontend/src/index.css
+++ b/apps/myjobhunter/frontend/src/index.css
@@ -53,6 +53,19 @@
     color: hsl(var(--foreground));
     font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   }
+
+  button:not(:disabled),
+  [role="button"]:not(:disabled),
+  [role="tab"],
+  [role="menuitem"],
+  summary {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"] {
+    cursor: not-allowed;
+  }
 }
 
 @layer utilities {

--- a/apps/myjobhunter/frontend/src/pages/Login.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Login.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
+import { Briefcase } from "lucide-react";
 import {
   LoginForm,
   LoadingButton,
@@ -131,7 +132,7 @@ export default function Login() {
     <div className="min-h-screen flex flex-col items-center justify-center bg-muted/30 px-4">
       <div className="mb-8 flex flex-col items-center gap-2">
         <div className="w-12 h-12 rounded-xl bg-primary flex items-center justify-center">
-          <span className="text-primary-foreground font-bold text-xl">J</span>
+          <Briefcase className="w-6 h-6 text-primary-foreground" aria-hidden />
         </div>
         <span className="text-xl font-semibold tracking-tight">MyJobHunter</span>
       </div>


### PR DESCRIPTION
## Summary

Explicit cursor-affordance rule in **both** apps' `index.css` plus a Lucide briefcase glyph on the MJH login page.

**Cursor regression (MJH only today, MBK future-proofed):**
- MJH is on Tailwind **v4**, which removed the v3 preflight rule `button { cursor: pointer }` (documented v4 breaking change). Every clickable control in MJH (Profile location pills, Edit, Add, dialog buttons, sign-in form, command palette, theme toggle) was rendering with `cursor: default`, killing the affordance.
- Restored the v3 behavior **explicitly** in MJH's `index.css` for `button`, `[role="button"]`, `[role="tab"]`, `[role="menuitem"]`, and `summary`, with `not-allowed` on disabled.
- Mirrored the **same** rule into MBK's `index.css` per the parity rule (MJH mirrors MBK on `frontend/src/index.css`). MBK is still on Tailwind v3 so the rule is a behavioral no-op today, but it documents the contract explicitly and future-proofs MBK's eventual v4 bump from silently regressing the same way MJH's did.

**Briefcase login glyph (MJH only):**
- The `/login` page rendered a literal "J" character on the blue brand square. Replaced with a Lucide `Briefcase` icon (consistent with the icon already used in Work history section headers and the job-hunt domain). MBK has its own brand mark, so this is correctly MJH-only.

## Why both apps in one PR

Per `apps/myjobhunter/CLAUDE.md` parity rule, `index.css` is a mirrored file with MBK as canonical. Fixing MJH alone would have left the canonical reference (MBK) silent on a contract MJH now depends on — exactly the "double work" pattern that gets flagged when the next app forks. The shared rule lives in both files until Tier-1 platform extraction lands a `packages/shared-frontend/src/styles/base.css` both apps consume.

## Files changed

- `apps/myjobhunter/frontend/src/index.css` — cursor rules in `@layer base`
- `apps/myjobhunter/frontend/src/pages/Login.tsx` — Briefcase icon, removed "J"
- `apps/mybookkeeper/frontend/src/index.css` — same cursor rules in `@layer base`

## Test plan

MJH:
- [ ] Hover over any pill / button on `/profile` — cursor changes to pointer
- [ ] Hover over disabled buttons (e.g. Save Changes when form is unchanged) — cursor shows `not-allowed`
- [ ] `/login` shows briefcase glyph in the blue square (white icon, light + dark mode)
- [ ] No regressions on `/applications`, `/companies`, `/dashboard`, `/settings`

MBK (regression check, since rule is no-op):
- [ ] Existing buttons / dropdowns / tabs still cursor as before
- [ ] No layout shift, no specificity conflicts with existing component styles
- [ ] Light + dark mode unaffected

## Follow-ups (not in this PR)

- Extract to `packages/shared-frontend/src/styles/base.css` (Tier-1 platform extraction backlog)
- `apps/myjobhunter/frontend/CLAUDE.md` says "TailwindCSS 3" — actually v4. Doc-only follow-up.
- Add a conformance test that fails when MJH's `index.css` drifts from MBK's on shared sections (Tier-5 platform extraction backlog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)