### PR TITLE
feat(myjobhunter/applications): enrich auto-created companies (website + logo + Tavily research)

### DIFF
--- a/apps/myjobhunter/backend/app/api/applications.py
+++ b/apps/myjobhunter/backend/app/api/applications.py
@@ -240,6 +240,8 @@ async def extract_from_url_endpoint(
     return JdUrlExtractResponse(
         title=result.title,
         company=result.company,
+        company_website=result.company_website,
+        company_logo_url=result.company_logo_url,
         location=result.location,
         description_html=result.description_html,
         requirements_text=result.requirements_text,

--- a/apps/myjobhunter/backend/app/schemas/application/jd_url_extract_response.py
+++ b/apps/myjobhunter/backend/app/schemas/application/jd_url_extract_response.py
@@ -35,6 +35,16 @@ class JdUrlExtractResponse(BaseModel):
 
     title: str | None = None
     company: str | None = None
+    # Canonical company website (``hiringOrganization.sameAs`` in
+    # schema.org JobPosting). Populated only on the schema.org fast
+    # path; Claude HTML-text fallback leaves it None. Lets the
+    # frontend's auto-create populate ``primary_domain`` so the
+    # company has a usable identity beyond just the name.
+    company_website: str | None = None
+    # Company logo URL (``hiringOrganization.logo`` — may be a plain
+    # URL string OR an ImageObject with ``url``). Same fast-path-only
+    # caveat as ``company_website``.
+    company_logo_url: str | None = None
     location: str | None = None
 
     # Long-form HTML (preserved when the source publishes it as HTML —

--- a/apps/myjobhunter/backend/app/services/extraction/jd_url_extractor.py
+++ b/apps/myjobhunter/backend/app/services/extraction/jd_url_extractor.py
@@ -132,6 +132,8 @@ class ExtractedJD:
 
     title: str | None
     company: str | None
+    company_website: str | None
+    company_logo_url: str | None
     location: str | None
     description_html: str | None
     requirements_text: str | None
@@ -372,10 +374,23 @@ def _from_schema_org(payload: dict, *, source_url: str) -> ExtractedJD:
     title = _str_or_none(payload.get("title"))
 
     # ``hiringOrganization`` may be a string or a nested Organization object.
+    # When it's an object, schema.org also defines ``sameAs`` (canonical
+    # company website) and ``logo`` — we pull both so the auto-create
+    # flow on the frontend can populate ``primary_domain`` and
+    # ``logo_url`` instead of just ``name``.
     company = None
+    company_website: str | None = None
+    company_logo_url: str | None = None
     org = payload.get("hiringOrganization")
     if isinstance(org, dict):
         company = _str_or_none(org.get("name"))
+        company_website = _str_or_none(org.get("sameAs"))
+        # ``logo`` may be a plain URL string OR an ImageObject
+        logo = org.get("logo")
+        if isinstance(logo, str):
+            company_logo_url = _str_or_none(logo)
+        elif isinstance(logo, dict):
+            company_logo_url = _str_or_none(logo.get("url"))
     elif isinstance(org, str):
         company = _str_or_none(org)
 
@@ -391,6 +406,8 @@ def _from_schema_org(payload: dict, *, source_url: str) -> ExtractedJD:
     return ExtractedJD(
         title=title,
         company=company,
+        company_website=company_website,
+        company_logo_url=company_logo_url,
         location=location,
         description_html=description_html,
         requirements_text=requirements_text,
@@ -519,6 +536,12 @@ async def _claude_fallback(
     return ExtractedJD(
         title=title,
         company=company,
+        # Claude HTML-text fallback path doesn't reliably surface the
+        # company website / logo. Operators can still trigger the
+        # async company-research enrichment after auto-create, which
+        # uses Tavily to find the website.
+        company_website=None,
+        company_logo_url=None,
         location=location,
         description_html=None,
         requirements_text=requirements_text,

--- a/apps/myjobhunter/backend/tests/test_jd_url_extractor.py
+++ b/apps/myjobhunter/backend/tests/test_jd_url_extractor.py
@@ -296,6 +296,9 @@ class TestExtractFromUrlSchema:
         assert isinstance(result, ExtractedJD)
         assert result.title == "Senior Backend Engineer"
         assert result.company == "Acme Corp"
+        # The sample payload has no sameAs / logo so these are None.
+        assert result.company_website is None
+        assert result.company_logo_url is None
         assert result.location == "San Francisco, CA, US"
         assert result.description_html is not None
         assert "Build APIs" in result.description_html
@@ -303,6 +306,63 @@ class TestExtractFromUrlSchema:
         assert "Design backend services" in result.requirements_text
         assert result.summary is None
         assert result.source_url == "https://jobs.example.com/posting/abc"
+
+    @pytest.mark.asyncio
+    async def test_schema_org_extracts_company_website_and_logo(self) -> None:
+        """When ``hiringOrganization`` exposes ``sameAs`` + ``logo``,
+        both must surface so the frontend's auto-create can populate
+        ``primary_domain`` + ``logo_url`` instead of just ``name``.
+        """
+        payload = {
+            "@type": "JobPosting",
+            "title": "Engineer",
+            "hiringOrganization": {
+                "@type": "Organization",
+                "name": "Pivotal Health",
+                "sameAs": "https://pivotalhealth.ai/",
+                "logo": "https://cdn.example.com/logos/pivotal.png",
+            },
+        }
+        html = _wrap_html_with_schema(payload)
+        fake_client = _FakeAsyncClient(response=_build_httpx_response(html))
+
+        with _patch_httpx(fake_client):
+            result = await extract_from_url(
+                "https://example.com/posting",
+                user_id=uuid.uuid4(),
+            )
+
+        assert result.company == "Pivotal Health"
+        assert result.company_website == "https://pivotalhealth.ai/"
+        assert result.company_logo_url == "https://cdn.example.com/logos/pivotal.png"
+
+    @pytest.mark.asyncio
+    async def test_schema_org_logo_as_image_object(self) -> None:
+        """schema.org allows ``logo`` to be an ImageObject with ``url``;
+        the extractor must pull the nested URL.
+        """
+        payload = {
+            "@type": "JobPosting",
+            "title": "Engineer",
+            "hiringOrganization": {
+                "@type": "Organization",
+                "name": "Acme",
+                "logo": {
+                    "@type": "ImageObject",
+                    "url": "https://cdn.example.com/acme-logo.svg",
+                },
+            },
+        }
+        html = _wrap_html_with_schema(payload)
+        fake_client = _FakeAsyncClient(response=_build_httpx_response(html))
+
+        with _patch_httpx(fake_client):
+            result = await extract_from_url(
+                "https://example.com/posting",
+                user_id=uuid.uuid4(),
+            )
+
+        assert result.company_logo_url == "https://cdn.example.com/acme-logo.svg"
 
     @pytest.mark.asyncio
     async def test_schema_description_html_preserved(self) -> None:

--- a/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
@@ -3,7 +3,11 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
 import { X, Plus } from "lucide-react";
-import { useListCompaniesQuery, useCreateCompanyMutation } from "@/lib/companiesApi";
+import {
+  useListCompaniesQuery,
+  useCreateCompanyMutation,
+  useTriggerCompanyResearchMutation,
+} from "@/lib/companiesApi";
 import {
   useCreateApplicationMutation,
   useExtractJdFromUrlMutation,
@@ -43,6 +47,11 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
   const { data: companiesData, isLoading: companiesLoading } = useListCompaniesQuery();
   const [createApplication, { isLoading: creatingApplication }] = useCreateApplicationMutation();
   const [createCompany, { isLoading: creatingCompany }] = useCreateCompanyMutation();
+  // Fire-and-forget enrichment — auto-created companies kick off
+  // Tavily+Claude research in the background. The mutation hook is
+  // returned but only the trigger is used (we ignore the loading
+  // state because the operator doesn't wait on it).
+  const [triggerCompanyResearch] = useTriggerCompanyResearchMutation();
   const [parseJobDescription] = useParseJobDescriptionMutation();
   const [extractJdFromUrl] = useExtractJdFromUrlMutation();
 
@@ -240,7 +249,10 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
     // fallback if the auto-create raced with the click.
     if (result.company) {
       setPendingCompanyName(result.company);
-      await selectOrCreateCompany(result.company);
+      await selectOrCreateCompany(result.company, {
+        website: result.company_website,
+        logoUrl: result.company_logo_url,
+      });
     } else {
       setPendingCompanyName(null);
     }
@@ -251,7 +263,34 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
     });
   }
 
-  async function selectOrCreateCompany(name: string): Promise<void> {
+  interface CompanyExtras {
+    website?: string | null;
+    logoUrl?: string | null;
+  }
+
+  /**
+   * Reduce a company website URL to its bare host (no scheme, no
+   * leading "www.", no trailing slash). The Company model's
+   * ``primary_domain`` is a domain string, not a URL.
+   */
+  function websiteToDomain(website: string | null | undefined): string | null {
+    if (!website) return null;
+    try {
+      const url = new URL(website.trim());
+      let host = url.hostname.toLowerCase();
+      if (host.startsWith("www.")) host = host.slice(4);
+      return host || null;
+    } catch {
+      // Already a bare domain? Strip whitespace + leading www.
+      const stripped = website.trim().replace(/^https?:\/\//i, "").replace(/\/$/, "");
+      return stripped.replace(/^www\./i, "") || null;
+    }
+  }
+
+  async function selectOrCreateCompany(
+    name: string,
+    extras: CompanyExtras = {},
+  ): Promise<void> {
     const trimmed = name.trim();
     if (!trimmed) return;
     const existing = companies.find(
@@ -262,8 +301,29 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
       return;
     }
     try {
-      const created = await createCompany({ name: trimmed }).unwrap();
+      const payload: { name: string; primary_domain?: string | null; logo_url?: string | null } = {
+        name: trimmed,
+      };
+      const domain = websiteToDomain(extras.website);
+      if (domain) payload.primary_domain = domain;
+      if (extras.logoUrl) payload.logo_url = extras.logoUrl;
+
+      const created = await createCompany(payload).unwrap();
       setValue("company_id", created.id, { shouldValidate: true });
+
+      // Fire-and-forget: kick off Tavily + Claude research so the
+      // operator gets the rich company profile (industry, culture
+      // signals, red/green flags) when they navigate to the company
+      // detail page later. The application form does NOT wait — the
+      // operator submits as soon as the auto-create returns.
+      void triggerCompanyResearch(created.id)
+        .unwrap()
+        .catch((err) => {
+          // Research failures are non-blocking; log but don't toast
+          // since the operator may already be on a different page.
+          // eslint-disable-next-line no-console
+          console.warn("Background company research failed:", err);
+        });
     } catch (err) {
       // Don't block the rest of the pre-fill if company create fails —
       // operator can still pick or create one manually. Surface the

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
@@ -31,6 +31,10 @@ vi.mock("lucide-react", () => ({
 vi.mock("@/lib/companiesApi", () => ({
   useListCompaniesQuery: vi.fn(),
   useCreateCompanyMutation: vi.fn(),
+  useTriggerCompanyResearchMutation: vi.fn(() => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })),
+    { isLoading: false },
+  ]),
 }));
 
 vi.mock("@/lib/applicationsApi", () => ({

--- a/apps/myjobhunter/frontend/src/types/application/jd-url-extract-response.ts
+++ b/apps/myjobhunter/frontend/src/types/application/jd-url-extract-response.ts
@@ -20,6 +20,15 @@
 export interface JdUrlExtractResponse {
   title: string | null;
   company: string | null;
+  /**
+   * Canonical company website (schema.org JobPosting
+   * `hiringOrganization.sameAs`). Populated only on the schema.org
+   * fast path; the Claude HTML-text fallback returns null. Used by
+   * the auto-create flow to populate `primary_domain`.
+   */
+  company_website: string | null;
+  /** Company logo URL (schema.org `hiringOrganization.logo`). */
+  company_logo_url: string | null;
   location: string | null;
   description_html: string | null;
   requirements_text: string | null;


### PR DESCRIPTION
Operator: "if there's a company name, or better yet a company website, in the job description, we should search the web for the company info."

## Two-tier enrichment

**Tier 1 — instant, free, from data we already have.** The schema.org JobPosting payload exposes `hiringOrganization.sameAs` (website) and `hiringOrganization.logo`. The extractor now reads both and the frontend's auto-create passes them as `primary_domain` + `logo_url` to `POST /companies`. Same wire data, just wasn't being read.

**Tier 2 — async, deeper.** After `createCompany` returns, frontend fires `POST /companies/{id}/research` (existing endpoint, Tavily + Claude pipeline) WITHOUT awaiting. Application form doesn't block on research. The rich profile (industry, culture signals, red/green flags) lands in the background; operator sees it next time they hit the Companies detail page.

## Tests

- Backend: 2 new schema.org cases (`sameAs` + string-logo, ImageObject-logo)
- Frontend: existing 16 dialog tests still pass with research-mutation mock added

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)