### PR TITLE
fix(mybookkeeper/leases): PDF preview opens in modal + signature row no longer wraps

### DIFF
--- a/apps/mybookkeeper/backend/app/services/leases/renderer.py
+++ b/apps/mybookkeeper/backend/app/services/leases/renderer.py
@@ -36,7 +36,13 @@ import re
 
 logger = logging.getLogger(__name__)
 
-SIGNATURE_LINE = "_______________________________"
+# Signature underscore line — kept moderate (20 chars) so a typical
+# "Landlord (Name): _____ Date: _____" row fits on a single line in
+# the rendered PDF without wrapping. Signers write across this width.
+SIGNATURE_LINE = "____________________"
+# Bare [DATE] gets a shorter line — dates are short ("MM/DD/YYYY") so
+# a 12-underscore slot is plenty.
+DATE_LINE = "____________"
 _SIGNATURE_KEY_RE = re.compile(r"\[([A-Z][A-Z0-9 _\-]*?SIGNATURE)\]")
 # ``[DATE]`` (bare) next to a signature line must be left blank for the signer
 # to write in — same treatment as SIGNATURE keys. ``[EFFECTIVE DATE]`` is a
@@ -65,7 +71,7 @@ def _augment_with_signature_lines(
         if key not in augmented:
             augmented[key] = SIGNATURE_LINE
     if _DATE_KEY_RE.search(template_text) and "DATE" not in augmented:
-        augmented["DATE"] = SIGNATURE_LINE
+        augmented["DATE"] = DATE_LINE
     return augmented
 
 

--- a/apps/mybookkeeper/backend/tests/test_lease_renderer.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_renderer.py
@@ -19,7 +19,7 @@ from app.services.leases.placeholder_extractor import (
     extract_placeholders_across_files,
     normalise_key,
 )
-from app.services.leases.renderer import SIGNATURE_LINE, render_md
+from app.services.leases.renderer import DATE_LINE, SIGNATURE_LINE, render_md
 
 
 # ---------------------------------------------------------------------------
@@ -81,16 +81,21 @@ class TestRenderMd:
         assert SIGNATURE_LINE not in out
 
     def test_bare_date_renders_as_blank_line_when_unset(self) -> None:
-        """``[DATE]`` next to a signature must render as a blank signing line."""
+        """``[DATE]`` next to a signature must render as a blank date slot.
+
+        Distinct from SIGNATURE_LINE: dates are short (MM/DD/YYYY) so we
+        use a narrower DATE_LINE to keep the row from wrapping in the PDF.
+        """
         out = render_md("Landlord: [LANDLORD SIGNATURE]  Date: [DATE]", {})
         assert "[DATE]" not in out
-        # Two underscore lines: one for the signature, one for the date slot.
-        assert out.count(SIGNATURE_LINE) == 2
+        assert SIGNATURE_LINE in out
+        assert DATE_LINE in out
 
     def test_bare_date_value_wins_over_blank_line(self) -> None:
         """A caller-supplied DATE value still wins over the blank-line default."""
         out = render_md("Date: [DATE]", {"DATE": "2026-05-30"})
         assert out == "Date: 2026-05-30"
+        assert DATE_LINE not in out
         assert SIGNATURE_LINE not in out
 
     def test_effective_date_does_not_get_blank_line_treatment(self) -> None:
@@ -98,6 +103,7 @@ class TestRenderMd:
         out = render_md("Effective: [EFFECTIVE DATE]", {})
         assert "[EFFECTIVE DATE]" in out
         assert SIGNATURE_LINE not in out
+        assert DATE_LINE not in out
 
     def test_duplicate_signature_placeholder_each_replaced(self) -> None:
         """Each occurrence of the same SIGNATURE key must be replaced — not just the first."""

--- a/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewerPdfBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/AttachmentViewerPdfBody.tsx
@@ -1,16 +1,57 @@
+import { useEffect, useState } from "react";
+
 export interface AttachmentViewerPdfBodyProps {
   url: string;
   filename: string;
 }
 
+/**
+ * The presigned URL carries ``Content-Disposition: attachment; filename=…``
+ * (PR #392) so saved-to-disk downloads use the friendly filename. The same
+ * header forces browsers to download — not render inline — when the URL is
+ * loaded directly into an ``<iframe src>``. To preview the PDF in the modal
+ * we fetch the bytes ourselves and feed the iframe a blob: URL, which
+ * always renders inline regardless of the original response disposition.
+ */
 export default function AttachmentViewerPdfBody({
   url,
   filename,
 }: AttachmentViewerPdfBodyProps) {
+  const [blobUrl, setBlobUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    let createdUrl: string | null = null;
+    fetch(url, { signal: controller.signal })
+      .then((r) => (r.ok ? r.blob() : Promise.reject(r.statusText)))
+      .then((blob) => {
+        createdUrl = URL.createObjectURL(blob);
+        setBlobUrl(createdUrl);
+      })
+      .catch(() => {
+        // Modal already shows the "Open in new tab" affordance; silent here.
+      });
+    return () => {
+      controller.abort();
+      if (createdUrl) URL.revokeObjectURL(createdUrl);
+    };
+  }, [url]);
+
+  if (blobUrl === null) {
+    return (
+      <div
+        className="h-full bg-white rounded-b-lg flex items-center justify-center"
+        data-testid="attachment-viewer-pdf-loading"
+      >
+        <div className="text-sm text-muted-foreground">Loading…</div>
+      </div>
+    );
+  }
+
   return (
     <div className="h-full bg-white rounded-b-lg">
       <iframe
-        src={url}
+        src={blobUrl}
         className="w-full h-full"
         title={filename}
         data-testid="attachment-viewer-iframe"


### PR DESCRIPTION
Two UX fixes:
1. PDF preview was opening in a new browser tab instead of the modal because PR #392's Content-Disposition: attachment forced the iframe to download. Fix: fetch + blob URL.
2. Signature row wrapped because SIGNATURE_LINE was 31 chars. Shortened to 20 + separate 12-char DATE_LINE for the date slot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)