### PR TITLE
fix(myjobhunter/applications): JD extract auto-finds-or-creates company

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
@@ -144,7 +144,7 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
     setJdMode({ kind: "extracting", url });
     try {
       const result = await extractJdFromUrl({ url }).unwrap();
-      applyExtractResult(result);
+      await applyExtractResult(result);
     } catch (err) {
       if (isAuthRequiredError(err)) {
         setJdMode({ kind: "authRequired", url });
@@ -180,7 +180,7 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
     setJdMode({ kind: "parsed", summary: result.summary, sourceUrl });
   }
 
-  function applyExtractResult(result: JdUrlExtractResponse) {
+  async function applyExtractResult(result: JdUrlExtractResponse) {
     // Echo the source URL into the form's URL field so the operator
     // doesn't have to paste it twice.
     setValue("url", result.source_url, { shouldValidate: true });
@@ -197,11 +197,40 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
     if (notesScaffold) {
       setValue("notes", notesScaffold, { shouldValidate: true });
     }
+    // Auto-find-or-create the company so the operator doesn't have to
+    // manually re-enter what we already extracted. Case-insensitive
+    // match against existing companies; create on miss.
+    if (result.company) {
+      await selectOrCreateCompany(result.company);
+    }
     setJdMode({
       kind: "parsed",
       summary: result.summary,
       sourceUrl: result.source_url,
     });
+  }
+
+  async function selectOrCreateCompany(name: string): Promise<void> {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    const existing = companies.find(
+      (c) => c.name.trim().toLowerCase() === trimmed.toLowerCase(),
+    );
+    if (existing) {
+      setValue("company_id", existing.id, { shouldValidate: true });
+      return;
+    }
+    try {
+      const created = await createCompany({ name: trimmed }).unwrap();
+      setValue("company_id", created.id, { shouldValidate: true });
+    } catch (err) {
+      // Don't block the rest of the pre-fill if company create fails —
+      // operator can still pick or create one manually. Surface the
+      // error so they know what happened.
+      showError(
+        `Couldn't auto-create company "${trimmed}": ${extractErrorMessage(err)}`,
+      );
+    }
   }
 
   // -------------------------------------------------------------------------

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
@@ -503,6 +503,120 @@ describe("AddApplicationDialog — JD paste-link flow", () => {
     expect(screen.getByText(/took too long/i)).toBeInTheDocument();
   });
 
+  it("auto-creates the company on extract when no match exists", async () => {
+    const user = userEvent.setup();
+    const mockExtract = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          title: "Senior Engineer",
+          company: "Pivotal Health",
+          location: "Remote",
+          description_html: null,
+          requirements_text: null,
+          summary: null,
+          source_url: "https://jobs.example.com/x",
+        }),
+    });
+    const mockCreateCompany = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          id: "co-123",
+          name: "Pivotal Health",
+          primary_domain: null,
+          logo_url: null,
+          industry: null,
+          size_range: null,
+          notes: null,
+          deleted_at: null,
+        }),
+    });
+
+    // Empty companies list → must auto-create.
+    mockUseListCompaniesQuery.mockReturnValue(emptyCompanies);
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      [mockExtract, { isLoading: false }] as unknown as ReturnType<typeof useExtractJdFromUrlMutation>,
+    );
+    mockUseCreateCompanyMutation.mockReturnValue(
+      [mockCreateCompany, { isLoading: false }] as unknown as ReturnType<typeof useCreateCompanyMutation>,
+    );
+
+    renderDialog();
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+    const urlInput = screen.getByLabelText(/job posting url/i);
+    await user.type(urlInput, "https://jobs.example.com/x");
+    await user.click(screen.getByRole("button", { name: /fetch and auto-fill/i }));
+
+    await waitFor(() => {
+      expect(mockCreateCompany).toHaveBeenCalledWith({ name: "Pivotal Health" });
+    });
+  });
+
+  it("auto-selects an existing company on extract (case-insensitive)", async () => {
+    const user = userEvent.setup();
+    const mockExtract = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          title: "Senior Engineer",
+          company: "PIVOTAL HEALTH",
+          location: "Remote",
+          description_html: null,
+          requirements_text: null,
+          summary: null,
+          source_url: "https://jobs.example.com/x",
+        }),
+    });
+    const mockCreateCompany = vi.fn();
+
+    // Existing companies — one matches case-insensitively.
+    mockUseListCompaniesQuery.mockReturnValue({
+      data: {
+        items: [
+          {
+            id: "co-existing",
+            name: "Pivotal Health",
+            primary_domain: null,
+            logo_url: null,
+            industry: null,
+            size_range: null,
+            notes: null,
+            deleted_at: null,
+          },
+        ],
+        total: 1,
+      },
+      isLoading: false,
+      isError: false,
+      error: undefined,
+    } as unknown as ReturnType<typeof useListCompaniesQuery>);
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      [mockExtract, { isLoading: false }] as unknown as ReturnType<typeof useExtractJdFromUrlMutation>,
+    );
+    mockUseCreateCompanyMutation.mockReturnValue(
+      [mockCreateCompany, { isLoading: false }] as unknown as ReturnType<typeof useCreateCompanyMutation>,
+    );
+
+    renderDialog();
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+    const urlInput = screen.getByLabelText(/job posting url/i);
+    await user.type(urlInput, "https://jobs.example.com/x");
+    await user.click(screen.getByRole("button", { name: /fetch and auto-fill/i }));
+
+    // Wait for pre-fill to land — role title becomes visible
+    await waitFor(() => {
+      expect(screen.getByText(/fields pre-filled from jd/i)).toBeInTheDocument();
+    });
+
+    // No createCompany call — existing one was found case-insensitively
+    expect(mockCreateCompany).not.toHaveBeenCalled();
+    // The company select should now have the matched company chosen.
+    // (There are multiple comboboxes in the dialog; pick the one with
+    // the company name as a visible option.)
+    const companyOption = screen.getByRole("option", {
+      name: "Pivotal Health",
+    }) as HTMLOptionElement;
+    expect(companyOption.selected).toBe(true);
+  });
+
   it("preserves typed URL when switching to text tab and back", async () => {
     const user = userEvent.setup();
     mockUseExtractJdFromUrlMutation.mockReturnValue(


### PR DESCRIPTION
Operator: "why do I have to enter the company?" — JD URL extract was pre-filling everything except Company.

## Fix

`applyExtractResult` now calls `selectOrCreateCompany` after the other field pre-fills:

1. Case-insensitive match against loaded companies → just set `company_id` to the matching row
2. No match → `createCompany({ name })` and select the created row
3. createCompany failure → toast + fall through (operator picks/creates manually)

## Tests

Two new Vitest cases (16/16 passing locally):
- Empty companies list + extract returns "Pivotal Health" → `createCompany` called with that name
- Existing companies list contains "Pivotal Health" + extract returns "PIVOTAL HEALTH" → matched case-insensitively, **no** `createCompany` call, the matching option is selected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)