### PR TITLE
refactor(mjh/discover): extract dialog form sections + dialog-enums type module

### DIFF
--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -1,35 +1,30 @@
 import { useState } from "react";
 import {
   ConfirmDialog,
-  FormField,
   showError,
   showSuccess,
   extractErrorMessage,
 } from "@platform/ui";
 import { useCreateDiscoverySourceMutation } from "@/store/discoverApi";
 import { useUpdateProfileMutation } from "@/lib/profileApi";
-import MultiChipInput from "./MultiChipInput";
-import ToggleChipGroup from "./ToggleChipGroup";
-import { INDUSTRY_CHIPS } from "./industry-chips";
 import { buildSavedSearchSummary } from "./saved-search-summary";
 import InlineBoldText from "./InlineBoldText";
 import { useDiscoveryDefaultsPrefill } from "./useDiscoveryDefaultsPrefill";
+import SearchInputsSection from "./dialog-sections/SearchInputsSection";
+import WhereWhenSection from "./dialog-sections/WhereWhenSection";
+import JobTypeSection from "./dialog-sections/JobTypeSection";
+import ExclusionsSection from "./dialog-sections/ExclusionsSection";
+import type {
+  Country,
+  DatePosted,
+  EmploymentType,
+  Experience,
+} from "@/types/discovery/dialog-enums";
 
 interface NewSavedSearchDialogProps {
   open: boolean;
   onClose: () => void;
 }
-
-type DatePosted = "all" | "today" | "3days" | "week" | "month";
-type Experience =
-  | ""
-  | "no_experience"
-  | "under_3_years_experience"
-  | "more_than_3_years_experience"
-  | "no_degree";
-
-const INPUT_CLASS =
-  "w-full px-3 py-2 border border-input rounded-md bg-background text-foreground";
 
 /**
  * Dialog for creating a new JSearch saved search.
@@ -41,22 +36,30 @@ const INPUT_CLASS =
  * server-side). Industry exclusions surface as toggle chips backed
  * by curated server-side keyword lists.
  *
- * Prefill orchestration (profile loading, suggestion derivation,
- * one-shot apply) lives in the ``useDiscoveryDefaultsPrefill`` hook.
- * Markdown bold rendering for the summary lives in ``InlineBoldText``.
+ * Composition:
+ *   - ``useDiscoveryDefaultsPrefill`` — owns profile/skills/work-history
+ *     fetches, suggestion derivation, one-shot prefill (useRef-backed
+ *     latch, not useState — flagged anti-pattern is gone)
+ *   - ``SearchInputsSection``, ``WhereWhenSection``, ``JobTypeSection``,
+ *     ``ExclusionsSection`` — JSX form-field clusters extracted by topic
+ *   - ``InlineBoldText`` — markdown-bold rendering for the summary
+ *   - ``buildSavedSearchSummary`` — pure helper that composes the
+ *     plain-English preview line
  */
 export default function NewSavedSearchDialog({
   open,
   onClose,
 }: NewSavedSearchDialogProps) {
-  // Form state — owned here, not in parent.
+  // Form state — owned here, not in parent. Future cleanup: migrate
+  // to react-hook-form (used elsewhere in the codebase) so 11 useState
+  // hooks collapse to one form context.
   const [roles, setRoles] = useState<string[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
   const [location, setLocation] = useState("");
-  const [country, setCountry] = useState("us");
+  const [country, setCountry] = useState<Country>("us");
   const [datePosted, setDatePosted] = useState<DatePosted>("week");
   const [remoteOnly, setRemoteOnly] = useState(false);
-  const [employmentType, setEmploymentType] = useState("FULLTIME");
+  const [employmentType, setEmploymentType] = useState<EmploymentType>("FULLTIME");
   const [experience, setExperience] = useState<Experience>("");
   const [minSalary, setMinSalary] = useState("");
   const [excludedIndustryChips, setExcludedIndustryChips] = useState<string[]>(
@@ -69,10 +72,6 @@ export default function NewSavedSearchDialog({
   const [updateProfile, { isLoading: isUpdatingProfile }] = useUpdateProfileMutation();
   const isLoading = isCreating || isUpdatingProfile;
 
-  // Hook owns: profile/skills/work-history fetches, suggestion
-  // derivation, one-shot prefill, and the "did this run" latch
-  // (useRef, not useState — ref is the right primitive for a flag
-  // that doesn't trigger re-renders).
   const {
     profile,
     recentRoleSuggestions,
@@ -83,9 +82,9 @@ export default function NewSavedSearchDialog({
     setRoles,
     setRemoteOnly,
     setMinSalary,
-    setCountry,
+    setCountry: (next) => setCountry(next as Country),
     setDatePosted,
-    setEmploymentType,
+    setEmploymentType: (next) => setEmploymentType(next as EmploymentType),
     setExperience,
     setExcludedIndustryChips,
     setExcludedKeywords,
@@ -107,12 +106,7 @@ export default function NewSavedSearchDialog({
     resetPrefill();
   }
 
-  async function handleConfirm() {
-    if (roles.length === 0) {
-      showError("Add at least one role title");
-      return;
-    }
-
+  function buildConfig(): Record<string, unknown> {
     const config: Record<string, unknown> = {
       roles,
       skills,
@@ -135,25 +129,36 @@ export default function NewSavedSearchDialog({
     if (excludedKeywords.length > 0) {
       config.excluded_keywords = excludedKeywords;
     }
+    return config;
+  }
+
+  function buildDefaults(): Record<string, unknown> {
+    return {
+      ...(profile?.discovery_defaults ?? {}),
+      country,
+      date_posted: datePosted,
+      employment_type: employmentType,
+      experience,
+      excluded_industry_chips: excludedIndustryChips,
+      excluded_keywords: excludedKeywords,
+    };
+  }
+
+  async function handleConfirm() {
+    if (roles.length === 0) {
+      showError("Add at least one role title");
+      return;
+    }
 
     try {
-      await createSource({ source: "jsearch", config }).unwrap();
+      await createSource({ source: "jsearch", config: buildConfig() }).unwrap();
 
       // Optionally persist the filter set as the operator's default
       // for future searches. Best-effort — if it fails, the saved
       // search still exists; we just toast a soft warning.
       if (saveAsDefaults) {
-        const defaults: Record<string, unknown> = {
-          ...(profile?.discovery_defaults ?? {}),
-          country,
-          date_posted: datePosted,
-          employment_type: employmentType,
-          experience,
-          excluded_industry_chips: excludedIndustryChips,
-          excluded_keywords: excludedKeywords,
-        };
         try {
-          await updateProfile({ discovery_defaults: defaults }).unwrap();
+          await updateProfile({ discovery_defaults: buildDefaults() }).unwrap();
         } catch (defaultsErr) {
           showError(
             extractErrorMessage(defaultsErr) ??
@@ -206,139 +211,40 @@ export default function NewSavedSearchDialog({
           </p>
         )}
 
-        <FormField label="Role(s)" required>
-          <MultiChipInput
-            value={roles}
-            onChange={setRoles}
-            placeholder='e.g. "Senior Backend Engineer"'
-            ariaLabel="Role titles"
-            suggestions={recentRoleSuggestions}
-          />
-        </FormField>
+        <SearchInputsSection
+          roles={roles}
+          onRolesChange={setRoles}
+          roleSuggestions={recentRoleSuggestions}
+          skills={skills}
+          onSkillsChange={setSkills}
+          skillSuggestions={skillSuggestions}
+          location={location}
+          onLocationChange={setLocation}
+          locationDisabled={remoteOnly}
+        />
 
-        <FormField label="Skills (optional)">
-          <MultiChipInput
-            value={skills}
-            onChange={setSkills}
-            placeholder="Python, FastAPI, PostgreSQL"
-            ariaLabel="Skills"
-            suggestions={skillSuggestions}
-          />
-        </FormField>
+        <WhereWhenSection
+          country={country}
+          onCountryChange={setCountry}
+          datePosted={datePosted}
+          onDatePostedChange={setDatePosted}
+        />
 
-        <FormField label="Location (optional)">
-          <input
-            type="text"
-            value={location}
-            onChange={(e) => setLocation(e.target.value)}
-            placeholder="City or 'Remote'"
-            className={INPUT_CLASS}
-            disabled={remoteOnly}
-          />
-          {remoteOnly && (
-            <p className="text-xs text-muted-foreground mt-1">
-              Disabled — you have remote-only on.
-            </p>
-          )}
-        </FormField>
+        <JobTypeSection
+          employmentType={employmentType}
+          onEmploymentTypeChange={setEmploymentType}
+          experience={experience}
+          onExperienceChange={setExperience}
+        />
 
-        <div className="grid grid-cols-2 gap-4">
-          <FormField label="Country">
-            <select
-              value={country}
-              onChange={(e) => setCountry(e.target.value)}
-              className={INPUT_CLASS}
-            >
-              <option value="us">United States</option>
-              <option value="ca">Canada</option>
-              <option value="uk">United Kingdom</option>
-              <option value="au">Australia</option>
-            </select>
-          </FormField>
-
-          <FormField label="Posted">
-            <select
-              value={datePosted}
-              onChange={(e) => setDatePosted(e.target.value as DatePosted)}
-              className={INPUT_CLASS}
-            >
-              <option value="today">Past 24 hours</option>
-              <option value="3days">Past 3 days</option>
-              <option value="week">Past week</option>
-              <option value="month">Past month</option>
-              <option value="all">Any time</option>
-            </select>
-          </FormField>
-        </div>
-
-        <div className="grid grid-cols-2 gap-4">
-          <FormField label="Employment type">
-            <select
-              value={employmentType}
-              onChange={(e) => setEmploymentType(e.target.value)}
-              className={INPUT_CLASS}
-            >
-              <option value="FULLTIME">Full-time</option>
-              <option value="CONTRACTOR">Contract</option>
-              <option value="PARTTIME">Part-time</option>
-              <option value="INTERN">Intern</option>
-              <option value="">Any</option>
-            </select>
-          </FormField>
-
-          <FormField label="Experience">
-            <select
-              value={experience}
-              onChange={(e) => setExperience(e.target.value as Experience)}
-              className={INPUT_CLASS}
-            >
-              <option value="">Any</option>
-              <option value="more_than_3_years_experience">3+ years</option>
-              <option value="under_3_years_experience">Under 3 years</option>
-              <option value="no_experience">Entry level</option>
-              <option value="no_degree">No degree required</option>
-            </select>
-          </FormField>
-        </div>
-
-        <FormField label="Minimum salary (USD, optional)">
-          <input
-            type="number"
-            value={minSalary}
-            onChange={(e) => setMinSalary(e.target.value)}
-            placeholder="150000"
-            min={0}
-            step={1000}
-            className={INPUT_CLASS}
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            Drops postings below the floor when source posts a salary range.
-            Postings without disclosed salary are kept.
-          </p>
-        </FormField>
-
-        <div>
-          <label className="block text-xs font-medium mb-1.5">
-            Exclude industries (one click skips all related companies + keywords)
-          </label>
-          <ToggleChipGroup
-            options={INDUSTRY_CHIPS}
-            value={excludedIndustryChips}
-            onChange={setExcludedIndustryChips}
-          />
-        </div>
-
-        <FormField label="Also exclude keywords (optional)">
-          <MultiChipInput
-            value={excludedKeywords}
-            onChange={setExcludedKeywords}
-            placeholder="junior, intern, ad hoc company name…"
-            ariaLabel="Excluded keywords"
-          />
-          <p className="text-xs text-muted-foreground mt-1">
-            Case-insensitive substring match against title, company, description, publisher.
-          </p>
-        </FormField>
+        <ExclusionsSection
+          minSalary={minSalary}
+          onMinSalaryChange={setMinSalary}
+          excludedIndustryChips={excludedIndustryChips}
+          onExcludedIndustryChipsChange={setExcludedIndustryChips}
+          excludedKeywords={excludedKeywords}
+          onExcludedKeywordsChange={setExcludedKeywords}
+        />
 
         <label className="flex items-center gap-2 text-sm">
           <input

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/ExclusionsSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/ExclusionsSection.tsx
@@ -1,0 +1,76 @@
+import { FormField } from "@platform/ui";
+import MultiChipInput from "../MultiChipInput";
+import ToggleChipGroup from "../ToggleChipGroup";
+import { INDUSTRY_CHIPS } from "../industry-chips";
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 border border-input rounded-md bg-background text-foreground";
+
+interface ExclusionsSectionProps {
+  minSalary: string;
+  onMinSalaryChange: (next: string) => void;
+  excludedIndustryChips: string[];
+  onExcludedIndustryChipsChange: (next: string[]) => void;
+  excludedKeywords: string[];
+  onExcludedKeywordsChange: (next: string[]) => void;
+}
+
+/**
+ * Salary floor + industry chip exclusions + ad-hoc keyword denylist.
+ *
+ * Three filters that drop postings before they reach the operator's
+ * inbox. Salary is post-fetch (we get the data, then drop). Industry
+ * chips expand server-side into a curated keyword list. Custom
+ * keywords are operator-typed substrings.
+ */
+export default function ExclusionsSection({
+  minSalary,
+  onMinSalaryChange,
+  excludedIndustryChips,
+  onExcludedIndustryChipsChange,
+  excludedKeywords,
+  onExcludedKeywordsChange,
+}: ExclusionsSectionProps) {
+  return (
+    <>
+      <FormField label="Minimum salary (USD, optional)">
+        <input
+          type="number"
+          value={minSalary}
+          onChange={(e) => onMinSalaryChange(e.target.value)}
+          placeholder="150000"
+          min={0}
+          step={1000}
+          className={INPUT_CLASS}
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Drops postings below the floor when source posts a salary range.
+          Postings without disclosed salary are kept.
+        </p>
+      </FormField>
+
+      <div>
+        <label className="block text-xs font-medium mb-1.5">
+          Exclude industries (one click skips all related companies + keywords)
+        </label>
+        <ToggleChipGroup
+          options={INDUSTRY_CHIPS}
+          value={excludedIndustryChips}
+          onChange={onExcludedIndustryChipsChange}
+        />
+      </div>
+
+      <FormField label="Also exclude keywords (optional)">
+        <MultiChipInput
+          value={excludedKeywords}
+          onChange={onExcludedKeywordsChange}
+          placeholder="junior, intern, ad hoc company name…"
+          ariaLabel="Excluded keywords"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Case-insensitive substring match against title, company, description, publisher.
+        </p>
+      </FormField>
+    </>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/JobTypeSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/JobTypeSection.tsx
@@ -1,0 +1,56 @@
+import { FormField } from "@platform/ui";
+import type { EmploymentType, Experience } from "@/types/discovery/dialog-enums";
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 border border-input rounded-md bg-background text-foreground";
+
+interface JobTypeSectionProps {
+  employmentType: EmploymentType;
+  onEmploymentTypeChange: (next: EmploymentType) => void;
+  experience: Experience;
+  onExperienceChange: (next: Experience) => void;
+}
+
+/**
+ * Employment-type + experience-level dropdowns. Two filters that
+ * narrow JSearch's source-side results before they reach our
+ * post-fetch filtering.
+ */
+export default function JobTypeSection({
+  employmentType,
+  onEmploymentTypeChange,
+  experience,
+  onExperienceChange,
+}: JobTypeSectionProps) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <FormField label="Employment type">
+        <select
+          value={employmentType}
+          onChange={(e) => onEmploymentTypeChange(e.target.value as EmploymentType)}
+          className={INPUT_CLASS}
+        >
+          <option value="FULLTIME">Full-time</option>
+          <option value="CONTRACTOR">Contract</option>
+          <option value="PARTTIME">Part-time</option>
+          <option value="INTERN">Intern</option>
+          <option value="">Any</option>
+        </select>
+      </FormField>
+
+      <FormField label="Experience">
+        <select
+          value={experience}
+          onChange={(e) => onExperienceChange(e.target.value as Experience)}
+          className={INPUT_CLASS}
+        >
+          <option value="">Any</option>
+          <option value="more_than_3_years_experience">3+ years</option>
+          <option value="under_3_years_experience">Under 3 years</option>
+          <option value="no_experience">Entry level</option>
+          <option value="no_degree">No degree required</option>
+        </select>
+      </FormField>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/SearchInputsSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/SearchInputsSection.tsx
@@ -1,0 +1,82 @@
+import { FormField } from "@platform/ui";
+import MultiChipInput from "../MultiChipInput";
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 border border-input rounded-md bg-background text-foreground";
+
+interface SearchInputsSectionProps {
+  roles: string[];
+  onRolesChange: (next: string[]) => void;
+  roleSuggestions: string[];
+
+  skills: string[];
+  onSkillsChange: (next: string[]) => void;
+  skillSuggestions: string[];
+
+  location: string;
+  onLocationChange: (next: string) => void;
+  /** When true, the location input is disabled and an explanatory
+   *  hint is shown below it. */
+  locationDisabled: boolean;
+}
+
+/**
+ * Form fields that determine WHAT we're searching for (role title +
+ * skills) and WHERE within the chosen country.
+ *
+ * Roles/skills use MultiChipInput with profile-derived suggestions.
+ * Location is folded into the JSearch query as "in <X>" server-side;
+ * disabled when remote-only is on (the country dropdown handles
+ * country-level scoping).
+ */
+export default function SearchInputsSection({
+  roles,
+  onRolesChange,
+  roleSuggestions,
+  skills,
+  onSkillsChange,
+  skillSuggestions,
+  location,
+  onLocationChange,
+  locationDisabled,
+}: SearchInputsSectionProps) {
+  return (
+    <>
+      <FormField label="Role(s)" required>
+        <MultiChipInput
+          value={roles}
+          onChange={onRolesChange}
+          placeholder='e.g. "Senior Backend Engineer"'
+          ariaLabel="Role titles"
+          suggestions={roleSuggestions}
+        />
+      </FormField>
+
+      <FormField label="Skills (optional)">
+        <MultiChipInput
+          value={skills}
+          onChange={onSkillsChange}
+          placeholder="Python, FastAPI, PostgreSQL"
+          ariaLabel="Skills"
+          suggestions={skillSuggestions}
+        />
+      </FormField>
+
+      <FormField label="Location (optional)">
+        <input
+          type="text"
+          value={location}
+          onChange={(e) => onLocationChange(e.target.value)}
+          placeholder="City or 'Remote'"
+          className={INPUT_CLASS}
+          disabled={locationDisabled}
+        />
+        {locationDisabled && (
+          <p className="text-xs text-muted-foreground mt-1">
+            Disabled — you have remote-only on.
+          </p>
+        )}
+      </FormField>
+    </>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/WhereWhenSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/WhereWhenSection.tsx
@@ -1,0 +1,55 @@
+import { FormField } from "@platform/ui";
+import type { Country, DatePosted } from "@/types/discovery/dialog-enums";
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 border border-input rounded-md bg-background text-foreground";
+
+interface WhereWhenSectionProps {
+  country: Country;
+  onCountryChange: (next: Country) => void;
+  datePosted: DatePosted;
+  onDatePostedChange: (next: DatePosted) => void;
+}
+
+/**
+ * Country + posted-window dropdowns. Two scoping fields that determine
+ * the bounds of what JSearch returns regardless of role / skill /
+ * exclusion filters.
+ */
+export default function WhereWhenSection({
+  country,
+  onCountryChange,
+  datePosted,
+  onDatePostedChange,
+}: WhereWhenSectionProps) {
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <FormField label="Country">
+        <select
+          value={country}
+          onChange={(e) => onCountryChange(e.target.value as Country)}
+          className={INPUT_CLASS}
+        >
+          <option value="us">United States</option>
+          <option value="ca">Canada</option>
+          <option value="uk">United Kingdom</option>
+          <option value="au">Australia</option>
+        </select>
+      </FormField>
+
+      <FormField label="Posted">
+        <select
+          value={datePosted}
+          onChange={(e) => onDatePostedChange(e.target.value as DatePosted)}
+          className={INPUT_CLASS}
+        >
+          <option value="today">Past 24 hours</option>
+          <option value="3days">Past 3 days</option>
+          <option value="week">Past week</option>
+          <option value="month">Past month</option>
+          <option value="all">Any time</option>
+        </select>
+      </FormField>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/types/discovery/dialog-enums.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/dialog-enums.ts
@@ -1,0 +1,19 @@
+/** Form-state enums for the New Saved Search dialog.
+ *
+ * Mirrors backend ``JSearchSourceConfig`` enums. Keeping these as
+ * frontend-side string literal types means typos in the form code
+ * fail at compile time, not at validation time.
+ */
+
+export type DatePosted = "all" | "today" | "3days" | "week" | "month";
+
+export type Country = "us" | "ca" | "uk" | "au";
+
+export type Experience =
+  | ""
+  | "no_experience"
+  | "under_3_years_experience"
+  | "more_than_3_years_experience"
+  | "no_degree";
+
+export type EmploymentType = "" | "FULLTIME" | "CONTRACTOR" | "PARTTIME" | "INTERN";


### PR DESCRIPTION
Closes the audit's god-component finding. PR #428 already extracted the prefill hook + markdown renderer; this PR extracts the four JSX form-field clusters into named sections.

## New files

- `types/discovery/dialog-enums.ts` — DatePosted / Country / EmploymentType / Experience literal types
- `dialog-sections/SearchInputsSection.tsx` — roles + skills + location
- `dialog-sections/WhereWhenSection.tsx` — country + posted
- `dialog-sections/JobTypeSection.tsx` — employment + experience
- `dialog-sections/ExclusionsSection.tsx` — salary + industry chips + custom keywords

## Numbers

- Dialog: 462 → 376 (PR #428) → **282** LOC (-39% total)
- Each section: <100 LOC, single responsibility
- Dialog enums now typed at the type module instead of inline

## Test plan

- [x] TypeScript check clean
- [x] Production build succeeds
- Sections are pure presentational; integration covered by existing dialog smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)