### PR TITLE
fix(mbk): drop Bank Accounts E2E test + skeleton section (Plaid removed)

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -1,7 +1,7 @@
 # Tech Debt
 
 > Last scanned: 2026-05-08
-> Issues: 0 critical, 5 high, 6 medium (1 deferred + 5 active), 0 low
+> Issues: 0 critical, 4 high, 6 medium (1 deferred + 5 active), 0 low
 
 ## High
 
@@ -46,11 +46,8 @@
 
 ---
 
-### [E2E tests] "Bank Accounts section renders" fails because Plaid section no longer exists on Integrations page
-**Effort:** XS
-**Location:** frontend/e2e/integrations.spec.ts:453
-**Problem:** The E2E test expects a "Bank Accounts" heading on the Integrations page but the page only renders a Gmail section. Either the Plaid UI was removed without updating the test, or the section is conditionally rendered and the condition is never true in test env.
-**Recommendation:** Either remove the Bank Accounts test block or restore the Plaid UI section. Not fixed in this PR to keep scope to Gmail disconnect.
+### ~~[E2E tests] "Bank Accounts section renders" fails because Plaid section no longer exists on Integrations page~~ RESOLVED
+**Resolved:** PR fix/mbk-bank-accounts-e2e (2026-05-08) — Plaid UI is intentionally not rendered (see in-flight `fix/mbk-disable-plaid` branch). Removed the `test.describe("Bank accounts (Plaid)")` block from `integrations.spec.ts`. Also removed the leftover Bank Accounts skeleton section from `IntegrationsSkeleton.tsx` so the loading state matches the rendered page (Gmail-only) per the project rule about skeleton structural parity.
 
 ---
 

--- a/apps/mybookkeeper/frontend/e2e/integrations.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/integrations.spec.ts
@@ -446,15 +446,4 @@ test.describe("Integrations UI", () => {
       await expect(disconnectBtn).not.toBeVisible({ timeout: 3000 });
     });
   });
-
-  // ─── Bank Accounts Section ──────────────────────────────────────────────────
-
-  test.describe("Bank accounts (Plaid)", () => {
-    test("Bank Accounts section renders with connect button", async ({ authedPage: page }) => {
-      await expect(page.getByText("Bank Accounts").first()).toBeVisible({ timeout: 10000 });
-      await expect(
-        page.getByText(/connect your bank to automatically import transactions/i)
-      ).toBeVisible({ timeout: 5000 });
-    });
-  });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/IntegrationsSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/IntegrationsSkeleton.tsx
@@ -3,17 +3,6 @@ import Skeleton from "@/shared/components/ui/Skeleton";
 export default function IntegrationsSkeleton() {
   return (
     <div className="space-y-6">
-      {/* Bank Accounts section */}
-      <section className="border rounded-lg p-6 space-y-4">
-        <div className="flex items-center justify-between">
-          <div className="space-y-1.5">
-            <Skeleton className="h-4 w-32" />
-            <Skeleton className="h-3 w-56" />
-          </div>
-          <Skeleton className="h-9 w-32 rounded-md" />
-        </div>
-      </section>
-
       {/* Gmail section */}
       <section className="border rounded-lg p-6 space-y-4">
         <div className="flex items-center justify-between">


### PR DESCRIPTION
## Summary

The Plaid Bank Accounts section was removed from MBK's Integrations page (only Gmail remains). The corresponding E2E test and skeleton section both pointed at UI that no longer exists.

- **`integrations.spec.ts`**: dropped the \`test.describe(\"Bank accounts (Plaid)\")\` block.
- **\`IntegrationsSkeleton.tsx\`**: dropped the leading Bank Accounts skeleton section. The skeleton previously rendered two sections while the loaded page renders one — visible layout shift on first paint.

Resolves the \"[E2E tests] Bank Accounts section renders fails because Plaid section no longer exists\" tech-debt entry. High count 5 → 4.

## Test plan

- [x] CI: backend-tests, frontend-build, frontend-layout-e2e
- [x] Skeleton structure now matches loaded page (1 Gmail section both before and after data load)

🤖 Generated with [Claude Code](https://claude.com/claude-code)