### PR TITLE
ux(mbk/leases): file-centric document UX; allow regenerate via re-pick

### DIFF
--- a/apps/mybookkeeper/backend/app/api/signed_leases.py
+++ b/apps/mybookkeeper/backend/app/api/signed_leases.py
@@ -257,14 +257,6 @@ async def add_templates_to_lease(
         )
     except signed_lease_service.SignedLeaseNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Lease not found") from exc
-    except signed_lease_service.TemplatesAlreadyLinkedError as exc:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "error": "templates_already_linked",
-                "template_ids": [str(tid) for tid in exc.duplicate_ids],
-            },
-        ) from exc
     except lease_template_service.TemplateNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Template not found") from exc
     except signed_lease_service.StorageNotConfiguredError as exc:

--- a/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
@@ -608,26 +608,31 @@ async def add_templates_and_generate(
             if template is None:
                 raise TemplateNotFoundError(f"Template {tid} not found")
 
-        # Reject any that are already linked.
+        # Already-linked templates being re-attached are treated as a
+        # regenerate request: their existing rendered files will be
+        # replaced rather than 409-rejected. Genuine new templates get
+        # join rows; duplicates skip the join row create (already linked).
         existing_rows = await signed_lease_template_repo.list_for_lease(
             db, lease_id=lease_id,
         )
         existing_ids = {r.template_id for r in existing_rows}
-        duplicates = [tid for tid in template_ids if tid in existing_ids]
-        if duplicates:
-            raise TemplatesAlreadyLinkedError(duplicates)
+        new_template_ids = [tid for tid in template_ids if tid not in existing_ids]
+        is_regenerate = any(tid in existing_ids for tid in template_ids)
 
         # Compute the starting display_order for the new links.
         max_order = await signed_lease_template_repo.max_display_order_for_lease(
             db, lease_id=lease_id,
         )
 
-        # Load files + placeholders for only the new templates.
-        new_files: list = []         # (template_file_row, template_id)
+        # Load files + placeholders. On regenerate (any template_id matches an
+        # existing link), re-render ALL linked templates' files so the
+        # generated documents stay internally consistent with lease.values.
+        # On a pure add (no duplicates), only render the new templates' files.
+        files_to_render: list = []         # (template_file_row, template_id)
         placeholders: list = []
         seen_placeholder_keys: set[str] = set()
-        # Also include placeholders from already-linked templates so computed
-        # expressions that reference existing keys still resolve correctly.
+        seen_file_template_ids: set[uuid.UUID] = set()
+
         for r in existing_rows:
             for p in await lease_template_placeholder_repo.list_for_template(
                 db, template_id=r.template_id,
@@ -635,13 +640,22 @@ async def add_templates_and_generate(
                 if p.key not in seen_placeholder_keys:
                     seen_placeholder_keys.add(p.key)
                     placeholders.append(p)
+            if is_regenerate and r.template_id not in seen_file_template_ids:
+                seen_file_template_ids.add(r.template_id)
+                tpl_files = await lease_template_file_repo.list_for_template(
+                    db, template_id=r.template_id,
+                )
+                for f in tpl_files:
+                    files_to_render.append((f, r.template_id))
 
-        for order_offset, tid in enumerate(template_ids):
-            tpl_files = await lease_template_file_repo.list_for_template(
-                db, template_id=tid,
-            )
-            for f in tpl_files:
-                new_files.append((f, tid))
+        for tid in template_ids:
+            if tid not in seen_file_template_ids:
+                seen_file_template_ids.add(tid)
+                tpl_files = await lease_template_file_repo.list_for_template(
+                    db, template_id=tid,
+                )
+                for f in tpl_files:
+                    files_to_render.append((f, tid))
             for p in await lease_template_placeholder_repo.list_for_template(
                 db, template_id=tid,
             ):
@@ -736,7 +750,9 @@ async def add_templates_and_generate(
             )
 
         # Persist the new template links before rendering (render can be long).
-        for order_offset, tid in enumerate(template_ids):
+        # Already-linked templates being regenerated skip this step — their
+        # join row already exists.
+        for order_offset, tid in enumerate(new_template_ids):
             await signed_lease_template_repo.create(
                 db,
                 lease_id=lease_id,
@@ -744,7 +760,36 @@ async def add_templates_and_generate(
                 display_order=max_order + 1 + order_offset,
             )
 
+        # On regenerate, delete the existing rendered_original attachments
+        # so the new render replaces them. The original imported PDFs (kind=
+        # ``signed_lease`` / ``signed_addendum``) are untouched.
+        rendered_keys_to_delete: list[str] = []
+        if is_regenerate:
+            existing_attachments = await signed_lease_attachment_repo.list_by_lease(
+                db, lease_id,
+            )
+            for att in existing_attachments:
+                if att.kind == "rendered_original":
+                    rendered_keys_to_delete.append(att.storage_key)
+                    await signed_lease_attachment_repo.delete_by_id_scoped_to_lease(
+                        db,
+                        attachment_id=att.id,
+                        lease_id=lease_id,
+                    )
+
         values_snapshot = dict(merged_values)
+
+    # Best-effort delete of the old rendered objects in MinIO. Run outside the
+    # DB unit-of-work so a storage outage doesn't roll back the DB delete; a
+    # leftover orphan in MinIO is preferable to losing the regenerate.
+    for key in rendered_keys_to_delete:
+        try:
+            storage.delete_file(key)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to delete superseded rendered file %s on regenerate",
+                key, exc_info=True,
+            )
 
     # Build substitution dict from the merged values (existing + resolved + override).
     substitutions: dict[str, str] = {
@@ -762,7 +807,7 @@ async def add_templates_and_generate(
 
     # Render each new template's files individually; partial success is fine.
     now = _dt.datetime.now(_dt.timezone.utc)
-    for f, tid in new_files:
+    for f, tid in files_to_render:
         uploaded_key: str | None = None
         try:
             raw = storage.download_file(f.storage_key)

--- a/apps/mybookkeeper/backend/tests/test_lease_add_template.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_add_template.py
@@ -215,7 +215,16 @@ async def test_add_templates_raises_not_found_for_unknown_template(db) -> None:
 
 
 @pytest.mark.asyncio
-async def test_add_templates_rejects_already_linked(db) -> None:
+async def test_add_templates_already_linked_treated_as_regenerate(db) -> None:
+    """Re-attaching an already-linked template is now a regenerate.
+
+    Pre-2026-05-08 the service raised ``TemplatesAlreadyLinkedError``. The
+    new behaviour: skip creating a duplicate join row and proceed with
+    rendering — so the host can edit values and re-render via the same
+    "Add document" path. Verify here at the unit level that the call no
+    longer raises (the full render is exercised by the storage-mocked test
+    further down).
+    """
     user_id = uuid.uuid4()
     org_id = uuid.uuid4()
     t1 = await lease_template_repo.create(
@@ -238,18 +247,30 @@ async def test_add_templates_rejects_already_linked(db) -> None:
     )
     await db.commit()
 
+    storage = MagicMock()
+    storage.upload_file = MagicMock(return_value=None)
+    storage.delete_file = MagicMock(return_value=None)
+    storage.download_file = MagicMock(return_value=b"")
+
     with _patch(
         "app.services.leases.signed_lease_service.unit_of_work",
         _make_fake_uow(db),
+    ), _patch(
+        "app.services.leases.signed_lease_service.get_storage",
+        return_value=storage,
     ):
-        with pytest.raises(TemplatesAlreadyLinkedError) as exc_info:
-            await add_templates_and_generate(
-                user_id=user_id,
-                organization_id=org_id,
-                lease_id=lease.id,
-                template_ids=[t1.id],
-            )
-    assert t1.id in exc_info.value.duplicate_ids
+        # Should NOT raise. The applicant lookup will return None because
+        # we passed a random uuid for applicant_id; the resolver loop
+        # tolerates a missing applicant.
+        result = await add_templates_and_generate(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            template_ids=[t1.id],
+        )
+    # Regenerate did not create a duplicate join row.
+    assert len(result.templates) == 1
+    assert result.templates[0].id == t1.id
 
 
 @pytest.mark.asyncio

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
@@ -11,7 +11,9 @@
  * - Continue → prefill mutation → values step with prefilled inputs
  * - Generate fires add-templates mutation with template_ids + values
  * - Success toast + modal close on 200
- * - 409 error toast on duplicate template conflict
+ * - Generic error toast when the mutation rejects (post-2026-05-08 the
+ *   backend treats already-linked templates as a regenerate, so 409 no
+ *   longer fires from this path)
  */
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -344,17 +346,45 @@ describe("LeaseAddTemplateModal", () => {
       target: { value: "2026-08-31" },
     });
     fireEvent.click(screen.getByTestId("lease-add-template-confirm"));
-    await waitFor(() => expect(showSuccessMock).toHaveBeenCalledWith("1 template added."));
+    await waitFor(() => expect(showSuccessMock).toHaveBeenCalledWith("Document added."));
     await waitFor(() =>
       expect(screen.queryByTestId("lease-add-template-modal")).toBeNull(),
     );
   });
 
-  it("shows 409-specific error toast on duplicate conflict", async () => {
+  it("shows a regenerate success toast when re-picking an already-linked template", async () => {
+    canWriteValue = true;
+    // Lease already has tpl-new attached — re-picking it should regenerate.
+    mockLease = buildLease({
+      templates: [
+        { id: "tpl-existing", name: "Master Lease", version: 1, display_order: 0 },
+        { id: "tpl-new", name: "Addendum", version: 2, display_order: 1 },
+      ],
+    });
+    renderDetail();
+    fireEvent.click(screen.getByTestId("lease-add-template-button"));
+    await waitFor(() =>
+      expect(screen.getByTestId("add-template-checkbox-tpl-new")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByTestId("add-template-checkbox-tpl-new"));
+    fireEvent.click(screen.getByTestId("lease-add-template-continue"));
+    await waitFor(() =>
+      expect(screen.getByTestId("addendum-input-NEW LEASE END DATE")).toBeInTheDocument(),
+    );
+    fireEvent.change(screen.getByTestId("addendum-input-NEW LEASE END DATE"), {
+      target: { value: "2026-08-31" },
+    });
+    fireEvent.click(screen.getByTestId("lease-add-template-confirm"));
+    await waitFor(() =>
+      expect(showSuccessMock).toHaveBeenCalledWith("Document regenerated."),
+    );
+  });
+
+  it("shows a generic error toast when the mutation rejects", async () => {
     canWriteValue = true;
     mockLease = buildLease();
     addTemplatesMock.mockReturnValue({
-      unwrap: () => Promise.reject({ status: 409 }),
+      unwrap: () => Promise.reject({ status: 500 }),
     });
     renderDetail();
     fireEvent.click(screen.getByTestId("lease-add-template-button"));
@@ -372,7 +402,7 @@ describe("LeaseAddTemplateModal", () => {
     fireEvent.click(screen.getByTestId("lease-add-template-confirm"));
     await waitFor(() =>
       expect(showErrorMock).toHaveBeenCalledWith(
-        "Some templates were already on this lease — pick different ones.",
+        "Couldn't generate the document. Want to try again?",
       ),
     );
   });

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateModal.tsx
@@ -65,8 +65,8 @@ export default function LeaseAddTemplateModal({
     refetch,
   } = useGetLeaseTemplatesQuery();
 
-  const excludeSet = new Set(existingTemplateIds);
-  const available = (data?.items ?? []).filter((t) => !excludeSet.has(t.id));
+  const linkedSet = new Set(existingTemplateIds);
+  const available = data?.items ?? [];
 
   function handleToggle(t: LeaseTemplateSummary) {
     setSelectedIds((prev) =>
@@ -116,25 +116,21 @@ export default function LeaseAddTemplateModal({
       return;
     }
 
+    const anyAlreadyLinked = selectedIds.some((id) => linkedSet.has(id));
+
     try {
       await addTemplates({
         leaseId,
         templateIds: selectedIds,
         values: valuesState.values,
       }).unwrap();
-      showSuccess(
-        `${selectedIds.length} template${selectedIds.length === 1 ? "" : "s"} added.`,
-      );
+      const noun =
+        selectedIds.length === 1 ? "Document" : `${selectedIds.length} documents`;
+      const verb = anyAlreadyLinked ? "regenerated" : "added";
+      showSuccess(`${noun} ${verb}.`);
       onClose();
-    } catch (err: unknown) {
-      const status = (err as { status?: number })?.status;
-      if (status === 409) {
-        showError(
-          "Some templates were already on this lease — pick different ones.",
-        );
-      } else {
-        showError("Couldn't add the templates. Want to try again?");
-      }
+    } catch {
+      showError("Couldn't generate the document. Want to try again?");
     }
   }
 
@@ -199,6 +195,7 @@ export default function LeaseAddTemplateModal({
                 >
                   {available.map((t) => {
                     const checked = selectedIds.includes(t.id);
+                    const alreadyLinked = linkedSet.has(t.id);
                     return (
                       <li key={t.id}>
                         <label
@@ -230,11 +227,18 @@ export default function LeaseAddTemplateModal({
                                 {t.description}
                               </p>
                             ) : null}
-                            <p className="text-xs text-muted-foreground mt-1">
-                              {t.placeholder_count}{" "}
-                              {t.placeholder_count === 1
-                                ? "placeholder"
-                                : "placeholders"}
+                            <p className="text-xs text-muted-foreground mt-1 flex items-center gap-2 flex-wrap">
+                              <span>
+                                {t.placeholder_count}{" "}
+                                {t.placeholder_count === 1
+                                  ? "placeholder"
+                                  : "placeholders"}
+                              </span>
+                              {alreadyLinked ? (
+                                <span className="text-[10px] uppercase tracking-wide bg-muted rounded px-1.5 py-0.5 font-medium">
+                                  on this lease — picking will regenerate
+                                </span>
+                              ) : null}
                             </p>
                           </div>
                         </label>

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -180,52 +180,6 @@ export default function LeaseDetail() {
             }
           />
 
-          {/* Documents generated from templates — extensions, addenda, disclosures,
-              etc. Section is shown for both generated and imported leases; the
-              underlying flow is the same. */}
-          <section
-            className="border rounded-lg p-4"
-            data-testid="lease-templates-card"
-          >
-            <div className="flex items-center justify-between gap-2 mb-2">
-              <p className="text-xs text-muted-foreground uppercase font-medium tracking-wide">
-                {lease.templates.length === 1 ? "Document" : "Documents"}
-              </p>
-              {canWrite ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setShowAddTemplateModal(true)}
-                  data-testid="lease-add-template-button"
-                  className="h-7 px-2 text-xs"
-                >
-                  <Plus size={12} className="mr-1" />
-                  Add document
-                </Button>
-              ) : null}
-            </div>
-            {lease.templates.length > 0 ? (
-              <ul className="flex flex-wrap gap-2">
-                {lease.templates.map((t) => (
-                  <li key={t.id}>
-                    <Link
-                      to={`/lease-templates/${t.id}`}
-                      data-testid={`lease-template-link-${t.id}`}
-                      className="inline-block text-xs px-2 py-1 rounded-md bg-muted text-foreground hover:bg-muted/70"
-                    >
-                      {t.name}{" "}
-                      <span className="text-muted-foreground">v{t.version}</span>
-                    </Link>
-                  </li>
-                ))}
-              </ul>
-            ) : (
-              <p className="text-xs text-muted-foreground">
-                No documents yet — add one to generate things like a lease extension or pet addendum.
-              </p>
-            )}
-          </section>
-
           {showAddTemplateModal && lease ? (
             <LeaseAddTemplateModal
               leaseId={lease.id}
@@ -283,11 +237,26 @@ export default function LeaseDetail() {
           </div>
 
           {tab === "files" ? (
-            <LeaseAttachmentsSection
-              leaseId={lease.id}
-              attachments={lease.attachments}
-              canWrite={canWrite}
-            />
+            <div className="space-y-3">
+              {canWrite ? (
+                <div className="flex justify-end">
+                  <Button
+                    variant="secondary"
+                    size="sm"
+                    onClick={() => setShowAddTemplateModal(true)}
+                    data-testid="lease-add-template-button"
+                  >
+                    <Plus size={14} className="mr-1" />
+                    Add document
+                  </Button>
+                </div>
+              ) : null}
+              <LeaseAttachmentsSection
+                leaseId={lease.id}
+                attachments={lease.attachments}
+                canWrite={canWrite}
+              />
+            </div>
           ) : null}
 
           {tab === "details" ? (


### PR DESCRIPTION
## Summary

Removes the "template link" concept from the lease detail UI and makes regeneration possible via re-picking the same template. Operator's UX critique was that the "Lease Extension Addendum v1" chip was a developer concept leaking into the UI — hosts think in terms of *documents on the lease*, not *templates linked to it*.

## Changes

**Backend**
- ``add_templates_and_generate`` treats already-linked template_ids as a regenerate (no more 409). Skips the duplicate join-row create, deletes existing ``rendered_original`` attachments, re-renders.
- All linked templates' files re-render on regenerate so generated docs stay consistent with the edited ``lease.values``.
- Route handler drops the 409 ``templates_already_linked`` mapping.

**Frontend**
- DOCUMENT card removed entirely from ``LeaseDetail``. The "Lease Extension Addendum v1" chip is gone.
- "Add document" button moved to top of Files tab. Files tab is the single source of truth for documents on a lease.
- ``LeaseAddTemplateModal`` shows all templates including already-linked ones, with a small "on this lease — picking will regenerate" badge for the linked ones.
- Success toast says "Document added" or "Document regenerated" based on intent.

**Tests**
- Backend duplicate-rejection test flipped to verify the regenerate path.
- Frontend 409 test replaced with regenerate + generic-error tests.

## Backwards compatibility

- API contract: the 409 ``templates_already_linked`` response is gone. No external consumers — only the modal in this PR uses this endpoint.
- All existing single-template-add flows are unchanged.

## Test plan

- [x] Backend tests pass locally (50 tests in `test_lease_add_template.py` + `test_default_source_resolver.py`)
- [ ] Manual: Sonu's lease post-deploy — DOCUMENT card gone, "Add document" button in Files tab; clicking it shows the addendum template flagged as "on this lease"; picking it + filling values + Generate replaces the rendered file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)