### PR TITLE
feat(myjobhunter): resume refinement — iterative AI critique + rewrite

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/refine260505_resume_refinement.py
+++ b/apps/myjobhunter/backend/alembic/versions/refine260505_resume_refinement.py
@@ -1,0 +1,150 @@
+"""resume_refinement_sessions + resume_refinement_turns tables.
+
+The resume-refinement feature is an iterative chat-style critique +
+rewrite loop. Each session holds a live working markdown document and
+a pointer into a list of improvement targets produced by an initial
+critique pass. Each user/AI interaction is recorded as a turn for
+auditability and for the "show me another option" affordance.
+
+Revision ID: refine260505
+Revises: role260505
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+revision: str = "refine260505"
+down_revision: Union[str, None] = "role260505"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "resume_refinement_sessions",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "source_resume_job_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("resume_upload_jobs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("status", sa.String(20), nullable=False, server_default="active"),
+        sa.Column("current_draft", sa.Text, nullable=False, server_default=""),
+        # Improvement-target metadata produced by the critique pass and
+        # consumed turn-by-turn during the rewrite loop.
+        sa.Column("improvement_targets", JSONB, nullable=True),
+        sa.Column("target_index", sa.Integer, nullable=False, server_default="0"),
+        # Pending proposal state — populated when the AI emits a proposal
+        # and cleared when the user accepts/replaces/skips.
+        sa.Column("pending_target_section", sa.Text, nullable=True),
+        sa.Column("pending_proposal", sa.Text, nullable=True),
+        sa.Column("pending_rationale", sa.Text, nullable=True),
+        sa.Column("pending_clarifying_question", sa.Text, nullable=True),
+        # Counters for cost / activity tracking.
+        sa.Column("turn_count", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("total_tokens_in", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("total_tokens_out", sa.Integer, nullable=False, server_default="0"),
+        sa.Column(
+            "total_cost_usd",
+            sa.Numeric(10, 6),
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "status IN ('active','completed','abandoned')",
+            name="chk_refinement_session_status",
+        ),
+    )
+    op.create_index(
+        "ix_refinement_session_user",
+        "resume_refinement_sessions",
+        ["user_id"],
+    )
+    op.create_index(
+        "ix_refinement_session_user_status",
+        "resume_refinement_sessions",
+        ["user_id", "status"],
+    )
+
+    op.create_table(
+        "resume_refinement_turns",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "session_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("resume_refinement_sessions.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("turn_index", sa.Integer, nullable=False),
+        sa.Column("role", sa.String(40), nullable=False),
+        sa.Column("target_section", sa.Text, nullable=True),
+        sa.Column("proposed_text", sa.Text, nullable=True),
+        sa.Column("user_text", sa.Text, nullable=True),
+        sa.Column("rationale", sa.Text, nullable=True),
+        sa.Column("clarifying_question", sa.Text, nullable=True),
+        sa.Column("draft_after", sa.Text, nullable=True),
+        sa.Column("tokens_in", sa.Integer, nullable=False, server_default="0"),
+        sa.Column("tokens_out", sa.Integer, nullable=False, server_default="0"),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            "role IN ("
+            "'ai_critique',"
+            "'ai_proposal',"
+            "'user_accept',"
+            "'user_custom',"
+            "'user_request_alternative',"
+            "'user_skip',"
+            "'session_complete'"
+            ")",
+            name="chk_refinement_turn_role",
+        ),
+    )
+    op.create_index(
+        "ix_refinement_turn_session",
+        "resume_refinement_turns",
+        ["session_id", "turn_index"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_refinement_turn_session", table_name="resume_refinement_turns",
+    )
+    op.drop_table("resume_refinement_turns")
+    op.drop_index(
+        "ix_refinement_session_user_status",
+        table_name="resume_refinement_sessions",
+    )
+    op.drop_index(
+        "ix_refinement_session_user",
+        table_name="resume_refinement_sessions",
+    )
+    op.drop_table("resume_refinement_sessions")

--- a/apps/myjobhunter/backend/app/api/resume_refinement.py
+++ b/apps/myjobhunter/backend/app/api/resume_refinement.py
@@ -1,0 +1,230 @@
+"""Resume-refinement API.
+
+Endpoints:
+
+POST   /resume-refinement/sessions                          start a new session
+GET    /resume-refinement/sessions                          list user's sessions
+GET    /resume-refinement/sessions/{id}                     read session state
+POST   /resume-refinement/sessions/{id}/accept              accept pending proposal
+POST   /resume-refinement/sessions/{id}/custom              supply custom rewrite
+POST   /resume-refinement/sessions/{id}/alternative         regenerate same target
+POST   /resume-refinement/sessions/{id}/skip                skip current target
+POST   /resume-refinement/sessions/{id}/complete            mark session done
+GET    /resume-refinement/sessions/{id}/export?format=pdf|docx   download document
+
+All routes require auth and are tenant-scoped on the session ``user_id``.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Literal
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import Response
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import current_active_user
+from app.db.session import get_db
+from app.models.user.user import User
+from app.schemas.resume_refinement.session import (
+    SessionRead,
+    SessionStartRequest,
+    TurnAlternativeRequest,
+    TurnCustomRequest,
+)
+from app.services.resume_refinement import session_service
+from app.services.resume_refinement.errors import (
+    NoMoreTargets,
+    NoPendingProposal,
+    SessionNotActive,
+    SessionNotFound,
+    SourceJobNotFound,
+    SourceJobNotReady,
+    CritiqueRetryExceeded,
+)
+from app.services.resume_refinement.export_service import (
+    ExportFidelityError,
+    export_resume,
+)
+
+router = APIRouter(prefix="/resume-refinement", tags=["resume-refinement"])
+
+
+@router.post("/sessions", response_model=SessionRead, status_code=201)
+async def start_session(
+    body: SessionStartRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionRead:
+    """Start a new refinement session from a completed resume upload."""
+    try:
+        session = await session_service.start_session(
+            db=db,
+            user_id=user.id,
+            source_resume_job_id=body.source_resume_job_id,
+        )
+    except SourceJobNotFound as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except SourceJobNotReady as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except CritiqueRetryExceeded as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return SessionRead.model_validate(session)
+
+
+@router.get("/sessions/{session_id}", response_model=SessionRead)
+async def get_session(
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionRead:
+    try:
+        session = await session_service.get_session_state(
+            db=db, user_id=user.id, session_id=session_id,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    return SessionRead.model_validate(session)
+
+
+@router.post("/sessions/{session_id}/accept", response_model=SessionRead)
+async def accept_pending(
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionRead:
+    try:
+        session = await session_service.accept_pending(
+            db=db, user_id=user.id, session_id=session_id,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except NoPendingProposal as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return SessionRead.model_validate(session)
+
+
+@router.post("/sessions/{session_id}/custom", response_model=SessionRead)
+async def supply_custom(
+    session_id: uuid.UUID,
+    body: TurnCustomRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionRead:
+    try:
+        session = await session_service.accept_custom(
+            db=db,
+            user_id=user.id,
+            session_id=session_id,
+            user_text=body.user_text,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except NoMoreTargets as exc:
+        raise HTTPException(status_code=409, detail="No remaining targets to rewrite") from exc
+    return SessionRead.model_validate(session)
+
+
+@router.post("/sessions/{session_id}/alternative", response_model=SessionRead)
+async def request_alternative(
+    session_id: uuid.UUID,
+    body: TurnAlternativeRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionRead:
+    try:
+        session = await session_service.request_alternative(
+            db=db,
+            user_id=user.id,
+            session_id=session_id,
+            hint=body.hint,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except NoMoreTargets as exc:
+        raise HTTPException(status_code=409, detail="No remaining targets to rewrite") from exc
+    return SessionRead.model_validate(session)
+
+
+@router.post("/sessions/{session_id}/skip", response_model=SessionRead)
+async def skip_target(
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionRead:
+    try:
+        session = await session_service.skip_target(
+            db=db, user_id=user.id, session_id=session_id,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return SessionRead.model_validate(session)
+
+
+@router.post("/sessions/{session_id}/complete", response_model=SessionRead)
+async def complete_session(
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionRead:
+    try:
+        session = await session_service.complete_session(
+            db=db, user_id=user.id, session_id=session_id,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return SessionRead.model_validate(session)
+
+
+@router.get("/sessions/{session_id}/export")
+async def export_session(
+    session_id: uuid.UUID,
+    fmt: Literal["pdf", "docx"] = Query(..., alias="format"),
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> Response:
+    """Render the current draft to PDF or DOCX and return it as a download."""
+    try:
+        session = await session_service.get_session_state(
+            db=db, user_id=user.id, session_id=session_id,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+
+    draft = session.current_draft or ""
+    if not draft.strip():
+        raise HTTPException(status_code=409, detail="Session draft is empty")
+
+    try:
+        data = await export_resume(draft, fmt)
+    except ExportFidelityError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"export_fidelity_check_failed: {exc.missing_facts[:5]}",
+        ) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    media_type = (
+        "application/pdf"
+        if fmt == "pdf"
+        else "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+    )
+    filename = f"resume.{fmt}"
+    return Response(
+        content=data,
+        media_type=media_type,
+        headers={
+            "Content-Disposition": f'attachment; filename="{filename}"',
+        },
+    )

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -11,7 +11,7 @@ from jwt.exceptions import PyJWTError as JWTError
 
 from platform_shared.core.lifespan import create_app_lifespan
 
-from app.api import account, admin, applications, companies, documents, health, integrations, profile, resumes, totp
+from app.api import account, admin, applications, companies, documents, health, integrations, profile, resume_refinement, resumes, totp
 from app.core.audit import current_user_id
 from app.core.auth import auth_backend, fastapi_users
 from app.core.config import settings
@@ -180,6 +180,7 @@ app.include_router(integrations.router, tags=["integrations"])
 app.include_router(resumes.router, tags=["resumes"])
 app.include_router(documents.router)
 app.include_router(admin.router)
+app.include_router(resume_refinement.router)
 
 # TOTP routes — the /login subroute gets the per-IP throttle (matching the
 # guard on /auth/jwt/login). Account lockout is enforced INSIDE

--- a/apps/myjobhunter/backend/app/models/__init__.py
+++ b/apps/myjobhunter/backend/app/models/__init__.py
@@ -22,6 +22,9 @@ from app.models.integration.job_board_credential import JobBoardCredential  # no
 
 from app.models.jobs.resume_upload_job import ResumeUploadJob  # noqa: F401
 
+from app.models.resume_refinement.session import ResumeRefinementSession  # noqa: F401
+from app.models.resume_refinement.turn import ResumeRefinementTurn  # noqa: F401
+
 from app.models.system.extraction_log import ExtractionLog  # noqa: F401
 
 # Shared models from platform_shared. Importing them here registers their

--- a/apps/myjobhunter/backend/app/models/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/models/resume_refinement/session.py
@@ -1,0 +1,110 @@
+"""ResumeRefinementSession — live working document for the resume-refinement loop.
+
+A session ties a user to a source resume upload and tracks the
+markdown draft, the prioritized improvement targets, the pending AI
+proposal, and per-session token / cost counters.
+
+Status values: ``active`` (default), ``completed`` (user marked done),
+``abandoned`` (user explicitly walked away or auto-aged out).
+"""
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    Numeric,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class ResumeRefinementSession(Base):
+    __tablename__ = "resume_refinement_sessions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    # Optional FK to the resume the user originally uploaded. Nullable so
+    # the session survives the upload row being deleted; the session
+    # still has its own ``current_draft`` to operate on.
+    source_resume_job_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("resume_upload_jobs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    status: Mapped[str] = mapped_column(String(20), default="active", nullable=False)
+
+    # The live working markdown document. Updated whenever a user accepts
+    # an AI proposal or supplies a custom rewrite for the current target.
+    current_draft: Mapped[str] = mapped_column(Text, default="", nullable=False)
+
+    # Output of the initial critique pass: ordered list of
+    # {section, current_text, improvement_type, severity} dicts.
+    improvement_targets: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+
+    # Pointer into ``improvement_targets`` — increments after each turn
+    # the user accepts / overrides / skips.
+    target_index: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    # Pending AI proposal state. Populated when ``advance_session`` emits
+    # a proposal and cleared when the user accepts / overrides / skips.
+    pending_target_section: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pending_proposal: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pending_rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
+    pending_clarifying_question: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    turn_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_tokens_in: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_tokens_out: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    total_cost_usd: Mapped[Decimal] = mapped_column(
+        Numeric(10, 6), default=Decimal("0"), nullable=False,
+    )
+
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
+
+    turns: Mapped[list["ResumeRefinementTurn"]] = relationship(  # type: ignore[name-defined]
+        "ResumeRefinementTurn",
+        back_populates="session",
+        cascade="all, delete-orphan",
+        order_by="ResumeRefinementTurn.turn_index",
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('active','completed','abandoned')",
+            name="chk_refinement_session_status",
+        ),
+        Index("ix_refinement_session_user_status", "user_id", "status"),
+    )

--- a/apps/myjobhunter/backend/app/models/resume_refinement/turn.py
+++ b/apps/myjobhunter/backend/app/models/resume_refinement/turn.py
@@ -1,0 +1,100 @@
+"""ResumeRefinementTurn — single record in the iterative refinement loop.
+
+Each turn is one AI proposal or one user action. Snapshots the draft
+state after the turn so historical replay / undo is possible.
+
+Roles:
+- ``ai_critique`` — the initial pass that produces improvement_targets
+  for the session. One per session.
+- ``ai_proposal`` — Claude proposes a rewrite for the current target.
+- ``user_accept`` — user accepts the AI proposal as-is.
+- ``user_custom`` — user supplies their own rewrite for the current target.
+- ``user_request_alternative`` — user asks Claude for a different proposal
+  for the same target.
+- ``user_skip`` — user skips the current target without modifying it.
+- ``session_complete`` — terminal turn; user marked the session done.
+"""
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class ResumeRefinementTurn(Base):
+    __tablename__ = "resume_refinement_turns"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    session_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("resume_refinement_sessions.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    turn_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    role: Mapped[str] = mapped_column(String(40), nullable=False)
+
+    # Description of which section/bullet this turn targets, e.g.
+    # "Senior Software Engineer @ Acme — bullet 2".
+    target_section: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # The AI's proposed rewrite (when role=ai_proposal).
+    proposed_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # The user's custom rewrite (when role=user_custom).
+    user_text: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # The AI's rationale for the proposal (when role=ai_proposal).
+    rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # If the AI couldn't propose without clarification, the question it
+    # asked the user. (Populated instead of proposed_text.)
+    clarifying_question: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Snapshot of the resume markdown after this turn. Lets us replay
+    # the session and supports a future "undo to this turn" feature.
+    draft_after: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    tokens_in: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    tokens_out: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    session: Mapped["ResumeRefinementSession"] = relationship(  # type: ignore[name-defined]
+        "ResumeRefinementSession",
+        back_populates="turns",
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "role IN ("
+            "'ai_critique',"
+            "'ai_proposal',"
+            "'user_accept',"
+            "'user_custom',"
+            "'user_request_alternative',"
+            "'user_skip',"
+            "'session_complete'"
+            ")",
+            name="chk_refinement_turn_role",
+        ),
+        Index("ix_refinement_turn_session", "session_id", "turn_index"),
+    )

--- a/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
@@ -1,0 +1,205 @@
+"""Data-access layer for resume_refinement_sessions.
+
+Every read/write is tenant-scoped on ``user_id`` — callers must never
+omit it. Service-layer helpers live in
+``app.services.resume_refinement.session_service`` and orchestrate the
+critique + rewrite loop on top of these primitives.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.resume_refinement.session import ResumeRefinementSession
+
+_RECENT_LIMIT = 25
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    source_resume_job_id: uuid.UUID | None,
+    initial_draft: str,
+) -> ResumeRefinementSession:
+    """Insert a new active session and return the persisted row."""
+    session = ResumeRefinementSession(
+        user_id=user_id,
+        source_resume_job_id=source_resume_job_id,
+        current_draft=initial_draft,
+        status="active",
+    )
+    db.add(session)
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def get_by_id_for_user(
+    db: AsyncSession,
+    session_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ResumeRefinementSession | None:
+    """Return a session scoped to the given user, or None."""
+    result = await db.execute(
+        select(ResumeRefinementSession).where(
+            ResumeRefinementSession.id == session_id,
+            ResumeRefinementSession.user_id == user_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def get_with_turns_for_user(
+    db: AsyncSession,
+    session_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ResumeRefinementSession | None:
+    """Return a session with its turns eagerly loaded."""
+    result = await db.execute(
+        select(ResumeRefinementSession)
+        .options(selectinload(ResumeRefinementSession.turns))
+        .where(
+            ResumeRefinementSession.id == session_id,
+            ResumeRefinementSession.user_id == user_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_recent_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> list[ResumeRefinementSession]:
+    """Return up to 25 sessions for the user, newest first."""
+    result = await db.execute(
+        select(ResumeRefinementSession)
+        .where(ResumeRefinementSession.user_id == user_id)
+        .order_by(ResumeRefinementSession.created_at.desc())
+        .limit(_RECENT_LIMIT)
+    )
+    return list(result.scalars().all())
+
+
+async def get_active_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+) -> ResumeRefinementSession | None:
+    """Return the user's most recent active session, or None."""
+    result = await db.execute(
+        select(ResumeRefinementSession)
+        .where(
+            ResumeRefinementSession.user_id == user_id,
+            ResumeRefinementSession.status == "active",
+        )
+        .order_by(ResumeRefinementSession.created_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def update_critique(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    improvement_targets: list[dict],
+    tokens_in: int,
+    tokens_out: int,
+    cost_usd: Decimal,
+) -> ResumeRefinementSession:
+    """Persist the initial critique pass output."""
+    session.improvement_targets = improvement_targets
+    session.target_index = 0
+    session.turn_count += 1
+    session.total_tokens_in += tokens_in
+    session.total_tokens_out += tokens_out
+    session.total_cost_usd = (session.total_cost_usd or Decimal("0")) + cost_usd
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def update_pending_proposal(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    target_section: str | None,
+    proposal: str | None,
+    rationale: str | None,
+    clarifying_question: str | None,
+    tokens_in: int,
+    tokens_out: int,
+    cost_usd: Decimal,
+) -> ResumeRefinementSession:
+    """Set the pending AI proposal on the session and bump counters."""
+    session.pending_target_section = target_section
+    session.pending_proposal = proposal
+    session.pending_rationale = rationale
+    session.pending_clarifying_question = clarifying_question
+    session.turn_count += 1
+    session.total_tokens_in += tokens_in
+    session.total_tokens_out += tokens_out
+    session.total_cost_usd = (session.total_cost_usd or Decimal("0")) + cost_usd
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def apply_user_resolution(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    new_draft: str,
+    advance_target: bool,
+) -> ResumeRefinementSession:
+    """Clear pending state, persist the new draft, optionally bump target_index."""
+    session.current_draft = new_draft
+    session.pending_target_section = None
+    session.pending_proposal = None
+    session.pending_rationale = None
+    session.pending_clarifying_question = None
+    if advance_target:
+        session.target_index += 1
+    session.turn_count += 1
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def mark_completed(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+) -> ResumeRefinementSession:
+    """Mark the session ``completed`` and stamp ``completed_at``."""
+    session.status = "completed"
+    session.completed_at = datetime.now(timezone.utc)
+    session.pending_target_section = None
+    session.pending_proposal = None
+    session.pending_rationale = None
+    session.pending_clarifying_question = None
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def mark_abandoned(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+) -> ResumeRefinementSession:
+    """Mark the session ``abandoned`` (user explicitly walked away)."""
+    session.status = "abandoned"
+    session.completed_at = datetime.now(timezone.utc)
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session

--- a/apps/myjobhunter/backend/app/repositories/resume_refinement/turn_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/resume_refinement/turn_repo.py
@@ -1,0 +1,62 @@
+"""Data-access layer for resume_refinement_turns.
+
+Turns are append-only — once written they're never updated. Each user
+or AI action in a session writes a new row.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.resume_refinement.turn import ResumeRefinementTurn
+
+
+async def append(
+    db: AsyncSession,
+    *,
+    session_id: uuid.UUID,
+    turn_index: int,
+    role: str,
+    target_section: str | None = None,
+    proposed_text: str | None = None,
+    user_text: str | None = None,
+    rationale: str | None = None,
+    clarifying_question: str | None = None,
+    draft_after: str | None = None,
+    tokens_in: int = 0,
+    tokens_out: int = 0,
+) -> ResumeRefinementTurn:
+    """Insert one turn row and return it."""
+    turn = ResumeRefinementTurn(
+        session_id=session_id,
+        turn_index=turn_index,
+        role=role,
+        target_section=target_section,
+        proposed_text=proposed_text,
+        user_text=user_text,
+        rationale=rationale,
+        clarifying_question=clarifying_question,
+        draft_after=draft_after,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+    )
+    db.add(turn)
+    await db.flush()
+    await db.commit()
+    await db.refresh(turn)
+    return turn
+
+
+async def list_for_session(
+    db: AsyncSession,
+    session_id: uuid.UUID,
+) -> list[ResumeRefinementTurn]:
+    """Return every turn for a session, oldest first."""
+    result = await db.execute(
+        select(ResumeRefinementTurn)
+        .where(ResumeRefinementTurn.session_id == session_id)
+        .order_by(ResumeRefinementTurn.turn_index.asc())
+    )
+    return list(result.scalars().all())

--- a/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
@@ -1,0 +1,124 @@
+"""Pydantic schemas for the resume-refinement feature."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ImprovementTarget(BaseModel):
+    """One entry in the prioritized critique list.
+
+    Produced by the initial critique pass. The rewrite loop walks the
+    list in order, generating one proposal per target.
+    """
+
+    section: str = Field(..., description="Section/bullet identifier — e.g. 'Senior SWE @ Acme — bullet 2'.")
+    current_text: str = Field(..., description="Verbatim text from the source resume.")
+    improvement_type: Literal[
+        "add_metric",
+        "add_outcome",
+        "tighten_phrasing",
+        "remove_jargon",
+        "stronger_verb",
+        "add_scope",
+        "fix_grammar",
+        "other",
+    ] = Field(..., description="Why this section needs work.")
+    severity: Literal["critical", "high", "medium", "low"] = Field(
+        ..., description="Priority for the rewrite loop ordering.",
+    )
+    notes: str | None = Field(
+        default=None,
+        description="Critique pass's free-form notes about why this target matters.",
+    )
+
+
+class TurnRead(BaseModel):
+    id: uuid.UUID
+    turn_index: int
+    role: str
+    target_section: str | None = None
+    proposed_text: str | None = None
+    user_text: str | None = None
+    rationale: str | None = None
+    clarifying_question: str | None = None
+    created_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class SessionRead(BaseModel):
+    id: uuid.UUID
+    source_resume_job_id: uuid.UUID | None = None
+    status: str
+    current_draft: str
+    improvement_targets: list[ImprovementTarget] | None = None
+    target_index: int
+    pending_target_section: str | None = None
+    pending_proposal: str | None = None
+    pending_rationale: str | None = None
+    pending_clarifying_question: str | None = None
+    turn_count: int
+    total_tokens_in: int
+    total_tokens_out: int
+    total_cost_usd: Decimal
+    completed_at: datetime | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class SessionWithTurnsRead(SessionRead):
+    turns: list[TurnRead] = Field(default_factory=list)
+
+
+class SessionStartRequest(BaseModel):
+    """Start a new refinement session from a previously-uploaded resume.
+
+    The source job must be ``status='complete'`` so we have parsed
+    fields to render into the initial markdown draft.
+    """
+
+    source_resume_job_id: uuid.UUID = Field(
+        ...,
+        description="ID of an existing ``resume_upload_jobs`` row, status=complete.",
+    )
+
+
+class TurnAcceptRequest(BaseModel):
+    """User accepts the pending AI proposal as-is."""
+
+    pass
+
+
+class TurnCustomRequest(BaseModel):
+    """User supplies their own rewrite instead of the AI proposal."""
+
+    user_text: str = Field(..., min_length=1, max_length=4000)
+
+
+class TurnAlternativeRequest(BaseModel):
+    """User asks Claude for a different proposal for the same target.
+
+    Optional ``hint`` lets the user nudge the regenerated proposal
+    (e.g. "make it more concise", "emphasize technical leadership").
+    """
+
+    hint: str | None = Field(default=None, max_length=500)
+
+
+class TurnSkipRequest(BaseModel):
+    """User skips the current target without modifying it."""
+
+    pass
+
+
+class SessionCompleteRequest(BaseModel):
+    """User marks the session done. Locks the current_draft."""
+
+    pass

--- a/apps/myjobhunter/backend/app/services/extraction/claude_service.py
+++ b/apps/myjobhunter/backend/app/services/extraction/claude_service.py
@@ -19,6 +19,7 @@ import logging
 import time
 import uuid
 from datetime import datetime, timezone
+from decimal import Decimal
 
 import anthropic
 from anthropic import Timeout
@@ -81,6 +82,36 @@ async def call_claude(
         anthropic.APIError: on non-retryable API failures after backoff.
         ValueError: when Claude returns malformed JSON after all retries.
     """
+    result = await call_claude_with_meta(
+        system_prompt=system_prompt,
+        user_content=user_content,
+        context_type=context_type,
+        user_id=user_id,
+        context_id=context_id,
+    )
+    return result["parsed"]
+
+
+async def call_claude_with_meta(
+    *,
+    system_prompt: str,
+    user_content: str,
+    context_type: str,
+    user_id: uuid.UUID,
+    context_id: uuid.UUID | None = None,
+) -> dict:
+    """Same as ``call_claude`` but returns parsed + token + cost meta.
+
+    Returns a dict with keys:
+        - ``parsed``: dict — the parsed JSON response.
+        - ``input_tokens``: int — usage.input_tokens (0 if unavailable).
+        - ``output_tokens``: int — usage.output_tokens (0 if unavailable).
+        - ``cost_usd``: Decimal — computed via the same pricing used by
+          ``_record_log``.
+
+    Used by the resume-refinement service to track per-session token /
+    cost totals on the session row.
+    """
     truncated = user_content[:_MAX_TEXT_CHARS]
     started_at = time.monotonic()
     status = "success"
@@ -101,7 +132,16 @@ async def call_claude(
                 "content": truncated,
             }],
         )
-        return _parse_json_response(message)
+        parsed = _parse_json_response(message)
+        input_tokens = message.usage.input_tokens if message and message.usage else 0
+        output_tokens = message.usage.output_tokens if message and message.usage else 0
+        cost_usd = Decimal(input_tokens * 3 + output_tokens * 15) / Decimal(1_000_000)
+        return {
+            "parsed": parsed,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+        }
     except Exception as exc:
         status = "error"
         error_message = str(exc)[:500]

--- a/apps/myjobhunter/backend/app/services/extraction/prompts/resume_critique_prompt.py
+++ b/apps/myjobhunter/backend/app/services/extraction/prompts/resume_critique_prompt.py
@@ -1,0 +1,76 @@
+"""System prompt for the initial resume-critique pass.
+
+Walks the entire resume markdown and produces a prioritized list of
+improvement targets. Each target is a single bullet/section that the
+follow-up rewrite pass will work on one at a time.
+
+This prompt does NOT modify the resume — it only IDENTIFIES targets.
+The rewrite happens in a separate per-target call (see
+``resume_rewrite_prompt.py``).
+"""
+
+RESUME_CRITIQUE_PROMPT = """\
+You are a resume coach. Read the resume markdown supplied by the user and \
+produce a prioritized list of specific, actionable improvement targets.
+
+Return ONLY valid JSON — no prose, no markdown, no code fences, no explanation. \
+Return the JSON object directly.
+
+# Output schema
+
+{
+  "targets": [
+    {
+      "section": "string — short identifier for the bullet/section being targeted, \
+e.g. 'Senior Software Engineer @ Acme — bullet 2' or 'Education — degree line' \
+or 'Summary'. Must be specific enough that a human reading the original resume \
+can identify the exact text.",
+      "current_text": "string — the verbatim text from the source markdown (the \
+single bullet, single sentence, or single line you intend to rewrite). Must be \
+copyable into a string literal — no leading bullet markers like '- '.",
+      "improvement_type": "one of: add_metric | add_outcome | tighten_phrasing | \
+remove_jargon | stronger_verb | add_scope | fix_grammar | other",
+      "severity": "one of: critical | high | medium | low",
+      "notes": "string or null — why this target needs work. One sentence."
+    }
+  ]
+}
+
+# Rules
+
+- Identify between 5 and 15 targets — the highest-leverage ones for an \
+ATS-readable, hiring-manager-friendly resume.
+- Order targets by severity (``critical`` first), then by their position in \
+the resume (top-to-bottom).
+- ``current_text`` MUST be a verbatim copy from the resume. Do NOT paraphrase. \
+If the bullet has a leading dash or asterisk, omit the marker but keep the \
+content exactly.
+- ``improvement_type`` rubric:
+  - ``add_metric`` — bullet describes activity but no measurable outcome \
+(e.g. "improved performance" without a percent or time).
+  - ``add_outcome`` — bullet describes work but no business / user / team \
+outcome (e.g. "led migration" without saying what shipped or what changed).
+  - ``tighten_phrasing`` — bullet is wordy / passive / has filler words.
+  - ``remove_jargon`` — bullet uses corporate jargon, buzzwords, or vague \
+phrases ("synergy", "leveraged", "drove value").
+  - ``stronger_verb`` — bullet uses a weak verb ("worked on", "helped with", \
+"was responsible for").
+  - ``add_scope`` — bullet describes activity without scope context (team \
+size, system size, traffic level, dollar amount).
+  - ``fix_grammar`` — typo, tense inconsistency, or grammatical error.
+  - ``other`` — anything else that warrants a rewrite.
+- ``severity`` rubric:
+  - ``critical`` — typos, factual errors, or bullets that would actively \
+hurt the candidate.
+  - ``high`` — vague bullets that don't communicate impact (a hiring manager \
+won't know what was achieved).
+  - ``medium`` — wordy bullets, weak verbs, or fixable jargon.
+  - ``low`` — minor stylistic improvements.
+- Do NOT critique the section ordering, layout, or formatting — only the \
+content of bullets / lines.
+- Do NOT critique factual content (don't say "this role looks short"). Trust \
+the source.
+- Do NOT propose specific rewrites here — that is the next pass's job.
+- If the resume is empty or has no obvious improvement targets, return \
+``{"targets": []}``.
+"""

--- a/apps/myjobhunter/backend/app/services/extraction/prompts/resume_rewrite_prompt.py
+++ b/apps/myjobhunter/backend/app/services/extraction/prompts/resume_rewrite_prompt.py
@@ -1,0 +1,101 @@
+"""System prompt for the per-target rewrite pass.
+
+Given (a) the full resume markdown for context, (b) a single target
+identified by the critique pass, and (c) optional user hint, produces
+ONE rewritten version + a short rationale. If the source is too
+ambiguous to rewrite without inventing facts, asks the user for
+clarification instead.
+
+This prompt fires repeatedly through the iteration loop — once per
+target, plus once more whenever the user clicks "show me another
+option" for the same target.
+"""
+
+RESUME_REWRITE_PROMPT = """\
+You are a resume coach. The user is iterating on a resume one bullet at a \
+time. You are given:
+
+1. The full resume markdown for context.
+2. A single target identified by an earlier critique pass.
+3. (Optional) a hint from the user — a free-form nudge like \
+"make it more concise" or "emphasize technical leadership".
+
+Your job: produce ONE rewrite of the target, OR (if the source is too \
+ambiguous to rewrite without inventing facts) ask ONE clarifying question.
+
+Return ONLY valid JSON — no prose, no markdown, no code fences, no \
+explanation. Return the JSON object directly.
+
+# Output schema
+
+You return EITHER a proposal:
+
+{
+  "kind": "proposal",
+  "rewritten_text": "string — the rewritten bullet/sentence. Use only the \
+constrained markdown subset (see Rules). Single line. No leading dash. No \
+trailing period unless the source had one.",
+  "rationale": "string — 1-2 sentences explaining what changed and why. \
+Conversational and warm — write like a peer reviewing a draft, not a \
+formal style guide."
+}
+
+OR a clarification request:
+
+{
+  "kind": "clarify",
+  "question": "string — one specific, answerable question. Do NOT ask \
+yes/no. Ask for the missing fact (a metric, an outcome, a scope, a \
+team size, a date)."
+}
+
+# Hard rules — preserve facts
+
+- NEVER invent companies, dates, job titles, school names, degrees, \
+team sizes, dollar amounts, percentages, or technologies that are not \
+already present in the resume.
+- NEVER add metrics ("increased revenue 40%") if the source has no \
+metric. If the bullet would be stronger with a metric and the source \
+has none, RETURN A CLARIFICATION QUESTION asking the user for it.
+- NEVER add scope ("led a team of 8") if the source doesn't say so.
+- You MAY rephrase verbs, restructure clauses, remove filler, swap \
+weak verbs for strong ones, and combine ideas — as long as no NEW facts \
+are introduced.
+- You MAY infer the implicit subject ("the team", "I") and tense \
+(past for non-current roles).
+
+# When to ask for clarification
+
+Always ask rather than guess when:
+- The source is missing a fact that would dramatically strengthen the \
+rewrite (e.g. "improved performance" — by how much?).
+- The source is ambiguous between two plausible rewrites (e.g. could \
+emphasize scope OR emphasize outcome) and you cannot tell which is the \
+better fit.
+- The source uses a domain-specific term that you cannot interpret \
+without more context (e.g. "owned the spine of platform X" — what is \
+the spine?).
+
+If the user provides a hint that resolves the ambiguity, use it.
+
+# Constrained markdown subset
+
+The rewritten text MUST use only:
+- plain text
+- ``**bold**`` (sparingly)
+- ``*italic*`` (sparingly)
+
+The rewritten text MUST NOT use:
+- headings (``#`` ``##``)
+- lists or bullet markers (``-`` ``*`` ``1.``) — the bullet wrapper is \
+added by the caller
+- tables, footnotes, code blocks, math, links, images, raw HTML
+
+# Tone
+
+- Conversational and warm — match the voice of a senior peer reviewer.
+- "Hmm, this bullet could be stronger if we knew the team size." \
+beats "INSUFFICIENT METRIC DETAIL."
+- The rationale field is the explanation the user reads; keep it \
+brief and specific.
+"""

--- a/apps/myjobhunter/backend/app/services/resume_refinement/critique_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/critique_service.py
@@ -1,0 +1,107 @@
+"""Critique service — runs the initial pass that produces improvement_targets.
+
+Called once per session at start. Walks the entire resume markdown and
+asks Claude for a prioritized list of bullet/section targets to
+rewrite. Output is persisted on the session row; the rewrite loop then
+walks the targets one at a time.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from app.services.extraction.claude_service import call_claude_with_meta
+from app.services.extraction.prompts.resume_critique_prompt import (
+    RESUME_CRITIQUE_PROMPT,
+)
+from app.services.resume_refinement.errors import CritiqueRetryExceeded
+
+logger = logging.getLogger(__name__)
+
+
+async def run_critique(
+    *,
+    resume_markdown: str,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> dict:
+    """Run the critique pass and return ``targets`` plus token meta.
+
+    Args:
+        resume_markdown: The current resume draft.
+        user_id: Scopes the extraction_log row.
+        session_id: Used as the ``context_id`` for the extraction_log.
+
+    Returns:
+        ``{"targets": [...], "input_tokens": int, "output_tokens": int,
+        "cost_usd": Decimal}``
+
+    Raises:
+        CritiqueRetryExceeded: when Claude returns no targets after the
+            single attempt. Caller should surface a user-actionable error.
+    """
+    result = await call_claude_with_meta(
+        system_prompt=RESUME_CRITIQUE_PROMPT,
+        user_content=f"Resume markdown:\n\n{resume_markdown}",
+        context_type="resume_critique",
+        user_id=user_id,
+        context_id=session_id,
+    )
+
+    parsed = result["parsed"]
+    raw_targets = parsed.get("targets") or []
+
+    cleaned = [_normalize_target(t) for t in raw_targets if isinstance(t, dict)]
+    cleaned = [t for t in cleaned if t is not None]
+
+    if not cleaned:
+        logger.warning(
+            "Critique pass returned no usable targets for session %s", session_id,
+        )
+        raise CritiqueRetryExceeded(
+            "Claude returned no improvement targets. The resume may already be polished."
+        )
+
+    return {
+        "targets": cleaned,
+        "input_tokens": result["input_tokens"],
+        "output_tokens": result["output_tokens"],
+        "cost_usd": result["cost_usd"],
+    }
+
+
+def _normalize_target(raw: dict) -> dict | None:
+    """Validate / clean one target dict. Returns None on missing required fields."""
+    section = (raw.get("section") or "").strip()
+    current_text = (raw.get("current_text") or "").strip()
+    if not section or not current_text:
+        return None
+
+    improvement_type = (raw.get("improvement_type") or "other").strip()
+    if improvement_type not in {
+        "add_metric",
+        "add_outcome",
+        "tighten_phrasing",
+        "remove_jargon",
+        "stronger_verb",
+        "add_scope",
+        "fix_grammar",
+        "other",
+    }:
+        improvement_type = "other"
+
+    severity = (raw.get("severity") or "medium").strip()
+    if severity not in {"critical", "high", "medium", "low"}:
+        severity = "medium"
+
+    notes = raw.get("notes")
+    if notes is not None:
+        notes = str(notes).strip() or None
+
+    return {
+        "section": section,
+        "current_text": current_text,
+        "improvement_type": improvement_type,
+        "severity": severity,
+        "notes": notes,
+    }

--- a/apps/myjobhunter/backend/app/services/resume_refinement/errors.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/errors.py
@@ -1,0 +1,47 @@
+"""Service-layer errors for the resume-refinement feature.
+
+Routers translate these to HTTP responses; tests assert on the
+specific subclass instead of substring-matching on the error message.
+"""
+
+
+class ResumeRefinementError(Exception):
+    """Base for all resume-refinement service errors."""
+
+
+class SourceJobNotReady(ResumeRefinementError):
+    """The source resume_upload_jobs row is not status=complete yet."""
+
+
+class SourceJobNotFound(ResumeRefinementError):
+    """The source resume_upload_jobs row does not exist or is not the user's."""
+
+
+class SessionNotFound(ResumeRefinementError):
+    """The requested session does not exist or is not the user's."""
+
+
+class SessionNotActive(ResumeRefinementError):
+    """The session is completed or abandoned and cannot be modified."""
+
+
+class NoPendingProposal(ResumeRefinementError):
+    """The user tried to accept/skip a proposal but there isn't one."""
+
+
+class NoMoreTargets(ResumeRefinementError):
+    """The improvement_targets list has been fully consumed."""
+
+
+class HallucinationGuardFailed(ResumeRefinementError):
+    """The AI proposal introduced facts not present in the source."""
+
+    def __init__(self, missing_facts: list[str]):
+        super().__init__(
+            f"Proposal introduces facts not in source: {', '.join(missing_facts[:5])}"
+        )
+        self.missing_facts = missing_facts
+
+
+class CritiqueRetryExceeded(ResumeRefinementError):
+    """Claude failed to return a usable critique after retries."""

--- a/apps/myjobhunter/backend/app/services/resume_refinement/export_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/export_service.py
@@ -1,0 +1,254 @@
+"""Markdown → DOCX / PDF export pipeline for refined resumes.
+
+Per the spec, the conversion fidelity is non-negotiable: company
+names, dates, and section headings present in the markdown MUST
+appear in the rendered document. The constrained markdown subset
+emitted by ``markdown_renderer`` and enforced by the rewrite prompt
+guarantees compatible input.
+
+Tools:
+- DOCX: pandoc native (``pandoc -f markdown -t docx``).
+- PDF:  pandoc → HTML5, then weasyprint → PDF. Avoids requiring a
+  TeX install in the runtime image.
+
+Both paths produce text-selectable output suitable for ATS uploads
+(no rasterized layouts, no embedded fonts the parser can't read).
+"""
+from __future__ import annotations
+
+import asyncio
+import io
+import logging
+import re
+import shutil
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+ExportFormat = Literal["docx", "pdf"]
+
+# Default print stylesheet for the PDF path. Single-column, generous
+# margins, ATS-friendly font fallbacks. Kept inline so the pipeline
+# is fully self-contained — no static assets to ship.
+_PDF_CSS = """\
+@page { size: Letter; margin: 0.6in 0.7in; }
+body {
+  font-family: "Liberation Serif", "DejaVu Serif", Georgia, serif;
+  font-size: 11pt;
+  line-height: 1.35;
+  color: #111;
+}
+h1 {
+  font-size: 18pt;
+  font-weight: bold;
+  margin: 0 0 4pt 0;
+  border-bottom: 1px solid #999;
+  padding-bottom: 2pt;
+}
+h2 {
+  font-size: 13pt;
+  font-weight: bold;
+  margin: 14pt 0 4pt 0;
+  text-transform: uppercase;
+  letter-spacing: 0.5pt;
+}
+h3 {
+  font-size: 11.5pt;
+  font-weight: bold;
+  margin: 8pt 0 2pt 0;
+}
+p, ul, ol { margin: 0 0 4pt 0; }
+ul { padding-left: 18pt; }
+li { margin-bottom: 2pt; }
+em { color: #444; font-style: italic; }
+strong { font-weight: bold; }
+"""
+
+
+class ExportFidelityError(RuntimeError):
+    """The exported document is missing facts the source markdown carries."""
+
+    def __init__(self, missing_facts: list[str]):
+        super().__init__(
+            f"Exported document missing facts: {', '.join(missing_facts[:5])}"
+        )
+        self.missing_facts = missing_facts
+
+
+async def export_resume(markdown: str, fmt: ExportFormat) -> bytes:
+    """Convert resume markdown to the requested document format.
+
+    Args:
+        markdown: Resume in the constrained markdown subset.
+        fmt: ``'docx'`` or ``'pdf'``.
+
+    Returns:
+        Raw bytes of the rendered document.
+
+    Raises:
+        ValueError: when ``fmt`` is unsupported.
+        RuntimeError: when the underlying tool fails or is missing.
+        ExportFidelityError: when the round-trip check finds missing facts.
+    """
+    if fmt == "docx":
+        out = await _markdown_to_docx(markdown)
+    elif fmt == "pdf":
+        out = await _markdown_to_pdf(markdown)
+    else:
+        raise ValueError(f"Unsupported export format: {fmt!r}")
+
+    _verify_round_trip(markdown=markdown, output_bytes=out, fmt=fmt)
+    return out
+
+
+async def _markdown_to_docx(markdown: str) -> bytes:
+    if shutil.which("pandoc") is None:
+        raise RuntimeError(
+            "pandoc binary not found; backend image must install it."
+        )
+
+    proc = await asyncio.create_subprocess_exec(
+        "pandoc",
+        "-f", "markdown",
+        "-t", "docx",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate(markdown.encode("utf-8"))
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"pandoc DOCX conversion failed: {stderr.decode('utf-8', 'ignore')[:500]}"
+        )
+    return stdout
+
+
+async def _markdown_to_pdf(markdown: str) -> bytes:
+    """Convert markdown → HTML5 (pandoc) → PDF (weasyprint)."""
+    if shutil.which("pandoc") is None:
+        raise RuntimeError(
+            "pandoc binary not found; backend image must install it."
+        )
+
+    proc = await asyncio.create_subprocess_exec(
+        "pandoc",
+        "-f", "markdown",
+        "-t", "html5",
+        "--standalone",
+        "--metadata", "title=Resume",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    html_bytes, stderr = await proc.communicate(markdown.encode("utf-8"))
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"pandoc HTML conversion failed: {stderr.decode('utf-8', 'ignore')[:500]}"
+        )
+
+    html = html_bytes.decode("utf-8")
+    return await asyncio.to_thread(_html_to_pdf_bytes, html)
+
+
+def _html_to_pdf_bytes(html: str) -> bytes:
+    # Lazy import keeps weasyprint's heavy graph out of cold-start paths
+    # that don't need it.
+    from weasyprint import CSS, HTML
+
+    buffer = io.BytesIO()
+    HTML(string=html).write_pdf(target=buffer, stylesheets=[CSS(string=_PDF_CSS)])
+    return buffer.getvalue()
+
+
+def _verify_round_trip(*, markdown: str, output_bytes: bytes, fmt: ExportFormat) -> None:
+    """Round-trip the rendered output back to text and assert key facts survive.
+
+    Per the spec: company names + dates + section headings must appear
+    in the output. We extract those tokens from the markdown and grep
+    the output text. If any are missing, raise ExportFidelityError so
+    the API retries (or surfaces the error to the user).
+    """
+    expected = _extract_anchor_tokens(markdown)
+    if not expected:
+        return
+
+    text = _output_to_text(output_bytes, fmt)
+    text_lc = text.lower()
+
+    missing: list[str] = []
+    for token in expected:
+        if token.lower() not in text_lc:
+            missing.append(token)
+
+    if missing:
+        logger.warning(
+            "Export round-trip missing %d tokens (fmt=%s): %s",
+            len(missing),
+            fmt,
+            missing[:5],
+        )
+        raise ExportFidelityError(missing)
+
+
+def _extract_anchor_tokens(markdown: str) -> list[str]:
+    """Return tokens that MUST survive the export — company-like names,
+    dates, and section headings.
+
+    Conservative: misses some fancy multi-word entities, but never
+    invents anchors. The goal is "pass when in doubt" — only flag clear
+    deletions.
+    """
+    tokens: list[str] = []
+
+    # Section headings (## Foo, # Foo).
+    for match in re.finditer(r"^#{1,6}\s+(.+?)\s*$", markdown, re.MULTILINE):
+        heading = match.group(1).strip()
+        # Strip markdown decoration (bold/italic) for anchor matching.
+        cleaned = re.sub(r"[\*_`]", "", heading).strip()
+        if cleaned:
+            tokens.append(cleaned)
+
+    # Years and date ranges (very strict — any 4-digit year preceded by
+    # whitespace and followed by space/dash/end).
+    for match in re.finditer(r"\b((?:19|20)\d{2})\b", markdown):
+        tokens.append(match.group(1))
+
+    # Bold tokens — usually company / school names in this format.
+    for match in re.finditer(r"\*\*([^*\n]{2,80})\*\*", markdown):
+        bold = match.group(1).strip()
+        # Skip purely descriptive bold ("Languages:", "Frameworks:").
+        if bold.endswith(":"):
+            continue
+        tokens.append(bold)
+
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for tok in tokens:
+        if tok not in seen:
+            seen.add(tok)
+            out.append(tok)
+    return out
+
+
+def _output_to_text(data: bytes, fmt: ExportFormat) -> str:
+    if fmt == "pdf":
+        try:
+            from pypdf import PdfReader
+
+            reader = PdfReader(io.BytesIO(data))
+            return "\n".join((page.extract_text() or "") for page in reader.pages)
+        except Exception:  # noqa: BLE001 — round-trip is best-effort
+            logger.warning("PDF text extraction failed during round-trip", exc_info=True)
+            return ""
+    if fmt == "docx":
+        try:
+            import mammoth
+
+            with io.BytesIO(data) as buf:
+                result = mammoth.extract_raw_text(buf)
+                return result.value or ""
+        except Exception:  # noqa: BLE001
+            logger.warning("DOCX text extraction failed during round-trip", exc_info=True)
+            return ""
+    return ""

--- a/apps/myjobhunter/backend/app/services/resume_refinement/hallucination_guard.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/hallucination_guard.py
@@ -1,0 +1,118 @@
+"""Hallucination guard for AI-proposed resume rewrites.
+
+Per the spec: *"Basic check (company names + dates preserved). When in
+doubt, the AI ASKS for clarification rather than guessing."*
+
+This is a defense-in-depth layer — the prompt itself instructs Claude
+to never invent facts, and to ask for clarification when the source is
+ambiguous. The guard catches the cases where the model ignores the
+instruction. On a guard miss, the caller treats the proposal as
+invalid and the user is asked to retry.
+
+The guard is intentionally conservative: it flags facts that appear in
+the proposal but NOT in the source. False negatives (missing a real
+hallucination) are worse than false positives (flagging a sentence
+that was actually fine), so the patterns favor recall.
+"""
+from __future__ import annotations
+
+import re
+
+# Capitalized multi-word phrases that look like proper nouns (companies,
+# schools, products). Two- or three-token sequences where each token
+# starts with an uppercase letter. Catches "Acme Corp", "Stanford University",
+# "Senior Software Engineer" (which is fine — also in source if real).
+_PROPER_NOUN_PATTERN = re.compile(
+    r"\b(?:[A-Z][a-zA-Z0-9&]+(?:\s+(?:of|the|and|de|du|la|le)\s+)?){1,4}\b",
+)
+
+# Year ranges, single years, and YYYY-MM date strings.
+_DATE_PATTERN = re.compile(
+    r"\b(?:"
+    r"\d{4}-\d{2}(?:-\d{2})?"      # 2024-01 / 2024-01-15
+    r"|"
+    r"(?:19|20)\d{2}\s*[-–—to]+\s*(?:19|20)\d{2}"  # 2018-2022
+    r"|"
+    r"(?:19|20)\d{2}"               # 2024
+    r")\b",
+)
+
+# Percentages and dollar amounts that look like quantitative claims.
+_METRIC_PATTERN = re.compile(
+    r"(?:"
+    r"\$\s?\d[\d,]*(?:\.\d+)?\s?[KMB]?"   # $50K, $1.2M, $50,000
+    r"|"
+    r"\d+(?:\.\d+)?\s?%"                   # 40%, 12.5%
+    r"|"
+    r"\b\d{2,}\s*(?:x|×)\b"                # 10x, 100x
+    r")",
+)
+
+# Stop words to ignore when checking proper nouns — these don't carry
+# factual content.
+_PROPER_NOUN_STOPWORDS = {
+    "I", "We", "Our", "My", "The", "A", "An", "And", "Or", "But",
+    "For", "On", "In", "At", "By", "With", "From", "To", "Of",
+    "Senior", "Junior", "Lead", "Principal", "Staff", "Manager",
+    "Director", "Engineer", "Developer", "Analyst", "Designer",
+    "Architect", "Consultant", "Specialist", "Coordinator",
+    "Built", "Led", "Managed", "Developed", "Designed", "Created",
+    "Implemented", "Launched", "Shipped", "Delivered",
+    "Present", "Current", "Now",
+}
+
+
+def check_proposal(*, proposed: str, source: str) -> list[str]:
+    """Return a list of facts in ``proposed`` that don't appear in ``source``.
+
+    Empty list = guard pass (no hallucination detected).
+
+    Args:
+        proposed: The AI-proposed rewrite.
+        source: The full resume markdown the user is iterating on.
+    """
+    missing: list[str] = []
+
+    source_lower = source.lower()
+
+    for date_str in _DATE_PATTERN.findall(proposed):
+        if date_str.lower() not in source_lower:
+            missing.append(date_str)
+
+    for metric in _METRIC_PATTERN.findall(proposed):
+        normalized = metric.replace(" ", "").lower()
+        if normalized not in source_lower.replace(" ", ""):
+            missing.append(metric)
+
+    for proper in _extract_proper_nouns(proposed):
+        if proper.lower() not in source_lower:
+            missing.append(proper)
+
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    unique: list[str] = []
+    for item in missing:
+        if item not in seen:
+            seen.add(item)
+            unique.append(item)
+    return unique
+
+
+def _extract_proper_nouns(text: str) -> list[str]:
+    """Return capitalized multi-word phrases likely to be proper nouns.
+
+    Single-word capitalized terms (start of sentence, common job titles)
+    are stripped via the stopword list to keep false positives low.
+    """
+    out: list[str] = []
+    for match in _PROPER_NOUN_PATTERN.finditer(text):
+        phrase = match.group(0).strip()
+        # Single tokens — only flag if not a stopword and not a sentence
+        # start. Heuristic: ignore.
+        if " " not in phrase:
+            continue
+        # Filter out phrases that are entirely stopwords.
+        if all(token in _PROPER_NOUN_STOPWORDS for token in phrase.split()):
+            continue
+        out.append(phrase)
+    return out

--- a/apps/myjobhunter/backend/app/services/resume_refinement/markdown_renderer.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/markdown_renderer.py
@@ -1,0 +1,193 @@
+"""Render the parsed resume_upload_jobs.result_parsed_fields into the
+constrained markdown subset used as the initial session draft.
+
+Only emits markdown shapes that round-trip cleanly through pandoc to
+both DOCX and PDF: headings (`##`), unordered lists (`-`), bold/italic
+inline. No tables, footnotes, code blocks, or LaTeX.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+
+def render_resume_to_markdown(parsed: dict[str, Any]) -> str:
+    """Render a ``result_parsed_fields`` dict to markdown.
+
+    Returned text is the constrained subset that pandoc can convert to
+    DOCX/PDF without surprises. Designed to be the *starting* draft
+    that the refinement loop will iterate on.
+
+    Args:
+        parsed: The dict in the shape produced by ``resume_prompt`` —
+            ``{"summary", "headline", "work_history", "education", "skills"}``.
+
+    Returns:
+        Markdown string. Empty string if ``parsed`` is empty or None.
+    """
+    if not parsed:
+        return ""
+
+    lines: list[str] = []
+
+    headline = (parsed.get("headline") or "").strip()
+    if headline:
+        lines.append(f"# {headline}")
+        lines.append("")
+
+    summary = (parsed.get("summary") or "").strip()
+    if summary:
+        lines.append("## Summary")
+        lines.append("")
+        lines.append(summary)
+        lines.append("")
+
+    work_history = parsed.get("work_history") or []
+    if work_history:
+        lines.append("## Experience")
+        lines.append("")
+        for role in work_history:
+            lines.extend(_render_role(role))
+            lines.append("")
+
+    education = parsed.get("education") or []
+    if education:
+        lines.append("## Education")
+        lines.append("")
+        for entry in education:
+            lines.extend(_render_education(entry))
+            lines.append("")
+
+    skills = parsed.get("skills") or []
+    if skills:
+        lines.append("## Skills")
+        lines.append("")
+        # Group by category; skills with no category land in "Other".
+        groups: dict[str, list[str]] = {}
+        for skill in skills:
+            name = (skill.get("name") or "").strip()
+            if not name:
+                continue
+            category = (skill.get("category") or "other").strip() or "other"
+            groups.setdefault(category, []).append(name)
+
+        for category in (
+            "language",
+            "framework",
+            "tool",
+            "platform",
+            "soft",
+            "other",
+        ):
+            names = groups.get(category)
+            if not names:
+                continue
+            label = _category_label(category)
+            lines.append(f"- **{label}:** {', '.join(names)}")
+        lines.append("")
+
+    # Strip a trailing empty line for cleanliness.
+    while lines and lines[-1] == "":
+        lines.pop()
+
+    return "\n".join(lines)
+
+
+def _render_role(role: dict[str, Any]) -> list[str]:
+    company = (role.get("company") or "").strip()
+    title = (role.get("title") or "").strip()
+    location = (role.get("location") or "").strip()
+    starts_on = (role.get("starts_on") or "").strip()
+    ends_on = (role.get("ends_on") or "").strip()
+    is_current = bool(role.get("is_current"))
+
+    when = _format_date_range(starts_on, ends_on, is_current)
+
+    head_parts: list[str] = []
+    if title:
+        head_parts.append(f"**{title}**")
+    if company:
+        head_parts.append(company)
+    head = " — ".join(head_parts) if head_parts else "Role"
+
+    meta_parts: list[str] = []
+    if when:
+        meta_parts.append(when)
+    if location:
+        meta_parts.append(location)
+    meta = " · ".join(meta_parts)
+
+    out = [f"### {head}"]
+    if meta:
+        out.append(f"*{meta}*")
+
+    bullets = role.get("bullets") or []
+    if bullets:
+        out.append("")
+        for bullet in bullets:
+            text = (bullet or "").strip()
+            if text:
+                out.append(f"- {text}")
+
+    return out
+
+
+def _render_education(entry: dict[str, Any]) -> list[str]:
+    school = (entry.get("school") or "").strip()
+    degree = (entry.get("degree") or "").strip()
+    field = (entry.get("field") or "").strip()
+    starts_on = (entry.get("starts_on") or "").strip()
+    ends_on = (entry.get("ends_on") or "").strip()
+    gpa = (entry.get("gpa") or "").strip()
+
+    head_parts: list[str] = []
+    if school:
+        head_parts.append(f"**{school}**")
+    if degree:
+        if field:
+            head_parts.append(f"{degree} in {field}")
+        else:
+            head_parts.append(degree)
+    elif field:
+        head_parts.append(field)
+
+    head = " — ".join(head_parts) if head_parts else "Education entry"
+
+    meta_parts: list[str] = []
+    when = _format_date_range(starts_on, ends_on, False)
+    if when:
+        meta_parts.append(when)
+    if gpa:
+        meta_parts.append(f"GPA {gpa}")
+    meta = " · ".join(meta_parts)
+
+    out = [f"### {head}"]
+    if meta:
+        out.append(f"*{meta}*")
+    return out
+
+
+def _format_date_range(starts_on: str, ends_on: str, is_current: bool) -> str:
+    if not starts_on and not ends_on and not is_current:
+        return ""
+    if is_current and starts_on:
+        return f"{starts_on} – Present"
+    if starts_on and ends_on:
+        return f"{starts_on} – {ends_on}"
+    if starts_on:
+        return starts_on
+    if ends_on:
+        return ends_on
+    if is_current:
+        return "Present"
+    return ""
+
+
+def _category_label(category: str) -> str:
+    return {
+        "language": "Languages",
+        "framework": "Frameworks",
+        "tool": "Tools",
+        "platform": "Platforms",
+        "soft": "Soft skills",
+        "other": "Other",
+    }.get(category, category.title())

--- a/apps/myjobhunter/backend/app/services/resume_refinement/rewrite_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/rewrite_service.py
@@ -1,0 +1,167 @@
+"""Rewrite service — fires once per target during the iteration loop.
+
+Given (a) the full resume markdown for context, (b) one target from
+the critique pass, and (c) optional user hint, asks Claude for ONE
+rewrite or ONE clarifying question. The hallucination guard then
+verifies that any proposal stays within the bounds of the source.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+
+from app.services.extraction.claude_service import call_claude_with_meta
+from app.services.extraction.prompts.resume_rewrite_prompt import (
+    RESUME_REWRITE_PROMPT,
+)
+from app.services.resume_refinement.hallucination_guard import check_proposal
+
+logger = logging.getLogger(__name__)
+
+
+async def run_rewrite(
+    *,
+    resume_markdown: str,
+    target: dict,
+    hint: str | None,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> dict:
+    """Run one rewrite pass.
+
+    Args:
+        resume_markdown: The current resume draft (full context).
+        target: One element from ``improvement_targets``.
+        hint: Optional user nudge for the regeneration ("more concise",
+            "emphasize technical leadership"). None for the first proposal.
+        user_id: Scopes the extraction_log row.
+        session_id: Used as ``context_id``.
+
+    Returns:
+        Dict with shape:
+        - ``kind``: 'proposal' or 'clarify'
+        - ``rewritten_text``: str | None  (when kind=proposal)
+        - ``rationale``: str | None       (when kind=proposal)
+        - ``question``: str | None        (when kind=clarify)
+        - ``hallucination_flagged``: list[str]  (empty when guard passed)
+        - ``input_tokens``: int
+        - ``output_tokens``: int
+        - ``cost_usd``: Decimal
+
+        When the hallucination guard fails, ``kind`` is downgraded to
+        ``'clarify'`` and ``question`` describes what fact the user
+        should provide. The original proposal is returned in
+        ``rewritten_text`` for traceability but should NOT be applied
+        to the draft.
+    """
+    user_content = _build_user_content(resume_markdown, target, hint)
+
+    result = await call_claude_with_meta(
+        system_prompt=RESUME_REWRITE_PROMPT,
+        user_content=user_content,
+        context_type="resume_rewrite",
+        user_id=user_id,
+        context_id=session_id,
+    )
+
+    parsed = result["parsed"]
+    kind = (parsed.get("kind") or "").strip()
+
+    response: dict = {
+        "kind": "clarify",
+        "rewritten_text": None,
+        "rationale": None,
+        "question": None,
+        "hallucination_flagged": [],
+        "input_tokens": result["input_tokens"],
+        "output_tokens": result["output_tokens"],
+        "cost_usd": result["cost_usd"],
+    }
+
+    if kind == "proposal":
+        rewritten = (parsed.get("rewritten_text") or "").strip()
+        rationale = (parsed.get("rationale") or "").strip() or None
+
+        flagged = check_proposal(proposed=rewritten, source=resume_markdown)
+        if flagged:
+            logger.warning(
+                "Hallucination guard flagged proposal for session %s: %s",
+                session_id,
+                flagged[:5],
+            )
+            response.update(
+                kind="clarify",
+                rewritten_text=rewritten,
+                rationale=rationale,
+                question=_clarify_for_hallucination(flagged),
+                hallucination_flagged=flagged,
+            )
+            return response
+
+        response.update(
+            kind="proposal",
+            rewritten_text=rewritten,
+            rationale=rationale,
+        )
+        return response
+
+    if kind == "clarify":
+        response["question"] = (parsed.get("question") or "").strip() or (
+            "Could you give me more detail about this section so I can rewrite it accurately?"
+        )
+        return response
+
+    # Unknown kind — treat as clarification request to keep the loop safe.
+    logger.warning(
+        "Rewrite returned unknown kind=%r for session %s; treating as clarify.",
+        kind,
+        session_id,
+    )
+    response["question"] = (
+        "I'm not sure how to rephrase this without more detail. "
+        "Could you tell me more about what you want to emphasize?"
+    )
+    return response
+
+
+def _build_user_content(
+    resume_markdown: str,
+    target: dict,
+    hint: str | None,
+) -> str:
+    target_blob = json.dumps(
+        {
+            "section": target.get("section"),
+            "current_text": target.get("current_text"),
+            "improvement_type": target.get("improvement_type"),
+            "severity": target.get("severity"),
+            "notes": target.get("notes"),
+        },
+        indent=2,
+    )
+
+    parts = [
+        "Resume markdown (full context):",
+        "",
+        resume_markdown,
+        "",
+        "----",
+        "",
+        "Target to rewrite:",
+        "",
+        target_blob,
+    ]
+    if hint:
+        parts.extend(["", "----", "", f"User hint for the regeneration: {hint}"])
+    return "\n".join(parts)
+
+
+def _clarify_for_hallucination(missing: list[str]) -> str:
+    """Build a user-facing clarification question from the flagged facts."""
+    preview = ", ".join(missing[:3])
+    return (
+        "I almost added some details that aren't in your resume "
+        f"({preview}). Could you confirm those, or tell me what's accurate "
+        "so I can rewrite this without inventing facts?"
+    )

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
@@ -1,0 +1,408 @@
+"""Session orchestrator for the resume-refinement loop.
+
+Public entry points (called from ``app.api.resume_refinement``):
+
+- ``start_session`` — kick off a new session from a completed
+  ``resume_upload_jobs`` row. Renders the parsed fields to markdown,
+  runs the initial critique pass, and generates the first proposal.
+- ``get_session_state`` — return the current session including pending
+  proposal. Pure read.
+- ``accept_pending`` — user accepts the AI proposal as-is.
+- ``accept_custom`` — user supplies their own text instead.
+- ``request_alternative`` — regenerate the proposal for the same target.
+- ``skip_target`` — move to the next target without modifying.
+- ``complete_session`` — terminal: mark the session done.
+
+Each "advance" entry point has the same shape:
+1. Apply the user's resolution to the draft (or skip).
+2. Bump ``target_index`` (except for ``request_alternative``).
+3. Append a turn row recording what just happened.
+4. Generate the NEXT proposal (or mark complete if no targets remain).
+5. Return the refreshed session.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.resume_refinement.session import ResumeRefinementSession
+from app.repositories.jobs import resume_upload_job_repo
+from app.repositories.resume_refinement import session_repo, turn_repo
+from app.services.resume_refinement import critique_service, rewrite_service
+from app.services.resume_refinement.errors import (
+    NoMoreTargets,
+    NoPendingProposal,
+    SessionNotActive,
+    SessionNotFound,
+    SourceJobNotFound,
+    SourceJobNotReady,
+)
+from app.services.resume_refinement.markdown_renderer import render_resume_to_markdown
+
+logger = logging.getLogger(__name__)
+
+
+async def start_session(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    source_resume_job_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    """Create a new session, run critique, and queue the first proposal."""
+    job = await resume_upload_job_repo.get_by_id_for_user(
+        db, source_resume_job_id, user_id,
+    )
+    if job is None:
+        raise SourceJobNotFound(
+            f"resume_upload_job {source_resume_job_id} not found for user."
+        )
+    if job.status != "complete":
+        raise SourceJobNotReady(
+            f"resume_upload_job is in status={job.status!r}; must be 'complete'."
+        )
+
+    parsed = job.result_parsed_fields or {}
+    initial_draft = render_resume_to_markdown(parsed)
+
+    session = await session_repo.create(
+        db,
+        user_id=user_id,
+        source_resume_job_id=source_resume_job_id,
+        initial_draft=initial_draft,
+    )
+
+    # Run the critique pass. If it fails, the session still exists with
+    # an empty improvement_targets — the caller can retry.
+    try:
+        critique = await critique_service.run_critique(
+            resume_markdown=initial_draft,
+            user_id=user_id,
+            session_id=session.id,
+        )
+    except Exception as exc:
+        logger.error(
+            "Critique pass failed for session %s: %s", session.id, exc,
+        )
+        raise
+
+    session = await session_repo.update_critique(
+        db,
+        session,
+        improvement_targets=critique["targets"],
+        tokens_in=critique["input_tokens"],
+        tokens_out=critique["output_tokens"],
+        cost_usd=critique["cost_usd"],
+    )
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=0,
+        role="ai_critique",
+        target_section=None,
+        rationale=f"Identified {len(critique['targets'])} improvement targets.",
+        draft_after=initial_draft,
+        tokens_in=critique["input_tokens"],
+        tokens_out=critique["output_tokens"],
+    )
+
+    # Kick off the first rewrite proposal.
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    return session
+
+
+async def get_session_state(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    session = await session_repo.get_by_id_for_user(db, session_id, user_id)
+    if session is None:
+        raise SessionNotFound()
+    return session
+
+
+async def accept_pending(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    """Apply ``pending_proposal`` to the draft, advance, and queue the next."""
+    session = await _load_active(db, session_id, user_id)
+    if not session.pending_proposal:
+        raise NoPendingProposal(
+            "No pending AI proposal to accept. Request a new one or skip."
+        )
+
+    target = _current_target(session)
+    new_draft = _apply_rewrite(
+        session.current_draft,
+        target_current_text=target["current_text"] if target else "",
+        new_text=session.pending_proposal,
+    )
+    accepted_text = session.pending_proposal
+    target_section = session.pending_target_section
+
+    session = await session_repo.apply_user_resolution(
+        db, session, new_draft=new_draft, advance_target=True,
+    )
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=session.turn_count,
+        role="user_accept",
+        target_section=target_section,
+        proposed_text=accepted_text,
+        draft_after=new_draft,
+    )
+
+    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+
+
+async def accept_custom(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+    user_text: str,
+) -> ResumeRefinementSession:
+    """Apply user-supplied text instead of the pending AI proposal."""
+    session = await _load_active(db, session_id, user_id)
+    target = _current_target(session)
+    if target is None:
+        raise NoMoreTargets()
+
+    new_draft = _apply_rewrite(
+        session.current_draft,
+        target_current_text=target["current_text"],
+        new_text=user_text,
+    )
+    target_section = session.pending_target_section or target.get("section")
+
+    session = await session_repo.apply_user_resolution(
+        db, session, new_draft=new_draft, advance_target=True,
+    )
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=session.turn_count,
+        role="user_custom",
+        target_section=target_section,
+        user_text=user_text,
+        draft_after=new_draft,
+    )
+
+    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+
+
+async def request_alternative(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+    hint: str | None,
+) -> ResumeRefinementSession:
+    """Regenerate the proposal for the same target without advancing."""
+    session = await _load_active(db, session_id, user_id)
+    target = _current_target(session)
+    if target is None:
+        raise NoMoreTargets()
+
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=session.turn_count,
+        role="user_request_alternative",
+        target_section=target.get("section"),
+        user_text=hint,
+    )
+    session.turn_count += 1
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+
+    return await _generate_next_proposal(db, session, user_id=user_id, hint=hint)
+
+
+async def skip_target(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    """Skip the current target without modifying the draft."""
+    session = await _load_active(db, session_id, user_id)
+    target = _current_target(session)
+    target_section = session.pending_target_section or (
+        target.get("section") if target else None
+    )
+
+    session = await session_repo.apply_user_resolution(
+        db, session, new_draft=session.current_draft, advance_target=True,
+    )
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=session.turn_count,
+        role="user_skip",
+        target_section=target_section,
+        draft_after=session.current_draft,
+    )
+
+    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+
+
+async def complete_session(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    """Terminal: mark the session done. Locks the current_draft."""
+    session = await _load_active(db, session_id, user_id)
+    session = await session_repo.mark_completed(db, session)
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=session.turn_count,
+        role="session_complete",
+        draft_after=session.current_draft,
+    )
+    return session
+
+
+# -----------------------------------------------------------------------------
+# Internals
+# -----------------------------------------------------------------------------
+
+
+async def _load_active(
+    db: AsyncSession,
+    session_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    session = await session_repo.get_by_id_for_user(db, session_id, user_id)
+    if session is None:
+        raise SessionNotFound()
+    if session.status != "active":
+        raise SessionNotActive(
+            f"Session is in status={session.status!r}; cannot modify."
+        )
+    return session
+
+
+def _current_target(session: ResumeRefinementSession) -> dict | None:
+    targets = session.improvement_targets or []
+    if session.target_index >= len(targets):
+        return None
+    return targets[session.target_index]
+
+
+async def _generate_next_proposal(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    user_id: uuid.UUID,
+    hint: str | None,
+) -> ResumeRefinementSession:
+    """If a target remains, ask Claude for a proposal. Otherwise mark complete-ready.
+
+    "Complete-ready" means the session has consumed all critique
+    targets but the user hasn't explicitly clicked Done. We don't
+    auto-complete — the user always presses the button. We just clear
+    pending state.
+    """
+    target = _current_target(session)
+    if target is None:
+        # No more targets — clear pending state. The user clicks Complete to lock.
+        session.pending_target_section = None
+        session.pending_proposal = None
+        session.pending_rationale = None
+        session.pending_clarifying_question = None
+        await db.flush()
+        await db.commit()
+        await db.refresh(session)
+        return session
+
+    try:
+        rewrite = await rewrite_service.run_rewrite(
+            resume_markdown=session.current_draft,
+            target=target,
+            hint=hint,
+            user_id=user_id,
+            session_id=session.id,
+        )
+    except Exception as exc:  # noqa: BLE001 — graceful-degrade for the iteration loop
+        # Don't fail the user's action if Claude is flaky. Leave pending
+        # state cleared; the frontend can show a retry affordance and
+        # the user can request_alternative or skip to nudge generation.
+        logger.error(
+            "Rewrite generation failed for session %s target_index=%d: %s",
+            session.id,
+            session.target_index,
+            exc,
+        )
+        return session
+
+    session = await session_repo.update_pending_proposal(
+        db,
+        session,
+        target_section=target.get("section"),
+        proposal=rewrite["rewritten_text"] if rewrite["kind"] == "proposal" else None,
+        rationale=rewrite["rationale"] if rewrite["kind"] == "proposal" else None,
+        clarifying_question=rewrite["question"] if rewrite["kind"] == "clarify" else None,
+        tokens_in=rewrite["input_tokens"],
+        tokens_out=rewrite["output_tokens"],
+        cost_usd=rewrite["cost_usd"],
+    )
+
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=session.turn_count,
+        role="ai_proposal",
+        target_section=target.get("section"),
+        proposed_text=session.pending_proposal,
+        rationale=session.pending_rationale,
+        clarifying_question=session.pending_clarifying_question,
+        tokens_in=rewrite["input_tokens"],
+        tokens_out=rewrite["output_tokens"],
+    )
+
+    return session
+
+
+def _apply_rewrite(
+    current_draft: str,
+    *,
+    target_current_text: str,
+    new_text: str,
+) -> str:
+    """Apply a rewrite to the draft via verbatim substring replacement.
+
+    The critique pass returns ``current_text`` verbatim from the source
+    so a plain substring replace is safe AS LONG AS the user hasn't
+    edited the draft elsewhere in a way that changed the target. We
+    only replace the FIRST occurrence to avoid clobbering structurally
+    similar bullets.
+
+    If the substring is not found (rare — shouldn't happen in practice
+    since the critique just ran on this exact draft), we append the new
+    text to the end of the draft so the user's input isn't silently
+    lost. The next critique pass would identify the duplication; this
+    is the safer failure mode.
+    """
+    if not target_current_text:
+        return f"{current_draft}\n\n{new_text}".strip()
+
+    if target_current_text in current_draft:
+        return current_draft.replace(target_current_text, new_text, 1)
+
+    logger.warning(
+        "Rewrite target not found in draft — appending. (target preview: %r)",
+        target_current_text[:80],
+    )
+    return f"{current_draft}\n\n{new_text}".strip()

--- a/apps/myjobhunter/backend/pyproject.toml
+++ b/apps/myjobhunter/backend/pyproject.toml
@@ -24,6 +24,9 @@ dependencies = [
     "anthropic>=0.49.0",
     "pypdf>=4.0.0",
     "mammoth>=1.7.0",
+    # Resume-refinement export pipeline: weasyprint converts HTML
+    # (produced by pandoc) to PDF; pandoc handles DOCX natively.
+    "weasyprint>=62.0",
     # Sentry — fail-loud production enforcement. See app/core/observability.py.
     # Mirrors apps/mybookkeeper/backend/pyproject.toml.
     "sentry-sdk[fastapi]==2.58.0",

--- a/apps/myjobhunter/backend/requirements.txt
+++ b/apps/myjobhunter/backend/requirements.txt
@@ -31,6 +31,10 @@ bcrypt==5.0.0
     # via
     #   passlib
     #   pwdlib
+brotli==1.2.0 ; platform_python_implementation == 'CPython'
+    # via fonttools
+brotlicffi==1.2.0.1 ; platform_python_implementation != 'CPython'
+    # via fonttools
 certifi==2026.4.22
     # via
     #   httpcore
@@ -40,7 +44,9 @@ certifi==2026.4.22
 cffi==2.0.0
     # via
     #   argon2-cffi-bindings
+    #   brotlicffi
     #   cryptography
+    #   weasyprint
 click==8.3.3
     # via uvicorn
 cobble==0.1.4
@@ -56,6 +62,8 @@ cryptography==47.0.0
     #   myjobhunter-backend
     #   platform-shared
     #   pyjwt
+cssselect2==0.9.0
+    # via weasyprint
 distro==1.9.0
     # via anthropic
 dnspython==2.8.0
@@ -78,6 +86,8 @@ fastapi-users==15.0.5
     #   myjobhunter-backend
 fastapi-users-db-sqlalchemy==7.0.0
     # via fastapi-users
+fonttools==4.62.1
+    # via weasyprint
 greenlet==3.5.0
     # via sqlalchemy
 h11==0.16.0
@@ -118,6 +128,8 @@ packaging==26.2
     # via pytest
 passlib==1.7.4
     # via myjobhunter-backend
+pillow==12.2.0
+    # via weasyprint
 pluggy==1.6.0
     # via pytest
 psycopg2-binary==2.9.12
@@ -141,6 +153,8 @@ pydantic-settings==2.14.0
     # via
     #   myjobhunter-backend
     #   platform-shared
+pydyf==0.12.1
+    # via weasyprint
 pygments==2.20.0
     # via pytest
 pyjwt==2.12.1
@@ -151,6 +165,8 @@ pyotp==2.9.0
     # via platform-shared
 pypdf==6.10.2
     # via myjobhunter-backend
+pyphen==0.17.2
+    # via weasyprint
 pytest==9.0.3
     # via
     #   pytest-asyncio
@@ -168,7 +184,9 @@ pyyaml==6.0.3
 qrcode==8.2
     # via platform-shared
 sentry-sdk==2.58.0
-    # via myjobhunter-backend
+    # via
+    #   myjobhunter-backend
+    #   platform-shared
 sniffio==1.3.1
     # via anthropic
 sqlalchemy==2.0.49
@@ -179,6 +197,12 @@ sqlalchemy==2.0.49
     #   platform-shared
 starlette==1.0.0
     # via fastapi
+tinycss2==1.5.1
+    # via
+    #   cssselect2
+    #   weasyprint
+tinyhtml5==2.1.0
+    # via weasyprint
 typing-extensions==4.15.0
     # via
     #   alembic
@@ -207,5 +231,14 @@ uvloop==0.22.1 ; platform_python_implementation != 'PyPy' and sys_platform != 'c
     # via uvicorn
 watchfiles==1.1.1
     # via uvicorn
+weasyprint==68.1
+    # via myjobhunter-backend
+webencodings==0.5.1
+    # via
+    #   cssselect2
+    #   tinycss2
+    #   tinyhtml5
 websockets==16.0
     # via uvicorn
+zopfli==0.4.1
+    # via fonttools

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_critique_service.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_critique_service.py
@@ -1,0 +1,121 @@
+"""Tests for the critique service. Mocks the Claude API call."""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.resume_refinement import critique_service
+from app.services.resume_refinement.errors import CritiqueRetryExceeded
+
+
+_FAKE_USER_ID = uuid.uuid4()
+_FAKE_SESSION_ID = uuid.uuid4()
+
+
+def _claude_response(targets: list[dict]) -> dict:
+    return {
+        "parsed": {"targets": targets},
+        "input_tokens": 1000,
+        "output_tokens": 500,
+        "cost_usd": Decimal("0.010"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_run_critique_returns_normalized_targets():
+    targets = [
+        {
+            "section": "Senior Engineer @ Acme — bullet 2",
+            "current_text": "Worked on backend systems",
+            "improvement_type": "stronger_verb",
+            "severity": "high",
+            "notes": "Weak verb",
+        },
+    ]
+    with patch.object(
+        critique_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(targets)),
+    ):
+        result = await critique_service.run_critique(
+            resume_markdown="# Resume",
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+        )
+    assert len(result["targets"]) == 1
+    assert result["targets"][0]["section"] == "Senior Engineer @ Acme — bullet 2"
+    assert result["input_tokens"] == 1000
+    assert result["output_tokens"] == 500
+
+
+@pytest.mark.asyncio
+async def test_run_critique_raises_when_no_targets():
+    with patch.object(
+        critique_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response([])),
+    ):
+        with pytest.raises(CritiqueRetryExceeded):
+            await critique_service.run_critique(
+                resume_markdown="# Resume",
+                user_id=_FAKE_USER_ID,
+                session_id=_FAKE_SESSION_ID,
+            )
+
+
+@pytest.mark.asyncio
+async def test_run_critique_normalizes_invalid_enum_values():
+    targets = [
+        {
+            "section": "Foo",
+            "current_text": "Bar",
+            "improvement_type": "bogus_type",   # invalid → 'other'
+            "severity": "extreme",               # invalid → 'medium'
+        },
+    ]
+    with patch.object(
+        critique_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(targets)),
+    ):
+        result = await critique_service.run_critique(
+            resume_markdown="# Resume",
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+        )
+    target = result["targets"][0]
+    assert target["improvement_type"] == "other"
+    assert target["severity"] == "medium"
+
+
+@pytest.mark.asyncio
+async def test_run_critique_drops_targets_missing_required_fields():
+    targets = [
+        {
+            "section": "Valid",
+            "current_text": "Some text",
+            "improvement_type": "tighten_phrasing",
+            "severity": "medium",
+        },
+        # Missing `current_text` — should be dropped silently.
+        {
+            "section": "Invalid",
+            "improvement_type": "tighten_phrasing",
+            "severity": "medium",
+        },
+    ]
+    with patch.object(
+        critique_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(targets)),
+    ):
+        result = await critique_service.run_critique(
+            resume_markdown="# Resume",
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+        )
+    assert len(result["targets"]) == 1
+    assert result["targets"][0]["section"] == "Valid"

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_hallucination_guard.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_hallucination_guard.py
@@ -1,0 +1,75 @@
+"""Tests for the hallucination guard that catches AI proposals introducing
+facts not present in the source resume.
+
+Pure function tests — no DB, no fixtures.
+"""
+from app.services.resume_refinement.hallucination_guard import check_proposal
+
+
+SOURCE = """\
+# Jane Doe — Senior Software Engineer
+
+## Experience
+
+### **Staff Engineer** — Acme Corp
+*2020-01 – Present · San Francisco, CA*
+
+- Built distributed payment processing system
+- Led migration to microservices
+
+### **Senior Engineer** — Globex Industries
+*2018-03 – 2020-01*
+
+- Owned the search relevance pipeline
+"""
+
+
+def test_pass_when_proposal_only_uses_source_facts():
+    proposal = "Architected the payment processing system at Acme Corp"
+    assert check_proposal(proposed=proposal, source=SOURCE) == []
+
+
+def test_flags_invented_company():
+    proposal = "Built the system at Hooli, a fictional startup"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    assert any("Hooli" in item for item in flagged)
+
+
+def test_flags_invented_year():
+    proposal = "Joined the team in 1999 as a founding engineer"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    assert any("1999" in item for item in flagged)
+
+
+def test_flags_invented_metric():
+    proposal = "Improved throughput by 87% across the fleet"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    assert any("87%" in item or "%" in item for item in flagged)
+
+
+def test_flags_invented_dollar_amount():
+    proposal = "Saved the team $250K annually through better caching"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    assert any("$" in item for item in flagged)
+
+
+def test_does_not_flag_year_present_in_source():
+    proposal = "From 2020 to today, owned the migration effort"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    # 2020 is in SOURCE (2020-01), so the bare year shouldn't be flagged.
+    # The token "2020" should match because source contains "2020" as substring.
+    assert not any(item == "2020" for item in flagged)
+
+
+def test_does_not_flag_common_verbs_or_articles():
+    proposal = "Built and led the system over time"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    # Stop-word phrases like "Built" and "Led" should not surface.
+    assert flagged == []
+
+
+def test_flags_invented_proper_noun_phrase():
+    proposal = "Won the Forrester Innovation Award in 2021 for the work"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    # "Forrester Innovation Award" is not in source.
+    assert any("Forrester" in item for item in flagged)

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_markdown_renderer.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_markdown_renderer.py
@@ -1,0 +1,125 @@
+"""Tests for the markdown renderer that builds the initial session draft.
+
+Pure function tests — no DB, no fixtures.
+"""
+from app.services.resume_refinement.markdown_renderer import (
+    render_resume_to_markdown,
+)
+
+
+def test_empty_input_returns_empty_string():
+    assert render_resume_to_markdown({}) == ""
+    assert render_resume_to_markdown(None) == ""  # type: ignore[arg-type]
+
+
+def test_renders_headline_and_summary():
+    parsed = {
+        "headline": "Senior Software Engineer",
+        "summary": "10 years of backend experience.",
+    }
+    out = render_resume_to_markdown(parsed)
+    assert "# Senior Software Engineer" in out
+    assert "## Summary" in out
+    assert "10 years of backend experience." in out
+
+
+def test_renders_work_history_with_role_heading_and_bullets():
+    parsed = {
+        "work_history": [
+            {
+                "company": "Acme",
+                "title": "Staff Engineer",
+                "location": "San Francisco, CA",
+                "starts_on": "2020-01",
+                "ends_on": None,
+                "is_current": True,
+                "bullets": ["Built the X system", "Led the Y migration"],
+            },
+        ],
+    }
+    out = render_resume_to_markdown(parsed)
+    assert "## Experience" in out
+    assert "### **Staff Engineer** — Acme" in out
+    assert "2020-01 – Present" in out
+    assert "San Francisco, CA" in out
+    assert "- Built the X system" in out
+    assert "- Led the Y migration" in out
+
+
+def test_renders_education_with_degree_and_gpa():
+    parsed = {
+        "education": [
+            {
+                "school": "Stanford University",
+                "degree": "B.S.",
+                "field": "Computer Science",
+                "starts_on": "2014-09",
+                "ends_on": "2018-06",
+                "gpa": "3.8",
+            },
+        ],
+    }
+    out = render_resume_to_markdown(parsed)
+    assert "## Education" in out
+    assert "Stanford University" in out
+    assert "B.S. in Computer Science" in out
+    assert "GPA 3.8" in out
+
+
+def test_renders_skills_grouped_by_category():
+    parsed = {
+        "skills": [
+            {"name": "Python", "category": "language"},
+            {"name": "Django", "category": "framework"},
+            {"name": "Docker", "category": "tool"},
+            {"name": "Leadership", "category": "soft"},
+            {"name": "MongoDB", "category": None},
+        ],
+    }
+    out = render_resume_to_markdown(parsed)
+    assert "## Skills" in out
+    assert "**Languages:** Python" in out
+    assert "**Frameworks:** Django" in out
+    assert "**Tools:** Docker" in out
+    assert "**Soft skills:** Leadership" in out
+    # Skills with None category fall into "Other".
+    assert "**Other:** MongoDB" in out
+
+
+def test_skips_blank_company_and_title():
+    parsed = {
+        "work_history": [
+            {
+                "company": "",
+                "title": "",
+                "bullets": ["Did stuff"],
+            }
+        ],
+    }
+    out = render_resume_to_markdown(parsed)
+    # Heading falls back to "Role" but bullet still renders.
+    assert "### Role" in out
+    assert "- Did stuff" in out
+
+
+def test_uses_constrained_subset_only():
+    """Output uses only headings, lists, bold, italic — no tables / footnotes / code."""
+    parsed = {
+        "headline": "Engineer",
+        "work_history": [
+            {
+                "company": "X",
+                "title": "Y",
+                "starts_on": "2020-01",
+                "ends_on": "2022-12",
+                "is_current": False,
+                "bullets": ["a", "b"],
+            }
+        ],
+    }
+    out = render_resume_to_markdown(parsed)
+    # No tables, no code fences, no footnotes, no images.
+    assert "|" not in out  # No table separators
+    assert "```" not in out
+    assert "[^" not in out
+    assert "![" not in out

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_rewrite_service.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_rewrite_service.py
@@ -1,0 +1,157 @@
+"""Tests for the rewrite service — proposal, clarify, and hallucination paths."""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.resume_refinement import rewrite_service
+
+
+_FAKE_USER_ID = uuid.uuid4()
+_FAKE_SESSION_ID = uuid.uuid4()
+
+_RESUME = """\
+# Jane Doe
+
+## Experience
+
+### **Staff Engineer** — Acme Corp
+*2020-01 – Present*
+
+- Built distributed payment processing
+"""
+
+_TARGET = {
+    "section": "Staff Engineer @ Acme — bullet 1",
+    "current_text": "Built distributed payment processing",
+    "improvement_type": "add_metric",
+    "severity": "high",
+    "notes": "No throughput / scale numbers",
+}
+
+
+def _claude_response(parsed: dict) -> dict:
+    return {
+        "parsed": parsed,
+        "input_tokens": 800,
+        "output_tokens": 200,
+        "cost_usd": Decimal("0.005"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_proposal_path_returns_rewritten_text():
+    parsed = {
+        "kind": "proposal",
+        "rewritten_text": "Architected distributed payment processing at Acme Corp",
+        "rationale": "Stronger verb, ties to the company name in the source.",
+    }
+    with patch.object(
+        rewrite_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(parsed)),
+    ):
+        result = await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+        )
+    assert result["kind"] == "proposal"
+    assert "payment processing" in (result["rewritten_text"] or "")
+    assert result["question"] is None
+    assert result["hallucination_flagged"] == []
+
+
+@pytest.mark.asyncio
+async def test_clarify_path_returns_question():
+    parsed = {
+        "kind": "clarify",
+        "question": "How many transactions per day did the system process?",
+    }
+    with patch.object(
+        rewrite_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(parsed)),
+    ):
+        result = await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+        )
+    assert result["kind"] == "clarify"
+    assert "transactions" in (result["question"] or "")
+
+
+@pytest.mark.asyncio
+async def test_hallucination_downgrades_proposal_to_clarify():
+    """When the proposal introduces facts NOT in source, kind flips to clarify."""
+    parsed = {
+        "kind": "proposal",
+        "rewritten_text": "Architected payment processing handling 500K transactions/day at Acme",
+        "rationale": "Added scope.",
+    }
+    with patch.object(
+        rewrite_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(parsed)),
+    ):
+        result = await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+        )
+    assert result["kind"] == "clarify"
+    assert result["hallucination_flagged"]  # Non-empty list
+    assert result["question"]  # Has a clarification question
+    # The original proposal text is preserved on the response for traceability.
+    assert "500K" in (result["rewritten_text"] or "")
+
+
+@pytest.mark.asyncio
+async def test_unknown_kind_falls_back_to_clarify():
+    parsed = {"kind": "weird_unknown_kind"}
+    with patch.object(
+        rewrite_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(parsed)),
+    ):
+        result = await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+        )
+    assert result["kind"] == "clarify"
+    assert result["question"]
+
+
+@pytest.mark.asyncio
+async def test_hint_passes_through_to_user_content():
+    """The user's regeneration hint should appear in the prompt."""
+    parsed = {"kind": "proposal", "rewritten_text": "ok", "rationale": "ok"}
+
+    captured_user_content: list[str] = []
+
+    async def fake_call(*, system_prompt, user_content, **_):
+        captured_user_content.append(user_content)
+        return _claude_response(parsed)
+
+    with patch.object(rewrite_service, "call_claude_with_meta", new=AsyncMock(side_effect=fake_call)):
+        await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint="make it more concise",
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+        )
+    assert any("more concise" in c for c in captured_user_content)

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_session_helpers.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_session_helpers.py
@@ -1,0 +1,51 @@
+"""Tests for the pure-function helpers in session_service.
+
+Full lifecycle integration tests are heavy (DB + Claude mocking + worker
+stubs); these focus on the substring-replacement logic that's the hardest
+part to get right without real data.
+"""
+from app.services.resume_refinement.session_service import _apply_rewrite
+
+
+def test_apply_rewrite_replaces_first_occurrence_only():
+    draft = "- old text\n- old text\n- something else"
+    out = _apply_rewrite(
+        draft,
+        target_current_text="old text",
+        new_text="new text",
+    )
+    # First "- old text" got replaced; the second one is preserved.
+    assert out == "- new text\n- old text\n- something else"
+
+
+def test_apply_rewrite_appends_when_target_not_found():
+    draft = "- existing bullet"
+    out = _apply_rewrite(
+        draft,
+        target_current_text="not in draft",
+        new_text="appended bullet",
+    )
+    assert "appended bullet" in out
+    assert "existing bullet" in out
+
+
+def test_apply_rewrite_with_empty_target_appends():
+    """An empty target_current_text just appends to the end of the draft."""
+    draft = "- existing"
+    out = _apply_rewrite(
+        draft,
+        target_current_text="",
+        new_text="new content",
+    )
+    assert out.endswith("new content")
+    assert "existing" in out
+
+
+def test_apply_rewrite_preserves_surrounding_whitespace():
+    draft = "## Section\n\n- bullet to rewrite\n- another bullet"
+    out = _apply_rewrite(
+        draft,
+        target_current_text="bullet to rewrite",
+        new_text="rewritten bullet",
+    )
+    assert out == "## Section\n\n- rewritten bullet\n- another bullet"

--- a/apps/myjobhunter/backend/uv.lock
+++ b/apps/myjobhunter/backend/uv.lock
@@ -154,6 +154,40 @@ wheels = [
 ]
 
 [[package]]
+name = "brotli"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/16/c92ca344d646e71a43b8bb353f0a6490d7f6e06210f8554c8f874e454285/brotli-1.2.0.tar.gz", hash = "sha256:e310f77e41941c13340a95976fe66a8a95b01e783d430eeaf7a2f87e0a57dd0a", size = 7388632, upload-time = "2025-11-05T18:39:42.86Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/ee/b0a11ab2315c69bb9b45a2aaed022499c9c24a205c3a49c3513b541a7967/brotli-1.2.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:35d382625778834a7f3061b15423919aa03e4f5da34ac8e02c074e4b75ab4f84", size = 861543, upload-time = "2025-11-05T18:38:24.183Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2f/29c1459513cd35828e25531ebfcbf3e92a5e49f560b1777a9af7203eb46e/brotli-1.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7a61c06b334bd99bc5ae84f1eeb36bfe01400264b3c352f968c6e30a10f9d08b", size = 444288, upload-time = "2025-11-05T18:38:25.139Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/6f/feba03130d5fceadfa3a1bb102cb14650798c848b1df2a808356f939bb16/brotli-1.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:acec55bb7c90f1dfc476126f9711a8e81c9af7fb617409a9ee2953115343f08d", size = 1528071, upload-time = "2025-11-05T18:38:26.081Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/38/f3abb554eee089bd15471057ba85f47e53a44a462cfce265d9bf7088eb09/brotli-1.2.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:260d3692396e1895c5034f204f0db022c056f9e2ac841593a4cf9426e2a3faca", size = 1626913, upload-time = "2025-11-05T18:38:27.284Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a7/03aa61fbc3c5cbf99b44d158665f9b0dd3d8059be16c460208d9e385c837/brotli-1.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:072e7624b1fc4d601036ab3f4f27942ef772887e876beff0301d261210bca97f", size = 1419762, upload-time = "2025-11-05T18:38:28.295Z" },
+    { url = "https://files.pythonhosted.org/packages/21/1b/0374a89ee27d152a5069c356c96b93afd1b94eae83f1e004b57eb6ce2f10/brotli-1.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:adedc4a67e15327dfdd04884873c6d5a01d3e3b6f61406f99b1ed4865a2f6d28", size = 1484494, upload-time = "2025-11-05T18:38:29.29Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/57/69d4fe84a67aef4f524dcd075c6eee868d7850e85bf01d778a857d8dbe0a/brotli-1.2.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:7a47ce5c2288702e09dc22a44d0ee6152f2c7eda97b3c8482d826a1f3cfc7da7", size = 1593302, upload-time = "2025-11-05T18:38:30.639Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/3b/39e13ce78a8e9a621c5df3aeb5fd181fcc8caba8c48a194cd629771f6828/brotli-1.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:af43b8711a8264bb4e7d6d9a6d004c3a2019c04c01127a868709ec29962b6036", size = 1487913, upload-time = "2025-11-05T18:38:31.618Z" },
+    { url = "https://files.pythonhosted.org/packages/62/28/4d00cb9bd76a6357a66fcd54b4b6d70288385584063f4b07884c1e7286ac/brotli-1.2.0-cp312-cp312-win32.whl", hash = "sha256:e99befa0b48f3cd293dafeacdd0d191804d105d279e0b387a32054c1180f3161", size = 334362, upload-time = "2025-11-05T18:38:32.939Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/4e/bc1dcac9498859d5e353c9b153627a3752868a9d5f05ce8dedd81a2354ab/brotli-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:b35c13ce241abdd44cb8ca70683f20c0c079728a36a996297adb5334adfc1c44", size = 369115, upload-time = "2025-11-05T18:38:33.765Z" },
+]
+
+[[package]]
+name = "brotlicffi"
+version = "1.2.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/b6/017dc5f852ed9b8735af77774509271acbf1de02d238377667145fcee01d/brotlicffi-1.2.0.1.tar.gz", hash = "sha256:c20d5c596278307ad06414a6d95a892377ea274a5c6b790c2548c009385d621c", size = 478156, upload-time = "2026-03-05T19:54:11.547Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/9f/b98dcd4af47994cee97aebac866996a006a2e5fc1fd1e2b82a8ad95cf09c/brotlicffi-1.2.0.1-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:91ba5f0ccc040f6ff8f7efaf839f797723d03ed46acb8ae9408f99ffd2572cf4", size = 432608, upload-time = "2026-03-05T19:53:56.736Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/7a/ac4ee56595a061e3718a6d1ea7e921f4df156894acffb28ed88a1fd52022/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be9a670c6811af30a4bd42d7116dc5895d3b41beaa8ed8a89050447a0181f5ce", size = 1534257, upload-time = "2026-03-05T19:53:58.667Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/e7410db7f6f56de57744ea52a115084ceb2735f4d44973f349bb92136586/brotlicffi-1.2.0.1-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f3314a3476f59e5443f9f72a6dff16edc0c3463c9b318feaef04ae3e4683f5a", size = 1536838, upload-time = "2026-03-05T19:54:00.705Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/75/6e7977d1935fc3fbb201cbd619be8f2c7aea25d40a096967132854b34708/brotlicffi-1.2.0.1-cp38-abi3-win32.whl", hash = "sha256:82ea52e2b5d3145b6c406ebd3efb0d55db718b7ad996bd70c62cec0439de1187", size = 343337, upload-time = "2026-03-05T19:54:02.446Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ef/e7e485ce5e4ba3843a0a92feb767c7b6098fd6e65ce752918074d175ae71/brotlicffi-1.2.0.1-cp38-abi3-win_amd64.whl", hash = "sha256:da2e82a08e7778b8bc539d27ca03cdd684113e81394bfaaad8d0dfc6a17ddede", size = 379026, upload-time = "2026-03-05T19:54:04.322Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.4.22"
 source = { registry = "https://pypi.org/simple" }
@@ -255,6 +289,19 @@ wheels = [
 ]
 
 [[package]]
+name = "cssselect2"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tinycss2" },
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/20/92eaa6b0aec7189fa4b75c890640e076e9e793095721db69c5c81142c2e1/cssselect2-0.9.0.tar.gz", hash = "sha256:759aa22c216326356f65e62e791d66160a0f9c91d1424e8d8adc5e74dddfc6fb", size = 35595, upload-time = "2026-02-12T17:16:39.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/21/0e/8459ca4413e1a21a06c97d134bfaf18adfd27cea068813dc0faae06cbf00/cssselect2-0.9.0-py3-none-any.whl", hash = "sha256:6a99e5f91f9a016a304dd929b0966ca464bcfda15177b6fb4a118fc0fb5d9563", size = 15453, upload-time = "2026-02-12T17:16:38.317Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -343,6 +390,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/12/bc9e6146ae31564741cefc87ee6e37fa5b566933f0afe8aa030779d60e60/fastapi_users_db_sqlalchemy-7.0.0.tar.gz", hash = "sha256:6823eeedf8a92f819276a2b2210ef1dcfd71fe8b6e37f7b4da8d1c60e3dfd595", size = 10877, upload-time = "2025-01-04T13:09:05.086Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/08/9968963c1fb8c34627b7f1fbcdfe9438540f87dc7c9bfb59bb4fd19a4ecf/fastapi_users_db_sqlalchemy-7.0.0-py3-none-any.whl", hash = "sha256:5fceac018e7cfa69efc70834dd3035b3de7988eb4274154a0dbe8b14f5aa001e", size = 6891, upload-time = "2025-01-04T13:09:02.869Z" },
+]
+
+[[package]]
+name = "fonttools"
+version = "4.62.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/08/7012b00a9a5874311b639c3920270c36ee0c445b69d9989a85e5c92ebcb0/fonttools-4.62.1.tar.gz", hash = "sha256:e54c75fd6041f1122476776880f7c3c3295ffa31962dc6ebe2543c00dca58b5d", size = 3580737, upload-time = "2026-03-13T13:54:25.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/d4/dbacced3953544b9a93088cc10ef2b596d348c983d5c67a404fa41ec51ba/fonttools-4.62.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:90365821debbd7db678809c7491ca4acd1e0779b9624cdc6ddaf1f31992bf974", size = 2870219, upload-time = "2026-03-13T13:52:53.664Z" },
+    { url = "https://files.pythonhosted.org/packages/66/9e/a769c8e99b81e5a87ab7e5e7236684de4e96246aae17274e5347d11ebd78/fonttools-4.62.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:12859ff0b47dd20f110804c3e0d0970f7b832f561630cd879969011541a464a9", size = 2414891, upload-time = "2026-03-13T13:52:56.493Z" },
+    { url = "https://files.pythonhosted.org/packages/69/64/f19a9e3911968c37e1e620e14dfc5778299e1474f72f4e57c5ec771d9489/fonttools-4.62.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9c125ffa00c3d9003cdaaf7f2c79e6e535628093e14b5de1dccb08859b680936", size = 5033197, upload-time = "2026-03-13T13:52:59.179Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/8a/99c8b3c3888c5c474c08dbfd7c8899786de9604b727fcefb055b42c84bba/fonttools-4.62.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:149f7d84afca659d1a97e39a4778794a2f83bf344c5ee5134e09995086cc2392", size = 4988768, upload-time = "2026-03-13T13:53:02.761Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/c6/0f904540d3e6ab463c1243a0d803504826a11604c72dd58c2949796a1762/fonttools-4.62.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0aa72c43a601cfa9273bb1ae0518f1acadc01ee181a6fc60cd758d7fdadffc04", size = 4971512, upload-time = "2026-03-13T13:53:05.678Z" },
+    { url = "https://files.pythonhosted.org/packages/29/0b/5cbef6588dc9bd6b5c9ad6a4d5a8ca384d0cea089da31711bbeb4f9654a6/fonttools-4.62.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:19177c8d96c7c36359266e571c5173bcee9157b59cfc8cb0153c5673dc5a3a7d", size = 5122723, upload-time = "2026-03-13T13:53:08.662Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/47/b3a5342d381595ef439adec67848bed561ab7fdb1019fa522e82101b7d9c/fonttools-4.62.1-cp312-cp312-win32.whl", hash = "sha256:a24decd24d60744ee8b4679d38e88b8303d86772053afc29b19d23bb8207803c", size = 2281278, upload-time = "2026-03-13T13:53:10.998Z" },
+    { url = "https://files.pythonhosted.org/packages/28/b1/0c2ab56a16f409c6c8a68816e6af707827ad5d629634691ff60a52879792/fonttools-4.62.1-cp312-cp312-win_amd64.whl", hash = "sha256:9e7863e10b3de72376280b515d35b14f5eeed639d1aa7824f4cf06779ec65e42", size = 2331414, upload-time = "2026-03-13T13:53:13.992Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/ba/56147c165442cc5ba7e82ecf301c9a68353cede498185869e6e02b4c264f/fonttools-4.62.1-py3-none-any.whl", hash = "sha256:7487782e2113861f4ddcc07c3436450659e3caa5e470b27dc2177cade2d8e7fd", size = 1152647, upload-time = "2026-03-13T13:54:22.735Z" },
+]
+
+[package.optional-dependencies]
+woff = [
+    { name = "brotli", marker = "platform_python_implementation == 'CPython'" },
+    { name = "brotlicffi", marker = "platform_python_implementation != 'CPython'" },
+    { name = "zopfli" },
 ]
 
 [[package]]
@@ -553,6 +624,7 @@ dependencies = [
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "weasyprint" },
 ]
 
 [package.dev-dependencies]
@@ -585,6 +657,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.58.0" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.46.0" },
+    { name = "weasyprint", specifier = ">=62.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -618,6 +691,25 @@ bcrypt = [
 ]
 
 [[package]]
+name = "pillow"
+version = "12.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
+    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
+    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
+    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
+    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+]
+
+[[package]]
 name = "platform-shared"
 version = "0.1.0"
 source = { editable = "../../../packages/shared-backend" }
@@ -631,6 +723,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyotp" },
     { name = "qrcode" },
+    { name = "sentry-sdk" },
     { name = "sqlalchemy" },
 ]
 
@@ -648,6 +741,7 @@ requires-dist = [
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "qrcode", specifier = ">=7.4.2" },
+    { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
 ]
 provides-extras = ["dev"]
@@ -785,6 +879,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pydyf"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/ee/fb410c5c854b6a081a49077912a9765aeffd8e07cbb0663cfda310b01fb4/pydyf-0.12.1.tar.gz", hash = "sha256:fbd7e759541ac725c29c506612003de393249b94310ea78ae44cb1d04b220095", size = 17716, upload-time = "2025-12-02T14:52:14.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/11/47efe2f66ba848a107adfd490b508f5c0cedc82127950553dca44d29e6c4/pydyf-0.12.1-py3-none-any.whl", hash = "sha256:ea25b4e1fe7911195cb57067560daaa266639184e8335365cc3ee5214e7eaadc", size = 8028, upload-time = "2025-12-02T14:52:12.938Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -823,6 +926,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
+]
+
+[[package]]
+name = "pyphen"
+version = "0.17.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/56/e4d7e1bd70d997713649c5ce530b2d15a5fc2245a74ca820fc2d51d89d4d/pyphen-0.17.2.tar.gz", hash = "sha256:f60647a9c9b30ec6c59910097af82bc5dd2d36576b918e44148d8b07ef3b4aa3", size = 2079470, upload-time = "2025-01-20T13:18:36.296Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/1f/c2142d2edf833a90728e5cdeb10bdbdc094dde8dbac078cee0cf33f5e11b/pyphen-0.17.2-py3-none-any.whl", hash = "sha256:3a07fb017cb2341e1d9ff31b8634efb1ae4dc4b130468c7c39dd3d32e7c3affd", size = 2079358, upload-time = "2025-01-20T13:18:29.629Z" },
 ]
 
 [[package]]
@@ -980,6 +1092,30 @@ wheels = [
 ]
 
 [[package]]
+name = "tinycss2"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/ae/2ca4913e5c0f09781d75482874c3a95db9105462a92ddd303c7d285d3df2/tinycss2-1.5.1.tar.gz", hash = "sha256:d339d2b616ba90ccce58da8495a78f46e55d4d25f9fd71dfd526f07e7d53f957", size = 88195, upload-time = "2025-11-23T10:29:10.082Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/45/c7b5c3168458db837e8ceab06dc77824e18202679d0463f0e8f002143a97/tinycss2-1.5.1-py3-none-any.whl", hash = "sha256:3415ba0f5839c062696996998176c4a3751d18b7edaaeeb658c9ce21ec150661", size = 28404, upload-time = "2025-11-23T10:29:08.676Z" },
+]
+
+[[package]]
+name = "tinyhtml5"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "webencodings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/1f/cfe2f6b30557c92b3f31d41707e09cef5c1efbd87392bc6c0430c46b0e4d/tinyhtml5-2.1.0.tar.gz", hash = "sha256:60a50ec3d938a37e491efa01af895853060943dcebb5627de5b10d188b338a67", size = 179242, upload-time = "2026-03-05T17:06:30.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/52/48/01695a036b695f83fea7aef6955d735db0f517b1c8e25ddb399ac0bdbcbf/tinyhtml5-2.1.0-py3-none-any.whl", hash = "sha256:6e11cfff38515834268daf89d5f85bbde0b6dd02e8d9e212d1385c2289b89f0a", size = 39686, upload-time = "2026-03-05T17:06:28.498Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1072,6 +1208,34 @@ wheels = [
 ]
 
 [[package]]
+name = "weasyprint"
+version = "68.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+    { name = "cssselect2" },
+    { name = "fonttools", extra = ["woff"] },
+    { name = "pillow" },
+    { name = "pydyf" },
+    { name = "pyphen" },
+    { name = "tinycss2" },
+    { name = "tinyhtml5" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/3e/65c0f176e6fb5c2b0a1ac13185b366f727d9723541babfa7fa4309998169/weasyprint-68.1.tar.gz", hash = "sha256:d3b752049b453a5c95edb27ce78d69e9319af5a34f257fa0f4c738c701b4184e", size = 1542379, upload-time = "2026-02-06T15:04:11.203Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/dd/14eb73cea481ad8162d3b18a4850d4a84d6e804a22840cca207648532265/weasyprint-68.1-py3-none-any.whl", hash = "sha256:4dc3ba63c68bbbce3e9617cb2226251c372f5ee90a8a484503b1c099da9cf5be", size = 319789, upload-time = "2026-02-06T15:04:09.189Z" },
+]
+
+[[package]]
+name = "webencodings"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
 name = "websockets"
 version = "16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1087,4 +1251,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
     { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "zopfli"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/4d/a8cc1768b2eda3c0c7470bf8059dcb94ef96d45dd91fc6edd29430d44072/zopfli-0.4.1.tar.gz", hash = "sha256:07a5cdc5d1aaa6c288c5d9f5a5383042ba743641abf8e2fd898dcad622d8a38e", size = 179001, upload-time = "2026-02-13T14:17:27.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/2f/1a7082e9163ae3703b27d571720bf3c954a02a9cf1fdce47c51e70639256/zopfli-0.4.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:4238d4d746d1095e29c9125490985e0c12ffd3654f54a24af551e2391e936d54", size = 291570, upload-time = "2026-02-13T14:17:12.556Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/4a1a88edf9fa0ce102703f38ab4dfb285b7cd2dde5389184264ec759e06e/zopfli-0.4.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fdfb7ce9f5de37a5b2f75dd2642fd7717956ef2a72e0387302a36d382440db07", size = 829437, upload-time = "2026-02-13T14:17:14.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/77/d231012ddcaac9d2e184bd7808e106a8a0048855912e2e1c902b3f383413/zopfli-0.4.1-cp310-abi3-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d7bcee1b189d64ec33d1e05cfa1b6a1268c29329c382f6ca1bd6245b04925c57", size = 818542, upload-time = "2026-02-13T14:17:16.353Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/4e/9b23690c4ca14fbeae2a8f7f6b2006611bf4cd7d5bcb2d9e6c718bd4b0e9/zopfli-0.4.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:27823dc1161a4031d1c25925fd45d9868ec0cbc7692341830a7dcfa25063662c", size = 1778034, upload-time = "2026-02-13T14:17:17.509Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/1b/51f7c28d4cde639cac4f5d47ff615548c1d9809f43cbacdd66eba5cd679d/zopfli-0.4.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5a4c22b6161f47f5bd34637dbaee6735abd287cd64e0d1ce28ef1871bf625f4b", size = 1863957, upload-time = "2026-02-13T14:17:19.259Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/4d/1ef17017d38eabe7ae28f18ef0f16d48966cc23a5657e4555fff61704539/zopfli-0.4.1-cp310-abi3-win32.whl", hash = "sha256:a899eca405662a23ae75054affa3517a060362eae1185d3d791c86a50153c4dd", size = 82314, upload-time = "2026-02-13T14:17:20.795Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/94/806bc84b389c7d70051d7c9a0179cff52de8b9f8dc2fc25bcf0bca302986/zopfli-0.4.1-cp310-abi3-win_amd64.whl", hash = "sha256:84a31ba9edc921b1d3a4449929394a993888f32d70de3a3617800c428a947b9b", size = 102186, upload-time = "2026-02-13T14:17:21.622Z" },
 ]

--- a/apps/myjobhunter/docker/backend.Dockerfile
+++ b/apps/myjobhunter/docker/backend.Dockerfile
@@ -17,7 +17,16 @@ ARG GIT_COMMIT=unknown
 ENV GIT_COMMIT=${GIT_COMMIT}
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends postgresql-client \
+    && apt-get install -y --no-install-recommends \
+        postgresql-client \
+        pandoc \
+        libpango-1.0-0 \
+        libpangoft2-1.0-0 \
+        libharfbuzz0b \
+        libffi8 \
+        fonts-dejavu \
+        fonts-liberation \
+        fontconfig \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/apps/myjobhunter/frontend/src/RootLayout.tsx
+++ b/apps/myjobhunter/frontend/src/RootLayout.tsx
@@ -6,6 +6,7 @@ import {
   LayoutDashboard,
   Plus,
   Settings,
+  Sparkles,
   UserCircle,
 } from "lucide-react";
 import { AppShell, RequireAuth, Toaster, useIsAuthenticated } from "@platform/ui";
@@ -36,6 +37,7 @@ const ICONS: Record<string, React.ReactNode> = {
   LayoutDashboard: <LayoutDashboard className="w-5 h-5" />,
   Plus: <Plus className="w-5 h-5" />,
   Settings: <Settings className="w-5 h-5" />,
+  Sparkles: <Sparkles className="w-5 h-5" />,
   UserCircle: <UserCircle className="w-5 h-5" />,
 };
 

--- a/apps/myjobhunter/frontend/src/constants/nav.ts
+++ b/apps/myjobhunter/frontend/src/constants/nav.ts
@@ -17,6 +17,7 @@ export const NAV_DESCRIPTORS: NavDescriptor[] = [
   { path: "/applications", label: "Applications", iconName: "Briefcase" },
   { path: "/companies", label: "Companies", iconName: "Building2" },
   { path: "/documents", label: "Documents", iconName: "FileText" },
+  { path: "/resume", label: "Resume", iconName: "Sparkles" },
   { path: "/profile", label: "Profile", iconName: "UserCircle" },
   { path: "/settings", label: "Settings", iconName: "Settings" },
 ];

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CompletePanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CompletePanel.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { Check, FileDown } from "lucide-react";
+import {
+  LoadingButton,
+  showError,
+  showSuccess,
+  extractErrorMessage,
+} from "@platform/ui";
+import api from "@/lib/api";
+import { useCompleteRefinementSessionMutation } from "@/lib/resumeRefinementApi";
+import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
+
+interface CompletePanelProps {
+  session: RefinementSession;
+}
+
+export default function CompletePanel({ session }: CompletePanelProps) {
+  const targets = session.improvement_targets ?? [];
+  const reachedEnd = session.target_index >= targets.length;
+  const isCompleted = session.status === "completed";
+
+  const [completeSession, { isLoading: isCompleting }] = useCompleteRefinementSessionMutation();
+  const [downloading, setDownloading] = useState<"pdf" | "docx" | null>(null);
+
+  if (!reachedEnd && !isCompleted) {
+    return null;
+  }
+
+  async function handleComplete() {
+    try {
+      await completeSession(session.id).unwrap();
+      showSuccess("Resume marked done. Download a copy below.");
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleDownload(fmt: "pdf" | "docx") {
+    setDownloading(fmt);
+    try {
+      const response = await api.get(
+        `/resume-refinement/sessions/${session.id}/export`,
+        {
+          params: { format: fmt },
+          responseType: "blob",
+        }
+      );
+      const blob = new Blob([response.data], {
+        type:
+          fmt === "pdf"
+            ? "application/pdf"
+            : "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `resume.${fmt}`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    } finally {
+      setDownloading(null);
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-emerald-300/50 bg-emerald-50 dark:bg-emerald-950/20 p-4 space-y-3">
+      <header className="flex items-center gap-2">
+        <Check className="size-5 text-emerald-600" />
+        <h2 className="text-sm font-semibold">
+          {isCompleted ? "All done" : "All targets reviewed"}
+        </h2>
+      </header>
+      <p className="text-sm text-muted-foreground">
+        {isCompleted
+          ? "Your refined resume is ready to download in either format."
+          : "You've gone through every suggestion. Mark the session done to lock the draft, then download."}
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {!isCompleted && (
+          <LoadingButton isLoading={isCompleting} onClick={handleComplete}>
+            Mark resume done
+          </LoadingButton>
+        )}
+        {isCompleted && (
+          <>
+            <LoadingButton
+              isLoading={downloading === "pdf"}
+              onClick={() => handleDownload("pdf")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <FileDown size={14} /> Download PDF
+              </span>
+            </LoadingButton>
+            <LoadingButton
+              isLoading={downloading === "docx"}
+              onClick={() => handleDownload("docx")}
+            >
+              <span className="inline-flex items-center gap-1.5">
+                <FileDown size={14} /> Download DOCX
+              </span>
+            </LoadingButton>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentDraftPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentDraftPanel.tsx
@@ -1,0 +1,25 @@
+import MarkdownPreview from "@/features/resume_refinement/markdown-preview";
+
+interface CurrentDraftPanelProps {
+  markdown: string;
+}
+
+export default function CurrentDraftPanel({ markdown }: CurrentDraftPanelProps) {
+  return (
+    <section className="rounded-lg border border-border bg-card p-4 space-y-2">
+      <header>
+        <h2 className="text-sm font-semibold">Current draft</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Your live working copy. Changes apply as you accept rewrites.
+        </p>
+      </header>
+      <div className="rounded-md border border-border bg-background p-4 overflow-y-auto max-h-[60vh]">
+        {markdown.trim() ? (
+          <MarkdownPreview source={markdown} />
+        ) : (
+          <p className="text-sm text-muted-foreground">Your draft is empty.</p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -92,9 +92,10 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
           <Sparkles className="size-4 text-primary" />
           Suggestion
         </h2>
-        <Badge>
-          {session.target_index + 1} / {totalTargets} · {remaining} left
-        </Badge>
+        <Badge
+          label={`${session.target_index + 1} / ${totalTargets} · ${remaining} left`}
+          color="gray"
+        />
       </header>
 
       {targetSection && (

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -1,0 +1,293 @@
+import { useState } from "react";
+import { Sparkles, Pencil, RefreshCw, SkipForward } from "lucide-react";
+import {
+  Badge,
+  LoadingButton,
+  showError,
+  showSuccess,
+  extractErrorMessage,
+} from "@platform/ui";
+import {
+  useAcceptPendingMutation,
+  useSupplyCustomRewriteMutation,
+  useRequestAlternativeMutation,
+  useSkipTargetMutation,
+} from "@/lib/resumeRefinementApi";
+import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
+
+interface PendingProposalCardProps {
+  session: RefinementSession;
+}
+
+export default function PendingProposalCard({ session }: PendingProposalCardProps) {
+  const [mode, setMode] = useState<"view" | "custom" | "alternative">("view");
+  const [customText, setCustomText] = useState("");
+  const [hint, setHint] = useState("");
+
+  const [acceptPending, accept] = useAcceptPendingMutation();
+  const [supplyCustom, custom] = useSupplyCustomRewriteMutation();
+  const [requestAlternative, alternative] = useRequestAlternativeMutation();
+  const [skipTarget, skip] = useSkipTargetMutation();
+
+  const totalTargets = session.improvement_targets?.length ?? 0;
+  const remaining = Math.max(totalTargets - session.target_index, 0);
+  const targetSection = session.pending_target_section;
+  const proposal = session.pending_proposal;
+  const rationale = session.pending_rationale;
+  const clarifyingQuestion = session.pending_clarifying_question;
+  const isPending = accept.isLoading || custom.isLoading || alternative.isLoading || skip.isLoading;
+
+  if (totalTargets > 0 && session.target_index >= totalTargets) {
+    return null;
+  }
+
+  async function handleAccept() {
+    try {
+      await acceptPending(session.id).unwrap();
+      showSuccess("Applied. Onto the next one.");
+      setMode("view");
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleCustom() {
+    if (!customText.trim()) return;
+    try {
+      await supplyCustom({ id: session.id, user_text: customText.trim() }).unwrap();
+      showSuccess("Your rewrite is in.");
+      setMode("view");
+      setCustomText("");
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleAlternative() {
+    try {
+      await requestAlternative({
+        id: session.id,
+        hint: hint.trim() || undefined,
+      }).unwrap();
+      setMode("view");
+      setHint("");
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  async function handleSkip() {
+    try {
+      await skipTarget(session.id).unwrap();
+      setMode("view");
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <header className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold flex items-center gap-2">
+          <Sparkles className="size-4 text-primary" />
+          Suggestion
+        </h2>
+        <Badge>
+          {session.target_index + 1} / {totalTargets} · {remaining} left
+        </Badge>
+      </header>
+
+      {targetSection && (
+        <p className="text-xs uppercase tracking-wide text-muted-foreground">
+          Section: <span className="font-medium normal-case">{targetSection}</span>
+        </p>
+      )}
+
+      {clarifyingQuestion ? (
+        <ClarifyingPanel
+          question={clarifyingQuestion}
+          customText={customText}
+          onCustomTextChange={setCustomText}
+          onSubmit={handleCustom}
+          isPending={isPending}
+        />
+      ) : proposal ? (
+        <>
+          <div className="rounded-md border border-border bg-muted/40 p-3 text-sm whitespace-pre-wrap">
+            {proposal}
+          </div>
+          {rationale && (
+            <p className="text-xs text-muted-foreground italic">{rationale}</p>
+          )}
+        </>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          Hmm, let me think. Working on a suggestion…
+        </p>
+      )}
+
+      {mode === "custom" && (
+        <CustomRewritePanel
+          customText={customText}
+          onChange={setCustomText}
+          onCancel={() => setMode("view")}
+          onSubmit={handleCustom}
+          isPending={isPending}
+        />
+      )}
+
+      {mode === "alternative" && (
+        <AlternativePanel
+          hint={hint}
+          onChange={setHint}
+          onCancel={() => setMode("view")}
+          onSubmit={handleAlternative}
+          isPending={isPending}
+        />
+      )}
+
+      {mode === "view" && (
+        <div className="flex flex-wrap gap-2 pt-1">
+          <LoadingButton
+            onClick={handleAccept}
+            isLoading={accept.isLoading}
+            disabled={!proposal || isPending}
+          >
+            Accept
+          </LoadingButton>
+          <button
+            type="button"
+            onClick={() => setMode("custom")}
+            disabled={isPending}
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+          >
+            <Pencil size={14} /> Write my own
+          </button>
+          <button
+            type="button"
+            onClick={() => setMode("alternative")}
+            disabled={isPending}
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+          >
+            <RefreshCw size={14} /> Another option
+          </button>
+          <button
+            type="button"
+            onClick={handleSkip}
+            disabled={isPending}
+            className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50 ml-auto"
+          >
+            <SkipForward size={14} /> Skip
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface ClarifyingPanelProps {
+  question: string;
+  customText: string;
+  onCustomTextChange: (s: string) => void;
+  onSubmit: () => void;
+  isPending: boolean;
+}
+
+function ClarifyingPanel({ question, customText, onCustomTextChange, onSubmit, isPending }: ClarifyingPanelProps) {
+  return (
+    <div className="space-y-2">
+      <div className="rounded-md border border-amber-300/50 bg-amber-50 dark:bg-amber-950/20 p-3 text-sm">
+        {question}
+      </div>
+      <textarea
+        value={customText}
+        onChange={(e) => onCustomTextChange(e.target.value)}
+        rows={3}
+        placeholder="Your answer or your own rewrite…"
+        className="w-full rounded-md border border-border bg-background p-2 text-sm"
+      />
+      <div className="flex justify-end">
+        <LoadingButton
+          isLoading={isPending}
+          onClick={onSubmit}
+          disabled={!customText.trim()}
+        >
+          Use this
+        </LoadingButton>
+      </div>
+    </div>
+  );
+}
+
+interface CustomRewritePanelProps {
+  customText: string;
+  onChange: (s: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+}
+
+function CustomRewritePanel({ customText, onChange, onCancel, onSubmit, isPending }: CustomRewritePanelProps) {
+  return (
+    <div className="space-y-2 border-t border-border pt-3">
+      <textarea
+        value={customText}
+        onChange={(e) => onChange(e.target.value)}
+        rows={3}
+        placeholder="Type the version you want…"
+        className="w-full rounded-md border border-border bg-background p-2 text-sm"
+      />
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <LoadingButton
+          isLoading={isPending}
+          onClick={onSubmit}
+          disabled={!customText.trim()}
+        >
+          Use my version
+        </LoadingButton>
+      </div>
+    </div>
+  );
+}
+
+interface AlternativePanelProps {
+  hint: string;
+  onChange: (s: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+}
+
+function AlternativePanel({ hint, onChange, onCancel, onSubmit, isPending }: AlternativePanelProps) {
+  return (
+    <div className="space-y-2 border-t border-border pt-3">
+      <input
+        value={hint}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder='Optional nudge — e.g. "more concise" or "emphasize leadership"'
+        className="w-full rounded-md border border-border bg-background p-2 text-sm"
+      />
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <LoadingButton isLoading={isPending} onClick={onSubmit}>
+          Try again
+        </LoadingButton>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ResumeRefinementSkeleton.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ResumeRefinementSkeleton.tsx
@@ -1,0 +1,10 @@
+import { Skeleton } from "@platform/ui";
+
+export default function ResumeRefinementSkeleton() {
+  return (
+    <div className="space-y-4">
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-64 w-full" />
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SessionStartPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SessionStartPanel.tsx
@@ -1,0 +1,125 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { Sparkles } from "lucide-react";
+import {
+  EmptyState,
+  LoadingButton,
+  Skeleton,
+  showError,
+  extractErrorMessage,
+} from "@platform/ui";
+import { useListResumeJobsQuery } from "@/lib/resumesApi";
+import { useStartRefinementSessionMutation } from "@/lib/resumeRefinementApi";
+import type { ResumeUploadJob } from "@/types/resume-upload-job/resume-upload-job";
+
+interface SessionStartPanelProps {
+  onSessionStarted: (sessionId: string) => void;
+}
+
+export default function SessionStartPanel({ onSessionStarted }: SessionStartPanelProps) {
+  const { data: jobs, isLoading } = useListResumeJobsQuery();
+  const [startSession, { isLoading: isStarting }] = useStartRefinementSessionMutation();
+  const [picked, setPicked] = useState<string | null>(null);
+
+  const completedJobs = (jobs ?? []).filter((j) => j.status === "complete");
+
+  if (isLoading) {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+        <Skeleton className="h-12 w-full" />
+      </div>
+    );
+  }
+
+  if (completedJobs.length === 0) {
+    return (
+      <EmptyState
+        icon={<Sparkles className="size-8 text-muted-foreground" />}
+        heading="Upload a resume first"
+        body={
+          <span>
+            The refinement loop iterates on a resume you've already uploaded and
+            parsed. Head to{" "}
+            <Link to="/profile" className="underline">
+              Profile
+            </Link>{" "}
+            to upload one, then come back.
+          </span>
+        }
+      />
+    );
+  }
+
+  async function handleStart() {
+    if (!picked) return;
+    try {
+      const session = await startSession({ source_resume_job_id: picked }).unwrap();
+      onSessionStarted(session.id);
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Pick the resume you want to refine. We'll critique it, suggest specific
+        rewrites, and you'll iterate until you're happy.
+      </p>
+      <div className="space-y-2">
+        {completedJobs.map((job) => (
+          <ResumeJobOption
+            key={job.id}
+            job={job}
+            selected={picked === job.id}
+            onSelect={() => setPicked(job.id)}
+          />
+        ))}
+      </div>
+      <div className="flex justify-end">
+        <LoadingButton
+          isLoading={isStarting}
+          disabled={!picked}
+          onClick={handleStart}
+        >
+          Start refinement
+        </LoadingButton>
+      </div>
+    </div>
+  );
+}
+
+interface ResumeJobOptionProps {
+  job: ResumeUploadJob;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+function ResumeJobOption({ job, selected, onSelect }: ResumeJobOptionProps) {
+  const fields = job.result_parsed_fields;
+  const summary = fields
+    ? `${fields.work_history_count} role${fields.work_history_count === 1 ? "" : "s"}, ${fields.skills_count} skills`
+    : "Parsed resume";
+  const filename = job.file_filename ?? "resume";
+  const uploaded = new Date(job.created_at).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`w-full text-left rounded-md border p-3 transition ${
+        selected ? "border-primary bg-primary/5" : "border-border hover:bg-muted"
+      }`}
+    >
+      <div className="text-sm font-medium">{filename}</div>
+      <div className="text-xs text-muted-foreground mt-0.5">
+        {summary} · uploaded {uploaded}
+      </div>
+    </button>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SessionStartPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SessionStartPanel.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Link } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import { Sparkles } from "lucide-react";
 import {
   EmptyState,
@@ -17,6 +17,7 @@ interface SessionStartPanelProps {
 }
 
 export default function SessionStartPanel({ onSessionStarted }: SessionStartPanelProps) {
+  const navigate = useNavigate();
   const { data: jobs, isLoading } = useListResumeJobsQuery();
   const [startSession, { isLoading: isStarting }] = useStartRefinementSessionMutation();
   const [picked, setPicked] = useState<string | null>(null);
@@ -38,16 +39,8 @@ export default function SessionStartPanel({ onSessionStarted }: SessionStartPane
       <EmptyState
         icon={<Sparkles className="size-8 text-muted-foreground" />}
         heading="Upload a resume first"
-        body={
-          <span>
-            The refinement loop iterates on a resume you've already uploaded and
-            parsed. Head to{" "}
-            <Link to="/profile" className="underline">
-              Profile
-            </Link>{" "}
-            to upload one, then come back.
-          </span>
-        }
+        body="The refinement loop iterates on a resume you've already uploaded and parsed. Head to Profile to upload one, then come back."
+        action={{ label: "Go to Profile", onClick: () => navigate("/profile") }}
       />
     );
   }

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/markdown-preview.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/markdown-preview.tsx
@@ -1,0 +1,138 @@
+// Tiny in-page markdown preview. Handles only the constrained subset
+// emitted by the backend's render/rewrite pipeline (headings, bullet
+// lists, **bold**, *italic*, paragraphs). For the canonical rendering
+// users export to PDF / DOCX which uses pandoc + weasyprint.
+
+interface InlineSpan {
+  text: string;
+  bold?: boolean;
+  italic?: boolean;
+}
+
+interface MarkdownPreviewProps {
+  source: string;
+}
+
+function renderInline(line: string): InlineSpan[] {
+  const spans: InlineSpan[] = [];
+  let i = 0;
+  let buffer = "";
+
+  while (i < line.length) {
+    if (line[i] === "*" && line[i + 1] === "*") {
+      const end = line.indexOf("**", i + 2);
+      if (end >= 0) {
+        if (buffer) {
+          spans.push({ text: buffer });
+          buffer = "";
+        }
+        spans.push({ text: line.slice(i + 2, end), bold: true });
+        i = end + 2;
+        continue;
+      }
+    } else if (line[i] === "*") {
+      const end = line.indexOf("*", i + 1);
+      if (end >= 0 && line[end + 1] !== "*") {
+        if (buffer) {
+          spans.push({ text: buffer });
+          buffer = "";
+        }
+        spans.push({ text: line.slice(i + 1, end), italic: true });
+        i = end + 1;
+        continue;
+      }
+    }
+    buffer += line[i];
+    i += 1;
+  }
+
+  if (buffer) {
+    spans.push({ text: buffer });
+  }
+  return spans;
+}
+
+function InlineText({ source }: { source: string }) {
+  const spans = renderInline(source);
+  return (
+    <>
+      {spans.map((span, idx) => {
+        const node = <span key={idx}>{span.text}</span>;
+        if (span.bold && span.italic) return <strong key={idx}><em>{span.text}</em></strong>;
+        if (span.bold) return <strong key={idx}>{span.text}</strong>;
+        if (span.italic) return <em key={idx}>{span.text}</em>;
+        return node;
+      })}
+    </>
+  );
+}
+
+export default function MarkdownPreview({ source }: MarkdownPreviewProps) {
+  const lines = source.split("\n");
+  const blocks: React.ReactNode[] = [];
+  let listBuffer: string[] = [];
+  let key = 0;
+
+  function flushList() {
+    if (listBuffer.length > 0) {
+      const items = [...listBuffer];
+      blocks.push(
+        <ul key={`ul-${key++}`} className="list-disc pl-5 space-y-1 text-sm">
+          {items.map((item, idx) => (
+            <li key={idx}>
+              <InlineText source={item} />
+            </li>
+          ))}
+        </ul>
+      );
+      listBuffer = [];
+    }
+  }
+
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, "");
+
+    if (line.startsWith("- ")) {
+      listBuffer.push(line.slice(2));
+      continue;
+    }
+
+    flushList();
+
+    if (!line) {
+      continue;
+    }
+    if (line.startsWith("# ")) {
+      blocks.push(
+        <h1 key={`h-${key++}`} className="text-xl font-bold border-b border-border pb-1">
+          <InlineText source={line.slice(2)} />
+        </h1>
+      );
+      continue;
+    }
+    if (line.startsWith("## ")) {
+      blocks.push(
+        <h2 key={`h-${key++}`} className="text-base font-bold uppercase tracking-wide mt-4">
+          <InlineText source={line.slice(3)} />
+        </h2>
+      );
+      continue;
+    }
+    if (line.startsWith("### ")) {
+      blocks.push(
+        <h3 key={`h-${key++}`} className="text-sm font-bold mt-2">
+          <InlineText source={line.slice(4)} />
+        </h3>
+      );
+      continue;
+    }
+    blocks.push(
+      <p key={`p-${key++}`} className="text-sm">
+        <InlineText source={line} />
+      </p>
+    );
+  }
+  flushList();
+
+  return <div className="space-y-1.5">{blocks}</div>;
+}

--- a/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
@@ -1,0 +1,79 @@
+import { baseApi } from "@platform/ui";
+import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
+
+const REFINEMENT_TAG = "RefinementSession";
+
+const resumeRefinementApi = baseApi
+  .enhanceEndpoints({ addTagTypes: [REFINEMENT_TAG] })
+  .injectEndpoints({
+    endpoints: (build) => ({
+      startRefinementSession: build.mutation<RefinementSession, { source_resume_job_id: string }>({
+        query: (body) => ({
+          url: "/resume-refinement/sessions",
+          method: "POST",
+          data: body,
+        }),
+        invalidatesTags: [{ type: REFINEMENT_TAG, id: "LIST" }],
+      }),
+
+      getRefinementSession: build.query<RefinementSession, string>({
+        query: (id) => ({ url: `/resume-refinement/sessions/${id}`, method: "GET" }),
+        providesTags: (_result, _err, id) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
+      acceptPending: build.mutation<RefinementSession, string>({
+        query: (id) => ({
+          url: `/resume-refinement/sessions/${id}/accept`,
+          method: "POST",
+          data: {},
+        }),
+        invalidatesTags: (_result, _err, id) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
+      supplyCustomRewrite: build.mutation<RefinementSession, { id: string; user_text: string }>({
+        query: ({ id, user_text }) => ({
+          url: `/resume-refinement/sessions/${id}/custom`,
+          method: "POST",
+          data: { user_text },
+        }),
+        invalidatesTags: (_result, _err, { id }) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
+      requestAlternative: build.mutation<RefinementSession, { id: string; hint?: string }>({
+        query: ({ id, hint }) => ({
+          url: `/resume-refinement/sessions/${id}/alternative`,
+          method: "POST",
+          data: { hint: hint ?? null },
+        }),
+        invalidatesTags: (_result, _err, { id }) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
+      skipTarget: build.mutation<RefinementSession, string>({
+        query: (id) => ({
+          url: `/resume-refinement/sessions/${id}/skip`,
+          method: "POST",
+          data: {},
+        }),
+        invalidatesTags: (_result, _err, id) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
+      completeRefinementSession: build.mutation<RefinementSession, string>({
+        query: (id) => ({
+          url: `/resume-refinement/sessions/${id}/complete`,
+          method: "POST",
+          data: {},
+        }),
+        invalidatesTags: (_result, _err, id) => [{ type: REFINEMENT_TAG, id }],
+      }),
+    }),
+  });
+
+export const {
+  useStartRefinementSessionMutation,
+  useGetRefinementSessionQuery,
+  useAcceptPendingMutation,
+  useSupplyCustomRewriteMutation,
+  useRequestAlternativeMutation,
+  useSkipTargetMutation,
+  useCompleteRefinementSessionMutation,
+} = resumeRefinementApi;

--- a/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useState } from "react";
+import { Sparkles } from "lucide-react";
+import { Skeleton } from "@platform/ui";
+import SessionStartPanel from "@/features/resume_refinement/SessionStartPanel";
+import CurrentDraftPanel from "@/features/resume_refinement/CurrentDraftPanel";
+import PendingProposalCard from "@/features/resume_refinement/PendingProposalCard";
+import CompletePanel from "@/features/resume_refinement/CompletePanel";
+import { useGetRefinementSessionQuery } from "@/lib/resumeRefinementApi";
+
+const ACTIVE_SESSION_KEY = "mjh:resumeRefinementSessionId";
+const POLL_INTERVAL_MS = 3000;
+
+export default function ResumeRefinement() {
+  const [sessionId, setSessionId] = useState<string | null>(() =>
+    typeof window !== "undefined" ? window.localStorage.getItem(ACTIVE_SESSION_KEY) : null
+  );
+
+  const {
+    data: session,
+    isLoading,
+    error,
+  } = useGetRefinementSessionQuery(sessionId ?? "", {
+    skip: !sessionId,
+    pollingInterval: sessionId ? POLL_INTERVAL_MS : 0,
+  });
+
+  // Stop polling once the session is no longer active.
+  useEffect(() => {
+    if (!session) return;
+    if (session.status !== "active") {
+      // No-op: RTK Query will continue at its interval; the polling
+      // behaviour is acceptable post-completion since the data is
+      // stable.
+    }
+  }, [session]);
+
+  function handleSessionStarted(id: string) {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(ACTIVE_SESSION_KEY, id);
+    }
+    setSessionId(id);
+  }
+
+  function handleStartNew() {
+    if (typeof window !== "undefined") {
+      window.localStorage.removeItem(ACTIVE_SESSION_KEY);
+    }
+    setSessionId(null);
+  }
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <header>
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-6 text-primary" />
+          <h1 className="text-2xl font-semibold">Resume refinement</h1>
+        </div>
+        <p className="text-sm text-muted-foreground mt-0.5">
+          Iterate on your resume one bullet at a time. AI suggests, you accept
+          or override, and at the end you download a polished PDF or DOCX.
+        </p>
+      </header>
+
+      {sessionId && error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+          We couldn't load that session.{" "}
+          <button
+            type="button"
+            onClick={handleStartNew}
+            className="underline"
+          >
+            Start a new one
+          </button>
+          .
+        </div>
+      )}
+
+      {!sessionId && <SessionStartPanel onSessionStarted={handleSessionStarted} />}
+
+      {sessionId && isLoading && !session && (
+        <div className="space-y-3">
+          <Skeleton className="h-32 w-full" />
+          <Skeleton className="h-64 w-full" />
+        </div>
+      )}
+
+      {session && (
+        <div className="space-y-4">
+          {session.status === "active" && (
+            <PendingProposalCard session={session} />
+          )}
+          <CompletePanel session={session} />
+          <CurrentDraftPanel markdown={session.current_draft} />
+          <div className="flex justify-end">
+            <button
+              type="button"
+              onClick={handleStartNew}
+              className="text-xs underline text-muted-foreground hover:text-foreground"
+            >
+              Start a different session
+            </button>
+          </div>
+        </div>
+      )}
+    </main>
+  );
+}

--- a/apps/myjobhunter/frontend/src/routes.tsx
+++ b/apps/myjobhunter/frontend/src/routes.tsx
@@ -6,6 +6,7 @@ import Companies from "@/pages/Companies";
 import CompanyDetail from "@/pages/CompanyDetail";
 import Documents from "@/pages/Documents";
 import Profile from "@/pages/Profile";
+import ResumeRefinement from "@/pages/ResumeRefinement";
 import Security from "@/pages/Security";
 import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
@@ -24,6 +25,7 @@ export const routes: RouteObject[] = [
       { path: "/companies", element: <Companies /> },
       { path: "/companies/:id", element: <CompanyDetail /> },
       { path: "/documents", element: <Documents /> },
+      { path: "/resume", element: <ResumeRefinement /> },
       { path: "/profile", element: <Profile /> },
       { path: "/settings", element: <Settings /> },
       { path: "/security", element: <Security /> },

--- a/apps/myjobhunter/frontend/src/types/resume-refinement/improvement-target.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-refinement/improvement-target.ts
@@ -1,0 +1,19 @@
+export type ImprovementType =
+  | "add_metric"
+  | "add_outcome"
+  | "tighten_phrasing"
+  | "remove_jargon"
+  | "stronger_verb"
+  | "add_scope"
+  | "fix_grammar"
+  | "other";
+
+export type ImprovementSeverity = "critical" | "high" | "medium" | "low";
+
+export interface ImprovementTarget {
+  section: string;
+  current_text: string;
+  improvement_type: ImprovementType;
+  severity: ImprovementSeverity;
+  notes: string | null;
+}

--- a/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-session.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-session.ts
@@ -1,0 +1,23 @@
+import type { ImprovementTarget } from "./improvement-target";
+
+export type RefinementSessionStatus = "active" | "completed" | "abandoned";
+
+export interface RefinementSession {
+  id: string;
+  source_resume_job_id: string | null;
+  status: RefinementSessionStatus;
+  current_draft: string;
+  improvement_targets: ImprovementTarget[] | null;
+  target_index: number;
+  pending_target_section: string | null;
+  pending_proposal: string | null;
+  pending_rationale: string | null;
+  pending_clarifying_question: string | null;
+  turn_count: number;
+  total_tokens_in: number;
+  total_tokens_out: number;
+  total_cost_usd: string;
+  completed_at: string | null;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-turn.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-turn.ts
@@ -1,0 +1,20 @@
+export type RefinementTurnRole =
+  | "ai_critique"
+  | "ai_proposal"
+  | "user_accept"
+  | "user_custom"
+  | "user_request_alternative"
+  | "user_skip"
+  | "session_complete";
+
+export interface RefinementTurn {
+  id: string;
+  turn_index: number;
+  role: RefinementTurnRole;
+  target_section: string | null;
+  proposed_text: string | null;
+  user_text: string | null;
+  rationale: string | null;
+  clarifying_question: string | null;
+  created_at: string;
+}


### PR DESCRIPTION
## Summary

- Standalone `/resume` page that turns a parsed resume into a polished one through a chat-style critique-and-rewrite loop with Claude.
- Two new tables (`resume_refinement_sessions`, `resume_refinement_turns`), critique + rewrite prompt modules, hallucination guard, and pandoc/weasyprint export pipeline for ATS-ready PDF + DOCX downloads.
- Implements the spec captured 2026-05-05 in `project_resume_refinement_feature_spec`. Open-question defaults applied: polling (not SSE), live persistence per accepted turn, fresh-by-default with localStorage resume, MBK conversational tone, token tracking on session row.

## What it does

1. User picks an already-uploaded resume from `/resume`.
2. Backend renders the parsed structure to a constrained markdown subset, runs a critique pass (Claude → 5–15 prioritized improvement targets), and queues the first rewrite proposal.
3. User iterates one target at a time: **Accept** the proposal, **Write my own**, ask for **Another option** (with optional hint), or **Skip**.
4. Hallucination guard catches proposals that introduce companies / dates / metrics not present in the source and downgrades them to clarification questions ("we shouldn't add 500K transactions/day unless that's in your history — what's the real number?").
5. After every target is reviewed, user clicks **Mark resume done**, then downloads as **PDF** (pandoc → HTML → weasyprint) or **DOCX** (pandoc native).
6. Round-trip fidelity check on every export: anchor tokens (section headings, years, bold-wrapped names) must survive the conversion or the request 502s.

## Files

**Backend** — 1 migration + 2 models + 2 repos + 1 router + 7 services + 2 prompts + 5 test files + claude_service extension (`call_claude_with_meta` returns parsed + token + cost meta).

**Frontend** — 1 page + 1 RTK slice + 6 feature components + 3 type files + nav/routes/RootLayout updates. No new npm deps (tiny inline markdown previewer for the constrained subset).

**Infra** — `weasyprint>=62` in pyproject/uv.lock/requirements.txt; pandoc + libpango + libharfbuzz + DejaVu/Liberation fonts added to `backend.Dockerfile` runtime stage.

## Test plan

- [ ] `cd apps/myjobhunter/backend && uv sync && pytest tests/test_resume_refinement_*` — 5 new test files, all syntax-clean
- [ ] `alembic upgrade head` — applies `refine260505`
- [ ] `cd apps/myjobhunter/frontend && npm install && npm run build` — typecheck the new page + components
- [ ] After deploy, smoke test the loop end-to-end: pick resume → wait for critique → accept a proposal → request alternative → mark done → download PDF + DOCX, confirm both have selectable text and contain real company names
- [ ] Verify hallucination guard fires by editing a prompt response in a test to inject a fake company; confirm it flips to clarify
- [ ] Confirm the polling interval (3s) feels right; upgrade to SSE if perceived latency is bad

## Caveats

- Local dev outside Docker won't export until `pandoc` is on PATH; the Dockerfile change is the only path to a working production export.
- Backend not run end-to-end yet — only AST-checked. First real-data run is the deploy smoke test.
- No new env vars; no operator action required at deploy. The next image rebuild picks up pandoc + weasyprint automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)