### PR TITLE
test(myjobhunter): backfill resume cache+prefetch + invite cancel UX

### DIFF
--- a/apps/myjobhunter/backend/tests/test_resume_refinement_proposal_cache.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_proposal_cache.py
@@ -1,0 +1,371 @@
+"""Tests for the proposal-cache + prefetch behavior on the
+resume-refinement session flow.
+
+Covers the user-visible contract of the cache shipped in PR #341 + the
+prefetch shipped in PR #344:
+
+  * ``navigate`` checks the cache first; cache HIT does NOT call Claude.
+  * ``navigate`` cache MISS falls through to ``_generate_next_proposal``.
+  * ``_prefetch_all_proposals`` calls Claude in parallel for every
+    target, writes each result to the cache, and degrades gracefully
+    on per-target failure.
+  * ``_prefetch_all_proposals`` honors the concurrency cap so a session
+    with many targets does not flood Anthropic.
+  * ``request_alternative`` invalidates the cache for the current
+    target before regeneration.
+
+All tests mock the DB-coupled repository functions and the Claude-
+coupled rewrite service. No DB, no network. Behavioral guarantees
+above are what matter, not the SQLAlchemy plumbing those helpers do
+under the hood — that's covered by integration tests when the conftest
+DB is available.
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.resume_refinement import session_service
+
+
+def _fake_session(
+    *,
+    targets: list[dict] | None = None,
+    target_index: int = 0,
+    proposal_cache: dict | None = None,
+):
+    """Lightweight stand-in for a ``ResumeRefinementSession`` row.
+
+    Carries only the attributes the cache + prefetch helpers actually
+    read. Mutations (like ``proposal_cache``) are visible to assertions
+    via direct attribute access, which is exactly what the production
+    flush-then-refresh cycle would yield.
+    """
+    s = MagicMock(spec=[])
+    s.id = uuid.uuid4()
+    s.user_id = uuid.uuid4()
+    s.improvement_targets = targets or []
+    s.target_index = target_index
+    s.current_draft = "## Resume\n- bullet 1"
+    s.proposal_cache = proposal_cache or {}
+    s.pending_target_section = None
+    s.pending_proposal = None
+    s.pending_rationale = None
+    s.pending_clarifying_question = None
+    s.total_tokens_in = 0
+    s.total_tokens_out = 0
+    s.total_cost_usd = Decimal("0")
+    s.turn_count = 0
+    return s
+
+
+def _target(section: str = "summary") -> dict:
+    return {
+        "section": section,
+        "current_text": "old text",
+        "improvement_type": "tighten_phrasing",
+        "severity": "medium",
+        "notes": None,
+    }
+
+
+def _rewrite_proposal(text: str = "new text") -> dict:
+    return {
+        "kind": "proposal",
+        "rewritten_text": text,
+        "rationale": "tighter phrasing",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cost_usd": Decimal("0.001"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# navigate — cache hit / miss
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_navigate_cache_hit_skips_claude_call() -> None:
+    """When ``proposal_cache`` has an entry for the destination target,
+    ``navigate`` MUST hydrate ``pending_*`` from cache and NOT invoke
+    the Claude rewrite service. This is the entire point of the cache —
+    nav becomes instant on revisit.
+    """
+    targets = [_target("a"), _target("b")]
+    cached_session = _fake_session(
+        targets=targets,
+        target_index=0,
+        proposal_cache={
+            "1": {
+                "section": "b",
+                "proposal": "cached b proposal",
+                "rationale": "cached b rationale",
+                "clarifying_question": None,
+            }
+        },
+    )
+
+    db = MagicMock()
+    rewrite_mock = AsyncMock(side_effect=AssertionError("Claude must NOT be called"))
+
+    async def fake_load_active(_db, session_id, user_id):
+        return cached_session
+
+    async def fake_set_target_index(_db, session, *, new_index):
+        session.target_index = new_index
+        return session
+
+    async def fake_hydrate(_db, session, *, target_index):
+        entry = session.proposal_cache.get(str(target_index))
+        if not entry:
+            return None
+        session.pending_target_section = entry["section"]
+        session.pending_proposal = entry["proposal"]
+        session.pending_rationale = entry["rationale"]
+        session.pending_clarifying_question = entry["clarifying_question"]
+        return session
+
+    with (
+        patch.object(session_service, "_load_active", new=fake_load_active),
+        patch.object(
+            session_service.session_repo,
+            "set_target_index",
+            new=fake_set_target_index,
+        ),
+        patch.object(
+            session_service.session_repo,
+            "hydrate_pending_from_cache",
+            new=fake_hydrate,
+        ),
+        patch.object(session_service.rewrite_service, "run_rewrite", new=rewrite_mock),
+    ):
+        result = await session_service.navigate(
+            db=db,
+            user_id=cached_session.user_id,
+            session_id=cached_session.id,
+            direction="next",
+        )
+
+    assert result is cached_session
+    assert result.target_index == 1
+    assert result.pending_proposal == "cached b proposal"
+    assert rewrite_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_navigate_cache_miss_falls_through_to_generation() -> None:
+    """When the cache has no entry for the destination target,
+    ``navigate`` MUST call ``_generate_next_proposal`` (which itself
+    calls Claude + writes the result back to cache for next time).
+    """
+    targets = [_target("a"), _target("b")]
+    session = _fake_session(targets=targets, target_index=0, proposal_cache={})
+    db = MagicMock()
+
+    async def fake_load_active(_db, session_id, user_id):
+        return session
+
+    async def fake_set_target_index(_db, sess, *, new_index):
+        sess.target_index = new_index
+        return sess
+
+    generate_mock = AsyncMock(return_value=session)
+
+    with (
+        patch.object(session_service, "_load_active", new=fake_load_active),
+        patch.object(
+            session_service.session_repo,
+            "set_target_index",
+            new=fake_set_target_index,
+        ),
+        patch.object(
+            session_service.session_repo,
+            "hydrate_pending_from_cache",
+            new=AsyncMock(return_value=None),  # cache miss
+        ),
+        patch.object(session_service, "_generate_next_proposal", new=generate_mock),
+    ):
+        await session_service.navigate(
+            db=db,
+            user_id=session.user_id,
+            session_id=session.id,
+            direction="next",
+        )
+
+    generate_mock.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# _prefetch_all_proposals — parallel fanout, failure tolerance
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_prefetch_writes_each_target_to_cache() -> None:
+    """Happy path: every target gets a proposal, every proposal lands
+    in the cache via ``cache_proposal``.
+    """
+    targets = [_target(f"section-{i}") for i in range(3)]
+    session = _fake_session(targets=targets)
+    db = MagicMock()
+
+    rewrite_mock = AsyncMock(
+        side_effect=[
+            _rewrite_proposal(f"proposal-{i}") for i in range(3)
+        ],
+    )
+
+    cache_calls: list[int] = []
+
+    async def fake_cache_proposal(_db, sess, *, target_index, **_):
+        cache_calls.append(target_index)
+        return sess
+
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    with (
+        patch.object(session_service.rewrite_service, "run_rewrite", new=rewrite_mock),
+        patch.object(
+            session_service.session_repo,
+            "cache_proposal",
+            new=fake_cache_proposal,
+        ),
+    ):
+        await session_service._prefetch_all_proposals(
+            db, session, user_id=session.user_id,
+        )
+
+    assert rewrite_mock.await_count == 3
+    assert sorted(cache_calls) == [0, 1, 2]
+    # Token counters MUST roll up so the operator's session totals
+    # reflect the prefetch spend.
+    assert session.total_tokens_in == 300
+    assert session.total_tokens_out == 150
+
+
+@pytest.mark.asyncio
+async def test_prefetch_one_target_failure_does_not_block_others() -> None:
+    """Per-target Claude failures degrade gracefully: the failing target
+    is left out of the cache, others still land. Session still ships.
+    """
+    targets = [_target(f"section-{i}") for i in range(3)]
+    session = _fake_session(targets=targets)
+    db = MagicMock()
+
+    async def flaky_rewrite(*args, **kwargs):
+        target = kwargs.get("target", {})
+        if target.get("section") == "section-1":
+            raise RuntimeError("Claude blew up on target 1")
+        return _rewrite_proposal(f"proposal for {target.get('section')}")
+
+    cache_calls: list[int] = []
+
+    async def fake_cache_proposal(_db, sess, *, target_index, **_):
+        cache_calls.append(target_index)
+        return sess
+
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    with (
+        patch.object(
+            session_service.rewrite_service,
+            "run_rewrite",
+            new=AsyncMock(side_effect=flaky_rewrite),
+        ),
+        patch.object(
+            session_service.session_repo,
+            "cache_proposal",
+            new=fake_cache_proposal,
+        ),
+    ):
+        result = await session_service._prefetch_all_proposals(
+            db, session, user_id=session.user_id,
+        )
+
+    # Two targets succeeded; the failing one was simply skipped.
+    assert sorted(cache_calls) == [0, 2]
+    # Session still returned (no exception propagated) so start_session
+    # can still serve the operator a usable session.
+    assert result is session
+
+
+@pytest.mark.asyncio
+async def test_prefetch_caps_in_flight_claude_calls() -> None:
+    """The semaphore caps concurrency at ``_PREFETCH_CONCURRENCY`` so a
+    session with many targets does not flood Anthropic with simultaneous
+    requests. Verify by counting peak in-flight calls during prefetch.
+    """
+    targets = [_target(f"section-{i}") for i in range(10)]
+    session = _fake_session(targets=targets)
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+
+    in_flight = 0
+    peak_in_flight = 0
+    lock = asyncio.Lock()
+
+    async def slow_rewrite(*args, **kwargs):
+        nonlocal in_flight, peak_in_flight
+        async with lock:
+            in_flight += 1
+            peak_in_flight = max(peak_in_flight, in_flight)
+        try:
+            await asyncio.sleep(0.01)
+            return _rewrite_proposal()
+        finally:
+            async with lock:
+                in_flight -= 1
+
+    async def fake_cache_proposal(_db, sess, **_):
+        return sess
+
+    with (
+        patch.object(
+            session_service.rewrite_service,
+            "run_rewrite",
+            new=AsyncMock(side_effect=slow_rewrite),
+        ),
+        patch.object(
+            session_service.session_repo,
+            "cache_proposal",
+            new=fake_cache_proposal,
+        ),
+    ):
+        await session_service._prefetch_all_proposals(
+            db, session, user_id=session.user_id,
+        )
+
+    # The cap is exposed as ``_PREFETCH_CONCURRENCY``. Peak observed
+    # parallelism must never exceed it; with 10 targets and the default
+    # cap of 5 we expect to actually hit the cap.
+    assert peak_in_flight <= session_service._PREFETCH_CONCURRENCY
+    assert peak_in_flight == session_service._PREFETCH_CONCURRENCY
+
+
+@pytest.mark.asyncio
+async def test_prefetch_with_empty_targets_is_noop() -> None:
+    """No targets → no Claude calls, session returned unchanged."""
+    session = _fake_session(targets=[])
+    db = MagicMock()
+    rewrite_mock = AsyncMock(side_effect=AssertionError("must not run"))
+
+    with patch.object(
+        session_service.rewrite_service, "run_rewrite", new=rewrite_mock,
+    ):
+        result = await session_service._prefetch_all_proposals(
+            db, session, user_id=session.user_id,
+        )
+
+    assert result is session
+    assert rewrite_mock.await_count == 0

--- a/apps/myjobhunter/frontend/src/features/admin/invites/__tests__/InviteRow.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/invites/__tests__/InviteRow.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the two-click cancel-invite UX (PR #335).
+ *
+ * Covers the state machine:
+ *   * idle → trash icon
+ *   * first click → red "Confirm?" pill, mutation NOT fired
+ *   * second click within 3s window → mutation fires, success toast
+ *   * 3s timeout → reverts to trash, no side effect
+ *   * blur during confirming → reverts to trash, no side effect
+ *   * mutation error → error toast surfaces
+ *
+ * Uses ``fireEvent`` (synchronous) rather than ``userEvent`` so the
+ * fake-timer interaction stays simple — userEvent v14's async pump
+ * doesn't compose cleanly with vi.useFakeTimers in this test setup.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+
+import InviteRow from "../InviteRow";
+import type { Invite } from "@/types/invite/invite";
+
+const showSuccess = vi.fn();
+const showError = vi.fn();
+let cancelInviteUnwrap: ReturnType<typeof vi.fn>;
+let isCancelling = false;
+
+vi.mock("lucide-react", () => ({
+  Trash2: () => <span data-testid="icon-trash" />,
+}));
+
+vi.mock("@platform/ui", () => ({
+  showSuccess: (...args: unknown[]) => showSuccess(...args),
+  showError: (...args: unknown[]) => showError(...args),
+  extractErrorMessage: (err: unknown) =>
+    err instanceof Error ? err.message : "unknown error",
+}));
+
+vi.mock("@/store/invitesApi", () => ({
+  useCancelInviteMutation: () => [
+    vi.fn(() => ({ unwrap: cancelInviteUnwrap })),
+    { isLoading: isCancelling },
+  ],
+}));
+
+vi.mock("../InviteStatusBadge", () => ({
+  default: ({ status }: { status: string }) => (
+    <span data-testid="status-badge">{status}</span>
+  ),
+}));
+
+vi.mock("../formatInviteDate", () => ({
+  formatInviteDate: (s: string) => s,
+}));
+
+const SAMPLE_INVITE: Invite = {
+  id: "11111111-1111-1111-1111-111111111111",
+  email: "candidate@example.com",
+  status: "pending",
+  expires_at: "2026-05-13T00:00:00Z",
+  accepted_at: null,
+  accepted_by: null,
+  created_by: "22222222-2222-2222-2222-222222222222",
+  created_at: "2026-05-06T00:00:00Z",
+};
+
+describe("InviteRow cancel UX", () => {
+  beforeEach(() => {
+    showSuccess.mockClear();
+    showError.mockClear();
+    cancelInviteUnwrap = vi.fn().mockResolvedValue(undefined);
+    isCancelling = false;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders the trash button in idle state", () => {
+    render(<InviteRow invite={SAMPLE_INVITE} />);
+
+    expect(screen.getByTestId("icon-trash")).toBeInTheDocument();
+    expect(screen.queryByText(/confirm\?/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText(/cancel invite for/i)).toBeInTheDocument();
+  });
+
+  it("first click swaps to a Confirm? pill without firing the mutation", () => {
+    render(<InviteRow invite={SAMPLE_INVITE} />);
+
+    fireEvent.click(screen.getByLabelText(/cancel invite for/i));
+
+    expect(screen.getByText(/confirm\?/i)).toBeInTheDocument();
+    expect(cancelInviteUnwrap).not.toHaveBeenCalled();
+    expect(showSuccess).not.toHaveBeenCalled();
+    expect(screen.getByLabelText(/confirm cancellation/i)).toBeInTheDocument();
+  });
+
+  it("second click within the 3s window fires the cancellation", async () => {
+    render(<InviteRow invite={SAMPLE_INVITE} />);
+
+    fireEvent.click(screen.getByLabelText(/cancel invite for/i));
+    fireEvent.click(screen.getByLabelText(/confirm cancellation/i));
+
+    await waitFor(() => {
+      expect(cancelInviteUnwrap).toHaveBeenCalledTimes(1);
+    });
+    expect(showSuccess).toHaveBeenCalledWith("Invite cancelled");
+  });
+
+  it("auto-reverts to idle after 3 seconds with no side effect", () => {
+    vi.useFakeTimers();
+    render(<InviteRow invite={SAMPLE_INVITE} />);
+
+    fireEvent.click(screen.getByLabelText(/cancel invite for/i));
+    expect(screen.getByText(/confirm\?/i)).toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(3100);
+    });
+
+    expect(screen.queryByText(/confirm\?/i)).not.toBeInTheDocument();
+    expect(cancelInviteUnwrap).not.toHaveBeenCalled();
+  });
+
+  it("aborts the pending confirmation on blur", () => {
+    render(<InviteRow invite={SAMPLE_INVITE} />);
+
+    fireEvent.click(screen.getByLabelText(/cancel invite for/i));
+    expect(screen.getByText(/confirm\?/i)).toBeInTheDocument();
+
+    fireEvent.blur(screen.getByLabelText(/confirm cancellation/i));
+
+    expect(screen.queryByText(/confirm\?/i)).not.toBeInTheDocument();
+    expect(cancelInviteUnwrap).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an error toast when the mutation rejects", async () => {
+    cancelInviteUnwrap = vi.fn().mockRejectedValue(new Error("backend exploded"));
+    render(<InviteRow invite={SAMPLE_INVITE} />);
+
+    fireEvent.click(screen.getByLabelText(/cancel invite for/i));
+    fireEvent.click(screen.getByLabelText(/confirm cancellation/i));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledTimes(1);
+    });
+    expect(showError.mock.calls[0]?.[0]).toMatch(/backend exploded/);
+    expect(showSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/apps/myjobhunter/frontend/src/lib/__tests__/auth.test.ts
+++ b/apps/myjobhunter/frontend/src/lib/__tests__/auth.test.ts
@@ -1,14 +1,40 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import axios from "axios";
 
+// vi.mock factories run BEFORE module-scope statements after the
+// hoisting pass, so any helper they reference must come from
+// vi.hoisted() to be initialized in time.
+const { mockResetApiState, mockResetApiStateAction, mockDispatch } = vi.hoisted(() => {
+  const action = { type: "api/util/resetApiState" };
+  return {
+    mockResetApiStateAction: action,
+    mockResetApiState: vi.fn(() => action),
+    mockDispatch: vi.fn(),
+  };
+});
+
 // Mock axios and @platform/ui auth-store before importing auth.ts
 vi.mock("@platform/ui", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@platform/ui")>();
   return {
     ...actual,
     notifyAuthChange: vi.fn(),
+    baseApi: {
+      ...actual.baseApi,
+      util: {
+        ...actual.baseApi.util,
+        resetApiState: mockResetApiState,
+      },
+    },
   };
 });
+
+// Mock the local store so we can assert resetApiState is dispatched on
+// auth transitions (PR #340 — wipes cached /users/me etc. so the next
+// signed-in user doesn't see the previous user's identity until refresh).
+vi.mock("@/lib/store", () => ({
+  store: { dispatch: mockDispatch },
+}));
 
 // Mock the api module to control HTTP calls
 vi.mock("@/lib/api", () => ({
@@ -106,13 +132,28 @@ describe("auth helpers", () => {
       await register("u@e.com", "securepass123");
 
       expect(mockApiPost).toHaveBeenCalledTimes(1);
-      expect(mockApiPost).toHaveBeenCalledWith("/auth/register", {
-        email: "u@e.com",
-        password: "securepass123",
-      });
+      expect(mockApiPost).toHaveBeenCalledWith(
+        "/auth/register",
+        { email: "u@e.com", password: "securepass123" },
+        { headers: {} },
+      );
       // Token must NOT be set — user has to verify their email first
       expect(localStorage.getItem("token")).toBeNull();
       expect(mockNotifyAuthChange).not.toHaveBeenCalled();
+    });
+
+    it("forwards X-Turnstile-Token header when supplied", async () => {
+      mockApiPost.mockResolvedValueOnce({
+        data: { id: "uuid", email: "u@e.com" },
+      });
+
+      await register("u@e.com", "securepass123", "ts-token-abc");
+
+      expect(mockApiPost).toHaveBeenCalledWith(
+        "/auth/register",
+        { email: "u@e.com", password: "securepass123" },
+        { headers: { "X-Turnstile-Token": "ts-token-abc" } },
+      );
     });
   });
 
@@ -139,6 +180,51 @@ describe("auth helpers", () => {
     it("is safe to call when no token is stored", () => {
       expect(() => signOut()).not.toThrow();
       expect(mockNotifyAuthChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("dispatches resetApiState so the next signed-in user does not see cached responses", () => {
+      localStorage.setItem("token", "some.token");
+
+      signOut();
+
+      // Cache wipe MUST happen on signOut so a subsequent signIn from
+      // a different user doesn't render previous-user data (the
+      // 2026-05-06 "still showed mybookkeeper6 as signed-in" bug).
+      expect(mockResetApiState).toHaveBeenCalledTimes(1);
+      expect(mockDispatch).toHaveBeenCalledWith(mockResetApiStateAction);
+    });
+  });
+
+  describe("RTK Query cache reset on auth transitions", () => {
+    it("signIn dispatches resetApiState BEFORE notifyAuthChange", async () => {
+      mockApiPost.mockResolvedValueOnce({
+        data: { access_token: "fresh.token", token_type: "bearer" },
+      });
+
+      await signIn("u@e.com", "pass");
+
+      // Both must fire on a successful sign-in; order matters because
+      // the auth-change notification triggers a re-render that should
+      // refetch /users/me against the NEW token, not the previous
+      // response.
+      expect(mockResetApiState).toHaveBeenCalledTimes(1);
+      expect(mockNotifyAuthChange).toHaveBeenCalledTimes(1);
+
+      const resetOrder = mockResetApiState.mock.invocationCallOrder[0]!;
+      const notifyOrder = mockNotifyAuthChange.mock.invocationCallOrder[0]!;
+      expect(resetOrder).toBeLessThan(notifyOrder);
+    });
+
+    it("signIn does NOT reset the cache on a totp_required response", async () => {
+      mockApiPost.mockResolvedValueOnce({
+        data: { detail: "totp_required" },
+      });
+
+      await signIn("u@e.com", "pass");
+
+      // 2FA gate hit; no token issued; nothing to wipe yet.
+      expect(mockResetApiState).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
Test backfill for PRs that shipped without unit coverage.

## Backend — proposal cache + prefetch (PR #341, #344)

6 pure-mock pytest cases in `test_resume_refinement_proposal_cache.py`:
- navigate cache HIT skips Claude (the whole feature claim)
- navigate cache MISS falls through to generation
- prefetch happy path — every target's proposal lands in cache, token counters roll up
- prefetch failure tolerance — one failing target doesn't block others
- prefetch concurrency cap — peak in-flight never exceeds `_PREFETCH_CONCURRENCY`
- prefetch with empty targets is a no-op

## Frontend — cancel-invite two-click UX (PR #335)

6 Vitest cases in `InviteRow.test.tsx` covering the state machine:
- idle: trash icon, no Confirm? text
- first click: swaps to red Confirm? pill, mutation NOT fired
- second click within window: mutation fires + success toast
- 3s auto-revert: returns to trash, no side effect
- blur during confirming: aborts pending confirmation
- mutation reject: error toast surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
