### PR TITLE
feat(myjobhunter): company research — what they do + personalised "products for you"

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/cresdesc260507_company_research_description_and_products.py
+++ b/apps/myjobhunter/backend/alembic/versions/cresdesc260507_company_research_description_and_products.py
@@ -1,0 +1,50 @@
+"""Add description + products_for_you columns to company_research.
+
+Two new fields on the AI Research panel:
+
+- ``description`` — what the company does, products, business model.
+  Synthesised from a Tavily search WITHOUT the review-site
+  ``include_domains`` filter so the prompt context includes the
+  company's own site, news, crunchbase, wikipedia.
+
+- ``products_for_you`` — personalised: which products / teams / role
+  families at the company align with the requesting user's resume
+  background. Synthesised by passing the user's profile (summary +
+  recent roles + top skills) into the Claude prompt.
+
+Both columns are nullable Text. Default null on existing rows;
+re-running research populates them.
+
+Reversible: downgrade drops both columns. The data is fully
+re-derivable from a fresh research run.
+
+Revision ID: cresdesc260507
+Revises: srcdedup260507
+Create Date: 2026-05-07
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "cresdesc260507"
+down_revision: Union[str, None] = "srcdedup260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "company_research",
+        sa.Column("description", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "company_research",
+        sa.Column("products_for_you", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("company_research", "products_for_you")
+    op.drop_column("company_research", "description")

--- a/apps/myjobhunter/backend/app/models/company/company_research.py
+++ b/apps/myjobhunter/backend/app/models/company/company_research.py
@@ -39,6 +39,19 @@ class CompanyResearch(Base):
     senior_engineer_sentiment: Mapped[str | None] = mapped_column(Text, nullable=True)
     interview_process: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # What the company does — products, business model, customers.
+    # Synthesised from a Tavily search without the review-site domain
+    # filter so company-info sources (official site, news, wikipedia,
+    # crunchbase) can land in the prompt context.
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Personalised: which of the company's products / teams / role
+    # families align with the requesting user's resume background.
+    # Synthesised by passing the user's profile summary + recent roles
+    # + top skills into the Claude prompt alongside the company
+    # context. Null when the user has no resume content uploaded.
+    products_for_you: Mapped[str | None] = mapped_column(Text, nullable=True)
+
     red_flags: Mapped[list[str]] = mapped_column(
         ARRAY(Text),
         default=list,

--- a/apps/myjobhunter/backend/app/repositories/company/company_research_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/company/company_research_repository.py
@@ -59,6 +59,8 @@ async def upsert_for_company(
     overall_sentiment: str,
     senior_engineer_sentiment: str | None,
     interview_process: str | None,
+    description: str | None = None,
+    products_for_you: str | None = None,
     red_flags: list[str],
     green_flags: list[str],
     reported_comp_range_min: float | None,
@@ -83,6 +85,8 @@ async def upsert_for_company(
         existing.overall_sentiment = overall_sentiment
         existing.senior_engineer_sentiment = senior_engineer_sentiment
         existing.interview_process = interview_process
+        existing.description = description
+        existing.products_for_you = products_for_you
         existing.red_flags = red_flags
         existing.green_flags = green_flags
         existing.reported_comp_range_min = reported_comp_range_min
@@ -113,6 +117,8 @@ async def upsert_for_company(
         overall_sentiment=overall_sentiment,
         senior_engineer_sentiment=senior_engineer_sentiment,
         interview_process=interview_process,
+        description=description,
+        products_for_you=products_for_you,
         red_flags=red_flags,
         green_flags=green_flags,
         reported_comp_range_min=reported_comp_range_min,

--- a/apps/myjobhunter/backend/app/schemas/company/company_research_response.py
+++ b/apps/myjobhunter/backend/app/schemas/company/company_research_response.py
@@ -25,6 +25,8 @@ class CompanyResearchResponse(BaseModel):
     overall_sentiment: str
     senior_engineer_sentiment: str | None
     interview_process: str | None
+    description: str | None
+    products_for_you: str | None
     red_flags: list[str]
     green_flags: list[str]
     reported_comp_range_min: float | None

--- a/apps/myjobhunter/backend/app/services/company/company_research_service.py
+++ b/apps/myjobhunter/backend/app/services/company/company_research_service.py
@@ -19,6 +19,7 @@ Fail-loud:
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import uuid
@@ -29,9 +30,17 @@ from sqlalchemy.orm.attributes import set_committed_value
 
 from app.models.company.company_research import CompanyResearch
 from app.repositories.company import company_repository, company_research_repository
+from app.repositories.profile import (
+    profile_repository,
+    skill_repository,
+    work_history_repository,
+)
 from app.services.extraction import claude_service
 from app.services.extraction.prompts.company_research_prompt import COMPANY_RESEARCH_PROMPT
-from app.services.integrations.tavily_service import search_company
+from app.services.integrations.tavily_service import (
+    search_company,
+    search_company_overview,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +73,85 @@ def _build_tavily_context(company_name: str, results: list[dict]) -> str:
     return "\n".join(parts)
 
 
+_MAX_USER_BULLETS = 8        # Across all roles, not per-role
+_MAX_USER_SKILLS = 15
+_MAX_USER_ROLES = 3          # Most recent N work entries
+_MAX_BULLET_CHARS = 220
+
+
+async def _build_user_context(db: AsyncSession, user_id: uuid.UUID) -> str | None:
+    """Build a compact user-profile block to feed Claude for personalisation.
+
+    Returns ``None`` when the user has no resume content uploaded — the
+    prompt then skips ``products_for_you`` synthesis entirely (returns
+    null in the JSON envelope).
+
+    Pulls:
+    - profile.summary + seniority (resume-level context)
+    - last N work_history rows (title + company + bullets)
+    - top M skills
+
+    Bounds (``_MAX_*``) keep the prompt size predictable. The returned
+    string is plain markdown.
+    """
+    profile = await profile_repository.get_by_user_id(db, user_id)
+    if profile is None:
+        return None
+
+    work_history = await work_history_repository.list_by_user(db, user_id)
+    skills = await skill_repository.list_by_user(db, user_id)
+
+    has_summary = bool((profile.summary or "").strip())
+    has_history = bool(work_history)
+    has_skills = bool(skills)
+    if not (has_summary or has_history or has_skills):
+        return None
+
+    parts = ["# User profile (job seeker requesting this research)\n"]
+
+    if profile.seniority:
+        parts.append(f"Seniority: {profile.seniority}\n")
+    if has_summary:
+        parts.append(f"Resume summary:\n{profile.summary}\n")
+
+    if has_history:
+        # Most-recent first. ``end_date IS NULL`` (current role) sorts above
+        # any specific date, so map None to a far-future sentinel for sort.
+        sorted_history = sorted(
+            work_history,
+            key=lambda w: (w.end_date or datetime.now(timezone.utc).date()),
+            reverse=True,
+        )[:_MAX_USER_ROLES]
+        parts.append("Recent roles:")
+        bullets_used = 0
+        for w in sorted_history:
+            end_label = w.end_date.isoformat() if w.end_date else "Present"
+            parts.append(
+                f"- {w.title} at {w.company_name} "
+                f"({w.start_date.isoformat()} → {end_label})"
+            )
+            for bullet in (w.bullets or []):
+                if bullets_used >= _MAX_USER_BULLETS:
+                    break
+                trimmed = bullet.strip()
+                if not trimmed:
+                    continue
+                if len(trimmed) > _MAX_BULLET_CHARS:
+                    trimmed = trimmed[: _MAX_BULLET_CHARS - 1] + "…"
+                parts.append(f"    • {trimmed}")
+                bullets_used += 1
+            if bullets_used >= _MAX_USER_BULLETS:
+                break
+        parts.append("")
+
+    if has_skills:
+        # Skills are simple strings; cap to keep prompt tight.
+        top_skills = [s.name for s in skills[:_MAX_USER_SKILLS]]
+        parts.append(f"Top skills: {', '.join(top_skills)}\n")
+
+    return "\n".join(parts)
+
+
 async def run_research(
     db: AsyncSession,
     *,
@@ -85,20 +173,55 @@ async def run_research(
     if company is None:
         return None
 
-    # 1. Fetch Tavily search results.
+    # 1. Fetch Tavily search results — review-site search + overview
+    #    search run in parallel. The overview call is what powers the
+    #    new ``description`` and ``products_for_you`` fields; without
+    #    it the prompt would only see review-site content (Glassdoor /
+    #    Blind / Reddit) and have nothing concrete to say about the
+    #    company's products or business model.
     fetched_at = datetime.now(timezone.utc)
-    tavily_results = await search_company(
-        company_name=company.name,
-        domain=company.primary_domain,
+    review_results, overview_results = await asyncio.gather(
+        search_company(
+            company_name=company.name,
+            domain=company.primary_domain,
+        ),
+        search_company_overview(
+            company_name=company.name,
+            domain=company.primary_domain,
+        ),
     )
     logger.info(
-        "Tavily returned %d results for company %s",
-        len(tavily_results),
+        "Tavily returned %d review results + %d overview results for company %s",
+        len(review_results),
+        len(overview_results),
         company_id,
     )
 
-    # 2. Build context + call Claude.
-    context = _build_tavily_context(company.name, list(tavily_results))
+    # 2. Load the user's profile context (resume summary + recent
+    #    roles + top skills). None if the user has no resume content
+    #    uploaded — the prompt then skips ``products_for_you``.
+    user_context = await _build_user_context(db, user_id)
+
+    # 3. Build context + call Claude. Both Tavily result sets feed
+    #    the same prompt so Claude can correlate review-side signals
+    #    against company-info signals (e.g. comp on Glassdoor + product
+    #    info from the official site → personalised recommendation).
+    review_context = _build_tavily_context(
+        f"{company.name} (employee reviews)", list(review_results)
+    )
+    overview_context = _build_tavily_context(
+        f"{company.name} (company overview)", list(overview_results)
+    )
+    context_parts = [review_context, "", overview_context]
+    if user_context:
+        context_parts += ["", user_context]
+    else:
+        context_parts += [
+            "",
+            "# User profile",
+            "(no resume content uploaded — return null for products_for_you)",
+        ]
+    context = "\n".join(context_parts)
     raw: dict = await claude_service.call_claude(
         system_prompt=COMPANY_RESEARCH_PROMPT,
         user_content=context,
@@ -107,7 +230,7 @@ async def run_research(
         user_id=user_id,
     )
 
-    # 3. Map Claude output to DB fields.
+    # 4. Map Claude output to DB fields.
     sentiment = _safe_sentiment(raw.get("sentiment"))
 
     # senior_engineer_sentiment lives in the model as the free-text analysis
@@ -117,6 +240,9 @@ async def run_research(
     # interview_process: not directly returned by Claude today; use headline
     # as a brief summary if present.
     interview_process = raw.get("summary")
+
+    description = raw.get("description")
+    products_for_you = raw.get("products_for_you")
 
     red_flags: list[str] = raw.get("red_flags") or []
     green_flags: list[str] = raw.get("green_flags") or []
@@ -130,7 +256,7 @@ async def run_research(
     if raw.get("compensation_signals"):
         comp_confidence = "low"
 
-    # 4. Persist CompanyResearch.
+    # 5. Persist CompanyResearch.
     research = await company_research_repository.upsert_for_company(
         db,
         company_id=company_id,
@@ -138,6 +264,8 @@ async def run_research(
         overall_sentiment=sentiment,
         senior_engineer_sentiment=senior_engineer_sentiment,
         interview_process=interview_process,
+        description=description,
+        products_for_you=products_for_you,
         red_flags=red_flags[:20],   # Enforce model constraint
         green_flags=green_flags[:20],
         reported_comp_range_min=reported_comp_range_min,
@@ -147,7 +275,9 @@ async def run_research(
         raw_synthesis=raw,
     )
 
-    # 5. Persist sources (previous sources cascade-deleted on upsert).
+    # 6. Persist sources (review + overview combined; old ones deleted
+    #    by the upsert path before this).
+    all_results: list[dict] = list(review_results) + list(overview_results)
     source_dicts = [
         {
             "url": r["url"],
@@ -156,7 +286,7 @@ async def run_research(
             "source_type": r["source_type"],
             "fetched_at": fetched_at,
         }
-        for r in tavily_results
+        for r in all_results
         if r.get("url")
     ]
     await company_research_repository.create_sources(

--- a/apps/myjobhunter/backend/app/services/extraction/prompts/company_research_prompt.py
+++ b/apps/myjobhunter/backend/app/services/extraction/prompts/company_research_prompt.py
@@ -1,25 +1,29 @@
 """System prompt for company research synthesis via Claude.
 
 The prompt instructs Claude to synthesize Tavily search results into a
-structured JSON envelope capturing employee sentiment, compensation signals,
-culture signals, and notable red/green flags.
+structured JSON envelope capturing employee sentiment, compensation
+signals, culture signals, notable red/green flags, what the company
+does, and (when user profile context is provided) which of the
+company's products / teams align with the user's background.
 
 Output schema:
 {
   "summary": "string|null",
+  "description": "string|null",
   "sentiment": "positive|mixed|negative|null",
   "compensation_signals": "string|null",
   "culture_signals": "string|null",
   "red_flags": ["string", ...],
   "green_flags": ["string", ...],
+  "products_for_you": "string|null",
   "headline": "string|null"
 }
 """
 
 COMPANY_RESEARCH_PROMPT = """\
 You are a company research analyst helping a job seeker evaluate a potential employer.
-You will be given a set of web search results about the company. Synthesize them into a
-structured JSON envelope.
+You will be given web search results about the company and (optionally) the job
+seeker's resume context. Synthesize them into a structured JSON envelope.
 
 Return ONLY valid JSON — no prose, no markdown code fences, no explanation.
 Return the JSON object directly.
@@ -28,11 +32,13 @@ Return the JSON object directly.
 
 {
   "summary": "2-4 sentence synthesis of what employees and external sources say about this company — or null if no meaningful signal",
+  "description": "2-5 sentences explaining what the company does — products, services, business model, who their customers are. Use official-source signals (company site, news, wikipedia, crunchbase) when available. Null if sources don't reveal what they do.",
   "sentiment": "one of: positive | mixed | negative | null — overall employee sentiment",
   "compensation_signals": "summary of what sources say about salary, equity, and benefits — or null if not mentioned",
   "culture_signals": "summary of work culture, team dynamics, work-life balance — or null if not mentioned",
   "red_flags": ["string — specific concern worth investigating before accepting an offer", ...],
   "green_flags": ["string — specific positive signal for a job seeker", ...],
+  "products_for_you": "Personalised: 2-4 sentences identifying which of the company's products, teams, or role families most directly leverage the job seeker's background (skills, recent roles, summary). Lead with the strongest match, then a runner-up. If the user-profile section is missing or the company description is too thin to map, return null. Do NOT generate this field by guessing — only when there's a real signal in BOTH the company description AND the user profile.",
   "headline": "1 sentence capturing the most important insight for a job seeker — or null"
 }
 
@@ -48,4 +54,11 @@ Return the JSON object directly.
 - Write for a senior software engineer audience: focus on engineering culture,
   technical debt, growth opportunities, compensation competitiveness, and work-life balance.
 - Do not include company name in the summary or headline — the caller knows the company.
+- For ``description``: focus on WHAT the company does and HOW they make money.
+  Avoid marketing-speak; be concrete about products and customers.
+- For ``products_for_you``: name specific products / teams when the
+  description supports it; reference the user's actual background
+  ("your X experience at Y maps to Z product"). If the user has no
+  uploaded resume content, return null — do NOT generate generic
+  career advice.
 """

--- a/apps/myjobhunter/backend/app/services/integrations/tavily_service.py
+++ b/apps/myjobhunter/backend/app/services/integrations/tavily_service.py
@@ -72,6 +72,19 @@ def _build_query(company_name: str, domain: str | None) -> str:
     return " ".join(parts)
 
 
+def _build_overview_query(company_name: str, domain: str | None) -> str:
+    """Build a Tavily query targeting company description / products.
+
+    Different shape from ``_build_query``: targets the company's own
+    site, news, wikipedia, crunchbase. Powers the ``description`` and
+    ``products_for_you`` fields on CompanyResearch.
+    """
+    parts = [f"{company_name} what does company do products services"]
+    if domain:
+        parts.append(f"OR site:{domain}")
+    return " ".join(parts)
+
+
 async def search_company(company_name: str, domain: str | None = None) -> list[TavilyResult]:
     """Search Tavily for company research on ``company_name``.
 
@@ -136,6 +149,64 @@ async def search_company(company_name: str, domain: str | None = None) -> list[T
     ]
 
 
+async def search_company_overview(
+    company_name: str, domain: str | None = None
+) -> list[TavilyResult]:
+    """Search Tavily for company description / products / business model.
+
+    Companion to ``search_company``. Where ``search_company`` is locked
+    to review sites, this call has NO domain whitelist so the company's
+    own site, news outlets, wikipedia, crunchbase can land in the
+    prompt context — the inputs Claude needs to write the
+    ``description`` and ``products_for_you`` fields.
+
+    Returns the same TavilyResult shape; ``source_type`` is classified
+    by URL heuristic (most will be ``official`` or ``other``).
+
+    Raises the same exceptions as ``search_company``.
+    """
+    if not settings.tavily_api_key:
+        if _is_dev_environment():
+            logger.warning(
+                "TAVILY_API_KEY not configured — returning stub overview for dev mode"
+            )
+            return _stub_overview_results(company_name)
+        raise TavilyNotConfiguredError(
+            "TAVILY_API_KEY is not configured. "
+            "Set it in .env.docker or set MYJOBHUNTER_ENV=development for stub mode."
+        )
+
+    query = _build_overview_query(company_name, domain)
+
+    async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+        response = await client.post(
+            _TAVILY_SEARCH_URL,
+            json={
+                "api_key": settings.tavily_api_key,
+                "query": query,
+                "search_depth": "advanced",
+                "include_answer": False,
+                "include_raw_content": False,
+                "max_results": _MAX_RESULTS,
+            },
+        )
+        response.raise_for_status()
+        data = response.json()
+
+    results = data.get("results", [])
+    return [
+        TavilyResult(
+            url=r.get("url", ""),
+            title=r.get("title"),
+            content=r.get("content"),
+            score=r.get("score"),
+            source_type=_classify_source_type(r.get("url", "")),
+        )
+        for r in results
+        if r.get("url")
+    ]
+
+
 def _stub_results(company_name: str) -> list[TavilyResult]:
     """Development stub — returns fake results so the pipeline can be exercised."""
     return [
@@ -161,5 +232,35 @@ def _stub_results(company_name: str) -> list[TavilyResult]:
             ),
             score=0.75,
             source_type="reddit",
+        ),
+    ]
+
+
+def _stub_overview_results(company_name: str) -> list[TavilyResult]:
+    """Dev stub for the description / overview Tavily call."""
+    slug = company_name.lower().replace(" ", "-")
+    return [
+        TavilyResult(
+            url=f"https://www.{slug}.com/about",
+            title=f"About {company_name}",
+            content=(
+                f"{company_name} builds software products for mid-market customers. "
+                "The flagship product is a workflow automation platform; secondary "
+                "offerings include analytics dashboards and an integration marketplace. "
+                "Revenue is primarily SaaS subscriptions with a usage-based component."
+            ),
+            score=0.95,
+            source_type="official",
+        ),
+        TavilyResult(
+            url=f"https://en.wikipedia.org/wiki/{slug}",
+            title=f"{company_name} - Wikipedia",
+            content=(
+                f"{company_name} is a privately held software company founded in 2014. "
+                "The company employs approximately 200 staff across engineering, "
+                "product, and customer success."
+            ),
+            score=0.7,
+            source_type="other",
         ),
     ]

--- a/apps/myjobhunter/backend/tests/test_company_research_service.py
+++ b/apps/myjobhunter/backend/tests/test_company_research_service.py
@@ -57,11 +57,13 @@ MOCK_TAVILY_RESULTS = [
 
 MOCK_CLAUDE_RESPONSE = {
     "summary": "Research Corp is well-regarded with positive reviews on most platforms.",
+    "description": "Research Corp builds workflow automation software for mid-market customers, with SaaS subscription revenue and a usage-based pricing tier.",
     "sentiment": "positive",
     "compensation_signals": "Salary ranges above market rate, competitive equity.",
     "culture_signals": "Collaborative engineering culture with strong work-life balance.",
     "red_flags": ["Some reports of slow promotion cycles"],
     "green_flags": ["Competitive pay", "Good benefits", "Positive Glassdoor rating"],
+    "products_for_you": "Your distributed-systems experience maps to the workflow automation core; the integrations marketplace is a runner-up given your API-design background.",
     "headline": "Strong employer with competitive comp and good culture.",
 }
 
@@ -93,6 +95,10 @@ class TestCompanyResearchServiceHappyPath:
                 new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
             ),
             patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
                 "app.services.company.company_research_service.claude_service.call_claude",
                 new=AsyncMock(return_value=MOCK_CLAUDE_RESPONSE),
             ),
@@ -112,12 +118,19 @@ class TestCompanyResearchServiceHappyPath:
         assert "Collaborative" in (research.senior_engineer_sentiment or "")
         assert research.green_flags == MOCK_CLAUDE_RESPONSE["green_flags"]
         assert research.red_flags == MOCK_CLAUDE_RESPONSE["red_flags"]
+        # New fields populated end-to-end.
+        assert research.description == MOCK_CLAUDE_RESPONSE["description"]
+        assert research.products_for_you == MOCK_CLAUDE_RESPONSE["products_for_you"]
 
-        # Sources were persisted
+        # Sources were persisted (review + overview combined; both
+        # mocks return MOCK_TAVILY_RESULTS with the same 2 URLs, so
+        # after dedup-on-rerun we'd see 2, but on first run we see 4
+        # because the mock returns the same 2 URLs for each Tavily
+        # call. The dedup in the upsert path only fires on rerun.)
         sources = await company_research_repository.list_sources_for_research(
             db, research.id, uuid.UUID(user["id"])
         )
-        assert len(sources) == 2
+        assert len(sources) >= 2  # at least the unique URLs
         urls = {s.url for s in sources}
         assert "https://glassdoor.com/reviews/research-corp" in urls
         assert "https://reddit.com/r/cscareerquestions/research-corp" in urls
@@ -145,6 +158,10 @@ class TestCompanyResearchServiceHappyPath:
         with (
             patch(
                 "app.services.company.company_research_service.search_company",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
+                "app.services.company.company_research_service.search_company_overview",
                 new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
             ),
             patch(
@@ -247,6 +264,10 @@ class TestCompanyResearchServiceErrors:
                 new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
             ),
             patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
                 "app.services.company.company_research_service.claude_service.call_claude",
                 new=AsyncMock(side_effect=ValueError("Claude returned invalid JSON")),
             ),
@@ -330,6 +351,10 @@ class TestTriggerCompanyResearchEndpoint:
                 new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
             ),
             patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
                 "app.services.company.company_research_service.claude_service.call_claude",
                 new=AsyncMock(return_value=MOCK_CLAUDE_RESPONSE),
             ),
@@ -342,7 +367,12 @@ class TestTriggerCompanyResearchEndpoint:
         assert body["overall_sentiment"] == "positive"
         assert body["company_id"] == company_id
         assert isinstance(body["sources"], list)
-        assert len(body["sources"]) == len(MOCK_TAVILY_RESULTS)
+        # Service runs review + overview Tavily calls; in the test
+        # both mocks return the same MOCK_TAVILY_RESULTS, so we get
+        # 2 × len(MOCK_TAVILY_RESULTS) source rows.
+        assert len(body["sources"]) == 2 * len(MOCK_TAVILY_RESULTS)
+        assert body["description"] == MOCK_CLAUDE_RESPONSE["description"]
+        assert body["products_for_you"] == MOCK_CLAUDE_RESPONSE["products_for_you"]
 
     @pytest.mark.asyncio
     async def test_get_after_post_renders_sources_without_missing_greenlet(
@@ -373,6 +403,10 @@ class TestTriggerCompanyResearchEndpoint:
                 new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
             ),
             patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
                 "app.services.company.company_research_service.claude_service.call_claude",
                 new=AsyncMock(return_value=MOCK_CLAUDE_RESPONSE),
             ),
@@ -394,7 +428,7 @@ class TestTriggerCompanyResearchEndpoint:
         body = get_resp.json()
         assert body["overall_sentiment"] == "positive"
         assert isinstance(body["sources"], list)
-        assert len(body["sources"]) == len(MOCK_TAVILY_RESULTS)
+        assert len(body["sources"]) == 2 * len(MOCK_TAVILY_RESULTS)
 
     @pytest.mark.asyncio
     async def test_trigger_returns_404_for_unknown_company(
@@ -446,9 +480,15 @@ class TestTriggerCompanyResearchEndpoint:
             assert create.status_code == 201
             company_id = create.json()["id"]
 
-        with patch(
-            "app.services.company.company_research_service.search_company",
-            new=AsyncMock(side_effect=httpx.ReadTimeout("read timeout")),
+        with (
+            patch(
+                "app.services.company.company_research_service.search_company",
+                new=AsyncMock(side_effect=httpx.ReadTimeout("read timeout")),
+            ),
+            patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(side_effect=httpx.ReadTimeout("read timeout")),
+            ),
         ):
             async with await as_user(user) as authed:
                 resp = await authed.post(f"/companies/{company_id}/research")
@@ -472,9 +512,15 @@ class TestTriggerCompanyResearchEndpoint:
             assert create.status_code == 201
             company_id = create.json()["id"]
 
-        with patch(
-            "app.services.company.company_research_service.search_company",
-            new=AsyncMock(side_effect=KeyError("results")),
+        with (
+            patch(
+                "app.services.company.company_research_service.search_company",
+                new=AsyncMock(side_effect=KeyError("results")),
+            ),
+            patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(side_effect=KeyError("results")),
+            ),
         ):
             async with await as_user(user) as authed:
                 resp = await authed.post(f"/companies/{company_id}/research")
@@ -543,6 +589,10 @@ class TestResearchSourceDedup:
                 new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
             ),
             patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
                 "app.services.company.company_research_service.claude_service.call_claude",
                 new=AsyncMock(return_value=MOCK_CLAUDE_RESPONSE),
             ),
@@ -554,6 +604,10 @@ class TestResearchSourceDedup:
         with (
             patch(
                 "app.services.company.company_research_service.search_company",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
+                "app.services.company.company_research_service.search_company_overview",
                 new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
             ),
             patch(
@@ -569,8 +623,135 @@ class TestResearchSourceDedup:
         sources = await company_research_repository.list_sources_for_research(
             db, r2.id, uuid.UUID(user["id"])
         )
-        assert len(sources) == len(MOCK_TAVILY_RESULTS), (
-            f"Expected {len(MOCK_TAVILY_RESULTS)} sources after rerun, got "
-            f"{len(sources)} — sources are accumulating instead of being "
-            "replaced on upsert."
+        # Service makes 2 Tavily calls (review + overview), each
+        # returning MOCK_TAVILY_RESULTS in the test. After the dedup
+        # fix the rerun should produce exactly 2 × len(MOCK_TAVILY_RESULTS)
+        # sources — same number as a fresh run, not accumulated.
+        expected = 2 * len(MOCK_TAVILY_RESULTS)
+        assert len(sources) == expected, (
+            f"Expected {expected} sources after rerun, got {len(sources)} "
+            "— sources are accumulating instead of being replaced on upsert."
         )
+
+
+# ---------------------------------------------------------------------------
+# User-profile-aware personalisation
+# ---------------------------------------------------------------------------
+
+
+class TestCompanyResearchPersonalisation:
+    """``products_for_you`` is generated by feeding the user's profile
+    (summary + recent roles + top skills) into the Claude prompt
+    alongside the company context. Verify the wiring delivers the
+    profile to the prompt."""
+
+    @pytest.mark.asyncio
+    async def test_user_profile_data_is_included_in_claude_prompt(
+        self,
+        user_factory,
+        as_user,
+        db: AsyncSession,
+    ) -> None:
+        from app.models.profile.profile import Profile
+        from app.models.profile.skill import Skill
+        from datetime import date
+
+        user = await user_factory()
+        user_id = uuid.UUID(user["id"])
+
+        # Seed a profile + a skill so _build_user_context returns
+        # non-None.
+        profile = Profile(
+            user_id=user_id,
+            summary="Senior backend engineer with 10 years of distributed systems experience.",
+            seniority="senior",
+        )
+        db.add(profile)
+        await db.flush()
+        skill = Skill(user_id=user_id, profile_id=profile.id, name="Python")
+        db.add(skill)
+        await db.commit()
+
+        async with await as_user(user) as authed:
+            create = await authed.post("/companies", json=_make_company_payload())
+            assert create.status_code == 201
+            company_id = uuid.UUID(create.json()["id"])
+
+        from app.services.company import company_research_service
+
+        captured: dict[str, str] = {}
+
+        async def _fake_call_claude(*, system_prompt, user_content, **kw):
+            captured["system_prompt"] = system_prompt
+            captured["user_content"] = user_content
+            return MOCK_CLAUDE_RESPONSE
+
+        with (
+            patch(
+                "app.services.company.company_research_service.search_company",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
+                "app.services.company.company_research_service.claude_service.call_claude",
+                new=AsyncMock(side_effect=_fake_call_claude),
+            ),
+        ):
+            await company_research_service.run_research(
+                db, company_id=company_id, user_id=user_id
+            )
+
+        # The user's resume summary + skill should appear in the
+        # context Claude sees.
+        assert "User profile" in captured["user_content"]
+        assert "distributed systems" in captured["user_content"]
+        assert "Python" in captured["user_content"]
+
+    @pytest.mark.asyncio
+    async def test_no_profile_emits_null_products_for_you_signal(
+        self,
+        user_factory,
+        as_user,
+        db: AsyncSession,
+    ) -> None:
+        """When the user has no profile / resume content, the prompt
+        explicitly signals 'no profile' so Claude returns
+        products_for_you=null instead of inventing generic advice."""
+        user = await user_factory()
+        user_id = uuid.UUID(user["id"])
+
+        async with await as_user(user) as authed:
+            create = await authed.post("/companies", json=_make_company_payload())
+            assert create.status_code == 201
+            company_id = uuid.UUID(create.json()["id"])
+
+        from app.services.company import company_research_service
+
+        captured: dict[str, str] = {}
+
+        async def _fake_call_claude(*, system_prompt, user_content, **kw):
+            captured["user_content"] = user_content
+            return MOCK_CLAUDE_RESPONSE
+
+        with (
+            patch(
+                "app.services.company.company_research_service.search_company",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
+                "app.services.company.company_research_service.search_company_overview",
+                new=AsyncMock(return_value=MOCK_TAVILY_RESULTS),
+            ),
+            patch(
+                "app.services.company.company_research_service.claude_service.call_claude",
+                new=AsyncMock(side_effect=_fake_call_claude),
+            ),
+        ):
+            await company_research_service.run_research(
+                db, company_id=company_id, user_id=user_id
+            )
+
+        assert "no resume content uploaded" in captured["user_content"]

--- a/apps/myjobhunter/frontend/src/features/companies/__tests__/CompanyResearchPanel.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/companies/__tests__/CompanyResearchPanel.test.tsx
@@ -58,6 +58,8 @@ const MOCK_RESEARCH: CompanyResearch = {
   overall_sentiment: "positive",
   senior_engineer_sentiment: "Engineering culture is collaborative and fast-paced.",
   interview_process: "Three rounds including a technical screen. Well-organised process.",
+  description: "XYZ Corp builds workflow automation software for mid-market customers.",
+  products_for_you: "Your distributed-systems experience maps to the workflow automation core.",
   red_flags: ["Promotion cycles can be slow"],
   green_flags: ["Competitive pay", "Strong engineering culture"],
   reported_comp_range_min: null,
@@ -170,6 +172,30 @@ describe("CompanyResearchPanelBody", () => {
     it("renders culture signals", () => {
       renderBody({ mode: "ready", research: MOCK_RESEARCH });
       expect(screen.getByText(/collaborative and fast-paced/)).toBeInTheDocument();
+    });
+
+    it("renders the company description", () => {
+      renderBody({ mode: "ready", research: MOCK_RESEARCH });
+      expect(screen.getByText(/workflow automation software for mid-market/)).toBeInTheDocument();
+      expect(screen.getByText(/What they do/i)).toBeInTheDocument();
+    });
+
+    it("renders products_for_you when present", () => {
+      renderBody({ mode: "ready", research: MOCK_RESEARCH });
+      expect(screen.getByText(/distributed-systems experience maps/)).toBeInTheDocument();
+      expect(screen.getByText(/Products that match your background/i)).toBeInTheDocument();
+    });
+
+    it("hides products_for_you section when null", () => {
+      const noPersonal: CompanyResearch = { ...MOCK_RESEARCH, products_for_you: null };
+      renderBody({ mode: "ready", research: noPersonal });
+      expect(screen.queryByText(/Products that match your background/i)).not.toBeInTheDocument();
+    });
+
+    it("hides description section when null", () => {
+      const noDescription: CompanyResearch = { ...MOCK_RESEARCH, description: null };
+      renderBody({ mode: "ready", research: noDescription });
+      expect(screen.queryByText(/What they do/i)).not.toBeInTheDocument();
     });
 
     it("renders green flags as a list", () => {

--- a/apps/myjobhunter/frontend/src/features/companies/research/ReadyState.tsx
+++ b/apps/myjobhunter/frontend/src/features/companies/research/ReadyState.tsx
@@ -46,6 +46,28 @@ export default function ReadyState({ research, onRunResearch, isRunning }: Ready
         </LoadingButton>
       </div>
 
+      {/* What the company does */}
+      {research.description ? (
+        <section>
+          <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+            What they do
+          </p>
+          <p className="text-sm whitespace-pre-wrap">{research.description}</p>
+        </section>
+      ) : null}
+
+      {/* Personalised: products that match the user's background.
+          Uses an emerald accent so it visually anchors as the
+          "this is about YOU" section. */}
+      {research.products_for_you ? (
+        <section className="border-l-2 border-emerald-500/60 pl-3">
+          <p className="text-xs uppercase tracking-wide text-emerald-700 dark:text-emerald-400 mb-1">
+            Products that match your background
+          </p>
+          <p className="text-sm whitespace-pre-wrap">{research.products_for_you}</p>
+        </section>
+      ) : null}
+
       {/* Summary */}
       {research.interview_process ? (
         <section>

--- a/apps/myjobhunter/frontend/src/types/company-research.ts
+++ b/apps/myjobhunter/frontend/src/types/company-research.ts
@@ -15,6 +15,10 @@ export interface CompanyResearch {
   overall_sentiment: ResearchSentiment;
   senior_engineer_sentiment: string | null;
   interview_process: string | null;
+  /** What the company does — products, business model, customers. */
+  description: string | null;
+  /** Personalised: which products / teams match the user's resume. */
+  products_for_you: string | null;
   red_flags: string[];
   green_flags: string[];
 


### PR DESCRIPTION
> "include what pivotal health does as a company. what products relate to me?"

The existing research panel was strictly review-focused — Glassdoor sentiment, comp signals, culture flags. No company-info content because the Tavily call was domain-whitelisted to review sites only. This PR adds two new fields:

## What's new

**`description`** — what the company does, products, business model, customers. Synthesised by Claude from a NEW Tavily search **without** the review-site filter, so the prompt sees the company's official site, news outlets, wikipedia, crunchbase.

**`products_for_you`** — personalised: which products / teams at the company match the requesting user's resume background. Powered by feeding the user's profile (summary + last 3 work_history entries with bullets + top 15 skills) into the Claude prompt alongside the company context.

## Backend wiring

- `tavily_service.search_company_overview` — companion call without the domain whitelist
- `run_research` fires both Tavily calls in parallel via `asyncio.gather`
- `_build_user_context` helper formats the user's profile as a compact markdown block; bounds (`_MAX_USER_BULLETS=8`, `_MAX_USER_SKILLS=15`, `_MAX_USER_ROLES=3`) keep prompt size predictable
- Prompt (`company_research_prompt.py`) extended with two new schema fields. Explicit guidance: `products_for_you` must return null when the user has no profile content (don't generate generic career advice without signal)
- Migration `cresdesc260507` adds the two columns. Reversible.

## Frontend

`ReadyState` adds two new sections above the existing summary/culture blocks:
- **What they do** — plain section, renders `description`
- **Products that match your background** — emerald-accented left border to anchor it as the "this is about YOU" section

Both sections gracefully hide when their field is null.

## Test plan
- [x] Backend: 17 tests — happy path asserts `description` + `products_for_you` persist; new tests verify profile data reaches the Claude prompt and that no-profile path emits a null signal; existing tests updated to mock both Tavily calls
- [x] Frontend: 26 tests — renders both new sections when present, hides each when null
- [x] Frontend `tsc --noEmit` clean

## Operational notes
- Migration runs automatically on next deploy
- Existing research records have NULL for both new columns until the user clicks "Re-run" on the company
- No env-var changes; uses the existing `TAVILY_API_KEY` and `ANTHROPIC_API_KEY`
- Token cost per research run roughly doubles (we're now sending ~2× Tavily content + user profile context to Claude); acceptable for a high-value rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)