### PR TITLE
refactor(mjh/job_analysis): extract score() from analyze()

### DIFF
--- a/apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py
+++ b/apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py
@@ -157,7 +157,13 @@ async def analyze(
     """Run a fit-analysis for ``user_id`` on the given JD.
 
     Exactly one of ``url`` / ``jd_text`` must be non-empty (the request
-    schema enforces this; this layer re-checks defensively).
+    schema enforces this; this layer re-checks defensively). When ``url``
+    is given, this function fetches it via ``jd_url_extractor.extract_from_url``
+    and composes a JD text body from the structured extraction.
+
+    For callers that already have JD text in hand (the discovery worker,
+    the chrome extension), prefer :func:`score` directly — it skips URL
+    resolution and accepts pre-extracted fields as a hint.
 
     Returns the persisted :class:`JobAnalysis` row.
 
@@ -175,7 +181,6 @@ async def analyze(
             "analyze() requires exactly one of url / jd_text",
         )
 
-    # ---- Step 1: resolve the JD source ----
     source_url: str | None
     resolved_jd_text: str
     if has_url:
@@ -191,52 +196,96 @@ async def analyze(
             raise JobAnalysisError(str(exc)) from exc
         except ValueError as exc:
             raise JobAnalysisInvalidUrlError(str(exc)) from exc
-        # Compose a single text body from the extracted fields. The
-        # analysis prompt only needs the JD content; everything else is
-        # auxiliary metadata we'll merge into the response's
-        # ``extracted`` field after Claude runs.
         resolved_jd_text = _join_extracted_text(extracted)
     else:
         assert jd_text is not None
         source_url = None
         resolved_jd_text = jd_text.strip()
 
-    if not resolved_jd_text:
+    return await score(
+        db,
+        user_id,
+        jd_text=resolved_jd_text,
+        source_url=source_url,
+    )
+
+
+async def score(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    jd_text: str,
+    source_url: str | None = None,
+    extracted_hint: dict | None = None,
+    discovered_job_id: uuid.UUID | None = None,
+) -> JobAnalysis:
+    """Score pre-resolved JD text against ``user_id``'s profile.
+
+    Pure JD-text-in, JobAnalysis-out: no URL fetching, no extra IO. Both
+    :func:`analyze` (paste-URL flow) and the discovery score worker call
+    this function so the scoring rubric, validation, and persistence
+    shape stay consistent across surfaces.
+
+    Args:
+        jd_text: The full JD text body. Must be non-empty after stripping.
+        source_url: Optional canonical URL the JD came from. Used for the
+            fingerprint and persisted on the JobAnalysis row.
+        extracted_hint: Optional pre-extracted fields the caller already
+            knows (title, company, location, salary, etc.) — Claude's
+            ``extracted`` block is merged with this hint, hint values
+            overriding for the fields it provides. The discovery worker
+            uses this so we don't pay Claude to re-extract structural
+            fields the source API already returned.
+        discovered_job_id: Optional FK back to the discovered_jobs row
+            this scoring run was triggered for. Stored as ``context_id``
+            on the extraction_log entry so per-feature cost rollups can
+            join.
+
+    Raises:
+        JobAnalysisError: Claude failed, returned malformed JSON, or
+            returned an envelope that didn't pass validation.
+    """
+    cleaned_jd = jd_text.strip() if jd_text else ""
+    if not cleaned_jd:
         raise JobAnalysisError(
-            "Resolved JD text is empty — refusing to call Claude on no content",
+            "score() requires non-empty jd_text",
         )
 
-    # ---- Step 2: load the operator's profile snapshot ----
     snapshot = await _load_profile_snapshot(db, user_id)
 
-    # ---- Step 3: call Claude ----
-    user_content = _build_user_content(snapshot=snapshot, jd_text=resolved_jd_text)
+    user_content = _build_user_content(snapshot=snapshot, jd_text=cleaned_jd)
     try:
         meta = await claude_service.call_claude_with_meta(
             system_prompt=JOB_ANALYSIS_PROMPT,
             user_content=user_content,
-            # extraction_logs check constraint doesn't yet include
-            # "job_analysis"; "other" is the legal bucket today.
+            # ``"job_analysis"`` is the dedicated bucket once migration
+            # disco260507 lands. Until then ``"other"`` is the legal
+            # value (extraction_logs CHECK constraint enforces).
             context_type="other",
             user_id=user_id,
-            context_id=None,
+            context_id=discovered_job_id,
         )
     except (anthropic.APIError, ValueError) as exc:
         logger.warning("Claude job-analysis call failed: %s", exc)
         raise JobAnalysisError(f"AI analysis failed: {exc}") from exc
 
-    parsed = meta["parsed"]
+    validated = _validate_response(meta["parsed"])
 
-    # ---- Step 4: validate the envelope ----
-    validated = _validate_response(parsed)
+    if extracted_hint:
+        merged = dict(validated["extracted"])
+        for key, value in extracted_hint.items():
+            if value is not None:
+                merged[key] = value
+        validated["extracted"] = merged
 
-    # ---- Step 5: persist + commit ----
-    fingerprint = _compute_fingerprint(source_url=source_url, jd_text=resolved_jd_text)
+    fingerprint = _compute_fingerprint(
+        source_url=source_url, jd_text=cleaned_jd,
+    )
 
     analysis = JobAnalysis(
         user_id=user_id,
         source_url=source_url,
-        jd_text=resolved_jd_text,
+        jd_text=cleaned_jd,
         fingerprint=fingerprint,
         extracted=validated["extracted"],
         verdict=validated["verdict"],

--- a/apps/myjobhunter/backend/tests/test_job_analysis_score.py
+++ b/apps/myjobhunter/backend/tests/test_job_analysis_score.py
@@ -1,0 +1,234 @@
+"""Tests for the extracted ``score()`` entrypoint of job_analysis_service.
+
+``score()`` is the pure JD-text-in / JobAnalysis-out function that both
+``analyze()`` (paste-URL flow) and the discovery score worker call. It
+is the seam where /analyze and discovery converge — these tests pin
+the contract:
+
+- jd_text required and non-empty
+- source_url is optional and persisted on the row
+- extracted_hint merges over Claude's ``extracted`` block (hint wins
+  for fields it provides; Claude wins for fields the hint omits)
+- discovered_job_id is passed through to the extraction_log via
+  ``context_id``
+
+The existing ``test_job_analysis_service.py`` continues to cover
+``analyze()`` end-to-end.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.job_analysis.job_analysis import JobAnalysis
+from app.services.job_analysis import job_analysis_service
+from app.services.job_analysis.job_analysis_service import (
+    JobAnalysisError,
+    score,
+)
+
+
+_FAKE_PATH = (
+    "app.services.job_analysis.job_analysis_service"
+    ".claude_service.call_claude_with_meta"
+)
+
+
+def _meta(**overrides) -> dict:
+    """Mock a successful Claude call envelope."""
+    base = {
+        "input_tokens": 1200,
+        "output_tokens": 400,
+        "cost_usd": 0.005,
+        "parsed": {
+            "verdict": "worth_considering",
+            "verdict_summary": "Reasonable fit overall — Python experience aligns.",
+            "extracted": {
+                "title": "Senior Backend Engineer",
+                "company": "Acme",
+                "location": "Remote",
+                "remote_type": "remote",
+                "posted_salary_min": 150000,
+                "posted_salary_max": 200000,
+                "posted_salary_currency": "USD",
+                "posted_salary_period": "year",
+                "summary": "Backend role at Acme.",
+            },
+            "dimensions": [
+                {"key": "skill_match", "status": "strong", "rationale": "ok"},
+                {"key": "seniority", "status": "aligned", "rationale": "ok"},
+                {"key": "salary", "status": "in_range", "rationale": "ok"},
+                {"key": "location_remote", "status": "compatible", "rationale": "ok"},
+                {"key": "work_auth", "status": "compatible", "rationale": "ok"},
+            ],
+            "red_flags": [],
+            "green_flags": ["Strong stack overlap"],
+        },
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.mark.asyncio
+async def test_score_persists_row_with_jd_text_only(
+    db: AsyncSession, user_factory,
+) -> None:
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+
+    with patch(_FAKE_PATH, new_callable=AsyncMock, return_value=_meta()):
+        result = await score(
+            db,
+            user_id,
+            jd_text="Senior Backend Engineer at Acme. Python required.",
+        )
+
+    assert isinstance(result, JobAnalysis)
+    assert result.user_id == user_id
+    assert result.jd_text.startswith("Senior Backend Engineer")
+    assert result.source_url is None
+    assert result.verdict == "worth_considering"
+
+
+@pytest.mark.asyncio
+async def test_score_persists_source_url_when_provided(
+    db: AsyncSession, user_factory,
+) -> None:
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+
+    with patch(_FAKE_PATH, new_callable=AsyncMock, return_value=_meta()):
+        result = await score(
+            db,
+            user_id,
+            jd_text="Senior Backend Engineer at Acme.",
+            source_url="https://www.linkedin.com/jobs/view/123",
+        )
+
+    assert result.source_url == "https://www.linkedin.com/jobs/view/123"
+
+
+@pytest.mark.asyncio
+async def test_score_rejects_empty_jd_text(
+    db: AsyncSession, user_factory,
+) -> None:
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+
+    with pytest.raises(JobAnalysisError):
+        await score(db, user_id, jd_text="")
+
+    with pytest.raises(JobAnalysisError):
+        await score(db, user_id, jd_text="   ")
+
+
+@pytest.mark.asyncio
+async def test_score_extracted_hint_overrides_claude_for_provided_fields(
+    db: AsyncSession, user_factory,
+) -> None:
+    """The discovery worker passes structural fields it already has from
+    the source API (title, company). Those should NOT be overwritten by
+    Claude's parsed extraction — Claude is for analysis, not re-extraction."""
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+
+    hint = {
+        "title": "Staff Software Engineer",
+        "company": "Stripe",
+        "location": "San Francisco, CA",
+    }
+
+    with patch(_FAKE_PATH, new_callable=AsyncMock, return_value=_meta()):
+        result = await score(
+            db,
+            user_id,
+            jd_text="Senior Backend Engineer at Acme. Python required.",
+            extracted_hint=hint,
+        )
+
+    # Hint values win for fields it provides.
+    assert result.extracted["title"] == "Staff Software Engineer"
+    assert result.extracted["company"] == "Stripe"
+    assert result.extracted["location"] == "San Francisco, CA"
+    # Claude wins for fields the hint omits.
+    assert result.extracted["remote_type"] == "remote"
+    assert result.extracted["posted_salary_min"] == 150000
+
+
+@pytest.mark.asyncio
+async def test_score_extracted_hint_with_none_values_does_not_override(
+    db: AsyncSession, user_factory,
+) -> None:
+    """Hint values that are None should NOT clobber Claude's extraction —
+    None means 'caller didn't provide this'."""
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+
+    hint = {"title": None, "company": "Stripe"}
+
+    with patch(_FAKE_PATH, new_callable=AsyncMock, return_value=_meta()):
+        result = await score(
+            db,
+            user_id,
+            jd_text="Senior Backend Engineer at Acme.",
+            extracted_hint=hint,
+        )
+
+    # title is None in hint → Claude's value wins
+    assert result.extracted["title"] == "Senior Backend Engineer"
+    # company is set in hint → hint wins
+    assert result.extracted["company"] == "Stripe"
+
+
+@pytest.mark.asyncio
+async def test_score_passes_discovered_job_id_to_extraction_log(
+    db: AsyncSession, user_factory,
+) -> None:
+    """The discovery worker passes discovered_job_id; we forward it to
+    the extraction_log via context_id so per-feature cost rollups can
+    join discovered_jobs ↔ extraction_logs."""
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+    fake_discovered_id = uuid.uuid4()
+
+    mock = AsyncMock(return_value=_meta())
+    with patch(_FAKE_PATH, new=mock):
+        await score(
+            db,
+            user_id,
+            jd_text="Senior Backend Engineer at Acme.",
+            discovered_job_id=fake_discovered_id,
+        )
+
+    # Verify context_id was forwarded to claude_service.
+    assert mock.await_count == 1
+    kwargs = mock.await_args.kwargs
+    assert kwargs["context_id"] == fake_discovered_id
+
+
+@pytest.mark.asyncio
+async def test_analyze_text_path_still_works_after_refactor(
+    db: AsyncSession, user_factory,
+) -> None:
+    """Sanity check: analyze() with jd_text still produces the same shape
+    as before the score() extraction. This pins the refactor."""
+    from app.services.job_analysis.job_analysis_service import analyze
+
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+
+    with patch(_FAKE_PATH, new_callable=AsyncMock, return_value=_meta()):
+        result = await analyze(
+            db,
+            user_id,
+            url=None,
+            jd_text="Senior Backend Engineer at Acme.",
+        )
+
+    assert isinstance(result, JobAnalysis)
+    assert result.user_id == user_id
+    assert result.source_url is None
+    assert result.verdict == "worth_considering"


### PR DESCRIPTION
## Summary

PR 2 of N for MJH proactive discovery (https://github.com/jykwon91/MyFreeApps/pull/403 is PR 1).

Splits the existing single-entrypoint job-analysis pipeline into two functions:

- **\`analyze(db, user_id, *, url, jd_text)\`** — paste-URL flow used by \`/jobs/analyze\`. Resolves URL → text via the existing \`jd_url_extractor\`, then delegates to \`score()\`.
- **\`score(db, user_id, *, jd_text, source_url, extracted_hint, discovered_job_id)\`** — pure JD-text-in / JobAnalysis-out. The Tier-2 service both \`/analyze\` and the upcoming discovery score worker (PR 4) call.

## Why

The discovery worker needs the same Claude scoring logic \`/analyze\` uses, but with:
- Pre-resolved JD text from the source API (no URL fetch needed)
- Pre-extracted structural fields (title, company, location, salary) the source API already returns
- A back-link to the \`discovered_jobs\` row for cost-tracking

Without this split, discovery would either duplicate the pipeline (drift risk) or round-trip through \`analyze()\` and pay for an unnecessary URL fetch.

## Behavior preserved

- \`analyze()\` signature unchanged — existing route handler + tests work as-is
- All validation, fingerprint, persistence, error-class hierarchy preserved
- \`context_type=\"other\"\` retained on the extraction_log call (PR 1 extends the enum to add \`\"job_analysis\"\`; a follow-up PR after both PR 1 and this one merge will switch both call sites)

## extracted_hint merging

When the discovery worker has structural fields from JSearch, it passes them as \`extracted_hint\`. The merge rule: hint values win for fields the caller provides (title, company, location); Claude's extraction wins for fields the hint omits (verdict, dimensions, summary). \`None\` in the hint does NOT override Claude.

## Test plan

- [x] New \`tests/test_job_analysis_score.py\` — 7 tests covering score() contract
- [x] Existing \`tests/test_job_analysis_service.py\` covers analyze() end-to-end (unchanged)
- [x] One pin test verifies analyze() shape after refactor

## Dependencies

- Independent of PR 1 (no schema dependency)
- PR 4 (discovery score worker) depends on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)