### PR TITLE
test(mbk/frontend): fix TaxDocuments.test.tsx (drop removed UI, dedupe matches)

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/TaxDocuments.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/TaxDocuments.test.tsx
@@ -171,12 +171,8 @@ describe("TaxDocuments", () => {
 
   it("renders year group in accordion layout", () => {
     renderPage();
-    expect(screen.getByText("2025")).toBeInTheDocument();
-  });
-
-  it("renders document count", () => {
-    renderPage();
-    expect(screen.getByText(/2 document/)).toBeInTheDocument();
+    // "2025" appears both as the year-filter <option> and the accordion trigger label.
+    expect(screen.getAllByText("2025").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders issuer names from documents", () => {
@@ -184,12 +180,6 @@ describe("TaxDocuments", () => {
     expect(screen.getByText("Vello LLC")).toBeInTheDocument();
     const airbnbElements = screen.getAllByText("Airbnb");
     expect(airbnbElements.length).toBeGreaterThanOrEqual(1);
-  });
-
-  it("renders key amounts in currency format", () => {
-    renderPage();
-    expect(screen.getByText("$45,724.88")).toBeInTheDocument();
-    expect(screen.getByText("$15,000.00")).toBeInTheDocument();
   });
 
   it("renders form type badges", () => {


### PR DESCRIPTION
## Summary

Three stale assertions:

1. **Year accordion**: \`\"2025\"\` matched both the year-filter \`<option>\` and the accordion trigger label. Switched to \`getAllByText().length >= 1\`.
2. **Document count**: page no longer renders \"2 documents\" — count is now just an unlabeled badge number inside the accordion trigger. Dropped the test (low signal vs the multi-match risk; the year-accordion test already covers \"the accordion renders\").
3. **Currency format**: \`TaxDocuments\` no longer renders raw \`key_amount\` values. The amount column was removed during the accordion redesign; only issuer name + form type + view/download buttons remain. Dropped the test.

Verified locally: 16 passed (down from 19 — 2 dropped, 1 modified).

Per the [Frontend tests] tech-debt entry's recommended order; one file per PR.

## Test plan

- [x] Local: \`npm test -- src/__tests__/TaxDocuments.test.tsx\` → 16 passed
- [x] CI: \`frontend-build / mybookkeeper\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)