### PR TITLE
fix(mjh/resume): feed prior conversation into every rewrite call

### DIFF
--- a/apps/myjobhunter/backend/app/services/extraction/prompts/resume_rewrite_prompt.py
+++ b/apps/myjobhunter/backend/app/services/extraction/prompts/resume_rewrite_prompt.py
@@ -15,10 +15,20 @@ RESUME_REWRITE_PROMPT = """\
 You are a resume coach. The user is iterating on a resume one bullet at a \
 time. You are given:
 
-1. The full resume markdown for context.
-2. A single target identified by an earlier critique pass.
-3. (Optional) a hint from the user — a free-form nudge like \
-"make it more concise" or "emphasize technical leadership".
+1. (Optional) the prior conversation in this refinement session — past \
+clarifying questions you asked, the user's answers, custom rewrites \
+they wrote in their own voice, and any hints they've given you. \
+TREAT THESE AS BINDING SESSION CONSTRAINTS. If the user has said "keep \
+the resume to one page" or "I left this section short on purpose", \
+respect that across every subsequent target. If the user has shown \
+their voice through custom rewrites, match that voice. Never re-ask \
+a question the user has already answered earlier in the session.
+2. The full resume markdown for context.
+3. A single target identified by an earlier critique pass.
+4. (Optional) a hint from the user — a free-form nudge like \
+"make it more concise" or "emphasize technical leadership". The hint \
+applies to THIS rewrite specifically; the prior conversation applies \
+to the whole session.
 
 Your job: produce ONE rewrite of the target, OR (if the source is too \
 ambiguous to rewrite without inventing facts) ask ONE clarifying question.

--- a/apps/myjobhunter/backend/app/services/resume_refinement/rewrite_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/rewrite_service.py
@@ -27,16 +27,27 @@ async def run_rewrite(
     hint: str | None,
     user_id: uuid.UUID,
     session_id: uuid.UUID,
+    prior_context: list[dict] | None = None,
 ) -> dict:
     """Run one rewrite pass.
 
     Args:
         resume_markdown: The current resume draft (full context).
         target: One element from ``improvement_targets``.
-        hint: Optional user nudge for the regeneration ("more concise",
-            "emphasize technical leadership"). None for the first proposal.
+        hint: Optional user nudge for THIS regeneration ("more concise",
+            "emphasize technical leadership"). None for the first
+            proposal. Distinct from ``prior_context`` — the hint is the
+            user's intent for THIS turn; ``prior_context`` is the
+            session-level history of stated preferences.
         user_id: Scopes the extraction_log row.
         session_id: Used as ``context_id``.
+        prior_context: Optional list of previous-turn distillations for
+            session-level memory. Each entry is
+            ``{"kind": str, "section": str | None, "text": str}``.
+            Passed straight into the user content as a "Prior
+            conversation" block so Claude can honour user-stated
+            constraints across targets (e.g. "keep it to one page",
+            "I left X out for length").
 
     Returns:
         Dict with shape:
@@ -55,7 +66,7 @@ async def run_rewrite(
         ``rewritten_text`` for traceability but should NOT be applied
         to the draft.
     """
-    user_content = _build_user_content(resume_markdown, target, hint)
+    user_content = _build_user_content(resume_markdown, target, hint, prior_context)
 
     result = await call_claude_with_meta(
         system_prompt=RESUME_REWRITE_PROMPT,
@@ -129,6 +140,7 @@ def _build_user_content(
     resume_markdown: str,
     target: dict,
     hint: str | None,
+    prior_context: list[dict] | None = None,
 ) -> str:
     target_blob = json.dumps(
         {
@@ -141,7 +153,21 @@ def _build_user_content(
         indent=2,
     )
 
-    parts = [
+    parts: list[str] = []
+    if prior_context:
+        rendered = _render_prior_context(prior_context)
+        if rendered:
+            parts.extend([
+                "Prior conversation in this refinement session "
+                "(oldest first — apply any user-stated constraints to this rewrite):",
+                "",
+                rendered,
+                "",
+                "----",
+                "",
+            ])
+
+    parts.extend([
         "Resume markdown (full context):",
         "",
         resume_markdown,
@@ -151,10 +177,22 @@ def _build_user_content(
         "Target to rewrite:",
         "",
         target_blob,
-    ]
+    ])
     if hint:
         parts.extend(["", "----", "", f"User hint for the regeneration: {hint}"])
     return "\n".join(parts)
+
+
+def _render_prior_context(entries: list[dict]) -> str:
+    lines: list[str] = []
+    for entry in entries:
+        kind = entry.get("kind", "")
+        section = entry.get("section") or "(general)"
+        text = (entry.get("text") or "").strip()
+        if not text:
+            continue
+        lines.append(f"- [{kind}] for {section}: {text}")
+    return "\n".join(lines)
 
 
 def _clarify_for_hallucination(missing: list[str]) -> str:

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
@@ -488,6 +488,58 @@ async def _load_active(
     return session
 
 
+def _build_prior_context(turns: list[Any]) -> list[dict[str, Any]]:
+    """Distill turn rows into the lightweight ``prior_context`` shape the
+    rewrite service feeds into Claude's user content.
+
+    Filters to the entries that carry signal Claude needs across targets:
+
+    - ``ai_critique`` rationale — the framing of the whole session
+    - ``ai_proposal`` clarifying questions — what was already asked
+    - ``user_custom`` text — the user's voice / preferred phrasing
+    - ``user_request_alternative`` hint — the user's stated nudges
+
+    Skips ``ai_proposal`` proposed_text (already reflected in
+    current_draft if accepted), ``user_accept`` (same), ``user_skip``
+    (no info), and ``session_complete`` (terminal). Keeping the list
+    narrow controls token cost — full transcripts grow linearly with
+    target count and would cost ~2x by the end of a 14-target session.
+    """
+    out: list[dict[str, Any]] = []
+    for turn in turns:
+        role = turn.role
+        section = turn.target_section
+        if role == "ai_critique":
+            text = (turn.rationale or "").strip()
+            if text:
+                out.append({"kind": "ai_critique", "section": None, "text": text})
+        elif role == "ai_proposal":
+            text = (turn.clarifying_question or "").strip()
+            if text:
+                out.append({
+                    "kind": "ai_clarification_question",
+                    "section": section,
+                    "text": text,
+                })
+        elif role == "user_custom":
+            text = (turn.user_text or "").strip()
+            if text:
+                out.append({
+                    "kind": "user_custom_rewrite",
+                    "section": section,
+                    "text": text,
+                })
+        elif role == "user_request_alternative":
+            text = (turn.user_text or "").strip()
+            if text:
+                out.append({
+                    "kind": "user_hint",
+                    "section": section,
+                    "text": text,
+                })
+    return out
+
+
 def _current_target(session: ResumeRefinementSession) -> dict | None:
     targets = session.improvement_targets or []
     if session.target_index >= len(targets):
@@ -521,6 +573,9 @@ async def _generate_next_proposal(
         await db.refresh(session)
         return session
 
+    prior_turns = await turn_repo.list_for_session(db, session.id)
+    prior_context = _build_prior_context(prior_turns)
+
     try:
         rewrite = await rewrite_service.run_rewrite(
             resume_markdown=session.current_draft,
@@ -528,6 +583,7 @@ async def _generate_next_proposal(
             hint=hint,
             user_id=user_id,
             session_id=session.id,
+            prior_context=prior_context,
         )
     except Exception as exc:  # noqa: BLE001 — graceful-degrade for the iteration loop
         # Don't fail the user's action if Claude is flaky. Leave pending
@@ -611,6 +667,13 @@ async def _prefetch_all_proposals(
     semaphore = asyncio.Semaphore(_PREFETCH_CONCURRENCY)
     current_draft = session.current_draft
 
+    # Prefetch fires right after the critique pass appends the
+    # ai_critique turn, so prior_context here will contain at most the
+    # critique rationale. Computing it once lets all parallel rewrites
+    # share the same session framing.
+    prior_turns = await turn_repo.list_for_session(db, session.id)
+    prior_context = _build_prior_context(prior_turns)
+
     async def _one(target_index: int, target: dict[str, Any]) -> dict[str, Any] | None:
         async with semaphore:
             try:
@@ -620,6 +683,7 @@ async def _prefetch_all_proposals(
                     hint=None,
                     user_id=user_id,
                     session_id=session.id,
+                    prior_context=prior_context,
                 )
             except Exception as exc:  # noqa: BLE001 — graceful per-target degrade
                 logger.warning(

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_proposal_cache.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_proposal_cache.py
@@ -237,6 +237,11 @@ async def test_prefetch_writes_each_target_to_cache() -> None:
             "cache_proposal",
             new=fake_cache_proposal,
         ),
+        patch.object(
+            session_service.turn_repo,
+            "list_for_session",
+            new=AsyncMock(return_value=[]),
+        ),
     ):
         await session_service._prefetch_all_proposals(
             db, session, user_id=session.user_id,
@@ -285,6 +290,11 @@ async def test_prefetch_one_target_failure_does_not_block_others() -> None:
             session_service.session_repo,
             "cache_proposal",
             new=fake_cache_proposal,
+        ),
+        patch.object(
+            session_service.turn_repo,
+            "list_for_session",
+            new=AsyncMock(return_value=[]),
         ),
     ):
         result = await session_service._prefetch_all_proposals(
@@ -340,6 +350,11 @@ async def test_prefetch_caps_in_flight_claude_calls() -> None:
             session_service.session_repo,
             "cache_proposal",
             new=fake_cache_proposal,
+        ),
+        patch.object(
+            session_service.turn_repo,
+            "list_for_session",
+            new=AsyncMock(return_value=[]),
         ),
     ):
         await session_service._prefetch_all_proposals(

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_renderer.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_renderer.py
@@ -387,12 +387,22 @@ async def test_start_session_draft_contains_company_and_skill_names():
             new_callable=AsyncMock,
         ),
         patch(
+            "app.services.resume_refinement.session_service.turn_repo.list_for_session",
+            new_callable=AsyncMock,
+            return_value=[],
+        ),
+        patch(
             "app.services.resume_refinement.session_service.rewrite_service.run_rewrite",
             new_callable=AsyncMock,
             return_value=fake_rewrite,
         ),
         patch(
             "app.services.resume_refinement.session_service.session_repo.update_pending_proposal",
+            new_callable=AsyncMock,
+            return_value=fake_session,
+        ),
+        patch(
+            "app.services.resume_refinement.session_service.session_repo.get_with_turns_for_user",
             new_callable=AsyncMock,
             return_value=fake_session,
         ),

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_rewrite_service.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_rewrite_service.py
@@ -155,3 +155,88 @@ async def test_hint_passes_through_to_user_content():
             session_id=_FAKE_SESSION_ID,
         )
     assert any("more concise" in c for c in captured_user_content)
+
+
+@pytest.mark.asyncio
+async def test_prior_context_passes_through_to_user_content():
+    """Session-level prior_context entries land in the prompt as a Prior
+    conversation block, so Claude honours user-stated constraints across
+    every target — not just the one a hint was attached to."""
+    parsed = {"kind": "proposal", "rewritten_text": "ok", "rationale": "ok"}
+
+    captured: list[str] = []
+
+    async def fake_call(*, system_prompt, user_content, **_):
+        captured.append(user_content)
+        return _claude_response(parsed)
+
+    prior_context = [
+        {"kind": "ai_critique", "section": None, "text": "5 of 14 bullets need stronger verbs."},
+        {
+            "kind": "user_hint",
+            "section": "Staff Engineer @ Acme — bullet 1",
+            "text": "I left R1Soft out to keep the resume to one page.",
+        },
+        {
+            "kind": "user_custom_rewrite",
+            "section": "Senior Engineer @ Acme — bullet 2",
+            "text": "Owned the migration end-to-end.",
+        },
+    ]
+
+    with patch.object(
+        rewrite_service, "call_claude_with_meta", new=AsyncMock(side_effect=fake_call)
+    ):
+        await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+            prior_context=prior_context,
+        )
+
+    body = captured[0]
+    assert "Prior conversation" in body
+    assert "one page" in body
+    assert "Owned the migration end-to-end" in body
+    assert "[ai_critique]" in body
+    assert "[user_hint]" in body
+    assert "[user_custom_rewrite]" in body
+
+
+@pytest.mark.asyncio
+async def test_empty_prior_context_omits_block():
+    """No prior_context (or an empty list) should NOT inject the heading
+    — Claude shouldn't see a misleading 'Prior conversation' label with
+    nothing under it."""
+    parsed = {"kind": "proposal", "rewritten_text": "ok", "rationale": "ok"}
+
+    captured: list[str] = []
+
+    async def fake_call(*, system_prompt, user_content, **_):
+        captured.append(user_content)
+        return _claude_response(parsed)
+
+    with patch.object(
+        rewrite_service, "call_claude_with_meta", new=AsyncMock(side_effect=fake_call)
+    ):
+        await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+            prior_context=[],
+        )
+        await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+            prior_context=None,
+        )
+
+    for body in captured:
+        assert "Prior conversation" not in body

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_session_helpers.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_session_helpers.py
@@ -4,7 +4,26 @@ Full lifecycle integration tests are heavy (DB + Claude mocking + worker
 stubs); these focus on the substring-replacement logic that's the hardest
 part to get right without real data.
 """
-from app.services.resume_refinement.session_service import _apply_rewrite
+from types import SimpleNamespace
+
+from app.services.resume_refinement.session_service import (
+    _apply_rewrite,
+    _build_prior_context,
+)
+
+
+def _turn(**fields) -> SimpleNamespace:
+    """Build a turn-shaped object with sensible defaults for the test."""
+    base = {
+        "role": "ai_proposal",
+        "target_section": None,
+        "rationale": None,
+        "clarifying_question": None,
+        "user_text": None,
+        "proposed_text": None,
+    }
+    base.update(fields)
+    return SimpleNamespace(**base)
 
 
 def test_apply_rewrite_replaces_first_occurrence_only():
@@ -49,3 +68,63 @@ def test_apply_rewrite_preserves_surrounding_whitespace():
         new_text="rewritten bullet",
     )
     assert out == "## Section\n\n- rewritten bullet\n- another bullet"
+
+
+def test_build_prior_context_keeps_signal_filters_noise():
+    """_build_prior_context distills turns into the lightweight shape the
+    rewrite prompt consumes — keeping the entries that carry session-level
+    constraints and filtering the ones that are already in current_draft
+    (user_accept) or carry no information (user_skip)."""
+    turns = [
+        _turn(role="ai_critique", rationale="14 bullets need work."),
+        _turn(
+            role="ai_proposal",
+            target_section="Staff Eng @ Acme — bullet 1",
+            clarifying_question="What was the throughput?",
+        ),
+        _turn(
+            role="user_request_alternative",
+            target_section="Staff Eng @ Acme — bullet 1",
+            user_text="Keep the resume to one page.",
+        ),
+        _turn(
+            role="ai_proposal",
+            target_section="Staff Eng @ Acme — bullet 1",
+            proposed_text="Architected payment processing.",
+        ),
+        _turn(role="user_accept", target_section="Staff Eng @ Acme — bullet 1"),
+        _turn(
+            role="user_custom",
+            target_section="Senior Eng @ Acme — bullet 2",
+            user_text="Owned the migration end-to-end.",
+        ),
+        _turn(role="user_skip", target_section="Senior Eng @ Acme — bullet 3"),
+        _turn(role="session_complete"),
+    ]
+
+    out = _build_prior_context(turns)
+
+    kinds = [e["kind"] for e in out]
+    assert kinds == [
+        "ai_critique",
+        "ai_clarification_question",
+        "user_hint",
+        "user_custom_rewrite",
+    ]
+    assert all("Architected payment processing" not in e["text"] for e in out)
+    assert all(e["kind"] not in ("user_accept", "user_skip", "session_complete") for e in out)
+
+
+def test_build_prior_context_drops_empty_text():
+    """Turns with the right role but no actual text content are skipped —
+    no point sending Claude a blank line with a label."""
+    turns = [
+        _turn(role="ai_critique", rationale=None),
+        _turn(role="ai_proposal", clarifying_question=""),
+        _turn(role="user_custom", user_text="   "),
+    ]
+    assert _build_prior_context(turns) == []
+
+
+def test_build_prior_context_empty_turns_returns_empty_list():
+    assert _build_prior_context([]) == []


### PR DESCRIPTION
## Bug

Operator: "I'm noticing an issue during refinement where it's not remembering my previous responses when refining a part of my resume."

Confirmed by reading \`rewrite_service._build_user_content\`: the prompt only included the resume + current target + an optional one-shot \`hint\`. Past clarifying-question answers, custom rewrites in the user's voice, and stated session-level constraints (e.g. "keep it to one page", "I left R1Soft out for length") were never re-fed to Claude on subsequent targets.

Concretely: when the user typed "I left it out to keep my resume 1 page" on Suggestion 1, that text routed through \`request_alternative\` as a one-shot \`hint\` — Claude saw it ONCE for that target's regeneration, then it dropped on the floor. Suggestion 2 had \`hint=None\` and Claude had no memory of the constraint.

## Fix

- \`rewrite_service.run_rewrite\` accepts a new optional \`prior_context: list[dict] | None\`. When non-empty, the user content gets a "Prior conversation in this refinement session" block before the resume markdown.
- \`session_service._build_prior_context\` distills turn rows into the \`[{kind, section, text}]\` shape, keeping only the entries that carry session-level signal:
  - \`ai_critique\` rationale (overall framing)
  - \`ai_proposal\` clarifying questions (in-flight Q&A)
  - \`user_custom\` text (user's voice / phrasing)
  - \`user_request_alternative\` hints (stated constraints)
  - skipped: \`ai_proposal\` proposed_text (already in current_draft if accepted), \`user_accept\` (same), \`user_skip\` (no info), \`session_complete\` (terminal marker)
- \`_generate_next_proposal\` and \`_prefetch_all_proposals\` fetch turns via \`turn_repo.list_for_session\` and pass the distilled list through. Prefetch fetches once and shares across all parallel rewrites.
- \`RESUME_REWRITE_PROMPT\` updated: explicit instruction that prior-conversation entries are **binding session constraints**. "If the user has said 'keep the resume to one page', respect that across every subsequent target." Plus: never re-ask a question already answered.

## Tests

- 2 new \`rewrite_service\` tests: prior_context lands in the prompt with the right markers; empty/None omits the heading block.
- 3 new \`_build_prior_context\` tests: signal-filtering matrix, empty-text drop, empty-list base case.
- 4 pre-existing tests updated (proposal_cache prefetch x3, renderer start_session integration x1) to mock \`turn_repo.list_for_session\` and \`session_repo.get_with_turns_for_user\`.

\`pytest tests/ -k resume_refinement\` — 43 passing locally (4 pre-existing failures excluded; not introduced by this PR).

## Test plan

- [x] Unit tests pass locally (43 in resume_refinement scope)
- [ ] CI green
- [ ] Manual on /resume after deploy: state a constraint on Suggestion 1 ("keep it to one page" via Another option) → advance to Suggestion 2 → confirm subsequent suggestions respect that constraint (don't suggest adding bullets, don't re-ask the same clarifying question)

## Token cost

Each prefetched rewrite at session start now includes the critique rationale (~50-100 extra tokens). Each subsequent rewrite includes prior user inputs (~50-200 extra tokens per past target). For a 14-target session: ~1-3K extra tokens total per session, ~$0.01 extra. Acceptable for the value delivered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)