### PR TITLE
chore(mbk/leases): clean up audit findings from PRs #415–#436

### DIFF
--- a/apps/mybookkeeper/backend/app/api/signed_leases.py
+++ b/apps/mybookkeeper/backend/app/api/signed_leases.py
@@ -45,6 +45,9 @@ from app.schemas.leases.signed_lease_response import SignedLeaseResponse
 from app.schemas.leases.signed_lease_add_templates_request import (
     SignedLeaseAddTemplatesRequest,
 )
+from app.schemas.leases.signed_lease_template_prefill_request import (
+    SignedLeaseTemplatePrefillRequest,
+)
 from app.schemas.leases.signed_lease_template_prefill_response import (
     SignedLeaseTemplatePrefillResponse,
 )
@@ -209,7 +212,7 @@ async def delete_lease(
 )
 async def prefill_addendum_placeholders(
     lease_id: uuid.UUID,
-    payload: SignedLeaseAddTemplatesRequest,
+    payload: SignedLeaseTemplatePrefillRequest,
     ctx: RequestContext = Depends(require_write_access),
 ) -> SignedLeaseTemplatePrefillResponse:
     """Return resolved + unresolved placeholder values for adding templates.

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_template_prefill_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_template_prefill_request.py
@@ -1,0 +1,23 @@
+"""Request body for POST /signed-leases/{lease_id}/template-prefill.
+
+Distinct from ``SignedLeaseAddTemplatesRequest`` — prefill is a dry-run
+read that only needs the template_ids the host has selected. The
+``values`` field on ``SignedLeaseAddTemplatesRequest`` is irrelevant
+here (the prefill endpoint computes its own resolved values).
+"""
+from __future__ import annotations
+
+import uuid
+
+from pydantic import BaseModel, field_validator
+
+
+class SignedLeaseTemplatePrefillRequest(BaseModel):
+    template_ids: list[uuid.UUID]
+
+    @field_validator("template_ids")
+    @classmethod
+    def require_non_empty(cls, v: list[uuid.UUID]) -> list[uuid.UUID]:
+        if not v:
+            raise ValueError("template_ids must contain at least one id")
+        return v

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_template_prefill_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_template_prefill_response.py
@@ -16,12 +16,20 @@ class SignedLeaseTemplatePrefillItem(BaseModel):
     input_type: str
     required: bool
     # Resolved value (auto-filled from default_source against applicant /
-    # lease / property / user). Empty string when no source resolved or no
-    # default_source was set on the placeholder.
+    # lease / property / user, or carried over from an earlier
+    # ``lease.values`` entry on regenerate). Empty string when no source
+    # resolved and no default_source was set.
     value: str
     # ``"applicant"`` / ``"inquiry"`` / ``"lease"`` / ``"property"`` /
-    # ``"user"`` / ``"today"`` if a value was resolved, else ``None``.
+    # ``"user"`` / ``"today"`` when ``resolve_default_source`` produced the
+    # value. ``None`` when the value either could not be resolved or was
+    # carried over from ``lease.values`` (in which case
+    # ``is_from_existing_values=True``).
     provenance: str | None
+    # True when ``value`` came from the lease's existing ``values`` dict
+    # (typical on a regenerate). The frontend uses this to label the field
+    # as "saved on lease" — outside the resolver's provenance contract.
+    is_from_existing_values: bool = False
 
 
 class SignedLeaseTemplatePrefillResponse(BaseModel):

--- a/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/signed_lease_service.py
@@ -31,6 +31,10 @@ from app.repositories.leases import (
 )
 from app.repositories.listings import listing_repo
 from app.repositories.properties import property_repo
+from app.repositories.user import user_repo
+from app.models.applicants.applicant import Applicant
+from app.models.inquiries.inquiry import Inquiry
+from app.models.properties.property import Property
 from app.models.user.user import User
 from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
@@ -274,6 +278,47 @@ def _denormalise_dates(values: dict[str, Any]) -> tuple[_dt.date | None, _dt.dat
     starts = next((_coerce(values[k]) for k in candidates_start if k in values), None)
     ends = next((_coerce(values[k]) for k in candidates_end if k in values), None)
     return starts, ends
+
+
+async def _load_resolution_context(
+    db,
+    *,
+    lease,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> tuple[Applicant | None, Inquiry | None, Property | None, User | None]:
+    """Load applicant + inquiry + property + host user for placeholder resolution.
+
+    Used by ``add_templates_and_generate`` and ``prefill_addendum_placeholders``
+    to populate ``default_source`` resolution against live ORM rows. All four
+    return values may be ``None`` — the resolver is expected to tolerate
+    missing context (e.g. an imported lease with no listing has no property).
+    """
+    applicant = await applicant_repo.get(
+        db,
+        applicant_id=lease.applicant_id,
+        organization_id=organization_id,
+        user_id=user_id,
+    )
+    inquiry = None
+    if applicant is not None and applicant.inquiry_id is not None:
+        inquiry = await get_by_applicant_inquiry_id(
+            db,
+            inquiry_id=applicant.inquiry_id,
+            organization_id=organization_id,
+            user_id=user_id,
+        )
+    property_record = None
+    if lease.listing_id is not None:
+        listing = await listing_repo.get_by_id(
+            db, lease.listing_id, organization_id,
+        )
+        if listing is not None and listing.property_id is not None:
+            property_record = await property_repo.get_by_id(
+                db, listing.property_id, organization_id,
+            )
+    user_record = await user_repo.get_by_id(db, user_id)
+    return applicant, inquiry, property_record, user_record
 
 
 # ---------------------------------------------------------------------------
@@ -667,31 +712,14 @@ async def add_templates_and_generate(
         # for any placeholder with a ``default_source`` set. This populates
         # ``[ORIGINAL LEASE START DATE]``, ``[PROPERTY ADDRESS]``, etc. on
         # addendum templates without forcing the host to retype them.
-        applicant = await applicant_repo.get(
-            db,
-            applicant_id=lease.applicant_id,
-            organization_id=organization_id,
-            user_id=user_id,
-        )
-        inquiry = None
-        if applicant is not None and applicant.inquiry_id is not None:
-            inquiry = await get_by_applicant_inquiry_id(
+        applicant, inquiry, property_record, user_record = (
+            await _load_resolution_context(
                 db,
-                inquiry_id=applicant.inquiry_id,
+                lease=lease,
                 organization_id=organization_id,
                 user_id=user_id,
             )
-        listing = None
-        property_record = None
-        if lease.listing_id is not None:
-            listing = await listing_repo.get_by_id(
-                db, lease.listing_id, organization_id,
-            )
-            if listing is not None and listing.property_id is not None:
-                property_record = await property_repo.get_by_id(
-                    db, listing.property_id, organization_id,
-                )
-        user_record = await db.get(User, user_id)
+        )
 
         merged_values: dict[str, str] = {
             k: ("" if v is None else str(v))
@@ -712,7 +740,7 @@ async def add_templates_and_generate(
                     property_record=property_record,
                     user_record=user_record,
                 )
-            except Exception:  # noqa: BLE001
+            except (ValueError, AttributeError):
                 logger.warning(
                     "default_source resolution failed for placeholder %s on lease %s",
                     p.key, lease_id, exc_info=True,
@@ -733,20 +761,17 @@ async def add_templates_and_generate(
         # consistent and the Details tab reflects what was used at render time.
         if merged_values != (lease.values or {}):
             new_start, new_end = _denormalise_dates(merged_values)
+            fields_to_update: dict[str, Any] = {"values": merged_values}
+            if new_start is not None and lease.starts_on is None:
+                fields_to_update["starts_on"] = new_start
+            if new_end is not None and lease.ends_on is None:
+                fields_to_update["ends_on"] = new_end
             await signed_lease_repo.update_lease(
                 db,
                 lease_id=lease_id,
                 user_id=user_id,
                 organization_id=organization_id,
-                fields={
-                    "values": merged_values,
-                    **(
-                        {"starts_on": new_start} if new_start is not None and lease.starts_on is None else {}
-                    ),
-                    **(
-                        {"ends_on": new_end} if new_end is not None and lease.ends_on is None else {}
-                    ),
-                },
+                fields=fields_to_update,
             )
 
         # Persist the new template links before rendering (render can be long).
@@ -919,30 +944,14 @@ async def prefill_addendum_placeholders(
                 placeholders.append(p)
 
         # Load resolution context once.
-        applicant = await applicant_repo.get(
-            db,
-            applicant_id=lease.applicant_id,
-            organization_id=organization_id,
-            user_id=user_id,
-        )
-        inquiry = None
-        if applicant is not None and applicant.inquiry_id is not None:
-            inquiry = await get_by_applicant_inquiry_id(
+        applicant, inquiry, property_record, user_record = (
+            await _load_resolution_context(
                 db,
-                inquiry_id=applicant.inquiry_id,
+                lease=lease,
                 organization_id=organization_id,
                 user_id=user_id,
             )
-        property_record = None
-        if lease.listing_id is not None:
-            listing = await listing_repo.get_by_id(
-                db, lease.listing_id, organization_id,
-            )
-            if listing is not None and listing.property_id is not None:
-                property_record = await property_repo.get_by_id(
-                    db, listing.property_id, organization_id,
-                )
-        user_record = await db.get(User, user_id)
+        )
 
         existing_values = lease.values or {}
 
@@ -962,7 +971,8 @@ async def prefill_addendum_placeholders(
                         input_type=p.input_type,
                         required=p.required,
                         value=str(existing),
-                        provenance="lease.values",
+                        provenance=None,
+                        is_from_existing_values=True,
                     )
                 )
                 continue
@@ -982,7 +992,7 @@ async def prefill_addendum_placeholders(
                     if resolved is not None and resolved != "":
                         value = str(resolved)
                         provenance = prov
-                except Exception:  # noqa: BLE001
+                except (ValueError, AttributeError):
                     logger.warning(
                         "default_source resolution failed for placeholder %s",
                         p.key, exc_info=True,

--- a/apps/mybookkeeper/backend/tests/test_lease_add_template.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_add_template.py
@@ -274,6 +274,96 @@ async def test_add_templates_already_linked_treated_as_regenerate(db) -> None:
 
 
 @pytest.mark.asyncio
+async def test_regenerate_deletes_old_rendered_attachments(db) -> None:
+    """Regenerate replaces old ``rendered_original`` attachments.
+
+    Closes the audit gap from 2026-05-08: the previous test only verified
+    that no error was raised, not that the deletion side-effect actually
+    fired. This one seeds an existing rendered attachment and asserts both
+    (a) the old DB row is gone after regenerate, and (b) the storage
+    delete_file was called for its key. Other attachment kinds (e.g.
+    ``signed_addendum`` from a prior import) MUST be preserved.
+    """
+    from app.repositories.leases import signed_lease_attachment_repo
+
+    user_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    t1 = await lease_template_repo.create(
+        db, user_id=user_id, organization_id=org_id, name="Extension",
+    )
+    lease = await signed_lease_repo.create(
+        db,
+        user_id=user_id,
+        organization_id=org_id,
+        applicant_id=uuid.uuid4(),
+        listing_id=None,
+        values={},
+        starts_on=None,
+        ends_on=None,
+        status="draft",
+        kind="generated",
+    )
+    await signed_lease_template_repo.create(
+        db, lease_id=lease.id, template_id=t1.id, display_order=0,
+    )
+    # Seed two attachments: one rendered_original (should be deleted on
+    # regenerate) and one signed_addendum (must survive).
+    import datetime as _dt
+    now = _dt.datetime.now(_dt.timezone.utc)
+    old_rendered = await signed_lease_attachment_repo.create(
+        db,
+        lease_id=lease.id,
+        storage_key="signed-leases/lease/old-rendered",
+        filename="extension.pdf",
+        content_type="application/pdf",
+        size_bytes=1024,
+        kind="rendered_original",
+        uploaded_by_user_id=user_id,
+        uploaded_at=now,
+    )
+    preserved_addendum = await signed_lease_attachment_repo.create(
+        db,
+        lease_id=lease.id,
+        storage_key="signed-leases/lease/preserved",
+        filename="house-rules.pdf",
+        content_type="application/pdf",
+        size_bytes=2048,
+        kind="signed_addendum",
+        uploaded_by_user_id=user_id,
+        uploaded_at=now,
+    )
+    await db.commit()
+
+    storage = MagicMock()
+    storage.upload_file = MagicMock(return_value=None)
+    storage.delete_file = MagicMock(return_value=None)
+    storage.download_file = MagicMock(return_value=b"")
+
+    with _patch(
+        "app.services.leases.signed_lease_service.unit_of_work",
+        _make_fake_uow(db),
+    ), _patch(
+        "app.services.leases.signed_lease_service.get_storage",
+        return_value=storage,
+    ):
+        await add_templates_and_generate(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            template_ids=[t1.id],
+        )
+
+    # The old rendered_original DB row is gone.
+    remaining = await signed_lease_attachment_repo.list_by_lease(db, lease.id)
+    remaining_ids = {a.id for a in remaining}
+    assert old_rendered.id not in remaining_ids
+    # The non-rendered attachment is preserved.
+    assert preserved_addendum.id in remaining_ids
+    # Storage was asked to delete the old rendered object.
+    storage.delete_file.assert_any_call("signed-leases/lease/old-rendered")
+
+
+@pytest.mark.asyncio
 async def test_add_templates_happy_path_links_and_renders(db) -> None:
     """End-to-end: new template link inserted, attachment created via mocked storage."""
     user_id = uuid.uuid4()

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
@@ -169,6 +169,7 @@ beforeEach(() => {
             required: true,
             value: "Sonu King",
             provenance: "applicant",
+            is_from_existing_values: false,
           },
           {
             key: "NEW LEASE END DATE",
@@ -177,6 +178,7 @@ beforeEach(() => {
             required: true,
             value: "",
             provenance: null,
+            is_from_existing_values: false,
           },
         ],
       }),

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateModal.tsx
@@ -1,10 +1,5 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
-import { ArrowLeft, Plus } from "lucide-react";
-import AlertBox from "@/shared/components/ui/AlertBox";
-import LoadingButton from "@/shared/components/ui/LoadingButton";
-import Button from "@/shared/components/ui/Button";
-import Skeleton from "@/shared/components/ui/Skeleton";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 import { useGetLeaseTemplatesQuery } from "@/shared/store/leaseTemplatesApi";
 import {
@@ -13,10 +8,15 @@ import {
 } from "@/shared/store/signedLeasesApi";
 import type { LeaseTemplateSummary } from "@/shared/types/lease/lease-template-summary";
 import type { SignedLeaseTemplatePrefillItem } from "@/shared/types/lease/signed-lease-template-prefill";
+import LeaseAddTemplatePickStep from "./LeaseAddTemplatePickStep";
+import LeaseAddTemplateValuesStep from "./LeaseAddTemplateValuesStep";
 
 export interface LeaseAddTemplateModalProps {
   leaseId: string;
-  /** IDs of templates already linked to this lease — excluded from the picker. */
+  /**
+   * IDs of templates already linked to this lease. They still appear in
+   * the picker — selecting one is a regenerate, not a duplicate-add.
+   */
   existingTemplateIds: string[];
   onClose: () => void;
 }
@@ -29,19 +29,18 @@ interface ValuesFormState {
 }
 
 /**
- * Two-step modal for adding lease templates to an existing signed lease.
+ * Two-step modal for attaching lease templates to a signed lease and
+ * generating their rendered output.
  *
- * Step 1 — pick: host picks one or more templates from a checklist of
- * templates not already linked to the lease.
+ * Step 1 (``LeaseAddTemplatePickStep``) — pick one or more templates.
+ * Already-linked templates are flagged so the host knows they'll regenerate.
  *
- * Step 2 — values: backend pre-fills as many placeholders as possible from
- * the parent lease, applicant, linked property, and host user. Host fills in
- * any genuinely-unknown fields (rent, dates, payment method, etc.) and
- * submits. Backend persists merged values to ``lease.values`` and renders
- * the new template files as additional attachments.
+ * Step 2 (``LeaseAddTemplateValuesStep``) — fill in placeholder values.
+ * The prefill endpoint pre-populates as many as it can from the applicant,
+ * lease, linked property, and host user; the host edits the rest.
  *
  * Works for both generated and imported leases. Imported leases use this
- * flow to attach addenda (e.g. extension addendums) without touching the
+ * flow to attach addenda (extension, pet rules, etc.) without touching the
  * original signed PDF.
  */
 export default function LeaseAddTemplateModal({
@@ -65,7 +64,10 @@ export default function LeaseAddTemplateModal({
     refetch,
   } = useGetLeaseTemplatesQuery();
 
-  const linkedSet = new Set(existingTemplateIds);
+  const linkedSet = useMemo(
+    () => new Set(existingTemplateIds),
+    [existingTemplateIds],
+  );
   const available = data?.items ?? [];
 
   function handleToggle(t: LeaseTemplateSummary) {
@@ -134,13 +136,6 @@ export default function LeaseAddTemplateModal({
     }
   }
 
-  function inputTypeAttr(t: string): string {
-    if (t === "date") return "date";
-    if (t === "email") return "email";
-    if (t === "phone") return "tel";
-    return "text";
-  }
-
   return (
     <Dialog.Root open onOpenChange={(isOpen) => { if (!isOpen) onClose(); }}>
       <Dialog.Portal>
@@ -159,203 +154,29 @@ export default function LeaseAddTemplateModal({
           </Dialog.Description>
 
           {step === "pick" ? (
-            <>
-              {isError ? (
-                <AlertBox
-                  variant="error"
-                  className="flex items-center justify-between gap-3"
-                >
-                  <span>I couldn't load your templates. Want me to try again?</span>
-                  <LoadingButton
-                    variant="secondary"
-                    size="sm"
-                    isLoading={isFetching}
-                    loadingText="Retrying..."
-                    onClick={() => refetch()}
-                  >
-                    Retry
-                  </LoadingButton>
-                </AlertBox>
-              ) : isLoading ? (
-                <div className="space-y-2" data-testid="lease-add-template-skeleton">
-                  <Skeleton className="h-14 w-full" />
-                  <Skeleton className="h-14 w-full" />
-                </div>
-              ) : available.length === 0 ? (
-                <p
-                  className="text-sm text-muted-foreground py-4 text-center"
-                  data-testid="lease-add-template-empty"
-                >
-                  All your templates are already on this lease.
-                </p>
-              ) : (
-                <ul
-                  className="space-y-2 max-h-72 overflow-y-auto"
-                  data-testid="lease-add-template-list"
-                >
-                  {available.map((t) => {
-                    const checked = selectedIds.includes(t.id);
-                    const alreadyLinked = linkedSet.has(t.id);
-                    return (
-                      <li key={t.id}>
-                        <label
-                          className={[
-                            "w-full flex items-start gap-3 border rounded-lg px-4 py-3 transition-colors min-h-[44px] cursor-pointer",
-                            checked
-                              ? "border-primary bg-primary/5"
-                              : "hover:bg-muted/50",
-                          ].join(" ")}
-                          data-testid={`add-template-option-${t.id}`}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={() => handleToggle(t)}
-                            className="mt-1 h-4 w-4 cursor-pointer"
-                            aria-label={`Select template ${t.name}`}
-                            data-testid={`add-template-checkbox-${t.id}`}
-                          />
-                          <div className="flex-1 min-w-0">
-                            <div className="flex items-center justify-between gap-2 flex-wrap">
-                              <span className="font-medium text-sm">{t.name}</span>
-                              <span className="text-xs text-muted-foreground shrink-0">
-                                v{t.version}
-                              </span>
-                            </div>
-                            {t.description ? (
-                              <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
-                                {t.description}
-                              </p>
-                            ) : null}
-                            <p className="text-xs text-muted-foreground mt-1 flex items-center gap-2 flex-wrap">
-                              <span>
-                                {t.placeholder_count}{" "}
-                                {t.placeholder_count === 1
-                                  ? "placeholder"
-                                  : "placeholders"}
-                              </span>
-                              {alreadyLinked ? (
-                                <span className="text-[10px] uppercase tracking-wide bg-muted rounded px-1.5 py-0.5 font-medium">
-                                  on this lease — picking will regenerate
-                                </span>
-                              ) : null}
-                            </p>
-                          </div>
-                        </label>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-
-              <div className="flex justify-end gap-2 pt-2">
-                <Button variant="ghost" size="sm" onClick={onClose}>
-                  Cancel
-                </Button>
-                <LoadingButton
-                  isLoading={isPrefilling}
-                  loadingText="Loading fields..."
-                  disabled={selectedIds.length === 0 || isPrefilling}
-                  onClick={() => void handleContinue()}
-                  data-testid="lease-add-template-continue"
-                >
-                  Continue
-                </LoadingButton>
-              </div>
-            </>
+            <LeaseAddTemplatePickStep
+              available={available}
+              linkedSet={linkedSet}
+              selectedIds={selectedIds}
+              onToggle={handleToggle}
+              isError={isError}
+              isLoading={isLoading}
+              isFetching={isFetching}
+              isPrefilling={isPrefilling}
+              onRetry={() => void refetch()}
+              onContinue={() => void handleContinue()}
+              onClose={onClose}
+            />
           ) : (
-            <>
-              {valuesState !== null && valuesState.items.length === 0 ? (
-                <p className="text-sm text-muted-foreground py-4 text-center">
-                  This template has nothing for you to fill in — everything is
-                  auto-handled. Click Generate to render it.
-                </p>
-              ) : (
-                <ul
-                  className="space-y-3 max-h-[60vh] overflow-y-auto pr-1"
-                  data-testid="lease-add-template-values-list"
-                >
-                  {(valuesState?.items ?? []).map((item) => {
-                    const value = valuesState?.values[item.key] ?? "";
-                    const provenance = item.provenance;
-                    const provenanceLabel =
-                      provenance === "applicant"
-                        ? "from applicant"
-                        : provenance === "lease"
-                          ? "from lease"
-                          : provenance === "property"
-                            ? "from property"
-                            : provenance === "user"
-                              ? "from your profile"
-                              : provenance === "today"
-                                ? "today's date"
-                                : provenance === "lease.values"
-                                  ? "saved on lease"
-                                  : null;
-                    return (
-                      <li key={item.key} className="flex flex-col gap-1">
-                        <label
-                          htmlFor={`addendum-input-${item.key}`}
-                          className="text-xs font-medium flex items-center gap-2 flex-wrap"
-                        >
-                          {item.display_label}
-                          {item.required ? (
-                            <span className="text-destructive" aria-hidden>
-                              *
-                            </span>
-                          ) : null}
-                          {provenanceLabel !== null ? (
-                            <span className="text-[10px] uppercase tracking-wide text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-normal">
-                              {provenanceLabel}
-                            </span>
-                          ) : null}
-                        </label>
-                        <input
-                          id={`addendum-input-${item.key}`}
-                          type={inputTypeAttr(item.input_type)}
-                          value={value}
-                          onChange={(e) =>
-                            handleValueChange(item.key, e.target.value)
-                          }
-                          className="px-3 py-2 text-sm border rounded-md bg-background"
-                          data-testid={`addendum-input-${item.key}`}
-                          placeholder={
-                            item.required ? "Required" : "Optional"
-                          }
-                        />
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-
-              <div className="flex items-center justify-between gap-2 pt-2">
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setStep("pick")}
-                  data-testid="lease-add-template-back"
-                >
-                  <ArrowLeft size={14} className="mr-1" />
-                  Back
-                </Button>
-                <div className="flex gap-2">
-                  <Button variant="ghost" size="sm" onClick={onClose}>
-                    Cancel
-                  </Button>
-                  <LoadingButton
-                    isLoading={isAdding}
-                    loadingText="Generating..."
-                    disabled={isAdding}
-                    onClick={() => void handleGenerate()}
-                    data-testid="lease-add-template-confirm"
-                  >
-                    <Plus size={14} className="mr-1" />
-                    Generate
-                  </LoadingButton>
-                </div>
-              </div>
-            </>
+            <LeaseAddTemplateValuesStep
+              items={valuesState?.items ?? []}
+              values={valuesState?.values ?? {}}
+              onValueChange={handleValueChange}
+              isAdding={isAdding}
+              onBack={() => setStep("pick")}
+              onClose={onClose}
+              onGenerate={() => void handleGenerate()}
+            />
           )}
         </Dialog.Content>
       </Dialog.Portal>

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplatePickStep.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplatePickStep.tsx
@@ -1,0 +1,147 @@
+import AlertBox from "@/shared/components/ui/AlertBox";
+import Button from "@/shared/components/ui/Button";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import Skeleton from "@/shared/components/ui/Skeleton";
+import type { LeaseTemplateSummary } from "@/shared/types/lease/lease-template-summary";
+
+export interface LeaseAddTemplatePickStepProps {
+  available: LeaseTemplateSummary[];
+  linkedSet: Set<string>;
+  selectedIds: string[];
+  onToggle: (template: LeaseTemplateSummary) => void;
+  isError: boolean;
+  isLoading: boolean;
+  isFetching: boolean;
+  isPrefilling: boolean;
+  onRetry: () => void;
+  onContinue: () => void;
+  onClose: () => void;
+}
+
+/**
+ * Step 1 of the Add Document modal: pick one or more templates from the
+ * host's library. Already-linked templates are listed with a small
+ * "picking will regenerate" badge so the host can knowingly trigger a
+ * regenerate via the same flow.
+ */
+export default function LeaseAddTemplatePickStep({
+  available,
+  linkedSet,
+  selectedIds,
+  onToggle,
+  isError,
+  isLoading,
+  isFetching,
+  isPrefilling,
+  onRetry,
+  onContinue,
+  onClose,
+}: LeaseAddTemplatePickStepProps) {
+  return (
+    <>
+      {isError ? (
+        <AlertBox
+          variant="error"
+          className="flex items-center justify-between gap-3"
+        >
+          <span>I couldn't load your templates. Want me to try again?</span>
+          <LoadingButton
+            variant="secondary"
+            size="sm"
+            isLoading={isFetching}
+            loadingText="Retrying..."
+            onClick={onRetry}
+          >
+            Retry
+          </LoadingButton>
+        </AlertBox>
+      ) : isLoading ? (
+        <div className="space-y-2" data-testid="lease-add-template-skeleton">
+          <Skeleton className="h-14 w-full" />
+          <Skeleton className="h-14 w-full" />
+        </div>
+      ) : available.length === 0 ? (
+        <p
+          className="text-sm text-muted-foreground py-4 text-center"
+          data-testid="lease-add-template-empty"
+        >
+          You don't have any templates yet — upload one from the Lease
+          Templates page first.
+        </p>
+      ) : (
+        <ul
+          className="space-y-2 max-h-72 overflow-y-auto"
+          data-testid="lease-add-template-list"
+        >
+          {available.map((t) => {
+            const checked = selectedIds.includes(t.id);
+            const alreadyLinked = linkedSet.has(t.id);
+            return (
+              <li key={t.id}>
+                <label
+                  className={[
+                    "w-full flex items-start gap-3 border rounded-lg px-4 py-3 transition-colors min-h-[44px] cursor-pointer",
+                    checked
+                      ? "border-primary bg-primary/5"
+                      : "hover:bg-muted/50",
+                  ].join(" ")}
+                  data-testid={`add-template-option-${t.id}`}
+                >
+                  <input
+                    type="checkbox"
+                    checked={checked}
+                    onChange={() => onToggle(t)}
+                    className="mt-1 h-4 w-4 cursor-pointer"
+                    aria-label={`Select template ${t.name}`}
+                    data-testid={`add-template-checkbox-${t.id}`}
+                  />
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center justify-between gap-2 flex-wrap">
+                      <span className="font-medium text-sm">{t.name}</span>
+                      <span className="text-xs text-muted-foreground shrink-0">
+                        v{t.version}
+                      </span>
+                    </div>
+                    {t.description ? (
+                      <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+                        {t.description}
+                      </p>
+                    ) : null}
+                    <p className="text-xs text-muted-foreground mt-1 flex items-center gap-2 flex-wrap">
+                      <span>
+                        {t.placeholder_count}{" "}
+                        {t.placeholder_count === 1
+                          ? "placeholder"
+                          : "placeholders"}
+                      </span>
+                      {alreadyLinked ? (
+                        <span className="text-[10px] uppercase tracking-wide bg-muted rounded px-1.5 py-0.5 font-medium">
+                          on this lease — picking will regenerate
+                        </span>
+                      ) : null}
+                    </p>
+                  </div>
+                </label>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="flex justify-end gap-2 pt-2">
+        <Button variant="ghost" size="sm" onClick={onClose}>
+          Cancel
+        </Button>
+        <LoadingButton
+          isLoading={isPrefilling}
+          loadingText="Loading fields..."
+          disabled={selectedIds.length === 0 || isPrefilling}
+          onClick={onContinue}
+          data-testid="lease-add-template-continue"
+        >
+          Continue
+        </LoadingButton>
+      </div>
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateValuesStep.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseAddTemplateValuesStep.tsx
@@ -1,0 +1,122 @@
+import { ArrowLeft, Plus } from "lucide-react";
+import Button from "@/shared/components/ui/Button";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import { PREFILL_PROVENANCE_LABELS } from "@/shared/lib/lease-labels";
+import type { SignedLeaseTemplatePrefillItem } from "@/shared/types/lease/signed-lease-template-prefill";
+
+export interface LeaseAddTemplateValuesStepProps {
+  items: SignedLeaseTemplatePrefillItem[];
+  values: Record<string, string>;
+  onValueChange: (key: string, value: string) => void;
+  isAdding: boolean;
+  onBack: () => void;
+  onClose: () => void;
+  onGenerate: () => void;
+}
+
+function inputTypeAttr(t: string): string {
+  if (t === "date") return "date";
+  if (t === "email") return "email";
+  if (t === "phone") return "tel";
+  return "text";
+}
+
+function provenanceLabelFor(item: SignedLeaseTemplatePrefillItem): string | null {
+  if (item.is_from_existing_values) return "saved on lease";
+  if (item.provenance === null) return null;
+  return PREFILL_PROVENANCE_LABELS[item.provenance] ?? null;
+}
+
+/**
+ * Step 2 of the Add Document modal: fill in placeholder values. Items are
+ * pre-populated by the prefill endpoint where possible (applicant /
+ * lease / property / user / today). The host edits anything wrong and
+ * fills the rest. Required fields show an asterisk; the parent modal
+ * blocks submit when any required field is blank.
+ */
+export default function LeaseAddTemplateValuesStep({
+  items,
+  values,
+  onValueChange,
+  isAdding,
+  onBack,
+  onClose,
+  onGenerate,
+}: LeaseAddTemplateValuesStepProps) {
+  return (
+    <>
+      {items.length === 0 ? (
+        <p className="text-sm text-muted-foreground py-4 text-center">
+          This template has nothing for you to fill in — everything is
+          auto-handled. Click Generate to render it.
+        </p>
+      ) : (
+        <ul
+          className="space-y-3 max-h-[60vh] overflow-y-auto pr-1"
+          data-testid="lease-add-template-values-list"
+        >
+          {items.map((item) => {
+            const value = values[item.key] ?? "";
+            const provenanceLabel = provenanceLabelFor(item);
+            return (
+              <li key={item.key} className="flex flex-col gap-1">
+                <label
+                  htmlFor={`addendum-input-${item.key}`}
+                  className="text-xs font-medium flex items-center gap-2 flex-wrap"
+                >
+                  {item.display_label}
+                  {item.required ? (
+                    <span className="text-destructive" aria-hidden>
+                      *
+                    </span>
+                  ) : null}
+                  {provenanceLabel !== null ? (
+                    <span className="text-[10px] uppercase tracking-wide text-muted-foreground bg-muted rounded px-1.5 py-0.5 font-normal">
+                      {provenanceLabel}
+                    </span>
+                  ) : null}
+                </label>
+                <input
+                  id={`addendum-input-${item.key}`}
+                  type={inputTypeAttr(item.input_type)}
+                  value={value}
+                  onChange={(e) => onValueChange(item.key, e.target.value)}
+                  className="px-3 py-2 text-sm border rounded-md bg-background"
+                  data-testid={`addendum-input-${item.key}`}
+                  placeholder={item.required ? "Required" : "Optional"}
+                />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+
+      <div className="flex items-center justify-between gap-2 pt-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onBack}
+          data-testid="lease-add-template-back"
+        >
+          <ArrowLeft size={14} className="mr-1" />
+          Back
+        </Button>
+        <div className="flex gap-2">
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Cancel
+          </Button>
+          <LoadingButton
+            isLoading={isAdding}
+            loadingText="Generating..."
+            disabled={isAdding}
+            onClick={onGenerate}
+            data-testid="lease-add-template-confirm"
+          >
+            <Plus size={14} className="mr-1" />
+            Generate
+          </LoadingButton>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/lease-labels.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/lease-labels.ts
@@ -79,3 +79,18 @@ export const SIGNED_LEASE_STATUS_NEXT: Record<SignedLeaseStatus, readonly Signed
   ended: [],
   terminated: [],
 };
+
+/**
+ * Human-friendly labels for the ``provenance`` field on
+ * ``SignedLeaseTemplatePrefillItem``. Mirrors the backend
+ * ``ProvenanceLabel`` type in ``default_source_resolver.py``. Unknown
+ * values fall through to ``null`` and no chip is rendered.
+ */
+export const PREFILL_PROVENANCE_LABELS: Record<string, string> = {
+  applicant: "from applicant",
+  inquiry: "from inquiry",
+  lease: "from lease",
+  property: "from property",
+  user: "from your profile",
+  today: "today's date",
+};

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-template-prefill.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-template-prefill.ts
@@ -5,6 +5,7 @@ export interface SignedLeaseTemplatePrefillItem {
   required: boolean;
   value: string;
   provenance: string | null;
+  is_from_existing_values: boolean;
 }
 
 export interface SignedLeaseTemplatePrefillResponse {


### PR DESCRIPTION
## Summary

Addresses the 9 self-audit findings from 2026-05-08 — code I introduced this session that violated project rules or duplicated logic. Scoped to my changes only; pre-existing tech debt in the same files is not touched.

## Findings → fixes

**Architecture violations (CLAUDE.md rule violations):**
- `db.get(User, user_id)` (2 call sites) → `user_repo.get_by_id`
- 25-line context-loading block duplicated → extracted `_load_resolution_context` helper
- 6-deep ternary in modal → `PREFILL_PROVENANCE_LABELS` constant lookup
- 364-line modal with inline step bodies → extracted `LeaseAddTemplatePickStep` + `LeaseAddTemplateValuesStep` into their own files (modal is now 175 lines of orchestration)

**Type contract:**
- Synthetic `provenance=\"lease.values\"` outside `ProvenanceLabel` contract → new `is_from_existing_values: bool` field on `SignedLeaseTemplatePrefillItem`
- Schema sharing between prefill + add endpoints (dead `values` field on prefill) → new `SignedLeaseTemplatePrefillRequest` (template_ids only)

**Readability + correctness:**
- Conditional dict-spread `**({\"starts_on\": ...} if ... else {})` → explicit `if` blocks populating `fields_to_update`
- Broad `except Exception` on pure-Python resolver call → narrowed to `(ValueError, AttributeError)` so spec typos fail loudly
- `linkedSet = new Set(...)` reallocated every render → `useMemo`

**Test coverage:**
- New `test_regenerate_deletes_old_rendered_attachments` closes the audit gap that the previous test only checked \"no error\" not \"old attachment removed\"

## Backwards compatibility

- `SignedLeaseAddTemplatesRequest.values` unchanged
- The synthetic `\"lease.values\"` provenance was an internal magic string with no external consumer
- All 51 backend tests pass locally (50 + 1 new)

## Test plan

- [x] All 51 backend tests pass
- [ ] Manual: pick a template that's already on a lease → verify the \"on this lease — picking will regenerate\" badge still shows; pick + Continue → values form prefills with \"saved on lease\" chip on existing values; submit → success toast says \"Document regenerated.\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)