### PR TITLE
fix(mjh/job_analysis): use context_type='job_analysis' (was 'other')

### DIFF
--- a/apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py
+++ b/apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py
@@ -258,10 +258,7 @@ async def score(
         meta = await claude_service.call_claude_with_meta(
             system_prompt=JOB_ANALYSIS_PROMPT,
             user_content=user_content,
-            # ``"job_analysis"`` is the dedicated bucket once migration
-            # disco260507 lands. Until then ``"other"`` is the legal
-            # value (extraction_logs CHECK constraint enforces).
-            context_type="other",
+            context_type="job_analysis",
             user_id=user_id,
             context_id=discovered_job_id,
         )


### PR DESCRIPTION
Migration disco260507 added the dedicated 'job_analysis' enum value (PR #403) but the score()/analyze() service still wrote 'other' with a stale TODO comment. Cost tracking can't separate discovery scoring from generic calls.

One-line fix + stale-comment cleanup. No backfill.

Discovered by g-tech-debt-scan audit (Critical #3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)