### PR TITLE
fix(myjobhunter/resume): clarifying-question answer feeds Claude, not the resume

### DIFF
--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ClarifyingPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ClarifyingPanel.tsx
@@ -24,7 +24,7 @@ export default function ClarifyingPanel({
         value={customText}
         onChange={(e) => onCustomTextChange(e.target.value)}
         rows={3}
-        placeholder="Your answer or your own rewrite…"
+        placeholder="Type your answer — I'll use it to compose a suggestion."
         className="w-full rounded-md border border-border bg-background p-2 text-sm"
       />
       <div className="flex justify-end">
@@ -33,7 +33,7 @@ export default function ClarifyingPanel({
           onClick={onSubmit}
           disabled={!customText.trim()}
         >
-          Use this
+          Submit answer
         </LoadingButton>
       </div>
     </div>

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -84,6 +84,27 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
     }
   }
 
+  // Distinct from handleCustom: when Claude asked a clarifying question,
+  // the operator's typed answer is CONTEXT for Claude to compose a
+  // better proposal — not the rewrite itself. Pipe it through
+  // request_alternative as the ``hint`` so the regenerated proposal
+  // reflects the answer. The cache for the current target is
+  // invalidated server-side, so the new proposal lands fresh.
+  async function handleClarifySubmit() {
+    if (!customText.trim()) return;
+    try {
+      await requestAlternative({
+        id: session.id,
+        hint: customText.trim(),
+      }).unwrap();
+      showSuccess("Got it — composing a suggestion with your context.");
+      resetMode();
+      setCustomText("");
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
   async function handleAlternative() {
     try {
       await requestAlternative({
@@ -151,7 +172,7 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
         clarifyingQuestion={clarifyingQuestion}
         customText={customText}
         onCustomTextChange={setCustomText}
-        onClarifySubmit={handleCustom}
+        onClarifySubmit={handleClarifySubmit}
         proposal={proposal}
         rationale={rationale}
         isPending={isPending}


### PR DESCRIPTION
## Summary

Operator: "i don't want to manually rewrite bullet points in my resume. i want you to come up with a response. if there's bits and pieces of information that will help you form a better response then ask that. i don't want to just rewrite myself."

## The bug

When Claude returned a `clarifying_question`, the textarea + "Use this" button was wired to `accept_custom` (`POST /sessions/{id}/custom`) — which uses the typed text **verbatim as the bullet**. The operator's answer was becoming the resume bullet.

## The fix

Route the clarifying-question answer to `request_alternative` (`POST /sessions/{id}/alternative`) with the answer as the `hint` parameter. Claude composes a fresh proposal informed by the answer; operator can then accept / regenerate / skip.

The cache invalidation in `request_alternative` already drops the stale proposal for the current target before regenerating, so the answer-informed proposal lands fresh.

## UX copy changes

- Button: "Use this" → "Submit answer" (clearer that the text is being submitted FOR Claude, not used AS the rewrite)
- Placeholder: "Your answer or your own rewrite…" → "Type your answer — I'll use it to compose a suggestion."
- Toast: "Got it — composing a suggestion with your context." so the operator sees the AI is working with their input

## What stays the same

The explicit "Custom rewrite" mode (Write my own button) is unchanged — that's the path for "I want to write this bullet myself." A clarifying-question answer is a different intent and now gets a different code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)