### PR TITLE
fix(sentry+leases): drop event_level to WARNING; modal empty state for missing files

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/useAttachmentViewMode.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/useAttachmentViewMode.test.ts
@@ -2,41 +2,48 @@
  * Unit tests for useAttachmentViewMode.
  *
  * Verifies the hook returns the correct discriminated-union value for each
- * content-type family handled by AttachmentViewer.
+ * content-type family handled by AttachmentViewer, plus the "unavailable"
+ * branch when the URL is empty (storage object missing).
  */
 import { describe, it, expect } from "vitest";
 import { useAttachmentViewMode } from "@/app/features/leases/useAttachmentViewMode";
 
-// Call the pure function directly — it has no React state, so no renderHook needed.
+const URL = "https://example.com/signed";
 
 describe("useAttachmentViewMode", () => {
-  it("returns 'pdf' for application/pdf", () => {
-    expect(useAttachmentViewMode({ contentType: "application/pdf" })).toBe("pdf");
+  it("returns 'pdf' for application/pdf with a URL", () => {
+    expect(useAttachmentViewMode({ url: URL, contentType: "application/pdf" })).toBe("pdf");
   });
 
-  it("returns 'image' for image/jpeg", () => {
-    expect(useAttachmentViewMode({ contentType: "image/jpeg" })).toBe("image");
+  it("returns 'image' for image/jpeg with a URL", () => {
+    expect(useAttachmentViewMode({ url: URL, contentType: "image/jpeg" })).toBe("image");
   });
 
-  it("returns 'image' for image/png", () => {
-    expect(useAttachmentViewMode({ contentType: "image/png" })).toBe("image");
+  it("returns 'image' for image/png with a URL", () => {
+    expect(useAttachmentViewMode({ url: URL, contentType: "image/png" })).toBe("image");
   });
 
-  it("returns 'image' for image/webp", () => {
-    expect(useAttachmentViewMode({ contentType: "image/webp" })).toBe("image");
+  it("returns 'image' for image/webp with a URL", () => {
+    expect(useAttachmentViewMode({ url: URL, contentType: "image/webp" })).toBe("image");
   });
 
-  it("returns 'other' for DOCX", () => {
+  it("returns 'other' for DOCX with a URL", () => {
     expect(
       useAttachmentViewMode({
+        url: URL,
         contentType:
           "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
       }),
     ).toBe("other");
   });
 
-  it("returns 'other' for unknown content types", () => {
-    expect(useAttachmentViewMode({ contentType: "text/plain" })).toBe("other");
-    expect(useAttachmentViewMode({ contentType: "" })).toBe("other");
+  it("returns 'other' for unknown content types with a URL", () => {
+    expect(useAttachmentViewMode({ url: URL, contentType: "text/plain" })).toBe("other");
+  });
+
+  it("returns 'unavailable' when URL is empty regardless of content type", () => {
+    expect(useAttachmentViewMode({ url: "", contentType: "application/pdf" })).toBe("unavailable");
+    expect(useAttachmentViewMode({ url: "", contentType: "image/png" })).toBe("unavailable");
+    expect(useAttachmentViewMode({ url: "", contentType: "text/plain" })).toBe("unavailable");
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/LeaseReceiptsRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/LeaseReceiptsRow.tsx
@@ -53,26 +53,14 @@ export default function LeaseReceiptsRow({ leaseId, onPreview }: LeaseReceiptsRo
         >
           <div className="flex items-center gap-2 min-w-0">
             <FileText className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
-            {att.presigned_url ? (
-              <button
-                type="button"
-                onClick={() => onPreview(att)}
-                className="text-left text-primary hover:underline font-medium truncate"
-                title={att.filename}
-              >
-                {att.filename}
-              </button>
-            ) : (
-              <a
-                href={undefined}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-left text-primary hover:underline font-medium truncate"
-                title={att.filename}
-              >
-                {att.filename}
-              </a>
-            )}
+            <button
+              type="button"
+              onClick={() => onPreview(att)}
+              className="text-left text-primary hover:underline font-medium truncate"
+              title={att.filename}
+            >
+              {att.filename}
+            </button>
           </div>
           {att.presigned_url ? (
             <a

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocuments.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocuments.tsx
@@ -59,9 +59,9 @@ export default function LinkedLeaseDocuments({ lease }: LinkedLeaseDocumentsProp
         onPreview={setViewing}
       />
 
-      {viewing?.presigned_url ? (
+      {viewing ? (
         <AttachmentViewer
-          url={viewing.presigned_url}
+          url={viewing.presigned_url ?? ""}
           filename={viewing.filename}
           contentType={viewing.content_type}
           onClose={() => setViewing(null)}

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocumentsList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocumentsList.tsx
@@ -38,10 +38,6 @@ export default function LinkedLeaseDocumentsList({
   return (
     <ul className="space-y-1">
       {attachments.map((att) => {
-        const canPreviewInline =
-          att.presigned_url !== null
-          && (att.content_type === "application/pdf"
-            || att.content_type.startsWith("image/"));
         const kindLabel =
           LEASE_ATTACHMENT_KIND_LABELS[att.kind as LeaseAttachmentKind] ?? att.kind;
 
@@ -53,28 +49,18 @@ export default function LinkedLeaseDocumentsList({
           >
             <div className="flex items-center gap-2 min-w-0">
               <FileText className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden="true" />
-              {canPreviewInline ? (
-                <button
-                  type="button"
-                  onClick={() => onPreview(att)}
-                  className="text-left text-primary hover:underline font-medium truncate"
-                  data-testid={`linked-lease-attachment-preview-${att.id}`}
-                  title={att.filename}
-                >
-                  {att.filename}
-                </button>
-              ) : (
-                <a
-                  href={att.presigned_url ?? undefined}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-left text-primary hover:underline font-medium truncate"
-                  data-testid={`linked-lease-attachment-download-link-${att.id}`}
-                  title={att.filename}
-                >
-                  {att.filename}
-                </a>
-              )}
+              {/* Filename always opens the AttachmentViewer modal — the
+                  modal renders the file when the URL is present, or a
+                  neutral "no longer available" message when it's not. */}
+              <button
+                type="button"
+                onClick={() => onPreview(att)}
+                className="text-left text-primary hover:underline font-medium truncate"
+                data-testid={`linked-lease-attachment-preview-${att.id}`}
+                title={att.filename}
+              >
+                {att.filename}
+              </button>
               <span className="text-xs text-muted-foreground shrink-0">{kindLabel}</span>
             </div>
             {att.presigned_url ? (

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseReceipts.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseReceipts.tsx
@@ -29,9 +29,9 @@ export default function LinkedLeaseReceipts({ leases }: LinkedLeaseReceiptsProps
           <LeaseReceiptsRow key={lease.id} leaseId={lease.id} onPreview={setViewing} />
         ))}
       </ul>
-      {viewing?.presigned_url ? (
+      {viewing ? (
         <AttachmentViewer
-          url={viewing.presigned_url}
+          url={viewing.presigned_url ?? ""}
           filename={viewing.filename}
           contentType={viewing.content_type}
           onClose={() => setViewing(null)}

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentRow.tsx
@@ -21,10 +21,6 @@ export default function InsurancePolicyAttachmentRow({
   onDelete,
 }: InsurancePolicyAttachmentRowProps) {
   const isMissing = att.is_available === false;
-  const canPreviewInline =
-    !isMissing
-    && att.presigned_url !== null
-    && (att.content_type === "application/pdf" || att.content_type.startsWith("image/"));
 
   useEffect(() => {
     if (!isMissing) return;
@@ -43,28 +39,18 @@ export default function InsurancePolicyAttachmentRow({
       data-testid={`insurance-attachment-${att.id}`}
     >
       <div className="flex items-center justify-between gap-2">
-        {canPreviewInline ? (
-          <button
-            type="button"
-            onClick={onPreview}
-            className="truncate text-left text-primary hover:underline font-medium min-w-0"
-            data-testid={`insurance-attachment-preview-${att.id}`}
-            title={att.filename}
-          >
-            {att.filename}
-          </button>
-        ) : (
-          <a
-            href={att.presigned_url ?? undefined}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="truncate text-left text-primary hover:underline font-medium min-w-0"
-            data-testid={`insurance-attachment-download-link-${att.id}`}
-            title={att.filename}
-          >
-            {att.filename}
-          </a>
-        )}
+        {/* Filename always opens the AttachmentViewer modal — viewer
+            renders the file when URL is present, neutral empty-state
+            when not. */}
+        <button
+          type="button"
+          onClick={onPreview}
+          className="truncate text-left text-primary hover:underline font-medium min-w-0"
+          data-testid={`insurance-attachment-preview-${att.id}`}
+          title={att.filename}
+        >
+          {att.filename}
+        </button>
 
         <div className="flex items-center gap-2 shrink-0">
           {att.presigned_url ? (

--- a/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/insurance/InsurancePolicyAttachmentsSection.tsx
@@ -176,9 +176,9 @@ export default function InsurancePolicyAttachmentsSection({
         </div>
       ) : null}
 
-      {viewingAttachment?.presigned_url ? (
+      {viewingAttachment ? (
         <AttachmentViewer
-          url={viewingAttachment.presigned_url}
+          url={viewingAttachment.presigned_url ?? ""}
           filename={viewingAttachment.filename}
           contentType={viewingAttachment.content_type}
           onClose={() => setViewingAttachment(null)}

--- a/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewer.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewer.tsx
@@ -4,6 +4,11 @@ import { useAttachmentViewMode } from "./useAttachmentViewMode";
 import AttachmentViewerBody from "./AttachmentViewerBody";
 
 export interface AttachmentViewerProps {
+  /**
+   * Presigned URL or empty string when the underlying object is missing.
+   * Empty triggers the "unavailable" body and suppresses the
+   * "Open in new tab" link in the header.
+   */
   url: string;
   filename: string;
   contentType: string;
@@ -18,6 +23,7 @@ export interface AttachmentViewerProps {
  * - PDF → iframe
  * - image/* → <img>
  * - anything else → download-only message (DOCX, etc.)
+ * - URL is empty (storage object missing) → "no longer available" message
  */
 export default function AttachmentViewer({
   url,
@@ -25,7 +31,7 @@ export default function AttachmentViewer({
   contentType,
   onClose,
 }: AttachmentViewerProps) {
-  const mode = useAttachmentViewMode({ contentType });
+  const mode = useAttachmentViewMode({ url, contentType });
 
   return (
     <Panel position="center" onClose={onClose}>
@@ -37,16 +43,18 @@ export default function AttachmentViewer({
           >
             {filename}
           </span>
-          <a
-            href={url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-xs text-primary hover:underline inline-flex items-center gap-1 shrink-0"
-            data-testid="attachment-viewer-open-in-new-tab"
-          >
-            <ExternalLink size={12} />
-            Open in new tab
-          </a>
+          {url ? (
+            <a
+              href={url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary hover:underline inline-flex items-center gap-1 shrink-0"
+              data-testid="attachment-viewer-open-in-new-tab"
+            >
+              <ExternalLink size={12} />
+              Open in new tab
+            </a>
+          ) : null}
         </div>
         <PanelCloseButton onClose={onClose} label="Close viewer" />
       </header>

--- a/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewerBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewerBody.tsx
@@ -2,6 +2,7 @@ import type { AttachmentViewMode } from "@/shared/types/lease/attachment-view-mo
 import AttachmentViewerImageBody from "./AttachmentViewerImageBody";
 import AttachmentViewerOtherBody from "./AttachmentViewerOtherBody";
 import AttachmentViewerPdfBody from "./AttachmentViewerPdfBody";
+import AttachmentViewerUnavailableBody from "./AttachmentViewerUnavailableBody";
 
 export interface AttachmentViewerBodyProps {
   mode: AttachmentViewMode;
@@ -21,5 +22,7 @@ export default function AttachmentViewerBody({
       return <AttachmentViewerImageBody url={url} filename={filename} />;
     case "other":
       return <AttachmentViewerOtherBody url={url} filename={filename} />;
+    case "unavailable":
+      return <AttachmentViewerUnavailableBody />;
   }
 }

--- a/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewerUnavailableBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewerUnavailableBody.tsx
@@ -1,0 +1,24 @@
+/**
+ * Body shown by the AttachmentViewer when the underlying storage object
+ * is gone. Plain centered muted text — not a destructive alert. The
+ * filename is rendered as the title in the modal header (handled by
+ * AttachmentViewer); this body just explains why nothing is loading.
+ */
+export default function AttachmentViewerUnavailableBody() {
+  return (
+    <div
+      className="flex h-full items-center justify-center p-8 text-center"
+      data-testid="attachment-viewer-unavailable-body"
+    >
+      <div className="max-w-sm space-y-2">
+        <p className="text-sm font-medium text-muted-foreground">
+          This document is no longer available.
+        </p>
+        <p className="text-xs text-muted-foreground/70">
+          The file may have been removed from storage. You can delete the row
+          and re-upload the original from the lease detail page.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentRow.tsx
@@ -24,10 +24,6 @@ export default function LeaseAttachmentRow({
   onKindChange,
 }: LeaseAttachmentRowProps) {
   const isMissing = att.is_available === false;
-  const canPreviewInline =
-    !isMissing
-    && att.presigned_url !== null
-    && (att.content_type === "application/pdf" || att.content_type.startsWith("image/"));
 
   useEffect(() => {
     if (!isMissing) return;
@@ -46,28 +42,17 @@ export default function LeaseAttachmentRow({
       data-testid={`lease-attachment-${att.id}`}
     >
       <div className="flex items-center justify-between gap-2">
-        {canPreviewInline ? (
-          <button
-            type="button"
-            onClick={onPreview}
-            className="truncate text-left text-primary hover:underline font-medium min-w-0"
-            data-testid={`lease-attachment-preview-${att.id}`}
-            title={att.filename}
-          >
-            {att.filename}
-          </button>
-        ) : (
-          <a
-            href={att.presigned_url ?? undefined}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="truncate text-left text-primary hover:underline font-medium min-w-0"
-            data-testid={`lease-attachment-download-link-${att.id}`}
-            title={att.filename}
-          >
-            {att.filename}
-          </a>
-        )}
+        {/* Filename always opens AttachmentViewer modal — viewer renders
+            file when URL present, neutral empty-state when not. */}
+        <button
+          type="button"
+          onClick={onPreview}
+          className="truncate text-left text-primary hover:underline font-medium min-w-0"
+          data-testid={`lease-attachment-preview-${att.id}`}
+          title={att.filename}
+        >
+          {att.filename}
+        </button>
 
         <div className="flex items-center gap-2 shrink-0">
           {att.presigned_url ? (

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentsSection.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAttachmentsSection.tsx
@@ -193,9 +193,9 @@ export default function LeaseAttachmentsSection({ leaseId, attachments, canWrite
         </div>
       ) : null}
 
-      {viewingAttachment?.presigned_url ? (
+      {viewingAttachment ? (
         <AttachmentViewer
-          url={viewingAttachment.presigned_url}
+          url={viewingAttachment.presigned_url ?? ""}
           filename={viewingAttachment.filename}
           contentType={viewingAttachment.content_type}
           onClose={() => setViewingAttachment(null)}

--- a/apps/mybookkeeper/frontend/src/app/features/leases/useAttachmentViewMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/useAttachmentViewMode.ts
@@ -1,17 +1,24 @@
 import type { AttachmentViewMode } from "@/shared/types/lease/attachment-view-mode";
 
 interface UseAttachmentViewModeArgs {
+  url: string;
   contentType: string;
 }
 
 /**
- * Resolves the viewer's render mode from the attachment content type.
+ * Resolves the viewer's render mode from the URL + content type.
  * Single source of truth so the body component is a flat switch instead of
  * a tower of conditionals.
+ *
+ * When the URL is empty, the viewer renders the "unavailable" body
+ * regardless of content type — the underlying object is missing from
+ * storage and there's nothing to load into an iframe / img tag.
  */
 export function useAttachmentViewMode({
+  url,
   contentType,
 }: UseAttachmentViewModeArgs): AttachmentViewMode {
+  if (!url) return "unavailable";
   if (contentType === "application/pdf") return "pdf";
   if (contentType.startsWith("image/")) return "image";
   return "other";

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/attachment-view-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/attachment-view-mode.ts
@@ -2,4 +2,4 @@
  * Discriminated union for what the AttachmentViewer body should render.
  * Replaces a chain of nested ternaries with a single switch.
  */
-export type AttachmentViewMode = "pdf" | "image" | "other";
+export type AttachmentViewMode = "pdf" | "image" | "other" | "unavailable";

--- a/packages/shared-backend/platform_shared/core/observability.py
+++ b/packages/shared-backend/platform_shared/core/observability.py
@@ -57,14 +57,23 @@ def init_sentry(*, dsn: str, environment: str) -> None:
         # Non-production: Sentry is optional — skip silently.
         return
 
-    # LoggingIntegration: capture INFO+ as breadcrumbs (attached to any
-    # subsequent error event for context), and INFO+ as standalone events
-    # so diagnostic logs are visible in Sentry without exposing a debug API.
-    # The breadcrumb level controls what rides on errors; the event level
-    # controls what gets posted as its own Sentry event.
+    # LoggingIntegration:
+    # - level=INFO         → INFO+ logs ride along as breadcrumbs on
+    #                        later events (debug context).
+    # - event_level=WARNING → only WARNING+ logs become standalone
+    #                        Sentry events.
+    #
+    # Was previously event_level=INFO, which forwarded every /health
+    # request log as its own Sentry event. That blew through the
+    # project's quota (~36h before 2026-05-06 18:00 UTC) and silently
+    # rate-limited ALL subsequent events — including the warning
+    # captures we rely on for missing-storage observability.
+    # WARNING+ is the correct ceiling: loud enough that orphan-storage,
+    # boot-guard, and silent-fail warnings reach Sentry; quiet enough
+    # that request-log noise doesn't burn the quota.
     logging_integration = LoggingIntegration(
         level=logging.INFO,
-        event_level=logging.INFO,
+        event_level=logging.WARNING,
     )
 
     try:


### PR DESCRIPTION
## What

Two related fixes:

### Sentry capture
`LoggingIntegration.event_level=INFO` was forwarding every `/health` log as a Sentry event → quota burned → ALL events rate-limited, including the warning captures we rely on for missing-storage observability. Drops to `event_level=WARNING`. INFO+ stays as breadcrumbs.

### Click UX
Per `g-design-ux` recommendation: filename click = always opens the AttachmentViewer modal. When `presigned_url` is empty (storage object missing), the modal body shows a neutral "This document is no longer available" message — no destructive alert, no re-upload picker, no broken `<a href={undefined}>` that shows the I-beam cursor and does nothing on click.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — 0 errors
- [x] Frontend `vitest run` (lease tests) — **27/27 pass**, includes new `useAttachmentViewMode` cases for `unavailable` mode
- [x] Backend `pytest tests/test_observability.py` — **8/8 pass**

## Verified data state

API returns `is_available=false` + `presigned_url=null` for all 4 attachments on the Sonu King lease (3 lease docs + 1 receipt). The modal-empty-state branch is the path the user will see post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)