### PR TITLE
test(mbk/e2e): tighten lease-import test, probe MinIO at runtime

### DIFF
--- a/apps/mybookkeeper/TECH_DEBT.md
+++ b/apps/mybookkeeper/TECH_DEBT.md
@@ -1,7 +1,7 @@
 # Tech Debt
 
 > Last scanned: 2026-05-08
-> Issues: 0 critical, 3 high, 4 medium (1 deferred + 3 active), 0 low
+> Issues: 0 critical, 2 high, 4 medium (1 deferred + 3 active), 0 low
 >
 > **Monorepo refactor audit (2026-05-08, post-resume-refinement work):** ~12 additional findings across three axes — backend reusability, frontend reusability, and long-files. Tracked under "## Monorepo refactor audit (2026-05-08)" below. These are extraction / split candidates, not regression bugs. Sister findings live in `apps/myjobhunter/TECH_DEBT.md`.
 
@@ -174,11 +174,8 @@ Output of two parallel scans (backend + frontend) for code that should live in `
 
 ---
 
-### [E2E] Lease import E2E test skips actual file upload (requires MinIO)
-**Effort:** S
-**Location:** `apps/mybookkeeper/frontend/e2e/lease-import.spec.ts` — "import dialog — submit triggers API call" test
-**Problem:** The lease import endpoint (`POST /signed-leases/import`) requires MinIO object storage to complete successfully. In local dev (no MinIO), the endpoint returns 503. The primary E2E test uses a seed API endpoint (`/test/seed-signed-lease`) to bypass storage, but the dialog submission test cannot verify the full happy path (navigate to detail page after upload). The test accepts either a navigation or an error toast as a valid outcome.
-**Recommendation:** Stand up a local MinIO container for E2E tests (via Docker Compose or MinIO standalone binary). Set `MINIO_ENDPOINT`, `MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY` in the CI env and test .env. Once MinIO is available, rewrite the dialog-submit test to verify the full navigation path. Alternatively, add a `TEST_STORAGE_MOCK=true` env flag to the backend that returns a fake presigned URL without actual upload.
+### ~~[E2E] Lease import E2E test skips actual file upload (requires MinIO)~~ RESOLVED
+**Resolved:** PR fix/mbk-lease-import-e2e-tighten (2026-05-08) — local-first approach, no CI E2E job. The test now probes `/admin/storage-health` at the start of the third test and `test.skip()`s cleanly with a remediation message ("start MinIO via `docker compose -f infra/docker-compose.yml up -d minio`") when storage is unreachable. When MinIO IS up, the test asserts the full happy path strictly: navigation to `/leases/{uuid}` + the imported-kind badge on the detail page. No more "either nav or error toast" permissiveness. Documented in `apps/mybookkeeper/frontend/e2e/README.md` (new file) — full E2E suite is local-only by design (CI cost vs solo-dev value didn't justify a docker-stack CI job; the layout-config CI job still catches Caddy / iframe / layout regressions).
 
 ---
 

--- a/apps/mybookkeeper/frontend/e2e/README.md
+++ b/apps/mybookkeeper/frontend/e2e/README.md
@@ -1,0 +1,38 @@
+# MyBookkeeper E2E tests
+
+Playwright tests under this directory split into two configs:
+
+- **`playwright.layout.config.ts`** — no backend. Tests fully mock their API surface via `page.route()` and read files off disk. Used in CI by the `frontend-layout-e2e / mybookkeeper` job.
+- **`playwright.config.ts`** — full backend required. Tests register a real user, drive the live UI, and assert real data effects. Run locally only.
+
+## Running the full suite locally
+
+```bash
+# Required for ALL full-config E2E tests:
+#   - Postgres reachable at the URL in backend/.env
+#   - Backend running on :8000 (`uvicorn app.main:app --reload` from backend/)
+#   - ALLOW_TEST_ADMIN_PROMOTION=true so /test/* endpoints are mounted
+#
+# Required for storage-touching tests (notably lease-import.spec.ts test 3):
+#   - MinIO running and reachable from the backend.
+
+# Bring up the shared infra MinIO (covers all monorepo apps):
+docker compose -f infra/docker-compose.yml up -d minio
+
+# Then from apps/mybookkeeper/frontend:
+npx playwright test
+```
+
+## Storage-required tests
+
+Tests that exercise the upload happy path (POST `/signed-leases/import`, POST `/listings/{id}/photos`, etc.) probe MinIO via `GET /admin/storage-health` at the start of the test and `test.skip()` cleanly with a remediation message if MinIO is unreachable.
+
+This means:
+- If you forget to start MinIO, the test won't silently pass — it'll skip with the exact command to fix it.
+- If you start MinIO, the test asserts the full happy path strictly (navigation to the new resource, no fallback to an error toast).
+
+The probe is per-test, not in `globalSetup`, so the rest of the suite still runs when MinIO is down.
+
+## Why no full-suite CI job?
+
+The full E2E suite needs a Docker stack (Postgres + MinIO + backend + worker + Caddy + frontend). Standing that up in CI on every PR adds 5–10 min of wall time and a maintenance surface (Dockerfile drift, env wiring, flake fixing) that isn't justified for a solo-dev repo. The discipline is: run `npx playwright test` locally before pushing PRs that touch backend services, frontend forms, or anything in `e2e/`. The layout-config tests still run in CI to catch the layout-shift / Caddy-header / blob-iframe class of regression.

--- a/apps/mybookkeeper/frontend/e2e/lease-import.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/lease-import.spec.ts
@@ -16,10 +16,22 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
  * Test 2: Exercises the import dialog UI — verifies submit is disabled until
  *         both an applicant and a file are provided.
  *
- * Test 3: Exercises the dialog interaction through to the API call — verifies
- *         the form submits correctly (the response may be a storage error in
- *         local dev if MinIO is not running, but the error toast is shown).
+ * Test 3: Full happy path — submits the import dialog and asserts navigation
+ *         to the new lease detail page. Requires MinIO to be reachable;
+ *         skips with a clear message if not (start it with
+ *         `docker compose -f infra/docker-compose.yml up -d minio`).
  */
+
+async function isMinioReachable(api: APIRequestContext): Promise<boolean> {
+  try {
+    const res = await api.get("/admin/storage-health");
+    if (!res.ok()) return false;
+    const body = (await res.json()) as { bucket_reachable: boolean | null };
+    return body.bucket_reachable === true;
+  } catch {
+    return false;
+  }
+}
 
 async function seedApplicant(
   api: APIRequestContext,
@@ -147,11 +159,21 @@ test.describe("Import Signed Lease", () => {
   );
 
   test(
-    "import dialog — submit triggers API call when applicant and file are provided",
+    "import dialog — full upload happy path navigates to lease detail",
     async ({ authedPage: page, api }) => {
+      // The import endpoint requires MinIO. Skip cleanly with a clear
+      // remediation message if storage isn't reachable, instead of
+      // silently passing on an error toast.
+      const minioUp = await isMinioReachable(api);
+      test.skip(
+        !minioUp,
+        "MinIO is not reachable — start it with `docker compose -f infra/docker-compose.yml up -d minio` and re-run.",
+      );
+
       const runId = Date.now();
       const applicantName = `E2E Dialog Submit ${runId}`;
       const seededApplicantIds: string[] = [];
+      const seededLeaseIds: string[] = [];
 
       try {
         const applicantId = await seedApplicant(api, applicantName);
@@ -189,29 +211,22 @@ test.describe("Import Signed Lease", () => {
         const submitBtn = page.getByTestId("import-submit");
         await expect(submitBtn).not.toBeDisabled();
 
-        // Click submit — the API call fires. In local dev (no MinIO) this will
-        // produce a 503 and show an error toast. In CI (with MinIO) it will
-        // navigate to the lease detail page. Either outcome is valid here.
+        // Click submit — with MinIO reachable, the upload + DB insert
+        // succeeds and the page navigates to the new lease's detail page.
         await submitBtn.click();
 
-        // Wait for either navigation or an error toast to appear.
-        await Promise.race([
-          page.waitForURL(/\/leases\/[0-9a-f-]{36}$/, { timeout: 10000 }).then(
-            async () => {
-              // Success path — clean up the created lease.
-              const leaseId = page.url().split("/leases/")[1];
-              if (leaseId) await deleteSignedLease(api, leaseId);
-            },
-          ).catch(() => null),
-          expect(
-            page.locator("[data-testid='toast-error'], [role='alert']").first(),
-          ).toBeVisible({ timeout: 10000 }).catch(() => null),
-        ]);
+        await page.waitForURL(/\/leases\/[0-9a-f-]{36}$/, { timeout: 15000 });
+        const leaseId = page.url().split("/leases/")[1];
+        if (leaseId) seededLeaseIds.push(leaseId);
 
-        // Either the dialog is gone (success) or it's still visible with error.
-        // The important assertion: we got past disabled-submit validation.
-        // (The exact outcome depends on MinIO availability.)
+        // Sanity check: detail page rendered the imported lease.
+        const kindBadge = page.getByTestId("lease-kind-badge");
+        await expect(kindBadge).toBeVisible({ timeout: 10000 });
+        await expect(kindBadge).toContainText("Imported");
       } finally {
+        for (const id of seededLeaseIds) {
+          await deleteSignedLease(api, id);
+        }
         for (const id of seededApplicantIds) {
           await deleteApplicant(api, id);
         }


### PR DESCRIPTION
## Summary

Resolves the [E2E] Lease import tech-debt entry via the **local-first** approach (no CI E2E job).

The third lease-import test was permissive — it accepted either navigation to the new lease OR a 503 error toast, since MinIO isn't always running in local dev. That made the assertion useless: a real regression that broke the upload happy path would still pass as long as the error toast surfaced.

### Changes

- **Probe `GET /admin/storage-health`** at the top of the third test. The E2E user is already promoted to admin in globalSetup.
- **If MinIO isn't reachable** → \`test.skip()\` with a clear remediation message pointing at \`docker compose -f infra/docker-compose.yml up -d minio\`.
- **If MinIO IS reachable** → assert the full happy path strictly: navigation to \`/leases/{uuid}\` within 15s + the \"Imported\" kind badge visible on the detail page.
- **Cleanup** the freshly-created lease in the finally block (no test data left behind).

Per-test probe (not globalSetup-level) so the other 30+ E2E specs still run when MinIO is down.

### Why no full-stack CI E2E job

Considered standing up Postgres + MinIO + backend + worker + Caddy in CI, but the cost (5–10 min wall time per PR + Dockerfile-drift maintenance + flake-fixing surface) didn't justify it for a solo-dev repo. Discipline: \`npx playwright test\` locally before pushing PRs that touch backend services, frontend forms, or anything in \`e2e/\`. The layout-config CI job still catches Caddy header / iframe / layout regressions.

Documented in \`apps/mybookkeeper/frontend/e2e/README.md\` (new file).

TECH_DEBT counts: 3 high → 2 high.

## Test plan

- [x] Local: \`npx playwright test e2e/lease-import.spec.ts --project=chromium\` (with MinIO up) → 3 passed
- [x] Local: same command (with MinIO down) → 2 passed, 1 skipped with remediation message
- [x] CI: backend-tests, frontend-build, frontend-layout-e2e

🤖 Generated with [Claude Code](https://claude.com/claude-code)