### PR TITLE
test(mbk/frontend): fix PendingInvites.test.tsx (mock + assertion drift)

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/PendingInvites.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PendingInvites.test.tsx
@@ -5,6 +5,10 @@ import type { OrgInvite } from "@/shared/types/organization/invite";
 
 vi.mock("@/shared/store/membersApi", () => ({
   useListInvitesQuery: vi.fn(),
+  useCancelInviteMutation: vi.fn(() => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })),
+    { isLoading: false },
+  ]),
 }));
 
 vi.mock("@/shared/hooks/useCurrentOrg", () => ({
@@ -41,7 +45,7 @@ describe("PendingInvites", () => {
     render(<PendingInvites />);
 
     expect(screen.getByText("test@example.com")).toBeInTheDocument();
-    expect(screen.getByText("pending")).toBeInTheDocument();
+    expect(screen.getByText("Pending")).toBeInTheDocument();
   });
 
   it("shows empty message when no pending invites", () => {


### PR DESCRIPTION
## Summary

- Add missing \`useCancelInviteMutation\` mock — without it the test file errors at module load with \"No \`useCancelInviteMutation\` export defined\" before any test runs.
- Update assertion: badge label is \`\"Pending\"\` (first-letter capitalized), not \`\"pending\"\`.

Both changes match the current shape of \`apps/mybookkeeper/frontend/src/app/features/organizations/PendingInvites.tsx\`. No logic change, just bringing the test back in sync.

Per the [Frontend tests] tech-debt entry's recommended order; one file per PR.

## Test plan

- [x] CI: \`frontend-build / mybookkeeper\` (runs vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)