### PR TITLE
refactor(mybookkeeper): consolidate formatHourlyRate to shared/utils

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/hourly-rate.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/hourly-rate.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { formatHourlyRate } from "@/shared/utils/hourly-rate";
+
+describe("formatHourlyRate", () => {
+  it("formats a numeric string as currency with /hr suffix", () => {
+    expect(formatHourlyRate("45")).toBe("$45.00/hr");
+    expect(formatHourlyRate("45.50")).toBe("$45.50/hr");
+    expect(formatHourlyRate("0")).toBe("$0.00/hr");
+  });
+
+  it("rounds to two decimal places", () => {
+    expect(formatHourlyRate("45.555")).toBe("$45.56/hr");
+    expect(formatHourlyRate("45.554")).toBe("$45.55/hr");
+  });
+
+  it("returns em-dash for null", () => {
+    expect(formatHourlyRate(null)).toBe("—");
+  });
+
+  it("returns em-dash for undefined", () => {
+    expect(formatHourlyRate(undefined)).toBe("—");
+  });
+
+  it("returns em-dash for non-numeric strings", () => {
+    expect(formatHourlyRate("abc")).toBe("—");
+    expect(formatHourlyRate("")).toBe("—");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorCard.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Star } from "lucide-react";
 import { formatRelativeTime } from "@/shared/lib/inquiry-date-format";
+import { formatHourlyRate } from "@/shared/utils/hourly-rate";
 import type { VendorSummary } from "@/shared/types/vendor/vendor-summary";
 import VendorCategoryBadge from "./VendorCategoryBadge";
 
@@ -12,13 +13,6 @@ export interface VendorCardProps {
    * redundant — it's implied by the active chip.
    */
   showCategoryBadge: boolean;
-}
-
-function formatHourlyRate(rate: string | null): string {
-  if (rate === null) return "Rate not set";
-  const num = Number(rate);
-  if (Number.isNaN(num)) return "Rate not set";
-  return `$${num.toFixed(2)}/hr`;
 }
 
 function formatLastUsed(lastUsedAt: string | null): string {

--- a/apps/mybookkeeper/frontend/src/app/features/vendors/VendorRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/vendors/VendorRow.tsx
@@ -1,20 +1,13 @@
 import { useNavigate } from "react-router-dom";
 import { Star } from "lucide-react";
 import { formatRelativeTime } from "@/shared/lib/inquiry-date-format";
+import { formatHourlyRate } from "@/shared/utils/hourly-rate";
 import type { VendorSummary } from "@/shared/types/vendor/vendor-summary";
 import VendorCategoryBadge from "./VendorCategoryBadge";
 
 export interface VendorRowProps {
   vendor: VendorSummary;
   showCategoryBadge: boolean;
-}
-
-function formatHourlyRate(rate: string | null): string {
-  if (rate === null) return "—";
-  // Backend returns Decimal as a string — strip trailing zeros for display.
-  const num = Number(rate);
-  if (Number.isNaN(num)) return "—";
-  return `$${num.toFixed(2)}/hr`;
 }
 
 function formatLastUsed(lastUsedAt: string | null): string {

--- a/apps/mybookkeeper/frontend/src/app/pages/VendorDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/VendorDetail.tsx
@@ -18,13 +18,7 @@ import VendorCategoryBadge from "@/app/features/vendors/VendorCategoryBadge";
 import VendorDetailSkeleton from "@/app/features/vendors/VendorDetailSkeleton";
 import VendorForm from "@/app/features/vendors/VendorForm";
 import DeleteVendorModal from "@/app/features/vendors/DeleteVendorModal";
-
-function formatHourlyRate(rate: string | null): string {
-  if (rate === null) return "Not set";
-  const num = Number(rate);
-  if (Number.isNaN(num)) return "Not set";
-  return `$${num.toFixed(2)} / hour`;
-}
+import { formatHourlyRate } from "@/shared/utils/hourly-rate";
 
 export default function VendorDetail() {
   const { vendorId } = useParams<{ vendorId: string }>();

--- a/apps/mybookkeeper/frontend/src/shared/utils/hourly-rate.ts
+++ b/apps/mybookkeeper/frontend/src/shared/utils/hourly-rate.ts
@@ -1,0 +1,17 @@
+/**
+ * Format a backend Decimal-as-string hourly rate for display.
+ *
+ * Returns the em-dash fallback when the rate is null or unparseable,
+ * matching the project-wide convention for "no value" cells in tables
+ * and detail views (cf. shared/utils/currency.ts, shared/utils/date.ts).
+ *
+ * Use the abbreviated `/hr` suffix everywhere — the long-form
+ * "$X.XX / hour" was an outlier on VendorDetail.tsx and has been
+ * removed in favour of consistency.
+ */
+export function formatHourlyRate(rate: string | null | undefined): string {
+  if (rate === null || rate === undefined) return "—";
+  const num = Number(rate);
+  if (Number.isNaN(num)) return "—";
+  return `$${num.toFixed(2)}/hr`;
+}


### PR DESCRIPTION
## Summary

Three identical-shape but divergent copies of \`formatHourlyRate\` were drifting:

| File | Null fallback | Suffix |
|---|---|---|
| \`app/pages/VendorDetail.tsx\` | \"Not set\" | \" / hour\" |
| \`app/features/vendors/VendorRow.tsx\` | \"—\" | \"/hr\" |
| \`app/features/vendors/VendorCard.tsx\` | \"Rate not set\" | \"/hr\" |

Same data point, same domain, three different display formats. Exactly the \"abstract utility functions into utility files\" pattern flagged in PR #284 (formatFileSize) — extending it here.

## Canonical version

\`apps/mybookkeeper/frontend/src/shared/utils/hourly-rate.ts\`:
- Fallback: em-dash \"—\" (matches the project-wide \"no value\" cell convention)
- Suffix: \"/hr\" (matches the dominant 2/3 callsites)

## Why MBK-local rather than \`@platform/ui\`

MBK can't currently consume \`@platform/ui\` due to the React 18 → 19 two-React-copies block. \`hourly-rate.ts\` lives in \`apps/mybookkeeper/frontend/src/shared/utils/\` next to its peers (\`currency.ts\`, \`date.ts\`, \`file-size.ts\`). When the React 19 bump unblocks shared consumption, this can be promoted to \`@platform/ui\` if MJH ever needs it (it currently has no hourly-rate use case).

## Test plan

- [ ] Tests pass (\`npm test -- hourly-rate\` from \`apps/mybookkeeper/frontend/\`)
- [ ] \`/vendors\` table shows \"—\" for vendors without an hourly rate (was previously \"—\" — no visible change)
- [ ] \`/vendors\` mobile cards show \"—\" for vendors without a rate (was previously \"Rate not set\" — visible change)
- [ ] \`/vendors/{id}\` detail page shows \"—\" instead of \"Not set\" (visible change), and \"$45.00/hr\" instead of \"$45.00 / hour\" (visible change — abbreviated)
- [ ] No duplicate \`formatHourlyRate\` definitions remain (\`grep -r \"function formatHourlyRate\" apps/mybookkeeper/frontend/src\` should return empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)