### PR TITLE
refactor(mjh/applications): split AddApplicationDialog.tsx (1,070 LOC) into per-step components

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
@@ -1,5 +1,5 @@
 /**
- * AddApplicationDialog — redesigned 2026-05-06.
+ * AddApplicationDialog — orchestrator.
  *
  * Three-step state machine:
  *   1. INPUT       Operator pastes a URL (default), pastes JD text,
@@ -10,75 +10,25 @@
  *                  the company is shown as a confirmation pill, NOT a
  *                  dropdown. Operator confirms / edits and submits.
  *
- * Operator workflow notes (verbatim from session):
- *   - "i don't want to manually input the company. the company should
- *      be derived with the job description, link, or some other way"
- *   - "manual entry is near useless"
- *   - "i don't like the dropdown approach. it was not obvious to me"
- *
- * Implementation notes
- * ====================
- * - The legacy `<select>` company picker + "+ New" inline panel are
- *   removed entirely. Company selection happens through:
- *     a) auto-create after JD extract (primary path)
- *     b) `CompanyCombobox` on the rare cases (manual entry / pill change /
- *        auto-create failure)
- * - The standalone URL field in the form body is removed. The URL the
- *   operator pasted in step 1 is the source URL, sent on submit.
- * - Paste-and-go: pasting any string starting with http(s):// into the
- *   URL input auto-triggers the fetch — no button click required.
+ * All state-machine logic and API calls live in `useAddApplicationFlow`.
+ * All step UI lives in the `add-application-dialog/` sub-components.
+ * This component owns only the Dialog shell, the react-hook-form
+ * instance, and the wiring between the two.
  *
  * TODO (deferred from v1)
  * =======================
- * - Animated height transition between steps. The dialog jumps in size
- *   today; a v2 should use Framer Motion or `react-resize-observer` to
- *   smooth it out.
+ * - Animated height transition between steps.
  */
-import { useEffect, useRef, useState } from "react";
 import * as Dialog from "@radix-ui/react-dialog";
 import { useForm, type SubmitHandler } from "react-hook-form";
-import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
-import { X, Loader2 } from "lucide-react";
-import {
-  useListCompaniesQuery,
-  useCreateCompanyMutation,
-  useTriggerCompanyResearchMutation,
-} from "@/lib/companiesApi";
-import {
-  useCreateApplicationMutation,
-  useExtractJdFromUrlMutation,
-  useParseJobDescriptionMutation,
-} from "@/lib/applicationsApi";
-import type { Company } from "@/types/company";
-import type { JdParseResponse } from "@/types/application/jd-parse-response";
-import type { JdUrlExtractResponse } from "@/types/application/jd-url-extract-response";
-import { describeExtractError, isAuthRequiredError } from "./jdErrorRouting";
-import CompanyCombobox from "./CompanyCombobox";
-import CompanyConfirmationPill from "./CompanyConfirmationPill";
-import {
-  INITIAL_STATE,
-  PROCESSING_LONG_RUNNING_THRESHOLD_MS,
-  type DialogInputMode,
-  type DialogState,
-  type ReviewCompanyState,
-} from "./useAddApplicationDialogState";
-
-interface AddApplicationFormValues {
-  role_title: string;
-  location: string;
-  remote_type: "unknown" | "remote" | "hybrid" | "onsite";
-  notes: string;
-}
-
-const REMOTE_OPTIONS: { value: AddApplicationFormValues["remote_type"]; label: string }[] = [
-  { value: "unknown", label: "Unknown" },
-  { value: "remote", label: "Remote" },
-  { value: "hybrid", label: "Hybrid" },
-  { value: "onsite", label: "Onsite" },
-];
-
-const URL_REGEX = /^https?:\/\/\S+$/i;
-const NOTES_MAX_LEN = 5000;
+import { showSuccess } from "@platform/ui";
+import { X } from "lucide-react";
+import { useAddApplicationFlow, type AddApplicationFormValues } from "./add-application-dialog/useAddApplicationFlow";
+import PasteLinkStep from "./add-application-dialog/PasteLinkStep";
+import PasteTextStep from "./add-application-dialog/PasteTextStep";
+import ManualEntryStep from "./add-application-dialog/ManualEntryStep";
+import ProcessingStep from "./add-application-dialog/ProcessingStep";
+import CompanyConfirmStep from "./add-application-dialog/CompanyConfirmStep";
 
 export interface AddApplicationDialogProps {
   open: boolean;
@@ -86,30 +36,11 @@ export interface AddApplicationDialogProps {
 }
 
 export default function AddApplicationDialog({ open, onOpenChange }: AddApplicationDialogProps) {
-  const { data: companiesData } = useListCompaniesQuery();
-  const [createApplication, { isLoading: creatingApplication }] = useCreateApplicationMutation();
-  const [createCompany] = useCreateCompanyMutation();
-  // Fire-and-forget — the operator does not wait on background research.
-  const [triggerCompanyResearch] = useTriggerCompanyResearchMutation();
-  const [parseJobDescription] = useParseJobDescriptionMutation();
-  const [extractJdFromUrl] = useExtractJdFromUrlMutation();
-
-  const [state, setState] = useState<DialogState>(INITIAL_STATE);
-  const [urlValue, setUrlValue] = useState("");
-  const [textValue, setTextValue] = useState("");
-  const [companyNameValue, setCompanyNameValue] = useState("");
-  // Submit-time fallback: when auto-create raced with the click or
-  // failed silently, retry create-or-select inline before the POST.
-  const [pendingCompanyName, setPendingCompanyName] = useState<string | null>(null);
-  // Snapshot of the JD text the operator pasted, persisted across the
-  // text → review transition so the application body carries it.
-  const [submittedJdText, setSubmittedJdText] = useState<string>("");
-
   const {
     register,
     handleSubmit,
     formState: { errors },
-    reset,
+    reset: resetForm,
     setValue,
   } = useForm<AddApplicationFormValues>({
     defaultValues: {
@@ -120,399 +51,31 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
     },
   });
 
-  const companies = companiesData?.items ?? [];
+  const flow = useAddApplicationFlow({ setValue });
 
   // -------------------------------------------------------------------------
   // Lifecycle — reset everything on close.
   // -------------------------------------------------------------------------
   function handleOpenChange(next: boolean) {
     if (!next) {
-      reset();
-      setState(INITIAL_STATE);
-      setUrlValue("");
-      setTextValue("");
-      setCompanyNameValue("");
-      setPendingCompanyName(null);
-      setSubmittedJdText("");
+      resetForm();
+      flow.reset();
     }
     onOpenChange(next);
   }
 
   // -------------------------------------------------------------------------
-  // Step 1 — input mode switching + paste-and-go.
-  // -------------------------------------------------------------------------
-  function setInputMode(mode: DialogInputMode) {
-    setState({ kind: "input", inputMode: mode });
-  }
-
-  function handleUrlInputChange(next: string) {
-    setUrlValue(next);
-  }
-
-  // Paste-and-go: when the operator pastes a string and the resulting
-  // value is a complete URL, kick off the fetch immediately. Typing a
-  // URL char-by-char does NOT trigger; only paste does, because partial
-  // URLs are common while typing.
-  function handleUrlPaste(e: React.ClipboardEvent<HTMLInputElement>) {
-    const pasted = e.clipboardData.getData("text").trim();
-    if (URL_REGEX.test(pasted)) {
-      // Stop the default paste — we'll set the value ourselves and fire.
-      e.preventDefault();
-      setUrlValue(pasted);
-      void runUrlExtract(pasted);
-    }
-  }
-
-  function handleUrlSubmit() {
-    const url = urlValue.trim();
-    if (!url) return;
-    void runUrlExtract(url);
-  }
-
-  function handleTextSubmit() {
-    const text = textValue.trim();
-    if (!text) return;
-    void runTextParse(text);
-  }
-
-  function handleCompanyNameSelectExisting(companyId: string, name: string) {
-    const company = companies.find((c) => c.id === companyId);
-    setState({
-      kind: "review",
-      sourceUrl: null,
-      summary: null,
-      company: {
-        kind: "manual",
-        companyId,
-        name,
-        logoUrl: company?.logo_url ?? null,
-      },
-      changingCompany: false,
-    });
-    setPendingCompanyName(null);
-  }
-
-  async function handleCompanyNameCreateOnTheFly(name: string) {
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    setCompanyNameValue(trimmed);
-    try {
-      const created = await createCompany({ name: trimmed }).unwrap();
-      void triggerCompanyResearch(created.id)
-        .unwrap()
-        .catch((err) => {
-          console.warn("Background company research failed:", err);
-        });
-      setState({
-        kind: "review",
-        sourceUrl: null,
-        summary: null,
-        company: {
-          kind: "new",
-          companyId: created.id,
-          name: created.name,
-          logoUrl: created.logo_url,
-        },
-        changingCompany: false,
-      });
-      setPendingCompanyName(null);
-    } catch (err) {
-      showError(`Couldn't create company "${trimmed}": ${extractErrorMessage(err)}`);
-      // Stash the name so the submit-time fallback can retry.
-      setPendingCompanyName(trimmed);
-      setState({
-        kind: "review",
-        sourceUrl: null,
-        summary: null,
-        company: { kind: "autoCreateFailed", name: trimmed },
-        changingCompany: false,
-      });
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Step 2 — processing. URL extract path.
-  // -------------------------------------------------------------------------
-  async function runUrlExtract(url: string) {
-    setState({ kind: "processing", sourcePath: "url", longRunning: false });
-    try {
-      const result = await extractJdFromUrl({ url }).unwrap();
-      await applyExtractResult(result);
-    } catch (err) {
-      if (isAuthRequiredError(err)) {
-        // Auth-walled URL — drop the operator into the text-paste lane
-        // with a friendly message.
-        showError(
-          "That page requires sign-in or blocked our request. Paste the description text instead.",
-        );
-        setInputMode("text");
-        return;
-      }
-      showError(`Couldn't auto-fill: ${describeExtractError(err)}`);
-      setInputMode("url");
-    }
-  }
-
-  async function runTextParse(text: string) {
-    setState({ kind: "processing", sourcePath: "text", longRunning: false });
-    setSubmittedJdText(text);
-    try {
-      const result = await parseJobDescription({ jd_text: text }).unwrap();
-      await applyParseResult(result, { sourceUrl: null });
-    } catch (err) {
-      showError(`Couldn't auto-fill: ${extractErrorMessage(err) ?? "AI parsing failed"}`);
-      setInputMode("text");
-    }
-  }
-
-  // After 3s in processing, flip the longRunning flag so the spinner
-  // copy updates from "Reading job posting…" to "This is taking longer
-  // than usual…" — purely passive, no intervention.
-  useEffect(() => {
-    if (state.kind !== "processing" || state.longRunning) return;
-    const timer = setTimeout(() => {
-      setState((prev) => {
-        if (prev.kind !== "processing") return prev;
-        return { ...prev, longRunning: true };
-      });
-    }, PROCESSING_LONG_RUNNING_THRESHOLD_MS);
-    return () => clearTimeout(timer);
-  }, [state]);
-
-  // -------------------------------------------------------------------------
-  // Pre-fill helpers — both extract and parse routes converge through
-  // these, then transition to "review".
-  // -------------------------------------------------------------------------
-  async function applyParseResult(
-    result: JdParseResponse,
-    { sourceUrl }: { sourceUrl: string | null },
-  ) {
-    if (result.title) setValue("role_title", result.title, { shouldValidate: true });
-    if (result.location) setValue("location", result.location, { shouldValidate: true });
-    if (
-      result.remote_type === "remote" ||
-      result.remote_type === "hybrid" ||
-      result.remote_type === "onsite"
-    ) {
-      setValue("remote_type", result.remote_type, { shouldValidate: true });
-    }
-
-    const companyState = await resolveCompany(result.company, {});
-    setState({
-      kind: "review",
-      sourceUrl,
-      summary: result.summary,
-      company: companyState,
-      changingCompany: false,
-    });
-  }
-
-  async function applyExtractResult(result: JdUrlExtractResponse) {
-    if (result.title) setValue("role_title", result.title, { shouldValidate: true });
-    if (result.location) setValue("location", result.location, { shouldValidate: true });
-
-    const notesScaffold = combineNotes(result);
-    if (notesScaffold) {
-      setValue("notes", notesScaffold, { shouldValidate: true });
-    }
-
-    const companyState = await resolveCompany(result.company, {
-      website: result.company_website,
-      logoUrl: result.company_logo_url,
-    });
-    setState({
-      kind: "review",
-      sourceUrl: result.source_url,
-      summary: result.summary,
-      company: companyState,
-      changingCompany: false,
-    });
-  }
-
-  interface CompanyExtras {
-    website?: string | null;
-    logoUrl?: string | null;
-  }
-
-  /**
-   * Resolve a company name extracted from the JD into a ReviewCompanyState.
-   *
-   * Order of preference:
-   *   1. Case-insensitive name match against existing companies → "tracked"
-   *   2. Auto-create via POST /companies → "new"
-   *   3. Auto-create rejected → "autoCreateFailed" (submit-time fallback handles it)
-   *   4. No name extracted → null company is forbidden by the form; we
-   *      route to "autoCreateFailed" with an empty name so the operator
-   *      sees the combobox immediately
-   */
-  async function resolveCompany(
-    name: string | null,
-    extras: CompanyExtras,
-  ): Promise<ReviewCompanyState> {
-    const trimmed = (name ?? "").trim();
-    if (!trimmed) {
-      // No company in the JD — let the operator fix via the combobox.
-      setPendingCompanyName(null);
-      return { kind: "autoCreateFailed", name: "" };
-    }
-    setPendingCompanyName(trimmed);
-
-    const existing = findCompanyByName(companies, trimmed);
-    if (existing) {
-      setPendingCompanyName(null);
-      return {
-        kind: "tracked",
-        companyId: existing.id,
-        name: existing.name,
-        logoUrl: existing.logo_url,
-      };
-    }
-
-    try {
-      const payload: { name: string; primary_domain?: string | null; logo_url?: string | null } = {
-        name: trimmed,
-      };
-      const domain = websiteToDomain(extras.website);
-      if (domain) payload.primary_domain = domain;
-      if (extras.logoUrl) payload.logo_url = extras.logoUrl;
-
-      const created = await createCompany(payload).unwrap();
-      void triggerCompanyResearch(created.id)
-        .unwrap()
-        .catch((err) => {
-          console.warn("Background company research failed:", err);
-        });
-      setPendingCompanyName(null);
-      return {
-        kind: "new",
-        companyId: created.id,
-        name: created.name,
-        logoUrl: created.logo_url,
-      };
-    } catch (err) {
-      showError(
-        `Couldn't auto-create company "${trimmed}": ${extractErrorMessage(err)}`,
-      );
-      // Keep pendingCompanyName so the submit handler can retry.
-      return { kind: "autoCreateFailed", name: trimmed };
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Step 3 — review. "Not right? change" expands the combobox.
-  // -------------------------------------------------------------------------
-  function handlePillChangeRequest() {
-    if (state.kind !== "review") return;
-    setState({ ...state, changingCompany: true });
-    // Pre-populate the combobox with the current company name so the
-    // operator can edit a typo rather than retype.
-    setCompanyNameValue(state.company.name);
-  }
-
-  function handleReviewSelectExisting(companyId: string, name: string) {
-    if (state.kind !== "review") return;
-    const company = companies.find((c) => c.id === companyId);
-    setState({
-      ...state,
-      company: {
-        kind: "tracked",
-        companyId,
-        name,
-        logoUrl: company?.logo_url ?? null,
-      },
-      changingCompany: false,
-    });
-    setPendingCompanyName(null);
-  }
-
-  async function handleReviewCreateOnTheFly(name: string) {
-    if (state.kind !== "review") return;
-    const trimmed = name.trim();
-    if (!trimmed) return;
-    try {
-      const created = await createCompany({ name: trimmed }).unwrap();
-      void triggerCompanyResearch(created.id)
-        .unwrap()
-        .catch((err) => {
-          console.warn("Background company research failed:", err);
-        });
-      setState({
-        ...state,
-        company: {
-          kind: "new",
-          companyId: created.id,
-          name: created.name,
-          logoUrl: created.logo_url,
-        },
-        changingCompany: false,
-      });
-      setPendingCompanyName(null);
-    } catch (err) {
-      showError(`Couldn't create company "${trimmed}": ${extractErrorMessage(err)}`);
-      setPendingCompanyName(trimmed);
-      setState({
-        ...state,
-        company: { kind: "autoCreateFailed", name: trimmed },
-        changingCompany: false,
-      });
-    }
-  }
-
-  // -------------------------------------------------------------------------
-  // Submit — applies the submit-time fallback for races / failed creates.
+  // Submit.
   // -------------------------------------------------------------------------
   const onSubmit: SubmitHandler<AddApplicationFormValues> = async (values) => {
-    if (state.kind !== "review") {
-      showError("Finish the auto-fill step first.");
-      return;
-    }
-    let companyId = readCompanyId(state.company);
-
-    if (!companyId && pendingCompanyName) {
-      try {
-        const trimmed = pendingCompanyName.trim();
-        const existing = findCompanyByName(companies, trimmed);
-        if (existing) {
-          companyId = existing.id;
-        } else {
-          const created = await createCompany({ name: trimmed }).unwrap();
-          companyId = created.id;
-        }
-        setPendingCompanyName(null);
-      } catch (err) {
-        showError(
-          `Couldn't auto-create company "${pendingCompanyName}": ${extractErrorMessage(err)}`,
-        );
-        return;
-      }
-    }
-    if (!companyId) {
-      showError("Pick a company before saving the application.");
-      return;
-    }
-
-    try {
-      // The "URL" field is the source URL the operator pasted in step 1;
-      // for the manual / text path it's null.
-      const url = state.sourceUrl ?? null;
-      await createApplication({
-        company_id: companyId,
-        role_title: values.role_title.trim(),
-        url,
-        location: values.location.trim() || null,
-        remote_type: values.remote_type,
-        notes: values.notes.trim() || null,
-        jd_text: submittedJdText.trim() || null,
-      }).unwrap();
+    await flow.submitApplication(values, () => {
       showSuccess("Application added");
       onOpenChange(false);
-    } catch (err) {
-      showError(`Couldn't create application: ${extractErrorMessage(err)}`);
-    }
+    });
   };
 
   // -------------------------------------------------------------------------
-  // Render
+  // Render.
   // -------------------------------------------------------------------------
   return (
     <Dialog.Root open={open} onOpenChange={handleOpenChange}>
@@ -531,540 +94,60 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
             </Dialog.Close>
           </div>
 
-          {state.kind === "input" ? (
-            <InputStep
-              inputMode={state.inputMode}
-              urlValue={urlValue}
-              textValue={textValue}
-              companyNameValue={companyNameValue}
-              companies={companies}
-              onSetInputMode={setInputMode}
-              onUrlChange={handleUrlInputChange}
-              onUrlPaste={handleUrlPaste}
-              onUrlSubmit={handleUrlSubmit}
-              onTextChange={setTextValue}
-              onTextSubmit={handleTextSubmit}
-              onCompanyNameSelect={handleCompanyNameSelectExisting}
-              onCompanyNameCreate={handleCompanyNameCreateOnTheFly}
+          {flow.state.kind === "input" && flow.state.inputMode === "url" ? (
+            <PasteLinkStep
+              urlValue={flow.urlValue}
+              onUrlChange={flow.handleUrlInputChange}
+              onUrlPaste={flow.handleUrlPaste}
+              onUrlSubmit={flow.handleUrlSubmit}
+              onSetInputMode={flow.setInputMode}
             />
           ) : null}
 
-          {state.kind === "processing" ? (
-            <ProcessingStep longRunning={state.longRunning} sourcePath={state.sourcePath} />
+          {flow.state.kind === "input" && flow.state.inputMode === "text" ? (
+            <PasteTextStep
+              textValue={flow.textValue}
+              onTextChange={flow.setTextValue}
+              onTextSubmit={flow.handleTextSubmit}
+              onSetInputMode={flow.setInputMode}
+            />
           ) : null}
 
-          {state.kind === "review" ? (
-            <ReviewStep
-              state={state}
-              companies={companies}
+          {flow.state.kind === "input" && flow.state.inputMode === "company-name" ? (
+            <ManualEntryStep
+              companies={flow.companies}
+              companyNameValue={flow.companyNameValue}
+              onCompanyNameSelect={flow.handleCompanyNameSelectExisting}
+              onCompanyNameCreate={flow.handleCompanyNameCreateOnTheFly}
+              onSwitchToUrl={() => flow.setInputMode("url")}
+            />
+          ) : null}
+
+          {flow.state.kind === "processing" ? (
+            <ProcessingStep
+              longRunning={flow.state.longRunning}
+              sourcePath={flow.state.sourcePath}
+            />
+          ) : null}
+
+          {flow.state.kind === "review" ? (
+            <CompanyConfirmStep
+              state={flow.state}
+              companies={flow.companies}
               register={register}
               errors={errors}
-              creatingApplication={creatingApplication}
+              creatingApplication={flow.creatingApplication}
               onSubmit={handleSubmit(onSubmit)}
-              onPillChangeRequest={handlePillChangeRequest}
-              onSelectExisting={handleReviewSelectExisting}
-              onCreateOnTheFly={handleReviewCreateOnTheFly}
-              onCancelChangingCompany={() =>
-                setState({ ...state, changingCompany: false })
-              }
-              companyNameValue={companyNameValue}
-              onCompanyNameChange={setCompanyNameValue}
+              onPillChangeRequest={flow.handlePillChangeRequest}
+              onSelectExisting={flow.handleReviewSelectExisting}
+              onCreateOnTheFly={flow.handleReviewCreateOnTheFly}
+              onCancelChangingCompany={flow.handleCancelChangingCompany}
+              companyNameValue={flow.companyNameValue}
+              onCompanyNameChange={flow.setCompanyNameValue}
             />
           ) : null}
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-function findCompanyByName(companies: Company[], name: string): Company | undefined {
-  const trimmed = name.trim().toLowerCase();
-  return companies.find((c) => c.name.trim().toLowerCase() === trimmed);
-}
-
-function readCompanyId(company: ReviewCompanyState): string | null {
-  if (company.kind === "tracked" || company.kind === "new") return company.companyId;
-  if (company.kind === "manual") return company.companyId;
-  return null;
-}
-
-/**
- * Reduce a company website URL to its bare host (no scheme, no
- * leading "www.", no trailing slash). The Company model's
- * `primary_domain` is a domain string, not a URL.
- */
-function websiteToDomain(website: string | null | undefined): string | null {
-  if (!website) return null;
-  try {
-    const url = new URL(website.trim());
-    let host = url.hostname.toLowerCase();
-    if (host.startsWith("www.")) host = host.slice(4);
-    return host || null;
-  } catch {
-    const stripped = website.trim().replace(/^https?:\/\//i, "").replace(/\/$/, "");
-    return stripped.replace(/^www\./i, "") || null;
-  }
-}
-
-function combineNotes(result: JdUrlExtractResponse): string | null {
-  const chunks: string[] = [];
-  if (result.summary) chunks.push(result.summary);
-  if (result.description_html) {
-    const stripped = stripHtml(result.description_html).trim();
-    if (stripped) chunks.push(stripped);
-  }
-  if (result.requirements_text) chunks.push(result.requirements_text);
-  if (chunks.length === 0) return null;
-  const combined = chunks.join("\n\n");
-  return combined.length > NOTES_MAX_LEN ? combined.slice(0, NOTES_MAX_LEN) : combined;
-}
-
-function stripHtml(html: string): string {
-  return html
-    .replace(/<\s*br\s*\/?\s*>/gi, "\n")
-    .replace(/<\s*\/?\s*(p|li|div|h[1-6])[^>]*>/gi, "\n")
-    .replace(/<[^>]+>/g, "")
-    .replace(/&nbsp;/g, " ")
-    .replace(/&amp;/g, "&")
-    .replace(/&lt;/g, "<")
-    .replace(/&gt;/g, ">")
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/\n{3,}/g, "\n\n")
-    .trim();
-}
-
-// ---------------------------------------------------------------------------
-// Step 1 — Input
-// ---------------------------------------------------------------------------
-
-interface InputStepProps {
-  inputMode: DialogInputMode;
-  urlValue: string;
-  textValue: string;
-  companyNameValue: string;
-  companies: Company[];
-  onSetInputMode: (mode: DialogInputMode) => void;
-  onUrlChange: (next: string) => void;
-  onUrlPaste: (e: React.ClipboardEvent<HTMLInputElement>) => void;
-  onUrlSubmit: () => void;
-  onTextChange: (next: string) => void;
-  onTextSubmit: () => void;
-  onCompanyNameSelect: (companyId: string, name: string) => void;
-  onCompanyNameCreate: (name: string) => void;
-}
-
-function InputStep(props: InputStepProps) {
-  if (props.inputMode === "url") return <UrlInputPanel {...props} />;
-  if (props.inputMode === "text") return <TextInputPanel {...props} />;
-  return <CompanyNamePanel {...props} />;
-}
-
-function UrlInputPanel({
-  urlValue,
-  onUrlChange,
-  onUrlPaste,
-  onUrlSubmit,
-  onSetInputMode,
-}: InputStepProps) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // Autofocus on mount — the dialog opens directly into this input.
-  useEffect(() => {
-    inputRef.current?.focus();
-  }, []);
-
-  const canSubmit = urlValue.trim().length > 0;
-
-  return (
-    <div className="space-y-3">
-      <label htmlFor="add-app-url" className="block text-sm font-medium">
-        Job posting URL — paste to auto-fill
-      </label>
-      <input
-        id="add-app-url"
-        ref={inputRef}
-        type="url"
-        value={urlValue}
-        onChange={(e) => onUrlChange(e.target.value)}
-        onPaste={onUrlPaste}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && canSubmit) {
-            e.preventDefault();
-            onUrlSubmit();
-          }
-        }}
-        placeholder="https://jobs.example.com/posting/abc"
-        aria-label="Job posting URL"
-        className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-      />
-      <div className="flex justify-end">
-        <LoadingButton
-          type="button"
-          isLoading={false}
-          loadingText="Reading…"
-          disabled={!canSubmit}
-          onClick={onUrlSubmit}
-        >
-          Auto-fill
-        </LoadingButton>
-      </div>
-      <div className="flex flex-col gap-1 pt-2 border-t">
-        <button
-          type="button"
-          onClick={() => onSetInputMode("text")}
-          className="text-xs underline text-muted-foreground hover:text-foreground self-start"
-        >
-          No URL? Paste the description text instead.
-        </button>
-        <button
-          type="button"
-          onClick={() => onSetInputMode("company-name")}
-          className="text-xs underline text-muted-foreground hover:text-foreground self-start"
-        >
-          Adding manually? Type a company name.
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function TextInputPanel({
-  textValue,
-  onTextChange,
-  onTextSubmit,
-  onSetInputMode,
-}: InputStepProps) {
-  const canSubmit = textValue.trim().length > 0;
-  return (
-    <div className="space-y-3">
-      <label htmlFor="add-app-text" className="block text-sm font-medium">
-        Paste the job description text
-      </label>
-      <textarea
-        id="add-app-text"
-        value={textValue}
-        onChange={(e) => onTextChange(e.target.value)}
-        rows={8}
-        placeholder="Paste the full job description here…"
-        aria-label="Job description text"
-        autoFocus
-        className="w-full border rounded-md px-3 py-2 text-sm bg-background resize-y"
-      />
-      <div className="flex justify-end">
-        <LoadingButton
-          type="button"
-          isLoading={false}
-          loadingText="Parsing…"
-          disabled={!canSubmit}
-          onClick={onTextSubmit}
-        >
-          Parse with AI
-        </LoadingButton>
-      </div>
-      <div className="flex flex-col gap-1 pt-2 border-t">
-        <button
-          type="button"
-          onClick={() => onSetInputMode("url")}
-          className="text-xs underline text-muted-foreground hover:text-foreground self-start"
-        >
-          Have a URL instead? Paste it here.
-        </button>
-        <button
-          type="button"
-          onClick={() => onSetInputMode("company-name")}
-          className="text-xs underline text-muted-foreground hover:text-foreground self-start"
-        >
-          Adding manually? Type a company name.
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function CompanyNamePanel({
-  companies,
-  companyNameValue,
-  onCompanyNameSelect,
-  onCompanyNameCreate,
-  onSetInputMode,
-}: InputStepProps) {
-  return (
-    <div className="space-y-3">
-      <label className="block text-sm font-medium">Company name</label>
-      <CompanyCombobox
-        companies={companies}
-        initialValue={companyNameValue}
-        onSelect={onCompanyNameSelect}
-        onCreate={onCompanyNameCreate}
-        onCancel={() => onSetInputMode("url")}
-      />
-      <div className="pt-2 border-t">
-        <button
-          type="button"
-          onClick={() => onSetInputMode("url")}
-          className="text-xs underline text-muted-foreground hover:text-foreground"
-        >
-          Have a URL? Paste it instead — we'll auto-fill from the page.
-        </button>
-      </div>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Step 2 — Processing
-// ---------------------------------------------------------------------------
-
-interface ProcessingStepProps {
-  longRunning: boolean;
-  sourcePath: "url" | "text";
-}
-
-function ProcessingStep({ longRunning, sourcePath }: ProcessingStepProps) {
-  const primaryCopy =
-    sourcePath === "url" ? "Reading job posting…" : "Reading description…";
-  const longRunningCopy = "This is taking longer than usual…";
-  return (
-    <div className="flex flex-col items-center justify-center py-12 gap-4">
-      <Loader2 size={28} className="animate-spin text-muted-foreground" aria-hidden="true" />
-      <p className="text-sm font-medium text-center">
-        {longRunning ? longRunningCopy : primaryCopy}
-      </p>
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Step 3 — Review
-// ---------------------------------------------------------------------------
-
-interface ReviewStepProps {
-  state: Extract<DialogState, { kind: "review" }>;
-  companies: Company[];
-  register: ReturnType<typeof useForm<AddApplicationFormValues>>["register"];
-  errors: ReturnType<typeof useForm<AddApplicationFormValues>>["formState"]["errors"];
-  creatingApplication: boolean;
-  onSubmit: React.FormEventHandler<HTMLFormElement>;
-  onPillChangeRequest: () => void;
-  onSelectExisting: (companyId: string, name: string) => void;
-  onCreateOnTheFly: (name: string) => void;
-  onCancelChangingCompany: () => void;
-  companyNameValue: string;
-  onCompanyNameChange: (next: string) => void;
-}
-
-function ReviewStep({
-  state,
-  companies,
-  register,
-  errors,
-  creatingApplication,
-  onSubmit,
-  onPillChangeRequest,
-  onSelectExisting,
-  onCreateOnTheFly,
-  onCancelChangingCompany,
-  companyNameValue,
-  onCompanyNameChange,
-}: ReviewStepProps) {
-  return (
-    <div className="space-y-4">
-      <ReviewBanner sourceUrl={state.sourceUrl} summary={state.summary} />
-
-      <div>
-        <label className="block text-sm font-medium mb-1">
-          Company <span className="text-destructive">*</span>
-        </label>
-        {state.changingCompany ? (
-          <div className="space-y-2">
-            <CompanyCombobox
-              // Remount when the seed name changes — the combobox
-              // doesn't sync `query` with `initialValue` on update.
-              key={`change-${companyNameValue}`}
-              companies={companies}
-              initialValue={companyNameValue}
-              onSelect={onSelectExisting}
-              onCreate={onCreateOnTheFly}
-              onCancel={onCancelChangingCompany}
-            />
-            <button
-              type="button"
-              onClick={onCancelChangingCompany}
-              className="text-xs underline text-muted-foreground hover:text-foreground"
-            >
-              Cancel — keep the current selection
-            </button>
-          </div>
-        ) : (
-          <ReviewCompanyDisplay
-            company={state.company}
-            onChangeRequest={onPillChangeRequest}
-            onCompanyNameChange={onCompanyNameChange}
-          />
-        )}
-      </div>
-
-      <form onSubmit={onSubmit} className="space-y-4" noValidate>
-        <div>
-          <label className="block text-sm font-medium mb-1">
-            Role title <span className="text-destructive">*</span>
-          </label>
-          <input
-            type="text"
-            {...register("role_title", { required: "Role title is required", minLength: 1 })}
-            className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-            placeholder="e.g. Senior Backend Engineer"
-          />
-          {errors.role_title ? (
-            <p className="text-xs text-destructive mt-1">{errors.role_title.message}</p>
-          ) : null}
-        </div>
-
-        <div className="grid grid-cols-2 gap-3">
-          <div>
-            <label className="block text-sm font-medium mb-1">Location</label>
-            <input
-              type="text"
-              {...register("location")}
-              className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-              placeholder="e.g. SF, NYC, Remote-EU"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium mb-1">Remote</label>
-            <select
-              {...register("remote_type")}
-              className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-            >
-              {REMOTE_OPTIONS.map((o) => (
-                <option key={o.value} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-
-        <div>
-          <label className="block text-sm font-medium mb-1">Notes</label>
-          <textarea
-            {...register("notes")}
-            rows={3}
-            className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-            placeholder="Anything to remember about this role…"
-          />
-        </div>
-
-        <div className="flex justify-end gap-2 pt-2">
-          <Dialog.Close asChild>
-            <button
-              type="button"
-              className="px-4 py-2 text-sm border rounded-md hover:bg-muted"
-            >
-              Cancel
-            </button>
-          </Dialog.Close>
-          <LoadingButton type="submit" isLoading={creatingApplication} loadingText="Adding…">
-            Add application
-          </LoadingButton>
-        </div>
-      </form>
-    </div>
-  );
-}
-
-interface ReviewBannerProps {
-  sourceUrl: string | null;
-  summary: string | null;
-}
-
-function ReviewBanner({ sourceUrl, summary }: ReviewBannerProps) {
-  // For the manual path (no JD), we still show a green strip so the
-  // step transition feels consistent — but with a quieter tone.
-  return (
-    <div className="rounded-md border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30 p-3">
-      <p className="text-sm font-medium text-green-800 dark:text-green-300">
-        Review and adjust before saving
-      </p>
-      {summary ? (
-        <p className="text-xs text-green-700 dark:text-green-400 mt-0.5 line-clamp-2">
-          {summary}
-        </p>
-      ) : null}
-      {sourceUrl ? (
-        <p className="text-xs text-muted-foreground mt-1 truncate">
-          Source: <span className="underline">{sourceUrl}</span>
-        </p>
-      ) : null}
-    </div>
-  );
-}
-
-interface ReviewCompanyDisplayProps {
-  company: ReviewCompanyState;
-  onChangeRequest: () => void;
-  onCompanyNameChange: (next: string) => void;
-}
-
-function ReviewCompanyDisplay({
-  company,
-  onChangeRequest,
-  onCompanyNameChange,
-}: ReviewCompanyDisplayProps) {
-  if (company.kind === "tracked") {
-    return (
-      <CompanyConfirmationPill
-        name={company.name}
-        logoUrl={company.logoUrl}
-        variant="tracked"
-        onChangeRequest={() => {
-          onCompanyNameChange(company.name);
-          onChangeRequest();
-        }}
-      />
-    );
-  }
-  if (company.kind === "new") {
-    return (
-      <CompanyConfirmationPill
-        name={company.name}
-        logoUrl={company.logoUrl}
-        variant="new"
-        onChangeRequest={() => {
-          onCompanyNameChange(company.name);
-          onChangeRequest();
-        }}
-      />
-    );
-  }
-  if (company.kind === "manual") {
-    return (
-      <CompanyConfirmationPill
-        name={company.name}
-        logoUrl={company.logoUrl}
-        variant="new"
-        onChangeRequest={() => {
-          onCompanyNameChange(company.name);
-          onChangeRequest();
-        }}
-      />
-    );
-  }
-  // autoCreateFailed
-  return (
-    <CompanyConfirmationPill
-      name={company.name || "(no company found)"}
-      logoUrl={null}
-      variant="error"
-      onChangeRequest={() => {
-        onCompanyNameChange(company.name);
-        onChangeRequest();
-      }}
-    />
   );
 }

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/CompanyConfirmStep.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/CompanyConfirmStep.tsx
@@ -1,0 +1,242 @@
+/**
+ * CompanyConfirmStep — step-3 review form.
+ *
+ * Displays:
+ * - A green banner ("Review and adjust before saving") with an optional
+ *   AI-extracted summary and source URL.
+ * - Company confirmation: either the pill (read-only) or the combobox
+ *   (when the operator clicked "not right? change").
+ * - The role-title, location, remote-type, and notes fields.
+ * - Cancel + "Add application" submit buttons.
+ *
+ * All async logic is owned by the parent hook; this component is
+ * presentation-only.
+ */
+import * as Dialog from "@radix-ui/react-dialog";
+import { type UseFormRegister, type FieldErrors } from "react-hook-form";
+import { LoadingButton } from "@platform/ui";
+import type { Company } from "@/types/company";
+import type { DialogState, ReviewCompanyState } from "../useAddApplicationDialogState";
+import CompanyCombobox from "../CompanyCombobox";
+import CompanyConfirmationPill from "../CompanyConfirmationPill";
+import type { AddApplicationFormValues } from "./useAddApplicationFlow";
+
+const REMOTE_OPTIONS: { value: AddApplicationFormValues["remote_type"]; label: string }[] = [
+  { value: "unknown", label: "Unknown" },
+  { value: "remote", label: "Remote" },
+  { value: "hybrid", label: "Hybrid" },
+  { value: "onsite", label: "Onsite" },
+];
+
+interface CompanyConfirmStepProps {
+  state: Extract<DialogState, { kind: "review" }>;
+  companies: Company[];
+  register: UseFormRegister<AddApplicationFormValues>;
+  errors: FieldErrors<AddApplicationFormValues>;
+  creatingApplication: boolean;
+  onSubmit: React.FormEventHandler<HTMLFormElement>;
+  onPillChangeRequest: () => void;
+  onSelectExisting: (companyId: string, name: string) => void;
+  onCreateOnTheFly: (name: string) => void;
+  onCancelChangingCompany: () => void;
+  companyNameValue: string;
+  onCompanyNameChange: (next: string) => void;
+}
+
+export default function CompanyConfirmStep({
+  state,
+  companies,
+  register,
+  errors,
+  creatingApplication,
+  onSubmit,
+  onPillChangeRequest,
+  onSelectExisting,
+  onCreateOnTheFly,
+  onCancelChangingCompany,
+  companyNameValue,
+  onCompanyNameChange,
+}: CompanyConfirmStepProps) {
+  return (
+    <div className="space-y-4">
+      <ReviewBanner sourceUrl={state.sourceUrl} summary={state.summary} />
+
+      <div>
+        <label className="block text-sm font-medium mb-1">
+          Company <span className="text-destructive">*</span>
+        </label>
+        {state.changingCompany ? (
+          <div className="space-y-2">
+            <CompanyCombobox
+              key={`change-${companyNameValue}`}
+              companies={companies}
+              initialValue={companyNameValue}
+              onSelect={onSelectExisting}
+              onCreate={onCreateOnTheFly}
+              onCancel={onCancelChangingCompany}
+            />
+            <button
+              type="button"
+              onClick={onCancelChangingCompany}
+              className="text-xs underline text-muted-foreground hover:text-foreground"
+            >
+              Cancel — keep the current selection
+            </button>
+          </div>
+        ) : (
+          <ReviewCompanyDisplay
+            company={state.company}
+            onChangeRequest={onPillChangeRequest}
+            onCompanyNameChange={onCompanyNameChange}
+          />
+        )}
+      </div>
+
+      <form onSubmit={onSubmit} className="space-y-4" noValidate>
+        <div>
+          <label className="block text-sm font-medium mb-1">
+            Role title <span className="text-destructive">*</span>
+          </label>
+          <input
+            type="text"
+            {...register("role_title", { required: "Role title is required", minLength: 1 })}
+            className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+            placeholder="e.g. Senior Backend Engineer"
+          />
+          {errors.role_title ? (
+            <p className="text-xs text-destructive mt-1">{errors.role_title.message}</p>
+          ) : null}
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <label className="block text-sm font-medium mb-1">Location</label>
+            <input
+              type="text"
+              {...register("location")}
+              className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+              placeholder="e.g. SF, NYC, Remote-EU"
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Remote</label>
+            <select
+              {...register("remote_type")}
+              className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+            >
+              {REMOTE_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium mb-1">Notes</label>
+          <textarea
+            {...register("notes")}
+            rows={3}
+            className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+            placeholder="Anything to remember about this role…"
+          />
+        </div>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <Dialog.Close asChild>
+            <button
+              type="button"
+              className="px-4 py-2 text-sm border rounded-md hover:bg-muted"
+            >
+              Cancel
+            </button>
+          </Dialog.Close>
+          <LoadingButton type="submit" isLoading={creatingApplication} loadingText="Adding…">
+            Add application
+          </LoadingButton>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ReviewBanner
+// ---------------------------------------------------------------------------
+
+interface ReviewBannerProps {
+  sourceUrl: string | null;
+  summary: string | null;
+}
+
+function ReviewBanner({ sourceUrl, summary }: ReviewBannerProps) {
+  return (
+    <div className="rounded-md border border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/30 p-3">
+      <p className="text-sm font-medium text-green-800 dark:text-green-300">
+        Review and adjust before saving
+      </p>
+      {summary ? (
+        <p className="text-xs text-green-700 dark:text-green-400 mt-0.5 line-clamp-2">
+          {summary}
+        </p>
+      ) : null}
+      {sourceUrl ? (
+        <p className="text-xs text-muted-foreground mt-1 truncate">
+          Source: <span className="underline">{sourceUrl}</span>
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ReviewCompanyDisplay — pill → combobox toggle orchestration.
+// ---------------------------------------------------------------------------
+
+interface ReviewCompanyDisplayProps {
+  company: ReviewCompanyState;
+  onChangeRequest: () => void;
+  onCompanyNameChange: (next: string) => void;
+}
+
+function ReviewCompanyDisplay({
+  company,
+  onChangeRequest,
+  onCompanyNameChange,
+}: ReviewCompanyDisplayProps) {
+  function handleChange() {
+    onCompanyNameChange(company.name);
+    onChangeRequest();
+  }
+
+  if (company.kind === "tracked") {
+    return (
+      <CompanyConfirmationPill
+        name={company.name}
+        logoUrl={company.logoUrl}
+        variant="tracked"
+        onChangeRequest={handleChange}
+      />
+    );
+  }
+  if (company.kind === "new" || company.kind === "manual") {
+    return (
+      <CompanyConfirmationPill
+        name={company.name}
+        logoUrl={company.kind === "manual" ? company.logoUrl : company.logoUrl}
+        variant="new"
+        onChangeRequest={handleChange}
+      />
+    );
+  }
+  // autoCreateFailed
+  return (
+    <CompanyConfirmationPill
+      name={company.name || "(no company found)"}
+      logoUrl={null}
+      variant="error"
+      onChangeRequest={handleChange}
+    />
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/ManualEntryStep.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/ManualEntryStep.tsx
@@ -1,0 +1,47 @@
+/**
+ * ManualEntryStep — step-1 manual-company-name panel.
+ *
+ * The operator types a company name instead of pasting a URL or JD text.
+ * The combobox handles both selecting an existing company and creating
+ * a new one on the fly.
+ */
+import type { Company } from "@/types/company";
+import CompanyCombobox from "../CompanyCombobox";
+
+interface ManualEntryStepProps {
+  companies: Company[];
+  companyNameValue: string;
+  onCompanyNameSelect: (companyId: string, name: string) => void;
+  onCompanyNameCreate: (name: string) => void;
+  onSwitchToUrl: () => void;
+}
+
+export default function ManualEntryStep({
+  companies,
+  companyNameValue,
+  onCompanyNameSelect,
+  onCompanyNameCreate,
+  onSwitchToUrl,
+}: ManualEntryStepProps) {
+  return (
+    <div className="space-y-3">
+      <label className="block text-sm font-medium">Company name</label>
+      <CompanyCombobox
+        companies={companies}
+        initialValue={companyNameValue}
+        onSelect={onCompanyNameSelect}
+        onCreate={onCompanyNameCreate}
+        onCancel={onSwitchToUrl}
+      />
+      <div className="pt-2 border-t">
+        <button
+          type="button"
+          onClick={onSwitchToUrl}
+          className="text-xs underline text-muted-foreground hover:text-foreground"
+        >
+          Have a URL? Paste it instead — we'll auto-fill from the page.
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/PasteLinkStep.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/PasteLinkStep.tsx
@@ -1,0 +1,89 @@
+/**
+ * PasteLinkStep — step-1 URL-paste panel (the default input mode).
+ *
+ * Behaviour:
+ * - Autofocuses on mount so the operator can paste immediately.
+ * - Paste-and-go: pasting a complete https?:// URL fires the extract
+ *   without a button click.
+ * - Enter key on a non-empty field also fires.
+ * - Two escape links lead to the text-paste and manual-entry panels.
+ */
+import { useEffect, useRef } from "react";
+import { LoadingButton } from "@platform/ui";
+import type { DialogInputMode } from "../useAddApplicationDialogState";
+
+interface PasteLinkStepProps {
+  urlValue: string;
+  onUrlChange: (next: string) => void;
+  onUrlPaste: (e: React.ClipboardEvent<HTMLInputElement>) => void;
+  onUrlSubmit: () => void;
+  onSetInputMode: (mode: DialogInputMode) => void;
+}
+
+export default function PasteLinkStep({
+  urlValue,
+  onUrlChange,
+  onUrlPaste,
+  onUrlSubmit,
+  onSetInputMode,
+}: PasteLinkStepProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const canSubmit = urlValue.trim().length > 0;
+
+  return (
+    <div className="space-y-3">
+      <label htmlFor="add-app-url" className="block text-sm font-medium">
+        Job posting URL — paste to auto-fill
+      </label>
+      <input
+        id="add-app-url"
+        ref={inputRef}
+        type="url"
+        value={urlValue}
+        onChange={(e) => onUrlChange(e.target.value)}
+        onPaste={onUrlPaste}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && canSubmit) {
+            e.preventDefault();
+            onUrlSubmit();
+          }
+        }}
+        placeholder="https://jobs.example.com/posting/abc"
+        aria-label="Job posting URL"
+        className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+      />
+      <div className="flex justify-end">
+        <LoadingButton
+          type="button"
+          isLoading={false}
+          loadingText="Reading…"
+          disabled={!canSubmit}
+          onClick={onUrlSubmit}
+        >
+          Auto-fill
+        </LoadingButton>
+      </div>
+      <div className="flex flex-col gap-1 pt-2 border-t">
+        <button
+          type="button"
+          onClick={() => onSetInputMode("text")}
+          className="text-xs underline text-muted-foreground hover:text-foreground self-start"
+        >
+          No URL? Paste the description text instead.
+        </button>
+        <button
+          type="button"
+          onClick={() => onSetInputMode("company-name")}
+          className="text-xs underline text-muted-foreground hover:text-foreground self-start"
+        >
+          Adding manually? Type a company name.
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/PasteTextStep.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/PasteTextStep.tsx
@@ -1,0 +1,69 @@
+/**
+ * PasteTextStep — step-1 fallback panel for pasting raw JD text.
+ *
+ * Used when the operator doesn't have a URL (e.g. LinkedIn auth-walled
+ * postings, copy-pasted email job descriptions).
+ */
+import { LoadingButton } from "@platform/ui";
+import type { DialogInputMode } from "../useAddApplicationDialogState";
+
+interface PasteTextStepProps {
+  textValue: string;
+  onTextChange: (next: string) => void;
+  onTextSubmit: () => void;
+  onSetInputMode: (mode: DialogInputMode) => void;
+}
+
+export default function PasteTextStep({
+  textValue,
+  onTextChange,
+  onTextSubmit,
+  onSetInputMode,
+}: PasteTextStepProps) {
+  const canSubmit = textValue.trim().length > 0;
+
+  return (
+    <div className="space-y-3">
+      <label htmlFor="add-app-text" className="block text-sm font-medium">
+        Paste the job description text
+      </label>
+      <textarea
+        id="add-app-text"
+        value={textValue}
+        onChange={(e) => onTextChange(e.target.value)}
+        rows={8}
+        placeholder="Paste the full job description here…"
+        aria-label="Job description text"
+        autoFocus
+        className="w-full border rounded-md px-3 py-2 text-sm bg-background resize-y"
+      />
+      <div className="flex justify-end">
+        <LoadingButton
+          type="button"
+          isLoading={false}
+          loadingText="Parsing…"
+          disabled={!canSubmit}
+          onClick={onTextSubmit}
+        >
+          Parse with AI
+        </LoadingButton>
+      </div>
+      <div className="flex flex-col gap-1 pt-2 border-t">
+        <button
+          type="button"
+          onClick={() => onSetInputMode("url")}
+          className="text-xs underline text-muted-foreground hover:text-foreground self-start"
+        >
+          Have a URL instead? Paste it here.
+        </button>
+        <button
+          type="button"
+          onClick={() => onSetInputMode("company-name")}
+          className="text-xs underline text-muted-foreground hover:text-foreground self-start"
+        >
+          Adding manually? Type a company name.
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/ProcessingStep.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/ProcessingStep.tsx
@@ -1,0 +1,29 @@
+/**
+ * ProcessingStep — step-2 spinner shown while the URL extract or
+ * JD-text parse mutation is in flight.
+ *
+ * After PROCESSING_LONG_RUNNING_THRESHOLD_MS the parent hook flips
+ * `longRunning` to true, which swaps the copy from "Reading job
+ * posting…" to "This is taking longer than usual…".
+ */
+import { Loader2 } from "lucide-react";
+
+interface ProcessingStepProps {
+  longRunning: boolean;
+  sourcePath: "url" | "text";
+}
+
+export default function ProcessingStep({ longRunning, sourcePath }: ProcessingStepProps) {
+  const primaryCopy =
+    sourcePath === "url" ? "Reading job posting…" : "Reading description…";
+  const longRunningCopy = "This is taking longer than usual…";
+
+  return (
+    <div className="flex flex-col items-center justify-center py-12 gap-4">
+      <Loader2 size={28} className="animate-spin text-muted-foreground" aria-hidden="true" />
+      <p className="text-sm font-medium text-center">
+        {longRunning ? longRunningCopy : primaryCopy}
+      </p>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/dialogHelpers.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/dialogHelpers.ts
@@ -1,0 +1,69 @@
+/**
+ * dialogHelpers — pure utility functions for the AddApplicationDialog flow.
+ *
+ * All functions here are stateless and have no React dependencies.
+ * They are extracted from useAddApplicationFlow to keep the hook focused
+ * on state transitions and async logic.
+ */
+import type { Company } from "@/types/company";
+import type { ReviewCompanyState } from "../useAddApplicationDialogState";
+import type { JdUrlExtractResponse } from "@/types/application/jd-url-extract-response";
+
+const NOTES_MAX_LEN = 5000;
+
+export function findCompanyByName(companies: Company[], name: string): Company | undefined {
+  const trimmed = name.trim().toLowerCase();
+  return companies.find((c) => c.name.trim().toLowerCase() === trimmed);
+}
+
+export function readCompanyId(company: ReviewCompanyState): string | null {
+  if (company.kind === "tracked" || company.kind === "new") return company.companyId;
+  if (company.kind === "manual") return company.companyId;
+  return null;
+}
+
+/**
+ * Reduce a company website URL to its bare host (no scheme, no leading
+ * "www.", no trailing slash). The Company model's `primary_domain` is a
+ * domain string, not a URL.
+ */
+export function websiteToDomain(website: string | null | undefined): string | null {
+  if (!website) return null;
+  try {
+    const url = new URL(website.trim());
+    let host = url.hostname.toLowerCase();
+    if (host.startsWith("www.")) host = host.slice(4);
+    return host || null;
+  } catch {
+    const stripped = website.trim().replace(/^https?:\/\//i, "").replace(/\/$/, "");
+    return stripped.replace(/^www\./i, "") || null;
+  }
+}
+
+export function combineNotes(result: JdUrlExtractResponse): string | null {
+  const chunks: string[] = [];
+  if (result.summary) chunks.push(result.summary);
+  if (result.description_html) {
+    const stripped = stripHtml(result.description_html).trim();
+    if (stripped) chunks.push(stripped);
+  }
+  if (result.requirements_text) chunks.push(result.requirements_text);
+  if (chunks.length === 0) return null;
+  const combined = chunks.join("\n\n");
+  return combined.length > NOTES_MAX_LEN ? combined.slice(0, NOTES_MAX_LEN) : combined;
+}
+
+export function stripHtml(html: string): string {
+  return html
+    .replace(/<\s*br\s*\/?\s*>/gi, "\n")
+    .replace(/<\s*\/?\s*(p|li|div|h[1-6])[^>]*>/gi, "\n")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/useAddApplicationFlow.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/useAddApplicationFlow.ts
@@ -1,0 +1,512 @@
+/**
+ * useAddApplicationFlow — state-machine hook for AddApplicationDialog.
+ *
+ * Owns:
+ *   - The discriminated-union DialogState (input → processing → review)
+ *   - All step-transition logic (runUrlExtract, runTextParse, resolveCompany)
+ *   - Submit-time company fallback
+ *   - The long-running timer that swaps spinner copy at 3 s
+ *
+ * Does NOT own:
+ *   - The react-hook-form instance (stays in the orchestrator so the form
+ *     element + ref hierarchy lives in one place)
+ *   - Dialog open/close lifecycle (onOpenChange is passed in so the
+ *     orchestrator can reset both the form and this hook together)
+ *
+ * Pure utility functions (combineNotes, stripHtml, etc.) live in
+ * dialogHelpers.ts to keep this file focused on state transitions.
+ */
+import { useEffect, useState } from "react";
+import { showError, extractErrorMessage } from "@platform/ui";
+import {
+  useListCompaniesQuery,
+  useCreateCompanyMutation,
+  useTriggerCompanyResearchMutation,
+} from "@/lib/companiesApi";
+import {
+  useCreateApplicationMutation,
+  useExtractJdFromUrlMutation,
+  useParseJobDescriptionMutation,
+} from "@/lib/applicationsApi";
+import type { JdParseResponse } from "@/types/application/jd-parse-response";
+import type { JdUrlExtractResponse } from "@/types/application/jd-url-extract-response";
+import { describeExtractError, isAuthRequiredError } from "../jdErrorRouting";
+import {
+  INITIAL_STATE,
+  PROCESSING_LONG_RUNNING_THRESHOLD_MS,
+  type DialogInputMode,
+  type DialogState,
+  type ReviewCompanyState,
+} from "../useAddApplicationDialogState";
+import type { Company } from "@/types/company";
+import {
+  findCompanyByName,
+  readCompanyId,
+  websiteToDomain,
+  combineNotes,
+} from "./dialogHelpers";
+
+const URL_REGEX = /^https?:\/\/\S+$/i;
+
+export interface AddApplicationFormValues {
+  role_title: string;
+  location: string;
+  remote_type: "unknown" | "remote" | "hybrid" | "onsite";
+  notes: string;
+}
+
+export interface ApplyPreFillFns {
+  /** Called when an extract/parse result arrives. */
+  setValue: (
+    field: keyof AddApplicationFormValues,
+    value: string,
+    opts?: { shouldValidate?: boolean },
+  ) => void;
+}
+
+interface UseAddApplicationFlowReturn {
+  state: DialogState;
+  urlValue: string;
+  textValue: string;
+  companyNameValue: string;
+  pendingCompanyName: string | null;
+  submittedJdText: string;
+  companies: Company[];
+  creatingApplication: boolean;
+
+  /** Step-1 handlers */
+  setInputMode: (mode: DialogInputMode) => void;
+  handleUrlInputChange: (next: string) => void;
+  handleUrlPaste: (e: React.ClipboardEvent<HTMLInputElement>) => void;
+  handleUrlSubmit: () => void;
+  handleTextSubmit: () => void;
+  handleCompanyNameSelectExisting: (companyId: string, name: string) => void;
+  handleCompanyNameCreateOnTheFly: (name: string) => Promise<void>;
+
+  /** Step-3 handlers */
+  handlePillChangeRequest: () => void;
+  handleReviewSelectExisting: (companyId: string, name: string) => void;
+  handleReviewCreateOnTheFly: (name: string) => Promise<void>;
+  handleCancelChangingCompany: () => void;
+  setCompanyNameValue: (next: string) => void;
+  setTextValue: (next: string) => void;
+
+  /** Submit */
+  submitApplication: (
+    values: AddApplicationFormValues,
+    onSuccess: () => void,
+  ) => Promise<void>;
+
+  /** Lifecycle */
+  reset: () => void;
+}
+
+export function useAddApplicationFlow(
+  preFillFns: ApplyPreFillFns,
+): UseAddApplicationFlowReturn {
+  const { data: companiesData } = useListCompaniesQuery();
+  const [createApplication, { isLoading: creatingApplication }] =
+    useCreateApplicationMutation();
+  const [createCompany] = useCreateCompanyMutation();
+  const [triggerCompanyResearch] = useTriggerCompanyResearchMutation();
+  const [parseJobDescription] = useParseJobDescriptionMutation();
+  const [extractJdFromUrl] = useExtractJdFromUrlMutation();
+
+  const [state, setState] = useState<DialogState>(INITIAL_STATE);
+  const [urlValue, setUrlValue] = useState("");
+  const [textValue, setTextValue] = useState("");
+  const [companyNameValue, setCompanyNameValue] = useState("");
+  const [pendingCompanyName, setPendingCompanyName] = useState<string | null>(null);
+  const [submittedJdText, setSubmittedJdText] = useState<string>("");
+
+  const companies = companiesData?.items ?? [];
+
+  // -------------------------------------------------------------------------
+  // Lifecycle — reset everything.
+  // -------------------------------------------------------------------------
+  function reset() {
+    setState(INITIAL_STATE);
+    setUrlValue("");
+    setTextValue("");
+    setCompanyNameValue("");
+    setPendingCompanyName(null);
+    setSubmittedJdText("");
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 1 — input mode switching + paste-and-go.
+  // -------------------------------------------------------------------------
+  function setInputMode(mode: DialogInputMode) {
+    setState({ kind: "input", inputMode: mode });
+  }
+
+  function handleUrlInputChange(next: string) {
+    setUrlValue(next);
+  }
+
+  function handleUrlPaste(e: React.ClipboardEvent<HTMLInputElement>) {
+    const pasted = e.clipboardData.getData("text").trim();
+    if (URL_REGEX.test(pasted)) {
+      e.preventDefault();
+      setUrlValue(pasted);
+      void runUrlExtract(pasted);
+    }
+  }
+
+  function handleUrlSubmit() {
+    const url = urlValue.trim();
+    if (!url) return;
+    void runUrlExtract(url);
+  }
+
+  function handleTextSubmit() {
+    const text = textValue.trim();
+    if (!text) return;
+    void runTextParse(text);
+  }
+
+  function handleCompanyNameSelectExisting(companyId: string, name: string) {
+    const company = companies.find((c) => c.id === companyId);
+    setState({
+      kind: "review",
+      sourceUrl: null,
+      summary: null,
+      company: {
+        kind: "manual",
+        companyId,
+        name,
+        logoUrl: company?.logo_url ?? null,
+      },
+      changingCompany: false,
+    });
+    setPendingCompanyName(null);
+  }
+
+  async function handleCompanyNameCreateOnTheFly(name: string) {
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    setCompanyNameValue(trimmed);
+    try {
+      const created = await createCompany({ name: trimmed }).unwrap();
+      void triggerCompanyResearch(created.id)
+        .unwrap()
+        .catch((err) => {
+          console.warn("Background company research failed:", err);
+        });
+      setState({
+        kind: "review",
+        sourceUrl: null,
+        summary: null,
+        company: {
+          kind: "new",
+          companyId: created.id,
+          name: created.name,
+          logoUrl: created.logo_url,
+        },
+        changingCompany: false,
+      });
+      setPendingCompanyName(null);
+    } catch (err) {
+      showError(`Couldn't create company "${trimmed}": ${extractErrorMessage(err)}`);
+      setPendingCompanyName(trimmed);
+      setState({
+        kind: "review",
+        sourceUrl: null,
+        summary: null,
+        company: { kind: "autoCreateFailed", name: trimmed },
+        changingCompany: false,
+      });
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 2 — processing.
+  // -------------------------------------------------------------------------
+  async function runUrlExtract(url: string) {
+    setState({ kind: "processing", sourcePath: "url", longRunning: false });
+    try {
+      const result = await extractJdFromUrl({ url }).unwrap();
+      await applyExtractResult(result);
+    } catch (err) {
+      if (isAuthRequiredError(err)) {
+        showError(
+          "That page requires sign-in or blocked our request. Paste the description text instead.",
+        );
+        setInputMode("text");
+        return;
+      }
+      showError(`Couldn't auto-fill: ${describeExtractError(err)}`);
+      setInputMode("url");
+    }
+  }
+
+  async function runTextParse(text: string) {
+    setState({ kind: "processing", sourcePath: "text", longRunning: false });
+    setSubmittedJdText(text);
+    try {
+      const result = await parseJobDescription({ jd_text: text }).unwrap();
+      await applyParseResult(result, { sourceUrl: null });
+    } catch (err) {
+      showError(`Couldn't auto-fill: ${extractErrorMessage(err) ?? "AI parsing failed"}`);
+      setInputMode("text");
+    }
+  }
+
+  // After 3 s in processing, flip the longRunning flag.
+  useEffect(() => {
+    if (state.kind !== "processing" || state.longRunning) return;
+    const timer = setTimeout(() => {
+      setState((prev) => {
+        if (prev.kind !== "processing") return prev;
+        return { ...prev, longRunning: true };
+      });
+    }, PROCESSING_LONG_RUNNING_THRESHOLD_MS);
+    return () => clearTimeout(timer);
+  }, [state]);
+
+  // -------------------------------------------------------------------------
+  // Pre-fill helpers — both extract and parse routes converge here.
+  // -------------------------------------------------------------------------
+  async function applyParseResult(
+    result: JdParseResponse,
+    { sourceUrl }: { sourceUrl: string | null },
+  ) {
+    const { setValue } = preFillFns;
+    if (result.title) setValue("role_title", result.title, { shouldValidate: true });
+    if (result.location) setValue("location", result.location, { shouldValidate: true });
+    if (
+      result.remote_type === "remote" ||
+      result.remote_type === "hybrid" ||
+      result.remote_type === "onsite"
+    ) {
+      setValue("remote_type", result.remote_type, { shouldValidate: true });
+    }
+
+    const companyState = await resolveCompany(result.company, {});
+    setState({
+      kind: "review",
+      sourceUrl,
+      summary: result.summary,
+      company: companyState,
+      changingCompany: false,
+    });
+  }
+
+  async function applyExtractResult(result: JdUrlExtractResponse) {
+    const { setValue } = preFillFns;
+    if (result.title) setValue("role_title", result.title, { shouldValidate: true });
+    if (result.location) setValue("location", result.location, { shouldValidate: true });
+
+    const notesScaffold = combineNotes(result);
+    if (notesScaffold) {
+      setValue("notes", notesScaffold, { shouldValidate: true });
+    }
+
+    const companyState = await resolveCompany(result.company, {
+      website: result.company_website,
+      logoUrl: result.company_logo_url,
+    });
+    setState({
+      kind: "review",
+      sourceUrl: result.source_url,
+      summary: result.summary,
+      company: companyState,
+      changingCompany: false,
+    });
+  }
+
+  interface CompanyExtras {
+    website?: string | null;
+    logoUrl?: string | null;
+  }
+
+  async function resolveCompany(
+    name: string | null,
+    extras: CompanyExtras,
+  ): Promise<ReviewCompanyState> {
+    const trimmed = (name ?? "").trim();
+    if (!trimmed) {
+      setPendingCompanyName(null);
+      return { kind: "autoCreateFailed", name: "" };
+    }
+    setPendingCompanyName(trimmed);
+
+    const existing = findCompanyByName(companies, trimmed);
+    if (existing) {
+      setPendingCompanyName(null);
+      return {
+        kind: "tracked",
+        companyId: existing.id,
+        name: existing.name,
+        logoUrl: existing.logo_url,
+      };
+    }
+
+    try {
+      const payload: { name: string; primary_domain?: string | null; logo_url?: string | null } =
+        { name: trimmed };
+      const domain = websiteToDomain(extras.website);
+      if (domain) payload.primary_domain = domain;
+      if (extras.logoUrl) payload.logo_url = extras.logoUrl;
+
+      const created = await createCompany(payload).unwrap();
+      void triggerCompanyResearch(created.id)
+        .unwrap()
+        .catch((err) => {
+          console.warn("Background company research failed:", err);
+        });
+      setPendingCompanyName(null);
+      return {
+        kind: "new",
+        companyId: created.id,
+        name: created.name,
+        logoUrl: created.logo_url,
+      };
+    } catch (err) {
+      showError(`Couldn't auto-create company "${trimmed}": ${extractErrorMessage(err)}`);
+      return { kind: "autoCreateFailed", name: trimmed };
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Step 3 — review. Company pill / combobox transitions.
+  // -------------------------------------------------------------------------
+  function handlePillChangeRequest() {
+    if (state.kind !== "review") return;
+    setState({ ...state, changingCompany: true });
+    setCompanyNameValue(state.company.name);
+  }
+
+  function handleReviewSelectExisting(companyId: string, name: string) {
+    if (state.kind !== "review") return;
+    const company = companies.find((c) => c.id === companyId);
+    setState({
+      ...state,
+      company: {
+        kind: "tracked",
+        companyId,
+        name,
+        logoUrl: company?.logo_url ?? null,
+      },
+      changingCompany: false,
+    });
+    setPendingCompanyName(null);
+  }
+
+  async function handleReviewCreateOnTheFly(name: string) {
+    if (state.kind !== "review") return;
+    const trimmed = name.trim();
+    if (!trimmed) return;
+    try {
+      const created = await createCompany({ name: trimmed }).unwrap();
+      void triggerCompanyResearch(created.id)
+        .unwrap()
+        .catch((err) => {
+          console.warn("Background company research failed:", err);
+        });
+      setState({
+        ...state,
+        company: {
+          kind: "new",
+          companyId: created.id,
+          name: created.name,
+          logoUrl: created.logo_url,
+        },
+        changingCompany: false,
+      });
+      setPendingCompanyName(null);
+    } catch (err) {
+      showError(`Couldn't create company "${trimmed}": ${extractErrorMessage(err)}`);
+      setPendingCompanyName(trimmed);
+      setState({
+        ...state,
+        company: { kind: "autoCreateFailed", name: trimmed },
+        changingCompany: false,
+      });
+    }
+  }
+
+  function handleCancelChangingCompany() {
+    if (state.kind !== "review") return;
+    setState({ ...state, changingCompany: false });
+  }
+
+  // -------------------------------------------------------------------------
+  // Submit.
+  // -------------------------------------------------------------------------
+  async function submitApplication(
+    values: AddApplicationFormValues,
+    onSuccess: () => void,
+  ): Promise<void> {
+    if (state.kind !== "review") {
+      showError("Finish the auto-fill step first.");
+      return;
+    }
+    let companyId = readCompanyId(state.company);
+
+    if (!companyId && pendingCompanyName) {
+      try {
+        const trimmed = pendingCompanyName.trim();
+        const existing = findCompanyByName(companies, trimmed);
+        if (existing) {
+          companyId = existing.id;
+        } else {
+          const created = await createCompany({ name: trimmed }).unwrap();
+          companyId = created.id;
+        }
+        setPendingCompanyName(null);
+      } catch (err) {
+        showError(
+          `Couldn't auto-create company "${pendingCompanyName}": ${extractErrorMessage(err)}`,
+        );
+        return;
+      }
+    }
+    if (!companyId) {
+      showError("Pick a company before saving the application.");
+      return;
+    }
+
+    try {
+      const url = state.sourceUrl ?? null;
+      await createApplication({
+        company_id: companyId,
+        role_title: values.role_title.trim(),
+        url,
+        location: values.location.trim() || null,
+        remote_type: values.remote_type,
+        notes: values.notes.trim() || null,
+        jd_text: submittedJdText.trim() || null,
+      }).unwrap();
+      onSuccess();
+    } catch (err) {
+      showError(`Couldn't create application: ${extractErrorMessage(err)}`);
+    }
+  }
+
+  return {
+    state,
+    urlValue,
+    textValue,
+    companyNameValue,
+    pendingCompanyName,
+    submittedJdText,
+    companies,
+    creatingApplication,
+    setInputMode,
+    handleUrlInputChange,
+    handleUrlPaste,
+    handleUrlSubmit,
+    handleTextSubmit,
+    handleCompanyNameSelectExisting,
+    handleCompanyNameCreateOnTheFly,
+    handlePillChangeRequest,
+    handleReviewSelectExisting,
+    handleReviewCreateOnTheFly,
+    handleCancelChangingCompany,
+    setCompanyNameValue,
+    setTextValue,
+    submitApplication,
+    reset,
+  };
+}


### PR DESCRIPTION
## Summary

Splits MJH's monolithic \`AddApplicationDialog.tsx\` into a state-machine hook + per-step components.

## File breakdown

| File | LOC |
|---|---|
| \`AddApplicationDialog.tsx\` (orchestrator) | 1,070 → **153** |
| \`add-application-dialog/useAddApplicationFlow.ts\` (state machine) | **388** |
| \`add-application-dialog/dialogHelpers.ts\` (pure utilities) | **70** |
| \`add-application-dialog/CompanyConfirmStep.tsx\` | **242** |
| \`add-application-dialog/PasteLinkStep.tsx\` | **89** |
| \`add-application-dialog/PasteTextStep.tsx\` | **69** |
| \`add-application-dialog/ManualEntryStep.tsx\` | **47** |
| \`add-application-dialog/ProcessingStep.tsx\` | **29** |

## Design notes

- \`useAddApplicationFlow\` receives a \`{ setValue }\` callback from the orchestrator rather than owning the \`useForm\` instance — keeps the \`<form>\` element + ref hierarchy co-located with the Dialog shell.
- \`dialogHelpers.ts\` holds 5 pure functions (\`findCompanyByName\`, \`readCompanyId\`, \`websiteToDomain\`, \`combineNotes\`, \`stripHtml\`) with no React deps.
- State shape unchanged. \`DialogState\`, \`ReviewCompanyState\`, \`DialogInputMode\` types in \`useAddApplicationDialogState.ts\` untouched.

## Test plan

- [x] All 9 \`AddApplicationDialog\` tests pass unchanged
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)