### PR TITLE
chore(infra): pre-push hook + CI check for lockfile drift

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,73 @@
+#!/bin/sh
+# Pre-push verification — catches the classes of failure that broke 6 deploys
+# on 2026-05-07:
+#   - uv.lock out of sync with pyproject.toml (was failing as
+#     `backend-deps-resolve` for hours; previously dismissed as flaky)
+#   - per-app frontend package-lock.json missing deps that the root
+#     workspace lockfile has (the `mammoth`-from-DOCX-preview class of bug)
+#
+# Install once with: bash scripts/install-hooks.sh
+# Bypass for emergencies with: git push --no-verify
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+RANGE_FILES=$(git diff --name-only "@{push}" 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
+
+color_red() { printf "\033[31m%s\033[0m\n" "$1"; }
+color_yellow() { printf "\033[33m%s\033[0m\n" "$1"; }
+color_green() { printf "\033[32m%s\033[0m\n" "$1"; }
+
+# ----- 1. uv.lock drift -----
+# Walk every backend with a pyproject.toml that has changed deps OR an
+# unsynced lockfile. Skipping when uv isn't installed so contributors
+# without the toolchain aren't blocked, but the hook nags them.
+if command -v uv >/dev/null 2>&1; then
+    for pyproject in $(find "$REPO_ROOT/apps" -mindepth 3 -maxdepth 3 -name "pyproject.toml" 2>/dev/null); do
+        backend_dir="$(dirname "$pyproject")"
+        rel="${backend_dir#"$REPO_ROOT/"}"
+        if ! (cd "$backend_dir" && uv lock --check 2>&1 | grep -q "needs to be updated"); then
+            continue
+        fi
+        color_red "✗ $rel/uv.lock is out of sync with pyproject.toml"
+        echo "  Run: cd $rel && uv lock && uv export --format requirements-txt --no-hashes --no-emit-project --output-file requirements.txt"
+        echo "  Then re-stage uv.lock + requirements.txt and push again."
+        echo "  (Bypass with --no-verify if you know what you're doing)"
+        exit 1
+    done
+else
+    color_yellow "⚠ uv not installed; skipping uv.lock drift check (install: https://docs.astral.sh/uv/)"
+fi
+
+# ----- 2. Per-app frontend lockfile drift -----
+# When an agent or contributor adds an npm dep via the workspace root,
+# only the root package-lock.json updates. The Dockerfile copies the
+# per-app lockfile, so docker build's `npm ci` fails with
+# "Missing: <package> from lock file". Catch it before push.
+if command -v node >/dev/null 2>&1; then
+    for fe_pkg in $(find "$REPO_ROOT/apps" -mindepth 3 -maxdepth 3 -path "*/frontend/package.json" 2>/dev/null); do
+        fe_dir="$(dirname "$fe_pkg")"
+        fe_lock="$fe_dir/package-lock.json"
+        rel="${fe_dir#"$REPO_ROOT/"}"
+        if [ ! -f "$fe_lock" ]; then
+            continue  # workspace-only project; no per-app lockfile needed
+        fi
+        # Quick check: every dep listed in package.json must appear in the per-app lockfile.
+        missing=$(node -e "
+            const pkg = require('$fe_pkg');
+            const lock = require('$fe_lock');
+            const deps = Object.keys({...pkg.dependencies, ...pkg.devDependencies});
+            const inLock = (lock.packages && lock.packages['']) ? Object.keys({...lock.packages[''].dependencies, ...lock.packages[''].devDependencies}) : [];
+            const missing = deps.filter(d => !inLock.includes(d));
+            console.log(missing.join(' '));
+        " 2>/dev/null || echo "")
+        if [ -n "$missing" ]; then
+            color_red "✗ $rel/package-lock.json is missing entries for: $missing"
+            echo "  Run: cd $rel && npm install --package-lock-only --no-workspaces"
+            echo "  Then re-stage package-lock.json and push again."
+            exit 1
+        fi
+    done
+fi
+
+color_green "✓ pre-push checks passed"

--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -131,6 +131,30 @@ jobs:
       - name: Build frontend
         run: npm run build --workspace=mybookkeeper-frontend
 
+  frontend-lockfile-drift:
+    # The caddy Dockerfile copies apps/mybookkeeper/frontend/package-lock.json
+    # and runs `npm ci` against it (NOT against the workspace root). If a dep
+    # is added via the workspace root only — as the DOCX-preview agent did
+    # with `mammoth` on 2026-05-07 — the per-app lockfile silently misses the
+    # entry and every deploy after fails at docker-build's `npm ci`. This
+    # job mimics the docker step so the gap surfaces at PR time.
+    name: frontend-lockfile-drift / mybookkeeper
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+
+      - name: Verify per-app lockfile resolves with strict npm ci
+        run: |
+          cd apps/mybookkeeper/frontend
+          npm ci --no-workspaces
+
   frontend-layout-e2e:
     name: frontend-layout-e2e / mybookkeeper
     runs-on: ubuntu-latest

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# One-time setup so git uses the in-repo hooks under .githooks/.
+# Run after every fresh clone: `bash scripts/install-hooks.sh`
+#
+# This points git at the repo's .githooks directory instead of the
+# default .git/hooks. The hooks are versioned with the rest of the code
+# so they update automatically with every pull — no per-developer drift.
+
+set -e
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+git config core.hooksPath .githooks
+chmod +x .githooks/* 2>/dev/null || true
+
+echo "✓ git hooks installed (core.hooksPath = .githooks)"
+echo "  Bypass any hook with --no-verify if you need to."


### PR DESCRIPTION
## Summary

Tonight's session lost ~6 deploys to two avoidable lockfile-drift patterns. This wires both a pre-push hook (fast local feedback) and a CI job (catches contributors who don't install the hook).

### Pre-push hook (`.githooks/pre-push`)

Install once after pulling: `bash scripts/install-hooks.sh`. Then every `git push` runs:

- `uv lock --check` for every backend with a `pyproject.toml`
- Per-app frontend lockfile drift check (every dep in `package.json` must also be in `package-lock.json`)

Bypass for emergencies: `git push --no-verify`. Skips gracefully when `uv` / `node` aren't installed.

### CI job (`frontend-lockfile-drift / mybookkeeper`)

Runs `cd apps/mybookkeeper/frontend && npm ci --no-workspaces` — mirrors exactly what the caddy Dockerfile does. Catches the per-app vs workspace-root lockfile drift at PR time without depending on local hook installation.

### What this would have caught tonight

- The `mammoth`-only-in-root-lockfile bug from PR #383 (one-line CI failure instead of 4-min deploy outage).
- The `pydantic[email]` extras drift that was hiding behind the "deps-resolve is flaky" misjudgment for hours.

## Operational

After merge, every contributor (including future me) should run `bash scripts/install-hooks.sh` once. Adding a note to root CLAUDE.md is a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)