### PR TITLE
feat(myjobhunter): verification-email send fails loud — Kenneth bug second-layer fix

### DIFF
--- a/apps/myjobhunter/backend/app/core/auth.py
+++ b/apps/myjobhunter/backend/app/core/auth.py
@@ -276,12 +276,17 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_request_verify(
         self, user: User, token: str, request: Optional[Request] = None,
     ) -> None:
-        """Send verification email when a token is generated (registration or resend)."""
-        success = send_verification_email(user.email, token)
-        if success:
-            logger.info("Verification email sent to user_id=%s", user.id)
-        else:
-            logger.warning("Failed to send verification email to user_id=%s", user.id)
+        """Send verification email when a token is generated (registration or resend).
+
+        Raises on any send failure so the registration / resend HTTP request
+        fails 5xx and the user retries — never returns a 2xx with the
+        verification email lost. The pre-2026-05-05 bool-returning version
+        silently swallowed failures, which produced the
+        kennethmontgo@gmail.com bug class (registered-but-unverified
+        account with no recovery path).
+        """
+        send_verification_email(user.email, token)
+        logger.info("Verification email sent to user_id=%s", user.id)
 
     async def on_after_verify(
         self, user: User, request: Optional[Request] = None,

--- a/apps/myjobhunter/backend/app/services/email/email_sender.py
+++ b/apps/myjobhunter/backend/app/services/email/email_sender.py
@@ -1,11 +1,31 @@
 """Email delivery wrapper.
 
 Routes to the shared SMTP EmailService when configured, or prints to stdout
-in console mode for dev/CI. Tests patch `send_email` directly.
+in console mode for dev/CI. Tests patch ``send_email`` / ``send_email_or_raise``
+directly.
+
+Two send functions:
+
+  - ``send_email()``           — best-effort. Returns bool. For non-critical
+                                 emails (cost alerts, demo flows) where
+                                 missed delivery is acceptable.
+  - ``send_email_or_raise()``  — fail-loud. Raises on any failure. For
+                                 critical-path emails (verification,
+                                 password reset, organization invites)
+                                 where silent loss leaves the user broken.
+
+The boot-time check (platform_shared.core.boot_guards.check_email_configured)
+already validates the configuration shape at lifespan startup; the
+``_or_raise`` variant is the runtime safety net for transient SMTP
+failures (network outage, auth rejection, recipient rejected).
 """
 import logging
 
-from platform_shared.services.email_service import EmailService
+from platform_shared.services.email_service import (
+    EmailNotConfiguredError,
+    EmailSendError,
+    EmailService,
+)
 
 from app.core.config import settings
 
@@ -22,12 +42,28 @@ def _smtp_service() -> EmailService:
     )
 
 
+def _log_console_send(to: list[str], subject: str, body_html: str) -> None:
+    """Console-mode "send" — for dev/CI flows that exercise the email
+    path without configuring SMTP."""
+    logger.info(
+        "[email:console] to=%s subject=%r body_chars=%d",
+        to,
+        subject,
+        len(body_html),
+    )
+
+
 def send_email(to: list[str], subject: str, body_html: str) -> bool:
-    """Send an email via the configured backend.
+    """Best-effort send. Returns True on success, False on failure.
 
     Console backend logs the subject + recipients + body length to stdout —
-    intentional for dev / CI so SMTP credentials are never required to test
+    intentional for dev/CI so SMTP credentials are never required to test
     flows that emit transactional email.
+
+    Use for non-critical emails. For critical-path emails (verification,
+    password reset), use ``send_email_or_raise`` so failures propagate
+    to the request handler instead of leaving the user in a half-broken
+    state.
     """
     if not to:
         return False
@@ -35,11 +71,41 @@ def send_email(to: list[str], subject: str, body_html: str) -> bool:
     if settings.email_backend == "smtp":
         return _smtp_service().send(to, subject, body_html)
 
-    # Default: console backend
-    logger.info(
-        "[email:console] to=%s subject=%r body_chars=%d",
-        to,
-        subject,
-        len(body_html),
-    )
+    _log_console_send(to, subject, body_html)
     return True
+
+
+def send_email_or_raise(to: list[str], subject: str, body_html: str) -> None:
+    """Fail-loud send. Raises on any failure.
+
+    Use for critical-path transactional emails — verification,
+    password reset, organization invites. The caller is expected to
+    propagate any exception so the HTTP request fails 5xx and the
+    user retries.
+
+    Raises:
+        ValueError: If ``to`` is empty.
+        EmailNotConfiguredError: If SMTP creds are missing while in
+            ``smtp`` mode (the boot guard should have caught this).
+        EmailSendError: If SMTP send fails (network, auth, recipient
+            rejected).
+
+    In ``console`` mode this never raises — useful for dev/CI flows
+    that exercise the email path without configuring SMTP.
+    """
+    if not to:
+        raise ValueError("Recipients list cannot be empty")
+
+    if settings.email_backend == "smtp":
+        _smtp_service().send_or_raise(to, subject, body_html)
+        return
+
+    _log_console_send(to, subject, body_html)
+
+
+__all__ = [
+    "send_email",
+    "send_email_or_raise",
+    "EmailNotConfiguredError",
+    "EmailSendError",
+]

--- a/apps/myjobhunter/backend/app/services/email/verification_email.py
+++ b/apps/myjobhunter/backend/app/services/email/verification_email.py
@@ -3,7 +3,7 @@ import html as html_mod
 import logging
 
 from app.core.config import settings
-from app.services.email.email_sender import send_email
+from app.services.email.email_sender import send_email_or_raise
 
 logger = logging.getLogger(__name__)
 
@@ -57,12 +57,21 @@ def _build_verification_html(verify_url: str) -> str:
 </div>"""
 
 
-def send_verification_email(recipient_email: str, token: str) -> bool:
+def send_verification_email(recipient_email: str, token: str) -> None:
+    """Send the email-verification message to a newly registered user.
+
+    Critical-path transactional email — raises rather than returning a
+    bool so any failure propagates to the request handler. The pre-2026-05-05
+    bool-returning version silently logged a warning on failure, which
+    is how kennethmontgo@gmail.com ended up with a registered-but-unverified
+    account and no recovery path.
+
+    Raises:
+        ValueError, EmailNotConfiguredError, EmailSendError — see
+        ``send_email_or_raise`` for semantics.
+    """
     base_url = settings.frontend_url.rstrip("/")
     verify_url = f"{base_url}/verify-email?token={token}"
     html = _build_verification_html(verify_url)
     subject = "Verify your MyJobHunter email"
-    success = send_email([recipient_email], subject, html)
-    if not success:
-        logger.warning("Failed to send verification email to %s", recipient_email)
-    return success
+    send_email_or_raise([recipient_email], subject, html)

--- a/apps/myjobhunter/backend/tests/test_email_verification.py
+++ b/apps/myjobhunter/backend/tests/test_email_verification.py
@@ -48,17 +48,18 @@ async def test_verify_token_flips_is_verified(
 ) -> None:
     user = await user_factory(verified=False)
 
-    # Capture the token by mocking send_email; the token is the second
-    # positional argument fastapi-users passes to on_after_request_verify,
-    # which then calls send_verification_email(email, token).
+    # Capture the token by mocking send_email_or_raise; the token is the
+    # second positional argument fastapi-users passes to
+    # on_after_request_verify, which then calls
+    # send_verification_email(email, token).
     captured_token: dict[str, str] = {}
 
     def _capture(recipients, subject, body_html):
         captured_token["body"] = body_html
-        return True
 
     with patch(
-        "app.services.email.verification_email.send_email", side_effect=_capture,
+        "app.services.email.verification_email.send_email_or_raise",
+        side_effect=_capture,
     ):
         resp = await client.post(
             "/auth/request-verify-token", json={"email": user["email"]},
@@ -91,7 +92,8 @@ async def test_request_verify_token_sends_email(
 ) -> None:
     user = await user_factory(verified=False)
     with patch(
-        "app.services.email.verification_email.send_email", return_value=True,
+        "app.services.email.verification_email.send_email_or_raise",
+        return_value=None,
     ) as mock_send:
         resp = await client.post(
             "/auth/request-verify-token", json={"email": user["email"]},
@@ -108,7 +110,8 @@ async def test_register_triggers_verification_email(
     client: AsyncClient,
 ) -> None:
     with patch(
-        "app.services.email.verification_email.send_email", return_value=True,
+        "app.services.email.verification_email.send_email_or_raise",
+        return_value=None,
     ) as mock_send:
         resp = await client.post(
             "/auth/register",


### PR DESCRIPTION
## Summary

Second-layer fix to the 2026-05-05 `kennethmontgo@gmail.com` outage. PR #293 added a boot guard that catches the misconfig case at deploy time; this PR catches runtime SMTP failures by migrating MJH's verification-email send to the fail-loud `send_email_or_raise()` introduced in PR #294.

## Changes

- **`app/services/email/email_sender.py`** — adds `send_email_or_raise()` alongside the existing `send_email()` (which stays best-effort). Console mode short-circuits silently (preserves dev/CI flows that don't have SMTP).
- **`app/services/email/verification_email.py`** — `send_verification_email()` now returns `None`, raises on send failure.
- **`app/core/auth.py`** — `on_after_request_verify()` drops the success/warning branch. Any send failure propagates → HTTP 5xx → user retries. No more half-broken accounts.
- **`tests/test_email_verification.py`** — three patches updated from `send_email` to `send_email_or_raise`, return values from `True` to `None`.

## Why this is layered defense

The #293 boot guard catches the most common case (operator deploys with `EMAIL_BACKEND=console` in production). This PR catches:
- Transient SMTP outages (auth temporarily revoked, network blip, recipient rejected)
- Future regressions where a code change accidentally re-introduces the silent-fail pattern
- Cases where the boot-guard check passes but the actual send fails

Together: \"fail at deploy OR fail at request\" — no path leaves a user in a half-broken state.

## Test plan

- [ ] CI runs MJH backend test suite — must stay green
- [ ] After merge + MJH deploy with valid SMTP creds: a fresh registration → verification email arrives → user verifies → login succeeds
- [ ] Simulate SMTP failure (block port 587 outbound or revoke app password) — registration request returns 5xx, user row not stranded as half-broken

## Follow-up

- Same migration for MJH password-reset email (when that flow exists)
- MBK email service migration to consume `platform_shared.services.email_service` — currently has its own local copy with the same silent-fail pattern (low priority since MBK SMTP is wired and working)

🤖 Generated with [Claude Code](https://claude.com/claude-code)