### PR TITLE
ux(mbk/leases): allow "Email to tenant" on imported leases with addenda

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailEmailButton.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailEmailButton.test.tsx
@@ -200,12 +200,30 @@ describe("LeaseDetail — Email to tenant button", () => {
     expect(screen.queryByTestId("lease-email-tenant-button")).toBeNull();
   });
 
-  it("is hidden for imported leases (their attachments aren't 'rendered')", () => {
-    // The contract is "Email to tenant" only on generated leases.
-    // Imported leases came in already-signed and the host has the file
-    // already; emailing it back to the tenant would be redundant.
+  it("is shown for imported leases that have a rendered addendum", () => {
+    // After PR #415 imported leases can attach addendum templates that
+    // produce ``rendered_original`` attachments. The host should be able to
+    // email those addenda the same way as a generated lease.
     canWriteValue = true;
     mockLease = buildLease({ kind: "imported" });
+    mockApplicant = buildApplicant();
+    renderDetail();
+    expect(screen.getByTestId("lease-email-tenant-button")).toBeInTheDocument();
+  });
+
+  it("is hidden when the imported lease has no rendered/signed-lease attachments", () => {
+    // E.g., a freshly-imported lease where the host uploaded only an
+    // inspection PDF or insurance proof — nothing to email yet.
+    canWriteValue = true;
+    mockLease = buildLease({
+      kind: "imported",
+      attachments: [
+        {
+          ...buildAttachment(),
+          kind: "move_in_inspection",
+        },
+      ],
+    });
     mockApplicant = buildApplicant();
     renderDetail();
     expect(screen.queryByTestId("lease-email-tenant-button")).toBeNull();

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -46,8 +46,15 @@ export default function LeaseDetail() {
   );
 
   const tenantHasEmail = Boolean(applicant?.contact_email);
-  const showEmailButton =
-    canWrite && lease?.kind === "generated" && lease?.attachments.length > 0;
+  // Show "Email to tenant" whenever the lease has a renderable attachment
+  // (rendered_original from a template flow, or signed_lease from import).
+  // Imported leases with addenda generated post-#415 also qualify — the
+  // email service already includes ``rendered_original`` in
+  // ``LEASE_EMAIL_ATTACHMENT_KINDS`` regardless of lease.kind.
+  const hasEmailableAttachment = (lease?.attachments ?? []).some(
+    (a) => a.kind === "rendered_original" || a.kind === "signed_lease",
+  );
+  const showEmailButton = canWrite && hasEmailableAttachment;
 
   async function handleGenerate() {
     if (!lease) return;


### PR DESCRIPTION
## Summary

Removes the `kind === \"generated\"` gate on the \"Email to tenant\" button so hosts can email rendered addenda from imported leases (Sonu's Lease Extension Addendum scenario). Backend already supports this — only the frontend was hiding the button.

## Why

After PR #415, imported leases can have `rendered_original` attachments (addenda generated from templates). The email service's `LEASE_EMAIL_ATTACHMENT_KINDS` already includes `rendered_original` and `signed_lease`. The route handler + `assert_can_email_tenant` have no kind check. The frontend gate was the only thing stopping it.

## New visibility rule

Show \"Email to tenant\" whenever the lease has at least one `rendered_original` or `signed_lease` attachment — the kinds the email service will actually send. Imported leases with only inspection / insurance attachments keep the button hidden.

## What gets emailed

The backend sends ALL `rendered_original` + `signed_lease` attachments in a single email. For Sonu, that means the original imported lease PDF + the rendered extension addendum get attached together — gives the tenant full context.

## Test plan

- [x] Frontend test flipped to assert imported-lease + addendum shows the button
- [x] New test asserts imported-lease + only inspection PDF hides it
- [ ] Manual: on Sonu's lease post-deploy, click \"Email to tenant\" — verify Sonu receives the rendered addendum at her contact_email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)