### PR TITLE
test(mbk/frontend): rewrite InviteAccept.test.tsx for new component shape

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/InviteAccept.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/InviteAccept.test.tsx
@@ -1,30 +1,70 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import InviteAccept from "@/app/pages/InviteAccept";
+import type { InviteInfo } from "@/shared/types/organization/invite";
 
 vi.mock("@/shared/store/membersApi", () => ({
-  useAcceptInviteMutation: vi.fn(),
+  useAcceptInviteMutation: vi.fn(() => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve(undefined) })),
+    {} as never,
+  ]),
+  useGetInviteInfoQuery: vi.fn(),
+}));
+
+vi.mock("@/shared/hooks/useCurrentUser", () => ({
+  useCurrentUser: vi.fn(),
 }));
 
 vi.mock("@/shared/lib/auth", () => ({
-  isAuthenticated: vi.fn(),
+  login: vi.fn(),
+  notifyAuthChange: vi.fn(),
 }));
 
-vi.mock("@/shared/utils/errorMessage", () => ({
-  extractErrorMessage: (err: unknown) =>
-    err instanceof Error ? err.message : "An unexpected error occurred",
+vi.mock("@/shared/lib/api", () => ({
+  default: { post: vi.fn() },
 }));
 
-import { useAcceptInviteMutation } from "@/shared/store/membersApi";
-import { isAuthenticated } from "@/shared/lib/auth";
+vi.mock("@/shared/components/ui/TurnstileWidget", () => ({
+  default: () => null,
+}));
 
-const mockNavigate = vi.fn();
+import { useGetInviteInfoQuery } from "@/shared/store/membersApi";
+import { useCurrentUser } from "@/shared/hooks/useCurrentUser";
 
-vi.mock("react-router-dom", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react-router-dom")>();
-  return { ...actual, useNavigate: () => mockNavigate };
-});
+function makeInviteInfo(overrides: Partial<InviteInfo> = {}): InviteInfo {
+  return {
+    org_name: "Acme Co",
+    org_role: "user",
+    inviter_name: "Alice",
+    email: "invitee@test.com",
+    expires_at: new Date(Date.now() + 86400000 * 7).toISOString(),
+    is_expired: false,
+    user_exists: true,
+    ...overrides,
+  };
+}
+
+function mockInviteQuery(overrides: {
+  data?: InviteInfo;
+  isLoading?: boolean;
+  error?: unknown;
+}) {
+  vi.mocked(useGetInviteInfoQuery).mockReturnValue({
+    data: overrides.data,
+    isLoading: overrides.isLoading ?? false,
+    error: overrides.error,
+  } as unknown as ReturnType<typeof useGetInviteInfoQuery>);
+}
+
+function mockCurrentUser(email: string | null) {
+  vi.mocked(useCurrentUser).mockReturnValue({
+    user: email ? ({ email } as never) : null,
+    isLoading: false,
+    isError: false,
+    error: undefined,
+  });
+}
 
 function renderWithToken(token: string) {
   return render(
@@ -36,162 +76,75 @@ function renderWithToken(token: string) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// Unauthenticated redirect
-// ---------------------------------------------------------------------------
-
-describe("InviteAccept \u2014 unauthenticated user", () => {
+describe("InviteAccept", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(isAuthenticated).mockReturnValue(false);
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap: vi.fn() }),
-      {} as never,
-    ]);
   });
 
-  it("redirects to login with the invite URL as returnTo when user is not authenticated", () => {
-    renderWithToken("abc-token");
-    expect(mockNavigate).toHaveBeenCalledWith(
-      "/login?returnTo=%2Finvite%2Fabc-token",
-      { replace: true }
-    );
+  it("shows skeleton placeholders while invite info is loading", () => {
+    mockInviteQuery({ isLoading: true });
+    mockCurrentUser(null);
+
+    const { container } = renderWithToken("any-token");
+
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
   });
 
-  it("does not call acceptInvite when user is not authenticated", () => {
-    const accept = vi.fn().mockReturnValue({ unwrap: vi.fn() });
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([accept, {} as never]);
-    renderWithToken("abc-token");
-    expect(accept).not.toHaveBeenCalled();
-  });
-});
+  it("shows 'Invite not found' when the query errors", () => {
+    mockInviteQuery({ error: { status: 404 } });
+    mockCurrentUser(null);
 
-// ---------------------------------------------------------------------------
-// Loading state
-// ---------------------------------------------------------------------------
+    renderWithToken("bad-token");
 
-describe("InviteAccept \u2014 loading state", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(isAuthenticated).mockReturnValue(true);
+    expect(screen.getByText("Invite not found")).toBeInTheDocument();
   });
 
-  it("shows skeleton loaders while the invite is being accepted", () => {
-    const unwrap = vi.fn().mockReturnValue(new Promise(() => {}));
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap }),
-      {} as never,
-    ]);
-    const { container } = renderWithToken("pending-token");
-    const skeletons = container.querySelectorAll(".animate-pulse");
-    expect(skeletons.length).toBeGreaterThan(0);
-  });
-});
+  it("shows 'Invite expired' when the invite is expired", () => {
+    mockInviteQuery({ data: makeInviteInfo({ is_expired: true }) });
+    mockCurrentUser(null);
 
-// ---------------------------------------------------------------------------
-// Success state
-// ---------------------------------------------------------------------------
+    renderWithToken("expired-token");
 
-describe("InviteAccept \u2014 success", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(isAuthenticated).mockReturnValue(true);
+    expect(screen.getByText("Invite expired")).toBeInTheDocument();
   });
 
-  it("shows the success heading after the invite is accepted", async () => {
-    const unwrap = vi.fn().mockResolvedValue({ organization_id: "org1", org_role: "member" });
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap }),
-      {} as never,
-    ]);
+  it("shows the joining state when authenticated as the invited email", () => {
+    mockInviteQuery({ data: makeInviteInfo({ email: "match@test.com" }) });
+    mockCurrentUser("match@test.com");
+
     renderWithToken("good-token");
-    await screen.findByText("You're in!");
+
+    expect(screen.getByText("Joining Acme Co...")).toBeInTheDocument();
   });
 
-  it("shows the redirect message after the invite is accepted", async () => {
-    const unwrap = vi.fn().mockResolvedValue({ organization_id: "org1", org_role: "member" });
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap }),
-      {} as never,
-    ]);
+  it("shows the wrong-user prompt when authed as a different email", () => {
+    mockInviteQuery({ data: makeInviteInfo({ email: "intended@test.com" }) });
+    mockCurrentUser("other@test.com");
+
     renderWithToken("good-token");
-    await screen.findByText("Redirecting you to the dashboard...");
+
+    expect(
+      screen.getByRole("button", { name: /Sign out and continue as intended@test.com/i })
+    ).toBeInTheDocument();
   });
 
-  it("navigates to / after a 2 second delay on success", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-    const unwrap = vi.fn().mockResolvedValue({ organization_id: "org1", org_role: "member" });
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap }),
-      {} as never,
-    ]);
+  it("shows the login form when the invitee already has an account", () => {
+    mockInviteQuery({ data: makeInviteInfo({ user_exists: true }) });
+    mockCurrentUser(null);
+
     renderWithToken("good-token");
-    await screen.findByText("You're in!");
-    await act(async () => { vi.advanceTimersByTime(2000); });
-    expect(mockNavigate).toHaveBeenCalledWith("/", { replace: true });
-    vi.useRealTimers();
+
+    expect(screen.getByRole("button", { name: /Sign in & join Acme Co/i })).toBeInTheDocument();
   });
 
-  it("calls acceptInvite with the token from the URL", async () => {
-    const unwrap = vi.fn().mockResolvedValue({ organization_id: "org1", org_role: "member" });
-    const accept = vi.fn().mockReturnValue({ unwrap });
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([accept, {} as never]);
-    renderWithToken("specific-token-xyz");
-    await screen.findByText("You're in!");
-    expect(accept).toHaveBeenCalledWith("specific-token-xyz");
-  });
-});
+  it("shows the registration form when the invitee is new", () => {
+    mockInviteQuery({ data: makeInviteInfo({ user_exists: false }) });
+    mockCurrentUser(null);
 
-// ---------------------------------------------------------------------------
-// Error state
-// ---------------------------------------------------------------------------
+    renderWithToken("good-token");
 
-describe("InviteAccept \u2014 error", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(isAuthenticated).mockReturnValue(true);
-  });
-
-  it("shows the Invite failed heading when the API call fails", async () => {
-    const unwrap = vi.fn().mockRejectedValue(new Error("Invalid or expired invite"));
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap }),
-      {} as never,
-    ]);
-    renderWithToken("bad-token");
-    await screen.findByText("Invite failed");
-  });
-
-  it("shows the error message returned by the API", async () => {
-    const unwrap = vi.fn().mockRejectedValue(new Error("Invalid or expired invite"));
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap }),
-      {} as never,
-    ]);
-    renderWithToken("bad-token");
-    await screen.findByText("Invalid or expired invite");
-  });
-
-  it("shows a Go to dashboard link when the invite fails", async () => {
-    const unwrap = vi.fn().mockRejectedValue(new Error("Invalid or expired invite"));
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap }),
-      {} as never,
-    ]);
-    renderWithToken("bad-token");
-    await screen.findByText("Invite failed");
-    const link = screen.getByRole("link", { name: "Go to dashboard" });
-    expect(link).toHaveAttribute("href", "/");
-  });
-
-  it("does not navigate automatically when the API call fails", async () => {
-    const unwrap = vi.fn().mockRejectedValue(new Error("Invalid or expired invite"));
-    vi.mocked(useAcceptInviteMutation).mockReturnValue([
-      vi.fn().mockReturnValue({ unwrap }),
-      {} as never,
-    ]);
-    renderWithToken("bad-token");
-    await screen.findByText("Invite failed");
-    expect(mockNavigate).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: /Create account & join Acme Co/i })
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

\`InviteAccept\` was refactored from a passive auto-redirect-to-login shell into an inline login/register screen that:
- Resolves the invite via \`useGetInviteInfoQuery\`
- Acts on the current user context (\`useCurrentUser\`)
- Renders one of: loading skeleton, \"Invite not found\", \"Invite expired\", joining-state, wrong-user prompt, login form, or register form

The old test asserted UI text (\`\"You're in!\"\`, \`\"Redirecting you to the dashboard...\"\`, \`\"Invite failed\"\`, \`\"Invalid or expired invite\"\`) that no longer renders.

This PR replaces the test entirely. New coverage:

| State | Assertion |
|---|---|
| info-loading | skeleton placeholders present |
| query error | \"Invite not found\" |
| expired | \"Invite expired\" |
| authed-as-invitee | \"Joining {org_name}...\" |
| wrong user | \"Sign out and continue as {email}\" button |
| returning user | \"Sign in & join {org_name}\" button |
| new user | \"Create account & join {org_name}\" button |

Per the [Frontend tests] tech-debt entry's recommended order; one file per PR.

## Test plan

- [x] CI: \`frontend-build / mybookkeeper\` (runs vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)