### PR TITLE
refactor(mbk): move test_utils.py out of app/api/ to app/test_helpers/

### DIFF
--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -286,8 +286,8 @@ app.include_router(taxpayer_profiles.router)
 app.include_router(demo.router)
 app.include_router(analytics.router)
 if settings.allow_test_admin_promotion:
-    from app.api import test_utils
-    app.include_router(test_utils.router)
+    from app.test_helpers.router import router as test_helpers_router
+    app.include_router(test_helpers_router)
 
 
 @app.get("/health")

--- a/apps/mybookkeeper/backend/app/test_helpers/auth.py
+++ b/apps/mybookkeeper/backend/app/test_helpers/auth.py
@@ -1,0 +1,36 @@
+"""Test-only auth helpers: the test-mode gate guard and admin-promotion endpoint."""
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from app.core.auth import current_active_user
+from app.core.config import settings
+from app.db.session import unit_of_work
+from app.models.user.user import Role, User
+from app.repositories.user import user_repo
+from app.schemas.user.user import UserRead
+
+router = APIRouter()
+
+
+def _require_test_mode() -> None:
+    if not settings.allow_test_admin_promotion:
+        raise HTTPException(status_code=404, detail="Not found")
+
+
+@router.post("/test/promote-admin", response_model=UserRead)
+async def promote_to_admin(
+    user: User = Depends(current_active_user),
+) -> User:
+    _require_test_mode()
+
+    if user.role == Role.ADMIN:
+        return user
+
+    async with unit_of_work() as db:
+        target = await user_repo.get_by_id(db, user.id)
+        if not target:
+            raise HTTPException(status_code=404, detail="User not found")
+        await user_repo.update_role(db, target, Role.ADMIN)
+        return target

--- a/apps/mybookkeeper/backend/app/test_helpers/mocks.py
+++ b/apps/mybookkeeper/backend/app/test_helpers/mocks.py
@@ -1,0 +1,173 @@
+"""Test-only mock-control endpoints: Gmail send stub, storage stub, reauth state."""
+
+import datetime as _dt
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+
+from app.core import storage as _storage_module
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member
+from app.db.session import unit_of_work
+from app.repositories import integration_repo
+from app.services.email import gmail_service
+from app.test_helpers.auth import _require_test_mode
+
+router = APIRouter()
+
+# Process-local ring buffer for capturing gmail send-with-attachment calls.
+# Populated by the mock stub installed via POST /test/mock-gmail-send/enable.
+# Cleared on each enable call so tests start with a clean capture window.
+_last_gmail_attachment_send: dict[str, object] | None = None
+
+
+@router.post("/test/mock-gmail-send/enable", status_code=204)
+async def enable_mock_gmail_send(
+    ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001 — gated by ctx
+) -> None:
+    """Replace ``gmail_service.send_message`` and ``send_message_with_attachment``
+    with stubs that return a fake message-id. Used by E2E so tests don't hit
+    the Gmail API.
+
+    The attachment stub also captures send-call kwargs in the process-local
+    ``_last_gmail_attachment_send`` ring buffer so tests can assert recipient
+    and subject via ``GET /test/last-gmail-send``.
+
+    The patch lives at module level — the next send call sees the stub.
+    ``disable`` restores the originals.
+    """
+    _require_test_mode()
+    global _last_gmail_attachment_send
+    _last_gmail_attachment_send = None  # clear capture window on each enable
+
+    if getattr(gmail_service, "_real_send_message", None) is None:
+        gmail_service._real_send_message = gmail_service.send_message  # type: ignore[attr-defined]
+
+    def _stub(*args: object, **kwargs: object) -> str:
+        return f"<e2e-mock-{uuid.uuid4().hex[:12]}@mybookkeeper.app>"
+
+    gmail_service.send_message = _stub  # type: ignore[assignment]
+
+    if getattr(gmail_service, "_real_send_message_with_attachment", None) is None:
+        gmail_service._real_send_message_with_attachment = gmail_service.send_message_with_attachment  # type: ignore[attr-defined]
+
+    def _attachment_stub(*args: object, **kwargs: object) -> str:
+        global _last_gmail_attachment_send
+        _last_gmail_attachment_send = {
+            "to_address": kwargs.get("to_address"),
+            "subject": kwargs.get("subject"),
+            "attachment_filename": kwargs.get("attachment_filename"),
+        }
+        return f"<e2e-mock-att-{uuid.uuid4().hex[:12]}@mybookkeeper.app>"
+
+    gmail_service.send_message_with_attachment = _attachment_stub  # type: ignore[assignment]
+
+    # Also mock storage so receipt PDF upload succeeds without a real MinIO.
+    if getattr(_storage_module, "_real_get_storage", None) is None:
+        _storage_module._real_get_storage = _storage_module.get_storage  # type: ignore[attr-defined]
+
+    class _NoOpStorage:
+        bucket = "mock-bucket"
+
+        def upload_file(self, key: str, content: bytes, content_type: str) -> str:
+            return key
+
+        def delete_file(self, key: str) -> None:
+            pass
+
+        def ensure_bucket(self) -> None:
+            pass
+
+    _no_op = _NoOpStorage()
+
+    def _storage_stub() -> _NoOpStorage:
+        return _no_op
+
+    _storage_module.get_storage = _storage_stub  # type: ignore[assignment]
+
+
+@router.post("/test/mock-gmail-send/disable", status_code=204)
+async def disable_mock_gmail_send(
+    ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001
+) -> None:
+    """Restore the real ``gmail_service.send_message`` and
+    ``send_message_with_attachment`` after E2E."""
+    _require_test_mode()
+    real = getattr(gmail_service, "_real_send_message", None)
+    if real is not None:
+        gmail_service.send_message = real  # type: ignore[assignment]
+        gmail_service._real_send_message = None  # type: ignore[attr-defined]
+
+    real_att = getattr(gmail_service, "_real_send_message_with_attachment", None)
+    if real_att is not None:
+        gmail_service.send_message_with_attachment = real_att  # type: ignore[assignment]
+        gmail_service._real_send_message_with_attachment = None  # type: ignore[attr-defined]
+
+    real_storage = getattr(_storage_module, "_real_get_storage", None)
+    if real_storage is not None:
+        _storage_module.get_storage = real_storage  # type: ignore[assignment]
+        _storage_module._real_get_storage = None  # type: ignore[attr-defined]
+
+
+class _LastGmailSendResponse(BaseModel):
+    captured: bool
+    to_address: str | None = None
+    subject: str | None = None
+    has_attachment: bool = False
+    attachment_filename: str | None = None
+
+
+@router.get("/test/last-gmail-send", response_model=_LastGmailSendResponse)
+async def get_last_gmail_send(
+    ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001
+) -> _LastGmailSendResponse:
+    """Return the args of the most recent mock send_message_with_attachment call.
+
+    Only populated when the mock stub is active (POST /test/mock-gmail-send/enable).
+    Used by E2E tests to assert that a receipt email was dispatched with the
+    correct recipient and attachment without hitting the real Gmail API.
+    """
+    _require_test_mode()
+    captured = _last_gmail_attachment_send
+    if captured is None:
+        return _LastGmailSendResponse(captured=False)
+    return _LastGmailSendResponse(
+        captured=True,
+        to_address=captured.get("to_address"),  # type: ignore[arg-type]
+        subject=captured.get("subject"),  # type: ignore[arg-type]
+        has_attachment="attachment_filename" in captured,
+        attachment_filename=captured.get("attachment_filename"),  # type: ignore[arg-type]
+    )
+
+
+class _SeedNeedsReauthRequest(BaseModel):
+    model_config = {"extra": "forbid"}
+
+    needs_reauth: bool = True
+
+
+@router.post("/test/seed-integration-reauth-state", status_code=204)
+async def seed_integration_reauth_state(
+    payload: _SeedNeedsReauthRequest,
+    ctx: RequestContext = Depends(current_org_member),
+) -> None:
+    """Set ``needs_reauth`` on the org's Gmail integration. Test-only.
+
+    Used by E2E Test C to verify the dialog surfaces the reconnect-required
+    state rather than a generic error when Gmail tokens are expired.
+    """
+    _require_test_mode()
+    async with unit_of_work() as db:
+        integration = await integration_repo.get_by_org_and_provider(
+            db, ctx.organization_id, "gmail",
+        )
+        if integration is None:
+            raise HTTPException(status_code=404, detail="No Gmail integration found")
+        now = _dt.datetime.now(_dt.timezone.utc)
+        if payload.needs_reauth:
+            await integration_repo.mark_needs_reauth(
+                db, integration, "e2e-test-forced-reauth", now,
+            )
+        else:
+            await integration_repo.clear_reauth_state(db, integration)

--- a/apps/mybookkeeper/backend/app/test_helpers/router.py
+++ b/apps/mybookkeeper/backend/app/test_helpers/router.py
@@ -1,0 +1,15 @@
+"""Unified test-helpers router.
+
+Aggregates the three sub-routers (auth, seed, mocks) into a single router
+suitable for conditional mounting in ``app/main.py``.
+"""
+
+from fastapi import APIRouter
+
+from app.test_helpers import auth, mocks, seed
+
+router = APIRouter(tags=["test"])
+
+router.include_router(auth.router)
+router.include_router(seed.router)
+router.include_router(mocks.router)

--- a/apps/mybookkeeper/backend/app/test_helpers/seed.py
+++ b/apps/mybookkeeper/backend/app/test_helpers/seed.py
@@ -1,65 +1,57 @@
+"""Test-only seed and cleanup endpoints for E2E test data management."""
+
 import datetime as _dt
 import uuid
 from decimal import Decimal
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
-from sqlalchemy import delete as _sa_delete
+from sqlalchemy import delete as _sa_delete, select as _sa_select
 
-from app.core.auth import current_active_user
 from app.core.context import RequestContext
-from app.core.config import settings
 from app.core.permissions import current_org_member
 from app.db.session import unit_of_work
 from app.models.applicants.applicant import Applicant
 from app.models.applicants.screening_result import ScreeningResult
-from app.models.user.user import Role, User
+from app.models.calendar.calendar_email_review_queue import CalendarEmailReviewQueue
+from app.models.leases.lease_template import LeaseTemplate
+from app.models.leases.signed_lease import SignedLease
+from app.models.leases.signed_lease_attachment import SignedLeaseAttachment
 from app.repositories import (
+    applicant_event_repo,
+    applicant_repo,
     inquiry_repo,
     integration_repo,
     listing_blackout_repo,
     listing_repo,
-)
-from app.repositories.applicants import (
-    applicant_event_repo,
-    applicant_repo,
     reference_repo,
+    review_queue_repo,
     screening_result_repo,
+    transaction_repo,
     video_call_note_repo,
 )
+from app.repositories.leases import (
+    lease_template_file_repo,
+    lease_template_placeholder_repo,
+    lease_template_repo,
+    signed_lease_repo,
+)
 from app.repositories.vendors import vendor_repo
-from app.repositories.user import user_repo
 from app.schemas.inquiries.inquiry_create_request import InquiryCreateRequest
 from app.schemas.inquiries.inquiry_response import InquiryResponse
-from app.schemas.user.user import UserRead
-from app.services.inquiries import inquiry_service
-from app.services.email import gmail_service
 from app.services.integrations import integration_service
+from app.services.inquiries import inquiry_service
+from app.services.leases import receipt_service
+from app.services.leases.default_source_map import get_default, guess_display_label
+from app.services.leases.placeholder_extractor import extract_placeholder_keys
+from app.test_helpers.auth import _require_test_mode
 
-router = APIRouter(prefix="/test", tags=["test"])
+router = APIRouter()
 
 
-def _require_test_mode() -> None:
-    if not settings.allow_test_admin_promotion:
-        raise HTTPException(status_code=404, detail="Not found")
-
-
-@router.post("/promote-admin", response_model=UserRead)
-async def promote_to_admin(
-    user: User = Depends(current_active_user),
-) -> User:
-    _require_test_mode()
-
-    if user.role == Role.ADMIN:
-        return user
-
-    async with unit_of_work() as db:
-        target = await user_repo.get_by_id(db, user.id)
-        if not target:
-            raise HTTPException(status_code=404, detail="User not found")
-        await user_repo.update_role(db, target, Role.ADMIN)
-        return target
-
+# ---------------------------------------------------------------------------
+# Listings
+# ---------------------------------------------------------------------------
 
 class _SeedListingRequest(BaseModel):
     property_id: uuid.UUID
@@ -73,7 +65,7 @@ class _SeedListingResponse(BaseModel):
     id: uuid.UUID
 
 
-@router.post("/seed-listing", response_model=_SeedListingResponse)
+@router.post("/test/seed-listing", response_model=_SeedListingResponse)
 async def seed_listing(
     payload: _SeedListingRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -100,7 +92,7 @@ async def seed_listing(
         return _SeedListingResponse(id=created.id)
 
 
-@router.delete("/listings/{listing_id}", status_code=204)
+@router.delete("/test/listings/{listing_id}", status_code=204)
 async def delete_listing(
     listing_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
@@ -110,6 +102,10 @@ async def delete_listing(
     async with unit_of_work() as db:
         await listing_repo.hard_delete_by_id(db, listing_id, ctx.organization_id)
 
+
+# ---------------------------------------------------------------------------
+# Blackouts
+# ---------------------------------------------------------------------------
 
 class _SeedBlackoutRequest(BaseModel):
     listing_id: uuid.UUID
@@ -123,7 +119,7 @@ class _SeedBlackoutResponse(BaseModel):
     id: uuid.UUID
 
 
-@router.post("/seed-blackout", response_model=_SeedBlackoutResponse)
+@router.post("/test/seed-blackout", response_model=_SeedBlackoutResponse)
 async def seed_blackout(
     payload: _SeedBlackoutRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -151,7 +147,7 @@ async def seed_blackout(
         return _SeedBlackoutResponse(id=row.id)
 
 
-@router.delete("/blackouts/{blackout_id}", status_code=204)
+@router.delete("/test/blackouts/{blackout_id}", status_code=204)
 async def delete_blackout(
     blackout_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
@@ -170,7 +166,11 @@ async def delete_blackout(
         )
 
 
-@router.post("/seed-inquiry", response_model=InquiryResponse)
+# ---------------------------------------------------------------------------
+# Inquiries
+# ---------------------------------------------------------------------------
+
+@router.post("/test/seed-inquiry", response_model=InquiryResponse)
 async def seed_inquiry(
     payload: InquiryCreateRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -191,7 +191,7 @@ async def seed_inquiry(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
 
-@router.delete("/inquiries/{inquiry_id}", status_code=204)
+@router.delete("/test/inquiries/{inquiry_id}", status_code=204)
 async def delete_inquiry(
     inquiry_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
@@ -207,11 +207,15 @@ async def delete_inquiry(
         await inquiry_repo.hard_delete_by_id(db, inquiry_id, ctx.organization_id)
 
 
+# ---------------------------------------------------------------------------
+# Gmail integration
+# ---------------------------------------------------------------------------
+
 class _SeedGmailRequest(BaseModel):
     has_send_scope: bool = True
 
 
-@router.post("/seed-gmail-integration", status_code=204)
+@router.post("/test/seed-gmail-integration", status_code=204)
 async def seed_gmail_integration(
     payload: _SeedGmailRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -237,7 +241,7 @@ async def seed_gmail_integration(
         )
 
 
-@router.delete("/seed-gmail-integration", status_code=204)
+@router.delete("/test/seed-gmail-integration", status_code=204)
 async def remove_gmail_integration(
     ctx: RequestContext = Depends(current_org_member),
 ) -> None:
@@ -251,97 +255,9 @@ async def remove_gmail_integration(
             await integration_repo.delete(db, existing)
 
 
-@router.post("/mock-gmail-send/enable", status_code=204)
-async def enable_mock_gmail_send(
-    ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001 — gated by ctx
-) -> None:
-    """Replace ``gmail_service.send_message`` and ``send_message_with_attachment``
-    with stubs that return a fake message-id. Used by E2E so tests don't hit
-    the Gmail API.
-
-    The attachment stub also captures send-call kwargs in the process-local
-    ``_last_gmail_attachment_send`` ring buffer so tests can assert recipient
-    and subject via ``GET /test/last-gmail-send``.
-
-    The patch lives at module level — the next send call sees the stub.
-    ``disable`` restores the originals.
-    """
-    _require_test_mode()
-    global _last_gmail_attachment_send
-    _last_gmail_attachment_send = None  # clear capture window on each enable
-
-    if getattr(gmail_service, "_real_send_message", None) is None:
-        gmail_service._real_send_message = gmail_service.send_message  # type: ignore[attr-defined]
-
-    def _stub(*args: object, **kwargs: object) -> str:
-        return f"<e2e-mock-{uuid.uuid4().hex[:12]}@mybookkeeper.app>"
-
-    gmail_service.send_message = _stub  # type: ignore[assignment]
-
-    if getattr(gmail_service, "_real_send_message_with_attachment", None) is None:
-        gmail_service._real_send_message_with_attachment = gmail_service.send_message_with_attachment  # type: ignore[attr-defined]
-
-    def _attachment_stub(*args: object, **kwargs: object) -> str:
-        global _last_gmail_attachment_send
-        _last_gmail_attachment_send = {
-            "to_address": kwargs.get("to_address"),
-            "subject": kwargs.get("subject"),
-            "attachment_filename": kwargs.get("attachment_filename"),
-        }
-        return f"<e2e-mock-att-{uuid.uuid4().hex[:12]}@mybookkeeper.app>"
-
-    gmail_service.send_message_with_attachment = _attachment_stub  # type: ignore[assignment]
-
-    # Also mock storage so receipt PDF upload succeeds without a real MinIO.
-    from app.core import storage as _storage_module
-
-    if getattr(_storage_module, "_real_get_storage", None) is None:
-        _storage_module._real_get_storage = _storage_module.get_storage  # type: ignore[attr-defined]
-
-    class _NoOpStorage:
-        bucket = "mock-bucket"
-
-        def upload_file(self, key: str, content: bytes, content_type: str) -> str:
-            return key
-
-        def delete_file(self, key: str) -> None:
-            pass
-
-        def ensure_bucket(self) -> None:
-            pass
-
-    _no_op = _NoOpStorage()
-
-    def _storage_stub() -> _NoOpStorage:
-        return _no_op
-
-    _storage_module.get_storage = _storage_stub  # type: ignore[assignment]
-
-
-@router.post("/mock-gmail-send/disable", status_code=204)
-async def disable_mock_gmail_send(
-    ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001
-) -> None:
-    """Restore the real ``gmail_service.send_message`` and
-    ``send_message_with_attachment`` after E2E."""
-    _require_test_mode()
-    real = getattr(gmail_service, "_real_send_message", None)
-    if real is not None:
-        gmail_service.send_message = real  # type: ignore[assignment]
-        gmail_service._real_send_message = None  # type: ignore[attr-defined]
-
-    real_att = getattr(gmail_service, "_real_send_message_with_attachment", None)
-    if real_att is not None:
-        gmail_service.send_message_with_attachment = real_att  # type: ignore[assignment]
-        gmail_service._real_send_message_with_attachment = None  # type: ignore[attr-defined]
-
-    from app.core import storage as _storage_module
-
-    real_storage = getattr(_storage_module, "_real_get_storage", None)
-    if real_storage is not None:
-        _storage_module.get_storage = real_storage  # type: ignore[assignment]
-        _storage_module._real_get_storage = None  # type: ignore[attr-defined]
-
+# ---------------------------------------------------------------------------
+# Applicants
+# ---------------------------------------------------------------------------
 
 class _SeedApplicantRequest(BaseModel):
     inquiry_id: uuid.UUID | None = None
@@ -363,7 +279,7 @@ class _SeedApplicantResponse(BaseModel):
     id: uuid.UUID
 
 
-@router.post("/seed-applicant", response_model=_SeedApplicantResponse)
+@router.post("/test/seed-applicant", response_model=_SeedApplicantResponse)
 async def seed_applicant(
     payload: _SeedApplicantRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -434,7 +350,7 @@ async def seed_applicant(
         return _SeedApplicantResponse(id=applicant.id)
 
 
-@router.delete("/screening/{screening_id}", status_code=204)
+@router.delete("/test/screening/{screening_id}", status_code=204)
 async def delete_screening_result(
     screening_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
@@ -451,7 +367,6 @@ async def delete_screening_result(
     async with unit_of_work() as db:
         # Tenant-scoped JOIN — the screening row inherits scope from its
         # parent applicant. Delete only if the calling org owns the parent.
-        from sqlalchemy import select as _sa_select
         result = await db.execute(
             _sa_select(ScreeningResult)
             .join(Applicant, Applicant.id == ScreeningResult.applicant_id)
@@ -469,7 +384,7 @@ async def delete_screening_result(
         )
 
 
-@router.delete("/applicants/{applicant_id}", status_code=204)
+@router.delete("/test/applicants/{applicant_id}", status_code=204)
 async def delete_applicant(
     applicant_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
@@ -499,6 +414,10 @@ async def delete_applicant(
         )
 
 
+# ---------------------------------------------------------------------------
+# Vendors
+# ---------------------------------------------------------------------------
+
 class _SeedVendorRequest(BaseModel):
     name: str = "E2E Test Vendor"
     category: str = "handyman"
@@ -515,7 +434,7 @@ class _SeedVendorResponse(BaseModel):
     id: uuid.UUID
 
 
-@router.post("/seed-vendor", response_model=_SeedVendorResponse)
+@router.post("/test/seed-vendor", response_model=_SeedVendorResponse)
 async def seed_vendor(
     payload: _SeedVendorRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -546,7 +465,7 @@ async def seed_vendor(
         return _SeedVendorResponse(id=created.id)
 
 
-@router.delete("/vendors/{vendor_id}", status_code=204)
+@router.delete("/test/vendors/{vendor_id}", status_code=204)
 async def delete_vendor(
     vendor_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
@@ -590,7 +509,7 @@ class _SeedLeaseTemplateResponse(BaseModel):
     id: uuid.UUID
 
 
-@router.post("/seed-lease-template", response_model=_SeedLeaseTemplateResponse)
+@router.post("/test/seed-lease-template", response_model=_SeedLeaseTemplateResponse)
 async def seed_lease_template(
     payload: _SeedLeaseTemplateRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -602,17 +521,6 @@ async def seed_lease_template(
     pipeline uses the real ``POST /lease-templates`` endpoint via the UI.
     """
     _require_test_mode()
-    from app.repositories.leases import (
-        lease_template_file_repo,
-        lease_template_placeholder_repo,
-        lease_template_repo,
-    )
-    from app.services.leases.default_source_map import (
-        get_default,
-        guess_display_label,
-    )
-    from app.services.leases.placeholder_extractor import extract_placeholder_keys
-
     async with unit_of_work() as db:
         template = await lease_template_repo.create(
             db,
@@ -647,16 +555,13 @@ async def seed_lease_template(
         return _SeedLeaseTemplateResponse(id=template.id)
 
 
-@router.delete("/lease-templates/{template_id}", status_code=204)
+@router.delete("/test/lease-templates/{template_id}", status_code=204)
 async def hard_delete_lease_template(
     template_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
 ) -> None:
     """Hard-delete a lease template (cascades files / placeholders). Test-only."""
     _require_test_mode()
-    from app.models.leases.lease_template import LeaseTemplate
-    from app.repositories.leases import lease_template_repo
-
     async with unit_of_work() as db:
         existing = await lease_template_repo.get(
             db,
@@ -688,7 +593,7 @@ class _SeedSignedLeaseResponse(BaseModel):
     attachment_ids: list[uuid.UUID] = []
 
 
-@router.post("/seed-signed-lease", response_model=_SeedSignedLeaseResponse, status_code=201)
+@router.post("/test/seed-signed-lease", response_model=_SeedSignedLeaseResponse, status_code=201)
 async def seed_signed_lease(
     payload: _SeedSignedLeaseRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -700,9 +605,6 @@ async def seed_signed_lease(
     endpoint) without requiring a real storage bucket.
     """
     _require_test_mode()
-    from app.models.leases.signed_lease import SignedLease
-    from app.models.leases.signed_lease_attachment import SignedLeaseAttachment
-
     now = _dt.datetime.now(_dt.timezone.utc)
     lease_id = uuid.uuid4()
     attachment_ids: list[uuid.UUID] = []
@@ -746,16 +648,13 @@ async def seed_signed_lease(
     return _SeedSignedLeaseResponse(id=lease_id, attachment_ids=attachment_ids)
 
 
-@router.delete("/signed-leases/{lease_id}", status_code=204)
+@router.delete("/test/signed-leases/{lease_id}", status_code=204)
 async def hard_delete_signed_lease(
     lease_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
 ) -> None:
     """Hard-delete a signed lease (cascades attachments). Test-only."""
     _require_test_mode()
-    from app.models.leases.signed_lease import SignedLease
-    from app.repositories.leases import signed_lease_repo
-
     async with unit_of_work() as db:
         existing = await signed_lease_repo.get(
             db,
@@ -788,7 +687,7 @@ class _SeedReviewQueueResponse(BaseModel):
     id: uuid.UUID
 
 
-@router.post("/seed-review-queue-item", response_model=_SeedReviewQueueResponse, status_code=201)
+@router.post("/test/seed-review-queue-item", response_model=_SeedReviewQueueResponse, status_code=201)
 async def seed_review_queue_item(
     payload: _SeedReviewQueueRequest,
     ctx: RequestContext = Depends(current_org_member),
@@ -800,8 +699,6 @@ async def seed_review_queue_item(
     ``ALLOW_TEST_ADMIN_PROMOTION``.
     """
     _require_test_mode()
-    from app.repositories.calendar import review_queue_repo
-
     parsed_payload = {
         "source_channel": payload.source_channel,
         "source_listing_id": payload.source_listing_id,
@@ -823,10 +720,6 @@ async def seed_review_queue_item(
         )
         if row is None:
             # Already exists — fetch the existing row to return its id.
-            from app.models.calendar.calendar_email_review_queue import (
-                CalendarEmailReviewQueue,
-            )
-            from sqlalchemy import select as _sa_select
             result = await db.execute(
                 _sa_select(CalendarEmailReviewQueue).where(
                     CalendarEmailReviewQueue.user_id == ctx.user_id,
@@ -838,17 +731,13 @@ async def seed_review_queue_item(
     return _SeedReviewQueueResponse(id=row.id)
 
 
-@router.delete("/review-queue/{item_id}", status_code=204)
+@router.delete("/test/review-queue/{item_id}", status_code=204)
 async def hard_delete_review_queue_item(
     item_id: uuid.UUID,
     ctx: RequestContext = Depends(current_org_member),
 ) -> None:
     """Hard-delete a review-queue item for E2E cleanup. Test-only."""
     _require_test_mode()
-    from app.models.calendar.calendar_email_review_queue import (
-        CalendarEmailReviewQueue,
-    )
-
     async with unit_of_work() as db:
         await db.execute(
             _sa_delete(CalendarEmailReviewQueue).where(
@@ -859,14 +748,8 @@ async def hard_delete_review_queue_item(
 
 
 # ---------------------------------------------------------------------------
-# Rent receipts — E2E seed + cleanup helpers
+# Rent receipts — E2E seed helper
 # ---------------------------------------------------------------------------
-
-# Process-local ring buffer for capturing gmail send-with-attachment calls.
-# Populated by the mock stub installed via POST /test/mock-gmail-send/enable.
-# Cleared on each enable call so tests start with a clean capture window.
-_last_gmail_attachment_send: dict[str, object] | None = None
-
 
 class _SeedRentPaymentRequest(BaseModel):
     model_config = {"extra": "forbid"}
@@ -887,7 +770,7 @@ class _SeedRentPaymentResponse(BaseModel):
 
 
 @router.post(
-    "/seed-rent-payment-attributed",
+    "/test/seed-rent-payment-attributed",
     response_model=_SeedRentPaymentResponse,
     status_code=201,
 )
@@ -910,20 +793,13 @@ async def seed_rent_payment_attributed(
     """
     _require_test_mode()
 
-    from decimal import Decimal as _Decimal
-    from app.models.leases.signed_lease import SignedLease
-    from app.repositories.applicants import applicant_repo
-    from app.repositories.inquiries import inquiry_repo
-    from app.repositories.transactions import transaction_repo
-    from app.services.leases import receipt_service
-
-    amount = _Decimal(payload.amount_cents) / 100
+    amount = Decimal(payload.amount_cents) / 100
     now = _dt.datetime.now(_dt.timezone.utc)
     today = now.date()
 
     async with unit_of_work() as db:
         # 1. Inquiry — provides tenant email for the receipt service lookup.
-        inquiry = await inquiry_repo.create(
+        created_inquiry = await inquiry_repo.create(
             db,
             organization_id=ctx.organization_id,
             user_id=ctx.user_id,
@@ -938,16 +814,16 @@ async def seed_rent_payment_attributed(
             db,
             organization_id=ctx.organization_id,
             user_id=ctx.user_id,
-            inquiry_id=inquiry.id,
+            inquiry_id=created_inquiry.id,
             legal_name=payload.tenant_legal_name,
             stage="lease_signed",
         )
 
         # 3. Signed lease linked to the applicant.
-        contract_start = (
+        _contract_start = (
             _dt.date.fromisoformat(payload.contract_start) if payload.contract_start else today
         )
-        contract_end = (
+        _contract_end = (
             _dt.date.fromisoformat(payload.contract_end)
             if payload.contract_end
             else today.replace(month=12, day=31) if today.month <= 12 else today
@@ -986,7 +862,7 @@ async def seed_rent_payment_attributed(
         )
 
         applicant_id = applicant.id
-        inquiry_id = inquiry.id
+        inquiry_id = created_inquiry.id
         signed_lease_id = lease.id
         transaction_id = txn.id
 
@@ -1004,66 +880,3 @@ async def seed_rent_payment_attributed(
         signed_lease_id=signed_lease_id,
         transaction_id=transaction_id,
     )
-
-
-class _LastGmailSendResponse(BaseModel):
-    captured: bool
-    to_address: str | None = None
-    subject: str | None = None
-    has_attachment: bool = False
-    attachment_filename: str | None = None
-
-
-@router.get("/last-gmail-send", response_model=_LastGmailSendResponse)
-async def get_last_gmail_send(
-    ctx: RequestContext = Depends(current_org_member),  # noqa: ARG001
-) -> _LastGmailSendResponse:
-    """Return the args of the most recent mock send_message_with_attachment call.
-
-    Only populated when the mock stub is active (POST /test/mock-gmail-send/enable).
-    Used by E2E tests to assert that a receipt email was dispatched with the
-    correct recipient and attachment without hitting the real Gmail API.
-    """
-    _require_test_mode()
-    captured = _last_gmail_attachment_send
-    if captured is None:
-        return _LastGmailSendResponse(captured=False)
-    return _LastGmailSendResponse(
-        captured=True,
-        to_address=captured.get("to_address"),  # type: ignore[arg-type]
-        subject=captured.get("subject"),  # type: ignore[arg-type]
-        has_attachment="attachment_filename" in captured,
-        attachment_filename=captured.get("attachment_filename"),  # type: ignore[arg-type]
-    )
-
-
-class _SeedNeedsReauthRequest(BaseModel):
-    model_config = {"extra": "forbid"}
-
-    needs_reauth: bool = True
-
-
-@router.post("/seed-integration-reauth-state", status_code=204)
-async def seed_integration_reauth_state(
-    payload: _SeedNeedsReauthRequest,
-    ctx: RequestContext = Depends(current_org_member),
-) -> None:
-    """Set ``needs_reauth`` on the org's Gmail integration. Test-only.
-
-    Used by E2E Test C to verify the dialog surfaces the reconnect-required
-    state rather than a generic error when Gmail tokens are expired.
-    """
-    _require_test_mode()
-    async with unit_of_work() as db:
-        integration = await integration_repo.get_by_org_and_provider(
-            db, ctx.organization_id, "gmail",
-        )
-        if integration is None:
-            raise HTTPException(status_code=404, detail="No Gmail integration found")
-        now = _dt.datetime.now(_dt.timezone.utc)
-        if payload.needs_reauth:
-            await integration_repo.mark_needs_reauth(
-                db, integration, "e2e-test-forced-reauth", now,
-            )
-        else:
-            await integration_repo.clear_reauth_state(db, integration)

--- a/apps/mybookkeeper/backend/tests/test_test_utils_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_test_utils_routes.py
@@ -59,7 +59,8 @@ def _patch_session(db: AsyncSession):
     # services they delegate to (inquiry_service.create_inquiry / .get_inquiry
     # etc.) — see the test in-memory SQLite session.
     with (
-        patch("app.api.test_utils.unit_of_work", _fake_uow),
+        patch("app.test_helpers.auth.unit_of_work", _fake_uow),
+        patch("app.test_helpers.seed.unit_of_work", _fake_uow),
         patch("app.services.inquiries.inquiry_service.unit_of_work", _fake_uow),
         patch(
             "app.services.inquiries.inquiry_service.AsyncSessionLocal",
@@ -93,7 +94,7 @@ class TestPromoteToAdmin:
     @pytest.mark.asyncio
     async def test_endpoint_gated_by_env_var(self) -> None:
         """The endpoint returns 404 when allow_test_admin_promotion is False."""
-        from app.api.test_utils import promote_to_admin
+        from app.test_helpers.auth import promote_to_admin
         from app.core.config import settings
         from fastapi import HTTPException
 
@@ -119,7 +120,7 @@ class TestPromoteToAdmin:
     async def test_endpoint_promotes_when_enabled(
         self, db: AsyncSession, regular_user: User,
     ) -> None:
-        from app.api.test_utils import promote_to_admin
+        from app.test_helpers.auth import promote_to_admin
         from app.core.config import settings
 
         original = settings.allow_test_admin_promotion
@@ -134,7 +135,7 @@ class TestPromoteToAdmin:
     async def test_endpoint_returns_admin_user_unchanged(
         self, db: AsyncSession, admin_user: User,
     ) -> None:
-        from app.api.test_utils import promote_to_admin
+        from app.test_helpers.auth import promote_to_admin
         from app.core.config import settings
 
         original = settings.allow_test_admin_promotion
@@ -154,7 +155,7 @@ class TestSeedInquiry:
         self, db: AsyncSession, regular_user: User,
     ) -> None:
         import datetime as _dt
-        from app.api.test_utils import seed_inquiry
+        from app.test_helpers.seed import seed_inquiry
         from app.core.config import settings
         from app.core.context import RequestContext
         from app.schemas.inquiries.inquiry_create_request import InquiryCreateRequest
@@ -186,7 +187,7 @@ class TestSeedInquiry:
         test_user: User,
     ) -> None:
         import datetime as _dt
-        from app.api.test_utils import seed_inquiry
+        from app.test_helpers.seed import seed_inquiry
         from app.core.config import settings
         from app.core.context import RequestContext
         from app.schemas.inquiries.inquiry_create_request import InquiryCreateRequest
@@ -217,7 +218,7 @@ class TestDeleteInquiry:
 
     @pytest.mark.asyncio
     async def test_endpoint_gated_by_env_var(self) -> None:
-        from app.api.test_utils import delete_inquiry
+        from app.test_helpers.seed import delete_inquiry
         from app.core.config import settings
         from app.core.context import RequestContext
         from fastapi import HTTPException
@@ -244,7 +245,7 @@ class TestDeleteInquiry:
         test_user: User,
     ) -> None:
         import datetime as _dt
-        from app.api.test_utils import delete_inquiry, seed_inquiry
+        from app.test_helpers.seed import delete_inquiry, seed_inquiry
         from app.core.config import settings
         from app.core.context import RequestContext
         from app.repositories import inquiry_repo
@@ -291,7 +292,7 @@ class TestSeedBlackout:
     ) -> None:
         import datetime as _dt
         from decimal import Decimal
-        from app.api.test_utils import (
+        from app.test_helpers.seed import (
             _SeedBlackoutRequest,
             delete_blackout,
             seed_blackout,
@@ -361,7 +362,7 @@ class TestSeedBlackout:
         import datetime as _dt
         from decimal import Decimal
         from fastapi import HTTPException
-        from app.api.test_utils import _SeedBlackoutRequest, seed_blackout
+        from app.test_helpers.seed import _SeedBlackoutRequest, seed_blackout
         from app.core.config import settings
         from app.core.context import RequestContext
         from app.models.listings.listing import Listing


### PR DESCRIPTION
Test-helper endpoints (1,069 LOC) were co-located with production routes in app/api/. Moved to app/test_helpers/ split into auth.py + seed.py + mocks.py + router.py. main.py mount conditional unchanged (still gated on MYBOOKKEEPER_ENABLE_TEST_HELPERS=1). 2,623 tests pass. From audit (High severity — risk if env flag ever ships true).