### PR TITLE
fix(myjobhunter): broaden research-endpoint exception coverage

### DIFF
--- a/apps/myjobhunter/backend/app/api/companies.py
+++ b/apps/myjobhunter/backend/app/api/companies.py
@@ -20,12 +20,15 @@ Companies use HARD delete (no ``deleted_at``) per the data model.
 """
 from __future__ import annotations
 
+import logging
 import uuid
 
 import anthropic
 import httpx
 from fastapi import APIRouter, Depends, HTTPException, Query, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
+
+logger = logging.getLogger(__name__)
 
 from app.core.auth import current_active_user
 from app.db.session import get_db
@@ -206,14 +209,48 @@ async def trigger_company_research(
             detail=f"Tavily research is not configured: {exc}",
         ) from exc
     except (anthropic.APIError, ValueError) as exc:
+        logger.exception(
+            "Company research failed: AI synthesis error company_id=%s",
+            company_id,
+        )
         raise HTTPException(
             status_code=502,
             detail=f"AI synthesis failed: {exc}",
         ) from exc
     except httpx.HTTPStatusError as exc:
+        logger.exception(
+            "Company research failed: Tavily HTTP %s company_id=%s",
+            exc.response.status_code,
+            company_id,
+        )
         raise HTTPException(
             status_code=502,
             detail=f"Tavily request failed: {exc.response.status_code}",
+        ) from exc
+    except httpx.RequestError as exc:
+        # Covers ConnectError, ReadTimeout, WriteTimeout, ConnectTimeout, etc.
+        # (parent of HTTPStatusError so this handler MUST come after the
+        # HTTPStatusError handler above.)
+        logger.exception(
+            "Company research failed: Tavily network error company_id=%s",
+            company_id,
+        )
+        raise HTTPException(
+            status_code=504,
+            detail=f"Research service network error: {type(exc).__name__}",
+        ) from exc
+    except Exception as exc:
+        # Final safety net — anything else (DB IntegrityError, KeyError,
+        # etc.) returned a bare 500 with no detail before. Log + propagate
+        # the exception type to the client so the next failure is
+        # diagnosable from DevTools alone.
+        logger.exception(
+            "Company research failed: unexpected error company_id=%s",
+            company_id,
+        )
+        raise HTTPException(
+            status_code=500,
+            detail=f"Research failed: {type(exc).__name__}: {exc}",
         ) from exc
 
     if research is None:

--- a/apps/myjobhunter/backend/tests/test_company_research_service.py
+++ b/apps/myjobhunter/backend/tests/test_company_research_service.py
@@ -376,3 +376,56 @@ class TestTriggerCompanyResearchEndpoint:
 
         resp = await client.post(f"/companies/{company_id}/research")
         assert resp.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_trigger_returns_504_on_tavily_timeout(
+        self,
+        user_factory,
+        as_user,
+    ) -> None:
+        """A Tavily ReadTimeout (httpx.RequestError, not HTTPStatusError)
+        must surface as 504 with a typed detail — NOT a bare 500."""
+        import httpx
+
+        user = await user_factory()
+
+        async with await as_user(user) as authed:
+            create = await authed.post("/companies", json=_make_company_payload())
+            assert create.status_code == 201
+            company_id = create.json()["id"]
+
+        with patch(
+            "app.services.company.company_research_service.search_company",
+            new=AsyncMock(side_effect=httpx.ReadTimeout("read timeout")),
+        ):
+            async with await as_user(user) as authed:
+                resp = await authed.post(f"/companies/{company_id}/research")
+
+        assert resp.status_code == 504
+        assert "ReadTimeout" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_trigger_returns_500_with_type_on_unexpected_error(
+        self,
+        user_factory,
+        as_user,
+    ) -> None:
+        """Unexpected exceptions (DB IntegrityError, KeyError, etc.)
+        surface 500 WITH the exception type+message — not a bare
+        'Internal Server Error' that gives the operator no signal."""
+        user = await user_factory()
+
+        async with await as_user(user) as authed:
+            create = await authed.post("/companies", json=_make_company_payload())
+            assert create.status_code == 201
+            company_id = create.json()["id"]
+
+        with patch(
+            "app.services.company.company_research_service.search_company",
+            new=AsyncMock(side_effect=KeyError("results")),
+        ):
+            async with await as_user(user) as authed:
+                resp = await authed.post(f"/companies/{company_id}/research")
+
+        assert resp.status_code == 500
+        assert "KeyError" in resp.json()["detail"]


### PR DESCRIPTION
## Symptom
Operator clicks "Research" on a company in MyJobHunter → frontend shows "Research failed. Please try again." DevTools shows `POST /companies/{id}/research` returning bare HTTP 500 with body `Internal Server Error` (no JSON `detail`). Sentry captures nothing.

## Root cause
The route only catches three typed exceptions:
- `TavilyNotConfiguredError` → 503
- `(anthropic.APIError, ValueError)` → 502
- `httpx.HTTPStatusError` → 502

Anything else falls through to FastAPI's default handler — a typeless 500 with no detail. The most likely actual trigger is `httpx.RequestError` (parent of `ReadTimeout`, `ConnectError`, `WriteTimeout`, etc.), since Tavily's `search_depth: "advanced"` call has a 30s timeout and can drift over it. `httpx.HTTPStatusError` only catches non-2xx HTTP responses — it does NOT catch network/timeout errors.

Other uncaught candidates: SQLAlchemy `IntegrityError`, `KeyError` from upstream response shape, `pydantic.ValidationError` from JSON parsing.

## Fix
- Add `httpx.RequestError` handler → 504 (gateway timeout) with exception type in detail. Positioned AFTER `httpx.HTTPStatusError` since `HTTPStatusError` is a subclass of `RequestError`.
- Add a generic `Exception` fallback → 500 with `f"{type(exc).__name__}: {exc}"` in detail. Operator can now read the real exception type from DevTools alone instead of getting a bare "Internal Server Error".
- `logger.exception()` on every non-503 path so the full stack trace hits container logs (and Sentry, when wired up).

## Test plan
- [x] `test_trigger_returns_504_on_tavily_timeout` — `httpx.ReadTimeout` from Tavily → 504, detail includes `ReadTimeout`
- [x] `test_trigger_returns_500_with_type_on_unexpected_error` — `KeyError` from Tavily → 500, detail includes `KeyError`
- [x] All 12 existing research-service tests still pass

## Operational followup
After merge, click "Research" on the failing company again. The next failure (if any) will surface a useful detail string in DevTools, which will pinpoint the actual root cause:
- `504 Research service network error: ReadTimeout` → Tavily slow / blocked → can switch `search_depth` to `"basic"` or raise the timeout
- `502 Tavily request failed: 401` → API key invalid → rotate
- `502 Tavily request failed: 429` → rate limit → backoff or upgrade plan
- `502 AI synthesis failed: ...` → Claude side
- `500 Research failed: <Type>: <message>` → DB or other; share the type and we'll patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)