### PR TITLE
feat(myjobhunter/resume): browse suggestions without acting (prev/next nav)

### DIFF
--- a/apps/myjobhunter/backend/app/api/resume_refinement.py
+++ b/apps/myjobhunter/backend/app/api/resume_refinement.py
@@ -27,6 +27,7 @@ from app.core.auth import current_active_user
 from app.db.session import get_db
 from app.models.user.user import User
 from app.schemas.resume_refinement.session import (
+    NavigateRequest,
     SessionRead,
     SessionStartRequest,
     TurnAlternativeRequest,
@@ -166,6 +167,37 @@ async def skip_target(
         raise HTTPException(status_code=404, detail="Session not found") from exc
     except SessionNotActive as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return SessionRead.model_validate(session)
+
+
+@router.post("/sessions/{session_id}/navigate", response_model=SessionRead)
+async def navigate(
+    session_id: uuid.UUID,
+    body: NavigateRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionRead:
+    """Browse suggestions without acting on them.
+
+    Moves ``target_index`` forward or backward and regenerates the
+    pending AI proposal for the new target. The current_draft is
+    untouched. 400 when the move would step out of bounds.
+    """
+    try:
+        session = await session_service.navigate(
+            db=db,
+            user_id=user.id,
+            session_id=session_id,
+            direction=body.direction,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except NoMoreTargets as exc:
+        raise HTTPException(status_code=409, detail="No improvement targets to navigate") from exc
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return SessionRead.model_validate(session)
 
 

--- a/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
@@ -175,6 +175,31 @@ async def apply_user_resolution(
     return session
 
 
+async def set_target_index(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    new_index: int,
+) -> ResumeRefinementSession:
+    """Move the iteration cursor without modifying the draft.
+
+    Used by the navigation entry point so the operator can browse
+    suggestions without committing to act on each one. Pending
+    proposal state is cleared (the previous proposal was for the
+    previous target); the caller may choose to regenerate immediately.
+    Does NOT bump ``turn_count`` — navigation isn't a content change.
+    """
+    session.target_index = new_index
+    session.pending_target_section = None
+    session.pending_proposal = None
+    session.pending_rationale = None
+    session.pending_clarifying_question = None
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
 async def mark_completed(
     db: AsyncSession,
     session: ResumeRefinementSession,

--- a/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
@@ -122,3 +122,12 @@ class SessionCompleteRequest(BaseModel):
     """User marks the session done. Locks the current_draft."""
 
     pass
+
+
+class NavigateRequest(BaseModel):
+    """Move the iteration cursor without acting on the current proposal."""
+
+    direction: Literal["next", "prev"] = Field(
+        ...,
+        description="Move to the next or previous improvement target.",
+    )

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
@@ -255,6 +255,48 @@ async def skip_target(
     return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
 
 
+async def navigate(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+    direction: str,
+) -> ResumeRefinementSession:
+    """Move the iteration cursor without consuming the active proposal.
+
+    Lets the operator browse suggestions before committing to act on
+    them. ``direction`` is ``"next"`` or ``"prev"`` — bounds-checked
+    against ``len(improvement_targets)``. The previous pending
+    proposal (if any) is cleared because it belonged to the previous
+    target; a fresh proposal is generated for the new target.
+
+    Raises:
+        SessionNotFound / SessionNotActive: standard load failures.
+        ValueError: ``direction`` is not "next" / "prev", OR the move
+            would step out of bounds.
+    """
+    session = await _load_active(db, session_id, user_id)
+    targets = session.improvement_targets or []
+    if not targets:
+        raise NoMoreTargets()
+
+    if direction == "next":
+        delta = 1
+    elif direction == "prev":
+        delta = -1
+    else:
+        raise ValueError(f"direction must be 'next' or 'prev', got {direction!r}")
+
+    new_index = session.target_index + delta
+    if new_index < 0:
+        raise ValueError("Already at the first suggestion.")
+    if new_index >= len(targets):
+        raise ValueError("Already at the last suggestion.")
+
+    session = await session_repo.set_target_index(db, session, new_index=new_index)
+    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+
+
 async def complete_session(
     *,
     db: AsyncSession,

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/NavigationButtons.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/NavigationButtons.tsx
@@ -1,0 +1,66 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { showError, extractErrorMessage } from "@platform/ui";
+import { useNavigateRefinementMutation } from "@/lib/resumeRefinementApi";
+import { NavDirection } from "@/features/resume_refinement/nav-direction";
+
+interface NavigationButtonsProps {
+  sessionId: string;
+  /** Zero-based index of the current target. */
+  targetIndex: number;
+  /** Total number of improvement targets in the session. */
+  totalTargets: number;
+  /**
+   * True while ANY mutation on the session is in flight (accept,
+   * skip, etc.). The navigation buttons share that disabled state so
+   * the operator can't fire two mutations at once.
+   */
+  isPending: boolean;
+}
+
+/**
+ * Prev / Next buttons that move the iteration cursor without
+ * accepting / skipping / overriding the active proposal. Disabled at
+ * the session boundaries (first / last target).
+ */
+export default function NavigationButtons({
+  sessionId,
+  targetIndex,
+  totalTargets,
+  isPending,
+}: NavigationButtonsProps) {
+  const [navigate, navState] = useNavigateRefinementMutation();
+  const atFirst = targetIndex <= 0;
+  const atLast = targetIndex >= totalTargets - 1;
+  const busy = isPending || navState.isLoading;
+
+  async function move(direction: NavDirection) {
+    try {
+      await navigate({ id: sessionId, direction }).unwrap();
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-1">
+      <button
+        type="button"
+        onClick={() => move(NavDirection.PREV)}
+        disabled={busy || atFirst}
+        aria-label="Previous suggestion"
+        className="inline-flex items-center justify-center rounded-md border w-8 h-8 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <ChevronLeft size={14} />
+      </button>
+      <button
+        type="button"
+        onClick={() => move(NavDirection.NEXT)}
+        disabled={busy || atLast}
+        aria-label="Next suggestion"
+        className="inline-flex items-center justify-center rounded-md border w-8 h-8 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        <ChevronRight size={14} />
+      </button>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -20,6 +20,7 @@ import CustomRewritePanel from "@/features/resume_refinement/CustomRewritePanel"
 import AlternativePanel from "@/features/resume_refinement/AlternativePanel";
 import TargetMetaBadges from "@/features/resume_refinement/TargetMetaBadges";
 import SuggestionProgressBar from "@/features/resume_refinement/SuggestionProgressBar";
+import NavigationButtons from "@/features/resume_refinement/NavigationButtons";
 import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
 
 interface PendingProposalCardProps {
@@ -107,12 +108,22 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
 
   return (
     <section className="rounded-lg border border-border bg-card p-4 space-y-3">
-      <header className="flex items-center justify-between">
-        <h2 className="text-sm font-semibold flex items-center gap-2">
-          <Sparkles className="size-4 text-primary" />
-          Suggestion {session.target_index + 1} of {totalTargets}
+      <header className="flex items-center justify-between gap-2">
+        <h2 className="text-sm font-semibold flex items-center gap-2 min-w-0">
+          <Sparkles className="size-4 text-primary shrink-0" />
+          <span className="truncate">
+            Suggestion {session.target_index + 1} of {totalTargets}
+          </span>
         </h2>
-        <Badge label={`${remaining} left`} color="gray" />
+        <div className="flex items-center gap-2 shrink-0">
+          <Badge label={`${remaining} left`} color="gray" />
+          <NavigationButtons
+            sessionId={session.id}
+            targetIndex={session.target_index}
+            totalTargets={totalTargets}
+            isPending={isPending}
+          />
+        </div>
       </header>
 
       <SuggestionProgressBar

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/nav-direction.ts
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/nav-direction.ts
@@ -1,0 +1,11 @@
+/**
+ * Direction values accepted by the navigation API. The literal values
+ * have to match the backend ``NavigateRequest.direction`` field
+ * exactly — it's a Pydantic ``Literal["next", "prev"]``.
+ */
+export const NavDirection = {
+  NEXT: "next",
+  PREV: "prev",
+} as const;
+
+export type NavDirection = (typeof NavDirection)[keyof typeof NavDirection];

--- a/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
@@ -1,4 +1,5 @@
 import { baseApi } from "@platform/ui";
+import type { NavDirection } from "@/features/resume_refinement/nav-direction";
 import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
 
 const REFINEMENT_TAG = "RefinementSession";
@@ -57,6 +58,18 @@ const resumeRefinementApi = baseApi
         invalidatesTags: (_result, _err, id) => [{ type: REFINEMENT_TAG, id }],
       }),
 
+      navigateRefinement: build.mutation<
+        RefinementSession,
+        { id: string; direction: NavDirection }
+      >({
+        query: ({ id, direction }) => ({
+          url: `/resume-refinement/sessions/${id}/navigate`,
+          method: "POST",
+          data: { direction },
+        }),
+        invalidatesTags: (_result, _err, { id }) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
       completeRefinementSession: build.mutation<RefinementSession, string>({
         query: (id) => ({
           url: `/resume-refinement/sessions/${id}/complete`,
@@ -75,5 +88,6 @@ export const {
   useSupplyCustomRewriteMutation,
   useRequestAlternativeMutation,
   useSkipTargetMutation,
+  useNavigateRefinementMutation,
   useCompleteRefinementSessionMutation,
 } = resumeRefinementApi;


### PR DESCRIPTION
Adds Prev/Next nav buttons to the suggestion card so the operator can browse all suggestions before acting on any. New POST /sessions/{id}/navigate with {direction: 'next'|'prev'}. Action row (Accept/Custom/Another/Skip) unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)