### PR TITLE
feat(myjobhunter/resume): cache AI proposals — nav becomes instant

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/propcache260506_resume_proposal_cache.py
+++ b/apps/myjobhunter/backend/alembic/versions/propcache260506_resume_proposal_cache.py
@@ -1,0 +1,49 @@
+"""Add ``proposal_cache`` JSONB column on resume_refinement_sessions.
+
+Caches generated AI proposals per target_index so navigation between
+suggestions doesn't burn an Anthropic round-trip on every move. The
+cache is keyed by stringified target_index (because JSON object keys
+must be strings):
+
+    {
+      "0": {"section": "...", "proposal": "...", "rationale": "...",
+            "clarifying_question": null},
+      "1": {...}
+    }
+
+Cache writes happen in ``_generate_next_proposal``; reads happen in
+``navigate``. ``request_alternative`` deliberately bypasses the cache
+(and overwrites the entry) so the operator can force a fresh
+generation.
+
+Revision ID: propcache260506
+Revises: inv260506
+Create Date: 2026-05-06
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "propcache260506"
+down_revision: Union[str, None] = "inv260506"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "resume_refinement_sessions",
+        sa.Column(
+            "proposal_cache",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("resume_refinement_sessions", "proposal_cache")

--- a/apps/myjobhunter/backend/app/models/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/models/resume_refinement/session.py
@@ -94,6 +94,19 @@ class ResumeRefinementSession(Base):
         nullable=False,
     )
 
+    # Per-target cache of generated AI proposals so navigating among
+    # suggestions doesn't burn a fresh Claude round-trip on every
+    # move. Keyed by stringified target_index. See
+    # ``_generate_next_proposal`` (write path) and ``navigate`` (read
+    # path) in session_service.py. ``request_alternative`` skips the
+    # cache so the operator can force a regeneration.
+    proposal_cache: Mapped[dict] = mapped_column(
+        JSONB,
+        nullable=False,
+        default=dict,
+        server_default="{}",
+    )
+
     turns: Mapped[list["ResumeRefinementTurn"]] = relationship(  # type: ignore[name-defined]
         "ResumeRefinementTurn",
         back_populates="session",

--- a/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
@@ -200,6 +200,81 @@ async def set_target_index(
     return session
 
 
+async def hydrate_pending_from_cache(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    target_index: int,
+) -> ResumeRefinementSession | None:
+    """If a cached proposal exists for ``target_index``, copy it onto
+    the pending_* fields and return the refreshed session. Returns
+    ``None`` when there's no cache entry — callers should fall through
+    to generation.
+    """
+    cache = session.proposal_cache or {}
+    entry = cache.get(str(target_index))
+    if not entry:
+        return None
+    session.pending_target_section = entry.get("section")
+    session.pending_proposal = entry.get("proposal")
+    session.pending_rationale = entry.get("rationale")
+    session.pending_clarifying_question = entry.get("clarifying_question")
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def cache_proposal(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    target_index: int,
+    target_section: str | None,
+    proposal: str | None,
+    rationale: str | None,
+    clarifying_question: str | None,
+) -> ResumeRefinementSession:
+    """Write the just-generated proposal into ``proposal_cache`` for
+    the given ``target_index`` so future navigations skip the AI call.
+
+    JSONB requires a fresh dict assignment for SQLAlchemy to detect
+    the change — mutating in place doesn't flush.
+    """
+    existing = dict(session.proposal_cache or {})
+    existing[str(target_index)] = {
+        "section": target_section,
+        "proposal": proposal,
+        "rationale": rationale,
+        "clarifying_question": clarifying_question,
+    }
+    session.proposal_cache = existing
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def invalidate_cached_proposal(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    target_index: int,
+) -> ResumeRefinementSession:
+    """Drop the cached proposal for ``target_index`` (used by
+    ``request_alternative`` so the next ``cache_proposal`` write is
+    the regenerated value).
+    """
+    existing = dict(session.proposal_cache or {})
+    if str(target_index) in existing:
+        del existing[str(target_index)]
+        session.proposal_cache = existing
+        await db.flush()
+        await db.commit()
+        await db.refresh(session)
+    return session
+
+
 async def mark_completed(
     db: AsyncSession,
     session: ResumeRefinementSession,

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
@@ -249,6 +249,14 @@ async def request_alternative(
     await db.commit()
     await db.refresh(session)
 
+    # Drop the cached proposal so this regeneration's output replaces
+    # the stale one. Without invalidation, a future navigate-back to
+    # this target would surface the OLD proposal even though the
+    # operator explicitly asked for a fresh take.
+    session = await session_repo.invalidate_cached_proposal(
+        db, session, target_index=session.target_index,
+    )
+
     return await _generate_next_proposal(db, session, user_id=user_id, hint=hint)
 
 
@@ -319,6 +327,19 @@ async def navigate(
         raise ValueError("Already at the last suggestion.")
 
     session = await session_repo.set_target_index(db, session, new_index=new_index)
+
+    # Cache hit: hydrate the pending_* fields from the previously
+    # generated proposal for this target. No Anthropic round-trip,
+    # so navigation is instant. The operator can still force a
+    # regeneration via ``request_alternative`` ("Another option").
+    cached = await session_repo.hydrate_pending_from_cache(
+        db, session, target_index=new_index,
+    )
+    if cached is not None:
+        return cached
+
+    # Cache miss: fall through to generation. ``_generate_next_proposal``
+    # writes the result back to the cache for future navigations.
     return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
 
 
@@ -504,6 +525,19 @@ async def _generate_next_proposal(
         tokens_in=rewrite["input_tokens"],
         tokens_out=rewrite["output_tokens"],
         cost_usd=rewrite["cost_usd"],
+    )
+
+    # Cache the proposal so navigating back to this target_index later
+    # is instant. ``request_alternative`` invalidates this entry before
+    # asking us to regenerate.
+    session = await session_repo.cache_proposal(
+        db,
+        session,
+        target_index=session.target_index,
+        target_section=session.pending_target_section,
+        proposal=session.pending_proposal,
+        rationale=session.pending_rationale,
+        clarifying_question=session.pending_clarifying_question,
     )
 
     await turn_repo.append(


### PR DESCRIPTION
## Summary

Operator: "why does navigating the resume refinement suggestions take a few seconds to load? it should be near instantaneous?"

Every Prev/Next click was calling Claude to generate a fresh rewrite for the new target. Browsing 13 suggestions = 13 round-trips at 2-5s each, and the cost is wasted when the operator is just orienting.

## Fix

Per-target proposal cache on the session row.

### Schema

New `resume_refinement_sessions.proposal_cache JSONB DEFAULT '{}'`. Migration `propcache260506` revises `inv260506`.

### Read / write paths

- **navigate** — `hydrate_pending_from_cache(target_index)` first; on hit, copy cached proposal onto `pending_*` and return. No Claude call.
- **_generate_next_proposal** — after successful generation, `cache_proposal()` writes the result back so future navigations hit.
- **request_alternative** ("Another option" button) — `invalidate_cached_proposal()` before generation so the regenerated value replaces the stale one. This is the operator's escape hatch from "I want a different take."

### Why this shape

- The operator already has the "Another option" button to force a fresh Claude call when needed
- Sessions are short-lived; JSONB compresses well — no eviction needed
- `accept` / `accept_custom` / `skip` advance the cursor; old entries staying in the cache is fine since the cursor doesn't go backward in those flows

## Test plan

- [ ] Click Next/Prev → instant transition (no spinner, no delay)
- [ ] Click "Another option" on a cached target → goes back to spinner; new proposal appears; navigating away then back shows the NEW proposal, not the previous one
- [ ] Navigate forward through all suggestions → first visit per target shows spinner (Claude call); revisits are instant
- [ ] Verify a fresh DB session starts with `proposal_cache = {}`

🤖 Generated with [Claude Code](https://claude.com/claude-code)