### PR TITLE
fix(mybookkeeper/leases): seed NUMBER OF DAYS computed_expr + render signature placeholders as blank line

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/nodexpr260507_seed_number_of_days_computed_expr.py
+++ b/apps/mybookkeeper/backend/alembic/versions/nodexpr260507_seed_number_of_days_computed_expr.py
@@ -1,0 +1,65 @@
+"""lease_template_placeholders: backfill NUMBER OF DAYS computed_expr
+
+The original template-extraction path hard-coded ``computed_expr=None``
+when seeding placeholders, even for keys whose ``input_type`` was
+``computed`` (e.g. ``NUMBER OF DAYS``). The renderer therefore left
+``[NUMBER OF DAYS]`` as literal text in every generated lease.
+
+This migration backfills the canonical expression for the ``NUMBER OF DAYS``
+keys (``(MOVE-OUT DATE - MOVE-IN DATE).days``) on rows that still have
+``computed_expr IS NULL``. Rows a host has customised (set to a different
+expression) are left alone.
+
+The downgrade nulls out rows whose ``computed_expr`` exactly matches the
+canonical expression — including any host-set rows that happened to use the
+same string. That's the deliberate trade for a clean rollback contract;
+hosts can re-set their override after the next forward run.
+
+Revision ID: nodexpr260507
+Revises: legtenp260507
+Create Date: 2026-05-07 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "nodexpr260507"
+down_revision: Union[str, None] = "legtenp260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_NUMBER_OF_DAYS_EXPR = "(MOVE-OUT DATE - MOVE-IN DATE).days"
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE lease_template_placeholders "
+            "SET computed_expr = :expr "
+            "WHERE input_type = 'computed' "
+            "  AND computed_expr IS NULL "
+            "  AND key IN (:k_space, :k_underscore)"
+        ).bindparams(
+            expr=_NUMBER_OF_DAYS_EXPR,
+            k_space="NUMBER OF DAYS",
+            k_underscore="NUMBER_OF_DAYS",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE lease_template_placeholders "
+            "SET computed_expr = NULL "
+            "WHERE input_type = 'computed' "
+            "  AND computed_expr = :expr "
+            "  AND key IN (:k_space, :k_underscore)"
+        ).bindparams(
+            expr=_NUMBER_OF_DAYS_EXPR,
+            k_space="NUMBER OF DAYS",
+            k_underscore="NUMBER_OF_DAYS",
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/api/test_utils.py
+++ b/apps/mybookkeeper/backend/app/api/test_utils.py
@@ -608,8 +608,8 @@ async def seed_lease_template(
         lease_template_repo,
     )
     from app.services.leases.default_source_map import (
+        get_default,
         guess_display_label,
-        guess_input_type_and_default,
     )
     from app.services.leases.placeholder_extractor import extract_placeholder_keys
 
@@ -632,16 +632,16 @@ async def seed_lease_template(
         )
         keys = extract_placeholder_keys(payload.source_text)
         for order, key in enumerate(keys):
-            input_type, default_source = guess_input_type_and_default(key)
+            seed = get_default(key)
             await lease_template_placeholder_repo.create(
                 db,
                 template_id=template.id,
                 key=key,
                 display_label=guess_display_label(key),
-                input_type=input_type,
+                input_type=seed.input_type,
                 required=True,
-                default_source=default_source,
-                computed_expr=None,
+                default_source=seed.default_source,
+                computed_expr=seed.computed_expr,
                 display_order=order,
             )
         return _SeedLeaseTemplateResponse(id=template.id)

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
@@ -1,9 +1,10 @@
-"""Heuristic default-source mapping for known placeholder keys.
+"""Heuristic default mapping for known placeholder keys.
 
 When a host uploads a template, the placeholder extractor produces raw keys
 (e.g. ``TENANT FULL NAME``). For a small allowlist of well-known keys we
-can pre-populate ``default_source`` and ``input_type`` so the host doesn't
-have to fill them in by hand. The host can always override.
+can pre-populate ``input_type``, ``default_source``, and ``computed_expr``
+so the host doesn't have to fill them in by hand. The host can always
+override.
 
 The keys are matched after normalisation (whitespace collapsed, uppercased).
 
@@ -12,40 +13,92 @@ The keys are matched after normalisation (whitespace collapsed, uppercased).
 - Single path: ``applicant.legal_name``, ``today``
 - Fallback chain: ``applicant.legal_name || inquiry.inquirer_name``
   (first non-None, non-empty value wins)
+
+``computed_expr`` values follow the DSL in ``services/leases/computed.py``:
+- ``(KEY_A - KEY_B).days`` — date diff (used for NUMBER OF DAYS)
+- ``(KEY_A + KEY_B)`` — string concat
+- ``today`` — current date
 """
 from __future__ import annotations
 
-# (input_type, default_source) — None means "no default".
-DEFAULT_SOURCE_MAP: dict[str, tuple[str, str | None]] = {
+from typing import NamedTuple
+
+
+class PlaceholderDefault(NamedTuple):
+    """Default seed for a known placeholder key."""
+
+    input_type: str
+    default_source: str | None
+    computed_expr: str | None = None
+
+
+_TEXT_APPLICANT_INQUIRER_NAME = PlaceholderDefault(
+    "text", "applicant.legal_name || inquiry.inquirer_name",
+)
+_DATE_CONTRACT_START = PlaceholderDefault(
+    "date", "applicant.contract_start || inquiry.desired_start_date",
+)
+_DATE_CONTRACT_END = PlaceholderDefault(
+    "date", "applicant.contract_end || inquiry.desired_end_date",
+)
+_TEXT_EMPLOYER = PlaceholderDefault(
+    "text", "applicant.employer_or_hospital || inquiry.inquirer_employer",
+)
+_DATE_TODAY = PlaceholderDefault("date", "today")
+
+
+# Single source of truth — every concern (input_type, default_source,
+# computed_expr) lives on one row per key.
+DEFAULT_SOURCE_MAP: dict[str, PlaceholderDefault] = {
     # Tenant identity — applicant-primary, inquiry fallback. ``contact_email``
     # and ``contact_phone`` were added to the applicant model so contact
     # details persist past the inquiry stage (the inquiry can be deleted).
-    "TENANT FULL NAME": ("text", "applicant.legal_name || inquiry.inquirer_name"),
-    "TENANT NAME": ("text", "applicant.legal_name || inquiry.inquirer_name"),
-    "TENANT EMAIL": ("email", "applicant.contact_email || inquiry.inquirer_email"),
-    "TENANT PHONE": ("phone", "applicant.contact_phone || inquiry.inquirer_phone"),
-    "TENANT EMPLOYER": ("text", "applicant.employer_or_hospital || inquiry.inquirer_employer"),
-    "EMPLOYER": ("text", "applicant.employer_or_hospital || inquiry.inquirer_employer"),
+    "TENANT FULL NAME": _TEXT_APPLICANT_INQUIRER_NAME,
+    "TENANT NAME": _TEXT_APPLICANT_INQUIRER_NAME,
+    "TENANT EMAIL": PlaceholderDefault(
+        "email", "applicant.contact_email || inquiry.inquirer_email",
+    ),
+    "TENANT PHONE": PlaceholderDefault(
+        "phone", "applicant.contact_phone || inquiry.inquirer_phone",
+    ),
+    "TENANT EMPLOYER": _TEXT_EMPLOYER,
+    "EMPLOYER": _TEXT_EMPLOYER,
     # Dates — applicant-primary (contract dates), inquiry fallback (desired dates).
-    "MOVE-IN DATE": ("date", "applicant.contract_start || inquiry.desired_start_date"),
-    "MOVE_IN_DATE": ("date", "applicant.contract_start || inquiry.desired_start_date"),
-    "MOVE IN DATE": ("date", "applicant.contract_start || inquiry.desired_start_date"),
-    "MOVE-OUT DATE": ("date", "applicant.contract_end || inquiry.desired_end_date"),
-    "MOVE_OUT_DATE": ("date", "applicant.contract_end || inquiry.desired_end_date"),
-    "MOVE OUT DATE": ("date", "applicant.contract_end || inquiry.desired_end_date"),
-    "EFFECTIVE DATE": ("date", "today"),
-    "DATE": ("date", "today"),
-    # Computed
-    "NUMBER OF DAYS": ("computed", None),
-    # Signature stubs — filled at signing time, not at generation.
-    "LANDLORD SIGNATURE": ("signature", None),
-    "TENANT SIGNATURE": ("signature", None),
+    "MOVE-IN DATE": _DATE_CONTRACT_START,
+    "MOVE_IN_DATE": _DATE_CONTRACT_START,
+    "MOVE IN DATE": _DATE_CONTRACT_START,
+    "MOVE-OUT DATE": _DATE_CONTRACT_END,
+    "MOVE_OUT_DATE": _DATE_CONTRACT_END,
+    "MOVE OUT DATE": _DATE_CONTRACT_END,
+    "EFFECTIVE DATE": _DATE_TODAY,
+    "DATE": _DATE_TODAY,
+    # Computed — auto-evaluated at generate time via the computed.py DSL.
+    "NUMBER OF DAYS": PlaceholderDefault(
+        "computed", None, computed_expr="(MOVE-OUT DATE - MOVE-IN DATE).days",
+    ),
+    # Signature stubs — filled at signing time, not at generation. The
+    # renderer substitutes these with a blank signature line so the rendered
+    # doc never shows literal ``[LANDLORD SIGNATURE]`` text.
+    "LANDLORD SIGNATURE": PlaceholderDefault("signature", None),
+    "TENANT SIGNATURE": PlaceholderDefault("signature", None),
 }
+
+_FALLBACK = PlaceholderDefault("text", None)
+
+
+def get_default(key: str) -> PlaceholderDefault:
+    """Return the default seed for ``key`` (or text/None for unknown keys)."""
+    return DEFAULT_SOURCE_MAP.get(key, _FALLBACK)
 
 
 def guess_input_type_and_default(key: str) -> tuple[str, str | None]:
-    """Return ``(input_type, default_source)`` for ``key`` (or text/None default)."""
-    return DEFAULT_SOURCE_MAP.get(key, ("text", None))
+    """Return ``(input_type, default_source)`` for ``key``.
+
+    Back-compat shim — new code should call :func:`get_default` directly to
+    also receive ``computed_expr``.
+    """
+    d = get_default(key)
+    return d.input_type, d.default_source
 
 
 def guess_display_label(key: str) -> str:

--- a/apps/mybookkeeper/backend/app/services/leases/lease_template_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_template_service.py
@@ -45,8 +45,8 @@ from app.services.leases.attachment_response_builder import (
 )
 from app.services.leases.computed import ComputedExprError, validate_expr
 from app.services.leases.default_source_map import (
+    get_default,
     guess_display_label,
-    guess_input_type_and_default,
 )
 from app.services.leases.default_source_resolver import (
     resolve_default_source,
@@ -289,16 +289,16 @@ async def upload_template(
         keys = extract_placeholders_across_files(extracted_texts)
         async with unit_of_work() as db:
             for order, key in enumerate(keys):
-                input_type, default_source = guess_input_type_and_default(key)
+                seed = get_default(key)
                 await lease_template_placeholder_repo.create(
                     db,
                     template_id=template_id,
                     key=key,
                     display_label=guess_display_label(key),
-                    input_type=input_type,
+                    input_type=seed.input_type,
                     required=True,
-                    default_source=default_source,
-                    computed_expr=None,
+                    default_source=seed.default_source,
+                    computed_expr=seed.computed_expr,
                     display_order=order,
                 )
     except Exception:
@@ -705,16 +705,16 @@ async def replace_template_files(
                         display_order=order,
                     )
                 else:
-                    input_type, default_source = guess_input_type_and_default(key)
+                    seed = get_default(key)
                     await lease_template_placeholder_repo.create(
                         db,
                         template_id=template_id,
                         key=key,
                         display_label=guess_display_label(key),
-                        input_type=input_type,
+                        input_type=seed.input_type,
                         required=True,
-                        default_source=default_source,
-                        computed_expr=None,
+                        default_source=seed.default_source,
+                        computed_expr=seed.computed_expr,
                         display_order=order,
                     )
 

--- a/apps/mybookkeeper/backend/app/services/leases/renderer.py
+++ b/apps/mybookkeeper/backend/app/services/leases/renderer.py
@@ -15,13 +15,40 @@ Supports three input forms:
 When ``python-docx`` is not installed (e.g. in CI without the optional dep),
 ``render_docx_bytes`` falls back to MD rendering of the extracted text — the
 caller is told the fallback fired so it can record the limitation.
+
+Signature placeholders (any bracketed key matching ``*SIGNATURE``) get a
+special substitution: a long underscore line, drawn at render time, so the
+rendered doc has a blank signing line in place of literal
+``[LANDLORD SIGNATURE]`` text. Signatures are applied at signing time, not
+generation time.
 """
 from __future__ import annotations
 
 import io
 import logging
+import re
 
 logger = logging.getLogger(__name__)
+
+SIGNATURE_LINE = "_______________________________"
+_SIGNATURE_KEY_RE = re.compile(r"\[([A-Z][A-Z0-9 _\-]*?SIGNATURE)\]")
+
+
+def _augment_with_signature_lines(
+    template_text: str, values: dict[str, str],
+) -> dict[str, str]:
+    """Return ``values`` with any unfilled ``*SIGNATURE`` keys mapped to a blank line.
+
+    Scans ``template_text`` for bracketed signature keys not already in
+    ``values`` and adds them with the underscore signature line. The
+    caller's ``values`` dict is not mutated.
+    """
+    augmented = dict(values)
+    for match in _SIGNATURE_KEY_RE.finditer(template_text):
+        key = match.group(1)
+        if key not in augmented:
+            augmented[key] = SIGNATURE_LINE
+    return augmented
 
 
 def _build_substitution_pattern(values: dict[str, str]) -> list[tuple[str, str]]:
@@ -39,10 +66,13 @@ def render_md(template_text: str, values: dict[str, str]) -> str:
     """Replace ``[KEY]`` tokens in ``template_text`` with ``values[KEY]``.
 
     Pure function. Unknown keys (placeholders not in ``values``) are left as
-    bracketed text so the host can spot them in the rendered output.
+    bracketed text so the host can spot them in the rendered output. Any
+    ``*SIGNATURE`` placeholder absent from ``values`` is replaced with a
+    blank signature line.
     """
+    augmented = _augment_with_signature_lines(template_text, values)
     output = template_text
-    for needle, replacement in _build_substitution_pattern(values):
+    for needle, replacement in _build_substitution_pattern(augmented):
         output = output.replace(needle, replacement)
     return output
 
@@ -71,7 +101,23 @@ def render_docx_bytes(
         logger.warning("Failed to parse DOCX bytes — returning original", exc_info=True)
         return docx_bytes, False
 
-    pattern = _build_substitution_pattern(values)
+    # Walk every paragraph (top-level + table cells) to find SIGNATURE keys
+    # the caller didn't supply, so the rendered doc shows a blank signing line.
+    # Known limitation: section headers/footers and tables nested inside table
+    # cells are not walked. The same paragraphs are also untouched by
+    # ``_substitute_in_paragraphs`` below, so this mirrors the existing
+    # substitution scope rather than expanding it.
+    all_text_chunks: list[str] = []
+    for paragraph in document.paragraphs:
+        all_text_chunks.append("".join(run.text for run in paragraph.runs))
+    for table in document.tables:
+        for row in table.rows:
+            for cell in row.cells:
+                for paragraph in cell.paragraphs:
+                    all_text_chunks.append("".join(run.text for run in paragraph.runs))
+    augmented = _augment_with_signature_lines("\n".join(all_text_chunks), values)
+
+    pattern = _build_substitution_pattern(augmented)
     _substitute_in_paragraphs(document.paragraphs, pattern)
     for table in document.tables:
         for row in table.rows:

--- a/apps/mybookkeeper/backend/tests/test_default_source_map.py
+++ b/apps/mybookkeeper/backend/tests/test_default_source_map.py
@@ -1,0 +1,50 @@
+"""Pure-function tests for the placeholder default-source map."""
+from __future__ import annotations
+
+from app.services.leases.default_source_map import (
+    DEFAULT_SOURCE_MAP,
+    PlaceholderDefault,
+    get_default,
+    guess_input_type_and_default,
+)
+
+
+class TestGetDefault:
+    def test_known_text_key(self) -> None:
+        d = get_default("TENANT FULL NAME")
+        assert d.input_type == "text"
+        assert d.default_source == "applicant.legal_name || inquiry.inquirer_name"
+        assert d.computed_expr is None
+
+    def test_unknown_key_falls_back_to_text(self) -> None:
+        d = get_default("ARBITRARY HOST FIELD")
+        assert d.input_type == "text"
+        assert d.default_source is None
+        assert d.computed_expr is None
+
+    def test_number_of_days_seeds_computed_expr(self) -> None:
+        """``NUMBER OF DAYS`` must seed the matching computed-DSL expression."""
+        d = get_default("NUMBER OF DAYS")
+        assert d.input_type == "computed"
+        assert d.default_source is None
+        assert d.computed_expr == "(MOVE-OUT DATE - MOVE-IN DATE).days"
+
+    def test_signature_keys_have_no_computed_expr(self) -> None:
+        for key in ("LANDLORD SIGNATURE", "TENANT SIGNATURE"):
+            d = get_default(key)
+            assert d.input_type == "signature"
+            assert d.default_source is None
+            assert d.computed_expr is None
+
+
+class TestBackCompatShim:
+    def test_returns_input_type_and_default_source(self) -> None:
+        input_type, default_source = guess_input_type_and_default("TENANT EMAIL")
+        assert input_type == "email"
+        assert default_source == "applicant.contact_email || inquiry.inquirer_email"
+
+
+class TestMapShape:
+    def test_every_entry_is_placeholder_default(self) -> None:
+        for key, value in DEFAULT_SOURCE_MAP.items():
+            assert isinstance(value, PlaceholderDefault), key

--- a/apps/mybookkeeper/backend/tests/test_lease_renderer.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_renderer.py
@@ -19,7 +19,7 @@ from app.services.leases.placeholder_extractor import (
     extract_placeholders_across_files,
     normalise_key,
 )
-from app.services.leases.renderer import render_md
+from app.services.leases.renderer import SIGNATURE_LINE, render_md
 
 
 # ---------------------------------------------------------------------------
@@ -60,6 +60,35 @@ class TestRenderMd:
         # Both should substitute correctly — TENANT EMAIL takes precedence
         # because longest-first ordering processes it before EMAIL.
         assert out == "alice@example.com vs noreply@x.com"
+
+    def test_signature_placeholder_renders_blank_line_when_unset(self) -> None:
+        """``[*SIGNATURE]`` keys absent from values get a blank signing line."""
+        text = "Landlord: [LANDLORD SIGNATURE]\nTenant: [TENANT SIGNATURE]"
+        out = render_md(text, {})
+        assert "[LANDLORD SIGNATURE]" not in out
+        assert "[TENANT SIGNATURE]" not in out
+        assert SIGNATURE_LINE in out
+        # Two signing lines, one per placeholder.
+        assert out.count(SIGNATURE_LINE) == 2
+
+    def test_signature_placeholder_value_wins_over_blank_line(self) -> None:
+        """A caller-supplied signature value takes precedence over the blank-line default."""
+        out = render_md(
+            "Landlord: [LANDLORD SIGNATURE]",
+            {"LANDLORD SIGNATURE": "/s/ Jason Kwon/"},
+        )
+        assert out == "Landlord: /s/ Jason Kwon/"
+        assert SIGNATURE_LINE not in out
+
+    def test_duplicate_signature_placeholder_each_replaced(self) -> None:
+        """Each occurrence of the same SIGNATURE key must be replaced — not just the first."""
+        text = (
+            "Landlord: [LANDLORD SIGNATURE] (initial here too: [LANDLORD SIGNATURE])"
+            "\nAnd one more: [LANDLORD SIGNATURE]"
+        )
+        out = render_md(text, {})
+        assert "[LANDLORD SIGNATURE]" not in out
+        assert out.count(SIGNATURE_LINE) == 3
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Generated leases for Andrew Le (and any other applicant whose template uses `[NUMBER OF DAYS]` / `[LANDLORD SIGNATURE]` / `[TENANT SIGNATURE]`) were rendering with literal placeholder text inside the document. Two distinct root causes:

1. **`[NUMBER OF DAYS]` was never computed** — `default_source_map.py` flagged the key as `input_type="computed"` but the template-extraction code path hard-coded `computed_expr=None`, so the substitution loop in `signed_lease_service.generate_lease` had nothing to evaluate. Fixed by seeding the canonical `(MOVE-OUT DATE - MOVE-IN DATE).days` expression and collapsing the parallel `default_source` / `computed_expr` lookups into a single `PlaceholderDefault` map (per architecture review).
2. **Signature placeholders rendered as literal text** — they're intentionally absent from `lease.values` because signatures get applied at signing time. The renderer's documented "unknown key stays bracketed" contract was leaving them in. Fixed by adding a renderer-level rule: any unfilled `*SIGNATURE` placeholder becomes a long underscore signing line.

Migration `nodexpr260507` backfills `computed_expr` on existing `lease_template_placeholders` rows so Andrew's already-uploaded template starts working without re-uploading.

## Pipeline applied

- `g-design-architecture` review → moved signature substitution from service-layer to renderer-layer; collapsed parallel dicts into `PlaceholderDefault` NamedTuple.
- `g-pre-commit` review → switched migration to parameterised SQL via `sa.text(...).bindparams(...)`; updated lingering `test_utils.py` caller; added duplicate-signature regression test; documented DOCX header/footer scope as a known limitation.

## ⚠️ Operational migration required

`nodexpr260507` runs automatically via `alembic upgrade head` in the deploy workflow. Forward-only is safe; downgrade nulls out rows whose `computed_expr` exactly matches the canonical expression (host-set rows that happen to use the same string would also clear — acceptable rollback contract, documented inline).

## Test plan

- [x] Unit: 4 new tests in `test_default_source_map.py` (`get_default`, back-compat shim, NUMBER OF DAYS seed, map-shape).
- [x] Unit: 3 new renderer tests (signature blank-line substitution, caller-value precedence, duplicate-occurrence).
- [ ] After deploy: open Andrew Le's lease → `[NUMBER OF DAYS]` should show a number, `[LANDLORD SIGNATURE]` / `[TENANT SIGNATURE]` should show blank signing lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)