### PR TITLE
docs: declare boot-guard env vars in both apps' .env.docker.example (re-do)

### DIFF
--- a/apps/mybookkeeper/backend/.env.docker.example
+++ b/apps/mybookkeeper/backend/.env.docker.example
@@ -1,12 +1,18 @@
-# Docker environment template
-# Copy to backend/.env.docker and fill in values:
+# Docker environment template — consumed by docker-compose.yml `env_file:` directive
+# for the migrate and api services. Copy to backend/.env.docker and fill in values:
 #   cp backend/.env.docker.example backend/.env.docker
 # DATABASE_URL is set via docker-compose.yml environment, not here.
 
-# Deployment environment — controls Sentry enforcement.
-# Set to "production" in prod deployments; Sentry DSN becomes REQUIRED.
+# Deployment environment — controls Sentry + Turnstile + email boot guards.
+# Set to "production" in prod deployments; SENTRY_DSN, TURNSTILE_SECRET_KEY,
+# and SMTP_USER/SMTP_PASSWORD all become REQUIRED.
 # Leave as "development" or "test" for local/CI environments.
 ENVIRONMENT=production
+
+# Sentry DSN — required when ENVIRONMENT=production. Boot fails loud if missing.
+# Use the per-app project DSN (mybookkeeper-backend project under the
+# mybookkeeper Sentry org), NOT the org-wide DSN.
+SENTRY_DSN=
 
 SECRET_KEY=change-me-to-random-64-chars
 ENCRYPTION_KEY=change-me-to-random-64-chars
@@ -18,6 +24,30 @@ CORS_ORIGINS=["https://your-domain.com"]
 OAUTH_REDIRECT_URI=https://your-domain.com/api/integrations/gmail/callback
 GOOGLE_OAUTH_REDIRECT_URI=https://your-domain.com/api/integrations/gmail/callback
 RUN_UPLOAD_WORKER=false
+
+# Cloudflare Turnstile CAPTCHA — required when ENVIRONMENT=production.
+# Boot guard (PR #292) crashes the lifespan if missing. /auth/register
+# and /auth/forgot-password are credential-stuffing entrypoints without it.
+TURNSTILE_SECRET_KEY=
+
+# Email delivery
+#
+# Production MUST use EMAIL_BACKEND=smtp with valid SMTP_USER /
+# SMTP_PASSWORD — the platform_shared boot guard (PR #293) crashes
+# the lifespan if EMAIL_BACKEND=console is set in non-development
+# environments, because console emails silently log to docker stdout
+# instead of reaching users.
+#
+# For Gmail SMTP: SMTP_USER is the sending address, SMTP_PASSWORD
+# is a Gmail app password (not the account password) — generate at
+# https://myaccount.google.com/apppasswords
+EMAIL_BACKEND=smtp
+EMAIL_FROM_NAME=MyBookkeeper
+EMAIL_FROM_ADDRESS=mybookkeeper6@gmail.com
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USER=
+SMTP_PASSWORD=
 
 # MinIO storage — points at the SHARED infra/ stack's container.
 # Bring up the infra stack first: docker compose -f infra/docker-compose.yml up -d

--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -47,12 +47,28 @@ LOCKOUT_AUTORESET_HOURS=24
 LOGIN_RATE_LIMIT_THRESHOLD=10
 LOGIN_RATE_LIMIT_WINDOW_SECONDS=300
 
-# Email delivery — "console" prints to stdout (dev/CI); "smtp" uses SMTP_* below
-EMAIL_BACKEND=console
+# Email delivery
+#
+# Production MUST use EMAIL_BACKEND=smtp with valid SMTP_USER /
+# SMTP_PASSWORD — the platform_shared boot guard (PR #293) crashes
+# the lifespan if EMAIL_BACKEND=console is set in non-development
+# environments, because console emails silently log to docker stdout
+# instead of reaching users (this is how the 2026-05-05 verification-
+# email outage happened).
+#
+# For local dev / CI, set EMAIL_BACKEND=console and leave SMTP_*
+# empty — verification emails will print to stdout for testing.
+#
+# For Gmail SMTP: SMTP_USER is the sending address, SMTP_PASSWORD
+# is a Gmail app password (not the account password) — generate at
+# https://myaccount.google.com/apppasswords. Sending account for MJH
+# is myjobhunter6@gmail.com.
+EMAIL_BACKEND=smtp
 EMAIL_FROM_NAME=MyJobHunter
-SMTP_HOST=
+EMAIL_FROM_ADDRESS=myjobhunter6@gmail.com
+SMTP_HOST=smtp.gmail.com
 SMTP_PORT=587
-SMTP_USER=
+SMTP_USER=myjobhunter6@gmail.com
 SMTP_PASSWORD=
 
 # MinIO storage — shared infra stack at infra/docker-compose.yml.


### PR DESCRIPTION
Re-do of #296/#298 (both auto-closed during parallel-merge batches).

## Summary

After PRs #292 (Turnstile boot guard) and #293 (email boot guard) landed, copying `.env.docker.example` → `.env.docker` produces a deploy that crashes at lifespan startup. This PR makes the examples self-documenting and deployable as-is.

**MJH:** flipped `EMAIL_BACKEND` to `smtp`, defaulted `SMTP_HOST=smtp.gmail.com`, pre-filled `SMTP_USER`/`EMAIL_FROM_ADDRESS` with `myjobhunter6@gmail.com`.

**MBK:** added the entire `SENTRY_DSN`, `TURNSTILE_SECRET_KEY`, `EMAIL_BACKEND`, `SMTP_*` section (was missing). Sentry comment clarifies per-app project DSN, not org-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)