### PR TITLE
fix(myjobhunter/auth): wipe RTK Query caches on sign-in/sign-out

### DIFF
--- a/apps/myjobhunter/frontend/src/lib/auth.ts
+++ b/apps/myjobhunter/frontend/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import api from "@/lib/api";
-import { notifyAuthChange } from "@platform/ui";
+import { baseApi, notifyAuthChange } from "@platform/ui";
+import { store } from "@/lib/store";
 import type { LoginResult } from "@/types/security/login-result";
 
 interface LoginResponse {
@@ -47,6 +48,11 @@ export async function signIn(
 
   if (response.data.access_token) {
     localStorage.setItem("token", response.data.access_token);
+    // Wipe RTK Query caches BEFORE notifying — every cached query under
+    // the previous user (e.g. /users/me) becomes stale the moment the
+    // identity changes. resetApiState clears the cache; the next mount
+    // of any component using a query refetches against the new token.
+    store.dispatch(baseApi.util.resetApiState());
     notifyAuthChange();
     return { status: "ok" };
   }
@@ -90,9 +96,12 @@ export async function requestVerifyToken(email: string): Promise<void> {
 }
 
 /**
- * Sign out — clear token and notify subscribers (triggers RequireAuth redirect).
+ * Sign out — clear token, wipe RTK Query caches so the next signed-in
+ * user doesn't see the previous user's cached data, and notify
+ * subscribers (triggers RequireAuth redirect).
  */
 export function signOut(): void {
   localStorage.removeItem("token");
+  store.dispatch(baseApi.util.resetApiState());
   notifyAuthChange();
 }


### PR DESCRIPTION
Fixes operator-reported "signed out of mybookkeeper6, signed in as jasonykwon91, sidebar still showed mybookkeeper6 until refresh."

Root cause: `/users/me` (and every other RTK Query) cached the previous user's response. The token flipped but the cache didn't.

Fix: dispatch `baseApi.util.resetApiState()` in both `signIn` (after the new token lands, before `notifyAuthChange`) and `signOut` (after the token clears, before `notifyAuthChange`). One line each, wipes every cached query under the previous identity.

Order matters in signIn: reset BEFORE notify so the re-render uses the new token, not a stale one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)