### PR TITLE
feat(mjh/discovery): schema for proactive job discovery

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/disco260507_discovery_tables.py
+++ b/apps/myjobhunter/backend/alembic/versions/disco260507_discovery_tables.py
@@ -1,0 +1,480 @@
+"""Add discovery tables: discovery_sources, discovery_fetches, discovered_jobs.
+
+Backs the new /discover surface — proactive discovery of job postings from
+public feeds (Greenhouse / Lever / Ashby / RemoteOK / HN) and aggregator
+APIs (FlyByAPIs wrapping Google Jobs for LinkedIn / Indeed coverage).
+
+Three tables ship together because they form a single coherent feature
+(operator config → fetch audit → discovered postings) and partial indexes
+on discovered_jobs reference all three states.
+
+Also extends two existing CHECK constraints:
+
+- ``application_events.source`` gains ``'discovery'`` so the kanban can
+  show provenance when the operator promotes a discovered job to an
+  application.
+
+- ``extraction_logs.context_type`` gains ``'job_analysis'`` so per-feature
+  cost rollups distinguish discovery scoring from the existing
+  one-off /analyze flow. The previous code abused ``'other'`` for this.
+
+Reversible: downgrade drops the three tables in reverse FK order, then
+restores the original CHECK constraints.
+
+Revision ID: disco260507
+Revises: cresdesc260507
+Create Date: 2026-05-07
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+revision: str = "disco260507"
+down_revision: Union[str, None] = "cresdesc260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_DISCOVERY_SOURCE_KINDS = (
+    "greenhouse",
+    "lever",
+    "ashby",
+    "remoteok",
+    "hn_who_is_hiring",
+    "workatastartup",
+    "flybyapis",
+    "other",
+)
+_FETCH_STATUSES = ("running", "success", "partial", "error")
+_REMOTE_TYPES = ("remote", "hybrid", "onsite", "unknown")
+_SALARY_PERIODS = ("annual", "hourly", "monthly")
+
+_OLD_APPEVENT_SOURCES = ("manual", "gmail", "calendar", "extension", "system")
+_NEW_APPEVENT_SOURCES = _OLD_APPEVENT_SOURCES + ("discovery",)
+
+_OLD_EXTRACTION_CONTEXTS = (
+    "resume_parse",
+    "jd_parse",
+    "company_research",
+    "cover_letter",
+    "resume_tailor",
+    "email_classify",
+    "other",
+)
+_NEW_EXTRACTION_CONTEXTS = (
+    "resume_parse",
+    "jd_parse",
+    "company_research",
+    "cover_letter",
+    "resume_tailor",
+    "email_classify",
+    "job_analysis",
+    "other",
+)
+
+
+def _quote_list(values: tuple[str, ...]) -> str:
+    return ",".join(f"'{v}'" for v in values)
+
+
+def upgrade() -> None:
+    # 1. discovery_sources — per-user saved-search rows. The fetch worker
+    #    polls this table to find what's due to refresh.
+    op.create_table(
+        "discovery_sources",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.String(30), nullable=False),
+        sa.Column(
+            "config",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "is_active",
+            sa.Boolean,
+            nullable=False,
+            server_default=sa.text("true"),
+        ),
+        sa.Column(
+            "fetch_interval_minutes",
+            sa.SmallInteger,
+            nullable=False,
+            server_default="1440",
+        ),
+        sa.Column("last_fetched_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_success_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_error_message", sa.Text, nullable=True),
+        sa.Column(
+            "last_seen_posted_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+        sa.Column(
+            "consecutive_failures",
+            sa.SmallInteger,
+            nullable=False,
+            server_default="0",
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            f"source IN ({_quote_list(_DISCOVERY_SOURCE_KINDS)})",
+            name="chk_discovery_source",
+        ),
+        sa.CheckConstraint(
+            "fetch_interval_minutes >= 15",
+            name="chk_discovery_fetch_interval_pos",
+        ),
+        sa.CheckConstraint(
+            "consecutive_failures >= 0",
+            name="chk_discovery_consecutive_failures",
+        ),
+    )
+    op.create_index(
+        "ix_discovery_source_user", "discovery_sources", ["user_id"],
+    )
+    op.create_index(
+        "uq_discovery_source_user_kind",
+        "discovery_sources",
+        ["user_id", "source"],
+        unique=True,
+        postgresql_where=sa.text("is_active = true"),
+    )
+    op.create_index(
+        "ix_discovery_source_due",
+        "discovery_sources",
+        ["last_fetched_at"],
+        postgresql_where=sa.text("is_active = true"),
+    )
+
+    # 2. discovery_fetches — append-only audit of every fetch cycle. One
+    #    row per (source × tick). Crash detection: rows with status='running'
+    #    older than 30 minutes are reaped to 'error'.
+    op.create_table(
+        "discovery_fetches",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "discovery_source_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("discovery_sources.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.String(30), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(20),
+            nullable=False,
+            server_default="running",
+        ),
+        sa.Column("http_status", sa.SmallInteger, nullable=True),
+        sa.Column(
+            "fetched_count", sa.Integer, nullable=False, server_default="0",
+        ),
+        sa.Column(
+            "new_count", sa.Integer, nullable=False, server_default="0",
+        ),
+        sa.Column(
+            "updated_count", sa.Integer, nullable=False, server_default="0",
+        ),
+        sa.Column("duration_ms", sa.Integer, nullable=True),
+        sa.Column("error_message", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            f"status IN ({_quote_list(_FETCH_STATUSES)})",
+            name="chk_discovery_fetch_status",
+        ),
+    )
+    op.create_index(
+        "ix_discovery_fetch_user_started",
+        "discovery_fetches",
+        ["user_id", "started_at"],
+    )
+    op.create_index(
+        "ix_discovery_fetch_source_started",
+        "discovery_fetches",
+        ["discovery_source_id", "started_at"],
+    )
+
+    # 3. discovered_jobs — the inbox. Per-user rows; same posting from
+    #    another user gets its own row (per-user scale at v1, refactor
+    #    to shared cache when MJH crosses ~10 active users).
+    op.create_table(
+        "discovered_jobs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column(
+            "user_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("source", sa.String(30), nullable=False),
+        sa.Column("source_external_id", sa.String(255), nullable=False),
+        sa.Column("source_publisher", sa.String(50), nullable=True),
+        sa.Column("source_url", sa.Text, nullable=True),
+        sa.Column("title", sa.String(300), nullable=False),
+        sa.Column("company_name", sa.String(300), nullable=False),
+        sa.Column(
+            "company_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("companies.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("location", sa.String(300), nullable=True),
+        sa.Column(
+            "remote_type",
+            sa.String(20),
+            nullable=False,
+            server_default="unknown",
+        ),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("description_normalized", sa.Text, nullable=True),
+        sa.Column("content_hash", sa.String(64), nullable=True),
+        sa.Column("posted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "discovered_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("expired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("salary_min", sa.Numeric(12, 2), nullable=True),
+        sa.Column("salary_max", sa.Numeric(12, 2), nullable=True),
+        sa.Column(
+            "salary_currency",
+            sa.String(3),
+            nullable=True,
+            server_default="USD",
+        ),
+        sa.Column("salary_period", sa.String(10), nullable=True),
+        sa.Column("score", sa.SmallInteger, nullable=True),
+        sa.Column("score_reason", sa.Text, nullable=True),
+        sa.Column("scored_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "scoring_extraction_log_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("extraction_logs.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("dismissed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("saved_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "promoted_application_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("applications.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("promoted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("raw_payload", JSONB, nullable=True),
+        sa.Column(
+            "fetch_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("discovery_fetches.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.CheckConstraint(
+            f"source IN ({_quote_list(_DISCOVERY_SOURCE_KINDS)})",
+            name="chk_discovered_source",
+        ),
+        sa.CheckConstraint(
+            f"remote_type IN ({_quote_list(_REMOTE_TYPES)})",
+            name="chk_discovered_remote_type",
+        ),
+        sa.CheckConstraint(
+            "score IS NULL OR (score >= 0 AND score <= 100)",
+            name="chk_discovered_score",
+        ),
+        sa.CheckConstraint(
+            f"salary_period IS NULL OR salary_period IN ({_quote_list(_SALARY_PERIODS)})",
+            name="chk_discovered_salary_period",
+        ),
+        sa.CheckConstraint(
+            "NOT (dismissed_at IS NOT NULL AND saved_at IS NOT NULL)",
+            name="chk_discovered_state",
+        ),
+        sa.CheckConstraint(
+            "(promoted_application_id IS NULL) = (promoted_at IS NULL)",
+            name="chk_discovered_promoted",
+        ),
+    )
+    op.create_index(
+        "ix_discovered_user_id", "discovered_jobs", ["user_id"],
+    )
+    # Primary dedup: same posting refetched from same source. UPSERT on
+    # this constraint advances seen_at without resetting state columns.
+    op.create_index(
+        "uq_discovered_user_source_extid",
+        "discovered_jobs",
+        ["user_id", "source", "source_external_id"],
+        unique=True,
+    )
+    # Cross-source dedup on active rows. Same posting on Greenhouse + an
+    # aggregator → keep the first; aggregator dup is silently dropped.
+    op.create_index(
+        "uq_discovered_user_content_hash",
+        "discovered_jobs",
+        ["user_id", "content_hash"],
+        unique=True,
+        postgresql_where=sa.text(
+            "content_hash IS NOT NULL AND dismissed_at IS NULL",
+        ),
+    )
+    # Inbox query: undismissed/unsaved/unpromoted, score DESC then newest.
+    op.create_index(
+        "ix_discovered_inbox",
+        "discovered_jobs",
+        ["user_id", "score", "discovered_at"],
+        postgresql_where=sa.text(
+            "dismissed_at IS NULL "
+            "AND saved_at IS NULL "
+            "AND promoted_application_id IS NULL"
+        ),
+    )
+    op.create_index(
+        "ix_discovered_saved",
+        "discovered_jobs",
+        ["user_id", "saved_at"],
+        postgresql_where=sa.text(
+            "saved_at IS NOT NULL AND dismissed_at IS NULL",
+        ),
+    )
+    op.create_index(
+        "ix_discovered_promoted_app",
+        "discovered_jobs",
+        ["promoted_application_id"],
+        postgresql_where=sa.text("promoted_application_id IS NOT NULL"),
+    )
+    op.create_index(
+        "ix_discovered_score_pending",
+        "discovered_jobs",
+        ["user_id", "discovered_at"],
+        postgresql_where=sa.text("score IS NULL"),
+    )
+    op.create_index(
+        "ix_discovered_company",
+        "discovered_jobs",
+        ["user_id", "company_id"],
+        postgresql_where=sa.text("company_id IS NOT NULL"),
+    )
+
+    # 4. Extend application_events.source to permit 'discovery'.
+    op.drop_constraint(
+        "chk_appevent_source", "application_events", type_="check",
+    )
+    op.create_check_constraint(
+        "chk_appevent_source",
+        "application_events",
+        f"source IN ({_quote_list(_NEW_APPEVENT_SOURCES)})",
+    )
+
+    # 5. Extend extraction_logs.context_type to permit 'job_analysis'.
+    op.drop_constraint(
+        "chk_extraction_log_context_type",
+        "extraction_logs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_extraction_log_context_type",
+        "extraction_logs",
+        f"context_type IN ({_quote_list(_NEW_EXTRACTION_CONTEXTS)})",
+    )
+
+
+def downgrade() -> None:
+    # Restore original CHECK constraints first.
+    op.drop_constraint(
+        "chk_extraction_log_context_type",
+        "extraction_logs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_extraction_log_context_type",
+        "extraction_logs",
+        f"context_type IN ({_quote_list(_OLD_EXTRACTION_CONTEXTS)})",
+    )
+
+    op.drop_constraint(
+        "chk_appevent_source", "application_events", type_="check",
+    )
+    op.create_check_constraint(
+        "chk_appevent_source",
+        "application_events",
+        f"source IN ({_quote_list(_OLD_APPEVENT_SOURCES)})",
+    )
+
+    # Drop in reverse FK dependency order: discovered_jobs → discovery_fetches → discovery_sources.
+    op.drop_index("ix_discovered_company", table_name="discovered_jobs")
+    op.drop_index("ix_discovered_score_pending", table_name="discovered_jobs")
+    op.drop_index("ix_discovered_promoted_app", table_name="discovered_jobs")
+    op.drop_index("ix_discovered_saved", table_name="discovered_jobs")
+    op.drop_index("ix_discovered_inbox", table_name="discovered_jobs")
+    op.drop_index(
+        "uq_discovered_user_content_hash", table_name="discovered_jobs",
+    )
+    op.drop_index(
+        "uq_discovered_user_source_extid", table_name="discovered_jobs",
+    )
+    op.drop_index("ix_discovered_user_id", table_name="discovered_jobs")
+    op.drop_table("discovered_jobs")
+
+    op.drop_index(
+        "ix_discovery_fetch_source_started", table_name="discovery_fetches",
+    )
+    op.drop_index(
+        "ix_discovery_fetch_user_started", table_name="discovery_fetches",
+    )
+    op.drop_table("discovery_fetches")
+
+    op.drop_index(
+        "ix_discovery_source_due", table_name="discovery_sources",
+    )
+    op.drop_index(
+        "uq_discovery_source_user_kind", table_name="discovery_sources",
+    )
+    op.drop_index(
+        "ix_discovery_source_user", table_name="discovery_sources",
+    )
+    op.drop_table("discovery_sources")

--- a/apps/myjobhunter/backend/alembic/versions/disco260507_discovery_tables.py
+++ b/apps/myjobhunter/backend/alembic/versions/disco260507_discovery_tables.py
@@ -45,7 +45,7 @@ _DISCOVERY_SOURCE_KINDS = (
     "remoteok",
     "hn_who_is_hiring",
     "workatastartup",
-    "flybyapis",
+    "jsearch",
     "other",
 )
 _FETCH_STATUSES = ("running", "success", "partial", "error")

--- a/apps/myjobhunter/backend/app/models/__init__.py
+++ b/apps/myjobhunter/backend/app/models/__init__.py
@@ -29,6 +29,10 @@ from app.models.resume_refinement.turn import ResumeRefinementTurn  # noqa: F401
 
 from app.models.system.extraction_log import ExtractionLog  # noqa: F401
 
+from app.models.discovery.discovery_source import DiscoverySource  # noqa: F401
+from app.models.discovery.discovery_fetch import DiscoveryFetch  # noqa: F401
+from app.models.discovery.discovered_job import DiscoveredJob  # noqa: F401
+
 from app.models.platform.invite import PlatformInvite  # noqa: F401
 
 # Shared models from platform_shared. Importing them here registers their

--- a/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
+++ b/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
@@ -169,7 +169,7 @@ class DiscoveredJob(Base):
     __table_args__ = (
         CheckConstraint(
             "source IN ('greenhouse','lever','ashby','remoteok',"
-            "'hn_who_is_hiring','workatastartup','flybyapis','other')",
+            "'hn_who_is_hiring','workatastartup','jsearch','other')",
             name="chk_discovered_source",
         ),
         CheckConstraint(

--- a/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
+++ b/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
@@ -1,0 +1,249 @@
+"""ORM model for ``discovered_jobs`` — the inbox of proactively-found postings.
+
+Per-user rows: each user gets their own row even for the same posting
+seen by another user. At v1 scale (single-user / small tenant count)
+this is simpler than a shared cache; refactor when MJH crosses ~10
+active users and storage starts mattering.
+
+Lifecycle:
+
+1. Worker fetches from a source, normalizes a posting, upserts on
+   ``(user_id, source, source_external_id)``.
+2. ``score`` / ``scored_at`` populated by a separate scoring job
+   triggered manually by the operator (cost gate).
+3. Operator triages: ``dismissed_at`` (won't reappear) /
+   ``saved_at`` (kept for later) / ``promoted_application_id``
+   (promoted into the applications kanban).
+4. ``expired_at`` set when the source removes the posting upstream.
+
+State invariants:
+
+- ``dismissed_at`` and ``saved_at`` are mutually exclusive
+  (chk_discovered_state).
+- ``promoted_application_id`` and ``promoted_at`` rise/fall together
+  (chk_discovered_promoted).
+
+Indexes:
+
+- ``uq_discovered_user_source_extid``: primary dedup, drives the worker
+  upsert. NOT partial — covers all rows including dismissed/expired so
+  a refetched posting we already dismissed stays dismissed.
+- ``uq_discovered_user_content_hash``: cross-source dedup on active
+  rows. Same posting on Greenhouse + an aggregator → keep the first;
+  the second silently drops at insert time.
+- ``ix_discovered_inbox``: the triage view. Partial WHERE not-dismissed,
+  not-saved, not-promoted keeps the index lean.
+- ``ix_discovered_score_pending``: scoring worker scans for
+  ``score IS NULL`` rows.
+
+PII / untrusted-input note: ``description`` and ``title`` come from
+external sources and may contain prompt-injection vectors. Every Claude
+call that reads ``description`` MUST use a system prompt that explicitly
+ignores embedded instructions (see job_analysis_service.score()).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Numeric,
+    SmallInteger,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class DiscoveredJob(Base):
+    __tablename__ = "discovered_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    source: Mapped[str] = mapped_column(String(30), nullable=False)
+    source_external_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    source_publisher: Mapped[str | None] = mapped_column(
+        String(50), nullable=True,
+    )
+    source_url: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    title: Mapped[str] = mapped_column(String(300), nullable=False)
+    company_name: Mapped[str] = mapped_column(String(300), nullable=False)
+    company_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("companies.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    location: Mapped[str | None] = mapped_column(String(300), nullable=True)
+    remote_type: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="unknown",
+    )
+
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    description_normalized: Mapped[str | None] = mapped_column(
+        Text, nullable=True,
+    )
+    content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    posted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    discovered_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        nullable=False,
+    )
+    expired_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    salary_min: Mapped[float | None] = mapped_column(Numeric(12, 2), nullable=True)
+    salary_max: Mapped[float | None] = mapped_column(Numeric(12, 2), nullable=True)
+    salary_currency: Mapped[str | None] = mapped_column(
+        String(3), nullable=True, server_default="USD",
+    )
+    salary_period: Mapped[str | None] = mapped_column(String(10), nullable=True)
+
+    score: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    score_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    scored_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    scoring_extraction_log_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("extraction_logs.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    dismissed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    saved_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    promoted_application_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("applications.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    promoted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    fetch_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("discovery_fetches.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "source IN ('greenhouse','lever','ashby','remoteok',"
+            "'hn_who_is_hiring','workatastartup','flybyapis','other')",
+            name="chk_discovered_source",
+        ),
+        CheckConstraint(
+            "remote_type IN ('remote','hybrid','onsite','unknown')",
+            name="chk_discovered_remote_type",
+        ),
+        CheckConstraint(
+            "score IS NULL OR (score >= 0 AND score <= 100)",
+            name="chk_discovered_score",
+        ),
+        CheckConstraint(
+            "salary_period IS NULL OR salary_period IN "
+            "('annual','hourly','monthly')",
+            name="chk_discovered_salary_period",
+        ),
+        CheckConstraint(
+            "NOT (dismissed_at IS NOT NULL AND saved_at IS NOT NULL)",
+            name="chk_discovered_state",
+        ),
+        CheckConstraint(
+            "(promoted_application_id IS NULL) = (promoted_at IS NULL)",
+            name="chk_discovered_promoted",
+        ),
+        Index("ix_discovered_user_id", "user_id"),
+        Index(
+            "uq_discovered_user_source_extid",
+            "user_id",
+            "source",
+            "source_external_id",
+            unique=True,
+        ),
+        Index(
+            "uq_discovered_user_content_hash",
+            "user_id",
+            "content_hash",
+            unique=True,
+            postgresql_where=text(
+                "content_hash IS NOT NULL AND dismissed_at IS NULL",
+            ),
+        ),
+        Index(
+            "ix_discovered_inbox",
+            "user_id",
+            "score",
+            "discovered_at",
+            postgresql_where=text(
+                "dismissed_at IS NULL "
+                "AND saved_at IS NULL "
+                "AND promoted_application_id IS NULL"
+            ),
+        ),
+        Index(
+            "ix_discovered_saved",
+            "user_id",
+            "saved_at",
+            postgresql_where=text(
+                "saved_at IS NOT NULL AND dismissed_at IS NULL",
+            ),
+        ),
+        Index(
+            "ix_discovered_promoted_app",
+            "promoted_application_id",
+            postgresql_where=text("promoted_application_id IS NOT NULL"),
+        ),
+        Index(
+            "ix_discovered_score_pending",
+            "user_id",
+            "discovered_at",
+            postgresql_where=text("score IS NULL"),
+        ),
+        Index(
+            "ix_discovered_company",
+            "user_id",
+            "company_id",
+            postgresql_where=text("company_id IS NOT NULL"),
+        ),
+    )

--- a/apps/myjobhunter/backend/app/models/discovery/discovery_fetch.py
+++ b/apps/myjobhunter/backend/app/models/discovery/discovery_fetch.py
@@ -1,0 +1,93 @@
+"""ORM model for ``discovery_fetches`` — append-only audit of fetch cycles.
+
+One row per (source × tick). Created with ``status='running'`` when the
+worker claims it; updated to ``'success'`` / ``'partial'`` / ``'error'``
+on completion. Stale ``running`` rows older than 30 minutes are reaped to
+``error`` so a worker crash doesn't leave the audit trail in a confusing
+state.
+
+Reused for both per-source observability ("show me last 24h of
+Greenhouse fetches for user X") and per-discovered_job traceability
+("which fetch surfaced this posting?" via ``discovered_jobs.fetch_id``).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    SmallInteger,
+    String,
+    Text,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class DiscoveryFetch(Base):
+    __tablename__ = "discovery_fetches"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    discovery_source_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("discovery_sources.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    source: Mapped[str] = mapped_column(String(30), nullable=False)
+
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    status: Mapped[str] = mapped_column(
+        String(20), nullable=False, server_default="running",
+    )
+    http_status: Mapped[int | None] = mapped_column(SmallInteger, nullable=True)
+    fetched_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0",
+    )
+    new_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0",
+    )
+    updated_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, server_default="0",
+    )
+    duration_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "status IN ('running','success','partial','error')",
+            name="chk_discovery_fetch_status",
+        ),
+        Index("ix_discovery_fetch_user_started", "user_id", "started_at"),
+        Index(
+            "ix_discovery_fetch_source_started",
+            "discovery_source_id",
+            "started_at",
+        ),
+    )

--- a/apps/myjobhunter/backend/app/models/discovery/discovery_source.py
+++ b/apps/myjobhunter/backend/app/models/discovery/discovery_source.py
@@ -1,0 +1,117 @@
+"""ORM model for ``discovery_sources`` — per-user saved-search rows.
+
+Each row is one source the operator has activated for proactive
+discovery. The ``source`` enum names the adapter we run (greenhouse,
+lever, ashby, remoteok, hn_who_is_hiring, workatastartup, flybyapis).
+``config`` carries adapter-specific settings (board slugs for ATS feeds,
+Boolean keyword strings for aggregator queries).
+
+The fetch worker polls ``WHERE is_active = true ORDER BY last_fetched_at
+NULLS FIRST`` and runs adapters whose ``last_fetched_at`` is older than
+``fetch_interval_minutes`` ago. A failure increments
+``consecutive_failures``; a circuit breaker pauses the source once that
+crosses 5.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    SmallInteger,
+    String,
+    Text,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class DiscoverySource(Base):
+    __tablename__ = "discovery_sources"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    source: Mapped[str] = mapped_column(String(30), nullable=False)
+    config: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=text("'{}'::jsonb"),
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, server_default=text("true"),
+    )
+    fetch_interval_minutes: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default="1440",
+    )
+
+    last_fetched_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    last_success_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    last_error_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    last_error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_seen_posted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    consecutive_failures: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, server_default="0",
+    )
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            "source IN ('greenhouse','lever','ashby','remoteok',"
+            "'hn_who_is_hiring','workatastartup','flybyapis','other')",
+            name="chk_discovery_source",
+        ),
+        CheckConstraint(
+            "fetch_interval_minutes >= 15",
+            name="chk_discovery_fetch_interval_pos",
+        ),
+        CheckConstraint(
+            "consecutive_failures >= 0",
+            name="chk_discovery_consecutive_failures",
+        ),
+        Index("ix_discovery_source_user", "user_id"),
+        Index(
+            "uq_discovery_source_user_kind",
+            "user_id",
+            "source",
+            unique=True,
+            postgresql_where=text("is_active = true"),
+        ),
+        Index(
+            "ix_discovery_source_due",
+            "last_fetched_at",
+            postgresql_where=text("is_active = true"),
+        ),
+    )

--- a/apps/myjobhunter/backend/app/models/discovery/discovery_source.py
+++ b/apps/myjobhunter/backend/app/models/discovery/discovery_source.py
@@ -2,7 +2,7 @@
 
 Each row is one source the operator has activated for proactive
 discovery. The ``source`` enum names the adapter we run (greenhouse,
-lever, ashby, remoteok, hn_who_is_hiring, workatastartup, flybyapis).
+lever, ashby, remoteok, hn_who_is_hiring, workatastartup, jsearch).
 ``config`` carries adapter-specific settings (board slugs for ATS feeds,
 Boolean keyword strings for aggregator queries).
 
@@ -90,7 +90,7 @@ class DiscoverySource(Base):
     __table_args__ = (
         CheckConstraint(
             "source IN ('greenhouse','lever','ashby','remoteok',"
-            "'hn_who_is_hiring','workatastartup','flybyapis','other')",
+            "'hn_who_is_hiring','workatastartup','jsearch','other')",
             name="chk_discovery_source",
         ),
         CheckConstraint(

--- a/apps/myjobhunter/backend/tests/test_discovery_models.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_models.py
@@ -1,0 +1,307 @@
+"""Schema-level tests for the discovery domain.
+
+Verifies:
+- All three tables can be created and rows inserted
+- Mutual-exclusion constraint fires (dismissed_at vs saved_at)
+- Promote consistency constraint fires (promoted_application_id ↔ promoted_at)
+- Score range constraint fires
+- Source enum constraint rejects unknown adapters
+- ``application_events.source`` accepts the new ``discovery`` value
+- ``extraction_logs.context_type`` accepts the new ``job_analysis`` value
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application.application import Application
+from app.models.application.application_event import ApplicationEvent
+from app.models.company.company import Company
+from app.models.discovery.discovered_job import DiscoveredJob
+from app.models.discovery.discovery_fetch import DiscoveryFetch
+from app.models.discovery.discovery_source import DiscoverySource
+from app.models.system.extraction_log import ExtractionLog
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _uid(user: dict) -> uuid.UUID:
+    return uuid.UUID(user["id"])
+
+
+@pytest.mark.asyncio
+async def test_discovery_source_create(db: AsyncSession, user_factory):
+    user = await user_factory()
+    src = DiscoverySource(
+        user_id=_uid(user),
+        source="flybyapis",
+        config={"query": "senior backend engineer python remote"},
+    )
+    db.add(src)
+    await db.commit()
+    await db.refresh(src)
+
+    assert src.id is not None
+    assert src.is_active is True
+    assert src.fetch_interval_minutes == 1440
+    assert src.consecutive_failures == 0
+
+
+@pytest.mark.asyncio
+async def test_discovery_source_rejects_unknown_kind(
+    db: AsyncSession, user_factory,
+):
+    user = await user_factory()
+    db.add(DiscoverySource(user_id=_uid(user), source="not_a_real_source"))
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_discovery_fetch_links_to_source(db: AsyncSession, user_factory):
+    user = await user_factory()
+    src = DiscoverySource(user_id=_uid(user), source="remoteok")
+    db.add(src)
+    await db.commit()
+    await db.refresh(src)
+
+    fetch = DiscoveryFetch(
+        user_id=_uid(user),
+        discovery_source_id=src.id,
+        source="remoteok",
+        started_at=_now(),
+    )
+    db.add(fetch)
+    await db.commit()
+    await db.refresh(fetch)
+
+    assert fetch.status == "running"
+    assert fetch.fetched_count == 0
+
+
+@pytest.mark.asyncio
+async def test_discovered_job_create_minimal(db: AsyncSession, user_factory):
+    user = await user_factory()
+    job = DiscoveredJob(
+        user_id=_uid(user),
+        source="flybyapis",
+        source_external_id="abc123",
+        title="Senior Backend Engineer",
+        company_name="Acme Corp",
+    )
+    db.add(job)
+    await db.commit()
+    await db.refresh(job)
+
+    assert job.id is not None
+    assert job.remote_type == "unknown"
+    assert job.salary_currency == "USD"
+    assert job.discovered_at is not None
+
+
+@pytest.mark.asyncio
+async def test_discovered_job_dedup_unique_constraint(
+    db: AsyncSession, user_factory,
+):
+    user = await user_factory()
+    db.add(
+        DiscoveredJob(
+            user_id=_uid(user),
+            source="flybyapis",
+            source_external_id="dup-1",
+            title="Job A",
+            company_name="Acme",
+        ),
+    )
+    await db.commit()
+
+    db.add(
+        DiscoveredJob(
+            user_id=_uid(user),
+            source="flybyapis",
+            source_external_id="dup-1",
+            title="Job A re-fetch",
+            company_name="Acme",
+        ),
+    )
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_discovered_job_state_mutex_constraint(
+    db: AsyncSession, user_factory,
+):
+    user = await user_factory()
+    job = DiscoveredJob(
+        user_id=_uid(user),
+        source="flybyapis",
+        source_external_id="state-1",
+        title="X",
+        company_name="Y",
+        dismissed_at=_now(),
+        saved_at=_now(),
+    )
+    db.add(job)
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_discovered_job_promote_consistency_constraint(
+    db: AsyncSession, user_factory,
+):
+    user = await user_factory()
+    company = Company(
+        user_id=_uid(user), name="Acme", primary_domain="acme.example.com",
+    )
+    db.add(company)
+    await db.commit()
+    await db.refresh(company)
+
+    app = Application(
+        user_id=_uid(user),
+        company_id=company.id,
+        role_title="Senior Backend Engineer",
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+
+    # Setting promoted_application_id but NOT promoted_at must fail.
+    db.add(
+        DiscoveredJob(
+            user_id=_uid(user),
+            source="flybyapis",
+            source_external_id="promote-1",
+            title="Z",
+            company_name="Acme",
+            promoted_application_id=app.id,
+            promoted_at=None,
+        ),
+    )
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_discovered_job_score_range_constraint(
+    db: AsyncSession, user_factory,
+):
+    user = await user_factory()
+    db.add(
+        DiscoveredJob(
+            user_id=_uid(user),
+            source="flybyapis",
+            source_external_id="score-1",
+            title="X",
+            company_name="Y",
+            score=150,  # > 100
+        ),
+    )
+    with pytest.raises(IntegrityError):
+        await db.commit()
+
+
+@pytest.mark.asyncio
+async def test_application_event_accepts_discovery_source(
+    db: AsyncSession, user_factory,
+):
+    """The chk_appevent_source extension should permit 'discovery'."""
+    user = await user_factory()
+    company = Company(
+        user_id=_uid(user), name="Acme", primary_domain="acme2.example.com",
+    )
+    db.add(company)
+    await db.commit()
+    await db.refresh(company)
+
+    app = Application(
+        user_id=_uid(user),
+        company_id=company.id,
+        role_title="Senior Backend Engineer",
+    )
+    db.add(app)
+    await db.commit()
+    await db.refresh(app)
+
+    event = ApplicationEvent(
+        user_id=_uid(user),
+        application_id=app.id,
+        event_type="applied",
+        occurred_at=_now(),
+        source="discovery",
+    )
+    db.add(event)
+    await db.commit()
+    await db.refresh(event)
+
+    assert event.source == "discovery"
+
+
+@pytest.mark.asyncio
+async def test_extraction_log_accepts_job_analysis_context(
+    db: AsyncSession, user_factory,
+):
+    """The chk_extraction_log_context_type extension should permit
+    'job_analysis'."""
+    user = await user_factory()
+    log = ExtractionLog(
+        user_id=_uid(user),
+        context_type="job_analysis",
+        model="claude-sonnet-4-6",
+        status="success",
+    )
+    db.add(log)
+    await db.commit()
+    await db.refresh(log)
+
+    assert log.context_type == "job_analysis"
+
+
+@pytest.mark.asyncio
+async def test_inbox_index_query_pattern(db: AsyncSession, user_factory):
+    """Smoke-test the partial inbox index by exercising its predicate."""
+    user = await user_factory()
+    # Active row — should appear in the inbox query.
+    db.add(
+        DiscoveredJob(
+            user_id=_uid(user),
+            source="flybyapis",
+            source_external_id="active-1",
+            title="Active",
+            company_name="Acme",
+            score=85,
+        ),
+    )
+    # Dismissed — should NOT appear.
+    db.add(
+        DiscoveredJob(
+            user_id=_uid(user),
+            source="flybyapis",
+            source_external_id="dismissed-1",
+            title="Dismissed",
+            company_name="Acme",
+            dismissed_at=_now(),
+        ),
+    )
+    await db.commit()
+
+    result = await db.execute(
+        select(DiscoveredJob).where(
+            DiscoveredJob.user_id == _uid(user),
+            DiscoveredJob.dismissed_at.is_(None),
+            DiscoveredJob.saved_at.is_(None),
+            DiscoveredJob.promoted_application_id.is_(None),
+        ),
+    )
+    rows = result.scalars().all()
+    assert len(rows) == 1
+    assert rows[0].source_external_id == "active-1"

--- a/apps/myjobhunter/backend/tests/test_discovery_models.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_models.py
@@ -41,7 +41,7 @@ async def test_discovery_source_create(db: AsyncSession, user_factory):
     user = await user_factory()
     src = DiscoverySource(
         user_id=_uid(user),
-        source="flybyapis",
+        source="jsearch",
         config={"query": "senior backend engineer python remote"},
     )
     db.add(src)
@@ -91,7 +91,7 @@ async def test_discovered_job_create_minimal(db: AsyncSession, user_factory):
     user = await user_factory()
     job = DiscoveredJob(
         user_id=_uid(user),
-        source="flybyapis",
+        source="jsearch",
         source_external_id="abc123",
         title="Senior Backend Engineer",
         company_name="Acme Corp",
@@ -114,7 +114,7 @@ async def test_discovered_job_dedup_unique_constraint(
     db.add(
         DiscoveredJob(
             user_id=_uid(user),
-            source="flybyapis",
+            source="jsearch",
             source_external_id="dup-1",
             title="Job A",
             company_name="Acme",
@@ -125,7 +125,7 @@ async def test_discovered_job_dedup_unique_constraint(
     db.add(
         DiscoveredJob(
             user_id=_uid(user),
-            source="flybyapis",
+            source="jsearch",
             source_external_id="dup-1",
             title="Job A re-fetch",
             company_name="Acme",
@@ -142,7 +142,7 @@ async def test_discovered_job_state_mutex_constraint(
     user = await user_factory()
     job = DiscoveredJob(
         user_id=_uid(user),
-        source="flybyapis",
+        source="jsearch",
         source_external_id="state-1",
         title="X",
         company_name="Y",
@@ -179,7 +179,7 @@ async def test_discovered_job_promote_consistency_constraint(
     db.add(
         DiscoveredJob(
             user_id=_uid(user),
-            source="flybyapis",
+            source="jsearch",
             source_external_id="promote-1",
             title="Z",
             company_name="Acme",
@@ -199,7 +199,7 @@ async def test_discovered_job_score_range_constraint(
     db.add(
         DiscoveredJob(
             user_id=_uid(user),
-            source="flybyapis",
+            source="jsearch",
             source_external_id="score-1",
             title="X",
             company_name="Y",
@@ -274,7 +274,7 @@ async def test_inbox_index_query_pattern(db: AsyncSession, user_factory):
     db.add(
         DiscoveredJob(
             user_id=_uid(user),
-            source="flybyapis",
+            source="jsearch",
             source_external_id="active-1",
             title="Active",
             company_name="Acme",
@@ -285,7 +285,7 @@ async def test_inbox_index_query_pattern(db: AsyncSession, user_factory):
     db.add(
         DiscoveredJob(
             user_id=_uid(user),
-            source="flybyapis",
+            source="jsearch",
             source_external_id="dismissed-1",
             title="Dismissed",
             company_name="Acme",


### PR DESCRIPTION
## Summary

PR 1 of N — foundation for the new /discover surface (proactive job-posting
discovery from public feeds + Google Jobs aggregator). This PR is schema-
only: tables, models, tests. No routes, no worker, no UI yet.

Three new tables:

- **discovery_sources**: per-user saved-search rows the worker polls
- **discovery_fetches**: append-only audit of every fetch cycle
- **discovered_jobs**: the inbox of proactively-found postings, with score, dismiss/save/promote state, and an optional back-link to a promoted application

Plus extends two existing CHECK constraints:

- `application_events.source` gains `'discovery'` for kanban provenance
- `extraction_logs.context_type` gains `'job_analysis'` (was being abused via `'other'`)

## Schema decisions

Per the design panels (UX/data/architecture/security/libraries) run before this PR:

- **Per-user rows** on `discovered_jobs` rather than shared-cache+join — simpler at MJH's current scale; refactor flagged for when MJH crosses ~10 active users
- **Mutually-exclusive `dismissed_at` / `saved_at`** enforced via `chk_discovered_state`; `promoted_application_id` ↔ `promoted_at` paired via `chk_discovered_promoted`
- **Partial indexes** on inbox/saved/score-pending/company — keep lean as dismissed/promoted rows accumulate
- **Promote-to-application** mirrors the existing `job_analyses.applied_application_id SET NULL` pattern

## Test plan

- [x] `tests/test_discovery_models.py` covers: insert + defaults, source-enum rejection, dedup unique constraint, state mutex, promote consistency, score range, application_events source extension, extraction_logs context extension, inbox-index partial query
- [x] Migration generates clean SQL (verified via `alembic upgrade head --sql`)
- [x] All models import cleanly into `Base.metadata`
- [ ] CI runs full pytest suite against fresh Postgres + verifies migration roundtrip

## Follow-ups (separate PRs)

- PR 2: extract `score()` from `analyze()` so both paths converge on one Tier-2 service
- PR 3: JSearch (Google Jobs aggregator) source adapter + boot guard for `JSEARCH_API_KEY`
- PR 4: discovery worker container + APScheduler + polling fetch loop
- PR 5: `/discover` API + frontend MVP

## ⚠️ Operational migration required

After this PR merges:

1. The next deploy runs `alembic upgrade head` automatically and applies migration `disco260507`. No manual VPS step needed for THIS PR.
2. PR 3 will require setting `JSEARCH_API_KEY` in `.env.docker` — operational migration note will be in that PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)