### PR TITLE
fix(mbk/applicants): allow contract dates to be explicitly nulled via PATCH

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -1,7 +1,7 @@
 # Tech Debt
 
 > Last scanned: 2026-05-08
-> Issues: 0 critical, 6 high, 6 medium (1 deferred + 5 active), 0 low
+> Issues: 0 critical, 6 high, 5 medium (1 deferred + 4 active), 0 low
 
 ## High
 
@@ -39,11 +39,8 @@
 
 ---
 
-### [Contract dates] Partial-update cannot explicitly null a date field
-**Effort:** S
-**Location:** `apps/mybookkeeper/backend/app/services/applicants/applicant_contract_service.py` — `update_contract_dates()`, comment at line 84-91; `apps/mybookkeeper/backend/app/schemas/applicants/applicant_update_request.py`
-**Problem:** The PATCH schema uses `None` as the default for both `contract_start` and `contract_end`, making it impossible to distinguish "field not sent" from "field explicitly set to null". The service treats `None` as "keep existing value", which is the correct UX for the inline date picker (users rarely want to null a date). However, if a future UX needs a "clear date" action, the API cannot express it without a schema change (e.g., using `UNSET` sentinel or a separate `clear_contract_start: bool` field).
-**Recommendation:** When a "clear date" UX is needed, extend the request schema to use `Annotated[date | None, Field(default=UNSET)]` with a custom sentinel, or add a separate `clear_fields: list[str]` parameter. Document this limitation in the schema docstring until then.
+### ~~[Contract dates] Partial-update cannot explicitly null a date field~~ RESOLVED
+**Resolved:** PR fix/mbk-contract-dates-nullable-patch (2026-05-08) — route now inspects `payload.model_fields_set` and passes per-field `*_sent` booleans to the service. Three caller intents are now distinguishable: omit → preserve, send date → set, send `null` → clear. New service test `test_explicit_null_clears_contract_end` covers the previously-impossible path.
 
 ---
 

--- a/apps/mybookkeeper/backend/app/api/applicants.py
+++ b/apps/mybookkeeper/backend/app/api/applicants.py
@@ -160,9 +160,15 @@ async def update_applicant(
 ) -> ApplicantDetailResponse:
     """Update an applicant's contract dates.
 
-    Both ``contract_start`` and ``contract_end`` are optional. Omitting a
-    field means "leave it unchanged" — the service resolves the existing
-    value from the DB and writes the merged result.
+    Both ``contract_start`` and ``contract_end`` are optional. Three
+    semantically-distinct caller intents are supported:
+    - omit a field → preserve the existing DB value (partial update).
+    - send a date → set the field to that date.
+    - send ``null`` → clear the field (set the DB column to NULL).
+
+    The route inspects ``payload.model_fields_set`` to distinguish "omitted"
+    from "explicitly null"; the service receives both the value and a
+    ``*_sent`` boolean per field.
 
     Errors:
         404 — applicant not found in the calling tenant.
@@ -170,6 +176,7 @@ async def update_applicant(
         422 — ``contract_end`` is not after ``contract_start`` when both
               are provided, or extra fields were sent.
     """
+    sent = payload.model_fields_set
     try:
         return await applicant_contract_service.update_contract_dates(
             organization_id=ctx.organization_id,
@@ -177,6 +184,8 @@ async def update_applicant(
             applicant_id=applicant_id,
             contract_start=payload.contract_start,
             contract_end=payload.contract_end,
+            contract_start_sent="contract_start" in sent,
+            contract_end_sent="contract_end" in sent,
         )
     except LookupError as exc:
         raise HTTPException(status_code=404, detail="Applicant not found") from exc

--- a/apps/mybookkeeper/backend/app/services/applicants/applicant_contract_service.py
+++ b/apps/mybookkeeper/backend/app/services/applicants/applicant_contract_service.py
@@ -45,16 +45,22 @@ async def update_contract_dates(
     applicant_id: uuid.UUID,
     contract_start: _dt.date | None,
     contract_end: _dt.date | None,
+    contract_start_sent: bool,
+    contract_end_sent: bool,
 ) -> ApplicantDetailResponse:
     """Update contract dates for an applicant.
 
-    ``contract_start`` and ``contract_end`` are the values from the request
-    (``None`` means "set the field to NULL", not "leave it unchanged").
-    Partial updates — where only one date is sent — resolve by merging with
-    the current DB value inside this function before writing.
+    Each field has BOTH a value and a ``*_sent`` boolean. The pair lets the
+    service distinguish three caller intents:
 
-    The route passes the raw Pydantic-parsed values; this function is
-    responsible for the merge, the lock check, the DB write, and the event.
+    - ``contract_start_sent=False`` → field omitted from the request; preserve
+      the existing DB value (partial-update semantics).
+    - ``contract_start_sent=True, contract_start=<date>`` → set to that date.
+    - ``contract_start_sent=True, contract_start=None`` → explicitly clear
+      the field (set DB column to NULL).
+
+    The route is responsible for inspecting ``payload.model_fields_set`` and
+    passing the booleans; the service stays Pydantic-agnostic.
 
     Raises:
         LookupError: applicant not found for (organization_id, user_id).
@@ -81,19 +87,11 @@ async def update_contract_dates(
         old_start = _iso_or_none(applicant.contract_start)
         old_end = _iso_or_none(applicant.contract_end)
 
-        # Resolve final values: None from the request means "set to NULL".
-        # The request schema uses None as the absent sentinel, so we must
-        # distinguish "not sent" from "explicitly set to null". Since we
-        # receive Python None for both, we treat None as "use existing" here
-        # to support partial updates (the most common case is "only change
-        # contract_end"). To explicitly null a date, the caller would need to
-        # send a different signal; for now partial-update semantics is the
-        # correct UX (setting a date to null from the date picker is unusual).
         resolved_start = (
-            contract_start if contract_start is not None else applicant.contract_start
+            contract_start if contract_start_sent else applicant.contract_start
         )
         resolved_end = (
-            contract_end if contract_end is not None else applicant.contract_end
+            contract_end if contract_end_sent else applicant.contract_end
         )
 
         await applicant_repo.update_contract_dates(

--- a/apps/mybookkeeper/backend/tests/test_applicant_contract_service.py
+++ b/apps/mybookkeeper/backend/tests/test_applicant_contract_service.py
@@ -102,6 +102,8 @@ async def test_happy_path_both_dates_updated(db: AsyncSession) -> None:
             applicant_id=applicant_id,
             contract_start=start,
             contract_end=end,
+            contract_start_sent=True,
+            contract_end_sent=True,
         )
 
     assert result.contract_start == start
@@ -167,6 +169,8 @@ async def test_partial_update_only_contract_end(db: AsyncSession) -> None:
             applicant_id=applicant_id,
             contract_start=None,  # not in the request → keep existing
             contract_end=new_end,
+            contract_start_sent=False,
+            contract_end_sent=True,
         )
 
     # contract_start must be preserved.
@@ -189,6 +193,79 @@ async def test_partial_update_only_contract_end(db: AsyncSession) -> None:
     assert len(change_events) == 1
     assert change_events[0].payload["to"]["contract_start"] == "2026-05-01"
     assert change_events[0].payload["to"]["contract_end"] == "2026-11-30"
+
+
+@pytest.mark.asyncio
+async def test_explicit_null_clears_contract_end(db: AsyncSession) -> None:
+    """contract_end_sent=True with contract_end=None → DB column set to NULL.
+
+    Verifies the audit fix from 2026-05-08 — previously sending ``null`` for
+    a date field was indistinguishable from omitting it, so the field could
+    only be set, never cleared.
+    """
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    existing_start = _dt.date(2026, 5, 1)
+    existing_end = _dt.date(2026, 11, 30)
+
+    applicant = _make_applicant(
+        db,
+        org_id=org_id,
+        user_id=user_id,
+        stage="approved",
+        contract_start=existing_start,
+        contract_end=existing_end,
+    )
+    await db.flush()
+    applicant_id = applicant.id
+
+    with patch(
+        "app.services.applicants.applicant_contract_service.unit_of_work",
+        _make_fake_uow(db),
+    ), patch(
+        "app.services.applicants.applicant_service.get_applicant",
+        new_callable=AsyncMock,
+    ) as mock_get:
+        from app.schemas.applicants.applicant_detail_response import ApplicantDetailResponse
+        now = _dt.datetime.now(_dt.timezone.utc)
+        mock_get.return_value = ApplicantDetailResponse(
+            id=applicant_id,
+            organization_id=org_id,
+            user_id=user_id,
+            stage="approved",
+            contract_start=existing_start,
+            contract_end=None,
+            created_at=now,
+            updated_at=now,
+        )
+
+        result = await update_contract_dates(
+            organization_id=org_id,
+            user_id=user_id,
+            applicant_id=applicant_id,
+            contract_start=None,
+            contract_end=None,
+            contract_start_sent=False,  # not in request → preserve
+            contract_end_sent=True,    # in request, value=None → clear
+        )
+
+    assert result.contract_start == existing_start
+    assert result.contract_end is None
+
+    await db.refresh(applicant)
+    assert applicant.contract_start == existing_start
+    assert applicant.contract_end is None
+
+    events_result = await db.execute(
+        select(ApplicantEvent).where(ApplicantEvent.applicant_id == applicant_id)
+    )
+    change_events = [
+        e for e in events_result.scalars().all()
+        if e.event_type == "contract_dates_changed"
+    ]
+    assert len(change_events) == 1
+    assert change_events[0].payload["from"]["contract_end"] == "2026-11-30"
+    assert change_events[0].payload["to"]["contract_end"] is None
 
 
 @pytest.mark.asyncio
@@ -220,6 +297,8 @@ async def test_lock_check_lease_signed_raises(db: AsyncSession) -> None:
             applicant_id=applicant_id,
             contract_start=_dt.date(2026, 4, 1),
             contract_end=_dt.date(2026, 9, 30),
+            contract_start_sent=True,
+            contract_end_sent=True,
         )
 
     # Dates must be unchanged — no partial write should have occurred.
@@ -250,6 +329,8 @@ async def test_unknown_applicant_raises_lookup_error(db: AsyncSession) -> None:
             applicant_id=uuid.uuid4(),
             contract_start=_dt.date(2026, 6, 1),
             contract_end=_dt.date(2026, 12, 31),
+            contract_start_sent=True,
+            contract_end_sent=True,
         )
 
 
@@ -287,6 +368,8 @@ async def test_event_actor_is_host(db: AsyncSession) -> None:
             applicant_id=applicant_id,
             contract_start=_dt.date(2026, 6, 1),
             contract_end=_dt.date(2026, 12, 31),
+            contract_start_sent=True,
+            contract_end_sent=True,
         )
 
     events_result = await db.execute(


### PR DESCRIPTION
## Summary

Closes a long-standing TECH_DEBT entry (originally flagged 2026-05-07). The PATCH endpoint couldn't distinguish \"field omitted\" from \"field set to null\" — both arrived as ``None``. Now uses Pydantic's ``model_fields_set`` so the route passes ``contract_start_sent`` / ``contract_end_sent`` booleans to the service alongside the values.

## Three caller intents now unambiguous

| Request | ``*_sent`` | Value | Result |
|---|---|---|---|
| Omit field | ``False`` | (any) | Preserve existing DB value |
| Send a date | ``True`` | ``2026-08-31`` | Set to that date |
| Send ``null`` | ``True`` | ``None`` | Clear (DB column → NULL) |

## Tests

- 4 existing service tests updated to pass new ``*_sent`` args
- New ``test_explicit_null_clears_contract_end`` covers the previously-impossible \"clear\" path
- 15 total tests pass locally

## MJH impact

**None.** ``apps/myjobhunter/`` has no applicants domain. No shared package code, no migration, no infra. MBK-isolated change.

## TECH_DEBT updates

- Marked ``[Contract dates] Partial-update cannot explicitly null a date field`` as RESOLVED
- Counts: medium 6 → 5 (1 deferred + 4 active)

🤖 Generated with [Claude Code](https://claude.com/claude-code)