### PR TITLE
feat(mjh/discovery): Phase C frontend — score badge, Apply button, dismiss reasons

### DIFF
--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
@@ -1,4 +1,5 @@
-import { Bookmark, ExternalLink, X } from "lucide-react";
+import { useState } from "react";
+import { Bookmark, Briefcase, Check, ExternalLink, X } from "lucide-react";
 import {
   Badge,
   Button,
@@ -11,7 +12,9 @@ import {
 } from "@platform/ui";
 import {
   useDismissDiscoveredJobMutation,
+  usePromoteDiscoveredJobMutation,
   useSaveDiscoveredJobMutation,
+  type DismissalReason,
 } from "@/store/discoverApi";
 import type { DiscoveredJob } from "@/types/discovery/discovered-job";
 
@@ -26,13 +29,40 @@ const REMOTE_LABEL: Record<string, string> = {
   unknown: "",
 };
 
+const DISMISS_REASONS: { value: DismissalReason; label: string }[] = [
+  { value: "wrong_stack", label: "Wrong tech stack" },
+  { value: "too_small_company", label: "Company too small" },
+  { value: "wrong_sector", label: "Wrong industry / sector" },
+  { value: "wrong_comp", label: "Compensation mismatch" },
+  { value: "not_remote", label: "Not actually remote" },
+  { value: "not_interested", label: "Not interested" },
+  { value: "other", label: "Other" },
+];
+
+interface ScoreVisual {
+  band: "strong" | "good" | "stretch" | "low";
+  label: string;
+  color: "green" | "blue" | "yellow" | "red";
+}
+
+function bandForScore(score: number | null): ScoreVisual | null {
+  if (score === null) return null;
+  if (score >= 85) return { band: "strong", label: "Strong fit", color: "green" };
+  if (score >= 60) return { band: "good", label: "Worth considering", color: "blue" };
+  if (score >= 30) return { band: "stretch", label: "Stretch", color: "yellow" };
+  return { band: "low", label: "Mismatch", color: "red" };
+}
+
 export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
   const [dismiss, { isLoading: isDismissing }] = useDismissDiscoveredJobMutation();
   const [save, { isLoading: isSaving }] = useSaveDiscoveredJobMutation();
+  const [promote, { isLoading: isPromoting }] = usePromoteDiscoveredJobMutation();
+  const [showReasons, setShowReasons] = useState(false);
 
-  async function handleDismiss() {
+  async function doDismiss(reason?: DismissalReason) {
     try {
-      await dismiss(job.id).unwrap();
+      await dismiss({ jobId: job.id, reason }).unwrap();
+      setShowReasons(false);
     } catch (err) {
       showError(extractErrorMessage(err) ?? "Couldn't dismiss this posting");
     }
@@ -47,6 +77,15 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
     }
   }
 
+  async function handlePromote() {
+    try {
+      await promote(job.id).unwrap();
+      showSuccess("Added to Applications");
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Couldn't add this to Applications");
+    }
+  }
+
   const remoteLabel = REMOTE_LABEL[job.remote_type] ?? "";
   const salaryLabel = formatSalaryRange(
     job.salary_min !== null ? String(job.salary_min) : null,
@@ -57,6 +96,8 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
   const hasSalary = salaryLabel && salaryLabel !== "—";
   const postedLabel = job.posted_at ? timeAgo(job.posted_at) : null;
   const isAlreadySaved = !!job.saved_at;
+  const isAlreadyPromoted = !!job.promoted_application_id;
+  const scoreVisual = bandForScore(job.score);
 
   return (
     <Card className="p-4 sm:p-5 space-y-3">
@@ -70,9 +111,12 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
             {job.location ? ` — ${job.location}` : ""}
           </p>
         </div>
-        {job.source_publisher && (
-          <Badge label={job.source_publisher} color="gray" />
-        )}
+        <div className="flex items-start gap-1.5 shrink-0">
+          {scoreVisual && <Badge label={scoreVisual.label} color={scoreVisual.color} />}
+          {job.source_publisher && (
+            <Badge label={job.source_publisher} color="gray" />
+          )}
+        </div>
       </div>
 
       <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
@@ -91,44 +135,104 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
         )}
       </div>
 
+      {job.score_reason && (
+        <p className="text-xs text-muted-foreground italic border-l-2 border-muted pl-2">
+          {job.score_reason}
+        </p>
+      )}
+
       {job.description && (
         <p className="text-sm text-muted-foreground line-clamp-3">
           {job.description}
         </p>
       )}
 
-      <div className="flex items-center gap-2 pt-1">
-        {job.source_url && (
-          <a
-            href={job.source_url}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium border rounded hover:bg-muted min-h-[44px] sm:min-h-[32px]"
+      {showReasons ? (
+        <div className="border rounded-md p-3 space-y-2">
+          <p className="text-xs font-medium">Why are you dismissing this?</p>
+          <div className="flex flex-wrap gap-1.5">
+            {DISMISS_REASONS.map((r) => (
+              <button
+                key={r.value}
+                type="button"
+                onClick={() => doDismiss(r.value)}
+                disabled={isDismissing}
+                className="px-2 py-1 text-xs border rounded hover:bg-muted"
+              >
+                {r.label}
+              </button>
+            ))}
+          </div>
+          <div className="flex items-center gap-2 pt-1">
+            <button
+              type="button"
+              onClick={() => doDismiss()}
+              disabled={isDismissing}
+              className="text-xs text-muted-foreground hover:underline"
+            >
+              Skip — dismiss without a reason
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowReasons(false)}
+              className="text-xs text-muted-foreground hover:underline ml-auto"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 pt-1 flex-wrap">
+          {job.source_url && (
+            <a
+              href={job.source_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium border rounded hover:bg-muted min-h-[44px] sm:min-h-[32px]"
+            >
+              <ExternalLink className="w-4 h-4" />
+              Open
+            </a>
+          )}
+          <Button
+            size="sm"
+            variant="primary"
+            onClick={handlePromote}
+            disabled={isPromoting || isAlreadyPromoted}
           >
-            <ExternalLink className="w-4 h-4" />
-            Open
-          </a>
-        )}
-        <Button
-          size="sm"
-          variant="secondary"
-          onClick={handleSave}
-          disabled={isSaving || isAlreadySaved}
-        >
-          <Bookmark className="w-4 h-4 mr-1" />
-          {isAlreadySaved ? "Saved" : "Save"}
-        </Button>
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={handleDismiss}
-          disabled={isDismissing}
-          className="ml-auto"
-          aria-label="Dismiss this posting"
-        >
-          <X className="w-4 h-4" />
-        </Button>
-      </div>
+            {isAlreadyPromoted ? (
+              <>
+                <Check className="w-4 h-4 mr-1" />
+                Applied
+              </>
+            ) : (
+              <>
+                <Briefcase className="w-4 h-4 mr-1" />
+                Apply
+              </>
+            )}
+          </Button>
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={handleSave}
+            disabled={isSaving || isAlreadySaved || isAlreadyPromoted}
+          >
+            <Bookmark className="w-4 h-4 mr-1" />
+            {isAlreadySaved ? "Saved" : "Save"}
+          </Button>
+          <Button
+            size="sm"
+            variant="ghost"
+            onClick={() => setShowReasons(true)}
+            disabled={isDismissing}
+            className="ml-auto"
+            aria-label="Dismiss this posting"
+          >
+            <X className="w-4 h-4" />
+          </Button>
+        </div>
+      )}
     </Card>
   );
 }

--- a/apps/myjobhunter/frontend/src/store/discoverApi.ts
+++ b/apps/myjobhunter/frontend/src/store/discoverApi.ts
@@ -1,4 +1,5 @@
 import { baseApi } from "@platform/ui";
+import type { Application } from "@/types/application";
 import type { DiscoveredJobListResponse } from "@/types/discovery/discovered-job";
 import type {
   DiscoverySource,
@@ -6,8 +7,17 @@ import type {
 } from "@/types/discovery/discovery-source";
 import type { DiscoveryFetchResult } from "@/types/discovery/discovery-fetch-result";
 
+export type DismissalReason =
+  | "wrong_stack"
+  | "too_small_company"
+  | "wrong_sector"
+  | "wrong_comp"
+  | "not_remote"
+  | "not_interested"
+  | "other";
+
 const apiWithTags = baseApi.enhanceEndpoints({
-  addTagTypes: ["DiscoverySource", "DiscoveredJob"],
+  addTagTypes: ["DiscoverySource", "DiscoveredJob", "Applications"],
 });
 
 const discoverApi = apiWithTags.injectEndpoints({
@@ -45,10 +55,14 @@ const discoverApi = apiWithTags.injectEndpoints({
       }),
       providesTags: ["DiscoveredJob"],
     }),
-    dismissDiscoveredJob: build.mutation<void, string>({
-      query: (jobId) => ({
+    dismissDiscoveredJob: build.mutation<
+      void,
+      { jobId: string; reason?: DismissalReason }
+    >({
+      query: ({ jobId, reason }) => ({
         url: `/discover/${jobId}/dismiss`,
         method: "POST",
+        data: reason ? { reason } : undefined,
       }),
       invalidatesTags: ["DiscoveredJob"],
     }),
@@ -58,6 +72,15 @@ const discoverApi = apiWithTags.injectEndpoints({
         method: "POST",
       }),
       invalidatesTags: ["DiscoveredJob"],
+    }),
+    promoteDiscoveredJob: build.mutation<Application, string>({
+      query: (jobId) => ({
+        url: `/discover/${jobId}/promote`,
+        method: "POST",
+      }),
+      // Promote creates an Application + flips the discovered_job's
+      // promoted_application_id, so both caches need invalidating.
+      invalidatesTags: ["DiscoveredJob", "Applications"],
     }),
   }),
 });
@@ -70,4 +93,5 @@ export const {
   useListDiscoveredJobsQuery,
   useDismissDiscoveredJobMutation,
   useSaveDiscoveredJobMutation,
+  usePromoteDiscoveredJobMutation,
 } = discoverApi;

--- a/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
@@ -19,6 +19,7 @@ export interface DiscoveredJob {
   score_reason: string | null;
   scored_at: string | null;
   dismissed_at: string | null;
+  dismissed_reason: string | null;
   saved_at: string | null;
   promoted_application_id: string | null;
 }


### PR DESCRIPTION
## Summary

Surfaces the fit-score from Phase C backend (#414) and wires the new endpoints (promote, dismiss-with-reason) into the inbox cards.

## Card visual changes

| Score | Badge | Color |
|---|---|---|
| ≥ 85 | Strong fit | green |
| 60–84 | Worth considering | blue |
| 30–59 | Stretch | yellow |
| < 30 | Mismatch | red |
| null | (no badge — still scoring or budget exhausted) | — |

- `score_reason` rendered as muted italic quote below meta line
- New primary **Apply** button → POST /discover/{id}/promote → creates Application, then shows 'Applied ✓' (disabled)
- Dismiss flow now opens an inline 7-option reason picker (Wrong tech stack / Company too small / Wrong industry / Comp mismatch / Not actually remote / Not interested / Other) with 'Skip — dismiss without a reason' fallback

## RTK changes

- New `DismissalReason` type union
- `dismissDiscoveredJob` now takes `{jobId, reason?}` (was just `jobId`)
- New `promoteDiscoveredJob` mutation; invalidates Applications cache so kanban refetches

## Test plan

- [x] TypeScript check clean
- [x] Production build succeeds
- [ ] Operator smoke-tests after deploy (scores fill in ~30s after refresh)

🤖 Generated with [Claude Code](https://claude.com/claude-code)