### PR TITLE
test(mbk/frontend): fix PublicInquiryForm.test.tsx (form schema drift)

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/PublicInquiryForm.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/PublicInquiryForm.test.tsx
@@ -73,10 +73,11 @@ async function fillValidForm(user: ReturnType<typeof userEvent.setup>) {
   await user.type(screen.getByTestId("public-inquiry-name"), "Alice Smith");
   await user.type(screen.getByTestId("public-inquiry-email"), "alice@example.com");
   await user.type(screen.getByTestId("public-inquiry-phone"), "555-123-4567");
-  await user.type(screen.getByTestId("public-inquiry-move-in"), futureDateIso());
-  const lease = screen.getByTestId("public-inquiry-lease-length");
-  await user.clear(lease);
-  await user.type(lease, "6");
+  await user.type(screen.getByTestId("public-inquiry-move-in"), futureDateIso(30));
+  await user.type(screen.getByTestId("public-inquiry-move-out-date"), futureDateIso(210));
+  const occupants = screen.getByTestId("public-inquiry-occupants");
+  await user.clear(occupants);
+  await user.type(occupants, "1");
   await user.click(screen.getByTestId("public-inquiry-pets-no"));
   await user.type(screen.getByTestId("public-inquiry-city"), "Austin");
   // Country defaults to US — region renders as the state dropdown.
@@ -251,10 +252,11 @@ describe("PublicInquiryForm — country / region", () => {
     await user.type(screen.getByTestId("public-inquiry-name"), "Bjorn Eriksen");
     await user.type(screen.getByTestId("public-inquiry-email"), "bjorn@example.no");
     await user.type(screen.getByTestId("public-inquiry-phone"), "555-987-6543");
-    await user.type(screen.getByTestId("public-inquiry-move-in"), futureDateIso());
-    const lease = screen.getByTestId("public-inquiry-lease-length");
-    await user.clear(lease);
-    await user.type(lease, "12");
+    await user.type(screen.getByTestId("public-inquiry-move-in"), futureDateIso(30));
+    await user.type(screen.getByTestId("public-inquiry-move-out-date"), futureDateIso(390));
+    const occupants = screen.getByTestId("public-inquiry-occupants");
+    await user.clear(occupants);
+    await user.type(occupants, "1");
     await user.click(screen.getByTestId("public-inquiry-pets-no"));
     await user.type(screen.getByTestId("public-inquiry-city"), "Oslo");
     await user.selectOptions(screen.getByTestId("public-inquiry-country"), "NO");


### PR DESCRIPTION
## Summary

\`PublicInquiryForm\` was refactored from
\`\`\`
move_in_date + lease_length_months
\`\`\`
to
\`\`\`
move_in_date + move_out_date + occupants
\`\`\`

The lease-length input was removed; two tests that referenced \`public-inquiry-lease-length\` crashed before they could finish typing the form. Updated the \`fillValidForm\` helper and the international-applicant test to fill \`move-out-date\` + \`occupants\` instead.

Verified locally: 14 passed (no behavior change to component, just bringing tests back in sync with the refactor).

Per the [Frontend tests] tech-debt entry's recommended order; one file per PR.

## Test plan

- [x] Local: \`npm test -- src/__tests__/PublicInquiryForm.test.tsx\` → 14 passed
- [x] CI: \`frontend-build / mybookkeeper\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)