### PR TITLE
feat(mbk/attribution): inline tenant picker for unmatched review items

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -1,7 +1,7 @@
 # Tech Debt
 
 > Last scanned: 2026-05-08
-> Issues: 0 critical, 3 high, 6 medium (1 deferred + 5 active), 0 low
+> Issues: 0 critical, 3 high, 5 medium (1 deferred + 4 active), 0 low
 
 ## High
 
@@ -54,11 +54,8 @@
 
 ---
 
-### [Attribution] Unmatched review items have no inline tenant-assign flow on the review panel
-**Effort:** S
-**Location:** `apps/mybookkeeper/frontend/src/app/features/attribution/AttributionReviewItem.tsx`, `AttributionReviewPanel.tsx`
-**Problem:** For `confidence="unmatched"` queue items (no proposed candidate), the review panel only shows a Reject button. To attribute an unmatched income transaction to a tenant the user must: (1) reject the queue item, (2) navigate to the Transactions page, (3) find the transaction, (4) open it, and (5) use the `AttributeTenantPicker`. This 5-step flow was intentional for Phase 1 but creates friction for the main "I got a Venmo payment and don't know who it's from" use case.
-**Recommendation:** Add an inline applicant select to `AttributionReviewItem` for `unmatched` items — reuse the same `lease_signed` applicants query already used by `AttributeTenantPicker`. On confirm, call `useAttributeTransactionManuallyMutation` (which also closes the queue item server-side). This collapses the 5-step flow to 2 steps on the review panel.
+### ~~[Attribution] Unmatched review items have no inline tenant-assign flow on the review panel~~ RESOLVED
+**Resolved:** PR feat/mbk-attribution-inline-picker (2026-05-08) — `AttributionReviewItem` now renders an inline `<select>` of `lease_signed` applicants for `unmatched` items, with a Link button that calls `useAttributeTransactionManuallyMutation`. The `attribute_manually` service was extended to also resolve any pending review-queue row for the txn in the same DB transaction (so the host doesn't have to also reject from the queue). 5-step flow collapsed to 2 steps on the review panel.
 
 ---
 

--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -367,7 +367,12 @@ async def attribute_manually(
     organization_id: uuid.UUID,
     user_id: uuid.UUID,
 ) -> dict:
-    """Manually attribute a transaction to an applicant."""
+    """Manually attribute a transaction to an applicant.
+
+    If a pending review-queue row exists for this transaction (because the
+    auto-pipeline previously couldn't decide), it is resolved as ``confirmed``
+    in the same transaction so the host doesn't have to reject it separately.
+    """
     async with unit_of_work() as db:
         txn = await txn_repo.get_by_id(db, transaction_id, organization_id)
         if not txn:
@@ -390,6 +395,12 @@ async def attribute_manually(
             property_id = await _get_property_id_for_applicant(db, applicant, organization_id)
             if property_id:
                 txn.property_id = property_id
+
+        review_row = await attribution_repo.get_by_transaction_id(
+            db, transaction_id, organization_id
+        )
+        if review_row and review_row.status == "pending":
+            await attribution_repo.resolve(db, review_row, status="confirmed")
 
         await receipt_service.create_pending_receipt_in_session(
             db,

--- a/apps/mybookkeeper/backend/tests/test_attribution_service_attribute_manually.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_service_attribute_manually.py
@@ -1,0 +1,164 @@
+"""Service-level test for attribution_service.attribute_manually.
+
+The newer behavior added 2026-05-08: when a host manually attributes a
+transaction that has a pending review-queue row, the row is resolved as
+``confirmed`` in the same transaction so the host doesn't have to also
+reject it from the review queue UI.
+
+This test does NOT exercise the Airbnb auto-pipeline path (covered by
+attribution_matcher / repo tests); it focuses strictly on the manual-
+attribute service surface.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch, AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.transactions.rent_attribution_review_queue import (
+    RentAttributionReviewQueue,
+)
+from app.models.transactions.transaction import Transaction
+from app.services.transactions.attribution_service import attribute_manually
+
+
+def _make_fake_uow(session: AsyncSession):
+    @asynccontextmanager
+    async def _fake_uow():
+        yield session
+
+    return _fake_uow
+
+
+@pytest.mark.asyncio
+async def test_attribute_manually_resolves_pending_review_row(db: AsyncSession):
+    """Manual attribute on a txn that has a pending review row resolves the row."""
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    applicant = Applicant(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        stage="lease_signed",
+        legal_name="Jane Doe",
+    )
+    db.add(applicant)
+
+    txn = Transaction(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        transaction_date=_dt.date(2026, 5, 1),
+        tax_year=2026,
+        amount="1500.00",
+        transaction_type="income",
+        category="uncategorized",
+        status="approved",
+        is_manual=False,
+    )
+    db.add(txn)
+
+    review = RentAttributionReviewQueue(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        organization_id=org_id,
+        transaction_id=txn.id,
+        proposed_applicant_id=None,
+        confidence="unmatched",
+        status="pending",
+    )
+    db.add(review)
+    await db.flush()
+
+    fake_uow = _make_fake_uow(db)
+
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        fake_uow,
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        new_callable=AsyncMock,
+    ):
+        result = await attribute_manually(
+            transaction_id=txn.id,
+            applicant_id=applicant.id,
+            organization_id=org_id,
+            user_id=user_id,
+        )
+
+    assert result["ok"] is True
+
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.applicant_id == applicant.id
+    assert refreshed_txn.attribution_source == "manual"
+    assert refreshed_txn.category == "rental_revenue"
+
+    refreshed_review = (
+        await db.execute(
+            select(RentAttributionReviewQueue).where(RentAttributionReviewQueue.id == review.id)
+        )
+    ).scalar_one()
+    assert refreshed_review.status == "confirmed"
+    assert refreshed_review.resolved_at is not None
+
+
+@pytest.mark.asyncio
+async def test_attribute_manually_no_review_row_works(db: AsyncSession):
+    """If there is no review row, manual attribute still succeeds (no-op for the queue)."""
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    applicant = Applicant(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        stage="lease_signed",
+        legal_name="Jane Doe",
+    )
+    db.add(applicant)
+
+    txn = Transaction(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        transaction_date=_dt.date(2026, 5, 1),
+        tax_year=2026,
+        amount="1500.00",
+        transaction_type="income",
+        category="uncategorized",
+        status="approved",
+        is_manual=False,
+    )
+    db.add(txn)
+    await db.flush()
+
+    fake_uow = _make_fake_uow(db)
+
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        fake_uow,
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        new_callable=AsyncMock,
+    ):
+        result = await attribute_manually(
+            transaction_id=txn.id,
+            applicant_id=applicant.id,
+            organization_id=org_id,
+            user_id=user_id,
+        )
+
+    assert result["ok"] is True
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.applicant_id == applicant.id

--- a/apps/mybookkeeper/frontend/src/__tests__/AttributionReviewPanel.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/AttributionReviewPanel.test.tsx
@@ -64,6 +64,17 @@ vi.mock("@/shared/store/attributionApi", () => ({
   useGetAttributionReviewQueueQuery: vi.fn(),
   useConfirmAttributionReviewMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
   useRejectAttributionReviewMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useAttributeTransactionManuallyMutation: vi.fn(() => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve({ ok: true, transaction_id: "txn-2" }) })),
+    { isLoading: false },
+  ]),
+}));
+
+vi.mock("@/shared/store/applicantsApi", () => ({
+  useGetApplicantsQuery: vi.fn(() => ({
+    data: { items: [{ id: "applicant-9", legal_name: "Bob Tenant" }], total: 1, has_more: false },
+    isLoading: false,
+  })),
 }));
 
 import {
@@ -174,5 +185,30 @@ describe("AttributionReviewPanel", () => {
     renderWithProviders(<AttributionReviewPanel />);
     const rejectButtons = screen.getAllByText("Not them");
     expect(rejectButtons).toHaveLength(2);
+  });
+
+  it("renders inline tenant picker for unmatched items", () => {
+    vi.mocked(useGetAttributionReviewQueueQuery).mockReturnValue({
+      data: queueWithItems,
+      isLoading: false,
+    } as unknown as ReturnType<typeof useGetAttributionReviewQueueQuery>);
+
+    renderWithProviders(<AttributionReviewPanel />);
+    // Only the unmatched item gets a Link button + tenant select.
+    expect(screen.getByRole("combobox", { name: /pick a tenant/i })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "Bob Tenant" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Link$/ })).toBeInTheDocument();
+  });
+
+  it("does not render inline picker on fuzzy items", () => {
+    // Show only the fuzzy item — picker should NOT appear.
+    vi.mocked(useGetAttributionReviewQueueQuery).mockReturnValue({
+      data: { ...queueWithItems, items: [queueWithItems.items[0]], pending_count: 1, total: 1 },
+      isLoading: false,
+    } as unknown as ReturnType<typeof useGetAttributionReviewQueueQuery>);
+
+    renderWithProviders(<AttributionReviewPanel />);
+    expect(screen.queryByRole("combobox", { name: /pick a tenant/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Link$/ })).not.toBeInTheDocument();
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/attribution/AttributionReviewItem.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/attribution/AttributionReviewItem.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
-import { CheckCircle, XCircle, HelpCircle } from "lucide-react";
+import { CheckCircle, XCircle, HelpCircle, UserCheck } from "lucide-react";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import { formatCurrency } from "@/shared/utils/currency";
 import type { AttributionReviewItem as ReviewItemType } from "@/shared/types/attribution/attribution-review";
 import {
   useConfirmAttributionReviewMutation,
   useRejectAttributionReviewMutation,
+  useAttributeTransactionManuallyMutation,
 } from "@/shared/store/attributionApi";
+import { useGetApplicantsQuery } from "@/shared/store/applicantsApi";
 import { showError, showSuccess } from "@/shared/lib/toast-store";
 
 export interface AttributionReviewItemProps {
@@ -16,7 +18,19 @@ export interface AttributionReviewItemProps {
 export default function AttributionReviewItem({ item }: AttributionReviewItemProps) {
   const [confirmReview, { isLoading: isConfirming }] = useConfirmAttributionReviewMutation();
   const [rejectReview, { isLoading: isRejecting }] = useRejectAttributionReviewMutation();
+  const [attributeManually, { isLoading: isAttributing }] = useAttributeTransactionManuallyMutation();
   const [isActing, setIsActing] = useState(false);
+  const [pickedApplicantId, setPickedApplicantId] = useState<string>("");
+
+  const isUnmatched = item.confidence === "unmatched";
+
+  // Only fetch the applicants list for unmatched items — otherwise this
+  // mounts on every fuzzy row in the queue and burns RTK cache pressure.
+  const { data: applicantsResponse, isLoading: loadingApplicants } = useGetApplicantsQuery(
+    { stage: "lease_signed", limit: 200 },
+    { skip: !isUnmatched },
+  );
+  const applicants = applicantsResponse?.items ?? [];
 
   const handleConfirm = async () => {
     setIsActing(true);
@@ -42,6 +56,24 @@ export default function AttributionReviewItem({ item }: AttributionReviewItemPro
     }
   };
 
+  const handleLink = async () => {
+    if (!pickedApplicantId || !item.transaction) return;
+    setIsActing(true);
+    try {
+      // Service also resolves the review-queue row, so no separate reject
+      // call is needed.
+      await attributeManually({
+        transaction_id: item.transaction.id,
+        applicant_id: pickedApplicantId,
+      }).unwrap();
+      showSuccess("Payment linked to tenant.");
+    } catch {
+      showError("Couldn't link that payment. Try again?");
+    } finally {
+      setIsActing(false);
+    }
+  };
+
   const txn = item.transaction;
   const proposed = item.proposed_applicant;
   const displayName = txn?.payer_name ?? txn?.vendor ?? "Unknown sender";
@@ -49,6 +81,9 @@ export default function AttributionReviewItem({ item }: AttributionReviewItemPro
   const txnDate = txn?.transaction_date
     ? new Date(txn.transaction_date).toLocaleDateString()
     : "—";
+
+  const anyLoading = (isConfirming || isRejecting || isAttributing) && isActing;
+  const showInlinePicker = isUnmatched && txn != null;
 
   return (
     <div className="flex flex-col sm:flex-row sm:items-start gap-4 p-4 border rounded-lg bg-card">
@@ -74,6 +109,35 @@ export default function AttributionReviewItem({ item }: AttributionReviewItemPro
             <span>Couldn't match this to any of your tenants.</span>
           </div>
         )}
+        {showInlinePicker && !loadingApplicants && applicants.length > 0 ? (
+          <div className="flex items-center gap-2 flex-wrap pt-1">
+            <select
+              value={pickedApplicantId}
+              onChange={(e) => setPickedApplicantId(e.target.value)}
+              className="border rounded px-2 py-1.5 text-sm bg-background min-h-[36px] max-w-[220px]"
+              aria-label="Pick a tenant for this payment"
+              disabled={anyLoading}
+            >
+              <option value="">— pick a tenant —</option>
+              {applicants.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.legal_name ?? "Unnamed"}
+                </option>
+              ))}
+            </select>
+            <LoadingButton
+              variant="primary"
+              size="sm"
+              isLoading={isAttributing && isActing}
+              loadingText="Linking..."
+              onClick={handleLink}
+              disabled={!pickedApplicantId || anyLoading}
+            >
+              <UserCheck className="h-3.5 w-3.5 mr-1" aria-hidden="true" />
+              Link
+            </LoadingButton>
+          </div>
+        ) : null}
       </div>
       <div className="flex items-center gap-2 shrink-0">
         {item.confidence === "fuzzy" && proposed ? (
@@ -83,7 +147,7 @@ export default function AttributionReviewItem({ item }: AttributionReviewItemPro
             isLoading={isConfirming && isActing}
             loadingText="Saving..."
             onClick={handleConfirm}
-            disabled={isRejecting && isActing}
+            disabled={(isRejecting || isAttributing) && isActing}
           >
             <CheckCircle className="h-4 w-4 mr-1" aria-hidden="true" />
             Yes, that's them
@@ -95,7 +159,7 @@ export default function AttributionReviewItem({ item }: AttributionReviewItemPro
           isLoading={isRejecting && isActing}
           loadingText="Skipping..."
           onClick={handleReject}
-          disabled={isConfirming && isActing}
+          disabled={(isConfirming || isAttributing) && isActing}
         >
           <XCircle className="h-4 w-4 mr-1" aria-hidden="true" />
           Not them


### PR DESCRIPTION
## Summary

Resolves the 5-step friction loop on unmatched income payments.

**Before**: reject the queue item → navigate to Transactions → find the txn → open it → use AttributeTenantPicker.
**After**: pick a tenant from the inline \`<select>\` on the review row → click \"Link\" → done.

### Backend

- \`attribute_manually\` was extended: when a pending review-queue row exists for the transaction, it's resolved as \`confirmed\` in the same DB transaction. The host doesn't need a separate reject call to clear the queue.
- New service-level tests in \`test_attribution_service_attribute_manually.py\` cover both the resolves-queue-row path and the no-queue-row no-op path. Existing 43 attribution tests pass unchanged.

### Frontend

- \`AttributionReviewItem\` renders a \`<select>\` of \`lease_signed\` applicants + a \"Link\" button — but **only for \`unmatched\` items** (skips the applicants query for fuzzy items so RTK cache pressure isn't multiplied across the queue).
- Existing fuzzy + reject behavior is unchanged.
- Two new tests in \`AttributionReviewPanel.test.tsx\` assert the picker shows for unmatched and stays hidden for fuzzy.

TECH_DEBT counts: 6 medium → 5 medium (1 deferred + 4 active).

## Test plan

- [x] Backend: \`pytest tests/test_attribution_service_attribute_manually.py tests/test_attribution_*.py\` → 45 passed (43 existing + 2 new)
- [x] Frontend: \`npm test -- src/__tests__/AttributionReviewPanel.test.tsx\` → 10 passed (8 existing + 2 new)
- [x] CI: backend-tests, frontend-build, frontend-layout-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)