### PR TITLE
fix(myjobhunter/ci): pre-create shared myfreeapps network before stack smoke

### DIFF
--- a/.github/workflows/integration-myjobhunter.yml
+++ b/.github/workflows/integration-myjobhunter.yml
@@ -54,6 +54,15 @@ jobs:
           MYJOBHUNTER_ENABLE_TEST_HELPERS=1
           EOF
 
+      - name: Create shared infra network
+        # apps/myjobhunter/docker-compose.yml declares `myfreeapps` as an
+        # external network (it's owned by the top-level infra/docker-compose
+        # stack at runtime, where shared MinIO lives). In CI we don't run
+        # the infra stack, so we create the network manually before bringing
+        # the app stack up. Without this, `docker compose up` fails with
+        # "network myfreeapps declared as external, but could not be found".
+        run: docker network create myfreeapps || true
+
       - name: Build and start stack
         working-directory: apps/myjobhunter
         env:


### PR DESCRIPTION
## Summary

The \`Stack smoke (compose up + health + login)\` job has been failing on every PR since the workflow landed:

\`\`\`
network myfreeapps declared as external, but could not be found
\`\`\`

\`apps/myjobhunter/docker-compose.yml\` declares the \`myfreeapps\` network as \`external: true\` — it's owned by the top-level \`infra/docker-compose.yml\` stack at runtime where shared MinIO lives. In CI we don't bring up the infra stack, so the external reference can't be resolved and \`docker compose up\` aborts.

Fix: a one-liner workflow step that creates the network manually before the compose-up. \`|| true\` so the step is idempotent across reruns.

## Why this PR is small + standalone

Pairs with #317 — together these unblock the \`Stack smoke\` + \`backend-tests / login-heavy\` failures that have been blocking PRs #312, #314, and #315. After both are merged, the only remaining failures on those PRs will be real per-PR issues.

## Test plan

- [ ] This PR's \`Stack smoke\` job goes green
- [ ] After merge, the next push to PR #315 shows stack-smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)