### PR TITLE
fix(myjobhunter): correct sha256 hash for theme-bootstrap inline script

### DIFF
--- a/apps/myjobhunter/docker/Caddyfile.docker
+++ b/apps/myjobhunter/docker/Caddyfile.docker
@@ -81,7 +81,7 @@
         #   form-action 'self'         — forms can only submit back to the app
         #   object-src 'none'          — no Flash/Java/legacy plugin embeds
         #   upgrade-insecure-requests  — auto-upgrade any stray http:// reference
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6n5b7wHrV5jmk=' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com; frame-src 'self' https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com; frame-src 'self' https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
 
         # Don't advertise the server software in the response headers.
         -Server


### PR DESCRIPTION
PR #308 had a one-character typo in the CSP hash (transcribed `Nf6n5b7w` instead of `Nf6nSb7w` from the browser console — `5` vs `S` confusion). Theme bootstrap script was still being blocked. Bundle + Turnstile widget unaffected; symptom was just the flash-of-wrong-theme + console error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)