### PR TITLE
fix(mjh/resumes): poll resume-upload-jobs while any are in flight

### DIFF
--- a/apps/myjobhunter/frontend/src/features/profile/ResumeJobRow.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/ResumeJobRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ChevronDown, ChevronUp, Download, FileText } from "lucide-react";
+import { ChevronDown, ChevronUp, Download, FileText, Loader2 } from "lucide-react";
 import { Badge, formatFileSize } from "@platform/ui";
 import type { ResumeUploadJob, ResumeUploadJobStatus } from "@/types/resume-upload-job/resume-upload-job";
 import ResumeJobParsedPanel from "@/features/profile/ResumeJobParsedPanel";
@@ -78,6 +78,13 @@ export default function ResumeJobRow({ job, onDownload, isDownloading }: ResumeJ
           ) : null}
         </div>
 
+        {(status === "queued" || status === "processing") && (
+          <Loader2
+            size={14}
+            className="text-muted-foreground animate-spin shrink-0"
+            aria-label="Processing"
+          />
+        )}
         <Badge label={STATUS_LABELS[status]} color={STATUS_COLORS[status]} />
 
         {mode.kind === "complete" ? (

--- a/apps/myjobhunter/frontend/src/features/profile/ResumeUploadSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/ResumeUploadSection.tsx
@@ -20,8 +20,31 @@ export interface ResumeUploadSectionProps {
   profileId: string;
 }
 
+// Status values that indicate the worker hasn't finished. While any
+// job is in one of these states we poll the list endpoint so the row
+// transitions from queued → processing → complete without the user
+// having to refresh the page.
+const NON_TERMINAL_STATUSES = new Set<string>(["queued", "processing"]);
+const INFLIGHT_POLL_INTERVAL_MS = 2000;
+
 export default function ResumeUploadSection({ profileId: _profileId }: ResumeUploadSectionProps) {
-  const { data: jobs, isLoading } = useListResumeJobsQuery();
+  // Initial render: jobs is undefined → hasInflightJob is false →
+  // pollingInterval=0, no poll. After the first fetch resolves, if
+  // any job is in queued/processing the hook re-subscribes with
+  // pollingInterval=2000 and RTK Query starts polling. When all jobs
+  // hit a terminal status we re-render with pollingInterval=0 and
+  // polling stops automatically.
+  const [pollingInterval, setPollingInterval] = useState(0);
+  const { data: jobs, isLoading } = useListResumeJobsQuery(undefined, {
+    pollingInterval,
+  });
+  useEffect(() => {
+    const hasInflight = (jobs ?? []).some((j) =>
+      NON_TERMINAL_STATUSES.has(j.status),
+    );
+    setPollingInterval(hasInflight ? INFLIGHT_POLL_INTERVAL_MS : 0);
+  }, [jobs]);
+
   const [uploadResume, { isLoading: isUploading }] = useUploadResumeMutation();
   const [downloadingJobId, setDownloadingJobId] = useState<string | null>(null);
 


### PR DESCRIPTION
## Bug

Operator uploaded a resume and had to manually refresh the page to see the worker complete processing. The list endpoint was fetched once on mount with no polling, so a row stayed pinned at "Queued" until the user navigated away and back.

## Fix

`pollingInterval` state on `useListResumeJobsQuery` toggled by an effect:
- When any job has status in {queued, processing} → poll at 2s
- When everything is terminal (complete / failed / cancelled) → stop
- RTK Query handles the timer transition automatically

Bonus: `Loader2` spin animation next to the status badge for in-flight rows so motion is visible.

## Test plan

- [x] Frontend typecheck clean
- [ ] CI runs full suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)