### PR TITLE
feat(mjh/discovery): /discover frontend MVP

### DIFF
--- a/apps/myjobhunter/frontend/src/RootLayout.tsx
+++ b/apps/myjobhunter/frontend/src/RootLayout.tsx
@@ -9,6 +9,7 @@ import {
   Settings,
   Shield,
   Sparkles,
+  Telescope,
   UserCircle,
 } from "lucide-react";
 import { AppShell, RequireAuth, Toaster, useIsAuthenticated } from "@platform/ui";
@@ -55,6 +56,7 @@ const ICONS: Record<string, React.ReactNode> = {
   Settings: <Settings className="w-5 h-5" />,
   Shield: <Shield className="w-5 h-5" />,
   Sparkles: <Sparkles className="w-5 h-5" />,
+  Telescope: <Telescope className="w-5 h-5" />,
   UserCircle: <UserCircle className="w-5 h-5" />,
 };
 

--- a/apps/myjobhunter/frontend/src/constants/nav.ts
+++ b/apps/myjobhunter/frontend/src/constants/nav.ts
@@ -19,6 +19,7 @@ export const NAV_DESCRIPTORS: NavDescriptor[] = [
   // Listed first per session decision: the application page is no
   // longer the first step in the new-job workflow.
   { path: "/analyze", label: "Analyze a job", iconName: "Search" },
+  { path: "/discover", label: "Discover", iconName: "Telescope" },
   { path: "/dashboard", label: "Dashboard", iconName: "LayoutDashboard" },
   { path: "/applications", label: "Applications", iconName: "Briefcase" },
   { path: "/companies", label: "Companies", iconName: "Building2" },

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
@@ -1,0 +1,134 @@
+import { Bookmark, ExternalLink, X } from "lucide-react";
+import {
+  Badge,
+  Button,
+  Card,
+  formatSalaryRange,
+  showError,
+  showSuccess,
+  timeAgo,
+  extractErrorMessage,
+} from "@platform/ui";
+import {
+  useDismissDiscoveredJobMutation,
+  useSaveDiscoveredJobMutation,
+} from "@/store/discoverApi";
+import type { DiscoveredJob } from "@/types/discovery/discovered-job";
+
+interface DiscoveredJobCardProps {
+  job: DiscoveredJob;
+}
+
+const REMOTE_LABEL: Record<string, string> = {
+  remote: "Remote",
+  hybrid: "Hybrid",
+  onsite: "On-site",
+  unknown: "",
+};
+
+export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
+  const [dismiss, { isLoading: isDismissing }] = useDismissDiscoveredJobMutation();
+  const [save, { isLoading: isSaving }] = useSaveDiscoveredJobMutation();
+
+  async function handleDismiss() {
+    try {
+      await dismiss(job.id).unwrap();
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Couldn't dismiss this posting");
+    }
+  }
+
+  async function handleSave() {
+    try {
+      await save(job.id).unwrap();
+      showSuccess("Saved");
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Couldn't save this posting");
+    }
+  }
+
+  const remoteLabel = REMOTE_LABEL[job.remote_type] ?? "";
+  const salaryLabel = formatSalaryRange(
+    job.salary_min !== null ? String(job.salary_min) : null,
+    job.salary_max !== null ? String(job.salary_max) : null,
+    job.salary_currency ?? "USD",
+    job.salary_period,
+  );
+  const hasSalary = salaryLabel && salaryLabel !== "—";
+  const postedLabel = job.posted_at ? timeAgo(job.posted_at) : null;
+  const isAlreadySaved = !!job.saved_at;
+
+  return (
+    <Card className="p-4 sm:p-5 space-y-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <h3 className="font-semibold text-base leading-snug truncate">
+            {job.title}
+          </h3>
+          <p className="text-sm text-muted-foreground truncate">
+            {job.company_name}
+            {job.location ? ` — ${job.location}` : ""}
+          </p>
+        </div>
+        {job.source_publisher && (
+          <Badge label={job.source_publisher} color="gray" />
+        )}
+      </div>
+
+      <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+        {remoteLabel && <span>{remoteLabel}</span>}
+        {hasSalary && (
+          <>
+            <span aria-hidden="true">•</span>
+            <span>{salaryLabel}</span>
+          </>
+        )}
+        {postedLabel && (
+          <>
+            <span aria-hidden="true">•</span>
+            <span>Posted {postedLabel}</span>
+          </>
+        )}
+      </div>
+
+      {job.description && (
+        <p className="text-sm text-muted-foreground line-clamp-3">
+          {job.description}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2 pt-1">
+        {job.source_url && (
+          <a
+            href={job.source_url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium border rounded hover:bg-muted min-h-[44px] sm:min-h-[32px]"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Open
+          </a>
+        )}
+        <Button
+          size="sm"
+          variant="secondary"
+          onClick={handleSave}
+          disabled={isSaving || isAlreadySaved}
+        >
+          <Bookmark className="w-4 h-4 mr-1" />
+          {isAlreadySaved ? "Saved" : "Save"}
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleDismiss}
+          disabled={isDismissing}
+          className="ml-auto"
+          aria-label="Dismiss this posting"
+        >
+          <X className="w-4 h-4" />
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -1,0 +1,131 @@
+import { useState } from "react";
+import { ConfirmDialog, FormField, showError, showSuccess, extractErrorMessage } from "@platform/ui";
+import { useCreateDiscoverySourceMutation } from "@/store/discoverApi";
+
+interface NewSavedSearchDialogProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+/**
+ * Dialog for creating a new JSearch saved search.
+ *
+ * v1 only supports JSearch (Google Jobs aggregator). Other adapters —
+ * Greenhouse, Lever, Ashby, RemoteOK, HN — are scaffolded in the
+ * backend enum but have no adapters yet. When they ship, this dialog
+ * picks up a source dropdown.
+ */
+export default function NewSavedSearchDialog({
+  open,
+  onClose,
+}: NewSavedSearchDialogProps) {
+  const [query, setQuery] = useState("");
+  const [country, setCountry] = useState("us");
+  const [datePosted, setDatePosted] = useState<"all" | "today" | "3days" | "week" | "month">("week");
+  const [remoteOnly, setRemoteOnly] = useState(false);
+
+  const [createSource, { isLoading }] = useCreateDiscoverySourceMutation();
+
+  function reset() {
+    setQuery("");
+    setCountry("us");
+    setDatePosted("week");
+    setRemoteOnly(false);
+  }
+
+  async function handleConfirm() {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      showError("Enter a search query");
+      return;
+    }
+    try {
+      await createSource({
+        source: "jsearch",
+        config: {
+          query: trimmed,
+          country,
+          date_posted: datePosted,
+          remote_jobs_only: remoteOnly,
+        },
+      }).unwrap();
+      showSuccess("Saved search created");
+      reset();
+      onClose();
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Failed to create saved search");
+    }
+  }
+
+  function handleCancel() {
+    reset();
+    onClose();
+  }
+
+  return (
+    <ConfirmDialog
+      open={open}
+      title="New saved search"
+      description="JSearch will run this query against Google Jobs (LinkedIn, Indeed, Glassdoor, ZipRecruiter)."
+      confirmLabel="Create"
+      isLoading={isLoading}
+      onConfirm={handleConfirm}
+      onCancel={handleCancel}
+    >
+      <div className="space-y-4">
+        <FormField label="Search query" required>
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder='"Senior Backend Engineer" Python'
+            className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground"
+            autoFocus
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Boolean operators supported. Example: "Senior Backend Engineer" Python remote
+          </p>
+        </FormField>
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField label="Country">
+            <select
+              value={country}
+              onChange={(e) => setCountry(e.target.value)}
+              className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground"
+            >
+              <option value="us">United States</option>
+              <option value="ca">Canada</option>
+              <option value="uk">United Kingdom</option>
+              <option value="au">Australia</option>
+            </select>
+          </FormField>
+
+          <FormField label="Posted">
+            <select
+              value={datePosted}
+              onChange={(e) => setDatePosted(e.target.value as typeof datePosted)}
+              className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground"
+            >
+              <option value="today">Past 24 hours</option>
+              <option value="3days">Past 3 days</option>
+              <option value="week">Past week</option>
+              <option value="month">Past month</option>
+              <option value="all">Any time</option>
+            </select>
+          </FormField>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={remoteOnly}
+            onChange={(e) => setRemoteOnly(e.target.checked)}
+            className="rounded"
+          />
+          <span>Remote jobs only</span>
+        </label>
+      </div>
+    </ConfirmDialog>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
@@ -1,0 +1,116 @@
+import { RefreshCw, Trash2 } from "lucide-react";
+import {
+  Badge,
+  Button,
+  Card,
+  LoadingButton,
+  showError,
+  showSuccess,
+  timeAgo,
+  extractErrorMessage,
+} from "@platform/ui";
+import {
+  useDeactivateDiscoverySourceMutation,
+  useListDiscoverySourcesQuery,
+  useRefreshDiscoverySourceMutation,
+} from "@/store/discoverApi";
+import type { DiscoverySource } from "@/types/discovery/discovery-source";
+
+export default function SavedSearchesPanel() {
+  const { data: sources, isLoading } = useListDiscoverySourcesQuery();
+
+  if (isLoading) {
+    return (
+      <Card className="p-4 text-sm text-muted-foreground">
+        Loading saved searches…
+      </Card>
+    );
+  }
+  if (!sources || sources.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-sm font-medium text-muted-foreground">
+        Saved searches
+      </h2>
+      {sources.map((source) => (
+        <SavedSearchRow key={source.id} source={source} />
+      ))}
+    </div>
+  );
+}
+
+function SavedSearchRow({ source }: { source: DiscoverySource }) {
+  const [refresh, { isLoading: isRefreshing }] = useRefreshDiscoverySourceMutation();
+  const [deactivate, { isLoading: isDeactivating }] = useDeactivateDiscoverySourceMutation();
+
+  const query =
+    typeof source.config?.query === "string" ? source.config.query : "(no query)";
+  const lastFetched = source.last_fetched_at
+    ? `Last fetched ${timeAgo(source.last_fetched_at)}`
+    : "Never fetched";
+
+  async function handleRefresh() {
+    try {
+      const result = await refresh(source.id).unwrap();
+      if (result.status === "success") {
+        showSuccess(
+          `Fetched ${result.fetched_count} posting${
+            result.fetched_count === 1 ? "" : "s"
+          } (${result.new_count} new)`,
+        );
+      } else if (result.error_message) {
+        showError(result.error_message);
+      }
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Refresh failed");
+    }
+  }
+
+  async function handleDeactivate() {
+    try {
+      await deactivate(source.id).unwrap();
+      showSuccess("Saved search removed");
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Couldn't remove saved search");
+    }
+  }
+
+  return (
+    <Card className="p-3 flex items-center justify-between gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <Badge label={source.source} color="gray" />
+          <span className="font-medium truncate text-sm">{query}</span>
+        </div>
+        <p className="text-xs text-muted-foreground mt-1">
+          {lastFetched}
+          {source.last_error_message ? ` — error: ${source.last_error_message}` : ""}
+        </p>
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <LoadingButton
+          size="sm"
+          variant="secondary"
+          isLoading={isRefreshing}
+          loadingText="Fetching…"
+          onClick={handleRefresh}
+        >
+          <RefreshCw className="w-4 h-4 mr-1" />
+          Refresh
+        </LoadingButton>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleDeactivate}
+          disabled={isDeactivating}
+          aria-label="Remove saved search"
+        >
+          <Trash2 className="w-4 h-4" />
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/myjobhunter/frontend/src/pages/Discover.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Discover.tsx
@@ -1,0 +1,94 @@
+import { useState } from "react";
+import { Plus, Telescope } from "lucide-react";
+import { Button, EmptyState } from "@platform/ui";
+import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
+import NewSavedSearchDialog from "@/features/discover/NewSavedSearchDialog";
+import SavedSearchesPanel from "@/features/discover/SavedSearchesPanel";
+import {
+  useListDiscoveredJobsQuery,
+  useListDiscoverySourcesQuery,
+} from "@/store/discoverApi";
+
+/**
+ * /discover — proactive job-posting inbox.
+ *
+ * Pulls postings from the configured saved searches (today: JSearch /
+ * Google Jobs only) into a triage list. The operator clicks "Save",
+ * "Dismiss", or the external "Open" link per posting.
+ *
+ * MVP scope (PR 5):
+ * - Single inbox view (no master-detail, no keyboard shortcuts)
+ * - Saved-search creation via inline dialog (no separate /preferences page)
+ * - Manual "Refresh" per saved search (no auto-scheduler yet)
+ * - No scoring UI (backend score() endpoint not yet wired in v1)
+ * - No promote-to-application yet (operator clicks the external Open
+ *   link, applies on the source, manually creates an Application via
+ *   /applications when ready)
+ */
+export default function Discover() {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  const { data: sources } = useListDiscoverySourcesQuery();
+  const { data: jobsData, isLoading } = useListDiscoveredJobsQuery({});
+
+  const hasSources = (sources?.length ?? 0) > 0;
+  const items = jobsData?.items ?? [];
+  const hasJobs = items.length > 0;
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6">
+      <header className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Discover</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            New postings from LinkedIn, Indeed, Glassdoor, and ZipRecruiter
+            via Google Jobs. Refresh a saved search to pull the latest.
+          </p>
+        </div>
+        <Button onClick={() => setDialogOpen(true)} className="shrink-0">
+          <Plus className="w-4 h-4 mr-1" />
+          New saved search
+        </Button>
+      </header>
+
+      <SavedSearchesPanel />
+
+      {!hasSources && (
+        <EmptyState
+          icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+          heading="No saved searches yet"
+          body={
+            "Create a saved search and I'll pull tailored postings from " +
+            "Google Jobs (LinkedIn, Indeed, Glassdoor, ZipRecruiter) every " +
+            "time you click Refresh."
+          }
+        />
+      )}
+
+      {hasSources && isLoading && (
+        <p className="text-sm text-muted-foreground">Loading postings…</p>
+      )}
+
+      {hasSources && !isLoading && !hasJobs && (
+        <EmptyState
+          icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+          heading="Inbox empty"
+          body="Click Refresh on a saved search above to fetch the latest postings."
+        />
+      )}
+
+      {hasJobs && (
+        <div className="space-y-3">
+          {items.map((job) => (
+            <DiscoveredJobCard key={job.id} job={job} />
+          ))}
+        </div>
+      )}
+
+      <NewSavedSearchDialog
+        open={dialogOpen}
+        onClose={() => setDialogOpen(false)}
+      />
+    </main>
+  );
+}

--- a/apps/myjobhunter/frontend/src/routes.tsx
+++ b/apps/myjobhunter/frontend/src/routes.tsx
@@ -1,6 +1,7 @@
 import { Navigate, type RouteObject } from "react-router-dom";
 import Dashboard from "@/pages/Dashboard";
 import Analyze from "@/pages/Analyze";
+import Discover from "@/pages/Discover";
 import Applications from "@/pages/Applications";
 import ApplicationDetail from "@/pages/ApplicationDetail";
 import Companies from "@/pages/Companies";
@@ -30,6 +31,7 @@ export const routes: RouteObject[] = [
       { index: true, element: <Navigate to="/dashboard" replace /> },
       { path: "/dashboard", element: <Dashboard /> },
       { path: "/analyze", element: <Analyze /> },
+      { path: "/discover", element: <Discover /> },
       { path: "/applications", element: <Applications /> },
       { path: "/applications/:id", element: <ApplicationDetail /> },
       { path: "/companies", element: <Companies /> },

--- a/apps/myjobhunter/frontend/src/store/discoverApi.ts
+++ b/apps/myjobhunter/frontend/src/store/discoverApi.ts
@@ -1,0 +1,73 @@
+import { baseApi } from "@platform/ui";
+import type { DiscoveredJobListResponse } from "@/types/discovery/discovered-job";
+import type {
+  DiscoverySource,
+  DiscoverySourceCreate,
+} from "@/types/discovery/discovery-source";
+import type { DiscoveryFetchResult } from "@/types/discovery/discovery-fetch-result";
+
+const apiWithTags = baseApi.enhanceEndpoints({
+  addTagTypes: ["DiscoverySource", "DiscoveredJob"],
+});
+
+const discoverApi = apiWithTags.injectEndpoints({
+  endpoints: (build) => ({
+    listDiscoverySources: build.query<DiscoverySource[], void>({
+      query: () => ({ url: "/discover/sources", method: "GET" }),
+      providesTags: ["DiscoverySource"],
+    }),
+    createDiscoverySource: build.mutation<DiscoverySource, DiscoverySourceCreate>({
+      query: (data) => ({ url: "/discover/sources", method: "POST", data }),
+      invalidatesTags: ["DiscoverySource"],
+    }),
+    deactivateDiscoverySource: build.mutation<void, string>({
+      query: (sourceId) => ({
+        url: `/discover/sources/${sourceId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["DiscoverySource"],
+    }),
+    refreshDiscoverySource: build.mutation<DiscoveryFetchResult, string>({
+      query: (sourceId) => ({
+        url: `/discover/sources/${sourceId}/refresh`,
+        method: "POST",
+      }),
+      invalidatesTags: ["DiscoverySource", "DiscoveredJob"],
+    }),
+    listDiscoveredJobs: build.query<
+      DiscoveredJobListResponse,
+      { state?: "inbox" | "saved" | "all"; limit?: number; offset?: number }
+    >({
+      query: ({ state = "inbox", limit = 50, offset = 0 } = {}) => ({
+        url: "/discover",
+        method: "GET",
+        params: { state, limit, offset },
+      }),
+      providesTags: ["DiscoveredJob"],
+    }),
+    dismissDiscoveredJob: build.mutation<void, string>({
+      query: (jobId) => ({
+        url: `/discover/${jobId}/dismiss`,
+        method: "POST",
+      }),
+      invalidatesTags: ["DiscoveredJob"],
+    }),
+    saveDiscoveredJob: build.mutation<void, string>({
+      query: (jobId) => ({
+        url: `/discover/${jobId}/save`,
+        method: "POST",
+      }),
+      invalidatesTags: ["DiscoveredJob"],
+    }),
+  }),
+});
+
+export const {
+  useListDiscoverySourcesQuery,
+  useCreateDiscoverySourceMutation,
+  useDeactivateDiscoverySourceMutation,
+  useRefreshDiscoverySourceMutation,
+  useListDiscoveredJobsQuery,
+  useDismissDiscoveredJobMutation,
+  useSaveDiscoveredJobMutation,
+} = discoverApi;

--- a/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
@@ -1,0 +1,30 @@
+/** A single discovered posting in the inbox. Mirrors backend DiscoveredJobResponse. */
+export interface DiscoveredJob {
+  id: string;
+  source: string;
+  source_publisher: string | null;
+  source_url: string | null;
+  title: string;
+  company_name: string;
+  location: string | null;
+  remote_type: string;
+  description: string | null;
+  posted_at: string | null;
+  discovered_at: string;
+  salary_min: number | null;
+  salary_max: number | null;
+  salary_currency: string | null;
+  salary_period: string | null;
+  score: number | null;
+  score_reason: string | null;
+  scored_at: string | null;
+  dismissed_at: string | null;
+  saved_at: string | null;
+  promoted_application_id: string | null;
+}
+
+export interface DiscoveredJobListResponse {
+  items: DiscoveredJob[];
+  total: number;
+  state: "inbox" | "saved" | "all";
+}

--- a/apps/myjobhunter/frontend/src/types/discovery/discovery-fetch-result.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovery-fetch-result.ts
@@ -1,0 +1,10 @@
+/** Returned by POST /discover/sources/{id}/refresh. */
+export interface DiscoveryFetchResult {
+  fetch_id: string;
+  status: "running" | "success" | "partial" | "error";
+  fetched_count: number;
+  new_count: number;
+  updated_count: number;
+  duration_ms: number | null;
+  error_message: string | null;
+}

--- a/apps/myjobhunter/frontend/src/types/discovery/discovery-source.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovery-source.ts
@@ -1,0 +1,22 @@
+/** A saved-search row. Mirrors backend DiscoverySourceResponse. */
+export interface DiscoverySource {
+  id: string;
+  source: string;
+  config: Record<string, unknown>;
+  is_active: boolean;
+  fetch_interval_minutes: number;
+  last_fetched_at: string | null;
+  last_success_at: string | null;
+  last_error_at: string | null;
+  last_error_message: string | null;
+  consecutive_failures: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Body for POST /discover/sources. */
+export interface DiscoverySourceCreate {
+  source: string;
+  config: Record<string, unknown>;
+  fetch_interval_minutes?: number;
+}


### PR DESCRIPTION
## Summary

PR 5 of the MJH proactive discovery feature. Wires the \`/discover\` page so the operator can manage saved searches, trigger fetches, and triage discovered postings without touching the API directly.

After this ships + the JSearch key is set on the VPS, the user has the full discovery loop in the browser.

## Operator flow

1. Visit \`/discover\` → see "No saved searches yet"
2. Click "New saved search" → enter Boolean query (e.g. \`"Senior Backend Engineer" Python remote\`), pick country / posted-window / remote-only
3. Click Refresh on the saved search → fetches from JSearch, populates inbox
4. Triage cards: **Open** (external link), **Save**, **Dismiss**

## What's in

- \`store/discoverApi.ts\` — RTK Query slice for the 7 backend endpoints from #407
- \`types/discovery/*\` — one type per file
- \`features/discover/NewSavedSearchDialog.tsx\` — modal form for creating JSearch saved searches
- \`features/discover/SavedSearchesPanel.tsx\` — per-row Refresh + Remove with toast feedback
- \`features/discover/DiscoveredJobCard.tsx\` — card with title, company, location, source publisher (LinkedIn/Indeed/etc.), salary, posted timeAgo, 3-line description, Open/Save/Dismiss
- \`pages/Discover.tsx\` — route with two empty states (no sources / sources but empty inbox)
- Sidebar nav: new "Discover" item between "Analyze a job" and "Dashboard" (Telescope icon)

## What's NOT in (deferred)

- Master-detail layout + keyboard shortcuts (j/k/s/d) — design panel recommended this; cut from MVP, can add later
- \`/discover/preferences\` dedicated page — inline dialog covers MVP needs
- Sidebar nav badge for "new since last visit" — needs backend last-visit tracking
- Scoring UI — backend score endpoint not built yet
- Promote-to-application — operator clicks Open, applies on source, manually creates Application via existing flow

## Test plan

- [x] TypeScript check passes (\`npm run typecheck\` clean)
- [x] Production build succeeds (\`npm run build\` clean, +12KB to bundle)
- [ ] CI runs full suite

## Dependencies

Independent of PRs #403/#404/#405/#407 in code (all backend already merged). Functionally depends on those for the API to exist.

## Operational note

Before the Refresh button does anything, the operator must set \`JSEARCH_API_KEY\` in \`apps/myjobhunter/backend/.env.docker\` on the VPS. Without it, Refresh shows a clear 503 error toast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)