### PR TITLE
fix(shared/sentry): drop googleapiclient + google.auth log noise via before_send

### DIFF
--- a/packages/shared-backend/platform_shared/core/observability.py
+++ b/packages/shared-backend/platform_shared/core/observability.py
@@ -16,6 +16,7 @@ optional — ``init_sentry()`` exits silently when the DSN is empty.
 """
 
 import logging
+from typing import Any
 
 import sentry_sdk
 from sentry_sdk.integrations.logging import LoggingIntegration
@@ -23,6 +24,38 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 logger = logging.getLogger(__name__)
 
 _PROD_ENV = "production"
+
+# Loggers whose WARNING+ output is library-internal cruft, not signal worth
+# burning Sentry quota on. Events whose ``logger`` field starts with any of
+# these prefixes are dropped via ``before_send`` before transport. Keep
+# this list narrow and intentional — the goal is dropping known noise, not
+# blanket-suppressing third-party libraries.
+#
+# - googleapiclient: emits an INFO/WARNING line every time it auto-refreshes
+#   a 401-expired token ("Refreshing credentials due to a 401 response.
+#   Attempt 1/2.") and a deprecation WARNING for ``file_cache is only
+#   supported with oauth2client<4.0.0`` on every Gmail API client construction.
+#   Both are normal library behaviour, not actionable signal.
+# - google.auth: same family — refresh-token / metadata-server logs.
+_NOISE_LOGGER_PREFIXES = (
+    "googleapiclient",
+    "google.auth",
+)
+
+
+def _drop_known_noise(
+    event: dict[str, Any], _hint: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Sentry ``before_send`` hook — drop events from known-noisy loggers.
+
+    Returning ``None`` causes the SDK to discard the event before transport.
+    Only filters log-record events from the noise allowlist above; uncaught
+    exceptions and explicit ``capture_*`` calls are unaffected.
+    """
+    logger_name = event.get("logger") or ""
+    if any(logger_name.startswith(prefix) for prefix in _NOISE_LOGGER_PREFIXES):
+        return None
+    return event
 
 
 class SentryNotConfiguredError(RuntimeError):
@@ -83,6 +116,7 @@ def init_sentry(*, dsn: str, environment: str) -> None:
             traces_sample_rate=0.1,
             environment=environment,
             integrations=[logging_integration],
+            before_send=_drop_known_noise,
         )
     except Exception:
         logger.warning(

--- a/packages/shared-backend/tests/test_observability.py
+++ b/packages/shared-backend/tests/test_observability.py
@@ -6,6 +6,7 @@ import pytest
 
 from platform_shared.core.observability import (
     SentryNotConfiguredError,
+    _drop_known_noise,
     init_sentry,
 )
 
@@ -55,3 +56,45 @@ class TestSentryInit:
     def test_propagates_init_failure(self, mock_init: MagicMock) -> None:
         with pytest.raises(RuntimeError, match="boom"):
             init_sentry(dsn="https://x@y/1", environment="development")
+
+    @patch("platform_shared.core.observability.sentry_sdk.init")
+    def test_before_send_hook_wired(self, mock_init: MagicMock) -> None:
+        init_sentry(dsn="https://x@y/1", environment="production")
+        assert mock_init.call_args.kwargs["before_send"] is _drop_known_noise
+
+
+class TestDropKnownNoise:
+    """``_drop_known_noise`` filters events from named-noisy library loggers
+    while preserving everything else (uncaught exceptions, app-logger events,
+    explicit ``capture_*`` calls)."""
+
+    def test_drops_googleapiclient_logger(self) -> None:
+        event = {"logger": "googleapiclient.discovery_cache"}
+        assert _drop_known_noise(event, {}) is None
+
+    def test_drops_googleapiclient_root_logger(self) -> None:
+        event = {"logger": "googleapiclient"}
+        assert _drop_known_noise(event, {}) is None
+
+    def test_drops_google_auth_logger(self) -> None:
+        event = {"logger": "google.auth.transport.requests"}
+        assert _drop_known_noise(event, {}) is None
+
+    def test_keeps_app_logger_events(self) -> None:
+        event = {"logger": "app.services.extraction.claude_service"}
+        assert _drop_known_noise(event, {}) is event
+
+    def test_keeps_event_with_no_logger_field(self) -> None:
+        # Uncaught exceptions captured via the FastAPI integration don't
+        # carry a ``logger`` field — must NOT be filtered.
+        event = {"exception": {"values": [{"type": "ValueError"}]}}
+        assert _drop_known_noise(event, {}) is event
+
+    def test_keeps_event_with_empty_logger(self) -> None:
+        event: dict = {"logger": ""}
+        assert _drop_known_noise(event, {}) is event
+
+    def test_does_not_match_unrelated_logger_with_similar_prefix(self) -> None:
+        # ``googleapi`` is not on the allowlist; only ``googleapiclient`` is.
+        event = {"logger": "googleapi"}
+        assert _drop_known_noise(event, {}) is event


### PR DESCRIPTION
## Summary

Adds a Sentry SDK \`before_send\` hook to \`platform_shared.core.observability.init_sentry\` that drops events from the \`googleapiclient.*\` and \`google.auth.*\` loggers. The hook is wired alongside the existing \`LoggingIntegration(event_level=WARNING)\` setting.

## Why

Today's MJH Sentry blackout investigation surfaced that the org's Sentry plan is the free Developer tier — 5K errors/month **shared across both \`mybookkeeper-api\` and \`myjobhunter-api\`**. The org budget is currently at 5K/5K → all events are being silently rate-limited via \`x-sentry-rate-limits\` in both projects.

The two largest noise sources after the May-6 \`event_level=INFO→WARNING\` fix are:

| Source | Behaviour |
|---|---|
| \`googleapiclient.*\` | Emits a WARNING/INFO every time it auto-refreshes a 401-expired Gmail OAuth token (\`Refreshing credentials due to a 401 response. Attempt 1/2.\`) — that's normal library behaviour, not actionable signal |
| \`googleapiclient\` (file_cache deprecation) | Emits \`file_cache is only supported with oauth2client<4.0.0\` on every Gmail API client construction — pure deprecation noise |

Both fire dozens of times per Gmail-discovery sweep. Filtering them buys real headroom without losing a single legitimate signal.

## What this preserves

The \`before_send\` hook only filters events whose \`logger\` field starts with one of the named prefixes. It does NOT touch:
- Uncaught exceptions captured by the FastAPI integration (no \`logger\` field on those events)
- Explicit \`sentry_sdk.capture_message(...)\` / \`capture_exception(...)\` calls
- App-logger events (\`app.services.*\`, \`platform_shared.*\`)

7 new tests in \`test_observability.py\` lock in the filtering matrix + verify the hook is wired into \`sentry_sdk.init\`.

## ⚠️ When to remove

This is a quota-budget bandaid, not a permanent stance on signal vs. noise. The operator was explicit:

> "in the event that i pay for more robust logging, i don't want to filter any logs out"

When the operator upgrades to Team plan ($26/mo, 50K errors) or higher, the entire filter should be ripped out. The procedure is captured in auto-memory at \`project_sentry_noise_filter_remove_on_paid.md\`:
1. Delete \`_drop_known_noise\` + \`_NOISE_LOGGER_PREFIXES\` from \`observability.py\`
2. Remove the \`before_send=_drop_known_noise\` kwarg from \`sentry_sdk.init(...)\`
3. Delete \`TestDropKnownNoise\` + \`test_before_send_hook_wired\` from \`test_observability.py\`

## Test plan

- [x] Unit tests pass locally (7 new + existing 8)
- [ ] CI green
- [ ] Post-deploy: confirm Gmail discovery sweeps no longer create new \`googleapiclient\` issues in either Sentry project
- [ ] Post-period-reset (June 5): confirm error budget consumption is meaningfully lower

🤖 Generated with [Claude Code](https://claude.com/claude-code)