### PR TITLE
fix(mjh/discovery): use RateLimiter.check() not .allow() on /refresh

### DIFF
--- a/apps/myjobhunter/backend/app/api/discover.py
+++ b/apps/myjobhunter/backend/app/api/discover.py
@@ -147,12 +147,7 @@ async def refresh_source(
     - 503 — JSEARCH_API_KEY not configured (or invalid)
     - 501 — no adapter for this source kind (shouldn't happen; defensive)
     """
-    ip = get_client_ip(request)
-    if not _REFRESH_LIMITER.allow(ip):
-        raise HTTPException(
-            status_code=429,
-            detail="Refresh rate limit exceeded — try again in a few minutes",
-        )
+    _REFRESH_LIMITER.check(get_client_ip(request))
 
     try:
         result = await discovery_fetch_service.fetch_source(


### PR DESCRIPTION
## Bug

POST `/discover/sources/{id}/refresh` 500s on every call:

```
File "/app/app/api/discover.py", line 151, in refresh_source
    if not _REFRESH_LIMITER.allow(ip):
AttributeError: 'RateLimiter' object has no attribute 'allow'
```

I used `.allow()` returning bool — the actual API is `.check(key)` which raises `HTTPException(429)` directly.

## Fix

One-liner — switch to `.check()` and let it raise. Matches the pattern used elsewhere in the codebase (login throttle, etc.).

## Discovered

Operator hit Refresh for the first time after PR #408 deploy. Frontend showed "Internal Server Error" toast; trace was in container logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)