### PR TITLE
feat(platform-shared): check_email_configured boot guard — Tier-1 (Kenneth fix)

### DIFF
--- a/apps/mybookkeeper/backend/app/core/config.py
+++ b/apps/mybookkeeper/backend/app/core/config.py
@@ -20,8 +20,10 @@ class Settings(BaseAppSettings):
     minio_bucket: str = "mybookkeeper-files"
     email_from_address: str = "mybookkeeper6@gmail.com"
     email_from_name: str = "MyBookkeeper"
-    # MBK historically hardcoded Gmail SMTP. Keeping the same default for
-    # parity; flip email_backend to "smtp" in .env.docker to enable.
+    # MBK historically hardcoded SMTP — opt in by default. Operators
+    # who want to silence outbound mail in a local sandbox can override
+    # to "console" via .env.docker.
+    email_backend: str = "smtp"
     smtp_host: str = "smtp.gmail.com"
 
     # ------------------------------------------------------------------

--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -14,7 +14,10 @@ import jwt
 from jwt.exceptions import PyJWTError as JWTError
 from sqlalchemy import text
 
-from platform_shared.core.boot_guards import check_turnstile_configured
+from platform_shared.core.boot_guards import (
+    check_email_configured,
+    check_turnstile_configured,
+)
 
 from app.core.auth import fastapi_users, auth_backend
 from app.core.config import settings
@@ -59,6 +62,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     init_sentry()
     check_turnstile_configured(
         turnstile_secret_key=settings.turnstile_secret_key,
+        environment=settings.environment,
+    )
+    check_email_configured(
+        email_backend=settings.email_backend,
+        smtp_user=settings.smtp_user,
+        smtp_password=settings.smtp_password,
         environment=settings.environment,
     )
     register_audit_listeners()

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -11,7 +11,10 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from jwt.exceptions import PyJWTError as JWTError
 
-from platform_shared.core.boot_guards import check_turnstile_configured
+from platform_shared.core.boot_guards import (
+    check_email_configured,
+    check_turnstile_configured,
+)
 
 from app.api import account, applications, companies, documents, health, integrations, profile, resumes, totp
 from app.core.audit import current_user_id, register_audit_listeners
@@ -63,6 +66,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
     init_sentry()
     check_turnstile_configured(
         turnstile_secret_key=settings.turnstile_secret_key,
+        environment=settings.environment,
+    )
+    check_email_configured(
+        email_backend=settings.email_backend,
+        smtp_user=settings.smtp_user,
+        smtp_password=settings.smtp_password,
         environment=settings.environment,
     )
     register_audit_listeners()

--- a/packages/shared-backend/platform_shared/core/boot_guards.py
+++ b/packages/shared-backend/platform_shared/core/boot_guards.py
@@ -54,3 +54,72 @@ def check_turnstile_configured(
         "/auth/forgot-password — running prod without it is a credential-stuffing "
         "vulnerability. Set TURNSTILE_SECRET_KEY or set ENVIRONMENT=development."
     )
+
+
+class EmailNotConfiguredError(RuntimeError):
+    """Raised at boot when the email backend is missing creds in a non-dev environment."""
+
+
+def check_email_configured(
+    *,
+    email_backend: str,
+    smtp_user: str,
+    smtp_password: str,
+    environment: str,
+) -> None:
+    """Fail loud at boot if email delivery isn't usable in a non-dev environment.
+
+    Two failure modes guarded:
+
+    1. ``email_backend == "console"`` in production / staging.
+       Console-mode emails go to stdout — fine for dev/CI where the
+       operator can see them, useless in production where they
+       silently disappear (this is exactly how the 2026-05-05
+       ``kennethmontgo@gmail.com`` registration broke: MJH was
+       deployed with the default console backend, the verification
+       email was logged to docker stdout, and the user could never
+       finish signup).
+
+    2. ``email_backend == "smtp"`` with empty ``SMTP_USER`` or
+       ``SMTP_PASSWORD``. The ``EmailService`` silently returns
+       ``False`` on send when creds are empty — an operator who
+       forgot to set them would only notice when users complain.
+
+    Both modes silently break critical-path flows (verification,
+    password reset, organization invites). Crash the lifespan so the
+    healthcheck catches the misconfig before users hit it.
+
+    Args:
+        email_backend: ``"console"`` (dev/CI default — log to stdout)
+            or ``"smtp"`` (production — send via SMTP).
+        smtp_user: SMTP authentication username. Required for
+            ``email_backend == "smtp"``.
+        smtp_password: SMTP authentication password. Required for
+            ``email_backend == "smtp"``.
+        environment: The deployment environment name. ``"development"``
+            and ``"test"`` allow any combination; everything else
+            requires a working ``smtp`` backend.
+
+    Raises:
+        EmailNotConfiguredError: If ``environment`` is not dev/test and
+            either (a) ``email_backend == "console"``, or (b)
+            ``email_backend == "smtp"`` with empty credentials.
+    """
+    if environment in _DEV_ENVIRONMENTS:
+        return
+    if email_backend == "console":
+        raise EmailNotConfiguredError(
+            "EMAIL_BACKEND='console' is not allowed in non-development "
+            "environments — verification emails, password resets, and other "
+            "transactional emails would silently log to stdout instead of "
+            "reaching users (this is how the 2026-05-05 MJH verification-email "
+            "outage happened). Set EMAIL_BACKEND=smtp and configure SMTP_USER "
+            "/ SMTP_PASSWORD, or set ENVIRONMENT=development."
+        )
+    if email_backend == "smtp" and not (smtp_user and smtp_password):
+        raise EmailNotConfiguredError(
+            "EMAIL_BACKEND='smtp' requires both SMTP_USER and SMTP_PASSWORD "
+            "to be set in non-development environments. Without them the "
+            "EmailService silently no-ops and transactional emails never "
+            "reach users. Set the credentials or set ENVIRONMENT=development."
+        )

--- a/packages/shared-backend/tests/test_boot_guards.py
+++ b/packages/shared-backend/tests/test_boot_guards.py
@@ -3,7 +3,9 @@
 import pytest
 
 from platform_shared.core.boot_guards import (
+    EmailNotConfiguredError,
     TurnstileNotConfiguredError,
+    check_email_configured,
     check_turnstile_configured,
 )
 
@@ -38,3 +40,80 @@ class TestCheckTurnstileConfigured:
 
     def test_inherits_from_runtime_error(self) -> None:
         assert issubclass(TurnstileNotConfiguredError, RuntimeError)
+
+
+class TestCheckEmailConfigured:
+    def test_dev_with_console_passes(self) -> None:
+        check_email_configured(
+            email_backend="console",
+            smtp_user="",
+            smtp_password="",
+            environment="development",
+        )
+
+    def test_test_with_console_passes(self) -> None:
+        check_email_configured(
+            email_backend="console",
+            smtp_user="",
+            smtp_password="",
+            environment="test",
+        )
+
+    def test_dev_with_smtp_and_empty_creds_passes(self) -> None:
+        check_email_configured(
+            email_backend="smtp",
+            smtp_user="",
+            smtp_password="",
+            environment="development",
+        )
+
+    def test_production_with_console_raises(self) -> None:
+        with pytest.raises(EmailNotConfiguredError) as exc:
+            check_email_configured(
+                email_backend="console",
+                smtp_user="",
+                smtp_password="",
+                environment="production",
+            )
+        assert "console" in str(exc.value).lower()
+        assert "verification" in str(exc.value).lower()
+
+    def test_staging_with_console_raises(self) -> None:
+        with pytest.raises(EmailNotConfiguredError):
+            check_email_configured(
+                email_backend="console",
+                smtp_user="",
+                smtp_password="",
+                environment="staging",
+            )
+
+    def test_production_with_smtp_and_empty_user_raises(self) -> None:
+        with pytest.raises(EmailNotConfiguredError) as exc:
+            check_email_configured(
+                email_backend="smtp",
+                smtp_user="",
+                smtp_password="x" * 16,
+                environment="production",
+            )
+        assert "SMTP_USER" in str(exc.value)
+
+    def test_production_with_smtp_and_empty_password_raises(self) -> None:
+        with pytest.raises(EmailNotConfiguredError) as exc:
+            check_email_configured(
+                email_backend="smtp",
+                smtp_user="user@example.com",
+                smtp_password="",
+                environment="production",
+            )
+        assert "SMTP_PASSWORD" in str(exc.value)
+
+    def test_production_with_smtp_and_full_creds_passes(self) -> None:
+        check_email_configured(
+            email_backend="smtp",
+            smtp_user="user@example.com",
+            smtp_password="x" * 16,
+            environment="production",
+        )
+
+    def test_inherits_from_runtime_error(self) -> None:
+        assert issubclass(EmailNotConfiguredError, RuntimeError)


### PR DESCRIPTION
## Summary

Fourth Tier-1 platform extraction PR. Direct response to today's production outage where `kennethmontgo@gmail.com` registered on MJH but never received a verification email — MJH was deployed with the default `email_backend=\"console\"`, so the verification email logged to docker stdout instead of reaching the user. Login then failed with `LOGIN_USER_NOT_VERIFIED` and the user had no recovery path.

## What this PR does

1. **`check_email_configured()`** in `platform_shared.core.boot_guards` with two failure modes:
   - `email_backend=\"console\"` in non-dev → crashes (production console emails silently disappear — the Kenneth bug)
   - `email_backend=\"smtp\"` with empty `SMTP_USER` or `SMTP_PASSWORD` in non-dev → crashes (the EmailService silent-fail pattern)
2. **Wires the guard** into both apps' lifespan, between Turnstile guard and audit listener registration.
3. **Sets MBK's `email_backend`** default to `\"smtp\"` (matches actual historical behavior). Without this, MBK would inherit the BaseAppSettings default of `\"console\"` and start crashing in production — breaking change avoided.

## What this PR does NOT do (follow-ups)

- Does NOT rip the silent-fail `return False` from `EmailService.send()` itself. That's a bigger refactor (5+ callers in MBK alone) and needs its own PR. This boot guard catches the most common case (misconfig at deploy time).
- Does NOT migrate MBK to consume `platform_shared.services.email_service`. Separate PR.

## ⚠️ Operational migration required

**After this PR merges, MJH production deploys will FAIL until the operator sets in `apps/myjobhunter/backend/.env.docker`:**

```
EMAIL_BACKEND=smtp
SMTP_USER=<gmail account>
SMTP_PASSWORD=<gmail app password>
```

This is intentional — the crash is louder than the previous silent disappearance of every verification email. Without these set, MJH cannot deliver verification emails, so booting it is harmful.

If you need to deploy MJH without SMTP for some reason, set `ENVIRONMENT=development` to bypass the guard (console mode emails accepted in dev/test).

## Verification

✅ 17 tests in `tests/test_boot_guards.py` — all pass:
- 8 turnstile-guard cases (unchanged from #292)
- 9 new email-guard cases covering all failure modes
- Both `MBK.Settings` and `MJH.Settings` instantiate correctly with their expected `email_backend` defaults

## Test plan

- [ ] CI runs both backend test suites — must stay green (no app code changes besides lifespan wiring)
- [ ] **Before merge:** confirm the operational migration plan above; operator must set `EMAIL_BACKEND` + creds in MJH's `.env.docker` before next MJH deploy, or MJH won't boot
- [ ] After merge + creds-set: a fresh MJH registration sends a real verification email
- [ ] MBK production deploy unaffected (already had SMTP creds wired; just newly explicit about `email_backend=\"smtp\"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)