### PR TITLE
refactor(mbk/leases): split lease_template_service.py (926 LOC) into CRUD + placeholder + render

### DIFF
--- a/apps/mybookkeeper/backend/app/services/leases/lease_template_placeholder_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_template_placeholder_service.py
@@ -1,0 +1,182 @@
+"""AI placeholder suggestion for lease templates.
+
+Extracts text from uploaded files and calls Claude to propose a named +
+typed list of placeholders that the host can review before persisting.
+
+Constants ``ALLOWED_TEMPLATE_MIME_TYPES`` and ``DOCX_MIME`` are defined here
+because both CRUD and placeholder-extraction need them. The CRUD module
+imports them from here to keep a single source of truth.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+
+from app.core.storage import get_storage
+from app.db.session import unit_of_work
+from app.repositories.leases import (
+    lease_template_file_repo,
+    lease_template_repo,
+)
+from app.schemas.leases.suggest_placeholders_response import (
+    SuggestedPlaceholderItem,
+    SuggestPlaceholdersResponse,
+)
+from app.services.leases.template_placeholder_extractor import (
+    suggest_placeholders as _ai_suggest_placeholders,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# MIME / content-type constants
+# ---------------------------------------------------------------------------
+
+ALLOWED_TEMPLATE_MIME_TYPES: frozenset[str] = frozenset({
+    "text/markdown",
+    "text/plain",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+})
+
+DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+
+
+# ---------------------------------------------------------------------------
+# Exceptions (shared with the CRUD module — re-exported from there)
+# ---------------------------------------------------------------------------
+
+class TemplateNotFoundError(LookupError):
+    pass
+
+
+class StorageNotConfiguredError(RuntimeError):
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers: content-type normalisation + text extraction
+# ---------------------------------------------------------------------------
+
+def normalise_content_type(declared: str | None, filename: str) -> str:
+    """Resolve a content type when the upload omits one or sends octet-stream.
+
+    DOCX uploads frequently arrive as ``application/octet-stream`` from
+    browser drag-drop, so we fall back to the filename extension.
+    """
+    if declared and declared in ALLOWED_TEMPLATE_MIME_TYPES:
+        return declared
+    lower = filename.lower()
+    if lower.endswith(".docx"):
+        return DOCX_MIME
+    if lower.endswith(".md"):
+        return "text/markdown"
+    if lower.endswith(".txt"):
+        return "text/plain"
+    if declared:
+        return declared
+    return "application/octet-stream"
+
+
+def extract_text_from_upload(content: bytes, content_type: str) -> str:
+    """Pull plain text out of the upload for placeholder extraction.
+
+    For DOCX we use python-docx if available; otherwise we can't extract
+    placeholders (the host can still edit the spec by hand later).
+    """
+    if content_type in ("text/markdown", "text/plain"):
+        try:
+            return content.decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            return ""
+    if content_type == DOCX_MIME:
+        try:
+            import io
+            import docx  # type: ignore[import-untyped]
+
+            document = docx.Document(io.BytesIO(content))
+            parts = [p.text for p in document.paragraphs]
+            for table in document.tables:
+                for row in table.rows:
+                    for cell in row.cells:
+                        for p in cell.paragraphs:
+                            parts.append(p.text)
+            return "\n".join(parts)
+        except ImportError:
+            logger.info(
+                "python-docx not installed — DOCX placeholder extraction skipped",
+            )
+            return ""
+        except Exception:  # noqa: BLE001
+            logger.warning("Failed to extract text from DOCX", exc_info=True)
+            return ""
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# AI placeholder suggestion
+# ---------------------------------------------------------------------------
+
+async def suggest_ai_placeholders(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    template_id: uuid.UUID,
+) -> SuggestPlaceholdersResponse:
+    """Run an AI pass over the template's files and propose placeholders.
+
+    Fetches file content from MinIO, extracts text from each file, then calls
+    Claude to propose a named + typed list of placeholders. The caller
+    (route handler) must NOT persist the result — the host reviews the list
+    and saves via the existing ``update_placeholder`` endpoint.
+
+    Returns a :class:`SuggestPlaceholdersResponse` with ``suggestions``,
+    ``truncated``, and an optional ``pages_note``.
+
+    Raises :class:`TemplateNotFoundError` if the template doesn't belong to the
+    caller. Storage errors are propagated (the route handler maps them to 503).
+    """
+    storage = get_storage()
+    if storage is None:
+        raise StorageNotConfiguredError("Object storage is not configured")
+
+    async with unit_of_work() as db:
+        template = await lease_template_repo.get(
+            db,
+            template_id=template_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if template is None:
+            raise TemplateNotFoundError(f"Template {template_id} not found")
+        files = await lease_template_file_repo.list_for_template(
+            db, template_id=template_id,
+        )
+
+    extracted_texts: list[str] = []
+    for f in files:
+        raw = storage.download_file(f.storage_key)
+        extracted_texts.append(extract_text_from_upload(raw, f.content_type))
+
+    combined_text = "\n\n".join(t for t in extracted_texts if t.strip())
+    result = await _ai_suggest_placeholders(combined_text)
+
+    pages_note: str | None = None
+    if result.truncated:
+        pages_note = (
+            "The document was too long to analyse in full — "
+            "I read the first portion. Some placeholders near the end may be missing."
+        )
+
+    return SuggestPlaceholdersResponse(
+        suggestions=[
+            SuggestedPlaceholderItem(
+                key=s.key,
+                description=s.description,
+                input_type=s.input_type,
+            )
+            for s in result.suggestions
+        ],
+        truncated=result.truncated,
+        pages_note=pages_note,
+    )

--- a/apps/mybookkeeper/backend/app/services/leases/lease_template_render_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_template_render_service.py
@@ -1,0 +1,44 @@
+"""Render helpers for lease templates.
+
+Provides ``load_template_source_texts`` which downloads raw file bytes from
+MinIO for use by the signed-lease render pipeline.
+"""
+from __future__ import annotations
+
+import uuid
+
+from app.core.storage import StorageClient
+from app.db.session import unit_of_work
+from app.repositories.leases import (
+    lease_template_file_repo,
+    lease_template_repo,
+)
+from app.services.leases.lease_template_placeholder_service import (
+    TemplateNotFoundError,
+)
+
+
+async def load_template_source_texts(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    template_id: uuid.UUID,
+    storage: StorageClient,
+) -> list[tuple[str, str, bytes]]:
+    """Return ``[(filename, content_type, raw_bytes)]`` in display order."""
+    async with unit_of_work() as db:
+        template = await lease_template_repo.get(
+            db,
+            template_id=template_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if template is None:
+            raise TemplateNotFoundError(f"Template {template_id} not found")
+        files = await lease_template_file_repo.list_for_template(
+            db, template_id=template_id,
+        )
+    out: list[tuple[str, str, bytes]] = []
+    for f in files:
+        out.append((f.filename, f.content_type, storage.download_file(f.storage_key)))
+    return out

--- a/apps/mybookkeeper/backend/app/services/leases/lease_template_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_template_service.py
@@ -1,4 +1,4 @@
-"""Service layer for lease templates.
+"""Service layer for lease templates — CRUD entry points.
 
 Per layered-architecture: routes thin, services orchestrate, repositories own
 queries. Tenant isolation is via ``(user_id, organization_id)`` per the
@@ -12,6 +12,11 @@ Pipeline for ``upload_template``:
 Pipeline for ``replace_files`` (re-upload to bump version):
     delete old MinIO objects → insert new files → re-extract placeholders →
     preserve host edits where keys still match.
+
+Sub-modules
+-----------
+- ``lease_template_placeholder_service`` — AI placeholder suggestion
+- ``lease_template_render_service``      — render / source-text helpers
 """
 from __future__ import annotations
 
@@ -19,7 +24,7 @@ import logging
 import uuid
 
 from app.core.config import settings
-from app.core.storage import StorageClient, get_storage
+from app.core.storage import get_storage
 from app.db.session import unit_of_work
 from app.repositories.applicants import applicant_repo
 from app.repositories.inquiries.inquiry_repo import get_by_applicant_inquiry_id
@@ -52,44 +57,28 @@ from app.services.leases.default_source_resolver import (
     resolve_default_source,
     validate_default_source_spec,
 )
-from app.schemas.leases.suggest_placeholders_response import (
-    SuggestPlaceholdersResponse,
-    SuggestedPlaceholderItem,
+from app.services.leases.lease_template_placeholder_service import (
+    ALLOWED_TEMPLATE_MIME_TYPES,
+    DOCX_MIME,
+    TemplateNotFoundError,
+    StorageNotConfiguredError,
+    extract_text_from_upload as _extract_text_from_upload,
+    normalise_content_type as _normalise_content_type,
+    suggest_ai_placeholders,
+)
+from app.services.leases.lease_template_render_service import (
+    load_template_source_texts,
 )
 from app.services.leases.placeholder_extractor import (
     extract_placeholders_across_files,
-)
-from app.services.leases.template_placeholder_extractor import (
-    suggest_placeholders as _ai_suggest_placeholders,
 )
 
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Allowlist for upload content types
+# Additional exceptions (CRUD-specific)
 # ---------------------------------------------------------------------------
-
-ALLOWED_TEMPLATE_MIME_TYPES: frozenset[str] = frozenset({
-    "text/markdown",
-    "text/plain",
-    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-})
-
-DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
-
-
-# ---------------------------------------------------------------------------
-# Exceptions
-# ---------------------------------------------------------------------------
-
-class TemplateNotFoundError(LookupError):
-    pass
-
-
-class StorageNotConfiguredError(RuntimeError):
-    pass
-
 
 class TemplateFileTooLargeError(ValueError):
     pass
@@ -120,63 +109,36 @@ class ApplicantNotFoundError(LookupError):
 
 
 # ---------------------------------------------------------------------------
+# Back-compat re-exports (keep the public surface identical)
+# ---------------------------------------------------------------------------
+# These names were previously defined in this module. External callers
+# (api/lease_templates.py, api/signed_leases.py, tests) access them as
+# ``lease_template_service.<Name>`` — the re-imports above satisfy that.
+__all__ = [
+    # Constants
+    "ALLOWED_TEMPLATE_MIME_TYPES",
+    "DOCX_MIME",
+    # Exceptions (base set from placeholder module)
+    "TemplateNotFoundError",
+    "StorageNotConfiguredError",
+    # Exceptions (CRUD-specific)
+    "TemplateFileTooLargeError",
+    "TemplateFileTypeRejectedError",
+    "TemplateInUseError",
+    "InvalidComputedExprError",
+    "InvalidDefaultSourceError",
+    "PlaceholderNotFoundError",
+    "ApplicantNotFoundError",
+    # Functions delegated to placeholder module
+    "suggest_ai_placeholders",
+    # Functions delegated to render module
+    "load_template_source_texts",
+]
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _normalise_content_type(declared: str | None, filename: str) -> str:
-    """Resolve a content type when the upload omits one or sends octet-stream.
-
-    DOCX uploads frequently arrive as ``application/octet-stream`` from
-    browser drag-drop, so we fall back to the filename extension.
-    """
-    if declared and declared in ALLOWED_TEMPLATE_MIME_TYPES:
-        return declared
-    lower = filename.lower()
-    if lower.endswith(".docx"):
-        return DOCX_MIME
-    if lower.endswith(".md"):
-        return "text/markdown"
-    if lower.endswith(".txt"):
-        return "text/plain"
-    if declared:
-        return declared
-    return "application/octet-stream"
-
-
-def _extract_text_from_upload(content: bytes, content_type: str) -> str:
-    """Pull plain text out of the upload for placeholder extraction.
-
-    For DOCX we use python-docx if available; otherwise we can't extract
-    placeholders (the host can still edit the spec by hand later).
-    """
-    if content_type in ("text/markdown", "text/plain"):
-        try:
-            return content.decode("utf-8", errors="replace")
-        except Exception:  # noqa: BLE001
-            return ""
-    if content_type == DOCX_MIME:
-        try:
-            import io
-            import docx  # type: ignore[import-untyped]
-
-            document = docx.Document(io.BytesIO(content))
-            parts = [p.text for p in document.paragraphs]
-            for table in document.tables:
-                for row in table.rows:
-                    for cell in row.cells:
-                        for p in cell.paragraphs:
-                            parts.append(p.text)
-            return "\n".join(parts)
-        except ImportError:
-            logger.info(
-                "python-docx not installed — DOCX placeholder extraction skipped",
-            )
-            return ""
-        except Exception:  # noqa: BLE001
-            logger.warning("Failed to extract text from DOCX", exc_info=True)
-            return ""
-    return ""
-
 
 def _build_summary_from_orm(template, *, file_count: int, placeholder_count: int) -> LeaseTemplateSummary:
     return LeaseTemplateSummary(
@@ -825,102 +787,3 @@ async def replace_template_files(
         template_id=template_id,
     )
 
-
-# ---------------------------------------------------------------------------
-# Helper: load a template's source files as text (used by signed-lease render)
-# ---------------------------------------------------------------------------
-
-async def load_template_source_texts(
-    *,
-    user_id: uuid.UUID,
-    organization_id: uuid.UUID,
-    template_id: uuid.UUID,
-    storage: StorageClient,
-) -> list[tuple[str, str, bytes]]:
-    """Return ``[(filename, content_type, raw_bytes)]`` in display order."""
-    async with unit_of_work() as db:
-        template = await lease_template_repo.get(
-            db,
-            template_id=template_id,
-            user_id=user_id,
-            organization_id=organization_id,
-        )
-        if template is None:
-            raise TemplateNotFoundError(f"Template {template_id} not found")
-        files = await lease_template_file_repo.list_for_template(
-            db, template_id=template_id,
-        )
-    out: list[tuple[str, str, bytes]] = []
-    for f in files:
-        out.append((f.filename, f.content_type, storage.download_file(f.storage_key)))
-    return out
-
-
-# ---------------------------------------------------------------------------
-# AI placeholder suggestion (Phase 2)
-# ---------------------------------------------------------------------------
-
-async def suggest_ai_placeholders(
-    *,
-    user_id: uuid.UUID,
-    organization_id: uuid.UUID,
-    template_id: uuid.UUID,
-) -> SuggestPlaceholdersResponse:
-    """Run an AI pass over the template's files and propose placeholders.
-
-    Fetches file content from MinIO, extracts text from each file, then calls
-    Claude to propose a named + typed list of placeholders. The caller
-    (route handler) must NOT persist the result — the host reviews the list
-    and saves via the existing ``update_placeholder`` endpoint.
-
-    Returns a :class:`SuggestPlaceholdersResponse` with ``suggestions``,
-    ``truncated``, and an optional ``pages_note``.
-
-    Raises :class:`TemplateNotFoundError` if the template doesn't belong to the
-    caller. Storage errors are propagated (the route handler maps them to 503).
-    """
-    storage = get_storage()
-    if storage is None:
-        raise StorageNotConfiguredError("Object storage is not configured")
-
-    async with unit_of_work() as db:
-        template = await lease_template_repo.get(
-            db,
-            template_id=template_id,
-            user_id=user_id,
-            organization_id=organization_id,
-        )
-        if template is None:
-            raise TemplateNotFoundError(f"Template {template_id} not found")
-        files = await lease_template_file_repo.list_for_template(
-            db, template_id=template_id,
-        )
-
-    # Extract text from every file.
-    extracted_texts: list[str] = []
-    for f in files:
-        raw = storage.download_file(f.storage_key)
-        extracted_texts.append(_extract_text_from_upload(raw, f.content_type))
-
-    combined_text = "\n\n".join(t for t in extracted_texts if t.strip())
-    result = await _ai_suggest_placeholders(combined_text)
-
-    pages_note: str | None = None
-    if result.truncated:
-        pages_note = (
-            "The document was too long to analyse in full — "
-            "I read the first portion. Some placeholders near the end may be missing."
-        )
-
-    return SuggestPlaceholdersResponse(
-        suggestions=[
-            SuggestedPlaceholderItem(
-                key=s.key,
-                description=s.description,
-                input_type=s.input_type,
-            )
-            for s in result.suggestions
-        ],
-        truncated=result.truncated,
-        pages_note=pages_note,
-    )


### PR DESCRIPTION
Split into 789 LOC CRUD module (preserved name) + 182 LOC placeholder service (AI extraction) + 44 LOC render service. CRUD module re-exports DOCX_MIME, ALLOWED_TEMPLATE_MIME_TYPES, TemplateNotFoundError, StorageNotConfiguredError, suggest_ai_placeholders, load_template_source_texts so callers need zero changes. 55/55 tests pass. From audit (Medium severity).