### PR TITLE
refactor(shared-frontend): extract InlineBoldText to @platform/ui

### DIFF
--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -8,7 +8,7 @@ import {
 import { useCreateDiscoverySourceMutation } from "@/store/discoverApi";
 import { useUpdateProfileMutation } from "@/lib/profileApi";
 import { buildSavedSearchSummary } from "./saved-search-summary";
-import InlineBoldText from "./InlineBoldText";
+import { InlineBoldText } from "@platform/ui";
 import { useDiscoveryDefaultsPrefill } from "./useDiscoveryDefaultsPrefill";
 import SearchInputsSection from "./dialog-sections/SearchInputsSection";
 import WhereWhenSection from "./dialog-sections/WhereWhenSection";

--- a/packages/shared-frontend/src/components/ui/InlineBoldText.tsx
+++ b/packages/shared-frontend/src/components/ui/InlineBoldText.tsx
@@ -1,4 +1,4 @@
-import { Fragment, type ReactNode } from "react";
+import { Fragment } from "react";
 
 interface InlineBoldTextProps {
   /** A string with **bold** segments. Other markdown is rendered as
@@ -10,13 +10,15 @@ interface InlineBoldTextProps {
 
 /**
  * Render a string with **markdown bold** segments inline. Tiny utility
- * for the saved-search summary preview — avoids pulling in a markdown
- * library when bold is the only thing we need.
+ * for places that need bold-only formatting without pulling in a full
+ * markdown library.
  *
- * The input strings are operator-controlled (role / skill / location
- * / keyword inputs all already trimmed by the form). XSS surface is
- * limited to React's text-node escaping, which handles HTML in the
- * input automatically.
+ * Use cases: chip-summary previews, plain-text callouts, anywhere you
+ * want bold emphasis on a substring without parsing block-level
+ * markdown (headings, lists, links, etc.).
+ *
+ * Input strings are caller-controlled. XSS surface is limited to React's
+ * text-node escaping, which handles HTML in the input automatically.
  */
 export default function InlineBoldText({
   text,
@@ -66,6 +68,3 @@ function parseBoldSegments(s: string): Segment[] {
 
 // Exported only for unit tests.
 export const __INTERNAL__ = { parseBoldSegments };
-
-// Suppress unused-import lint for the optional ReactNode export shape.
-export type { ReactNode };

--- a/packages/shared-frontend/src/index.ts
+++ b/packages/shared-frontend/src/index.ts
@@ -34,6 +34,7 @@ export { default as FormField } from "./components/ui/FormField";
 export { default as Toaster } from "./components/ui/Toaster";
 export { default as TurnstileWidget } from "./components/ui/TurnstileWidget";
 export { default as ConfirmDialog } from "./components/ui/ConfirmDialog";
+export { default as InlineBoldText } from "./components/ui/InlineBoldText";
 
 // Layout components
 export { default as AppShell } from "./components/layout/AppShell";


### PR DESCRIPTION
## Summary

Extracts the 65-line markdown-bold renderer from MJH's feature folder to the shared package. Obviously generic — no MJH-specific logic.

## Changes

- \`packages/shared-frontend/src/components/ui/InlineBoldText.tsx\` — new (moved from MJH)
- \`packages/shared-frontend/src/index.ts\` — re-export added
- \`apps/myjobhunter/frontend/src/features/discover/InlineBoldText.tsx\` — deleted
- \`apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx\` — import updated to \`@platform/ui\`

## Blocker check

No React 19 blocker — MJH already consumes \`@platform/ui\`. MBK can adopt once it migrates to React 19.

## From audit

Resolves the High-priority "InlineBoldText extractable to \`@platform/ui\` now" item from the 2026-05-08 monorepo refactor audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)