### PR TITLE
chore(infra): prepare codebase for myfreeapps.org domain switch

### DIFF
--- a/apps/mybookkeeper/backend/.env.docker.example
+++ b/apps/mybookkeeper/backend/.env.docker.example
@@ -19,10 +19,10 @@ ENCRYPTION_KEY=change-me-to-random-64-chars
 ANTHROPIC_API_KEY=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
-FRONTEND_URL=https://your-domain.com
-CORS_ORIGINS=["https://your-domain.com"]
-OAUTH_REDIRECT_URI=https://your-domain.com/api/integrations/gmail/callback
-GOOGLE_OAUTH_REDIRECT_URI=https://your-domain.com/api/integrations/gmail/callback
+FRONTEND_URL=https://mybookkeeper.myfreeapps.org
+CORS_ORIGINS=["https://mybookkeeper.myfreeapps.org"]
+OAUTH_REDIRECT_URI=https://mybookkeeper.myfreeapps.org/api/integrations/gmail/callback
+GOOGLE_OAUTH_REDIRECT_URI=https://mybookkeeper.myfreeapps.org/api/integrations/gmail/callback
 RUN_UPLOAD_WORKER=false
 
 # Cloudflare Turnstile CAPTCHA — required when ENVIRONMENT=production.
@@ -53,7 +53,7 @@ SMTP_PASSWORD=
 # Bring up the infra stack first: docker compose -f infra/docker-compose.yml up -d
 # See infra/MIGRATION.md for the migration runbook.
 MINIO_ENDPOINT=myfreeapps-minio:9000
-MINIO_PUBLIC_ENDPOINT=https://storage.your-domain.com
+MINIO_PUBLIC_ENDPOINT=https://storage.myfreeapps.org
 MINIO_ACCESS_KEY=
 MINIO_SECRET_KEY=
 MINIO_BUCKET=mybookkeeper-files

--- a/apps/mybookkeeper/deploy/setup.sh
+++ b/apps/mybookkeeper/deploy/setup.sh
@@ -24,7 +24,8 @@ read -rp "Google Client Secret: " GOOGLE_CLIENT_SECRET
 
 APP_DIR=/srv/mybookkeeper
 SERVER_IP=$(curl -s ifconfig.me 2>/dev/null || hostname -I | awk '{print $1}')
-DOMAIN=$(echo $SERVER_IP | tr '.' '-').sslip.io
+# Default to the production domain; override with DOMAIN env var for staging/dev VPS.
+DOMAIN=${DOMAIN:-mybookkeeper.myfreeapps.org}
 DB_URL="postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@localhost/mybookkeeper"
 SECRET_KEY=$(openssl rand -hex 32)
 ENCRYPTION_KEY=$(openssl rand -hex 32)

--- a/apps/myjobhunter/.env.example
+++ b/apps/myjobhunter/.env.example
@@ -1,2 +1,2 @@
 DB_PASSWORD=change-me
-DOMAIN=myjobhunter.165-245-134-251.sslip.io
+DOMAIN=myjobhunter.myfreeapps.org

--- a/apps/myjobhunter/CLAUDE.md
+++ b/apps/myjobhunter/CLAUDE.md
@@ -177,19 +177,19 @@ vim apps/myjobhunter/backend/.env.docker
 
 The seed script reads safe-to-reuse keys from MBK's running config (Anthropic API key, lockout
 tunables, log level) and generates fresh secrets for per-app values (SECRET_KEY, ENCRYPTION_KEY,
-DB_PASSWORD). FRONTEND_URL and CORS_ORIGINS are pre-filled with the sslip.io domain.
+DB_PASSWORD). FRONTEND_URL and CORS_ORIGINS are pre-filled with the myfreeapps.org domain.
 
 **Day-to-day deploys:** Push to main or merge a PR — GitHub Actions deploys automatically.
 
 **Routing:**
-- Domain: `myjobhunter.165-245-134-251.sslip.io`
+- Domain: `myjobhunter.myfreeapps.org`
 - Host Caddy (TLS termination at `/etc/caddy/Caddyfile`) proxies to docker Caddy on `127.0.0.1:8092`
 - Docker Caddy (baked into caddy image) owns routing, security headers, CSP, SPA fallback, and `/api/*` → backend proxy
 
 **Health check:**
 ```bash
 curl http://127.0.0.1:8092/health    # from VPS (bypasses host Caddy)
-curl https://myjobhunter.165-245-134-251.sslip.io/health  # public
+curl https://myjobhunter.myfreeapps.org/health  # public
 ```
 
 **Database backup/restore:**

--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -25,8 +25,8 @@ GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
 # Frontend / CORS
-FRONTEND_URL=https://myjobhunter.165-245-134-251.sslip.io
-CORS_ORIGINS=["https://myjobhunter.165-245-134-251.sslip.io"]
+FRONTEND_URL=https://myjobhunter.myfreeapps.org
+CORS_ORIGINS=["https://myjobhunter.myfreeapps.org"]
 
 # JWT
 JWT_LIFETIME_SECONDS=1800
@@ -77,7 +77,7 @@ SMTP_PASSWORD=
 # generate via: docker exec myfreeapps-minio mc admin user add local <key> <secret>
 # Then attach: docker exec myfreeapps-minio mc admin policy attach local readwrite --user=<key>
 MINIO_ENDPOINT=myfreeapps-minio:9000
-MINIO_PUBLIC_ENDPOINT=https://storage.165-245-134-251.sslip.io
+MINIO_PUBLIC_ENDPOINT=https://storage.myfreeapps.org
 MINIO_ACCESS_KEY=
 MINIO_SECRET_KEY=
 MINIO_BUCKET=myjobhunter-files

--- a/apps/myjobhunter/scripts/seed-env-from-mbk.sh
+++ b/apps/myjobhunter/scripts/seed-env-from-mbk.sh
@@ -89,8 +89,8 @@ LOGIN_RATE_LIMIT_WINDOW_SECONDS=$(get_mbk LOGIN_RATE_LIMIT_WINDOW_SECONDS)
     echo "GOOGLE_CLIENT_SECRET="
     echo "TURNSTILE_SECRET_KEY="
     echo "TURNSTILE_SITE_KEY="
-    echo "FRONTEND_URL=https://myjobhunter.165-245-134-251.sslip.io"
-    echo 'CORS_ORIGINS=["https://myjobhunter.165-245-134-251.sslip.io"]'
+    echo "FRONTEND_URL=https://myjobhunter.myfreeapps.org"
+    echo 'CORS_ORIGINS=["https://myjobhunter.myfreeapps.org"]'
     echo ""
     echo "EMAIL_BACKEND=console"
     echo "EMAIL_FROM_NAME=MyJobHunter"

--- a/infra/bootstrap-app-minio.sh
+++ b/infra/bootstrap-app-minio.sh
@@ -78,7 +78,7 @@ APP_COMPOSE="$APP_DIR/docker-compose.yml"
 INFRA_ENV="$REPO_ROOT/infra/.env"
 MINIO_CONTAINER="myfreeapps-minio"
 BUCKET="${APP_SLUG}-files"
-PUBLIC_ENDPOINT="https://storage.165-245-134-251.sslip.io"
+PUBLIC_ENDPOINT="https://storage.myfreeapps.org"
 
 [[ -d "$APP_DIR" ]]      || { red "missing: $APP_DIR"; exit 1; }
 [[ -f "$APP_ENV_FILE" ]] || { red "missing: $APP_ENV_FILE"; exit 1; }


### PR DESCRIPTION
## Summary

Updates all example files, one-time setup scripts, and docs to reference the new `myfreeapps.org` subdomains instead of the temporary `sslip.io` addresses. **Nothing in the production runtime path is changed by this PR.** The VPS env files at `/srv/myfreeapps/apps/*/backend/.env.docker` continue to use `sslip.io` until the operator manually flips them per the checklist below.

### Domain mapping

| Old (sslip.io) | New (myfreeapps.org) |
|---|---|
| `165-245-134-251.sslip.io` | `mybookkeeper.myfreeapps.org` |
| `myjobhunter.165-245-134-251.sslip.io` | `myjobhunter.myfreeapps.org` |
| `storage.165-245-134-251.sslip.io` | `storage.myfreeapps.org` |

### Files changed

- `apps/mybookkeeper/backend/.env.docker.example` — `FRONTEND_URL`, `CORS_ORIGINS`, `OAUTH_REDIRECT_URI`, `GOOGLE_OAUTH_REDIRECT_URI`, `MINIO_PUBLIC_ENDPOINT`
- `apps/mybookkeeper/deploy/setup.sh` — replaced the IP-derived `sslip.io` domain with `DOMAIN=${DOMAIN:-mybookkeeper.myfreeapps.org}` (operator can override with `DOMAIN=custom.example.com bash setup.sh` for staging VPS)
- `apps/myjobhunter/.env.example` — `DOMAIN` value
- `apps/myjobhunter/backend/.env.docker.example` — `FRONTEND_URL`, `CORS_ORIGINS`, `MINIO_PUBLIC_ENDPOINT`
- `apps/myjobhunter/scripts/seed-env-from-mbk.sh` — default `FRONTEND_URL` / `CORS_ORIGINS` written to new env files
- `infra/bootstrap-app-minio.sh` — `PUBLIC_ENDPOINT`
- `apps/myjobhunter/CLAUDE.md` — doc references to health check URLs and seed script description

### What is intentionally NOT changed

- `infra/Caddyfile` — the shared host Caddyfile (synced to `/etc/caddy/Caddyfile` on deploy) must be updated **after** DNS propagates. Updating it before would cause Caddy's ACME TLS provisioning to fail because the new domain names won't have A records pointing to the VPS yet. See step 7 in the checklist below.
- Live VPS env files at `/srv/myfreeapps/apps/*/backend/.env.docker` — these are outside the repo and are flipped manually per the checklist.
- The project memory at `~/.claude/projects/.../memory/project_app_domains_and_sentry.md` — that's in the auto-memory tier (not in this repo). Update it manually or via `/curate-memory` after the domain switch is live.

---

## ⚠️ User action required — ordered steps to flip production

These steps must be completed **in order** after this PR merges. The app continues serving on sslip.io until step 8.

**1. Buy `myfreeapps.org` from a registrar**
   - Namecheap, Cloudflare Registrar, or your preferred registrar.

**2. Create DNS A records pointing to VPS IP `165.245.134.251`**
   ```
   mybookkeeper.myfreeapps.org  →  165.245.134.251
   myjobhunter.myfreeapps.org   →  165.245.134.251
   storage.myfreeapps.org       →  165.245.134.251
   myfreeapps.org               →  165.245.134.251  (apex, optional)
   ```

**3. Wait for DNS to propagate (~5–30 min; up to 48 h for some registrars)**
   ```bash
   dig +short mybookkeeper.myfreeapps.org
   # Must return: 165.245.134.251
   ```

**4. Update Google Cloud Console — OAuth redirect URIs**

   In [Google Cloud Console → APIs & Services → Credentials](https://console.cloud.google.com/apis/credentials), add these authorized redirect URIs to your OAuth 2.0 client:
   ```
   https://mybookkeeper.myfreeapps.org/api/integrations/gmail/callback
   ```
   (MJH doesn't use Gmail OAuth yet, so no MJH entry needed at this step.)

**5. Generate new Cloudflare Turnstile site keys for the new domains**

   Turnstile site keys are bound to the origin domain. Go to [Cloudflare Turnstile dashboard](https://dash.cloudflare.com/?to=/:account/turnstile):
   - Create a new widget for `mybookkeeper.myfreeapps.org` → get new `VITE_TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY`
   - Create a new widget for `myjobhunter.myfreeapps.org` → get new `VITE_TURNSTILE_SITE_KEY` + `TURNSTILE_SECRET_KEY`

**6. SSH to VPS — update env files**
   ```bash
   ssh deploy@165.245.134.251

   # MyBookkeeper
   vim /srv/myfreeapps/apps/mybookkeeper/backend/.env.docker
   # Update:
   #   FRONTEND_URL=https://mybookkeeper.myfreeapps.org
   #   CORS_ORIGINS=["https://mybookkeeper.myfreeapps.org"]
   #   OAUTH_REDIRECT_URI=https://mybookkeeper.myfreeapps.org/api/integrations/gmail/callback
   #   GOOGLE_OAUTH_REDIRECT_URI=https://mybookkeeper.myfreeapps.org/api/integrations/gmail/callback
   #   MINIO_PUBLIC_ENDPOINT=https://storage.myfreeapps.org
   #   TURNSTILE_SECRET_KEY=<new MBK secret key>
   #   VITE_TURNSTILE_SITE_KEY=<new MBK site key>   ← also in .env.docker for build args

   # MyJobHunter
   vim /srv/myfreeapps/apps/myjobhunter/backend/.env.docker
   # Update:
   #   FRONTEND_URL=https://myjobhunter.myfreeapps.org
   #   CORS_ORIGINS=["https://myjobhunter.myfreeapps.org"]
   #   MINIO_PUBLIC_ENDPOINT=https://storage.myfreeapps.org
   #   TURNSTILE_SECRET_KEY=<new MJH secret key>
   #   TURNSTILE_SITE_KEY=<new MJH site key>

   # Compose-level DOMAIN for MJH
   vim /srv/myfreeapps/apps/myjobhunter/.env
   # Update:
   #   DOMAIN=myjobhunter.myfreeapps.org
   ```

**7. Update and reload `infra/Caddyfile` on the VPS**

   Edit `/etc/caddy/Caddyfile` on the VPS. Replace the sslip.io site blocks with the new domains:
   ```
   # Before:
   165-245-134-251.sslip.io { ... }
   myjobhunter.165-245-134-251.sslip.io { ... }
   storage.165-245-134-251.sslip.io { ... }

   # After:
   mybookkeeper.myfreeapps.org { ... }
   myjobhunter.myfreeapps.org { ... }
   storage.myfreeapps.org { ... }
   ```
   Then reload:
   ```bash
   caddy reload --config /etc/caddy/Caddyfile
   # Caddy will auto-provision TLS certs from Let's Encrypt for the new domains.
   ```

   **Do this step only after DNS has propagated** (step 3 check passes). Reloading Caddy before DNS is ready will cause ACME challenges to fail and the old certs to be abandoned before new ones are issued.

**8. Trigger a redeploy**
   ```bash
   # Either push any commit to main, OR run manually on VPS:
   sudo mybookkeeper-update
   # and/or:
   docker compose -f /srv/myfreeapps/apps/myjobhunter/docker-compose.yml pull && \
   docker compose -f /srv/myfreeapps/apps/myjobhunter/docker-compose.yml up -d
   ```
   The frontend bundle must be rebuilt with the new `VITE_TURNSTILE_SITE_KEY` value baked in.

**9. Verify**
   ```bash
   curl -s https://mybookkeeper.myfreeapps.org/health | jq .
   curl -s https://myjobhunter.myfreeapps.org/health | jq .
   # Visit both URLs in a browser and confirm login + registration work
   ```

---

## Test plan

- [x] `uv lock --check` passes (no Python dep changes)
- [x] Grep for `sslip.io` and `your-domain.com` across all modified files returns zero hits
- [ ] After domain switch: health checks return 200 on both new domains
- [ ] After domain switch: registration flow completes with Turnstile on both apps
- [ ] After domain switch: Gmail OAuth redirect works on MyBookkeeper