### PR TITLE
fix(mybookkeeper/leases): default auto_email_tenant to FALSE (manual sends only)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/noaut260507_default_auto_email_tenant_to_false.py
+++ b/apps/mybookkeeper/backend/alembic/versions/noaut260507_default_auto_email_tenant_to_false.py
@@ -1,0 +1,51 @@
+"""signed_leases: flip auto_email_tenant default from true → false
+
+Operator preferred manual control over every tenant email instead of
+opt-out automation. Two changes:
+
+1. Flip the column ``server_default`` so new rows default to FALSE.
+2. Backfill existing rows where ``last_emailed_to_tenant_at IS NULL``
+   to FALSE — i.e. leases that haven't already triggered an
+   auto-email won't suddenly fire on the next regenerate.
+
+Leases that already auto-emailed (``last_emailed_to_tenant_at IS NOT
+NULL``) are left alone — their ``auto_email_tenant`` value is now
+moot anyway since the idempotency gate prevents a second send.
+
+Revision ID: noaut260507
+Revises: leasemail260507
+Create Date: 2026-05-07 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "noaut260507"
+down_revision: Union[str, None] = "leasemail260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "signed_leases",
+        "auto_email_tenant",
+        server_default=sa.false(),
+    )
+    op.execute(
+        sa.text(
+            "UPDATE signed_leases "
+            "SET auto_email_tenant = false "
+            "WHERE auto_email_tenant = true "
+            "  AND last_emailed_to_tenant_at IS NULL"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "signed_leases",
+        "auto_email_tenant",
+        server_default=sa.true(),
+    )

--- a/apps/mybookkeeper/backend/app/models/leases/signed_lease.py
+++ b/apps/mybookkeeper/backend/app/models/leases/signed_lease.py
@@ -102,11 +102,13 @@ class SignedLease(Base):
 
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
 
-    # Auto-email-tenant behaviour. Default TRUE so the feature is opt-out.
-    # Cleared to FALSE per-lease via ``PATCH /signed-leases/{id}`` when the
-    # host wants to deliver the document by another channel.
+    # Auto-email-tenant behaviour. Default FALSE — the host opts in per-lease
+    # via ``PATCH /signed-leases/{id}`` (or sends manually via the
+    # "Email to tenant" button on the detail page). Default flipped from
+    # TRUE → FALSE on 2026-05-07 because the operator preferred manual
+    # control over every send.
     auto_email_tenant: Mapped[bool] = mapped_column(
-        Boolean, nullable=False, default=True, server_default=text("true"),
+        Boolean, nullable=False, default=False, server_default=text("false"),
     )
     # Stamped on first successful auto-email send. Used as the idempotency
     # gate so a Regenerate does not re-send. ``POST /signed-leases/{id}/email-tenant``


### PR DESCRIPTION
Operator wants manual sends only. Flips column default + backfills un-emailed leases. The 'Email to tenant' button still works for explicit sends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)