### PR TITLE
feat(mybookkeeper/leases): delete lease from UI

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/LeasesListBody.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeasesListBody.test.tsx
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for LeasesListBody — covers the delete affordance.
+ *
+ * Coverage:
+ * - Delete button absent when canWrite is false
+ * - Delete button present when canWrite is true
+ * - Clicking delete button opens the ConfirmDialog
+ * - Confirming calls onDelete with the correct lease
+ * - Cancelling closes the dialog without calling onDelete
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import LeasesListBody from "@/app/features/leases/LeasesListBody";
+import type { SignedLeaseSummary } from "@/shared/types/lease/signed-lease-summary";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const LEASE_A: SignedLeaseSummary = {
+  id: "aaaaaaaa-0000-0000-0000-000000000001",
+  user_id: "u1",
+  organization_id: "org-1",
+  template_id: null,
+  applicant_id: "app-1",
+  listing_id: null,
+  kind: "generated",
+  status: "draft",
+  starts_on: "2026-06-01",
+  ends_on: "2027-05-31",
+  generated_at: "2026-05-01T10:00:00Z",
+  signed_at: null,
+  created_at: "2026-05-01T10:00:00Z",
+  updated_at: "2026-05-01T10:00:00Z",
+  applicant_legal_name: "Andrew Le",
+};
+
+const LEASE_B: SignedLeaseSummary = {
+  id: "bbbbbbbb-0000-0000-0000-000000000002",
+  user_id: "u1",
+  organization_id: "org-1",
+  template_id: null,
+  applicant_id: "app-1",
+  listing_id: null,
+  kind: "imported",
+  status: "signed",
+  starts_on: "2025-01-01",
+  ends_on: "2025-12-31",
+  generated_at: null,
+  signed_at: "2025-01-05T00:00:00Z",
+  created_at: "2025-01-05T00:00:00Z",
+  updated_at: "2025-01-05T00:00:00Z",
+  applicant_legal_name: "Andrew Le",
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderList({
+  leases = [LEASE_A, LEASE_B],
+  canWrite = false,
+  onDelete = vi.fn(),
+  isDeleting = false,
+}: {
+  leases?: SignedLeaseSummary[];
+  canWrite?: boolean;
+  onDelete?: () => Promise<void>;
+  isDeleting?: boolean;
+} = {}) {
+  return render(
+    <MemoryRouter>
+      <LeasesListBody
+        mode="list"
+        leases={leases}
+        canWrite={canWrite}
+        onDelete={onDelete}
+        isDeleting={isDeleting}
+      />
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LeasesListBody — delete affordance", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders both lease rows in the table", () => {
+    renderList({ canWrite: true });
+    expect(screen.getByTestId(`lease-row-${LEASE_A.id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`lease-row-${LEASE_B.id}`)).toBeInTheDocument();
+  });
+
+  it("hides delete buttons when canWrite is false", () => {
+    renderList({ canWrite: false });
+    expect(screen.queryByTestId(`lease-delete-btn-${LEASE_A.id}`)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(`lease-delete-btn-${LEASE_B.id}`)).not.toBeInTheDocument();
+  });
+
+  it("shows delete buttons when canWrite is true", () => {
+    renderList({ canWrite: true });
+    expect(screen.getByTestId(`lease-delete-btn-${LEASE_A.id}`)).toBeInTheDocument();
+    expect(screen.getByTestId(`lease-delete-btn-${LEASE_B.id}`)).toBeInTheDocument();
+  });
+
+  it("opens the confirmation dialog when delete button is clicked", async () => {
+    renderList({ canWrite: true });
+
+    await userEvent.click(screen.getByTestId(`lease-delete-btn-${LEASE_A.id}`));
+
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+    expect(screen.getByText(/delete this lease/i)).toBeInTheDocument();
+    // The dialog description mentions the short ID and permanence warning
+    expect(screen.getByText(/permanently remove Lease aaaaaaaa/i)).toBeInTheDocument();
+  });
+
+  it("calls onDelete with the correct lease when confirmed", async () => {
+    const onDelete = vi.fn().mockResolvedValue(undefined);
+    renderList({ canWrite: true, onDelete });
+
+    await userEvent.click(screen.getByTestId(`lease-delete-btn-${LEASE_A.id}`));
+    await userEvent.click(screen.getByRole("button", { name: /^delete$/i }));
+
+    await waitFor(() => {
+      expect(onDelete).toHaveBeenCalledTimes(1);
+      expect(onDelete).toHaveBeenCalledWith(LEASE_A);
+    });
+  });
+
+  it("closes the dialog without calling onDelete when cancelled", async () => {
+    const onDelete = vi.fn();
+    renderList({ canWrite: true, onDelete });
+
+    await userEvent.click(screen.getByTestId(`lease-delete-btn-${LEASE_B.id}`));
+    expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    });
+    expect(onDelete).not.toHaveBeenCalled();
+  });
+
+  it("shows loading state on the confirm button while deleting", () => {
+    const onDelete = vi.fn();
+    const { rerender } = render(
+      <MemoryRouter>
+        <LeasesListBody
+          mode="list"
+          leases={[LEASE_A]}
+          canWrite
+          onDelete={onDelete}
+          isDeleting={false}
+        />
+      </MemoryRouter>,
+    );
+
+    // Open the dialog first (synchronous state set)
+    screen.getByTestId(`lease-delete-btn-${LEASE_A.id}`).click();
+
+    // Rerender with isDeleting=true while dialog is open
+    rerender(
+      <MemoryRouter>
+        <LeasesListBody
+          mode="list"
+          leases={[LEASE_A]}
+          canWrite
+          onDelete={onDelete}
+          isDeleting
+        />
+      </MemoryRouter>,
+    );
+
+    const confirmBtn = screen.getByRole("button", { name: /processing/i });
+    expect(confirmBtn).toBeDisabled();
+  });
+
+  it("renders loading skeleton in loading mode", () => {
+    render(
+      <MemoryRouter>
+        <LeasesListBody mode="loading" leases={[]} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByTestId("leases-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders empty state in empty mode", () => {
+    render(
+      <MemoryRouter>
+        <LeasesListBody mode="empty" leases={[]} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/no leases yet/i)).toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantDetailBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantDetailBody.tsx
@@ -156,7 +156,7 @@ export default function ApplicantDetailBody({ applicant }: ApplicantDetailBodyPr
           <h2 className="text-sm font-medium">Leases</h2>
           <div className="space-y-4">
             {linkedLeases.map((lease) => (
-              <LinkedLeaseDocuments key={lease.id} lease={lease} />
+              <LinkedLeaseDocuments key={lease.id} lease={lease} canWrite={canWrite} />
             ))}
           </div>
         </section>

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocuments.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocuments.tsx
@@ -1,15 +1,22 @@
 import { useState } from "react";
-import { useGetSignedLeaseByIdQuery } from "@/shared/store/signedLeasesApi";
+import { Trash2 } from "lucide-react";
+import {
+  useGetSignedLeaseByIdQuery,
+  useDeleteSignedLeaseMutation,
+} from "@/shared/store/signedLeasesApi";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
 import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
 import type { SignedLeaseSummary } from "@/shared/types/lease/signed-lease-summary";
 import SignedLeaseStatusBadge from "@/app/features/leases/SignedLeaseStatusBadge";
 import AttachmentViewer from "@/app/features/leases/AttachmentViewer";
+import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
 import { formatLongDate } from "@/shared/lib/inquiry-date-format";
 import LinkedLeaseDocumentsBody from "./LinkedLeaseDocumentsBody";
 import { useLinkedLeaseDocumentsMode } from "./useLinkedLeaseDocumentsMode";
 
 export interface LinkedLeaseDocumentsProps {
   lease: SignedLeaseSummary;
+  canWrite?: boolean;
 }
 
 const RECEIPT_KIND = "rent_receipt";
@@ -25,9 +32,11 @@ const RECEIPT_KIND = "rent_receipt";
  * broken state. The host-side recovery path is the existing
  * delete + upload flow on the lease detail page.
  */
-export default function LinkedLeaseDocuments({ lease }: LinkedLeaseDocumentsProps) {
+export default function LinkedLeaseDocuments({ lease, canWrite = false }: LinkedLeaseDocumentsProps) {
   const { data: detail, isLoading } = useGetSignedLeaseByIdQuery(lease.id);
+  const [deleteLease, { isLoading: isDeleting }] = useDeleteSignedLeaseMutation();
   const [viewing, setViewing] = useState<SignedLeaseAttachment | null>(null);
+  const [confirmDelete, setConfirmDelete] = useState(false);
 
   const dates =
     lease.starts_on || lease.ends_on
@@ -41,15 +50,52 @@ export default function LinkedLeaseDocuments({ lease }: LinkedLeaseDocumentsProp
 
   const mode = useLinkedLeaseDocumentsMode({ isLoading, attachments });
 
+  async function handleConfirmDelete() {
+    try {
+      await deleteLease(lease.id).unwrap();
+      showSuccess("Lease deleted.");
+    } catch {
+      showError("Couldn't delete that lease. Please try again.");
+    } finally {
+      setConfirmDelete(false);
+    }
+  }
+
   return (
     <div className="space-y-2" data-testid={`linked-lease-${lease.id}`}>
-      <div className="flex items-center gap-2 flex-wrap text-sm">
-        <span className="font-medium">
-          {lease.kind === "imported" ? "Imported lease" : "Generated lease"}
-        </span>
-        <SignedLeaseStatusBadge status={lease.status} />
-        {dates ? (
-          <span className="text-xs text-muted-foreground">{dates}</span>
+      {confirmDelete ? (
+        <ConfirmDialog
+          open
+          title="Delete this lease?"
+          description={`This will permanently remove Lease ${lease.id.slice(0, 8)} and all its attachments. This can't be undone.`}
+          confirmLabel="Delete"
+          variant="danger"
+          isLoading={isDeleting}
+          onConfirm={() => void handleConfirmDelete()}
+          onCancel={() => setConfirmDelete(false)}
+        />
+      ) : null}
+
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div className="flex items-center gap-2 flex-wrap text-sm">
+          <span className="font-medium">
+            {lease.kind === "imported" ? "Imported lease" : "Generated lease"}
+          </span>
+          <SignedLeaseStatusBadge status={lease.status} />
+          {dates ? (
+            <span className="text-xs text-muted-foreground">{dates}</span>
+          ) : null}
+        </div>
+        {canWrite ? (
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            aria-label={`Delete lease ${lease.id.slice(0, 8)}`}
+            data-testid={`linked-lease-delete-btn-${lease.id}`}
+            className="text-muted-foreground hover:text-destructive transition-colors p-1 rounded min-h-[44px] min-w-[44px] flex items-center justify-center sm:min-h-[32px] sm:min-w-[32px]"
+          >
+            <Trash2 size={14} aria-hidden="true" />
+          </button>
         ) : null}
       </div>
 

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeasesListBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeasesListBody.tsx
@@ -1,13 +1,19 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
+import { Trash2 } from "lucide-react";
 import type { LeasesListMode } from "@/shared/types/lease/leases-list-mode";
 import type { SignedLeaseSummary } from "@/shared/types/lease/signed-lease-summary";
 import EmptyState from "@/shared/components/ui/EmptyState";
+import ConfirmDialog from "@/shared/components/ui/ConfirmDialog";
 import LeasesListSkeleton from "./LeasesListSkeleton";
 import SignedLeaseStatusBadge from "./SignedLeaseStatusBadge";
 
 export interface LeasesListBodyProps {
   mode: LeasesListMode;
   leases: SignedLeaseSummary[];
+  canWrite?: boolean;
+  onDelete?: (lease: SignedLeaseSummary) => Promise<void>;
+  isDeleting?: boolean;
 }
 
 function formatDate(iso: string): string {
@@ -15,7 +21,25 @@ function formatDate(iso: string): string {
   return Number.isNaN(d.getTime()) ? "—" : d.toLocaleDateString();
 }
 
-export default function LeasesListBody({ mode, leases }: LeasesListBodyProps) {
+export default function LeasesListBody({
+  mode,
+  leases,
+  canWrite = false,
+  onDelete,
+  isDeleting = false,
+}: LeasesListBodyProps) {
+  const [pendingDelete, setPendingDelete] = useState<SignedLeaseSummary | null>(null);
+
+  function handleDeleteClick(lease: SignedLeaseSummary) {
+    setPendingDelete(lease);
+  }
+
+  async function handleConfirmDelete() {
+    if (!pendingDelete || !onDelete) return;
+    await onDelete(pendingDelete);
+    setPendingDelete(null);
+  }
+
   switch (mode) {
     case "loading":
       return <LeasesListSkeleton />;
@@ -26,6 +50,19 @@ export default function LeasesListBody({ mode, leases }: LeasesListBodyProps) {
     case "list":
       return (
         <>
+          {pendingDelete ? (
+            <ConfirmDialog
+              open
+              title="Delete this lease?"
+              description={`This will permanently remove Lease ${pendingDelete.id.slice(0, 8)} and all its attachments. This can't be undone.`}
+              confirmLabel="Delete"
+              variant="danger"
+              isLoading={isDeleting}
+              onConfirm={() => void handleConfirmDelete()}
+              onCancel={() => setPendingDelete(null)}
+            />
+          ) : null}
+
           {/* Desktop table */}
           <div
             className="hidden md:block border rounded-lg overflow-hidden"
@@ -40,13 +77,14 @@ export default function LeasesListBody({ mode, leases }: LeasesListBodyProps) {
                   <th className="px-4 py-2 font-medium">Generated</th>
                   <th className="px-4 py-2 font-medium">Signed</th>
                   <th className="px-4 py-2 font-medium">Status</th>
+                  {canWrite ? <th className="px-4 py-2 font-medium sr-only">Actions</th> : null}
                 </tr>
               </thead>
               <tbody>
                 {leases.map((lease) => (
                   <tr
                     key={lease.id}
-                    className="border-t hover:bg-muted/40 cursor-pointer"
+                    className="border-t hover:bg-muted/40"
                     data-testid={`lease-row-${lease.id}`}
                   >
                     <td className="px-4 py-2">
@@ -82,6 +120,19 @@ export default function LeasesListBody({ mode, leases }: LeasesListBodyProps) {
                     <td className="px-4 py-2">
                       <SignedLeaseStatusBadge status={lease.status} />
                     </td>
+                    {canWrite ? (
+                      <td className="px-2 py-2 text-right">
+                        <button
+                          type="button"
+                          onClick={() => handleDeleteClick(lease)}
+                          aria-label={`Delete lease ${lease.id.slice(0, 8)}`}
+                          data-testid={`lease-delete-btn-${lease.id}`}
+                          className="text-muted-foreground hover:text-destructive transition-colors p-1 rounded min-h-[44px] min-w-[44px] flex items-center justify-center sm:min-h-[32px] sm:min-w-[32px]"
+                        >
+                          <Trash2 size={14} aria-hidden="true" />
+                        </button>
+                      </td>
+                    ) : null}
                   </tr>
                 ))}
               </tbody>
@@ -91,21 +142,34 @@ export default function LeasesListBody({ mode, leases }: LeasesListBodyProps) {
           {/* Mobile cards */}
           <ul className="md:hidden space-y-3" data-testid="leases-mobile">
             {leases.map((lease) => (
-              <li key={lease.id}>
-                <Link
-                  to={`/leases/${lease.id}`}
-                  className="block border rounded-lg p-3 hover:bg-muted/40"
-                >
-                  <div className="flex items-center justify-between">
-                    <span className="font-medium text-sm">
-                      Lease {lease.id.slice(0, 8)}
-                    </span>
-                    <SignedLeaseStatusBadge status={lease.status} />
-                  </div>
-                  <p className="text-xs text-muted-foreground mt-1">
-                    {lease.starts_on ?? "—"} → {lease.ends_on ?? "—"}
-                  </p>
-                </Link>
+              <li key={lease.id} className="border rounded-lg">
+                <div className="flex items-start justify-between gap-2 p-3">
+                  <Link
+                    to={`/leases/${lease.id}`}
+                    className="block flex-1 hover:bg-muted/40 rounded"
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium text-sm">
+                        Lease {lease.id.slice(0, 8)}
+                      </span>
+                      <SignedLeaseStatusBadge status={lease.status} />
+                    </div>
+                    <p className="text-xs text-muted-foreground mt-1">
+                      {lease.starts_on ?? "—"} → {lease.ends_on ?? "—"}
+                    </p>
+                  </Link>
+                  {canWrite ? (
+                    <button
+                      type="button"
+                      onClick={() => handleDeleteClick(lease)}
+                      aria-label={`Delete lease ${lease.id.slice(0, 8)}`}
+                      data-testid={`lease-delete-btn-mobile-${lease.id}`}
+                      className="text-muted-foreground hover:text-destructive transition-colors p-2 rounded min-h-[44px] min-w-[44px] flex items-center justify-center shrink-0"
+                    >
+                      <Trash2 size={14} aria-hidden="true" />
+                    </button>
+                  ) : null}
+                </div>
               </li>
             ))}
           </ul>

--- a/apps/mybookkeeper/frontend/src/app/pages/Leases.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Leases.tsx
@@ -5,10 +5,15 @@ import AlertBox from "@/shared/components/ui/AlertBox";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import Button from "@/shared/components/ui/Button";
 import { useCanWrite } from "@/shared/hooks/useOrgRole";
-import { useGetSignedLeasesQuery } from "@/shared/store/signedLeasesApi";
+import {
+  useGetSignedLeasesQuery,
+  useDeleteSignedLeaseMutation,
+} from "@/shared/store/signedLeasesApi";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
 import LeaseImportDialog from "@/app/features/leases/LeaseImportDialog";
 import { useLeasesListMode } from "@/app/features/leases/useLeasesListMode";
 import LeasesListBody from "@/app/features/leases/LeasesListBody";
+import type { SignedLeaseSummary } from "@/shared/types/lease/signed-lease-summary";
 
 export default function Leases() {
   const canWrite = useCanWrite();
@@ -16,8 +21,18 @@ export default function Leases() {
   const [showImportDialog, setShowImportDialog] = useState(false);
   const { data, isLoading, isFetching, isError, refetch } =
     useGetSignedLeasesQuery();
+  const [deleteLease, { isLoading: isDeleting }] = useDeleteSignedLeaseMutation();
   const leases = data?.items ?? [];
   const mode = useLeasesListMode({ isLoading, isError, leaseCount: leases.length });
+
+  async function handleDelete(lease: SignedLeaseSummary) {
+    try {
+      await deleteLease(lease.id).unwrap();
+      showSuccess("Lease deleted.");
+    } catch {
+      showError("Couldn't delete that lease. Please try again.");
+    }
+  }
 
   return (
     <main className="p-4 sm:p-8 space-y-6">
@@ -65,7 +80,13 @@ export default function Leases() {
         </AlertBox>
       ) : null}
 
-      <LeasesListBody mode={mode} leases={leases} />
+      <LeasesListBody
+        mode={mode}
+        leases={leases}
+        canWrite={canWrite}
+        onDelete={handleDelete}
+        isDeleting={isDeleting}
+      />
     </main>
   );
 }

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -635,6 +635,7 @@
         "LeaseImportDialog.test.tsx",
         "LeaseGenerateForm.test.tsx",
         "LeaseNew.test.tsx",
+        "LeasesListBody.test.tsx",
         "AISuggestionsPanel.test.tsx",
         "LeaseTemplateUploadDialog.test.tsx",
         "AttachmentViewer.test.tsx",


### PR DESCRIPTION
## Summary

- Adds a trash icon delete button to every row on the Leases list page (`/leases`) — hidden behind `canWrite` so read-only org members see nothing
- Adds the same delete affordance to each linked lease block on the Applicant detail page (`/applicants/:id`)
- Both surfaces use the existing `ConfirmDialog` component (title: "Delete this lease?", body mentions the short lease ID and warns it's permanent, red "Delete" button)
- The existing `deleteSignedLease` RTK Query mutation is wired — on success the list re-fetches automatically via cache invalidation; success/error toasts follow project conventions
- Delete button shows loading state (disabled + "Processing…") while the API call is in flight
- Mobile cards on `/leases` also get the delete button (44×44px touch target)

## Files changed

- `apps/mybookkeeper/frontend/src/app/features/leases/LeasesListBody.tsx` — delete button + ConfirmDialog wired inside the component (state local to list body)
- `apps/mybookkeeper/frontend/src/app/pages/Leases.tsx` — wires `useDeleteSignedLeaseMutation`, passes `onDelete`/`isDeleting`/`canWrite` down to `LeasesListBody`
- `apps/mybookkeeper/frontend/src/app/features/applicants/LinkedLeaseDocuments.tsx` — adds delete button + ConfirmDialog for the applicant detail surface; accepts new optional `canWrite` prop
- `apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantDetailBody.tsx` — passes `canWrite` to `LinkedLeaseDocuments`
- `apps/mybookkeeper/frontend/src/__tests__/LeasesListBody.test.tsx` — 9 unit tests covering: button visibility (canWrite gate), dialog open/close, onDelete call with correct lease, loading state, skeleton, empty state
- `apps/mybookkeeper/scripts/test-map.json` — adds `LeasesListBody.test.tsx` to the leases domain

## Test plan

- [ ] `vitest run src/__tests__/LeasesListBody.test.tsx` — 9 tests pass
- [ ] `vitest run` on all lease + applicant tests — 89 tests pass for touched files
- [ ] CI frontend-build passes (TypeScript clean)
- [ ] Backend: no changes — `DELETE /signed-leases/{lease_id}` already existed

🤖 Generated with [Claude Code](https://claude.com/claude-code)