### PR TITLE
feat(platform-shared): Role enum + require_role — RBAC foundation

### DIFF
--- a/apps/mybookkeeper/backend/app/models/user/user.py
+++ b/apps/mybookkeeper/backend/app/models/user/user.py
@@ -1,16 +1,17 @@
-import enum
 from datetime import datetime
 
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
 from sqlalchemy import Boolean, DateTime, SmallInteger, String, Text, Enum as SAEnum
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
+from platform_shared.core.permissions import Role
+
 from app.db.base import Base
 
-
-class Role(str, enum.Enum):
-    ADMIN = "admin"
-    USER = "user"
+# Re-export for backwards compatibility — many MBK files import Role
+# from `app.models.user.user`. The canonical location is now
+# `platform_shared.core.permissions.Role`.
+__all__ = ["User", "Role"]
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):

--- a/apps/myjobhunter/backend/alembic/versions/role260505_add_user_role_column.py
+++ b/apps/myjobhunter/backend/alembic/versions/role260505_add_user_role_column.py
@@ -1,0 +1,56 @@
+"""Add user.role column with platform_shared.core.permissions.Role enum.
+
+Foundation slice of the eventual full RBAC port. Adds a single
+platform-level role column (ADMIN | USER) so MJH can gate admin-only
+routes via ``platform_shared.core.permissions.require_role`` without
+needing the full organization + members system in place.
+
+Per-organization roles (when MJH ports the orgs/members system) layer
+on top of this — they don't replace it.
+
+The enum is created as a PostgreSQL ENUM type named ``user_role``;
+default ``user`` for all existing rows. Downgrade drops the column
+and the type.
+
+Revision ID: role260505
+Revises: docs260504
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "role260505"
+down_revision: Union[str, None] = "docs260504"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Postgres enum types must be created explicitly before they can be
+    # used in ``ALTER TABLE``. ``create_type=False`` on the column
+    # prevents alembic from auto-creating the type a second time inline.
+    user_role_enum = sa.Enum(
+        "admin",
+        "user",
+        name="user_role",
+    )
+    user_role_enum.create(op.get_bind(), checkfirst=True)
+
+    op.add_column(
+        "users",
+        sa.Column(
+            "role",
+            sa.Enum("admin", "user", name="user_role", create_type=False),
+            nullable=False,
+            server_default="user",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("users", "role")
+    sa.Enum(name="user_role").drop(op.get_bind(), checkfirst=True)

--- a/apps/myjobhunter/backend/app/models/user/user.py
+++ b/apps/myjobhunter/backend/app/models/user/user.py
@@ -2,11 +2,17 @@ import uuid
 from datetime import datetime
 
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
-from sqlalchemy import Boolean, DateTime, SmallInteger, String
+from sqlalchemy import Boolean, DateTime, Enum as SAEnum, SmallInteger, String
 from sqlalchemy.orm import Mapped, mapped_column
+
+from platform_shared.core.permissions import Role
 
 from app.core.encrypted_string_type import EncryptedString
 from app.db.base import Base
+
+# Re-export for downstream callers that prefer ``from app.models.user.user
+# import Role`` over reaching into platform_shared directly. Mirrors MBK.
+__all__ = ["User", "Role"]
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):
@@ -20,6 +26,17 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     __tablename__ = "users"
 
     display_name: Mapped[str] = mapped_column(String(100), default="")
+
+    # Platform-level role (ADMIN | USER). Gates platform-wide admin
+    # routes via ``platform_shared.core.permissions.require_role``. Per-
+    # organization roles (when MJH ports the orgs/members system) layer
+    # on top of this — they don't replace it.
+    role: Mapped[Role] = mapped_column(
+        SAEnum(Role, name="user_role", values_callable=lambda enum_cls: [e.value for e in enum_cls]),
+        default=Role.USER,
+        server_default=Role.USER.value,
+        nullable=False,
+    )
 
     # TOTP secret + recovery codes are stored encrypted at rest via the
     # ``EncryptedString`` TypeDecorator (Fernet, MJH PII key family). The

--- a/packages/shared-backend/platform_shared/core/permissions.py
+++ b/packages/shared-backend/platform_shared/core/permissions.py
@@ -1,0 +1,106 @@
+"""Platform-level role enum + admin dependency.
+
+Foundation slice of the broader RBAC contract. Apps that need the full
+organization + members + per-org roles tier can layer on top of this
+in their own ``app/core/permissions.py`` (see
+apps/mybookkeeper/backend/app/core/permissions.py for the canonical
+example), but the simple "is the user a platform admin" check
+belongs here so every app gets it for free.
+
+Scope of THIS module:
+
+  - ``Role`` enum (ADMIN | USER) — single column on the User table
+  - ``require_role(*roles)`` dependency factory
+  - ``current_admin`` — pre-baked dependency for admin-only routes
+
+Explicitly NOT in scope (belongs in app-level permissions.py):
+
+  - Organization / OrganizationMember / OrgRole
+  - ``current_org_member`` and ``require_write_access`` /
+    ``require_org_role`` dependencies
+  - Demo-org rejection helpers
+  - Anything that reads the X-Organization-Id header
+
+This module has zero coupling to any organization schema. The single
+``user.role`` column is sufficient to enforce platform-level admin
+gates for routes like ``/admin/auth-events``, ``/admin/storage-health``,
+or ``/admin/users``.
+
+Apps must declare a ``role`` column on their User model that uses
+this enum:
+
+    from platform_shared.core.permissions import Role
+
+    class User(SQLAlchemyBaseUserTableUUID, Base):
+        role: Mapped[Role] = mapped_column(SAEnum(Role), default=Role.USER)
+"""
+from __future__ import annotations
+
+import enum
+from typing import Awaitable, Callable, Protocol
+
+from fastapi import Depends, HTTPException
+
+
+class Role(str, enum.Enum):
+    """Platform-level user role.
+
+    Apps that need finer-grained per-organization roles should layer
+    those in their own permissions module on top of this one — keep
+    the platform-level enum minimal.
+    """
+
+    ADMIN = "admin"
+    USER = "user"
+
+
+class _RoleHolder(Protocol):
+    """Anything with a ``role`` attribute exposing a ``Role``.
+
+    Used to type the ``require_role`` factory's dependency without
+    coupling to any specific User model — apps' own User class
+    satisfies this Protocol structurally.
+    """
+
+    role: Role
+
+
+def require_role(
+    *roles: Role,
+    current_active_user: Callable[..., Awaitable[_RoleHolder]],
+) -> Callable[..., Awaitable[_RoleHolder]]:
+    """Build a FastAPI dependency that gates a route on user.role.
+
+    Args:
+        *roles: Allowed Role values. The user's role must be in this
+            set or the dependency raises 403.
+        current_active_user: The app's ``current_active_user``
+            dependency from fastapi-users — passed in so this module
+            stays decoupled from any specific User model. Each app
+            wires its own.
+
+    Example (in app/core/permissions.py):
+
+        from platform_shared.core.permissions import Role, require_role
+        from app.core.auth import current_active_user
+
+        require_admin = require_role(Role.ADMIN, current_active_user=current_active_user)
+
+    Then in route handlers:
+
+        @router.get("/admin/auth-events", dependencies=[Depends(require_admin)])
+        async def list_auth_events(...): ...
+
+    Raises:
+        HTTPException 403 with detail "Insufficient permissions" when
+        the user's role is not in the allowed set.
+    """
+
+    async def _check(user: _RoleHolder = Depends(current_active_user)) -> _RoleHolder:
+        if user.role not in roles:
+            raise HTTPException(
+                status_code=403, detail="Insufficient permissions"
+            )
+        return user
+
+    return _check

--- a/packages/shared-backend/tests/test_permissions.py
+++ b/packages/shared-backend/tests/test_permissions.py
@@ -1,0 +1,80 @@
+"""Unit tests for platform_shared.core.permissions."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import Depends, FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+from platform_shared.core.permissions import Role, require_role
+
+
+class _FakeUser:
+    """Stand-in for an app's User model — only needs a `role` attribute."""
+
+    def __init__(self, role: Role) -> None:
+        self.role = role
+
+
+class TestRoleEnum:
+    def test_admin_value(self) -> None:
+        assert Role.ADMIN.value == "admin"
+
+    def test_user_value(self) -> None:
+        assert Role.USER.value == "user"
+
+    def test_two_values_only(self) -> None:
+        assert set(Role) == {Role.ADMIN, Role.USER}
+
+    def test_str_subclass(self) -> None:
+        # Role inherits from str so JSON serialisation works without a custom encoder.
+        assert isinstance(Role.ADMIN, str)
+        assert Role.ADMIN == "admin"
+
+
+class TestRequireRole:
+    def _build_app(self, *, allowed_roles: tuple[Role, ...], user_role: Role) -> FastAPI:
+        app = FastAPI()
+
+        async def fake_current_active_user() -> _FakeUser:
+            return _FakeUser(role=user_role)
+
+        gate = require_role(
+            *allowed_roles, current_active_user=fake_current_active_user
+        )
+
+        @app.get("/protected")
+        async def protected(user: _FakeUser = Depends(gate)) -> dict:
+            return {"role": user.role.value}
+
+        return app
+
+    def test_admin_passes_admin_gate(self) -> None:
+        app = self._build_app(allowed_roles=(Role.ADMIN,), user_role=Role.ADMIN)
+        client = TestClient(app)
+        resp = client.get("/protected")
+        assert resp.status_code == 200
+        assert resp.json() == {"role": "admin"}
+
+    def test_user_blocked_from_admin_gate(self) -> None:
+        app = self._build_app(allowed_roles=(Role.ADMIN,), user_role=Role.USER)
+        client = TestClient(app)
+        resp = client.get("/protected")
+        assert resp.status_code == 403
+        assert resp.json()["detail"] == "Insufficient permissions"
+
+    def test_admin_passes_admin_or_user_gate(self) -> None:
+        app = self._build_app(
+            allowed_roles=(Role.ADMIN, Role.USER), user_role=Role.ADMIN
+        )
+        client = TestClient(app)
+        resp = client.get("/protected")
+        assert resp.status_code == 200
+
+    def test_user_passes_admin_or_user_gate(self) -> None:
+        app = self._build_app(
+            allowed_roles=(Role.ADMIN, Role.USER), user_role=Role.USER
+        )
+        client = TestClient(app)
+        resp = client.get("/protected")
+        assert resp.status_code == 200


### PR DESCRIPTION
Foundation slice of the broader RBAC port. Extracts platform-level Role enum + require_role dependency factory to platform_shared so MJH can inherit them without porting the full organizations + members system.

## What this PR does

- New: `platform_shared.core.permissions` with Role enum (ADMIN, USER) + require_role factory
- MBK migrates to import Role from platform_shared (re-exports for 16 dependent files)
- MJH adds role column to User model + Alembic migration (`role260505`)
- 8 unit tests for the shared module (all pass)

## What this unblocks

- Task #79 (auth events admin view) — can now port to MJH with require_role gate
- Future RBAC work layers on this foundation; doesn't replace it

## ⚠️ Operational migration required

After merge, MJH's deploy workflow runs the new `role260505` Alembic migration to add the column with server_default='user'. All existing MJH users default to USER role on upgrade. MBK schema unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)