### PR TITLE
fix(mybookkeeper/leases): output PDF for DOCX templates instead of DOCX

### DIFF
--- a/apps/mybookkeeper/backend/app/services/leases/renderer.py
+++ b/apps/mybookkeeper/backend/app/services/leases/renderer.py
@@ -167,6 +167,47 @@ def _substitute_in_paragraphs(paragraphs, pattern: list[tuple[str, str]]) -> Non
             run.text = ""
 
 
+def render_docx_bytes_to_pdf(
+    docx_bytes: bytes, values: dict[str, str],
+) -> tuple[bytes, bool]:
+    """Render a DOCX template into a PDF after placeholder substitution.
+
+    Pipeline: ``docx_bytes`` → python-docx (substitute placeholders, merge
+    runs) → mammoth (DOCX → markdown) → reportlab (markdown → PDF).
+
+    Returns ``(pdf_bytes, used_docx_library)``. Falls back to a markdown
+    render of the extracted text if either python-docx or mammoth aren't
+    installed — same contract as ``render_docx_bytes``.
+    """
+    rendered_docx, used_docx = render_docx_bytes(docx_bytes, values)
+    if not used_docx:
+        # python-docx not installed; we never substituted. Best we can do
+        # is render the raw bytes' decoded text.
+        text = docx_bytes.decode("utf-8", errors="replace")
+        substituted = render_md(text, values)
+        return render_pdf_from_text(substituted), False
+
+    try:
+        import mammoth  # type: ignore[import-untyped]
+    except ImportError:  # pragma: no cover — mammoth is in pyproject deps
+        logger.warning(
+            "mammoth not installed — falling back to plain-text PDF render",
+        )
+        # Last-resort: extract text via python-docx and render as PDF.
+        try:
+            import docx  # type: ignore[import-untyped]
+            doc = docx.Document(io.BytesIO(rendered_docx))
+            extracted = "\n\n".join(p.text for p in doc.paragraphs if p.text.strip())
+            return render_pdf_from_text(extracted), True
+        except Exception:  # noqa: BLE001
+            return render_pdf_from_text(""), True
+
+    # mammoth converts DOCX → markdown preserving headings, lists, tables.
+    result = mammoth.convert_to_markdown(io.BytesIO(rendered_docx))
+    md_text = result.value
+    return render_pdf_from_text(md_text), True
+
+
 def render_pdf_from_text(rendered_text: str) -> bytes:
     """Generate a simple PDF from rendered plain/markdown text via ``reportlab``.
 

--- a/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
@@ -43,7 +43,7 @@ from app.services.leases.attachment_response_builder import (
 )
 from app.services.leases.computed import ComputedExprError, evaluate
 from app.services.leases.renderer import (
-    render_docx_bytes,
+    render_docx_bytes_to_pdf,
     render_md,
     render_pdf_from_text,
 )
@@ -586,17 +586,13 @@ async def generate_lease(
         for f in files:
             raw = storage.download_file(f.storage_key)
             if f.content_type == DOCX_MIME:
-                rendered_bytes, used_docx = render_docx_bytes(raw, substitutions)
-                if used_docx:
-                    out_filename = _ensure_suffix(f.filename, ".docx")
-                    out_ct = DOCX_MIME
-                else:
-                    # Fall back to a markdown render of an empty body — log as
-                    # a Phase 1.5 limitation (DOCX rendering disabled).
-                    text = raw.decode("utf-8", errors="replace")
-                    rendered_bytes = render_md(text, substitutions).encode("utf-8")
-                    out_filename = _ensure_suffix(f.filename, ".md")
-                    out_ct = "text/markdown"
+                # DOCX templates render to PDF: substitute placeholders via
+                # python-docx, convert to markdown via mammoth, then to PDF
+                # via reportlab. Single output format (PDF) for every
+                # generated lease — easier for hosts and tenants to handle.
+                rendered_bytes, _ = render_docx_bytes_to_pdf(raw, substitutions)
+                out_filename = _swap_extension(f.filename, ".pdf")
+                out_ct = "application/pdf"
             elif f.content_type in ("text/markdown", "text/plain"):
                 text = raw.decode("utf-8", errors="replace")
                 rendered_md_text = render_md(text, substitutions)


### PR DESCRIPTION
## Summary

Generated leases were shipping as DOCX when the source template was DOCX. User wants PDFs uniformly.

Pipeline: `docx_bytes` → python-docx (substitute placeholders, merge runs) → mammoth (DOCX → markdown) → reportlab (markdown → PDF). Reuses the existing reportlab generator already wired for the markdown branch. mammoth was already in pyproject.toml (no dep change needed).

## Test plan

- [x] `uv lock --check` clean
- [ ] Regenerate Andrew Le's lease post-deploy → all attachments are .pdf, content readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)