### PR TITLE
fix(@platform/ui/AppShell): add min-h-0 to main flex column

### DIFF
--- a/packages/shared-frontend/src/components/layout/AppShell.tsx
+++ b/packages/shared-frontend/src/components/layout/AppShell.tsx
@@ -189,8 +189,12 @@ export default function AppShell({
         </aside>
       )}
 
-      {/* Main column */}
-      <div className="flex flex-col flex-1 min-w-0">
+      {/* Main column. ``min-h-0`` is required so the inner ``main``'s
+          ``overflow-y-auto`` constrains to the allocated flex height
+          rather than the min-content of its descendants. Without it,
+          some browsers let the column grow past the viewport, which
+          surfaces as a scroll-bar that runs past the actual content. */}
+      <div className="flex flex-col flex-1 min-w-0 min-h-0">
         {/* Top bar */}
         <header className="flex items-center gap-4 px-4 py-3 border-b bg-background shrink-0 h-14">
           {headerTitle && (


### PR DESCRIPTION
## Summary

One-line fix to AppShell that resolves the phantom-scroll bug on every MJH page.

## Symptom

On MJH \`/profile\` (and every other AppShell-mounted page), the page scrolls far past the visible content — scrollbar runs into a black gap below the last rendered element.

## Root cause

AppShell's main flex column has \`flex flex-col flex-1 min-w-0\` but no \`min-h-0\`. The inner \`<main className=\"flex-1 overflow-y-auto\">\` is supposed to clamp to the column's allocated height. Without \`min-h-0\` on the column, the column sizes to its content's min-content height instead, and \`overflow-y-auto\` scrolls within that oversized container. The phantom-scroll gap is the difference.

This is a documented Tailwind/CSS flex pattern: \"flex-column-with-overflow-child\" requires \`min-h-0\` on the column.

## Test plan

- [ ] After deploy, navigate to MJH Profile and verify the page no longer scrolls past content
- [ ] Same check on Dashboard, Applications, Companies, Documents, Settings, Security, Resume

## Affects

Every consumer of \`@platform/ui\`'s AppShell. Currently MJH only — MBK still uses its own \`Layout.tsx\` (blocked on React 19 migration). Hardens the shared component for future consumers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)