### PR TITLE
feat(platform-shared): create_app_lifespan factory — Tier-1 culmination

### DIFF
--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -3,8 +3,6 @@ import logging
 import os
 import subprocess
 import time
-from contextlib import asynccontextmanager
-from collections.abc import AsyncGenerator
 from datetime import datetime, timezone
 
 from fastapi import Depends, FastAPI, Request
@@ -14,10 +12,7 @@ import jwt
 from jwt.exceptions import PyJWTError as JWTError
 from sqlalchemy import text
 
-from platform_shared.core.boot_guards import (
-    check_email_configured,
-    check_turnstile_configured,
-)
+from platform_shared.core.lifespan import create_app_lifespan
 
 from app.core.auth import fastapi_users, auth_backend
 from app.core.config import settings
@@ -41,7 +36,7 @@ def _resolve_git_commit() -> str:
 GIT_COMMIT = _resolve_git_commit()
 STARTUP_TIMESTAMP = datetime.now(timezone.utc).isoformat()
 
-from app.core.audit import current_user_id, register_audit_listeners
+from app.core.audit import current_user_id
 from app.core.rate_limit import check_account_not_locked, check_login_rate_limit, check_password_reset_rate_limit, check_register_rate_limit, require_turnstile
 from app.db.session import AsyncSessionLocal
 from app.schemas.user.user import UserRead, UserCreate, UserUpdate
@@ -57,22 +52,18 @@ logging.basicConfig(
 logger = logging.getLogger("app")
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    init_sentry()
-    check_turnstile_configured(
-        turnstile_secret_key=settings.turnstile_secret_key,
-        environment=settings.environment,
-    )
-    check_email_configured(
-        email_backend=settings.email_backend,
-        smtp_user=settings.smtp_user,
-        smtp_password=settings.smtp_password,
-        environment=settings.environment,
-    )
-    register_audit_listeners()
-    ensure_bucket()
-    worker_task: asyncio.Task[None] | None = None
+_worker_task: asyncio.Task[None] | None = None
+
+
+async def _on_startup() -> None:
+    """MBK-specific startup: spawn the Dramatiq upload-processor worker.
+
+    The worker pulls Document rows in status=processing and runs the
+    extraction pipeline; if RUN_UPLOAD_WORKER is False (e.g. running
+    a one-off migration container), we skip it so the same image can
+    boot without grabbing the queue.
+    """
+    global _worker_task
     if settings.run_upload_worker:
         async def _run_worker() -> None:
             try:
@@ -80,16 +71,27 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
             except asyncio.CancelledError:
                 pass
 
-        worker_task = asyncio.create_task(_run_worker())
+        _worker_task = asyncio.create_task(_run_worker())
 
-    yield
 
-    if worker_task and not worker_task.done():
-        worker_task.cancel()
+async def _on_shutdown() -> None:
+    """MBK-specific shutdown: cancel the upload worker."""
+    global _worker_task
+    if _worker_task and not _worker_task.done():
+        _worker_task.cancel()
         try:
-            await worker_task
+            await _worker_task
         except asyncio.CancelledError:
             pass
+
+
+lifespan = create_app_lifespan(
+    settings=settings,
+    init_sentry=init_sentry,
+    bucket_init=ensure_bucket,
+    on_startup=_on_startup,
+    on_shutdown=_on_shutdown,
+)
 
 
 app = FastAPI(title="MyBookkeeper API", lifespan=lifespan)

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -2,8 +2,6 @@ import logging
 import os
 import subprocess
 import time
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 import jwt
@@ -11,13 +9,10 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from jwt.exceptions import PyJWTError as JWTError
 
-from platform_shared.core.boot_guards import (
-    check_email_configured,
-    check_turnstile_configured,
-)
+from platform_shared.core.lifespan import create_app_lifespan
 
 from app.api import account, applications, companies, documents, health, integrations, profile, resumes, totp
-from app.core.audit import current_user_id, register_audit_listeners
+from app.core.audit import current_user_id
 from app.core.auth import auth_backend, fastapi_users
 from app.core.config import settings
 from app.core.observability import init_sentry
@@ -61,22 +56,11 @@ logging.basicConfig(
 logger = logging.getLogger("app")
 
 
-@asynccontextmanager
-async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
-    init_sentry()
-    check_turnstile_configured(
-        turnstile_secret_key=settings.turnstile_secret_key,
-        environment=settings.environment,
-    )
-    check_email_configured(
-        email_backend=settings.email_backend,
-        smtp_user=settings.smtp_user,
-        smtp_password=settings.smtp_password,
-        environment=settings.environment,
-    )
-    register_audit_listeners()
-    ensure_bucket()
-    yield
+lifespan = create_app_lifespan(
+    settings=settings,
+    init_sentry=init_sentry,
+    bucket_init=ensure_bucket,
+)
 
 
 app = FastAPI(

--- a/packages/shared-backend/platform_shared/core/lifespan.py
+++ b/packages/shared-backend/platform_shared/core/lifespan.py
@@ -1,0 +1,180 @@
+"""FastAPI lifespan factory — Tier-1 platform extraction culmination.
+
+The pre-extraction pattern: every app's main.py opened with a hand-rolled
+asynccontextmanager that called the same boot guards in the same order:
+init_sentry → check_turnstile → check_email → register_audit_listeners →
+ensure_bucket → app-specific. This was the exact drift surface the
+Tier-1 extraction series (PRs #290-#294) was built to remove — every
+copy of the lifespan was an opportunity to forget a guard or run them
+in the wrong order.
+
+This factory composes the boot guards in the canonical order and lets
+each app provide ONLY its app-specific bits via callable hooks. Apps'
+main.py shrinks from ~30 lifespan lines to a single ``create_app_lifespan(...)``
+call.
+
+Boot order (rationale documented inline below):
+
+  1. init_sentry()                — first, so any boot-guard failure
+                                    is captured as a Sentry event
+  2. check_turnstile_configured() — fail loud on missing CAPTCHA in prod
+  3. check_email_configured()     — fail loud on missing SMTP creds /
+                                    console mode in prod
+  4. register_audit_listeners()   — wire SQLAlchemy listeners before any
+                                    request handler can write
+  5. bucket_init()                — verify MinIO reachable; refuse to
+                                    boot if storage missing
+  6. extra_startup()              — app-specific (e.g. MBK spawns the
+                                    upload worker; MJH has nothing yet)
+  7. yield                        — app handles requests
+  8. extra_shutdown()             — app-specific cleanup (e.g. cancel
+                                    the upload worker task)
+
+Usage:
+
+    from platform_shared.core.lifespan import create_app_lifespan
+
+    from app.core.config import settings
+    from app.services.storage.bucket_initializer import ensure_bucket
+
+    lifespan = create_app_lifespan(
+        settings=settings,
+        bucket_init=ensure_bucket,
+    )
+
+    app = FastAPI(title="MyJobHunter API", lifespan=lifespan)
+
+    # Or with app-specific startup/shutdown:
+    async def _on_startup():
+        ...
+
+    async def _on_shutdown():
+        ...
+
+    lifespan = create_app_lifespan(
+        settings=settings,
+        bucket_init=ensure_bucket,
+        on_startup=_on_startup,
+        on_shutdown=_on_shutdown,
+    )
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator, Awaitable, Callable
+from contextlib import asynccontextmanager
+from typing import Any, Protocol
+
+from fastapi import FastAPI
+
+from platform_shared.core.audit import register_audit_listeners
+from platform_shared.core.boot_guards import (
+    check_email_configured,
+    check_turnstile_configured,
+)
+
+
+class _SettingsProtocol(Protocol):
+    """The Settings shape this factory needs.
+
+    BaseAppSettings (and any subclass) satisfies this contract. Using
+    a Protocol instead of a hard import keeps platform_shared.core.lifespan
+    orthogonal to platform_shared.core.settings — the factory works with
+    any object that exposes these fields.
+    """
+
+    sentry_dsn: str
+    environment: str
+    turnstile_secret_key: str
+    email_backend: str
+    smtp_user: str
+    smtp_password: str
+
+
+# init_sentry needs to be passed in as a callable rather than imported,
+# because each app has a thin wrapper (app.core.observability) that
+# binds settings.sentry_dsn / settings.environment internally — see
+# PR #291. Apps pass that wrapper into the factory.
+InitSentryFn = Callable[[], None]
+BucketInitFn = Callable[[], None]
+LifecycleHook = Callable[[], Awaitable[None] | None]
+
+
+def create_app_lifespan(
+    *,
+    settings: _SettingsProtocol,
+    init_sentry: InitSentryFn,
+    bucket_init: BucketInitFn = lambda: None,
+    on_startup: LifecycleHook | None = None,
+    on_shutdown: LifecycleHook | None = None,
+) -> Callable[[FastAPI], Any]:
+    """Build a FastAPI lifespan asynccontextmanager that runs the canonical
+    boot sequence + the app-provided hooks.
+
+    Args:
+        settings: An object exposing the BaseAppSettings shape — used to
+            thread sentry_dsn, environment, turnstile_secret_key,
+            email_backend, smtp_user, smtp_password through the boot
+            guards.
+        init_sentry: The app's wrapper around
+            platform_shared.core.observability.init_sentry. Apps wire
+            their own settings.sentry_dsn / settings.environment inside
+            the wrapper so callers here don't need to thread them.
+        bucket_init: Optional callable that verifies MinIO bucket
+            existence at startup. Defaults to a no-op for apps that
+            don't use object storage. Most apps pass their
+            ``services.storage.bucket_initializer.ensure_bucket``.
+        on_startup: Optional async or sync callable invoked AFTER all
+            shared boot steps but BEFORE the lifespan yields. Use for
+            app-specific work like spawning background tasks.
+        on_shutdown: Optional async or sync callable invoked AFTER the
+            lifespan yields. Use for app-specific cleanup.
+
+    Returns:
+        A callable that takes a FastAPI app and returns an async
+        context manager — the shape FastAPI's ``lifespan=`` parameter
+        expects.
+    """
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+        # 1. Sentry first — so any boot-guard failure below is
+        #    captured as a Sentry event with the full traceback.
+        init_sentry()
+
+        # 2. Boot guards — fail loud in non-dev environments. Each
+        #    raises a subclass of RuntimeError that crashes the
+        #    lifespan, fails the healthcheck, and triggers a deploy
+        #    rollback.
+        check_turnstile_configured(
+            turnstile_secret_key=settings.turnstile_secret_key,
+            environment=settings.environment,
+        )
+        check_email_configured(
+            email_backend=settings.email_backend,
+            smtp_user=settings.smtp_user,
+            smtp_password=settings.smtp_password,
+            environment=settings.environment,
+        )
+
+        # 3. Side-effect inits — wire SQLAlchemy listeners before any
+        #    request handler can run a write, and verify MinIO is
+        #    reachable.
+        register_audit_listeners()
+        bucket_init()
+
+        # 4. App-specific startup hook (workers, cron registration, etc.)
+        if on_startup is not None:
+            result = on_startup()
+            if hasattr(result, "__await__"):
+                await result  # type: ignore[misc]
+
+        try:
+            yield
+        finally:
+            # 5. App-specific shutdown hook
+            if on_shutdown is not None:
+                result = on_shutdown()
+                if hasattr(result, "__await__"):
+                    await result  # type: ignore[misc]
+
+    return lifespan

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -82,73 +82,78 @@ class TestNoLocalBootGuards:
 
 
 @pytest.mark.parametrize("app", _APPS)
-class TestLifespanCallsSharedGuards:
-    """Each app's lifespan must call all the shared boot guards.
+class TestLifespanUsesSharedFactory:
+    """Each app's lifespan must be built via the shared
+    ``create_app_lifespan`` factory rather than a hand-rolled
+    ``@asynccontextmanager`` that re-implements the canonical boot
+    sequence.
 
-    This is the parity contract: missing a guard in one app while having
-    it in the other is the drift this series prevents.
+    This is the parity contract: the boot order (sentry, turnstile,
+    email, audit, bucket) is centralised in
+    ``platform_shared.core.lifespan`` and unit-tested there. App
+    main.py files just compose the factory with their settings + an
+    optional bucket_init / on_startup / on_shutdown.
     """
 
-    def test_lifespan_calls_check_turnstile_configured(self, app: str) -> None:
+    def test_imports_create_app_lifespan(self, app: str) -> None:
         main_src = _read("apps", app, "backend", "app", "main.py")
-        assert "check_turnstile_configured(" in main_src, (
-            f"{app}/backend/app/main.py lifespan does not call "
-            f"check_turnstile_configured(). Add it after init_sentry() — "
-            f"production deploys without TURNSTILE_SECRET_KEY are a "
-            f"credential-stuffing vulnerability."
+        assert "from platform_shared.core.lifespan import create_app_lifespan" in main_src, (
+            f"{app}/backend/app/main.py must import create_app_lifespan "
+            f"from platform_shared.core.lifespan — see PR #301 for the "
+            f"canonical lifespan composition pattern."
         )
 
-    def test_lifespan_calls_check_email_configured(self, app: str) -> None:
+    def test_calls_create_app_lifespan(self, app: str) -> None:
         main_src = _read("apps", app, "backend", "app", "main.py")
-        assert "check_email_configured(" in main_src, (
-            f"{app}/backend/app/main.py lifespan does not call "
-            f"check_email_configured(). Add it after check_turnstile_configured() — "
-            f"the 2026-05-05 Kenneth verification-email outage was caused by "
-            f"console-mode email backend silently logging to stdout in "
-            f"production."
+        assert "create_app_lifespan(" in main_src, (
+            f"{app}/backend/app/main.py must build its lifespan via "
+            f"create_app_lifespan(...) instead of a hand-rolled "
+            f"@asynccontextmanager."
         )
 
-    def test_lifespan_calls_init_sentry(self, app: str) -> None:
+    def test_passes_settings_to_factory(self, app: str) -> None:
         main_src = _read("apps", app, "backend", "app", "main.py")
-        assert "init_sentry()" in main_src, (
-            f"{app}/backend/app/main.py lifespan must call init_sentry() "
-            f"to satisfy the production observability contract."
+        assert "settings=settings" in main_src, (
+            f"{app}/backend/app/main.py must pass settings=settings to "
+            f"create_app_lifespan so the boot guards can read sentry_dsn, "
+            f"turnstile_secret_key, and email_backend."
         )
 
-    def test_lifespan_calls_register_audit_listeners(self, app: str) -> None:
+    def test_passes_init_sentry_to_factory(self, app: str) -> None:
         main_src = _read("apps", app, "backend", "app", "main.py")
-        assert "register_audit_listeners(" in main_src, (
-            f"{app}/backend/app/main.py lifespan must call "
-            f"register_audit_listeners() — without it, no audit_log rows "
-            f"get written for any model write."
+        assert "init_sentry=init_sentry" in main_src, (
+            f"{app}/backend/app/main.py must pass init_sentry=init_sentry "
+            f"to create_app_lifespan. The wrapper from "
+            f"app.core.observability binds settings.sentry_dsn / "
+            f"settings.environment internally."
         )
 
-
-class TestLifespanGuardOrder:
-    """Boot guards must run in a specific order so each one's preconditions
-    are satisfied: Sentry first (so guard failures get captured), then the
-    config guards in any order, then the side-effect inits."""
-
-    @pytest.mark.parametrize("app", _APPS)
-    def test_init_sentry_runs_before_check_turnstile(self, app: str) -> None:
+    def test_passes_bucket_init_to_factory(self, app: str) -> None:
+        """Both apps use MinIO and should wire ensure_bucket through
+        the factory's bucket_init parameter so the canonical boot
+        order (sentry → guards → audit → bucket → app-startup) is
+        enforced."""
         main_src = _read("apps", app, "backend", "app", "main.py")
-        sentry_idx = main_src.find("init_sentry()")
-        turnstile_idx = main_src.find("check_turnstile_configured(")
-        assert 0 < sentry_idx < turnstile_idx, (
-            f"{app}/backend/app/main.py: init_sentry() must run BEFORE "
-            f"check_turnstile_configured() so any boot-guard failure is "
-            f"captured by Sentry."
+        assert "bucket_init=ensure_bucket" in main_src, (
+            f"{app}/backend/app/main.py must pass "
+            f"bucket_init=ensure_bucket to create_app_lifespan."
         )
 
-    @pytest.mark.parametrize("app", _APPS)
-    def test_init_sentry_runs_before_check_email(self, app: str) -> None:
+    def test_does_not_define_local_lifespan(self, app: str) -> None:
+        """The hand-rolled `async def lifespan(...)` was the drift surface
+        this Tier-1 series eliminated. Apps must NOT redefine it."""
         main_src = _read("apps", app, "backend", "app", "main.py")
-        sentry_idx = main_src.find("init_sentry()")
-        email_idx = main_src.find("check_email_configured(")
-        assert 0 < sentry_idx < email_idx, (
-            f"{app}/backend/app/main.py: init_sentry() must run BEFORE "
-            f"check_email_configured() so any boot-guard failure is "
-            f"captured by Sentry."
+        # Match a function definition that opens a lifespan
+        local_def = re.search(
+            r"^async\s+def\s+lifespan\s*\(",
+            main_src,
+            re.MULTILINE,
+        )
+        assert local_def is None, (
+            f"{app}/backend/app/main.py defines a local async lifespan(). "
+            f"Use create_app_lifespan() from platform_shared instead. "
+            f"App-specific startup/shutdown belongs in on_startup / "
+            f"on_shutdown hooks passed to the factory."
         )
 
 

--- a/packages/shared-backend/tests/test_lifespan.py
+++ b/packages/shared-backend/tests/test_lifespan.py
@@ -1,0 +1,261 @@
+"""Unit tests for platform_shared.core.lifespan.create_app_lifespan."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+
+from platform_shared.core.boot_guards import (
+    EmailNotConfiguredError,
+    TurnstileNotConfiguredError,
+)
+from platform_shared.core.lifespan import create_app_lifespan
+
+
+def _settings(
+    *,
+    environment: str = "development",
+    sentry_dsn: str = "",
+    turnstile_secret_key: str = "",
+    email_backend: str = "console",
+    smtp_user: str = "",
+    smtp_password: str = "",
+) -> SimpleNamespace:
+    """Build a settings-like namespace for tests."""
+    return SimpleNamespace(
+        environment=environment,
+        sentry_dsn=sentry_dsn,
+        turnstile_secret_key=turnstile_secret_key,
+        email_backend=email_backend,
+        smtp_user=smtp_user,
+        smtp_password=smtp_password,
+    )
+
+
+@pytest.fixture
+def app() -> FastAPI:
+    return FastAPI()
+
+
+class TestBootSequenceOrder:
+    """The factory must call boot steps in the canonical order."""
+
+    @pytest.mark.asyncio
+    async def test_calls_in_correct_order(self, app: FastAPI, monkeypatch) -> None:
+        order: list[str] = []
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            lambda: order.append("audit"),
+        )
+
+        lifespan = create_app_lifespan(
+            settings=_settings(),
+            init_sentry=lambda: order.append("sentry"),
+            bucket_init=lambda: order.append("bucket"),
+            on_startup=lambda: order.append("startup"),
+            on_shutdown=lambda: order.append("shutdown"),
+        )
+
+        async with lifespan(app):
+            order.append("yielded")
+
+        assert order == ["sentry", "audit", "bucket", "startup", "yielded", "shutdown"]
+
+
+class TestBootGuardsRunWithSettings:
+    """The factory must thread settings into the boot guards correctly."""
+
+    @pytest.mark.asyncio
+    async def test_production_with_no_turnstile_raises(self, app: FastAPI, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="",  # missing
+                email_backend="smtp",
+                smtp_user="x",
+                smtp_password="y" * 16,
+            ),
+            init_sentry=MagicMock(),
+        )
+        with pytest.raises(TurnstileNotConfiguredError):
+            async with lifespan(app):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_production_with_console_email_raises(self, app: FastAPI, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="present",
+                email_backend="console",
+            ),
+            init_sentry=MagicMock(),
+        )
+        with pytest.raises(EmailNotConfiguredError):
+            async with lifespan(app):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_dev_environment_passes_with_empty_creds(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(environment="development"),
+            init_sentry=MagicMock(),
+        )
+        async with lifespan(app):
+            pass
+
+
+class TestSentryFirst:
+    """init_sentry must run BEFORE the boot guards so guard failures get
+    captured."""
+
+    @pytest.mark.asyncio
+    async def test_sentry_runs_before_turnstile_failure(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        sentry_called = []
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="",  # will raise
+                email_backend="smtp",
+                smtp_user="x",
+                smtp_password="y" * 16,
+            ),
+            init_sentry=lambda: sentry_called.append("sentry"),
+        )
+        with pytest.raises(TurnstileNotConfiguredError):
+            async with lifespan(app):
+                pass
+        assert sentry_called == ["sentry"]
+
+
+class TestOptionalHooks:
+    """on_startup and on_shutdown are optional; sync and async both supported."""
+
+    @pytest.mark.asyncio
+    async def test_no_hooks_provided(self, app: FastAPI, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(),
+            init_sentry=MagicMock(),
+        )
+        async with lifespan(app):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_sync_startup_hook_runs(self, app: FastAPI, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        called = []
+        lifespan = create_app_lifespan(
+            settings=_settings(),
+            init_sentry=MagicMock(),
+            on_startup=lambda: called.append("startup"),
+        )
+        async with lifespan(app):
+            pass
+        assert called == ["startup"]
+
+    @pytest.mark.asyncio
+    async def test_async_startup_hook_runs(self, app: FastAPI, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        called = []
+
+        async def _async_startup() -> None:
+            called.append("async-startup")
+
+        lifespan = create_app_lifespan(
+            settings=_settings(),
+            init_sentry=MagicMock(),
+            on_startup=_async_startup,
+        )
+        async with lifespan(app):
+            pass
+        assert called == ["async-startup"]
+
+    @pytest.mark.asyncio
+    async def test_shutdown_runs_even_on_yield_exception(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        called = []
+        lifespan = create_app_lifespan(
+            settings=_settings(),
+            init_sentry=MagicMock(),
+            on_shutdown=lambda: called.append("shutdown"),
+        )
+        with pytest.raises(RuntimeError):
+            async with lifespan(app):
+                raise RuntimeError("boom")
+        assert called == ["shutdown"]
+
+
+class TestBucketInit:
+    """bucket_init is optional but commonly provided."""
+
+    @pytest.mark.asyncio
+    async def test_default_bucket_init_is_noop(self, app: FastAPI, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        # No bucket_init provided — should not raise
+        lifespan = create_app_lifespan(
+            settings=_settings(),
+            init_sentry=MagicMock(),
+        )
+        async with lifespan(app):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_bucket_init_called(self, app: FastAPI, monkeypatch) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        bucket_called = []
+        lifespan = create_app_lifespan(
+            settings=_settings(),
+            init_sentry=MagicMock(),
+            bucket_init=lambda: bucket_called.append("bucket"),
+        )
+        async with lifespan(app):
+            pass
+        assert bucket_called == ["bucket"]


### PR DESCRIPTION
## Summary

Tier-1 culmination — the lifespan body now lives in one tested location instead of two hand-maintained copies. Each app's `main.py` lifespan goes from ~18 hand-rolled lines to a 5-line factory call.

## What's shared now

`platform_shared.core.lifespan.create_app_lifespan(...)` composes:

1. `init_sentry()` — captured Sentry covers boot-guard failures below
2. `check_turnstile_configured()` — fail-loud in prod
3. `check_email_configured()` — fail-loud in prod
4. `register_audit_listeners()` — wire before any request handler
5. `bucket_init()` — verify MinIO reachable
6. `on_startup()` — app-specific hook (workers, etc.)
7. `yield` — app handles requests
8. `on_shutdown()` — app-specific cleanup

## Per-app callsites

**MJH** (`apps/myjobhunter/backend/app/main.py`):
```python
lifespan = create_app_lifespan(
    settings=settings,
    init_sentry=init_sentry,
    bucket_init=ensure_bucket,
)
```

**MBK** — same pattern + `on_startup` / `on_shutdown` for the Dramatiq upload-processor worker (the only MBK-specific lifecycle behaviour).

## Verification

✅ 11 new unit tests in `tests/test_lifespan.py` — all pass:
- Boot order, production fail-loud paths, sentry-runs-before-guards, optional sync/async hooks, shutdown-on-exception, bucket_init default

✅ Conformance tests updated (`TestLifespanUsesSharedFactory` replaces per-call assertions):
- imports `create_app_lifespan`
- passes `settings=settings`, `init_sentry=init_sentry`, `bucket_init=ensure_bucket`
- does NOT define a local `async def lifespan(`

✅ Total **50 tests pass** across boot-guards + lifespan + conformance suites

## Test plan

- [ ] CI runs both backend test suites — must stay green
- [ ] Deploy MBK to staging — `/health` returns OK, `/api/version` returns commit SHA, audit log writes succeed
- [ ] Deploy MJH to staging — same checks. Worker spawn/cancel for MBK validated indirectly via document-extraction smoke test

## Risk

The boot order is preserved 1:1 from the previous hand-rolled lifespans — same guards, same order, just centralised. The MBK worker spawn/cancel logic is unchanged (moved to `on_startup` / `on_shutdown` hooks but the implementation body is identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)