### PR TITLE
fix(myjobhunter/tests): update Document construction after kind rename

### DIFF
--- a/apps/myjobhunter/backend/tests/test_account_deletion.py
+++ b/apps/myjobhunter/backend/tests/test_account_deletion.py
@@ -405,9 +405,9 @@ async def test_delete_cascades_all_domain_rows(db: AsyncSession) -> None:
     db.add(Document(
         user_id=user.id,
         application_id=application.id,
-        document_type="cover_letter",
+        title="Cover letter",
+        kind="cover_letter",
         file_path="/tmp/cover.pdf",
-        generated_by="user",
     ))
 
     db.add(JobBoardCredential(

--- a/apps/myjobhunter/backend/tests/test_data_export.py
+++ b/apps/myjobhunter/backend/tests/test_data_export.py
@@ -144,9 +144,9 @@ async def test_export_returns_user_data(db: AsyncSession) -> None:
     db.add(Document(
         user_id=user.id,
         application_id=application.id,
-        document_type="cover_letter",
+        title="Cover letter",
+        kind="cover_letter",
         file_path="/tmp/cover.pdf",
-        generated_by="user",
     ))
     await db.flush()
 


### PR DESCRIPTION
## Summary

Two MJH tests have been failing on every PR's \`backend-tests / login-heavy\` job since migration \`docs260504_documents_domain\` landed:

- \`test_account_deletion.py::test_delete_cascades_all_domain_rows\`
- \`test_data_export.py::test_export_returns_user_data\`

Both construct \`Document(...)\` with the old kwargs the migration removed:

| Old kwarg | After migration |
|---|---|
| \`document_type=\"cover_letter\"\` | \`kind=\"cover_letter\"\` (column renamed; same CheckConstraint values) |
| \`generated_by=\"user\"\` | dropped entirely |
| _(none)_ | \`title\` is now NOT NULL — added \`title=\"Cover letter\"\` |

## Why this PR is small + standalone

This is the proximate root-cause of the \`Stack smoke\` and \`backend-tests / myjobhunter / login-heavy\` failures blocking PRs #312, #314, and #315 (the failures predate every one of those branches; they reproduce on plain main). Fixing in a 4-line surgical PR off main so all three downstream PRs can rebase cleanly.

No production code is affected; this is test-only.

## Test plan

- [ ] \`pytest apps/myjobhunter/backend/tests/test_account_deletion.py::test_delete_cascades_all_domain_rows\` — passes
- [ ] \`pytest apps/myjobhunter/backend/tests/test_data_export.py::test_export_returns_user_data\` — passes
- [ ] CI \`backend-tests / myjobhunter / login-heavy\` job goes green
- [ ] CI \`Stack smoke (compose up + health + login)\` goes green (assuming it was the same root cause; if a different failure surfaces, separate fix follows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)