### PR TITLE
fix(myjobhunter/resume): make Prev/Next nav buttons visible (text labels)

### DIFF
--- a/apps/myjobhunter/frontend/src/features/resume_refinement/NavigationButtons.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/NavigationButtons.tsx
@@ -42,23 +42,25 @@ export default function NavigationButtons({
   }
 
   return (
-    <div className="flex items-center gap-1">
+    <div className="flex items-center gap-2">
       <button
         type="button"
         onClick={() => move(NavDirection.PREV)}
         disabled={busy || atFirst}
         aria-label="Previous suggestion"
-        className="inline-flex items-center justify-center rounded-md border w-8 h-8 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+        className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
       >
         <ChevronLeft size={14} />
+        <span>Prev</span>
       </button>
       <button
         type="button"
         onClick={() => move(NavDirection.NEXT)}
         disabled={busy || atLast}
         aria-label="Next suggestion"
-        className="inline-flex items-center justify-center rounded-md border w-8 h-8 hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
+        className="inline-flex items-center gap-1 rounded-md border border-border bg-background px-2.5 py-1 text-xs font-medium hover:bg-muted disabled:opacity-40 disabled:cursor-not-allowed"
       >
+        <span>Next</span>
         <ChevronRight size={14} />
       </button>
     </div>


### PR DESCRIPTION
## Summary

The Prev/Next navigation controls shipped in PR #329 as 32x32 chevron-only icons with default \`border\` styling. In the dark theme that lands as a faint icon against a faintly-bordered tile against an only-slightly-darker card background — operator can't see them in production.

## Fix

Full pill buttons with chevron + text label ("Prev" / "Next"), explicit \`bg-background\` and \`border-border\` so they're unambiguous against the suggestion-card background regardless of theme. Same disabled states (opacity 40 at session boundaries).

Lives in the same place — header next to the "X left" badge — so no layout / spacing churn.

## Test plan

- [ ] Refresh the resume refinement page; chevron + "Prev" / "Next" pill buttons should be clearly visible in the suggestion card header.
- [ ] Click "Next" → moves to next suggestion without taking action; "Prev" → moves back.
- [ ] At first suggestion, "Prev" is dimmed and not clickable; at last suggestion, "Next" is dimmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)