### PR TITLE
fix(mybookkeeper/leases): migrate legacy applicant.email/phone placeholder source

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/legtenp260507_migrate_legacy_applicant_email_phone_default_source.py
+++ b/apps/mybookkeeper/backend/alembic/versions/legtenp260507_migrate_legacy_applicant_email_phone_default_source.py
@@ -1,0 +1,67 @@
+"""lease_template_placeholders: migrate legacy ``applicant.email`` / ``applicant.phone`` specs
+
+The very first version of ``services/leases/default_source_map.py`` seeded
+``TENANT EMAIL`` / ``TENANT PHONE`` placeholders with ``applicant.email`` and
+``applicant.phone`` — paths that never resolved (the applicant model had no
+such columns at the time, and the resolver allowlist did not include them).
+
+That value was later changed in code to ``inquiry.inquirer_email`` /
+``inquiry.inquirer_phone``, and then again (in PR #377) to the
+``applicant.contact_email || inquiry.inquirer_email`` fallback chain.
+PR #377's migration only rewrote rows that matched the second of those three
+historical values, so templates uploaded under the original seed are still
+stuck with the legacy invalid spec — the resolver returns ``None`` and the
+generate-lease form shows an empty TENANT EMAIL / TENANT PHONE input.
+
+This migration covers the remaining legacy rows.
+
+Revision ID: legtenp260507
+Revises: tenpcontact260506
+Create Date: 2026-05-07 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "legtenp260507"
+down_revision: Union[str, None] = "tenpcontact260506"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE lease_template_placeholders
+        SET default_source = 'applicant.contact_email || inquiry.inquirer_email'
+        WHERE key IN ('TENANT EMAIL', 'TENANT_EMAIL')
+          AND default_source = 'applicant.email'
+        """,
+    )
+    op.execute(
+        """
+        UPDATE lease_template_placeholders
+        SET default_source = 'applicant.contact_phone || inquiry.inquirer_phone'
+        WHERE key IN ('TENANT PHONE', 'TENANT_PHONE')
+          AND default_source = 'applicant.phone'
+        """,
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        UPDATE lease_template_placeholders
+        SET default_source = 'applicant.email'
+        WHERE key IN ('TENANT EMAIL', 'TENANT_EMAIL')
+          AND default_source = 'applicant.contact_email || inquiry.inquirer_email'
+        """,
+    )
+    op.execute(
+        """
+        UPDATE lease_template_placeholders
+        SET default_source = 'applicant.phone'
+        WHERE key IN ('TENANT PHONE', 'TENANT_PHONE')
+          AND default_source = 'applicant.contact_phone || inquiry.inquirer_phone'
+        """,
+    )


### PR DESCRIPTION
## Summary

PR #377 rewrote `default_source = 'inquiry.inquirer_email'` rows to the applicant-fallback chain, but the screenshot from the live app shows the inputs still empty with `applicant.email` / `applicant.phone` as the placeholder hint. Tracing the history of `services/leases/default_source_map.py`:

1. **Original seed**: `"TENANT EMAIL": ("email", "applicant.email")` — never resolved (no such column on applicant).
2. **First fix**: changed to `"inquiry.inquirer_email"`.
3. **PR #377**: changed to `"applicant.contact_email || inquiry.inquirer_email"` + migrated step-2 rows.

Templates uploaded under the original seed still hold the step-1 invalid spec. The resolver returns `None`, the input renders empty, and the placeholder hint just echoes the bad spec. This migration sweeps those rows.

Idempotent (only updates exact-match) and reversible.

## Test plan

- [ ] After deploy, reload Generate Lease for Andrew Le → TENANT EMAIL / TENANT PHONE populate with "from applicant" badge (assumes Andrew's `contact_email` was populated by PR #375's backfill, which it should have been).

🤖 Generated with [Claude Code](https://claude.com/claude-code)