### PR TITLE
fix(myjobhunter): add /register page so invite-email links work

### DIFF
--- a/apps/myjobhunter/frontend/src/pages/Register.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Register.tsx
@@ -1,0 +1,268 @@
+import { useCallback, useEffect, useState } from "react";
+import { Link, useSearchParams, Navigate } from "react-router-dom";
+import {
+  LoadingButton,
+  TurnstileWidget,
+  extractErrorMessage,
+} from "@platform/ui";
+import { Briefcase } from "lucide-react";
+import { register } from "@/lib/auth";
+import { useGetInviteInfoQuery } from "@/store/invitesApi";
+
+const INVITE_TOKEN_STORAGE_KEY = "myjobhunter.pendingInviteToken";
+
+/**
+ * Invite-only registration page.
+ *
+ * Reads the ``?invite=<token>`` query param, validates the token via
+ * ``GET /invites/{token}/info``, and pre-binds the email field to the
+ * invited address. MyJobHunter does not (yet) support self-serve
+ * registration — without a valid invite the page rejects the user with
+ * a "go to login" CTA.
+ *
+ * After a successful POST /auth/register the page stores the raw
+ * invite token in ``sessionStorage`` so that a follow-up post-login
+ * step can call ``POST /invites/{token}/accept`` to mark the audit
+ * trail. The accept step is best-effort and not blocking — the account
+ * is fully usable even if the accept call never fires.
+ */
+export default function Register() {
+  const [searchParams] = useSearchParams();
+  const inviteToken = searchParams.get("invite") || "";
+
+  if (!inviteToken) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <RegisterWithInvite token={inviteToken} />;
+}
+
+interface RegisterWithInviteProps {
+  token: string;
+}
+
+function RegisterWithInvite({ token }: RegisterWithInviteProps) {
+  const {
+    data: invite,
+    isLoading,
+    isError,
+    error,
+  } = useGetInviteInfoQuery(token);
+
+  const [password, setPassword] = useState("");
+  const [submitError, setSubmitError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [registered, setRegistered] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState("");
+  const [termsAccepted, setTermsAccepted] = useState(false);
+
+  const handleTurnstileVerify = useCallback((value: string) => {
+    setTurnstileToken(value);
+  }, []);
+
+  const handleTurnstileExpire = useCallback(() => {
+    setTurnstileToken("");
+  }, []);
+
+  useEffect(() => {
+    if (registered && token) {
+      try {
+        sessionStorage.setItem(INVITE_TOKEN_STORAGE_KEY, token);
+      } catch {
+        // sessionStorage failure is non-fatal — accept is best-effort
+      }
+    }
+  }, [registered, token]);
+
+  if (isLoading) {
+    return <CenteredCard title="Checking your invite…" />;
+  }
+
+  if (isError) {
+    return (
+      <InviteRejectedCard
+        message={
+          extractInviteErrorMessage(error) ??
+          "This invite link is invalid or has expired."
+        }
+      />
+    );
+  }
+
+  if (!invite) {
+    return <InviteRejectedCard message="Could not load invite details." />;
+  }
+
+  if (invite.status === "expired") {
+    return (
+      <InviteRejectedCard message="This invite has expired. Ask the operator to send a new one." />
+    );
+  }
+
+  if (invite.status === "accepted") {
+    return (
+      <InviteRejectedCard
+        message="This invite has already been used. Sign in to your account instead."
+        showLogin
+      />
+    );
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setSubmitError("");
+
+    if (password.length < 12) {
+      setSubmitError("Password must be at least 12 characters.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await register(invite!.email, password, turnstileToken);
+      setRegistered(true);
+    } catch (err) {
+      setSubmitError(extractErrorMessage(err));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  if (registered) {
+    return (
+      <CenteredCard title="Check your inbox">
+        <p className="text-sm text-muted-foreground">
+          We sent a verification link to <strong>{invite.email}</strong>. Click
+          the link in that email to activate your account, then{" "}
+          <Link to="/login" className="text-primary hover:underline">
+            sign in
+          </Link>
+          .
+        </p>
+      </CenteredCard>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-muted">
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm">
+          <div className="flex items-center gap-2 mb-6">
+            <Briefcase className="size-6 text-primary" />
+            <h1 className="text-2xl font-semibold">Create your account</h1>
+          </div>
+          <p className="text-sm text-muted-foreground mb-6">
+            You've been invited to MyJobHunter. Set a password to finish
+            creating your account.
+          </p>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Email</label>
+              <input
+                type="email"
+                value={invite.email}
+                readOnly
+                className="w-full border rounded-md px-3 py-2 text-sm bg-muted text-muted-foreground cursor-not-allowed"
+                aria-readonly="true"
+              />
+              <p className="text-xs text-muted-foreground mt-1">
+                Bound to your invite. Contact the operator to use a different
+                address.
+              </p>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Password</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                required
+                minLength={12}
+                placeholder="At least 12 characters"
+              />
+            </div>
+            <TurnstileWidget
+              onVerify={handleTurnstileVerify}
+              onExpire={handleTurnstileExpire}
+            />
+            <label className="flex items-start gap-2 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={termsAccepted}
+                onChange={(e) => setTermsAccepted(e.target.checked)}
+                className="mt-0.5 h-4 w-4 shrink-0 rounded border accent-primary cursor-pointer"
+              />
+              <span className="text-sm text-muted-foreground leading-snug">
+                I agree to use this service responsibly.
+              </span>
+            </label>
+            {submitError ? (
+              <p className="text-destructive text-sm">{submitError}</p>
+            ) : null}
+            <LoadingButton
+              type="submit"
+              isLoading={isSubmitting}
+              loadingText="Creating account…"
+              className="w-full"
+              disabled={isSubmitting || !termsAccepted}
+            >
+              Sign up
+            </LoadingButton>
+          </form>
+          <p className="text-sm text-muted-foreground text-center mt-4">
+            Already have an account?{" "}
+            <Link to="/login" className="text-primary hover:underline">
+              Sign in
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CenteredCardProps {
+  title: string;
+  children?: React.ReactNode;
+}
+
+function CenteredCard({ title, children }: CenteredCardProps) {
+  return (
+    <div className="min-h-screen flex flex-col bg-muted">
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm text-center">
+          <h1 className="text-2xl font-semibold mb-4">{title}</h1>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface InviteRejectedCardProps {
+  message: string;
+  showLogin?: boolean;
+}
+
+function InviteRejectedCard({ message, showLogin = true }: InviteRejectedCardProps) {
+  return (
+    <CenteredCard title="Invite unavailable">
+      <p className="text-sm text-muted-foreground mb-6">{message}</p>
+      {showLogin ? (
+        <Link
+          to="/login"
+          className="text-primary hover:underline text-sm"
+        >
+          Go to sign in
+        </Link>
+      ) : null}
+    </CenteredCard>
+  );
+}
+
+function extractInviteErrorMessage(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
+  const detail = (error as { data?: { detail?: unknown } })?.data?.detail;
+  return typeof detail === "string" ? detail : null;
+}

--- a/apps/myjobhunter/frontend/src/routes.tsx
+++ b/apps/myjobhunter/frontend/src/routes.tsx
@@ -10,6 +10,7 @@ import ResumeRefinement from "@/pages/ResumeRefinement";
 import Security from "@/pages/Security";
 import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
+import Register from "@/pages/Register";
 import VerifyEmail from "@/pages/VerifyEmail";
 import NotFound from "@/pages/NotFound";
 import AdminDashboard from "@/pages/admin/AdminDashboard";
@@ -61,6 +62,7 @@ export const routes: RouteObject[] = [
     ],
   },
   { path: "/login", element: <Login /> },
+  { path: "/register", element: <Register /> },
   { path: "/verify-email", element: <VerifyEmail /> },
   { path: "*", element: <NotFound /> },
 ];


### PR DESCRIPTION
## Summary

User reported clicking the invite-email link landed on the SPA's catch-all 404 page. Root cause: the platform-invite email points to \`\${frontend_url}/register?invite=<token>\`, but the SPA had no \`/register\` route.

The invite system shipped in PR #324 was incomplete — backend was wired correctly but the frontend page was never built.

## What this adds

**\`pages/Register.tsx\`** — invite-only registration:
- Reads \`?invite=<token>\` query param
- Validates via \`GET /invites/{token}/info\`
- Pre-binds the email field to the invited address (read-only)
- Calls \`POST /auth/register\` with Turnstile forwarded as \`X-Turnstile-Token\`
- After register: shows "check your inbox" + persists raw token in \`sessionStorage\` for a future post-login \`POST /invites/{token}/accept\` call (audit trail)
- Without an invite query param: redirects to \`/login\` — MyJobHunter is invite-only

Invite states surface through dedicated rejection cards:
- 404 from info endpoint → "invite link is invalid or expired"
- \`status=expired\` → "invite has expired, ask the operator"
- \`status=accepted\` → "already used, sign in instead"

## Why this should have been caught earlier

The user (rightly) called out: "why was this not thoroughly tested with e2e tests?". The invite system shipped without an E2E that exercised the full flow (admin sends → recipient clicks email → recipient registers → recipient logs in). Adding that E2E is tracked as follow-up; this PR fixes the immediate user-facing 404 first.

## Test plan

- [ ] \`/register?invite=<valid-token>\` shows registration form with email pre-filled
- [ ] \`/register\` (no token) redirects to \`/login\`
- [ ] \`/register?invite=<bogus-token>\` shows "invite invalid" rejection card
- [ ] \`/register?invite=<expired-token>\` shows "expired" rejection card
- [ ] Submit with valid invite → "check your inbox" message + email arrives
- [ ] Click verification link → log in → invite token persists in sessionStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)