### PR TITLE
feat(myjobhunter): paste-link path on Add Application — fetch + parse JD URL

### DIFF
--- a/apps/myjobhunter/backend/app/api/applications.py
+++ b/apps/myjobhunter/backend/app/api/applications.py
@@ -28,10 +28,13 @@ from __future__ import annotations
 import datetime as _dt
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from platform_shared.core.request_utils import get_client_ip
+
 from app.core.auth import current_active_user
+from app.core.rate_limit import RateLimiter
 from app.db.session import get_db
 from app.models.user.user import User
 from app.schemas.application.application_contact_create_request import ApplicationContactCreateRequest
@@ -45,9 +48,17 @@ from app.schemas.application.application_response import ApplicationResponse
 from app.schemas.application.application_update_request import ApplicationUpdateRequest
 from app.schemas.application.jd_parse_request import JdParseRequest
 from app.schemas.application.jd_parse_response import JdParseResponse
+from app.schemas.application.jd_url_extract_request import JdUrlExtractRequest
+from app.schemas.application.jd_url_extract_response import JdUrlExtractResponse
 from app.services.application import application_service
 from app.services.application.application_service import CompanyNotOwnedError
 from app.services.application.jd_parsing_service import JdParseError, parse_jd
+from app.services.extraction.jd_url_extractor import (
+    JDFetchAuthRequiredError,
+    JDFetchError,
+    JDFetchTimeoutError,
+    extract_from_url,
+)
 
 router = APIRouter()
 
@@ -56,6 +67,14 @@ _CONTACT_NOT_FOUND_DETAIL = "Contact not found"
 
 # Pagination safety cap — prevents pathological limit values.
 _MAX_LIMIT = 500
+
+# Per-IP rate limit for the JD URL extractor. 10 requests / 5 minutes is
+# generous for a legitimate operator (one-paste-per-application throughput)
+# but tight enough to prevent the endpoint being used as an SSRF probe or
+# a free third-party HTML scraper. Pre-instantiated at module import so all
+# requests share the same sliding-window state. Pattern mirrors
+# admin_invites._INVITE_INFO_LIMITER.
+_JD_URL_EXTRACT_LIMITER = RateLimiter(max_attempts=10, window_seconds=300)
 
 
 @router.get("/applications")
@@ -152,6 +171,81 @@ async def parse_job_description(
             detail=f"JD parsing failed: {exc}",
         ) from exc
     return JdParseResponse(**result.to_dict())
+
+
+@router.post(
+    "/applications/extract-from-url",
+    response_model=JdUrlExtractResponse,
+    status_code=200,
+)
+async def extract_from_url_endpoint(
+    payload: JdUrlExtractRequest,
+    request: Request,
+    user: User = Depends(current_active_user),
+) -> JdUrlExtractResponse:
+    """Fetch a job-posting URL and extract structured fields from it.
+
+    Two-tier strategy: schema.org JobPosting fast path for any modern ATS,
+    Claude HTML-text fallback for everything else. Returns the extracted
+    fields for client-side preview / form pre-fill — does NOT persist
+    an Application row (the frontend then submits ``POST /applications``
+    with the merged values once the user has reviewed them).
+
+    Rate limit: 10 requests per 5 minutes per IP. Bypassing requires
+    going through ``POST /applications/parse-jd`` (the paste-text path),
+    which has its own gating.
+
+    Status codes:
+    - 200 on success — body is the extracted ``JdUrlExtractResponse``.
+    - 400 when the URL is malformed (non-http(s), missing host).
+    - 422 ``auth_required`` when the URL is auth-walled (LinkedIn,
+      Glassdoor) or when the fetched page returned <500 visible bytes
+      after stripping. The frontend prompts the user to paste the
+      description text instead.
+    - 429 when the per-IP rate limit is exceeded.
+    - 502 when the upstream returned non-2xx, the body could not be
+      parsed, or the Claude fallback failed.
+    - 504 when the upstream fetch timed out.
+
+    No DB session — the only persistence is an ``extraction_logs`` row
+    written inside ``claude_service._record_log`` on the Tier-2 path
+    via its own session.
+    """
+    _JD_URL_EXTRACT_LIMITER.check(get_client_ip(request))
+
+    url_str = str(payload.url)
+    try:
+        result = await extract_from_url(url_str, user_id=user.id)
+    except JDFetchAuthRequiredError as exc:
+        # 422 with a stable ``detail`` literal so the frontend can route
+        # on it deterministically without parsing the human-readable
+        # message.
+        raise HTTPException(status_code=422, detail="auth_required") from exc
+    except JDFetchTimeoutError as exc:
+        raise HTTPException(
+            status_code=504,
+            detail=f"Timed out fetching URL: {exc}",
+        ) from exc
+    except JDFetchError as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"Couldn't extract JD from URL: {exc}",
+        ) from exc
+    except ValueError as exc:
+        # Defensive — Pydantic AnyHttpUrl should reject malformed URLs at
+        # the schema layer, but service-level _validate_url adds a second
+        # check for things like ``ftp://`` that slip through ``AnyHttpUrl``.
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return JdUrlExtractResponse(
+        title=result.title,
+        company=result.company,
+        location=result.location,
+        description_html=result.description_html,
+        requirements_text=result.requirements_text,
+        summary=result.summary,
+        source_url=result.source_url,
+    )
 
 
 @router.post("/applications", response_model=ApplicationResponse, status_code=201)

--- a/apps/myjobhunter/backend/app/schemas/application/jd_url_extract_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/jd_url_extract_request.py
@@ -1,0 +1,32 @@
+"""Pydantic schema for POST /applications/extract-from-url request body.
+
+The endpoint accepts a single URL pointing at a job posting (career-page
+listing, ATS posting, etc.). The service tries the schema.org JobPosting
+fast path first, then falls back to a Claude HTML-text extraction. The
+parsed result is returned for client-side preview / form pre-fill — no
+Application row is created here.
+
+``url`` is validated as ``AnyHttpUrl`` so the caller cannot submit a
+``file://``, ``data:``, or otherwise non-HTTP scheme.  Schema-level
+URL validation runs BEFORE the route handler, so an invalid URL never
+reaches the rate limiter or fetcher.
+
+``extra='forbid'`` defends against forwarding extra fields (cargo-cult
+copying of body shape) and matches the rest of the application schemas.
+"""
+from __future__ import annotations
+
+from pydantic import AnyHttpUrl, BaseModel, ConfigDict, field_serializer
+
+
+class JdUrlExtractRequest(BaseModel):
+    """Body for POST /applications/extract-from-url."""
+
+    url: AnyHttpUrl
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_serializer("url")
+    def _serialize_url(self, value: AnyHttpUrl) -> str:
+        """Coerce AnyHttpUrl to plain string when round-tripping the schema."""
+        return str(value)

--- a/apps/myjobhunter/backend/app/schemas/application/jd_url_extract_response.py
+++ b/apps/myjobhunter/backend/app/schemas/application/jd_url_extract_response.py
@@ -1,0 +1,57 @@
+"""Pydantic schema for POST /applications/extract-from-url response body.
+
+Mirrors the ``ExtractedJD`` dataclass returned by the
+``jd_url_extractor`` service. Every field is nullable except
+``source_url`` — the source URL is always echoed back so the client can
+display "fetched from <url>" when pre-filling the Add Application form.
+
+``description_html`` and ``requirements_text`` are deliberately
+typed as plain strings (not Pydantic ``Html`` / ``Text`` distinct types)
+because the frontend renders them inside a sanitized text area and a
+Markdown renderer respectively — the type-system distinction would not
+buy us anything beyond an extra coercion.
+
+The frontend converts the response into the existing
+``JdParseResponse``-shaped form pre-fill values via ``setValue`` calls
+in ``AddApplicationDialog`` — so this schema does NOT include the
+salary / remote-type / seniority fields the Claude JD-text parser
+emits. Those continue to be populated by ``POST /applications/parse-jd``
+when the operator chooses the "Paste the description text" path or
+the URL path runs through the HTML-text Claude fallback.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class JdUrlExtractResponse(BaseModel):
+    """Structured fields extracted from a job-posting URL.
+
+    All fields are nullable so the schema can represent a JD that
+    came back partial (e.g. a schema.org payload with only ``title``
+    and ``description``). The frontend pre-fills any non-null value
+    and leaves the rest blank for the operator to type in.
+    """
+
+    title: str | None = None
+    company: str | None = None
+    location: str | None = None
+
+    # Long-form HTML (preserved when the source publishes it as HTML —
+    # JobPosting.description is commonly an HTML string per schema.org).
+    description_html: str | None = None
+
+    # Plain-text or Markdown bullet list of requirements when the source
+    # surfaces them separately. May be ``None`` even on success — many
+    # postings bundle requirements into the description body.
+    requirements_text: str | None = None
+
+    # 1–3 sentence plain-English summary. Only populated when Claude is
+    # invoked on the HTML-text fallback path; the schema.org fast path
+    # leaves this null because the JobPosting payload does not carry
+    # a summary field.
+    summary: str | None = None
+
+    # Source URL is echoed back verbatim so the UI can show
+    # "Fetched from <url>" alongside the pre-fill banner.
+    source_url: str

--- a/apps/myjobhunter/backend/app/services/extraction/jd_url_extractor.py
+++ b/apps/myjobhunter/backend/app/services/extraction/jd_url_extractor.py
@@ -1,0 +1,567 @@
+"""Fetch a job-posting URL and extract structured fields from it.
+
+Two-tier strategy — schema.org fast path first, Claude HTML-text fallback
+second. The ordering is deliberate: schema.org JobPosting is the public,
+standardised contract that every modern ATS (Ashby, Greenhouse, Lever,
+Workday, Indeed) server-renders into the page, and reading it costs zero
+Claude tokens. Only when no JobPosting payload exists do we strip the
+visible HTML to text and ship it to Claude.
+
+Tier 1 — schema.org JobPosting fast path
+========================================
+- Fetch the page with httpx (15s timeout, follow redirects, send a
+  realistic User-Agent so anti-bot heuristics don't outright reject us).
+- Parse the response with BeautifulSoup using the lxml parser.
+- Find every ``<script type="application/ld+json">`` block.
+- For each block, ``json.loads`` it (handle both ``dict`` and ``list``
+  shapes — some sites embed ``{"@graph": [...]}``).
+- Pull the first object whose ``"@type" == "JobPosting"`` (case-insensitive)
+  or whose ``"@type"`` array contains ``"JobPosting"``.
+- Map ``title`` / ``hiringOrganization.name`` / ``jobLocation.address.*``
+  / ``description`` / ``responsibilities`` into the ``ExtractedJD``
+  shape.
+
+Tier 2 — HTML-to-text → Claude fallback
+=======================================
+- BeautifulSoup ``get_text(separator='\\n')`` on the response body, with
+  ``<script>``, ``<style>``, ``<noscript>``, ``<svg>`` removed first so
+  noise from minified JS doesn't drown the useful copy.
+- Collapse runs of blank lines to a single blank.
+- If the resulting text is shorter than ``_MIN_VISIBLE_BYTES`` (500 chars),
+  raise ``JDFetchAuthRequiredError`` — almost always a login wall, a CDN
+  challenge page, or a JS-only renderer that gave us a placeholder.
+- Otherwise hand the text to ``claude_service.call_claude`` with the
+  existing JD-parsing system prompt, then translate the Claude dict
+  back into the ``ExtractedJD`` shape.
+
+Auth-walled domain shortcut
+===========================
+LinkedIn job pages and Glassdoor postings live behind authentication
+that we can't bypass without an OAuth flow we don't have. Recognise
+the URL up front and raise ``JDFetchAuthRequiredError`` BEFORE making a
+network call so the operator gets clean feedback ("paste the text
+instead") and we don't waste a Claude turn on an HTML page that's
+mostly the navigation bar.
+
+Tenant scoping
+==============
+``user_id`` is only used to scope the ``extraction_logs`` row written
+by ``claude_service`` on the Tier-2 fallback. The endpoint layer
+authenticates the caller; this module never persists any other rows.
+
+Errors raised
+=============
+- ``JDFetchAuthRequiredError`` — the URL is auth-walled OR the page
+  returned a near-empty body. Mapped to HTTP 422 ``auth_required``.
+- ``JDFetchTimeoutError`` — httpx timed out. Mapped to HTTP 504.
+- ``JDFetchError`` — the fetch returned a non-2xx status, the body
+  could not be parsed, or the Claude fallback raised. Mapped to HTTP 502.
+- ``ValueError`` — the URL string is malformed (no scheme / no host).
+  Mapped to HTTP 400.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import re
+import uuid
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+import anthropic
+import httpx
+from bs4 import BeautifulSoup
+
+from app.services.extraction import claude_service
+from app.services.extraction.prompts.jd_parsing_prompt import JD_PARSING_PROMPT
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+# httpx total timeout. 15s is generous for a single-page fetch and bounds the
+# operator-blocking wait. Connect timeout defaults to the same value via
+# httpx.Timeout below — we don't need finer-grained control here.
+_FETCH_TIMEOUT_SECONDS = 15.0
+
+# A realistic User-Agent so our request looks like a desktop browser and
+# isn't summarily blocked by anti-bot defaults. Career sites rarely care
+# about UA, but a Python-default UA gets blanket-rejected by some CDNs.
+_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/123.0.0.0 Safari/537.36 "
+    "MyJobHunter/1.0 (+https://myjobhunter.app)"
+)
+
+# Below this many visible-text bytes we treat the page as auth-walled or
+# JS-rendered and surface "paste the text instead" rather than waste a
+# Claude turn on a navbar.
+_MIN_VISIBLE_BYTES = 500
+
+# Cap the body we read to bound memory + Claude input tokens.
+_MAX_FETCH_BYTES = 2_000_000  # 2 MB — every legitimate JD page fits.
+
+# Hard-coded auth-walled domains. Ordered so the most-common cases match
+# first — substring match on ``netloc`` keeps the table readable.
+_AUTH_WALLED_DOMAINS: tuple[str, ...] = (
+    "linkedin.com/jobs",
+    "linkedin.com/job/",
+    "glassdoor.com/job-listing",
+    "glassdoor.com/Job/",
+    # ``ziprecruiter.com`` posts can be read anonymously today; if that
+    # changes add it here.
+)
+
+
+# ---------------------------------------------------------------------------
+# Result + error types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class ExtractedJD:
+    """Fields extracted from a job-posting URL.
+
+    See ``app/schemas/application/jd_url_extract_response.py`` for the
+    Pydantic mirror of this shape.
+    """
+
+    title: str | None
+    company: str | None
+    location: str | None
+    description_html: str | None
+    requirements_text: str | None
+    summary: str | None
+    source_url: str
+
+
+class JDFetchError(RuntimeError):
+    """The fetch or parse failed in a way that should surface as HTTP 502.
+
+    Wraps both upstream HTTP errors (non-2xx, parse failures) and the
+    Claude fallback when it raises. The route handler stringifies this
+    for the response detail.
+    """
+
+
+class JDFetchTimeoutError(JDFetchError):
+    """The upstream fetch exceeded ``_FETCH_TIMEOUT_SECONDS`` — HTTP 504."""
+
+
+class JDFetchAuthRequiredError(JDFetchError):
+    """The URL points at an auth-walled domain or the fetched body is
+    empty enough that we infer auth is required. HTTP 422.
+
+    The frontend surfaces a "couldn't reach — paste the text instead"
+    affordance and switches to the paste-text tab.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+async def extract_from_url(url: str, *, user_id: uuid.UUID) -> ExtractedJD:
+    """Fetch ``url`` and extract structured JD fields.
+
+    Args:
+        url: Absolute http(s) URL of a job posting.
+        user_id: Caller's user ID — propagated to ``claude_service`` for
+            ``extraction_logs`` scoping on the Tier-2 fallback path.
+
+    Returns:
+        A populated :class:`ExtractedJD`. Field-level missingness is
+        signalled with ``None`` — callers should never see a ``""``.
+
+    Raises:
+        ValueError: ``url`` is not a valid absolute http(s) URL.
+        JDFetchAuthRequiredError: auth-walled domain or empty body.
+        JDFetchTimeoutError: upstream fetch timed out.
+        JDFetchError: any other fetch / parse / Claude failure.
+    """
+    parsed = _validate_url(url)
+
+    if _is_auth_walled(parsed.netloc + parsed.path):
+        logger.info("JD URL is auth-walled domain — short-circuiting: %s", url)
+        raise JDFetchAuthRequiredError(
+            "This site requires sign-in — paste the description text instead.",
+        )
+
+    html = await _fetch_html(url)
+    soup = BeautifulSoup(html, "lxml")
+
+    # Tier 1 — schema.org JobPosting fast path
+    schema_payload = _find_jobposting_schema(soup)
+    if schema_payload is not None:
+        logger.info("JD URL extracted via schema.org JobPosting: %s", url)
+        return _from_schema_org(schema_payload, source_url=url)
+
+    # Tier 2 — strip visible HTML and pass to Claude
+    visible_text = _strip_visible_text(soup)
+    if len(visible_text) < _MIN_VISIBLE_BYTES:
+        logger.info(
+            "JD URL produced %d visible bytes (<%d) — auth-walled or JS-only: %s",
+            len(visible_text),
+            _MIN_VISIBLE_BYTES,
+            url,
+        )
+        raise JDFetchAuthRequiredError(
+            "Couldn't read enough text from this page — paste the description text instead.",
+        )
+
+    return await _claude_fallback(visible_text, source_url=url, user_id=user_id)
+
+
+# ---------------------------------------------------------------------------
+# URL validation + auth-walled detection
+# ---------------------------------------------------------------------------
+
+
+def _validate_url(url: str) -> Any:
+    """Parse ``url`` and ensure scheme/netloc are present.
+
+    Raises ValueError on anything we wouldn't want to feed to httpx —
+    relative URLs, ``file://``, ``data:``, missing host, etc.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise ValueError("url must be a non-empty string")
+    parsed = urlparse(url.strip())
+    if parsed.scheme not in ("http", "https"):
+        raise ValueError(f"url scheme must be http or https, got {parsed.scheme!r}")
+    if not parsed.netloc:
+        raise ValueError("url must include a host (netloc)")
+    return parsed
+
+
+def _is_auth_walled(needle: str) -> bool:
+    """Substring match the URL path against the auth-walled domain table."""
+    haystack = needle.lower()
+    return any(domain in haystack for domain in _AUTH_WALLED_DOMAINS)
+
+
+# ---------------------------------------------------------------------------
+# httpx fetch
+# ---------------------------------------------------------------------------
+
+
+async def _fetch_html(url: str) -> str:
+    """Fetch ``url`` and return the response body as a string.
+
+    Raises:
+        JDFetchTimeoutError: on httpx timeout.
+        JDFetchAuthRequiredError: on 401/403 (most ATSes use these for
+            authenticated sections — the public posting URL won't 401
+            unless we hit an auth-walled section).
+        JDFetchError: on any other non-2xx, network error, or oversized body.
+    """
+    headers = {
+        "User-Agent": _USER_AGENT,
+        # Request HTML preferentially — some sites content-negotiate to
+        # JSON when the Accept header is too generic.
+        "Accept": (
+            "text/html,application/xhtml+xml,application/xml;q=0.9,"
+            "*/*;q=0.8"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+    }
+    timeout = httpx.Timeout(_FETCH_TIMEOUT_SECONDS)
+    try:
+        async with httpx.AsyncClient(
+            follow_redirects=True,
+            timeout=timeout,
+            headers=headers,
+        ) as client:
+            resp = await client.get(url)
+    except httpx.TimeoutException as exc:
+        raise JDFetchTimeoutError(f"Timed out fetching {url}") from exc
+    except httpx.HTTPError as exc:
+        raise JDFetchError(f"Network error fetching {url}: {exc}") from exc
+
+    if resp.status_code in (401, 403):
+        raise JDFetchAuthRequiredError(
+            f"Page returned {resp.status_code} — paste the description text instead.",
+        )
+    if resp.status_code >= 400:
+        raise JDFetchError(
+            f"Upstream returned HTTP {resp.status_code} for {url}",
+        )
+
+    # Cap body size to bound memory. ``resp.content`` is bytes — we encode
+    # the limit there since multi-byte characters can blow past a char limit.
+    if len(resp.content) > _MAX_FETCH_BYTES:
+        raise JDFetchError(
+            f"Page body exceeds {_MAX_FETCH_BYTES} bytes — refusing to parse",
+        )
+
+    return resp.text
+
+
+# ---------------------------------------------------------------------------
+# schema.org JobPosting parsing
+# ---------------------------------------------------------------------------
+
+
+def _find_jobposting_schema(soup: BeautifulSoup) -> dict | None:
+    """Walk all ``<script type="application/ld+json">`` blocks and return
+    the first JobPosting payload found, or ``None`` if no block matches.
+
+    Handles three real-world shapes:
+    - A single JobPosting dict at the top level
+    - A list of objects (multiple types on one page)
+    - An ``@graph`` wrapper holding a list of typed objects
+
+    Type matching is case-insensitive and handles both ``"@type": "JobPosting"``
+    and ``"@type": ["JobPosting", ...]`` forms.
+    """
+    for script in soup.find_all("script", attrs={"type": "application/ld+json"}):
+        raw = script.string or script.get_text() or ""
+        if not raw.strip():
+            continue
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            # Some sites have multiple concatenated JSON blocks. Skip the
+            # block silently — Tier 2 (Claude) will catch the content.
+            continue
+
+        candidates = _flatten_ld_candidates(data)
+        for obj in candidates:
+            if _is_jobposting(obj):
+                return obj
+    return None
+
+
+def _flatten_ld_candidates(data: object) -> list[dict]:
+    """Yield every dict-like object from a JSON-LD blob.
+
+    JSON-LD payloads can be:
+    - ``{...}``                    — single object
+    - ``[{...}, {...}]``           — list of objects
+    - ``{"@graph": [{...}, ...]}`` — graph wrapper
+    """
+    out: list[dict] = []
+    if isinstance(data, dict):
+        out.append(data)
+        graph = data.get("@graph")
+        if isinstance(graph, list):
+            out.extend(item for item in graph if isinstance(item, dict))
+    elif isinstance(data, list):
+        out.extend(item for item in data if isinstance(item, dict))
+    return out
+
+
+def _is_jobposting(obj: dict) -> bool:
+    """Return True if ``@type`` indicates a JobPosting (case-insensitive)."""
+    type_field = obj.get("@type")
+    if isinstance(type_field, str):
+        return type_field.lower() == "jobposting"
+    if isinstance(type_field, list):
+        return any(
+            isinstance(t, str) and t.lower() == "jobposting" for t in type_field
+        )
+    return False
+
+
+def _from_schema_org(payload: dict, *, source_url: str) -> ExtractedJD:
+    """Map a JobPosting JSON-LD dict into an :class:`ExtractedJD`."""
+    title = _str_or_none(payload.get("title"))
+
+    # ``hiringOrganization`` may be a string or a nested Organization object.
+    company = None
+    org = payload.get("hiringOrganization")
+    if isinstance(org, dict):
+        company = _str_or_none(org.get("name"))
+    elif isinstance(org, str):
+        company = _str_or_none(org)
+
+    location = _extract_schema_location(payload)
+
+    # ``description`` is commonly an HTML string per schema.org spec.
+    description_html = _str_or_none(payload.get("description"))
+
+    # ``responsibilities`` — schema.org allows either a plain string or
+    # a list. Newline-join lists into a readable bullet block.
+    requirements_text = _extract_schema_requirements(payload)
+
+    return ExtractedJD(
+        title=title,
+        company=company,
+        location=location,
+        description_html=description_html,
+        requirements_text=requirements_text,
+        # No summary — JobPosting payloads don't expose a short summary.
+        summary=None,
+        source_url=source_url,
+    )
+
+
+def _extract_schema_location(payload: dict) -> str | None:
+    """Pull a human-readable location string from schema.org JobPosting.
+
+    ``jobLocation`` may be a single Place, a list of Places, or absent.
+    Each Place has an ``address`` (PostalAddress) with addressLocality /
+    addressRegion / addressCountry. We join the parts that exist.
+    """
+    locations = payload.get("jobLocation")
+    if isinstance(locations, dict):
+        return _format_postal_address(locations.get("address"))
+    if isinstance(locations, list):
+        for loc in locations:
+            if isinstance(loc, dict):
+                formatted = _format_postal_address(loc.get("address"))
+                if formatted:
+                    return formatted
+    # Some payloads put the address one level up.
+    if "address" in payload:
+        return _format_postal_address(payload.get("address"))
+    return None
+
+
+def _format_postal_address(address: object) -> str | None:
+    """Join PostalAddress fields into ``locality, region, country``."""
+    if not isinstance(address, dict):
+        if isinstance(address, str):
+            return _str_or_none(address)
+        return None
+    parts: list[str] = []
+    for key in ("addressLocality", "addressRegion", "addressCountry"):
+        value = address.get(key)
+        # ``addressCountry`` can itself be ``{"@type": "Country", "name": "US"}``.
+        if isinstance(value, dict):
+            value = value.get("name")
+        cleaned = _str_or_none(value)
+        if cleaned and cleaned not in parts:
+            parts.append(cleaned)
+    return ", ".join(parts) if parts else None
+
+
+def _extract_schema_requirements(payload: dict) -> str | None:
+    """Newline-join JobPosting.responsibilities (string or list)."""
+    raw = payload.get("responsibilities")
+    if isinstance(raw, str):
+        return _str_or_none(raw)
+    if isinstance(raw, list):
+        items = [_str_or_none(item) for item in raw]
+        items = [i for i in items if i]
+        return "\n".join(items) if items else None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# HTML → text + Claude fallback
+# ---------------------------------------------------------------------------
+
+
+_BLANKS = re.compile(r"\n{3,}")
+
+
+def _strip_visible_text(soup: BeautifulSoup) -> str:
+    """Return the page's visible text with noise stripped.
+
+    Removes ``<script>``, ``<style>``, ``<noscript>``, ``<svg>`` first
+    so minified JS / inline CSS doesn't pollute the corpus, then collapses
+    runs of 3+ blank lines into 2.
+    """
+    for tag in soup(["script", "style", "noscript", "svg"]):
+        tag.decompose()
+    text = soup.get_text(separator="\n")
+    # Collapse Windows line endings + excessive blank runs.
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = _BLANKS.sub("\n\n", text)
+    return text.strip()
+
+
+async def _claude_fallback(
+    visible_text: str,
+    *,
+    source_url: str,
+    user_id: uuid.UUID,
+) -> ExtractedJD:
+    """Send the stripped visible text to Claude and translate the response.
+
+    Reuses the existing JD-parsing system prompt and ``call_claude``
+    plumbing so token/cost accounting flows through ``extraction_logs``
+    the same way the paste-text path does. The Claude dict shape is
+    well-known (see ``jd_parsing_prompt.py``); we project the relevant
+    fields onto :class:`ExtractedJD` here and bundle the must-have +
+    nice-to-have lists into ``requirements_text`` so the form pre-fill
+    has something concrete to display.
+    """
+    try:
+        parsed = await claude_service.call_claude(
+            system_prompt=JD_PARSING_PROMPT,
+            user_content=visible_text,
+            context_type="jd_url_parse",
+            user_id=user_id,
+            context_id=None,
+        )
+    except (anthropic.APIError, ValueError) as exc:
+        logger.warning("Claude JD-URL fallback failed for %s: %s", source_url, exc)
+        raise JDFetchError(f"AI extraction failed: {exc}") from exc
+
+    title = _str_or_none(parsed.get("title"))
+    company = _str_or_none(parsed.get("company"))
+    location = _str_or_none(parsed.get("location"))
+    summary = _str_or_none(parsed.get("summary"))
+
+    must_have = _string_list(parsed.get("must_have_requirements"))
+    nice_have = _string_list(parsed.get("nice_to_have_requirements"))
+    requirements_text = _format_requirements_block(must_have, nice_have)
+
+    # No description_html — Claude returns a summary; the visible HTML is
+    # not preserved through the parse. The form's notes / description
+    # fields are filled from the summary + requirements.
+    return ExtractedJD(
+        title=title,
+        company=company,
+        location=location,
+        description_html=None,
+        requirements_text=requirements_text,
+        summary=summary,
+        source_url=source_url,
+    )
+
+
+def _format_requirements_block(
+    must_have: list[str],
+    nice_have: list[str],
+) -> str | None:
+    """Render two requirement lists as a Markdown-friendly bullet block."""
+    if not must_have and not nice_have:
+        return None
+    chunks: list[str] = []
+    if must_have:
+        chunks.append("Must have:\n" + "\n".join(f"- {item}" for item in must_have))
+    if nice_have:
+        chunks.append("Nice to have:\n" + "\n".join(f"- {item}" for item in nice_have))
+    return "\n\n".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _str_or_none(value: object) -> str | None:
+    """Coerce ``value`` to a stripped string, or None if empty / wrong type."""
+    if not value or not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped if stripped else None
+
+
+def _string_list(value: object) -> list[str]:
+    """Coerce ``value`` to a list of cleaned non-empty strings."""
+    if not isinstance(value, list):
+        return []
+    out: list[str] = []
+    for item in value:
+        cleaned = _str_or_none(item)
+        if cleaned:
+            out.append(cleaned)
+    return out

--- a/apps/myjobhunter/backend/pyproject.toml
+++ b/apps/myjobhunter/backend/pyproject.toml
@@ -24,6 +24,13 @@ dependencies = [
     "anthropic>=0.49.0",
     "pypdf>=4.0.0",
     "mammoth>=1.7.0",
+    # JD URL extractor (POST /applications/extract-from-url): parses HTML from
+    # arbitrary career-page URLs to either (a) extract schema.org JobPosting
+    # JSON-LD blocks server-rendered by modern ATSes, or (b) strip visible
+    # text for the Claude HTML-fallback path. lxml (declared via beautifulsoup4)
+    # is the parser we feed BeautifulSoup — faster + stricter than html.parser.
+    "beautifulsoup4>=4.12.0",
+    "lxml>=5.2.0",
     # Resume-refinement export pipeline: weasyprint converts HTML
     # (produced by pandoc) to PDF; pandoc handles DOCX natively.
     "weasyprint>=62.0",

--- a/apps/myjobhunter/backend/requirements.txt
+++ b/apps/myjobhunter/backend/requirements.txt
@@ -31,6 +31,8 @@ bcrypt==5.0.0
     # via
     #   passlib
     #   pwdlib
+beautifulsoup4==4.14.3
+    # via myjobhunter-backend
 brotli==1.2.0 ; platform_python_implementation == 'CPython'
     # via fonttools
 brotlicffi==1.2.0.1 ; platform_python_implementation != 'CPython'
@@ -74,6 +76,7 @@ email-validator==2.3.0
     # via
     #   fastapi-users
     #   myjobhunter-backend
+    #   pydantic
 fastapi==0.136.1
     # via
     #   fastapi-users
@@ -112,6 +115,8 @@ iniconfig==2.3.0
     # via pytest
 jiter==0.14.0
     # via anthropic
+lxml==6.1.0
+    # via myjobhunter-backend
 makefun==1.16.0
     # via fastapi-users
 mako==1.3.12
@@ -189,6 +194,8 @@ sentry-sdk==2.58.0
     #   platform-shared
 sniffio==1.3.1
     # via anthropic
+soupsieve==2.8.3
+    # via beautifulsoup4
 sqlalchemy==2.0.49
     # via
     #   alembic
@@ -208,6 +215,7 @@ typing-extensions==4.15.0
     #   alembic
     #   anthropic
     #   anyio
+    #   beautifulsoup4
     #   fastapi
     #   minio
     #   pydantic

--- a/apps/myjobhunter/backend/tests/test_jd_url_extractor.py
+++ b/apps/myjobhunter/backend/tests/test_jd_url_extractor.py
@@ -1,0 +1,701 @@
+"""Tests for the JD URL extractor service + POST /applications/extract-from-url.
+
+The service's two-tier strategy gives us four orthogonal paths to cover:
+
+1. **Schema.org fast path** — page contains a JSON-LD JobPosting block.
+   Should map fields directly without invoking Claude.
+2. **HTML fallback** — page has no JSON-LD JobPosting; visible text is
+   stripped and shipped to Claude.
+3. **Auth-walled domain** — URL matches the hard-coded blocklist
+   (linkedin.com/jobs, glassdoor.com/job-listing). Should raise
+   ``JDFetchAuthRequiredError`` BEFORE making a network call.
+4. **Empty / tiny page** — fetched body has <500 visible bytes after
+   stripping. Same auth-required signal.
+
+We never make real HTTP requests — every fetch is mocked at the
+``httpx.AsyncClient`` boundary. Claude is mocked at the
+``claude_service.call_claude`` boundary, matching the pattern used in
+``test_jd_parsing_service.py``.
+
+The HTTP endpoint tests run through FastAPI's TestClient via the
+``user_factory`` + ``as_user`` fixtures defined in ``conftest.py``.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from app.services.extraction.jd_url_extractor import (
+    ExtractedJD,
+    JDFetchAuthRequiredError,
+    JDFetchError,
+    JDFetchTimeoutError,
+    _find_jobposting_schema,
+    _strip_visible_text,
+    _validate_url,
+    extract_from_url,
+)
+from bs4 import BeautifulSoup
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_SCHEMA_PAYLOAD = {
+    "@context": "https://schema.org/",
+    "@type": "JobPosting",
+    "title": "Senior Backend Engineer",
+    "description": "<p>Build APIs at scale. Strong Python required.</p>",
+    "hiringOrganization": {
+        "@type": "Organization",
+        "name": "Acme Corp",
+    },
+    "jobLocation": {
+        "@type": "Place",
+        "address": {
+            "@type": "PostalAddress",
+            "addressLocality": "San Francisco",
+            "addressRegion": "CA",
+            "addressCountry": "US",
+        },
+    },
+    "responsibilities": [
+        "Design backend services",
+        "Mentor engineers",
+    ],
+}
+
+
+def _wrap_html_with_schema(payload: object) -> str:
+    """Return an HTML doc with the given JSON-LD payload embedded.
+
+    The payload may be a single dict, a list, or a graph wrapper — we
+    embed it verbatim and add enough body text so any caller falling
+    through to the visible-text fallback wouldn't trigger the
+    auth-walled short-circuit by accident.
+    """
+    body_filler = "x" * 600
+    return f"""
+    <!doctype html>
+    <html><head>
+      <title>Job posting</title>
+      <script type="application/ld+json">{json.dumps(payload)}</script>
+    </head>
+    <body>
+      <h1>Job</h1>
+      <p>Some visible page content that would be enough text on its own.</p>
+      {body_filler}
+    </body>
+    </html>
+    """
+
+
+def _build_httpx_response(text: str, status_code: int = 200) -> httpx.Response:
+    """Build a real httpx.Response so .text / .content / .status_code align."""
+    return httpx.Response(
+        status_code=status_code,
+        content=text.encode("utf-8"),
+        request=httpx.Request("GET", "https://example.test/job"),
+    )
+
+
+class _FakeAsyncClient:
+    """Stand-in for ``httpx.AsyncClient`` in async-with usage.
+
+    Implements ``__aenter__`` / ``__aexit__`` and a ``get`` coroutine that
+    returns / raises whatever was configured in the constructor.
+    """
+
+    def __init__(
+        self,
+        *,
+        response: httpx.Response | None = None,
+        raise_exc: BaseException | None = None,
+    ) -> None:
+        self._response = response
+        self._raise = raise_exc
+        self.last_url: str | None = None
+        self.last_headers: dict[str, str] | None = None
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def get(self, url: str) -> httpx.Response:
+        self.last_url = url
+        if self._raise is not None:
+            raise self._raise
+        assert self._response is not None
+        return self._response
+
+
+def _patch_httpx(client: _FakeAsyncClient) -> Any:
+    """Patch httpx.AsyncClient to return ``client`` regardless of args."""
+    return patch(
+        "app.services.extraction.jd_url_extractor.httpx.AsyncClient",
+        return_value=client,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _validate_url — pure
+# ---------------------------------------------------------------------------
+
+
+class TestValidateUrl:
+    def test_https_url_ok(self) -> None:
+        result = _validate_url("https://jobs.example.com/posting/abc")
+        assert result.scheme == "https"
+        assert result.netloc == "jobs.example.com"
+
+    def test_http_url_ok(self) -> None:
+        result = _validate_url("http://example.com/")
+        assert result.scheme == "http"
+
+    def test_bare_string_rejected(self) -> None:
+        with pytest.raises(ValueError, match="non-empty"):
+            _validate_url("")
+
+    def test_relative_url_rejected(self) -> None:
+        with pytest.raises(ValueError, match="scheme"):
+            _validate_url("/jobs/abc")
+
+    def test_ftp_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="scheme"):
+            _validate_url("ftp://example.com/file")
+
+    def test_file_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="scheme"):
+            _validate_url("file:///etc/passwd")
+
+    def test_data_scheme_rejected(self) -> None:
+        with pytest.raises(ValueError, match="scheme"):
+            _validate_url("data:text/plain,hello")
+
+    def test_missing_host_rejected(self) -> None:
+        with pytest.raises(ValueError, match="host"):
+            _validate_url("https://")
+
+
+# ---------------------------------------------------------------------------
+# Schema.org JobPosting fast path
+# ---------------------------------------------------------------------------
+
+
+class TestFindJobPostingSchema:
+    def test_finds_top_level_jobposting(self) -> None:
+        html = _wrap_html_with_schema(SAMPLE_SCHEMA_PAYLOAD)
+        soup = BeautifulSoup(html, "lxml")
+        result = _find_jobposting_schema(soup)
+        assert result is not None
+        assert result["title"] == "Senior Backend Engineer"
+
+    def test_finds_jobposting_in_list(self) -> None:
+        payload = [
+            {"@type": "WebPage", "name": "Careers"},
+            SAMPLE_SCHEMA_PAYLOAD,
+        ]
+        html = _wrap_html_with_schema(payload)  # type: ignore[arg-type]
+        soup = BeautifulSoup(html, "lxml")
+        result = _find_jobposting_schema(soup)
+        assert result is not None
+        assert result["title"] == "Senior Backend Engineer"
+
+    def test_finds_jobposting_in_graph(self) -> None:
+        payload = {
+            "@context": "https://schema.org",
+            "@graph": [
+                {"@type": "Organization", "name": "Acme"},
+                SAMPLE_SCHEMA_PAYLOAD,
+            ],
+        }
+        html = _wrap_html_with_schema(payload)
+        soup = BeautifulSoup(html, "lxml")
+        result = _find_jobposting_schema(soup)
+        assert result is not None
+        assert result["title"] == "Senior Backend Engineer"
+
+    def test_handles_type_array(self) -> None:
+        payload = dict(SAMPLE_SCHEMA_PAYLOAD)
+        payload["@type"] = ["JobPosting", "Thing"]  # type: ignore[assignment]
+        html = _wrap_html_with_schema(payload)
+        soup = BeautifulSoup(html, "lxml")
+        result = _find_jobposting_schema(soup)
+        assert result is not None
+
+    def test_returns_none_when_no_jobposting(self) -> None:
+        html = """<html><head>
+        <script type="application/ld+json">{"@type": "Article"}</script>
+        </head><body></body></html>"""
+        soup = BeautifulSoup(html, "lxml")
+        assert _find_jobposting_schema(soup) is None
+
+    def test_skips_malformed_json_block(self) -> None:
+        html = """<html><head>
+        <script type="application/ld+json">not json</script>
+        <script type="application/ld+json">{"@type": "JobPosting", "title": "OK"}</script>
+        </head><body></body></html>"""
+        soup = BeautifulSoup(html, "lxml")
+        result = _find_jobposting_schema(soup)
+        assert result is not None
+        assert result["title"] == "OK"
+
+
+# ---------------------------------------------------------------------------
+# _strip_visible_text — pure
+# ---------------------------------------------------------------------------
+
+
+class TestStripVisibleText:
+    def test_removes_script_and_style(self) -> None:
+        html = """<html><body>
+        <script>var noisy = 1;</script>
+        <style>.x { color: red; }</style>
+        <p>Real content here</p>
+        </body></html>"""
+        soup = BeautifulSoup(html, "lxml")
+        text = _strip_visible_text(soup)
+        assert "noisy" not in text
+        assert "color: red" not in text
+        assert "Real content here" in text
+
+    def test_collapses_excessive_blank_lines(self) -> None:
+        html = "<html><body>\n\n\n\n\n<p>One</p>\n\n\n\n\n<p>Two</p></body></html>"
+        soup = BeautifulSoup(html, "lxml")
+        text = _strip_visible_text(soup)
+        # Three or more blank lines collapse to two newlines (one blank line).
+        assert "\n\n\n" not in text
+
+
+# ---------------------------------------------------------------------------
+# extract_from_url — schema.org happy path
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFromUrlSchema:
+    @pytest.mark.asyncio
+    async def test_schema_org_happy_path(self) -> None:
+        html = _wrap_html_with_schema(SAMPLE_SCHEMA_PAYLOAD)
+        fake_client = _FakeAsyncClient(response=_build_httpx_response(html))
+
+        with _patch_httpx(fake_client):
+            result = await extract_from_url(
+                "https://jobs.example.com/posting/abc",
+                user_id=uuid.uuid4(),
+            )
+
+        assert isinstance(result, ExtractedJD)
+        assert result.title == "Senior Backend Engineer"
+        assert result.company == "Acme Corp"
+        assert result.location == "San Francisco, CA, US"
+        assert result.description_html is not None
+        assert "Build APIs" in result.description_html
+        assert result.requirements_text is not None
+        assert "Design backend services" in result.requirements_text
+        assert result.summary is None
+        assert result.source_url == "https://jobs.example.com/posting/abc"
+
+    @pytest.mark.asyncio
+    async def test_schema_description_html_preserved(self) -> None:
+        payload = {
+            "@type": "JobPosting",
+            "title": "Engineer",
+            "description": "<div><strong>Bold</strong> emphasised text.</div>",
+        }
+        html = _wrap_html_with_schema(payload)
+        fake_client = _FakeAsyncClient(response=_build_httpx_response(html))
+
+        with _patch_httpx(fake_client):
+            result = await extract_from_url(
+                "https://example.com/posting",
+                user_id=uuid.uuid4(),
+            )
+
+        assert result.description_html is not None
+        assert "<strong>Bold</strong>" in result.description_html
+
+    @pytest.mark.asyncio
+    async def test_schema_org_missing_optional_fields(self) -> None:
+        # Title only — verify nullable mapping works without crashing.
+        payload = {"@type": "JobPosting", "title": "Engineer"}
+        html = _wrap_html_with_schema(payload)
+        fake_client = _FakeAsyncClient(response=_build_httpx_response(html))
+
+        with _patch_httpx(fake_client):
+            result = await extract_from_url(
+                "https://example.com/posting",
+                user_id=uuid.uuid4(),
+            )
+
+        assert result.title == "Engineer"
+        assert result.company is None
+        assert result.location is None
+        assert result.description_html is None
+        assert result.requirements_text is None
+
+    @pytest.mark.asyncio
+    async def test_schema_does_not_invoke_claude(self) -> None:
+        """The fast path must NOT spend Claude tokens."""
+        html = _wrap_html_with_schema(SAMPLE_SCHEMA_PAYLOAD)
+        fake_client = _FakeAsyncClient(response=_build_httpx_response(html))
+
+        mock_call = AsyncMock()
+        with _patch_httpx(fake_client), patch(
+            "app.services.extraction.jd_url_extractor.claude_service.call_claude",
+            mock_call,
+        ):
+            await extract_from_url(
+                "https://example.com/posting",
+                user_id=uuid.uuid4(),
+            )
+
+        mock_call.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# extract_from_url — HTML-text Claude fallback
+# ---------------------------------------------------------------------------
+
+
+_NO_SCHEMA_HTML = """
+<!doctype html>
+<html><head><title>Job</title></head>
+<body>
+  <h1>Senior Engineer</h1>
+  <h2>Acme Corp — Remote</h2>
+  <p>We're looking for an engineer to build great things.</p>
+""" + "<p>Plenty of body text. " * 50 + """
+</body></html>
+"""
+
+
+class TestExtractFromUrlHtmlFallback:
+    @pytest.mark.asyncio
+    async def test_html_fallback_invokes_claude(self) -> None:
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response(_NO_SCHEMA_HTML),
+        )
+        claude_payload = {
+            "title": "Senior Engineer",
+            "company": "Acme Corp",
+            "location": "Remote",
+            "summary": "Engineer at Acme.",
+            "must_have_requirements": ["Python", "Postgres"],
+            "nice_to_have_requirements": ["Kubernetes"],
+            "responsibilities": ["Build things"],
+            "remote_type": "remote",
+            "salary_min": None,
+            "salary_max": None,
+            "salary_currency": None,
+            "salary_period": None,
+            "seniority": "senior",
+        }
+
+        with _patch_httpx(fake_client), patch(
+            "app.services.extraction.jd_url_extractor.claude_service.call_claude",
+            new_callable=AsyncMock,
+            return_value=claude_payload,
+        ) as mock_call:
+            user_id = uuid.uuid4()
+            result = await extract_from_url(
+                "https://example.com/posting",
+                user_id=user_id,
+            )
+
+        # Claude was called with the stripped visible text + the JD-parsing prompt.
+        mock_call.assert_called_once()
+        call_kwargs = mock_call.call_args.kwargs
+        assert call_kwargs["context_type"] == "jd_url_parse"
+        assert call_kwargs["user_id"] == user_id
+        assert call_kwargs["context_id"] is None
+        # The user_content must be plain text with the JD body — verify our
+        # h1 / h2 made it through and HTML tags did not.
+        user_content = call_kwargs["user_content"]
+        assert "Senior Engineer" in user_content
+        assert "Acme Corp" in user_content
+        assert "<h1>" not in user_content
+        assert "<p>" not in user_content
+
+        # Result is mapped from the Claude response.
+        assert result.title == "Senior Engineer"
+        assert result.company == "Acme Corp"
+        assert result.location == "Remote"
+        assert result.summary == "Engineer at Acme."
+        assert result.requirements_text is not None
+        assert "Must have:" in result.requirements_text
+        assert "Python" in result.requirements_text
+        assert "Nice to have:" in result.requirements_text
+        assert "Kubernetes" in result.requirements_text
+        assert result.description_html is None
+        assert result.source_url == "https://example.com/posting"
+
+    @pytest.mark.asyncio
+    async def test_claude_failure_raises_jdfetcherror(self) -> None:
+        import anthropic
+
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response(_NO_SCHEMA_HTML),
+        )
+        with _patch_httpx(fake_client), patch(
+            "app.services.extraction.jd_url_extractor.claude_service.call_claude",
+            new_callable=AsyncMock,
+            side_effect=anthropic.APIConnectionError(request=None),
+        ):
+            with pytest.raises(JDFetchError, match="AI extraction"):
+                await extract_from_url(
+                    "https://example.com/posting",
+                    user_id=uuid.uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_claude_invalid_json_raises_jdfetcherror(self) -> None:
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response(_NO_SCHEMA_HTML),
+        )
+        with _patch_httpx(fake_client), patch(
+            "app.services.extraction.jd_url_extractor.claude_service.call_claude",
+            new_callable=AsyncMock,
+            side_effect=ValueError("invalid json"),
+        ):
+            with pytest.raises(JDFetchError, match="AI extraction"):
+                await extract_from_url(
+                    "https://example.com/posting",
+                    user_id=uuid.uuid4(),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Auth-walled domains + tiny pages
+# ---------------------------------------------------------------------------
+
+
+class TestAuthWalledShortCircuit:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://www.linkedin.com/jobs/view/123456",
+            "https://linkedin.com/jobs/view/abc",
+            "https://www.glassdoor.com/job-listing/software-engineer-acme-JV_KO0,17_KE18,22.htm",
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_auth_walled_domain_short_circuits(self, url: str) -> None:
+        # The fetcher should never be called.
+        sentinel = MagicMock()
+        with patch(
+            "app.services.extraction.jd_url_extractor.httpx.AsyncClient",
+            sentinel,
+        ):
+            with pytest.raises(JDFetchAuthRequiredError):
+                await extract_from_url(url, user_id=uuid.uuid4())
+        sentinel.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tiny_page_after_strip_raises_auth_required(self) -> None:
+        # Page with no JSON-LD and <500 visible bytes.
+        tiny_html = "<html><body><p>Sign in to view this listing.</p></body></html>"
+        fake_client = _FakeAsyncClient(response=_build_httpx_response(tiny_html))
+
+        with _patch_httpx(fake_client):
+            with pytest.raises(JDFetchAuthRequiredError):
+                await extract_from_url(
+                    "https://acme.example.com/login",
+                    user_id=uuid.uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_401_response_raises_auth_required(self) -> None:
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response("Unauthorized", status_code=401),
+        )
+        with _patch_httpx(fake_client):
+            with pytest.raises(JDFetchAuthRequiredError):
+                await extract_from_url(
+                    "https://acme.example.com/protected",
+                    user_id=uuid.uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_403_response_raises_auth_required(self) -> None:
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response("Forbidden", status_code=403),
+        )
+        with _patch_httpx(fake_client):
+            with pytest.raises(JDFetchAuthRequiredError):
+                await extract_from_url(
+                    "https://acme.example.com/protected",
+                    user_id=uuid.uuid4(),
+                )
+
+
+# ---------------------------------------------------------------------------
+# Error mapping: timeout / non-2xx / network failures
+# ---------------------------------------------------------------------------
+
+
+class TestFetchErrors:
+    @pytest.mark.asyncio
+    async def test_timeout_raises_jdfetchtimeouterror(self) -> None:
+        fake_client = _FakeAsyncClient(
+            raise_exc=httpx.ConnectTimeout("timed out"),
+        )
+        with _patch_httpx(fake_client):
+            with pytest.raises(JDFetchTimeoutError):
+                await extract_from_url(
+                    "https://slow.example.com/job",
+                    user_id=uuid.uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_500_raises_jdfetcherror(self) -> None:
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response("Bad gateway", status_code=502),
+        )
+        with _patch_httpx(fake_client):
+            with pytest.raises(JDFetchError, match="HTTP 502"):
+                await extract_from_url(
+                    "https://broken.example.com/job",
+                    user_id=uuid.uuid4(),
+                )
+
+    @pytest.mark.asyncio
+    async def test_invalid_url_raises_value_error(self) -> None:
+        with pytest.raises(ValueError):
+            await extract_from_url("not-a-url", user_id=uuid.uuid4())
+
+
+# ---------------------------------------------------------------------------
+# HTTP endpoint tests via FastAPI TestClient
+# ---------------------------------------------------------------------------
+
+
+_VALID_URL = "https://jobs.example.com/posting/abc"
+
+
+class TestExtractFromUrlEndpoint:
+    @pytest.mark.asyncio
+    async def test_happy_path_returns_200(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        html = _wrap_html_with_schema(SAMPLE_SCHEMA_PAYLOAD)
+        fake_client = _FakeAsyncClient(response=_build_httpx_response(html))
+
+        with _patch_httpx(fake_client):
+            async with await as_user(user) as authed:
+                resp = await authed.post(
+                    "/applications/extract-from-url",
+                    json={"url": _VALID_URL},
+                )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["title"] == "Senior Backend Engineer"
+        assert body["company"] == "Acme Corp"
+        assert body["location"] == "San Francisco, CA, US"
+        assert body["source_url"] == _VALID_URL
+
+    @pytest.mark.asyncio
+    async def test_auth_required_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/applications/extract-from-url",
+                json={"url": "https://www.linkedin.com/jobs/view/123"},
+            )
+
+        assert resp.status_code == 422, resp.text
+        assert resp.json()["detail"] == "auth_required"
+
+    @pytest.mark.asyncio
+    async def test_timeout_returns_504(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        fake_client = _FakeAsyncClient(
+            raise_exc=httpx.ConnectTimeout("timed out"),
+        )
+
+        with _patch_httpx(fake_client):
+            async with await as_user(user) as authed:
+                resp = await authed.post(
+                    "/applications/extract-from-url",
+                    json={"url": _VALID_URL},
+                )
+
+        assert resp.status_code == 504, resp.text
+
+    @pytest.mark.asyncio
+    async def test_upstream_error_returns_502(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response("Server error", status_code=500),
+        )
+
+        with _patch_httpx(fake_client):
+            async with await as_user(user) as authed:
+                resp = await authed.post(
+                    "/applications/extract-from-url",
+                    json={"url": _VALID_URL},
+                )
+
+        assert resp.status_code == 502, resp.text
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client) -> None:
+        resp = await client.post(
+            "/applications/extract-from-url",
+            json={"url": _VALID_URL},
+        )
+        assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_malformed_url_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        # Pydantic AnyHttpUrl rejects non-URLs at the schema layer.
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/applications/extract-from-url",
+                json={"url": "not-a-url"},
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_extra_fields_rejected_422(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/applications/extract-from-url",
+                json={"url": _VALID_URL, "evil_field": "x"},
+            )
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_missing_url_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/applications/extract-from-url",
+                json={},
+            )
+        assert resp.status_code == 422

--- a/apps/myjobhunter/backend/uv.lock
+++ b/apps/myjobhunter/backend/uv.lock
@@ -154,6 +154,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
 name = "brotli"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -531,6 +544,32 @@ wheels = [
 ]
 
 [[package]]
+name = "lxml"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/30/9abc9e34c657c33834eaf6cd02124c61bdf5944d802aa48e69be8da3585d/lxml-6.1.0.tar.gz", hash = "sha256:bfd57d8008c4965709a919c3e9a98f76c2c7cb319086b3d26858250620023b13", size = 4197006, upload-time = "2026-04-18T04:32:51.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/d4/9326838b59dc36dfae42eec9656b97520f9997eee1de47b8316aaeed169c/lxml-6.1.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:d2f17a16cd8751e8eb233a7e41aecdf8e511712e00088bf9be455f604cd0d28d", size = 8570663, upload-time = "2026-04-18T04:27:48.253Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/a4/053745ce1f8303ccbb788b86c0db3a91b973675cefc42566a188637b7c40/lxml-6.1.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:f0cea5b1d3e6e77d71bd2b9972eb2446221a69dc52bb0b9c3c6f6e5700592d93", size = 4624024, upload-time = "2026-04-18T04:27:52.594Z" },
+    { url = "https://files.pythonhosted.org/packages/90/97/a517944b20f8fd0932ad2109482bee4e29fe721416387a363306667941f6/lxml-6.1.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fc46da94826188ed45cb53bd8e3fc076ae22675aea2087843d4735627f867c6d", size = 4930895, upload-time = "2026-04-18T04:32:56.29Z" },
+    { url = "https://files.pythonhosted.org/packages/94/7c/e08a970727d556caa040a44773c7b7e3ad0f0d73dedc863543e9a8b931f2/lxml-6.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:9147d8e386ec3b82c3b15d88927f734f565b0aaadef7def562b853adca45784a", size = 5093820, upload-time = "2026-04-18T04:32:58.94Z" },
+    { url = "https://files.pythonhosted.org/packages/88/ee/2a5c2aa2c32016a226ca25d3e1056a8102ea6e1fe308bf50213586635400/lxml-6.1.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5715e0e28736a070f3f34a7ccc09e2fdcba0e3060abbcf61a1a5718ff6d6b105", size = 5005790, upload-time = "2026-04-18T04:33:01.272Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/38/a0db9be8f38ad6043ab9429487c128dd1d30f07956ef43040402f8da49e8/lxml-6.1.0-cp312-cp312-manylinux_2_26_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4937460dc5df0cdd2f06a86c285c28afda06aefa3af949f9477d3e8df430c485", size = 5630827, upload-time = "2026-04-18T04:33:04.036Z" },
+    { url = "https://files.pythonhosted.org/packages/31/ba/3c13d3fc24b7cacf675f808a3a1baabf43a30d0cd24c98f94548e9aa58eb/lxml-6.1.0-cp312-cp312-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bc783ee3147e60a25aa0445ea82b3e8aabb83b240f2b95d32cb75587ff781814", size = 5240445, upload-time = "2026-04-18T04:33:06.87Z" },
+    { url = "https://files.pythonhosted.org/packages/55/ba/eeef4ccba09b2212fe239f46c1692a98db1878e0872ae320756488878a94/lxml-6.1.0-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:40d9189f80075f2e1f88db21ef815a2b17b28adf8e50aaf5c789bfe737027f32", size = 5350121, upload-time = "2026-04-18T04:33:09.365Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/01/1da87c7b587c38d0cbe77a01aae3b9c1c49ed47d76918ef3db8fc151b1ca/lxml-6.1.0-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:05b9b8787e35bec69e68daf4952b2e6dfcfb0db7ecf1a06f8cdfbbac4eb71aad", size = 4694949, upload-time = "2026-04-18T04:33:11.628Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/88/7db0fe66d5aaf128443ee1623dec3db1576f3e4c17751ec0ef5866468590/lxml-6.1.0-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0f0f08beb0182e3e9a86fae124b3c47a7b41b7b69b225e1377db983802404e54", size = 5243901, upload-time = "2026-04-18T04:33:13.95Z" },
+    { url = "https://files.pythonhosted.org/packages/00/a8/1346726af7d1f6fca1f11223ba34001462b0a3660416986d37641708d57c/lxml-6.1.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73becf6d8c81d4c76b1014dbd3584cb26d904492dcf73ca85dc8bff08dcd6d2d", size = 5048054, upload-time = "2026-04-18T04:33:16.965Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/b7/85057012f035d1a0c87e02f8c723ca3c3e6e0728bcf4cb62080b21b1c1e3/lxml-6.1.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1ae225f66e5938f4fa29d37e009a3bb3b13032ac57eb4eb42afa44f6e4054e69", size = 4777324, upload-time = "2026-04-18T04:33:19.832Z" },
+    { url = "https://files.pythonhosted.org/packages/75/6c/ad2f94a91073ef570f33718040e8e160d5fb93331cf1ab3ca1323f939e2d/lxml-6.1.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:690022c7fae793b0489aa68a658822cea83e0d5933781811cabbf5ea3bcfe73d", size = 5645702, upload-time = "2026-04-18T04:33:22.436Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/89/0bb6c0bd549c19004c60eea9dc554dd78fd647b72314ef25d460e0d208c6/lxml-6.1.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:63aeafc26aac0be8aff14af7871249e87ea1319be92090bfd632ec68e03b16a5", size = 5232901, upload-time = "2026-04-18T04:33:26.21Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d9/d609a11fb567da9399f525193e2b49847b5a409cdebe737f06a8b7126bdc/lxml-6.1.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:264c605ab9c0e4aa1a679636f4582c4d3313700009fac3ec9c3412ed0d8f3e1d", size = 5261333, upload-time = "2026-04-18T04:33:28.984Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/3a/ac3f99ec8ac93089e7dd556f279e0d14c24de0a74a507e143a2e4b496e7c/lxml-6.1.0-cp312-cp312-win32.whl", hash = "sha256:56971379bc5ee8037c5a0f09fa88f66cdb7d37c3e38af3e45cf539f41131ac1f", size = 3596289, upload-time = "2026-04-18T04:27:42.819Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/a7/0a915557538593cb1bbeedcd40e13c7a261822c26fecbbdb71dad0c2f540/lxml-6.1.0-cp312-cp312-win_amd64.whl", hash = "sha256:bba078de0031c219e5dd06cf3e6bf8fb8e6e64a77819b358f53bb132e3e03366", size = 3997059, upload-time = "2026-04-18T04:27:46.764Z" },
+    { url = "https://files.pythonhosted.org/packages/92/96/a5dc078cf0126fbfbc35611d77ecd5da80054b5893e28fb213a5613b9e1d/lxml-6.1.0-cp312-cp312-win_arm64.whl", hash = "sha256:c3592631e652afa34999a088f98ba7dfc7d6aff0d535c410bea77a71743f3819", size = 3659552, upload-time = "2026-04-18T04:27:51.133Z" },
+]
+
+[[package]]
 name = "makefun"
 version = "1.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -607,11 +646,13 @@ dependencies = [
     { name = "anthropic" },
     { name = "anyio" },
     { name = "asyncpg" },
+    { name = "beautifulsoup4" },
     { name = "cryptography" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
     { name = "httpx" },
+    { name = "lxml" },
     { name = "mammoth" },
     { name = "minio" },
     { name = "passlib", extra = ["bcrypt"] },
@@ -640,11 +681,13 @@ requires-dist = [
     { name = "anthropic", specifier = ">=0.49.0" },
     { name = "anyio", specifier = "==4.13.0" },
     { name = "asyncpg", specifier = "==0.31.0" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "cryptography", specifier = "==47.0.0" },
     { name = "email-validator", specifier = "==2.3.0" },
     { name = "fastapi", specifier = "==0.136.1" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = "==15.0.5" },
     { name = "httpx", specifier = "==0.28.1" },
+    { name = "lxml", specifier = ">=5.2.0" },
     { name = "mammoth", specifier = ">=1.7.0" },
     { name = "minio", specifier = "==7.2.20" },
     { name = "passlib", extras = ["bcrypt"], specifier = "==1.7.4" },
@@ -719,7 +762,7 @@ dependencies = [
     { name = "fastapi" },
     { name = "httpx" },
     { name = "minio" },
-    { name = "pydantic" },
+    { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pyotp" },
     { name = "qrcode" },
@@ -735,7 +778,7 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "minio", specifier = ">=7.2.0" },
-    { name = "pydantic", specifier = ">=2.9.0" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.5.0" },
     { name = "pyotp", specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -832,6 +875,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e4/40d09941a2cebcb20609b86a559817d5b9291c49dd6f8c87e5feffbe703a/pydantic-2.13.3.tar.gz", hash = "sha256:af09e9d1d09f4e7fe37145c1f577e1d61ceb9a41924bf0094a36506285d0a84d", size = 844068, upload-time = "2026-04-20T14:46:43.632Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/0a/fd7d723f8f8153418fb40cf9c940e82004fce7e987026b08a68a36dd3fe7/pydantic-2.13.3-py3-none-any.whl", hash = "sha256:6db14ac8dfc9a1e57f87ea2c0de670c251240f43cb0c30a5130e9720dc612927", size = 471981, upload-time = "2026-04-20T14:46:41.402Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]
@@ -1051,6 +1099,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
 ]
 
 [[package]]

--- a/apps/myjobhunter/frontend/e2e/applications-jd-url-extract.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/applications-jd-url-extract.spec.ts
@@ -1,0 +1,140 @@
+/**
+ * E2E: Paste-link path on Add Application dialog.
+ *
+ * Covers the new flow: user opens "Add application", picks the URL tab
+ * (default), pastes a job-posting URL, clicks Fetch, the form pre-fills
+ * with extracted fields. Also covers the 422 auth_required path
+ * (LinkedIn / Glassdoor) which surfaces a "switch to paste-text" CTA.
+ *
+ * Why mock the API instead of hitting the real endpoint?
+ * ------------------------------------------------------
+ * The extract-from-url endpoint fetches external URLs server-side.
+ * Driving real fetches from a CI smoke test is fragile (the target site
+ * could change, rate-limit, or be unreachable). We mock at the browser
+ * level via `page.route` so the test exercises the full UI state machine
+ * (loading → success / authRequired) without external dependencies.
+ *
+ * For coverage of the actual extraction logic, see the backend pytest
+ * suite at `tests/test_jd_url_extractor.py`.
+ */
+import { test, expect } from "@playwright/test";
+import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+
+test.describe("Applications — paste-link JD URL extract", () => {
+  test("paste a URL, fetch, fields pre-fill in the form", async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request);
+
+    try {
+      await loginViaUI(page, user);
+
+      // Mock the extract endpoint to return a realistic schema.org-style payload.
+      await page.route("**/api/applications/extract-from-url", async (route) => {
+        const request = route.request();
+        const body = request.postDataJSON() as { url: string };
+        expect(body.url).toBe("https://jobs.example.com/posting/abc");
+        await route.fulfill({
+          status: 200,
+          contentType: "application/json",
+          body: JSON.stringify({
+            title: "Senior Backend Engineer",
+            company: "Acme Corp",
+            location: "San Francisco, CA, US",
+            description_html: "<p>Build APIs at scale.</p>",
+            requirements_text: null,
+            summary: null,
+            source_url: "https://jobs.example.com/posting/abc",
+          }),
+        });
+      });
+
+      // Navigate to Applications and open the dialog.
+      await page.getByRole("link", { name: /applications/i }).first().click();
+      await page.waitForURL("**/applications");
+      await page.getByRole("button", { name: /add application/i }).first().click();
+      await expect(
+        page.getByRole("dialog", { name: /add application/i }),
+      ).toBeVisible();
+
+      // Expand the auto-fill panel — the prompt is collapsed initially.
+      await page.getByRole("button", { name: /paste a link or job description to auto-fill/i }).click();
+
+      // URL tab is the default. Confirm by checking for the URL input.
+      const urlInput = page.getByLabel(/job posting url/i);
+      await expect(urlInput).toBeVisible();
+
+      // Type a URL and click "Fetch and auto-fill".
+      await urlInput.fill("https://jobs.example.com/posting/abc");
+      await page.getByRole("button", { name: /fetch and auto-fill/i }).click();
+
+      // Success banner appears.
+      await expect(page.getByText(/fields pre-filled from jd/i)).toBeVisible({
+        timeout: 5_000,
+      });
+      await expect(page.getByText(/fetched from/i)).toBeVisible();
+
+      // The role title is pre-filled.
+      await expect(page.getByLabel(/role title/i)).toHaveValue("Senior Backend Engineer");
+
+      // The location is pre-filled.
+      await expect(page.getByLabel(/^location/i)).toHaveValue("San Francisco, CA, US");
+
+      // The URL field is also pre-filled with the source URL.
+      await expect(page.locator("input[type='url']").first()).toHaveValue(
+        "https://jobs.example.com/posting/abc",
+      );
+    } finally {
+      await deleteTestUser(request, user);
+    }
+  });
+
+  test("auth-walled URL surfaces 'paste the description text instead' affordance", async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request);
+
+    try {
+      await loginViaUI(page, user);
+
+      // Mock 422 auth_required — this is the response the backend returns
+      // for LinkedIn / Glassdoor / tiny pages.
+      await page.route("**/api/applications/extract-from-url", async (route) => {
+        await route.fulfill({
+          status: 422,
+          contentType: "application/json",
+          body: JSON.stringify({ detail: "auth_required" }),
+        });
+      });
+
+      await page.getByRole("link", { name: /applications/i }).first().click();
+      await page.waitForURL("**/applications");
+      await page.getByRole("button", { name: /add application/i }).first().click();
+
+      await page.getByRole("button", { name: /paste a link or job description to auto-fill/i }).click();
+
+      const urlInput = page.getByLabel(/job posting url/i);
+      await urlInput.fill("https://www.linkedin.com/jobs/view/12345");
+      await page.getByRole("button", { name: /fetch and auto-fill/i }).click();
+
+      // Auth-required banner is shown — distinct from the generic "Couldn't auto-fill" banner.
+      await expect(page.getByText(/couldn't reach this page/i)).toBeVisible({
+        timeout: 5_000,
+      });
+
+      // The "paste the description text instead" button is offered.
+      const switchButton = page.getByRole("button", {
+        name: /paste the description text instead/i,
+      });
+      await expect(switchButton).toBeVisible();
+
+      // Clicking it switches the active tab to the text panel.
+      await switchButton.click();
+      await expect(page.getByLabel(/job description text/i)).toBeVisible();
+    } finally {
+      await deleteTestUser(request, user);
+    }
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
@@ -2,13 +2,21 @@ import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
-import { X, Plus, Sparkles, ChevronDown, ChevronUp } from "lucide-react";
+import { X, Plus } from "lucide-react";
 import { useListCompaniesQuery, useCreateCompanyMutation } from "@/lib/companiesApi";
-import { useCreateApplicationMutation, useParseJobDescriptionMutation } from "@/lib/applicationsApi";
+import {
+  useCreateApplicationMutation,
+  useExtractJdFromUrlMutation,
+  useParseJobDescriptionMutation,
+} from "@/lib/applicationsApi";
 import type { CompanyCreateRequest } from "@/types/company-create-request";
+import type { JdParseResponse } from "@/types/application/jd-parse-response";
+import type { JdUrlExtractResponse } from "@/types/application/jd-url-extract-response";
 import CompanyForm from "@/features/companies/CompanyForm";
-import type { JdParseMode } from "./useJdParseMode";
-import { JD_PARSE_MODE_IDLE } from "./useJdParseMode";
+import { JdAutoFillSection } from "./JdAutoFillSection";
+import type { JdInputTab, JdParseMode } from "./useJdParseMode";
+import { JD_INPUT_TAB_DEFAULT, JD_PARSE_MODE_IDLE } from "./useJdParseMode";
+import { describeExtractError, isAuthRequiredError } from "./jdErrorRouting";
 
 interface AddApplicationFormValues {
   company_id: string;
@@ -35,10 +43,16 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
   const { data: companiesData, isLoading: companiesLoading } = useListCompaniesQuery();
   const [createApplication, { isLoading: creatingApplication }] = useCreateApplicationMutation();
   const [createCompany, { isLoading: creatingCompany }] = useCreateCompanyMutation();
-  const [parseJobDescription, { isLoading: parsing }] = useParseJobDescriptionMutation();
+  const [parseJobDescription] = useParseJobDescriptionMutation();
+  const [extractJdFromUrl] = useExtractJdFromUrlMutation();
 
   const [showNewCompany, setShowNewCompany] = useState(false);
   const [jdMode, setJdMode] = useState<JdParseMode>(JD_PARSE_MODE_IDLE);
+  const [jdTab, setJdTab] = useState<JdInputTab>(JD_INPUT_TAB_DEFAULT);
+  // Persist the buffers across tab switches so the user doesn't lose what
+  // they typed in one tab when they peek at the other.
+  const [pastedJdText, setPastedJdText] = useState("");
+  const [pastedUrl, setPastedUrl] = useState("");
 
   const {
     register,
@@ -63,6 +77,9 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
       reset();
       setShowNewCompany(false);
       setJdMode(JD_PARSE_MODE_IDLE);
+      setJdTab(JD_INPUT_TAB_DEFAULT);
+      setPastedJdText("");
+      setPastedUrl("");
     }
     onOpenChange(next);
   }
@@ -77,10 +94,9 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
         remote_type: values.remote_type,
         notes: values.notes.trim() || null,
         // Preserve the pasted JD text if the user went through the parse flow.
-        jd_text:
-          jdMode.kind === "pasting" || jdMode.kind === "parsing"
-            ? jdMode.jdText.trim() || null
-            : null,
+        // The URL-extract path doesn't capture raw JD text — that lives in
+        // description_html on the JdUrlExtractResponse and is not yet sent on.
+        jd_text: pastedJdText.trim() || null,
       }).unwrap();
       showSuccess("Application added");
       onOpenChange(false);
@@ -101,31 +117,15 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
     }
   };
 
+  // -------------------------------------------------------------------------
+  // JD parse flow — paste-text path (existing)
+  // -------------------------------------------------------------------------
   async function handleParseJd() {
-    if (jdMode.kind !== "pasting" || !jdMode.jdText.trim()) return;
-
-    const jdText = jdMode.jdText;
-    setJdMode({ kind: "parsing", jdText });
-
+    if (!pastedJdText.trim()) return;
+    setJdMode({ kind: "parsing", jdText: pastedJdText });
     try {
-      const result = await parseJobDescription({ jd_text: jdText }).unwrap();
-
-      // Pre-fill form fields with Claude's extracted values where non-null.
-      if (result.title) {
-        setValue("role_title", result.title, { shouldValidate: true });
-      }
-      if (result.location) {
-        setValue("location", result.location, { shouldValidate: true });
-      }
-      if (result.remote_type && result.remote_type !== "unknown") {
-        setValue(
-          "remote_type",
-          result.remote_type as AddApplicationFormValues["remote_type"],
-          { shouldValidate: true },
-        );
-      }
-
-      setJdMode({ kind: "parsed", summary: result.summary });
+      const result = await parseJobDescription({ jd_text: pastedJdText }).unwrap();
+      applyParseResult(result, { sourceUrl: null });
     } catch (err) {
       setJdMode({
         kind: "failed",
@@ -133,6 +133,115 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
           extractErrorMessage(err) ?? "AI parsing failed — please fill fields manually",
       });
     }
+  }
+
+  // -------------------------------------------------------------------------
+  // JD extract flow — URL path (new)
+  // -------------------------------------------------------------------------
+  async function handleFetchUrl() {
+    const url = pastedUrl.trim();
+    if (!url) return;
+    setJdMode({ kind: "extracting", url });
+    try {
+      const result = await extractJdFromUrl({ url }).unwrap();
+      applyExtractResult(result);
+    } catch (err) {
+      if (isAuthRequiredError(err)) {
+        setJdMode({ kind: "authRequired", url });
+        return;
+      }
+      setJdMode({
+        kind: "failed",
+        errorMessage: describeExtractError(err),
+      });
+    }
+  }
+
+  // Pre-fill helper — both the text-parse and URL-extract paths converge here
+  // (text-parse calls applyParseResult; URL-extract maps to a JdParseResponse
+  // shape via mapExtractToParse and then calls the same).
+  function applyParseResult(
+    result: JdParseResponse,
+    { sourceUrl }: { sourceUrl: string | null },
+  ) {
+    if (result.title) {
+      setValue("role_title", result.title, { shouldValidate: true });
+    }
+    if (result.location) {
+      setValue("location", result.location, { shouldValidate: true });
+    }
+    if (
+      result.remote_type === "remote" ||
+      result.remote_type === "hybrid" ||
+      result.remote_type === "onsite"
+    ) {
+      setValue("remote_type", result.remote_type, { shouldValidate: true });
+    }
+    setJdMode({ kind: "parsed", summary: result.summary, sourceUrl });
+  }
+
+  function applyExtractResult(result: JdUrlExtractResponse) {
+    // Echo the source URL into the form's URL field so the operator
+    // doesn't have to paste it twice.
+    setValue("url", result.source_url, { shouldValidate: true });
+    if (result.title) {
+      setValue("role_title", result.title, { shouldValidate: true });
+    }
+    if (result.location) {
+      setValue("location", result.location, { shouldValidate: true });
+    }
+    // Combine description + requirements into the notes field as a
+    // best-effort scaffold the operator can edit. We strip HTML tags
+    // here client-side because the form's notes field is plain text.
+    const notesScaffold = combineNotes(result);
+    if (notesScaffold) {
+      setValue("notes", notesScaffold, { shouldValidate: true });
+    }
+    setJdMode({
+      kind: "parsed",
+      summary: result.summary,
+      sourceUrl: result.source_url,
+    });
+  }
+
+  // -------------------------------------------------------------------------
+  // Tab switching — preserves the buffer of the OTHER tab so the user can
+  // flip without losing input.
+  // -------------------------------------------------------------------------
+  function handleSwitchTab(next: JdInputTab) {
+    setJdTab(next);
+    if (next === "url") {
+      setJdMode({ kind: "fetching", url: pastedUrl });
+    } else {
+      setJdMode({ kind: "pasting", jdText: pastedJdText });
+    }
+  }
+
+  function handleExpand() {
+    // Expand into whichever tab is currently selected, defaulting to URL.
+    if (jdTab === "url") {
+      setJdMode({ kind: "fetching", url: pastedUrl });
+    } else {
+      setJdMode({ kind: "pasting", jdText: pastedJdText });
+    }
+  }
+
+  function handleCollapse() {
+    setJdMode(JD_PARSE_MODE_IDLE);
+  }
+
+  function handleDismiss() {
+    setJdMode(JD_PARSE_MODE_IDLE);
+  }
+
+  function handleUrlChange(url: string) {
+    setPastedUrl(url);
+    setJdMode({ kind: "fetching", url });
+  }
+
+  function handleTextChange(text: string) {
+    setPastedJdText(text);
+    setJdMode({ kind: "pasting", jdText: text });
   }
 
   const companies = companiesData?.items ?? [];
@@ -155,20 +264,17 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
             </Dialog.Close>
           </div>
 
-          {/* JD paste + parse section — collapses after a successful parse */}
-          <JdParseSection
+          <JdAutoFillSection
             mode={jdMode}
-            parsing={parsing}
-            onToggle={() =>
-              setJdMode((prev) =>
-                prev.kind === "idle"
-                  ? { kind: "pasting", jdText: "" }
-                  : JD_PARSE_MODE_IDLE,
-              )
-            }
-            onTextChange={(text) => setJdMode({ kind: "pasting", jdText: text })}
+            tab={jdTab}
+            onExpand={handleExpand}
+            onCollapse={handleCollapse}
+            onSwitchTab={handleSwitchTab}
+            onUrlChange={handleUrlChange}
+            onTextChange={handleTextChange}
+            onFetch={handleFetchUrl}
             onParse={handleParseJd}
-            onDismiss={() => setJdMode(JD_PARSE_MODE_IDLE)}
+            onDismiss={handleDismiss}
           />
 
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
@@ -177,7 +283,6 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
                 Company <span className="text-destructive">*</span>
               </label>
               {showNewCompany ? (
-                // Inline panel — NOT a nested Dialog (a11y rule: no dialogs inside dialogs).
                 <div className="border rounded-md p-4 bg-muted/30">
                   <p className="text-xs font-medium text-muted-foreground mb-3">New company</p>
                   <CompanyForm
@@ -301,130 +406,48 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
 }
 
 // ---------------------------------------------------------------------------
-// JdParseSection — isolated sub-component for the paste + parse UX.
-// Extracted to keep the parent component lean.
+// Notes field scaffold — combine description + requirements text from the
+// URL-extract response into a single Markdown-friendly block. Plain-text
+// strip the description because the notes textarea is not HTML-aware.
 // ---------------------------------------------------------------------------
 
-interface JdParseSectionProps {
-  mode: JdParseMode;
-  parsing: boolean;
-  onToggle: () => void;
-  onTextChange: (text: string) => void;
-  onParse: () => void;
-  onDismiss: () => void;
+function combineNotes(result: JdUrlExtractResponse): string | null {
+  const chunks: string[] = [];
+  if (result.summary) {
+    chunks.push(result.summary);
+  }
+  if (result.description_html) {
+    const stripped = stripHtml(result.description_html).trim();
+    if (stripped) {
+      chunks.push(stripped);
+    }
+  }
+  if (result.requirements_text) {
+    chunks.push(result.requirements_text);
+  }
+  if (chunks.length === 0) return null;
+  // Truncate to the form's documented notes max so we don't blow past it.
+  const combined = chunks.join("\n\n");
+  return combined.length > NOTES_MAX_LEN ? combined.slice(0, NOTES_MAX_LEN) : combined;
 }
 
-function JdParseSection({
-  mode,
-  parsing,
-  onToggle,
-  onTextChange,
-  onParse,
-  onDismiss,
-}: JdParseSectionProps) {
-  if (mode.kind === "parsed") {
-    return (
-      <div className="mb-4 rounded-md border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30 p-3 flex items-start justify-between gap-2">
-        <div>
-          <p className="text-sm font-medium text-green-800 dark:text-green-300">
-            Fields pre-filled from JD
-          </p>
-          {mode.summary ? (
-            <p className="text-xs text-green-700 dark:text-green-400 mt-0.5 line-clamp-2">
-              {mode.summary}
-            </p>
-          ) : null}
-          <p className="text-xs text-muted-foreground mt-1">
-            Review and adjust the fields below before saving.
-          </p>
-        </div>
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="text-muted-foreground hover:text-foreground shrink-0 mt-0.5"
-          aria-label="Dismiss parse result"
-        >
-          <X size={14} />
-        </button>
-      </div>
-    );
-  }
+const NOTES_MAX_LEN = 5000;
 
-  if (mode.kind === "failed") {
-    return (
-      <div className="mb-4 rounded-md border border-destructive/30 bg-destructive/5 p-3 flex items-start justify-between gap-2">
-        <div>
-          <p className="text-sm font-medium text-destructive">AI parsing failed</p>
-          <p className="text-xs text-muted-foreground mt-0.5">{mode.errorMessage}</p>
-        </div>
-        <button
-          type="button"
-          onClick={onDismiss}
-          className="text-muted-foreground hover:text-foreground shrink-0 mt-0.5"
-          aria-label="Dismiss error"
-        >
-          <X size={14} />
-        </button>
-      </div>
-    );
-  }
-
-  if (mode.kind === "idle") {
-    return (
-      <div className="mb-4">
-        <button
-          type="button"
-          onClick={onToggle}
-          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <Sparkles size={14} />
-          Paste job description to auto-fill
-          <ChevronDown size={14} />
-        </button>
-      </div>
-    );
-  }
-
-  // mode.kind === "pasting" | "parsing"
-  const jdText = mode.jdText;
-  const canParse = jdText.trim().length > 0;
-
-  return (
-    <div className="mb-4 space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium flex items-center gap-1.5">
-          <Sparkles size={14} />
-          Job description
-        </span>
-        <button
-          type="button"
-          onClick={onToggle}
-          className="text-muted-foreground hover:text-foreground"
-          aria-label="Collapse job description panel"
-        >
-          <ChevronUp size={14} />
-        </button>
-      </div>
-
-      <textarea
-        value={jdText}
-        onChange={(e) => onTextChange(e.target.value)}
-        rows={6}
-        placeholder="Paste the full job description here…"
-        className="w-full border rounded-md px-3 py-2 text-sm bg-background resize-y"
-        disabled={parsing}
-        aria-label="Job description text"
-      />
-
-      <LoadingButton
-        type="button"
-        isLoading={parsing}
-        loadingText="Parsing…"
-        disabled={!canParse || parsing}
-        onClick={onParse}
-      >
-        Parse with AI
-      </LoadingButton>
-    </div>
-  );
+function stripHtml(html: string): string {
+  // Conservative client-side strip — replace tags with newlines so paragraph
+  // structure survives, then collapse runs of whitespace. We do NOT use
+  // dangerouslySetInnerHTML or a full HTML sanitiser here — the notes
+  // field is plain text on submission.
+  return html
+    .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+    .replace(/<\s*\/?\s*(p|li|div|h[1-6])[^>]*>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
 }

--- a/apps/myjobhunter/frontend/src/features/applications/JdAutoFillSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/JdAutoFillSection.tsx
@@ -1,0 +1,387 @@
+/**
+ * Auto-fill section for AddApplicationDialog.
+ *
+ * Lets the operator either paste a job-posting URL ("Paste a link" tab,
+ * default) or paste the JD text directly ("Paste the description text"
+ * tab). Both paths funnel through the parent's `onPrefill` callback,
+ * which `setValue`s the application form fields.
+ *
+ * State machine
+ * =============
+ * The visible UI is a switch over `mode.kind`:
+ *
+ *   idle           → collapsed prompt button
+ *   fetching/url   → URL input + Fetch button (URL tab)
+ *   pasting/text   → JD textarea + Parse button (text tab)
+ *   extracting     → URL Fetch in flight (button shows spinner)
+ *   parsing        → text Parse in flight (button shows spinner)
+ *   parsed         → success banner, fields pre-filled below
+ *   failed         → error banner with dismiss
+ *   authRequired   → URL was auth-walled — banner with "switch to text" affordance
+ *
+ * Tab persistence
+ * ===============
+ * The active tab is held by `tab` state in the parent (so a sibling
+ * component re-render doesn't reset it). When the user types into the
+ * URL field then switches to the text tab, the URL is preserved in
+ * `mode.url`; when they switch back, the URL re-renders. Same for
+ * jdText. We do NOT carry the value across tabs (URL → textarea) — they
+ * are different inputs.
+ *
+ * Visible loading feedback
+ * ========================
+ * Per the project's visible-loading-feedback rule, every async operation
+ * here uses a LoadingButton with explicit `isLoading` state. The fetch
+ * and parse paths both flip to a spinner immediately on click and
+ * disable until the response or error returns.
+ */
+import { useId } from "react";
+import { LoadingButton } from "@platform/ui";
+import { Sparkles, ChevronDown, ChevronUp, X, Link as LinkIcon, FileText } from "lucide-react";
+import type { JdInputTab, JdParseMode } from "./useJdParseMode";
+
+export interface JdAutoFillSectionProps {
+  mode: JdParseMode;
+  tab: JdInputTab;
+  /** Called when user clicks the collapsed expand button. */
+  onExpand: () => void;
+  /** Collapse the panel, return to idle state. */
+  onCollapse: () => void;
+  /** Called when user clicks a tab header. Switches the active input. */
+  onSwitchTab: (next: JdInputTab) => void;
+  /** Called as the URL input changes. */
+  onUrlChange: (url: string) => void;
+  /** Called as the JD textarea changes. */
+  onTextChange: (text: string) => void;
+  /** Called when the user clicks "Fetch" on the URL tab. */
+  onFetch: () => void;
+  /** Called when the user clicks "Parse with AI" on the text tab. */
+  onParse: () => void;
+  /** Dismiss success / error banners and return to idle. */
+  onDismiss: () => void;
+}
+
+export function JdAutoFillSection(props: JdAutoFillSectionProps) {
+  const { mode } = props;
+
+  if (mode.kind === "parsed") {
+    return <ParsedBanner summary={mode.summary} sourceUrl={mode.sourceUrl} onDismiss={props.onDismiss} />;
+  }
+
+  if (mode.kind === "failed") {
+    return <FailedBanner errorMessage={mode.errorMessage} onDismiss={props.onDismiss} />;
+  }
+
+  if (mode.kind === "authRequired") {
+    return (
+      <AuthRequiredBanner
+        url={mode.url}
+        onSwitchToText={() => props.onSwitchTab("text")}
+        onDismiss={props.onDismiss}
+      />
+    );
+  }
+
+  if (mode.kind === "idle") {
+    return <IdlePrompt onExpand={props.onExpand} />;
+  }
+
+  // mode.kind ∈ { fetching, extracting, pasting, parsing }
+  return <ActiveInput {...props} />;
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components — extracted so each renderer stays lean
+// ---------------------------------------------------------------------------
+
+interface IdlePromptProps {
+  onExpand: () => void;
+}
+
+function IdlePrompt({ onExpand }: IdlePromptProps) {
+  return (
+    <div className="mb-4">
+      <button
+        type="button"
+        onClick={onExpand}
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <Sparkles size={14} />
+        Paste a link or job description to auto-fill
+        <ChevronDown size={14} />
+      </button>
+    </div>
+  );
+}
+
+interface ParsedBannerProps {
+  summary: string | null;
+  sourceUrl: string | null;
+  onDismiss: () => void;
+}
+
+function ParsedBanner({ summary, sourceUrl, onDismiss }: ParsedBannerProps) {
+  return (
+    <div className="mb-4 rounded-md border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30 p-3 flex items-start justify-between gap-2">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-green-800 dark:text-green-300">
+          Fields pre-filled from JD
+        </p>
+        {summary ? (
+          <p className="text-xs text-green-700 dark:text-green-400 mt-0.5 line-clamp-2">
+            {summary}
+          </p>
+        ) : null}
+        {sourceUrl ? (
+          <p className="text-xs text-muted-foreground mt-1 truncate">
+            Fetched from <span className="underline">{sourceUrl}</span>
+          </p>
+        ) : null}
+        <p className="text-xs text-muted-foreground mt-1">
+          Review and adjust the fields below before saving.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-muted-foreground hover:text-foreground shrink-0 mt-0.5"
+        aria-label="Dismiss parse result"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}
+
+interface FailedBannerProps {
+  errorMessage: string;
+  onDismiss: () => void;
+}
+
+function FailedBanner({ errorMessage, onDismiss }: FailedBannerProps) {
+  return (
+    <div className="mb-4 rounded-md border border-destructive/30 bg-destructive/5 p-3 flex items-start justify-between gap-2">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-destructive">Couldn't auto-fill</p>
+        <p className="text-xs text-muted-foreground mt-0.5">{errorMessage}</p>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-muted-foreground hover:text-foreground shrink-0 mt-0.5"
+        aria-label="Dismiss error"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}
+
+interface AuthRequiredBannerProps {
+  url: string;
+  onSwitchToText: () => void;
+  onDismiss: () => void;
+}
+
+function AuthRequiredBanner({ url, onSwitchToText, onDismiss }: AuthRequiredBannerProps) {
+  return (
+    <div className="mb-4 rounded-md border border-amber-200 bg-amber-50 dark:border-amber-800 dark:bg-amber-950/30 p-3 flex items-start justify-between gap-2">
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-amber-800 dark:text-amber-300">
+          Couldn't reach this page
+        </p>
+        <p className="text-xs text-amber-700 dark:text-amber-400 mt-0.5">
+          {humanizeAuthRequired(url)}
+        </p>
+        <button
+          type="button"
+          onClick={onSwitchToText}
+          className="mt-2 text-xs underline text-amber-900 dark:text-amber-200 hover:text-amber-700"
+        >
+          Paste the description text instead
+        </button>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="text-muted-foreground hover:text-foreground shrink-0 mt-0.5"
+        aria-label="Dismiss"
+      >
+        <X size={14} />
+      </button>
+    </div>
+  );
+}
+
+function humanizeAuthRequired(url: string): string {
+  try {
+    const host = new URL(url).hostname.replace(/^www\./, "");
+    return `${host} requires sign-in or blocked our request. Paste the description text from the page directly.`;
+  } catch {
+    return "This page requires sign-in or blocked our request. Paste the description text from the page directly.";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Active input — tab header + URL or textarea panel
+// ---------------------------------------------------------------------------
+
+type ActiveInputProps = JdAutoFillSectionProps;
+
+function ActiveInput(props: ActiveInputProps) {
+  const headerId = useId();
+  return (
+    <div className="mb-4 space-y-3" role="region" aria-labelledby={headerId}>
+      <div className="flex items-center justify-between">
+        <span id={headerId} className="text-sm font-medium flex items-center gap-1.5">
+          <Sparkles size={14} />
+          Auto-fill from JD
+        </span>
+        <button
+          type="button"
+          onClick={props.onCollapse}
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="Collapse auto-fill panel"
+        >
+          <ChevronUp size={14} />
+        </button>
+      </div>
+
+      <TabSelector active={props.tab} onSwitch={props.onSwitchTab} />
+
+      {props.tab === "url" ? (
+        <UrlInputPanel {...props} />
+      ) : (
+        <TextInputPanel {...props} />
+      )}
+    </div>
+  );
+}
+
+interface TabSelectorProps {
+  active: JdInputTab;
+  onSwitch: (next: JdInputTab) => void;
+}
+
+function TabSelector({ active, onSwitch }: TabSelectorProps) {
+  return (
+    <div role="tablist" aria-label="JD input method" className="grid grid-cols-2 gap-2">
+      <TabButton
+        active={active === "url"}
+        onClick={() => onSwitch("url")}
+        icon={<LinkIcon size={14} />}
+        label="Paste a link"
+        controls="jd-url-panel"
+      />
+      <TabButton
+        active={active === "text"}
+        onClick={() => onSwitch("text")}
+        icon={<FileText size={14} />}
+        label="Paste the description"
+        controls="jd-text-panel"
+      />
+    </div>
+  );
+}
+
+interface TabButtonProps {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  controls: string;
+}
+
+function TabButton({ active, onClick, icon, label, controls }: TabButtonProps) {
+  // Tailwind class composition kept flat — no nested ternaries.
+  const baseClass =
+    "inline-flex items-center justify-center gap-1.5 px-3 py-2 text-sm rounded-md border min-h-[40px] transition-colors";
+  const activeClass = "bg-primary text-primary-foreground border-primary";
+  const inactiveClass = "bg-background text-foreground border-input hover:bg-muted";
+  const className = active ? `${baseClass} ${activeClass}` : `${baseClass} ${inactiveClass}`;
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      aria-controls={controls}
+      onClick={onClick}
+      className={className}
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}
+
+function UrlInputPanel(props: ActiveInputProps) {
+  const { mode } = props;
+  const url = mode.kind === "fetching" ? mode.url : mode.kind === "extracting" ? mode.url : "";
+  const isExtracting = mode.kind === "extracting";
+  const canFetch = url.trim().length > 0 && !isExtracting;
+  const inputId = useId();
+
+  return (
+    <div id="jd-url-panel" role="tabpanel" className="space-y-2">
+      <label htmlFor={inputId} className="block text-xs text-muted-foreground">
+        Job posting URL
+      </label>
+      <input
+        id={inputId}
+        type="url"
+        value={url}
+        onChange={(e) => props.onUrlChange(e.target.value)}
+        placeholder="https://jobs.example.com/posting/abc"
+        className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+        disabled={isExtracting}
+        aria-label="Job posting URL"
+        autoFocus
+      />
+      <LoadingButton
+        type="button"
+        isLoading={isExtracting}
+        loadingText="Fetching…"
+        disabled={!canFetch}
+        onClick={props.onFetch}
+      >
+        Fetch and auto-fill
+      </LoadingButton>
+      <p className="text-xs text-muted-foreground">
+        Works for most career pages. LinkedIn and Glassdoor require sign-in — for those,
+        paste the description text instead.
+      </p>
+    </div>
+  );
+}
+
+function TextInputPanel(props: ActiveInputProps) {
+  const { mode } = props;
+  const jdText =
+    mode.kind === "pasting" ? mode.jdText : mode.kind === "parsing" ? mode.jdText : "";
+  const isParsing = mode.kind === "parsing";
+  const canParse = jdText.trim().length > 0 && !isParsing;
+
+  return (
+    <div id="jd-text-panel" role="tabpanel" className="space-y-2">
+      <textarea
+        value={jdText}
+        onChange={(e) => props.onTextChange(e.target.value)}
+        rows={6}
+        placeholder="Paste the full job description here…"
+        className="w-full border rounded-md px-3 py-2 text-sm bg-background resize-y"
+        disabled={isParsing}
+        aria-label="Job description text"
+        autoFocus
+      />
+      <LoadingButton
+        type="button"
+        isLoading={isParsing}
+        loadingText="Parsing…"
+        disabled={!canParse}
+        onClick={props.onParse}
+      >
+        Parse with AI
+      </LoadingButton>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
@@ -1,11 +1,14 @@
 /**
- * Smoke tests for AddApplicationDialog — focused on the inline company-create flow.
+ * Smoke tests for AddApplicationDialog.
  *
- * Tests:
- * - "+ New" button shows the CompanyForm inline panel
- * - Filling and submitting CompanyForm calls createCompany, auto-selects the new
- *   company in the application dropdown, and closes the panel
- * - Cancel on CompanyForm closes the panel without submitting
+ * Three scenario groups:
+ * - Inline company-create flow (existing — "+ New" panel)
+ * - JD paste-text flow (existing — "Paste the description" tab + AI parse)
+ * - JD URL-extract flow (new — "Paste a link" tab + Fetch button)
+ *
+ * Each group mocks the RTK Query hooks at the module boundary; no real
+ * network calls. The radix Dialog and lucide-react icons are stubbed so
+ * jsdom doesn't choke on the SVG children.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, within } from "@testing-library/react";
@@ -14,9 +17,6 @@ import AddApplicationDialog from "../AddApplicationDialog";
 
 // ---- mocks ----
 
-// Lucide icons render as SVG elements which cause "Objects are not valid as
-// a React child" in the jsdom test environment when used inside plain button
-// children. Mock them as null-rendering stubs.
 vi.mock("lucide-react", () => ({
   X: () => null,
   Plus: () => null,
@@ -25,6 +25,7 @@ vi.mock("lucide-react", () => ({
   ChevronUp: () => null,
   Download: () => null,
   FileText: () => null,
+  Link: () => null,
 }));
 
 vi.mock("@/lib/companiesApi", () => ({
@@ -35,6 +36,7 @@ vi.mock("@/lib/companiesApi", () => ({
 vi.mock("@/lib/applicationsApi", () => ({
   useCreateApplicationMutation: vi.fn(),
   useParseJobDescriptionMutation: vi.fn(),
+  useExtractJdFromUrlMutation: vi.fn(),
 }));
 
 vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
@@ -42,8 +44,6 @@ vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
   return {
     ...actual,
     Portal: ({ children }: { children: React.ReactNode }) => children,
-    // Dialog.Close must close the dialog — make it call onOpenChange via a
-    // wrapper button. In our simplified mock it just renders children normally.
     Close: ({ asChild, children }: { asChild?: boolean; children: React.ReactNode }) => {
       void asChild;
       return <>{children}</>;
@@ -79,13 +79,18 @@ vi.mock("@platform/ui", async (importOriginal) => {
 });
 
 import { useListCompaniesQuery, useCreateCompanyMutation } from "@/lib/companiesApi";
-import { useCreateApplicationMutation, useParseJobDescriptionMutation } from "@/lib/applicationsApi";
+import {
+  useCreateApplicationMutation,
+  useExtractJdFromUrlMutation,
+  useParseJobDescriptionMutation,
+} from "@/lib/applicationsApi";
 import { showSuccess } from "@platform/ui";
 
 const mockUseListCompaniesQuery = vi.mocked(useListCompaniesQuery);
 const mockUseCreateCompanyMutation = vi.mocked(useCreateCompanyMutation);
 const mockUseCreateApplicationMutation = vi.mocked(useCreateApplicationMutation);
 const mockUseParseJobDescriptionMutation = vi.mocked(useParseJobDescriptionMutation);
+const mockUseExtractJdFromUrlMutation = vi.mocked(useExtractJdFromUrlMutation);
 const mockShowSuccess = vi.mocked(showSuccess);
 
 const emptyCompanies = {
@@ -95,17 +100,25 @@ const emptyCompanies = {
   error: undefined,
 } as unknown as ReturnType<typeof useListCompaniesQuery>;
 
+// Default mutation state — never called unless the test sets a specific
+// return value via `.mockReturnValue` again.
+function defaultMutation<T>(): T {
+  return [vi.fn(), { isLoading: false }] as unknown as T;
+}
+
 describe("AddApplicationDialog — inline company create", () => {
   const mockOnOpenChange = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseCreateApplicationMutation.mockReturnValue(
-      [vi.fn(), { isLoading: false }] as unknown as ReturnType<typeof useCreateApplicationMutation>,
+      defaultMutation<ReturnType<typeof useCreateApplicationMutation>>(),
     );
-    // Default: parse mutation is idle (never called in most tests).
     mockUseParseJobDescriptionMutation.mockReturnValue(
-      [vi.fn(), { isLoading: false }] as unknown as ReturnType<typeof useParseJobDescriptionMutation>,
+      defaultMutation<ReturnType<typeof useParseJobDescriptionMutation>>(),
+    );
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useExtractJdFromUrlMutation>>(),
     );
   });
 
@@ -118,14 +131,12 @@ describe("AddApplicationDialog — inline company create", () => {
   it("shows the company dropdown with a '+ New' button by default", () => {
     mockUseListCompaniesQuery.mockReturnValue(emptyCompanies);
     mockUseCreateCompanyMutation.mockReturnValue(
-      [vi.fn(), { isLoading: false }] as unknown as ReturnType<typeof useCreateCompanyMutation>,
+      defaultMutation<ReturnType<typeof useCreateCompanyMutation>>(),
     );
 
     renderDialog();
 
-    // The "+ New" button should be visible
     expect(screen.getByRole("button", { name: /add new company/i })).toBeInTheDocument();
-    // CompanyForm should NOT be visible yet
     expect(screen.queryByText("New company")).not.toBeInTheDocument();
   });
 
@@ -133,16 +144,14 @@ describe("AddApplicationDialog — inline company create", () => {
     const user = userEvent.setup();
     mockUseListCompaniesQuery.mockReturnValue(emptyCompanies);
     mockUseCreateCompanyMutation.mockReturnValue(
-      [vi.fn(), { isLoading: false }] as unknown as ReturnType<typeof useCreateCompanyMutation>,
+      defaultMutation<ReturnType<typeof useCreateCompanyMutation>>(),
     );
 
     renderDialog();
 
     await user.click(screen.getByRole("button", { name: /add new company/i }));
 
-    // CompanyForm header label is now visible
     expect(screen.getByText("New company")).toBeInTheDocument();
-    // The company dropdown should be hidden
     expect(screen.queryByRole("button", { name: /add new company/i })).not.toBeInTheDocument();
   });
 
@@ -160,10 +169,8 @@ describe("AddApplicationDialog — inline company create", () => {
     const companyPanel = screen.getByText("New company").closest("div")!;
     expect(companyPanel).toBeInTheDocument();
 
-    // Click cancel inside the CompanyForm panel (not the outer dialog Cancel)
     await user.click(within(companyPanel).getByRole("button", { name: /cancel/i }));
 
-    // Panel closed, dropdown visible again
     expect(screen.queryByText("New company")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /add new company/i })).toBeInTheDocument();
     expect(mockCreate).not.toHaveBeenCalled();
@@ -176,8 +183,6 @@ describe("AddApplicationDialog — inline company create", () => {
       unwrap: () => Promise.resolve(newCompany),
     });
 
-    // Initially no companies; after create the list would have the new one.
-    // The mock just returns empty — the auto-select via setValue is what we test.
     mockUseListCompaniesQuery.mockReturnValue(emptyCompanies);
     mockUseCreateCompanyMutation.mockReturnValue(
       [mockCreate, { isLoading: false }] as unknown as ReturnType<typeof useCreateCompanyMutation>,
@@ -185,28 +190,20 @@ describe("AddApplicationDialog — inline company create", () => {
 
     renderDialog();
 
-    // Open the inline form
     await user.click(screen.getByRole("button", { name: /add new company/i }));
-
-    // Fill in the company name
     await user.type(screen.getByLabelText(/name/i), "New Corp");
-
-    // Submit the company form
     await user.click(screen.getByRole("button", { name: /create company/i }));
 
     await waitFor(() => {
-      // Mutation was called with the correct payload
       expect(mockCreate).toHaveBeenCalledWith({
         name: "New Corp",
         primary_domain: null,
         industry: null,
         hq_location: null,
       });
-      // Success toast fired
       expect(mockShowSuccess).toHaveBeenCalledWith('Company "New Corp" created');
     });
 
-    // The panel closed, dropdown is back
     await waitFor(() => {
       expect(screen.queryByText("New company")).not.toBeInTheDocument();
     });
@@ -214,20 +211,23 @@ describe("AddApplicationDialog — inline company create", () => {
 });
 
 // ---------------------------------------------------------------------------
-// JD paste + parse UX tests
+// Paste-text flow — existing JD AI parse path
 // ---------------------------------------------------------------------------
 
-describe("AddApplicationDialog — JD parse flow", () => {
+describe("AddApplicationDialog — JD paste-text flow", () => {
   const mockOnOpenChange = vi.fn();
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseCreateApplicationMutation.mockReturnValue(
-      [vi.fn(), { isLoading: false }] as unknown as ReturnType<typeof useCreateApplicationMutation>,
+      defaultMutation<ReturnType<typeof useCreateApplicationMutation>>(),
     );
     mockUseListCompaniesQuery.mockReturnValue(emptyCompanies);
     mockUseCreateCompanyMutation.mockReturnValue(
-      [vi.fn(), { isLoading: false }] as unknown as ReturnType<typeof useCreateCompanyMutation>,
+      defaultMutation<ReturnType<typeof useCreateCompanyMutation>>(),
+    );
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useExtractJdFromUrlMutation>>(),
     );
   });
 
@@ -235,31 +235,45 @@ describe("AddApplicationDialog — JD parse flow", () => {
     return render(<AddApplicationDialog open={open} onOpenChange={mockOnOpenChange} />);
   }
 
-  it("shows the 'Paste job description to auto-fill' button by default", () => {
+  it("shows the collapsed auto-fill prompt by default", () => {
     mockUseParseJobDescriptionMutation.mockReturnValue(
-      [vi.fn(), { isLoading: false }] as unknown as ReturnType<typeof useParseJobDescriptionMutation>,
+      defaultMutation<ReturnType<typeof useParseJobDescriptionMutation>>(),
     );
 
     renderDialog();
 
-    expect(screen.getByText(/paste job description to auto-fill/i)).toBeInTheDocument();
-    // Textarea is hidden in idle state
+    expect(screen.getByText(/paste a link or job description to auto-fill/i)).toBeInTheDocument();
     expect(screen.queryByRole("textbox", { name: /job description text/i })).not.toBeInTheDocument();
   });
 
-  it("shows the JD textarea when the expand button is clicked", async () => {
+  it("expanding the panel defaults to the URL tab", async () => {
     const user = userEvent.setup();
     mockUseParseJobDescriptionMutation.mockReturnValue(
-      [vi.fn(), { isLoading: false }] as unknown as ReturnType<typeof useParseJobDescriptionMutation>,
+      defaultMutation<ReturnType<typeof useParseJobDescriptionMutation>>(),
     );
 
     renderDialog();
 
-    await user.click(screen.getByText(/paste job description to auto-fill/i));
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+
+    // URL tab is the default — the URL input should be visible.
+    expect(screen.getByLabelText(/job posting url/i)).toBeInTheDocument();
+    // The text-tab textarea is NOT visible until the user switches.
+    expect(screen.queryByRole("textbox", { name: /job description text/i })).not.toBeInTheDocument();
+  });
+
+  it("switching to text tab shows the JD textarea", async () => {
+    const user = userEvent.setup();
+    mockUseParseJobDescriptionMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useParseJobDescriptionMutation>>(),
+    );
+
+    renderDialog();
+
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+    await user.click(screen.getByRole("tab", { name: /paste the description/i }));
 
     expect(screen.getByRole("textbox", { name: /job description text/i })).toBeInTheDocument();
-    // The expand button should be gone, replaced by collapse
-    expect(screen.queryByText(/paste job description to auto-fill/i)).not.toBeInTheDocument();
   });
 
   it("calls parseJobDescription mutation when 'Parse with AI' is clicked", async () => {
@@ -289,21 +303,18 @@ describe("AddApplicationDialog — JD parse flow", () => {
 
     renderDialog();
 
-    // Open the JD panel
-    await user.click(screen.getByText(/paste job description to auto-fill/i));
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+    await user.click(screen.getByRole("tab", { name: /paste the description/i }));
 
-    // Type some JD text
     const textarea = screen.getByRole("textbox", { name: /job description text/i });
     await user.type(textarea, "Senior Engineer at Acme Corp");
 
-    // Click parse
     await user.click(screen.getByRole("button", { name: /parse with ai/i }));
 
     await waitFor(() => {
       expect(mockParse).toHaveBeenCalledWith({ jd_text: "Senior Engineer at Acme Corp" });
     });
 
-    // After success, shows the parsed confirmation banner
     await waitFor(() => {
       expect(screen.getByText(/fields pre-filled from jd/i)).toBeInTheDocument();
     });
@@ -321,7 +332,8 @@ describe("AddApplicationDialog — JD parse flow", () => {
 
     renderDialog();
 
-    await user.click(screen.getByText(/paste job description to auto-fill/i));
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+    await user.click(screen.getByRole("tab", { name: /paste the description/i }));
 
     const textarea = screen.getByRole("textbox", { name: /job description text/i });
     await user.type(textarea, "Some JD text");
@@ -329,53 +341,190 @@ describe("AddApplicationDialog — JD parse flow", () => {
     await user.click(screen.getByRole("button", { name: /parse with ai/i }));
 
     await waitFor(() => {
-      expect(screen.getByText(/ai parsing failed/i)).toBeInTheDocument();
+      expect(screen.getByText(/couldn't auto-fill/i)).toBeInTheDocument();
     });
   });
+});
 
-  it("dismiss button on success banner resets to idle state", async () => {
+// ---------------------------------------------------------------------------
+// New: paste-link flow — JD URL extract path
+// ---------------------------------------------------------------------------
+
+describe("AddApplicationDialog — JD paste-link flow", () => {
+  const mockOnOpenChange = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCreateApplicationMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useCreateApplicationMutation>>(),
+    );
+    mockUseListCompaniesQuery.mockReturnValue(emptyCompanies);
+    mockUseCreateCompanyMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useCreateCompanyMutation>>(),
+    );
+    mockUseParseJobDescriptionMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useParseJobDescriptionMutation>>(),
+    );
+  });
+
+  function renderDialog(open = true) {
+    return render(<AddApplicationDialog open={open} onOpenChange={mockOnOpenChange} />);
+  }
+
+  it("calls extractJdFromUrl when 'Fetch and auto-fill' is clicked", async () => {
     const user = userEvent.setup();
-    const mockParse = vi.fn().mockReturnValue({
+    const mockExtract = vi.fn().mockReturnValue({
       unwrap: () =>
         Promise.resolve({
-          title: null,
-          company: null,
-          location: null,
-          remote_type: null,
-          salary_min: null,
-          salary_max: null,
-          salary_currency: null,
-          salary_period: null,
-          seniority: null,
-          must_have_requirements: [],
-          nice_to_have_requirements: [],
-          responsibilities: [],
+          title: "Senior Backend Engineer",
+          company: "Acme Corp",
+          location: "San Francisco, CA, US",
+          description_html: "<p>Build APIs at scale.</p>",
+          requirements_text: "Must have:\n- Python",
           summary: null,
+          source_url: "https://jobs.example.com/abc",
         }),
     });
 
-    mockUseParseJobDescriptionMutation.mockReturnValue(
-      [mockParse, { isLoading: false }] as unknown as ReturnType<typeof useParseJobDescriptionMutation>,
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      [mockExtract, { isLoading: false }] as unknown as ReturnType<typeof useExtractJdFromUrlMutation>,
     );
 
     renderDialog();
 
-    await user.click(screen.getByText(/paste job description to auto-fill/i));
-    const textarea = screen.getByRole("textbox", { name: /job description text/i });
-    await user.type(textarea, "Some JD");
-    await user.click(screen.getByRole("button", { name: /parse with ai/i }));
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
 
-    // Wait for success banner
+    // URL tab is default. Type a URL and click fetch.
+    const urlInput = screen.getByLabelText(/job posting url/i);
+    await user.type(urlInput, "https://jobs.example.com/abc");
+
+    await user.click(screen.getByRole("button", { name: /fetch and auto-fill/i }));
+
+    await waitFor(() => {
+      expect(mockExtract).toHaveBeenCalledWith({ url: "https://jobs.example.com/abc" });
+    });
+
     await waitFor(() => {
       expect(screen.getByText(/fields pre-filled from jd/i)).toBeInTheDocument();
     });
+    // Source URL is shown in the success banner.
+    expect(screen.getByText(/fetched from/i)).toBeInTheDocument();
+  });
 
-    // Dismiss it
-    await user.click(screen.getByRole("button", { name: /dismiss parse result/i }));
-
-    // Back to idle — the expand button is visible again
-    await waitFor(() => {
-      expect(screen.getByText(/paste job description to auto-fill/i)).toBeInTheDocument();
+  it("shows authRequired banner with 'switch to paste-text' affordance on 422 auth_required", async () => {
+    const user = userEvent.setup();
+    const mockExtract = vi.fn().mockReturnValue({
+      // RTK Query rejects with the error shape from axiosBaseQuery.
+      unwrap: () =>
+        Promise.reject({
+          status: 422,
+          data: { detail: "auth_required" },
+        }),
     });
+
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      [mockExtract, { isLoading: false }] as unknown as ReturnType<typeof useExtractJdFromUrlMutation>,
+    );
+
+    renderDialog();
+
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+
+    const urlInput = screen.getByLabelText(/job posting url/i);
+    await user.type(urlInput, "https://www.linkedin.com/jobs/view/123");
+
+    await user.click(screen.getByRole("button", { name: /fetch and auto-fill/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/couldn't reach this page/i)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /paste the description text instead/i })).toBeInTheDocument();
+  });
+
+  it("clicking 'paste the description text instead' switches to the text tab", async () => {
+    const user = userEvent.setup();
+    const mockExtract = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.reject({
+          status: 422,
+          data: { detail: "auth_required" },
+        }),
+    });
+
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      [mockExtract, { isLoading: false }] as unknown as ReturnType<typeof useExtractJdFromUrlMutation>,
+    );
+
+    renderDialog();
+
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+
+    const urlInput = screen.getByLabelText(/job posting url/i);
+    await user.type(urlInput, "https://www.linkedin.com/jobs/view/123");
+
+    await user.click(screen.getByRole("button", { name: /fetch and auto-fill/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /paste the description text instead/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /paste the description text instead/i }));
+
+    // Text tab is now active — the textarea is visible.
+    await waitFor(() => {
+      expect(screen.getByRole("textbox", { name: /job description text/i })).toBeInTheDocument();
+    });
+  });
+
+  it("shows generic error banner on 502 / 504 / network failures", async () => {
+    const user = userEvent.setup();
+    const mockExtract = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.reject({ status: 504, data: "Gateway timeout" }),
+    });
+
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      [mockExtract, { isLoading: false }] as unknown as ReturnType<typeof useExtractJdFromUrlMutation>,
+    );
+
+    renderDialog();
+
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+
+    const urlInput = screen.getByLabelText(/job posting url/i);
+    await user.type(urlInput, "https://slow.example.com/job");
+
+    await user.click(screen.getByRole("button", { name: /fetch and auto-fill/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/couldn't auto-fill/i)).toBeInTheDocument();
+    });
+    // Specific 504 wording.
+    expect(screen.getByText(/took too long/i)).toBeInTheDocument();
+  });
+
+  it("preserves typed URL when switching to text tab and back", async () => {
+    const user = userEvent.setup();
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useExtractJdFromUrlMutation>>(),
+    );
+
+    renderDialog();
+
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+
+    const urlInput = screen.getByLabelText(/job posting url/i);
+    await user.type(urlInput, "https://jobs.example.com/abc");
+
+    // Switch to text tab.
+    await user.click(screen.getByRole("tab", { name: /paste the description/i }));
+    expect(screen.queryByLabelText(/job posting url/i)).not.toBeInTheDocument();
+
+    // Switch back.
+    await user.click(screen.getByRole("tab", { name: /paste a link/i }));
+
+    // URL is still there.
+    const restored = screen.getByLabelText(/job posting url/i) as HTMLInputElement;
+    expect(restored.value).toBe("https://jobs.example.com/abc");
   });
 });

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/jdErrorRouting.test.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/jdErrorRouting.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for the JD URL extract error-routing helpers.
+ *
+ * The frontend reads two pieces of information off RTK Query's error
+ * response (`{ status, data }`):
+ *   1. `isAuthRequiredError` — distinguishes the 422 + auth_required
+ *      case from every other 422 (which are validation errors).
+ *   2. `describeExtractError` — picks a user-friendly sentence based on
+ *      the status code, with a sensible fallback.
+ */
+import { describe, it, expect } from "vitest";
+import { describeExtractError, isAuthRequiredError } from "../jdErrorRouting";
+
+describe("isAuthRequiredError", () => {
+  it("matches a 422 response with detail 'auth_required'", () => {
+    expect(
+      isAuthRequiredError({ status: 422, data: { detail: "auth_required" } }),
+    ).toBe(true);
+  });
+
+  it("does NOT match a 422 with a different detail", () => {
+    expect(
+      isAuthRequiredError({ status: 422, data: { detail: "some_other_error" } }),
+    ).toBe(false);
+  });
+
+  it("does NOT match a 422 with no body", () => {
+    expect(isAuthRequiredError({ status: 422, data: undefined })).toBe(false);
+  });
+
+  it("does NOT match a 400 with auth_required body", () => {
+    // Status code is part of the contract — only 422 is the documented
+    // auth-required signal.
+    expect(
+      isAuthRequiredError({ status: 400, data: { detail: "auth_required" } }),
+    ).toBe(false);
+  });
+
+  it("does NOT match a 504 timeout", () => {
+    expect(isAuthRequiredError({ status: 504, data: "Timeout" })).toBe(false);
+  });
+
+  it("does NOT match a non-object error", () => {
+    expect(isAuthRequiredError("error string")).toBe(false);
+    expect(isAuthRequiredError(null)).toBe(false);
+    expect(isAuthRequiredError(undefined)).toBe(false);
+    expect(isAuthRequiredError(42)).toBe(false);
+  });
+
+  it("does NOT match an Error instance", () => {
+    expect(isAuthRequiredError(new Error("boom"))).toBe(false);
+  });
+});
+
+describe("describeExtractError", () => {
+  it("explains 504 as a slow-page timeout", () => {
+    expect(describeExtractError({ status: 504, data: "" })).toMatch(/took too long/i);
+  });
+
+  it("explains 502 as an extraction failure", () => {
+    expect(describeExtractError({ status: 502, data: "" })).toMatch(/couldn't extract/i);
+  });
+
+  it("explains 429 as a rate-limit hit", () => {
+    expect(describeExtractError({ status: 429, data: "" })).toMatch(/too many/i);
+  });
+
+  it("explains 400 as a malformed URL", () => {
+    expect(describeExtractError({ status: 400, data: "" })).toMatch(/url.*right/i);
+  });
+
+  it("falls back to a generic message for unknown errors", () => {
+    expect(describeExtractError({ status: 599, data: "Unknown" })).toMatch(/couldn't fetch/i);
+    expect(describeExtractError(null)).toMatch(/couldn't fetch/i);
+    expect(describeExtractError("some string")).toMatch(/couldn't fetch/i);
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/applications/jdErrorRouting.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/jdErrorRouting.ts
@@ -1,0 +1,67 @@
+/**
+ * Routing helpers for the JD URL extraction error responses.
+ *
+ * The backend returns a small, stable set of HTTP statuses for the
+ * `POST /applications/extract-from-url` endpoint:
+ *
+ * - 422 + `{detail: "auth_required"}` — URL is auth-walled (LinkedIn,
+ *   Glassdoor) or returned a near-empty body. UI should switch to the
+ *   "paste text" affordance.
+ * - 504 — upstream timeout. Surfaced as a normal error.
+ * - 502 — upstream HTTP error or AI extraction failed.
+ * - 429 — per-IP rate limit exceeded.
+ * - 400 — malformed URL (Pydantic AnyHttpUrl rejects it).
+ *
+ * RTK Query surfaces errors as `{ status: number; data: unknown }`. We
+ * read both fields defensively because `unknown` covers a string error
+ * message (axios timeouts) and a structured FastAPI body
+ * (`{detail: ...}`).
+ *
+ * Keeping this routing in one place — instead of inlined in the dialog
+ * — means the dialog file's switch statement stays small and the rules
+ * are easy to test in isolation.
+ */
+
+interface ApiErrorShape {
+  status?: number;
+  data?: unknown;
+}
+
+/**
+ * Returns true when the error is the backend's "auth_required" response —
+ * HTTP 422 with `{detail: "auth_required"}` — meaning the URL is
+ * auth-walled or returned a near-empty body. The UI should switch the
+ * user to the paste-text tab rather than show a generic error.
+ */
+export function isAuthRequiredError(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const e = err as ApiErrorShape;
+  if (e.status !== 422) return false;
+  if (typeof e.data !== "object" || e.data === null) return false;
+  const data = e.data as Record<string, unknown>;
+  return data.detail === "auth_required";
+}
+
+/**
+ * User-friendly message for non-auth-required failures of the URL
+ * extractor. Falls back to a generic message when the error shape is
+ * unrecognised.
+ */
+export function describeExtractError(err: unknown): string {
+  if (typeof err === "object" && err !== null) {
+    const e = err as ApiErrorShape;
+    if (e.status === 504) {
+      return "The page took too long to load. Try again or paste the description text.";
+    }
+    if (e.status === 502) {
+      return "Couldn't extract the job description from that page. Paste the description text instead.";
+    }
+    if (e.status === 429) {
+      return "Too many requests. Wait a few minutes and try again.";
+    }
+    if (e.status === 400) {
+      return "That URL doesn't look right. Make sure it starts with http:// or https://.";
+    }
+  }
+  return "Couldn't fetch that URL. Paste the description text instead.";
+}

--- a/apps/myjobhunter/frontend/src/features/applications/useJdParseMode.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/useJdParseMode.ts
@@ -1,21 +1,47 @@
 /**
- * Discriminated union for the JD paste / parse UX state in AddApplicationDialog.
+ * Discriminated union for the JD paste / parse / fetch UX state in
+ * AddApplicationDialog.
+ *
+ * The dialog supports two input modes — URL ("Paste a link") and free-text
+ * ("Paste the description text"). The URL path defaults because the
+ * operator's stated preference is paste-link first; both call the
+ * Add Application form pre-fill flow when they succeed.
  *
  * States:
- * - idle: textarea hidden; "Paste JD to auto-fill" button visible
- * - pasting: textarea visible; "Parse with AI" button visible
- * - parsing: API call in flight; button shows spinner
- * - parsed: fields pre-filled from Claude; success banner visible
- * - failed: API call returned error; error message visible
+ * - idle:   panel collapsed; "Paste link or description to auto-fill" visible
+ * - pasting (text): textarea visible; "Parse with AI" button visible
+ * - fetching (url): URL input visible; "Fetch" button visible
+ * - parsing: text-parse API call in flight; button shows spinner
+ * - extracting: URL-extract API call in flight; button shows spinner
+ * - parsed: fields pre-filled successfully; success banner visible
+ * - failed: API call returned an error; error message visible
+ * - authRequired: URL was auth-walled (LinkedIn / Glassdoor / tiny-page);
+ *   error banner with a "Switch to paste-text" affordance
  *
  * The flat switch over `mode.kind` in the component avoids nested ternaries
  * and makes each state's rendering path explicit.
+ *
+ * Carrying `jdText` and `url` through the parsing/extracting states means
+ * the user's input survives an in-flight error — the textarea or URL
+ * input redisplays the original value when the API throws.
  */
 export type JdParseMode =
   | { kind: "idle" }
   | { kind: "pasting"; jdText: string }
+  | { kind: "fetching"; url: string }
   | { kind: "parsing"; jdText: string }
-  | { kind: "parsed"; summary: string | null }
-  | { kind: "failed"; errorMessage: string };
+  | { kind: "extracting"; url: string }
+  | { kind: "parsed"; summary: string | null; sourceUrl: string | null }
+  | { kind: "failed"; errorMessage: string }
+  | { kind: "authRequired"; url: string };
 
 export const JD_PARSE_MODE_IDLE: JdParseMode = { kind: "idle" };
+
+/**
+ * Tab selector for the input method. Persisted in component state so
+ * switching tabs doesn't lose the user's typed input — see
+ * AddApplicationDialog.handleSwitchTab for the preservation logic.
+ */
+export type JdInputTab = "url" | "text";
+
+export const JD_INPUT_TAB_DEFAULT: JdInputTab = "url";

--- a/apps/myjobhunter/frontend/src/lib/applicationsApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/applicationsApi.ts
@@ -6,6 +6,8 @@ import type { ApplicationEvent } from "@/types/application-event";
 import type { ApplicationEventCreateRequest } from "@/types/application-event-create-request";
 import type { ApplicationEventListResponse } from "@/types/application-event-list-response";
 import type { JdParseResponse } from "@/types/application/jd-parse-response";
+import type { JdUrlExtractRequest } from "@/types/application/jd-url-extract-request";
+import type { JdUrlExtractResponse } from "@/types/application/jd-url-extract-response";
 
 const APPLICATIONS_TAG = "Applications";
 const APPLICATION_EVENTS_TAG = "ApplicationEvents";
@@ -111,6 +113,30 @@ const applicationsApi = baseApi.enhanceEndpoints({
         data: body,
       }),
     }),
+
+    /**
+     * POST /applications/extract-from-url
+     *
+     * Fetches a job-posting URL and extracts structured fields server-side.
+     * Two-tier strategy: schema.org JobPosting fast path, Claude HTML-text
+     * fallback. Stateless — does NOT create an Application row.
+     *
+     * Status codes the caller must handle:
+     * - 200 → JdUrlExtractResponse with extracted fields
+     * - 422 with detail "auth_required" → URL is auth-walled (LinkedIn,
+     *   Glassdoor) or the page returned <500 visible bytes. Switch to the
+     *   paste-text tab.
+     * - 429 → per-IP rate limit exceeded (10 / 5 minutes)
+     * - 502 → upstream error or AI extraction failed
+     * - 504 → upstream fetch timed out
+     */
+    extractJdFromUrl: build.mutation<JdUrlExtractResponse, JdUrlExtractRequest>({
+      query: (body) => ({
+        url: "/applications/extract-from-url",
+        method: "POST",
+        data: body,
+      }),
+    }),
   }),
 });
 
@@ -123,4 +149,5 @@ export const {
   useListApplicationEventsQuery,
   useLogApplicationEventMutation,
   useParseJobDescriptionMutation,
+  useExtractJdFromUrlMutation,
 } = applicationsApi;

--- a/apps/myjobhunter/frontend/src/types/application/jd-url-extract-request.ts
+++ b/apps/myjobhunter/frontend/src/types/application/jd-url-extract-request.ts
@@ -1,0 +1,12 @@
+/**
+ * TypeScript type for POST /applications/extract-from-url request body.
+ * Mirrors `JdUrlExtractRequest` in
+ * apps/myjobhunter/backend/app/schemas/application/jd_url_extract_request.py.
+ *
+ * The backend validates the URL via Pydantic AnyHttpUrl — only http(s)
+ * URLs with a host are accepted. Anything else returns 422 at the
+ * schema layer before the service runs.
+ */
+export interface JdUrlExtractRequest {
+  url: string;
+}

--- a/apps/myjobhunter/frontend/src/types/application/jd-url-extract-response.ts
+++ b/apps/myjobhunter/frontend/src/types/application/jd-url-extract-response.ts
@@ -1,0 +1,28 @@
+/**
+ * TypeScript type for POST /applications/extract-from-url response.
+ * Mirrors `JdUrlExtractResponse` in
+ * apps/myjobhunter/backend/app/schemas/application/jd_url_extract_response.py.
+ *
+ * All fields are nullable except `source_url` — the source URL is always
+ * echoed back so the UI can display "Fetched from <url>" alongside the
+ * pre-fill banner.
+ *
+ * `description_html` is HTML when the source publishes it that way
+ * (schema.org JobPosting.description is commonly an HTML string). The
+ * frontend renders it via plain-text textarea today; future iterations
+ * may sanitise + render the HTML inline.
+ *
+ * `requirements_text` is plain text or Markdown — when populated by the
+ * Claude HTML-text fallback it's a Markdown bullet block ("Must have:\n
+ * - X\n- Y\n\nNice to have:\n- Z"). When populated from schema.org
+ * JobPosting.responsibilities it's a newline-joined plain-text list.
+ */
+export interface JdUrlExtractResponse {
+  title: string | null;
+  company: string | null;
+  location: string | null;
+  description_html: string | null;
+  requirements_text: string | null;
+  summary: string | null;
+  source_url: string;
+}


### PR DESCRIPTION
## Summary

Operator can now paste a **job-posting URL** in the Add Application dialog instead of copy/pasting the JD text. The dialog grows a tab toggle (URL / Text), defaulting to URL.

**Two-tier extraction:**
1. **schema.org JobPosting fast path** — parses JSON-LD blocks server-rendered by modern ATSes (Ashby, Greenhouse, Lever, Workday, Indeed). Zero Claude tokens spent.
2. **HTML-text Claude fallback** — for sites without schema.org, strips visible text via BeautifulSoup and reuses the existing JD-parsing prompt at `services/extraction/prompts/jd_parsing_prompt.py`.

**Honest limits** surfaced in the UI:
- LinkedIn / Glassdoor postings → short-circuit before the network call; banner shows "couldn't reach this page — paste the description text instead" with a button that switches to the text tab.
- Tiny pages (<500 visible bytes after strip) → same auth_required signal.
- 504 / 502 / 429 / 400 each get a distinct user-friendly message via `jdErrorRouting.ts`.

## Backend

- `POST /applications/extract-from-url` returning `JdUrlExtractResponse`
- Per-IP rate limit: 10 / 5 min (same pattern as `_INVITE_INFO_LIMITER`)
- Status codes: 200 / 400 / 422 \`auth_required\` / 429 / 502 / 504
- New service `app/services/extraction/jd_url_extractor.py`
- Pydantic schemas under `app/schemas/application/jd_url_extract_{request,response}.py`
- New deps: `beautifulsoup4`, `lxml` — `pyproject.toml` + `uv.lock` + `requirements.txt` regenerated

## Frontend

- New tab UI extracted to `features/applications/JdAutoFillSection.tsx`
- New RTK Query mutation `useExtractJdFromUrlMutation` in `lib/applicationsApi.ts`
- TS types at `types/application/jd-url-extract-{request,response}.ts`
- Discriminated `JdParseMode` union extended with `fetching` / `extracting` / `authRequired` states
- Tab buffer preservation — switching tabs keeps your typed URL or text
- `LoadingButton` spinners on both Fetch and Parse buttons (visible-loading-feedback rule)

## Tests

- 32 backend unit tests (schema.org happy path, list / graph wrappers, malformed JSON, auth-walled short-circuit, tiny-page detection, 401/403, timeout, 502, malformed URL, Claude failure mapping)
- 7 backend endpoint tests (run against a real Postgres in CI)
- 27 frontend unit tests (paste-text flow, paste-link flow, auth_required → switch-to-text, generic error routing, tab buffer preservation)
- 12 unit tests for `jdErrorRouting` helpers
- 2 E2E tests at `e2e/applications-jd-url-extract.spec.ts` (happy path + auth-required CTA), API mocked via `page.route()`

## Test plan

- [x] Backend unit tests (\`pytest tests/test_jd_url_extractor.py -k \"not Endpoint\"\`) — 32/32 pass locally
- [x] Frontend tests (\`vitest run src/features/applications src/lib/__tests__/applicationsApi.test.ts\`) — 33/33 pass locally
- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean on touched files
- [x] \`vite build\` succeeds
- [ ] CI green (\`ci-myjobhunter\` runs the endpoint suite against a real Postgres, \`integration-myjobhunter\` runs Playwright)
- [ ] Manual smoke after merge against the operator's example URL \`https://jobs.ashbyhq.com/pivotal-health/74f89bd9-30ca-4cf9-ab50-e0f1d2af2431\` (schema.org fast path)

## What this PR deliberately does NOT add

- Headless-browser fallback (Playwright) — the schema.org path covers JS-rendered ATSes that still server-render JobPosting
- Per-domain custom extractors — fragile vs. schema.org + Claude
- Caching — the operator pastes each URL once

🤖 Generated with [Claude Code](https://claude.com/claude-code)