### PR TITLE
chore: log monorepo refactor audit findings (~30 items, 2026-05-08)

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -2,6 +2,170 @@
 
 > Last scanned: 2026-05-08
 > Issues: 0 critical, 3 high, 5 medium (1 deferred + 4 active), 0 low
+>
+> **Monorepo refactor audit (2026-05-08, post-resume-refinement work):** ~12 additional findings across three axes — backend reusability, frontend reusability, and long-files. Tracked under "## Monorepo refactor audit (2026-05-08)" below. These are extraction / split candidates, not regression bugs. Sister findings live in `apps/myjobhunter/TECH_DEBT.md`.
+
+## Monorepo refactor audit (2026-05-08)
+
+Output of two parallel scans (backend + frontend) for code that should live in `packages/shared-*` but doesn't, plus an audit of files exceeding 500 LOC. Both apps' findings recorded; this file owns MBK-side entries.
+
+### Backend reusability
+
+#### CRITICAL — Test fixtures duplicated between MBK + MJH
+
+**Effort:** M
+**Location:** `apps/mybookkeeper/backend/tests/conftest.py:121-135` (`test_user`, `test_org`) and `apps/myjobhunter/backend/tests/conftest.py:200-246` (`user_factory`).
+**Problem:** Both apps implement near-identical user/org factory fixtures with email confirmation + password hashing setup. MJH's version is more sophisticated (hard-delete cleanup, monkeypatch fast hasher); MBK's is older / simpler. Drift will accumulate as new auth fields land.
+**Recommendation:** Extract canonical fixtures to `packages/shared-backend/platform_shared/testing/factories.py` + `platform_shared/testing/conftest.py`. Provide an integration guide so per-app conftests register the shared factories with one import.
+
+---
+
+#### HIGH — Soft-delete pattern reimplemented in 10+ MBK repos
+
+**Effort:** S
+**Location:** MBK: `applicants_repo.soft_delete()`, `inquiry_repo.soft_delete_by_id()`, `vendor_repo.soft_delete()`, plus 7 more (10 total). MJH has 2 sister implementations.
+**Problem:** Identical logic each time — set `deleted_at=now()`, idempotent if already deleted. MJH's signature (`soft_delete(db, instance)`) is cleaner; MBK uses positional-args. Diverging tenant-scope rules: MBK enforces `user_id` + `org_id`; MJH enforces `user_id` only.
+**Recommendation:** Extract to `platform_shared/repositories/soft_delete_mixin.py` with optional scope kwargs. Refactor MBK's 10 repos + MJH's 2 to use the mixin. Lock the idempotency contract in shared tests.
+
+---
+
+#### HIGH — `StorageNotConfiguredError` defined identically across 5 files
+
+**Effort:** XS
+**Location:** MBK: `core/storage.py`, `services/leases/lease_template_service.py`, `services/listings/listing_photo_service.py`, `services/screening/screening_service.py` (4 places). MJH: `core/storage.py`.
+**Problem:** Same exception class declared in 5 files. Already partially in `platform_shared/core/storage.py`.
+**Recommendation:** Consolidate as a re-export from `platform_shared/core/storage.py` and delete the local copies. One-line import change per call site.
+
+---
+
+#### HIGH — MBK has local copies of code already in `platform_shared`
+
+**Effort:** S
+**Location:**
+- `app/services/user/totp_service.py` — duplicate of `platform_shared/services/totp_service.py` (MJH already imports from shared)
+- `app/services/system/auth_event_service.py` — mirrors `platform_shared/services/auth_event_service.py`
+- `app/services/system/admin_user_service_factory.py` — stub re-export wrapping `platform_shared/services/admin_user_service.py`
+
+**Problem:** Parity drift, not extraction work. Each local copy risks divergence on the next bug fix.
+**Recommendation:** Delete the local files; update imports across `app/api/totp.py` and any other consumers to import directly from `platform_shared`. Verify with `grep -r "app.services.user.totp_service" apps/mybookkeeper`.
+
+---
+
+#### MEDIUM — Pagination response envelopes hardcoded in 8+ MBK schemas
+
+**Effort:** M
+**Location:** `ApplicantListResponse`, `InquiryListResponse`, `ListingListResponse`, `VendorListResponse`, plus 4 more (`items: list[T], total: int, has_more: bool` shape).
+**Problem:** Each domain redefines the same envelope. MJH has zero pagination today and will repeat the mistake when it adds CRUD listings.
+**Recommendation:** Extract a generic `ListResponse[ItemT]` to `platform_shared/schemas/pagination.py`. Both apps inherit. MJH adopts the pattern as it builds its first list endpoints (cheaper to do early).
+
+---
+
+#### MEDIUM — `StatusResponse` / `CountResponse` / `SuccessResponse` defined only in MBK
+
+**Effort:** XS
+**Location:** `app/schemas/common.py`.
+**Problem:** Three reusable response types live in MBK only; MJH reuses `dict[str, Any]` for the same shapes (loose typing).
+**Recommendation:** Move to `platform_shared/schemas/common.py`; both apps import.
+
+---
+
+#### MEDIUM — Email template rendering duplicated with per-app branding
+
+**Effort:** M
+**Location:** MBK: `services/system/verification_email.py`, `services/system/password_reset_email.py`. MJH: `services/email/verification_email.py` (minimal version).
+**Problem:** Both render HTML email templates inline; both will drift over time.
+**Recommendation:** Extract template rendering to `platform_shared/services/email_templates/` with hooks for app-specific branding (logo URL, sender name). Branding stays per-app via `Settings`.
+
+---
+
+#### MEDIUM — DB session + `unit_of_work` pattern duplicated
+
+**Effort:** S
+**Location:** MBK: `db/session.py`. MJH: `db/session.py`.
+**Problem:** Both implement near-identical session factory + `unit_of_work` context manager. Already partially in `platform_shared/db/`. MBK has org-isolation hooks that need to remain.
+**Recommendation:** Reduce both local versions to thin re-exports from `platform_shared/db/session.py` plus app-specific overrides. Verify org-isolation hooks aren't lost.
+
+---
+
+#### LOW — Request context (`org_id`, `user_id` tracking) only in MBK
+
+**Effort:** S
+**Location:** `app/core/context.py::RequestContext`.
+**Problem:** MJH has user-only context today. When MJH adds multi-tenancy (Phase 4+), the pattern will be needed.
+**Recommendation:** Defer until MJH spec needs orgs. Track in this entry.
+
+---
+
+### Frontend reusability (MBK-side)
+
+> **Blocked-on-react-19.** MBK can't import from `@platform/ui` until the React 18→19 upgrade lands (two-React-copies runtime crash, see `project_mbk_platform_ui_migration_blocked` in auto-memory). MJH already uses `@platform/ui` and has the corresponding entries in its TECH_DEBT.
+
+#### HIGH (blocked-on-react-19) — Status-colored Badge component
+
+**Effort:** S (post-React-19)
+**Location:** MBK: `features/documents/StatusBadge.tsx:9-32`. Sister implementations in MJH: `features/admin/invites/InviteStatusBadge.tsx`, `features/documents/DocumentKindBadge.tsx`.
+**Problem:** Same enum→color-map→Badge render pattern in both apps, 3+ uses per app.
+**Recommendation:** Extract a generic `<StatusBadge value={...} colors={...} />` to `packages/shared-frontend/src/components/StatusBadge.tsx`. Re-enable for MBK after React 19 upgrade.
+
+---
+
+#### HIGH (blocked-on-react-19) — Confirm-delete dialog wrapper
+
+**Effort:** S (post-React-19)
+**Location:** MBK: `features/vendors/DeleteVendorModal.tsx` (wraps shared `ConfirmDialog`). MJH: `features/admin/demo/DeleteDemoConfirmDialog.tsx` (rebuilds from Radix).
+**Problem:** MBK delegates to shared, MJH reimplements. Both are the same shape with destructive styling.
+**Recommendation:** Extract a `DeleteConfirmDialog` wrapper around `ConfirmDialog` with destructive default styling (warning icon, red Confirm button) to `packages/shared-frontend/src/components/DeleteConfirmDialog.tsx`. Both apps consume.
+
+---
+
+### Long files (>500 LOC) — production code
+
+#### HIGH — `app/services/leases/signed_lease_service.py` (1,647 LOC)
+
+**Effort:** L
+**Problem:** Whole lease lifecycle in one file: apply → generate PDF → email → sign → store → lookup → renew. Hardest file to navigate in the repo.
+**Recommendation:** Split into `lease_apply_service.py`, `lease_pdf_service.py`, `lease_email_service.py`, `lease_lifecycle_service.py`. Highest payoff in the audit.
+
+---
+
+#### HIGH — `app/api/test_utils.py` (1,069 LOC)
+
+**Effort:** M
+**Problem:** Test-helper endpoints mounted in production routing. Gated behind `MYBOOKKEEPER_ENABLE_TEST_HELPERS=1` env flag, but they're discoverable in `app/api/` alongside real routes.
+**Recommendation:** Move to `app/test_helpers/` (separate package). Mount conditionally in `main.py`. Reduces blast radius if the env flag ever ships true.
+
+---
+
+#### MEDIUM — `app/repositories/transactions/transaction_repo.py` (943 LOC)
+
+**Effort:** M
+**Problem:** List filters + bulk ops + reconciliation queries all in one repo file.
+**Recommendation:** Split into `transaction_list_repo.py` (filters/queries), `transaction_bulk_repo.py` (bulk ops), `transaction_reconciliation_repo.py`.
+
+---
+
+#### MEDIUM — `frontend/src/app/pages/PublicInquiryForm.tsx` (934 LOC)
+
+**Effort:** M
+**Problem:** Form + listing detail + auto-fill + submit flow all inline in the page.
+**Recommendation:** Extract step components (`PublicInquiryListingPanel`, `PublicInquiryFormStep`, `PublicInquirySuccessStep`) and a state-machine hook.
+
+---
+
+#### MEDIUM — `app/services/leases/lease_template_service.py` (926 LOC)
+
+**Effort:** M
+**Problem:** Template CRUD + AI placeholder extraction + render + auto-prepend dog disclosure all together.
+**Recommendation:** Split into `lease_template_crud_service.py`, `lease_template_placeholder_service.py` (AI extraction), `lease_template_render_service.py`.
+
+---
+
+#### MEDIUM — `app/services/tax/tax_advisor_service.py` (590 LOC) and `services/leases/receipt_service.py` (584 LOC)
+
+**Effort:** S each
+**Recommendation:** Borderline — split if a clear seam exists. Watch for further growth.
+
+---
 
 ## High
 

--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -9,6 +9,113 @@ removed and the counts in this header are updated.
 
 > Silent-fail follow-up audit: 2026-05-08 (post-#426 ripple investigation, triggered by today's resume-refinement 500 in PR #435). 8 new findings spanning shared platform + both apps; tracked under "## Silent-fail audit (2026-05-08)" below. PR #426 ripped silent-fail from `_record_log` only — same pattern survives in 8 other third-party wrappers across the monorepo.
 
+> Monorepo refactor audit (2026-05-08): ~10 additional findings under "## Monorepo refactor audit (2026-05-08)" below. MJH-specific extraction / split candidates. Sister findings live in `apps/mybookkeeper/TECH_DEBT.md`.
+
+---
+
+## Monorepo refactor audit (2026-05-08)
+
+### Backend reusability (MJH-side)
+
+#### CRITICAL — Test fixtures duplicated between MBK + MJH
+
+See sister entry in `apps/mybookkeeper/TECH_DEBT.md`. MJH side: `apps/myjobhunter/backend/tests/conftest.py:200-246` (`user_factory` — the more sophisticated implementation, with hard-delete cleanup + monkeypatch fast hasher). When extracted to `platform_shared/testing/factories.py`, MJH's pattern should be the canonical version; MBK's test fixtures will need to adopt it.
+
+---
+
+#### HIGH — Soft-delete pattern reimplemented
+
+See sister entry in MBK. MJH side: `application_repository.soft_delete()`, `document_repo.soft_delete()` (2 implementations). MJH's signature (`soft_delete(db, instance)`) is cleaner than MBK's positional-args style. When extracted, MJH's shape should be the canonical version.
+
+---
+
+#### HIGH — `StorageNotConfiguredError` defined identically across 5 files
+
+See sister entry in MBK. MJH side: `core/storage.py`. Consolidate as a re-export from `platform_shared/core/storage.py`.
+
+---
+
+#### MEDIUM — Pagination response envelopes — adopt early in MJH
+
+**Effort:** S
+**Problem:** MBK has 8 hardcoded `*ListResponse` envelopes. MJH has zero pagination today and is about to start adding CRUD listings (Phase 2+).
+**Recommendation:** When the shared `ListResponse[ItemT]` Pydantic generic lands in `platform_shared/schemas/pagination.py`, MJH should adopt it for every list endpoint from the start — cheaper than backfilling later.
+
+---
+
+#### MEDIUM — `StatusResponse` / `CountResponse` / `SuccessResponse` adoption
+
+**Effort:** XS
+**Problem:** MJH currently returns `dict[str, Any]` for status/success/count responses, losing strict typing.
+**Recommendation:** When MBK's `schemas/common.py` extracts to `platform_shared/schemas/common.py`, MJH should adopt the typed responses across all endpoints that currently return dicts.
+
+---
+
+### Frontend reusability (MJH-side)
+
+> MJH already imports from `@platform/ui`, so these extractions are NOT blocked-on-react-19 from the MJH side. They become unblocked-for-MBK once MBK upgrades to React 19.
+
+#### HIGH — Extract `InlineBoldText` to `@platform/ui` now
+
+**Effort:** S
+**Location:** `apps/myjobhunter/frontend/src/features/discover/InlineBoldText.tsx` (65 LOC).
+**Problem:** Generic markdown-bold renderer (parses `**text**`) living in a feature folder. MJH-only consumer today, but obviously reusable.
+**Recommendation:** Move to `packages/shared-frontend/src/components/InlineBoldText.tsx`. Re-export from `@platform/ui` index. Update MJH import.
+
+---
+
+#### HIGH (blocked-on-react-19 from MBK side) — Status-colored Badge components
+
+See sister entry in MBK. MJH-side files: `features/admin/invites/InviteStatusBadge.tsx`, `features/documents/DocumentKindBadge.tsx`. MJH could extract its own `<StatusBadge>` to `@platform/ui` now (since MJH consumes shared); MBK adopts after React 19.
+
+---
+
+#### HIGH (blocked-on-react-19 from MBK side) — Confirm-delete dialog wrapper
+
+See sister entry in MBK. MJH-side file: `features/admin/demo/DeleteDemoConfirmDialog.tsx` (rebuilds from Radix instead of wrapping shared `ConfirmDialog`). When `DeleteConfirmDialog` lands in `@platform/ui`, MJH should refactor away from raw Radix.
+
+---
+
+#### MEDIUM — `MarkdownPreview` borderline-extractable
+
+**Effort:** M
+**Location:** `apps/myjobhunter/frontend/src/features/resume_refinement/markdown-preview.tsx` (210 LOC, full block + inline markdown).
+**Problem:** Specialized renderer; MJH-only today.
+**Recommendation:** Defer until MBK or another app needs markdown rendering.
+
+---
+
+### Long files (>500 LOC) — MJH-side production code
+
+#### HIGH — `apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx` (1,070 LOC)
+
+**Effort:** M
+**Problem:** Multi-step dialog with paste-link / paste-text / manual / company-confirm states all inline.
+**Recommendation:** Extract per-step components (`PasteLinkStep`, `PasteTextStep`, `ManualEntryStep`, `CompanyConfirmStep`) and a state-machine hook (`useAddApplicationFlow`).
+
+---
+
+#### MEDIUM — `apps/myjobhunter/backend/app/services/resume_refinement/session_service.py` (795 LOC)
+
+**Effort:** M
+**Problem:** Started at ~600 LOC; my own additions in PRs #456 (chat history wrapping) and #460 (prior_context fetching) bumped it past 700 without splitting. Now has start_session + 6 mutation entry points + 5 helpers + critique/rewrite orchestration.
+**Recommendation:** Split into `session_lifecycle_service.py` (start / get / complete), `session_turn_service.py` (accept / custom / alternative / skip / navigate), and keep helpers in a third module. This entry is on me to fix first.
+
+---
+
+#### MEDIUM — `apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py` (786 LOC)
+
+**Effort:** M
+**Problem:** Analyze + score + promote + extraction-log management all together.
+**Recommendation:** Split into `job_analysis_service.py` (analyze + score), `job_analysis_promote_service.py` (promote-to-application).
+
+---
+
+#### MEDIUM — `apps/myjobhunter/backend/app/services/extraction/jd_url_extractor.py` (590 LOC)
+
+**Effort:** S
+**Recommendation:** Borderline — likely splittable into `jd_url_fetcher.py` (HTTP fetching) + `jd_url_parser.py` (HTML→JD extraction). Watch for growth.
+
 ---
 
 ## Silent-fail audit (2026-05-08)


### PR DESCRIPTION
## Summary

Documents the output of three parallel scans run today, all into TECH_DEBT.md per project convention.

- **Backend reusability scan** — what should live in \`packages/shared-backend/platform_shared\` but doesn't (15 findings)
- **Frontend reusability scan** — what should live in \`@platform/ui\` but doesn't (8 findings, mostly blocked-on-react-19 for MBK)
- **Long-files audit** — production code >500 LOC with proposed split shape (8 findings)

Total: ~30 candidates, no code changes. Each finding is its own future PR.

## Top items by severity

| Severity | Item |
|---|---|
| Critical | Test fixtures duplicated MBK ↔ MJH (extract to \`platform_shared/testing\`) |
| High | Soft-delete pattern reimplemented in 12+ repos across both apps |
| High | \`StorageNotConfiguredError\` defined identically in 5 files |
| High | MBK has local copies of code already in \`platform_shared\` (TOTP service, auth event service, admin user service factory) |
| High | \`signed_lease_service.py\` at 1,647 LOC (largest production file) |
| High | \`test_utils.py\` at 1,069 LOC (test helpers in production routing) |
| High | \`AddApplicationDialog.tsx\` at 1,070 LOC (multi-step dialog inline) |
| High | \`InlineBoldText\` extractable to \`@platform/ui\` NOW (no React 19 blocker) |
| Medium | 8 hardcoded \`*ListResponse\` envelopes in MBK; MJH should adopt shared pagination from the start |
| Medium | \`session_service.py\` at 795 LOC (my additions bumped it past 700 — on me to fix first) |

## Where to find them

- \`apps/mybookkeeper/TECH_DEBT.md\` → "Monorepo refactor audit (2026-05-08)" section
- \`apps/myjobhunter/TECH_DEBT.md\` → "Monorepo refactor audit (2026-05-08)" section
- Sister entries cross-reference each other

## Test plan

- [x] No code changes; just markdown
- [ ] CI green (markdown-only — should sail)

🤖 Generated with [Claude Code](https://claude.com/claude-code)