### PR TITLE
test(myjobhunter): add formatFileSize to ResumeJobRow @platform/ui mock

### DIFF
--- a/apps/myjobhunter/frontend/src/features/profile/__tests__/ResumeJobRow.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/__tests__/ResumeJobRow.test.tsx
@@ -28,6 +28,9 @@ vi.mock("@platform/ui", () => ({
   Badge: ({ label, color }: { label: string; color: string }) => (
     <span data-testid="badge" data-color={color}>{label}</span>
   ),
+  // The component reads formatFileSize for the size suffix; identity
+  // string is fine here — the test asserts behavior, not formatting.
+  formatFileSize: (bytes: number) => `${bytes} bytes`,
 }));
 
 vi.mock("lucide-react", () => ({


### PR DESCRIPTION
11 ResumeJobRow tests were failing because the `@platform/ui` mock didn't include `formatFileSize`. Component imports it; mock didn't return it; vitest threw on every render.

3-line fix. 11 tests now pass.

(DocumentList.test.tsx had the same gap but uses `importOriginal` + spread, so `formatFileSize` was already covered. 1 unrelated DocumentList test still fails on a duplicate-text query — separate issue, leaving for follow-up.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)