### PR TITLE
fix(myjobhunter/invites): two-click inline cancel (no modal, no native alert)

### DIFF
--- a/apps/myjobhunter/frontend/src/features/admin/invites/InviteRow.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/invites/InviteRow.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { Trash2 } from "lucide-react";
 import {
   extractErrorMessage,
@@ -13,20 +14,49 @@ export interface InviteRowProps {
   invite: Invite;
 }
 
+const CONFIRM_WINDOW_MS = 3000;
+
 /**
  * Single row in the pending-invites table. Shows email, status badge,
- * expiry, and a cancel button. The cancel mutation auto-invalidates
- * the list cache via the `Invite` tag in `invitesApi`.
+ * expiry, and a cancel button.
+ *
+ * Cancel UX is a two-click inline confirm (no modal, no native alert):
+ * first click swaps the trash icon for a "Confirm?" pill that auto-
+ * reverts after 3s; second click within that window fires the
+ * cancellation. Per design review — see g-design-ux note 2026-05-06.
  */
 export default function InviteRow({ invite }: InviteRowProps) {
   const [cancelInvite, { isLoading: isCancelling }] = useCancelInviteMutation();
+  const [confirming, setConfirming] = useState(false);
+  const confirmTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  async function handleCancel() {
-    if (
-      !window.confirm(`Cancel invite for ${invite.email}? This cannot be undone.`)
-    ) {
-      return;
+  function clearConfirmTimer() {
+    if (confirmTimerRef.current !== null) {
+      clearTimeout(confirmTimerRef.current);
+      confirmTimerRef.current = null;
     }
+  }
+
+  // Cancel the pending timeout if the row unmounts (which happens
+  // immediately after a successful cancel — RTK Query invalidates the
+  // Invite tag and re-renders the list). Prevents a setState on an
+  // unmounted component.
+  useEffect(() => {
+    return () => clearConfirmTimer();
+  }, []);
+
+  function startConfirmation() {
+    setConfirming(true);
+    clearConfirmTimer();
+    confirmTimerRef.current = setTimeout(() => {
+      setConfirming(false);
+      confirmTimerRef.current = null;
+    }, CONFIRM_WINDOW_MS);
+  }
+
+  async function commitCancel() {
+    clearConfirmTimer();
+    setConfirming(false);
     try {
       await cancelInvite(invite.id).unwrap();
       showSuccess("Invite cancelled");
@@ -34,6 +64,28 @@ export default function InviteRow({ invite }: InviteRowProps) {
       showError(`Couldn't cancel: ${extractErrorMessage(err)}`);
     }
   }
+
+  function handleClick() {
+    if (isCancelling) return;
+    if (confirming) {
+      void commitCancel();
+      return;
+    }
+    startConfirmation();
+  }
+
+  function handleBlur() {
+    // Tabbing away from the button in confirming state aborts the
+    // pending confirmation. Belt-and-braces with the 3s auto-revert.
+    if (confirming) {
+      clearConfirmTimer();
+      setConfirming(false);
+    }
+  }
+
+  const ariaLabel = confirming
+    ? `Confirm cancellation of invite for ${invite.email}`
+    : `Cancel invite for ${invite.email}`;
 
   return (
     <div className="flex items-center justify-between gap-3 p-3 border rounded-lg hover:bg-muted/30 transition-colors">
@@ -46,15 +98,32 @@ export default function InviteRow({ invite }: InviteRowProps) {
           Expires {formatInviteDate(invite.expires_at)}
         </p>
       </div>
-      <button
-        type="button"
-        onClick={handleCancel}
-        disabled={isCancelling}
-        title="Cancel invite"
-        className="p-1.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive disabled:opacity-50 min-h-[44px] min-w-[44px] flex items-center justify-center"
-      >
-        <Trash2 size={14} />
-      </button>
+      <span aria-live="polite">
+        {confirming ? (
+          <button
+            type="button"
+            onClick={handleClick}
+            onBlur={handleBlur}
+            disabled={isCancelling}
+            aria-label={ariaLabel}
+            className="inline-flex items-center gap-1.5 rounded-md bg-destructive px-3 py-1.5 text-xs font-medium text-destructive-foreground hover:bg-destructive/90 disabled:opacity-50 min-h-[44px]"
+          >
+            <Trash2 size={14} aria-hidden="true" />
+            <span>Confirm?</span>
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleClick}
+            disabled={isCancelling}
+            aria-label={ariaLabel}
+            title="Cancel invite"
+            className="p-1.5 rounded hover:bg-destructive/10 text-muted-foreground hover:text-destructive disabled:opacity-50 min-h-[44px] min-w-[44px] flex items-center justify-center"
+          >
+            <Trash2 size={14} aria-hidden="true" />
+          </button>
+        )}
+      </span>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Replaces the native \`window.confirm()\` browser dialog on cancel-invite with a two-click inline confirm. Operator rejected both modal and native alert as acceptable patterns.

## How it works

1. Click trash icon → button swaps to a red "Confirm?" pill
2. Click again within 3s → invite is cancelled
3. Wait 3s, tab away, or click anywhere else → reverts to trash icon, nothing happens

## Why two-click (per g-design-ux)

| Pattern | Verdict |
|---|---|
| Toast-with-undo | Would require extending \`@platform/ui\`'s \`Toaster\` with an action-button slot — disproportionate for a low-traffic page |
| Inline slide-out | Same UX, more layout shift |
| Hold-to-confirm | Mobile novelty; bad keyboard a11y |
| Status popover | Adds 3 clicks to do what was 1 |
| **Two-click confirm** | Zero layout shift, no shared-package changes, self-resets on inaction, immediately legible |

## Implementation notes

- Local \`confirming\` state + \`useRef\` for the 3s timeout id
- Cleanup on unmount (RTK Query invalidates the \`Invite\` tag on cancel and removes the row — without cleanup the timeout fires a setState on an unmounted component)
- \`onBlur\` aborts the pending confirmation as defense-in-depth with the auto-revert
- ARIA label changes with state, wrapped in \`aria-live="polite"\` so screen readers announce the state change
- 44x44 minimum touch target preserved in both states

## Test plan

- [ ] Click trash on a pending invite → red "Confirm?" appears
- [ ] Wait 3s → reverts to trash icon, no API call fired
- [ ] Click trash, then click "Confirm?" → invite is cancelled, success toast appears
- [ ] Click trash, then tab to another element → reverts to trash, no API call
- [ ] Click trash, click "Confirm?", attempt rapid third click → button is disabled during cancellation

🤖 Generated with [Claude Code](https://claude.com/claude-code)