### PR TITLE
fix(mybookkeeper/leases): surface missing storage objects + offer re-upload

### DIFF
--- a/apps/mybookkeeper/backend/app/core/storage.py
+++ b/apps/mybookkeeper/backend/app/core/storage.py
@@ -108,6 +108,24 @@ class StorageClient:
             "last_modified": stat.last_modified,
         }
 
+    def object_exists(self, key: str) -> bool:
+        """Whether the object exists. ``False`` only on NoSuchKey.
+
+        Distinct from ``head_object``: this re-raises transient S3 errors
+        (network blip, signature mismatch, server 5xx) so the caller sees
+        a real exception instead of confusing a service outage with a
+        missing object. Used by per-request response builders to flag
+        orphan attachment rows whose underlying file is gone — see
+        ``services/leases/attachment_response_builder.py``.
+        """
+        try:
+            self._client.stat_object(self._bucket, key)
+        except S3Error as exc:
+            if exc.code in {"NoSuchKey", "NoSuchObject"}:
+                return False
+            raise
+        return True
+
     def generate_presigned_url(self, key: str, expires_in_seconds: int) -> str:
         """Sign a GET URL for `key` valid for `expires_in_seconds`.
 

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_attachment_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_attachment_response.py
@@ -18,5 +18,11 @@ class SignedLeaseAttachmentResponse(BaseModel):
     uploaded_by_user_id: uuid.UUID
     uploaded_at: _dt.datetime
     presigned_url: str | None = None
+    # ``False`` means the row exists in the DB but the underlying MinIO
+    # object is missing (NoSuchKey on HEAD). Set by the response builder so
+    # the UI can render "File missing — re-upload" instead of an "Open" link
+    # that 404s. Defaults to ``True`` so legacy callers / tests that
+    # construct this schema directly don't have to set it.
+    is_available: bool = True
 
     model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/services/leases/attachment_response_builder.py
+++ b/apps/mybookkeeper/backend/app/services/leases/attachment_response_builder.py
@@ -9,12 +9,22 @@ Storage is a hard requirement (the lifespan refuses to boot if MinIO is
 unreachable). Per-request signing is purely cryptographic and cannot
 fail under normal operation; any exception bubbles up so the request
 returns 500 with a real stack trace, surfacing the misconfiguration
-loudly. Silent ``presigned_url=None`` placeholders were the source of
-the PR #201–#204 outage trail and are no longer permitted on this path.
+loudly. Silent ``presigned_url=None`` placeholders for *MinIO outages*
+were the source of the PR #201–#204 outage trail and are no longer
+permitted on this path.
+
+Distinct from that anti-pattern: when MinIO is up but a *specific
+object* is missing (NoSuchKey on HEAD), the corresponding attachment
+row is flagged via ``is_available=False`` so the UI can surface a
+"File missing — re-upload" affordance instead of an "Open" link that
+404s on the user with raw S3 XML. This is a data-integrity signal,
+not a service-outage degradation — see ``StorageClient.object_exists``.
 """
 from __future__ import annotations
 
-from typing import TypeVar
+import logging
+
+import sentry_sdk
 
 from app.core.config import settings
 from app.core.storage import StorageClient, get_storage
@@ -25,30 +35,64 @@ from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
 
-_T = TypeVar("_T", LeaseTemplateFileResponse, SignedLeaseAttachmentResponse)
+logger = logging.getLogger(__name__)
 
 
 def _sign_one(storage: StorageClient, key: str) -> str:
     return storage.generate_presigned_url(key, settings.presigned_url_ttl_seconds)
 
 
-def _attach(rows: list[_T]) -> list[_T]:
-    if not rows:
-        return rows
-    storage = get_storage()
-    return [
-        r.model_copy(update={"presigned_url": _sign_one(storage, r.storage_key)})
-        for r in rows
-    ]
-
-
 def attach_presigned_urls_to_files(
     files: list[LeaseTemplateFileResponse],
 ) -> list[LeaseTemplateFileResponse]:
-    return _attach(files)
+    if not files:
+        return files
+    storage = get_storage()
+    return [
+        f.model_copy(update={"presigned_url": _sign_one(storage, f.storage_key)})
+        for f in files
+    ]
 
 
 def attach_presigned_urls_to_attachments(
     attachments: list[SignedLeaseAttachmentResponse],
 ) -> list[SignedLeaseAttachmentResponse]:
-    return _attach(attachments)
+    """Mint a presigned URL per attachment, or flag missing objects.
+
+    For each row we ``HEAD`` the underlying object. If MinIO returns
+    ``NoSuchKey`` we set ``is_available=False`` and leave ``presigned_url``
+    null so the UI can render a re-upload affordance. We also report the
+    miss to Sentry (one event per orphan) so the operator has
+    observability without a diagnostic API surfacing user data.
+
+    Transient S3 errors propagate as exceptions per ``object_exists``.
+    """
+    if not attachments:
+        return attachments
+    storage = get_storage()
+    out: list[SignedLeaseAttachmentResponse] = []
+    for row in attachments:
+        if not storage.object_exists(row.storage_key):
+            logger.warning(
+                "Lease attachment object missing in storage: lease_id=%s "
+                "attachment_id=%s storage_key=%s",
+                row.lease_id, row.id, row.storage_key,
+            )
+            with sentry_sdk.new_scope() as scope:
+                scope.set_tag("lease_id", str(row.lease_id))
+                scope.set_tag("attachment_id", str(row.id))
+                scope.set_extra("storage_key", row.storage_key)
+                sentry_sdk.capture_message(
+                    "lease_attachment_storage_object_missing",
+                    level="warning",
+                )
+            out.append(row.model_copy(update={
+                "presigned_url": None,
+                "is_available": False,
+            }))
+            continue
+        out.append(row.model_copy(update={
+            "presigned_url": _sign_one(storage, row.storage_key),
+            "is_available": True,
+        }))
+    return out

--- a/apps/mybookkeeper/backend/tests/test_attachment_response_builder.py
+++ b/apps/mybookkeeper/backend/tests/test_attachment_response_builder.py
@@ -1,0 +1,129 @@
+"""Tests for ``attach_presigned_urls_to_attachments``.
+
+Covers the orphan-detection path added with the lease-attachment-missing UX:
+- HEAD ok → ``is_available=True`` and ``presigned_url`` set
+- HEAD NoSuchKey → ``is_available=False`` and ``presigned_url=None``
+- transient S3 error → exception propagates (no silent degradation)
+- empty input list → returns empty list without touching storage
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.schemas.leases.signed_lease_attachment_response import (
+    SignedLeaseAttachmentResponse,
+)
+from app.services.leases.attachment_response_builder import (
+    attach_presigned_urls_to_attachments,
+)
+
+
+def _row(**overrides) -> SignedLeaseAttachmentResponse:
+    base = {
+        "id": uuid.uuid4(),
+        "lease_id": uuid.uuid4(),
+        "filename": "lease.pdf",
+        "storage_key": f"signed-leases/{uuid.uuid4()}/{uuid.uuid4()}",
+        "content_type": "application/pdf",
+        "size_bytes": 1024,
+        "kind": "signed_lease",
+        "uploaded_by_user_id": uuid.uuid4(),
+        "uploaded_at": _dt.datetime.now(_dt.timezone.utc),
+        "presigned_url": None,
+        "is_available": True,
+    }
+    base.update(overrides)
+    return SignedLeaseAttachmentResponse(**base)
+
+
+def _mock_storage(*, exists: bool = True, raise_exc: Exception | None = None) -> MagicMock:
+    storage = MagicMock()
+    if raise_exc is not None:
+        storage.object_exists.side_effect = raise_exc
+    else:
+        storage.object_exists.return_value = exists
+    storage.generate_presigned_url.return_value = "https://example.com/signed-url"
+    return storage
+
+
+class TestAttachPresignedUrlsToAttachments:
+    def test_empty_list_returns_empty(self) -> None:
+        with patch(
+            "app.services.leases.attachment_response_builder.get_storage",
+        ) as get_storage:
+            result = attach_presigned_urls_to_attachments([])
+            assert result == []
+            get_storage.assert_not_called()
+
+    def test_present_object_gets_presigned_url(self) -> None:
+        row = _row()
+        storage = _mock_storage(exists=True)
+        with patch(
+            "app.services.leases.attachment_response_builder.get_storage",
+            return_value=storage,
+        ):
+            [out] = attach_presigned_urls_to_attachments([row])
+        assert out.is_available is True
+        assert out.presigned_url == "https://example.com/signed-url"
+        storage.object_exists.assert_called_once_with(row.storage_key)
+        storage.generate_presigned_url.assert_called_once()
+
+    def test_missing_object_flips_is_available_and_skips_url(self) -> None:
+        row = _row(presigned_url=None, is_available=True)
+        storage = _mock_storage(exists=False)
+        with patch(
+            "app.services.leases.attachment_response_builder.get_storage",
+            return_value=storage,
+        ), patch(
+            "app.services.leases.attachment_response_builder.sentry_sdk",
+        ) as sentry_mock:
+            [out] = attach_presigned_urls_to_attachments([row])
+        assert out.is_available is False
+        assert out.presigned_url is None
+        storage.generate_presigned_url.assert_not_called()
+        sentry_mock.capture_message.assert_called_once()
+        # Confirm we set the lease_id / attachment_id tags so Sentry groups
+        # missing-file events by lease (operator can see at-a-glance whether
+        # this is one orphan or many).
+        scope_cm = sentry_mock.new_scope.return_value
+        scope = scope_cm.__enter__.return_value
+        tag_calls = {call.args[0]: call.args[1] for call in scope.set_tag.call_args_list}
+        assert tag_calls["lease_id"] == str(row.lease_id)
+        assert tag_calls["attachment_id"] == str(row.id)
+
+    def test_transient_error_propagates(self) -> None:
+        row = _row()
+        storage = _mock_storage(raise_exc=RuntimeError("MinIO 503"))
+        with patch(
+            "app.services.leases.attachment_response_builder.get_storage",
+            return_value=storage,
+        ):
+            with pytest.raises(RuntimeError, match="MinIO 503"):
+                attach_presigned_urls_to_attachments([row])
+
+    def test_mixed_present_and_missing_in_one_call(self) -> None:
+        present = _row()
+        missing = _row()
+
+        def exists_side_effect(key: str) -> bool:
+            return key == present.storage_key
+
+        storage = MagicMock()
+        storage.object_exists.side_effect = exists_side_effect
+        storage.generate_presigned_url.return_value = "https://example.com/signed"
+
+        with patch(
+            "app.services.leases.attachment_response_builder.get_storage",
+            return_value=storage,
+        ), patch("app.services.leases.attachment_response_builder.sentry_sdk"):
+            results = attach_presigned_urls_to_attachments([present, missing])
+
+        by_id = {r.id: r for r in results}
+        assert by_id[present.id].is_available is True
+        assert by_id[present.id].presigned_url == "https://example.com/signed"
+        assert by_id[missing.id].is_available is False
+        assert by_id[missing.id].presigned_url is None

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAttachmentKind.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAttachmentKind.test.tsx
@@ -97,6 +97,7 @@ const ATTACHMENT: SignedLeaseAttachment = {
   uploaded_by_user_id: "user-1",
   uploaded_at: "2026-05-01T10:00:00Z",
   presigned_url: "https://storage.example.com/presigned/lease.pdf",
+  is_available: true,
 };
 
 describe("LeaseAttachmentsSection — kind picker", () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAttachmentRowMissing.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAttachmentRowMissing.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Behavior tests for LeaseAttachmentRow when the underlying storage
+ * object is missing (NoSuchKey). The backend response builder flips
+ * `is_available=false` and clears `presigned_url`; the row should
+ * render a "File missing" alert with a "Re-upload" button instead of
+ * the normal Open / Download links.
+ */
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import LeaseAttachmentsSection from "@/app/features/leases/LeaseAttachmentsSection";
+import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
+
+const updateMock = vi.fn();
+const deleteMock = vi.fn();
+const uploadMock = vi.fn();
+
+vi.mock("@/shared/store/signedLeasesApi", () => ({
+  useUploadSignedLeaseAttachmentMutation: () => [uploadMock, { isLoading: false }],
+  useDeleteSignedLeaseAttachmentMutation: () => [deleteMock, {}],
+  useUpdateLeaseAttachmentMutation: () => [updateMock, {}],
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+const ORPHAN_ATTACHMENT: SignedLeaseAttachment = {
+  id: "att-orphan",
+  lease_id: "lease-1",
+  filename: "1 - Lease Agreement.pdf",
+  storage_key: "signed-leases/lease-1/att-orphan",
+  content_type: "application/pdf",
+  size_bytes: 1024,
+  kind: "signed_lease",
+  uploaded_by_user_id: "user-1",
+  uploaded_at: "2026-05-01T10:00:00Z",
+  presigned_url: null,
+  is_available: false,
+};
+
+function renderSection(att: SignedLeaseAttachment, canWrite = true) {
+  return render(
+    <Provider store={store}>
+      <LeaseAttachmentsSection
+        leaseId="lease-1"
+        attachments={[att]}
+        canWrite={canWrite}
+      />
+    </Provider>,
+  );
+}
+
+describe("LeaseAttachmentRow — missing file UX", () => {
+  beforeEach(() => {
+    updateMock.mockReset();
+    deleteMock.mockReset();
+    uploadMock.mockReset();
+  });
+
+  it("renders the 'File missing' alert and re-upload button when is_available=false", () => {
+    renderSection(ORPHAN_ATTACHMENT);
+    expect(
+      screen.getByTestId(`lease-attachment-missing-${ORPHAN_ATTACHMENT.id}`),
+    ).toHaveTextContent(/File missing/i);
+    expect(
+      screen.getByTestId(`lease-attachment-reupload-${ORPHAN_ATTACHMENT.id}`),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the preview button and download link when is_available=false", () => {
+    renderSection(ORPHAN_ATTACHMENT);
+    expect(
+      screen.queryByTestId(`lease-attachment-preview-${ORPHAN_ATTACHMENT.id}`),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId(`lease-attachment-download-${ORPHAN_ATTACHMENT.id}`),
+    ).toBeNull();
+  });
+
+  it("hides the re-upload button when canWrite=false", () => {
+    renderSection(ORPHAN_ATTACHMENT, false);
+    expect(
+      screen.queryByTestId(`lease-attachment-reupload-${ORPHAN_ATTACHMENT.id}`),
+    ).toBeNull();
+    // The 'File missing' message itself remains so the user understands
+    // why they can't open the file.
+    expect(
+      screen.getByTestId(`lease-attachment-missing-${ORPHAN_ATTACHMENT.id}`),
+    ).toBeInTheDocument();
+  });
+
+  it("re-upload triggers DELETE then POST with the same kind", async () => {
+    deleteMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+    uploadMock.mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({ ...ORPHAN_ATTACHMENT, id: "att-new", is_available: true }),
+    });
+
+    renderSection(ORPHAN_ATTACHMENT);
+
+    const reuploadButton = screen.getByTestId(
+      `lease-attachment-reupload-${ORPHAN_ATTACHMENT.id}`,
+    );
+    // The hidden file input is sibling to the button. Find via container.
+    const li = reuploadButton.closest("li") as HTMLElement;
+    const fileInput = li.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    const file = new File(["replacement bytes"], "replacement.pdf", {
+      type: "application/pdf",
+    });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(deleteMock).toHaveBeenCalledWith({
+        leaseId: "lease-1",
+        attachmentId: "att-orphan",
+      });
+      expect(uploadMock).toHaveBeenCalledWith({
+        leaseId: "lease-1",
+        file,
+        kind: "signed_lease",
+      });
+    });
+  });
+
+  it("does not call DELETE when re-upload picks an unsupported file type", () => {
+    renderSection(ORPHAN_ATTACHMENT);
+
+    const reuploadButton = screen.getByTestId(
+      `lease-attachment-reupload-${ORPHAN_ATTACHMENT.id}`,
+    );
+    const li = reuploadButton.closest("li") as HTMLElement;
+    const fileInput = li.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+
+    const file = new File(["nope"], "shady.exe", {
+      type: "application/x-msdownload",
+    });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    expect(deleteMock).not.toHaveBeenCalled();
+    expect(uploadMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/useLinkedLeaseDocumentsMode.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/useLinkedLeaseDocumentsMode.test.ts
@@ -13,6 +13,7 @@ const mockAttachment: SignedLeaseAttachment = {
   uploaded_by_user_id: "user-1",
   uploaded_at: "2026-01-01T00:00:00Z",
   presigned_url: "https://example.com/lease.pdf",
+  is_available: true,
 };
 
 describe("useLinkedLeaseDocumentsMode", () => {

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentRow.tsx
@@ -1,4 +1,5 @@
-import { Download, Trash2 } from "lucide-react";
+import { useRef } from "react";
+import { AlertTriangle, Download, Trash2, Upload } from "lucide-react";
 import { LEASE_ATTACHMENT_KIND_LABELS } from "@/shared/lib/lease-labels";
 import {
   LEASE_ATTACHMENT_KINDS,
@@ -12,12 +13,31 @@ export interface LeaseAttachmentRowProps {
   onPreview: () => void;
   onDelete: () => void;
   onKindChange: (kind: LeaseAttachmentKind) => void;
+  onReupload: (file: File) => void;
 }
 
-export default function LeaseAttachmentRow({ att, canWrite, onPreview, onDelete, onKindChange }: LeaseAttachmentRowProps) {
+const REUPLOAD_ACCEPT = [
+  "application/pdf",
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  "image/jpeg",
+  "image/png",
+  "image/webp",
+].join(",");
+
+export default function LeaseAttachmentRow({
+  att,
+  canWrite,
+  onPreview,
+  onDelete,
+  onKindChange,
+  onReupload,
+}: LeaseAttachmentRowProps) {
+  const reuploadInputRef = useRef<HTMLInputElement>(null);
+  const isMissing = att.is_available === false;
   const canPreview =
-    att.presigned_url !== null &&
-    (att.content_type === "application/pdf" || att.content_type.startsWith("image/"));
+    !isMissing
+    && att.presigned_url !== null
+    && (att.content_type === "application/pdf" || att.content_type.startsWith("image/"));
 
   return (
     <li
@@ -36,13 +56,18 @@ export default function LeaseAttachmentRow({ att, canWrite, onPreview, onDelete,
             {att.filename}
           </button>
         ) : (
-          <span className="truncate text-muted-foreground min-w-0" title={att.filename}>
+          <span
+            className={`truncate min-w-0 ${
+              isMissing ? "text-destructive" : "text-muted-foreground"
+            }`}
+            title={att.filename}
+          >
             {att.filename}
           </span>
         )}
 
         <div className="flex items-center gap-2 shrink-0">
-          {att.presigned_url ? (
+          {!isMissing && att.presigned_url ? (
             <a
               href={att.presigned_url}
               target="_blank"
@@ -66,6 +91,38 @@ export default function LeaseAttachmentRow({ att, canWrite, onPreview, onDelete,
           ) : null}
         </div>
       </div>
+
+      {isMissing ? (
+        <div
+          className="flex items-center gap-2 text-xs text-destructive"
+          data-testid={`lease-attachment-missing-${att.id}`}
+          role="alert"
+        >
+          <AlertTriangle size={14} aria-hidden="true" />
+          <span>File missing from storage.</span>
+          {canWrite ? (
+            <button
+              type="button"
+              onClick={() => reuploadInputRef.current?.click()}
+              className="inline-flex items-center gap-1 px-2 py-1 text-xs border rounded hover:bg-muted min-h-[28px]"
+              data-testid={`lease-attachment-reupload-${att.id}`}
+            >
+              <Upload size={12} aria-hidden="true" /> Re-upload
+            </button>
+          ) : null}
+          <input
+            ref={reuploadInputRef}
+            type="file"
+            className="hidden"
+            accept={REUPLOAD_ACCEPT}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) onReupload(file);
+              e.target.value = "";
+            }}
+          />
+        </div>
+      ) : null}
 
       <div className="flex items-center gap-2">
         {canWrite ? (

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentsSection.tsx
@@ -93,6 +93,31 @@ export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite
     }
   }
 
+  async function handleReupload(att: SignedLeaseAttachment, file: File) {
+    if (file.type && !ALLOWED_MIME.includes(file.type)) {
+      showError(`${file.name}: unsupported file type.`);
+      return;
+    }
+    // Delete the orphan row first, then upload the new file under the same
+    // kind. The orphan is already broken so loss of the row mid-flow is
+    // acceptable — the user can retry the upload via the dropzone.
+    try {
+      await deleteAttachment({ leaseId, attachmentId: att.id }).unwrap();
+    } catch {
+      showError("Couldn't remove the broken file. Please try again.");
+      return;
+    }
+    try {
+      await uploadAttachment({ leaseId, file, kind: att.kind }).unwrap();
+      showSuccess(`${file.name} uploaded.`);
+    } catch (e: unknown) {
+      const status = (e as { status?: number }).status;
+      if (status === 413) showError(`${file.name} is too large.`);
+      else if (status === 415) showError(`${file.name}: unsupported file type.`);
+      else showError(`Couldn't upload ${file.name}.`);
+    }
+  }
+
   return (
     <section className="space-y-3">
       {attachments.length === 0 ? (
@@ -109,6 +134,7 @@ export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite
               onPreview={() => setViewingAttachment(att)}
               onDelete={() => void handleDelete(att)}
               onKindChange={(kind) => void handleKindChange(att, kind)}
+              onReupload={(file) => void handleReupload(att, file)}
             />
           ))}
         </ul>

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-attachment.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-attachment.ts
@@ -16,4 +16,11 @@ export interface SignedLeaseAttachment {
   uploaded_by_user_id: string;
   uploaded_at: string;
   presigned_url: string | null;
+  /**
+   * `false` when the underlying MinIO object is missing (NoSuchKey on HEAD).
+   * The UI surfaces a "File missing — re-upload" affordance instead of the
+   * normal Open / Download links so the user gets an actionable error.
+   * Defaults to `true` for backwards-compat with older API responses.
+   */
+  is_available: boolean;
 }


### PR DESCRIPTION
## Why

When you clicked "Open" on the Sonu King lease's "1 - Lease Agreement.pdf", you got a raw MinIO XML error (`NoSuchKey`) because the DB row exists but the object is gone. The UI gave no indication the file was missing — just a broken link.

Sentry shows a related incident on 2026-05-04 where the API was talking to MinIO at `localhost:9000` (wrong endpoint), so it's plausible objects were lost during that window. Either way, "DB row points at a missing key" is a real failure mode and the UI should handle it.

## What changed

**Backend**
- `StorageClient.object_exists(key) -> bool` — returns `False` on `NoSuchKey`, **re-raises** transient S3 errors so we don't conflate service outage with data loss
- `SignedLeaseAttachmentResponse.is_available: bool = True`
- `attach_presigned_urls_to_attachments` HEAD-checks each row; on miss it sets `is_available=False` + `presigned_url=None` and fires `sentry_sdk.capture_message` with `lease_id` / `attachment_id` tags

**Frontend**
- `SignedLeaseAttachment.is_available` field added
- `LeaseAttachmentRow` renders a `File missing from storage.` alert with a `Re-upload` button (canWrite only) when `is_available=false`. Preview button + download icon are hidden.
- The re-upload flow: file picker → DELETE the orphan row → POST the new file under the same `kind`. If DELETE fails the user sees a toast and the row stays. If POST fails after a successful DELETE, the user sees a toast and can retry via the dropzone — the orphan was already broken so transient "row deleted but no replacement" is acceptable.

**Why not a "list all orphans" admin endpoint?**
Per the project rule "no diagnostic APIs that surface user data" — Sentry capture instead. The HEAD-check fires on every list/read of an attachment row, so missing files surface to operator dashboards without a dedicated endpoint listing user data.

## Test plan

- [x] Backend `pytest tests/test_attachment_response_builder.py` — **5/5 pass** (present, missing, transient, empty, mixed)
- [x] Backend `pytest tests/ -k 'lease or storage or attachment or receipt or signed'` — **185 pass, 4 skipped, 0 fail**
- [x] Frontend `npx vitest run src/__tests__/LeaseAttachmentRowMissing.test.tsx src/__tests__/LeaseAttachmentKind.test.tsx src/__tests__/useLinkedLeaseDocumentsMode.test.ts` — **24/24 pass**
- [x] Frontend `npm run lint` — 0 errors (only pre-existing warnings)
- [x] Frontend `npx tsc --noEmit` — clean

## Operational migration

None. New nullable field with a `True` default; old API responses still type-check; `is_available=true` for every present object means existing UI flows are unchanged.

## Latency note

The HEAD-check adds one MinIO `stat_object` call per attachment per list/get. Inside the docker network this is microseconds; for a tenant with ~5 attachments it's negligible. If we ever see a hot path slow down, we can switch to lazy verification on click instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)