### PR TITLE
hotfix(mybookkeeper): merge moveout260507 + nodexpr260507 alembic heads

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/mrgheads260507_merge_moveout_and_nodexpr_heads.py
+++ b/apps/mybookkeeper/backend/alembic/versions/mrgheads260507_merge_moveout_and_nodexpr_heads.py
@@ -1,0 +1,34 @@
+"""merge: moveout260507 + nodexpr260507 into a single head
+
+PR #380 (``moveout260507``) and PR #381 (``nodexpr260507``) were both
+authored on top of ``legtenp260507`` and merged to main back-to-back.
+Alembic refuses to ``upgrade head`` with more than one head, so every
+deploy after the second merge fails with exit 255 in the migrate
+service before the new images can promote.
+
+This is a no-op merge revision — it only joins the two parents into
+one head. Both feature migrations have already run (or will run) in
+either order; alembic's stamp + version graph just needs a single
+descendant.
+
+Revision ID: mrgheads260507
+Revises: moveout260507, nodexpr260507
+Create Date: 2026-05-07 06:00:00.000000
+"""
+from typing import Sequence, Union
+
+revision: str = "mrgheads260507"
+down_revision: Union[str, Sequence[str], None] = (
+    "moveout260507",
+    "nodexpr260507",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

PR #380 (`moveout260507`) and PR #381 (`nodexpr260507`) both have `down_revision = "legtenp260507"`. Alembic refuses to `upgrade head` when there are multiple heads, so every deploy since #381 merged has failed in the migrate service with exit 255. **Neither feature is actually live in prod** — the new images keep getting built but the migrate step blocks the cutover.

This is a no-op merge revision joining both parents into one head.

## Why this slipped past CI

`backend-tests` runs on a fresh DB and so it walked one parent → success. The multi-heads condition only manifests when `alembic upgrade head` is invoked against a DB that already has both parents stamped — which is exactly what happens on the deploy step.

## Action item for next session (not in scope here)

Add a CI check that runs `alembic heads` and fails the build if it returns more than one revision. Prevents this class of bug at PR time.

## Test plan

- [x] `alembic heads` locally returns `mrgheads260507` (single head) after applying the new revision.
- [ ] Deploy lands cleanly + the two pending migrations run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)