### PR TITLE
fix(myjobhunter/resume): show + highlight what the AI is refining

### DIFF
--- a/apps/myjobhunter/frontend/src/features/resume_refinement/AlternativePanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/AlternativePanel.tsx
@@ -1,0 +1,41 @@
+import { LoadingButton } from "@platform/ui";
+
+interface AlternativePanelProps {
+  hint: string;
+  onChange: (s: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+}
+
+export default function AlternativePanel({
+  hint,
+  onChange,
+  onCancel,
+  onSubmit,
+  isPending,
+}: AlternativePanelProps) {
+  return (
+    <div className="space-y-2 border-t border-border pt-3">
+      <input
+        value={hint}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder='Optional nudge — e.g. "more concise" or "emphasize leadership"'
+        className="w-full rounded-md border border-border bg-background p-2 text-sm"
+      />
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <LoadingButton isLoading={isPending} onClick={onSubmit}>
+          Try again
+        </LoadingButton>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ClarifyingPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ClarifyingPanel.tsx
@@ -1,0 +1,41 @@
+import { LoadingButton } from "@platform/ui";
+
+interface ClarifyingPanelProps {
+  question: string;
+  customText: string;
+  onCustomTextChange: (s: string) => void;
+  onSubmit: () => void;
+  isPending: boolean;
+}
+
+export default function ClarifyingPanel({
+  question,
+  customText,
+  onCustomTextChange,
+  onSubmit,
+  isPending,
+}: ClarifyingPanelProps) {
+  return (
+    <div className="space-y-2">
+      <div className="rounded-md border border-amber-300/50 bg-amber-50 dark:bg-amber-950/20 p-3 text-sm">
+        {question}
+      </div>
+      <textarea
+        value={customText}
+        onChange={(e) => onCustomTextChange(e.target.value)}
+        rows={3}
+        placeholder="Your answer or your own rewrite…"
+        className="w-full rounded-md border border-border bg-background p-2 text-sm"
+      />
+      <div className="flex justify-end">
+        <LoadingButton
+          isLoading={isPending}
+          onClick={onSubmit}
+          disabled={!customText.trim()}
+        >
+          Use this
+        </LoadingButton>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentDraftPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentDraftPanel.tsx
@@ -2,20 +2,25 @@ import MarkdownPreview from "@/features/resume_refinement/markdown-preview";
 
 interface CurrentDraftPanelProps {
   markdown: string;
+  /** When set, the matching block in the preview gets a yellow band + auto-scroll. */
+  highlightText?: string | null;
 }
 
-export default function CurrentDraftPanel({ markdown }: CurrentDraftPanelProps) {
+export default function CurrentDraftPanel({ markdown, highlightText }: CurrentDraftPanelProps) {
   return (
     <section className="rounded-lg border border-border bg-card p-4 space-y-2">
       <header>
         <h2 className="text-sm font-semibold">Current draft</h2>
         <p className="text-xs text-muted-foreground mt-0.5">
-          Your live working copy. Changes apply as you accept rewrites.
+          Your live working copy.{" "}
+          {highlightText
+            ? "The highlighted line is what we're refining now."
+            : "Changes apply as you accept rewrites."}
         </p>
       </header>
       <div className="rounded-md border border-border bg-background p-4 overflow-y-auto max-h-[60vh]">
         {markdown.trim() ? (
-          <MarkdownPreview source={markdown} />
+          <MarkdownPreview source={markdown} highlightText={highlightText} />
         ) : (
           <p className="text-sm text-muted-foreground">Your draft is empty.</p>
         )}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentTargetBlock.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentTargetBlock.tsx
@@ -1,0 +1,17 @@
+interface CurrentTargetBlockProps {
+  text: string;
+}
+
+// Small amber-bordered block that quotes the verbatim source text the
+// AI is targeting. Mirrors the highlight band the draft preview uses
+// so users see "this is what we're refining" in two places at once.
+export default function CurrentTargetBlock({ text }: CurrentTargetBlockProps) {
+  return (
+    <div className="rounded-md border border-amber-300/60 bg-amber-50/60 dark:bg-amber-500/10 p-3">
+      <p className="text-[11px] uppercase tracking-wide text-amber-900/70 dark:text-amber-200/70 font-semibold mb-1">
+        Currently
+      </p>
+      <p className="text-sm whitespace-pre-wrap">{text}</p>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CustomRewritePanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CustomRewritePanel.tsx
@@ -1,0 +1,46 @@
+import { LoadingButton } from "@platform/ui";
+
+interface CustomRewritePanelProps {
+  customText: string;
+  onChange: (s: string) => void;
+  onCancel: () => void;
+  onSubmit: () => void;
+  isPending: boolean;
+}
+
+export default function CustomRewritePanel({
+  customText,
+  onChange,
+  onCancel,
+  onSubmit,
+  isPending,
+}: CustomRewritePanelProps) {
+  return (
+    <div className="space-y-2 border-t border-border pt-3">
+      <textarea
+        value={customText}
+        onChange={(e) => onChange(e.target.value)}
+        rows={3}
+        placeholder="Type the version you want…"
+        className="w-full rounded-md border border-border bg-background p-2 text-sm"
+      />
+      <div className="flex gap-2 justify-end">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isPending}
+          className="rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <LoadingButton
+          isLoading={isPending}
+          onClick={onSubmit}
+          disabled={!customText.trim()}
+        >
+          Use my version
+        </LoadingButton>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -32,6 +32,11 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
   const totalTargets = session.improvement_targets?.length ?? 0;
   const remaining = Math.max(totalTargets - session.target_index, 0);
   const targetSection = session.pending_target_section;
+  const activeTarget =
+    session.improvement_targets && session.target_index < session.improvement_targets.length
+      ? session.improvement_targets[session.target_index]
+      : null;
+  const currentText = activeTarget?.current_text ?? null;
   const proposal = session.pending_proposal;
   const rationale = session.pending_rationale;
   const clarifyingQuestion = session.pending_clarifying_question;
@@ -104,6 +109,15 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
         </p>
       )}
 
+      {currentText && (
+        <div className="rounded-md border border-amber-300/60 bg-amber-50/60 dark:bg-amber-500/10 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-amber-900/70 dark:text-amber-200/70 font-semibold mb-1">
+            Currently
+          </p>
+          <p className="text-sm whitespace-pre-wrap">{currentText}</p>
+        </div>
+      )}
+
       {clarifyingQuestion ? (
         <ClarifyingPanel
           question={clarifyingQuestion}
@@ -113,14 +127,15 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
           isPending={isPending}
         />
       ) : proposal ? (
-        <>
-          <div className="rounded-md border border-border bg-muted/40 p-3 text-sm whitespace-pre-wrap">
-            {proposal}
-          </div>
+        <div className="rounded-md border border-emerald-400/50 bg-emerald-50/60 dark:bg-emerald-500/10 p-3">
+          <p className="text-[11px] uppercase tracking-wide text-emerald-900/70 dark:text-emerald-200/70 font-semibold mb-1">
+            Proposed rewrite
+          </p>
+          <p className="text-sm whitespace-pre-wrap">{proposal}</p>
           {rationale && (
-            <p className="text-xs text-muted-foreground italic">{rationale}</p>
+            <p className="text-xs text-muted-foreground italic mt-2">{rationale}</p>
           )}
-        </>
+        </div>
       ) : (
         <p className="text-sm text-muted-foreground">
           Hmm, let me think. Working on a suggestion…

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -118,29 +118,16 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
         </div>
       )}
 
-      {clarifyingQuestion ? (
-        <ClarifyingPanel
-          question={clarifyingQuestion}
-          customText={customText}
-          onCustomTextChange={setCustomText}
-          onSubmit={handleCustom}
-          isPending={isPending}
-        />
-      ) : proposal ? (
-        <div className="rounded-md border border-emerald-400/50 bg-emerald-50/60 dark:bg-emerald-500/10 p-3">
-          <p className="text-[11px] uppercase tracking-wide text-emerald-900/70 dark:text-emerald-200/70 font-semibold mb-1">
-            Proposed rewrite
-          </p>
-          <p className="text-sm whitespace-pre-wrap">{proposal}</p>
-          {rationale && (
-            <p className="text-xs text-muted-foreground italic mt-2">{rationale}</p>
-          )}
-        </div>
-      ) : (
-        <p className="text-sm text-muted-foreground">
-          Hmm, let me think. Working on a suggestion…
-        </p>
-      )}
+      <SuggestionBody
+        clarifyingQuestion={clarifyingQuestion}
+        customText={customText}
+        onCustomTextChange={setCustomText}
+        onClarifySubmit={handleCustom}
+        proposal={proposal}
+        rationale={rationale}
+        isPending={isPending}
+      />
+
 
       {mode === "custom" && (
         <CustomRewritePanel
@@ -198,6 +185,61 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
         </div>
       )}
     </section>
+  );
+}
+
+interface SuggestionBodyProps {
+  clarifyingQuestion: string | null;
+  customText: string;
+  onCustomTextChange: (s: string) => void;
+  onClarifySubmit: () => void;
+  proposal: string | null;
+  rationale: string | null;
+  isPending: boolean;
+}
+
+// Three-way render of the suggestion area: clarification request,
+// AI proposal, or "thinking" placeholder. Early returns instead of a
+// nested ternary chain per the project's JSX-conditional convention.
+function SuggestionBody({
+  clarifyingQuestion,
+  customText,
+  onCustomTextChange,
+  onClarifySubmit,
+  proposal,
+  rationale,
+  isPending,
+}: SuggestionBodyProps) {
+  if (clarifyingQuestion) {
+    return (
+      <ClarifyingPanel
+        question={clarifyingQuestion}
+        customText={customText}
+        onCustomTextChange={onCustomTextChange}
+        onSubmit={onClarifySubmit}
+        isPending={isPending}
+      />
+    );
+  }
+
+  if (proposal) {
+    return (
+      <div className="rounded-md border border-emerald-400/50 bg-emerald-50/60 dark:bg-emerald-500/10 p-3">
+        <p className="text-[11px] uppercase tracking-wide text-emerald-900/70 dark:text-emerald-200/70 font-semibold mb-1">
+          Proposed rewrite
+        </p>
+        <p className="text-sm whitespace-pre-wrap">{proposal}</p>
+        {rationale && (
+          <p className="text-xs text-muted-foreground italic mt-2">{rationale}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      Hmm, let me think. Working on a suggestion…
+    </p>
   );
 }
 

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionActions.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionActions.tsx
@@ -1,0 +1,61 @@
+import { Pencil, RefreshCw, SkipForward } from "lucide-react";
+import { LoadingButton } from "@platform/ui";
+
+interface SuggestionActionsProps {
+  onAccept: () => void;
+  onSwitchToCustom: () => void;
+  onSwitchToAlternative: () => void;
+  onSkip: () => void;
+  isPending: boolean;
+  acceptIsLoading: boolean;
+  hasProposal: boolean;
+}
+
+// Action row shown when the user is in VIEW mode: accept the AI's
+// proposal, write their own, ask for another option, or skip.
+// Extracted to keep PendingProposalCard focused on orchestration.
+export default function SuggestionActions({
+  onAccept,
+  onSwitchToCustom,
+  onSwitchToAlternative,
+  onSkip,
+  isPending,
+  acceptIsLoading,
+  hasProposal,
+}: SuggestionActionsProps) {
+  return (
+    <div className="flex flex-wrap gap-2 pt-1">
+      <LoadingButton
+        onClick={onAccept}
+        isLoading={acceptIsLoading}
+        disabled={!hasProposal || isPending}
+      >
+        Accept
+      </LoadingButton>
+      <button
+        type="button"
+        onClick={onSwitchToCustom}
+        disabled={isPending}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+      >
+        <Pencil size={14} /> Write my own
+      </button>
+      <button
+        type="button"
+        onClick={onSwitchToAlternative}
+        disabled={isPending}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+      >
+        <RefreshCw size={14} /> Another option
+      </button>
+      <button
+        type="button"
+        onClick={onSkip}
+        disabled={isPending}
+        className="inline-flex items-center gap-1.5 rounded-md border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50 ml-auto"
+      >
+        <SkipForward size={14} /> Skip
+      </button>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionBody.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionBody.tsx
@@ -1,0 +1,56 @@
+import ClarifyingPanel from "@/features/resume_refinement/ClarifyingPanel";
+
+interface SuggestionBodyProps {
+  clarifyingQuestion: string | null;
+  customText: string;
+  onCustomTextChange: (s: string) => void;
+  onClarifySubmit: () => void;
+  proposal: string | null;
+  rationale: string | null;
+  isPending: boolean;
+}
+
+// Three-way render of the suggestion area: clarification request,
+// AI proposal, or "thinking" placeholder. Uses early returns instead
+// of a nested ternary chain per the JSX-conditional convention.
+export default function SuggestionBody({
+  clarifyingQuestion,
+  customText,
+  onCustomTextChange,
+  onClarifySubmit,
+  proposal,
+  rationale,
+  isPending,
+}: SuggestionBodyProps) {
+  if (clarifyingQuestion) {
+    return (
+      <ClarifyingPanel
+        question={clarifyingQuestion}
+        customText={customText}
+        onCustomTextChange={onCustomTextChange}
+        onSubmit={onClarifySubmit}
+        isPending={isPending}
+      />
+    );
+  }
+
+  if (proposal) {
+    return (
+      <div className="rounded-md border border-emerald-400/50 bg-emerald-50/60 dark:bg-emerald-500/10 p-3">
+        <p className="text-[11px] uppercase tracking-wide text-emerald-900/70 dark:text-emerald-200/70 font-semibold mb-1">
+          Proposed rewrite
+        </p>
+        <p className="text-sm whitespace-pre-wrap">{proposal}</p>
+        {rationale && (
+          <p className="text-xs text-muted-foreground italic mt-2">{rationale}</p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <p className="text-sm text-muted-foreground">
+      Hmm, let me think. Working on a suggestion…
+    </p>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/markdown-preview.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/markdown-preview.tsx
@@ -1,7 +1,15 @@
+import { useEffect, useRef } from "react";
+
 // Tiny in-page markdown preview. Handles only the constrained subset
 // emitted by the backend's render/rewrite pipeline (headings, bullet
 // lists, **bold**, *italic*, paragraphs). For the canonical rendering
 // users export to PDF / DOCX which uses pandoc + weasyprint.
+//
+// `highlightText`: when provided, any block (heading / paragraph /
+// list-item) whose plain text contains this substring is wrapped in a
+// highlight band. The first matching block becomes the auto-scroll
+// target so users immediately see where the active refinement target
+// lives in the full draft.
 
 interface InlineSpan {
   text: string;
@@ -11,6 +19,7 @@ interface InlineSpan {
 
 interface MarkdownPreviewProps {
   source: string;
+  highlightText?: string | null;
 }
 
 function renderInline(line: string): InlineSpan[] {
@@ -57,21 +66,47 @@ function InlineText({ source }: { source: string }) {
   return (
     <>
       {spans.map((span, idx) => {
-        const node = <span key={idx}>{span.text}</span>;
         if (span.bold && span.italic) return <strong key={idx}><em>{span.text}</em></strong>;
         if (span.bold) return <strong key={idx}>{span.text}</strong>;
         if (span.italic) return <em key={idx}>{span.text}</em>;
-        return node;
+        return <span key={idx}>{span.text}</span>;
       })}
     </>
   );
 }
 
-export default function MarkdownPreview({ source }: MarkdownPreviewProps) {
+// Strip markdown decoration so a heading like "**Staff Engineer** — Acme"
+// matches a target_current_text of "Staff Engineer — Acme".
+function plainText(line: string): string {
+  return line.replace(/\*\*?/g, "").trim();
+}
+
+function shouldHighlight(line: string, highlightText: string | null | undefined): boolean {
+  if (!highlightText) return false;
+  const needle = highlightText.trim();
+  if (!needle) return false;
+  return plainText(line).includes(needle) || line.trim().includes(needle);
+}
+
+const HIGHLIGHT_CLASS =
+  "rounded-md border-l-4 border-amber-400 bg-amber-50/60 dark:bg-amber-500/10 -ml-2 pl-3 py-1";
+
+export default function MarkdownPreview({ source, highlightText }: MarkdownPreviewProps) {
   const lines = source.split("\n");
   const blocks: React.ReactNode[] = [];
-  let listBuffer: string[] = [];
+  let listBuffer: { text: string; highlight: boolean }[] = [];
   let key = 0;
+  const firstHighlightRef = useRef<HTMLElement | null>(null);
+  let firstHighlightAssigned = false;
+
+  // Capture-callback: assigns the first matching DOM node to the ref so
+  // useEffect can scroll to it once, on every re-render where the
+  // highlight target changes.
+  function attachIfFirst(node: HTMLElement | null, isHighlight: boolean) {
+    if (!isHighlight || !node || firstHighlightAssigned) return;
+    firstHighlightAssigned = true;
+    firstHighlightRef.current = node;
+  }
 
   function flushList() {
     if (listBuffer.length > 0) {
@@ -79,8 +114,12 @@ export default function MarkdownPreview({ source }: MarkdownPreviewProps) {
       blocks.push(
         <ul key={`ul-${key++}`} className="list-disc pl-5 space-y-1 text-sm">
           {items.map((item, idx) => (
-            <li key={idx}>
-              <InlineText source={item} />
+            <li
+              key={idx}
+              ref={(node) => attachIfFirst(node, item.highlight)}
+              className={item.highlight ? HIGHLIGHT_CLASS : undefined}
+            >
+              <InlineText source={item.text} />
             </li>
           ))}
         </ul>
@@ -93,46 +132,78 @@ export default function MarkdownPreview({ source }: MarkdownPreviewProps) {
     const line = raw.replace(/\s+$/, "");
 
     if (line.startsWith("- ")) {
-      listBuffer.push(line.slice(2));
+      const text = line.slice(2);
+      listBuffer.push({ text, highlight: shouldHighlight(text, highlightText) });
       continue;
     }
 
     flushList();
 
-    if (!line) {
-      continue;
-    }
+    if (!line) continue;
+
     if (line.startsWith("# ")) {
+      const text = line.slice(2);
+      const hl = shouldHighlight(text, highlightText);
       blocks.push(
-        <h1 key={`h-${key++}`} className="text-xl font-bold border-b border-border pb-1">
-          <InlineText source={line.slice(2)} />
+        <h1
+          key={`h-${key++}`}
+          ref={(node) => attachIfFirst(node, hl)}
+          className={`text-xl font-bold border-b border-border pb-1 ${hl ? HIGHLIGHT_CLASS : ""}`}
+        >
+          <InlineText source={text} />
         </h1>
       );
       continue;
     }
     if (line.startsWith("## ")) {
+      const text = line.slice(3);
+      const hl = shouldHighlight(text, highlightText);
       blocks.push(
-        <h2 key={`h-${key++}`} className="text-base font-bold uppercase tracking-wide mt-4">
-          <InlineText source={line.slice(3)} />
+        <h2
+          key={`h-${key++}`}
+          ref={(node) => attachIfFirst(node, hl)}
+          className={`text-base font-bold uppercase tracking-wide mt-4 ${hl ? HIGHLIGHT_CLASS : ""}`}
+        >
+          <InlineText source={text} />
         </h2>
       );
       continue;
     }
     if (line.startsWith("### ")) {
+      const text = line.slice(4);
+      const hl = shouldHighlight(text, highlightText);
       blocks.push(
-        <h3 key={`h-${key++}`} className="text-sm font-bold mt-2">
-          <InlineText source={line.slice(4)} />
+        <h3
+          key={`h-${key++}`}
+          ref={(node) => attachIfFirst(node, hl)}
+          className={`text-sm font-bold mt-2 ${hl ? HIGHLIGHT_CLASS : ""}`}
+        >
+          <InlineText source={text} />
         </h3>
       );
       continue;
     }
+
+    const hl = shouldHighlight(line, highlightText);
     blocks.push(
-      <p key={`p-${key++}`} className="text-sm">
+      <p
+        key={`p-${key++}`}
+        ref={(node) => attachIfFirst(node, hl)}
+        className={`text-sm ${hl ? HIGHLIGHT_CLASS : ""}`}
+      >
         <InlineText source={line} />
       </p>
     );
   }
   flushList();
+
+  // Auto-scroll the matched block into view whenever the target changes.
+  useEffect(() => {
+    const node = firstHighlightRef.current;
+    if (node) {
+      node.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, [highlightText]);
 
   return <div className="space-y-1.5">{blocks}</div>;
 }

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/suggestion-mode.ts
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/suggestion-mode.ts
@@ -1,0 +1,16 @@
+/**
+ * UI-only state machine for the suggestion card's input area:
+ * - VIEW: showing the AI's proposal / clarification with action buttons
+ * - CUSTOM: user is typing their own rewrite of the current target
+ * - ALTERNATIVE: user is asking the AI to regenerate with an optional hint
+ *
+ * Local to the resume-refinement feature; not part of the backend
+ * session/turn enum.
+ */
+export const SuggestionMode = {
+  VIEW: "view",
+  CUSTOM: "custom",
+  ALTERNATIVE: "alternative",
+} as const;
+
+export type SuggestionMode = (typeof SuggestionMode)[keyof typeof SuggestionMode];

--- a/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
@@ -49,7 +49,7 @@ export default function ResumeRefinement() {
   }
 
   return (
-    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+    <main className="p-4 sm:p-8 space-y-6 max-w-6xl">
       <header>
         <div className="flex items-center gap-2">
           <Sparkles className="size-6 text-primary" />
@@ -84,24 +84,39 @@ export default function ResumeRefinement() {
         </div>
       )}
 
-      {session && (
-        <div className="space-y-4">
-          {session.status === "active" && (
-            <PendingProposalCard session={session} />
-          )}
-          <CompletePanel session={session} />
-          <CurrentDraftPanel markdown={session.current_draft} />
-          <div className="flex justify-end">
-            <button
-              type="button"
-              onClick={handleStartNew}
-              className="text-xs underline text-muted-foreground hover:text-foreground"
-            >
-              Start a different session
-            </button>
+      {session && (() => {
+        const activeTarget =
+          session.improvement_targets &&
+          session.target_index < session.improvement_targets.length
+            ? session.improvement_targets[session.target_index]
+            : null;
+        const highlightText = activeTarget?.current_text ?? null;
+        return (
+          <div className="grid gap-4 lg:grid-cols-2 lg:items-start">
+            <div className="space-y-4">
+              {session.status === "active" && (
+                <PendingProposalCard session={session} />
+              )}
+              <CompletePanel session={session} />
+            </div>
+            <div className="lg:sticky lg:top-4 space-y-4">
+              <CurrentDraftPanel
+                markdown={session.current_draft}
+                highlightText={highlightText}
+              />
+              <div className="flex justify-end">
+                <button
+                  type="button"
+                  onClick={handleStartNew}
+                  className="text-xs underline text-muted-foreground hover:text-foreground"
+                >
+                  Start a different session
+                </button>
+              </div>
+            </div>
           </div>
-        </div>
-      )}
+        );
+      })()}
     </main>
   );
 }


### PR DESCRIPTION
## Summary

Three UX issues on the resume refinement loop, fixed:

1. **\"Currently:\" block in the suggestion card.** Quotes the verbatim source text the AI is targeting, in an amber-bordered block. No more cross-referencing the section name against the full draft.
2. **Old → new diff on AI proposals.** \"Currently\" block (amber) plus \"Proposed rewrite\" block (emerald) so before/after is scannable at a glance.
3. **Highlight + auto-scroll in the Current draft.** Any block whose plain text contains the active target's \`current_text\` gets a left-border amber band, and the first match is scrolled into view on every turn.

Layout reorganized: suggestion on the left, **sticky** draft preview on the right at lg+ widths. User can read the AI's question and watch the live highlight without scrolling.

## Test plan

- [ ] Start a refinement session, verify each AI suggestion shows the verbatim source under \"Currently\"
- [ ] When an AI proposal arrives, both \"Currently\" and \"Proposed rewrite\" blocks render side-by-side in their respective colors
- [ ] On a wider viewport, the draft preview stays visible while you scroll the suggestions on the left
- [ ] As you accept / skip targets, the highlight in the draft moves and auto-scrolls to the new target
- [ ] No regression on smaller (mobile) viewports — the two-column layout collapses to single-column

🤖 Generated with [Claude Code](https://claude.com/claude-code)