### PR TITLE
fix(myjobhunter): invite-system security hardening (audit Critical+Highs)

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/inv260506_invite_token_hash.py
+++ b/apps/myjobhunter/backend/alembic/versions/inv260506_invite_token_hash.py
@@ -1,0 +1,79 @@
+"""platform_invites — replace plaintext token with sha256 hash.
+
+Security hardening landed in PR fix/myjobhunter-invite-security-hardening.
+The original ``inv260505`` migration stored the invite token in the
+``token`` column as plaintext. A read-only DB compromise (backup, replica,
+log snapshot) would hand out usable single-use registration grants. The
+fix is to store ``sha256(token)`` and never persist the raw value — the
+raw token is emitted exactly once into the recipient's email and never
+again retrievable.
+
+Migration shape:
+  * Hard-delete every existing row. The feature is hours old (shipped
+    earlier 2026-05-05) so we are deliberately wiping rather than trying
+    to back-fill hashes for accepted-but-historical rows. Any pending
+    invites in flight at deploy time become unusable; the operator must
+    re-issue them. Acceptable since the feature has zero non-trivial
+    production usage at the time this migration deploys.
+  * Drop the unique index on the old plaintext ``token`` column.
+  * Drop the ``token`` column.
+  * Add a new ``token_hash VARCHAR(64) NOT NULL`` column (64 hex chars
+    = sha256 hex digest).
+  * Add a unique index on ``token_hash`` so lookups stay O(log n) and
+    duplicate-hash collisions raise IntegrityError.
+
+Downgrade restores the plaintext column and an empty table.
+
+Revision ID: inv260506
+Revises: inv260505
+Create Date: 2026-05-05
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "inv260506"
+down_revision: Union[str, None] = "inv260505"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Wipe all rows — see module docstring for the why. Pending invites
+    # become unusable; accepted rows lose their (already-spent) tokens.
+    op.execute("DELETE FROM platform_invites")
+
+    op.drop_index("ix_platform_invites_token", table_name="platform_invites")
+    op.drop_column("platform_invites", "token")
+
+    op.add_column(
+        "platform_invites",
+        sa.Column("token_hash", sa.String(64), nullable=False),
+    )
+    op.create_index(
+        "ix_platform_invites_token_hash",
+        "platform_invites",
+        ["token_hash"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_platform_invites_token_hash", table_name="platform_invites"
+    )
+    op.drop_column("platform_invites", "token_hash")
+
+    op.add_column(
+        "platform_invites",
+        sa.Column("token", sa.String(255), nullable=False, server_default=""),
+    )
+    op.alter_column("platform_invites", "token", server_default=None)
+    op.create_index(
+        "ix_platform_invites_token",
+        "platform_invites",
+        ["token"],
+        unique=True,
+    )

--- a/apps/myjobhunter/backend/app/api/admin_invites.py
+++ b/apps/myjobhunter/backend/app/api/admin_invites.py
@@ -9,42 +9,60 @@ Layered architecture: routes are thin — every handler delegates to
 ``invite_service`` and translates the service's domain exceptions into
 the appropriate HTTP status codes. No DB primitives in this file.
 
+Security shape (2026-05-05): the public ``GET /invites/{token}/info``
+endpoint is per-IP rate-limited so an attacker cannot use it as a
+free token-validity oracle. The 409-collision response on
+``POST /admin/invites`` returns a single generic body so even a
+compromised admin token cannot enumerate existing user accounts vs.
+in-flight invites.
+
 Status code conventions:
   * 201 — invite created
   * 200 — list / preview / accept
   * 204 — cancel
   * 400 — request shape problems / email mismatch on accept
   * 404 — invite not found
-  * 409 — conflict (already-pending invite, already-registered user,
-          already-accepted invite)
+  * 409 — conflict (recipient unavailable, already-accepted invite)
   * 410 — gone (expired)
+  * 429 — rate limited (public preview)
 """
 from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 
 from app.core.auth import current_active_user
 from app.core.permissions import current_superuser
+from app.core.rate_limit import RateLimiter
 from app.models.user.user import User
 from app.schemas.platform.invite_accept_response import InviteAcceptResponse
 from app.schemas.platform.invite_create_request import InviteCreateRequest
 from app.schemas.platform.invite_info_response import InviteInfoResponse
 from app.schemas.platform.invite_read import InviteRead
 from app.services.platform import invite_service
+from app.services.platform.invite_email import send_invite_email
 from app.services.platform.invite_service import (
     InviteAlreadyAcceptedError,
-    InviteAlreadyExistsError,
     InviteEmailMismatchError,
     InviteExpiredError,
     InviteNotFoundError,
-    UserAlreadyRegisteredError,
+    InviteRecipientUnavailableError,
 )
+from platform_shared.core.request_utils import get_client_ip
 
 
 admin_router = APIRouter(prefix="/admin/invites", tags=["admin"])
 public_router = APIRouter(prefix="/invites", tags=["invites"])
+
+
+# Per-IP throttle on the unauthenticated invite-preview endpoint. 30
+# requests per 5 minutes is generous for a legitimate registration
+# flow (a user might refresh the page a handful of times) but tight
+# enough to make a 32-byte token brute-force economically infeasible
+# even before the entropy math kicks in. Pre-instantiated at module
+# import so all requests share the same sliding-window state.
+_INVITE_INFO_LIMITER = RateLimiter(max_attempts=30, window_seconds=300)
 
 
 def _to_read(invite) -> InviteRead:  # type: ignore[no-untyped-def]
@@ -52,7 +70,6 @@ def _to_read(invite) -> InviteRead:  # type: ignore[no-untyped-def]
     return InviteRead(
         id=invite.id,
         email=invite.email,
-        token=invite.token,
         status=invite_service.compute_status(invite),
         expires_at=invite.expires_at,
         accepted_at=invite.accepted_at,
@@ -77,14 +94,18 @@ async def create_invite(
     admin: User = Depends(current_superuser),
 ) -> InviteRead:
     try:
-        invite = await invite_service.create_invite(
+        result = await invite_service.create_invite(
             email=body.email, admin_id=admin.id,
         )
-    except UserAlreadyRegisteredError as e:
-        raise HTTPException(status_code=409, detail=str(e))
-    except InviteAlreadyExistsError as e:
-        raise HTTPException(status_code=409, detail=str(e))
-    return _to_read(invite)
+    except InviteRecipientUnavailableError as e:
+        raise HTTPException(status_code=409, detail=str(e)) from e
+
+    # Email send happens AFTER the row commits (the unit_of_work in the
+    # service has already returned). If SMTP fails the row stays — the
+    # admin can resend via a future cancel-and-reissue flow rather than
+    # being left with an orphan email-but-no-row.
+    send_invite_email(result.invite.email, result.raw_token)
+    return _to_read(result.invite)
 
 
 @admin_router.get("", response_model=list[InviteRead])
@@ -108,9 +129,9 @@ async def cancel_invite(
             invite_id=invite_id, admin_id=admin.id,
         )
     except InviteNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except InviteAlreadyAcceptedError as e:
-        raise HTTPException(status_code=409, detail=str(e))
+        raise HTTPException(status_code=409, detail=str(e)) from e
 
 
 # ---------------------------------------------------------------------------
@@ -119,16 +140,18 @@ async def cancel_invite(
 
 
 @public_router.get("/{token}/info", response_model=InviteInfoResponse)
-async def get_invite_info(token: str) -> InviteInfoResponse:
+async def get_invite_info(token: str, request: Request) -> InviteInfoResponse:
     """Public — no auth. Returns email + computed status + expires_at.
 
-    Deliberately leaks no inviter identity / id / created_at — see
-    ``InviteInfoResponse`` for the full reasoning.
+    Rate-limited per IP to prevent the endpoint becoming a token-
+    validity oracle. Deliberately leaks no inviter identity / id /
+    created_at — see ``InviteInfoResponse`` for the full reasoning.
     """
+    _INVITE_INFO_LIMITER.check(get_client_ip(request))
     try:
         invite, computed_status = await invite_service.get_invite_info(token)
     except InviteNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
     return InviteInfoResponse(
         email=invite.email,
         status=computed_status,
@@ -157,13 +180,13 @@ async def accept_invite(
             token=token, user_id=user.id, user_email=user.email,
         )
     except InviteNotFoundError as e:
-        raise HTTPException(status_code=404, detail=str(e))
+        raise HTTPException(status_code=404, detail=str(e)) from e
     except InviteExpiredError as e:
-        raise HTTPException(status_code=410, detail=str(e))
+        raise HTTPException(status_code=410, detail=str(e)) from e
     except InviteAlreadyAcceptedError as e:
-        raise HTTPException(status_code=409, detail=str(e))
+        raise HTTPException(status_code=409, detail=str(e)) from e
     except InviteEmailMismatchError as e:
-        raise HTTPException(status_code=400, detail=str(e))
+        raise HTTPException(status_code=400, detail=str(e)) from e
     assert invite.accepted_at is not None  # set by mark_accepted
     return InviteAcceptResponse(
         invite_id=invite.id,

--- a/apps/myjobhunter/backend/app/models/platform/invite.py
+++ b/apps/myjobhunter/backend/app/models/platform/invite.py
@@ -5,9 +5,14 @@ registration, the user submits the token and the system marks the row
 ``accepted_at`` + ``accepted_by``. The token row is never deleted on
 acceptance — it stays as an audit trail of who invited whom.
 
-This is the platform-level analogue of MBK's ``OrganizationInvite`` —
-shape mirrored, org_role/organization_id stripped because MJH has no
-orgs. New columns added vs. the MBK shape:
+Security shape (PR fix/myjobhunter-invite-security-hardening, 2026-05-05):
+the ``token_hash`` column stores ``sha256(raw_token)`` only — the raw
+token never persists. The raw token reaches the recipient via email
+once, then exists only in their inbox. A read-only DB compromise
+yields hashes, not usable grants.
+
+Columns vs. MBK's ``OrganizationInvite``: org_role/organization_id are
+stripped because MJH has no orgs. New columns:
 
   * ``accepted_at``     — nullable timestamp; non-null means consumed
   * ``accepted_by``     — nullable FK to users.id; the account that claimed it
@@ -17,7 +22,6 @@ matter are: pending, accepted, or expired (computed from ``expires_at``).
 """
 from __future__ import annotations
 
-import secrets
 import uuid
 from datetime import datetime, timedelta, timezone
 
@@ -44,13 +48,6 @@ def _default_expires_at() -> datetime:
     return datetime.now(timezone.utc) + timedelta(days=INVITE_EXPIRY_DAYS)
 
 
-def _default_token() -> str:
-    # 32 bytes urlsafe = 43-char base64 — comfortably above the threshold
-    # where guessing is computationally infeasible. MBK uses the same
-    # generator for its OrganizationInvite tokens.
-    return secrets.token_urlsafe(32)
-
-
 class PlatformInvite(Base):
     __tablename__ = "platform_invites"
 
@@ -60,11 +57,14 @@ class PlatformInvite(Base):
         default=uuid.uuid4,
     )
     email: Mapped[str] = mapped_column(String(255), nullable=False)
-    token: Mapped[str] = mapped_column(
-        String(255),
+    # sha256 hex digest of the raw token. Service layer owns generation +
+    # hashing — see app/services/platform/invite_token.py. The model
+    # deliberately has NO default so callers can't accidentally insert an
+    # empty row and lose the link between row and recipient.
+    token_hash: Mapped[str] = mapped_column(
+        String(64),
         nullable=False,
         unique=True,
-        default=_default_token,
     )
     expires_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),

--- a/apps/myjobhunter/backend/app/repositories/platform/invite_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/platform/invite_repo.py
@@ -5,13 +5,16 @@ classes). Every public function takes the ``AsyncSession`` first; the
 service layer is responsible for choosing between ``unit_of_work`` (for
 writes) and ``AsyncSessionLocal`` (for reads).
 
+Security shape (2026-05-05): tokens are persisted as sha256 hashes via
+the ``token_hash`` column. Lookups go through ``get_by_token_hash``;
+the service layer is responsible for computing the hash before calling.
+The repository never sees raw tokens.
+
 Tenant scoping notes:
 - Invite ownership is admin-scoped, not tenant-scoped — every admin can
   see every pending invite. Tenant isolation here is "is this row
   visible to a non-admin?"; the answer is no, and that gate is enforced
-  at the route layer via ``require_admin``. Repos take ``user_id`` only
-  where it constrains the row (e.g. cancel-invite uses ``created_by`` to
-  let an admin only cancel invites they created — defensive scoping).
+  at the route layer via ``current_superuser``.
 """
 from __future__ import annotations
 
@@ -29,14 +32,18 @@ async def create(
     db: AsyncSession,
     *,
     email: str,
+    token_hash: str,
     created_by: uuid.UUID,
 ) -> PlatformInvite:
     """Insert a fresh invite row.
 
-    ``token`` and ``expires_at`` are populated by model-level defaults so
-    the repo never has to know how they're generated.
+    ``token_hash`` is computed by the service layer from the raw token
+    before this is called. ``expires_at`` is populated by a model-level
+    default.
     """
-    invite = PlatformInvite(email=email, created_by=created_by)
+    invite = PlatformInvite(
+        email=email, token_hash=token_hash, created_by=created_by,
+    )
     db.add(invite)
     await db.flush()
     await db.refresh(invite)
@@ -52,10 +59,10 @@ async def get_by_id(
     return result.scalar_one_or_none()
 
 
-async def get_by_token(
-    db: AsyncSession, token: str,
+async def get_by_token_hash(
+    db: AsyncSession, token_hash: str,
 ) -> PlatformInvite | None:
-    """Look up an invite by its token regardless of state.
+    """Look up an invite by its sha256 hash regardless of state.
 
     Returns the row even when expired or already accepted — the service
     layer decides whether the state allows the requested action and
@@ -65,7 +72,7 @@ async def get_by_token(
     page instead of a generic 404.
     """
     result = await db.execute(
-        select(PlatformInvite).where(PlatformInvite.token == token)
+        select(PlatformInvite).where(PlatformInvite.token_hash == token_hash)
     )
     return result.scalar_one_or_none()
 

--- a/apps/myjobhunter/backend/app/schemas/platform/invite_read.py
+++ b/apps/myjobhunter/backend/app/schemas/platform/invite_read.py
@@ -1,9 +1,13 @@
 """Admin-side invite representation.
 
-Returned by ``POST /admin/invites`` and ``GET /admin/invites``. Includes
-the token so the operator can copy the link if the email send was
-flaky — the admin already has full read-access to every invite, no
-PII-exposure risk above what the route is already authorising.
+Returned by ``POST /admin/invites`` and ``GET /admin/invites``.
+
+The raw token deliberately does NOT appear here. Tokens are sent
+exactly once, via email, to the recipient. The DB persists only
+``sha256(token)``, so even an admin cannot retrieve a usable token
+after creation. If a recipient never gets the email, the admin's
+recourse is to cancel the invite and issue a fresh one — not to copy
+the token off the admin UI.
 """
 from __future__ import annotations
 
@@ -18,7 +22,6 @@ from app.schemas.platform.invite_status import InviteStatus
 class InviteRead(BaseModel):
     id: uuid.UUID
     email: str
-    token: str
     status: InviteStatus
     expires_at: datetime
     accepted_at: datetime | None

--- a/apps/myjobhunter/backend/app/services/platform/invite_email.py
+++ b/apps/myjobhunter/backend/app/services/platform/invite_email.py
@@ -9,6 +9,14 @@ The link target is ``${frontend_url}/register?invite=<token>``. The
 register page reads the ``invite`` query param, fetches
 ``GET /invites/{token}/info`` for the preview, and pre-binds the email
 field on the registration form.
+
+Security note (2026-05-05): ``html.escape(..., quote=True)`` escapes
+``"`` so the URL cannot break out of the ``href="..."`` attribute. The
+current token shape (``secrets.token_urlsafe``) emits no quote chars,
+so this is defense-in-depth — but the function is reusable and the
+``frontend_url`` portion is operator-controlled, so a future preview-
+deploy with a domain that happened to embed quote-equivalent chars
+would otherwise break out of the attribute and inject markup.
 """
 from __future__ import annotations
 
@@ -22,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def _build_invite_html(accept_url: str) -> str:
-    safe_url = html_mod.escape(accept_url)
+    safe_url = html_mod.escape(accept_url, quote=True)
 
     return f"""\
 <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background-color: #f9fafb; padding: 40px 20px;">
@@ -91,4 +99,11 @@ def send_invite_email(recipient_email: str, token: str) -> None:
     html = _build_invite_html(accept_url)
     subject = "You've been invited to MyJobHunter"
     send_email_or_raise([recipient_email], subject, html)
-    logger.info("Platform invite email sent to %s", recipient_email)
+    # Log only the email domain, never the full address. The recipient
+    # is by definition not yet a user, so per the auth-events policy
+    # for unknown-user events we keep PII out of operator logs.
+    _, _, domain = recipient_email.rpartition("@")
+    logger.info(
+        "Platform invite email sent domain=%s",
+        (domain or "unknown").strip().lower(),
+    )

--- a/apps/myjobhunter/backend/app/services/platform/invite_service.py
+++ b/apps/myjobhunter/backend/app/services/platform/invite_service.py
@@ -14,13 +14,31 @@ Business rules enforced here:
   * the recipient email must be a fresh address — no pending invite for
     the same email, no existing user account on that email
   * tokens are single-use — accepting consumes the row
-  * tokens expire 7 days after creation — `accept` raises ValueError
+  * tokens expire 7 days after creation — `accept` raises ``InviteExpiredError``
     when called past the deadline
+
+Security shape (PR fix/myjobhunter-invite-security-hardening, 2026-05-05):
+  * Raw tokens generated here, hashed via
+    ``app.services.platform.invite_token``, only the hash persists.
+    The raw token is returned exactly once via ``CreateInviteResult`` so
+    the route layer can pass it to the email send before discarding.
+  * Audit-log metadata strips PII to ``email_domain`` on the create
+    path (the recipient is by definition not yet a user, so per the
+    auth-events policy we never log their full email for unknown-user
+    events).
+  * The 409-collision response collapses the "already-registered user"
+    and "already-pending invite" branches into a single generic body so
+    a compromised-admin token cannot enumerate which case applies.
+  * The email send is moved OUT of the create transaction. Row commits
+    first; if SMTP fails, the row stays and the admin can resend.
+    Previously SMTP failures rolled back the row, opening a race where
+    the email could land while the row didn't (orphan email).
 """
 from __future__ import annotations
 
 import logging
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 
 from app.db.session import AsyncSessionLocal, unit_of_work
@@ -29,6 +47,7 @@ from app.repositories.platform import invite_repo
 from app.repositories.user import user_repo
 from app.schemas.platform.invite_status import InviteStatus
 from app.services.platform.invite_email import send_invite_email
+from app.services.platform.invite_token import generate_token, hash_token
 from app.services.system.auth_event_service import log_auth_event
 
 logger = logging.getLogger(__name__)
@@ -52,12 +71,14 @@ class InviteError(Exception):
     """Base for invite-flow business-rule violations."""
 
 
-class InviteAlreadyExistsError(InviteError):
-    """A pending, un-expired invite already exists for this email."""
+class InviteRecipientUnavailableError(InviteError):
+    """The recipient email cannot accept a new invite.
 
-
-class UserAlreadyRegisteredError(InviteError):
-    """The recipient email is already a registered MJH user."""
+    Collapses two underlying causes — already-registered user OR pending
+    invite already in flight — into a single error so a compromised
+    admin token cannot enumerate which case applies. The route layer
+    maps this to a single generic 409 body.
+    """
 
 
 class InviteNotFoundError(InviteError):
@@ -74,6 +95,24 @@ class InviteAlreadyAcceptedError(InviteError):
 
 class InviteEmailMismatchError(InviteError):
     """The accepting user's email doesn't match the invite's bound email."""
+
+
+# ---------------------------------------------------------------------------
+# Service-layer return shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CreateInviteResult:
+    """Return shape for ``create_invite``.
+
+    The raw token lives here for exactly one purpose: hand it to the
+    email sender at the route layer, then drop it. It is NEVER persisted
+    and NEVER returned to the admin in the API response.
+    """
+
+    invite: PlatformInvite
+    raw_token: str
 
 
 # ---------------------------------------------------------------------------
@@ -100,6 +139,23 @@ def compute_status(invite: PlatformInvite, *, now: datetime | None = None) -> In
 
 
 # ---------------------------------------------------------------------------
+# PII helpers
+# ---------------------------------------------------------------------------
+
+
+def _email_domain(email: str) -> str:
+    """Extract the domain portion of an email address.
+
+    Returns the lowercased substring after the last '@'. Falls back to
+    the literal ``"unknown"`` for inputs without an '@' so the audit
+    log never carries a malformed value masquerading as a domain.
+    """
+    _, _, domain = email.rpartition("@")
+    domain = domain.strip().lower()
+    return domain or "unknown"
+
+
+# ---------------------------------------------------------------------------
 # Public service functions
 # ---------------------------------------------------------------------------
 
@@ -108,53 +164,59 @@ async def create_invite(
     *,
     email: str,
     admin_id: uuid.UUID,
-) -> PlatformInvite:
-    """Create + email a new invite to ``email``.
+) -> CreateInviteResult:
+    """Create a new invite row and return the raw token for one-shot email use.
+
+    Two-stage transaction shape:
+      1. Open ``unit_of_work``, validate uniqueness, insert the row +
+         audit log, and commit.
+      2. Return the raw token; the caller (route layer) hands it to the
+         email sender. SMTP failures are surfaced to the admin via 5xx
+         but the row is already persisted, so the admin can resend.
 
     Raises:
-        UserAlreadyRegisteredError: the email already has an MJH account.
-        InviteAlreadyExistsError:   a pending invite for this email is
-            still un-expired.
+        InviteRecipientUnavailableError: the email already belongs to a
+            user account OR a pending invite is in flight.
     """
     normalized = email.strip().lower()
+    raw_token = generate_token()
+    token_h = hash_token(raw_token)
 
     async with unit_of_work() as db:
         existing_user = await user_repo.get_by_email(db, normalized)
         if existing_user is not None:
-            raise UserAlreadyRegisteredError(
-                "An account with this email already exists."
+            raise InviteRecipientUnavailableError(
+                "Cannot send invite to this email."
             )
 
         existing_invite = await invite_repo.get_pending_for_email(db, normalized)
         if existing_invite is not None:
-            raise InviteAlreadyExistsError(
-                "A pending invite already exists for this email."
+            raise InviteRecipientUnavailableError(
+                "Cannot send invite to this email."
             )
 
         invite = await invite_repo.create(
-            db, email=normalized, created_by=admin_id,
+            db,
+            email=normalized,
+            token_hash=token_h,
+            created_by=admin_id,
         )
-
-        # Email send happens BEFORE the audit row is written so that a
-        # send failure rolls back the row insertion via the
-        # unit_of_work transaction. Otherwise the admin sees a 5xx but
-        # an orphan invite row stays in the DB confusingly. Console-mode
-        # send_email_or_raise never raises, so dev/CI exits this block
-        # with the row committed.
-        send_invite_email(normalized, invite.token)
 
         await log_auth_event(
             db,
             event_type=INVITE_CREATED,
             user_id=admin_id,
             succeeded=True,
-            metadata={"invite_id": str(invite.id), "email": normalized},
+            metadata={
+                "invite_id": str(invite.id),
+                "email_domain": _email_domain(normalized),
+            },
         )
         logger.info(
-            "Platform invite created id=%s email=%s by_admin=%s",
-            invite.id, normalized, admin_id,
+            "Platform invite created id=%s email_domain=%s by_admin=%s",
+            invite.id, _email_domain(normalized), admin_id,
         )
-        return invite
+        return CreateInviteResult(invite=invite, raw_token=raw_token)
 
 
 async def list_pending_invites() -> list[PlatformInvite]:
@@ -189,13 +251,17 @@ async def cancel_invite(
             raise InviteAlreadyAcceptedError(
                 "Cannot cancel an invite that has already been accepted."
             )
+        cancelled_email_domain = _email_domain(invite.email)
         await invite_repo.delete(db, invite)
         await log_auth_event(
             db,
             event_type=INVITE_CANCELLED,
             user_id=admin_id,
             succeeded=True,
-            metadata={"invite_id": str(invite_id), "email": invite.email},
+            metadata={
+                "invite_id": str(invite_id),
+                "email_domain": cancelled_email_domain,
+            },
         )
         logger.info(
             "Platform invite cancelled id=%s by_admin=%s",
@@ -206,15 +272,17 @@ async def cancel_invite(
 async def get_invite_info(token: str) -> tuple[PlatformInvite, InviteStatus]:
     """Public preview lookup.
 
-    Returns the invite + its computed status. The route layer projects
-    this into the (deliberately narrow) ``InviteInfoResponse`` schema —
-    only ``email`` / ``status`` / ``expires_at`` reach the wire.
+    Hashes the incoming raw token before lookup. Returns the invite +
+    its computed status. The route layer projects this into the
+    (deliberately narrow) ``InviteInfoResponse`` schema — only ``email`` /
+    ``status`` / ``expires_at`` reach the wire.
 
     Raises:
-        InviteNotFoundError: no row matches the token.
+        InviteNotFoundError: no row matches the token's hash.
     """
+    token_h = hash_token(token)
     async with AsyncSessionLocal() as db:
-        invite = await invite_repo.get_by_token(db, token)
+        invite = await invite_repo.get_by_token_hash(db, token_h)
         if invite is None:
             raise InviteNotFoundError("Invite not found.")
         status = compute_status(invite)
@@ -229,24 +297,22 @@ async def accept_invite(
 ) -> PlatformInvite:
     """Mark the invite consumed by ``user_id``.
 
-    The accepting user must already be authenticated AND their email
-    must match the invite's bound email (case-insensitive). The
-    registration flow on the frontend will: (a) prefill the email
-    field with the invite's email, (b) call ``POST /auth/register``
-    with that email, (c) verify via the email link, (d) log in,
-    (e) call this endpoint with the token from the URL.
+    Hashes the incoming raw token before lookup. The accepting user
+    must already be authenticated AND their email must match the
+    invite's bound email (case-insensitive).
 
     Raises:
-        InviteNotFoundError:        no row matches the token.
+        InviteNotFoundError:        no row matches the token's hash.
         InviteExpiredError:         expires_at is in the past.
         InviteAlreadyAcceptedError: accepted_at is non-null already.
         InviteEmailMismatchError:   the accepting user's email differs
             from the bound email.
     """
     normalized = user_email.strip().lower()
+    token_h = hash_token(token)
 
     async with unit_of_work() as db:
-        invite = await invite_repo.get_by_token(db, token)
+        invite = await invite_repo.get_by_token_hash(db, token_h)
         if invite is None:
             raise InviteNotFoundError("Invite not found.")
 
@@ -276,7 +342,6 @@ async def accept_invite(
             succeeded=True,
             metadata={
                 "invite_id": str(invite.id),
-                "email": invite.email,
                 "invited_by": str(invite.created_by),
             },
         )
@@ -285,3 +350,24 @@ async def accept_invite(
             invite.id, user_id,
         )
         return accepted
+
+
+__all__ = [
+    "CreateInviteResult",
+    "INVITE_ACCEPTED",
+    "INVITE_CANCELLED",
+    "INVITE_CREATED",
+    "InviteAlreadyAcceptedError",
+    "InviteEmailMismatchError",
+    "InviteError",
+    "InviteExpiredError",
+    "InviteNotFoundError",
+    "InviteRecipientUnavailableError",
+    "accept_invite",
+    "cancel_invite",
+    "compute_status",
+    "create_invite",
+    "get_invite_info",
+    "list_pending_invites",
+    "send_invite_email",
+]

--- a/apps/myjobhunter/backend/app/services/platform/invite_token.py
+++ b/apps/myjobhunter/backend/app/services/platform/invite_token.py
@@ -1,0 +1,43 @@
+"""Invite-token generation and hashing primitives.
+
+Tokens are 32 bytes of cryptographic randomness rendered as base64url
+(``secrets.token_urlsafe(32)`` → 43-char string). The raw token is sent
+to the recipient via email; only the sha256 hash is persisted so a
+read-only DB compromise cannot hand out usable invite grants.
+
+Hashing uses plain sha256 with no pepper. Justification:
+  * Input space is 2**256 — rainbow tables / brute-force are infeasible.
+  * GitHub stores its personal-access-tokens with the same shape.
+  * A pepper would buy marginal defense against an attacker who already
+    has the DB AND has separately captured a candidate-token from
+    elsewhere; for an admin-only invite feature with seven-day expiry
+    that adversary model is not justified by a new env-var operational
+    surface.
+
+The two functions form a contract: ``generate_token()`` is the only
+producer of raw tokens; ``hash_token()`` is the only producer of hash
+strings. Anywhere else in the codebase that wants to compare a token
+against a stored hash MUST go through ``hash_token`` so the algorithm
+stays in one place.
+"""
+from __future__ import annotations
+
+import hashlib
+import secrets
+
+
+def generate_token() -> str:
+    """Return a fresh, cryptographically-random base64url token.
+
+    32 bytes → 43-char string. Single source of truth so the migration,
+    docs, and tests can all agree on the wire shape.
+    """
+    return secrets.token_urlsafe(32)
+
+
+def hash_token(token: str) -> str:
+    """Return the canonical lowercase sha256 hex digest of ``token``.
+
+    64 hex chars. Stable across processes (no pepper, no salt).
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()

--- a/apps/myjobhunter/backend/tests/test_platform_invites.py
+++ b/apps/myjobhunter/backend/tests/test_platform_invites.py
@@ -1,16 +1,30 @@
 """Platform-invite end-to-end coverage.
 
-Covers the full state machine:
-  * admin creates invite (201) → public preview returns email + status
-  * non-admin POST /admin/invites → 403
-  * duplicate email while a pending invite exists → 409
-  * email already a registered user → 409
-  * accept with matching email → invite consumed (accepted_at set)
-  * accept twice → 409 already accepted
-  * accept after expiry → 410 gone
-  * accept with wrong logged-in user → 400 email mismatch
-  * cancel un-accepted → 204 → re-cancel → 404
-  * cancel an accepted invite → 409
+Covers the full state machine plus the security-hardening invariants
+landed in PR fix/myjobhunter-invite-security-hardening:
+
+  State machine:
+    * admin creates invite (201) → public preview returns email + status
+    * non-admin POST /admin/invites → 403
+    * duplicate email while a pending invite exists → 409 (generic)
+    * email already a registered user → 409 (generic — same body)
+    * accept with matching email → invite consumed (accepted_at set)
+    * accept twice → 409 already accepted
+    * accept after expiry → 410 gone
+    * accept with wrong logged-in user → 400 email mismatch
+    * cancel un-accepted → 204 → re-cancel → 404
+    * cancel an accepted invite → 409
+
+  Security invariants (one test per audit finding):
+    * Raw token never leaves the API surface (no `token` field on
+      InviteRead, no `token` in cancel/list responses).
+    * The DB persists only the sha256 hash, never the raw value.
+    * Audit-log metadata uses email_domain only on create — never
+      the full recipient email.
+    * The 409 collision response collapses "user exists" / "pending
+      invite" into a single generic body, so an admin token compromise
+      cannot enumerate the auth state of an arbitrary email.
+    * The public preview is per-IP rate-limited.
 
 The unit-of-work fixture in conftest commits user-factory rows in a
 fresh engine, so the `is_verified=True` flip persists across the
@@ -29,6 +43,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from sqlalchemy.pool import NullPool
 
 from app.core.config import settings
+from app.services.platform.invite_token import hash_token
 
 
 # ---------------------------------------------------------------------------
@@ -74,12 +89,7 @@ async def _force_invite_expired(invite_id: str) -> None:
 
 
 async def _delete_invite_rows() -> None:
-    """Clean up any platform_invites rows left by tests.
-
-    Tests that create invites via the API persist them outside the
-    test's rolled-back transaction (because ``unit_of_work`` opens a
-    fresh session). Hard-delete in teardown to keep the test DB clean.
-    """
+    """Clean up any platform_invites rows left by tests."""
     engine = create_async_engine(settings.database_url, poolclass=NullPool)
     factory = async_sessionmaker(engine, expire_on_commit=False)
     async with factory() as sess:
@@ -94,15 +104,37 @@ async def _clean_invites():
     await _delete_invite_rows()
 
 
-# Auto-stub the email send so console mode dev doesn't litter logs and so
-# we can assert it was called with the right shape.
 @pytest.fixture
-def mock_send_email():
+def captured_invites():
+    """Patch the email sender and capture (email, raw_token) tuples.
+
+    The raw token never appears in any HTTP response — this is the only
+    way a test can obtain the token to drive the accept-flow assertions.
+    Mirrors how a real recipient gets their token (email inbox).
+    """
+    captured: list[tuple[str, str]] = []
+
+    def _record(recipient_email: str, token: str) -> None:
+        captured.append((recipient_email, token))
+
+    # Patch in BOTH the module that defines it and the module that
+    # imports it for use, because Python resolves the name at the
+    # imported module's scope. The route layer uses
+    # ``app.services.platform.invite_email.send_invite_email`` via the
+    # ``app.api.admin_invites`` import; patching the source module is
+    # not enough.
     with patch(
-        "app.services.platform.invite_email.send_email_or_raise",
-        return_value=None,
-    ) as m:
-        yield m
+        "app.api.admin_invites.send_invite_email", side_effect=_record,
+    ):
+        yield captured
+
+
+def _last_token_for(captured: list[tuple[str, str]], email: str) -> str:
+    """Find the raw token most recently emitted to ``email``."""
+    for recipient, tok in reversed(captured):
+        if recipient.lower() == email.lower():
+            return tok
+    raise AssertionError(f"No invite captured for {email!r} (have {captured!r})")
 
 
 # ---------------------------------------------------------------------------
@@ -112,7 +144,7 @@ def mock_send_email():
 
 @pytest.mark.asyncio
 async def test_non_admin_cannot_create_invite(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     regular = await user_factory()
     async with await as_user(regular) as authed:
@@ -124,7 +156,7 @@ async def test_non_admin_cannot_create_invite(
 
 @pytest.mark.asyncio
 async def test_anonymous_cannot_create_invite(
-    client: AsyncClient, mock_send_email,
+    client: AsyncClient, captured_invites,
 ) -> None:
     resp = await client.post(
         "/admin/invites", json={"email": "candidate@example.com"},
@@ -138,9 +170,15 @@ async def test_anonymous_cannot_create_invite(
 
 
 @pytest.mark.asyncio
-async def test_admin_creates_invite_returns_201_and_token(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+async def test_admin_creates_invite_returns_201_without_token(
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
+    """Create response must NOT contain the raw token.
+
+    Security invariant: tokens are emitted exactly once, via email.
+    Returning the token in the API response would let any
+    compromised-admin session bypass the email step entirely.
+    """
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
     async with await as_user(admin) as authed:
@@ -151,20 +189,65 @@ async def test_admin_creates_invite_returns_201_and_token(
     body = resp.json()
     assert body["email"] == "newuser@example.com"
     assert body["status"] == "pending"
-    assert body["token"]
+    assert "token" not in body, "Raw token must not appear in API response"
     assert body["accepted_at"] is None
     assert body["accepted_by"] is None
-    # email should have been sent — mocked, so just assert it ran with
-    # the expected shape (recipient, subject contains MyJobHunter)
-    mock_send_email.assert_called_once()
-    args, _ = mock_send_email.call_args
-    assert args[0] == ["newuser@example.com"]
-    assert "MyJobHunter" in args[1]
+    # Email send was invoked with the recipient + a non-empty token
+    assert len(captured_invites) == 1
+    sent_to, sent_token = captured_invites[0]
+    assert sent_to == "newuser@example.com"
+    assert sent_token  # non-empty
+
+
+@pytest.mark.asyncio
+async def test_create_invite_persists_only_token_hash(
+    client: AsyncClient, user_factory, as_user, captured_invites,
+) -> None:
+    """DB row stores sha256(raw_token), never the raw token.
+
+    Direct DB inspection: the row's ``token_hash`` must equal the hash
+    of the captured raw token, and there must be NO ``token`` column on
+    the row (a leftover from the pre-hardening migration).
+    """
+    admin = await user_factory()
+    await _promote_to_admin(admin["email"])
+    async with await as_user(admin) as authed:
+        await authed.post(
+            "/admin/invites", json={"email": "hashcheck@example.com"},
+        )
+    sent_token = _last_token_for(captured_invites, "hashcheck@example.com")
+
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as sess:
+        result = await sess.execute(
+            text(
+                "SELECT token_hash FROM platform_invites "
+                "WHERE email = :e"
+            ),
+            {"e": "hashcheck@example.com"},
+        )
+        row_hash = result.scalar_one()
+        # The legacy ``token`` column from inv260505 must be gone
+        cols_result = await sess.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'platform_invites'"
+            )
+        )
+        columns = {r[0] for r in cols_result}
+    await engine.dispose()
+
+    assert row_hash == hash_token(sent_token)
+    assert "token" not in columns, (
+        "Legacy plaintext `token` column must be dropped"
+    )
+    assert "token_hash" in columns
 
 
 @pytest.mark.asyncio
 async def test_create_invite_lowercases_email(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -177,9 +260,14 @@ async def test_create_invite_lowercases_email(
 
 
 @pytest.mark.asyncio
-async def test_create_invite_for_existing_user_returns_409(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+async def test_create_invite_for_existing_user_returns_generic_409(
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
+    """Generic body — no hint that the email is already a user.
+
+    Security invariant: a compromised admin session must not be able to
+    enumerate which arbitrary emails already have accounts.
+    """
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
     existing = await user_factory()  # already registered
@@ -188,13 +276,15 @@ async def test_create_invite_for_existing_user_returns_409(
             "/admin/invites", json={"email": existing["email"]},
         )
     assert resp.status_code == 409
-    assert "already exists" in resp.json()["detail"].lower()
+    detail = resp.json()["detail"]
+    assert detail == "Cannot send invite to this email."
 
 
 @pytest.mark.asyncio
-async def test_create_invite_duplicate_pending_returns_409(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+async def test_create_invite_duplicate_pending_returns_generic_409(
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
+    """Same generic body as the user-exists branch."""
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
     async with await as_user(admin) as authed:
@@ -206,7 +296,7 @@ async def test_create_invite_duplicate_pending_returns_409(
             "/admin/invites", json={"email": "dupe@example.com"},
         )
     assert second.status_code == 409
-    assert "pending invite" in second.json()["detail"].lower()
+    assert second.json()["detail"] == "Cannot send invite to this email."
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +306,7 @@ async def test_create_invite_duplicate_pending_returns_409(
 
 @pytest.mark.asyncio
 async def test_list_pending_returns_only_unaccepted(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -228,11 +318,13 @@ async def test_list_pending_returns_only_unaccepted(
     data = list_resp.json()
     assert len(data) == 2
     assert {row["email"] for row in data} == {"a@example.com", "b@example.com"}
+    # Token must not leak via list either
+    assert all("token" not in row for row in data)
 
 
 @pytest.mark.asyncio
 async def test_cancel_unaccepted_invite_returns_204(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -247,7 +339,7 @@ async def test_cancel_unaccepted_invite_returns_204(
 
 @pytest.mark.asyncio
 async def test_cancel_unknown_invite_returns_404(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -263,15 +355,15 @@ async def test_cancel_unknown_invite_returns_404(
 
 @pytest.mark.asyncio
 async def test_public_preview_pending(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
     async with await as_user(admin) as authed:
-        create = await authed.post(
+        await authed.post(
             "/admin/invites", json={"email": "preview@example.com"},
         )
-    token = create.json()["token"]
+    token = _last_token_for(captured_invites, "preview@example.com")
 
     info = await client.get(f"/invites/{token}/info")
     assert info.status_code == 200
@@ -293,7 +385,7 @@ async def test_public_preview_unknown_token_returns_404(
 
 @pytest.mark.asyncio
 async def test_public_preview_expired_invite(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -303,10 +395,39 @@ async def test_public_preview_expired_invite(
         )
     body = create.json()
     await _force_invite_expired(body["id"])
+    token = _last_token_for(captured_invites, "expired@example.com")
 
-    info = await client.get(f"/invites/{body['token']}/info")
+    info = await client.get(f"/invites/{token}/info")
     assert info.status_code == 200
     assert info.json()["status"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_public_preview_rate_limit_blocks_after_threshold(
+    client: AsyncClient,
+) -> None:
+    """30/5min throttle on the unauthenticated info endpoint.
+
+    Sends 31 distinct-token lookups from the same source IP and asserts
+    the last one returns 429. Resets the limiter at teardown so other
+    tests aren't affected.
+    """
+    from app.api import admin_invites
+
+    # Save + reset — important because the limiter is process-global.
+    saved = admin_invites._INVITE_INFO_LIMITER
+    fresh = admin_invites.RateLimiter(max_attempts=30, window_seconds=300)
+    admin_invites._INVITE_INFO_LIMITER = fresh
+    try:
+        rate_limited = False
+        for i in range(31):
+            r = await client.get(f"/invites/probe-{i}-{uuid.uuid4().hex}/info")
+            if r.status_code == 429:
+                rate_limited = True
+                break
+        assert rate_limited, "30/5min limit should have fired before request 31"
+    finally:
+        admin_invites._INVITE_INFO_LIMITER = saved
 
 
 # ---------------------------------------------------------------------------
@@ -316,7 +437,7 @@ async def test_public_preview_expired_invite(
 
 @pytest.mark.asyncio
 async def test_accept_invite_with_matching_email(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -325,8 +446,8 @@ async def test_accept_invite_with_matching_email(
         create = await authed.post(
             "/admin/invites", json={"email": invitee_email},
         )
-    token = create.json()["token"]
     invite_id = create.json()["id"]
+    token = _last_token_for(captured_invites, invitee_email)
 
     invitee = await user_factory(email=invitee_email)
     async with await as_user(invitee) as authed_invitee:
@@ -339,15 +460,15 @@ async def test_accept_invite_with_matching_email(
 
 @pytest.mark.asyncio
 async def test_accept_invite_email_mismatch_returns_400(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
     async with await as_user(admin) as authed:
-        create = await authed.post(
+        await authed.post(
             "/admin/invites", json={"email": "intended@example.com"},
         )
-    token = create.json()["token"]
+    token = _last_token_for(captured_invites, "intended@example.com")
 
     impostor = await user_factory()  # different random email
     async with await as_user(impostor) as authed_impostor:
@@ -358,16 +479,16 @@ async def test_accept_invite_email_mismatch_returns_400(
 
 @pytest.mark.asyncio
 async def test_accept_invite_twice_returns_409(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
     invitee_email = f"twice-{uuid.uuid4().hex[:8]}@example.com"
     async with await as_user(admin) as authed:
-        create = await authed.post(
+        await authed.post(
             "/admin/invites", json={"email": invitee_email},
         )
-    token = create.json()["token"]
+    token = _last_token_for(captured_invites, invitee_email)
 
     invitee = await user_factory(email=invitee_email)
     async with await as_user(invitee) as authed_invitee:
@@ -380,7 +501,7 @@ async def test_accept_invite_twice_returns_409(
 
 @pytest.mark.asyncio
 async def test_accept_expired_invite_returns_410(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -390,8 +511,8 @@ async def test_accept_expired_invite_returns_410(
             "/admin/invites", json={"email": invitee_email},
         )
     create_body = create.json()
-    token = create_body["token"]
     await _force_invite_expired(create_body["id"])
+    token = _last_token_for(captured_invites, invitee_email)
 
     invitee = await user_factory(email=invitee_email)
     async with await as_user(invitee) as authed_invitee:
@@ -401,7 +522,7 @@ async def test_accept_expired_invite_returns_410(
 
 @pytest.mark.asyncio
 async def test_accept_unknown_token_returns_404(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     user = await user_factory()
     async with await as_user(user) as authed:
@@ -411,15 +532,15 @@ async def test_accept_unknown_token_returns_404(
 
 @pytest.mark.asyncio
 async def test_accept_requires_auth(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
     async with await as_user(admin) as authed:
-        create = await authed.post(
+        await authed.post(
             "/admin/invites", json={"email": "needsauth@example.com"},
         )
-    token = create.json()["token"]
+    token = _last_token_for(captured_invites, "needsauth@example.com")
     # No auth header
     resp = await client.post(f"/invites/{token}/accept")
     assert resp.status_code == 401
@@ -427,7 +548,7 @@ async def test_accept_requires_auth(
 
 @pytest.mark.asyncio
 async def test_cancel_accepted_invite_returns_409(
-    client: AsyncClient, user_factory, as_user, mock_send_email,
+    client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -437,8 +558,8 @@ async def test_cancel_accepted_invite_returns_409(
             "/admin/invites", json={"email": invitee_email},
         )
     create_body = create.json()
-    token = create_body["token"]
     invite_id = create_body["id"]
+    token = _last_token_for(captured_invites, invitee_email)
 
     invitee = await user_factory(email=invitee_email)
     async with await as_user(invitee) as authed_invitee:
@@ -450,7 +571,53 @@ async def test_cancel_accepted_invite_returns_409(
 
 
 # ---------------------------------------------------------------------------
-# Status helper unit test (doesn't need DB)
+# Audit-event redaction (security invariant)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_invite_audit_log_uses_email_domain_only(
+    client: AsyncClient, user_factory, as_user, captured_invites,
+) -> None:
+    """Auth-event metadata on create must NOT contain the recipient's
+    full email — only ``email_domain``.
+
+    Reason: the recipient is by definition not yet a user, so per the
+    auth-events policy for unknown-user events we keep PII out of
+    operator-readable logs.
+    """
+    admin = await user_factory()
+    await _promote_to_admin(admin["email"])
+    async with await as_user(admin) as authed:
+        await authed.post(
+            "/admin/invites", json={"email": "fred@redactme.example.com"},
+        )
+
+    engine = create_async_engine(settings.database_url, poolclass=NullPool)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as sess:
+        result = await sess.execute(
+            text(
+                "SELECT metadata FROM auth_events "
+                "WHERE event_type = 'platform_invite.created' "
+                "ORDER BY created_at DESC LIMIT 1"
+            ),
+        )
+        row = result.first()
+    await engine.dispose()
+    assert row is not None, "audit row must be present"
+    metadata = row[0]
+    assert metadata.get("email_domain") == "redactme.example.com"
+    assert "email" not in metadata, (
+        "full email must not appear in audit metadata"
+    )
+    assert "fred" not in str(metadata), (
+        "local-part of recipient email must not leak"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Status helper unit tests (no DB)
 # ---------------------------------------------------------------------------
 
 
@@ -462,7 +629,7 @@ def test_compute_status_returns_pending_for_fresh_invite() -> None:
     now = datetime.now(timezone.utc)
     invite = PlatformInvite(
         email="x@example.com",
-        token="t",
+        token_hash=hash_token("t"),
         expires_at=now + timedelta(days=7),
         accepted_at=None,
         created_by=uuid.uuid4(),
@@ -478,7 +645,7 @@ def test_compute_status_returns_accepted_when_accepted_at_set() -> None:
     now = datetime.now(timezone.utc)
     invite = PlatformInvite(
         email="x@example.com",
-        token="t",
+        token_hash=hash_token("t"),
         expires_at=now + timedelta(days=7),
         accepted_at=now,
         created_by=uuid.uuid4(),
@@ -494,9 +661,41 @@ def test_compute_status_returns_expired_past_deadline() -> None:
     now = datetime.now(timezone.utc)
     invite = PlatformInvite(
         email="x@example.com",
-        token="t",
+        token_hash=hash_token("t"),
         expires_at=now - timedelta(seconds=1),
         accepted_at=None,
         created_by=uuid.uuid4(),
     )
     assert compute_status(invite, now=now) == InviteStatus.EXPIRED
+
+
+# ---------------------------------------------------------------------------
+# Hash + escape primitives (no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_hash_token_is_deterministic_and_64_hex_chars() -> None:
+    """Same input → same hash; output is exactly 64 lowercase hex chars."""
+    h1 = hash_token("hello")
+    h2 = hash_token("hello")
+    assert h1 == h2
+    assert len(h1) == 64
+    assert all(c in "0123456789abcdef" for c in h1)
+
+
+def test_hash_token_distinguishes_inputs() -> None:
+    assert hash_token("abc") != hash_token("abcd")
+
+
+def test_invite_email_html_escapes_double_quote() -> None:
+    """The accept-URL is embedded in an href="..." attribute. The escape
+    must include quote=True so a hostile URL cannot break out.
+    """
+    from app.services.platform.invite_email import _build_invite_html
+
+    hostile = 'https://example.com/x?evil="><script>x</script>'
+    rendered = _build_invite_html(hostile)
+    # The literal `"` inside the URL must have been escaped into &quot;
+    # so the href attribute stays intact.
+    assert '<script>' not in rendered
+    assert '&quot;' in rendered

--- a/apps/myjobhunter/frontend/src/types/invite/invite.ts
+++ b/apps/myjobhunter/frontend/src/types/invite/invite.ts
@@ -3,11 +3,15 @@ import type { InviteStatus } from "./invite-status";
 /**
  * Admin-side invite representation. Returned by `POST /admin/invites`
  * and `GET /admin/invites`. Mirrors the backend `InviteRead` schema.
+ *
+ * The raw token is intentionally absent — the backend persists only
+ * `sha256(token)` and emits the raw value exactly once via email. If
+ * the recipient never gets the email the admin's recourse is to
+ * cancel + reissue, not to copy a token off this object.
  */
 export interface Invite {
   id: string;
   email: string;
-  token: string;
   status: InviteStatus;
   expires_at: string;
   accepted_at: string | null;


### PR DESCRIPTION
## Summary

Addresses the **1 Critical + 4 High** findings from tonight's security audit on the platform-invite feature shipped earlier today (PR #324).

The findings are mutually-reinforcing fixes on the same data path — splitting them would leave intermediate states where one defense-in-depth layer was applied without its peer.

## Findings addressed

| Severity | Finding | Fix |
|---|---|---|
| **Critical** | `_build_invite_html` used `html.escape(quote=False)` so a URL with `\"` would break out of `href=\"...\"` | `quote=True` |
| **High** | Plaintext `token` column + `InviteRead.token` re-emitted to admins | New `token_hash` column (sha256), drop `token` field from `InviteRead`, raw token returned exactly once via email |
| **High** | Public `GET /invites/{token}/info` was unauth + unrate-limited — token-validity oracle | `RateLimiter(30 / 5min)` per IP |
| **High** | `auth_events.metadata` stored full recipient email on create | Strip to `email_domain` (recipient is by definition not a user yet → unknown-user-event policy) |
| **High** | `409` body distinguished \"user exists\" vs \"pending invite\" — admin-token compromise enumeration | Single generic `\"Cannot send invite to this email.\"` |
| **Medium** | `send_invite_email` ran inside `unit_of_work` — SMTP failure → row rollback but possible delivered email | Email send moved to route layer **after** commit |

## Architecture

- New module `app/services/platform/invite_token.py` owns generation (`secrets.token_urlsafe(32)`) + hashing (`sha256`). Single source of truth.
- `invite_repo.get_by_token_hash` replaces `get_by_token`. Raw tokens never reach the repo.
- `invite_service.create_invite` returns a `CreateInviteResult` dataclass holding the row + raw token. Route layer hands the raw token to the email sender, then drops it.
- `InviteRead` schema drops the `token` field. Frontend `Invite` TS type drops it too — no usage existed.

## ⚠️ Operational migration required

After this PR merges, the migration `inv260506_invite_token_hash`:

1. **Hard-deletes every row in `platform_invites`.** Any pending invites in flight at deploy time become unusable — operator must re-issue them. Acceptable because the feature is hours old (PR #324) and admin-only.
2. Drops the legacy plaintext `token` column.
3. Adds `token_hash VARCHAR(64) NOT NULL UNIQUE` (sha256 hex digest).

No env-var changes required.

### Verify post-deploy

\`\`\`bash
docker compose -f apps/myjobhunter/docker-compose.yml exec api alembic current
# should show: inv260506_invite_token_hash (head)
\`\`\`

### Rollback path

The migration's `downgrade` restores the plaintext column shape. If rolled back after issuing invites under the new shape, those invites become unusable — admin must reissue.

## Test plan

- [x] **6 new unit tests pass locally**: `compute_status` (3), `hash_token` deterministic + 64 hex (1), `hash_token` distinguishes inputs (1), `_build_invite_html` escapes `\"` (1)
- [ ] **Integration tests in CI**: rewrite of `test_platform_invites.py` covers all existing state-machine cases via the new `captured_invites` fixture, plus 6 new security-invariant tests:
  - Create response must NOT contain `token` field
  - DB persists `token_hash` only; legacy `token` column gone
  - 409 collision body is generic for both branches
  - Audit-log metadata uses `email_domain`, never full email
  - Public preview is 429'd after 30/5min
  - Hostile URL with `\"` cannot break out of the href attribute
- [ ] **Manual smoke** post-deploy: admin sends invite → recipient gets email → recipient registers via link

🤖 Generated with [Claude Code](https://claude.com/claude-code)