### PR TITLE
docs: declare boot-guard env vars in both apps' .env.docker.example

### DIFF
--- a/apps/mybookkeeper/backend/.env.docker.example
+++ b/apps/mybookkeeper/backend/.env.docker.example
@@ -1,12 +1,17 @@
-# Docker environment template
-# Copy to backend/.env.docker and fill in values:
+# Docker environment template — consumed by docker-compose.yml `env_file:` directive
+# for the migrate and api services. Copy to backend/.env.docker and fill in values:
 #   cp backend/.env.docker.example backend/.env.docker
 # DATABASE_URL is set via docker-compose.yml environment, not here.
 
-# Deployment environment — controls Sentry enforcement.
-# Set to "production" in prod deployments; Sentry DSN becomes REQUIRED.
+# Deployment environment — controls Sentry + Turnstile + email boot guards.
+# Set to "production" in prod deployments; SENTRY_DSN, TURNSTILE_SECRET_KEY,
+# and SMTP_USER/SMTP_PASSWORD all become REQUIRED.
 # Leave as "development" or "test" for local/CI environments.
 ENVIRONMENT=production
+
+# Sentry DSN — required when ENVIRONMENT=production. Boot fails loud if missing.
+# Project: mybookkeeper (Sentry org), look up the MBK-specific DSN in the dashboard.
+SENTRY_DSN=
 
 SECRET_KEY=change-me-to-random-64-chars
 ENCRYPTION_KEY=change-me-to-random-64-chars
@@ -18,6 +23,30 @@ CORS_ORIGINS=["https://your-domain.com"]
 OAUTH_REDIRECT_URI=https://your-domain.com/api/integrations/gmail/callback
 GOOGLE_OAUTH_REDIRECT_URI=https://your-domain.com/api/integrations/gmail/callback
 RUN_UPLOAD_WORKER=false
+
+# Cloudflare Turnstile CAPTCHA — both must be set in prod or the boot guard
+# (PR #292) crashes the lifespan. /auth/register and /auth/forgot-password
+# are credential-stuffing entrypoints without it.
+TURNSTILE_SECRET_KEY=
+
+# Email delivery
+#
+# Production MUST use EMAIL_BACKEND=smtp with valid SMTP_USER /
+# SMTP_PASSWORD — the platform_shared boot guard (PR #293) crashes
+# the lifespan if EMAIL_BACKEND=console is set in non-development
+# environments, because console emails silently log to docker stdout
+# instead of reaching users.
+#
+# For Gmail SMTP: SMTP_USER is the sending address, SMTP_PASSWORD
+# is a Gmail app password (not the account password) — generate at
+# https://myaccount.google.com/apppasswords
+EMAIL_BACKEND=smtp
+EMAIL_FROM_NAME=MyBookkeeper
+EMAIL_FROM_ADDRESS=mybookkeeper6@gmail.com
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
 
 # MinIO storage — points at the SHARED infra/ stack's container.
 # Bring up the infra stack first: docker compose -f infra/docker-compose.yml up -d

--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -47,10 +47,24 @@ LOCKOUT_AUTORESET_HOURS=24
 LOGIN_RATE_LIMIT_THRESHOLD=10
 LOGIN_RATE_LIMIT_WINDOW_SECONDS=300
 
-# Email delivery — "console" prints to stdout (dev/CI); "smtp" uses SMTP_* below
-EMAIL_BACKEND=console
+# Email delivery
+#
+# Production MUST use EMAIL_BACKEND=smtp with valid SMTP_USER /
+# SMTP_PASSWORD — the platform_shared boot guard (PR #293) crashes
+# the lifespan if EMAIL_BACKEND=console is set in non-development
+# environments, because console emails silently log to docker stdout
+# instead of reaching users (this is how the 2026-05-05 verification-
+# email outage happened).
+#
+# For local dev / CI, set EMAIL_BACKEND=console and leave SMTP_*
+# empty — verification emails will print to stdout for testing.
+#
+# For Gmail SMTP: SMTP_USER is the sending address, SMTP_PASSWORD
+# is a Gmail app password (not the account password) — generate at
+# https://myaccount.google.com/apppasswords
+EMAIL_BACKEND=smtp
 EMAIL_FROM_NAME=MyJobHunter
-SMTP_HOST=
+SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
 SMTP_USER=
 SMTP_PASSWORD=


### PR DESCRIPTION
## Summary

Quick docs fix following the boot-guard PRs (#292 turnstile, #293 email). An operator copying `.env.docker.example` to `.env.docker` after those merged would get a deploy that crashes at lifespan startup — the example didn't declare the new required env vars.

## Changes

**MJH** (`apps/myjobhunter/backend/.env.docker.example`):
- `EMAIL_BACKEND` flipped `console` → `smtp` (production must use SMTP; the boot guard rejects `console` in non-dev)
- `SMTP_HOST` defaulted to `smtp.gmail.com`
- Inline comment explaining the Kenneth bug context + Gmail app-password link

**MBK** (`apps/mybookkeeper/backend/.env.docker.example`):
- Added the entire `SENTRY_DSN`, `TURNSTILE_SECRET_KEY`, `EMAIL_BACKEND`, `SMTP_*`, `EMAIL_FROM_NAME`, `EMAIL_FROM_ADDRESS` section — these were missing entirely

## Why

The example IS the contract between the codebase and the operator. After this lands, copying-and-filling-in produces a deployable config, not a broken one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)