### PR TITLE
refactor(shared): extract common response schemas (Status / Count / Success) to platform_shared

### DIFF
--- a/apps/mybookkeeper/backend/app/schemas/common.py
+++ b/apps/mybookkeeper/backend/app/schemas/common.py
@@ -2,18 +2,12 @@ import uuid
 
 from pydantic import BaseModel
 
+from platform_shared.schemas.common import (  # noqa: F401
+    CountResponse,
+    StatusResponse,
+    SuccessResponse,
+)
+
 
 class BulkIdsRequest(BaseModel):
     ids: list[uuid.UUID]
-
-
-class StatusResponse(BaseModel):
-    status: str
-
-
-class CountResponse(BaseModel):
-    count: int
-
-
-class SuccessResponse(BaseModel):
-    success: bool

--- a/packages/shared-backend/platform_shared/schemas/common.py
+++ b/packages/shared-backend/platform_shared/schemas/common.py
@@ -1,0 +1,21 @@
+"""Generic Pydantic response schemas shared across all apps.
+
+These three shapes appear in every app's API surface — any endpoint that
+acknowledges an action (status), returns a count, or reports a boolean
+outcome uses one of these. Keeping them here means MJH (and every future
+app) can import from ``platform_shared`` instead of reimplementing them
+as ``dict[str, Any]``.
+"""
+from pydantic import BaseModel
+
+
+class StatusResponse(BaseModel):
+    status: str
+
+
+class CountResponse(BaseModel):
+    count: int
+
+
+class SuccessResponse(BaseModel):
+    success: bool

--- a/packages/shared-backend/tests/test_common_schemas.py
+++ b/packages/shared-backend/tests/test_common_schemas.py
@@ -1,0 +1,33 @@
+"""Unit tests for platform_shared.schemas.common."""
+from platform_shared.schemas.common import CountResponse, StatusResponse, SuccessResponse
+
+
+class TestStatusResponse:
+    def test_valid(self) -> None:
+        r = StatusResponse(status="ok")
+        assert r.status == "ok"
+
+    def test_serialises(self) -> None:
+        assert StatusResponse(status="done").model_dump() == {"status": "done"}
+
+
+class TestCountResponse:
+    def test_valid(self) -> None:
+        r = CountResponse(count=42)
+        assert r.count == 42
+
+    def test_serialises(self) -> None:
+        assert CountResponse(count=0).model_dump() == {"count": 0}
+
+
+class TestSuccessResponse:
+    def test_true(self) -> None:
+        r = SuccessResponse(success=True)
+        assert r.success is True
+
+    def test_false(self) -> None:
+        r = SuccessResponse(success=False)
+        assert r.success is False
+
+    def test_serialises(self) -> None:
+        assert SuccessResponse(success=True).model_dump() == {"success": True}


### PR DESCRIPTION
## Summary

Moves three reusable response Pydantic types from MBK to \`platform_shared/schemas/common.py\`:

- \`StatusResponse\`
- \`CountResponse\`
- \`SuccessResponse\`

## What changes

- \`packages/shared-backend/platform_shared/schemas/common.py\` (new) — three classes verbatim
- \`packages/shared-backend/tests/test_common_schemas.py\` (new) — 7 tests for valid construction + \`model_dump()\` serialization
- \`apps/mybookkeeper/backend/app/schemas/common.py\` — replaces the three local classes with a re-export block (\`# noqa: F401\`); leaves \`BulkIdsRequest\` in place since it's MBK-specific (used by api/documents.py + api/transactions.py)

## Back-compat

Existing MBK imports \`from app.schemas.common import StatusResponse\` continue to resolve via re-exports.

## MJH adoption

Not in scope for this PR. MJH currently returns raw \`dict[str, Any]\` for the same shapes — separate adoption PR will switch those endpoints to use the shared types.

## Test plan

- [x] 7 new shared tests pass
- [x] 2,623 MBK tests pass (no regressions)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)