### PR TITLE
fix(mjh/discover): inbox polling + replace Loading text with skeletons

### DIFF
--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobsSkeleton.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobsSkeleton.tsx
@@ -1,0 +1,46 @@
+import { Card, Skeleton } from "@platform/ui";
+
+/**
+ * Loading skeleton for the /discover inbox card list.
+ *
+ * Cell widths mirror DiscoveredJobCard's loaded layout:
+ *   - Title (~60% width)
+ *   - Company + location (~40%)
+ *   - Three meta chips
+ *   - Description body (3 short lines)
+ *   - Action button row (4 fixed-width buttons)
+ *
+ * No layout shift on first data arrival.
+ */
+export default function DiscoveredJobsSkeleton({ count = 3 }: { count?: number }) {
+  return (
+    <div className="space-y-3" aria-busy="true">
+      {Array.from({ length: count }).map((_, i) => (
+        <Card key={i} className="p-4 sm:p-5 space-y-3">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <Skeleton className="h-5 w-3/5" />
+              <Skeleton className="h-4 w-2/5" />
+            </div>
+            <Skeleton className="h-5 w-16" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-3 w-12" />
+            <Skeleton className="h-3 w-20" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <div className="space-y-1.5">
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-full" />
+            <Skeleton className="h-3 w-5/6" />
+          </div>
+          <div className="flex gap-2 pt-1">
+            <Skeleton className="h-9 w-16" />
+            <Skeleton className="h-9 w-20" />
+            <Skeleton className="h-9 w-16" />
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
@@ -9,6 +9,7 @@ import {
   timeAgo,
   extractErrorMessage,
 } from "@platform/ui";
+import SavedSearchesSkeleton from "@/features/discover/SavedSearchesSkeleton";
 import {
   useDeactivateDiscoverySourceMutation,
   useListDiscoverySourcesQuery,
@@ -20,11 +21,7 @@ export default function SavedSearchesPanel() {
   const { data: sources, isLoading } = useListDiscoverySourcesQuery();
 
   if (isLoading) {
-    return (
-      <Card className="p-4 text-sm text-muted-foreground">
-        Loading saved searches…
-      </Card>
-    );
+    return <SavedSearchesSkeleton />;
   }
   if (!sources || sources.length === 0) {
     return null;

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchesSkeleton.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchesSkeleton.tsx
@@ -1,0 +1,31 @@
+import { Card, Skeleton } from "@platform/ui";
+
+/**
+ * Loading skeleton for the saved-searches panel.
+ *
+ * Mirrors SavedSearchRow: source badge, query string, last-fetched
+ * meta line, two action buttons (Refresh, Remove). No layout shift
+ * on data arrival.
+ */
+export default function SavedSearchesSkeleton({ rows = 1 }: { rows?: number }) {
+  return (
+    <div className="space-y-2" aria-busy="true">
+      <Skeleton className="h-4 w-28" />
+      {Array.from({ length: rows }).map((_, i) => (
+        <Card key={i} className="p-3 flex items-center justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-5 w-16" />
+              <Skeleton className="h-4 w-48" />
+            </div>
+            <Skeleton className="h-3 w-32" />
+          </div>
+          <div className="flex items-center gap-1 shrink-0">
+            <Skeleton className="h-9 w-24" />
+            <Skeleton className="h-9 w-9" />
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/pages/Discover.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Discover.tsx
@@ -2,12 +2,18 @@ import { useState } from "react";
 import { Plus, Telescope } from "lucide-react";
 import { Button, EmptyState } from "@platform/ui";
 import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
+import DiscoveredJobsSkeleton from "@/features/discover/DiscoveredJobsSkeleton";
 import NewSavedSearchDialog from "@/features/discover/NewSavedSearchDialog";
 import SavedSearchesPanel from "@/features/discover/SavedSearchesPanel";
 import {
   useListDiscoveredJobsQuery,
   useListDiscoverySourcesQuery,
 } from "@/store/discoverApi";
+
+// Background scoring runs after /refresh as a FastAPI BackgroundTask
+// (~30s for 20 postings). Poll the inbox at 4s while the page is open
+// so score badges fill in without the operator refreshing manually.
+const INBOX_POLL_INTERVAL_MS = 4000;
 
 /**
  * /discover — proactive job-posting inbox.
@@ -29,7 +35,10 @@ export default function Discover() {
   const [dialogOpen, setDialogOpen] = useState(false);
 
   const { data: sources } = useListDiscoverySourcesQuery();
-  const { data: jobsData, isLoading } = useListDiscoveredJobsQuery({});
+  const { data: jobsData, isLoading } = useListDiscoveredJobsQuery(
+    {},
+    { pollingInterval: INBOX_POLL_INTERVAL_MS },
+  );
 
   const hasSources = (sources?.length ?? 0) > 0;
   const items = jobsData?.items ?? [];
@@ -65,9 +74,7 @@ export default function Discover() {
         />
       )}
 
-      {hasSources && isLoading && (
-        <p className="text-sm text-muted-foreground">Loading postings…</p>
-      )}
+      {hasSources && isLoading && <DiscoveredJobsSkeleton />}
 
       {hasSources && !isLoading && !hasJobs && (
         <EmptyState


### PR DESCRIPTION
Two related findings from the tech-debt audit:

1. **No polling for score completion.** Backend /refresh schedules background scoring (~30s) but `useListDiscoveredJobsQuery` had no `pollingInterval` — score badges only appeared on manual refresh. Adds 4s polling.

2. **Plain 'Loading…' text** violated the project's skeleton parity rule. Replaced with two new skeletons that mirror loaded layouts (DiscoveredJobCard and SavedSearchRow), eliminating layout shift on data arrival.

Discovered by g-tech-debt-scan (High #6+#7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)