### PR TITLE
feat(mjh/discovery): saved-search filters (location, employment, experience, min salary, excluded keywords)

### DIFF
--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
@@ -64,11 +64,26 @@ class DiscoveryUnsupportedSourceError(DiscoveryFetchError):
 # and returning a list[RawPosting] dict. Add new entries here as adapters
 # come online.
 async def _run_jsearch(config: dict[str, Any]) -> list[dict]:
-    query = (config.get("query") or "").strip()
-    if not query:
+    base_query = (config.get("query") or "").strip()
+    if not base_query:
         raise DiscoveryFetchError(
             "JSearch source missing required config.query",
         )
+
+    # JSearch's /search endpoint takes location inside the query string
+    # (e.g. "developer in Chicago"). If the operator filled the dedicated
+    # location field, fold it into the query so the source-side filter
+    # narrows results instead of returning the world and filtering later.
+    location = (config.get("location") or "").strip()
+    if location:
+        # Don't double-append "in <X>" if the operator already wrote it.
+        if " in " not in base_query.lower():
+            query = f"{base_query} in {location}"
+        else:
+            query = base_query
+    else:
+        query = base_query
+
     return await jsearch.search(
         query=query,
         page=int(config.get("page", 1)),
@@ -77,7 +92,75 @@ async def _run_jsearch(config: dict[str, Any]) -> list[dict]:
         country=config.get("country", "us"),
         remote_jobs_only=bool(config.get("remote_jobs_only", False)),
         employment_types=config.get("employment_types"),
+        job_requirements=config.get("job_requirements"),
     )
+
+
+# ---------------------------------------------------------------------------
+# Post-fetch filtering — operator preferences applied before upsert.
+# ---------------------------------------------------------------------------
+
+
+def _apply_post_fetch_filters(
+    postings: list[dict],
+    config: dict[str, Any],
+) -> list[dict]:
+    """Drop postings that match operator-configured exclusions.
+
+    Two filters today, both stored on ``discovery_sources.config``:
+
+    1. ``min_salary_usd`` (int, optional) — drop postings whose
+       ``salary_min`` is set AND below the floor. Postings with no
+       salary information pass through (the source didn't disclose;
+       we don't punish the listing for that).
+
+    2. ``excluded_keywords`` (list[str], optional) — case-insensitive
+       substring match against title + company_name + description +
+       source_publisher. One unified list lets the operator block
+       specific companies ("lockheed"), industries ("defense",
+       "government"), and title words ("junior", "intern") through one
+       UI.
+    """
+    min_salary_raw = config.get("min_salary_usd")
+    try:
+        min_salary = float(min_salary_raw) if min_salary_raw is not None else None
+    except (TypeError, ValueError):
+        min_salary = None
+
+    excluded = config.get("excluded_keywords")
+    if isinstance(excluded, list):
+        excluded_lower = [
+            kw.strip().lower() for kw in excluded
+            if isinstance(kw, str) and kw.strip()
+        ]
+    else:
+        excluded_lower = []
+
+    if min_salary is None and not excluded_lower:
+        return postings
+
+    kept: list[dict] = []
+    for p in postings:
+        # Salary floor: skip when the source disclosed a min and it's
+        # below the floor. None salary = unknown = pass-through.
+        if min_salary is not None:
+            posting_min = p.get("salary_min")
+            if posting_min is not None and posting_min < min_salary:
+                continue
+
+        # Excluded keywords: substring match in any of the visible
+        # text fields. A single match is enough to drop the posting.
+        if excluded_lower:
+            haystack = " ".join(
+                str(p.get(field) or "").lower()
+                for field in ("title", "company_name", "description", "source_publisher")
+            )
+            if any(kw in haystack for kw in excluded_lower):
+                continue
+
+        kept.append(p)
+
+    return kept
 
 
 _ADAPTERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[dict]]]] = {
@@ -168,6 +251,9 @@ async def fetch_source(
         raise DiscoveryFetchError(str(exc)) from exc
 
     fetched_count = len(postings)
+
+    # ---- Apply operator's post-fetch filters (min salary, excluded keywords) ----
+    postings = _apply_post_fetch_filters(postings, source.config or {})
 
     # ---- Upsert ----
     if postings:

--- a/apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py
@@ -106,6 +106,7 @@ async def search(
     country: str = "us",
     remote_jobs_only: bool = False,
     employment_types: str | None = None,
+    job_requirements: str | None = None,
     api_key: str | None = None,
 ) -> list[dict]:
     """Run a JSearch query and return normalized RawPosting dicts.
@@ -123,6 +124,9 @@ async def search(
         country: 2-letter ISO code. Defaults to ``us``.
         remote_jobs_only: When True, sets the source-side filter.
         employment_types: Comma-separated filter, e.g. ``FULLTIME,CONTRACTOR``.
+        job_requirements: One or more (comma-separated) of
+            ``no_experience``, ``under_3_years_experience``,
+            ``more_than_3_years_experience``, ``no_degree``.
         api_key: Override for tests. Production reads ``settings.jsearch_api_key``.
 
     Returns:
@@ -156,6 +160,8 @@ async def search(
         params["remote_jobs_only"] = "true"
     if employment_types:
         params["employment_types"] = employment_types
+    if job_requirements:
+        params["job_requirements"] = job_requirements
 
     headers = {
         "X-RapidAPI-Key": key,

--- a/apps/myjobhunter/backend/tests/test_discovery_post_fetch_filters.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_post_fetch_filters.py
@@ -1,0 +1,130 @@
+"""Unit tests for the discovery post-fetch filter.
+
+Pure function — no DB, no HTTP. Verifies the operator's
+``min_salary_usd`` and ``excluded_keywords`` filters drop the right
+postings before they're upserted into ``discovered_jobs``.
+"""
+from __future__ import annotations
+
+from app.services.discovery.discovery_fetch_service import (
+    _apply_post_fetch_filters,
+)
+
+
+def _posting(**overrides):
+    base = {
+        "title": "Senior Software Engineer",
+        "company_name": "Acme",
+        "description": "We're looking for a senior engineer.",
+        "source_publisher": "LinkedIn",
+        "salary_min": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_no_config_keeps_everything() -> None:
+    postings = [_posting(), _posting(title="Junior Dev"), _posting(salary_min=50000)]
+    assert _apply_post_fetch_filters(postings, {}) == postings
+
+
+def test_min_salary_drops_below_floor() -> None:
+    postings = [
+        _posting(salary_min=80000),
+        _posting(salary_min=150000),
+        _posting(salary_min=200000),
+    ]
+    result = _apply_post_fetch_filters(postings, {"min_salary_usd": 150000})
+    assert len(result) == 2
+    assert {p["salary_min"] for p in result} == {150000, 200000}
+
+
+def test_min_salary_keeps_unknown_salary() -> None:
+    """A posting with salary_min=None should NOT be dropped — we don't
+    know the salary, so we don't punish the listing for the source not
+    disclosing."""
+    postings = [_posting(salary_min=None), _posting(salary_min=50000)]
+    result = _apply_post_fetch_filters(postings, {"min_salary_usd": 100000})
+    assert len(result) == 1
+    assert result[0]["salary_min"] is None
+
+
+def test_excluded_keyword_matches_title() -> None:
+    postings = [_posting(title="Junior Software Engineer"), _posting(title="Senior")]
+    result = _apply_post_fetch_filters(postings, {"excluded_keywords": ["junior"]})
+    assert len(result) == 1
+    assert result[0]["title"] == "Senior"
+
+
+def test_excluded_keyword_matches_company() -> None:
+    postings = [
+        _posting(company_name="Lockheed Martin"),
+        _posting(company_name="Stripe"),
+    ]
+    result = _apply_post_fetch_filters(
+        postings, {"excluded_keywords": ["lockheed"]},
+    )
+    assert len(result) == 1
+    assert result[0]["company_name"] == "Stripe"
+
+
+def test_excluded_keyword_matches_description() -> None:
+    postings = [
+        _posting(description="Top secret defense clearance required"),
+        _posting(description="Build cool product features"),
+    ]
+    result = _apply_post_fetch_filters(
+        postings, {"excluded_keywords": ["defense"]},
+    )
+    assert len(result) == 1
+    assert "defense" not in result[0]["description"].lower()
+
+
+def test_excluded_keywords_case_insensitive() -> None:
+    postings = [_posting(company_name="LOCKHEED MARTIN")]
+    result = _apply_post_fetch_filters(
+        postings, {"excluded_keywords": ["lockheed"]},
+    )
+    assert result == []
+
+
+def test_excluded_keywords_empty_strings_ignored() -> None:
+    """Whitespace-only entries shouldn't accidentally match every posting."""
+    postings = [_posting(), _posting(title="Junior")]
+    result = _apply_post_fetch_filters(
+        postings, {"excluded_keywords": ["  ", "", "junior"]},
+    )
+    assert len(result) == 1
+
+
+def test_combined_min_salary_and_excluded_keywords() -> None:
+    postings = [
+        _posting(title="Junior Eng", salary_min=200000),  # excluded word
+        _posting(title="Senior Eng", salary_min=80000),  # below floor
+        _posting(title="Senior Eng", salary_min=200000),  # KEEP
+        _posting(title="Senior Eng", salary_min=None),  # unknown salary, KEEP
+        _posting(title="Senior Eng", company_name="Lockheed Martin"),  # excluded
+    ]
+    result = _apply_post_fetch_filters(
+        postings,
+        {"min_salary_usd": 150000, "excluded_keywords": ["junior", "lockheed"]},
+    )
+    assert len(result) == 2
+    titles_companies = [(p["title"], p["company_name"]) for p in result]
+    assert ("Senior Eng", "Acme") in titles_companies
+    # Both kept rows have title "Senior Eng" — distinguish by salary
+    salaries = sorted(
+        (p["salary_min"] for p in result),
+        key=lambda v: (v is None, v),
+    )
+    assert salaries == [200000, None]
+
+
+def test_min_salary_invalid_raw_falls_back_to_no_filter() -> None:
+    """If min_salary_usd is a non-numeric value, treat as not configured
+    rather than crashing."""
+    postings = [_posting(salary_min=10000)]
+    result = _apply_post_fetch_filters(
+        postings, {"min_salary_usd": "not a number"},
+    )
+    assert len(result) == 1

--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -7,30 +7,54 @@ interface NewSavedSearchDialogProps {
   onClose: () => void;
 }
 
+type DatePosted = "all" | "today" | "3days" | "week" | "month";
+type Experience = "" | "no_experience" | "under_3_years_experience" | "more_than_3_years_experience" | "no_degree";
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 border border-input rounded-md bg-background text-foreground";
+
 /**
  * Dialog for creating a new JSearch saved search.
  *
- * v1 only supports JSearch (Google Jobs aggregator). Other adapters —
- * Greenhouse, Lever, Ashby, RemoteOK, HN — are scaffolded in the
- * backend enum but have no adapters yet. When they ship, this dialog
- * picks up a source dropdown.
+ * Filter axes (passed to JSearch query-time):
+ *   - query (Boolean keywords)
+ *   - location (folded into query as "in <X>" when set)
+ *   - country, date_posted, remote_jobs_only
+ *   - employment_types (FULLTIME default)
+ *   - job_requirements (experience level)
+ *
+ * Filter axes (applied post-fetch, before upsert):
+ *   - min_salary_usd
+ *   - excluded_keywords (substring match against title + company +
+ *     description + source_publisher; one unified denylist for blocked
+ *     companies, industries, and title words)
  */
 export default function NewSavedSearchDialog({
   open,
   onClose,
 }: NewSavedSearchDialogProps) {
   const [query, setQuery] = useState("");
+  const [location, setLocation] = useState("");
   const [country, setCountry] = useState("us");
-  const [datePosted, setDatePosted] = useState<"all" | "today" | "3days" | "week" | "month">("week");
+  const [datePosted, setDatePosted] = useState<DatePosted>("week");
   const [remoteOnly, setRemoteOnly] = useState(false);
+  const [employmentType, setEmploymentType] = useState("FULLTIME");
+  const [experience, setExperience] = useState<Experience>("");
+  const [minSalary, setMinSalary] = useState("");
+  const [excludedKeywordsRaw, setExcludedKeywordsRaw] = useState("");
 
   const [createSource, { isLoading }] = useCreateDiscoverySourceMutation();
 
   function reset() {
     setQuery("");
+    setLocation("");
     setCountry("us");
     setDatePosted("week");
     setRemoteOnly(false);
+    setEmploymentType("FULLTIME");
+    setExperience("");
+    setMinSalary("");
+    setExcludedKeywordsRaw("");
   }
 
   async function handleConfirm() {
@@ -39,16 +63,30 @@ export default function NewSavedSearchDialog({
       showError("Enter a search query");
       return;
     }
+
+    const config: Record<string, unknown> = {
+      query: trimmed,
+      country,
+      date_posted: datePosted,
+      remote_jobs_only: remoteOnly,
+    };
+    if (location.trim()) config.location = location.trim();
+    if (employmentType) config.employment_types = employmentType;
+    if (experience) config.job_requirements = experience;
+
+    const minSalaryNum = Number(minSalary);
+    if (minSalary && Number.isFinite(minSalaryNum) && minSalaryNum > 0) {
+      config.min_salary_usd = Math.floor(minSalaryNum);
+    }
+
+    const excluded = excludedKeywordsRaw
+      .split(/[,\n]/)
+      .map((s) => s.trim())
+      .filter(Boolean);
+    if (excluded.length > 0) config.excluded_keywords = excluded;
+
     try {
-      await createSource({
-        source: "jsearch",
-        config: {
-          query: trimmed,
-          country,
-          date_posted: datePosted,
-          remote_jobs_only: remoteOnly,
-        },
-      }).unwrap();
+      await createSource({ source: "jsearch", config }).unwrap();
       showSuccess("Saved search created");
       reset();
       onClose();
@@ -79,11 +117,24 @@ export default function NewSavedSearchDialog({
             value={query}
             onChange={(e) => setQuery(e.target.value)}
             placeholder='"Senior Backend Engineer" Python'
-            className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground"
+            className={INPUT_CLASS}
             autoFocus
           />
           <p className="text-xs text-muted-foreground mt-1">
-            Boolean operators supported. Example: "Senior Backend Engineer" Python remote
+            Boolean operators supported. Example: "Senior Backend Engineer" Python
+          </p>
+        </FormField>
+
+        <FormField label="Location (optional)">
+          <input
+            type="text"
+            value={location}
+            onChange={(e) => setLocation(e.target.value)}
+            placeholder="Remote, San Francisco, New York, etc."
+            className={INPUT_CLASS}
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Folded into the query as "in &lt;location&gt;". Leave blank for any.
           </p>
         </FormField>
 
@@ -92,7 +143,7 @@ export default function NewSavedSearchDialog({
             <select
               value={country}
               onChange={(e) => setCountry(e.target.value)}
-              className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground"
+              className={INPUT_CLASS}
             >
               <option value="us">United States</option>
               <option value="ca">Canada</option>
@@ -104,8 +155,8 @@ export default function NewSavedSearchDialog({
           <FormField label="Posted">
             <select
               value={datePosted}
-              onChange={(e) => setDatePosted(e.target.value as typeof datePosted)}
-              className="w-full px-3 py-2 border border-input rounded-md bg-background text-foreground"
+              onChange={(e) => setDatePosted(e.target.value as DatePosted)}
+              className={INPUT_CLASS}
             >
               <option value="today">Past 24 hours</option>
               <option value="3days">Past 3 days</option>
@@ -115,6 +166,67 @@ export default function NewSavedSearchDialog({
             </select>
           </FormField>
         </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <FormField label="Employment type">
+            <select
+              value={employmentType}
+              onChange={(e) => setEmploymentType(e.target.value)}
+              className={INPUT_CLASS}
+            >
+              <option value="FULLTIME">Full-time</option>
+              <option value="CONTRACTOR">Contract</option>
+              <option value="PARTTIME">Part-time</option>
+              <option value="INTERN">Intern</option>
+              <option value="">Any</option>
+            </select>
+          </FormField>
+
+          <FormField label="Experience">
+            <select
+              value={experience}
+              onChange={(e) => setExperience(e.target.value as Experience)}
+              className={INPUT_CLASS}
+            >
+              <option value="">Any</option>
+              <option value="more_than_3_years_experience">3+ years</option>
+              <option value="under_3_years_experience">Under 3 years</option>
+              <option value="no_experience">Entry level</option>
+              <option value="no_degree">No degree required</option>
+            </select>
+          </FormField>
+        </div>
+
+        <FormField label="Minimum salary (USD, optional)">
+          <input
+            type="number"
+            value={minSalary}
+            onChange={(e) => setMinSalary(e.target.value)}
+            placeholder="e.g. 150000"
+            min={0}
+            step={1000}
+            className={INPUT_CLASS}
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Drops postings below this floor when the source posts a salary range.
+            Postings with no salary disclosed are kept.
+          </p>
+        </FormField>
+
+        <FormField label="Excluded keywords (optional)">
+          <textarea
+            value={excludedKeywordsRaw}
+            onChange={(e) => setExcludedKeywordsRaw(e.target.value)}
+            placeholder={"lockheed, peraton, defense, government,\njunior, intern, contract"}
+            rows={3}
+            className={INPUT_CLASS}
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Comma- or newline-separated. Drops postings whose title, company,
+            description, or publisher contains any of these (case-insensitive).
+            Use this to skip industries, companies, or seniority levels you don't want.
+          </p>
+        </FormField>
 
         <label className="flex items-center gap-2 text-sm">
           <input


### PR DESCRIPTION
## Summary

Operator's first real use of /discover surfaced too much noise — defense industry roles (Lockheed, Peraton, KBR), government, mixed remote/on-site, mixed full-time/contract. This PR adds five new saved-search filters to narrow at fetch time so the inbox is signal-only.

## Filters

### JSearch query-time (narrow the API call itself)

| Filter | Notes |
|---|---|
| Location | Folded into query as "in <X>" — JSearch doesn't expose a separate location param |
| Employment type | FULLTIME default; CONTRACTOR/PARTTIME/INTERN/Any |
| Experience level | 3+yr / under 3yr / entry / no degree / any |

### Post-fetch (applied in the service before upsert)

| Filter | Behavior |
|---|---|
| Min salary | Drops postings below floor when source posts a salary range. Postings with no salary disclosed pass through. |
| Excluded keywords | Case-insensitive substring match against title + company + description + publisher. ONE unified denylist covers blocked companies ("lockheed"), industries ("defense", "government"), and seniority words ("junior", "intern"). |

## Why one `excluded_keywords` field

Operator's pain was a mix — Lockheed (company), defense (industry), junior (title word). Splitting into three lists multiplies UI complexity for the same effect since all three end up as substring matches anyway. One textarea wins.

## Test plan

- [x] 10 unit tests in `tests/test_discovery_post_fetch_filters.py` (no-config / min-salary floor / unknown-salary pass-through / keyword matches title|company|description / case-insensitive / whitespace-ignored / combined / invalid-type)
- [x] Frontend typecheck clean
- [ ] CI runs full suite

## What's NOT in this PR

- Edit-existing-saved-search UI — operator deletes + recreates for now. Bigger UX change; defer until the friction is real.
- Dedicated "exclude publishers" field — `excluded_keywords` already covers this (add "ziprecruiter" to the denylist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)