### PR TITLE
refactor(shared): consolidate StorageNotConfiguredError to platform_shared

### DIFF
--- a/apps/mybookkeeper/backend/app/api/screening.py
+++ b/apps/mybookkeeper/backend/app/api/screening.py
@@ -169,10 +169,12 @@ async def upload_screening_result(
         raise HTTPException(status_code=422, detail=str(exc)) from exc
     except screening_service.UnknownProviderError as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except screening_service.StorageNotConfiguredError as exc:
+        # Storage is a deploy-time config issue — distinct from a request
+        # error. 503 lets the operator distinguish "missing config" from
+        # "client did something wrong".
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
     except screening_service.ScreeningServiceError as exc:
-        # Includes StorageNotConfiguredError → 503.
-        if "storage" in str(exc).lower():
-            raise HTTPException(status_code=503, detail=str(exc)) from exc
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except Exception as exc:
         # Defer to the report-processor exception class via duck typing —

--- a/apps/mybookkeeper/backend/app/core/storage.py
+++ b/apps/mybookkeeper/backend/app/core/storage.py
@@ -25,19 +25,13 @@ from urllib.parse import urlparse
 from minio import Minio
 from minio.error import S3Error
 
+from platform_shared.core.storage import StorageNotConfiguredError  # noqa: F401 — re-exported for back-compat
+
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
 _client: "StorageClient | None" = None
-
-
-class StorageNotConfiguredError(RuntimeError):
-    """Raised when MinIO env vars are missing or incomplete.
-
-    Distinct from a transient outage: this is a *deployment-time* fault
-    that should crash the app at boot, not a per-request degradation.
-    """
 
 
 def _parse_endpoint(url: str) -> tuple[str, bool]:

--- a/apps/mybookkeeper/backend/app/services/leases/lease_template_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_template_service.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 import logging
 import uuid
 
+from platform_shared.core.storage import StorageNotConfiguredError
+
 from app.core.config import settings
 from app.core.storage import StorageClient, get_storage
 from app.db.session import unit_of_work
@@ -84,10 +86,6 @@ DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.docu
 # ---------------------------------------------------------------------------
 
 class TemplateNotFoundError(LookupError):
-    pass
-
-
-class StorageNotConfiguredError(RuntimeError):
     pass
 
 

--- a/apps/mybookkeeper/backend/app/services/listings/blackout_service.py
+++ b/apps/mybookkeeper/backend/app/services/listings/blackout_service.py
@@ -17,6 +17,8 @@ import logging
 import uuid
 from datetime import datetime, timezone
 
+from platform_shared.core.storage import StorageNotConfiguredError  # noqa: F401 — re-exported for back-compat
+
 from app.core.config import settings
 from app.core.storage import get_storage
 from app.db.session import unit_of_work
@@ -64,10 +66,6 @@ class AttachmentTooLargeError(ValueError):
 
 class AttachmentTypeRejectedError(ValueError):
     """Raised when the sniffed content type is not in the allowlist."""
-
-
-class StorageNotConfiguredError(RuntimeError):
-    """Raised when MinIO/S3 storage is not configured."""
 
 
 # ---------------------------------------------------------------------------

--- a/apps/mybookkeeper/backend/app/services/listings/listing_photo_service.py
+++ b/apps/mybookkeeper/backend/app/services/listings/listing_photo_service.py
@@ -14,6 +14,8 @@ import logging
 import uuid
 from typing import Any
 
+from platform_shared.core.storage import StorageNotConfiguredError  # noqa: F401 — re-exported for back-compat
+
 from app.core.storage import get_storage
 from app.db.session import unit_of_work
 from app.repositories import listing_photo_repo, listing_repo
@@ -26,15 +28,6 @@ logger = logging.getLogger(__name__)
 
 class ListingNotFoundError(LookupError):
     """Raised when the listing the caller scoped against does not exist."""
-
-
-class StorageNotConfiguredError(RuntimeError):
-    """Raised when MinIO/S3 storage is not configured.
-
-    Photo uploads require object storage — unlike documents which can fall back
-    to DB-side storage, photos are too large for that and benefit from CDN
-    fronting. Surfaces as HTTP 503.
-    """
 
 
 async def upload_photos(

--- a/apps/mybookkeeper/backend/app/services/screening/screening_service.py
+++ b/apps/mybookkeeper/backend/app/services/screening/screening_service.py
@@ -20,6 +20,8 @@ import logging
 import uuid
 from typing import Protocol
 
+from platform_shared.core.storage import StorageNotConfiguredError  # noqa: F401 — re-exported for back-compat
+
 from app.core.applicant_enums import SCREENING_PROVIDERS, SCREENING_STATUSES
 from app.core.storage import get_storage
 from app.db.session import unit_of_work
@@ -121,11 +123,11 @@ class ScreeningUploadValidationError(ScreeningServiceError):
     """
 
 
-class StorageNotConfiguredError(ScreeningServiceError):
-    """Object storage required for the screening upload is unavailable.
-
-    The route handler maps this to HTTP 503 — uploads need somewhere to go.
-    """
+# StorageNotConfiguredError previously inherited from ScreeningServiceError
+# so the route's broad catch would map it to 503 via a string-match hack
+# ("if 'storage' in str(exc).lower()"). Switched to the canonical class
+# from platform_shared (imported at top of file) so the route can catch
+# it explicitly without the string-match — see api/screening.py.
 
 
 def get_provider(name: str) -> ScreeningProvider:

--- a/apps/myjobhunter/backend/app/core/storage.py
+++ b/apps/myjobhunter/backend/app/core/storage.py
@@ -22,19 +22,13 @@ from urllib.parse import urlparse
 from minio import Minio
 from minio.error import S3Error
 
+from platform_shared.core.storage import StorageNotConfiguredError  # noqa: F401 — re-exported for back-compat
+
 from app.core.config import settings
 
 logger = logging.getLogger(__name__)
 
 _client: "StorageClient | None" = None
-
-
-class StorageNotConfiguredError(RuntimeError):
-    """Raised when MinIO env vars are missing or incomplete.
-
-    Distinct from a transient outage: this is a *deployment-time* fault
-    that should crash the app at boot, not a per-request degradation.
-    """
 
 
 def _parse_endpoint(url: str) -> tuple[str, bool]:

--- a/packages/shared-backend/platform_shared/core/storage.py
+++ b/packages/shared-backend/platform_shared/core/storage.py
@@ -10,7 +10,17 @@ from minio.error import S3Error
 logger = logging.getLogger(__name__)
 
 
-class StorageClient:
+class StorageNotConfiguredError(RuntimeError):
+    """Raised when MinIO/S3 storage is required but not configured.
+
+    Distinct from a transient storage outage — this is a deploy-time config
+    error. Endpoints that require storage should map this to a 503 so the
+    operator can distinguish a missing-config from a transient blip.
+
+    Lives in ``platform_shared`` so both apps raise (and catch) the same
+    class, instead of each app defining its own and pattern-matching on
+    string content.
+    """
     def __init__(self, client: Minio, bucket: str) -> None:
         self._client = client
         self._bucket = bucket

--- a/packages/shared-backend/platform_shared/core/storage.py
+++ b/packages/shared-backend/platform_shared/core/storage.py
@@ -21,6 +21,9 @@ class StorageNotConfiguredError(RuntimeError):
     class, instead of each app defining its own and pattern-matching on
     string content.
     """
+
+
+class StorageClient:
     def __init__(self, client: Minio, bucket: str) -> None:
         self._client = client
         self._bucket = bucket


### PR DESCRIPTION
## Summary

Consolidates the 6 of 7 local \`StorageNotConfiguredError\` definitions into one canonical class in \`platform_shared/core/storage.py\`. Removes a string-match hack in the screening route.

## Audit correction

Audit said 5 definitions; actual count was **7**, with one diverging:

| File | Before | After |
|---|---|---|
| platform_shared/core/storage.py | absent | **canonical** |
| apps/mybookkeeper/backend/app/core/storage.py | local | re-export |
| apps/myjobhunter/backend/app/core/storage.py | local | re-export |
| .../leases/lease_template_service.py | local | re-export |
| .../listings/listing_photo_service.py | local | re-export |
| .../listings/blackout_service.py | local | re-export |
| .../screening/screening_service.py | **inherited from \`ScreeningServiceError\`** | imports canonical |
| .../leases/signed_lease_service.py | local | **skipped** (split PR in flight) |

## The screening divergence

\`screening_service.StorageNotConfiguredError\` previously inherited from \`ScreeningServiceError\` so the route could catch it via:

\`\`\`python
except screening_service.ScreeningServiceError as exc:
    if "storage" in str(exc).lower():           # ← string-match hack
        raise HTTPException(status_code=503, detail=str(exc)) from exc
    raise HTTPException(status_code=400, detail=str(exc)) from exc
\`\`\`

Switched to **Option B** (cleaner per project preference "never use hacks"):

\`\`\`python
except screening_service.StorageNotConfiguredError as exc:    # ← explicit
    raise HTTPException(status_code=503, detail=str(exc)) from exc
except screening_service.ScreeningServiceError as exc:
    raise HTTPException(status_code=400, detail=str(exc)) from exc
\`\`\`

## Back-compat preserved

Existing import paths still work via re-exports:
- \`from app.services.screening.screening_service import StorageNotConfiguredError\` ✓
- \`from app.core.storage import StorageNotConfiguredError\` ✓
- \`from app.services.listings.listing_photo_service import StorageNotConfiguredError\` ✓

\`test_screening.test_storage_unconfigured_maps_to_503\` continues to pass.

## Skipped: signed_lease_service.py

That file (1,647 LOC) is being split in a parallel PR (the \`refactor/mbk-split-signed-lease-service\` branch). Cleaning it up there avoids a merge conflict. Follow-up commit will remove the leftover local class once both PRs land.

## From audit

Resolves the High-priority "StorageNotConfiguredError defined identically in 5 files" item from the 2026-05-08 monorepo refactor audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)