### PR TITLE
fix(ci): unblock MJH stack-smoke (MinIO startup check)

### DIFF
--- a/.github/workflows/integration-myjobhunter.yml
+++ b/.github/workflows/integration-myjobhunter.yml
@@ -52,6 +52,15 @@ jobs:
           LOG_LEVEL=INFO
           EMAIL_BACKEND=console
           MYJOBHUNTER_ENABLE_TEST_HELPERS=1
+          # MinIO is part of the shared infra stack on the VPS; in CI we
+          # don't run it. The boot guard would otherwise fail with
+          # StorageNotConfiguredError. Skip the bucket-existence check
+          # at startup; document endpoints (which DO need MinIO) are
+          # not exercised by the smoke test.
+          MINIO_SKIP_STARTUP_CHECK=true
+          MINIO_ENDPOINT=ci-placeholder:9000
+          MINIO_ACCESS_KEY=ci-placeholder
+          MINIO_SECRET_KEY=ci-placeholder-do-not-use
           EOF
 
       - name: Create shared infra network


### PR DESCRIPTION
Stack smoke has been red on every PR with `StorageNotConfiguredError` because MinIO isn't running in CI. Setting `MINIO_SKIP_STARTUP_CHECK=true` is exactly what the lifespan's escape hatch is for.

**Why beyond the immediate fix:** every PR this session was admin-merged past "pre-existing stack-smoke failure". A real regression in compose / Caddyfile / lifespan would have been swallowed under the same noise. Restoring the green/red signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)