### PR TITLE
ux(mbk/leases): rename "Add addendum/template" → "Add document"

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Unit tests for ``LeaseAddTemplateModal`` and the "Add template" button
+ * Unit tests for ``LeaseAddTemplateModal`` and the "Add document" button
  * visibility in ``LeaseDetail``.
  *
  * Covers:
@@ -185,7 +185,7 @@ beforeEach(() => {
 // Button visibility
 // ---------------------------------------------------------------------------
 
-describe("LeaseDetail — Add template button visibility", () => {
+describe("LeaseDetail — Add document button visibility", () => {
   it("shows the button on a generated lease when canWrite=true", () => {
     canWriteValue = true;
     mockLease = buildLease({ kind: "generated" });
@@ -213,7 +213,7 @@ describe("LeaseDetail — Add template button visibility", () => {
 // ---------------------------------------------------------------------------
 
 describe("LeaseAddTemplateModal", () => {
-  it("opens when the 'Add template' button is clicked", async () => {
+  it("opens when the 'Add document' button is clicked", async () => {
     canWriteValue = true;
     mockLease = buildLease();
     renderDetail();

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateModal.tsx
@@ -154,11 +154,11 @@ export default function LeaseAddTemplateModal({
           data-testid="lease-add-template-modal"
         >
           <Dialog.Title className="text-base font-semibold">
-            {step === "pick" ? "Add template" : "Fill in details"}
+            {step === "pick" ? "Add document" : "Fill in details"}
           </Dialog.Title>
           <Dialog.Description className="text-sm text-muted-foreground -mt-2">
             {step === "pick"
-              ? "Select one or more templates to generate and append to this lease."
+              ? "Pick a template to generate a document — extension, addendum, disclosure, etc."
               : "I've pre-filled what I could. Edit anything that's wrong, and fill in the rest."}
           </Dialog.Description>
 

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -180,16 +180,16 @@ export default function LeaseDetail() {
             }
           />
 
-          {/* Templates list — generated leases use templates as the source of
-              truth; imported leases can attach addendum templates that render
-              alongside the original PDF. */}
+          {/* Documents generated from templates — extensions, addenda, disclosures,
+              etc. Section is shown for both generated and imported leases; the
+              underlying flow is the same. */}
           <section
             className="border rounded-lg p-4"
             data-testid="lease-templates-card"
           >
             <div className="flex items-center justify-between gap-2 mb-2">
               <p className="text-xs text-muted-foreground uppercase font-medium tracking-wide">
-                {lease.templates.length === 1 ? "Template" : "Templates"}
+                {lease.templates.length === 1 ? "Document" : "Documents"}
               </p>
               {canWrite ? (
                 <Button
@@ -200,7 +200,7 @@ export default function LeaseDetail() {
                   className="h-7 px-2 text-xs"
                 >
                   <Plus size={12} className="mr-1" />
-                  {lease.kind === "imported" ? "Add addendum" : "Add template"}
+                  Add document
                 </Button>
               ) : null}
             </div>
@@ -221,9 +221,7 @@ export default function LeaseDetail() {
               </ul>
             ) : (
               <p className="text-xs text-muted-foreground">
-                {lease.kind === "imported"
-                  ? "No addenda yet — add one to generate a document like a lease extension."
-                  : "No templates yet — add one to generate documents."}
+                No documents yet — add one to generate things like a lease extension or pet addendum.
               </p>
             )}
           </section>


### PR DESCRIPTION
## Summary

Renames the lease-detail templates-card button from `Add addendum` (imported leases) / `Add template` (generated leases) → `Add document` for both. Operator caught that "addendum" is technically narrow — extensions are *amendments*, not addenda; pet rules are addenda; disclosures are neither. "Add document" is generic and accurate for any template kind.

## Changes

- Button label always `Add document`
- Section header: `Document` / `Documents` (was `Template` / `Templates`)
- Empty state: `No documents yet — add one to generate things like a lease extension or pet addendum.`
- Modal step-1 title: `Add document` (was `Add template`)
- Modal step-1 description: `Pick a template to generate a document — extension, addendum, disclosure, etc.`
- Test docstrings + describe names updated. Assertions use `data-testid` (unchanged) so existing tests pass.

## Test plan

- [x] Backend unaffected — no changes
- [ ] Manual smoke after deploy: button reads "Add document" on both imported and generated leases

🤖 Generated with [Claude Code](https://claude.com/claude-code)