### PR TITLE
refactor(mybookkeeper): email_service wraps platform_shared — Tier-1 closeout

### DIFF
--- a/apps/mybookkeeper/backend/app/services/system/email_service.py
+++ b/apps/mybookkeeper/backend/app/services/system/email_service.py
@@ -1,62 +1,87 @@
-"""Email service using Gmail SMTP."""
+"""MyBookkeeper email service.
+
+Thin wrapper around ``platform_shared.services.email_service.EmailService``.
+The actual SMTP transport, STARTTLS hardening, and fail-loud /
+best-effort split live in the shared layer. This module:
+
+  - Constructs the EmailService from MBK Settings
+  - Exposes module-level functions matching the historical API
+    (send_email, send_email_or_raise, is_configured, get_recipients,
+    send_cost_alert, send_test_email) so existing callers don't change
+  - Owns the MBK-specific cost alert + test email HTML templates
+  - Routes the cost-alert recipients list (an MBK-specific feature)
+"""
 
 import html as html_mod
 import logging
-import smtplib
-from email.mime.multipart import MIMEMultipart
-from email.mime.text import MIMEText
+from functools import lru_cache
+
+from platform_shared.services.email_service import (
+    EmailNotConfiguredError,
+    EmailSendError,
+    EmailService,
+)
 
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
 
-def _smtp_configured() -> bool:
-    return bool(settings.smtp_user and settings.smtp_password)
+@lru_cache(maxsize=1)
+def _get_email_service() -> EmailService:
+    """Build the shared EmailService from MBK Settings.
+
+    Cached so we construct one instance per process. Tests can clear
+    the cache via ``_get_email_service.cache_clear()`` if they need
+    to swap settings mid-run.
+    """
+    return EmailService(
+        smtp_host=settings.smtp_host,
+        smtp_port=settings.smtp_port,
+        smtp_user=settings.smtp_user,
+        smtp_password=settings.smtp_password,
+        from_name=settings.email_from_name,
+    )
 
 
 def is_configured() -> bool:
-    return _smtp_configured()
+    return _get_email_service().is_configured()
 
 
 def get_recipients() -> list[str]:
+    """Cost-alert recipient list, parsed from a comma-separated env var."""
     raw = settings.cost_alert_recipients.strip()
     if not raw:
         return []
     return [addr.strip() for addr in raw.split(",") if addr.strip()]
 
 
-def _send_via_smtp(to: list[str], subject: str, body_html: str) -> bool:
-    msg = MIMEMultipart("alternative")
-    msg["From"] = f"{settings.email_from_name} <{settings.smtp_user}>"
-    msg["To"] = ", ".join(to)
-    msg["Subject"] = subject
-    msg.attach(MIMEText(body_html, "html"))
-
-    try:
-        with smtplib.SMTP(settings.smtp_host, settings.smtp_port) as server:
-            server.starttls()
-            server.login(settings.smtp_user, settings.smtp_password)
-            server.sendmail(settings.smtp_user, to, msg.as_string())
-        logger.info("Email sent via SMTP to %s: %s", to, subject)
-        return True
-    except Exception:
-        logger.warning("Failed to send email via SMTP to %s", to, exc_info=True)
-        return False
-
-
 def send_email(to: list[str], subject: str, body_html: str) -> bool:
+    """Best-effort send. Returns True on success, False on failure.
+
+    Use for non-critical emails (cost alerts, demos, inquiry
+    notifications). Critical-path callers (verification, password
+    reset, organization invites) MUST use ``send_email_or_raise``.
+    """
     if not to:
         return False
+    return _get_email_service().send(to, subject, body_html)
 
-    if _smtp_configured():
-        return _send_via_smtp(to, subject, body_html)
 
-    logger.warning("No email service configured (set SMTP_USER and SMTP_PASSWORD)")
-    return False
+def send_email_or_raise(to: list[str], subject: str, body_html: str) -> None:
+    """Fail-loud send. Raises on any failure.
+
+    Raises:
+        ValueError: If ``to`` is empty.
+        EmailNotConfiguredError: If SMTP creds are missing.
+        EmailSendError: If SMTP send fails (network, auth, recipient
+            rejected).
+    """
+    _get_email_service().send_or_raise(to, subject, body_html)
 
 
 def send_cost_alert(severity: str, message: str, cost: float, budget: float) -> bool:
+    """Best-effort cost-alert email — operator-facing, OK to drop on failure."""
     recipients = get_recipients()
     if not recipients:
         return False
@@ -67,7 +92,7 @@ def send_cost_alert(severity: str, message: str, cost: float, budget: float) -> 
     html = f"""
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 480px; margin: 0 auto;">
       <div style="background: {color}; color: white; padding: 16px 20px; border-radius: 8px 8px 0 0;">
-        <h2 style="margin: 0; font-size: 18px;">Cost Alert — {label}</h2>
+        <h2 style="margin: 0; font-size: 18px;">Cost Alert &mdash; {label}</h2>
       </div>
       <div style="border: 1px solid #e5e7eb; border-top: none; padding: 20px; border-radius: 0 0 8px 8px;">
         <p style="margin: 0 0 16px 0; font-size: 15px; color: #374151;">{html_mod.escape(message)}</p>
@@ -88,10 +113,13 @@ def send_cost_alert(severity: str, message: str, cost: float, budget: float) -> 
     </div>
     """
 
-    return send_email(recipients, f"[MyBookkeeper] Cost Alert — {label}", html)
+    return send_email(recipients, f"[MyBookkeeper] Cost Alert &mdash; {label}", html)
 
 
 def send_test_email(to: str) -> bool:
+    """Best-effort test email — used by the operator-only POST /admin/test-email
+    endpoint to verify SMTP wiring. Reasonable to swallow the failure (the
+    HTTP response surfaces it via the False return)."""
     html = """
     <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 480px; margin: 0 auto;">
       <div style="background: #22c55e; color: white; padding: 16px 20px; border-radius: 8px 8px 0 0;">
@@ -104,4 +132,16 @@ def send_test_email(to: str) -> bool:
       </div>
     </div>
     """
-    return send_email([to], "[MyBookkeeper] Email Test — Success", html)
+    return send_email([to], "[MyBookkeeper] Email Test &mdash; Success", html)
+
+
+__all__ = [
+    "EmailNotConfiguredError",
+    "EmailSendError",
+    "is_configured",
+    "get_recipients",
+    "send_email",
+    "send_email_or_raise",
+    "send_cost_alert",
+    "send_test_email",
+]


### PR DESCRIPTION
Migrates MBK's local email_service.py to wrap platform_shared.services.email_service (same shape MJH already uses). Adds send_email_or_raise. Existing 7 callers preserve their bool-returning API. STARTTLS hardening + send semantics inherited from platform_shared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)