### PR TITLE
feat(mbk/leases): allow templates on imported leases (addendum support)

### DIFF
--- a/apps/mybookkeeper/backend/app/api/signed_leases.py
+++ b/apps/mybookkeeper/backend/app/api/signed_leases.py
@@ -45,6 +45,9 @@ from app.schemas.leases.signed_lease_response import SignedLeaseResponse
 from app.schemas.leases.signed_lease_add_templates_request import (
     SignedLeaseAddTemplatesRequest,
 )
+from app.schemas.leases.signed_lease_template_prefill_response import (
+    SignedLeaseTemplatePrefillResponse,
+)
 from app.schemas.leases.signed_lease_update_request import (
     SignedLeaseUpdateRequest,
 )
@@ -200,19 +203,25 @@ async def delete_lease(
     return Response(status_code=204)
 
 
-@router.post("/{lease_id}/templates", response_model=SignedLeaseResponse)
-async def add_templates_to_lease(
+@router.post(
+    "/{lease_id}/template-prefill",
+    response_model=SignedLeaseTemplatePrefillResponse,
+)
+async def prefill_addendum_placeholders(
     lease_id: uuid.UUID,
     payload: SignedLeaseAddTemplatesRequest,
     ctx: RequestContext = Depends(require_write_access),
-) -> SignedLeaseResponse:
-    """Add one or more templates to an existing generated lease and render them.
+) -> SignedLeaseTemplatePrefillResponse:
+    """Return resolved + unresolved placeholder values for adding templates.
 
-    Only templates not already linked to the lease may be added. Returns the
-    updated ``SignedLeaseResponse`` (templates + attachments refreshed).
+    The frontend calls this after the host picks templates in the "Add
+    template" modal. Returns one row per non-signature, non-computed
+    placeholder so the values form can render with auto-filled defaults
+    for known fields (tenant name, lease dates, property address, etc.)
+    and empty inputs for fields that need manual entry.
     """
     try:
-        return await signed_lease_service.add_templates_and_generate(
+        return await signed_lease_service.prefill_addendum_placeholders(
             user_id=ctx.user_id,
             organization_id=ctx.organization_id,
             lease_id=lease_id,
@@ -220,10 +229,34 @@ async def add_templates_to_lease(
         )
     except signed_lease_service.SignedLeaseNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Lease not found") from exc
-    except signed_lease_service.ImportedLeaseTemplateError as exc:
-        raise HTTPException(
-            status_code=422, detail="imported_lease_cannot_add_templates",
-        ) from exc
+    except lease_template_service.TemplateNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Template not found") from exc
+
+
+@router.post("/{lease_id}/templates", response_model=SignedLeaseResponse)
+async def add_templates_to_lease(
+    lease_id: uuid.UUID,
+    payload: SignedLeaseAddTemplatesRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> SignedLeaseResponse:
+    """Add one or more templates to an existing lease and render them.
+
+    Works for both generated and imported leases. For imported leases the
+    caller MUST pass ``values`` covering at least the required, non-signature,
+    non-computed placeholders that don't have an auto-resolvable
+    ``default_source``. Returns the updated ``SignedLeaseResponse`` (templates
+    + attachments refreshed).
+    """
+    try:
+        return await signed_lease_service.add_templates_and_generate(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            lease_id=lease_id,
+            template_ids=payload.template_ids,
+            values_override=payload.values,
+        )
+    except signed_lease_service.SignedLeaseNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Lease not found") from exc
     except signed_lease_service.TemplatesAlreadyLinkedError as exc:
         raise HTTPException(
             status_code=409,

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_add_templates_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_add_templates_request.py
@@ -3,11 +3,16 @@ from __future__ import annotations
 
 import uuid
 
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, Field, field_validator
 
 
 class SignedLeaseAddTemplatesRequest(BaseModel):
     template_ids: list[uuid.UUID]
+    # Caller-supplied placeholder values, applied on top of the lease's
+    # existing values and any auto-resolved defaults. Required when
+    # attaching a template to an imported lease whose ``lease.values`` is
+    # empty by construction; optional when adding to a generated lease.
+    values: dict[str, str] | None = Field(default=None)
 
     @field_validator("template_ids")
     @classmethod

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_template_prefill_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_template_prefill_response.py
@@ -1,0 +1,28 @@
+"""Response body for POST /signed-leases/{lease_id}/template-prefill.
+
+Returned to the frontend after the user picks one or more templates from the
+"Add template" modal. The frontend uses this to render a values form with as
+many fields auto-filled as possible (so the host doesn't re-type information
+already on file), with the remaining placeholders surfaced as empty inputs.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class SignedLeaseTemplatePrefillItem(BaseModel):
+    key: str
+    display_label: str
+    input_type: str
+    required: bool
+    # Resolved value (auto-filled from default_source against applicant /
+    # lease / property / user). Empty string when no source resolved or no
+    # default_source was set on the placeholder.
+    value: str
+    # ``"applicant"`` / ``"inquiry"`` / ``"lease"`` / ``"property"`` /
+    # ``"user"`` / ``"today"`` if a value was resolved, else ``None``.
+    provenance: str | None
+
+
+class SignedLeaseTemplatePrefillResponse(BaseModel):
+    items: list[SignedLeaseTemplatePrefillItem]

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_map.py
@@ -46,6 +46,13 @@ _TEXT_EMPLOYER = PlaceholderDefault(
 )
 _DATE_TODAY = PlaceholderDefault("date", "today")
 
+# Existing-lease defaults — used when an addendum template is attached to a
+# signed lease that already has known term dates and a linked property.
+_DATE_LEASE_START = PlaceholderDefault("date", "lease.starts_on")
+_DATE_LEASE_END = PlaceholderDefault("date", "lease.ends_on")
+_TEXT_PROPERTY_ADDRESS = PlaceholderDefault("text", "property.address")
+_TEXT_LANDLORD_NAME = PlaceholderDefault("text", "user.name")
+
 
 # Single source of truth — every concern (input_type, default_source,
 # computed_expr) lives on one row per key.
@@ -90,6 +97,20 @@ DEFAULT_SOURCE_MAP: dict[str, PlaceholderDefault] = {
     # doc never shows literal ``[LANDLORD SIGNATURE]`` text.
     "LANDLORD SIGNATURE": PlaceholderDefault("signature", None),
     "TENANT SIGNATURE": PlaceholderDefault("signature", None),
+    # Addendum placeholders — used when a template is attached to an existing
+    # signed lease (e.g. a Lease Extension Addendum). These pull from the
+    # parent lease and its linked property/landlord so the host doesn't
+    # re-type information already on file.
+    "ORIGINAL LEASE START DATE": _DATE_LEASE_START,
+    "ORIGINAL LEASE END DATE": _DATE_LEASE_END,
+    "LEASE START DATE": _DATE_LEASE_START,
+    "LEASE END DATE": _DATE_LEASE_END,
+    "PROPERTY ADDRESS": _TEXT_PROPERTY_ADDRESS,
+    "PREMISES ADDRESS": _TEXT_PROPERTY_ADDRESS,
+    "PROPERTY NAME": PlaceholderDefault("text", "property.name"),
+    "LANDLORD FULL NAME": _TEXT_LANDLORD_NAME,
+    "LANDLORD NAME": _TEXT_LANDLORD_NAME,
+    "LANDLORD EMAIL": PlaceholderDefault("email", "user.email"),
 }
 
 _FALLBACK = PlaceholderDefault("text", None)

--- a/apps/mybookkeeper/backend/app/services/leases/default_source_resolver.py
+++ b/apps/mybookkeeper/backend/app/services/leases/default_source_resolver.py
@@ -29,6 +29,9 @@ from typing import Any
 
 from app.models.applicants.applicant import Applicant
 from app.models.inquiries.inquiry import Inquiry
+from app.models.leases.signed_lease import SignedLease
+from app.models.properties.property import Property
+from app.models.user.user import User
 
 # ---------------------------------------------------------------------------
 # Allowed namespace prefixes and their attribute allowlists
@@ -57,11 +60,35 @@ _INQUIRY_ATTRS: frozenset[str] = frozenset({
     "desired_end_date",
 })
 
+# Existing signed lease — used when attaching addendum templates to a lease
+# that already has a known term. The original lease's ``starts_on`` /
+# ``ends_on`` populate ``[ORIGINAL LEASE START DATE]`` / ``[ORIGINAL LEASE
+# END DATE]`` on extension addenda without forcing the host to re-type them.
+_LEASE_ATTRS: frozenset[str] = frozenset({
+    "starts_on",
+    "ends_on",
+})
+
+# Property the lease's listing points at — for ``[PROPERTY ADDRESS]`` style
+# placeholders on any per-property addendum.
+_PROPERTY_ATTRS: frozenset[str] = frozenset({
+    "address",
+    "name",
+})
+
+# Landlord identity — pulled from the host's user row. Today the User model
+# only stores ``name``; if the operator later adds a notice/mailing address
+# field the allowlist can be widened here.
+_USER_ATTRS: frozenset[str] = frozenset({
+    "name",
+    "email",
+})
+
 _SPECIAL_SOURCES: frozenset[str] = frozenset({"today"})
 
-# A valid single segment: "today", "applicant.<attr>", or "inquiry.<attr>".
+# A valid single segment: ``today`` or one of the supported namespaced fields.
 _SEGMENT_RE = re.compile(
-    r"^(?:today|applicant\.\w+|inquiry\.\w+)$"
+    r"^(?:today|applicant\.\w+|inquiry\.\w+|lease\.\w+|property\.\w+|user\.\w+)$"
 )
 
 
@@ -113,37 +140,69 @@ def _validate_segment(segment: str, full_spec: str) -> None:
             f"Unknown inquiry field '{attr}' in '{full_spec}'. "
             f"Allowed: {sorted(_INQUIRY_ATTRS)}"
         )
+    if namespace == "lease" and attr not in _LEASE_ATTRS:
+        raise ValueError(
+            f"Unknown lease field '{attr}' in '{full_spec}'. "
+            f"Allowed: {sorted(_LEASE_ATTRS)}"
+        )
+    if namespace == "property" and attr not in _PROPERTY_ATTRS:
+        raise ValueError(
+            f"Unknown property field '{attr}' in '{full_spec}'. "
+            f"Allowed: {sorted(_PROPERTY_ATTRS)}"
+        )
+    if namespace == "user" and attr not in _USER_ATTRS:
+        raise ValueError(
+            f"Unknown user field '{attr}' in '{full_spec}'. "
+            f"Allowed: {sorted(_USER_ATTRS)}"
+        )
 
 
 # ---------------------------------------------------------------------------
 # Resolution
 # ---------------------------------------------------------------------------
 
-ProvenanceLabel = str  # "applicant" | "inquiry" | "today"
+ProvenanceLabel = str  # "applicant" | "inquiry" | "lease" | "property" | "user" | "today"
 
 
 def resolve_default_source(
     spec: str,
     applicant: Applicant,
     inquiry: Inquiry | None,
+    *,
+    lease: SignedLease | None = None,
+    property_record: Property | None = None,
+    user_record: User | None = None,
 ) -> tuple[Any | None, ProvenanceLabel | None]:
     """Evaluate a ``default_source`` spec against live ORM rows.
 
     Returns ``(value, provenance)`` where:
     - ``value`` is the resolved plaintext (or ``None`` if nothing resolved).
-    - ``provenance`` is ``"applicant"``, ``"inquiry"``, or ``"today"`` indicating
-      which segment produced the value, or ``None`` if nothing resolved.
+    - ``provenance`` indicates which segment produced the value (``applicant``,
+      ``inquiry``, ``lease``, ``property``, ``user``, or ``today``), or
+      ``None`` if nothing resolved.
 
     PII is decrypted automatically by the ``EncryptedString`` TypeDecorator —
     callers receive plaintext.
 
     Dates are returned as ISO-8601 strings (``YYYY-MM-DD``) for consistency
     with the frontend ``<input type="date">`` format.
+
+    The keyword-only ``lease`` / ``property_record`` / ``user_record`` params
+    are optional. Existing call sites that only have applicant + inquiry
+    context (e.g. fresh-lease creation) keep working — segments referencing
+    a missing namespace simply resolve to ``None``.
     """
     segments = [s.strip() for s in spec.split("||")]
 
     for segment in segments:
-        value = _evaluate_segment(segment, applicant, inquiry)
+        value = _evaluate_segment(
+            segment,
+            applicant,
+            inquiry,
+            lease=lease,
+            property_record=property_record,
+            user_record=user_record,
+        )
         if value is not None and value != "":
             provenance = _segment_provenance(segment)
             if isinstance(value, datetime.date):
@@ -157,6 +216,10 @@ def _evaluate_segment(
     segment: str,
     applicant: Applicant,
     inquiry: Inquiry | None,
+    *,
+    lease: SignedLease | None = None,
+    property_record: Property | None = None,
+    user_record: User | None = None,
 ) -> Any | None:
     if segment == "today":
         return datetime.date.today()
@@ -168,6 +231,18 @@ def _evaluate_segment(
         if inquiry is None:
             return None
         return getattr(inquiry, attr, None)
+    if namespace == "lease":
+        if lease is None:
+            return None
+        return getattr(lease, attr, None)
+    if namespace == "property":
+        if property_record is None:
+            return None
+        return getattr(property_record, attr, None)
+    if namespace == "user":
+        if user_record is None:
+            return None
+        return getattr(user_record, attr, None)
     return None
 
 

--- a/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
@@ -20,6 +20,7 @@ from app.core.lease_enums import LEASE_ATTACHMENT_KINDS, SIGNED_LEASE_STATUSES
 from app.core.storage import get_storage
 from app.db.session import unit_of_work
 from app.repositories.applicants import applicant_repo
+from app.repositories.inquiries.inquiry_repo import get_by_applicant_inquiry_id
 from app.repositories.leases import (
     lease_template_file_repo,
     lease_template_placeholder_repo,
@@ -29,6 +30,8 @@ from app.repositories.leases import (
     signed_lease_template_repo,
 )
 from app.repositories.listings import listing_repo
+from app.repositories.properties import property_repo
+from app.models.user.user import User
 from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
@@ -38,10 +41,15 @@ from app.schemas.leases.signed_lease_list_response import (
 from app.schemas.leases.signed_lease_response import SignedLeaseResponse
 from app.schemas.leases.signed_lease_summary import SignedLeaseSummary
 from app.schemas.leases.signed_lease_template_link import SignedLeaseTemplateLink
+from app.schemas.leases.signed_lease_template_prefill_response import (
+    SignedLeaseTemplatePrefillItem,
+    SignedLeaseTemplatePrefillResponse,
+)
 from app.services.leases.attachment_response_builder import (
     attach_presigned_urls_to_attachments,
 )
 from app.services.leases.computed import ComputedExprError, evaluate
+from app.services.leases.default_source_resolver import resolve_default_source
 from app.services.leases.renderer import (
     render_docx_bytes_to_pdf,
     render_md,
@@ -549,19 +557,26 @@ async def add_templates_and_generate(
     organization_id: uuid.UUID,
     lease_id: uuid.UUID,
     template_ids: list[uuid.UUID],
+    values_override: dict[str, str] | None = None,
 ) -> SignedLeaseResponse:
     """Link additional templates to an existing lease and render only their files.
 
     Validates:
     - All ``template_ids`` exist and belong to the same org as the lease.
     - None are already linked to the lease (returns the duplicates in the error).
-    - ``lease.kind == "generated"`` (imported leases don't support templates).
+
+    Both generated and imported leases are supported. For imported leases
+    ``lease.values`` is empty by construction (the original was uploaded as a
+    PDF) — the caller may pass ``values_override`` to provide values for the
+    addendum's placeholders, and the resolver will additionally pre-fill any
+    placeholder whose ``default_source`` resolves against the parent lease,
+    its applicant, the linked property, or the host user.
 
     Then, for each new template:
     - Inserts a row in ``signed_lease_templates`` with display_order = max + N.
-    - Downloads each template file, runs placeholder substitution using
-      ``lease.values``, and uploads the rendered output as a new
-      ``SignedLeaseAttachment`` (kind=``rendered_original``).
+    - Downloads each template file, runs placeholder substitution, and uploads
+      the rendered output as a new ``SignedLeaseAttachment``
+      (kind=``rendered_original``).
     - Does NOT touch existing attachments.
 
     Partial success: if one template's render fails the DB row and MinIO
@@ -581,10 +596,6 @@ async def add_templates_and_generate(
         )
         if lease is None:
             raise SignedLeaseNotFoundError(f"Lease {lease_id} not found")
-        if lease.kind != "generated":
-            raise ImportedLeaseTemplateError(
-                "Cannot add templates to an imported lease"
-            )
 
         # Validate every template is in scope.
         for tid in template_ids:
@@ -638,6 +649,92 @@ async def add_templates_and_generate(
                     seen_placeholder_keys.add(p.key)
                     placeholders.append(p)
 
+        # Resolve auto-fillable defaults (applicant / lease / property / user)
+        # for any placeholder with a ``default_source`` set. This populates
+        # ``[ORIGINAL LEASE START DATE]``, ``[PROPERTY ADDRESS]``, etc. on
+        # addendum templates without forcing the host to retype them.
+        applicant = await applicant_repo.get(
+            db,
+            applicant_id=lease.applicant_id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        inquiry = None
+        if applicant is not None and applicant.inquiry_id is not None:
+            inquiry = await get_by_applicant_inquiry_id(
+                db,
+                inquiry_id=applicant.inquiry_id,
+                organization_id=organization_id,
+                user_id=user_id,
+            )
+        listing = None
+        property_record = None
+        if lease.listing_id is not None:
+            listing = await listing_repo.get_by_id(
+                db, lease.listing_id, organization_id,
+            )
+            if listing is not None and listing.property_id is not None:
+                property_record = await property_repo.get_by_id(
+                    db, listing.property_id, organization_id,
+                )
+        user_record = await db.get(User, user_id)
+
+        merged_values: dict[str, str] = {
+            k: ("" if v is None else str(v))
+            for k, v in (lease.values or {}).items()
+        }
+        for p in placeholders:
+            existing = merged_values.get(p.key)
+            if existing not in (None, ""):
+                continue
+            if not p.default_source:
+                continue
+            try:
+                resolved, _ = resolve_default_source(
+                    p.default_source,
+                    applicant,
+                    inquiry,
+                    lease=lease,
+                    property_record=property_record,
+                    user_record=user_record,
+                )
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "default_source resolution failed for placeholder %s on lease %s",
+                    p.key, lease_id, exc_info=True,
+                )
+                continue
+            if resolved is not None and resolved != "":
+                merged_values[p.key] = str(resolved)
+
+        # Caller-supplied values win over both existing values and resolved
+        # defaults — they represent the host's explicit choice for this render.
+        if values_override:
+            for k, v in values_override.items():
+                if v is None:
+                    continue
+                merged_values[k] = str(v)
+
+        # Persist merged values to the lease so subsequent regenerations stay
+        # consistent and the Details tab reflects what was used at render time.
+        if merged_values != (lease.values or {}):
+            new_start, new_end = _denormalise_dates(merged_values)
+            await signed_lease_repo.update_lease(
+                db,
+                lease_id=lease_id,
+                user_id=user_id,
+                organization_id=organization_id,
+                fields={
+                    "values": merged_values,
+                    **(
+                        {"starts_on": new_start} if new_start is not None and lease.starts_on is None else {}
+                    ),
+                    **(
+                        {"ends_on": new_end} if new_end is not None and lease.ends_on is None else {}
+                    ),
+                },
+            )
+
         # Persist the new template links before rendering (render can be long).
         for order_offset, tid in enumerate(template_ids):
             await signed_lease_template_repo.create(
@@ -647,9 +744,9 @@ async def add_templates_and_generate(
                 display_order=max_order + 1 + order_offset,
             )
 
-        values_snapshot = dict(lease.values or {})
+        values_snapshot = dict(merged_values)
 
-    # Build substitution dict from the lease's existing values.
+    # Build substitution dict from the merged values (existing + resolved + override).
     substitutions: dict[str, str] = {
         k: "" if v is None else str(v) for k, v in values_snapshot.items()
     }
@@ -722,6 +819,142 @@ async def add_templates_and_generate(
         organization_id=organization_id,
         lease_id=lease_id,
     )
+
+
+async def prefill_addendum_placeholders(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    lease_id: uuid.UUID,
+    template_ids: list[uuid.UUID],
+) -> SignedLeaseTemplatePrefillResponse:
+    """Compute resolved + unresolved placeholder values for a template + lease pair.
+
+    Walks the placeholders for the requested templates (deduped) and resolves
+    each via ``default_source`` against the parent lease, its applicant /
+    inquiry, the linked property, and the host user. Returns one row per
+    placeholder so the frontend can render a values form that is mostly
+    pre-filled and editable, with empty inputs for genuinely unknown fields.
+
+    Skips placeholders with ``input_type`` of ``signature`` or ``computed`` —
+    those are filled at signing time or evaluated at render time, not by the
+    host in the form.
+    """
+    async with unit_of_work() as db:
+        lease = await signed_lease_repo.get(
+            db,
+            lease_id=lease_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if lease is None:
+            raise SignedLeaseNotFoundError(f"Lease {lease_id} not found")
+
+        # Validate every template belongs to the org (cheap, prevents cross-org leak).
+        for tid in template_ids:
+            template = await lease_template_repo.get(
+                db,
+                template_id=tid,
+                user_id=user_id,
+                organization_id=organization_id,
+            )
+            if template is None:
+                raise TemplateNotFoundError(f"Template {tid} not found")
+
+        # Gather + dedupe placeholders across requested templates.
+        placeholders: list = []
+        seen_keys: set[str] = set()
+        for tid in template_ids:
+            for p in await lease_template_placeholder_repo.list_for_template(
+                db, template_id=tid,
+            ):
+                if p.key in seen_keys:
+                    continue
+                seen_keys.add(p.key)
+                placeholders.append(p)
+
+        # Load resolution context once.
+        applicant = await applicant_repo.get(
+            db,
+            applicant_id=lease.applicant_id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+        inquiry = None
+        if applicant is not None and applicant.inquiry_id is not None:
+            inquiry = await get_by_applicant_inquiry_id(
+                db,
+                inquiry_id=applicant.inquiry_id,
+                organization_id=organization_id,
+                user_id=user_id,
+            )
+        property_record = None
+        if lease.listing_id is not None:
+            listing = await listing_repo.get_by_id(
+                db, lease.listing_id, organization_id,
+            )
+            if listing is not None and listing.property_id is not None:
+                property_record = await property_repo.get_by_id(
+                    db, listing.property_id, organization_id,
+                )
+        user_record = await db.get(User, user_id)
+
+        existing_values = lease.values or {}
+
+        items: list[SignedLeaseTemplatePrefillItem] = []
+        for p in placeholders:
+            if p.input_type in ("signature", "computed"):
+                continue
+
+            # Existing lease.values wins over default_source so the user's
+            # earlier choices on a generated lease aren't silently overridden.
+            existing = existing_values.get(p.key)
+            if existing not in (None, ""):
+                items.append(
+                    SignedLeaseTemplatePrefillItem(
+                        key=p.key,
+                        display_label=p.display_label,
+                        input_type=p.input_type,
+                        required=p.required,
+                        value=str(existing),
+                        provenance="lease.values",
+                    )
+                )
+                continue
+
+            value: str = ""
+            provenance: str | None = None
+            if p.default_source:
+                try:
+                    resolved, prov = resolve_default_source(
+                        p.default_source,
+                        applicant,
+                        inquiry,
+                        lease=lease,
+                        property_record=property_record,
+                        user_record=user_record,
+                    )
+                    if resolved is not None and resolved != "":
+                        value = str(resolved)
+                        provenance = prov
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "default_source resolution failed for placeholder %s",
+                        p.key, exc_info=True,
+                    )
+
+            items.append(
+                SignedLeaseTemplatePrefillItem(
+                    key=p.key,
+                    display_label=p.display_label,
+                    input_type=p.input_type,
+                    required=p.required,
+                    value=value,
+                    provenance=provenance,
+                )
+            )
+
+    return SignedLeaseTemplatePrefillResponse(items=items)
 
 
 def should_auto_email_after_generate(

--- a/apps/mybookkeeper/backend/tests/test_default_source_resolver.py
+++ b/apps/mybookkeeper/backend/tests/test_default_source_resolver.py
@@ -240,3 +240,108 @@ class TestValidateDefaultSourceSpec:
     def test_whitespace_only_raises_value_error(self) -> None:
         with pytest.raises(ValueError):
             validate_default_source_spec("   ")
+
+    def test_valid_lease_starts_on(self) -> None:
+        validate_default_source_spec("lease.starts_on")  # must not raise
+
+    def test_valid_lease_ends_on(self) -> None:
+        validate_default_source_spec("lease.ends_on")  # must not raise
+
+    def test_valid_property_address(self) -> None:
+        validate_default_source_spec("property.address")  # must not raise
+
+    def test_valid_user_name(self) -> None:
+        validate_default_source_spec("user.name")  # must not raise
+
+    def test_unknown_lease_field_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown lease field"):
+            validate_default_source_spec("lease.nonexistent")
+
+    def test_unknown_property_field_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown property field"):
+            validate_default_source_spec("property.nonexistent")
+
+    def test_unknown_user_field_raises_value_error(self) -> None:
+        with pytest.raises(ValueError, match="Unknown user field"):
+            validate_default_source_spec("user.nonexistent")
+
+
+# ---------------------------------------------------------------------------
+# resolve_default_source — lease / property / user namespaces
+#
+# Added 2026-05-07 with the imported-lease-addendum feature. The new
+# namespaces let addendum templates resolve ``[ORIGINAL LEASE START DATE]``
+# / ``[PROPERTY ADDRESS]`` / ``[LANDLORD FULL NAME]`` from the parent lease
+# row + linked property + host user without forcing the host to retype.
+# ---------------------------------------------------------------------------
+
+class TestResolveLeasePropertyUser:
+    def test_lease_starts_on_returns_iso_date(self) -> None:
+        applicant = _make_applicant()
+        lease = MagicMock()
+        lease.starts_on = datetime.date(2026, 5, 3)
+        lease.ends_on = None
+        value, prov = resolve_default_source(
+            "lease.starts_on", applicant, None, lease=lease,
+        )
+        assert value == "2026-05-03"
+        assert prov == "lease"
+
+    def test_lease_ends_on_returns_iso_date(self) -> None:
+        applicant = _make_applicant()
+        lease = MagicMock()
+        lease.starts_on = None
+        lease.ends_on = datetime.date(2026, 5, 17)
+        value, prov = resolve_default_source(
+            "lease.ends_on", applicant, None, lease=lease,
+        )
+        assert value == "2026-05-17"
+        assert prov == "lease"
+
+    def test_lease_attribute_none_returns_none(self) -> None:
+        applicant = _make_applicant()
+        lease = MagicMock()
+        lease.starts_on = None
+        value, prov = resolve_default_source(
+            "lease.starts_on", applicant, None, lease=lease,
+        )
+        assert value is None
+        assert prov is None
+
+    def test_lease_namespace_without_lease_returns_none(self) -> None:
+        """If the spec references lease.* but no lease was passed, resolve to None."""
+        applicant = _make_applicant()
+        value, prov = resolve_default_source(
+            "lease.starts_on", applicant, None,
+        )
+        assert value is None
+        assert prov is None
+
+    def test_property_address_resolves(self) -> None:
+        applicant = _make_applicant()
+        prop = MagicMock()
+        prop.address = "123 Main St, Austin TX"
+        value, prov = resolve_default_source(
+            "property.address", applicant, None, property_record=prop,
+        )
+        assert value == "123 Main St, Austin TX"
+        assert prov == "property"
+
+    def test_user_name_resolves(self) -> None:
+        applicant = _make_applicant()
+        user = MagicMock()
+        user.name = "Jason Kwon"
+        value, prov = resolve_default_source(
+            "user.name", applicant, None, user_record=user,
+        )
+        assert value == "Jason Kwon"
+        assert prov == "user"
+
+    def test_existing_callers_unaffected_by_new_kwargs(self) -> None:
+        """Pre-2026-05-07 callers (no lease/property/user kwargs) keep working."""
+        applicant = _make_applicant(legal_name="Jane Doe")
+        value, prov = resolve_default_source(
+            "applicant.legal_name", applicant, None,
+        )
+        assert value == "Jane Doe"
+        assert prov == "applicant"

--- a/apps/mybookkeeper/backend/tests/test_lease_add_template.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_add_template.py
@@ -1,8 +1,10 @@
 """Tests for the "add template to existing lease" feature.
 
 Covers:
-- Service: happy path, duplicate rejection, imported-lease rejection,
-  missing template rejection
+- Service: happy path, duplicate rejection, missing template rejection
+- Service: imported leases now ALLOW templates (post-2026-05-07) — the
+  ``ImportedLeaseTemplateError`` class is retained for back-compat but the
+  flow no longer raises it.
 - Repo: max_display_order_for_lease helper
 - API: 200, 404, 409, 422 contract tests
 - Schema: SignedLeaseAddTemplatesRequest validates non-empty list
@@ -143,7 +145,15 @@ async def test_add_templates_raises_not_found_for_unknown_lease(db) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_templates_rejects_imported_lease(db) -> None:
+async def test_add_templates_imported_lease_accepted(db) -> None:
+    """Imported leases now ALLOW templates (addendum support).
+
+    The flow no longer raises ``ImportedLeaseTemplateError`` purely because
+    ``lease.kind == "imported"``. The error class is retained for back-compat
+    but is unreachable from this code path. Verify by passing a non-existent
+    template — the failure must be ``TemplateNotFoundError`` (the actual
+    problem) rather than the old kind-rejection error.
+    """
     user_id = uuid.uuid4()
     org_id = uuid.uuid4()
     lease = await signed_lease_repo.create(
@@ -164,7 +174,7 @@ async def test_add_templates_rejects_imported_lease(db) -> None:
         "app.services.leases.signed_lease_service.unit_of_work",
         _make_fake_uow(db),
     ):
-        with pytest.raises(ImportedLeaseTemplateError):
+        with pytest.raises(TemplateNotFoundError):
             await add_templates_and_generate(
                 user_id=user_id,
                 organization_id=org_id,

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
@@ -3,12 +3,15 @@
  * visibility in ``LeaseDetail``.
  *
  * Covers:
- * - Button only visible when canWrite=true AND lease.kind="generated"
+ * - Button visible when canWrite=true on BOTH generated and imported leases
+ *   (post-2026-05-07 — imported leases can attach addendum templates)
+ * - Hidden when canWrite=false (read-only viewers)
  * - Modal renders with available templates (excluding already-linked ones)
- * - "Add and generate" button is disabled when nothing selected
- * - Fires mutation with correct template_ids on confirm
- * - Shows success toast and closes modal on 200
- * - Shows 409-specific error toast on duplicate template conflict
+ * - "Continue" disabled when nothing selected
+ * - Continue → prefill mutation → values step with prefilled inputs
+ * - Generate fires add-templates mutation with template_ids + values
+ * - Success toast + modal close on 200
+ * - 409 error toast on duplicate template conflict
  */
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -24,6 +27,7 @@ import type { LeaseTemplateSummary } from "@/shared/types/lease/lease-template-s
 // ---------------------------------------------------------------------------
 
 const addTemplatesMock = vi.fn();
+const prefillMock = vi.fn();
 const generateMock = vi.fn(() => ({ unwrap: () => Promise.resolve() }));
 const updateMock = vi.fn(() => ({ unwrap: () => Promise.resolve() }));
 
@@ -43,6 +47,7 @@ vi.mock("@/shared/store/signedLeasesApi", () => ({
   useGetSignedLeaseByIdQuery: (...args: unknown[]) =>
     useGetSignedLeaseByIdQueryMock(...args),
   useAddSignedLeaseTemplatesMutation: () => [addTemplatesMock, { isLoading: false }],
+  usePrefillAddendumPlaceholdersMutation: () => [prefillMock, { isLoading: false }],
 }));
 
 vi.mock("@/shared/store/applicantsApi", () => ({
@@ -151,6 +156,29 @@ beforeEach(() => {
   vi.clearAllMocks();
   canWriteValue = true;
   addTemplatesMock.mockReturnValue({ unwrap: () => Promise.resolve({}) });
+  prefillMock.mockReturnValue({
+    unwrap: () =>
+      Promise.resolve({
+        items: [
+          {
+            key: "TENANT FULL NAME",
+            display_label: "Tenant full name",
+            input_type: "text",
+            required: true,
+            value: "Sonu King",
+            provenance: "applicant",
+          },
+          {
+            key: "NEW LEASE END DATE",
+            display_label: "New lease end date",
+            input_type: "date",
+            required: true,
+            value: "",
+            provenance: null,
+          },
+        ],
+      }),
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -165,11 +193,11 @@ describe("LeaseDetail — Add template button visibility", () => {
     expect(screen.getByTestId("lease-add-template-button")).toBeInTheDocument();
   });
 
-  it("hides the button on an imported lease", () => {
+  it("shows the button on an imported lease (addendum support)", () => {
     canWriteValue = true;
     mockLease = buildLease({ kind: "imported", templates: [] });
     renderDetail();
-    expect(screen.queryByTestId("lease-add-template-button")).toBeNull();
+    expect(screen.getByTestId("lease-add-template-button")).toBeInTheDocument();
   });
 
   it("hides the button when canWrite=false", () => {
@@ -208,18 +236,18 @@ describe("LeaseAddTemplateModal", () => {
     expect(screen.getByTestId("add-template-option-tpl-new")).toBeInTheDocument();
   });
 
-  it("'Add and generate' button is disabled when nothing selected", async () => {
+  it("'Continue' button is disabled when nothing selected", async () => {
     canWriteValue = true;
     mockLease = buildLease();
     renderDetail();
     fireEvent.click(screen.getByTestId("lease-add-template-button"));
     await waitFor(() =>
-      expect(screen.getByTestId("lease-add-template-confirm")).toBeInTheDocument(),
+      expect(screen.getByTestId("lease-add-template-continue")).toBeInTheDocument(),
     );
-    expect(screen.getByTestId("lease-add-template-confirm")).toBeDisabled();
+    expect(screen.getByTestId("lease-add-template-continue")).toBeDisabled();
   });
 
-  it("fires the mutation with correct template_ids on confirm", async () => {
+  it("Continue → prefill → values step shows prefilled inputs", async () => {
     canWriteValue = true;
     mockLease = buildLease();
     renderDetail();
@@ -228,13 +256,75 @@ describe("LeaseAddTemplateModal", () => {
       expect(screen.getByTestId("add-template-checkbox-tpl-new")).toBeInTheDocument(),
     );
     fireEvent.click(screen.getByTestId("add-template-checkbox-tpl-new"));
+    fireEvent.click(screen.getByTestId("lease-add-template-continue"));
+    await waitFor(() =>
+      expect(prefillMock).toHaveBeenCalledWith({
+        leaseId: "lease-1",
+        templateIds: ["tpl-new"],
+      }),
+    );
+    // Values step renders inputs from the prefill response
+    await waitFor(() =>
+      expect(screen.getByTestId("addendum-input-TENANT FULL NAME")).toBeInTheDocument(),
+    );
+    expect(
+      (screen.getByTestId("addendum-input-TENANT FULL NAME") as HTMLInputElement).value,
+    ).toBe("Sonu King");
+    expect(
+      (screen.getByTestId("addendum-input-NEW LEASE END DATE") as HTMLInputElement).value,
+    ).toBe("");
+  });
+
+  it("Generate fires add-templates mutation with template_ids + values", async () => {
+    canWriteValue = true;
+    mockLease = buildLease();
+    renderDetail();
+    fireEvent.click(screen.getByTestId("lease-add-template-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-template-checkbox-tpl-new")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-template-checkbox-tpl-new"));
+    fireEvent.click(screen.getByTestId("lease-add-template-continue"));
+    await waitFor(() =>
+      expect(screen.getByTestId("addendum-input-NEW LEASE END DATE")).toBeInTheDocument(),
+    );
+    // Fill the required-and-empty field
+    fireEvent.change(screen.getByTestId("addendum-input-NEW LEASE END DATE"), {
+      target: { value: "2026-08-31" },
+    });
     fireEvent.click(screen.getByTestId("lease-add-template-confirm"));
     await waitFor(() =>
       expect(addTemplatesMock).toHaveBeenCalledWith({
         leaseId: "lease-1",
         templateIds: ["tpl-new"],
+        values: {
+          "TENANT FULL NAME": "Sonu King",
+          "NEW LEASE END DATE": "2026-08-31",
+        },
       }),
     );
+  });
+
+  it("blocks Generate when a required field is empty", async () => {
+    canWriteValue = true;
+    mockLease = buildLease();
+    renderDetail();
+    fireEvent.click(screen.getByTestId("lease-add-template-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-template-checkbox-tpl-new")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-template-checkbox-tpl-new"));
+    fireEvent.click(screen.getByTestId("lease-add-template-continue"));
+    await waitFor(() =>
+      expect(screen.getByTestId("addendum-input-NEW LEASE END DATE")).toBeInTheDocument(),
+    );
+    // NEW LEASE END DATE is required and empty — clicking Generate must
+    // surface a validation error and NOT call the mutation.
+    fireEvent.click(screen.getByTestId("lease-add-template-confirm"));
+    await waitFor(() =>
+      expect(showErrorMock).toHaveBeenCalled(),
+    );
+    expect(addTemplatesMock).not.toHaveBeenCalled();
   });
 
   it("shows success toast and closes modal on successful add", async () => {
@@ -246,6 +336,13 @@ describe("LeaseAddTemplateModal", () => {
       expect(screen.getByTestId("add-template-checkbox-tpl-new")).toBeInTheDocument(),
     );
     fireEvent.click(screen.getByTestId("add-template-checkbox-tpl-new"));
+    fireEvent.click(screen.getByTestId("lease-add-template-continue"));
+    await waitFor(() =>
+      expect(screen.getByTestId("addendum-input-NEW LEASE END DATE")).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByTestId("addendum-input-NEW LEASE END DATE"), {
+      target: { value: "2026-08-31" },
+    });
     fireEvent.click(screen.getByTestId("lease-add-template-confirm"));
     await waitFor(() => expect(showSuccessMock).toHaveBeenCalledWith("1 template added."));
     await waitFor(() =>
@@ -265,6 +362,13 @@ describe("LeaseAddTemplateModal", () => {
       expect(screen.getByTestId("add-template-checkbox-tpl-new")).toBeInTheDocument(),
     );
     fireEvent.click(screen.getByTestId("add-template-checkbox-tpl-new"));
+    fireEvent.click(screen.getByTestId("lease-add-template-continue"));
+    await waitFor(() =>
+      expect(screen.getByTestId("addendum-input-NEW LEASE END DATE")).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByTestId("addendum-input-NEW LEASE END DATE"), {
+      target: { value: "2026-08-31" },
+    });
     fireEvent.click(screen.getByTestId("lease-add-template-confirm"));
     await waitFor(() =>
       expect(showErrorMock).toHaveBeenCalledWith(

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateModal.tsx
@@ -1,14 +1,18 @@
 import { useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { Plus } from "lucide-react";
+import { ArrowLeft, Plus } from "lucide-react";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import Button from "@/shared/components/ui/Button";
 import Skeleton from "@/shared/components/ui/Skeleton";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useGetLeaseTemplatesQuery } from "@/shared/store/leaseTemplatesApi";
-import { useAddSignedLeaseTemplatesMutation } from "@/shared/store/signedLeasesApi";
+import {
+  useAddSignedLeaseTemplatesMutation,
+  usePrefillAddendumPlaceholdersMutation,
+} from "@/shared/store/signedLeasesApi";
 import type { LeaseTemplateSummary } from "@/shared/types/lease/lease-template-summary";
+import type { SignedLeaseTemplatePrefillItem } from "@/shared/types/lease/signed-lease-template-prefill";
 
 export interface LeaseAddTemplateModalProps {
   leaseId: string;
@@ -17,20 +21,42 @@ export interface LeaseAddTemplateModalProps {
   onClose: () => void;
 }
 
+type Step = "pick" | "values";
+
+interface ValuesFormState {
+  items: SignedLeaseTemplatePrefillItem[];
+  values: Record<string, string>;
+}
+
 /**
- * Modal that lets the host pick additional lease templates to add to an
- * existing generated lease. Only templates NOT already on the lease appear.
- * On confirm, calls POST /signed-leases/{leaseId}/templates and re-fetches
- * the lease detail so attachments and template list refresh.
+ * Two-step modal for adding lease templates to an existing signed lease.
+ *
+ * Step 1 — pick: host picks one or more templates from a checklist of
+ * templates not already linked to the lease.
+ *
+ * Step 2 — values: backend pre-fills as many placeholders as possible from
+ * the parent lease, applicant, linked property, and host user. Host fills in
+ * any genuinely-unknown fields (rent, dates, payment method, etc.) and
+ * submits. Backend persists merged values to ``lease.values`` and renders
+ * the new template files as additional attachments.
+ *
+ * Works for both generated and imported leases. Imported leases use this
+ * flow to attach addenda (e.g. extension addendums) without touching the
+ * original signed PDF.
  */
 export default function LeaseAddTemplateModal({
   leaseId,
   existingTemplateIds,
   onClose,
 }: LeaseAddTemplateModalProps) {
+  const [step, setStep] = useState<Step>("pick");
   const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [valuesState, setValuesState] = useState<ValuesFormState | null>(null);
+
   const [addTemplates, { isLoading: isAdding }] =
     useAddSignedLeaseTemplatesMutation();
+  const [prefill, { isLoading: isPrefilling }] =
+    usePrefillAddendumPlaceholdersMutation();
   const {
     data,
     isLoading,
@@ -48,10 +74,54 @@ export default function LeaseAddTemplateModal({
     );
   }
 
-  async function handleConfirm() {
+  async function handleContinue() {
     if (selectedIds.length === 0) return;
     try {
-      await addTemplates({ leaseId, templateIds: selectedIds }).unwrap();
+      const result = await prefill({
+        leaseId,
+        templateIds: selectedIds,
+      }).unwrap();
+      const initialValues: Record<string, string> = {};
+      for (const item of result.items) {
+        initialValues[item.key] = item.value;
+      }
+      setValuesState({ items: result.items, values: initialValues });
+      setStep("values");
+    } catch {
+      showError("Couldn't load the template fields. Want to try again?");
+    }
+  }
+
+  function handleValueChange(key: string, value: string) {
+    setValuesState((prev) =>
+      prev === null
+        ? prev
+        : { ...prev, values: { ...prev.values, [key]: value } },
+    );
+  }
+
+  async function handleGenerate() {
+    if (valuesState === null) return;
+
+    const missingRequired = valuesState.items
+      .filter((it) => it.required && it.input_type !== "signature")
+      .filter((it) => (valuesState.values[it.key] ?? "").trim() === "")
+      .map((it) => it.display_label);
+    if (missingRequired.length > 0) {
+      showError(
+        `Please fill in: ${missingRequired.slice(0, 3).join(", ")}${
+          missingRequired.length > 3 ? "..." : ""
+        }`,
+      );
+      return;
+    }
+
+    try {
+      await addTemplates({
+        leaseId,
+        templateIds: selectedIds,
+        values: valuesState.values,
+      }).unwrap();
       showSuccess(
         `${selectedIds.length} template${selectedIds.length === 1 ? "" : "s"} added.`,
       );
@@ -68,116 +138,221 @@ export default function LeaseAddTemplateModal({
     }
   }
 
+  function inputTypeAttr(t: string): string {
+    if (t === "date") return "date";
+    if (t === "email") return "email";
+    if (t === "phone") return "tel";
+    return "text";
+  }
+
   return (
     <Dialog.Root open onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 bg-black/50 z-[70]" />
         <Dialog.Content
-          className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-lg rounded-lg border bg-card p-6 shadow-lg flex flex-col gap-4"
+          className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 z-[70] w-full max-w-lg rounded-lg border bg-card p-6 shadow-lg flex flex-col gap-4 max-h-[90vh] overflow-hidden"
           data-testid="lease-add-template-modal"
         >
           <Dialog.Title className="text-base font-semibold">
-            Add template
+            {step === "pick" ? "Add template" : "Fill in details"}
           </Dialog.Title>
           <Dialog.Description className="text-sm text-muted-foreground -mt-2">
-            Select one or more templates to generate and append to this lease.
+            {step === "pick"
+              ? "Select one or more templates to generate and append to this lease."
+              : "I've pre-filled what I could. Edit anything that's wrong, and fill in the rest."}
           </Dialog.Description>
 
-          {isError ? (
-            <AlertBox
-              variant="error"
-              className="flex items-center justify-between gap-3"
-            >
-              <span>I couldn't load your templates. Want me to try again?</span>
-              <LoadingButton
-                variant="secondary"
-                size="sm"
-                isLoading={isFetching}
-                loadingText="Retrying..."
-                onClick={() => refetch()}
-              >
-                Retry
-              </LoadingButton>
-            </AlertBox>
-          ) : isLoading ? (
-            <div className="space-y-2" data-testid="lease-add-template-skeleton">
-              <Skeleton className="h-14 w-full" />
-              <Skeleton className="h-14 w-full" />
-            </div>
-          ) : available.length === 0 ? (
-            <p
-              className="text-sm text-muted-foreground py-4 text-center"
-              data-testid="lease-add-template-empty"
-            >
-              All your templates are already on this lease.
-            </p>
-          ) : (
-            <ul
-              className="space-y-2 max-h-72 overflow-y-auto"
-              data-testid="lease-add-template-list"
-            >
-              {available.map((t) => {
-                const checked = selectedIds.includes(t.id);
-                return (
-                  <li key={t.id}>
-                    <label
-                      className={[
-                        "w-full flex items-start gap-3 border rounded-lg px-4 py-3 transition-colors min-h-[44px] cursor-pointer",
-                        checked
-                          ? "border-primary bg-primary/5"
-                          : "hover:bg-muted/50",
-                      ].join(" ")}
-                      data-testid={`add-template-option-${t.id}`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => handleToggle(t)}
-                        className="mt-1 h-4 w-4 cursor-pointer"
-                        aria-label={`Select template ${t.name}`}
-                        data-testid={`add-template-checkbox-${t.id}`}
-                      />
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center justify-between gap-2 flex-wrap">
-                          <span className="font-medium text-sm">{t.name}</span>
-                          <span className="text-xs text-muted-foreground shrink-0">
-                            v{t.version}
-                          </span>
-                        </div>
-                        {t.description ? (
-                          <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
-                            {t.description}
-                          </p>
-                        ) : null}
-                        <p className="text-xs text-muted-foreground mt-1">
-                          {t.placeholder_count}{" "}
-                          {t.placeholder_count === 1
-                            ? "placeholder"
-                            : "placeholders"}
-                        </p>
-                      </div>
-                    </label>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
+          {step === "pick" ? (
+            <>
+              {isError ? (
+                <AlertBox
+                  variant="error"
+                  className="flex items-center justify-between gap-3"
+                >
+                  <span>I couldn't load your templates. Want me to try again?</span>
+                  <LoadingButton
+                    variant="secondary"
+                    size="sm"
+                    isLoading={isFetching}
+                    loadingText="Retrying..."
+                    onClick={() => refetch()}
+                  >
+                    Retry
+                  </LoadingButton>
+                </AlertBox>
+              ) : isLoading ? (
+                <div className="space-y-2" data-testid="lease-add-template-skeleton">
+                  <Skeleton className="h-14 w-full" />
+                  <Skeleton className="h-14 w-full" />
+                </div>
+              ) : available.length === 0 ? (
+                <p
+                  className="text-sm text-muted-foreground py-4 text-center"
+                  data-testid="lease-add-template-empty"
+                >
+                  All your templates are already on this lease.
+                </p>
+              ) : (
+                <ul
+                  className="space-y-2 max-h-72 overflow-y-auto"
+                  data-testid="lease-add-template-list"
+                >
+                  {available.map((t) => {
+                    const checked = selectedIds.includes(t.id);
+                    return (
+                      <li key={t.id}>
+                        <label
+                          className={[
+                            "w-full flex items-start gap-3 border rounded-lg px-4 py-3 transition-colors min-h-[44px] cursor-pointer",
+                            checked
+                              ? "border-primary bg-primary/5"
+                              : "hover:bg-muted/50",
+                          ].join(" ")}
+                          data-testid={`add-template-option-${t.id}`}
+                        >
+                          <input
+                            type="checkbox"
+                            checked={checked}
+                            onChange={() => handleToggle(t)}
+                            className="mt-1 h-4 w-4 cursor-pointer"
+                            aria-label={`Select template ${t.name}`}
+                            data-testid={`add-template-checkbox-${t.id}`}
+                          />
+                          <div className="flex-1 min-w-0">
+                            <div className="flex items-center justify-between gap-2 flex-wrap">
+                              <span className="font-medium text-sm">{t.name}</span>
+                              <span className="text-xs text-muted-foreground shrink-0">
+                                v{t.version}
+                              </span>
+                            </div>
+                            {t.description ? (
+                              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+                                {t.description}
+                              </p>
+                            ) : null}
+                            <p className="text-xs text-muted-foreground mt-1">
+                              {t.placeholder_count}{" "}
+                              {t.placeholder_count === 1
+                                ? "placeholder"
+                                : "placeholders"}
+                            </p>
+                          </div>
+                        </label>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
 
-          <div className="flex justify-end gap-2 pt-2">
-            <Button variant="ghost" size="sm" onClick={onClose}>
-              Cancel
-            </Button>
-            <LoadingButton
-              isLoading={isAdding}
-              loadingText="Generating..."
-              disabled={selectedIds.length === 0 || isAdding}
-              onClick={() => void handleConfirm()}
-              data-testid="lease-add-template-confirm"
-            >
-              <Plus size={14} className="mr-1" />
-              Add and generate
-            </LoadingButton>
-          </div>
+              <div className="flex justify-end gap-2 pt-2">
+                <Button variant="ghost" size="sm" onClick={onClose}>
+                  Cancel
+                </Button>
+                <LoadingButton
+                  isLoading={isPrefilling}
+                  loadingText="Loading fields..."
+                  disabled={selectedIds.length === 0 || isPrefilling}
+                  onClick={() => void handleContinue()}
+                  data-testid="lease-add-template-continue"
+                >
+                  Continue
+                </LoadingButton>
+              </div>
+            </>
+          ) : (
+            <>
+              {valuesState !== null && valuesState.items.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-4 text-center">
+                  This template has nothing for you to fill in — everything is
+                  auto-handled. Click Generate to render it.
+                </p>
+              ) : (
+                <ul
+                  className="space-y-3 max-h-[60vh] overflow-y-auto pr-1"
+                  data-testid="lease-add-template-values-list"
+                >
+                  {(valuesState?.items ?? []).map((item) => {
+                    const value = valuesState?.values[item.key] ?? "";
+                    const provenance = item.provenance;
+                    const provenanceLabel =
+                      provenance === "applicant"
+                        ? "from applicant"
+                        : provenance === "lease"
+                          ? "from lease"
+                          : provenance === "property"
+                            ? "from property"
+                            : provenance === "user"
+                              ? "from your profile"
+                              : provenance === "today"
+                                ? "today's date"
+                                : provenance === "lease.values"
+                                  ? "saved on lease"
+                                  : null;
+                    return (
+                      <li key={item.key} className="flex flex-col gap-1">
+                        <label
+                          htmlFor={`addendum-input-${item.key}`}
+                          className="text-xs font-medium flex items-center gap-2 flex-wrap"
+                        >
+                          {item.display_label}
+                          {item.required ? (
+                            <span className="text-destructive" aria-hidden>
+                              *
+                            </span>
+                          ) : null}
+                          {provenanceLabel !== null ? (
+                            <span className="text-[10px] uppercase tracking-wide text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-normal">
+                              {provenanceLabel}
+                            </span>
+                          ) : null}
+                        </label>
+                        <input
+                          id={`addendum-input-${item.key}`}
+                          type={inputTypeAttr(item.input_type)}
+                          value={value}
+                          onChange={(e) =>
+                            handleValueChange(item.key, e.target.value)
+                          }
+                          className="px-3 py-2 text-sm border rounded-md bg-background"
+                          data-testid={`addendum-input-${item.key}`}
+                          placeholder={
+                            item.required ? "Required" : "Optional"
+                          }
+                        />
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+
+              <div className="flex items-center justify-between gap-2 pt-2">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setStep("pick")}
+                  data-testid="lease-add-template-back"
+                >
+                  <ArrowLeft size={14} className="mr-1" />
+                  Back
+                </Button>
+                <div className="flex gap-2">
+                  <Button variant="ghost" size="sm" onClick={onClose}>
+                    Cancel
+                  </Button>
+                  <LoadingButton
+                    isLoading={isAdding}
+                    loadingText="Generating..."
+                    disabled={isAdding}
+                    onClick={() => void handleGenerate()}
+                    data-testid="lease-add-template-confirm"
+                  >
+                    <Plus size={14} className="mr-1" />
+                    Generate
+                  </LoadingButton>
+                </div>
+              </div>
+            </>
+          )}
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -180,51 +180,53 @@ export default function LeaseDetail() {
             }
           />
 
-          {/* Templates list — only for generated leases */}
-          {lease.kind === "generated" ? (
-            <section
-              className="border rounded-lg p-4"
-              data-testid="lease-templates-card"
-            >
-              <div className="flex items-center justify-between gap-2 mb-2">
-                <p className="text-xs text-muted-foreground uppercase font-medium tracking-wide">
-                  {lease.templates.length === 1 ? "Template" : "Templates"}
-                </p>
-                {canWrite ? (
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={() => setShowAddTemplateModal(true)}
-                    data-testid="lease-add-template-button"
-                    className="h-7 px-2 text-xs"
-                  >
-                    <Plus size={12} className="mr-1" />
-                    Add template
-                  </Button>
-                ) : null}
-              </div>
-              {lease.templates.length > 0 ? (
-                <ul className="flex flex-wrap gap-2">
-                  {lease.templates.map((t) => (
-                    <li key={t.id}>
-                      <Link
-                        to={`/lease-templates/${t.id}`}
-                        data-testid={`lease-template-link-${t.id}`}
-                        className="inline-block text-xs px-2 py-1 rounded-md bg-muted text-foreground hover:bg-muted/70"
-                      >
-                        {t.name}{" "}
-                        <span className="text-muted-foreground">v{t.version}</span>
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              ) : (
-                <p className="text-xs text-muted-foreground">
-                  No templates yet — add one to generate documents.
-                </p>
-              )}
-            </section>
-          ) : null}
+          {/* Templates list — generated leases use templates as the source of
+              truth; imported leases can attach addendum templates that render
+              alongside the original PDF. */}
+          <section
+            className="border rounded-lg p-4"
+            data-testid="lease-templates-card"
+          >
+            <div className="flex items-center justify-between gap-2 mb-2">
+              <p className="text-xs text-muted-foreground uppercase font-medium tracking-wide">
+                {lease.templates.length === 1 ? "Template" : "Templates"}
+              </p>
+              {canWrite ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setShowAddTemplateModal(true)}
+                  data-testid="lease-add-template-button"
+                  className="h-7 px-2 text-xs"
+                >
+                  <Plus size={12} className="mr-1" />
+                  {lease.kind === "imported" ? "Add addendum" : "Add template"}
+                </Button>
+              ) : null}
+            </div>
+            {lease.templates.length > 0 ? (
+              <ul className="flex flex-wrap gap-2">
+                {lease.templates.map((t) => (
+                  <li key={t.id}>
+                    <Link
+                      to={`/lease-templates/${t.id}`}
+                      data-testid={`lease-template-link-${t.id}`}
+                      className="inline-block text-xs px-2 py-1 rounded-md bg-muted text-foreground hover:bg-muted/70"
+                    >
+                      {t.name}{" "}
+                      <span className="text-muted-foreground">v{t.version}</span>
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                {lease.kind === "imported"
+                  ? "No addenda yet — add one to generate a document like a lease extension."
+                  : "No templates yet — add one to generate documents."}
+              </p>
+            )}
+          </section>
 
           {showAddTemplateModal && lease ? (
             <LeaseAddTemplateModal

--- a/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
@@ -6,6 +6,7 @@ import type { SignedLeaseDetail } from "@/shared/types/lease/signed-lease-detail
 import type { SignedLeaseImportRequest } from "@/shared/types/lease/signed-lease-import-request";
 import type { SignedLeaseListArgs } from "@/shared/types/lease/signed-lease-list-args";
 import type { SignedLeaseListResponse } from "@/shared/types/lease/signed-lease-list-response";
+import type { SignedLeaseTemplatePrefillResponse } from "@/shared/types/lease/signed-lease-template-prefill";
 import type { SignedLeaseUpdateRequest } from "@/shared/types/lease/signed-lease-update-request";
 
 /**
@@ -162,17 +163,35 @@ const signedLeasesApi = baseApi.injectEndpoints({
 
     addSignedLeaseTemplates: builder.mutation<
       SignedLeaseDetail,
-      { leaseId: string; templateIds: string[] }
+      {
+        leaseId: string;
+        templateIds: string[];
+        values?: Record<string, string>;
+      }
     >({
-      query: ({ leaseId, templateIds }) => ({
+      query: ({ leaseId, templateIds, values }) => ({
         url: `/signed-leases/${leaseId}/templates`,
         method: "POST",
-        data: { template_ids: templateIds },
+        data: {
+          template_ids: templateIds,
+          ...(values ? { values } : {}),
+        },
       }),
       invalidatesTags: (_r, _e, { leaseId }) => [
         { type: "SignedLease", id: leaseId },
         { type: "SignedLease", id: "LIST" },
       ],
+    }),
+
+    prefillAddendumPlaceholders: builder.mutation<
+      SignedLeaseTemplatePrefillResponse,
+      { leaseId: string; templateIds: string[] }
+    >({
+      query: ({ leaseId, templateIds }) => ({
+        url: `/signed-leases/${leaseId}/template-prefill`,
+        method: "POST",
+        data: { template_ids: templateIds },
+      }),
     }),
   }),
 });
@@ -190,4 +209,5 @@ export const {
   useImportSignedLeaseMutation,
   useUpdateLeaseAttachmentMutation,
   useAddSignedLeaseTemplatesMutation,
+  usePrefillAddendumPlaceholdersMutation,
 } = signedLeasesApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-template-prefill.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-template-prefill.ts
@@ -1,0 +1,12 @@
+export interface SignedLeaseTemplatePrefillItem {
+  key: string;
+  display_label: string;
+  input_type: string;
+  required: boolean;
+  value: string;
+  provenance: string | null;
+}
+
+export interface SignedLeaseTemplatePrefillResponse {
+  items: SignedLeaseTemplatePrefillItem[];
+}


### PR DESCRIPTION
## Summary

Lifts the ``lease.kind == \"generated\"`` gate so hosts can attach addendum templates (lease extension, pet addendum, etc.) directly to imported leases via the existing \"Add template\" UI. The render flow auto-fills as many placeholders as possible from existing data (applicant, lease dates, property, host user), and the host fills in only the genuinely unknown fields (rent, new dates, payment method).

## Why

The operator hit this on a real tenant: Sonu King's lease (imported) needs an extension addendum. The original flow forced the operator to either (a) hand-fill a Word doc with Find & Replace and upload as a Signed addendum file, or (b) skip the template feature entirely. The data MBK already has — tenant name from applicant, term dates from the lease record, property address from the linked listing — was being thrown away.

## What changes

**Backend**
- ``add_templates_and_generate`` no longer raises ``ImportedLeaseTemplateError``; imported leases route through the same render flow as generated leases.
- New optional ``values_override`` parameter merges caller-supplied values into ``lease.values`` before render and persists.
- Auto-resolves any placeholder with a ``default_source`` set against parent lease, applicant + inquiry, linked property, and host user.
- New endpoint ``POST /signed-leases/{id}/template-prefill`` returns the resolution result per placeholder so the frontend can render a values form with sensible defaults.
- ``default_source_resolver`` extended with three new namespaces: ``lease.starts_on`` / ``ends_on``, ``property.address`` / ``name``, ``user.name`` / ``email``. Existing applicant + inquiry callers are not affected.
- ``default_source_map`` seeds the canonical addendum placeholder keys with their auto-resolvable sources.

**Frontend**
- LeaseDetail removes the ``kind === \"generated\"`` gate. Imported leases show an \"Add addendum\" CTA in the templates card; generated leases keep the \"Add template\" label.
- LeaseAddTemplateModal becomes a two-step modal: (1) pick templates, (2) fill values. The values step calls the prefill endpoint, surfaces per-field provenance hints (\"from applicant\", \"from lease\", \"today's date\"), and validates required fields before submit.

**Tests**
- 9 new resolver unit tests covering the lease/property/user namespaces.
- Imported-lease test flipped from \"rejects\" to \"accepted\".
- Modal test rewritten to cover both steps + required-field validation.

## Backwards compatibility

- ``ImportedLeaseTemplateError`` is retained as an exception class but is no longer raised from ``add_templates_and_generate``. Other callers that catch it keep compiling.
- Existing ``add_templates_and_generate`` callers without ``values_override`` keep working; behaviour is strictly improved (placeholders with ``default_source`` that previously rendered as empty strings now resolve).

## Operational migration

None required. No schema changes, no env vars added. Existing templates already in the DB get the new auto-resolution behaviour the next time they're attached to a lease.

## Test plan

- [x] Backend resolver tests (9 new) — all green
- [x] Backend service tests (test_lease_add_template) — 9 passing including the flipped imported-lease test
- [ ] Frontend unit tests (LeaseAddTemplateModal) — local node_modules not installed; relying on CI
- [ ] Manual smoke: upload Lease Extension Addendum template → attach to an imported lease → verify values form prefills → fill remaining + Generate → verify rendered PDF appears as new attachment alongside the original imported PDF

🤖 Generated with [Claude Code](https://claude.com/claude-code)