### PR TITLE
fix(mjh/resume): tell Claude to clarify on uninformative hints ("temp", "asdf", etc.)

### DIFF
--- a/apps/myjobhunter/backend/app/services/extraction/prompts/resume_rewrite_prompt.py
+++ b/apps/myjobhunter/backend/app/services/extraction/prompts/resume_rewrite_prompt.py
@@ -85,8 +85,24 @@ better fit.
 - The source uses a domain-specific term that you cannot interpret \
 without more context (e.g. "owned the spine of platform X" — what is \
 the spine?).
+- **The user's hint is uninformative.** Hints like ``temp``, ``asdf``, \
+``test``, ``ok``, a single character, gibberish, or any short string \
+that doesn't carry a directive (no verb of intent, no specific fact, \
+no described preference) give you NOTHING actionable. DO NOT just \
+regenerate the same proposal as if the hint were substantive — the \
+user will see two near-identical responses and lose trust. Instead, \
+return ``kind=clarify`` with a question that asks what they actually \
+want changed, and echo their input back so they know you saw it. \
+Example: ``"That came through as just \\"temp\\" — what specifically \
+should be different about this rewrite? Shorter? More technical? \
+More impact-focused?"``
+- **The user's hint contradicts a session constraint they stated \
+earlier.** If they said "keep it to one page" earlier and now hint \
+"add more detail to this section", surface the contradiction in your \
+clarification rather than silently picking one.
 
-If the user provides a hint that resolves the ambiguity, use it.
+If the user provides a substantive hint that resolves the ambiguity, \
+use it.
 
 # Constrained markdown subset
 

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_rewrite_service.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_rewrite_service.py
@@ -240,3 +240,24 @@ async def test_empty_prior_context_omits_block():
 
     for body in captured:
         assert "Prior conversation" not in body
+
+
+def test_system_prompt_instructs_claude_to_clarify_on_vague_hint():
+    """The rewrite prompt must explicitly tell Claude to return a clarify
+    question when the user's hint is uninformative (e.g. ``temp``, ``asdf``).
+    Without this guard, Claude regenerates near-identical proposals and the
+    user sees what looks like a stuck loop. Reported by operator on
+    2026-05-08."""
+    from app.services.extraction.prompts.resume_rewrite_prompt import (
+        RESUME_REWRITE_PROMPT,
+    )
+    # The prompt must reference uninformative-hint detection by example
+    # so Claude has anchors for what counts as actionable signal.
+    assert "uninformative" in RESUME_REWRITE_PROMPT.lower()
+    assert "temp" in RESUME_REWRITE_PROMPT
+    assert "asdf" in RESUME_REWRITE_PROMPT
+    # And it must direct Claude to ``clarify``, not regenerate.
+    assert "kind=clarify" in RESUME_REWRITE_PROMPT or "kind=\"clarify\"" in RESUME_REWRITE_PROMPT
+    # And it must instruct echoing the user's input back, so they know
+    # their submission was observed and not silently dropped.
+    assert "echo" in RESUME_REWRITE_PROMPT.lower()


### PR DESCRIPTION
## Bug

Operator typed \"temp\" as a regenerate hint, got back the same proposal as before with no acknowledgment that the input was even seen. From their perspective the loop looked stuck.

> "if i send a response that doesn't make sense, ask for clarification. I said 'temp' and you just repeated the response from before. you need to be smarter about responses by analyzing what the user says just like how we do in this clade code session"

## Root cause

The rewrite prompt accepts any hint as substantive. When the hint carries no actionable signal (single word, gibberish, no described preference), Claude tries to make sense of it and produces near-identical regenerations.

## Fix

Extends the "When to ask for clarification" section of \`RESUME_REWRITE_PROMPT\` with explicit examples of uninformative hints (\`temp\`, \`asdf\`, \`test\`, \`ok\`, single chars, gibberish) and the required behaviour:

- Return \`kind=clarify\` rather than regenerating
- Echo the user's input back so they know it was observed (\`"That came through as just \\"temp\\" — what specifically should be different..."\`)
- Offer concrete directions (shorter / more technical / more impact-focused)

Also adds a **contradiction guard**: when the hint conflicts with a session constraint stated earlier ("keep it to one page" then "add more detail"), Claude is instructed to surface the conflict instead of silently picking one side.

## Test plan

- [x] Regression test on prompt content (locks in the guard so future edits don't strip it)
- [x] Existing 7 rewrite_service tests pass
- [ ] CI green
- [ ] Manual on /resume after deploy: type \"temp\" as a regenerate hint → get a clarifying question that echoes "temp" back, NOT a near-duplicate proposal

🤖 Generated with [Claude Code](https://claude.com/claude-code)