### PR TITLE
feat(mjh/discovery): Phase C backend — fit-score, promote, dismissal-reason

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/discrsn260507_discovered_jobs_dismissed_reason.py
+++ b/apps/myjobhunter/backend/alembic/versions/discrsn260507_discovered_jobs_dismissed_reason.py
@@ -1,0 +1,65 @@
+"""Add ``discovered_jobs.dismissed_reason`` column.
+
+Captures the operator's reason when they dismiss a posting. Used as a
+teaching signal for future scoring iterations (Phase D) so MJH can
+weight similar postings down without the operator re-typing exclusion
+rules.
+
+Phase C — coexists with Phase B's ``profiles.discovery_defaults``.
+
+Allowed values (CHECK constraint):
+    wrong_stack, too_small_company, wrong_sector, wrong_comp,
+    not_remote, not_interested, other
+
+Reversible: downgrade drops the column + constraint.
+
+Revision ID: discrsn260507
+Revises: discdef260507
+Create Date: 2026-05-07
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "discrsn260507"
+down_revision: Union[str, None] = "discdef260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_REASONS = (
+    "wrong_stack",
+    "too_small_company",
+    "wrong_sector",
+    "wrong_comp",
+    "not_remote",
+    "not_interested",
+    "other",
+)
+
+
+def _quoted(values: tuple[str, ...]) -> str:
+    return ",".join(f"'{v}'" for v in values)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "discovered_jobs",
+        sa.Column("dismissed_reason", sa.String(30), nullable=True),
+    )
+    op.create_check_constraint(
+        "chk_discovered_dismissed_reason",
+        "discovered_jobs",
+        f"dismissed_reason IS NULL OR dismissed_reason IN ({_quoted(_REASONS)})",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "chk_discovered_dismissed_reason",
+        "discovered_jobs",
+        type_="check",
+    )
+    op.drop_column("discovered_jobs", "dismissed_reason")

--- a/apps/myjobhunter/backend/app/api/discover.py
+++ b/apps/myjobhunter/backend/app/api/discover.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from platform_shared.core.request_utils import get_client_ip
@@ -32,14 +32,23 @@ from app.core.rate_limit import RateLimiter
 from app.db.session import get_db
 from app.models.user.user import User
 from app.repositories.discovery import discovery_repository
+from app.schemas.application.application_response import ApplicationResponse
 from app.schemas.discovery.discovery_schemas import (
+    DiscoveredJobDismissRequest,
     DiscoveredJobListResponse,
     DiscoveredJobResponse,
     DiscoveryFetchResultResponse,
     DiscoverySourceCreate,
     DiscoverySourceResponse,
 )
-from app.services.discovery import discovery_fetch_service
+from app.services.discovery.discovery_promote_service import (
+    DiscoveryPromoteError,
+)
+from app.services.discovery import (
+    discovery_fetch_service,
+    discovery_promote_service,
+    discovery_score_service,
+)
 from app.services.discovery.discovery_fetch_service import (
     DiscoveryFetchError,
     DiscoverySourceInactiveError,
@@ -133,6 +142,7 @@ async def deactivate_source(
 async def refresh_source(
     source_id: uuid.UUID,
     request: Request,
+    background_tasks: BackgroundTasks,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
 ) -> DiscoveryFetchResultResponse:
@@ -177,6 +187,15 @@ async def refresh_source(
     except (JSearchInvalidResponseError, DiscoveryFetchError) as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
+    # Phase C: kick off scoring of the freshly-fetched postings as a
+    # background task so /refresh returns immediately. The frontend
+    # polls /discover and watches scores fill in. The task uses its
+    # own DB session; failures are logged + swallowed.
+    if result.get("new_count", 0) > 0:
+        background_tasks.add_task(
+            discovery_score_service.score_user_inbox, user.id,
+        )
+
     return DiscoveryFetchResultResponse(**result)
 
 
@@ -212,10 +231,16 @@ async def list_discovered(
 )
 async def dismiss_job(
     job_id: uuid.UUID,
+    payload: DiscoveredJobDismissRequest | None = None,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
 ) -> None:
-    ok = await discovery_repository.dismiss_discovered(db, job_id, user.id)
+    """Dismiss a discovered job. Optional ``reason`` is captured as a
+    teaching signal for future scoring."""
+    reason = payload.reason if payload else None
+    ok = await discovery_repository.dismiss_discovered(
+        db, job_id, user.id, reason=reason,
+    )
     if not ok:
         raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
     await db.commit()
@@ -234,3 +259,31 @@ async def save_job(
     if not ok:
         raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
     await db.commit()
+
+
+@router.post(
+    "/{job_id}/promote",
+    response_model=ApplicationResponse,
+    status_code=201,
+)
+async def promote_job(
+    job_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> ApplicationResponse:
+    """Convert a discovered job into a tracked Application.
+
+    Idempotent — a second call for the same discovered_job returns the
+    existing application instead of creating a duplicate.
+
+    Status codes:
+    - 201 — Application created (or returned existing one)
+    - 404 — discovered_job not found / not owned by caller
+    """
+    try:
+        application = await discovery_promote_service.promote_discovered_job(
+            db, user.id, job_id,
+        )
+    except DiscoveryPromoteError:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
+    return ApplicationResponse.model_validate(application)

--- a/apps/myjobhunter/backend/app/core/config.py
+++ b/apps/myjobhunter/backend/app/core/config.py
@@ -32,6 +32,13 @@ class Settings(BaseAppSettings):
     # required in production for the discovery feature to fetch.
     jsearch_api_key: str = ""
 
+    # /discover scoring budget (Phase C). The per-user daily cap is the
+    # smaller of these two values. ``discovery_daily_budget_usd`` is the
+    # default operator-friendly cap; ``..._hard_cap`` is the absolute
+    # ceiling no per-profile override may exceed.
+    discovery_daily_budget_usd: float = 0.30
+    discovery_daily_budget_usd_hard_cap: float = 2.00
+
     # ------------------------------------------------------------------
     # Google OAuth (Gmail integration — Phase 3)
     # ------------------------------------------------------------------

--- a/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
+++ b/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
@@ -135,6 +135,9 @@ class DiscoveredJob(Base):
     dismissed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True,
     )
+    dismissed_reason: Mapped[str | None] = mapped_column(
+        String(30), nullable=True,
+    )
     saved_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True,
     )
@@ -188,6 +191,12 @@ class DiscoveredJob(Base):
         CheckConstraint(
             "NOT (dismissed_at IS NOT NULL AND saved_at IS NOT NULL)",
             name="chk_discovered_state",
+        ),
+        CheckConstraint(
+            "dismissed_reason IS NULL OR dismissed_reason IN ("
+            "'wrong_stack','too_small_company','wrong_sector',"
+            "'wrong_comp','not_remote','not_interested','other')",
+            name="chk_discovered_dismissed_reason",
         ),
         CheckConstraint(
             "(promoted_application_id IS NULL) = (promoted_at IS NULL)",

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import desc, select, update
+from sqlalchemy import desc, nulls_last, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -266,8 +266,9 @@ async def list_discovered(
     # else "all": no extra filter
     stmt = (
         stmt.order_by(
-            desc(DiscoveredJob.score.is_(None)),  # scored rows first
-            desc(DiscoveredJob.score),
+            # Highest score first; unscored rows fall to the bottom
+            # (nulls_last so an unscored row never beats a scored one).
+            nulls_last(desc(DiscoveredJob.score)),
             desc(DiscoveredJob.discovered_at),
         )
         .limit(limit)
@@ -289,9 +290,18 @@ async def get_discovered(
 
 
 async def dismiss_discovered(
-    db: AsyncSession, job_id: uuid.UUID, user_id: uuid.UUID,
+    db: AsyncSession,
+    job_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    reason: str | None = None,
 ) -> bool:
-    """Mark a discovered job as dismissed. Idempotent."""
+    """Mark a discovered job as dismissed. Idempotent.
+
+    ``reason`` is an optional structured signal used for future scoring
+    iterations. The CHECK constraint enforces the enum at the DB layer;
+    callers should validate / coerce before calling.
+    """
     job = await get_discovered(db, job_id, user_id)
     if job is None:
         return False
@@ -300,7 +310,9 @@ async def dismiss_discovered(
         job.saved_at = None
     if job.dismissed_at is None:
         job.dismissed_at = datetime.now(timezone.utc)
-        await db.flush()
+    if reason is not None:
+        job.dismissed_reason = reason
+    await db.flush()
     return True
 
 
@@ -318,3 +330,29 @@ async def save_discovered(
         job.saved_at = datetime.now(timezone.utc)
         await db.flush()
     return True
+
+
+async def list_unscored_for_user(
+    db: AsyncSession, user_id: uuid.UUID, *, limit: int = 20,
+) -> list[DiscoveredJob]:
+    """Return the freshest unscored postings for the user.
+
+    Used by the Phase C scoring loop after a fetch cycle. Filters out
+    rows the operator has already triaged (dismissed / saved / promoted)
+    so we don't waste tokens scoring rows the operator no longer cares
+    about.
+    """
+    stmt = (
+        select(DiscoveredJob)
+        .where(
+            DiscoveredJob.user_id == user_id,
+            DiscoveredJob.score.is_(None),
+            DiscoveredJob.dismissed_at.is_(None),
+            DiscoveredJob.saved_at.is_(None),
+            DiscoveredJob.promoted_application_id.is_(None),
+        )
+        .order_by(desc(DiscoveredJob.discovered_at))
+        .limit(limit)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())

--- a/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
@@ -93,10 +93,34 @@ class DiscoveredJobResponse(BaseModel):
     score_reason: str | None
     scored_at: datetime | None
     dismissed_at: datetime | None
+    dismissed_reason: str | None = None
     saved_at: datetime | None
     promoted_application_id: uuid.UUID | None
 
     model_config = ConfigDict(from_attributes=True)
+
+
+_DISMISS_REASONS = (
+    "wrong_stack",
+    "too_small_company",
+    "wrong_sector",
+    "wrong_comp",
+    "not_remote",
+    "not_interested",
+    "other",
+)
+
+
+class DiscoveredJobDismissRequest(BaseModel):
+    """Body for ``POST /discover/{id}/dismiss``. All fields optional."""
+
+    reason: Literal[_DISMISS_REASONS] | None = Field(  # type: ignore[valid-type]
+        default=None,
+        description=(
+            "Structured signal for why the operator dismissed this posting. "
+            "Used as a teaching input for future scoring iterations."
+        ),
+    )
 
 
 class DiscoveredJobListResponse(BaseModel):

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_promote_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_promote_service.py
@@ -1,0 +1,144 @@
+"""Promote a discovered job into the applications kanban.
+
+Mirrors ``job_analysis_service.apply_to_application`` but starts from
+a ``DiscoveredJob`` row (which already has structured fields from the
+source API) rather than a JD-analysis row. Idempotent: a second
+promote call for the same discovered_job returns the existing
+application.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.application.application import Application
+from app.models.application.application_event import ApplicationEvent
+from app.models.company.company import Company
+from app.repositories.application import (
+    application_event_repository,
+    application_repository,
+)
+from app.repositories.company import company_repository
+from app.repositories.discovery import discovery_repository
+
+logger = logging.getLogger(__name__)
+
+
+# JSearch's ``job_publisher`` strings normalized to the application source
+# enum on application_events.source. Values not in this map fall to
+# 'direct' (user followed an external apply link to apply directly).
+_PUBLISHER_TO_SOURCE: dict[str, str] = {
+    "linkedin": "linkedin",
+    "indeed": "indeed",
+    "ziprecruiter": "ziprecruiter",
+    "greenhouse": "greenhouse",
+    "lever": "lever",
+}
+
+
+_VALID_REMOTE_TYPES = frozenset({"remote", "hybrid", "onsite"})
+
+
+class DiscoveryPromoteError(RuntimeError):
+    """Discovered job not found / not owned by caller — HTTP 404."""
+
+
+async def promote_discovered_job(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    discovered_job_id: uuid.UUID,
+) -> Application:
+    """Create an Application from a DiscoveredJob. Idempotent.
+
+    If ``promoted_application_id`` is already set on the discovered_job
+    AND the referenced application still exists, return that. Otherwise
+    create a fresh Application + initial ``applied`` event, mark the
+    discovered_job as promoted, commit.
+    """
+    job = await discovery_repository.get_discovered(db, discovered_job_id, user_id)
+    if job is None:
+        raise DiscoveryPromoteError(
+            f"discovered_job {discovered_job_id} not found",
+        )
+
+    if job.promoted_application_id is not None:
+        existing = await application_repository.get_by_id(
+            db, job.promoted_application_id, user_id,
+        )
+        if existing is not None:
+            return existing
+        # The previous link points at a deleted/missing app. Fall
+        # through and create a fresh one.
+
+    company = await _find_or_create_company(
+        db, user_id=user_id, name=job.company_name,
+    )
+
+    publisher_norm = (job.source_publisher or "").lower()
+    application_source = _PUBLISHER_TO_SOURCE.get(publisher_norm, "direct")
+
+    remote_type = (
+        job.remote_type if job.remote_type in _VALID_REMOTE_TYPES else "unknown"
+    )
+
+    application = Application(
+        user_id=user_id,
+        company_id=company.id,
+        role_title=(job.title or "Untitled role")[:200],
+        url=job.source_url,
+        jd_text=job.description,
+        location=job.location,
+        remote_type=remote_type,
+        posted_salary_min=float(job.salary_min) if job.salary_min is not None else None,
+        posted_salary_max=float(job.salary_max) if job.salary_max is not None else None,
+        posted_salary_currency=(job.salary_currency or "USD")[:3].upper(),
+        posted_salary_period=job.salary_period,
+        source=application_source,
+        notes=job.score_reason,
+    )
+    application = await application_repository.create(db, application)
+
+    initial_event = ApplicationEvent(
+        user_id=user_id,
+        application_id=application.id,
+        event_type="applied",
+        occurred_at=datetime.now(timezone.utc),
+        # 'discovery' was added to the chk_appevent_source enum in
+        # migration disco260507. Records provenance for the kanban.
+        source="discovery",
+    )
+    await application_event_repository.create(db, initial_event)
+
+    job.promoted_application_id = application.id
+    job.promoted_at = datetime.now(timezone.utc)
+    # Promoted rows are no longer in the inbox; if the operator
+    # had also saved the row, clear that flag for consistency.
+    job.saved_at = None
+    await db.flush()
+
+    await db.commit()
+    await db.refresh(application)
+    logger.info(
+        "discovery promote: user=%s discovered_job=%s -> application=%s",
+        user_id, discovered_job_id, application.id,
+    )
+    return application
+
+
+async def _find_or_create_company(
+    db: AsyncSession, *, user_id: uuid.UUID, name: str,
+) -> Company:
+    """Find a company by case-insensitive name, or create one."""
+    cleaned = (name or "Unknown company").strip() or "Unknown company"
+    matches = await company_repository.list_by_user(
+        db, user_id, name_search=cleaned,
+    )
+    needle = cleaned.lower()
+    for c in matches:
+        if c.name.strip().lower() == needle:
+            return c
+    fresh = Company(user_id=user_id, name=cleaned[:200])
+    return await company_repository.create(db, fresh)

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_score_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_score_service.py
@@ -1,0 +1,180 @@
+"""Discovery scoring loop — runs after a fetch cycle to rate new postings.
+
+After ``discovery_fetch_service.fetch_source`` upserts new rows, this
+loop pulls the freshest unscored postings for the user, calls the
+shared ``job_analysis_service.score()`` against the operator's profile
+snapshot, and persists the score + reasoning back onto the
+``discovered_jobs`` row.
+
+Cost guard
+==========
+
+Each scoring call costs ~$0.005-$0.01 in Anthropic tokens. To bound
+runaway cost we:
+
+1. Cap how many postings we score per cycle (``DEFAULT_SCORE_BATCH``).
+2. Aggregate today's spend from ``extraction_logs`` and stop the loop
+   when it exceeds the per-user daily budget.
+3. The hard ceiling lives in env (``DISCOVERY_DAILY_BUDGET_USD_HARD_CAP``,
+   default $2.00). The per-user setting may not exceed this.
+
+Async + isolated session
+========================
+
+Because this is invoked as a FastAPI ``BackgroundTask`` after the
+/refresh response is sent, it runs WITHOUT the request's DB session.
+We open a fresh ``AsyncSessionLocal`` here so DB work is owned by the
+loop and cleaned up cleanly.
+
+If the FastAPI process restarts mid-loop, unscored postings just stay
+unscored. The next /refresh picks them up because
+``list_unscored_for_user`` orders by ``discovered_at DESC`` and the
+loop is idempotent (only writes ``score`` when it was previously NULL).
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, time, timezone
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.db.session import AsyncSessionLocal
+from app.models.discovery.discovered_job import DiscoveredJob
+from app.models.system.extraction_log import ExtractionLog
+from app.repositories.discovery import discovery_repository
+from app.services.job_analysis.job_analysis_service import (
+    JobAnalysisError,
+    score as score_jd,
+)
+
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_SCORE_BATCH = 20
+DEFAULT_DAILY_BUDGET_USD = 0.30
+
+
+async def score_user_inbox(user_id: uuid.UUID, *, batch: int = DEFAULT_SCORE_BATCH) -> None:
+    """Score up to ``batch`` unscored postings for ``user_id``.
+
+    Stops early when the per-user daily budget is exhausted. Per-call
+    failures are logged + swallowed; one bad posting does not abort the
+    rest of the batch.
+
+    Designed to run as a FastAPI ``BackgroundTask`` after /refresh
+    returns. No-op when there are no unscored postings or the budget
+    is already spent.
+    """
+    daily_cap = _resolve_daily_budget()
+
+    async with AsyncSessionLocal() as db:
+        spent_today = await _spent_today(db, user_id)
+        if spent_today >= daily_cap:
+            logger.info(
+                "discovery score: budget exhausted user=%s spent=%.4f cap=%.2f",
+                user_id, spent_today, daily_cap,
+            )
+            return
+
+        candidates = await discovery_repository.list_unscored_for_user(
+            db, user_id, limit=batch,
+        )
+        if not candidates:
+            return
+
+        logger.info(
+            "discovery score: starting user=%s candidates=%d budget_remaining=%.4f",
+            user_id, len(candidates), daily_cap - spent_today,
+        )
+
+        scored = 0
+        budget_hits = False
+
+        for job in candidates:
+            # Re-check budget each iteration — earlier scoring calls
+            # added cost, the hard cap may now be reached.
+            spent_today = await _spent_today(db, user_id)
+            if spent_today >= daily_cap:
+                budget_hits = True
+                break
+
+            try:
+                analysis = await score_jd(
+                    db,
+                    user_id,
+                    jd_text=job.description or job.title,
+                    source_url=job.source_url,
+                    extracted_hint={
+                        "title": job.title,
+                        "company": job.company_name,
+                        "location": job.location,
+                    },
+                    discovered_job_id=job.id,
+                )
+            except JobAnalysisError as exc:
+                logger.warning(
+                    "discovery score: failed user=%s job=%s err=%s",
+                    user_id, job.id, exc,
+                )
+                continue
+
+            # Map the verdict to a 0-100 score for sorting. Per the
+            # JD-analysis rubric, only four values are possible.
+            score_int = _verdict_to_score(analysis.verdict)
+            job.score = score_int
+            job.score_reason = (analysis.verdict_summary or "")[:1000]
+            job.scored_at = datetime.now(timezone.utc)
+            await db.flush()
+            await db.commit()
+            scored += 1
+
+        logger.info(
+            "discovery score: complete user=%s scored=%d budget_hit=%s",
+            user_id, scored, budget_hits,
+        )
+
+
+def _verdict_to_score(verdict: str) -> int:
+    """Collapse the JD-analysis verdict into a 0-100 sort key."""
+    return {
+        "strong_fit": 90,
+        "worth_considering": 70,
+        "stretch": 40,
+        "mismatch": 15,
+    }.get(verdict, 50)
+
+
+def _resolve_daily_budget() -> float:
+    """Read the per-user daily budget cap.
+
+    For Phase C v1 we use a single env-driven cap for all users. Phase D
+    will read a per-profile override clamped to this hard ceiling.
+    """
+    fallback = DEFAULT_DAILY_BUDGET_USD
+    raw = getattr(settings, "discovery_daily_budget_usd", None)
+    try:
+        value = float(raw) if raw is not None else fallback
+    except (TypeError, ValueError):
+        value = fallback
+    hard_cap_raw = getattr(settings, "discovery_daily_budget_usd_hard_cap", 2.0)
+    try:
+        hard_cap = float(hard_cap_raw)
+    except (TypeError, ValueError):
+        hard_cap = 2.0
+    return min(value, hard_cap)
+
+
+async def _spent_today(db: AsyncSession, user_id: uuid.UUID) -> float:
+    """Sum cost_usd from extraction_logs for this user since midnight UTC."""
+    today_start = datetime.combine(
+        datetime.now(timezone.utc).date(), time.min, tzinfo=timezone.utc,
+    )
+    stmt = select(func.coalesce(func.sum(ExtractionLog.cost_usd), 0)).where(
+        ExtractionLog.user_id == user_id,
+        ExtractionLog.created_at >= today_start,
+    )
+    result = await db.execute(stmt)
+    return float(result.scalar_one() or 0)


### PR DESCRIPTION
## Summary

Phase C backend. Implements the application-strategist's pivot from "filter discovery" to "rank discovery, filter as guard rails."

## What's enabled

After /refresh fetches new postings, a background task scores them against the operator's profile snapshot. The inbox default-sorts by score so the highest-fit roles bubble up. Operator clicks "Apply" on a card → an Application appears in their kanban with discovery provenance.

## Endpoints

| Method | Path | Change |
|---|---|---|
| POST | /discover/sources/{id}/refresh | Now schedules score-loop as BackgroundTask after successful fetch |
| POST | /discover/{id}/dismiss | Now accepts optional `reason` body (typed enum) |
| POST | **/discover/{id}/promote** | NEW — converts discovered_job → Application |

## Cost guard

- Per-user daily budget: $0.30 default, $2.00 hard cap (env-configurable)
- Loop stops when today's `extraction_logs.cost_usd` sum exceeds budget
- Per-call failures logged + swallowed; one bad posting doesn't abort the batch

## Migration

- `discrsn260507`: adds `discovered_jobs.dismissed_reason String(30)` + CHECK constraint with 7 allowed values

## What's NOT in this PR

- Frontend score badge + promote button + dismissal-reason picker — that's Phase C-2
- Profile-level scoring inputs (preferred_industries, preferred_stack) — score() doesn't consume those yet

## Test plan

- [x] 28 existing filter tests pass unchanged
- [x] Migration generates clean SQL via `alembic upgrade --sql`
- [x] All routes register cleanly
- [ ] CI runs full backend test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)