### PR TITLE
fix(myjobhunter): GET /research MissingGreenlet on sources lazy-load

### DIFF
--- a/apps/myjobhunter/backend/app/services/company/company_research_service.py
+++ b/apps/myjobhunter/backend/app/services/company/company_research_service.py
@@ -25,6 +25,7 @@ import uuid
 from datetime import datetime, timezone
 
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import set_committed_value
 
 from app.models.company.company_research import CompanyResearch
 from app.repositories.company import company_repository, company_research_repository
@@ -201,6 +202,14 @@ async def get_research(
     sources = await company_research_repository.list_sources_for_research(
         db, research.id, user_id
     )
-    # Attach sources directly to avoid a second round-trip via relationship.
-    research.sources = sources
+    # ``research.sources = sources`` LOOKS like it loads the relationship
+    # but SQLAlchemy tracks load-state separately from the attribute
+    # value. A plain assignment leaves the relationship marked as
+    # un-loaded, so when Pydantic later accesses ``research.sources``
+    # via ``from_attributes=True`` it triggers a lazy-load —
+    # MissingGreenlet because Pydantic's getter is sync and async I/O
+    # can't run there. ``set_committed_value`` writes the value AND
+    # marks the relationship loaded, so subsequent access is a plain
+    # attribute read with no DB hit.
+    set_committed_value(research, "sources", sources)
     return research

--- a/apps/myjobhunter/backend/tests/test_company_research_service.py
+++ b/apps/myjobhunter/backend/tests/test_company_research_service.py
@@ -345,6 +345,58 @@ class TestTriggerCompanyResearchEndpoint:
         assert len(body["sources"]) == len(MOCK_TAVILY_RESULTS)
 
     @pytest.mark.asyncio
+    async def test_get_after_post_renders_sources_without_missing_greenlet(
+        self,
+        user_factory,
+        as_user,
+    ) -> None:
+        """Regression: GET /research after POST in a new session must
+        not trigger SQLAlchemy MissingGreenlet via Pydantic lazy-load
+        of the sources relationship.
+
+        Reproduction (before set_committed_value fix): the service
+        manually assigned ``research.sources = sources`` but SQLAlchemy
+        treated the relationship as un-loaded. Pydantic's
+        ``from_attributes=True`` getter was sync; SQLAlchemy tried
+        async I/O for the lazy-load and raised
+        sqlalchemy.exc.MissingGreenlet."""
+        user = await user_factory()
+
+        async with await as_user(user) as authed:
+            create = await authed.post("/companies", json=_make_company_payload())
+            assert create.status_code == 201
+            company_id = create.json()["id"]
+
+        with (
+            patch(
+                "app.services.company.company_research_service.search_company",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
+                "app.services.company.company_research_service.claude_service.call_claude",
+                new=AsyncMock(return_value=MOCK_CLAUDE_RESPONSE),
+            ),
+        ):
+            async with await as_user(user) as authed:
+                post_resp = await authed.post(f"/companies/{company_id}/research")
+        assert post_resp.status_code == 200
+
+        # New session — this is the actual reproduction. Until the
+        # set_committed_value fix landed, this returned 500
+        # MissingGreenlet from Pydantic accessing research.sources.
+        async with await as_user(user) as authed:
+            get_resp = await authed.get(f"/companies/{company_id}/research")
+
+        assert get_resp.status_code == 200, (
+            f"GET /research expected 200, got {get_resp.status_code}: "
+            f"{get_resp.text[:300]}"
+        )
+        body = get_resp.json()
+        assert body["overall_sentiment"] == "positive"
+        assert isinstance(body["sources"], list)
+        assert len(body["sources"]) == len(MOCK_TAVILY_RESULTS)
+
+    @pytest.mark.asyncio
     async def test_trigger_returns_404_for_unknown_company(
         self,
         user_factory,


### PR DESCRIPTION
## Symptom
GET /companies/{id}/research returns 500 with this detail (surfaced by PR #374's typed exception coverage):

> Failed to load research: MissingGreenlet: greenlet_spawn has not been called; can't call await_only() here. Was IO attempted in an unexpected place? (Background on this error at: https://sqlalche.me/e/20/xd2s)

## Root cause
The service did:
```python
research.sources = sources  # plain assignment
return research
```

Plain attribute assignment writes the value but **SQLAlchemy tracks relationship load-state separately from the attribute value**. The relationship stays flagged as un-loaded. When Pydantic later renders the response via `from_attributes=True`, it calls `getattr(research, 'sources')` which triggers a lazy-load. The lazy-load attempts async I/O from inside Pydantic's sync getter → `MissingGreenlet`.

This bug has existed since GET was implemented; it was hidden behind FastAPI's default bare-500 handler until PR #374 added the typed detail.

## Fix
`set_committed_value(research, "sources", sources)` from `sqlalchemy.orm.attributes`. This writes the value **and** marks the relationship as loaded so subsequent access is a plain in-memory read.

```python
from sqlalchemy.orm.attributes import set_committed_value
...
set_committed_value(research, "sources", sources)
```

This is the documented SQLAlchemy way to populate relationships from external queries — preferable to refactoring the parent query to use `selectinload` because it keeps the per-source `user_id` tenant filter that `list_sources_for_research` enforces.

## Test plan
- [x] `test_get_after_post_renders_sources_without_missing_greenlet` — reproduces the failure: POST then GET in separate sessions, asserts 200 with the sources list intact. Without the fix, this returns 500 MissingGreenlet.
- [x] All 15 existing research-service tests still pass.

## Verification after deploy
Reload Pivotal Health detail page → GET /research should return 200 with the sources list, no 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)