### PR TITLE
fix(mjh/resume): Enter to submit on resume-refinement chat textareas

### DIFF
--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ClarifyingPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ClarifyingPanel.tsx
@@ -1,3 +1,4 @@
+import { type KeyboardEvent } from "react";
 import { LoadingButton } from "@platform/ui";
 
 interface ClarifyingPanelProps {
@@ -15,6 +16,13 @@ export default function ClarifyingPanel({
   onSubmit,
   isPending,
 }: ClarifyingPanelProps) {
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key !== "Enter" || e.shiftKey) return;
+    e.preventDefault();
+    if (isPending || !customText.trim()) return;
+    onSubmit();
+  }
+
   return (
     <div className="space-y-2">
       <div className="rounded-md border border-amber-300/50 bg-amber-50 dark:bg-amber-950/20 p-3 text-sm">
@@ -23,8 +31,9 @@ export default function ClarifyingPanel({
       <textarea
         value={customText}
         onChange={(e) => onCustomTextChange(e.target.value)}
+        onKeyDown={handleKeyDown}
         rows={3}
-        placeholder="Type your answer — I'll use it to compose a suggestion."
+        placeholder="Type your answer — I'll use it to compose a suggestion. Enter to send, Shift+Enter for newline."
         className="w-full rounded-md border border-border bg-background p-2 text-sm"
       />
       <div className="flex justify-end">

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CustomRewritePanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CustomRewritePanel.tsx
@@ -1,3 +1,4 @@
+import { type KeyboardEvent } from "react";
 import { LoadingButton } from "@platform/ui";
 
 interface CustomRewritePanelProps {
@@ -15,13 +16,21 @@ export default function CustomRewritePanel({
   onSubmit,
   isPending,
 }: CustomRewritePanelProps) {
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key !== "Enter" || e.shiftKey) return;
+    e.preventDefault();
+    if (isPending || !customText.trim()) return;
+    onSubmit();
+  }
+
   return (
     <div className="space-y-2 border-t border-border pt-3">
       <textarea
         value={customText}
         onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
         rows={3}
-        placeholder="Type the version you want…"
+        placeholder="Type the version you want… Enter to send, Shift+Enter for newline."
         className="w-full rounded-md border border-border bg-background p-2 text-sm"
       />
       <div className="flex gap-2 justify-end">


### PR DESCRIPTION
## Summary

The two textareas on \`/resume\` (\`ClarifyingPanel\` for the "Submit answer" path and \`CustomRewritePanel\` for "Use my version") now submit on Enter. Shift+Enter still inserts a newline, matching standard chat-input convention.

\`onKeyDown\` handler:
- \`Enter\` (without Shift) → \`preventDefault\` + call \`onSubmit\`
- \`Shift+Enter\` → default behaviour (newline)
- Empty trimmed text or in-flight request → suppress submit (matches the existing button \`disabled\` rule)

## Test plan

- [ ] Type "i left it out in order to keep my resume 1 page" + Enter → submits without clicking the button
- [ ] Shift+Enter inserts a newline as before
- [ ] Empty field + Enter → does nothing
- [ ] Mid-flight (button shows spinner) + Enter → does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)