### PR TITLE
fix(mbk): disable Plaid router — not in use, was a Sentry noise source

### DIFF
--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -42,7 +42,13 @@ from app.db.session import AsyncSessionLocal
 from app.schemas.user.user import UserRead, UserCreate, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 from app.workers.upload_processor_worker import main as worker_main
-from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, properties, public_inquiries, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, plaid, vendors, webhooks, exports, imports, health_dashboard, totp, taxpayer_profiles
+from app.api import account, activities, analytics, applicants, attribution, blackouts, booking_statements, calendar, classification_rules, costs, db_admin, demo, documents, frontend_errors, inquiries, insurance_policies, lease_templates, listings, properties, public_inquiries, rent_receipts, reply_templates, signed_leases, tenants, summary, integrations, audit, prompts, admin, organizations, transactions, reconciliation, screening, tax_completeness, tax_documents, tax_profile, tax_returns, tax_year_profiles, vendors, webhooks, exports, imports, health_dashboard, totp, taxpayer_profiles
+# Plaid disabled (2026-05-08) — operator is not using Plaid; the unmounted
+# webhook endpoint was a probe-traffic noise source on Sentry. Underlying
+# code preserved (api/plaid.py, services/integrations/plaid_*.py, models,
+# schemas, repository) for future revival — re-add ``plaid`` to the import
+# list above and uncomment the include_router below.
+# from app.api import plaid
 
 logging.basicConfig(
     level=logging.INFO,
@@ -266,7 +272,8 @@ app.include_router(tax_documents.router)
 app.include_router(tax_completeness.router)
 app.include_router(tax_year_profiles.router)
 app.include_router(activities.router)
-app.include_router(plaid.router)
+# Plaid disabled (2026-05-08) — see import comment near line 45.
+# app.include_router(plaid.router)
 app.include_router(webhooks.router)
 app.include_router(exports.router)
 app.include_router(imports.router)


### PR DESCRIPTION
## Summary

Operator confirmed they are not using Plaid right now. The Plaid webhook endpoint was emitting WARNING-level Sentry events on every probe-traffic signature failure (\`Plaid webhook signature failed\`, \`Plaid webhook for unknown item\`, \`Plaid-Verification JWT missing kid\`), contributing to the org-wide Sentry quota burn that's currently rate-limiting both MBK and MJH.

## What this does

Comments out the two lines in \`apps/mybookkeeper/backend/app/main.py\` that wire Plaid:
1. The \`plaid\` import in the multi-import line at line 45.
2. The \`app.include_router(plaid.router)\` call.

That removes every \`/api/plaid/*\` endpoint from the routing table. Probes get clean 404s instead of triggering signature-validation warnings.

## What's preserved

All Plaid-feature code stays in place for future revival:
- Backend: \`api/plaid.py\`, \`services/integrations/plaid_*.py\`, \`models/integrations/plaid_*.py\`, \`schemas/integrations/plaid.py\`, \`repositories/integrations/plaid_repo.py\`, \`core/plaid_webhook_verifier.py\`, \`integrations/plaid_client.py\`
- Frontend: \`plaidApi.ts\`, \`PlaidConnect.tsx\`, \`PlaidItemList.tsx\`, \`PlaidAccountMapping.tsx\` — these were already orphaned (no page imports them)

To re-enable: uncomment the two main.py lines and re-render the Plaid components on the Settings → Integrations page.

## Test plan

- [x] Greppped for any test that hits \`/api/plaid\` — none found
- [x] Greppped for any test that imports the plaid router directly — none found
- [ ] CI green
- [ ] Post-deploy: \`curl -i https://<mbk>/api/plaid/health\` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)