### PR TITLE
refactor(mbk/integrations): extract GmailHeaderActions, drop nested ternaries

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -1,7 +1,7 @@
 # Tech Debt
 
 > Last scanned: 2026-05-08
-> Issues: 0 critical, 3 high, 5 medium (1 deferred + 4 active), 0 low
+> Issues: 0 critical, 3 high, 4 medium (1 deferred + 3 active), 0 low
 >
 > **Monorepo refactor audit (2026-05-08, post-resume-refinement work):** ~12 additional findings across three axes — backend reusability, frontend reusability, and long-files. Tracked under "## Monorepo refactor audit (2026-05-08)" below. These are extraction / split candidates, not regression bugs. Sister findings live in `apps/myjobhunter/TECH_DEBT.md`.
 
@@ -241,11 +241,8 @@ Output of two parallel scans (backend + frontend) for code that should live in `
 
 ---
 
-### [Frontend] Stacked ternary chains in JSX rendering (per-file audit needed)
-**Effort:** M
-**Location:** Unknown — no clean grep heuristic. Audit per-domain (`features/transactions/`, `features/applicants/`, `features/leases/`, `features/integrations/`).
-**Problem:** Per the new global config rule (jkwon-claude-config #92), nested ternaries in JSX are unreadable past 2 levels. The canonical fix is a `useXxxMode()` hook returning a discriminated union plus a `switch` in the body component dispatching to one subcomponent per state. Reference impl: `apps/mybookkeeper/frontend/src/app/features/documents/DocumentViewer.tsx` + `useDocumentViewMode.ts` + `DocumentViewerBody.tsx` (PR #238).
-**Recommendation:** Tackle per-domain, not as a sweep — each refactor needs human judgment about the right discriminated-union shape. Start with the highest-traffic domains (transactions, integrations). Use the DocumentViewer trio as the worked example.
+### ~~[Frontend] Stacked ternary chains in JSX rendering (per-file audit needed)~~ RESOLVED
+**Resolved:** Audit (2026-05-08, Explore agent) found ONE genuine 3+-level ternary chain: `app/pages/Integrations.tsx` lines 216-282 (Gmail action button group). Fixed in PR refactor/mbk-gmail-action-mode (2026-05-08) by extracting a `GmailHeaderActions` sub-component using early returns to dispatch on `(no gmail) → Connect / (needs_reauth) → Reconnect / (active) → Sync+Disconnect group`. The confirm-sync and confirm-disconnect sub-states moved into the new component as local state. Other candidate files (LinkedLeaseDocuments, AttributionReviewPanel, CalendarEventBar, Inquiry*, ReconciliationSourcesBody, ReceivedDocumentsGrouped, FormCompletenessCard, TransactionForm) were checked — most are 2-level (acceptable per rule), one (ReconciliationSourcesBody) already uses the discriminated-union pattern.
 
 ---
 

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/GmailHeaderActions.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/GmailHeaderActions.tsx
@@ -1,0 +1,143 @@
+import { useState } from "react";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import type { Integration } from "@/shared/types/integration/integration";
+
+export interface GmailHeaderActionsProps {
+  gmail: Integration | undefined;
+  isConnecting: boolean;
+  isSyncing: boolean;
+  isSyncStarting: boolean;
+  isCancelling: boolean;
+  isDisconnecting: boolean;
+  latestSyncLogId: number | null;
+  onConnect: () => void;
+  onSync: () => void;
+  onCancel: (syncLogId?: number) => void;
+  onDisconnect: () => void;
+}
+
+/**
+ * Renders the Sync / Cancel / Disconnect / Connect / Reconnect button group
+ * to the right of the Gmail header. Branches by Integration state via early
+ * returns rather than nested ternaries; sub-state for the inline "Are you
+ * sure?" confirms is local to this component.
+ */
+export default function GmailHeaderActions({
+  gmail,
+  isConnecting,
+  isSyncing,
+  isSyncStarting,
+  isCancelling,
+  isDisconnecting,
+  latestSyncLogId,
+  onConnect,
+  onSync,
+  onCancel,
+  onDisconnect,
+}: GmailHeaderActionsProps) {
+  const [confirmSync, setConfirmSync] = useState(false);
+  const [confirmDisconnect, setConfirmDisconnect] = useState(false);
+
+  if (!gmail) {
+    return (
+      <LoadingButton
+        onClick={onConnect}
+        isLoading={isConnecting}
+        loadingText="Connecting..."
+      >
+        Connect Gmail
+      </LoadingButton>
+    );
+  }
+
+  if (gmail.needs_reauth) {
+    // Token expired — show Reconnect instead of Sync/Disconnect. The OAuth
+    // flow replaces the tokens without requiring a disconnect.
+    return (
+      <LoadingButton
+        onClick={onConnect}
+        isLoading={isConnecting}
+        loadingText="Reconnecting..."
+        data-testid="gmail-reconnect-button"
+      >
+        Reconnect Gmail
+      </LoadingButton>
+    );
+  }
+
+  const handleSyncConfirmed = () => {
+    setConfirmSync(false);
+    onSync();
+  };
+
+  const handleDisconnectConfirmed = () => {
+    setConfirmDisconnect(false);
+    onDisconnect();
+  };
+
+  return (
+    <>
+      {confirmSync ? (
+        <div className="flex items-center gap-2 border rounded-md px-3 py-1.5 text-sm">
+          <span className="text-muted-foreground">Start email sync?</span>
+          <button onClick={handleSyncConfirmed} className="text-primary font-medium hover:underline">
+            Yes
+          </button>
+          <button
+            onClick={() => setConfirmSync(false)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            No
+          </button>
+        </div>
+      ) : (
+        <LoadingButton
+          variant="secondary"
+          onClick={() => setConfirmSync(true)}
+          disabled={isSyncing}
+          isLoading={isSyncing || isSyncStarting}
+          loadingText="Syncing..."
+        >
+          Sync now
+        </LoadingButton>
+      )}
+      {isSyncing ? (
+        <LoadingButton
+          variant="ghost"
+          onClick={() => onCancel(latestSyncLogId ?? undefined)}
+          isLoading={isCancelling}
+          loadingText="Cancelling..."
+          className="text-destructive hover:text-destructive"
+        >
+          Cancel
+        </LoadingButton>
+      ) : confirmDisconnect ? (
+        <div className="flex items-center gap-2 border rounded-md px-3 py-1.5 text-sm">
+          <span className="text-muted-foreground">Disconnect Gmail?</span>
+          <button
+            onClick={handleDisconnectConfirmed}
+            className="text-destructive font-medium hover:underline"
+          >
+            Yes
+          </button>
+          <button
+            onClick={() => setConfirmDisconnect(false)}
+            className="text-muted-foreground hover:text-foreground"
+          >
+            No
+          </button>
+        </div>
+      ) : (
+        <LoadingButton
+          variant="ghost"
+          onClick={() => setConfirmDisconnect(true)}
+          isLoading={isDisconnecting}
+          loadingText="Disconnecting..."
+          className="text-destructive hover:text-destructive"
+        >
+          Disconnect
+        </LoadingButton>
+      )}
+    </>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/Integrations.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Integrations.tsx
@@ -23,6 +23,7 @@ import { useToast } from "@/shared/hooks/useToast";
 import { useCanWrite } from "@/shared/hooks/useOrgRole";
 import { useInvalidateOnExtractionComplete } from "@/shared/hooks/useInvalidateOnExtractionComplete";
 import IntegrationsSkeleton from "@/app/features/integrations/IntegrationsSkeleton";
+import GmailHeaderActions from "@/app/features/integrations/GmailHeaderActions";
 import LoadingButton from "@/shared/components/ui/LoadingButton";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import AlertBox from "@/shared/components/ui/AlertBox";
@@ -97,18 +98,13 @@ export default function Integrations() {
       .catch((err) => showError(`Connect failed: ${extractErrorMessage(err)}`));
   }, [connectGmail, showError]);
 
-  const [confirmSync, setConfirmSync] = useState(false);
-  const [confirmDisconnect, setConfirmDisconnect] = useState(false);
-
   const handleSync = useCallback(() => {
-    setConfirmSync(false);
     syncGmail()
       .unwrap()
       .catch((err) => showError(`Sync failed: ${extractErrorMessage(err)}`));
   }, [syncGmail, showError]);
 
   const handleDisconnect = useCallback(() => {
-    setConfirmDisconnect(false);
     disconnectGmail()
       .unwrap()
       .then(() => showSuccess("Disconnected from Gmail. You can reconnect anytime."))
@@ -211,83 +207,19 @@ export default function Integrations() {
 
               {canWrite ? (
                 <div className="flex gap-2">
-                  {gmail ? (
-                    <>
-                      {gmail.needs_reauth ? (
-                        /* Token expired — show Reconnect instead of Sync/Disconnect.
-                           The OAuth flow replaces the tokens without requiring a disconnect. */
-                        <LoadingButton
-                          onClick={handleConnect}
-                          isLoading={isConnecting}
-                          loadingText="Reconnecting..."
-                          data-testid="gmail-reconnect-button"
-                        >
-                          Reconnect Gmail
-                        </LoadingButton>
-                      ) : (
-                        <>
-                          {confirmSync ? (
-                            <div className="flex items-center gap-2 border rounded-md px-3 py-1.5 text-sm">
-                              <span className="text-muted-foreground">Start email sync?</span>
-                              <button onClick={handleSync} className="text-primary font-medium hover:underline">Yes</button>
-                              <button onClick={() => setConfirmSync(false)} className="text-muted-foreground hover:text-foreground">No</button>
-                            </div>
-                          ) : (
-                            <LoadingButton
-                              variant="secondary"
-                              onClick={() => setConfirmSync(true)}
-                              disabled={isSyncing}
-                              isLoading={isSyncing || isSyncStarting}
-                              loadingText="Syncing..."
-                            >
-                              Sync now
-                            </LoadingButton>
-                          )}
-                          {isSyncing ? (
-                            <LoadingButton
-                              variant="ghost"
-                              onClick={() => handleCancel(latestLog?.id)}
-                              isLoading={isCancelling}
-                              loadingText="Cancelling..."
-                              className="text-destructive hover:text-destructive"
-                            >
-                              Cancel
-                            </LoadingButton>
-                          ) : confirmDisconnect ? (
-                            <div className="flex items-center gap-2 border rounded-md px-3 py-1.5 text-sm">
-                              <span className="text-muted-foreground">Disconnect Gmail?</span>
-                              <button
-                                onClick={handleDisconnect}
-                                className="text-destructive font-medium hover:underline"
-                              >
-                                Yes
-                              </button>
-                              <button
-                                onClick={() => setConfirmDisconnect(false)}
-                                className="text-muted-foreground hover:text-foreground"
-                              >
-                                No
-                              </button>
-                            </div>
-                          ) : (
-                            <LoadingButton
-                              variant="ghost"
-                              onClick={() => setConfirmDisconnect(true)}
-                              isLoading={isDisconnecting}
-                              loadingText="Disconnecting..."
-                              className="text-destructive hover:text-destructive"
-                            >
-                              Disconnect
-                            </LoadingButton>
-                          )}
-                        </>
-                      )}
-                    </>
-                  ) : (
-                    <LoadingButton onClick={handleConnect} isLoading={isConnecting} loadingText="Connecting...">
-                      Connect Gmail
-                    </LoadingButton>
-                  )}
+                  <GmailHeaderActions
+                    gmail={gmail}
+                    isConnecting={isConnecting}
+                    isSyncing={isSyncing}
+                    isSyncStarting={isSyncStarting}
+                    isCancelling={isCancelling}
+                    isDisconnecting={isDisconnecting}
+                    latestSyncLogId={latestLog?.id ?? null}
+                    onConnect={handleConnect}
+                    onSync={handleSync}
+                    onCancel={handleCancel}
+                    onDisconnect={handleDisconnect}
+                  />
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
## Summary

The Gmail action button group on Integrations.tsx was the only genuine 3+-deep nested-ternary violation in the MBK frontend (per the per-domain audit done today via Explore agent). Branches were:

\`\`\`
canWrite ? gmail ?
            gmail.needs_reauth ? <Reconnect> : (
              confirmSync ? <ConfirmSyncDialog> : <SyncBtn>
              isSyncing ? <Cancel> : confirmDisconnect ? <ConfirmDisconnectDialog> : <DisconnectBtn>
            )
          : <ConnectBtn>
        : null
\`\`\`

Extracted to \`GmailHeaderActions\` with early returns:

\`\`\`tsx
if (!gmail) return <Connect />;
if (gmail.needs_reauth) return <Reconnect />;
return <SyncAndDisconnectGroup />;
\`\`\`

\`confirmSync\` + \`confirmDisconnect\` state moved into the new component (only used inside it). Page-level Integrations.tsx is now a cleaner header-info + actions split.

No behavior change.

TECH_DEBT counts: 5 medium → 4 medium (1 deferred + 3 active). Other candidate files inspected (LinkedLeaseDocuments, AttributionReviewPanel, CalendarEventBar, Inquiry*, ReconciliationSourcesBody, ReceivedDocumentsGrouped, FormCompletenessCard, TransactionForm) were either 2-level (acceptable) or already used the discriminated-union pattern.

## Test plan

- [x] \`npx tsc --noEmit\` → clean
- [x] \`npm test -- src/__tests__/Integrations.test.tsx\` → 36 passed (all existing behavior preserved)
- [x] \`npm run lint\` → no new errors (2 pre-existing on main are unchanged)
- [x] CI: backend-tests, frontend-build, frontend-layout-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)