### PR TITLE
fix(myjobhunter/applications): coerce AnyHttpUrl url to str (HTTP 500 hotfix)

### DIFF
--- a/apps/myjobhunter/backend/app/services/application/application_service.py
+++ b/apps/myjobhunter/backend/app/services/application/application_service.py
@@ -156,11 +156,17 @@ async def create_application(
             f"Company {request.company_id} not found under user {user_id}",
         )
 
+    # ``url`` is typed as Pydantic ``AnyHttpUrl`` for input validation.
+    # In Pydantic v2 that's a ``Url`` wrapper object — NOT a str
+    # subclass — so passing it directly to SQLAlchemy / asyncpg raises
+    # at parameter-bind time (HTTP 500). Coerce to plain str before
+    # persistence. Same pattern as company_service.create_company's
+    # logo_url fix from PR #363.
     application = Application(
         user_id=user_id,
         company_id=request.company_id,
         role_title=request.role_title,
-        url=request.url,
+        url=str(request.url) if request.url is not None else None,
         jd_text=request.jd_text,
         jd_parsed=request.jd_parsed,
         source=request.source,


### PR DESCRIPTION
Operator: "application post threw a 500".

Same root cause as PR #363's company logo_url bug — Pydantic v2's `AnyHttpUrl` is a `Url` wrapper object that asyncpg can't bind. PR #365's redesign now always populates `url` from the operator's pasted source URL, so the bug fires every time. Before the redesign, the standalone URL field in the form body was usually empty, masking the issue.

Fix: `str(request.url) if … else None` in `create_application`. Update path was already safe (uses `model_dump` which runs the serializer).

Audit: only application + company create paths needed the coercion. Update paths use model_dump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)