### PR TITLE
fix(mybookkeeper/leases): hide [DATE] from the generate-lease form

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/datehide260507_set_date_input_type_to_signature.py
+++ b/apps/mybookkeeper/backend/alembic/versions/datehide260507_set_date_input_type_to_signature.py
@@ -1,0 +1,53 @@
+"""lease_template_placeholders: hide bare DATE from generate-lease form
+
+The generate-lease form filters out ``input_type='signature'`` placeholders
+because they're filled at signing time, not at generation. Bare ``[DATE]``
+(distinct from ``[EFFECTIVE DATE]``) belongs in that same bucket — the
+host shouldn't have to type a date that the signer writes by hand.
+
+This migration updates existing rows where ``key = 'DATE'`` and
+``input_type = 'date'`` (the legacy seed) to ``input_type = 'signature'``,
+which:
+  - Hides the field from the generate-lease form (matches LANDLORD/TENANT
+    SIGNATURE behavior).
+  - Continues to render as a blank underscore line via the renderer's
+    DATE-specific augment rule (no renderer change needed).
+
+Host customisations (rows where someone changed input_type or default_source
+manually) are left alone.
+
+Revision ID: datehide260507
+Revises: dateblank260507
+Create Date: 2026-05-07 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "datehide260507"
+down_revision: Union[str, None] = "dateblank260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE lease_template_placeholders "
+            "SET input_type = 'signature' "
+            "WHERE key = 'DATE' "
+            "  AND input_type = 'date'"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        sa.text(
+            "UPDATE lease_template_placeholders "
+            "SET input_type = 'date' "
+            "WHERE key = 'DATE' "
+            "  AND input_type = 'signature'"
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
@@ -73,13 +73,14 @@ DEFAULT_SOURCE_MAP: dict[str, PlaceholderDefault] = {
     # ``EFFECTIVE DATE`` is the lease commencement date — auto-filled from
     # today's date at generation time because it is a document property, not
     # a field the signer fills in.
-    #
-    # ``DATE`` (bare) appears next to signature lines ("Landlord: ___  Date:
-    # ___"). It must be left blank so the physical signer writes in the date
-    # they sign — the same treatment as LANDLORD SIGNATURE / TENANT SIGNATURE.
-    # The renderer substitutes unfilled [DATE] placeholders with a blank
-    # underscore line via ``_augment_with_date_lines`` in renderer.py.
     "EFFECTIVE DATE": _DATE_TODAY,
+    # ``DATE`` (bare) appears next to signature lines ("Landlord: ___  Date:
+    # ___"). Marked ``input_type="signature"`` so the generate-lease form
+    # hides it (filled at signing time, not at generation), matching the
+    # treatment of LANDLORD SIGNATURE / TENANT SIGNATURE. The renderer
+    # substitutes unfilled ``[DATE]`` with a blank underscore line at render
+    # time via ``_augment_with_signature_lines`` in renderer.py.
+    "DATE": PlaceholderDefault("signature", None),
     # Computed — auto-evaluated at generate time via the computed.py DSL.
     "NUMBER OF DAYS": PlaceholderDefault(
         "computed", None, computed_expr="(MOVE-OUT DATE - MOVE-IN DATE).days",

--- a/apps/mybookkeeper/backend/tests/test_default_source_map.py
+++ b/apps/mybookkeeper/backend/tests/test_default_source_map.py
@@ -36,10 +36,14 @@ class TestGetDefault:
             assert d.default_source is None
             assert d.computed_expr is None
 
-    def test_bare_date_has_no_default_source(self) -> None:
-        """``[DATE]`` next to a signature line stays blank for the signer."""
+    def test_bare_date_uses_signature_input_type(self) -> None:
+        """``[DATE]`` is hidden from the generate-lease form (filled at signing time).
+
+        Marking it ``input_type="signature"`` reuses the existing signature
+        filter so the form auto-hides DATE without new form-side code.
+        """
         d = get_default("DATE")
-        assert d.input_type == "text"
+        assert d.input_type == "signature"
         assert d.default_source is None
 
     def test_effective_date_still_defaults_to_today(self) -> None:


### PR DESCRIPTION
## Summary

User reported being blocked by a required \`Date\` field on the generate-lease form. PR #388 already made `[DATE]` render as a blank line in the doc, but the form was still requiring it as input.

Fix: mark `DATE` as `input_type="signature"`. The generate-lease form already filters out signature-typed placeholders (matching LANDLORD/TENANT SIGNATURE behavior). DATE now auto-hides — zero form-side code change.

Migration `datehide260507` updates existing rows where `key='DATE' AND input_type='date'` to the new shape.

## Test plan

- [x] Unit: `test_default_source_map.py` asserts DATE uses `signature` input_type
- [x] `uv lock --check` passes locally
- [ ] After deploy: open Generate Lease form for any applicant → no Date field shown → Generate → rendered doc still has blank `Date: ___` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)