### PR TITLE
fix(mjh/extraction): permit resume-refinement + jd-url contexts in chk_extraction_log_context_type

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/extctx260507_extraction_log_resume_refinement_contexts.py
+++ b/apps/myjobhunter/backend/alembic/versions/extctx260507_extraction_log_resume_refinement_contexts.py
@@ -1,0 +1,85 @@
+"""Extend ``chk_extraction_log_context_type`` to permit resume-refinement
+and JD-URL extraction context values.
+
+The CHECK constraint on ``extraction_logs.context_type`` was last
+extended in ``disco260507_discovery_tables.py`` to add ``'job_analysis'``.
+It still rejects three context values that the application code already
+writes:
+
+- ``resume_critique`` — emitted by ``critique_service.run_critique``
+  during resume-refinement session start.
+- ``resume_rewrite`` — emitted by ``rewrite_service.run_rewrite`` during
+  per-target proposal generation.
+- ``jd_url_parse`` — emitted by ``jd_url_extractor`` when fetching +
+  parsing a JD from a pasted URL on the Add Application flow.
+
+These were silently swallowed until PR #426 removed the bare
+``try/except`` around the extraction-log INSERT in
+``claude_service._record_log``. Now the IntegrityError propagates out
+of the ``finally`` block in ``call_claude_with_meta``, surfacing as a
+500 on POST /api/resume-refinement/sessions (and on JD-URL parsing).
+
+No data backfill — historical rows are unaffected. New rows for these
+contexts will land correctly going forward, restoring per-feature cost
+rollups for resume refinement and URL-based JD ingestion.
+
+Revision ID: extctx260507
+Revises: discrsn260507
+Create Date: 2026-05-07
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "extctx260507"
+down_revision: Union[str, None] = "discrsn260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_OLD_EXTRACTION_CONTEXTS = (
+    "resume_parse",
+    "jd_parse",
+    "company_research",
+    "cover_letter",
+    "resume_tailor",
+    "email_classify",
+    "job_analysis",
+    "other",
+)
+_NEW_EXTRACTION_CONTEXTS = _OLD_EXTRACTION_CONTEXTS + (
+    "resume_critique",
+    "resume_rewrite",
+    "jd_url_parse",
+)
+
+
+def _quote_list(values: tuple[str, ...]) -> str:
+    return ",".join(f"'{v}'" for v in values)
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "chk_extraction_log_context_type",
+        "extraction_logs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_extraction_log_context_type",
+        "extraction_logs",
+        f"context_type IN ({_quote_list(_NEW_EXTRACTION_CONTEXTS)})",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "chk_extraction_log_context_type",
+        "extraction_logs",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_extraction_log_context_type",
+        "extraction_logs",
+        f"context_type IN ({_quote_list(_OLD_EXTRACTION_CONTEXTS)})",
+    )

--- a/apps/myjobhunter/backend/app/models/system/extraction_log.py
+++ b/apps/myjobhunter/backend/app/models/system/extraction_log.py
@@ -50,7 +50,11 @@ class ExtractionLog(Base):
 
     __table_args__ = (
         CheckConstraint(
-            "context_type IN ('resume_parse','jd_parse','company_research','cover_letter','resume_tailor','email_classify','other')",
+            "context_type IN ("
+            "'resume_parse','jd_parse','company_research','cover_letter',"
+            "'resume_tailor','email_classify','job_analysis','other',"
+            "'resume_critique','resume_rewrite','jd_url_parse'"
+            ")",
             name="chk_extraction_log_context_type",
         ),
         CheckConstraint(

--- a/apps/myjobhunter/backend/tests/test_discovery_models.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_models.py
@@ -267,6 +267,33 @@ async def test_extraction_log_accepts_job_analysis_context(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "context_type",
+    ["resume_critique", "resume_rewrite", "jd_url_parse"],
+)
+async def test_extraction_log_accepts_resume_refinement_contexts(
+    db: AsyncSession, user_factory, context_type: str,
+):
+    """The extctx260507 migration permits the resume-refinement and
+    JD-URL contexts emitted by critique_service, rewrite_service, and
+    jd_url_extractor. Until that migration, these violated
+    ``chk_extraction_log_context_type`` and surfaced as 500s once the
+    silent-fail in ``_record_log`` was removed (PR #426)."""
+    user = await user_factory()
+    log = ExtractionLog(
+        user_id=_uid(user),
+        context_type=context_type,
+        model="claude-sonnet-4-6",
+        status="success",
+    )
+    db.add(log)
+    await db.commit()
+    await db.refresh(log)
+
+    assert log.context_type == context_type
+
+
+@pytest.mark.asyncio
 async def test_inbox_index_query_pattern(db: AsyncSession, user_factory):
     """Smoke-test the partial inbox index by exercising its predicate."""
     user = await user_factory()


### PR DESCRIPTION
## Summary

POST `/api/resume-refinement/sessions` started returning 500 after PR #426 landed. Same root cause for any JD-URL-paste flow on Add Application.

## Root cause

The DB CHECK constraint `chk_extraction_log_context_type` was last extended in `disco260507_discovery_tables.py` to add `'job_analysis'` but never updated to include three context values the application code **already writes**:

| Caller | `context_type` |
|---|---|
| `services/resume_refinement/critique_service.py:46` | `resume_critique` |
| `services/resume_refinement/rewrite_service.py:63` | `resume_rewrite` |
| `services/extraction/jd_url_extractor.py:516` | `jd_url_parse` |

Until PR #426, `claude_service._record_log` wrapped the `extraction_logs` INSERT in a bare `try/except` and silently swallowed the `IntegrityError`. PR #426 ripped that silent-fail (correctly — cost-tracking writes are load-bearing for budget enforcement), and the constraint violation now propagates out of `call_claude_with_meta`'s `finally` block. Resume refinement (and JD-URL parsing) now 500s with body `"Internal Server Error"`.

## Fix

1. New migration `extctx260507_extraction_log_resume_refinement_contexts.py` — drops + recreates `chk_extraction_log_context_type` with the three missing values added.
2. Sync `app/models/system/extraction_log.py` `__table_args__` `CheckConstraint` literal to match the new DB shape (the model was already drifted — it was also missing `job_analysis` from `disco260507`).
3. Parametrized test in `test_discovery_models.py` exercising all three new values; existing `job_analysis` test untouched.

No data backfill — historical rows are unaffected. Per-feature cost rollups for resume refinement and URL-based JD ingestion start working correctly going forward.

## ⚠️ Operational migration required

The migration runs automatically on the next deploy via `alembic upgrade head`. No env-var changes required.

### How to verify post-deploy

\`\`\`bash
docker compose -f apps/myjobhunter/docker-compose.yml exec api \
  alembic current
# Should report: extctx260507 (head)
\`\`\`

### Smoke test the fix

After deploy, click "Start refinement" on `/resume`. Should succeed (POST `/api/resume-refinement/sessions` returns 201).

### Rollback path

If the migration fails or the deploy needs to be reverted, the previous image still works — but resume-refinement and JD-URL parsing will continue to 500 until this lands. There is no graceful-degrade path while #426's silent-fail removal is in place.

## Sidebar — Sentry blackout for MJH

Discovered while diagnosing this: the `myjobhunter-api` Sentry project has zero error events in the last 30 days. This 500 should have been captured. Either `SENTRY_DSN` isn't set in `apps/myjobhunter/backend/.env.docker` on the VPS, or it's pointed at the wrong project. Worth verifying — without Sentry we'd be guessing instead of diagnosing. Tracked separately from this PR.

## Test plan

- [x] Unit tests pass locally (`tests/test_discovery_models.py::test_extraction_log_accepts_resume_refinement_contexts[*]`)
- [x] Existing `job_analysis` context test still passes
- [x] `alembic upgrade head` applies cleanly on dev DB
- [x] `alembic heads` reports single head (`extctx260507`)
- [ ] CI green
- [ ] Post-deploy: click Start refinement on /resume → 201, page advances

🤖 Generated with [Claude Code](https://claude.com/claude-code)