### PR TITLE
fix(infra): wire VITE_TURNSTILE_SITE_KEY through caddy build for both apps

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -48,7 +48,14 @@ jobs:
             echo "Env files present — proceeding"
 
             echo "--- Build and deploy with Docker ---"
-            docker compose -f apps/mybookkeeper/docker-compose.yml build
+            # --env-file flag exposes backend/.env.docker variables to docker
+            # compose's build args (caddy.build.args reads VITE_TURNSTILE_SITE_KEY
+            # from the shell). Without --env-file the bundle gets baked with an
+            # empty site key and TurnstileWidget renders null in production —
+            # the 2026-05-05 silent-registration-broken bug.
+            docker compose -f apps/mybookkeeper/docker-compose.yml \
+              --env-file apps/mybookkeeper/backend/.env.docker \
+              build
             docker compose -f apps/mybookkeeper/docker-compose.yml up -d --remove-orphans
 
             echo "--- One-time cleanup: remove obsolete frontend_dist volume ---"

--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -49,7 +49,14 @@ jobs:
             echo "Env files present — proceeding"
 
             echo "--- Build and deploy with Docker ---"
-            docker compose -f apps/myjobhunter/docker-compose.yml build
+            # --env-file flag exposes backend/.env.docker variables to docker
+            # compose's build args (caddy.build.args reads VITE_TURNSTILE_SITE_KEY
+            # from the shell). Without --env-file the bundle gets baked with an
+            # empty site key and TurnstileWidget renders null in production —
+            # the 2026-05-05 silent-registration-broken bug.
+            docker compose -f apps/myjobhunter/docker-compose.yml \
+              --env-file apps/myjobhunter/backend/.env.docker \
+              build
             docker compose -f apps/myjobhunter/docker-compose.yml up -d --remove-orphans
 
             echo "--- One-time cleanup: remove obsolete frontend_dist volume ---"

--- a/apps/mybookkeeper/docker-compose.yml
+++ b/apps/mybookkeeper/docker-compose.yml
@@ -108,6 +108,15 @@ services:
     build:
       context: ../..
       dockerfile: apps/mybookkeeper/docker/caddy.Dockerfile
+      args:
+        # Frontend public env baked into the Vite bundle at build time.
+        # Read from the host shell environment when `docker compose build`
+        # runs; the deploy workflow / operator passes these via
+        # `--env-file backend/.env.docker` or by sourcing the file before
+        # build. Empty values produce a bundle where TurnstileWidget
+        # returns null and registration silently 400s — see the
+        # caddy.Dockerfile comment for the full failure mode.
+        VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
     restart: always
     ports:
       # Bind only to localhost — host Caddy is the public front door and proxies here.

--- a/apps/mybookkeeper/docker/caddy.Dockerfile
+++ b/apps/mybookkeeper/docker/caddy.Dockerfile
@@ -27,6 +27,22 @@ WORKDIR /build
 COPY apps/mybookkeeper/frontend/package.json apps/mybookkeeper/frontend/package-lock.json ./
 RUN npm ci
 COPY apps/mybookkeeper/frontend/ ./
+
+# Frontend build-time public env. Vite inlines anything prefixed with
+# VITE_ into the bundle at build time — these MUST be passed as build
+# args from docker-compose, NOT runtime env vars on the caddy container,
+# because the bundle is already minified and frozen by the time caddy
+# starts.
+#
+# VITE_TURNSTILE_SITE_KEY: Cloudflare Turnstile public site key.
+# Empty value → TurnstileWidget renders null and registration POSTs
+# without a captcha token, so the backend's require_turnstile dependency
+# returns 400 captcha_token_required. This was the 2026-05-05 silent-
+# registration-broken bug — the SECRET key was wired but the SITE key
+# never made it into the bundle because this ARG didn't exist.
+ARG VITE_TURNSTILE_SITE_KEY=
+ENV VITE_TURNSTILE_SITE_KEY=${VITE_TURNSTILE_SITE_KEY}
+
 RUN npm run build
 
 FROM caddy:2-alpine

--- a/apps/myjobhunter/docker-compose.yml
+++ b/apps/myjobhunter/docker-compose.yml
@@ -79,6 +79,15 @@ services:
     build:
       context: ../..
       dockerfile: apps/myjobhunter/docker/caddy.Dockerfile
+      args:
+        # Frontend public env baked into the Vite bundle at build time.
+        # Read from the host shell environment when `docker compose build`
+        # runs; the deploy workflow / operator passes these via
+        # `--env-file backend/.env.docker` or by sourcing the file before
+        # build. Empty values produce a bundle where TurnstileWidget
+        # returns null and registration silently 400s — see the
+        # caddy.Dockerfile comment for the full failure mode.
+        VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
     restart: unless-stopped
     ports:
       # Bind only to localhost — host Caddy is the public front door and proxies here.

--- a/apps/myjobhunter/docker/caddy.Dockerfile
+++ b/apps/myjobhunter/docker/caddy.Dockerfile
@@ -31,6 +31,22 @@ COPY apps/myjobhunter/frontend/package.json ./apps/myjobhunter/frontend/
 RUN npm ci --ignore-scripts
 COPY packages/shared-frontend ./packages/shared-frontend
 COPY apps/myjobhunter/frontend ./apps/myjobhunter/frontend
+
+# Frontend build-time public env. Vite inlines anything prefixed with
+# VITE_ into the bundle at build time — these MUST be passed as build
+# args from docker-compose, NOT runtime env vars on the caddy container,
+# because the bundle is already minified and frozen by the time caddy
+# starts.
+#
+# VITE_TURNSTILE_SITE_KEY: Cloudflare Turnstile public site key.
+# Empty value → TurnstileWidget renders null and registration POSTs
+# without a captcha token, so the backend's require_turnstile dependency
+# returns 400 captcha_token_required. This was the 2026-05-05 silent-
+# registration-broken bug — the SECRET key was wired but the SITE key
+# never made it into the bundle because this ARG didn't exist.
+ARG VITE_TURNSTILE_SITE_KEY=
+ENV VITE_TURNSTILE_SITE_KEY=${VITE_TURNSTILE_SITE_KEY}
+
 RUN npm run build --workspace=apps/myjobhunter/frontend
 
 FROM caddy:2-alpine

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -191,3 +191,91 @@ class TestObservabilityWrapperShape:
                 f"sentry_sdk directly. Delegate to "
                 f"platform_shared.core.observability."
             )
+
+
+@pytest.mark.parametrize("app", _APPS)
+class TestTurnstileBundleWiring:
+    """The 2026-05-05 silent-registration-broken bug: VITE_TURNSTILE_SITE_KEY
+    was missing from the docker-compose build-arg → caddy.Dockerfile ARG path,
+    so every production bundle was built with an empty site key and the
+    TurnstileWidget rendered null. Backend rejected every registration with
+    400 captcha_token_required.
+
+    This conformance check fails CI if either the Dockerfile ARG or the
+    docker-compose build-args wiring is missing — preventing the same drift.
+
+    Note: this is a structural conformance check, NOT a bundle smoke test.
+    The bundle smoke test (e.g. an E2E that asserts a Turnstile widget
+    renders on the registration page) is a separate follow-up tracked in
+    the broader test backlog.
+    """
+
+    def test_caddy_dockerfile_declares_turnstile_arg(self, app: str) -> None:
+        """The frontend build stage in caddy.Dockerfile must declare ARG +
+        ENV for VITE_TURNSTILE_SITE_KEY before the `npm run build` line."""
+        dockerfile_src = _read("apps", app, "docker", "caddy.Dockerfile")
+        assert "ARG VITE_TURNSTILE_SITE_KEY" in dockerfile_src, (
+            f"{app}/docker/caddy.Dockerfile must declare "
+            f"`ARG VITE_TURNSTILE_SITE_KEY=` before `RUN npm run build` "
+            f"so docker-compose can pass the public Turnstile site key "
+            f"into the Vite bundle. Without this, the bundle is built "
+            f"with an empty key, TurnstileWidget renders null, and "
+            f"registration silently 400s in production."
+        )
+        assert "ENV VITE_TURNSTILE_SITE_KEY" in dockerfile_src, (
+            f"{app}/docker/caddy.Dockerfile must set "
+            f"`ENV VITE_TURNSTILE_SITE_KEY=${{VITE_TURNSTILE_SITE_KEY}}` "
+            f"after the ARG declaration so Vite picks up the value at "
+            f"build time."
+        )
+        # The ARG/ENV must come BEFORE the npm run build line, otherwise
+        # the build runs with no env set.
+        arg_idx = dockerfile_src.find("ARG VITE_TURNSTILE_SITE_KEY")
+        build_idx = dockerfile_src.find("npm run build")
+        assert 0 < arg_idx < build_idx, (
+            f"{app}/docker/caddy.Dockerfile: ARG VITE_TURNSTILE_SITE_KEY "
+            f"must be declared BEFORE `RUN npm run build`, otherwise "
+            f"Vite runs without the env value."
+        )
+
+    def test_docker_compose_passes_turnstile_arg_to_caddy(self, app: str) -> None:
+        """The caddy service in docker-compose.yml must declare a
+        build.args block that maps VITE_TURNSTILE_SITE_KEY from the shell
+        env (where the operator / deploy workflow sources backend/.env.docker)."""
+        compose_src = _read("apps", app, "docker-compose.yml")
+        assert "VITE_TURNSTILE_SITE_KEY:" in compose_src, (
+            f"{app}/docker-compose.yml must include `VITE_TURNSTILE_SITE_KEY: "
+            f"${{TURNSTILE_SITE_KEY:-}}` under the caddy service's "
+            f"`build.args:` block. Without this, the caddy.Dockerfile's "
+            f"ARG sees no value at build time and the bundle is baked "
+            f"with an empty Turnstile site key."
+        )
+        assert "${TURNSTILE_SITE_KEY" in compose_src, (
+            f"{app}/docker-compose.yml: VITE_TURNSTILE_SITE_KEY build "
+            f"arg must reference ${{TURNSTILE_SITE_KEY}} (no VITE_ "
+            f"prefix on the right-hand side) so docker compose reads "
+            f"the value from the same env var name the backend uses."
+        )
+
+    def test_deploy_workflow_uses_env_file_for_build(self, app: str) -> None:
+        """The deploy workflow must pass `--env-file backend/.env.docker`
+        to `docker compose build` so the build-args block can resolve
+        TURNSTILE_SITE_KEY from the env file."""
+        workflow_src = _read(".github", "workflows", f"deploy-{app}.yml")
+        # Match a `docker compose ... --env-file ...backend/.env.docker ... build`
+        # invocation, allowing shell line-continuations (backslash + newline)
+        # between the segments. Re-DOTALL lets `.` cross newlines so the
+        # wrapped multi-line form in the workflow is matched.
+        match = re.search(
+            r"docker\s+compose.*?--env-file.*?backend/\.env\.docker.*?\bbuild\b",
+            workflow_src,
+            re.DOTALL,
+        )
+        assert match is not None, (
+            f".github/workflows/deploy-{app}.yml must invoke "
+            f"`docker compose --env-file apps/{app}/backend/.env.docker "
+            f"... build` so TURNSTILE_SITE_KEY (and other build-time env "
+            f"vars) are exposed to docker compose's build.args block. "
+            f"Without --env-file, the build runs with no .env.docker "
+            f"values and bundles get baked with empty defaults."
+        )


### PR DESCRIPTION
Both apps' production registration has been silently broken since Turnstile was wired up — site key never reaches the Vite bundle. Today's MJH outage exposed it; MBK has been broken just as long but no new users were noticing.

## Root cause

`TurnstileWidget.tsx` reads `import.meta.env.VITE_TURNSTILE_SITE_KEY` at build time and returns `null` when empty. Neither `caddy.Dockerfile` declared the ARG, neither `docker-compose.yml` passed the build arg, neither deploy workflow sourced `backend/.env.docker` for the build. The env var had no path from `.env.docker` → docker compose → Vite.

Result: every production bundle was built with an empty site key → no widget rendered → registration POSTs without a token → backend (correctly) returns 400 `captcha_token_required`.

## Fix (3 layers)

| File | Change |
|---|---|
| `apps/{app}/docker/caddy.Dockerfile` | Add `ARG VITE_TURNSTILE_SITE_KEY=` + `ENV ...` BEFORE `RUN npm run build` |
| `apps/{app}/docker-compose.yml` | Caddy service `build.args:` maps `VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}` |
| `.github/workflows/deploy-{app}.yml` | Pass `--env-file apps/{app}/backend/.env.docker` to `docker compose build` |

## Conformance test (prevents regression)

`packages/shared-backend/tests/test_app_conformance.py` — new `TestTurnstileBundleWiring` class with 6 tests (3 per app):
- Dockerfile declares the ARG + ENV
- ARG runs before `npm run build`
- docker-compose passes the build arg
- Deploy workflow uses `--env-file`

**All 28 conformance tests pass.** CI fails if any of the wiring drifts again.

## Operational migration after merge

Operator must on the VPS, for each app:
1. Set `TURNSTILE_SITE_KEY=<public key>` in `backend/.env.docker` (alongside the existing secret)
2. Rebuild + recreate caddy:
   ```
   docker compose -f apps/{app}/docker-compose.yml      --env-file apps/{app}/backend/.env.docker      build --no-cache caddy
   docker compose -f apps/{app}/docker-compose.yml up -d --force-recreate caddy
   ```
3. Hard-refresh browser → Turnstile widget renders → registration succeeds

The next deploy via GitHub Actions will pick up the wiring automatically once both keys are in `.env.docker` on the VPS.

## Lesson learned

Boot guards check runtime env. Frontend bundles freeze build-time env. Two different layers; need separate guards. Conformance tests now cover both — this is the structural fix that should have been in PR #292.

E2E test that runs the actual browser registration flow (mocking the Cloudflare endpoint with [Turnstile's documented test keys](https://developers.cloudflare.com/turnstile/troubleshooting/testing/)) is queued as the next follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)