### PR TITLE
test(mbk/frontend): refactor ContractDatesEditor toast tests to runAllTimersAsync

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -1,7 +1,7 @@
 # Tech Debt
 
 > Last scanned: 2026-05-08
-> Issues: 0 critical, 3 high, 6 medium (1 deferred + 5 active), 0 low
+> Issues: 0 critical, 3 high, 5 medium (1 deferred + 4 active), 0 low
 
 ## High
 
@@ -62,11 +62,8 @@
 
 ---
 
-### [Frontend tests] Debounce + async toast tests require switching between fake/real timers per test [DEFERRED]
-**Effort:** S
-**Location:** `apps/mybookkeeper/frontend/src/__tests__/ContractDatesEditor.test.tsx` — `shows success toast` and `shows error toast` tests (lines 129-162)
-**Problem:** Tests that verify debounce behavior use `vi.useFakeTimers()` (to control `setTimeout`), but toast-verification tests must call `vi.useRealTimers()` at the top of the test because `waitFor` with fake timers doesn't flush async promise chains reliably. This creates a brittle pattern: if a new test forgets to switch, it silently passes or flakes. The root cause is mixing synchronous timer control with async RTK mutation resolution.
-**Recommendation:** Refactor toast tests to use `vi.runAllTimersAsync()` (Vitest ≥ 1.6) which advances both fake timers and microtask queue atomically. This would allow all tests to keep `vi.useFakeTimers()` throughout the describe block.
+### ~~[Frontend tests] Debounce + async toast tests require switching between fake/real timers per test~~ RESOLVED
+**Resolved:** PR fix/mbk-contract-dates-timer-tests (2026-05-08) — both toast tests now use `vi.runAllTimersAsync()` inside an `act()` block, draining fake timers + microtasks atomically. The fake/real timer toggling is gone; all 8 tests in the file run under the same timer mode set by the describe-level `beforeEach`.
 
 ---
 

--- a/apps/mybookkeeper/frontend/src/__tests__/ContractDatesEditor.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/ContractDatesEditor.test.tsx
@@ -10,7 +10,7 @@
  * - Success toast when the mutation resolves
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { store } from "@/shared/store";
 import ContractDatesEditor from "@/app/features/applicants/ContractDatesEditor";
@@ -127,7 +127,6 @@ describe("ContractDatesEditor", () => {
   });
 
   it("shows success toast after successful save", async () => {
-    vi.useRealTimers(); // Switch to real timers for async resolution.
     mockUpdateDates.mockReturnValue({ unwrap: () => Promise.resolve({}) });
     renderEditor({ stage: "approved", value: "2026-12-31" });
     const input = screen.getByTestId("contract-date-input-contract_end");
@@ -135,14 +134,18 @@ describe("ContractDatesEditor", () => {
     fireEvent.change(input, { target: { value: "2026-11-30" } });
     fireEvent.blur(input);
 
-    // Wait for the debounce + async mutation.
-    await waitFor(() => expect(mockShowSuccess).toHaveBeenCalledOnce(), {
-      timeout: 2000,
+    // runAllTimersAsync advances fake timers AND drains the microtask queue
+    // atomically, so the debounce fires + the unwrap() promise resolves +
+    // the toast effect lands in one step. Avoids the brittle fake/real timer
+    // toggling pattern that mixed timer modes per-test.
+    await act(async () => {
+      await vi.runAllTimersAsync();
     });
+
+    expect(mockShowSuccess).toHaveBeenCalledOnce();
   });
 
   it("shows error toast and reverts value on mutation failure", async () => {
-    vi.useRealTimers(); // Switch to real timers for async resolution.
     mockUpdateDates.mockReturnValue({
       unwrap: () => Promise.reject({ data: { detail: { message: "Something went wrong" } } }),
     });
@@ -152,11 +155,11 @@ describe("ContractDatesEditor", () => {
     fireEvent.change(input, { target: { value: "2026-11-30" } });
     fireEvent.blur(input);
 
-    // Wait for the debounce + async mutation.
-    await waitFor(() => expect(mockShowError).toHaveBeenCalledOnce(), {
-      timeout: 2000,
+    await act(async () => {
+      await vi.runAllTimersAsync();
     });
 
+    expect(mockShowError).toHaveBeenCalledOnce();
     // Value should revert to the original.
     expect(input.value).toBe("2026-12-31");
   });


### PR DESCRIPTION
## Summary

Resolves the [DEFERRED] tech-debt entry about ContractDatesEditor mixing fake + real timers.

The two toast tests (\`shows success toast\`, \`shows error toast\`) used to switch to \`vi.useRealTimers()\` at the top of each test — needed because the file-level \`beforeEach\` set fake timers, but \`waitFor()\` with fake timers doesn't flush async promise chains reliably. That toggling pattern is brittle: a new toast-style test that forgets the switch silently flakes.

The fix: drop the toggle, drive both tests with a single
\`\`\`ts
await act(async () => {
  await vi.runAllTimersAsync();
});
\`\`\`
which advances fake timers AND drains the microtask queue atomically. All 8 tests now run under the same timer mode.

Verified locally: \`npm test -- src/__tests__/ContractDatesEditor.test.tsx\` → 8 passed.

TECH_DEBT counts: 6 medium → 5 medium (1 deferred + 4 active).

## Test plan

- [x] Local: 8 passed (no behavior change)
- [x] CI: \`frontend-build / mybookkeeper\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)