### PR TITLE
fix(mbk/leases): show rendered addenda on imported leases

### DIFF
--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -285,11 +285,7 @@ export default function LeaseDetail() {
           {tab === "files" ? (
             <LeaseAttachmentsSection
               leaseId={lease.id}
-              attachments={
-                lease.kind === "imported"
-                  ? lease.attachments.filter((a) => a.kind !== "rendered_original")
-                  : lease.attachments
-              }
+              attachments={lease.attachments}
               canWrite={canWrite}
             />
           ) : null}


### PR DESCRIPTION
## Summary

Drops the imported-lease filter that hid all `rendered_original` attachments from the Files tab. After PR #415 added the ability to attach addendum templates to imported leases, that filter started hiding exactly the documents hosts wanted to see — the rendered extension addendum was created correctly but invisible.

## Root cause

The filter at `LeaseDetail.tsx:289-291` predated PR #415:

\`\`\`tsx
lease.kind === "imported"
  ? lease.attachments.filter((a) => a.kind !== "rendered_original")
  : lease.attachments
\`\`\`

Pre-#415, imported leases couldn't have addendum templates, so any `rendered_original` was assumed to be a duplicate of the imported PDF. Post-#415, `rendered_original` on imported leases is the rendered addendum the host just generated.

## Fix

Drop the filter. Original imported PDFs land with `signed_lease` / `signed_addendum` kinds (set at upload), so showing all attachments doesn't reintroduce the duplicate-the-original problem.

## Test plan

- [ ] Manual: Sonu's lease — refresh after deploy, the rendered Lease Extension Addendum should appear in the Files tab as the 5th file

🤖 Generated with [Claude Code](https://claude.com/claude-code)