### PR TITLE
fix(myjobhunter/applications): auto-find-or-create company on JD-parse path too

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
@@ -161,7 +161,7 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
     setJdMode({ kind: "parsing", jdText: pastedJdText });
     try {
       const result = await parseJobDescription({ jd_text: pastedJdText }).unwrap();
-      applyParseResult(result, { sourceUrl: null });
+      await applyParseResult(result, { sourceUrl: null });
     } catch (err) {
       setJdMode({
         kind: "failed",
@@ -196,7 +196,7 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
   // Pre-fill helper — both the text-parse and URL-extract paths converge here
   // (text-parse calls applyParseResult; URL-extract maps to a JdParseResponse
   // shape via mapExtractToParse and then calls the same).
-  function applyParseResult(
+  async function applyParseResult(
     result: JdParseResponse,
     { sourceUrl }: { sourceUrl: string | null },
   ) {
@@ -212,6 +212,16 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
       result.remote_type === "onsite"
     ) {
       setValue("remote_type", result.remote_type, { shouldValidate: true });
+    }
+    // Same auto-find-or-create the URL-extract path uses. Without
+    // this, the operator pastes a JD text, lets Claude parse it,
+    // and the form STILL bounces with "Company is required" because
+    // the parse response's company field was being silently dropped.
+    if (result.company) {
+      setPendingCompanyName(result.company);
+      await selectOrCreateCompany(result.company);
+    } else {
+      setPendingCompanyName(null);
     }
     setJdMode({ kind: "parsed", summary: result.summary, sourceUrl });
   }

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
@@ -320,6 +320,64 @@ describe("AddApplicationDialog — JD paste-text flow", () => {
     });
   });
 
+  it("auto-creates the company on parse-with-AI when no match exists", async () => {
+    const user = userEvent.setup();
+    const mockParse = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          title: "Senior Engineer",
+          company: "Pivotal Health",
+          location: "Remote",
+          remote_type: "remote",
+          salary_min: null,
+          salary_max: null,
+          salary_currency: null,
+          salary_period: null,
+          seniority: null,
+          must_have_requirements: [],
+          nice_to_have_requirements: [],
+          responsibilities: [],
+          summary: null,
+        }),
+    });
+    const mockCreateCompany = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          id: "co-new",
+          name: "Pivotal Health",
+          primary_domain: null,
+          logo_url: null,
+          industry: null,
+          size_range: null,
+          notes: null,
+          deleted_at: null,
+        }),
+    });
+
+    mockUseListCompaniesQuery.mockReturnValue(emptyCompanies);
+    mockUseParseJobDescriptionMutation.mockReturnValue(
+      [mockParse, { isLoading: false }] as unknown as ReturnType<typeof useParseJobDescriptionMutation>,
+    );
+    mockUseCreateCompanyMutation.mockReturnValue(
+      [mockCreateCompany, { isLoading: false }] as unknown as ReturnType<typeof useCreateCompanyMutation>,
+    );
+
+    renderDialog();
+    await user.click(screen.getByText(/paste a link or job description to auto-fill/i));
+    await user.click(screen.getByRole("tab", { name: /paste the description/i }));
+
+    const textarea = screen.getByRole("textbox", { name: /job description text/i });
+    await user.type(textarea, "JD text mentioning Pivotal Health");
+    await user.click(screen.getByRole("button", { name: /parse with ai/i }));
+
+    await waitFor(() => {
+      // The text-parse path now MUST auto-create the company —
+      // operator's stated workflow is never to manually re-enter what
+      // we already extracted.
+      expect(mockCreateCompany).toHaveBeenCalledWith({ name: "Pivotal Health" });
+    });
+  });
+
   it("shows error banner when parse mutation fails", async () => {
     const user = userEvent.setup();
     const mockParse = vi.fn().mockReturnValue({


### PR DESCRIPTION
Third operator call-out on the same issue. PR #351/#356 wired auto-create on the URL-extract path; the JD-text-paste path was still dropping company on the floor and bouncing the form on 'Company is required'.

Now both paths have parity. `applyParseResult` calls the same `selectOrCreateCompany` + `pendingCompanyName` setup, and `handleParseJd` awaits.

17/17 dialog tests pass.

Next: enrich auto-created companies with website/industry/logo via web search (operator's stated follow-up). Tracked separately so this fix ships independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)