### PR TITLE
fix(myjobhunter): admin/demo cleanup (audit M+L follow-ups)

### DIFF
--- a/apps/myjobhunter/backend/app/schemas/user/user_base.py
+++ b/apps/myjobhunter/backend/app/schemas/user/user_base.py
@@ -7,13 +7,14 @@ from fastapi_users import schemas
 class UserRead(schemas.BaseUser[uuid.UUID]):
     display_name: str = ""
     totp_enabled: bool = False
-    # Demo flag — exposed so the demo-cleanup admin tooling can identify
-    # seeded accounts. ``is_superuser`` is inherited from
+    # NOTE: ``is_demo`` is intentionally NOT exposed on this schema.
+    # Demo-cleanup admin tooling reads it directly from the DB via
+    # ``demo_repo`` — there is no need to leak demo-status to every
+    # ``GET /users/me`` response. ``is_superuser`` is inherited from
     # fastapi-users' BaseUser so the SPA can gate the operator-only
     # admin dashboard. MJH does not have a multi-tier role system —
     # the operator is the sole superuser; everyone else is a regular
     # user.
-    is_demo: bool = False
 
 
 class UserCreate(schemas.BaseUserCreate):

--- a/apps/myjobhunter/backend/app/services/demo/demo_service.py
+++ b/apps/myjobhunter/backend/app/services/demo/demo_service.py
@@ -146,9 +146,13 @@ async def create_demo_user(
 
         user_id = user.id
 
+    # Log only the email domain — demo emails today are non-deliverable
+    # (`.local`), but the same log shape would copy-paste into a real
+    # signup flow if extracted later. PII redaction by default.
+    _, _, _domain = final_email.rpartition("@")
     logger.info(
-        "DEMO_ACTION created demo user user_id=%s email=%s",
-        user_id, final_email,
+        "DEMO_ACTION created demo user user_id=%s email_domain=%s",
+        user_id, (_domain or "unknown").lower(),
     )
 
     return DemoCreateResponse(
@@ -185,11 +189,10 @@ async def delete_demo_user(user_id: uuid.UUID) -> DemoDeleteResponse:
     async with unit_of_work() as db:
         target = await demo_repo.get_demo_user_by_id(db, user_id)
         if target is None:
-            raise LookupError(
-                f"No demo user with id {user_id} exists. "
-                "It may have already been deleted, or the id refers to "
-                "a real (non-demo) account."
-            )
+            # Single byte-identical body for both "id is bogus" and "id
+            # is a real (non-demo) user" branches, so the endpoint
+            # cannot be used as an oracle to enumerate real accounts.
+            raise LookupError("Demo user not found.")
         await demo_repo.delete_demo_user_cascade(db, user_id=user_id)
 
     logger.info("DEMO_ACTION deleted demo user user_id=%s", user_id)

--- a/apps/myjobhunter/backend/tests/test_demo_service.py
+++ b/apps/myjobhunter/backend/tests/test_demo_service.py
@@ -212,9 +212,15 @@ async def test_delete_demo_user_cascades_data() -> None:
 
 
 async def test_delete_demo_user_refuses_unknown_id() -> None:
-    """Deleting a non-existent id raises LookupError (404)."""
-    with pytest.raises(LookupError, match="No demo user"):
+    """Deleting a non-existent id raises LookupError (404).
+
+    The error body is intentionally generic — it must be byte-identical
+    for both "id is bogus" and "id is a real (non-demo) user" so the
+    endpoint cannot be used as an account-enumeration oracle.
+    """
+    with pytest.raises(LookupError) as exc_info:
         await demo_service.delete_demo_user(uuid.uuid4())
+    assert str(exc_info.value) == "Demo user not found."
 
 
 # ---------------------------------------------------------------------------

--- a/apps/myjobhunter/frontend/src/lib/userApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/userApi.ts
@@ -17,7 +17,6 @@ export interface CurrentUser {
   totp_enabled: boolean;
   is_verified: boolean;
   is_superuser: boolean;
-  is_demo: boolean;
 }
 
 export interface UpdateUserRequest {

--- a/packages/shared-backend/platform_shared/api/admin_router.py
+++ b/packages/shared-backend/platform_shared/api/admin_router.py
@@ -22,7 +22,7 @@ import uuid
 from collections.abc import Callable
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from platform_shared.schemas.admin_user import (
     AdminUserRead,
@@ -59,9 +59,11 @@ def build_admin_router(
 
     @router.get("/users", response_model=list[response_model])  # type: ignore[valid-type]
     async def list_users(
+        limit: int = Query(50, ge=1, le=200),
+        offset: int = Query(0, ge=0),
         admin: Any = Depends(current_admin),
     ) -> list[Any]:
-        return list(await service.list_users())
+        return list(await service.list_users(limit=limit, offset=offset))
 
     @router.patch(
         "/users/{user_id}/role", response_model=response_model,  # type: ignore[valid-type]

--- a/packages/shared-backend/platform_shared/repositories/admin_user_repo.py
+++ b/packages/shared-backend/platform_shared/repositories/admin_user_repo.py
@@ -19,9 +19,25 @@ from sqlalchemy.ext.asyncio import AsyncSession
 TUser = TypeVar("TUser")
 
 
-async def list_all(db: AsyncSession, user_model: type[TUser]) -> Sequence[TUser]:
-    """Return every user in the table, ordered by email."""
-    result = await db.execute(select(user_model).order_by(user_model.email))
+async def list_all(
+    db: AsyncSession,
+    user_model: type[TUser],
+    *,
+    limit: int = 50,
+    offset: int = 0,
+) -> Sequence[TUser]:
+    """Return a page of users, ordered by email.
+
+    Defaults to a 50-row page so a single compromised admin token cannot
+    exfiltrate the entire user table in one request. Callers asking for
+    a full export must paginate.
+    """
+    result = await db.execute(
+        select(user_model)
+        .order_by(user_model.email)
+        .limit(limit)
+        .offset(offset)
+    )
     return result.scalars().all()
 
 

--- a/packages/shared-backend/platform_shared/services/admin_user_service.py
+++ b/packages/shared-backend/platform_shared/services/admin_user_service.py
@@ -60,10 +60,19 @@ class AdminUserService(Generic[TUser]):
         self._unit_of_work = unit_of_work
         self._async_session_factory = async_session_factory
 
-    async def list_users(self) -> Sequence[TUser]:
-        """Return every user in the table, ordered by email."""
+    async def list_users(
+        self, *, limit: int = 50, offset: int = 0,
+    ) -> Sequence[TUser]:
+        """Return a page of users, ordered by email.
+
+        Defaults to 50 per page so an admin-token compromise yields one
+        page at a time, not the full table. Callers asking for a full
+        export must paginate explicitly.
+        """
         async with self._async_session_factory() as db:
-            return await admin_user_repo.list_all(db, self._user_model)
+            return await admin_user_repo.list_all(
+                db, self._user_model, limit=limit, offset=offset,
+            )
 
     async def update_user_role(
         self, user_id: uuid.UUID, role: Role, admin: TUser,

--- a/packages/shared-backend/tests/test_admin_user_service.py
+++ b/packages/shared-backend/tests/test_admin_user_service.py
@@ -252,3 +252,36 @@ async def test_list_users_delegates_to_repo():
     ):
         users = list(await service.list_users())
     assert users == [target_a, target_b]
+
+
+@pytest.mark.asyncio
+async def test_list_users_passes_pagination_kwargs():
+    """The service must forward limit/offset to the repo verbatim.
+
+    Default values matter: ``limit=50, offset=0`` is the security
+    backstop against a single compromised admin token exfiltrating
+    the entire user table.
+    """
+    service, _ = _build_service(target=None)
+    mock = AsyncMock(return_value=[])
+    with patch(
+        "platform_shared.services.admin_user_service.admin_user_repo.list_all",
+        new=mock,
+    ):
+        await service.list_users(limit=10, offset=20)
+    _, kwargs = mock.call_args
+    assert kwargs == {"limit": 10, "offset": 20}
+
+
+@pytest.mark.asyncio
+async def test_list_users_default_limit_is_50():
+    service, _ = _build_service(target=None)
+    mock = AsyncMock(return_value=[])
+    with patch(
+        "platform_shared.services.admin_user_service.admin_user_repo.list_all",
+        new=mock,
+    ):
+        await service.list_users()
+    _, kwargs = mock.call_args
+    assert kwargs["limit"] == 50
+    assert kwargs["offset"] == 0


### PR DESCRIPTION
## Summary

Wraps up the lower-severity findings from tonight's security audit. Each fix is small + self-contained; bundled because they share a deploy and don't depend on each other.

| Severity | Finding | Fix |
|---|---|---|
| **Medium** | M1 — \`is_demo\` exposed on \`UserRead\` | Drop from schema (admin tooling reads from DB directly). Drop from frontend \`CurrentUser\` (no UI usage). |
| **Medium** | M3 — Demo-delete 404 message hinted at real-account oracle | Collapse to byte-identical \`\"Demo user not found.\"\` |
| **Medium** | M5 — \`DEMO_ACTION created\` log line wrote full email | Switch to \`email_domain\` only |
| **Low** | L2 — \`GET /admin/users\` returned every user in one shot | Pagination: \`limit\` (default 50, max 200), \`offset\` (default 0) |

## What's deferred (still open from the audit)

- **M2** — TOTP step-up on \`toggle_superuser\`. Highest-privilege op flips silently with no re-auth. This needs its own PR (new step-up auth flow + TOTP-confirm endpoint), not a cleanup bundle.
- M4 + L1 already addressed in PR #331 (invite-system hardening).
- L3 is note-only — Bearer-token auth means CSRF isn't exploitable.

## Test plan

- [x] **2 new shared-backend unit tests pass**: \`list_users\` forwards \`limit\`/\`offset\` kwargs verbatim; defaults are \`50\`/\`0\`. (Existing 14 tests still pass — full \`test_admin_user_service.py\` is 16 green.)
- [x] **\`test_delete_demo_user_refuses_unknown_id\` updated** to assert the new exact \`\"Demo user not found.\"\` body
- [ ] **CI** confirms backend integration tests still pass under the smaller \`UserRead\` schema (no test referenced \`is_demo\` from the read shape — verified via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)