### PR TITLE
test(mbk/frontend): fix VendorDetail.test.tsx assertion drift

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/VendorDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/VendorDetail.test.tsx
@@ -106,7 +106,7 @@ describe("VendorDetail page", () => {
 
   it("renders the formatted hourly rate and flat-rate notes", () => {
     renderVendorDetail();
-    expect(screen.getByTestId("vendor-hourly-rate")).toHaveTextContent("$125.00 / hour");
+    expect(screen.getByTestId("vendor-hourly-rate")).toHaveTextContent("$125.00/hr");
     expect(screen.getByTestId("vendor-flat-rate-notes")).toHaveTextContent(
       /Flat \$200 for drain unclog/,
     );
@@ -157,13 +157,13 @@ describe("VendorDetail page", () => {
     expect(screen.getByTestId("vendor-flat-rate-notes")).toHaveTextContent("—");
   });
 
-  it("falls back to 'Not set' for missing hourly rate", () => {
+  it("falls back to em dash for missing hourly rate", () => {
     vi.mocked(useGetVendorByIdQuery).mockReturnValueOnce({
       ...defaultDetailState,
       data: { ...mockVendor, hourly_rate: null },
     } as unknown as DetailQueryReturn);
     renderVendorDetail();
-    expect(screen.getByTestId("vendor-hourly-rate")).toHaveTextContent("Not set");
+    expect(screen.getByTestId("vendor-hourly-rate")).toHaveTextContent("—");
   });
 
   it("renders 'Never used' when last_used_at is null", () => {


### PR DESCRIPTION
## Summary

Two assertions referenced UI text that changed during refactoring:

- **Hourly rate format**: \`\"$125.00 / hour\"\` → \`\"$125.00/hr\"\`
- **Missing-rate fallback**: \`\"Not set\"\` → \`\"—\"\` (em dash, matching the same-shape fallback used elsewhere in the component for missing phone/email/address)

Verified locally: all 14 tests in \`VendorDetail.test.tsx\` now pass.

Per the [Frontend tests] tech-debt entry's recommended order; one file per PR.

## Test plan

- [x] Local: \`npm test -- src/__tests__/VendorDetail.test.tsx\` → 14 passed
- [x] CI: \`frontend-build / mybookkeeper\` (runs vitest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)