### PR TITLE
feat(myjobhunter): forgot-password + reset-password pages

### DIFF
--- a/apps/myjobhunter/frontend/.gitignore
+++ b/apps/myjobhunter/frontend/.gitignore
@@ -1,0 +1,6 @@
+
+# tsc-emitted artifacts of vite.config.ts / vitest.config.ts
+vite.config.d.ts
+vite.config.js
+vitest.config.d.ts
+vitest.config.js

--- a/apps/myjobhunter/frontend/src/lib/__tests__/auth.test.ts
+++ b/apps/myjobhunter/frontend/src/lib/__tests__/auth.test.ts
@@ -45,7 +45,14 @@ vi.mock("@/lib/api", () => ({
 
 import api from "@/lib/api";
 import { notifyAuthChange } from "@platform/ui";
-import { signIn, register, requestVerifyToken, signOut } from "@/lib/auth";
+import {
+  signIn,
+  register,
+  requestVerifyToken,
+  signOut,
+  forgotPassword,
+  resetPassword,
+} from "@/lib/auth";
 
 const mockApiPost = vi.mocked(api.post);
 const mockNotifyAuthChange = vi.mocked(notifyAuthChange);
@@ -192,6 +199,39 @@ describe("auth helpers", () => {
       // 2026-05-06 "still showed mybookkeeper6 as signed-in" bug).
       expect(mockResetApiState).toHaveBeenCalledTimes(1);
       expect(mockDispatch).toHaveBeenCalledWith(mockResetApiStateAction);
+    });
+  });
+
+  describe("forgotPassword", () => {
+    it("posts the email to /auth/forgot-password with no Turnstile header by default", async () => {
+      mockApiPost.mockResolvedValueOnce({ data: null });
+      await forgotPassword("u@e.com");
+      expect(mockApiPost).toHaveBeenCalledWith(
+        "/auth/forgot-password",
+        { email: "u@e.com" },
+        { headers: {} },
+      );
+    });
+
+    it("forwards X-Turnstile-Token header when supplied", async () => {
+      mockApiPost.mockResolvedValueOnce({ data: null });
+      await forgotPassword("u@e.com", "ts-tok");
+      expect(mockApiPost).toHaveBeenCalledWith(
+        "/auth/forgot-password",
+        { email: "u@e.com" },
+        { headers: { "X-Turnstile-Token": "ts-tok" } },
+      );
+    });
+  });
+
+  describe("resetPassword", () => {
+    it("posts token + new password to /auth/reset-password", async () => {
+      mockApiPost.mockResolvedValueOnce({ data: null });
+      await resetPassword("the-token", "supersecret-12chars");
+      expect(mockApiPost).toHaveBeenCalledWith("/auth/reset-password", {
+        token: "the-token",
+        password: "supersecret-12chars",
+      });
     });
   });
 

--- a/apps/myjobhunter/frontend/src/lib/auth.ts
+++ b/apps/myjobhunter/frontend/src/lib/auth.ts
@@ -96,6 +96,42 @@ export async function requestVerifyToken(email: string): Promise<void> {
 }
 
 /**
+ * Request a password-reset email for ``email``.
+ *
+ * Backend always returns 202 — even for unknown / unverified emails —
+ * so we never leak which addresses are registered. Errors here are
+ * deliberately swallowed at the call site so the UI shows the same
+ * "check your inbox" affordance for valid + invalid addresses.
+ *
+ * Turnstile token is forwarded as ``X-Turnstile-Token`` (the backend's
+ * ``require_turnstile`` dependency runs on /forgot-password). In dev /
+ * CI the token is empty and the backend short-circuits.
+ */
+export async function forgotPassword(
+  email: string,
+  turnstileToken = "",
+): Promise<void> {
+  await api.post(
+    "/auth/forgot-password",
+    { email },
+    {
+      headers: turnstileToken ? { "X-Turnstile-Token": turnstileToken } : {},
+    },
+  );
+}
+
+/**
+ * Submit a new password using the token from the reset email.
+ *
+ * The reset endpoint deliberately has no Turnstile gate — the email-link
+ * token is the security control at this step. Failures bubble up so
+ * the UI can show "expired link" vs "weak password" vs "network error".
+ */
+export async function resetPassword(token: string, password: string): Promise<void> {
+  await api.post("/auth/reset-password", { token, password });
+}
+
+/**
  * Sign out — clear token, wipe RTK Query caches so the next signed-in
  * user doesn't see the previous user's cached data, and notify
  * subscribers (triggers RequireAuth redirect).

--- a/apps/myjobhunter/frontend/src/pages/ForgotPassword.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ForgotPassword.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useState } from "react";
+import { Link } from "react-router-dom";
+import { LoadingButton, TurnstileWidget } from "@platform/ui";
+import { Briefcase } from "lucide-react";
+import { forgotPassword } from "@/lib/auth";
+
+/**
+ * Forgot-password entry — operator types their email, we POST to
+ * ``/auth/forgot-password``, backend mails a token-bearing reset link
+ * (or no-ops silently for unknown emails). The submitted-state UI
+ * always shows "check your inbox" regardless of whether the address
+ * was actually known — anti-enumeration.
+ */
+export default function ForgotPassword() {
+  const [email, setEmail] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [turnstileToken, setTurnstileToken] = useState("");
+
+  const handleTurnstileVerify = useCallback((token: string) => {
+    setTurnstileToken(token);
+  }, []);
+
+  const handleTurnstileExpire = useCallback(() => {
+    setTurnstileToken("");
+  }, []);
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (!email.trim()) return;
+    setIsLoading(true);
+    try {
+      await forgotPassword(email.trim(), turnstileToken);
+    } catch {
+      // Swallow — anti-enumeration. The UI always shows
+      // "check your inbox" so a hostile observer can't tell from the
+      // network response whether the email was registered.
+    }
+    setSubmitted(true);
+    setIsLoading(false);
+  }
+
+  if (submitted) {
+    return (
+      <CenteredCard title="Check your inbox">
+        <p className="text-sm text-muted-foreground mb-6">
+          If an account exists for <strong>{email}</strong>, we've sent a
+          password reset link. Check your inbox and spam folder.
+        </p>
+        <Link to="/login" className="text-sm text-primary hover:underline">
+          Back to sign in
+        </Link>
+      </CenteredCard>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-muted">
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm">
+          <div className="flex items-center gap-2 mb-6">
+            <Briefcase className="size-6 text-primary" />
+            <h1 className="text-2xl font-semibold">Reset your password</h1>
+          </div>
+          <p className="text-sm text-muted-foreground mb-6">
+            Enter your account email and we'll send you a link to reset
+            your password.
+          </p>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div>
+              <label
+                htmlFor="forgot-email"
+                className="block text-sm font-medium mb-1"
+              >
+                Email
+              </label>
+              <input
+                id="forgot-email"
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full border rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                required
+                disabled={isLoading}
+                autoComplete="email"
+              />
+            </div>
+            <TurnstileWidget
+              onVerify={handleTurnstileVerify}
+              onExpire={handleTurnstileExpire}
+            />
+            <LoadingButton
+              type="submit"
+              isLoading={isLoading}
+              loadingText="Sending..."
+              className="w-full"
+              disabled={isLoading || !email.trim()}
+            >
+              Send reset link
+            </LoadingButton>
+          </form>
+          <p className="text-sm text-muted-foreground text-center mt-4">
+            <Link to="/login" className="text-primary hover:underline">
+              Back to sign in
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CenteredCardProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function CenteredCard({ title, children }: CenteredCardProps) {
+  return (
+    <div className="min-h-screen flex flex-col bg-muted">
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm text-center">
+          <h1 className="text-2xl font-semibold mb-4">{title}</h1>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/pages/Login.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Login.tsx
@@ -230,6 +230,15 @@ export default function Login() {
               }
             />
 
+            <p className="mt-4 text-sm text-center text-muted-foreground">
+              <a
+                href="/forgot-password"
+                className="text-primary hover:underline"
+              >
+                Forgot password?
+              </a>
+            </p>
+
             {needsVerification ? (
               <div
                 data-testid="resend-verification-banner"

--- a/apps/myjobhunter/frontend/src/pages/ResetPassword.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ResetPassword.tsx
@@ -1,0 +1,167 @@
+import { useEffect, useState } from "react";
+import { Link, useNavigate, useSearchParams } from "react-router-dom";
+import {
+  LoadingButton,
+  PasswordPair,
+  extractErrorMessage,
+} from "@platform/ui";
+import { Briefcase } from "lucide-react";
+import { resetPassword } from "@/lib/auth";
+
+/**
+ * Reset-password page — invoked from the email link the operator
+ * received after submitting the forgot-password form. The token from
+ * ``?token=...`` proves they own the email; submitting a new password
+ * updates the account.
+ *
+ * The token is captured once on mount, then stripped from the URL via
+ * ``window.history.replaceState`` so it doesn't leak into the browser
+ * history / referer headers if the operator navigates away.
+ *
+ * Password pair (new + confirm + show/hide toggle + a11y) comes from
+ * the shared ``PasswordPair`` so this stays in sync with the
+ * Register page's UX.
+ */
+export default function ResetPassword() {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [token] = useState(() => searchParams.get("token"));
+
+  useEffect(() => {
+    if (token) {
+      window.history.replaceState(null, "", "/reset-password");
+    }
+  }, [token]);
+
+  const [password, setPassword] = useState("");
+  const [confirmPassword, setConfirmPassword] = useState("");
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  if (!token) {
+    return (
+      <CenteredCard title="Invalid link">
+        <p className="text-sm text-muted-foreground mb-6">
+          This password reset link is invalid or has expired. Request a
+          fresh one to continue.
+        </p>
+        <Link
+          to="/forgot-password"
+          className="text-sm text-primary hover:underline"
+        >
+          Request new link
+        </Link>
+      </CenteredCard>
+    );
+  }
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    setError("");
+
+    if (password.length < 12) {
+      setError("Password must be at least 12 characters.");
+      return;
+    }
+    if (password !== confirmPassword) {
+      setError("Passwords don't match.");
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      await resetPassword(token!, password);
+      setSuccess(true);
+    } catch (err) {
+      const message = extractErrorMessage(err);
+      if (message.toLowerCase().includes("token")) {
+        setError(
+          "This reset link has expired or already been used. Request a new one.",
+        );
+      } else {
+        setError(message || "Failed to reset password. Please try again.");
+      }
+    }
+    setIsLoading(false);
+  }
+
+  if (success) {
+    return (
+      <CenteredCard title="Password updated">
+        <p className="text-sm text-muted-foreground mb-6">
+          You can sign in with your new password now.
+        </p>
+        <button
+          type="button"
+          onClick={() => navigate("/login", { replace: true })}
+          className="w-full bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium hover:bg-primary/90"
+        >
+          Sign in
+        </button>
+      </CenteredCard>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex flex-col bg-muted">
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm">
+          <div className="flex items-center gap-2 mb-6">
+            <Briefcase className="size-6 text-primary" />
+            <h1 className="text-2xl font-semibold">Choose a new password</h1>
+          </div>
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <PasswordPair
+              password={password}
+              onPasswordChange={setPassword}
+              confirmPassword={confirmPassword}
+              onConfirmPasswordChange={setConfirmPassword}
+              label="New password"
+              disabled={isLoading}
+            />
+            {error ? (
+              <p className="text-destructive text-sm">{error}</p>
+            ) : null}
+            <LoadingButton
+              type="submit"
+              isLoading={isLoading}
+              loadingText="Resetting..."
+              className="w-full"
+              disabled={
+                isLoading ||
+                password.length < 12 ||
+                password !== confirmPassword
+              }
+            >
+              Reset password
+            </LoadingButton>
+          </form>
+          <p className="text-sm text-muted-foreground text-center mt-4">
+            <Link to="/login" className="text-primary hover:underline">
+              Back to sign in
+            </Link>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+interface CenteredCardProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+function CenteredCard({ title, children }: CenteredCardProps) {
+  return (
+    <div className="min-h-screen flex flex-col bg-muted">
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm text-center">
+          <h1 className="text-2xl font-semibold mb-4">{title}</h1>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/routes.tsx
+++ b/apps/myjobhunter/frontend/src/routes.tsx
@@ -11,6 +11,8 @@ import Security from "@/pages/Security";
 import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
 import Register from "@/pages/Register";
+import ForgotPassword from "@/pages/ForgotPassword";
+import ResetPassword from "@/pages/ResetPassword";
 import VerifyEmail from "@/pages/VerifyEmail";
 import NotFound from "@/pages/NotFound";
 import AdminDashboard from "@/pages/admin/AdminDashboard";
@@ -63,6 +65,8 @@ export const routes: RouteObject[] = [
   },
   { path: "/login", element: <Login /> },
   { path: "/register", element: <Register /> },
+  { path: "/forgot-password", element: <ForgotPassword /> },
+  { path: "/reset-password", element: <ResetPassword /> },
   { path: "/verify-email", element: <VerifyEmail /> },
   { path: "*", element: <NotFound /> },
 ];


### PR DESCRIPTION
MJH was missing both pages despite the backend reset-password router being mounted. Building the gap now (MBK already has these).

## What ships

- `pages/ForgotPassword.tsx` — email + Turnstile, always shows "check your inbox" on submit (anti-enumeration)
- `pages/ResetPassword.tsx` — captures `?token=` once, strips from URL via `history.replaceState`, uses shared `<PasswordPair>` for new+confirm with show/hide toggle (consistent with Register)
- Routes `/forgot-password` and `/reset-password`
- "Forgot password?" link below LoginForm
- `forgotPassword` (fire-and-swallow) + `resetPassword` (errors propagate so UI distinguishes expired-link vs weak-password vs network) helpers in `lib/auth.ts`
- 3 new Vitest cases for the helpers

## MBK status

MBK already has both pages with its own pattern. Upgrading MBK to use shared `<PasswordPair>` is gated on the React 18→19 bump. When that unblocks, MBK swaps its inline pair for `<PasswordPair>` and gains parity for free.

## Bonus

Untracked the four `vite.config.{d.ts,js}` / `vitest.config.{d.ts,js}` artifacts that have been polluting working trees all session, and added a `.gitignore` entry for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)