### PR TITLE
fix(myjobhunter): admin nav label + replace J logo with briefcase emoji

### DIFF
--- a/apps/myjobhunter/frontend/src/RootLayout.tsx
+++ b/apps/myjobhunter/frontend/src/RootLayout.tsx
@@ -58,10 +58,13 @@ export default function RootLayout() {
 
   const user = isAuthenticated ? getUserFromToken() : { name: "You", email: "" };
 
+  // Matches the favicon (briefcase emoji from index.html) so the
+  // brand mark is consistent everywhere it shows. The previous
+  // text-based "J" tile read like a dev placeholder.
   const logo = (
     <div className="flex items-center gap-2">
-      <div className="w-7 h-7 rounded-lg bg-primary flex items-center justify-center shrink-0">
-        <span className="text-primary-foreground font-bold text-sm">J</span>
+      <div className="w-7 h-7 rounded-lg bg-primary/10 flex items-center justify-center shrink-0 text-base leading-none">
+        <span aria-hidden="true">💼</span>
       </div>
       <span className="font-semibold text-sm">MyJobHunter</span>
     </div>

--- a/apps/myjobhunter/frontend/src/constants/nav.ts
+++ b/apps/myjobhunter/frontend/src/constants/nav.ts
@@ -24,15 +24,19 @@ export const NAV_DESCRIPTORS: NavDescriptor[] = [
 ];
 
 /**
- * Admin-only nav descriptors. Appended to the user nav by `buildNav`
- * when called with `includeAdmin=true`. Hidden by default; the
- * RootLayout decides who sees these by inspecting the user's role.
+ * Superuser-only nav descriptors. Appended to the user nav by `buildNav`
+ * when called with `includeAdmin=true`. The RootLayout decides who sees
+ * these by inspecting `is_superuser` via `useIsSuperuser`.
+ *
+ * Single landing point — `/admin` — with sub-pages (demo, invites)
+ * surfaced via the dashboard's card grid rather than separate nav
+ * items. Avoids cluttering the sidebar with one-off operator tools.
  */
 export const ADMIN_NAV_DESCRIPTORS: NavDescriptor[] = [
   {
-    path: ADMIN_ROUTES.DEMO_USERS,
-    label: "Demo accounts",
-    iconName: "Wand2",
+    path: ADMIN_ROUTES.DASHBOARD,
+    label: "Admin",
+    iconName: "Shield",
   },
 ];
 


### PR DESCRIPTION
Two visual fixes that were intended in #325 but lost in the branch shuffle:

1. **nav.ts**: `ADMIN_NAV_DESCRIPTORS` now points at `/admin` with label "Admin" + Shield icon (was pointing at `/admin/demo` with label "Demo accounts"). Result: deployed sidebar showed the pre-#325 layout despite #325 landing.
2. **Logo**: replaced the placeholder "J" tile with the briefcase emoji (💼) so the brand mark matches the favicon.

No backend or routing changes. Frontend tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)