### PR TITLE
feat(mjh/discovery): Phase B — profile-level discovery defaults

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/discdef260507_profile_discovery_defaults.py
+++ b/apps/myjobhunter/backend/alembic/versions/discdef260507_profile_discovery_defaults.py
@@ -1,0 +1,55 @@
+"""Add ``profiles.discovery_defaults`` JSONB column.
+
+Stores per-operator defaults for the New Saved Search dialog so the
+operator configures their excluded industries, employment-type
+preference, etc. once and has it pre-populated on every new saved
+search. Phase B of the discovery filter overhaul.
+
+Shape stored on the column (loose, intentionally — frontend evolves
+the keys faster than we want migrations for):
+
+    {
+        "excluded_industry_chips": ["government_defense", ...],
+        "excluded_keywords": ["lockheed", ...],
+        "employment_type": "FULLTIME",
+        "experience": "more_than_3_years_experience",
+        "country": "us",
+        "date_posted": "week",
+        "preferred_industries": [...],   // Phase C scoring input
+        "preferred_stack": [...],        // Phase C scoring input
+        "rejected_stack": [...]          // Phase C scoring input
+    }
+
+Reversible: downgrade drops the column.
+
+Revision ID: discdef260507
+Revises: disco260507
+Create Date: 2026-05-07
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "discdef260507"
+down_revision: Union[str, None] = "disco260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "profiles",
+        sa.Column(
+            "discovery_defaults",
+            JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("profiles", "discovery_defaults")

--- a/apps/myjobhunter/backend/app/models/profile/profile.py
+++ b/apps/myjobhunter/backend/app/models/profile/profile.py
@@ -50,6 +50,14 @@ class Profile(Base):
     summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     timezone: Mapped[str | None] = mapped_column(String(50), nullable=True)
 
+    # Per-operator defaults for the New Saved Search dialog. Loose
+    # JSONB so the frontend can evolve keys faster than migrations.
+    # Phase B of /discover. Phase C reads preferred_industries /
+    # preferred_stack / rejected_stack as scoring inputs.
+    discovery_defaults: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, server_default=func.jsonb_build_object(),
+    )
+
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         default=lambda: datetime.now(timezone.utc),

--- a/apps/myjobhunter/backend/app/schemas/profile/profile_response.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/profile_response.py
@@ -40,6 +40,10 @@ class ProfileResponse(BaseModel):
     summary: str | None = None
     timezone: str | None = None
 
+    # /discover saved-search defaults (Phase B). Loose JSONB so the
+    # frontend can evolve keys faster than backend migrations.
+    discovery_defaults: dict = {}
+
     created_at: datetime
     updated_at: datetime
 

--- a/apps/myjobhunter/backend/app/schemas/profile/profile_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/profile_update_request.py
@@ -35,6 +35,11 @@ class ProfileUpdateRequest(BaseModel):
     summary: str | None = None
     timezone: str | None = Field(default=None, max_length=_TIMEZONE_MAX)
 
+    # /discover saved-search defaults (Phase B). Replaces the entire
+    # JSONB blob when set — frontend reads-modifies-writes the whole
+    # object, which is fine at this size (<2KB).
+    discovery_defaults: dict | None = Field(default=None)
+
     model_config = ConfigDict(extra="forbid")
 
     @field_validator("work_auth_status")

--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -7,7 +7,7 @@ import {
   extractErrorMessage,
 } from "@platform/ui";
 import { useCreateDiscoverySourceMutation } from "@/store/discoverApi";
-import { useGetProfileQuery } from "@/lib/profileApi";
+import { useGetProfileQuery, useUpdateProfileMutation } from "@/lib/profileApi";
 import { useListSkillsQuery } from "@/lib/skillsApi";
 import { useListWorkHistoryQuery } from "@/lib/workHistoryApi";
 import MultiChipInput from "./MultiChipInput";
@@ -69,8 +69,11 @@ export default function NewSavedSearchDialog({
   );
   const [excludedKeywords, setExcludedKeywords] = useState<string[]>([]);
   const [didPrefill, setDidPrefill] = useState(false);
+  const [saveAsDefaults, setSaveAsDefaults] = useState(false);
 
-  const [createSource, { isLoading }] = useCreateDiscoverySourceMutation();
+  const [createSource, { isLoading: isCreating }] = useCreateDiscoverySourceMutation();
+  const [updateProfile, { isLoading: isUpdatingProfile }] = useUpdateProfileMutation();
+  const isLoading = isCreating || isUpdatingProfile;
 
   const recentRoleSuggestions = useMemo(() => {
     if (!workHistoryData?.items) return [];
@@ -96,10 +99,14 @@ export default function NewSavedSearchDialog({
   }, [skillsData]);
 
   // One-shot pre-fill on first open after profile loads.
+  // Preference order: profile.discovery_defaults (operator-saved) >
+  // heuristic from profile fields (seniority, salary, etc.).
   useEffect(() => {
     if (!open) return;
     if (didPrefill) return;
     if (!profile) return;
+
+    const defaults = profile.discovery_defaults ?? {};
 
     // Roles: most-recent work history title.
     if (recentRoleSuggestions.length > 0) {
@@ -117,8 +124,13 @@ export default function NewSavedSearchDialog({
       }
     }
 
-    // Experience: map profile.seniority into JSearch's enum.
-    if (profile.seniority) {
+    // Saved defaults override the heuristics for fields they cover.
+    if (defaults.country) setCountry(defaults.country);
+    if (defaults.date_posted) setDatePosted(defaults.date_posted as DatePosted);
+    if (defaults.employment_type !== undefined) setEmploymentType(defaults.employment_type);
+    if (defaults.experience !== undefined) {
+      setExperience(defaults.experience as Experience);
+    } else if (profile.seniority) {
       const s = profile.seniority.toLowerCase();
       if (s.includes("senior") || s.includes("staff") || s.includes("principal") || s.includes("lead")) {
         setExperience("more_than_3_years_experience");
@@ -127,6 +139,12 @@ export default function NewSavedSearchDialog({
       } else if (s.includes("mid")) {
         setExperience("under_3_years_experience");
       }
+    }
+    if (Array.isArray(defaults.excluded_industry_chips)) {
+      setExcludedIndustryChips(defaults.excluded_industry_chips);
+    }
+    if (Array.isArray(defaults.excluded_keywords)) {
+      setExcludedKeywords(defaults.excluded_keywords);
     }
 
     setDidPrefill(true);
@@ -145,6 +163,7 @@ export default function NewSavedSearchDialog({
     setExcludedIndustryChips([]);
     setExcludedKeywords([]);
     setDidPrefill(false);
+    setSaveAsDefaults(false);
   }
 
   async function handleConfirm() {
@@ -178,6 +197,30 @@ export default function NewSavedSearchDialog({
 
     try {
       await createSource({ source: "jsearch", config }).unwrap();
+
+      // Optionally persist the filter set as the operator's default
+      // for future searches. Best-effort — if it fails, the saved
+      // search still exists; we just toast a soft warning.
+      if (saveAsDefaults) {
+        const defaults: Record<string, unknown> = {
+          ...(profile?.discovery_defaults ?? {}),
+          country,
+          date_posted: datePosted,
+          employment_type: employmentType,
+          experience,
+          excluded_industry_chips: excludedIndustryChips,
+          excluded_keywords: excludedKeywords,
+        };
+        try {
+          await updateProfile({ discovery_defaults: defaults }).unwrap();
+        } catch (defaultsErr) {
+          showError(
+            extractErrorMessage(defaultsErr) ??
+              "Saved search created, but couldn't update your defaults",
+          );
+        }
+      }
+
       showSuccess("Saved search created");
       reset();
       onClose();
@@ -364,6 +407,19 @@ export default function NewSavedSearchDialog({
             className="rounded"
           />
           <span>Remote jobs only</span>
+        </label>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={saveAsDefaults}
+            onChange={(e) => setSaveAsDefaults(e.target.checked)}
+            className="rounded"
+          />
+          <span>
+            Save these filters (industries, employment, experience, etc.)
+            as my defaults for new searches
+          </span>
         </label>
 
         {summary && (

--- a/apps/myjobhunter/frontend/src/types/profile/profile-update-request.ts
+++ b/apps/myjobhunter/frontend/src/types/profile/profile-update-request.ts
@@ -1,3 +1,5 @@
+import type { DiscoveryDefaults } from "./profile";
+
 /**
  * Body for PATCH /profile. All fields optional.
  * Mirrors ProfileUpdateRequest in backend/app/schemas/profile/profile_update_request.py.
@@ -13,4 +15,5 @@ export interface ProfileUpdateRequest {
   seniority?: string | null;
   summary?: string | null;
   timezone?: string | null;
+  discovery_defaults?: DiscoveryDefaults | null;
 }

--- a/apps/myjobhunter/frontend/src/types/profile/profile.ts
+++ b/apps/myjobhunter/frontend/src/types/profile/profile.ts
@@ -24,6 +24,23 @@ export interface Profile {
   summary: string | null;
   timezone: string | null;
 
+  /** Per-operator defaults for the /discover New Saved Search dialog
+   *  (Phase B). Loose shape; see {@link DiscoveryDefaults}. */
+  discovery_defaults: DiscoveryDefaults;
+
   created_at: string;
   updated_at: string;
+}
+
+export interface DiscoveryDefaults {
+  excluded_industry_chips?: string[];
+  excluded_keywords?: string[];
+  employment_type?: string;
+  experience?: string;
+  country?: string;
+  date_posted?: string;
+  // Phase C scoring inputs (written by Phase C).
+  preferred_industries?: string[];
+  preferred_stack?: string[];
+  rejected_stack?: string[];
 }


### PR DESCRIPTION
## Summary

Phase B of the discovery filter overhaul. Operator's filter setup persists across saved-search creations.

## What changed

**Backend**
- Migration `discdef260507` adds `profiles.discovery_defaults` JSONB column (NOT NULL DEFAULT '{}')
- ProfileResponse and ProfileUpdateRequest schemas carry the field
- Loose JSONB shape so the frontend can evolve keys without per-key migrations

**Frontend**
- DiscoveryDefaults type captures the loose shape (chips, custom keywords, employment, experience, country, date_posted, plus Phase-C-only preferred/rejected stacks)
- Dialog reads profile.discovery_defaults on open and applies saved keys (overrides the heuristic seniority→experience mapping for fields the operator has explicitly set)
- New 'Save these filters as my defaults for new searches' checkbox below remote-only toggle
- On Create with checkbox on, PATCHes /profile with current filter state. Best-effort: saved search succeeds even if profile update fails (soft toast warning)

## Test plan

- [x] Migration generates clean SQL
- [x] Pydantic schemas accept the field
- [x] Frontend typecheck clean
- [x] Frontend build succeeds

## Operational

After merge + deploy, the alembic upgrade adds the column with a default empty JSON. Existing profiles get `{}` automatically. No operator action needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)