### PR TITLE
feat(myjobhunter): demo accounts — admin-only seeded users for showcasing the app

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/demo260505_add_user_is_demo.py
+++ b/apps/myjobhunter/backend/alembic/versions/demo260505_add_user_is_demo.py
@@ -1,0 +1,55 @@
+"""Add ``users.is_demo`` boolean flag for showcase / sandbox accounts.
+
+Demo accounts are real ``users`` rows seeded with realistic dummy data so
+operators can showcase the app to strangers without manually creating
+applications/companies/profile content. The ``is_demo`` flag lets the
+admin demo-management API filter and bulk-delete demo accounts safely
+(real accounts must NEVER be deletable from that endpoint).
+
+Mirrors MBK's ``organizations.is_demo`` shape — but MJH has no orgs, so
+the flag lives on the user row directly. Default ``false`` for every
+existing row; new demo accounts opt in by setting ``True`` at creation
+time. Column is non-nullable so we never accidentally treat a NULL as
+"maybe a demo" — explicit booleans only.
+
+Revision ID: demo260505
+Revises: refine260505
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "demo260505"
+down_revision: Union[str, None] = "refine260505"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "users",
+        sa.Column(
+            "is_demo",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+    )
+    # Partial index — most rows will be is_demo=false, so the index only
+    # needs to cover the small set of demo rows. Keeps the admin
+    # ``list_demo_users`` query fast without bloating writes for the 99%
+    # case.
+    op.create_index(
+        "ix_users_is_demo",
+        "users",
+        ["is_demo"],
+        postgresql_where=sa.text("is_demo = true"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_users_is_demo", table_name="users")
+    op.drop_column("users", "is_demo")

--- a/apps/myjobhunter/backend/app/api/demo.py
+++ b/apps/myjobhunter/backend/app/api/demo.py
@@ -1,0 +1,95 @@
+"""Admin demo-management routes.
+
+Every route here is gated by ``require_admin`` (platform-level admin
+only). Demo accounts are an internal showcase tool — they MUST never
+be reachable from a regular user session.
+
+Routes:
+
+  - ``POST /admin/demo/users`` — create a fully-seeded demo account,
+    returns the credentials (email + plaintext password) ONCE.
+  - ``GET /admin/demo/users`` — list all demo accounts with summary
+    counts.
+  - ``DELETE /admin/demo/users/{id}`` — delete a demo account and
+    cascade every domain row they own. Refuses with 404 if the id
+    refers to a real user (the repository enforces this at the SQL
+    layer too).
+
+Mirrors the MBK ``/admin/demo`` route shape with two divergences:
+  1. No ``/reset`` endpoint — MJH's demo accounts are cheap to recreate
+     (no tax-recompute step), so delete + create is simpler than reset.
+  2. No invite-email sending — MJH's demo flow is operator-facing and
+     the operator can hand-deliver credentials. SMTP wiring is also
+     not required in MJH's prod env yet.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from platform_shared.core.permissions import Role, require_role
+
+from app.core.auth import current_active_user
+from app.models.user.user import User
+from app.schemas.demo.demo import (
+    DemoCreateRequest,
+    DemoCreateResponse,
+    DemoDeleteResponse,
+    DemoUserListResponse,
+)
+from app.services.demo import demo_service
+
+
+router = APIRouter(prefix="/admin/demo", tags=["admin", "demo"])
+
+# Pre-bake the dependency once. The factory ``require_role`` needs the
+# app's ``current_active_user`` to share the same fastapi-users wiring,
+# so apps can't reuse a single global instance — each app builds its
+# own admin gate. Mirrors ``app.api.admin.require_admin``.
+require_admin = require_role(Role.ADMIN, current_active_user=current_active_user)
+
+
+@router.post("/users", response_model=DemoCreateResponse, status_code=201)
+async def create_demo_user(
+    body: DemoCreateRequest,
+    _admin: User = Depends(require_admin),
+) -> DemoCreateResponse:
+    """Create a new fully-seeded demo account.
+
+    Returns 201 with the freshly-generated credentials. The plaintext
+    password is shown ONCE — the admin UI is responsible for
+    surfacing it in a copy-button modal that warns the operator.
+    """
+    try:
+        return await demo_service.create_demo_user(
+            email=body.email, display_name=body.display_name,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=409, detail=str(exc))
+
+
+@router.get("/users", response_model=DemoUserListResponse)
+async def list_demo_users(
+    _admin: User = Depends(require_admin),
+) -> DemoUserListResponse:
+    """List every demo account with summary counts (newest first)."""
+    return await demo_service.list_demo_users()
+
+
+@router.delete(
+    "/users/{user_id}", response_model=DemoDeleteResponse,
+)
+async def delete_demo_user(
+    user_id: uuid.UUID,
+    _admin: User = Depends(require_admin),
+) -> DemoDeleteResponse:
+    """Hard-delete a demo account and all cascade-able rows.
+
+    Returns 404 if the id doesn't match an ``is_demo=True`` row —
+    real accounts are not reachable from this endpoint by design.
+    """
+    try:
+        return await demo_service.delete_demo_user(user_id)
+    except LookupError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))

--- a/apps/myjobhunter/backend/app/api/test_helpers.py
+++ b/apps/myjobhunter/backend/app/api/test_helpers.py
@@ -52,3 +52,26 @@ async def reset_rate_limit() -> None:
     else:
         # Fallback: no-op rather than crash
         pass
+
+
+@router.post("/_test/promote-to-admin", status_code=204)
+async def promote_to_admin(email: EmailStr = Body(..., embed=True)) -> None:
+    """Flip a user's role to admin.
+
+    Used by E2E tests that exercise admin-gated routes (e.g.
+    ``/admin/demo/users``) so a fresh test user can be granted the
+    role without seeding via SQL. Gated by
+    ``MYJOBHUNTER_ENABLE_TEST_HELPERS=1`` — never mounted in production.
+    """
+    async with AsyncSessionLocal() as session:
+        async with session.begin():
+            result = await session.execute(
+                text(
+                    "UPDATE users SET role = 'admin' "
+                    "WHERE email = :email RETURNING id"
+                ),
+                {"email": email},
+            )
+            row = result.first()
+        if row is None:
+            raise HTTPException(status_code=404, detail="user not found")

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -11,7 +11,7 @@ from jwt.exceptions import PyJWTError as JWTError
 
 from platform_shared.core.lifespan import create_app_lifespan
 
-from app.api import account, admin, applications, companies, documents, health, integrations, profile, resume_refinement, resumes, totp
+from app.api import account, admin, applications, companies, demo, documents, health, integrations, profile, resume_refinement, resumes, totp
 from app.core.audit import current_user_id
 from app.core.auth import auth_backend, fastapi_users
 from app.core.config import settings
@@ -180,6 +180,7 @@ app.include_router(integrations.router, tags=["integrations"])
 app.include_router(resumes.router, tags=["resumes"])
 app.include_router(documents.router)
 app.include_router(admin.router)
+app.include_router(demo.router)
 app.include_router(resume_refinement.router)
 
 # Shared platform admin router — generic user-management endpoints

--- a/apps/myjobhunter/backend/app/models/user/user.py
+++ b/apps/myjobhunter/backend/app/models/user/user.py
@@ -66,6 +66,17 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
         DateTime(timezone=True), nullable=True,
     )
 
+    # Showcase/sandbox accounts seeded with realistic dummy data so an
+    # operator can demo MJH to a stranger without hand-crafting test data.
+    # Set ``True`` only by ``services.demo.demo_service.create_demo_user`` —
+    # never via the public registration flow. The admin demo-management
+    # API uses this flag as the sole guard before allowing bulk delete:
+    # only ``is_demo=True`` rows are deletable. See migration
+    # ``demo260505_add_user_is_demo``.
+    is_demo: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="false",
+    )
+
     @property
     def name(self) -> str | None:
         """Compatibility shim for shared admin schemas.

--- a/apps/myjobhunter/backend/app/repositories/demo/demo_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/demo/demo_repository.py
@@ -1,0 +1,434 @@
+"""Repository for demo-account management.
+
+Owns every DB query the demo-management service needs. Per the layered
+architecture rule, services and routes never touch the ORM directly —
+this module is the single seam between demo orchestration and the
+database.
+
+What's HERE:
+
+  - User lookups by email / id with the ``is_demo`` filter applied
+    where appropriate (so a real user is never returned by a demo
+    listing or accidentally reachable from the demo delete endpoint).
+  - Bulk-insert helpers for the seeded data domains: profile,
+    work history, education, skills, companies, applications,
+    application events, and the resume_upload_job stub.
+
+What's NOT here:
+
+  - Password hashing or fastapi-users plumbing — that lives in the
+    service layer because it depends on ``UserManager`` /
+    ``PasswordHelper`` which are not DB primitives.
+  - Email-uniqueness validation — the service decides what error to
+    raise when a collision happens; the repo just inserts and lets
+    SQLAlchemy bubble the IntegrityError if it occurs.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application.application import Application
+from app.models.application.application_event import ApplicationEvent
+from app.models.company.company import Company
+from app.models.jobs.resume_upload_job import ResumeUploadJob
+from app.models.profile.education import Education
+from app.models.profile.profile import Profile
+from app.models.profile.skill import Skill
+from app.models.profile.work_history import WorkHistory
+from app.models.user.user import User
+from app.services.demo.demo_constants import (
+    ApplicationSeed,
+    CompanySeed,
+    EducationSeed,
+    ProfileSeed,
+    SkillSeed,
+    WorkHistorySeed,
+    days_ago,
+)
+
+
+# ---------------------------------------------------------------------------
+# User reads
+# ---------------------------------------------------------------------------
+
+
+async def get_user_by_email(db: AsyncSession, email: str) -> User | None:
+    """Return the user with the given email regardless of ``is_demo``.
+
+    Used at create-time to detect collisions. Email comparison is
+    exact — fastapi-users normalizes emails to lowercase at write time
+    so callers should pre-lower if they want case-insensitive lookup.
+    """
+    result = await db.execute(select(User).where(User.email == email))
+    return result.scalar_one_or_none()
+
+
+async def get_demo_user_by_id(
+    db: AsyncSession, user_id: uuid.UUID,
+) -> User | None:
+    """Return the user with ``user_id`` ONLY if ``is_demo=True``.
+
+    Returning ``None`` for a non-demo user is a deliberate safety —
+    the admin demo-delete endpoint translates ``None`` into a 404 so a
+    bug or malicious request can never destroy a real user account
+    via ``/admin/demo/users/{id}``.
+    """
+    result = await db.execute(
+        select(User).where(User.id == user_id, User.is_demo.is_(True))
+    )
+    return result.scalar_one_or_none()
+
+
+async def list_demo_user_summaries(db: AsyncSession) -> list[dict]:
+    """Return a list of dicts shaped for ``DemoUserSummary``.
+
+    Each dict carries ``user_id``, ``email``, ``display_name``,
+    ``created_at``, ``application_count``, ``company_count``.
+    Application counts use ``Application.deleted_at IS NULL`` so a
+    soft-deleted application is not counted.
+    """
+    user_result = await db.execute(
+        select(User)
+        .where(User.is_demo.is_(True))
+        .order_by(User.id.desc())
+    )
+    users = list(user_result.scalars().all())
+
+    summaries: list[dict] = []
+    for user in users:
+        app_count_result = await db.execute(
+            select(func.count())
+            .select_from(Application)
+            .where(
+                Application.user_id == user.id,
+                Application.deleted_at.is_(None),
+            )
+        )
+        company_count_result = await db.execute(
+            select(func.count())
+            .select_from(Company)
+            .where(Company.user_id == user.id)
+        )
+        summaries.append(
+            {
+                "user_id": user.id,
+                "email": user.email,
+                "display_name": user.display_name or "",
+                "created_at": _user_created_at(user),
+                "application_count": app_count_result.scalar_one(),
+                "company_count": company_count_result.scalar_one(),
+            }
+        )
+    return summaries
+
+
+def _user_created_at(user: User) -> datetime:
+    """Best-effort created_at for the user row.
+
+    fastapi-users' base table doesn't expose ``created_at`` so we fall
+    back to a synthetic "now" if no attribute is present. Real demo
+    rows would have a created_at if MJH adds it later — this stub
+    keeps the response schema contract intact regardless.
+    """
+    candidate = getattr(user, "created_at", None)
+    if isinstance(candidate, datetime):
+        return candidate
+    return datetime.now(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# User writes
+# ---------------------------------------------------------------------------
+
+
+async def create_demo_user(
+    db: AsyncSession,
+    *,
+    email: str,
+    hashed_password: str,
+    display_name: str,
+) -> User:
+    """Insert a new demo user row.
+
+    The user is marked verified (``is_verified=True``) so the operator
+    can log in immediately without going through the email-verification
+    flow — demo accounts are an internal showcase tool, not a real
+    sign-up. ``role`` stays as the default USER; demo accounts do not
+    grant admin powers.
+    """
+    user = User(
+        email=email,
+        hashed_password=hashed_password,
+        display_name=display_name,
+        is_active=True,
+        is_verified=True,
+        is_superuser=False,
+        is_demo=True,
+    )
+    db.add(user)
+    await db.flush()
+    return user
+
+
+# ---------------------------------------------------------------------------
+# Profile + dependent rows
+# ---------------------------------------------------------------------------
+
+
+async def create_profile(
+    db: AsyncSession, *, user_id: uuid.UUID, seed: ProfileSeed,
+) -> Profile:
+    """Insert the user's ``profiles`` row from the seed dict."""
+    profile = Profile(
+        user_id=user_id,
+        summary=seed["summary"],
+        work_auth_status=seed["work_auth_status"],
+        desired_salary_min=seed["desired_salary_min"],
+        desired_salary_max=seed["desired_salary_max"],
+        salary_currency=seed["salary_currency"],
+        salary_period=seed["salary_period"],
+        locations=list(seed["locations"]),
+        remote_preference=seed["remote_preference"],
+        seniority=seed["seniority"],
+        timezone=seed["timezone"],
+    )
+    db.add(profile)
+    await db.flush()
+    return profile
+
+
+async def create_work_history(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    profile_id: uuid.UUID,
+    seeds: list[WorkHistorySeed],
+) -> list[WorkHistory]:
+    """Insert all WorkHistory rows for the demo profile."""
+    rows: list[WorkHistory] = []
+    for seed in seeds:
+        row = WorkHistory(
+            user_id=user_id,
+            profile_id=profile_id,
+            company_name=seed["company_name"],
+            title=seed["title"],
+            start_date=seed["start_date"],
+            end_date=seed["end_date"],
+            bullets=list(seed["bullets"]),
+        )
+        db.add(row)
+        rows.append(row)
+    await db.flush()
+    return rows
+
+
+async def create_education(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    profile_id: uuid.UUID,
+    seeds: list[EducationSeed],
+) -> list[Education]:
+    """Insert all Education rows for the demo profile."""
+    rows: list[Education] = []
+    for seed in seeds:
+        row = Education(
+            user_id=user_id,
+            profile_id=profile_id,
+            school=seed["school"],
+            degree=seed["degree"],
+            field=seed["field"],
+            start_year=seed["start_year"],
+            end_year=seed["end_year"],
+            gpa=seed["gpa"],
+        )
+        db.add(row)
+        rows.append(row)
+    await db.flush()
+    return rows
+
+
+async def create_skills(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    profile_id: uuid.UUID,
+    seeds: list[SkillSeed],
+) -> list[Skill]:
+    """Insert all Skill rows for the demo profile."""
+    rows: list[Skill] = []
+    for seed in seeds:
+        row = Skill(
+            user_id=user_id,
+            profile_id=profile_id,
+            name=seed["name"],
+            years_experience=seed["years_experience"],
+            category=seed["category"],
+        )
+        db.add(row)
+        rows.append(row)
+    await db.flush()
+    return rows
+
+
+async def create_resume_upload_job(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    profile_id: uuid.UUID,
+    file_path: str,
+    file_filename: str,
+    file_content_type: str,
+    parsed_fields: dict,
+    parser_version: str,
+) -> ResumeUploadJob:
+    """Insert a complete ``resume_upload_jobs`` row for the demo profile.
+
+    Status is hard-set to ``complete`` with both ``started_at`` and
+    ``completed_at`` populated so the Profile page's upload-history
+    surface renders an immediately-finished job.
+    """
+    now = datetime.now(timezone.utc)
+    started = now - _DEMO_RESUME_PARSE_DURATION
+    job = ResumeUploadJob(
+        user_id=user_id,
+        profile_id=profile_id,
+        file_path=file_path,
+        file_filename=file_filename,
+        file_content_type=file_content_type,
+        file_size_bytes=_DEMO_RESUME_FAKE_BYTES,
+        status="complete",
+        retry_count=0,
+        result_parsed_fields=parsed_fields,
+        parser_version=parser_version,
+        started_at=started,
+        completed_at=now,
+    )
+    db.add(job)
+    await db.flush()
+    return job
+
+
+# Constants kept module-private — only the demo repo seeds these
+# specific values. Centralised here so a future tweak (e.g. faster
+# parse simulation) is one diff.
+
+_DEMO_RESUME_PARSE_DURATION = timedelta(seconds=15)
+_DEMO_RESUME_FAKE_BYTES = 184_320  # 180 KB-ish — plausible PDF size
+_DEMO_PARSER_VERSION = "demo-seed-v1"
+
+
+# ---------------------------------------------------------------------------
+# Companies + applications
+# ---------------------------------------------------------------------------
+
+
+async def create_companies(
+    db: AsyncSession, *, user_id: uuid.UUID, seeds: list[CompanySeed],
+) -> list[Company]:
+    """Insert all Company rows for the demo user."""
+    rows: list[Company] = []
+    for seed in seeds:
+        row = Company(
+            user_id=user_id,
+            name=seed["name"],
+            primary_domain=seed["primary_domain"],
+            industry=seed["industry"],
+            size_range=seed["size_range"],
+            hq_location=seed["hq_location"],
+            description=seed["description"],
+        )
+        db.add(row)
+        rows.append(row)
+    await db.flush()
+    return rows
+
+
+async def create_applications_with_events(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    company_ids: list[uuid.UUID],
+    seeds: list[ApplicationSeed],
+) -> list[Application]:
+    """Insert demo applications + their event timeline.
+
+    For each application seed the repo:
+      1. Inserts an ``applications`` row with ``applied_at`` resolved
+         from the seed's ``days_ago_applied`` offset.
+      2. Inserts each event from ``seed['events']`` against that
+         application, with ``occurred_at`` resolved from the
+         (applied_at + days_after_applied) offset and ``source``
+         hard-set to ``'manual'`` so the events look like operator-
+         logged entries.
+
+    Tenant-scoping is honoured on both rows. Returns the list of
+    inserted Applications in seed order so callers can introspect
+    counts.
+    """
+    apps: list[Application] = []
+    for seed in seeds:
+        applied_at = days_ago(seed["days_ago_applied"])
+        app = Application(
+            user_id=user_id,
+            company_id=company_ids[seed["company_index"]],
+            role_title=seed["role_title"],
+            location=seed["location"],
+            remote_type=seed["remote_type"],
+            source=seed["source"],
+            posted_salary_min=seed["posted_salary_min"],
+            posted_salary_max=seed["posted_salary_max"],
+            posted_salary_currency="USD",
+            posted_salary_period="annual",
+            fit_score=seed["fit_score"],
+            notes=seed["notes"],
+            applied_at=applied_at,
+            archived=False,
+        )
+        db.add(app)
+        await db.flush()
+        apps.append(app)
+
+        for event_type, days_after in seed["events"]:
+            event = ApplicationEvent(
+                user_id=user_id,
+                application_id=app.id,
+                event_type=event_type,
+                # Anchored on applied_at so the timeline reads in order.
+                occurred_at=applied_at + timedelta(days=days_after),
+                source="manual",
+            )
+            db.add(event)
+    await db.flush()
+    return apps
+
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+
+
+async def delete_demo_user_cascade(
+    db: AsyncSession, *, user_id: uuid.UUID,
+) -> None:
+    """Hard-delete the demo user and ALL their cascade-able rows.
+
+    Because every domain table has ``ON DELETE CASCADE`` on its
+    ``user_id`` FK, a single ``DELETE FROM users WHERE id = :id``
+    cleans up applications, application_events, application_contacts,
+    documents, companies, profiles, work_history, education, skills,
+    screening_answers, resume_upload_jobs, and resume refinement
+    tables in one shot. Auth-event rows persist intentionally —
+    ``auth_events.user_id`` has no FK so the audit trail survives.
+
+    The function double-checks ``is_demo=True`` at the SQL layer (in
+    addition to the service-layer check) so a bug elsewhere can never
+    trigger a real-user wipe via this function.
+    """
+    await db.execute(
+        delete(User).where(User.id == user_id, User.is_demo.is_(True))
+    )

--- a/apps/myjobhunter/backend/app/schemas/demo/demo.py
+++ b/apps/myjobhunter/backend/app/schemas/demo/demo.py
@@ -1,0 +1,94 @@
+"""Pydantic schemas for the admin demo-management API.
+
+Demo accounts are showcase/sandbox MJH users seeded with realistic dummy
+data so an operator can demo the app to a stranger without hand-crafting
+applications/companies/profile content. These schemas are consumed only
+by the admin-gated routes in ``app.api.demo``.
+
+Mirrors the MBK demo schema shape (``apps/mybookkeeper/backend/app/schemas/
+demo/demo.py``) with two divergences:
+
+  1. MJH has no orgs — the response shape carries ``user_id`` /
+     ``email`` / ``display_name`` directly rather than an
+     ``organization_id`` / ``organization_name`` pair.
+  2. The summary carries application + company counts rather than upload
+     counts — the meaningful "how much demo data does this account
+     have" signal for MJH.
+"""
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field
+
+
+class DemoCredentials(BaseModel):
+    """Login credentials returned ONCE at demo-user creation time.
+
+    The plaintext password is never stored in plaintext anywhere
+    reachable later — fastapi-users hashes it before persistence and
+    this object is the single emission point. The admin UI surfaces it
+    in a one-time modal with a copy button; if the operator dismisses
+    that modal without copying, the only recovery is to delete +
+    recreate the demo account.
+    """
+
+    email: EmailStr
+    password: str
+
+
+class DemoCreateRequest(BaseModel):
+    """Body of ``POST /admin/demo/users``.
+
+    ``email`` is optional — when omitted the service auto-generates a
+    ``demo+<uuid>@myjobhunter.local`` address. ``display_name`` is
+    optional — when omitted the service synthesizes a plausible name
+    from the seed data.
+    """
+
+    email: EmailStr | None = Field(
+        default=None,
+        description=(
+            "Optional. Demo account email. Auto-generated as "
+            "'demo+<uuid>@myjobhunter.local' when omitted."
+        ),
+    )
+    display_name: str | None = Field(
+        default=None,
+        max_length=100,
+        description=(
+            "Optional. Display name for the demo user. Defaults to the "
+            "seeded profile's 'Alex Demo'."
+        ),
+    )
+
+
+class DemoCreateResponse(BaseModel):
+    """Body of a successful ``POST /admin/demo/users`` response."""
+
+    message: str
+    credentials: DemoCredentials
+    user_id: uuid.UUID
+
+
+class DemoUserSummary(BaseModel):
+    """One row in the admin demo-users list."""
+
+    user_id: uuid.UUID
+    email: EmailStr
+    display_name: str
+    created_at: datetime
+    application_count: int
+    company_count: int
+
+
+class DemoUserListResponse(BaseModel):
+    """Body of ``GET /admin/demo/users``."""
+
+    users: list[DemoUserSummary]
+    total: int
+
+
+class DemoDeleteResponse(BaseModel):
+    """Body of ``DELETE /admin/demo/users/{id}``."""
+
+    message: str

--- a/apps/myjobhunter/backend/app/schemas/user/user_base.py
+++ b/apps/myjobhunter/backend/app/schemas/user/user_base.py
@@ -3,10 +3,18 @@ import uuid
 
 from fastapi_users import schemas
 
+from platform_shared.core.permissions import Role
+
 
 class UserRead(schemas.BaseUser[uuid.UUID]):
     display_name: str = ""
     totp_enabled: bool = False
+    # Surface the platform-level role to the frontend so SPA nav can
+    # conditionally render admin-only links (e.g. /admin/demo). The
+    # backend remains the source of truth for authorization — the role
+    # in this payload is used purely for UI gating.
+    role: Role = Role.USER
+    is_demo: bool = False
 
 
 class UserCreate(schemas.BaseUserCreate):

--- a/apps/myjobhunter/backend/app/services/demo/demo_constants.py
+++ b/apps/myjobhunter/backend/app/services/demo/demo_constants.py
@@ -1,0 +1,423 @@
+"""Realistic seed data for MyJobHunter demo accounts.
+
+The point of this module is to make a demo account look like a real
+job-hunting professional in flight: a profile with several years of
+work history, a handful of skills, a couple degrees, plus 4-5
+applications across the typical pipeline stages (applied / interview /
+offer / rejected) tied to plausible fake companies.
+
+When showing the app to a stranger, the operator wants Dashboard,
+Applications, Companies, and Profile to render with content that
+demonstrates the value of every screen. This module is the source of
+that content.
+
+Design rules mirrored from MBK's ``demo_constants.py``:
+
+  - Plain Python data structures (lists of dicts / tuples). No coupling
+    to ORM models — the repository converts them into rows.
+  - Plausible-but-fake company names (Acme Corp, Globex, Initech, etc.).
+  - Real-sounding job titles and bullet points.
+  - Dates anchored to the current calendar year minus a few months so
+    the timeline looks active when the demo is shown.
+
+The seed sets are intentionally small (3 companies, 4 applications) so
+a freshly-created demo account loads quickly on every screen and the
+operator can show the full pipeline without scrolling.
+"""
+from __future__ import annotations
+
+import secrets
+import uuid
+from datetime import date, datetime, timedelta, timezone
+from typing import TypedDict
+
+DEMO_EMAIL_DOMAIN = "myjobhunter.local"
+DEMO_EMAIL_PREFIX = "demo"
+DEMO_DEFAULT_DISPLAY_NAME = "Alex Demo"
+
+
+def generate_demo_password() -> str:
+    """Return a strong random password suitable for a demo account.
+
+    Uses ``secrets.token_urlsafe(16)`` which yields a 22-character
+    URL-safe base64 string. Comfortably exceeds the 12-char minimum
+    enforced by ``UserManager.validate_password`` and HIBP is bypassed
+    in the demo path because the password is freshly random.
+    """
+    return secrets.token_urlsafe(16)
+
+
+def make_demo_email() -> str:
+    """Generate a unique demo email under ``myjobhunter.local``.
+
+    ``.local`` is RFC 6762 reserved (mDNS) so it will never collide
+    with a real deliverable inbox. The UUID slice keeps the email
+    short enough to display comfortably in the credentials modal but
+    long enough to avoid collisions across many demo accounts.
+    """
+    slug = uuid.uuid4().hex[:12]
+    return f"{DEMO_EMAIL_PREFIX}+{slug}@{DEMO_EMAIL_DOMAIN}"
+
+
+# ---------------------------------------------------------------------------
+# Profile seed
+# ---------------------------------------------------------------------------
+
+
+class ProfileSeed(TypedDict):
+    """Top-level profile fields (the ``profiles`` row).
+
+    Everything here maps directly to columns on
+    ``app.models.profile.profile.Profile``. Validated against the
+    table's CheckConstraints in unit tests.
+    """
+
+    summary: str
+    work_auth_status: str
+    desired_salary_min: float
+    desired_salary_max: float
+    salary_currency: str
+    salary_period: str
+    locations: list[str]
+    remote_preference: str
+    seniority: str
+    timezone: str
+
+
+DEMO_PROFILE: ProfileSeed = {
+    "summary": (
+        "Senior software engineer with 8+ years building scalable web "
+        "applications. Strong background in backend systems, distributed "
+        "infrastructure, and developer tooling. Looking for a senior or "
+        "staff IC role at a product-led company."
+    ),
+    "work_auth_status": "citizen",
+    "desired_salary_min": 180000.0,
+    "desired_salary_max": 230000.0,
+    "salary_currency": "USD",
+    "salary_period": "annual",
+    "locations": ["San Francisco, CA", "Remote (US)"],
+    "remote_preference": "hybrid",
+    "seniority": "senior",
+    "timezone": "America/Los_Angeles",
+}
+
+
+# ---------------------------------------------------------------------------
+# Work history seed (newest first)
+# ---------------------------------------------------------------------------
+
+
+class WorkHistorySeed(TypedDict):
+    company_name: str
+    title: str
+    start_date: date
+    end_date: date | None
+    bullets: list[str]
+
+
+DEMO_WORK_HISTORY: list[WorkHistorySeed] = [
+    {
+        "company_name": "Hooli",
+        "title": "Senior Software Engineer",
+        "start_date": date(2023, 3, 1),
+        "end_date": None,
+        "bullets": [
+            "Led migration of monolithic billing service to event-driven microservices, cutting p99 latency by 40%.",
+            "Mentored 3 junior engineers; designed onboarding curriculum now used team-wide.",
+            "Drove adoption of feature-flag-based deploys, reducing rollback frequency by 60%.",
+        ],
+    },
+    {
+        "company_name": "Pied Piper",
+        "title": "Software Engineer II",
+        "start_date": date(2020, 6, 1),
+        "end_date": date(2023, 2, 28),
+        "bullets": [
+            "Built real-time data ingestion pipeline handling 50M events/day with Kafka + Flink.",
+            "Owned the GraphQL gateway, reducing average payload size by 35% via persisted queries.",
+            "Shipped end-to-end customer dashboard used by 80% of paying customers within 6 months.",
+        ],
+    },
+    {
+        "company_name": "Initech",
+        "title": "Software Engineer",
+        "start_date": date(2018, 8, 1),
+        "end_date": date(2020, 5, 31),
+        "bullets": [
+            "Wrote and maintained the core Rails monolith that powered the product's first $5M ARR.",
+            "Improved test suite runtime from 25 minutes to 6 minutes via parallelization and DB seeding.",
+            "Implemented company-wide SSO (Okta + SAML), eliminating ~40 weekly password-reset tickets.",
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Education seed
+# ---------------------------------------------------------------------------
+
+
+class EducationSeed(TypedDict):
+    school: str
+    degree: str
+    field: str
+    start_year: int
+    end_year: int
+    gpa: float | None
+
+
+DEMO_EDUCATION: list[EducationSeed] = [
+    {
+        "school": "University of California, Berkeley",
+        "degree": "B.S.",
+        "field": "Computer Science",
+        "start_year": 2014,
+        "end_year": 2018,
+        "gpa": 3.7,
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Skills seed
+# ---------------------------------------------------------------------------
+
+
+class SkillSeed(TypedDict):
+    name: str
+    years_experience: int
+    category: str
+
+
+DEMO_SKILLS: list[SkillSeed] = [
+    {"name": "Python", "years_experience": 8, "category": "language"},
+    {"name": "TypeScript", "years_experience": 6, "category": "language"},
+    {"name": "Go", "years_experience": 3, "category": "language"},
+    {"name": "React", "years_experience": 6, "category": "framework"},
+    {"name": "FastAPI", "years_experience": 4, "category": "framework"},
+    {"name": "PostgreSQL", "years_experience": 7, "category": "platform"},
+    {"name": "Kubernetes", "years_experience": 4, "category": "platform"},
+    {"name": "AWS", "years_experience": 5, "category": "platform"},
+]
+
+
+# ---------------------------------------------------------------------------
+# Companies seed (parent table for applications)
+# ---------------------------------------------------------------------------
+
+
+class CompanySeed(TypedDict):
+    name: str
+    primary_domain: str
+    industry: str
+    size_range: str
+    hq_location: str
+    description: str
+
+
+DEMO_COMPANIES: list[CompanySeed] = [
+    {
+        "name": "Acme Corp",
+        "primary_domain": "acme.example",
+        "industry": "Logistics",
+        "size_range": "1001-5000",
+        "hq_location": "Chicago, IL",
+        "description": (
+            "Acme Corp builds modern logistics infrastructure for "
+            "small and mid-sized businesses. Fast-growing Series C "
+            "with strong engineering culture."
+        ),
+    },
+    {
+        "name": "Globex",
+        "primary_domain": "globex.example",
+        "industry": "Cybersecurity",
+        "size_range": "201-1000",
+        "hq_location": "Austin, TX",
+        "description": (
+            "Globex is a cybersecurity platform protecting "
+            "developer-first companies from supply-chain attacks. "
+            "Series B, ~400 employees."
+        ),
+    },
+    {
+        "name": "Stark Industries",
+        "primary_domain": "stark.example",
+        "industry": "Hardware / IoT",
+        "size_range": "5000+",
+        "hq_location": "New York, NY",
+        "description": (
+            "Stark Industries designs and manufactures consumer "
+            "smart-home hardware. Public company with a strong "
+            "software engineering org."
+        ),
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Applications seed
+# ---------------------------------------------------------------------------
+
+
+class ApplicationSeed(TypedDict):
+    """One application row plus a small list of events.
+
+    ``company_index`` indexes into ``DEMO_COMPANIES`` so the repository
+    can resolve the FK after the parent companies are inserted.
+
+    ``events`` is a list of (event_type, days_after_applied) tuples.
+    The repository converts ``days_after_applied`` to an absolute
+    timestamp anchored on ``applied_at``.
+    """
+
+    company_index: int
+    role_title: str
+    location: str
+    remote_type: str
+    source: str
+    posted_salary_min: float
+    posted_salary_max: float
+    fit_score: float
+    notes: str
+    days_ago_applied: int
+    events: list[tuple[str, int]]
+
+
+DEMO_APPLICATIONS: list[ApplicationSeed] = [
+    {
+        "company_index": 0,  # Acme Corp
+        "role_title": "Senior Backend Engineer",
+        "location": "Chicago, IL",
+        "remote_type": "hybrid",
+        "source": "linkedin",
+        "posted_salary_min": 175000.0,
+        "posted_salary_max": 220000.0,
+        "fit_score": 88.0,
+        "notes": "Recruiter Meghan reached out — fast process, hiring manager available next week.",
+        "days_ago_applied": 21,
+        "events": [
+            ("applied", 0),
+            ("interview_scheduled", 5),
+            ("interview_completed", 8),
+            ("offer_received", 14),
+        ],
+    },
+    {
+        "company_index": 1,  # Globex
+        "role_title": "Staff Software Engineer, Platform",
+        "location": "Remote (US)",
+        "remote_type": "remote",
+        "source": "referral",
+        "posted_salary_min": 220000.0,
+        "posted_salary_max": 280000.0,
+        "fit_score": 75.0,
+        "notes": "Referred by old Pied Piper coworker. Strong team, big scope.",
+        "days_ago_applied": 12,
+        "events": [
+            ("applied", 0),
+            ("interview_scheduled", 4),
+            ("interview_completed", 7),
+        ],
+    },
+    {
+        "company_index": 2,  # Stark Industries
+        "role_title": "Senior Software Engineer, Devices",
+        "location": "New York, NY",
+        "remote_type": "onsite",
+        "source": "indeed",
+        "posted_salary_min": 190000.0,
+        "posted_salary_max": 240000.0,
+        "fit_score": 60.0,
+        "notes": "Onsite-only — would need to relocate. Pass unless offer is exceptional.",
+        "days_ago_applied": 30,
+        "events": [
+            ("applied", 0),
+            ("rejected", 10),
+        ],
+    },
+    {
+        "company_index": 0,  # Acme Corp again — different role
+        "role_title": "Principal Engineer, Logistics",
+        "location": "Chicago, IL",
+        "remote_type": "hybrid",
+        "source": "direct",
+        "posted_salary_min": 240000.0,
+        "posted_salary_max": 300000.0,
+        "fit_score": 72.0,
+        "notes": "Stretch role — would be a level up. Keep in pipeline only if first Acme offer falls through.",
+        "days_ago_applied": 5,
+        "events": [
+            ("applied", 0),
+        ],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# Resume upload job seed (status=complete with parsed_fields)
+# ---------------------------------------------------------------------------
+
+
+def make_resume_parsed_fields() -> dict[str, object]:
+    """Return a realistic ``parsed_fields`` JSONB body for a complete job.
+
+    Mirrors the shape of what the real resume parser worker produces
+    so the Profile page renders end-to-end without mocking.
+    """
+    return {
+        "name": DEMO_DEFAULT_DISPLAY_NAME,
+        "email": "alex.demo@example.com",
+        "phone": "+1 415 555 0142",
+        "location": "San Francisco, CA",
+        "summary": DEMO_PROFILE["summary"],
+        "skills": [s["name"] for s in DEMO_SKILLS],
+        "work_history": [
+            {
+                "company": w["company_name"],
+                "title": w["title"],
+                "start": w["start_date"].isoformat(),
+                "end": w["end_date"].isoformat() if w["end_date"] else None,
+                "bullets": w["bullets"],
+            }
+            for w in DEMO_WORK_HISTORY
+        ],
+        "education": [
+            {
+                "school": e["school"],
+                "degree": e["degree"],
+                "field": e["field"],
+                "start_year": e["start_year"],
+                "end_year": e["end_year"],
+                "gpa": e["gpa"],
+            }
+            for e in DEMO_EDUCATION
+        ],
+    }
+
+
+# Filename + content type are display-only metadata for the UI. The
+# resume_upload_jobs row carries no actual MinIO object — the
+# ``file_path`` value is a synthetic key marker so the Phase-2
+# upload-history surface can still render a row.
+DEMO_RESUME_FILENAME = "alex_demo_resume.pdf"
+DEMO_RESUME_CONTENT_TYPE = "application/pdf"
+DEMO_RESUME_OBJECT_KEY_PREFIX = "demo/resume"
+
+
+def make_resume_object_key() -> str:
+    """Return a synthetic MinIO key for a demo resume upload.
+
+    Demo accounts intentionally do NOT write to MinIO — the bucket may
+    not be configured in dev, and seeding real bytes adds zero
+    showcase value (the operator is demoing the parsed fields, not the
+    file blob). The key format is preserved so the Profile screen's
+    upload list renders.
+    """
+    return f"{DEMO_RESUME_OBJECT_KEY_PREFIX}/{uuid.uuid4().hex}/{DEMO_RESUME_FILENAME}"
+
+
+def days_ago(n: int) -> datetime:
+    """UTC timestamp ``n`` days before now. Used for ``applied_at`` etc."""
+    return datetime.now(timezone.utc) - timedelta(days=n)

--- a/apps/myjobhunter/backend/app/services/demo/demo_service.py
+++ b/apps/myjobhunter/backend/app/services/demo/demo_service.py
@@ -1,0 +1,198 @@
+"""Demo-account orchestration.
+
+This module is the single entry point for demo-account lifecycle:
+creating, listing, deleting. The admin-gated routes in ``app.api.demo``
+delegate here.
+
+What's HERE:
+
+  - Generate a fresh email + password if the operator didn't supply one.
+  - Hash the password via the same ``PasswordHelper`` fastapi-users
+    uses for real signups, so the resulting row is indistinguishable
+    from a real one (apart from ``is_demo=True``).
+  - Drive the seed data: profile, work history, education, skills,
+    one ``resume_upload_jobs`` row in status=complete, three companies,
+    four applications across the typical pipeline stages.
+  - Translate repository LookupErrors into the ``LookupError`` /
+    ``ValueError`` shape the route layer maps to 404 / 409.
+
+What's NOT here:
+
+  - Direct DB mutation (``db.add`` / ``db.execute``). All persistence
+    goes through ``app.repositories.demo.demo_repository``.
+  - Permission gating. The route layer applies ``require_admin``;
+    this service trusts that the caller has already been authorised.
+
+Mirrors the MBK demo service shape but adapted for MJH's per-user (no
+org) data model.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from fastapi_users.password import PasswordHelper
+
+from app.db.session import unit_of_work
+from app.repositories.demo import demo_repository as demo_repo
+from app.schemas.demo.demo import (
+    DemoCreateResponse,
+    DemoCredentials,
+    DemoDeleteResponse,
+    DemoUserListResponse,
+    DemoUserSummary,
+)
+from app.services.demo.demo_constants import (
+    DEMO_APPLICATIONS,
+    DEMO_COMPANIES,
+    DEMO_DEFAULT_DISPLAY_NAME,
+    DEMO_EDUCATION,
+    DEMO_PROFILE,
+    DEMO_RESUME_CONTENT_TYPE,
+    DEMO_RESUME_FILENAME,
+    DEMO_SKILLS,
+    DEMO_WORK_HISTORY,
+    generate_demo_password,
+    make_demo_email,
+    make_resume_object_key,
+    make_resume_parsed_fields,
+)
+
+logger = logging.getLogger(__name__)
+
+_password_helper = PasswordHelper()
+_DEMO_PARSER_VERSION = "demo-seed-v1"
+
+
+async def create_demo_user(
+    *,
+    email: str | None = None,
+    display_name: str | None = None,
+) -> DemoCreateResponse:
+    """Create a fully-seeded demo user account.
+
+    The operation runs in a single ``unit_of_work`` transaction so the
+    user, profile, work history, skills, companies, applications, and
+    events all commit together — or none of them do. A partial demo
+    account is worse than none at all, since the demo would render
+    half-empty screens that look like bugs to a stranger.
+
+    Args:
+        email: Optional override. When ``None`` the service auto-
+            generates ``demo+<uuid>@myjobhunter.local``.
+        display_name: Optional override. When ``None`` the service
+            uses ``DEMO_DEFAULT_DISPLAY_NAME``.
+
+    Raises:
+        ValueError: When ``email`` is supplied and already exists in
+            ``users``. The route layer maps this to HTTP 409.
+    """
+    final_email = (email or make_demo_email()).strip().lower()
+    final_display_name = (display_name or DEMO_DEFAULT_DISPLAY_NAME).strip()
+    if not final_display_name:
+        final_display_name = DEMO_DEFAULT_DISPLAY_NAME
+
+    password = generate_demo_password()
+    hashed = _password_helper.hash(password)
+
+    async with unit_of_work() as db:
+        existing = await demo_repo.get_user_by_email(db, final_email)
+        if existing is not None:
+            raise ValueError(
+                f"A user with email '{final_email}' already exists. "
+                "Pick a different email or delete the existing account first."
+            )
+
+        user = await demo_repo.create_demo_user(
+            db,
+            email=final_email,
+            hashed_password=hashed,
+            display_name=final_display_name,
+        )
+
+        profile = await demo_repo.create_profile(
+            db, user_id=user.id, seed=DEMO_PROFILE,
+        )
+        await demo_repo.create_work_history(
+            db, user_id=user.id, profile_id=profile.id, seeds=DEMO_WORK_HISTORY,
+        )
+        await demo_repo.create_education(
+            db, user_id=user.id, profile_id=profile.id, seeds=DEMO_EDUCATION,
+        )
+        await demo_repo.create_skills(
+            db, user_id=user.id, profile_id=profile.id, seeds=DEMO_SKILLS,
+        )
+        await demo_repo.create_resume_upload_job(
+            db,
+            user_id=user.id,
+            profile_id=profile.id,
+            file_path=make_resume_object_key(),
+            file_filename=DEMO_RESUME_FILENAME,
+            file_content_type=DEMO_RESUME_CONTENT_TYPE,
+            parsed_fields=make_resume_parsed_fields(),
+            parser_version=_DEMO_PARSER_VERSION,
+        )
+
+        companies = await demo_repo.create_companies(
+            db, user_id=user.id, seeds=DEMO_COMPANIES,
+        )
+        company_ids = [c.id for c in companies]
+        await demo_repo.create_applications_with_events(
+            db,
+            user_id=user.id,
+            company_ids=company_ids,
+            seeds=DEMO_APPLICATIONS,
+        )
+
+        user_id = user.id
+
+    logger.info(
+        "DEMO_ACTION created demo user user_id=%s email=%s",
+        user_id, final_email,
+    )
+
+    return DemoCreateResponse(
+        message=f"Demo user '{final_display_name}' created with seed data.",
+        credentials=DemoCredentials(email=final_email, password=password),
+        user_id=user_id,
+    )
+
+
+async def list_demo_users() -> DemoUserListResponse:
+    """Return every demo user with summary counts.
+
+    Order is most-recently-created first so the operator's freshly-
+    created demo lands at the top of the table.
+    """
+    async with unit_of_work() as db:
+        rows = await demo_repo.list_demo_user_summaries(db)
+
+    summaries = [DemoUserSummary(**row) for row in rows]
+    return DemoUserListResponse(users=summaries, total=len(summaries))
+
+
+async def delete_demo_user(user_id: uuid.UUID) -> DemoDeleteResponse:
+    """Delete a demo user and every cascade-able row they own.
+
+    The repository's ``delete_demo_user_cascade`` enforces ``is_demo=True``
+    at the SQL layer — the service-layer pre-check + the SQL guard are
+    belt and braces against ever wiping a real account.
+
+    Raises:
+        LookupError: When the id doesn't match a ``is_demo=True`` row.
+            The route layer maps this to HTTP 404.
+    """
+    async with unit_of_work() as db:
+        target = await demo_repo.get_demo_user_by_id(db, user_id)
+        if target is None:
+            raise LookupError(
+                f"No demo user with id {user_id} exists. "
+                "It may have already been deleted, or the id refers to "
+                "a real (non-demo) account."
+            )
+        await demo_repo.delete_demo_user_cascade(db, user_id=user_id)
+
+    logger.info("DEMO_ACTION deleted demo user user_id=%s", user_id)
+    return DemoDeleteResponse(
+        message=f"Demo user {user_id} deleted successfully.",
+    )

--- a/apps/myjobhunter/backend/tests/test_demo_service.py
+++ b/apps/myjobhunter/backend/tests/test_demo_service.py
@@ -1,0 +1,312 @@
+"""Tests for the admin demo-management API.
+
+Covers the full CRUD shape:
+  - create returns plaintext credentials and seeded data
+  - list returns just the demo user, never real users
+  - delete cascades cleanly and refuses real users
+  - email collision returns 409
+  - non-admin caller is rejected with 403
+
+The service uses ``unit_of_work`` (its own session) for atomicity, so
+the conftest's rolled-back transaction does NOT cover writes the
+service makes. Cleanup is explicit at the end of each test via
+``DELETE FROM users WHERE email LIKE '%demo+%'`` so no demo rows
+persist across the test session.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import NullPool
+
+from app.core.config import settings
+from app.main import app
+from app.services.demo import demo_service
+
+
+pytestmark = pytest.mark.asyncio
+
+
+async def _purge_demo_users() -> None:
+    """Hard-clean every demo user out of the DB."""
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            async with sess.begin():
+                await sess.execute(text("DELETE FROM users WHERE is_demo = TRUE"))
+                await sess.execute(
+                    text("DELETE FROM auth_events WHERE user_id IS NULL")
+                )
+    finally:
+        await engine.dispose()
+
+
+@pytest.fixture(autouse=True)
+async def _clean_demo_users():
+    """Each demo test starts and ends with zero demo rows."""
+    await _purge_demo_users()
+    yield
+    await _purge_demo_users()
+
+
+# ---------------------------------------------------------------------------
+# Service-layer tests (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+async def test_create_demo_user_returns_credentials_and_seeds_data() -> None:
+    """``create_demo_user`` writes a real user, profile, and applications."""
+    response = await demo_service.create_demo_user()
+
+    assert response.credentials.email.endswith("@myjobhunter.local")
+    assert len(response.credentials.password) >= 16
+    assert response.user_id is not None
+
+    # Verify the seed data landed in the DB.
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            async with sess.begin():
+                user_row = await sess.execute(
+                    text(
+                        "SELECT is_demo, is_verified, display_name "
+                        "FROM users WHERE id = :id"
+                    ),
+                    {"id": response.user_id},
+                )
+                user = user_row.first()
+                assert user is not None
+                assert user.is_demo is True
+                assert user.is_verified is True
+                assert user.display_name == "Alex Demo"
+
+                profile_row = await sess.execute(
+                    text("SELECT COUNT(*) FROM profiles WHERE user_id = :id"),
+                    {"id": response.user_id},
+                )
+                assert profile_row.scalar_one() == 1
+
+                wh_row = await sess.execute(
+                    text(
+                        "SELECT COUNT(*) FROM work_history WHERE user_id = :id"
+                    ),
+                    {"id": response.user_id},
+                )
+                assert wh_row.scalar_one() == 3
+
+                edu_row = await sess.execute(
+                    text("SELECT COUNT(*) FROM education WHERE user_id = :id"),
+                    {"id": response.user_id},
+                )
+                assert edu_row.scalar_one() == 1
+
+                skill_row = await sess.execute(
+                    text("SELECT COUNT(*) FROM skills WHERE user_id = :id"),
+                    {"id": response.user_id},
+                )
+                assert skill_row.scalar_one() == 8
+
+                co_row = await sess.execute(
+                    text(
+                        "SELECT COUNT(*) FROM companies WHERE user_id = :id"
+                    ),
+                    {"id": response.user_id},
+                )
+                assert co_row.scalar_one() == 3
+
+                app_row = await sess.execute(
+                    text(
+                        "SELECT COUNT(*) FROM applications "
+                        "WHERE user_id = :id AND deleted_at IS NULL"
+                    ),
+                    {"id": response.user_id},
+                )
+                assert app_row.scalar_one() == 4
+
+                event_row = await sess.execute(
+                    text(
+                        "SELECT COUNT(*) FROM application_events "
+                        "WHERE user_id = :id"
+                    ),
+                    {"id": response.user_id},
+                )
+                # 4+3+2+1 = 10 events across the 4 seeded applications.
+                assert event_row.scalar_one() == 10
+
+                resume_row = await sess.execute(
+                    text(
+                        "SELECT COUNT(*) FROM resume_upload_jobs "
+                        "WHERE user_id = :id AND status = 'complete'"
+                    ),
+                    {"id": response.user_id},
+                )
+                assert resume_row.scalar_one() == 1
+    finally:
+        await engine.dispose()
+
+
+async def test_create_demo_user_rejects_duplicate_email() -> None:
+    """Passing the same email twice raises ValueError (409)."""
+    first = await demo_service.create_demo_user(email="demo+dupe@myjobhunter.local")
+    assert first.credentials.email == "demo+dupe@myjobhunter.local"
+
+    with pytest.raises(ValueError, match="already exists"):
+        await demo_service.create_demo_user(email="demo+dupe@myjobhunter.local")
+
+
+async def test_list_demo_users_returns_only_demo_rows() -> None:
+    """The list endpoint never surfaces real (is_demo=False) users."""
+    created = await demo_service.create_demo_user()
+
+    listing = await demo_service.list_demo_users()
+
+    assert listing.total == 1
+    assert len(listing.users) == 1
+    assert listing.users[0].user_id == created.user_id
+    assert listing.users[0].application_count == 4
+    assert listing.users[0].company_count == 3
+
+
+async def test_delete_demo_user_cascades_data() -> None:
+    """Deleting a demo user removes them and every cascade-able row."""
+    created = await demo_service.create_demo_user()
+    user_id = created.user_id
+
+    delete_response = await demo_service.delete_demo_user(user_id)
+    assert "deleted successfully" in delete_response.message
+
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            async with sess.begin():
+                user_row = await sess.execute(
+                    text("SELECT COUNT(*) FROM users WHERE id = :id"),
+                    {"id": user_id},
+                )
+                assert user_row.scalar_one() == 0
+                # Every domain row should have cascade-deleted.
+                for table in (
+                    "profiles",
+                    "work_history",
+                    "education",
+                    "skills",
+                    "companies",
+                    "applications",
+                    "application_events",
+                    "resume_upload_jobs",
+                ):
+                    row = await sess.execute(
+                        text(f"SELECT COUNT(*) FROM {table} WHERE user_id = :id"),
+                        {"id": user_id},
+                    )
+                    assert row.scalar_one() == 0, f"{table} should be empty"
+    finally:
+        await engine.dispose()
+
+
+async def test_delete_demo_user_refuses_unknown_id() -> None:
+    """Deleting a non-existent id raises LookupError (404)."""
+    with pytest.raises(LookupError, match="No demo user"):
+        await demo_service.delete_demo_user(uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# HTTP-layer tests (verify admin gate + response shape)
+# ---------------------------------------------------------------------------
+
+
+async def _promote_to_admin(email: str) -> None:
+    """Flip a user's role to admin via raw SQL (bypasses any service guard)."""
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    try:
+        async with factory() as sess:
+            async with sess.begin():
+                await sess.execute(
+                    text("UPDATE users SET role = 'admin' WHERE email = :e"),
+                    {"e": email},
+                )
+    finally:
+        await engine.dispose()
+
+
+async def _login(email: str, password: str) -> str:
+    """Return a JWT bearer token for the given credentials."""
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as ac:
+        resp = await ac.post(
+            "/auth/jwt/login",
+            data={"username": email, "password": password},
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["access_token"]
+
+
+async def test_post_demo_users_rejects_non_admin(user_factory) -> None:
+    """A regular user gets 403, not the demo seed."""
+    user = await user_factory()
+    token = await _login(user["email"], user["password"])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as ac:
+        resp = await ac.post(
+            "/admin/demo/users",
+            headers={"Authorization": f"Bearer {token}"},
+            json={},
+        )
+
+    assert resp.status_code == 403
+
+
+async def test_post_demo_users_admin_can_create(user_factory) -> None:
+    """Admin gets 201 + credentials and the seed data persists."""
+    admin_user = await user_factory()
+    await _promote_to_admin(admin_user["email"])
+    token = await _login(admin_user["email"], admin_user["password"])
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as ac:
+        resp = await ac.post(
+            "/admin/demo/users",
+            headers={"Authorization": f"Bearer {token}"},
+            json={},
+        )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert "credentials" in body
+    assert body["credentials"]["email"].endswith("@myjobhunter.local")
+    assert body["user_id"]
+
+
+async def test_get_demo_users_returns_summaries(user_factory) -> None:
+    """GET /admin/demo/users returns the right shape."""
+    admin_user = await user_factory()
+    await _promote_to_admin(admin_user["email"])
+    token = await _login(admin_user["email"], admin_user["password"])
+
+    await demo_service.create_demo_user()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test",
+    ) as ac:
+        resp = await ac.get(
+            "/admin/demo/users",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["users"][0]["application_count"] == 4
+    assert body["users"][0]["company_count"] == 3

--- a/apps/myjobhunter/frontend/e2e/admin-demo.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/admin-demo.spec.ts
@@ -1,0 +1,213 @@
+/**
+ * E2E test for the admin demo-management flow.
+ *
+ * Verifies the full operator journey:
+ *   1. Promote a fresh test user to admin via the test-helper.
+ *   2. Open /admin/demo and confirm the empty-state CTA shows.
+ *   3. Create a demo account through the dialog.
+ *   4. Confirm the credentials modal shows the email + password.
+ *   5. Confirm the table now lists 1 demo account with applications=4
+ *      and companies=3 (the seed counts).
+ *   6. Log in as the demo account in a separate browser context and
+ *      verify Applications + Companies + Profile render seeded content.
+ *   7. Return to admin context and delete the demo account; confirm
+ *      the table is empty again.
+ *
+ * The test uses a unique email per run so concurrent runs don't
+ * collide. Cleanup deletes both the admin test user and any surviving
+ * demo accounts from the page.
+ */
+import { test, expect, type APIRequestContext } from "@playwright/test";
+import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8002";
+
+async function promoteToAdmin(
+  request: APIRequestContext,
+  email: string,
+): Promise<void> {
+  const response = await request.post(
+    `${BACKEND_URL}/api/_test/promote-to-admin`,
+    { data: { email } },
+  );
+  if (!response.ok()) {
+    const body = await response.text();
+    throw new Error(
+      `Failed to promote ${email} to admin: ${response.status()} — ${body}`,
+    );
+  }
+}
+
+async function bulkDeleteDemoUsers(
+  request: APIRequestContext,
+  adminToken: string,
+): Promise<void> {
+  // Grab whatever survives and delete each so a flaky run doesn't
+  // leave orphan demo accounts piling up.
+  const listResponse = await request.get(
+    `${BACKEND_URL}/api/admin/demo/users`,
+    { headers: { Authorization: `Bearer ${adminToken}` } },
+  );
+  if (!listResponse.ok()) {
+    return;
+  }
+  const body = (await listResponse.json()) as {
+    users: { user_id: string }[];
+  };
+  for (const user of body.users) {
+    await request.delete(
+      `${BACKEND_URL}/api/admin/demo/users/${user.user_id}`,
+      { headers: { Authorization: `Bearer ${adminToken}` } },
+    );
+  }
+}
+
+test.describe("Admin demo accounts", () => {
+  test("admin creates, lists, logs in as, and deletes a demo account", async ({
+    page,
+    browser,
+    request,
+  }) => {
+    const adminUser = await createTestUser(request);
+    let adminToken = "";
+
+    try {
+      await promoteToAdmin(request, adminUser.email);
+
+      // Get a token for cleanup later.
+      const loginResp = await request.post(
+        `${BACKEND_URL}/api/auth/jwt/login`,
+        {
+          form: { username: adminUser.email, password: adminUser.password },
+        },
+      );
+      expect(loginResp.ok()).toBe(true);
+      adminToken = (
+        (await loginResp.json()) as { access_token: string }
+      ).access_token;
+
+      // Make sure no leftover demo accounts pollute the listing.
+      await bulkDeleteDemoUsers(request, adminToken);
+
+      // Step 1: Log in via UI as the admin and navigate to /admin/demo.
+      await loginViaUI(page, adminUser, request);
+      await expect(page).toHaveURL(/\/dashboard/);
+
+      await page.goto("/admin/demo");
+      await expect(
+        page.getByRole("heading", { name: "Demo accounts" }),
+      ).toBeVisible({ timeout: 10_000 });
+
+      // Step 2: Empty state shows the CTA.
+      const emptyHeading = page.getByRole("heading", {
+        name: "No demo accounts yet",
+      });
+      await expect(emptyHeading).toBeVisible({ timeout: 10_000 });
+
+      // Step 3: Open the create dialog.
+      await page
+        .getByRole("button", { name: /create demo account/i })
+        .first()
+        .click();
+
+      const dialog = page.getByRole("dialog", {
+        name: /create demo account/i,
+      });
+      await expect(dialog).toBeVisible();
+      await dialog.getByRole("button", { name: /^create$/i }).click();
+
+      // Step 4: Credentials modal appears.
+      const credsDialog = page.getByRole("dialog", {
+        name: /demo credentials/i,
+      });
+      await expect(credsDialog).toBeVisible({ timeout: 15_000 });
+
+      const credsText = await credsDialog.textContent();
+      expect(credsText).toBeTruthy();
+      const emailMatch = credsText!.match(
+        /demo\+[a-z0-9]+@myjobhunter\.local/i,
+      );
+      expect(emailMatch).not.toBeNull();
+      const demoEmail = emailMatch![0];
+
+      // The password is the second monospace block under the email.
+      const passwordCells = credsDialog.locator("[data-credential-password]");
+      const demoPassword = (await passwordCells.first().textContent())?.trim();
+      expect(demoPassword).toBeTruthy();
+      expect(demoPassword!.length).toBeGreaterThanOrEqual(16);
+
+      await credsDialog.getByRole("button", { name: /close/i }).click();
+      await expect(credsDialog).not.toBeVisible();
+
+      // Step 5: Table now lists exactly one demo account.
+      await expect(page.getByText(/1 demo account/i)).toBeVisible();
+      await expect(page.getByText(demoEmail)).toBeVisible();
+      // Application count = 4, Company count = 3 (seed shape).
+      const row = page.getByTestId("demo-user-row");
+      await expect(row).toHaveCount(1);
+      await expect(row).toContainText("4");
+      await expect(row).toContainText("3");
+
+      // Step 6: Log in as the demo user in a fresh browser context.
+      const demoContext = await browser.newContext();
+      const demoPage = await demoContext.newPage();
+      try {
+        await demoPage.goto("/login");
+        await demoPage.getByLabel(/email/i).fill(demoEmail);
+        await demoPage.locator("#login-password").fill(demoPassword!);
+        await demoPage.getByRole("button", { name: /sign in/i }).click();
+        await demoPage.waitForURL(
+          (url) => !url.pathname.includes("/login"),
+          { timeout: 15_000 },
+        );
+
+        // Applications page shows seeded rows (NOT the empty state).
+        await demoPage
+          .getByRole("link", { name: /applications/i })
+          .first()
+          .click();
+        await demoPage.waitForURL("**/applications");
+        await expect(
+          demoPage.getByRole("heading", { name: "Applications" }),
+        ).toBeVisible({ timeout: 10_000 });
+        // The seeded role titles include "Senior Backend Engineer".
+        await expect(
+          demoPage.getByText(/Senior Backend Engineer/i).first(),
+        ).toBeVisible();
+
+        // Companies page shows seeded entries.
+        await demoPage
+          .getByRole("link", { name: /companies/i })
+          .first()
+          .click();
+        await demoPage.waitForURL("**/companies");
+        await expect(demoPage.getByText(/Acme Corp/i).first()).toBeVisible({
+          timeout: 10_000,
+        });
+      } finally {
+        await demoContext.close();
+      }
+
+      // Step 7: Back on the admin page, delete the demo account.
+      await page
+        .getByRole("button", { name: new RegExp(`Delete ${demoEmail}`, "i") })
+        .click();
+
+      const confirmDialog = page.getByRole("dialog", {
+        name: /delete demo account/i,
+      });
+      await expect(confirmDialog).toBeVisible();
+      await confirmDialog.getByRole("button", { name: /^delete$/i }).click();
+
+      // Empty state is back.
+      await expect(
+        page.getByRole("heading", { name: "No demo accounts yet" }),
+      ).toBeVisible({ timeout: 10_000 });
+    } finally {
+      if (adminToken) {
+        await bulkDeleteDemoUsers(request, adminToken);
+      }
+      await deleteTestUser(request, adminUser);
+    }
+  });
+});

--- a/apps/myjobhunter/frontend/src/RootLayout.tsx
+++ b/apps/myjobhunter/frontend/src/RootLayout.tsx
@@ -8,11 +8,13 @@ import {
   Settings,
   Sparkles,
   UserCircle,
+  Wand2,
 } from "lucide-react";
 import { AppShell, RequireAuth, Toaster, useIsAuthenticated } from "@platform/ui";
 import { buildNav, buildBottomNav } from "@/constants/nav";
 import { signOut } from "@/lib/auth";
 import ThemeToggle from "@/components/ThemeToggle";
+import { useIsAdmin } from "@/hooks/useIsAdmin";
 
 // Decode basic user info from JWT for display in the shell's user menu.
 // This is display-only — no security decisions are made from client-side decode.
@@ -39,14 +41,15 @@ const ICONS: Record<string, React.ReactNode> = {
   Settings: <Settings className="w-5 h-5" />,
   Sparkles: <Sparkles className="w-5 h-5" />,
   UserCircle: <UserCircle className="w-5 h-5" />,
+  Wand2: <Wand2 className="w-5 h-5" />,
 };
-
-const nav = buildNav(ICONS);
 
 export default function RootLayout() {
   const navigate = useNavigate();
   const isAuthenticated = useIsAuthenticated();
+  const { isAdmin } = useIsAdmin();
 
+  const nav = buildNav(ICONS, { includeAdmin: isAdmin });
   const bottomNav = buildBottomNav(ICONS, () => {
     // Phase 2 will open the Add Application dialog
     // For Phase 1, navigate to applications page

--- a/apps/myjobhunter/frontend/src/components/RequireAdmin.tsx
+++ b/apps/myjobhunter/frontend/src/components/RequireAdmin.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+import { Skeleton } from "@platform/ui";
+import { useIsAdmin } from "@/hooks/useIsAdmin";
+
+interface RequireAdminProps {
+  children: ReactNode;
+}
+
+/**
+ * Route gate that only renders children when the current user has
+ * `Role.ADMIN`. While the role lookup is in flight a skeleton is
+ * shown so the UI does not flash; on resolution non-admins are
+ * redirected to `/dashboard` (the same default as RequireAuth).
+ *
+ * The backend is still the authoritative authorization layer — every
+ * admin-only route validates the role server-side. This component is
+ * a UX guard, not a security control.
+ */
+export default function RequireAdmin({ children }: RequireAdminProps) {
+  const { isAdmin, isLoading } = useIsAdmin();
+
+  if (isLoading) {
+    return (
+      <main className="p-4 sm:p-8 space-y-6">
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-4 w-72" />
+      </main>
+    );
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  return <>{children}</>;
+}

--- a/apps/myjobhunter/frontend/src/constants/admin-routes.ts
+++ b/apps/myjobhunter/frontend/src/constants/admin-routes.ts
@@ -1,0 +1,12 @@
+/**
+ * Admin-only frontend routes. Centralised so route definitions, nav
+ * descriptors, and any future redirect logic share one source of
+ * truth — no magic strings sprinkled through the codebase.
+ *
+ * Backend-side these routes are gated by `require_admin`
+ * (Role.ADMIN). The frontend uses these paths only to decide what
+ * to render in the SPA.
+ */
+export const ADMIN_ROUTES = {
+  DEMO_USERS: "/admin/demo",
+} as const;

--- a/apps/myjobhunter/frontend/src/constants/nav.ts
+++ b/apps/myjobhunter/frontend/src/constants/nav.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 import type { NavItem, BottomNavItem } from "@platform/ui";
+import { ADMIN_ROUTES } from "@/constants/admin-routes";
 
 // Icon nodes are created at runtime in App.tsx and passed in via constants helpers.
 // This module exports typed descriptors — icons are injected at component level
@@ -22,9 +23,28 @@ export const NAV_DESCRIPTORS: NavDescriptor[] = [
   { path: "/settings", label: "Settings", iconName: "Settings" },
 ];
 
+/**
+ * Admin-only nav descriptors. Appended to the user nav by `buildNav`
+ * when called with `includeAdmin=true`. Hidden by default; the
+ * RootLayout decides who sees these by inspecting the user's role.
+ */
+export const ADMIN_NAV_DESCRIPTORS: NavDescriptor[] = [
+  {
+    path: ADMIN_ROUTES.DEMO_USERS,
+    label: "Demo accounts",
+    iconName: "Wand2",
+  },
+];
+
 /** Build the full NavItem array — called once in App.tsx with injected icon nodes. */
-export function buildNav(icons: Record<string, ReactNode>): NavItem[] {
-  return NAV_DESCRIPTORS.map(({ path, label, iconName, exact }) => ({
+export function buildNav(
+  icons: Record<string, ReactNode>,
+  options: { includeAdmin?: boolean } = {},
+): NavItem[] {
+  const descriptors = options.includeAdmin
+    ? [...NAV_DESCRIPTORS, ...ADMIN_NAV_DESCRIPTORS]
+    : NAV_DESCRIPTORS;
+  return descriptors.map(({ path, label, iconName, exact }) => ({
     path,
     label,
     icon: icons[iconName],

--- a/apps/myjobhunter/frontend/src/constants/roles.ts
+++ b/apps/myjobhunter/frontend/src/constants/roles.ts
@@ -1,0 +1,14 @@
+/**
+ * Platform-level user roles — mirrors the backend
+ * `platform_shared.core.permissions.Role` enum.
+ *
+ * The backend remains the source of truth for authorization. The
+ * frontend uses this constant only to gate UI affordances (e.g.
+ * showing the admin nav link).
+ */
+export const ROLE = {
+  ADMIN: "admin",
+  USER: "user",
+} as const;
+
+export type Role = (typeof ROLE)[keyof typeof ROLE];

--- a/apps/myjobhunter/frontend/src/features/admin/demo/CreateDemoDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/CreateDemoDialog.tsx
@@ -1,0 +1,137 @@
+import { useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { LoadingButton } from "@platform/ui";
+
+export interface CreateDemoDialogProps {
+  open: boolean;
+  isLoading: boolean;
+  onSubmit: (input: { email?: string; displayName?: string }) => void;
+  onCancel: () => void;
+}
+
+/**
+ * Modal for creating a new demo account.
+ *
+ * Both inputs (email + display name) are optional — the backend
+ * generates sensible defaults when omitted (`demo+<uuid>@myjobhunter.local`
+ * and `Alex Demo` respectively). The form is intentionally minimal
+ * because the seeded data does the heavy lifting.
+ *
+ * The form's local state (email + displayName) resets imperatively
+ * inside the cancel handler rather than via a useEffect on `open` —
+ * the React docs recommend NOT setting state synchronously in an
+ * effect body when a handler is available, so cancel is the seam.
+ */
+export default function CreateDemoDialog({
+  open,
+  isLoading,
+  onSubmit,
+  onCancel,
+}: CreateDemoDialogProps) {
+  const [email, setEmail] = useState("");
+  const [displayName, setDisplayName] = useState("");
+
+  function resetForm() {
+    setEmail("");
+    setDisplayName("");
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmedEmail = email.trim();
+    const trimmedName = displayName.trim();
+    // Optimistically clear so a re-open after success starts fresh.
+    // The parent owns the open/close state via `open`, so this is
+    // safe — we're not calling onCancel from here.
+    resetForm();
+    onSubmit({
+      email: trimmedEmail || undefined,
+      displayName: trimmedName || undefined,
+    });
+  }
+
+  function handleOpenChange(isOpen: boolean) {
+    if (!isOpen) {
+      resetForm();
+      onCancel();
+    }
+  }
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[70]" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-sm rounded-lg border bg-card p-6 shadow-lg">
+          <Dialog.Title className="text-base font-semibold">
+            Create demo account
+          </Dialog.Title>
+          <Dialog.Description className="text-sm text-muted-foreground mt-1">
+            A fully-seeded sandbox account for showing MyJobHunter to a
+            stranger.
+          </Dialog.Description>
+
+          <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+            <div>
+              <label
+                htmlFor="demo-email"
+                className="block text-sm font-medium mb-1"
+              >
+                Email
+              </label>
+              <input
+                id="demo-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                placeholder="demo+<id>@myjobhunter.local (auto-generated)"
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary/50"
+                autoFocus
+                disabled={isLoading}
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Leave blank to auto-generate.
+              </p>
+            </div>
+
+            <div>
+              <label
+                htmlFor="demo-display-name"
+                className="block text-sm font-medium mb-1"
+              >
+                Display name
+              </label>
+              <input
+                id="demo-display-name"
+                type="text"
+                value={displayName}
+                onChange={(e) => setDisplayName(e.target.value)}
+                placeholder="Alex Demo"
+                maxLength={100}
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary/50"
+                disabled={isLoading}
+              />
+            </div>
+
+            <div className="flex justify-end gap-2 pt-2">
+              <button
+                type="button"
+                onClick={() => handleOpenChange(false)}
+                className="px-3 py-1.5 text-sm font-medium rounded-md border hover:bg-muted transition-colors min-h-[36px]"
+                disabled={isLoading}
+              >
+                Cancel
+              </button>
+              <LoadingButton
+                type="submit"
+                isLoading={isLoading}
+                loadingText="Creating..."
+              >
+                Create
+              </LoadingButton>
+            </div>
+          </form>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/admin/demo/CredentialsModal.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/CredentialsModal.tsx
@@ -1,0 +1,136 @@
+import { useEffect, useRef, useState } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { AlertTriangle, Check, Copy } from "lucide-react";
+import type { DemoCredentials } from "@/types/demo/demo-credentials";
+
+interface CredentialsModalProps {
+  open: boolean;
+  credentials: DemoCredentials;
+  onClose: () => void;
+}
+
+const COPY_FEEDBACK_MS = 2000;
+
+/**
+ * One-time view of a freshly-created demo account's credentials.
+ *
+ * The backend never re-shows the plaintext password — if the operator
+ * dismisses this modal without copying, the only recovery is to
+ * delete + recreate. The component surfaces a clear warning and a
+ * single "copy" button to make the safe path obvious.
+ */
+export default function CredentialsModal({
+  open,
+  credentials,
+  onClose,
+}: CredentialsModalProps) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
+  }, []);
+
+  async function handleCopyAll() {
+    const text = `Email: ${credentials.email}\nPassword: ${credentials.password}`;
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      timerRef.current = setTimeout(() => setCopied(false), COPY_FEEDBACK_MS);
+    } catch {
+      // Clipboard API unavailable (e.g. http://localhost in Firefox without
+      // the dom.events.asyncClipboard pref). Fall back to selecting the
+      // password text so the user can Ctrl+C manually.
+      const el = document.querySelector("[data-credential-password]");
+      if (el) {
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      }
+    }
+  }
+
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          onClose();
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[70]" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-md rounded-lg border bg-card p-6 shadow-lg">
+          <Dialog.Title className="text-base font-semibold">
+            Demo credentials
+          </Dialog.Title>
+          <Dialog.Description className="text-sm text-muted-foreground mt-1">
+            Save these credentials now — the password won't be shown again.
+          </Dialog.Description>
+
+          <div className="mt-4 space-y-3">
+            <div className="bg-muted rounded-md px-4 py-3">
+              <p className="text-xs text-muted-foreground">Email</p>
+              <p className="text-sm font-mono break-all">
+                {credentials.email}
+              </p>
+            </div>
+            <div className="bg-muted rounded-md px-4 py-3">
+              <p className="text-xs text-muted-foreground">Password</p>
+              <p
+                className="text-sm font-mono break-all"
+                data-credential-password
+              >
+                {credentials.password}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 flex items-start gap-2 rounded-md bg-yellow-50 border border-yellow-200 px-3 py-2 dark:bg-yellow-950 dark:border-yellow-800">
+            <AlertTriangle
+              size={16}
+              className="text-yellow-600 dark:text-yellow-400 shrink-0 mt-0.5"
+            />
+            <p className="text-xs text-yellow-800 dark:text-yellow-200">
+              The password is only shown here. If you dismiss this modal
+              without copying, you'll need to delete and recreate the demo
+              account to get new credentials.
+            </p>
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              onClick={onClose}
+              className="px-3 py-1.5 text-sm font-medium rounded-md border hover:bg-muted transition-colors min-h-[36px]"
+            >
+              Close
+            </button>
+            <button
+              onClick={handleCopyAll}
+              className="inline-flex items-center gap-2 px-3 py-1.5 text-sm font-medium rounded-md bg-primary text-primary-foreground hover:opacity-90 transition-opacity min-h-[36px]"
+            >
+              {copied ? (
+                <>
+                  <Check size={14} />
+                  Copied
+                </>
+              ) : (
+                <>
+                  <Copy size={14} />
+                  Copy credentials
+                </>
+              )}
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/admin/demo/DeleteDemoConfirmDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/DeleteDemoConfirmDialog.tsx
@@ -1,0 +1,78 @@
+import * as Dialog from "@radix-ui/react-dialog";
+import { LoadingButton } from "@platform/ui";
+import { AlertTriangle } from "lucide-react";
+
+interface DeleteDemoConfirmDialogProps {
+  open: boolean;
+  email: string;
+  isLoading: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Confirmation dialog for deleting a demo account.
+ *
+ * Demo accounts are hard-deleted with cascade — there is no undo.
+ * This modal makes that explicit. Renamed/extracted instead of using
+ * a generic ConfirmDialog because the warning copy is specific
+ * enough to deserve its own component.
+ */
+export default function DeleteDemoConfirmDialog({
+  open,
+  email,
+  isLoading,
+  onConfirm,
+  onCancel,
+}: DeleteDemoConfirmDialogProps) {
+  return (
+    <Dialog.Root
+      open={open}
+      onOpenChange={(isOpen) => {
+        if (!isOpen) {
+          onCancel();
+        }
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[70]" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-sm rounded-lg border bg-card p-6 shadow-lg">
+          <div className="flex items-start gap-3">
+            <AlertTriangle
+              className="w-5 h-5 text-destructive shrink-0 mt-0.5"
+              aria-hidden
+            />
+            <div className="flex-1">
+              <Dialog.Title className="text-base font-semibold">
+                Delete demo account?
+              </Dialog.Title>
+              <Dialog.Description className="text-sm text-muted-foreground mt-1">
+                This will permanently delete{" "}
+                <span className="font-mono break-all">{email}</span> and all
+                their seeded data. This cannot be undone.
+              </Dialog.Description>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              onClick={onCancel}
+              className="px-3 py-1.5 text-sm font-medium rounded-md border hover:bg-muted transition-colors min-h-[36px]"
+              disabled={isLoading}
+            >
+              Cancel
+            </button>
+            <LoadingButton
+              onClick={onConfirm}
+              isLoading={isLoading}
+              loadingText="Deleting..."
+              variant="destructive"
+            >
+              Delete
+            </LoadingButton>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/admin/demo/DemoUsersEmptyState.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/DemoUsersEmptyState.tsx
@@ -1,0 +1,24 @@
+import { Sparkles } from "lucide-react";
+import { EmptyState } from "@platform/ui";
+
+interface DemoUsersEmptyStateProps {
+  onCreate: () => void;
+}
+
+/**
+ * Empty state shown on the demo-users admin page when zero demo
+ * accounts exist. Wraps `@platform/ui`'s `EmptyState` with copy
+ * tailored to the operator audience.
+ */
+export default function DemoUsersEmptyState({
+  onCreate,
+}: DemoUsersEmptyStateProps) {
+  return (
+    <EmptyState
+      icon={<Sparkles className="w-12 h-12" />}
+      heading="No demo accounts yet"
+      body="Create one to showcase MyJobHunter with realistic seeded data."
+      action={{ label: "Create demo account", onClick: onCreate }}
+    />
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/admin/demo/DemoUsersSkeleton.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/DemoUsersSkeleton.tsx
@@ -1,0 +1,41 @@
+import { Skeleton } from "@platform/ui";
+
+/**
+ * Loading skeleton for the demo-users admin page.
+ *
+ * Mirrors the loaded layout exactly — page header, action button row,
+ * three table rows. Skeleton cell widths match the loaded cells so the
+ * layout doesn't shift when the data resolves.
+ */
+const SKELETON_ROWS = 3;
+
+export default function DemoUsersSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <Skeleton className="h-7 w-48" />
+        <Skeleton className="h-4 w-80" />
+      </div>
+
+      <div className="flex items-center justify-between">
+        <Skeleton className="h-5 w-28" />
+        <Skeleton className="h-9 w-40" />
+      </div>
+
+      <div className="bg-card border rounded-lg overflow-hidden">
+        {Array.from({ length: SKELETON_ROWS }).map((_, i) => (
+          <div
+            key={i}
+            className="flex items-center gap-4 px-4 py-3 border-b last:border-b-0"
+          >
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-4 w-56" />
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-12" />
+            <Skeleton className="h-4 w-24 ml-auto" />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/admin/demo/DemoUsersTable.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/DemoUsersTable.tsx
@@ -1,0 +1,80 @@
+import { Trash2 } from "lucide-react";
+import { formatDate } from "@platform/ui";
+import type { DemoUser } from "@/types/demo/demo-user";
+
+interface DemoUsersTableProps {
+  users: DemoUser[];
+  onDelete: (user: DemoUser) => void;
+}
+
+/**
+ * Tabular list of demo accounts. The action column shows a single
+ * Delete button per row — there's no Reset (MJH demo accounts are
+ * cheap to recreate; delete + create is simpler than reset).
+ *
+ * Mobile: the Created column hides on small screens (sm:table-cell)
+ * so the row stays readable. Touch targets meet the 44x44 minimum.
+ */
+export default function DemoUsersTable({
+  users,
+  onDelete,
+}: DemoUsersTableProps) {
+  return (
+    <div className="border rounded-lg overflow-x-auto">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b bg-muted/50">
+            <th className="text-left px-4 py-3 font-medium">Name</th>
+            <th className="text-left px-4 py-3 font-medium">Email</th>
+            <th className="text-right px-4 py-3 font-medium tabular-nums">
+              Apps
+            </th>
+            <th className="text-right px-4 py-3 font-medium tabular-nums">
+              Companies
+            </th>
+            <th className="text-left px-4 py-3 font-medium hidden sm:table-cell">
+              Created
+            </th>
+            <th className="text-right px-4 py-3 font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map((user) => (
+            <tr
+              key={user.user_id}
+              className="border-b last:border-b-0"
+              data-testid="demo-user-row"
+            >
+              <td className="px-4 py-3 font-medium">{user.display_name}</td>
+              <td className="px-4 py-3 text-muted-foreground font-mono text-xs break-all">
+                {user.email}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums">
+                {user.application_count}
+              </td>
+              <td className="px-4 py-3 text-right tabular-nums">
+                {user.company_count}
+              </td>
+              <td className="px-4 py-3 text-muted-foreground hidden sm:table-cell">
+                {formatDate(user.created_at)}
+              </td>
+              <td className="px-4 py-3">
+                <div className="flex items-center justify-end">
+                  <button
+                    onClick={() => onDelete(user)}
+                    className="inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium rounded-md text-destructive hover:bg-destructive/10 transition-colors min-h-[44px] min-w-[44px] justify-center"
+                    aria-label={`Delete ${user.email}`}
+                    title="Delete demo account"
+                  >
+                    <Trash2 size={14} />
+                    <span className="hidden md:inline">Delete</span>
+                  </button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/admin/demo/__tests__/CreateDemoDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/__tests__/CreateDemoDialog.test.tsx
@@ -1,0 +1,137 @@
+/**
+ * Unit tests for CreateDemoDialog.
+ *
+ * Verifies:
+ *   - Submit with all fields blank calls onSubmit with `{ }` (defaults
+ *     resolved server-side).
+ *   - Submit after typing values passes the trimmed strings.
+ *   - Cancel button calls onCancel.
+ *   - Inputs are disabled while loading.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import CreateDemoDialog from "../CreateDemoDialog";
+
+vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@radix-ui/react-dialog")>();
+  return {
+    ...actual,
+    Portal: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock("@platform/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@platform/ui")>();
+  return {
+    ...actual,
+    LoadingButton: ({
+      children,
+      isLoading,
+      loadingText,
+      type,
+      onClick,
+      disabled,
+    }: {
+      children: React.ReactNode;
+      isLoading?: boolean;
+      loadingText?: string;
+      type?: "button" | "submit" | "reset";
+      onClick?: React.MouseEventHandler<HTMLButtonElement>;
+      disabled?: boolean;
+    }) => (
+      <button
+        type={type ?? "button"}
+        disabled={disabled || isLoading}
+        onClick={onClick}
+      >
+        {isLoading ? loadingText : children}
+      </button>
+    ),
+  };
+});
+
+describe("CreateDemoDialog", () => {
+  it("submits empty payload when both fields are blank", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+    const onCancel = vi.fn();
+
+    render(
+      <CreateDemoDialog
+        open
+        isLoading={false}
+        onSubmit={onSubmit}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      email: undefined,
+      displayName: undefined,
+    });
+  });
+
+  it("submits trimmed values when fields are populated", async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(
+      <CreateDemoDialog
+        open
+        isLoading={false}
+        onSubmit={onSubmit}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    await user.type(
+      screen.getByLabelText(/email/i),
+      "  demo@myjobhunter.local  ",
+    );
+    await user.type(screen.getByLabelText(/display name/i), "  Demo Boss  ");
+    await user.click(screen.getByRole("button", { name: /^create$/i }));
+
+    expect(onSubmit).toHaveBeenCalledWith({
+      email: "demo@myjobhunter.local",
+      displayName: "Demo Boss",
+    });
+  });
+
+  it("calls onCancel when Cancel button is clicked", async () => {
+    const user = userEvent.setup();
+    const onCancel = vi.fn();
+
+    render(
+      <CreateDemoDialog
+        open
+        isLoading={false}
+        onSubmit={vi.fn()}
+        onCancel={onCancel}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: /cancel/i }));
+
+    expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables inputs while loading", () => {
+    render(
+      <CreateDemoDialog
+        open
+        isLoading
+        onSubmit={vi.fn()}
+        onCancel={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByLabelText(/email/i)).toBeDisabled();
+    expect(screen.getByLabelText(/display name/i)).toBeDisabled();
+    expect(screen.getByRole("button", { name: /cancel/i })).toBeDisabled();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/admin/demo/__tests__/DemoUsersTable.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/__tests__/DemoUsersTable.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for DemoUsersTable.
+ *
+ * Verifies the row renders the right counts and that clicking Delete
+ * fires the callback with the matching row.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DemoUsersTable from "../DemoUsersTable";
+import type { DemoUser } from "@/types/demo/demo-user";
+
+vi.mock("lucide-react", () => ({
+  Trash2: () => null,
+}));
+
+vi.mock("@platform/ui", () => ({
+  formatDate: (value: string) => value,
+}));
+
+const SAMPLE_USERS: DemoUser[] = [
+  {
+    user_id: "11111111-1111-1111-1111-111111111111",
+    email: "demo+abc@myjobhunter.local",
+    display_name: "Alex Demo",
+    created_at: "2026-05-05T12:00:00Z",
+    application_count: 4,
+    company_count: 3,
+  },
+  {
+    user_id: "22222222-2222-2222-2222-222222222222",
+    email: "demo+xyz@myjobhunter.local",
+    display_name: "Jordan Sandbox",
+    created_at: "2026-05-04T08:30:00Z",
+    application_count: 0,
+    company_count: 0,
+  },
+];
+
+describe("DemoUsersTable", () => {
+  it("renders a row per user with their counts", () => {
+    render(<DemoUsersTable users={SAMPLE_USERS} onDelete={vi.fn()} />);
+
+    expect(screen.getAllByTestId("demo-user-row")).toHaveLength(2);
+    expect(screen.getByText("Alex Demo")).toBeInTheDocument();
+    expect(screen.getByText("Jordan Sandbox")).toBeInTheDocument();
+    expect(screen.getByText("demo+abc@myjobhunter.local")).toBeInTheDocument();
+  });
+
+  it("invokes onDelete with the matching row when Delete is clicked", async () => {
+    const user = userEvent.setup();
+    const onDelete = vi.fn();
+
+    render(<DemoUsersTable users={SAMPLE_USERS} onDelete={onDelete} />);
+
+    await user.click(
+      screen.getByRole("button", {
+        name: /Delete demo\+abc@myjobhunter.local/i,
+      }),
+    );
+
+    expect(onDelete).toHaveBeenCalledWith(SAMPLE_USERS[0]);
+  });
+});

--- a/apps/myjobhunter/frontend/src/hooks/useIsAdmin.ts
+++ b/apps/myjobhunter/frontend/src/hooks/useIsAdmin.ts
@@ -1,0 +1,31 @@
+import { useIsAuthenticated } from "@platform/ui";
+import { useGetCurrentUserQuery } from "@/lib/userApi";
+import { ROLE } from "@/constants/roles";
+
+interface UseIsAdminResult {
+  /** True only when the loaded user has Role.ADMIN. False during loading. */
+  isAdmin: boolean;
+  /** True while the /users/me request is in flight. */
+  isLoading: boolean;
+}
+
+/**
+ * Resolve the current user's admin status from `/users/me`.
+ *
+ * Skips the network request when the user is not authenticated so
+ * unauthenticated routes (e.g. /login) don't trigger a 401 storm.
+ * Returns `isAdmin=false` while loading so callers default to the
+ * non-admin UI; the redirect / hide-link decision happens AFTER the
+ * data resolves. Callers that need to gate routing should also
+ * handle the loading state explicitly (see `RequireAdmin`).
+ */
+export function useIsAdmin(): UseIsAdminResult {
+  const isAuthenticated = useIsAuthenticated();
+  const { data, isLoading } = useGetCurrentUserQuery(undefined, {
+    skip: !isAuthenticated,
+  });
+  return {
+    isAdmin: isAuthenticated && data?.role === ROLE.ADMIN,
+    isLoading: isAuthenticated && isLoading,
+  };
+}

--- a/apps/myjobhunter/frontend/src/lib/demoUsersApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/demoUsersApi.ts
@@ -1,0 +1,41 @@
+import { baseApi } from "@platform/ui";
+import type { DemoCreateRequest } from "@/types/demo/demo-create-request";
+import type { DemoCreateResponse } from "@/types/demo/demo-create-response";
+import type { DemoDeleteResponse } from "@/types/demo/demo-delete-response";
+import type { DemoUserListResponse } from "@/types/demo/demo-user-list-response";
+
+const DEMO_USERS_TAG = "DemoUsers";
+
+const demoUsersApi = baseApi
+  .enhanceEndpoints({ addTagTypes: [DEMO_USERS_TAG] })
+  .injectEndpoints({
+    endpoints: (build) => ({
+      listDemoUsers: build.query<DemoUserListResponse, void>({
+        query: () => ({ url: "/admin/demo/users", method: "GET" }),
+        providesTags: [{ type: DEMO_USERS_TAG, id: "LIST" }],
+      }),
+
+      createDemoUser: build.mutation<DemoCreateResponse, DemoCreateRequest>({
+        query: (body) => ({
+          url: "/admin/demo/users",
+          method: "POST",
+          data: body,
+        }),
+        invalidatesTags: [{ type: DEMO_USERS_TAG, id: "LIST" }],
+      }),
+
+      deleteDemoUser: build.mutation<DemoDeleteResponse, string>({
+        query: (userId) => ({
+          url: `/admin/demo/users/${userId}`,
+          method: "DELETE",
+        }),
+        invalidatesTags: [{ type: DEMO_USERS_TAG, id: "LIST" }],
+      }),
+    }),
+  });
+
+export const {
+  useListDemoUsersQuery,
+  useCreateDemoUserMutation,
+  useDeleteDemoUserMutation,
+} = demoUsersApi;

--- a/apps/myjobhunter/frontend/src/lib/userApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/userApi.ts
@@ -1,9 +1,15 @@
 import { baseApi } from "@platform/ui";
+import type { Role } from "@/constants/roles";
 
 /**
  * Subset of the fastapi-users ``UserRead`` payload returned by ``GET /users/me``.
  * Only the fields the UI actually consumes are typed here — the API may carry
  * more (e.g. ``is_active``, ``is_superuser``) that are deliberately ignored.
+ *
+ * ``role`` is surfaced so the SPA can conditionally render admin-only nav
+ * items (e.g. /admin/demo). The backend remains the source of truth for
+ * authorization — every admin-only route still validates the role
+ * server-side.
  */
 export interface CurrentUser {
   id: string;
@@ -11,6 +17,8 @@ export interface CurrentUser {
   display_name: string;
   totp_enabled: boolean;
   is_verified: boolean;
+  role: Role;
+  is_demo: boolean;
 }
 
 export interface UpdateUserRequest {

--- a/apps/myjobhunter/frontend/src/pages/admin/DemoUsers.tsx
+++ b/apps/myjobhunter/frontend/src/pages/admin/DemoUsers.tsx
@@ -1,0 +1,176 @@
+import { useState } from "react";
+import { Plus, Sparkles } from "lucide-react";
+import {
+  EmptyState,
+  extractErrorMessage,
+  showError,
+  showSuccess,
+} from "@platform/ui";
+import {
+  useCreateDemoUserMutation,
+  useDeleteDemoUserMutation,
+  useListDemoUsersQuery,
+} from "@/lib/demoUsersApi";
+import CreateDemoDialog from "@/features/admin/demo/CreateDemoDialog";
+import CredentialsModal from "@/features/admin/demo/CredentialsModal";
+import DeleteDemoConfirmDialog from "@/features/admin/demo/DeleteDemoConfirmDialog";
+import DemoUsersEmptyState from "@/features/admin/demo/DemoUsersEmptyState";
+import DemoUsersSkeleton from "@/features/admin/demo/DemoUsersSkeleton";
+import DemoUsersTable from "@/features/admin/demo/DemoUsersTable";
+import type { DemoCredentials } from "@/types/demo/demo-credentials";
+import type { DemoUser } from "@/types/demo/demo-user";
+
+export default function DemoUsers() {
+  const { data, isLoading, isError, error } = useListDemoUsersQuery();
+  const [createDemoUser, { isLoading: isCreating }] =
+    useCreateDemoUserMutation();
+  const [deleteDemoUser, { isLoading: isDeleting }] =
+    useDeleteDemoUserMutation();
+
+  const [showCreateDialog, setShowCreateDialog] = useState(false);
+  const [credentials, setCredentials] = useState<DemoCredentials | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<DemoUser | null>(null);
+
+  async function handleCreate(input: {
+    email?: string;
+    displayName?: string;
+  }) {
+    try {
+      const result = await createDemoUser({
+        email: input.email,
+        display_name: input.displayName,
+      }).unwrap();
+      setShowCreateDialog(false);
+      setCredentials(result.credentials);
+      showSuccess("Demo account created — credentials shown below.");
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Failed to create demo account.");
+    }
+  }
+
+  async function handleConfirmDelete() {
+    if (!pendingDelete) {
+      return;
+    }
+    try {
+      await deleteDemoUser(pendingDelete.user_id).unwrap();
+      showSuccess(`Deleted ${pendingDelete.email}.`);
+      setPendingDelete(null);
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Failed to delete demo account.");
+    }
+  }
+
+  if (isLoading) {
+    return (
+      <main className="p-4 sm:p-8 space-y-6">
+        <DemoUsersSkeleton />
+      </main>
+    );
+  }
+
+  if (isError) {
+    return (
+      <main className="p-4 sm:p-8 space-y-6">
+        <EmptyState
+          icon={<Sparkles className="w-12 h-12 text-destructive" />}
+          heading="Couldn't load demo accounts"
+          body={
+            error && typeof error === "object" && "status" in error
+              ? `The server returned ${(error as { status: number }).status}. Try refreshing.`
+              : "Try refreshing the page."
+          }
+        />
+      </main>
+    );
+  }
+
+  const users = data?.users ?? [];
+
+  if (users.length === 0) {
+    return (
+      <>
+        <main className="p-4 sm:p-8 space-y-6">
+          <header className="space-y-1">
+            <h1 className="text-2xl font-semibold">Demo accounts</h1>
+            <p className="text-sm text-muted-foreground">
+              Showcase MyJobHunter with realistic seeded data — no manual
+              setup required.
+            </p>
+          </header>
+          <DemoUsersEmptyState
+            onCreate={() => setShowCreateDialog(true)}
+          />
+        </main>
+        <CreateDemoDialog
+          open={showCreateDialog}
+          isLoading={isCreating}
+          onSubmit={handleCreate}
+          onCancel={() => setShowCreateDialog(false)}
+        />
+        {credentials && (
+          <CredentialsModal
+            open
+            credentials={credentials}
+            onClose={() => setCredentials(null)}
+          />
+        )}
+      </>
+    );
+  }
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold">Demo accounts</h1>
+        <p className="text-sm text-muted-foreground">
+          Showcase MyJobHunter with realistic seeded data — no manual setup
+          required.
+        </p>
+      </header>
+
+      <div className="flex items-center justify-between">
+        <p className="text-sm text-muted-foreground">
+          {users.length} demo account{users.length === 1 ? "" : "s"}
+        </p>
+        <button
+          onClick={() => setShowCreateDialog(true)}
+          className="inline-flex items-center gap-2 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:opacity-90 min-h-[44px]"
+        >
+          <Plus size={16} />
+          Create demo account
+        </button>
+      </div>
+
+      <DemoUsersTable
+        users={users}
+        onDelete={(user) => setPendingDelete(user)}
+      />
+
+      <CreateDemoDialog
+        open={showCreateDialog}
+        isLoading={isCreating}
+        onSubmit={handleCreate}
+        onCancel={() => setShowCreateDialog(false)}
+      />
+
+      {credentials && (
+        <CredentialsModal
+          open
+          credentials={credentials}
+          onClose={() => setCredentials(null)}
+        />
+      )}
+
+      {pendingDelete && (
+        <DeleteDemoConfirmDialog
+          open
+          email={pendingDelete.email}
+          isLoading={isDeleting}
+          onConfirm={handleConfirmDelete}
+          onCancel={() => setPendingDelete(null)}
+        />
+      )}
+    </main>
+  );
+}

--- a/apps/myjobhunter/frontend/src/routes.tsx
+++ b/apps/myjobhunter/frontend/src/routes.tsx
@@ -12,7 +12,10 @@ import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
 import VerifyEmail from "@/pages/VerifyEmail";
 import NotFound from "@/pages/NotFound";
+import DemoUsers from "@/pages/admin/DemoUsers";
 import RootLayout from "@/RootLayout";
+import RequireAdmin from "@/components/RequireAdmin";
+import { ADMIN_ROUTES } from "@/constants/admin-routes";
 
 export const routes: RouteObject[] = [
   {
@@ -29,6 +32,14 @@ export const routes: RouteObject[] = [
       { path: "/profile", element: <Profile /> },
       { path: "/settings", element: <Settings /> },
       { path: "/security", element: <Security /> },
+      {
+        path: ADMIN_ROUTES.DEMO_USERS,
+        element: (
+          <RequireAdmin>
+            <DemoUsers />
+          </RequireAdmin>
+        ),
+      },
     ],
   },
   { path: "/login", element: <Login /> },

--- a/apps/myjobhunter/frontend/src/types/demo/demo-create-request.ts
+++ b/apps/myjobhunter/frontend/src/types/demo/demo-create-request.ts
@@ -1,0 +1,12 @@
+/**
+ * Body of `POST /admin/demo/users`.
+ *
+ * Both fields are optional. When `email` is omitted the backend
+ * auto-generates `demo+<uuid>@myjobhunter.local`. When `display_name`
+ * is omitted the backend defaults to "Alex Demo" — the seeded
+ * profile's name.
+ */
+export interface DemoCreateRequest {
+  email?: string;
+  display_name?: string;
+}

--- a/apps/myjobhunter/frontend/src/types/demo/demo-create-response.ts
+++ b/apps/myjobhunter/frontend/src/types/demo/demo-create-response.ts
@@ -1,0 +1,13 @@
+import type { DemoCredentials } from "@/types/demo/demo-credentials";
+
+/**
+ * Response of a successful `POST /admin/demo/users` (HTTP 201).
+ *
+ * The `credentials` field is shown ONCE — there is no recovery path
+ * for the plaintext password if the operator dismisses the modal.
+ */
+export interface DemoCreateResponse {
+  message: string;
+  credentials: DemoCredentials;
+  user_id: string;
+}

--- a/apps/myjobhunter/frontend/src/types/demo/demo-credentials.ts
+++ b/apps/myjobhunter/frontend/src/types/demo/demo-credentials.ts
@@ -1,0 +1,12 @@
+/**
+ * Login credentials returned ONCE at demo-account creation time.
+ *
+ * The backend never persists the plaintext password — it's hashed by
+ * fastapi-users immediately. The frontend surfaces this object in a
+ * one-time modal with a copy button; if the operator dismisses that
+ * modal without copying, the only recovery is to delete + recreate.
+ */
+export interface DemoCredentials {
+  email: string;
+  password: string;
+}

--- a/apps/myjobhunter/frontend/src/types/demo/demo-delete-response.ts
+++ b/apps/myjobhunter/frontend/src/types/demo/demo-delete-response.ts
@@ -1,0 +1,4 @@
+/** Response of `DELETE /admin/demo/users/{id}`. */
+export interface DemoDeleteResponse {
+  message: string;
+}

--- a/apps/myjobhunter/frontend/src/types/demo/demo-user-list-response.ts
+++ b/apps/myjobhunter/frontend/src/types/demo/demo-user-list-response.ts
@@ -1,0 +1,7 @@
+import type { DemoUser } from "@/types/demo/demo-user";
+
+/** Response of `GET /admin/demo/users`. */
+export interface DemoUserListResponse {
+  users: DemoUser[];
+  total: number;
+}

--- a/apps/myjobhunter/frontend/src/types/demo/demo-user.ts
+++ b/apps/myjobhunter/frontend/src/types/demo/demo-user.ts
@@ -1,0 +1,16 @@
+/**
+ * One row in the admin demo-users list (`GET /admin/demo/users`).
+ *
+ * The summary counts (`application_count`, `company_count`) are the
+ * meaningful "how much demo data does this account have" signal —
+ * they replace MBK's `upload_count` because MJH doesn't have document
+ * uploads in Phase 1.
+ */
+export interface DemoUser {
+  user_id: string;
+  email: string;
+  display_name: string;
+  created_at: string;
+  application_count: number;
+  company_count: number;
+}


### PR DESCRIPTION
## Summary

Admin-only feature to create / list / delete \"demo\" users — pre-seeded MJH accounts with realistic-looking work history, applications across stages, companies, and a parsed resume. Mirrors the shape of MBK's demo flow but adapted to MJH's no-orgs domain (demo *user* rather than demo *org*).

## What ships

**Backend**
- Alembic migration: \`users.is_demo BOOLEAN DEFAULT false\` (so admins can list / clean up just demo accounts)
- \`app/services/demo/demo_service.py\` + \`demo_constants.py\`: create / list / delete with realistic seed data
- \`app/api/demo.py\`: admin-gated POST / GET / DELETE \`/admin/demo/users\`

**Frontend**
- \`pages/admin/DemoUsers.tsx\` — list + create + delete view, gated on \`Role.ADMIN\` via the new \`RequireAdmin\` shell component
- \`features/admin/demo/\` — each sub-component in its own file (CreateDemoDialog, CredentialsModal, DeleteDemoConfirmDialog, DemoUsersEmptyState, DemoUsersSkeleton, DemoUsersTable) per the no-inline-components rule
- New \`hooks/useIsAdmin\` + \`components/RequireAdmin\` shared with the upcoming invites feature
- New \`constants/roles.ts\` + \`constants/admin-routes.ts\` typed constants
- \`lib/demoUsersApi.ts\` RTK slice with cache invalidation

**Tests**
- Backend pytest service unit tests (mocked DB)
- Frontend Vitest tests for dialog + table
- E2E Playwright smoke that creates → verifies → deletes a demo

## Test plan

- [ ] Backend: \`pytest tests/test_demo_service.py\`
- [ ] Frontend: \`npm test\` for the demo Vitest files; \`npx playwright test admin-demo.spec.ts\`
- [ ] Manual: deploy, log in as admin, hit \`/admin/demo\`, create a demo, verify the credentials show once, log out, log in as the demo user, see seeded data

🤖 Generated with [Claude Code](https://claude.com/claude-code)