### PR TITLE
fix(mybookkeeper/leases): populate TENANT EMAIL/PHONE from applicant contact fields

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/tenpcontact260506_update_tenant_email_phone_default_source.py
+++ b/apps/mybookkeeper/backend/alembic/versions/tenpcontact260506_update_tenant_email_phone_default_source.py
@@ -1,0 +1,61 @@
+"""lease_template_placeholders: add applicant fallback to TENANT EMAIL/PHONE default_source
+
+Existing placeholder rows for ``TENANT EMAIL`` / ``TENANT PHONE`` were seeded
+with ``inquiry.inquirer_email`` / ``inquiry.inquirer_phone`` because at the
+time the applicant model had no contact fields. The applicant now has
+``contact_email`` and ``contact_phone`` (added in ``appcontact260506``), so
+the resolver should prefer the applicant value with the inquiry as fallback.
+
+This migration only updates rows that still hold the legacy single-source
+spec; rows a host has customized are left alone.
+
+Revision ID: tenpcontact260506
+Revises: appcontact260506
+Create Date: 2026-05-06 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "tenpcontact260506"
+down_revision: Union[str, None] = "appcontact260506"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE lease_template_placeholders
+        SET default_source = 'applicant.contact_email || inquiry.inquirer_email'
+        WHERE key IN ('TENANT EMAIL', 'TENANT_EMAIL')
+          AND default_source = 'inquiry.inquirer_email'
+        """,
+    )
+    op.execute(
+        """
+        UPDATE lease_template_placeholders
+        SET default_source = 'applicant.contact_phone || inquiry.inquirer_phone'
+        WHERE key IN ('TENANT PHONE', 'TENANT_PHONE')
+          AND default_source = 'inquiry.inquirer_phone'
+        """,
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE lease_template_placeholders
+        SET default_source = 'inquiry.inquirer_email'
+        WHERE key IN ('TENANT EMAIL', 'TENANT_EMAIL')
+          AND default_source = 'applicant.contact_email || inquiry.inquirer_email'
+        """,
+    )
+    op.execute(
+        """
+        UPDATE lease_template_placeholders
+        SET default_source = 'inquiry.inquirer_phone'
+        WHERE key IN ('TENANT PHONE', 'TENANT_PHONE')
+          AND default_source = 'applicant.contact_phone || inquiry.inquirer_phone'
+        """,
+    )

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
@@ -12,21 +12,18 @@ The keys are matched after normalisation (whitespace collapsed, uppercased).
 - Single path: ``applicant.legal_name``, ``today``
 - Fallback chain: ``applicant.legal_name || inquiry.inquirer_name``
   (first non-None, non-empty value wins)
-
-NOTE: Applicant has no ``email`` or ``phone`` columns — those PII fields
-live only on the Inquiry model (``inquirer_email``, ``inquirer_phone``).
-For those fields the inquiry is the primary source with no applicant fallback.
 """
 from __future__ import annotations
 
 # (input_type, default_source) — None means "no default".
 DEFAULT_SOURCE_MAP: dict[str, tuple[str, str | None]] = {
-    # Tenant identity — applicant-primary where the field exists, inquiry fallback otherwise.
+    # Tenant identity — applicant-primary, inquiry fallback. ``contact_email``
+    # and ``contact_phone`` were added to the applicant model so contact
+    # details persist past the inquiry stage (the inquiry can be deleted).
     "TENANT FULL NAME": ("text", "applicant.legal_name || inquiry.inquirer_name"),
     "TENANT NAME": ("text", "applicant.legal_name || inquiry.inquirer_name"),
-    # Email and phone only exist on Inquiry — no applicant fallback.
-    "TENANT EMAIL": ("email", "inquiry.inquirer_email"),
-    "TENANT PHONE": ("phone", "inquiry.inquirer_phone"),
+    "TENANT EMAIL": ("email", "applicant.contact_email || inquiry.inquirer_email"),
+    "TENANT PHONE": ("phone", "applicant.contact_phone || inquiry.inquirer_phone"),
     "TENANT EMPLOYER": ("text", "applicant.employer_or_hospital || inquiry.inquirer_employer"),
     "EMPLOYER": ("text", "applicant.employer_or_hospital || inquiry.inquirer_employer"),
     # Dates — applicant-primary (contract dates), inquiry fallback (desired dates).

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_resolver.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_resolver.py
@@ -37,6 +37,8 @@ from app.models.inquiries.inquiry import Inquiry
 _APPLICANT_ATTRS: frozenset[str] = frozenset({
     "legal_name",
     "employer_or_hospital",
+    "contact_email",
+    "contact_phone",
     "contract_start",
     "contract_end",
     "dob",

--- a/apps/mybookkeeper/backend/tests/test_default_source_resolver.py
+++ b/apps/mybookkeeper/backend/tests/test_default_source_resolver.py
@@ -26,12 +26,16 @@ from app.services.leases.default_source_resolver import (
 def _make_applicant(
     legal_name: str | None = None,
     employer_or_hospital: str | None = None,
+    contact_email: str | None = None,
+    contact_phone: str | None = None,
     contract_start: datetime.date | None = None,
     contract_end: datetime.date | None = None,
 ) -> MagicMock:
     a = MagicMock()
     a.legal_name = legal_name
     a.employer_or_hospital = employer_or_hospital
+    a.contact_email = contact_email
+    a.contact_phone = contact_phone
     a.contract_start = contract_start
     a.contract_end = contract_end
     a.dob = None
@@ -125,13 +129,32 @@ class TestResolveDefaultSource:
         assert value == "2026-03-01"
         assert prov == "applicant"
 
-    def test_inquiry_email_no_applicant_field(self) -> None:
-        """Email only exists on Inquiry — single inquiry source."""
-        applicant = _make_applicant()
-        inquiry = _make_inquiry(inquirer_email="tenant@example.com")
-        value, prov = resolve_default_source("inquiry.inquirer_email", applicant, inquiry)
-        assert value == "tenant@example.com"
+    def test_applicant_contact_email_wins_over_inquiry_inquirer_email(self) -> None:
+        applicant = _make_applicant(contact_email="tenant@applicant.com")
+        inquiry = _make_inquiry(inquirer_email="tenant@inquiry.com")
+        value, prov = resolve_default_source(
+            "applicant.contact_email || inquiry.inquirer_email", applicant, inquiry,
+        )
+        assert value == "tenant@applicant.com"
+        assert prov == "applicant"
+
+    def test_applicant_contact_email_falls_back_to_inquiry(self) -> None:
+        applicant = _make_applicant(contact_email=None)
+        inquiry = _make_inquiry(inquirer_email="tenant@inquiry.com")
+        value, prov = resolve_default_source(
+            "applicant.contact_email || inquiry.inquirer_email", applicant, inquiry,
+        )
+        assert value == "tenant@inquiry.com"
         assert prov == "inquiry"
+
+    def test_applicant_contact_phone_wins_over_inquiry_inquirer_phone(self) -> None:
+        applicant = _make_applicant(contact_phone="555-0100")
+        inquiry = _make_inquiry(inquirer_phone="555-0200")
+        value, prov = resolve_default_source(
+            "applicant.contact_phone || inquiry.inquirer_phone", applicant, inquiry,
+        )
+        assert value == "555-0100"
+        assert prov == "applicant"
 
     def test_empty_string_treated_as_none_falls_through_to_fallback(self) -> None:
         applicant = _make_applicant(legal_name="")
@@ -170,6 +193,16 @@ class TestValidateDefaultSourceSpec:
     def test_valid_chain_with_spaces(self) -> None:
         validate_default_source_spec(
             "applicant.legal_name || inquiry.inquirer_name"
+        )  # must not raise
+
+    def test_valid_applicant_contact_email_chain(self) -> None:
+        validate_default_source_spec(
+            "applicant.contact_email || inquiry.inquirer_email"
+        )  # must not raise
+
+    def test_valid_applicant_contact_phone_chain(self) -> None:
+        validate_default_source_spec(
+            "applicant.contact_phone || inquiry.inquirer_phone"
         )  # must not raise
 
     def test_valid_chain_without_spaces(self) -> None:


### PR DESCRIPTION
## Summary

When generating a lease, `[TENANT EMAIL]` and `[TENANT PHONE]` placeholders were left empty even though the applicant's contact info had been captured (PR #375 added `contact_email` / `contact_phone` to the applicant model). The placeholder defaults still pointed at `inquiry.inquirer_email` / `inquiry.inquirer_phone` only, with no applicant fallback — so an applicant whose source inquiry was deleted, or who was created without an inquiry, generated leases with blank tenant contact fields.

- `default_source_map.py` — TENANT EMAIL/PHONE now use the standard `applicant.<field> || inquiry.<field>` fallback shape, matching TENANT FULL NAME / TENANT EMPLOYER / MOVE-IN DATE / MOVE-OUT DATE.
- `default_source_resolver.py` — extend `_APPLICANT_ATTRS` allowlist with `contact_email` and `contact_phone` so the new specs pass `validate_default_source_spec`.
- `alembic/versions/tenpcontact260506_*.py` — rewrites legacy seeded `default_source` values in `lease_template_placeholders` to the new fallback chain. Only updates rows that still match the old single-source spec — any host-customized override is left untouched.

## ⚠️ Operational migration required

Migration `tenpcontact260506` runs automatically on the next backend deploy via the standard `alembic upgrade head` step in the deploy workflow. No operator action needed. Safe to roll forward and roll back (downgrade reverts the same rows).

## Test plan

- [x] Unit: `test_default_source_resolver.py` — added `applicant.contact_email`/`contact_phone` win-over-inquiry, fall-through-to-inquiry, validation cases. Existing `test_inquiry_email_no_applicant_field` removed (no longer a valid shape).
- [ ] Verify on prod: generate a lease for an applicant with `contact_email` set — `[TENANT EMAIL]` should be populated with provenance "from applicant".
- [ ] Verify legacy template rows: `lease_template_placeholders` for `TENANT EMAIL` / `TENANT PHONE` keys with `default_source = 'inquiry.inquirer_email'` are rewritten in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)