### PR TITLE
fix(platform_shared/admin): TOTP step-up on toggle_superuser (audit M2)

### DIFF
--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -191,12 +191,29 @@ app.include_router(resume_refinement.router)
 # mount alongside this under the same /admin prefix.
 from platform_shared.api.admin_router import build_admin_router
 from app.core.permissions import current_admin
+from app.db.session import AsyncSessionLocal
 from app.services.system.admin_user_service_factory import shared_admin_user_service
+from app.services.user.totp_service import verify_totp_code as _verify_totp_code
+
+
+# Step-up verifier for the shared toggle_superuser endpoint. Opens a
+# fresh session because the route itself does not bind one — the
+# admin object passed in carries only the user id.
+async def _superuser_step_up(admin, totp_code: str) -> bool:
+    if not getattr(admin, "totp_enabled", False):
+        # Operator without 2FA enrollment cannot perform the highest-
+        # privilege op. Forces the right shape: any user with
+        # is_superuser=True must also have TOTP set up.
+        return False
+    async with AsyncSessionLocal() as db:
+        return await _verify_totp_code(db, admin.id, totp_code)
+
 
 app.include_router(
     build_admin_router(
         service=shared_admin_user_service,
         current_admin=current_admin,
+        step_up_verify=_superuser_step_up,
     )
 )
 

--- a/packages/shared-backend/platform_shared/api/admin_router.py
+++ b/packages/shared-backend/platform_shared/api/admin_router.py
@@ -1,25 +1,37 @@
 """Shared admin user-management router factory.
 
 Each app calls ``build_admin_router(...)`` with its own ``current_admin``
-dependency and an instantiated ``AdminUserService`` and mounts the
-returned router. Routes:
+dependency, an instantiated ``AdminUserService``, and a ``step_up_verify``
+callable, then mounts the returned router. Routes:
 
     GET    /admin/users                       — list users
     PATCH  /admin/users/{id}/role             — change role
     PATCH  /admin/users/{id}/activate         — set is_active=true
     PATCH  /admin/users/{id}/deactivate       — set is_active=false
-    PATCH  /admin/users/{id}/superuser        — toggle is_superuser
+    PATCH  /admin/users/{id}/superuser        — toggle is_superuser (TOTP step-up required)
     GET    /admin/stats/users                 — user count summary
 
 Apps remain free to mount additional admin endpoints under the same
 ``/admin`` prefix in their own routers (storage health, app-specific
 stats, domain cleanups, etc.). FastAPI handles overlapping prefixes
 across routers fine as long as paths don't collide.
+
+Step-up verification (PR fix/myjobhunter-superuser-totp-stepup):
+The ``toggle_superuser`` endpoint requires a TOTP code in the request
+body. The factory's ``step_up_verify`` callable is responsible for
+checking the code against the calling admin's enrolled secret. This
+keeps shared code free of TOTP-specific imports while letting each app
+plug in its own verifier (e.g. MJH's ``verify_totp_code`` from
+``app.services.user.totp_service``). A consumer that does NOT have TOTP
+infrastructure cannot mount this router safely — by design, since the
+audit flagged unconditional ``toggle_superuser`` flips as a Medium-
+severity defect (a leaked admin session token grants permanent
+superuser persistence).
 """
 from __future__ import annotations
 
 import uuid
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -27,15 +39,25 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from platform_shared.schemas.admin_user import (
     AdminUserRead,
     AdminUserRoleUpdate,
+    SuperuserToggleRequest,
     UserStats,
 )
 from platform_shared.services.admin_user_service import AdminUserService
+
+
+StepUpVerifier = Callable[[Any, str], Awaitable[bool]]
+"""Signature: ``(admin_user, totp_code) -> bool``.
+
+Returns True when the code is valid for the given admin, False
+otherwise. The router treats False as a 403 step-up failure.
+"""
 
 
 def build_admin_router(
     *,
     service: AdminUserService,
     current_admin: Callable[..., Any],
+    step_up_verify: StepUpVerifier,
     response_model: type[Any] = AdminUserRead,
 ) -> APIRouter:
     """Construct the shared admin router.
@@ -44,8 +66,11 @@ def build_admin_router(
         service: The app's instance of ``AdminUserService`` (carries the
             User class + unit_of_work / session_factory).
         current_admin: The app's FastAPI dependency that yields a User
-            after gating on ``Role.ADMIN``. Each app builds its own via
-            ``platform_shared.core.permissions.require_role``.
+            after gating on ``Role.ADMIN`` / ``is_superuser``. Each app
+            builds its own.
+        step_up_verify: Callable that verifies a TOTP code against the
+            calling admin's enrolled secret. REQUIRED — the router
+            refuses to flip ``is_superuser`` without it.
         response_model: Optional override for the user response schema.
             Defaults to ``AdminUserRead``. Apps that want to return
             richer per-user fields can subclass it and pass the
@@ -113,8 +138,19 @@ def build_admin_router(
     )
     async def toggle_superuser(
         user_id: uuid.UUID,
+        body: SuperuserToggleRequest,
         admin: Any = Depends(current_admin),
     ) -> Any:
+        # Step-up gate: the highest-privilege op in the system requires
+        # a fresh TOTP code, not just an active session token. Audit-flagged
+        # 2026-05-06 — a leaked admin session token would otherwise grant
+        # permanent superuser persistence.
+        ok = await step_up_verify(admin, body.totp_code)
+        if not ok:
+            raise HTTPException(
+                status_code=403,
+                detail="step_up_failed",
+            )
         try:
             return await service.toggle_superuser(user_id, admin)
         except PermissionError as exc:

--- a/packages/shared-backend/platform_shared/schemas/admin_user.py
+++ b/packages/shared-backend/platform_shared/schemas/admin_user.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import uuid
 
-from pydantic import BaseModel, ConfigDict, EmailStr
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 from platform_shared.core.permissions import Role
 
@@ -39,6 +39,27 @@ class AdminUserRoleUpdate(BaseModel):
     """Body for PATCH /admin/users/{id}/role."""
 
     role: Role
+
+
+class SuperuserToggleRequest(BaseModel):
+    """Body for PATCH /admin/users/{id}/superuser.
+
+    Step-up auth: the calling admin must supply a current TOTP code
+    (or a recovery code) along with the toggle. The router's
+    ``step_up_verify`` callable validates it against the admin's
+    enrolled secret. A leaked session token alone is NOT sufficient
+    to flip the most-privileged flag in the system.
+    """
+
+    totp_code: str = Field(
+        ...,
+        min_length=1,
+        max_length=20,
+        description=(
+            "Current 6-digit TOTP code or a recovery code from the "
+            "calling admin's authenticator. Required."
+        ),
+    )
 
 
 class UserStats(BaseModel):

--- a/packages/shared-backend/tests/test_admin_router_stepup.py
+++ b/packages/shared-backend/tests/test_admin_router_stepup.py
@@ -1,0 +1,162 @@
+"""Tests for the ``toggle_superuser`` step-up gate in
+``platform_shared.api.admin_router``.
+
+Verifies that the router refuses to flip ``is_superuser`` without a
+valid TOTP code, and that the validation surfaces as the right HTTP
+status. Service-layer behaviour (self-target, missing-user, etc.) is
+tested separately in ``test_admin_user_service.py``.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from platform_shared.api.admin_router import build_admin_router
+from platform_shared.core.permissions import Role
+from platform_shared.services.admin_user_service import AdminUserService
+
+
+class _FakeUser:
+    def __init__(
+        self,
+        *,
+        id: uuid.UUID | None = None,
+        role: Role = Role.ADMIN,
+        is_superuser: bool = True,
+        is_active: bool = True,
+        is_verified: bool = True,
+        email: str = "admin@example.com",
+        name: str = "Admin",
+    ) -> None:
+        self.id = id or uuid.uuid4()
+        self.role = role
+        self.is_superuser = is_superuser
+        self.is_active = is_active
+        self.is_verified = is_verified
+        self.email = email
+        self.name = name
+
+
+def _build_app(
+    *,
+    target_user: _FakeUser,
+    admin_user: _FakeUser,
+    step_up_verify: AsyncMock,
+) -> FastAPI:
+    fake_db = MagicMock(name="db")
+
+    @asynccontextmanager
+    async def fake_uow():
+        yield fake_db
+
+    @asynccontextmanager
+    async def fake_factory():
+        yield fake_db
+
+    service = AdminUserService(
+        user_model=_FakeUser,
+        unit_of_work=fake_uow,
+        async_session_factory=fake_factory,
+    )
+
+    async def fake_current_admin() -> _FakeUser:
+        return admin_user
+
+    # Patch the repo on the imported module — must match the path the
+    # service uses internally.
+    from platform_shared.repositories import admin_user_repo
+
+    admin_user_repo.get_by_id = AsyncMock(return_value=target_user)  # type: ignore[assignment]
+
+    router = build_admin_router(
+        service=service,
+        current_admin=fake_current_admin,
+        step_up_verify=step_up_verify,
+    )
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_toggle_superuser_rejects_missing_totp_code() -> None:
+    """No body → 422 (Pydantic validation; totp_code is required)."""
+    target = _FakeUser(is_superuser=False)
+    admin = _FakeUser()
+    verifier = AsyncMock(return_value=True)
+    app = _build_app(target_user=target, admin_user=admin, step_up_verify=verifier)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.patch(
+            f"/admin/users/{target.id}/superuser",
+            json={},
+        )
+    assert resp.status_code == 422
+    assert verifier.await_count == 0
+    assert target.is_superuser is False
+
+
+@pytest.mark.asyncio
+async def test_toggle_superuser_rejects_invalid_totp_code() -> None:
+    """Step-up verifier returns False → 403 step_up_failed."""
+    target = _FakeUser(is_superuser=False)
+    admin = _FakeUser()
+    verifier = AsyncMock(return_value=False)
+    app = _build_app(target_user=target, admin_user=admin, step_up_verify=verifier)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.patch(
+            f"/admin/users/{target.id}/superuser",
+            json={"totp_code": "000000"},
+        )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "step_up_failed"
+    verifier.assert_awaited_once_with(admin, "000000")
+    # Service must NOT have flipped the flag.
+    assert target.is_superuser is False
+
+
+@pytest.mark.asyncio
+async def test_toggle_superuser_succeeds_with_valid_totp_code() -> None:
+    """Step-up verifier returns True → service flips the flag."""
+    target = _FakeUser(is_superuser=False)
+    admin = _FakeUser()
+    verifier = AsyncMock(return_value=True)
+    app = _build_app(target_user=target, admin_user=admin, step_up_verify=verifier)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.patch(
+            f"/admin/users/{target.id}/superuser",
+            json={"totp_code": "123456"},
+        )
+    assert resp.status_code == 200
+    verifier.assert_awaited_once_with(admin, "123456")
+    assert target.is_superuser is True
+
+
+@pytest.mark.asyncio
+async def test_toggle_superuser_step_up_runs_before_self_target_check() -> None:
+    """Self-target attempts must still pay the step-up cost.
+
+    Belt-and-braces: even if a malicious flow somehow bypasses the
+    service-layer self-target guard, the step-up gate fires first.
+    """
+    admin = _FakeUser()
+    verifier = AsyncMock(return_value=False)
+    # target == admin — service would raise ValueError, but we should
+    # 403 on step-up failure FIRST and never reach the service.
+    app = _build_app(target_user=admin, admin_user=admin, step_up_verify=verifier)
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as client:
+        resp = await client.patch(
+            f"/admin/users/{admin.id}/superuser",
+            json={"totp_code": "wrong"},
+        )
+    assert resp.status_code == 403
+    assert resp.json()["detail"] == "step_up_failed"


### PR DESCRIPTION
## Summary

Closes the **M2** finding from the 2026-05-06 security audit. `toggle_superuser` is the highest-privilege op in the system — flipping any user's `is_superuser` to True grants permanent admin access — and was protected only by an active session token. A leaked admin token would have silently granted permanent superuser persistence with no second factor.

## What changed

Backend only — no frontend admin-user-management page exists in MJH yet, so the route is currently unused from any UI. This prepares the shape for when one's built.

- New schema `SuperuserToggleRequest { totp_code: str }` — required body
- `build_admin_router(step_up_verify=...)` is now a **required** kwarg. A consumer that doesn't have TOTP infrastructure cannot mount this router — by design, since shipping the endpoint without step-up was the audit defect.
- Step-up failure returns `403 {"detail": "step_up_failed"}` BEFORE the service-layer self-target / lookup checks fire (a wrong code shouldn't leak whether the target exists)
- MJH's `main.py` wires `_superuser_step_up` which delegates to the existing `verify_totp_code` helper

## Tests

4 new router-level tests in `test_admin_router_stepup.py`:
- missing `totp_code` → 422 (Pydantic validation)
- invalid code → 403 `step_up_failed`
- valid code → 200, service flips the flag
- self-target with bad code → 403 (step-up fires before self-target ValueError)

Existing 16 service-layer tests still green (20/20 total in shared package).

## ⚠️ Operational migration

For the only existing superuser (`jasonykwon91@gmail.com`): confirm TOTP is enrolled BEFORE deploying. Without enrollment, future `toggle_superuser` calls will return 403 `step_up_failed` because `totp_enabled` is False.

The operator already had TOTP enrolled per session memory, so this is just a sanity check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)