### PR TITLE
feat(myjobhunter): port automated daily DB backup from MBK

### DIFF
--- a/apps/myjobhunter/CLAUDE.md
+++ b/apps/myjobhunter/CLAUDE.md
@@ -193,13 +193,18 @@ curl https://myjobhunter.165-245-134-251.sslip.io/health  # public
 ```
 
 **Database backup/restore:**
-MJH does not yet have automated backup scripts (MBK has `deploy/backup.sh` + systemd timer;
-MJH should mirror this — see TECH_DEBT.md). For now, manual backup:
+Automated daily backups via systemd timer at 02:00 to
+`/srv/myfreeapps/apps/myjobhunter/backups/` with 30-day retention. Setup +
+restore procedure documented in `apps/myjobhunter/deploy/DATABASE_BACKUP_RECOVERY.md`.
+
+Manual backup (anytime):
 ```bash
-# On VPS:
-docker compose -f apps/myjobhunter/docker-compose.yml exec postgres \
-  pg_dump -U myjobhunter myjobhunter | gzip > /tmp/mjh-$(date +%Y%m%d).sql.gz
+sudo /srv/myfreeapps/apps/myjobhunter/deploy/backup.sh
 ```
+
+Off-host replication is NOT currently configured — local backups only.
+Add `rclone sync` or `aws s3 sync` as a second timer for off-host
+durability.
 
 **When to SSH into the server:**
 - First-time env file setup (seed-env-from-mbk.sh)

--- a/apps/myjobhunter/deploy/DATABASE_BACKUP_RECOVERY.md
+++ b/apps/myjobhunter/deploy/DATABASE_BACKUP_RECOVERY.md
@@ -1,0 +1,131 @@
+# MyJobHunter Database Backup + Recovery
+
+Mirrors apps/mybookkeeper/deploy/DATABASE_BACKUP_RECOVERY.md with paths
+adjusted for MJH's location at `/srv/myfreeapps/apps/myjobhunter/`.
+
+## What gets backed up
+
+- **PostgreSQL DB** (`myjobhunter` database, all tables) — gzipped SQL
+  dump via `pg_dump`. One file per run, named
+  `myjobhunter_YYYYMMDD_HHMMSS.sql.gz`.
+
+## What does NOT get backed up by this script
+
+- **MinIO object storage** — MJH's MinIO is shared infra, owned by
+  `infra/docker-compose.yml`. Bucket-level backups belong with the
+  infra layer, not this per-app script.
+- **Backend/frontend code** — already in git.
+- **`.env.docker` files** — operator should keep these in their
+  password manager. The setup script does NOT regenerate them.
+
+## Backup location + retention
+
+- Path: `/srv/myfreeapps/apps/myjobhunter/backups/`
+- Retention: 30 days (older files deleted by the script)
+- Filename pattern: `myjobhunter_YYYYMMDD_HHMMSS.sql.gz`
+
+Override with env vars passed to the script:
+```bash
+BACKUP_DIR=/different/path RETENTION_DAYS=7 /srv/myfreeapps/apps/myjobhunter/deploy/backup.sh
+```
+
+## Schedule
+
+Two equivalent options — pick one.
+
+### Option A: systemd timer (recommended)
+
+Install once on the VPS:
+
+```bash
+sudo cp /srv/myfreeapps/apps/myjobhunter/deploy/myjobhunter-backup.service \
+        /etc/systemd/system/
+sudo cp /srv/myfreeapps/apps/myjobhunter/deploy/myjobhunter-backup.timer \
+        /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now myjobhunter-backup.timer
+```
+
+Verify:
+```bash
+sudo systemctl list-timers | grep myjobhunter
+# expected: next run at 02:00 tomorrow
+
+sudo journalctl -u myjobhunter-backup.service --since "1 hour ago"
+# expected: clean log + "DB backup created: ..."
+```
+
+### Option B: crontab
+
+Add to root's crontab (`sudo crontab -e`):
+```cron
+0 2 * * * /srv/myfreeapps/apps/myjobhunter/deploy/backup.sh
+```
+
+Then verify:
+```bash
+ls -la /srv/myfreeapps/apps/myjobhunter/backups/
+# expected: at least one .sql.gz file the morning after install
+```
+
+## Manual backup (run anytime)
+
+```bash
+sudo /srv/myfreeapps/apps/myjobhunter/deploy/backup.sh
+```
+
+The script is idempotent (no harm in running multiple times in a day —
+each gets its own timestamped filename).
+
+## Restore from a backup
+
+**WARNING: this is destructive — the existing DB contents are dropped.**
+
+```bash
+# Stop the api + worker containers so nothing tries to write during restore
+cd /srv/myfreeapps/apps/myjobhunter
+docker compose stop api resume-parser
+
+# Pick the backup to restore
+BACKUP_FILE=/srv/myfreeapps/apps/myjobhunter/backups/myjobhunter_20260505_020000.sql.gz
+
+# Drop + recreate the DB inside the postgres container
+docker compose exec -T postgres psql -U myjobhunter -c "DROP DATABASE IF EXISTS myjobhunter_restore_tmp;"
+docker compose exec -T postgres psql -U myjobhunter -c "CREATE DATABASE myjobhunter_restore_tmp;"
+
+# Stream the backup in
+gunzip -c "$BACKUP_FILE" | docker compose exec -T postgres psql -U myjobhunter myjobhunter_restore_tmp
+
+# If the restore looks good (run sanity queries against myjobhunter_restore_tmp first):
+docker compose exec -T postgres psql -U myjobhunter -c "DROP DATABASE myjobhunter;"
+docker compose exec -T postgres psql -U myjobhunter -c "ALTER DATABASE myjobhunter_restore_tmp RENAME TO myjobhunter;"
+
+# Restart the app
+docker compose start api resume-parser
+```
+
+## Smoke test the backup right after installing
+
+After running steps in Option A or B, manually trigger one run to confirm everything works:
+
+```bash
+# systemd timer:
+sudo systemctl start myjobhunter-backup.service
+sudo journalctl -u myjobhunter-backup.service -f
+# Ctrl+C once you see "DB backup created"
+
+# Or directly:
+sudo /srv/myfreeapps/apps/myjobhunter/deploy/backup.sh
+ls -la /srv/myfreeapps/apps/myjobhunter/backups/
+```
+
+## Off-host replication (recommended)
+
+This script writes to local disk only. If the VPS volume is lost, you
+lose all backups. Replicate to a remote location nightly:
+
+- **Cheapest**: `rclone sync /srv/myfreeapps/apps/myjobhunter/backups/ b2:my-bucket/myjobhunter-backups/`
+- **AWS**: `aws s3 sync ...`
+
+Add as a second cron entry / second systemd timer that fires after the local
+backup completes (e.g., 02:30).

--- a/apps/myjobhunter/deploy/backup.sh
+++ b/apps/myjobhunter/deploy/backup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# MyJobHunter Database + MinIO Backup Script
+#
+# Run on the VPS via systemd timer (apps/myjobhunter/deploy/myjobhunter-backup.timer)
+# OR via crontab (`0 2 * * * /srv/myfreeapps/apps/myjobhunter/deploy/backup.sh`).
+#
+# Mirrors apps/mybookkeeper/deploy/backup.sh with two intentional divergences:
+#   1. MJH's postgres runs INSIDE docker (whereas MBK runs PG natively on
+#      the host). pg_dump is invoked via `docker compose exec` so the
+#      script works without installing PG client tools on the VPS.
+#   2. MJH's MinIO is shared infra (apps/../infra/docker-compose.yml owns
+#      the myfreeapps-minio container), so the bucket-level backup belongs
+#      with the infra layer — NOT this per-app script. We only back up the
+#      DB here.
+
+set -euo pipefail
+
+# Resolve absolute path so this script works regardless of CWD when invoked
+# via cron / systemd. SCRIPT_DIR points at apps/myjobhunter/deploy/.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+COMPOSE_FILE="$APP_DIR/docker-compose.yml"
+ENV_FILE="$APP_DIR/.env"
+
+BACKUP_DIR="${BACKUP_DIR:-/srv/myfreeapps/apps/myjobhunter/backups}"
+DB_NAME="${DB_NAME:-myjobhunter}"
+DB_USER="${DB_USER:-myjobhunter}"
+RETENTION_DAYS="${RETENTION_DAYS:-30}"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="${BACKUP_DIR}/${DB_NAME}_${TIMESTAMP}.sql.gz"
+
+mkdir -p "$BACKUP_DIR"
+
+# pg_dump runs inside the postgres container so we don't need PG client
+# tools installed on the VPS. The container has direct local-socket
+# access to its own datadir, so no password / auth is needed.
+docker compose --env-file "$ENV_FILE" -f "$COMPOSE_FILE" exec -T postgres \
+    pg_dump -U "$DB_USER" "$DB_NAME" | gzip > "$BACKUP_FILE"
+
+if [ ! -s "$BACKUP_FILE" ]; then
+    echo "ERROR: Backup file is empty — $BACKUP_FILE" >&2
+    rm -f "$BACKUP_FILE"
+    exit 1
+fi
+
+echo "DB backup created: $BACKUP_FILE ($(du -h "$BACKUP_FILE" | cut -f1))"
+
+# Clean up old backups beyond retention.
+find "$BACKUP_DIR" -name "${DB_NAME}_*.sql.gz" -mtime +"${RETENTION_DAYS}" -delete
+echo "Cleaned up backups older than ${RETENTION_DAYS} days"

--- a/apps/myjobhunter/deploy/myjobhunter-backup.service
+++ b/apps/myjobhunter/deploy/myjobhunter-backup.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=MyJobHunter database backup
+After=docker.service network-online.target
+Requires=docker.service
+# Don't start if the docker compose stack isn't running — postgres needs to be up.
+ConditionPathExists=/srv/myfreeapps/apps/myjobhunter/docker-compose.yml
+
+[Service]
+Type=oneshot
+WorkingDirectory=/srv/myfreeapps/apps/myjobhunter
+ExecStart=/srv/myfreeapps/apps/myjobhunter/deploy/backup.sh
+# Run as root because the script invokes `docker compose exec` which
+# requires socket access. If the operator has set up rootless docker
+# or added themselves to the docker group, change this to a less
+# privileged account.
+User=root
+StandardOutput=journal
+StandardError=journal

--- a/apps/myjobhunter/deploy/myjobhunter-backup.timer
+++ b/apps/myjobhunter/deploy/myjobhunter-backup.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=MyJobHunter daily database backup at 2 AM
+
+[Timer]
+# Run daily at 02:00 local time. Persistent=true so a backup runs on
+# the next boot if the VPS was offline at 02:00 (e.g., post-reboot,
+# post-deploy).
+OnCalendar=*-*-* 02:00:00
+Persistent=true
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Closes the MJH→MBK backup-automation gap. systemd timer + script + recovery docs all included.

Two divergences from MBK's script: uses 'docker compose exec postgres pg_dump' (MJH PG is containerized), and does NOT back up MinIO (shared infra owns that).

## ⚠️ Operational migration required

After merge, install the systemd unit files on the VPS:

```
sudo cp /srv/myfreeapps/apps/myjobhunter/deploy/myjobhunter-backup.{service,timer} /etc/systemd/system/
sudo systemctl daemon-reload
sudo systemctl enable --now myjobhunter-backup.timer
```

Then verify with `sudo systemctl list-timers | grep myjobhunter`.

Closes task #83.

🤖 Generated with [Claude Code](https://claude.com/claude-code)