### PR TITLE
docs(myjobhunter): correct stale 'TailwindCSS 3' to v4

### DIFF
--- a/apps/myjobhunter/frontend/CLAUDE.md
+++ b/apps/myjobhunter/frontend/CLAUDE.md
@@ -5,7 +5,7 @@
 | Layer | Tech |
 |---|---|
 | Framework | React 18 + TypeScript + Vite 5 |
-| Styling | TailwindCSS 3 (CSS variables for theming) |
+| Styling | TailwindCSS 4 (CSS-first config via `@import "tailwindcss"`; CSS variables for theming) |
 | State | Redux Toolkit + RTK Query (`baseApi` from `@platform/ui`) |
 | Routing | React Router v6 (data router — `createBrowserRouter`) |
 | Forms | React Hook Form (for any form with validation or >3 fields) |


### PR DESCRIPTION
## Summary

One-line correction: `apps/myjobhunter/frontend/CLAUDE.md` claimed the stack uses TailwindCSS 3, but `package.json` has `tailwindcss: ^4.2.4` and `index.css` uses the v4-only `@import \"tailwindcss\"` directive.

This drift surfaced while diagnosing the cursor regression in #286 — a future agent reading the doc would have wasted context expecting v3 preflight behaviour.

MBK is still on Tailwind v3, so its CLAUDE.md remains correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)