### PR TITLE
fix(mybookkeeper/leases): don't auto-fill [DATE] at generation time

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/dateblank260507_clear_date_default_source.py
+++ b/apps/mybookkeeper/backend/alembic/versions/dateblank260507_clear_date_default_source.py
@@ -1,0 +1,56 @@
+"""lease_template_placeholders: clear default_source for bare DATE key
+
+``[DATE]`` next to a signature line should be left blank for the physical
+signer to fill in — the same treatment as ``[LANDLORD SIGNATURE]`` /
+``[TENANT SIGNATURE]``. Previously ``default_source_map`` mapped the bare
+``DATE`` key to ``"today"``, so generated leases auto-filled today's date
+where a blank signing line should appear.
+
+This migration clears ``default_source`` on existing rows where
+``key = 'DATE'`` and ``default_source = 'today'``. Rows the host has
+already customised to a non-"today" source are left alone.
+
+``EFFECTIVE DATE`` (a document-level date auto-filled at generation time)
+is deliberately NOT touched — only the bare ``DATE`` key is cleared.
+
+Revision ID: dateblank260507
+Revises: leasemulti260507
+Create Date: 2026-05-07 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "dateblank260507"
+down_revision: Union[str, None] = "leasemulti260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE lease_template_placeholders "
+            "SET default_source = NULL "
+            "WHERE key = :key "
+            "  AND default_source = :old_source"
+        ).bindparams(
+            key="DATE",
+            old_source="today",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE lease_template_placeholders "
+            "SET default_source = :old_source "
+            "WHERE key = :key "
+            "  AND default_source IS NULL"
+        ).bindparams(
+            key="DATE",
+            old_source="today",
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
@@ -70,8 +70,16 @@ DEFAULT_SOURCE_MAP: dict[str, PlaceholderDefault] = {
     "MOVE-OUT DATE": _DATE_CONTRACT_END,
     "MOVE_OUT_DATE": _DATE_CONTRACT_END,
     "MOVE OUT DATE": _DATE_CONTRACT_END,
+    # ``EFFECTIVE DATE`` is the lease commencement date — auto-filled from
+    # today's date at generation time because it is a document property, not
+    # a field the signer fills in.
+    #
+    # ``DATE`` (bare) appears next to signature lines ("Landlord: ___  Date:
+    # ___"). It must be left blank so the physical signer writes in the date
+    # they sign — the same treatment as LANDLORD SIGNATURE / TENANT SIGNATURE.
+    # The renderer substitutes unfilled [DATE] placeholders with a blank
+    # underscore line via ``_augment_with_date_lines`` in renderer.py.
     "EFFECTIVE DATE": _DATE_TODAY,
-    "DATE": _DATE_TODAY,
     # Computed — auto-evaluated at generate time via the computed.py DSL.
     "NUMBER OF DAYS": PlaceholderDefault(
         "computed", None, computed_expr="(MOVE-OUT DATE - MOVE-IN DATE).days",

--- a/apps/mybookkeeper/backend/app/services/leases/renderer.py
+++ b/apps/mybookkeeper/backend/app/services/leases/renderer.py
@@ -16,11 +16,17 @@ When ``python-docx`` is not installed (e.g. in CI without the optional dep),
 ``render_docx_bytes`` falls back to MD rendering of the extracted text — the
 caller is told the fallback fired so it can record the limitation.
 
-Signature placeholders (any bracketed key matching ``*SIGNATURE``) get a
-special substitution: a long underscore line, drawn at render time, so the
-rendered doc has a blank signing line in place of literal
-``[LANDLORD SIGNATURE]`` text. Signatures are applied at signing time, not
-generation time.
+Blank-line substitution rules:
+- Signature placeholders (any bracketed key matching ``*SIGNATURE``) get a
+  blank underscore line so the rendered doc shows a signing line in place of
+  literal ``[LANDLORD SIGNATURE]`` text. Signatures are applied at signing
+  time, not generation time.
+- The bare ``[DATE]`` placeholder (as distinct from ``[EFFECTIVE DATE]``)
+  appears next to signature lines ("Date: ____"). It must be left blank for
+  the physical signer to write in — the same rule as SIGNATURE keys.
+  ``default_source_map`` intentionally has no ``default_source`` for ``DATE``
+  so the resolver does not fill it at generate time; this renderer substitutes
+  any unfilled ``[DATE]`` with a blank underscore line.
 """
 from __future__ import annotations
 
@@ -32,22 +38,34 @@ logger = logging.getLogger(__name__)
 
 SIGNATURE_LINE = "_______________________________"
 _SIGNATURE_KEY_RE = re.compile(r"\[([A-Z][A-Z0-9 _\-]*?SIGNATURE)\]")
+# ``[DATE]`` (bare) next to a signature line must be left blank for the signer
+# to write in — same treatment as SIGNATURE keys. ``[EFFECTIVE DATE]`` is a
+# document property filled at generation time and is NOT matched here.
+_DATE_KEY_RE = re.compile(r"\[DATE\]")
 
 
 def _augment_with_signature_lines(
     template_text: str, values: dict[str, str],
 ) -> dict[str, str]:
-    """Return ``values`` with any unfilled ``*SIGNATURE`` keys mapped to a blank line.
+    """Return ``values`` with any unfilled blank-line placeholders substituted.
 
-    Scans ``template_text`` for bracketed signature keys not already in
-    ``values`` and adds them with the underscore signature line. The
-    caller's ``values`` dict is not mutated.
+    Covers two classes of placeholder that must be left blank for the physical
+    signer to fill in:
+
+    - ``*SIGNATURE`` keys (e.g. ``[LANDLORD SIGNATURE]``, ``[TENANT SIGNATURE]``)
+    - The bare ``[DATE]`` key (date-of-signing, distinct from ``[EFFECTIVE DATE]``)
+
+    Scans ``template_text`` for matching keys not already in ``values`` and
+    maps them to the underscore blank line. The caller's ``values`` dict is
+    not mutated.
     """
     augmented = dict(values)
     for match in _SIGNATURE_KEY_RE.finditer(template_text):
         key = match.group(1)
         if key not in augmented:
             augmented[key] = SIGNATURE_LINE
+    if _DATE_KEY_RE.search(template_text) and "DATE" not in augmented:
+        augmented["DATE"] = SIGNATURE_LINE
     return augmented
 
 

--- a/apps/mybookkeeper/backend/tests/test_default_source_map.py
+++ b/apps/mybookkeeper/backend/tests/test_default_source_map.py
@@ -36,6 +36,18 @@ class TestGetDefault:
             assert d.default_source is None
             assert d.computed_expr is None
 
+    def test_bare_date_has_no_default_source(self) -> None:
+        """``[DATE]`` next to a signature line stays blank for the signer."""
+        d = get_default("DATE")
+        assert d.input_type == "text"
+        assert d.default_source is None
+
+    def test_effective_date_still_defaults_to_today(self) -> None:
+        """``[EFFECTIVE DATE]`` is a document property — keeps today's-date default."""
+        d = get_default("EFFECTIVE DATE")
+        assert d.input_type == "date"
+        assert d.default_source == "today"
+
 
 class TestBackCompatShim:
     def test_returns_input_type_and_default_source(self) -> None:

--- a/apps/mybookkeeper/backend/tests/test_lease_renderer.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_renderer.py
@@ -80,6 +80,25 @@ class TestRenderMd:
         assert out == "Landlord: /s/ Jason Kwon/"
         assert SIGNATURE_LINE not in out
 
+    def test_bare_date_renders_as_blank_line_when_unset(self) -> None:
+        """``[DATE]`` next to a signature must render as a blank signing line."""
+        out = render_md("Landlord: [LANDLORD SIGNATURE]  Date: [DATE]", {})
+        assert "[DATE]" not in out
+        # Two underscore lines: one for the signature, one for the date slot.
+        assert out.count(SIGNATURE_LINE) == 2
+
+    def test_bare_date_value_wins_over_blank_line(self) -> None:
+        """A caller-supplied DATE value still wins over the blank-line default."""
+        out = render_md("Date: [DATE]", {"DATE": "2026-05-30"})
+        assert out == "Date: 2026-05-30"
+        assert SIGNATURE_LINE not in out
+
+    def test_effective_date_does_not_get_blank_line_treatment(self) -> None:
+        """``[EFFECTIVE DATE]`` must NOT match the bare DATE blank-line rule."""
+        out = render_md("Effective: [EFFECTIVE DATE]", {})
+        assert "[EFFECTIVE DATE]" in out
+        assert SIGNATURE_LINE not in out
+
     def test_duplicate_signature_placeholder_each_replaced(self) -> None:
         """Each occurrence of the same SIGNATURE key must be replaced — not just the first."""
         text = (


### PR DESCRIPTION
## Summary

Generated leases were rendering today's date next to signature blocks (`Landlord: ___ Date: 2026-05-07`) — but the signer should write the date when they physically sign, not have it auto-filled at generation time.

- `default_source_map.py`: remove `today` default for bare `[DATE]`. `[EFFECTIVE DATE]` (lease commencement, document property) still defaults to today.
- `renderer.py`: extend the signature-blank-line rule to also cover unfilled `[DATE]`.
- Migration `dateblank260507` clears `default_source = 'today'` on existing `DATE` rows.

## Test plan

- [x] Unit: `test_default_source_map.py` — DATE has no default; EFFECTIVE DATE still has today.
- [x] Unit: `test_lease_renderer.py` — DATE absent → blank line; caller value wins; EFFECTIVE DATE not affected.
- [x] `uv lock --check` passes locally before push.
- [ ] After deploy: regenerate Andrew Le's lease → Date next to signatures should be a blank line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)