### PR TITLE
fix(myjobhunter): finish kind/title rename in document schema + export

### DIFF
--- a/apps/myjobhunter/backend/app/schemas/application/document.py
+++ b/apps/myjobhunter/backend/app/schemas/application/document.py
@@ -1,4 +1,4 @@
-"""Document schemas — Phase 1 stub."""
+"""Document schemas — Phase 2."""
 import uuid
 from datetime import datetime
 
@@ -7,10 +7,14 @@ from pydantic import BaseModel
 
 class DocumentRead(BaseModel):
     id: uuid.UUID
-    application_id: uuid.UUID
-    document_type: str
-    generated_by: str
-    version: int
+    application_id: uuid.UUID | None = None
+    title: str
+    kind: str
+    body: str | None = None
+    file_path: str | None = None
+    filename: str | None = None
+    content_type: str | None = None
+    size_bytes: int | None = None
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/apps/myjobhunter/backend/app/services/user/account_service.py
+++ b/apps/myjobhunter/backend/app/services/user/account_service.py
@@ -230,11 +230,14 @@ def _application_contact_to_export_dict(item: ApplicationContact) -> dict:
 def _document_to_export_dict(item: Document) -> dict:
     return {
         "id": str(item.id),
-        "application_id": str(item.application_id),
-        "document_type": item.document_type,
+        "application_id": str(item.application_id) if item.application_id else None,
+        "title": item.title,
+        "kind": item.kind,
+        "body": item.body,
         "file_path": item.file_path,
-        "generated_by": item.generated_by,
-        "version": item.version,
+        "filename": item.filename,
+        "content_type": item.content_type,
+        "size_bytes": item.size_bytes,
         "deleted_at": item.deleted_at.isoformat() if item.deleted_at else None,
         "created_at": item.created_at.isoformat() if item.created_at else None,
     }


### PR DESCRIPTION
## Summary

Two more readers of \`document_type\` / \`generated_by\` / \`version\` were missed in #317. Symptom: \`backend-tests / login-heavy\` keeps failing with \`AttributeError: 'Document' object has no attribute 'document_type'\` on \`test_data_export.py::test_export_returns_user_data\`.

| File | What changed |
|---|---|
| \`apps/myjobhunter/backend/app/schemas/application/document.py\` | DocumentRead schema updated to the Phase-2 fields (\`title\`, \`kind\`, \`body\`, \`file_path\`, \`filename\`, \`content_type\`, \`size_bytes\`) |
| \`apps/myjobhunter/backend/app/services/user/account_service.py\` | \`_document_to_export_dict\` reads the new column names |

No migration, no env changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)