### PR TITLE
fix(myjobhunter/register): confirm-password field with UX polish

### DIFF
--- a/apps/myjobhunter/frontend/src/pages/Register.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Register.tsx
@@ -51,6 +51,7 @@ function RegisterWithInvite({ token }: RegisterWithInviteProps) {
 
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
+  const [confirmTouched, setConfirmTouched] = useState(false);
   const [submitError, setSubmitError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [registered, setRegistered] = useState(false);
@@ -187,7 +188,14 @@ function RegisterWithInvite({ token }: RegisterWithInviteProps) {
                 minLength={12}
                 placeholder="At least 12 characters"
                 autoComplete="new-password"
+                aria-describedby="password-hint"
               />
+              <p
+                id="password-hint"
+                className="text-xs text-muted-foreground mt-1"
+              >
+                At least 12 characters.
+              </p>
             </div>
             <div>
               <label className="block text-sm font-medium mb-1">
@@ -197,17 +205,27 @@ function RegisterWithInvite({ token }: RegisterWithInviteProps) {
                 type="password"
                 value={confirmPassword}
                 onChange={(e) => setConfirmPassword(e.target.value)}
+                onBlur={() => setConfirmTouched(true)}
                 className="w-full border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
                 required
                 minLength={12}
-                placeholder="Re-type your password"
+                placeholder="Confirm your password"
                 autoComplete="new-password"
                 aria-invalid={
-                  confirmPassword.length > 0 && confirmPassword !== password
+                  confirmTouched && confirmPassword !== password
+                }
+                aria-describedby={
+                  confirmTouched && confirmPassword !== password
+                    ? "confirm-password-error"
+                    : undefined
                 }
               />
-              {confirmPassword.length > 0 && confirmPassword !== password ? (
-                <p className="text-xs text-destructive mt-1">
+              {confirmTouched && confirmPassword !== password ? (
+                <p
+                  id="confirm-password-error"
+                  role="alert"
+                  className="text-xs text-destructive mt-1"
+                >
                   Passwords don't match.
                 </p>
               ) : null}

--- a/apps/myjobhunter/frontend/src/pages/Register.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Register.tsx
@@ -50,6 +50,7 @@ function RegisterWithInvite({ token }: RegisterWithInviteProps) {
   } = useGetInviteInfoQuery(token);
 
   const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
   const [submitError, setSubmitError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [registered, setRegistered] = useState(false);
@@ -117,6 +118,11 @@ function RegisterWithInvite({ token }: RegisterWithInviteProps) {
       return;
     }
 
+    if (password !== confirmPassword) {
+      setSubmitError("Passwords don't match. Re-type the same password in both fields.");
+      return;
+    }
+
     setIsSubmitting(true);
     try {
       await register(invite!.email, password, turnstileToken);
@@ -180,7 +186,31 @@ function RegisterWithInvite({ token }: RegisterWithInviteProps) {
                 required
                 minLength={12}
                 placeholder="At least 12 characters"
+                autoComplete="new-password"
               />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Confirm password
+              </label>
+              <input
+                type="password"
+                value={confirmPassword}
+                onChange={(e) => setConfirmPassword(e.target.value)}
+                className="w-full border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                required
+                minLength={12}
+                placeholder="Re-type your password"
+                autoComplete="new-password"
+                aria-invalid={
+                  confirmPassword.length > 0 && confirmPassword !== password
+                }
+              />
+              {confirmPassword.length > 0 && confirmPassword !== password ? (
+                <p className="text-xs text-destructive mt-1">
+                  Passwords don't match.
+                </p>
+              ) : null}
             </div>
             <TurnstileWidget
               onVerify={handleTurnstileVerify}
@@ -205,7 +235,12 @@ function RegisterWithInvite({ token }: RegisterWithInviteProps) {
               isLoading={isSubmitting}
               loadingText="Creating account…"
               className="w-full"
-              disabled={isSubmitting || !termsAccepted}
+              disabled={
+                isSubmitting ||
+                !termsAccepted ||
+                password.length < 12 ||
+                password !== confirmPassword
+              }
             >
               Sign up
             </LoadingButton>


### PR DESCRIPTION
## Summary

Adds a confirm-password field to the invite-driven registration page, then iterates per a UX-design review for best-practice polish.

## What it does

- Two stacked password inputs ("Password" + "Confirm password")
- Mismatch indicator fires **on blur** of the confirm field, not on every keystroke (per design review — keystroke-level errors during entry are noisy on mobile and shame the user mid-type)
- Submit button stays disabled until: terms accepted, password ≥ 12 chars, AND both fields match
- Inline error has \`role=\"alert\"\` so screen readers announce it the moment it appears
- \`aria-describedby\` on the password field links to the "At least 12 characters" hint
- \`aria-describedby\` on the confirm field links to the mismatch error only while it's visible
- Promoted the password constraint from a \`placeholder\` to a proper helper paragraph with an id (placeholder text disappears once the user starts typing — a hint should outlast typing)
- \`autoComplete=\"new-password\"\` on both fields so password managers fill the suggested-password into both rather than auto-filling an existing saved password into the new one

## Why

Operator: typo on the only password input would have shipped the account with a password they couldn't remember. Recovery requires the forgot-password flow. A confirm field is the standard registration pattern.

The blur-trigger + role=alert + aria-describedby polish came from a g-design-ux review the operator asked for explicitly.

## Test plan

- [ ] Type matching passwords → no error, submit enabled (after terms checked)
- [ ] Type mismatched passwords → no error visible while typing in confirm
- [ ] Type mismatched, then tab away from confirm → "Passwords don't match" appears in red, submit disabled
- [ ] Fix the mismatch → error disappears, submit enables
- [ ] Screen reader announces the constraint when password field is focused
- [ ] Screen reader announces "Passwords don't match" alert when error appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)