### PR TITLE
test(mbk/frontend): fix 3 broken test files + update TECH_DEBT to reality

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -1,6 +1,6 @@
 # Tech Debt
 
-> Last scanned: 2026-05-07
+> Last scanned: 2026-05-08
 > Issues: 0 critical, 6 high, 6 medium (1 deferred + 5 active), 0 low
 
 ## High
@@ -21,11 +21,16 @@
 
 ---
 
-### [Frontend tests] Pre-existing frontend unit test failures unrelated to attribution PR
-**Effort:** M
-**Location:** frontend/src/__tests__/DocumentUploadZone.test.tsx, InviteAccept.test.tsx, PendingInvites.test.tsx, Documents.test.tsx, useDashboardFilter.test.ts, ApplicantDetail.test.tsx, ListingDetail.test.tsx
-**Problem:** Failures across 7 files on main. Root causes: (a) `useMediaQuery` hook crashes during render in `DocumentUploadZone` — likely needs a jsdom matchMedia polyfill or vi.mock; (b) `filterState.selectedCategories.size` returns 4 instead of 1 in `useDashboardFilter`; (c) `ApplicantDetail` and `ListingDetail` test mocks are missing fields added in PR #187 (tenant lifecycle) — `tenant_ended_at`, `tenant_ended_reason`. Note: `DrillDownPanel.test.tsx` and `Transactions.test.tsx` attribution-fixture failures (missing `applicant_id`/`attribution_source`/`payer_name`) were fixed in PR #213.
-**Recommendation:** Triage in a dedicated session. Fix `DocumentUploadZone` matchMedia mock first (lowest effort, unblocks the most tests). Then update the `ApplicantDetail` and `ListingDetail` mocks to include the PR #187 fields.
+### [Frontend tests] Pre-existing frontend unit test failures (partial cleanup 2026-05-08)
+**Effort:** M (remaining)
+**Location:** frontend/src/__tests__/InviteAccept.test.tsx, PendingInvites.test.tsx, PublicInquiryForm.test.tsx, TaxDocuments.test.tsx, Transactions.test.tsx, VendorDetail.test.tsx
+**Problem:** Of the original 7-file failure list (DocumentUploadZone, InviteAccept, PendingInvites, Documents, useDashboardFilter, ApplicantDetail, ListingDetail) some were fixed organically; ListingDetail was fixed in this session by adding 4 missing `useGetChannelsQuery` / `useGetListingChannelsQuery` / channel-mutation hooks to the mock block (the actual cause turned out to be stale RTK Query mocks, not the PR #187 tenant_lifecycle backfill the prior entry guessed at). New failures emerged not in the original list:
+- **InviteAccept**, **PendingInvites**: stale mocks PLUS the components were refactored — assertions reference UI text that no longer renders ("You're in!", "Redirecting you to...", "Invite failed", "Invalid or expired invite"). Each test needs a read of the current component before rewriting.
+- **PublicInquiryForm**: looking for `data-testid="public-inquiry-lease-length"` — testid no longer exists. Form was refactored.
+- **TaxDocuments**: text-matcher drift — `2025` matches multiple elements; `/2 document/` and `$45,724.88` no longer present.
+- **Transactions**: text-matcher drift + missing tooltip titles ("Rules I've learned from your corrections — click to view or manage them", "Import transactions from a bank CSV file"). `Home Depot` matches multiple elements.
+- **VendorDetail**: same `Home Depot` multi-match — fixture has duplicates or component renders the vendor name twice.
+**Recommendation:** Per-file investigation. Each test was written against an older component shape; the fix for each is "open the current component, see what it renders, rewrite the assertion." Recommended order by effort: PendingInvites (small, self-contained) → InviteAccept (small, self-contained) → VendorDetail (probably one-line fixture fix) → Transactions, TaxDocuments, PublicInquiryForm (each needs more rewrite). Don't try to do all in one PR — one file per PR keeps each diff focused.
 
 ---
 

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
@@ -227,7 +227,12 @@ describe("LeaseAddTemplateModal", () => {
     );
   });
 
-  it("only shows templates NOT already on the lease", async () => {
+  it("shows all templates including ones already on the lease (regenerate flow)", async () => {
+    // Post-PR-#429 the picker no longer hides already-linked templates —
+    // re-picking is treated as a regenerate. Both should appear; the
+    // already-linked one carries an inline "picking will regenerate" hint
+    // (not asserted here — covered by the regenerate-success-toast test
+    // below).
     canWriteValue = true;
     mockLease = buildLease(); // already has tpl-existing
     renderDetail();
@@ -235,9 +240,12 @@ describe("LeaseAddTemplateModal", () => {
     await waitFor(() =>
       expect(screen.getByTestId("lease-add-template-modal")).toBeInTheDocument(),
     );
-    // tpl-new should appear, tpl-existing should NOT
-    expect(screen.queryByTestId("add-template-option-tpl-existing")).toBeNull();
-    expect(screen.getByTestId("add-template-option-tpl-new")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("add-template-option-tpl-existing"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("add-template-option-tpl-new"),
+    ).toBeInTheDocument();
   });
 
   it("'Continue' button is disabled when nothing selected", async () => {

--- a/apps/mybookkeeper/frontend/src/__tests__/ListingDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/ListingDetail.test.tsx
@@ -71,6 +71,11 @@ vi.mock("@/shared/store/listingsApi", () => ({
   useCreateListingExternalIdMutation: vi.fn(() => [vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })), { isLoading: false }]),
   useUpdateListingExternalIdMutation: vi.fn(() => [vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })), { isLoading: false }]),
   useDeleteListingExternalIdMutation: vi.fn(() => [vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })), { isLoading: false }]),
+  useGetChannelsQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  useGetListingChannelsQuery: vi.fn(() => ({ data: [], isLoading: false })),
+  useCreateListingChannelMutation: vi.fn(() => [vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })), { isLoading: false }]),
+  useUpdateChannelListingMutation: vi.fn(() => [vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })), { isLoading: false }]),
+  useDeleteChannelListingMutation: vi.fn(() => [vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })), { isLoading: false }]),
 }));
 
 vi.mock("@/shared/store/propertiesApi", () => ({

--- a/apps/mybookkeeper/frontend/src/__tests__/SignedLeaseStatusPicker.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/SignedLeaseStatusPicker.test.tsx
@@ -10,7 +10,8 @@
  *   ``SIGNED_LEASE_STATUS_NEXT`` map.
  * - Picking a state calls ``onChange`` with the picked value.
  */
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import SignedLeaseStatusPicker from "@/app/features/leases/SignedLeaseStatusPicker";
 
@@ -45,10 +46,11 @@ describe("SignedLeaseStatusPicker", () => {
     expect(trigger).toHaveAttribute("aria-label", "Change status from Generated");
   });
 
-  it("opens menu showing only the allowed next states for 'generated'", () => {
+  it("opens menu showing only the allowed next states for 'generated'", async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     render(<SignedLeaseStatusPicker status="generated" onChange={onChange} />);
-    fireEvent.click(screen.getByTestId("signed-lease-status-picker-trigger"));
+    await user.click(screen.getByTestId("signed-lease-status-picker-trigger"));
     // Generated -> Sent or Signed (per SIGNED_LEASE_STATUS_NEXT)
     expect(
       screen.getByTestId("signed-lease-status-picker-option-sent"),
@@ -69,10 +71,11 @@ describe("SignedLeaseStatusPicker", () => {
     ).toBeNull();
   });
 
-  it("opens menu showing 'active' as the only next state from 'signed'", () => {
+  it("opens menu showing 'active' as the only next state from 'signed'", async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     render(<SignedLeaseStatusPicker status="signed" onChange={onChange} />);
-    fireEvent.click(screen.getByTestId("signed-lease-status-picker-trigger"));
+    await user.click(screen.getByTestId("signed-lease-status-picker-trigger"));
     expect(
       screen.getByTestId("signed-lease-status-picker-option-active"),
     ).toBeInTheDocument();
@@ -81,11 +84,14 @@ describe("SignedLeaseStatusPicker", () => {
     ).toBeNull();
   });
 
-  it("calls onChange with the picked status", () => {
+  it("calls onChange with the picked status", async () => {
+    const user = userEvent.setup();
     const onChange = vi.fn();
     render(<SignedLeaseStatusPicker status="generated" onChange={onChange} />);
-    fireEvent.click(screen.getByTestId("signed-lease-status-picker-trigger"));
-    fireEvent.click(screen.getByTestId("signed-lease-status-picker-option-signed"));
+    await user.click(screen.getByTestId("signed-lease-status-picker-trigger"));
+    await user.click(
+      screen.getByTestId("signed-lease-status-picker-option-signed"),
+    );
     expect(onChange).toHaveBeenCalledWith("signed");
     expect(onChange).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## Summary

Partial cleanup of \"Pre-existing frontend unit test failures\" from TECH_DEBT.md. 25 tests recovered; TECH_DEBT entry rewritten with accurate per-file root causes for the 6 files still failing.

## Files fixed

| File | Tests fixed | Root cause |
|---|---|---|
| `ListingDetail.test.tsx` | 21 | Missing 4 channel-related RTK Query hook mocks (the original TECH_DEBT entry's guess about `tenant_ended_at` was wrong) |
| `SignedLeaseStatusPicker.test.tsx` | 3 | My regression from earlier today — Radix DropdownMenu doesn't open via `fireEvent.click`; switched to `userEvent.setup()` per project pattern |
| `LeaseAddTemplateModal.test.tsx` | 1 | Test asserted pre-#429 behavior (picker hid linked templates); flipped to assert the post-#429 regenerate flow |

## TECH_DEBT updates

- Bumped \"Last scanned\" → 2026-05-08
- Removed ListingDetail / DocumentUploadZone / Documents / useDashboardFilter / ApplicantDetail from the \"7 file\" list (organically fixed or fixed here)
- Added the actually-failing files: InviteAccept, PendingInvites (component drift), PublicInquiryForm (testid removed), TaxDocuments / Transactions / VendorDetail (text-matcher drift)
- Honest per-file root-cause notes; recommended per-file PR cadence

## MJH flag

**No effect on MJH.** All changes are MBK frontend test files + MBK TECH_DEBT.md. No shared package, no schema, no infra change.

## Test plan

- [x] All 39 tests in 3 fixed files pass locally
- [ ] CI confirms no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)