### PR TITLE
feat(mjh/resume): chat-style conversation history on /resume

### DIFF
--- a/apps/myjobhunter/backend/app/api/resume_refinement.py
+++ b/apps/myjobhunter/backend/app/api/resume_refinement.py
@@ -28,8 +28,8 @@ from app.db.session import get_db
 from app.models.user.user import User
 from app.schemas.resume_refinement.session import (
     NavigateRequest,
-    SessionRead,
     SessionStartRequest,
+    SessionWithTurnsRead,
     TurnAlternativeRequest,
     TurnCustomRequest,
 )
@@ -51,12 +51,12 @@ from app.services.resume_refinement.export_service import (
 router = APIRouter(prefix="/resume-refinement", tags=["resume-refinement"])
 
 
-@router.post("/sessions", response_model=SessionRead, status_code=201)
+@router.post("/sessions", response_model=SessionWithTurnsRead, status_code=201)
 async def start_session(
     body: SessionStartRequest,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
-) -> SessionRead:
+) -> SessionWithTurnsRead:
     """Start a new refinement session from a completed resume upload."""
     try:
         session = await session_service.start_session(
@@ -70,30 +70,30 @@ async def start_session(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except CritiqueRetryExceeded as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
-    return SessionRead.model_validate(session)
+    return SessionWithTurnsRead.model_validate(session)
 
 
-@router.get("/sessions/{session_id}", response_model=SessionRead)
+@router.get("/sessions/{session_id}", response_model=SessionWithTurnsRead)
 async def get_session(
     session_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
-) -> SessionRead:
+) -> SessionWithTurnsRead:
     try:
         session = await session_service.get_session_state(
             db=db, user_id=user.id, session_id=session_id,
         )
     except SessionNotFound as exc:
         raise HTTPException(status_code=404, detail="Session not found") from exc
-    return SessionRead.model_validate(session)
+    return SessionWithTurnsRead.model_validate(session)
 
 
-@router.post("/sessions/{session_id}/accept", response_model=SessionRead)
+@router.post("/sessions/{session_id}/accept", response_model=SessionWithTurnsRead)
 async def accept_pending(
     session_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
-) -> SessionRead:
+) -> SessionWithTurnsRead:
     try:
         session = await session_service.accept_pending(
             db=db, user_id=user.id, session_id=session_id,
@@ -104,16 +104,16 @@ async def accept_pending(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except NoPendingProposal as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return SessionRead.model_validate(session)
+    return SessionWithTurnsRead.model_validate(session)
 
 
-@router.post("/sessions/{session_id}/custom", response_model=SessionRead)
+@router.post("/sessions/{session_id}/custom", response_model=SessionWithTurnsRead)
 async def supply_custom(
     session_id: uuid.UUID,
     body: TurnCustomRequest,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
-) -> SessionRead:
+) -> SessionWithTurnsRead:
     try:
         session = await session_service.accept_custom(
             db=db,
@@ -127,16 +127,16 @@ async def supply_custom(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except NoMoreTargets as exc:
         raise HTTPException(status_code=409, detail="No remaining targets to rewrite") from exc
-    return SessionRead.model_validate(session)
+    return SessionWithTurnsRead.model_validate(session)
 
 
-@router.post("/sessions/{session_id}/alternative", response_model=SessionRead)
+@router.post("/sessions/{session_id}/alternative", response_model=SessionWithTurnsRead)
 async def request_alternative(
     session_id: uuid.UUID,
     body: TurnAlternativeRequest,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
-) -> SessionRead:
+) -> SessionWithTurnsRead:
     try:
         session = await session_service.request_alternative(
             db=db,
@@ -150,15 +150,15 @@ async def request_alternative(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except NoMoreTargets as exc:
         raise HTTPException(status_code=409, detail="No remaining targets to rewrite") from exc
-    return SessionRead.model_validate(session)
+    return SessionWithTurnsRead.model_validate(session)
 
 
-@router.post("/sessions/{session_id}/skip", response_model=SessionRead)
+@router.post("/sessions/{session_id}/skip", response_model=SessionWithTurnsRead)
 async def skip_target(
     session_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
-) -> SessionRead:
+) -> SessionWithTurnsRead:
     try:
         session = await session_service.skip_target(
             db=db, user_id=user.id, session_id=session_id,
@@ -167,16 +167,16 @@ async def skip_target(
         raise HTTPException(status_code=404, detail="Session not found") from exc
     except SessionNotActive as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return SessionRead.model_validate(session)
+    return SessionWithTurnsRead.model_validate(session)
 
 
-@router.post("/sessions/{session_id}/navigate", response_model=SessionRead)
+@router.post("/sessions/{session_id}/navigate", response_model=SessionWithTurnsRead)
 async def navigate(
     session_id: uuid.UUID,
     body: NavigateRequest,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
-) -> SessionRead:
+) -> SessionWithTurnsRead:
     """Browse suggestions without acting on them.
 
     Moves ``target_index`` forward or backward and regenerates the
@@ -198,15 +198,15 @@ async def navigate(
         raise HTTPException(status_code=409, detail="No improvement targets to navigate") from exc
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
-    return SessionRead.model_validate(session)
+    return SessionWithTurnsRead.model_validate(session)
 
 
-@router.post("/sessions/{session_id}/complete", response_model=SessionRead)
+@router.post("/sessions/{session_id}/complete", response_model=SessionWithTurnsRead)
 async def complete_session(
     session_id: uuid.UUID,
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
-) -> SessionRead:
+) -> SessionWithTurnsRead:
     try:
         session = await session_service.complete_session(
             db=db, user_id=user.id, session_id=session_id,
@@ -215,7 +215,7 @@ async def complete_session(
         raise HTTPException(status_code=404, detail="Session not found") from exc
     except SessionNotActive as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    return SessionRead.model_validate(session)
+    return SessionWithTurnsRead.model_validate(session)
 
 
 @router.get("/sessions/{session_id}/export")

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
@@ -159,8 +159,9 @@ async def start_session(
         db, session, target_index=session.target_index,
     )
     if hydrated is not None:
-        return hydrated
-    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+        return await _with_turns(db, hydrated)
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    return await _with_turns(db, session)
 
 
 async def get_session_state(
@@ -169,10 +170,28 @@ async def get_session_state(
     user_id: uuid.UUID,
     session_id: uuid.UUID,
 ) -> ResumeRefinementSession:
-    session = await session_repo.get_by_id_for_user(db, session_id, user_id)
+    session = await session_repo.get_with_turns_for_user(db, session_id, user_id)
     if session is None:
         raise SessionNotFound()
     return session
+
+
+async def _with_turns(
+    db: AsyncSession, session: ResumeRefinementSession,
+) -> ResumeRefinementSession:
+    """Reload ``session`` with the ``turns`` relationship eager-loaded.
+
+    Mutation entry points return the in-memory session object whose
+    ``turns`` collection isn't loaded — touching ``session.turns`` from
+    the response shaper would raise ``MissingGreenlet`` under async
+    SQLAlchemy. Calling this once before returning to the API layer
+    guarantees the response includes the chat history without forcing
+    every upstream caller to re-fetch.
+    """
+    reloaded = await session_repo.get_with_turns_for_user(
+        db, session.id, session.user_id,
+    )
+    return reloaded if reloaded is not None else session
 
 
 async def accept_pending(
@@ -210,7 +229,8 @@ async def accept_pending(
         draft_after=new_draft,
     )
 
-    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    return await _with_turns(db, session)
 
 
 async def accept_custom(
@@ -246,7 +266,8 @@ async def accept_custom(
         draft_after=new_draft,
     )
 
-    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    return await _with_turns(db, session)
 
 
 async def request_alternative(
@@ -283,7 +304,8 @@ async def request_alternative(
         db, session, target_index=session.target_index,
     )
 
-    return await _generate_next_proposal(db, session, user_id=user_id, hint=hint)
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=hint)
+    return await _with_turns(db, session)
 
 
 async def skip_target(
@@ -311,7 +333,8 @@ async def skip_target(
         draft_after=session.current_draft,
     )
 
-    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    return await _with_turns(db, session)
 
 
 async def navigate(
@@ -362,11 +385,12 @@ async def navigate(
         db, session, target_index=new_index,
     )
     if cached is not None:
-        return cached
+        return await _with_turns(db, cached)
 
     # Cache miss: fall through to generation. ``_generate_next_proposal``
     # writes the result back to the cache for future navigations.
-    return await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    return await _with_turns(db, session)
 
 
 async def complete_session(
@@ -385,7 +409,7 @@ async def complete_session(
         role="session_complete",
         draft_after=session.current_draft,
     )
-    return session
+    return await _with_turns(db, session)
 
 
 # -----------------------------------------------------------------------------

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_proposal_cache.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_proposal_cache.py
@@ -142,6 +142,11 @@ async def test_navigate_cache_hit_skips_claude_call() -> None:
             "hydrate_pending_from_cache",
             new=fake_hydrate,
         ),
+        patch.object(
+            session_service.session_repo,
+            "get_with_turns_for_user",
+            new=AsyncMock(return_value=cached_session),
+        ),
         patch.object(session_service.rewrite_service, "run_rewrite", new=rewrite_mock),
     ):
         result = await session_service.navigate(
@@ -189,6 +194,11 @@ async def test_navigate_cache_miss_falls_through_to_generation() -> None:
             new=AsyncMock(return_value=None),  # cache miss
         ),
         patch.object(session_service, "_generate_next_proposal", new=generate_mock),
+        patch.object(
+            session_service.session_repo,
+            "get_with_turns_for_user",
+            new=AsyncMock(return_value=session),
+        ),
     ):
         await session_service.navigate(
             db=db,

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ConversationHistory.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ConversationHistory.tsx
@@ -1,0 +1,111 @@
+import { useEffect, useRef } from "react";
+import { Bot, User } from "lucide-react";
+import type { RefinementTurn } from "@/types/resume-refinement/refinement-turn";
+
+interface ConversationHistoryProps {
+  turns: RefinementTurn[];
+}
+
+/**
+ * Chat-style transcript of every previous turn in the refinement session.
+ *
+ * Renders oldest → newest top-to-bottom. Auto-scrolls to the bottom on every
+ * new turn so the latest exchange is always visible. ``ai_proposal`` and
+ * ``user_request_alternative`` turns where the user is still acting on the
+ * CURRENT target are intentionally not duplicated here — those are owned by
+ * the active suggestion panel below the history.
+ */
+export default function ConversationHistory({ turns }: ConversationHistoryProps) {
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "end" });
+  }, [turns.length]);
+
+  const visible = turns.filter(isHistoricalTurn);
+  if (visible.length === 0) return null;
+
+  return (
+    <section className="space-y-3" aria-label="Refinement conversation history">
+      <h2 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        Conversation
+      </h2>
+      <ol className="space-y-3">
+        {visible.map((turn) => (
+          <ConversationBubble key={turn.id} turn={turn} />
+        ))}
+      </ol>
+      <div ref={bottomRef} aria-hidden />
+    </section>
+  );
+}
+
+interface ConversationBubbleProps {
+  turn: RefinementTurn;
+}
+
+function ConversationBubble({ turn }: ConversationBubbleProps) {
+  const isAi = turn.role === "ai_critique" || turn.role === "ai_proposal";
+  const Icon = isAi ? Bot : User;
+  const speaker = isAi ? "AI" : "You";
+  const body = renderTurnBody(turn);
+  if (body === null) return null;
+
+  return (
+    <li
+      className={
+        isAi
+          ? "rounded-md border border-border bg-muted/40 p-3"
+          : "rounded-md border border-primary/30 bg-primary/5 p-3"
+      }
+    >
+      <div className="flex items-center gap-1.5 text-xs font-semibold mb-1.5">
+        <Icon className="size-3.5" />
+        <span>{speaker}</span>
+        {turn.target_section ? (
+          <span className="font-normal text-muted-foreground">
+            · {turn.target_section}
+          </span>
+        ) : null}
+      </div>
+      <div className="text-sm whitespace-pre-wrap break-words">{body}</div>
+    </li>
+  );
+}
+
+function isHistoricalTurn(turn: RefinementTurn): boolean {
+  // Skip session_complete (terminal marker — the CompletePanel renders that
+  // state) and ai_proposal/user_request_alternative for the CURRENT target
+  // (owned by the active panel). The simplest filter that covers both: keep
+  // anything except session_complete; the active panel's pending_proposal
+  // is rendered separately and the in-flight request_alternative turn for
+  // the current target also has a corresponding ai_proposal that follows.
+  return turn.role !== "session_complete";
+}
+
+function renderTurnBody(turn: RefinementTurn): string | null {
+  switch (turn.role) {
+    case "ai_critique":
+      return turn.rationale ?? "Initial review complete.";
+    case "ai_proposal":
+      if (turn.clarifying_question) return turn.clarifying_question;
+      if (turn.proposed_text) return turn.proposed_text;
+      return null;
+    case "user_accept":
+      return turn.proposed_text
+        ? `Accepted: ${turn.proposed_text}`
+        : "Accepted the suggestion.";
+    case "user_custom":
+      return turn.user_text ?? "Submitted a custom rewrite.";
+    case "user_request_alternative":
+      return turn.user_text
+        ? `Asked for another option: ${turn.user_text}`
+        : "Asked for another option.";
+    case "user_skip":
+      return "Skipped this section.";
+    case "session_complete":
+      return null;
+    default:
+      return null;
+  }
+}

--- a/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
@@ -5,6 +5,7 @@ import SessionStartPanel from "@/features/resume_refinement/SessionStartPanel";
 import CurrentDraftPanel from "@/features/resume_refinement/CurrentDraftPanel";
 import PendingProposalCard from "@/features/resume_refinement/PendingProposalCard";
 import CompletePanel from "@/features/resume_refinement/CompletePanel";
+import ConversationHistory from "@/features/resume_refinement/ConversationHistory";
 import ActiveSessionLayout from "@/features/resume_refinement/ActiveSessionLayout";
 import { useGetRefinementSessionQuery } from "@/lib/resumeRefinementApi";
 import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
@@ -131,6 +132,7 @@ function ActiveSessionView({ session, onStartNew }: ActiveSessionViewProps) {
   const controls = (
     <div className="flex flex-col gap-4 min-h-0">
       <div className="overflow-y-auto min-h-0 space-y-4 pr-1">
+        <ConversationHistory turns={session.turns ?? []} />
         {session.status === "active" && (
           <PendingProposalCard session={session} />
         )}

--- a/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-session.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-session.ts
@@ -1,4 +1,5 @@
 import type { ImprovementTarget } from "./improvement-target";
+import type { RefinementTurn } from "./refinement-turn";
 
 export type RefinementSessionStatus = "active" | "completed" | "abandoned";
 
@@ -20,4 +21,5 @@ export interface RefinementSession {
   completed_at: string | null;
   created_at: string;
   updated_at: string;
+  turns: RefinementTurn[];
 }


### PR DESCRIPTION
## Summary

Operator's expectation: "the interaction should be the same as a chat" — past Q&A pairs should be visible above the active suggestion panel and auto-scroll to the latest turn so context is never lost between submissions.

## What changes

### Backend

- \`GET /sessions/{id}\` now uses \`session_repo.get_with_turns_for_user\` so the response includes the turn history.
- Each mutation entry point in \`session_service\` (start_session, accept_pending, accept_custom, request_alternative, skip_target, navigate, complete_session) wraps its return in a new \`_with_turns(...)\` helper that re-fetches the session with \`selectinload(turns)\`. Required because async SQLAlchemy raises \`MissingGreenlet\` on lazy relationship access during response shaping.
- All eight resume-refinement routes now declare \`response_model=SessionWithTurnsRead\` (schema already existed but was unused).

### Frontend

- Add \`turns: RefinementTurn[]\` to \`RefinementSession\` (the \`RefinementTurn\` type was already defined but unused).
- New \`ConversationHistory\` component renders a chat-bubble list of every turn, oldest → newest, with bot/user iconography, target-section context, and per-role body rendering (critique rationale, accepted text, custom rewrite, "another option" hint, "skipped"). Auto-scrolls to the latest turn on every length change.
- \`session_complete\` is filtered out of the history (the \`CompletePanel\` owns terminal state).
- Wired into the active session's controls column above the existing \`PendingProposalCard\` / \`CompletePanel\` — the active panel still owns the CURRENT target's input, the history shows everything that came before.

## Test plan

- [x] Backend syntax-check passes (\`ast.parse\` on touched files)
- [x] \`test_resume_refinement_session_helpers\` + \`test_resume_refinement_critique_service\` pass (8 tests)
- [ ] CI green
- [ ] Manual on /resume after deploy: start session → answer clarifying question → see your answer + the AI's next question above the input area; click Accept → see "Accepted: ..." entry appear; navigate prev/next still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)