### PR TITLE
feat(mybookkeeper/leases): friendly download filenames + signing-state tracking

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/leasesign260507_add_signing_state_columns.py
+++ b/apps/mybookkeeper/backend/alembic/versions/leasesign260507_add_signing_state_columns.py
@@ -1,0 +1,49 @@
+"""Add signing-state columns to signed_lease_attachments.
+
+The host can now mark a lease attachment as signed by the tenant, the
+landlord, or both. The columns drive the friendly download filename
+("Lease Agreement - tenant signed.pdf" / "- fully signed.pdf") so a
+downloaded file is self-describing instead of a bare GUID.
+
+Both columns default to NULL — every existing row migrates as
+"unsigned by either party", which is the correct retroactive label for
+attachments uploaded before this PR. Forward-only data migration; no
+backfill required.
+
+Revision ID: leasesign260507
+Revises: datehide260507
+Create Date: 2026-05-07 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "leasesign260507"
+down_revision: Union[str, None] = "datehide260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "signed_lease_attachments",
+        sa.Column(
+            "signed_by_tenant_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "signed_lease_attachments",
+        sa.Column(
+            "signed_by_landlord_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("signed_lease_attachments", "signed_by_landlord_at")
+    op.drop_column("signed_lease_attachments", "signed_by_tenant_at")

--- a/apps/mybookkeeper/backend/app/api/signed_leases.py
+++ b/apps/mybookkeeper/backend/app/api/signed_leases.py
@@ -17,6 +17,9 @@ from app.core.permissions import current_org_member, require_write_access
 from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
+from app.schemas.leases.signed_lease_attachment_signing_state_request import (
+    SignedLeaseAttachmentSigningStateRequest,
+)
 from app.schemas.leases.signed_lease_attachment_update_request import (
     SignedLeaseAttachmentUpdateRequest,
 )
@@ -273,6 +276,38 @@ async def update_attachment(
         raise HTTPException(status_code=404, detail="Not found") from exc
     except signed_lease_service.InvalidAttachmentKindError as exc:
         raise HTTPException(status_code=422, detail=str(exc)) from exc
+
+
+@router.patch(
+    "/{lease_id}/attachments/{attachment_id}/signing-state",
+    response_model=SignedLeaseAttachmentResponse,
+)
+async def update_attachment_signing_state(
+    lease_id: uuid.UUID,
+    attachment_id: uuid.UUID,
+    payload: SignedLeaseAttachmentSigningStateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> SignedLeaseAttachmentResponse:
+    # Only forward the keys the caller explicitly sent so omitted keys
+    # leave the existing column untouched (sentinel-based partial PATCH).
+    signing_fields = {
+        key: getattr(payload, key)
+        for key in payload.model_fields_set
+        if key in {"signed_by_tenant_at", "signed_by_landlord_at"}
+    }
+    try:
+        return await signed_lease_service.update_attachment_signing_state(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            lease_id=lease_id,
+            attachment_id=attachment_id,
+            signing_fields=signing_fields,
+        )
+    except (
+        signed_lease_service.SignedLeaseNotFoundError,
+        signed_lease_service.AttachmentNotFoundError,
+    ) as exc:
+        raise HTTPException(status_code=404, detail="Not found") from exc
 
 
 @router.delete(

--- a/apps/mybookkeeper/backend/app/core/storage.py
+++ b/apps/mybookkeeper/backend/app/core/storage.py
@@ -126,17 +126,34 @@ class StorageClient:
             raise
         return True
 
-    def generate_presigned_url(self, key: str, expires_in_seconds: int) -> str:
+    def generate_presigned_url(
+        self,
+        key: str,
+        expires_in_seconds: int,
+        *,
+        response_content_disposition: str | None = None,
+    ) -> str:
         """Sign a GET URL for `key` valid for `expires_in_seconds`.
 
         The URL points at whatever endpoint this client was constructed
         with — for `_DualEndpointStorageClient` the inner public client is
         used so the browser can reach it.
+
+        When ``response_content_disposition`` is set (e.g. ``'attachment;
+        filename="Lease Agreement - tenant signed.pdf"'``), the value is
+        signed into the URL via the ``response-content-disposition``
+        S3 query parameter so MinIO emits it as a response header on the
+        GET. Browsers honor this for filename selection on download.
         """
         return self._client.presigned_get_object(
             self._bucket,
             key,
             expires=timedelta(seconds=expires_in_seconds),
+            response_headers=(
+                {"response-content-disposition": response_content_disposition}
+                if response_content_disposition
+                else None
+            ),
         )
 
     def ensure_bucket(self) -> None:
@@ -169,11 +186,22 @@ class _DualEndpointStorageClient(StorageClient):
         super().__init__(internal_client, bucket)
         self._public_client = public_client
 
-    def generate_presigned_url(self, key: str, expires_in_seconds: int) -> str:
+    def generate_presigned_url(
+        self,
+        key: str,
+        expires_in_seconds: int,
+        *,
+        response_content_disposition: str | None = None,
+    ) -> str:
         return self._public_client.presigned_get_object(
             self._bucket,
             key,
             expires=timedelta(seconds=expires_in_seconds),
+            response_headers=(
+                {"response-content-disposition": response_content_disposition}
+                if response_content_disposition
+                else None
+            ),
         )
 
 

--- a/apps/mybookkeeper/backend/app/models/leases/signed_lease_attachment.py
+++ b/apps/mybookkeeper/backend/app/models/leases/signed_lease_attachment.py
@@ -60,6 +60,19 @@ class SignedLeaseAttachment(Base):
         server_default=func.now(),
     )
 
+    # Signing state. NULL = not yet signed by that party. Drives the
+    # friendly download filename suffix (" - tenant signed" / " - fully
+    # signed") so a downloaded file is self-describing instead of a bare
+    # GUID. Only meaningful for the lease document itself
+    # (``rendered_original`` / ``signed_lease`` kinds); other kinds
+    # (inspections, insurance, etc.) ignore these columns.
+    signed_by_tenant_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    signed_by_landlord_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
     __table_args__ = (
         CheckConstraint(
             f"kind IN {LEASE_ATTACHMENT_KINDS_SQL}",

--- a/apps/mybookkeeper/backend/app/repositories/leases/signed_lease_attachment_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/leases/signed_lease_attachment_repo.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from typing import Any
 
 from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -95,6 +96,44 @@ async def update_kind_scoped_to_lease(
         .values(kind=kind)
     )
     await db.refresh(row)
+    return row
+
+
+async def update_signing_state_scoped_to_lease(
+    db: AsyncSession,
+    attachment_id: uuid.UUID,
+    lease_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> SignedLeaseAttachment | None:
+    """Update signing-state fields on an attachment, scoped to its lease.
+
+    ``fields`` must only contain ``signed_by_tenant_at`` and/or
+    ``signed_by_landlord_at``; the caller is responsible for the
+    allowlist. Both ``attachment_id`` AND ``lease_id`` must match —
+    same composite-WHERE IDOR guard as ``update_kind_scoped_to_lease``.
+
+    Empty ``fields`` is a no-op that still loads + returns the row so
+    the caller can render the unchanged response without an extra query.
+    """
+    result = await db.execute(
+        select(SignedLeaseAttachment).where(
+            SignedLeaseAttachment.id == attachment_id,
+            SignedLeaseAttachment.lease_id == lease_id,
+        )
+    )
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    if fields:
+        await db.execute(
+            update(SignedLeaseAttachment)
+            .where(
+                SignedLeaseAttachment.id == attachment_id,
+                SignedLeaseAttachment.lease_id == lease_id,
+            )
+            .values(**fields)
+        )
+        await db.refresh(row)
     return row
 
 

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_attachment_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_attachment_response.py
@@ -17,6 +17,10 @@ class SignedLeaseAttachmentResponse(BaseModel):
     kind: str
     uploaded_by_user_id: uuid.UUID
     uploaded_at: _dt.datetime
+    # Signing-state timestamps. NULL = not yet signed by that party.
+    # Drives the friendly download filename suffix.
+    signed_by_tenant_at: _dt.datetime | None = None
+    signed_by_landlord_at: _dt.datetime | None = None
     presigned_url: str | None = None
     # ``False`` means the row exists in the DB but the underlying MinIO
     # object is missing (NoSuchKey on HEAD). Set by the response builder so

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_attachment_signing_state_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_attachment_signing_state_request.py
@@ -1,0 +1,23 @@
+"""Request body for PATCH /signed-leases/{lease_id}/attachments/{attachment_id}/signing-state.
+
+Both fields are independently optional. Sending ``null`` explicitly clears
+that party's signature; omitting the field leaves the existing value in
+place. The frontend therefore needs to send the full intended state on
+every PATCH.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SignedLeaseAttachmentSigningStateRequest(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    # Sentinel ``UNSET`` semantics — if a key is absent from the JSON body,
+    # the field stays untouched on the row. Pydantic 2 exposes the absence
+    # via ``model_fields_set`` so the service layer can tell "send null
+    # explicitly to clear" from "field omitted".
+    signed_by_tenant_at: _dt.datetime | None = None
+    signed_by_landlord_at: _dt.datetime | None = None

--- a/apps/mybookkeeper/backend/app/services/leases/attachment_response_builder.py
+++ b/apps/mybookkeeper/backend/app/services/leases/attachment_response_builder.py
@@ -30,6 +30,7 @@ from app.schemas.leases.lease_template_file_response import (
 from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
+from app.services.leases.lease_filename import friendly_download_filename
 from app.services.storage.presigned_url_attacher import (
     attach_presigned_url_with_head_check,
 )
@@ -50,4 +51,5 @@ def attach_presigned_urls_to_attachments(
     return attach_presigned_url_with_head_check(
         attachments,
         sentry_event_name="lease_attachment_storage_object_missing",
+        download_filename_resolver=friendly_download_filename,
     )

--- a/apps/mybookkeeper/backend/app/services/leases/lease_filename.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_filename.py
@@ -1,0 +1,92 @@
+"""Friendly download filename derivation for lease attachments.
+
+Pure function. The caller (presigned-URL builder) reads the result and
+sets it as ``Content-Disposition: attachment; filename="..."`` on the
+MinIO presigned URL so the browser saves the file under a human name
+instead of the storage-key GUID.
+
+Suffix rules (only applied to the main lease document — kinds
+``signed_lease`` and ``rendered_original``):
+
+| signed_by_tenant_at | signed_by_landlord_at | suffix              |
+|---------------------|-----------------------|---------------------|
+| NULL                | NULL                  | (none)              |
+| set                 | NULL                  | " - tenant signed"  |
+| NULL                | set                   | " - landlord signed"|
+| set                 | set                   | " - fully signed"   |
+
+For all other attachment kinds (inspections, insurance, addenda, etc.)
+the original filename is returned unchanged — those documents are not
+"signed by tenant / landlord" in the same sense.
+
+The file extension is preserved: a ``.docx`` master template stays
+``.docx``, a ``.pdf`` signed lease stays ``.pdf``.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import os
+from typing import Protocol
+
+
+_LEASE_DOCUMENT_KINDS: frozenset[str] = frozenset({
+    "rendered_original",
+    "signed_lease",
+})
+
+
+class _AttachmentLike(Protocol):
+    """Minimal shape ``friendly_download_filename`` reads.
+
+    Both the SQLAlchemy ORM row (``SignedLeaseAttachment``) and the
+    Pydantic response (``SignedLeaseAttachmentResponse``) satisfy this
+    protocol via attribute access.
+    """
+
+    filename: str
+    kind: str
+    signed_by_tenant_at: _dt.datetime | None
+    signed_by_landlord_at: _dt.datetime | None
+
+
+def friendly_download_filename(attachment: _AttachmentLike) -> str:
+    """Return the human-readable filename to surface on download.
+
+    Pure: depends only on the four fields read from ``attachment``.
+    Never raises.
+    """
+    base_name = attachment.filename or ""
+
+    if attachment.kind not in _LEASE_DOCUMENT_KINDS:
+        return base_name
+
+    suffix = _signing_suffix(
+        signed_by_tenant_at=attachment.signed_by_tenant_at,
+        signed_by_landlord_at=attachment.signed_by_landlord_at,
+    )
+    if not suffix:
+        return base_name
+
+    stem, ext = os.path.splitext(base_name)
+    if not stem or base_name.startswith("."):
+        # Defensive: filename was just an extension (e.g. ``.docx``,
+        # which splitext reads as stem='.docx' ext='') or empty. Don't
+        # synthesize a name that would render the dotfile odd.
+        return base_name
+    return f"{stem}{suffix}{ext}"
+
+
+def _signing_suffix(
+    *,
+    signed_by_tenant_at: _dt.datetime | None,
+    signed_by_landlord_at: _dt.datetime | None,
+) -> str:
+    tenant = signed_by_tenant_at is not None
+    landlord = signed_by_landlord_at is not None
+    if tenant and landlord:
+        return " - fully signed"
+    if tenant:
+        return " - tenant signed"
+    if landlord:
+        return " - landlord signed"
+    return ""

--- a/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
@@ -989,6 +989,47 @@ async def list_attachments(
     return _attachment_responses(rows)
 
 
+async def update_attachment_signing_state(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    lease_id: uuid.UUID,
+    attachment_id: uuid.UUID,
+    signing_fields: dict[str, _dt.datetime | None],
+) -> SignedLeaseAttachmentResponse:
+    """Set / clear signing-state timestamps on a lease attachment.
+
+    ``signing_fields`` is the subset of ``{"signed_by_tenant_at",
+    "signed_by_landlord_at"}`` the host explicitly set on the request
+    body — keys absent from the body are left untouched. ``None`` values
+    explicitly clear that party's signature. Field-name validation is
+    enforced at the schema layer (Pydantic ``extra="forbid"``); this
+    function trusts the keys it receives.
+    """
+    async with unit_of_work() as db:
+        lease = await signed_lease_repo.get(
+            db,
+            lease_id=lease_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if lease is None:
+            raise SignedLeaseNotFoundError(f"Lease {lease_id} not found")
+
+        row = await signed_lease_attachment_repo.update_signing_state_scoped_to_lease(
+            db,
+            attachment_id=attachment_id,
+            lease_id=lease_id,
+            fields=signing_fields,
+        )
+        if row is None:
+            raise AttachmentNotFoundError(f"Attachment {attachment_id} not found")
+
+        response = SignedLeaseAttachmentResponse.model_validate(row)
+
+    return attach_presigned_urls_to_attachments([response])[0]
+
+
 async def update_attachment_kind(
     *,
     user_id: uuid.UUID,

--- a/apps/mybookkeeper/backend/app/services/storage/presigned_url_attacher.py
+++ b/apps/mybookkeeper/backend/app/services/storage/presigned_url_attacher.py
@@ -22,7 +22,8 @@ of the PR #201–#204 outage trail and are no longer permitted.
 from __future__ import annotations
 
 import logging
-from typing import TypeVar
+from typing import Callable, TypeVar
+from urllib.parse import quote
 
 import sentry_sdk
 from pydantic import BaseModel
@@ -35,6 +36,21 @@ logger = logging.getLogger(__name__)
 _T = TypeVar("_T", bound=BaseModel)
 
 
+def build_attachment_disposition(filename: str) -> str:
+    """Build a ``Content-Disposition: attachment`` header value.
+
+    Emits both the legacy ASCII ``filename=`` and the RFC 5987
+    ``filename*=UTF-8''<percent-encoded>`` form so non-ASCII names round-
+    trip cleanly across browsers. Inner double-quotes and backslashes in
+    the ASCII form are escaped per RFC 6266; falling back to the
+    percent-encoded form on browsers that respect ``filename*`` covers
+    everything else (e.g. accented characters, emoji).
+    """
+    safe_ascii = filename.replace("\\", "\\\\").replace('"', '\\"')
+    encoded = quote(filename, safe="")
+    return f'attachment; filename="{safe_ascii}"; filename*=UTF-8\'\'{encoded}'
+
+
 def attach_presigned_url_with_head_check(
     items: list[_T],
     *,
@@ -43,6 +59,7 @@ def attach_presigned_url_with_head_check(
     is_available_attr: str = "is_available",
     sentry_event_name: str,
     extra_sentry_tags: dict[str, str] | None = None,
+    download_filename_resolver: Callable[[_T], str | None] | None = None,
 ) -> list[_T]:
     """Attach a presigned URL + is_available flag to each item in-place
     (returns new model copies — Pydantic models are immutable).
@@ -62,6 +79,14 @@ def attach_presigned_url_with_head_check(
             Sentry event (e.g., ``{"domain": "insurance"}``). Per-row
             tags such as ``lease_id`` / ``attachment_id`` are wired
             automatically when the model exposes those attributes.
+        download_filename_resolver: optional callable that maps a row to
+            the human-readable download filename. When provided and it
+            returns a non-empty string, the presigned URL is signed with
+            ``response-content-disposition: attachment; filename="..."``
+            so MinIO emits the header on the GET — the browser saves the
+            file under that name instead of the storage-key GUID.
+            Returning ``None`` skips the disposition for that row (used
+            by inline-displayed assets like listing photos).
 
     Returns:
         New list of model copies with the two fields set. Items whose
@@ -103,7 +128,16 @@ def attach_presigned_url_with_head_check(
                 is_available_attr: False,
             }))
             continue
-        url = storage.generate_presigned_url(key, settings.presigned_url_ttl_seconds)
+        disposition: str | None = None
+        if download_filename_resolver is not None:
+            resolved = download_filename_resolver(item)
+            if resolved:
+                disposition = build_attachment_disposition(resolved)
+        url = storage.generate_presigned_url(
+            key,
+            settings.presigned_url_ttl_seconds,
+            response_content_disposition=disposition,
+        )
         out.append(item.model_copy(update={
             presigned_url_attr: url,
             is_available_attr: True,

--- a/apps/mybookkeeper/backend/tests/conftest.py
+++ b/apps/mybookkeeper/backend/tests/conftest.py
@@ -60,7 +60,9 @@ def _patch_storage_for_tests(monkeypatch):
     """
     fake = MagicMock()
     fake.bucket = "test-bucket"
-    fake.generate_presigned_url.side_effect = lambda key, ttl: f"https://signed/{key}"
+    fake.generate_presigned_url.side_effect = (
+        lambda key, ttl, **_kwargs: f"https://signed/{key}"
+    )
     fake.ensure_bucket.return_value = None
     # ``generate_key`` is the storage key generator used by upload paths;
     # returning a MagicMock from it would fail downstream INSERTs that

--- a/apps/mybookkeeper/backend/tests/test_attachment_response_builder.py
+++ b/apps/mybookkeeper/backend/tests/test_attachment_response_builder.py
@@ -33,6 +33,8 @@ def _row(**overrides) -> SignedLeaseAttachmentResponse:
         "kind": "signed_lease",
         "uploaded_by_user_id": uuid.uuid4(),
         "uploaded_at": _dt.datetime.now(_dt.timezone.utc),
+        "signed_by_tenant_at": None,
+        "signed_by_landlord_at": None,
         "presigned_url": None,
         "is_available": True,
     }
@@ -71,6 +73,79 @@ class TestAttachPresignedUrlsToAttachments:
         assert out.presigned_url == "https://example.com/signed-url"
         storage.object_exists.assert_called_once_with(row.storage_key)
         storage.generate_presigned_url.assert_called_once()
+
+    def test_unsigned_lease_uses_original_filename_in_disposition(self) -> None:
+        row = _row(filename="Lease Agreement.pdf", kind="signed_lease")
+        storage = _mock_storage(exists=True)
+        with patch(
+            "app.services.storage.presigned_url_attacher.get_storage",
+            return_value=storage,
+        ):
+            attach_presigned_urls_to_attachments([row])
+        disposition = storage.generate_presigned_url.call_args.kwargs[
+            "response_content_disposition"
+        ]
+        assert 'filename="Lease Agreement.pdf"' in disposition
+        assert "tenant signed" not in disposition
+        assert "fully signed" not in disposition
+
+    def test_tenant_signed_lease_appends_tenant_signed_suffix(self) -> None:
+        row = _row(
+            filename="Lease Agreement.pdf",
+            kind="signed_lease",
+            signed_by_tenant_at=_dt.datetime.now(_dt.timezone.utc),
+        )
+        storage = _mock_storage(exists=True)
+        with patch(
+            "app.services.storage.presigned_url_attacher.get_storage",
+            return_value=storage,
+        ):
+            attach_presigned_urls_to_attachments([row])
+        disposition = storage.generate_presigned_url.call_args.kwargs[
+            "response_content_disposition"
+        ]
+        assert 'filename="Lease Agreement - tenant signed.pdf"' in disposition
+
+    def test_fully_signed_lease_appends_fully_signed_suffix(self) -> None:
+        now = _dt.datetime.now(_dt.timezone.utc)
+        row = _row(
+            filename="Lease Agreement.pdf",
+            kind="signed_lease",
+            signed_by_tenant_at=now,
+            signed_by_landlord_at=now,
+        )
+        storage = _mock_storage(exists=True)
+        with patch(
+            "app.services.storage.presigned_url_attacher.get_storage",
+            return_value=storage,
+        ):
+            attach_presigned_urls_to_attachments([row])
+        disposition = storage.generate_presigned_url.call_args.kwargs[
+            "response_content_disposition"
+        ]
+        assert 'filename="Lease Agreement - fully signed.pdf"' in disposition
+
+    def test_inspection_kind_keeps_original_filename(self) -> None:
+        # Even if the signing-state columns are populated by accident,
+        # non-lease kinds must not get the suffix.
+        now = _dt.datetime.now(_dt.timezone.utc)
+        row = _row(
+            filename="Move-In Inspection.pdf",
+            kind="move_in_inspection",
+            signed_by_tenant_at=now,
+            signed_by_landlord_at=now,
+        )
+        storage = _mock_storage(exists=True)
+        with patch(
+            "app.services.storage.presigned_url_attacher.get_storage",
+            return_value=storage,
+        ):
+            attach_presigned_urls_to_attachments([row])
+        disposition = storage.generate_presigned_url.call_args.kwargs[
+            "response_content_disposition"
+        ]
+        assert 'filename="Move-In Inspection.pdf"' in disposition
+        assert "signed" not in disposition
 
     def test_missing_object_flips_is_available_and_skips_url(self) -> None:
         row = _row(presigned_url=None, is_available=True)

--- a/apps/mybookkeeper/backend/tests/test_lease_attachment_kind.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_attachment_kind.py
@@ -30,7 +30,12 @@ def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
     )
 
 
-def _attachment_response(kind: str = "signed_lease") -> dict:
+def _attachment_response(
+    kind: str = "signed_lease",
+    *,
+    signed_by_tenant_at: _dt.datetime | None = None,
+    signed_by_landlord_at: _dt.datetime | None = None,
+) -> dict:
     """Build a minimal SignedLeaseAttachmentResponse payload."""
     from app.schemas.leases.signed_lease_attachment_response import (
         SignedLeaseAttachmentResponse,
@@ -46,6 +51,8 @@ def _attachment_response(kind: str = "signed_lease") -> dict:
         kind=kind,
         uploaded_by_user_id=uuid.uuid4(),
         uploaded_at=_dt.datetime.now(_dt.timezone.utc),
+        signed_by_tenant_at=signed_by_tenant_at,
+        signed_by_landlord_at=signed_by_landlord_at,
         presigned_url=None,
     ).model_dump(mode="json")
 
@@ -207,6 +214,128 @@ class TestUpdateAttachmentKind:
                 resp = client.patch(
                     f"/signed-leases/{lease_id}/attachments/{attachment_id}",
                     json={"kind": "signed_addendum"},
+                )
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+
+
+class TestUpdateAttachmentSigningState:
+    def test_partial_patch_only_forwards_set_keys(self) -> None:
+        """Omitted keys must NOT be forwarded — they preserve the existing value.
+
+        The frontend can ``PATCH {"signed_by_tenant_at": "..."}`` to mark
+        the tenant signature without clobbering the landlord timestamp.
+        """
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+        tenant_at = _dt.datetime(2026, 5, 7, tzinfo=_dt.timezone.utc)
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.signed_lease_service.update_attachment_signing_state",
+                return_value=_attachment_response(
+                    "signed_lease", signed_by_tenant_at=tenant_at,
+                ),
+            ) as mock_call:
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/signed-leases/{lease_id}/attachments/{attachment_id}/signing-state",
+                    json={"signed_by_tenant_at": tenant_at.isoformat()},
+                )
+            assert resp.status_code == 200, resp.text
+            kwargs = mock_call.call_args.kwargs
+            assert kwargs["signing_fields"] == {
+                "signed_by_tenant_at": tenant_at,
+            }
+            # ``signed_by_landlord_at`` was omitted from the body and must NOT
+            # appear in the dict forwarded to the service — that's how the
+            # service knows to leave the column untouched.
+            assert "signed_by_landlord_at" not in kwargs["signing_fields"]
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_explicit_null_clears_signature(self) -> None:
+        """Sending null explicitly must clear the column."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.signed_lease_service.update_attachment_signing_state",
+                return_value=_attachment_response("signed_lease"),
+            ) as mock_call:
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/signed-leases/{lease_id}/attachments/{attachment_id}/signing-state",
+                    json={"signed_by_tenant_at": None},
+                )
+            assert resp.status_code == 200
+            assert mock_call.call_args.kwargs["signing_fields"] == {
+                "signed_by_tenant_at": None,
+            }
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_unknown_field_returns_422(self) -> None:
+        """Pydantic ``extra=forbid`` rejects unknown fields."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            client = TestClient(app)
+            resp = client.patch(
+                f"/signed-leases/{lease_id}/attachments/{attachment_id}/signing-state",
+                json={"signed_by_random_third_party_at": "2026-01-01T00:00:00Z"},
+            )
+            assert resp.status_code == 422
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_cross_tenant_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.services.leases.signed_lease_service import (
+            SignedLeaseNotFoundError,
+        )
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.signed_lease_service.update_attachment_signing_state",
+                side_effect=SignedLeaseNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/signed-leases/{lease_id}/attachments/{attachment_id}/signing-state",
+                    json={"signed_by_tenant_at": "2026-05-07T00:00:00Z"},
+                )
+            assert resp.status_code == 404
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_attachment_not_found_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, attachment_id = uuid.uuid4(), uuid.uuid4()
+
+        from app.services.leases.signed_lease_service import (
+            AttachmentNotFoundError,
+        )
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.signed_lease_service.update_attachment_signing_state",
+                side_effect=AttachmentNotFoundError("not found"),
+            ):
+                client = TestClient(app)
+                resp = client.patch(
+                    f"/signed-leases/{lease_id}/attachments/{attachment_id}/signing-state",
+                    json={"signed_by_landlord_at": "2026-05-07T00:00:00Z"},
                 )
             assert resp.status_code == 404
         finally:

--- a/apps/mybookkeeper/backend/tests/test_lease_filename.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_filename.py
@@ -1,0 +1,158 @@
+"""Unit tests for ``friendly_download_filename``.
+
+Pure-function tests — covers all four cases from the user spec:
+  1. unsigned by both → original filename
+  2. signed by tenant only → " - tenant signed" suffix
+  3. signed by both → " - fully signed" suffix
+  4. non-lease kind → original filename, no suffix
+
+Plus the secondary "landlord-only" branch that the implementation
+covers for completeness, plus extension-preservation edge cases.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from dataclasses import dataclass
+
+from app.services.leases.lease_filename import friendly_download_filename
+
+
+@dataclass
+class _FakeAttachment:
+    filename: str
+    kind: str
+    signed_by_tenant_at: _dt.datetime | None = None
+    signed_by_landlord_at: _dt.datetime | None = None
+
+
+def _now() -> _dt.datetime:
+    return _dt.datetime(2026, 5, 7, 12, 0, 0, tzinfo=_dt.timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# The four cases the user explicitly enumerated.
+# ---------------------------------------------------------------------------
+
+
+class TestFriendlyDownloadFilenameSpec:
+    def test_unsigned_returns_original_docx(self) -> None:
+        att = _FakeAttachment(
+            filename="Lease Agreement.docx",
+            kind="signed_lease",
+        )
+        assert friendly_download_filename(att) == "Lease Agreement.docx"
+
+    def test_tenant_only_signed_appends_tenant_signed_pdf(self) -> None:
+        att = _FakeAttachment(
+            filename="Lease Agreement.pdf",
+            kind="signed_lease",
+            signed_by_tenant_at=_now(),
+        )
+        assert (
+            friendly_download_filename(att)
+            == "Lease Agreement - tenant signed.pdf"
+        )
+
+    def test_both_signed_appends_fully_signed(self) -> None:
+        att = _FakeAttachment(
+            filename="Lease Agreement.pdf",
+            kind="signed_lease",
+            signed_by_tenant_at=_now(),
+            signed_by_landlord_at=_now(),
+        )
+        assert (
+            friendly_download_filename(att)
+            == "Lease Agreement - fully signed.pdf"
+        )
+
+    def test_non_lease_kind_passes_through_unchanged(self) -> None:
+        att = _FakeAttachment(
+            filename="Move-In Inspection.pdf",
+            kind="move_in_inspection",
+            # Even when the columns are populated (e.g., a host
+            # accidentally set them on a non-lease row), inspections
+            # must not get the signing suffix.
+            signed_by_tenant_at=_now(),
+            signed_by_landlord_at=_now(),
+        )
+        assert (
+            friendly_download_filename(att) == "Move-In Inspection.pdf"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Secondary cases — landlord-only, extension preservation, edge guards.
+# ---------------------------------------------------------------------------
+
+
+class TestFriendlyDownloadFilenameEdges:
+    def test_landlord_only_signed_uses_landlord_suffix(self) -> None:
+        att = _FakeAttachment(
+            filename="Lease Agreement.pdf",
+            kind="signed_lease",
+            signed_by_landlord_at=_now(),
+        )
+        assert (
+            friendly_download_filename(att)
+            == "Lease Agreement - landlord signed.pdf"
+        )
+
+    def test_rendered_original_kind_also_gets_suffix(self) -> None:
+        att = _FakeAttachment(
+            filename="Lease Agreement.docx",
+            kind="rendered_original",
+            signed_by_tenant_at=_now(),
+        )
+        assert (
+            friendly_download_filename(att)
+            == "Lease Agreement - tenant signed.docx"
+        )
+
+    def test_signed_addendum_kind_passes_through_unchanged(self) -> None:
+        att = _FakeAttachment(
+            filename="Pet Addendum.pdf",
+            kind="signed_addendum",
+            signed_by_tenant_at=_now(),
+            signed_by_landlord_at=_now(),
+        )
+        assert friendly_download_filename(att) == "Pet Addendum.pdf"
+
+    def test_filename_with_no_extension_still_gets_suffix(self) -> None:
+        att = _FakeAttachment(
+            filename="Lease Agreement",
+            kind="signed_lease",
+            signed_by_tenant_at=_now(),
+        )
+        assert (
+            friendly_download_filename(att)
+            == "Lease Agreement - tenant signed"
+        )
+
+    def test_filename_with_multiple_dots_only_swaps_final_extension(self) -> None:
+        att = _FakeAttachment(
+            filename="2026.05.07 Lease Agreement.pdf",
+            kind="signed_lease",
+            signed_by_tenant_at=_now(),
+        )
+        assert (
+            friendly_download_filename(att)
+            == "2026.05.07 Lease Agreement - tenant signed.pdf"
+        )
+
+    def test_empty_filename_returns_empty(self) -> None:
+        att = _FakeAttachment(
+            filename="",
+            kind="signed_lease",
+            signed_by_tenant_at=_now(),
+        )
+        assert friendly_download_filename(att) == ""
+
+    def test_dotfile_only_returns_unchanged_to_avoid_empty_stem(self) -> None:
+        # ``os.path.splitext('.docx')`` returns ('.docx', '') — stem is
+        # empty. Defensive fallback: don't synthesize a name, return as-is.
+        att = _FakeAttachment(
+            filename=".docx",
+            kind="signed_lease",
+            signed_by_tenant_at=_now(),
+        )
+        assert friendly_download_filename(att) == ".docx"

--- a/apps/mybookkeeper/backend/tests/test_listing_photo_service.py
+++ b/apps/mybookkeeper/backend/tests/test_listing_photo_service.py
@@ -41,7 +41,9 @@ def _patch_builder_storage(monkeypatch):
 
     fake = MagicMock()
     fake.object_exists.return_value = True
-    fake.generate_presigned_url.side_effect = lambda key, ttl: f"https://signed/{key}"
+    fake.generate_presigned_url.side_effect = (
+        lambda key, ttl, **_kwargs: f"https://signed/{key}"
+    )
     monkeypatch.setattr(presigned_url_attacher, "get_storage", lambda: fake)
 
 

--- a/apps/mybookkeeper/backend/tests/test_photo_response_builder.py
+++ b/apps/mybookkeeper/backend/tests/test_photo_response_builder.py
@@ -48,7 +48,9 @@ class TestAttachPresignedUrls:
         photos = [_make_response("a"), _make_response("b")]
         storage = MagicMock()
         storage.object_exists.return_value = True
-        storage.generate_presigned_url.side_effect = lambda key, ttl: f"https://signed/{key}"
+        storage.generate_presigned_url.side_effect = (
+            lambda key, ttl, **_kwargs: f"https://signed/{key}"
+        )
         with patch(
             "app.services.storage.presigned_url_attacher.get_storage",
             return_value=storage,

--- a/apps/mybookkeeper/backend/tests/test_presigned_url_attacher.py
+++ b/apps/mybookkeeper/backend/tests/test_presigned_url_attacher.py
@@ -30,6 +30,7 @@ from app.schemas.applicants.screening_result_response import (
 )
 from app.services.storage.presigned_url_attacher import (
     attach_presigned_url_with_head_check,
+    build_attachment_disposition,
 )
 
 
@@ -146,6 +147,53 @@ class TestSharedHelper:
         assert out.presigned_url is None
         storage.object_exists.assert_not_called()
 
+    def test_resolver_attaches_content_disposition(self) -> None:
+        row = _row(filename="Lease Agreement.pdf")
+        storage = _mock_storage(exists=True)
+        with patch(
+            "app.services.storage.presigned_url_attacher.get_storage",
+            return_value=storage,
+        ):
+            attach_presigned_url_with_head_check(
+                [row],
+                sentry_event_name="test_event",
+                download_filename_resolver=lambda r: f"{r.filename}",
+            )
+        call = storage.generate_presigned_url.call_args
+        assert call.kwargs["response_content_disposition"] == (
+            'attachment; filename="Lease Agreement.pdf"; '
+            "filename*=UTF-8''Lease%20Agreement.pdf"
+        )
+
+    def test_resolver_returning_none_skips_disposition(self) -> None:
+        row = _row()
+        storage = _mock_storage(exists=True)
+        with patch(
+            "app.services.storage.presigned_url_attacher.get_storage",
+            return_value=storage,
+        ):
+            attach_presigned_url_with_head_check(
+                [row],
+                sentry_event_name="test_event",
+                download_filename_resolver=lambda r: None,
+            )
+        call = storage.generate_presigned_url.call_args
+        assert call.kwargs["response_content_disposition"] is None
+
+    def test_no_resolver_passes_no_disposition(self) -> None:
+        row = _row()
+        storage = _mock_storage(exists=True)
+        with patch(
+            "app.services.storage.presigned_url_attacher.get_storage",
+            return_value=storage,
+        ):
+            attach_presigned_url_with_head_check(
+                [row],
+                sentry_event_name="test_event",
+            )
+        call = storage.generate_presigned_url.call_args
+        assert call.kwargs["response_content_disposition"] is None
+
     def test_mixed_present_and_missing(self) -> None:
         present = _row()
         missing = _row()
@@ -170,3 +218,25 @@ class TestSharedHelper:
         by_id = {r.id: r for r in results}
         assert by_id[present.id].is_available is True
         assert by_id[missing.id].is_available is False
+
+
+class TestBuildAttachmentDisposition:
+    def test_ascii_filename(self) -> None:
+        assert build_attachment_disposition("Lease.pdf") == (
+            'attachment; filename="Lease.pdf"; filename*=UTF-8\'\'Lease.pdf'
+        )
+
+    def test_filename_with_spaces_percent_encoded_in_filename_star(self) -> None:
+        out = build_attachment_disposition("Lease Agreement.pdf")
+        assert 'filename="Lease Agreement.pdf"' in out
+        assert "filename*=UTF-8''Lease%20Agreement.pdf" in out
+
+    def test_filename_with_quotes_escaped_in_ascii_form(self) -> None:
+        out = build_attachment_disposition('a"b.pdf')
+        assert 'filename="a\\"b.pdf"' in out
+
+    def test_unicode_filename_uses_filename_star(self) -> None:
+        out = build_attachment_disposition("계약서.pdf")
+        # Korean chars become %-escaped in the RFC 5987 form.
+        assert "filename*=UTF-8''" in out
+        assert "%EA%B3%84%EC%95%BD%EC%84%9C.pdf" in out

--- a/apps/mybookkeeper/backend/tests/test_storage.py
+++ b/apps/mybookkeeper/backend/tests/test_storage.py
@@ -161,6 +161,22 @@ class TestStorageClientMethods:
         assert call[0][0] == "test-bucket"
         assert call[0][1] == "org/uuid/photo.jpg"
         assert call.kwargs["expires"] == timedelta(seconds=3600)
+        # No response-content-disposition by default — listing photos
+        # rely on the omitted query param so the browser displays inline.
+        assert call.kwargs["response_headers"] is None
+
+    def test_generate_presigned_url_passes_content_disposition(self) -> None:
+        client, mock_minio = self._make_client()
+        mock_minio.presigned_get_object.return_value = "https://signed-url"
+        client.generate_presigned_url(
+            "signed-leases/x/y",
+            3600,
+            response_content_disposition='attachment; filename="Lease.pdf"',
+        )
+        call = mock_minio.presigned_get_object.call_args
+        assert call.kwargs["response_headers"] == {
+            "response-content-disposition": 'attachment; filename="Lease.pdf"',
+        }
 
     def test_head_object_returns_metadata_when_present(self) -> None:
         client, mock_minio = self._make_client()
@@ -212,6 +228,23 @@ class TestDualEndpointStorageClient:
         assert url == "https://storage.example.com/signed"
         public.presigned_get_object.assert_called_once()
         internal.presigned_get_object.assert_not_called()
+
+    def test_presigned_url_disposition_propagates_to_public_client(self) -> None:
+        internal = MagicMock()
+        public = MagicMock()
+        public.presigned_get_object.return_value = "https://storage.example.com/signed"
+        client = _DualEndpointStorageClient(internal, public, "bucket")
+
+        client.generate_presigned_url(
+            "signed-leases/x/y",
+            3600,
+            response_content_disposition='attachment; filename="Lease.pdf"',
+        )
+
+        call = public.presigned_get_object.call_args
+        assert call.kwargs["response_headers"] == {
+            "response-content-disposition": 'attachment; filename="Lease.pdf"',
+        }
 
     def test_uploads_go_to_internal_client(self) -> None:
         internal = MagicMock()


### PR DESCRIPTION
## Summary

The user reported that downloading a lease attachment saved the file under its storage-key GUID — completely opaque, no extension, no hint at what the file was. This wires a human-readable filename onto every lease attachment download, and the filename reflects the document's signing state.

- `Lease Agreement.docx` (unsigned by both)
- `Lease Agreement - tenant signed.pdf` (signed by tenant only)
- `Lease Agreement - fully signed.pdf` (signed by both)
- Other attachment kinds (inspections, insurance, addenda) keep their original filename, no suffix.

## What changed

**Schema** — adds `signed_by_tenant_at` and `signed_by_landlord_at` (timestamptz, nullable) to `signed_lease_attachments`. Migration `leasesign260507` is forward-only with no backfill — every existing row inherits `NULL` which is the correct retroactive label.

**Pure helper** — `services/leases/lease_filename.py::friendly_download_filename` derives the human filename from the four fields (`filename`, `kind`, `signed_by_tenant_at`, `signed_by_landlord_at`). 11 unit tests pin every branch.

**Presigned-URL plumbing** — `StorageClient.generate_presigned_url` now accepts `response_content_disposition` and forwards it to MinIO via the `response-content-disposition` query param. The shared `attach_presigned_url_with_head_check` accepts a `download_filename_resolver` callback. Lease attachments opt in through `attach_presigned_urls_to_attachments`; listing photos and other inline-displayed assets keep the existing inline behavior.

**API** — `PATCH /signed-leases/{lease_id}/attachments/{attachment_id}/signing-state` with `{signed_by_tenant_at?: ISO, signed_by_landlord_at?: ISO}`. Sentinel partial PATCH semantics: keys absent leave the column untouched, explicit `null` clears the signature. Same composite-WHERE IDOR guard as the existing kind-update path.

**Frontend wire-up** — out of scope for this PR; the suffix logic is in place so the moment the host marks a row as signed (via API or a future UI), the next download lands under the correct filename.

## Test plan

- [x] 11 helper unit tests (`test_lease_filename.py`)
- [x] Storage client accepts `response_content_disposition` (single + dual endpoint)
- [x] Attacher passes the disposition through, skips when resolver returns None, skips when no resolver
- [x] Lease seam end-to-ends all four user-spec cases through `attach_presigned_urls_to_attachments`
- [x] PATCH endpoint: partial PATCH, explicit null, unknown field 422, cross-tenant 404, attachment-not-found 404
- [x] Full backend suite: 2566 passed, 5 skipped
- [x] `uv lock --check` clean
- [x] `npm run build` (mbk frontend) clean

## ⚠️ Operational migration required

After this PR merges, the next deploy runs Alembic migration `leasesign260507` which adds two nullable `timestamptz` columns to `signed_lease_attachments`. No backfill needed. Forward-only.

### How to verify

```bash
docker compose -f apps/mybookkeeper/docker-compose.yml exec api alembic current
# Should show: leasesign260507 (head)
```

### Rollback path

The migration's `downgrade` drops the two columns. To revert: revert this PR in main AND run `alembic downgrade -1` in the same deploy. The previous image expects the columns to be absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)