### PR TITLE
fix(mjh/discovery): rate-limit threshold + window driven by Settings

### DIFF
--- a/apps/myjobhunter/backend/app/api/discover.py
+++ b/apps/myjobhunter/backend/app/api/discover.py
@@ -28,6 +28,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from platform_shared.core.request_utils import get_client_ip
 
 from app.core.auth import current_active_user
+from app.core.config import settings
 from app.core.rate_limit import RateLimiter
 from app.db.session import get_db
 from app.models.user.user import User
@@ -65,10 +66,14 @@ router = APIRouter(prefix="/discover", tags=["discovery"])
 
 _NOT_FOUND_DETAIL = "Discovery resource not found"
 
-# 30 / 5 min — fetches hit JSearch (paid). Cap is generous for one
-# operator running ad-hoc refreshes but limits blast radius if a key
-# leaks.
-_REFRESH_LIMITER = RateLimiter(max_attempts=30, window_seconds=300)
+# Fetches hit JSearch (paid). Cap is generous for one operator running
+# ad-hoc refreshes but limits blast radius if a key leaks. Defaults
+# (30 / 5 min) live in Settings so an operator can lower them without
+# code changes.
+_REFRESH_LIMITER = RateLimiter(
+    max_attempts=settings.discovery_refresh_rate_limit_threshold,
+    window_seconds=settings.discovery_refresh_rate_limit_window_seconds,
+)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/myjobhunter/backend/app/core/config.py
+++ b/apps/myjobhunter/backend/app/core/config.py
@@ -39,6 +39,13 @@ class Settings(BaseAppSettings):
     discovery_daily_budget_usd: float = 0.30
     discovery_daily_budget_usd_hard_cap: float = 2.00
 
+    # /discover refresh rate-limit (per IP). JSearch is paid; cap how
+    # often an operator can hit /refresh in a window to bound runaway
+    # cost from a stuck retry loop or a leaked credential. Defaults
+    # mirror the previous hardcoded values in api/discover.py.
+    discovery_refresh_rate_limit_threshold: int = 30
+    discovery_refresh_rate_limit_window_seconds: int = 300
+
     # ------------------------------------------------------------------
     # Google OAuth (Gmail integration — Phase 3)
     # ------------------------------------------------------------------


### PR DESCRIPTION
Hardcoded magic numbers `RateLimiter(max_attempts=30, window_seconds=300)` replaced with two Settings fields. Operator can now dial the cap via env without redeploy. Defaults preserve current behavior.

Discovered by g-tech-debt-scan (High #9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)