### PR TITLE
fix(mjh/discovery): document JSEARCH_API_KEY + DISCOVERY_DAILY_BUDGET_USD* in .env.docker.example

### DIFF
--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -24,6 +24,24 @@ TAVILY_API_KEY=
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 
+# JSearch (RapidAPI / Google Jobs aggregator) — required for the
+# /discover proactive job-discovery feature to fetch postings.
+# Get a key by subscribing to "JSearch" by openwebninja on RapidAPI
+# (https://rapidapi.com/letscrape-6bRBa3QguO5/api/jsearch). Free tier
+# (200 req/mo) is fine for one operator; Pro ($9.99/mo, 10k req) for
+# active hunting.
+#
+# When this is unset and the operator hits POST /discover/sources/{id}/refresh
+# the route returns 503 with a clear "API key not configured" message.
+JSEARCH_API_KEY=
+
+# /discover scoring budget. The score worker stops calling Claude
+# when today's extraction_logs.cost_usd sum exceeds the smaller of
+# these two values. Default $0.30/day (~30 scoring calls) with a
+# $2.00 hard ceiling no per-profile override may exceed.
+DISCOVERY_DAILY_BUDGET_USD=0.30
+DISCOVERY_DAILY_BUDGET_USD_HARD_CAP=2.00
+
 # Frontend / CORS
 FRONTEND_URL=https://myjobhunter.myfreeapps.org
 CORS_ORIGINS=["https://myjobhunter.myfreeapps.org"]


### PR DESCRIPTION
Three Settings fields shipped without landing in the env template:
- `JSEARCH_API_KEY` (PR #405)
- `DISCOVERY_DAILY_BUDGET_USD` (PR #414)
- `DISCOVERY_DAILY_BUDGET_USD_HARD_CAP` (PR #414)

Runtime works because `env_file:` passes everything from `.env.docker` into the container — but a fresh deploy from the example file would silently lack these.

Discovered by g-tech-debt-scan audit (Critical #2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)