### PR TITLE
fix(myjobhunter/resume): draft panel fills viewport so the full resume is visible

### DIFF
--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentDraftPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CurrentDraftPanel.tsx
@@ -18,7 +18,16 @@ export default function CurrentDraftPanel({ markdown, highlightText }: CurrentDr
             : "Changes apply as you accept rewrites."}
         </p>
       </header>
-      <div className="rounded-md border border-border bg-background p-4 overflow-y-auto max-h-[60vh]">
+      {/* Fill the visible viewport on desktop so the operator always
+          sees the full resume while iterating on the suggestion card.
+          ``calc(100dvh - 12rem)`` reserves room for the AppShell
+          header (3.5rem) + page top padding (1-2rem) + this section's
+          own header / padding (~3rem). ``dvh`` follows mobile-browser
+          chrome so the panel never gets buried under a slide-up
+          toolbar. The inner block keeps its own ``overflow-y-auto``
+          so a long resume scrolls inside the panel rather than
+          pushing the page. */}
+      <div className="rounded-md border border-border bg-background p-4 overflow-y-auto max-h-[calc(100dvh-12rem)]">
         {markdown.trim() ? (
           <MarkdownPreview source={markdown} highlightText={highlightText} />
         ) : (


### PR DESCRIPTION
Stop-gap fix while a broader UX redesign is in flight.

Operator feedback: "i can't see my full resume on the right side so it's not clear what's going on". The CurrentDraftPanel was clipped at `max-h-[60vh]`; longer resumes hid sections below the highlighted line inside an inner scrollbar that wasn't obvious.

Switched to `max-h-[calc(100dvh-12rem)]` so the panel fills the visible viewport minus header + padding, with internal scroll only if the resume genuinely exceeds. `dvh` (dynamic viewport height) handles mobile browser chrome cleanly.

A `g-design-ux` agent is reviewing the broader flow (spatial hierarchy, missing context, completion shape) — that lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)