### PR TITLE
feat(mjh/discovery): Phase A — profile-driven saved-search dialog

### DIFF
--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
@@ -29,6 +29,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.discovery.discovery_source import DiscoverySource
 from app.repositories.discovery import discovery_repository
+from app.services.discovery.industry_denylists import expand_excluded_keywords
 from app.services.discovery.sources import jsearch
 
 logger = logging.getLogger(__name__)
@@ -64,10 +65,10 @@ class DiscoveryUnsupportedSourceError(DiscoveryFetchError):
 # and returning a list[RawPosting] dict. Add new entries here as adapters
 # come online.
 async def _run_jsearch(config: dict[str, Any]) -> list[dict]:
-    base_query = (config.get("query") or "").strip()
+    base_query = _build_jsearch_query(config)
     if not base_query:
         raise DiscoveryFetchError(
-            "JSearch source missing required config.query",
+            "JSearch source missing required config.query (or config.roles)",
         )
 
     # JSearch's /search endpoint takes location inside the query string
@@ -91,9 +92,58 @@ async def _run_jsearch(config: dict[str, Any]) -> list[dict]:
         date_posted=config.get("date_posted", "all"),
         country=config.get("country", "us"),
         remote_jobs_only=bool(config.get("remote_jobs_only", False)),
-        employment_types=config.get("employment_types"),
-        job_requirements=config.get("job_requirements"),
+        employment_types=config.get("employment_types") or config.get("employment_type"),
+        job_requirements=config.get("job_requirements") or config.get("experience"),
     )
+
+
+def _build_jsearch_query(config: dict[str, Any]) -> str:
+    """Assemble the JSearch query string from structured config.
+
+    Two shapes accepted:
+
+    1. **Legacy** — caller pre-built the Boolean string in
+       ``config.query``. We use it verbatim.
+    2. **Structured** — caller supplied ``roles`` (list of titles)
+       and/or ``skills`` (list of skill names). We assemble:
+
+           ("Role 1" OR "Role 2") (Skill1 OR Skill2)
+
+       Quoted phrases for multi-word roles, parens around the OR
+       group so JSearch treats it as a single clause. Skills are
+       not quoted (single tokens) and are also OR'd.
+
+    Empty / missing → returns an empty string and the caller raises.
+    """
+    raw_query = (config.get("query") or "").strip()
+    if raw_query:
+        return raw_query
+
+    roles_raw = config.get("roles") or []
+    skills_raw = config.get("skills") or []
+
+    role_parts = [r.strip() for r in roles_raw if isinstance(r, str) and r.strip()]
+    skill_parts = [s.strip() for s in skills_raw if isinstance(s, str) and s.strip()]
+
+    parts: list[str] = []
+
+    if role_parts:
+        # Quote multi-word role titles so JSearch matches the phrase.
+        quoted = [
+            f'"{r}"' if " " in r else r for r in role_parts
+        ]
+        if len(quoted) == 1:
+            parts.append(quoted[0])
+        else:
+            parts.append("(" + " OR ".join(quoted) + ")")
+
+    if skill_parts:
+        if len(skill_parts) == 1:
+            parts.append(skill_parts[0])
+        else:
+            parts.append("(" + " OR ".join(skill_parts) + ")")
+
+    return " ".join(parts).strip()
 
 
 # ---------------------------------------------------------------------------
@@ -127,14 +177,16 @@ def _apply_post_fetch_filters(
     except (TypeError, ValueError):
         min_salary = None
 
-    excluded = config.get("excluded_keywords")
-    if isinstance(excluded, list):
-        excluded_lower = [
-            kw.strip().lower() for kw in excluded
-            if isinstance(kw, str) and kw.strip()
-        ]
-    else:
-        excluded_lower = []
+    # Two sources of excluded keywords merged together:
+    #   - operator's custom strings on ``config.excluded_keywords``
+    #   - industry chip expansions on ``config.excluded_industry_chips``
+    # ``expand_excluded_keywords`` deduplicates + lowercases.
+    raw_custom = config.get("excluded_keywords")
+    raw_chips = config.get("excluded_industry_chips")
+    excluded_lower = expand_excluded_keywords(
+        chips=raw_chips if isinstance(raw_chips, list) else None,
+        custom_keywords=raw_custom if isinstance(raw_custom, list) else None,
+    )
 
     if min_salary is None and not excluded_lower:
         return postings

--- a/apps/myjobhunter/backend/app/services/discovery/industry_denylists.py
+++ b/apps/myjobhunter/backend/app/services/discovery/industry_denylists.py
@@ -1,0 +1,167 @@
+"""Curated keyword denylists for industry-exclusion chips on /discover.
+
+The frontend's "Exclude industries" toggle group surfaces semantic chips
+(``government_defense``, ``staffing_recruiting``, etc.) — short labels
+the operator clicks instead of recalling and typing 16 individual
+company names. The chip names are stored on
+``discovery_sources.config.excluded_industry_chips``; this module
+expands them into the actual substring-match keyword list at fetch
+time.
+
+Why expansion at fetch time (not at save time)
+==============================================
+
+Storing the chip names rather than the expanded keyword list means we
+can refine the underlying lists (add a newly-spun-up defense
+contractor, drop one that's broadened beyond gov work) without
+migrating every existing saved search's config. Existing searches
+benefit from the new lists on their next refresh.
+
+Why substring match (not exact match or regex)
+==============================================
+
+The operator's mental model is "if any of these words appear in the
+title, company, description, or publisher field of a posting, drop
+it." Substring is the simplest implementation that matches that
+model. Edge cases (false-positive matches like "ManTech" → "tech",
+"defensive" → "defense") are rare and the cost is dropping a posting
+the operator probably wouldn't have wanted anyway.
+
+Adding new chips
+================
+
+1. Pick a snake_case key.
+2. Add an entry below with the keywords (lowercase; substring match
+   is case-insensitive at apply time).
+3. Mirror the entry in ``apps/myjobhunter/frontend/src/features/discover/industry-chips.ts``
+   so the frontend renders a chip with the same key.
+4. The keyword list should be conservative — false-positives drop
+   real opportunities. Add a company / term only if the operator
+   would always want it filtered.
+"""
+from __future__ import annotations
+
+from typing import Iterable
+
+
+# Each chip key maps to the substring keywords it expands into. Keep
+# entries lowercase; the apply step lowercases haystacks before
+# matching so case doesn't matter at match time.
+INDUSTRY_DENYLISTS: dict[str, tuple[str, ...]] = {
+    "government_defense": (
+        # Top-tier US defense contractors and their common abbreviations.
+        "lockheed martin",
+        "lockheed",
+        "boeing defense",
+        "northrop grumman",
+        "northrop",
+        "raytheon",
+        "rtx ",  # space avoids matching "rtx 4090" gpu mentions
+        "general dynamics",
+        "bae systems",
+        "l3harris",
+        "leidos",
+        "saic",
+        "caci",
+        "mantech",
+        "booz allen",
+        "mitre",
+        "anduril",
+        "peraton",
+        "kbr",
+        # Clearance + federal-customer language.
+        "secret clearance",
+        "top secret",
+        "ts/sci",
+        "tssci",
+        "active clearance",
+        "security clearance",
+        "dod ",
+        "department of defense",
+        "defense contractor",
+        "federal contractor",
+        "us federal",
+        "intelligence community",
+    ),
+    "staffing_recruiting": (
+        # Third-party staffing/recruiting firms — postings are
+        # typically W2 contracts at a real client, not jobs at the
+        # firm itself. Operator usually wants to skip these.
+        "staffing",
+        "recruiting firm",
+        "contract to hire",
+        "w2 contract",
+        "c2c",
+        "corp to corp",
+        "jobs via dice",
+        "via dice",
+        "jobs via",
+    ),
+    "consulting_big4": (
+        "deloitte",
+        "accenture",
+        "kpmg",
+        "ernst & young",
+        "ernst and young",
+        "pricewaterhousecoopers",
+        "pwc ",
+    ),
+    "crypto_web3": (
+        "crypto",
+        "blockchain",
+        "web3",
+        "defi",
+        "nft",
+        "smart contract engineer",
+    ),
+    "adtech_gambling": (
+        "adtech",
+        "ad tech",
+        "programmatic ad",
+        "gambling",
+        "sportsbook",
+        "casino",
+        "betting",
+    ),
+}
+
+
+def expand_excluded_keywords(
+    chips: Iterable[str] | None,
+    custom_keywords: Iterable[str] | None,
+) -> list[str]:
+    """Merge industry chip expansions with the operator's custom keywords.
+
+    Returns a deduplicated list of lowercase substrings ready to feed
+    into the post-fetch filter's case-insensitive match.
+
+    Unknown chip keys are silently skipped — they're stored on the
+    saved search's config so a frontend bug renaming a chip key
+    shouldn't break the worker.
+    """
+    out: list[str] = []
+    seen: set[str] = set()
+
+    if chips:
+        for chip in chips:
+            if not isinstance(chip, str):
+                continue
+            keywords = INDUSTRY_DENYLISTS.get(chip)
+            if keywords is None:
+                continue
+            for kw in keywords:
+                normalized = kw.strip().lower()
+                if normalized and normalized not in seen:
+                    seen.add(normalized)
+                    out.append(normalized)
+
+    if custom_keywords:
+        for kw in custom_keywords:
+            if not isinstance(kw, str):
+                continue
+            normalized = kw.strip().lower()
+            if normalized and normalized not in seen:
+                seen.add(normalized)
+                out.append(normalized)
+
+    return out

--- a/apps/myjobhunter/backend/tests/test_discovery_industry_chips.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_industry_chips.py
@@ -1,0 +1,198 @@
+"""Tests for industry-chip expansion + structured-query assembly.
+
+Covers:
+- ``expand_excluded_keywords`` merges chip expansions with custom keywords,
+  deduplicates, lowercases, and silently skips unknown chips.
+- ``_build_jsearch_query`` assembles Boolean queries from structured
+  ``roles`` / ``skills`` config; falls back to legacy ``query``.
+- End-to-end: a structured config with industry chips drops the right
+  postings via ``_apply_post_fetch_filters``.
+"""
+from __future__ import annotations
+
+from app.services.discovery.discovery_fetch_service import (
+    _apply_post_fetch_filters,
+    _build_jsearch_query,
+)
+from app.services.discovery.industry_denylists import (
+    INDUSTRY_DENYLISTS,
+    expand_excluded_keywords,
+)
+
+
+# ===========================================================================
+# expand_excluded_keywords
+# ===========================================================================
+
+
+def test_expand_known_chip_returns_keywords() -> None:
+    result = expand_excluded_keywords(chips=["government_defense"], custom_keywords=None)
+    assert "lockheed martin" in result
+    assert "secret clearance" in result
+    assert all(kw == kw.lower() for kw in result)
+
+
+def test_expand_unknown_chip_silently_skipped() -> None:
+    result = expand_excluded_keywords(
+        chips=["not_a_real_chip", "government_defense"],
+        custom_keywords=None,
+    )
+    # Real chip's keywords still expanded; unknown chip just doesn't add.
+    assert "lockheed martin" in result
+
+
+def test_expand_merges_chip_and_custom_dedups() -> None:
+    # "lockheed" is in the chip's expanded list AND the custom list.
+    result = expand_excluded_keywords(
+        chips=["government_defense"],
+        custom_keywords=["lockheed martin", "Anthropic Crypto Bot"],
+    )
+    # Each entry appears exactly once.
+    assert result.count("lockheed martin") == 1
+    assert "anthropic crypto bot" in result  # lowercased
+
+
+def test_expand_handles_none_inputs() -> None:
+    assert expand_excluded_keywords(None, None) == []
+    assert expand_excluded_keywords([], []) == []
+
+
+def test_expand_skips_non_string_entries() -> None:
+    result = expand_excluded_keywords(
+        chips=[123, "government_defense", None],  # type: ignore[list-item]
+        custom_keywords=[True, "valid", ""],  # type: ignore[list-item]
+    )
+    assert "valid" in result
+    assert "lockheed martin" in result
+
+
+def test_all_known_chip_keys_have_non_empty_expansions() -> None:
+    """Every chip in INDUSTRY_DENYLISTS must expand to at least one
+    keyword — an empty list would be a footgun."""
+    for chip_key, keywords in INDUSTRY_DENYLISTS.items():
+        assert len(keywords) > 0, f"chip {chip_key!r} has empty expansion"
+        # All keywords lowercase for the case-insensitive match.
+        for kw in keywords:
+            assert kw == kw.lower(), f"{chip_key}/{kw!r} not lowercased"
+
+
+# ===========================================================================
+# _build_jsearch_query
+# ===========================================================================
+
+
+def test_build_query_single_role_no_skills() -> None:
+    assert _build_jsearch_query({"roles": ["Backend Engineer"]}) == '"Backend Engineer"'
+
+
+def test_build_query_single_role_with_skills() -> None:
+    result = _build_jsearch_query({
+        "roles": ["Senior Backend Engineer"],
+        "skills": ["Python", "FastAPI"],
+    })
+    assert result == '"Senior Backend Engineer" (Python OR FastAPI)'
+
+
+def test_build_query_multiple_roles() -> None:
+    result = _build_jsearch_query({
+        "roles": ["Senior Backend Engineer", "Staff Software Engineer"],
+    })
+    assert result == '("Senior Backend Engineer" OR "Staff Software Engineer")'
+
+
+def test_build_query_legacy_raw_query_passes_through() -> None:
+    assert _build_jsearch_query({"query": "anything goes"}) == "anything goes"
+
+
+def test_build_query_legacy_takes_precedence_over_structured() -> None:
+    """If both ``query`` and ``roles`` are set, ``query`` wins. Legacy
+    saved searches keep their behavior; new structured ones must not
+    set ``query``."""
+    result = _build_jsearch_query({
+        "query": "raw boolean",
+        "roles": ["ignored"],
+    })
+    assert result == "raw boolean"
+
+
+def test_build_query_empty_when_nothing_set() -> None:
+    assert _build_jsearch_query({}) == ""
+
+
+def test_build_query_skips_blank_roles_and_skills() -> None:
+    result = _build_jsearch_query({
+        "roles": ["", "  ", "Real Role"],
+        "skills": [None, "", "Python"],  # type: ignore[list-item]
+    })
+    assert result == '"Real Role" Python'
+
+
+def test_build_query_single_word_role_not_quoted() -> None:
+    """One-word role titles don't need phrase quoting."""
+    result = _build_jsearch_query({"roles": ["Engineer"]})
+    assert result == "Engineer"
+
+
+# ===========================================================================
+# End-to-end: structured config + industry chip → post-fetch filter
+# ===========================================================================
+
+
+def _posting(**overrides):
+    base = {
+        "title": "Senior Software Engineer",
+        "company_name": "Acme",
+        "description": "We're a SaaS company hiring engineers.",
+        "source_publisher": "LinkedIn",
+        "salary_min": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_government_defense_chip_drops_lockheed() -> None:
+    postings = [
+        _posting(company_name="Lockheed Martin"),
+        _posting(company_name="Stripe"),
+    ]
+    config = {"excluded_industry_chips": ["government_defense"]}
+    result = _apply_post_fetch_filters(postings, config)
+    assert len(result) == 1
+    assert result[0]["company_name"] == "Stripe"
+
+
+def test_government_defense_chip_drops_clearance_required() -> None:
+    postings = [
+        _posting(description="Active TS/SCI clearance required."),
+        _posting(description="Build cool consumer features."),
+    ]
+    config = {"excluded_industry_chips": ["government_defense"]}
+    result = _apply_post_fetch_filters(postings, config)
+    assert len(result) == 1
+    assert "ts/sci" not in result[0]["description"].lower()
+
+
+def test_chip_and_custom_combine() -> None:
+    postings = [
+        _posting(title="Junior Eng"),  # custom
+        _posting(company_name="Lockheed Martin"),  # chip
+        _posting(title="Senior Eng", company_name="Stripe"),  # KEEP
+    ]
+    config = {
+        "excluded_industry_chips": ["government_defense"],
+        "excluded_keywords": ["junior"],
+    }
+    result = _apply_post_fetch_filters(postings, config)
+    assert len(result) == 1
+    assert result[0]["company_name"] == "Stripe"
+
+
+def test_staffing_chip_drops_via_dice_postings() -> None:
+    postings = [
+        _posting(company_name="Jobs via Dice", description="W2 contract"),
+        _posting(company_name="Real Company", description="Direct hire"),
+    ]
+    config = {"excluded_industry_chips": ["staffing_recruiting"]}
+    result = _apply_post_fetch_filters(postings, config)
+    assert len(result) == 1
+    assert result[0]["company_name"] == "Real Company"

--- a/apps/myjobhunter/frontend/src/features/discover/MultiChipInput.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/MultiChipInput.tsx
@@ -1,0 +1,120 @@
+import { useRef, useState, type KeyboardEvent } from "react";
+import { X } from "lucide-react";
+
+interface MultiChipInputProps {
+  value: string[];
+  onChange: (next: string[]) => void;
+  placeholder?: string;
+  ariaLabel?: string;
+  /** Suggestions shown as one-tap chips below the input. Already-added
+   *  values are filtered out automatically. */
+  suggestions?: string[];
+}
+
+/**
+ * Controlled multi-chip text input.
+ *
+ * Operator types a value, presses Enter (or comma), and the value
+ * becomes a chip. Backspace on an empty input removes the last chip.
+ *
+ * Mobile-friendly: each chip's remove button is a 36px tap target.
+ *
+ * Local to features/discover for now; promote to ``@platform/ui`` when
+ * MBK needs the same primitive.
+ */
+export default function MultiChipInput({
+  value,
+  onChange,
+  placeholder,
+  ariaLabel,
+  suggestions,
+}: MultiChipInputProps) {
+  const [draft, setDraft] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  function addValue(raw: string) {
+    const cleaned = raw.trim();
+    if (!cleaned) return;
+    if (value.includes(cleaned)) return;
+    onChange([...value, cleaned]);
+  }
+
+  function removeAt(index: number) {
+    onChange(value.filter((_, i) => i !== index));
+    inputRef.current?.focus();
+  }
+
+  function handleKeyDown(e: KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault();
+      addValue(draft);
+      setDraft("");
+    } else if (e.key === "Backspace" && draft === "" && value.length > 0) {
+      e.preventDefault();
+      removeAt(value.length - 1);
+    }
+  }
+
+  const availableSuggestions = (suggestions ?? []).filter(
+    (s) => !value.includes(s),
+  );
+
+  return (
+    <div>
+      <div
+        className="flex flex-wrap gap-1.5 items-center px-2 py-1.5 border border-input rounded-md bg-background min-h-[44px]"
+        onClick={() => inputRef.current?.focus()}
+      >
+        {value.map((chip, i) => (
+          <span
+            key={`${chip}-${i}`}
+            className="inline-flex items-center gap-1 px-2 py-1 bg-muted rounded text-xs"
+          >
+            <span>{chip}</span>
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                removeAt(i);
+              }}
+              className="inline-flex items-center justify-center w-4 h-4 hover:text-destructive"
+              aria-label={`Remove ${chip}`}
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </span>
+        ))}
+        <input
+          ref={inputRef}
+          type="text"
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => {
+            if (draft.trim()) {
+              addValue(draft);
+              setDraft("");
+            }
+          }}
+          placeholder={value.length === 0 ? placeholder : ""}
+          aria-label={ariaLabel}
+          className="flex-1 min-w-[120px] bg-transparent text-sm focus:outline-none py-1"
+        />
+      </div>
+      {availableSuggestions.length > 0 && (
+        <div className="flex flex-wrap gap-1 mt-1.5">
+          {availableSuggestions.map((s) => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => addValue(s)}
+              className="px-2 py-0.5 text-xs border border-dashed border-muted-foreground/40 rounded text-muted-foreground hover:text-foreground hover:border-foreground"
+            >
+              + {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -1,6 +1,19 @@
-import { useState } from "react";
-import { ConfirmDialog, FormField, showError, showSuccess, extractErrorMessage } from "@platform/ui";
+import { useEffect, useMemo, useState } from "react";
+import {
+  ConfirmDialog,
+  FormField,
+  showError,
+  showSuccess,
+  extractErrorMessage,
+} from "@platform/ui";
 import { useCreateDiscoverySourceMutation } from "@/store/discoverApi";
+import { useGetProfileQuery } from "@/lib/profileApi";
+import { useListSkillsQuery } from "@/lib/skillsApi";
+import { useListWorkHistoryQuery } from "@/lib/workHistoryApi";
+import MultiChipInput from "./MultiChipInput";
+import ToggleChipGroup from "./ToggleChipGroup";
+import { INDUSTRY_CHIPS } from "./industry-chips";
+import { buildSavedSearchSummary } from "./saved-search-summary";
 
 interface NewSavedSearchDialogProps {
   open: boolean;
@@ -8,7 +21,12 @@ interface NewSavedSearchDialogProps {
 }
 
 type DatePosted = "all" | "today" | "3days" | "week" | "month";
-type Experience = "" | "no_experience" | "under_3_years_experience" | "more_than_3_years_experience" | "no_degree";
+type Experience =
+  | ""
+  | "no_experience"
+  | "under_3_years_experience"
+  | "more_than_3_years_experience"
+  | "no_degree";
 
 const INPUT_CLASS =
   "w-full px-3 py-2 border border-input rounded-md bg-background text-foreground";
@@ -16,24 +34,29 @@ const INPUT_CLASS =
 /**
  * Dialog for creating a new JSearch saved search.
  *
- * Filter axes (passed to JSearch query-time):
- *   - query (Boolean keywords)
- *   - location (folded into query as "in <X>" when set)
- *   - country, date_posted, remote_jobs_only
- *   - employment_types (FULLTIME default)
- *   - job_requirements (experience level)
- *
- * Filter axes (applied post-fetch, before upsert):
- *   - min_salary_usd
- *   - excluded_keywords (substring match against title + company +
- *     description + source_publisher; one unified denylist for blocked
- *     companies, industries, and title words)
+ * Phase A redesign:
+ *   - Pre-fills every field from the operator's existing profile so they
+ *     review/confirm rather than start from blank.
+ *   - Replaces the free-form Boolean query field with structured Role +
+ *     Skill chip inputs. The Boolean query is assembled server-side.
+ *   - Industry exclusions surface as toggle chips backed by curated
+ *     server-side keyword lists.
+ *   - Plain-English summary updates reactively below the form so the
+ *     operator confirms what they're about to save.
  */
 export default function NewSavedSearchDialog({
   open,
   onClose,
 }: NewSavedSearchDialogProps) {
-  const [query, setQuery] = useState("");
+  const { data: profile } = useGetProfileQuery(undefined, { skip: !open });
+  const { data: skillsData } = useListSkillsQuery(undefined, { skip: !open });
+  const { data: workHistoryData } = useListWorkHistoryQuery(undefined, {
+    skip: !open,
+  });
+
+  // Form state — owned here, not in parent.
+  const [roles, setRoles] = useState<string[]>([]);
+  const [skills, setSkills] = useState<string[]>([]);
   const [location, setLocation] = useState("");
   const [country, setCountry] = useState("us");
   const [datePosted, setDatePosted] = useState<DatePosted>("week");
@@ -41,12 +64,77 @@ export default function NewSavedSearchDialog({
   const [employmentType, setEmploymentType] = useState("FULLTIME");
   const [experience, setExperience] = useState<Experience>("");
   const [minSalary, setMinSalary] = useState("");
-  const [excludedKeywordsRaw, setExcludedKeywordsRaw] = useState("");
+  const [excludedIndustryChips, setExcludedIndustryChips] = useState<string[]>(
+    [],
+  );
+  const [excludedKeywords, setExcludedKeywords] = useState<string[]>([]);
+  const [didPrefill, setDidPrefill] = useState(false);
 
   const [createSource, { isLoading }] = useCreateDiscoverySourceMutation();
 
+  const recentRoleSuggestions = useMemo(() => {
+    if (!workHistoryData?.items) return [];
+    // Most recent 3 distinct role titles from work history.
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const w of workHistoryData.items) {
+      const t = w.title?.trim();
+      if (!t || seen.has(t)) continue;
+      seen.add(t);
+      out.push(t);
+      if (out.length >= 3) break;
+    }
+    return out;
+  }, [workHistoryData]);
+
+  const skillSuggestions = useMemo(() => {
+    if (!skillsData?.items) return [];
+    return skillsData.items
+      .map((s) => s.name)
+      .filter((n): n is string => !!n && n.trim().length > 0)
+      .slice(0, 8);
+  }, [skillsData]);
+
+  // One-shot pre-fill on first open after profile loads.
+  useEffect(() => {
+    if (!open) return;
+    if (didPrefill) return;
+    if (!profile) return;
+
+    // Roles: most-recent work history title.
+    if (recentRoleSuggestions.length > 0) {
+      setRoles([recentRoleSuggestions[0]]);
+    }
+
+    // Remote: from profile preference.
+    setRemoteOnly(profile.remote_preference === "remote_only");
+
+    // Salary: from desired_salary_min.
+    if (profile.desired_salary_min) {
+      const parsed = Number(profile.desired_salary_min);
+      if (Number.isFinite(parsed) && parsed > 0) {
+        setMinSalary(String(Math.floor(parsed)));
+      }
+    }
+
+    // Experience: map profile.seniority into JSearch's enum.
+    if (profile.seniority) {
+      const s = profile.seniority.toLowerCase();
+      if (s.includes("senior") || s.includes("staff") || s.includes("principal") || s.includes("lead")) {
+        setExperience("more_than_3_years_experience");
+      } else if (s.includes("junior") || s.includes("entry")) {
+        setExperience("no_experience");
+      } else if (s.includes("mid")) {
+        setExperience("under_3_years_experience");
+      }
+    }
+
+    setDidPrefill(true);
+  }, [open, profile, recentRoleSuggestions, didPrefill]);
+
   function reset() {
-    setQuery("");
+    setRoles([]);
+    setSkills([]);
     setLocation("");
     setCountry("us");
     setDatePosted("week");
@@ -54,36 +142,39 @@ export default function NewSavedSearchDialog({
     setEmploymentType("FULLTIME");
     setExperience("");
     setMinSalary("");
-    setExcludedKeywordsRaw("");
+    setExcludedIndustryChips([]);
+    setExcludedKeywords([]);
+    setDidPrefill(false);
   }
 
   async function handleConfirm() {
-    const trimmed = query.trim();
-    if (!trimmed) {
-      showError("Enter a search query");
+    if (roles.length === 0) {
+      showError("Add at least one role title");
       return;
     }
 
     const config: Record<string, unknown> = {
-      query: trimmed,
+      roles,
+      skills,
       country,
       date_posted: datePosted,
       remote_jobs_only: remoteOnly,
     };
     if (location.trim()) config.location = location.trim();
-    if (employmentType) config.employment_types = employmentType;
-    if (experience) config.job_requirements = experience;
+    if (employmentType) config.employment_type = employmentType;
+    if (experience) config.experience = experience;
 
     const minSalaryNum = Number(minSalary);
     if (minSalary && Number.isFinite(minSalaryNum) && minSalaryNum > 0) {
       config.min_salary_usd = Math.floor(minSalaryNum);
     }
 
-    const excluded = excludedKeywordsRaw
-      .split(/[,\n]/)
-      .map((s) => s.trim())
-      .filter(Boolean);
-    if (excluded.length > 0) config.excluded_keywords = excluded;
+    if (excludedIndustryChips.length > 0) {
+      config.excluded_industry_chips = excludedIndustryChips;
+    }
+    if (excludedKeywords.length > 0) {
+      config.excluded_keywords = excludedKeywords;
+    }
 
     try {
       await createSource({ source: "jsearch", config }).unwrap();
@@ -100,6 +191,20 @@ export default function NewSavedSearchDialog({
     onClose();
   }
 
+  const summary = buildSavedSearchSummary({
+    roles,
+    skills,
+    location,
+    country,
+    datePosted,
+    remoteOnly,
+    employmentType,
+    experience,
+    minSalary,
+    excludedIndustryChips,
+    excludedKeywords,
+  });
+
   return (
     <ConfirmDialog
       open={open}
@@ -110,19 +215,31 @@ export default function NewSavedSearchDialog({
       onConfirm={handleConfirm}
       onCancel={handleCancel}
     >
-      <div className="space-y-4">
-        <FormField label="Search query" required>
-          <input
-            type="text"
-            value={query}
-            onChange={(e) => setQuery(e.target.value)}
-            placeholder='"Senior Backend Engineer" Python'
-            className={INPUT_CLASS}
-            autoFocus
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            Boolean operators supported. Example: "Senior Backend Engineer" Python
+      <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
+        {didPrefill && (
+          <p className="text-xs text-muted-foreground bg-muted/40 px-3 py-2 rounded">
+            Pre-filled from your profile. Edit anything below.
           </p>
+        )}
+
+        <FormField label="Role(s)" required>
+          <MultiChipInput
+            value={roles}
+            onChange={setRoles}
+            placeholder='e.g. "Senior Backend Engineer"'
+            ariaLabel="Role titles"
+            suggestions={recentRoleSuggestions}
+          />
+        </FormField>
+
+        <FormField label="Skills (optional)">
+          <MultiChipInput
+            value={skills}
+            onChange={setSkills}
+            placeholder="Python, FastAPI, PostgreSQL"
+            ariaLabel="Skills"
+            suggestions={skillSuggestions}
+          />
         </FormField>
 
         <FormField label="Location (optional)">
@@ -130,12 +247,15 @@ export default function NewSavedSearchDialog({
             type="text"
             value={location}
             onChange={(e) => setLocation(e.target.value)}
-            placeholder="Remote, San Francisco, New York, etc."
+            placeholder="City or 'Remote'"
             className={INPUT_CLASS}
+            disabled={remoteOnly}
           />
-          <p className="text-xs text-muted-foreground mt-1">
-            Folded into the query as "in &lt;location&gt;". Leave blank for any.
-          </p>
+          {remoteOnly && (
+            <p className="text-xs text-muted-foreground mt-1">
+              Disabled — you have remote-only on.
+            </p>
+          )}
         </FormField>
 
         <div className="grid grid-cols-2 gap-4">
@@ -202,29 +322,37 @@ export default function NewSavedSearchDialog({
             type="number"
             value={minSalary}
             onChange={(e) => setMinSalary(e.target.value)}
-            placeholder="e.g. 150000"
+            placeholder="150000"
             min={0}
             step={1000}
             className={INPUT_CLASS}
           />
           <p className="text-xs text-muted-foreground mt-1">
-            Drops postings below this floor when the source posts a salary range.
-            Postings with no salary disclosed are kept.
+            Drops postings below the floor when source posts a salary range.
+            Postings without disclosed salary are kept.
           </p>
         </FormField>
 
-        <FormField label="Excluded keywords (optional)">
-          <textarea
-            value={excludedKeywordsRaw}
-            onChange={(e) => setExcludedKeywordsRaw(e.target.value)}
-            placeholder={"lockheed, peraton, defense, government,\njunior, intern, contract"}
-            rows={3}
-            className={INPUT_CLASS}
+        <div>
+          <label className="block text-xs font-medium mb-1.5">
+            Exclude industries (one click skips all related companies + keywords)
+          </label>
+          <ToggleChipGroup
+            options={INDUSTRY_CHIPS}
+            value={excludedIndustryChips}
+            onChange={setExcludedIndustryChips}
+          />
+        </div>
+
+        <FormField label="Also exclude keywords (optional)">
+          <MultiChipInput
+            value={excludedKeywords}
+            onChange={setExcludedKeywords}
+            placeholder="junior, intern, ad hoc company name…"
+            ariaLabel="Excluded keywords"
           />
           <p className="text-xs text-muted-foreground mt-1">
-            Comma- or newline-separated. Drops postings whose title, company,
-            description, or publisher contains any of these (case-insensitive).
-            Use this to skip industries, companies, or seniority levels you don't want.
+            Case-insensitive substring match against title, company, description, publisher.
           </p>
         </FormField>
 
@@ -237,7 +365,42 @@ export default function NewSavedSearchDialog({
           />
           <span>Remote jobs only</span>
         </label>
+
+        {summary && (
+          <div className="border-t pt-3 mt-2">
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              {renderInlineMarkdown(summary)}
+            </p>
+          </div>
+        )}
       </div>
     </ConfirmDialog>
   );
+}
+
+/**
+ * Render a tiny subset of markdown (only **bold**) inline.
+ *
+ * Avoids pulling in a markdown library for one rendering. The summary
+ * is operator-controlled text passed through {@link buildSavedSearchSummary},
+ * so the only risk surface is the operator's own input — which is bounded
+ * (role / skill / location / keyword strings, all already trimmed).
+ */
+function renderInlineMarkdown(s: string): React.ReactNode {
+  const parts: React.ReactNode[] = [];
+  const re = /\*\*(.+?)\*\*/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  let key = 0;
+  while ((m = re.exec(s)) !== null) {
+    if (m.index > last) parts.push(s.slice(last, m.index));
+    parts.push(
+      <strong key={`b-${key++}`} className="text-foreground">
+        {m[1]}
+      </strong>,
+    );
+    last = m.index + m[0].length;
+  }
+  if (last < s.length) parts.push(s.slice(last));
+  return parts;
 }

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
@@ -46,8 +46,19 @@ function SavedSearchRow({ source }: { source: DiscoverySource }) {
   const [refresh, { isLoading: isRefreshing }] = useRefreshDiscoverySourceMutation();
   const [deactivate, { isLoading: isDeactivating }] = useDeactivateDiscoverySourceMutation();
 
-  const query =
-    typeof source.config?.query === "string" ? source.config.query : "(no query)";
+  // New saved searches use ``roles`` (list); legacy ones use ``query`` (string).
+  // Show whatever's available with a sensible fallback.
+  const query = (() => {
+    const roles = source.config?.roles;
+    if (Array.isArray(roles) && roles.length > 0) {
+      const validRoles = roles.filter((r): r is string => typeof r === "string");
+      if (validRoles.length > 0) return validRoles.join(" / ");
+    }
+    if (typeof source.config?.query === "string" && source.config.query) {
+      return source.config.query;
+    }
+    return "(no query)";
+  })();
   const lastFetched = source.last_fetched_at
     ? `Last fetched ${timeAgo(source.last_fetched_at)}`
     : "Never fetched";

--- a/apps/myjobhunter/frontend/src/features/discover/ToggleChipGroup.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/ToggleChipGroup.tsx
@@ -1,0 +1,58 @@
+interface ToggleOption {
+  value: string;
+  label: string;
+}
+
+interface ToggleChipGroupProps {
+  options: ToggleOption[];
+  value: string[];
+  onChange: (next: string[]) => void;
+}
+
+/**
+ * Multi-select chip group. Each chip toggles its value in/out of the
+ * array. Selected chips highlight; unselected are ghost-styled.
+ *
+ * Used on /discover for the "Exclude industries" surface where each
+ * chip semantically represents a curated denylist (defined server-side
+ * in industry_denylists.py).
+ *
+ * Mobile-friendly: chips wrap and each one is 36px tall by default.
+ */
+export default function ToggleChipGroup({
+  options,
+  value,
+  onChange,
+}: ToggleChipGroupProps) {
+  function toggle(v: string) {
+    if (value.includes(v)) {
+      onChange(value.filter((x) => x !== v));
+    } else {
+      onChange([...value, v]);
+    }
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {options.map((opt) => {
+        const selected = value.includes(opt.value);
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => toggle(opt.value)}
+            aria-pressed={selected}
+            className={[
+              "px-3 py-1.5 rounded-full text-xs font-medium transition min-h-[36px]",
+              selected
+                ? "bg-primary text-primary-foreground border border-primary"
+                : "bg-background text-muted-foreground border border-input hover:text-foreground hover:border-foreground",
+            ].join(" ")}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/industry-chips.ts
+++ b/apps/myjobhunter/frontend/src/features/discover/industry-chips.ts
@@ -1,0 +1,30 @@
+/** Industry-exclusion chips rendered on the New Saved Search dialog.
+ *
+ * Each chip's ``value`` matches a key in
+ * ``apps/myjobhunter/backend/app/services/discovery/industry_denylists.py``.
+ * The backend expands the chip to a substring keyword list at fetch
+ * time; the frontend only shows the label.
+ *
+ * Adding a new chip
+ * =================
+ *
+ * 1. Pick a snake_case key (must match the backend constant key).
+ * 2. Add a row here with a short, scannable label.
+ * 3. Mirror the entry in the backend constant. Without the backend
+ *    expansion the chip is a no-op (which is silently OK — the
+ *    operator's selection is preserved on the saved search but no
+ *    keywords are added to the filter).
+ */
+
+export interface IndustryChip {
+  value: string;
+  label: string;
+}
+
+export const INDUSTRY_CHIPS: IndustryChip[] = [
+  { value: "government_defense", label: "Government & Defense" },
+  { value: "staffing_recruiting", label: "Staffing / Recruiting" },
+  { value: "consulting_big4", label: "Big 4 Consulting" },
+  { value: "crypto_web3", label: "Crypto / Web3" },
+  { value: "adtech_gambling", label: "Ad Tech / Gambling" },
+];

--- a/apps/myjobhunter/frontend/src/features/discover/saved-search-summary.ts
+++ b/apps/myjobhunter/frontend/src/features/discover/saved-search-summary.ts
@@ -1,0 +1,130 @@
+import { INDUSTRY_CHIPS } from "./industry-chips";
+
+interface SummaryInput {
+  roles: string[];
+  skills: string[];
+  location: string;
+  country: string;
+  datePosted: string;
+  remoteOnly: boolean;
+  employmentType: string;
+  experience: string;
+  minSalary: string;
+  excludedIndustryChips: string[];
+  excludedKeywords: string[];
+}
+
+const DATE_LABELS: Record<string, string> = {
+  today: "the past 24 hours",
+  "3days": "the past 3 days",
+  week: "the past week",
+  month: "the past month",
+  all: "any time",
+};
+
+const COUNTRY_LABELS: Record<string, string> = {
+  us: "the US",
+  ca: "Canada",
+  uk: "the UK",
+  au: "Australia",
+};
+
+const EMPLOYMENT_LABELS: Record<string, string> = {
+  FULLTIME: "full-time",
+  CONTRACTOR: "contract",
+  PARTTIME: "part-time",
+  INTERN: "internship",
+};
+
+const EXPERIENCE_LABELS: Record<string, string> = {
+  no_experience: "entry-level",
+  under_3_years_experience: "under 3 years experience",
+  more_than_3_years_experience: "3+ years experience",
+  no_degree: "no-degree-required",
+};
+
+/**
+ * Render a saved-search config as one plain-English sentence the operator
+ * reads back before clicking Create.
+ *
+ * Keep it tight: skip clauses for fields at default values so the output
+ * is scannable. The summary updates reactively as form state changes —
+ * cheap to compute, no API calls.
+ */
+export function buildSavedSearchSummary(input: SummaryInput): string {
+  const {
+    roles,
+    skills,
+    location,
+    country,
+    datePosted,
+    remoteOnly,
+    employmentType,
+    experience,
+    minSalary,
+    excludedIndustryChips,
+    excludedKeywords,
+  } = input;
+
+  if (roles.length === 0) {
+    return "Add at least one role to preview the search.";
+  }
+
+  const parts: string[] = [];
+
+  // Lead: "This will search for X / Y / Z roles"
+  const roleClause = roles.join(" / ");
+  parts.push(`This will search for **${roleClause}** roles`);
+
+  if (skills.length > 0) {
+    parts.push(`matching **${skills.join(", ")}**`);
+  }
+
+  if (remoteOnly) {
+    parts.push("**remote-only**");
+  } else if (location.trim()) {
+    parts.push(`in **${location.trim()}**`);
+  }
+
+  parts.push(`posted in **${DATE_LABELS[datePosted] ?? datePosted}**`);
+
+  parts.push(`in **${COUNTRY_LABELS[country] ?? country.toUpperCase()}**`);
+
+  if (employmentType && EMPLOYMENT_LABELS[employmentType]) {
+    parts.push(`(${EMPLOYMENT_LABELS[employmentType]})`);
+  }
+
+  if (experience && EXPERIENCE_LABELS[experience]) {
+    parts.push(`requiring ${EXPERIENCE_LABELS[experience]}`);
+  }
+
+  const minSalaryNum = Number(minSalary);
+  if (minSalary && Number.isFinite(minSalaryNum) && minSalaryNum > 0) {
+    const formatted = new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    }).format(minSalaryNum);
+    parts.push(`paying **${formatted}**+`);
+  }
+
+  // Exclusions clause
+  const exclusionLabels: string[] = [];
+  for (const chipKey of excludedIndustryChips) {
+    const chip = INDUSTRY_CHIPS.find((c) => c.value === chipKey);
+    if (chip) exclusionLabels.push(chip.label);
+  }
+  if (excludedKeywords.length > 0) {
+    exclusionLabels.push(`"${excludedKeywords.slice(0, 3).join('", "')}"${
+      excludedKeywords.length > 3 ? ` +${excludedKeywords.length - 3} more` : ""
+    }`);
+  }
+
+  let summary = parts.join(" ") + ".";
+
+  if (exclusionLabels.length > 0) {
+    summary += ` Excluding ${exclusionLabels.join(" and ")}.`;
+  }
+
+  return summary;
+}


### PR DESCRIPTION
## Summary

Phase A of the discovery filter overhaul. Implements the UX panel + application-strategist's recommendation: stop making the operator type Boolean queries and exclusion lists. Use the profile data MJH already has.

## What changed

**Backend**
- New `industry_denylists.py` module with curated chip → keyword expansions (Government & Defense expands to 30 terms covering Lockheed/Northrop/Peraton/Leidos/MITRE/etc. + clearance language)
- Structured query assembly: backend builds `("Senior Backend" OR "Staff SWE") (Python OR FastAPI)` from `config.roles` + `config.skills` arrays. Legacy `config.query` still works.
- 18 new unit tests

**Frontend**
- `MultiChipInput` (chip-list text input) and `ToggleChipGroup` (multi-select pill group) — local to features/discover for now
- Dialog rewrite: pre-fills role from work history, remote toggle from profile, salary from profile, experience from profile.seniority
- Roles + Skills as chip inputs with profile-derived suggestions
- Industry chips (5 presets) backed by server-side keyword lists
- Plain-English summary updates reactively below the form

## What's NOT in this PR

- Edit-existing-saved-search UI (defer until friction is real)
- 'Save as my defaults' checkbox + profile.discovery_defaults — that's Phase B
- Fit-score ranking — Phase C

## Test plan

- [x] 28 backend unit tests pass (10 existing + 18 new)
- [x] Frontend typecheck clean
- [x] Production build succeeds

## Backwards compat

Existing saved searches keep working — the legacy `config.query` shape is still honored. New ones use the structured `config.roles/skills/chips` shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)