### PR TITLE
feat(myjobhunter/kanban): swim lanes (Strong fit / Else) within each column

### DIFF
--- a/apps/myjobhunter/frontend/src/features/kanban/KanbanColumn.tsx
+++ b/apps/myjobhunter/frontend/src/features/kanban/KanbanColumn.tsx
@@ -3,14 +3,24 @@
  * - Header (title + count)
  * - Per-column scroll container (overflow-y: auto)
  * - dnd-kit SortableContext for the cards inside
+ * - Internal swim lanes: cards grouped by verdict (Strong fit / Else)
+ *   with collapsible lane headers, persisted to localStorage
  *
  * The outer board has NO horizontal scroll — the four columns are a fixed
  * grid. Each column scrolls vertically independently.
+ *
+ * Swim lanes are vertical sections within each column. Drag-drop targets
+ * the column (not the lane); the card's lane is determined by its
+ * ``verdict``, not by where it's dropped. Operator can collapse a lane
+ * to hide its cards across all columns — collapse state is global per
+ * lane via ``mjh_kanban_lane_<lane>`` localStorage key.
  */
+import { ChevronDown, ChevronRight } from "lucide-react";
 import { useDroppable } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import KanbanCard from "./KanbanCard";
 import { columnDroppableId } from "./use-kanban-drag-handler";
+import { useLaneCollapse, type KanbanLane } from "./use-lane-collapse";
 import type { KanbanColumn as KanbanColumnId } from "@/types/kanban/kanban-column";
 import { KANBAN_COLUMN_LABELS } from "@/types/kanban/kanban-column";
 import type { KanbanItem } from "@/types/kanban/kanban-item";
@@ -21,6 +31,15 @@ interface KanbanColumnProps {
   onSelectCard: (id: string) => void;
 }
 
+const LANE_LABELS: Record<KanbanLane, string> = {
+  strong_fit: "Strong fit",
+  everything_else: "Everything else",
+};
+
+function laneFor(verdict: string | null): KanbanLane {
+  return verdict === "strong_fit" ? "strong_fit" : "everything_else";
+}
+
 export default function KanbanColumn({
   column,
   items,
@@ -28,6 +47,11 @@ export default function KanbanColumn({
 }: KanbanColumnProps) {
   const droppableId = columnDroppableId(column);
   const { setNodeRef, isOver } = useDroppable({ id: droppableId });
+
+  const strongFit = items.filter((i) => laneFor(i.verdict) === "strong_fit");
+  const everythingElse = items.filter(
+    (i) => laneFor(i.verdict) === "everything_else",
+  );
 
   return (
     <section
@@ -44,7 +68,7 @@ export default function KanbanColumn({
 
       <div
         ref={setNodeRef}
-        className={`flex-1 min-h-0 overflow-y-auto p-2 space-y-2 transition-colors ${
+        className={`flex-1 min-h-0 overflow-y-auto p-2 transition-colors ${
           isOver ? "bg-primary/5" : ""
         }`}
         data-kanban-droppable={droppableId}
@@ -53,9 +77,12 @@ export default function KanbanColumn({
           items={items.map((i) => i.id)}
           strategy={verticalListSortingStrategy}
         >
-          {items.map((item) => (
-            <KanbanCard key={item.id} item={item} onSelect={onSelectCard} />
-          ))}
+          <Lane lane="strong_fit" items={strongFit} onSelectCard={onSelectCard} />
+          <Lane
+            lane="everything_else"
+            items={everythingElse}
+            onSelectCard={onSelectCard}
+          />
         </SortableContext>
 
         {items.length === 0 ? (
@@ -65,5 +92,52 @@ export default function KanbanColumn({
         ) : null}
       </div>
     </section>
+  );
+}
+
+interface LaneProps {
+  lane: KanbanLane;
+  items: KanbanItem[];
+  onSelectCard: (id: string) => void;
+}
+
+function Lane({ lane, items, onSelectCard }: LaneProps) {
+  const { collapsed, toggle } = useLaneCollapse(lane);
+  const isStrong = lane === "strong_fit";
+
+  // Render the lane header even when empty in this column — operator
+  // needs to see both lanes exist (UX review: "lane with 0 cards: show
+  // header with count of 0 + 'None' placeholder. Don't hide.")
+  return (
+    <div className="mb-2 last:mb-0">
+      <button
+        type="button"
+        onClick={toggle}
+        aria-expanded={!collapsed}
+        aria-label={`${LANE_LABELS[lane]} lane`}
+        className="w-full flex items-center gap-1.5 px-1 py-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {collapsed ? (
+          <ChevronRight size={12} aria-hidden="true" />
+        ) : (
+          <ChevronDown size={12} aria-hidden="true" />
+        )}
+        <span className={isStrong ? "text-emerald-700 dark:text-emerald-400" : ""}>
+          {LANE_LABELS[lane]}
+        </span>
+        <span className="ml-auto tabular-nums">{items.length}</span>
+      </button>
+      {collapsed ? null : (
+        <div className="space-y-2 pt-1">
+          {items.length === 0 ? (
+            <p className="text-[11px] text-muted-foreground/70 px-2 py-1">None</p>
+          ) : (
+            items.map((item) => (
+              <KanbanCard key={item.id} item={item} onSelect={onSelectCard} />
+            ))
+          )}
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/kanban/use-lane-collapse.ts
+++ b/apps/myjobhunter/frontend/src/features/kanban/use-lane-collapse.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * Per-lane collapse state, persisted to localStorage.
+ *
+ * Per UX review: lanes are independently collapsible. Operator may
+ * want to focus only on Strong fits some days. Collapse state must
+ * survive refresh.
+ *
+ * Storage key shape: ``mjh_kanban_lane_<lane>`` — boolean (true =
+ * collapsed). The hook returns the current state + a toggle callback.
+ *
+ * Listens to ``storage`` events so the kanban stays in sync across
+ * tabs (collapse a lane in tab A → tab B's kanban hides it on next
+ * render).
+ */
+export type KanbanLane = "strong_fit" | "everything_else";
+
+const PREFIX = "mjh_kanban_lane_";
+
+function storageKey(lane: KanbanLane): string {
+  return `${PREFIX}${lane}`;
+}
+
+function readCollapsed(lane: KanbanLane): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(storageKey(lane)) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function useLaneCollapse(lane: KanbanLane): {
+  collapsed: boolean;
+  toggle: () => void;
+} {
+  const [collapsed, setCollapsed] = useState<boolean>(() => readCollapsed(lane));
+
+  // Sync across tabs.
+  useEffect(() => {
+    function handler(event: StorageEvent) {
+      if (event.key === storageKey(lane)) {
+        setCollapsed(event.newValue === "true");
+      }
+    }
+    window.addEventListener("storage", handler);
+    return () => window.removeEventListener("storage", handler);
+  }, [lane]);
+
+  const toggle = useCallback(() => {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(storageKey(lane), String(next));
+      } catch {
+        // localStorage failures are non-blocking — operator just loses
+        // the persistence, the in-memory state still flips.
+      }
+      return next;
+    });
+  }, [lane]);
+
+  return { collapsed, toggle };
+}


### PR DESCRIPTION
Restores the swim-lane behavior PR #371 dropped. Cards in each column group into two collapsible sections — Strong fit on top, Everything else below — keyed on the JobAnalysis verdict. Lane collapse persists in localStorage and syncs across tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)