### PR TITLE
fix(mjh/discovery): re-raise typed adapter errors so route handlers can map them

### DIFF
--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
@@ -286,9 +286,15 @@ async def fetch_source(
     try:
         postings = await adapter(source.config or {})
     except Exception as exc:
-        # Any adapter exception → mark fetch + source as failed but
-        # don't propagate beyond this service. Caller gets a typed
-        # error result.
+        # Persist the audit row + source-level failure, then re-raise
+        # the ORIGINAL exception so the route layer can map typed
+        # adapter errors (JSearchAuthError → 503, JSearchTransientError
+        # → 502 specific) to specific HTTP statuses. The previous
+        # ``raise DiscoveryFetchError(str(exc)) from exc`` pattern
+        # silently downgraded every adapter failure to the generic 502
+        # branch — operators got "JSearch upstream is unavailable"
+        # when the real issue was a missing API key (which deserves
+        # 503 + a key-config message).
         logger.warning(
             "discovery fetch failed: source=%s id=%s error=%s",
             source.source, source.id, exc,
@@ -300,7 +306,7 @@ async def fetch_source(
             db, source, success=False, error_message=str(exc),
         )
         await db.commit()
-        raise DiscoveryFetchError(str(exc)) from exc
+        raise
 
     fetched_count = len(postings)
 


### PR DESCRIPTION
## Bug

The fetch service wrapped `except Exception: raise DiscoveryFetchError(str(exc)) from exc` around the adapter call, converting every adapter failure into the generic `DiscoveryFetchError`. The route handler tries to catch `JSearchAuthError` (→ 503), `JSearchTransientError` (→ 502 specific), and `JSearchInvalidResponseError` separately — but those handlers were **dead code** because the typed exceptions never escaped the service.

## Practical impact

Missing JSEARCH_API_KEY surfaced as 502 'JSearch upstream is unavailable' instead of 503 'API key not configured.' Operator wouldn't know the real cause from the response.

## Fix

Write the audit row + commit, then plain `raise` (re-raise the original) instead of wrapping. The route's existing typed `except` clauses now fire correctly.

## Discovery

Found by `g-tech-debt-scan` audit (Critical severity finding #1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)