### PR TITLE
feat(myjobhunter): admin auth-events listing route

### DIFF
--- a/apps/myjobhunter/backend/app/api/admin.py
+++ b/apps/myjobhunter/backend/app/api/admin.py
@@ -1,0 +1,66 @@
+"""Platform admin routes.
+
+Currently only auth-events listing — the security incident review tool.
+Other MBK admin endpoints (storage-health, user role management, platform
+stats) can land in this file as MJH grows; mirror the MBK shape when
+porting.
+
+All routes here are gated by ``require_role(Role.ADMIN, ...)`` —
+platform-level admin only. Per-organization admin (when MJH ports the
+orgs/members system) gates against ``OrgRole`` not ``Role`` and lives
+in a different module.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.core.permissions import Role, require_role
+
+from app.core.auth import current_active_user
+from app.db.session import get_db
+from app.models.user.user import User
+from app.repositories.system import auth_event_repo
+from app.schemas.system.auth_event import AuthEventRead
+
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+# Pre-baked admin gate — built once and reused per route. Each app must
+# wire its own because the shared `require_role` factory needs the
+# app's `current_active_user` dependency (which depends on the app's
+# fastapi-users config).
+require_admin = require_role(Role.ADMIN, current_active_user=current_active_user)
+
+
+@router.get("/auth-events", response_model=list[AuthEventRead])
+async def list_auth_events(
+    user_id: Optional[uuid.UUID] = None,
+    event_type: Optional[str] = None,
+    since: Optional[datetime] = None,
+    limit: int = Query(100, le=500),
+    offset: int = 0,
+    admin: User = Depends(require_admin),
+    db: AsyncSession = Depends(get_db),
+) -> list[AuthEventRead]:
+    """List auth events with optional filters, newest first.
+
+    Operator-only endpoint for security incident review. All filters AND
+    together. ``limit`` capped at 500 to avoid massive responses.
+
+    Mirrors MBK's GET /admin/auth-events shape exactly.
+    """
+    events = await auth_event_repo.list_filtered(
+        db,
+        user_id=user_id,
+        event_type=event_type,
+        since=since,
+        limit=limit,
+        offset=offset,
+    )
+    return list(events)

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -11,7 +11,7 @@ from jwt.exceptions import PyJWTError as JWTError
 
 from platform_shared.core.lifespan import create_app_lifespan
 
-from app.api import account, applications, companies, documents, health, integrations, profile, resumes, totp
+from app.api import account, admin, applications, companies, documents, health, integrations, profile, resumes, totp
 from app.core.audit import current_user_id
 from app.core.auth import auth_backend, fastapi_users
 from app.core.config import settings
@@ -179,6 +179,7 @@ app.include_router(companies.router, tags=["companies"])
 app.include_router(integrations.router, tags=["integrations"])
 app.include_router(resumes.router, tags=["resumes"])
 app.include_router(documents.router)
+app.include_router(admin.router)
 
 # TOTP routes — the /login subroute gets the per-IP throttle (matching the
 # guard on /auth/jwt/login). Account lockout is enforced INSIDE

--- a/apps/myjobhunter/backend/app/repositories/system/auth_event_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/system/auth_event_repo.py
@@ -1,0 +1,51 @@
+"""Auth-event read repository for the admin auth-events route.
+
+Mirrors apps/mybookkeeper/backend/app/repositories/system/auth_event_repo.py
+``list_filtered`` shape exactly. Writes go through
+``app/services/system/auth_event_service.log_auth_event`` (already shared).
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.system.auth_event import AuthEvent
+
+
+async def list_filtered(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID | None = None,
+    event_type: str | None = None,
+    since: datetime | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> Sequence[AuthEvent]:
+    """List auth events with optional filters, newest first.
+
+    All filters AND together. ``limit`` should be capped by the route
+    (MBK uses ``Query(100, le=500)``).
+    """
+    filters: list = []
+    if user_id is not None:
+        filters.append(AuthEvent.user_id == user_id)
+    if event_type is not None:
+        filters.append(AuthEvent.event_type == event_type)
+    if since is not None:
+        filters.append(AuthEvent.created_at >= since)
+
+    query = (
+        select(AuthEvent)
+        .order_by(AuthEvent.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    if filters:
+        query = query.where(and_(*filters))
+
+    result = await db.execute(query)
+    return result.scalars().all()

--- a/apps/myjobhunter/backend/app/schemas/system/auth_event.py
+++ b/apps/myjobhunter/backend/app/schemas/system/auth_event.py
@@ -1,0 +1,24 @@
+"""Read schema for the admin auth-events listing route.
+
+Mirrors apps/mybookkeeper/backend/app/schemas/system/auth_event.py exactly.
+The ``event_metadata`` alias maps to the model's ``event_metadata`` field
+(which itself maps to the SQL column ``metadata`` per the shared
+``platform_shared.db.models.auth_event.AuthEvent``).
+"""
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class AuthEventRead(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID | None = None
+    event_type: str
+    ip_address: str | None = None
+    user_agent: str | None = None
+    metadata: dict = Field(alias="event_metadata")
+    succeeded: bool
+    created_at: datetime
+
+    model_config = {"from_attributes": True, "populate_by_name": True}


### PR DESCRIPTION
Mirrors MBK GET /admin/auth-events for security incident review. Uses the Role + require_role foundation from PR #311.

Closes task #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)