### PR TITLE
refactor(shared): extract soft-delete pattern from 7 call sites to platform_shared

### DIFF
--- a/apps/mybookkeeper/backend/app/repositories/calendar/review_queue_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/calendar/review_queue_repo.py
@@ -14,6 +14,7 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.calendar.calendar_email_review_queue import CalendarEmailReviewQueue
+from platform_shared.repositories.soft_delete import soft_delete as _shared_soft_delete
 
 
 async def list_pending(
@@ -134,5 +135,5 @@ async def soft_delete(
     deleted_at: datetime,
 ) -> None:
     """Soft-delete a queue item (user dismissed without acting)."""
-    item.deleted_at = deleted_at
+    await _shared_soft_delete(db, item, deleted_at=deleted_at)
     await db.flush()

--- a/apps/mybookkeeper/backend/app/repositories/documents/document_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/documents/document_repo.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import undefer
 
 from app.models.documents.document import Document
+from platform_shared.repositories.soft_delete import soft_delete as _shared_soft_delete
 
 
 async def list_filtered(
@@ -117,7 +118,7 @@ async def refresh(db: AsyncSession, document: Document) -> None:
 
 
 async def delete(db: AsyncSession, document: Document) -> None:
-    document.deleted_at = datetime.now(timezone.utc)
+    await _shared_soft_delete(db, document)
     document.status = "deleted"
 
 

--- a/apps/mybookkeeper/backend/app/repositories/transactions/transaction_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/transactions/transaction_repo.py
@@ -13,6 +13,7 @@ from app.core.vendors import normalize_vendor
 from app.models.extraction.extraction import Extraction
 from app.models.transactions.transaction import Transaction
 from app.models.transactions.transaction_document import TransactionDocument
+from platform_shared.repositories.soft_delete import soft_delete as _shared_soft_delete
 
 
 class _date_diff_days(FunctionElement):
@@ -74,9 +75,8 @@ async def soft_delete_by_document_id(
     result = await db.execute(stmt)
     transactions = list(result.scalars().all())
 
-    now = datetime.now(timezone.utc)
     for txn in transactions:
-        txn.deleted_at = now
+        await _shared_soft_delete(db, txn)
         txn.status = "duplicate"
 
     return transactions
@@ -91,7 +91,7 @@ async def soft_delete_by_external_id(
     """Soft-delete a transaction by external source and ID."""
     txn = await find_by_external_id(db, organization_id, external_source, external_id)
     if txn:
-        txn.deleted_at = datetime.now(timezone.utc)
+        await _shared_soft_delete(db, txn)
         txn.status = "duplicate"
 
 
@@ -265,7 +265,7 @@ async def bulk_delete(
 
 
 async def mark_deleted(db: AsyncSession, transaction: Transaction) -> None:
-    transaction.deleted_at = datetime.now(timezone.utc)
+    await _shared_soft_delete(db, transaction)
     transaction.status = "duplicate"
     await db.flush()
 

--- a/apps/myjobhunter/backend/app/repositories/application/application_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/application/application_repository.py
@@ -30,6 +30,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.application.application import Application
+from platform_shared.repositories.soft_delete import soft_delete as _shared_soft_delete
 from app.models.application.application_event import ApplicationEvent
 from app.models.company.company import Company
 from app.models.job_analysis.job_analysis import JobAnalysis
@@ -335,8 +336,8 @@ async def soft_delete(db: AsyncSession, application: Application) -> Application
     returned unchanged (no second timestamp update). Hard deletes are
     forbidden by convention; rows persist for audit + restore.
     """
-    if application.deleted_at is None:
-        application.deleted_at = _dt.datetime.now(_dt.timezone.utc)
+    newly_deleted = await _shared_soft_delete(db, application)
+    if newly_deleted:
         await db.flush()
         await db.refresh(application)
     return application

--- a/apps/myjobhunter/backend/app/repositories/documents/document_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/documents/document_repo.py
@@ -10,7 +10,6 @@ soft-delete service function to make DELETE idempotent).
 """
 from __future__ import annotations
 
-import datetime as _dt
 import uuid
 from typing import Any
 
@@ -18,6 +17,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.application.document import Document
+from platform_shared.repositories.soft_delete import soft_delete as _shared_soft_delete
 
 # Allowlist of columns safe to update via the dynamic ``update`` function.
 # Excludes server-managed columns (id, user_id, created_at, updated_at, deleted_at)
@@ -138,8 +138,8 @@ async def soft_delete(db: AsyncSession, document: Document) -> Document:
     Idempotent — if ``deleted_at`` is already set, the existing timestamp
     is preserved.
     """
-    if document.deleted_at is None:
-        document.deleted_at = _dt.datetime.now(_dt.timezone.utc)
+    newly_deleted = await _shared_soft_delete(db, document)
+    if newly_deleted:
         await db.flush()
         await db.refresh(document)
     return document

--- a/packages/shared-backend/platform_shared/repositories/soft_delete.py
+++ b/packages/shared-backend/platform_shared/repositories/soft_delete.py
@@ -1,0 +1,66 @@
+"""Shared soft-delete helper.
+
+The single public function ``soft_delete`` encapsulates the idempotent
+"set ``deleted_at`` to now" mutation that is repeated across every
+app-level repository that supports soft-deletion.
+
+Contract
+--------
+* The field is set only when it is currently ``None``.  If it is already
+  populated the row is left unchanged and the function returns ``False``.
+* The caller is responsible for flushing and committing the session; this
+  function intentionally does neither so callers can batch mutations in a
+  single transaction.
+* Tenant-scope filtering (``user_id`` / ``org_id`` WHERE clauses) stays in
+  the per-repository function — that is app-specific logic that must not
+  leak into shared infrastructure.
+* Any extra fields that must change alongside ``deleted_at`` (e.g.
+  ``status = "duplicate"``) stay in the per-repository function; only the
+  timestamp flip is delegated here.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def soft_delete(
+    db: AsyncSession,
+    instance: Any,
+    *,
+    deleted_at: datetime | None = None,
+    deleted_at_field: str = "deleted_at",
+) -> bool:
+    """Set ``instance.<deleted_at_field>`` to now if not already set.
+
+    Parameters
+    ----------
+    db:
+        The active async session.  The session is NOT flushed or committed
+        by this function — callers control transaction boundaries.
+    instance:
+        Any ORM model instance that has a ``deleted_at`` column (or
+        whichever field name is given via ``deleted_at_field``).
+    deleted_at:
+        Timestamp to stamp the row with.  Defaults to
+        ``datetime.now(timezone.utc)`` when ``None``.  Pass an explicit
+        value when a service layer generates a single ``now`` to keep all
+        rows in the same logical operation consistent.
+    deleted_at_field:
+        Name of the timestamp column to set.  Defaults to ``"deleted_at"``.
+
+    Returns
+    -------
+    bool
+        ``True`` if the row was newly soft-deleted, ``False`` if it was
+        already deleted (idempotent — no mutation performed).
+    """
+    current: datetime | None = getattr(instance, deleted_at_field)
+    if current is not None:
+        return False
+
+    stamp = deleted_at if deleted_at is not None else datetime.now(timezone.utc)
+    setattr(instance, deleted_at_field, stamp)
+    return True

--- a/packages/shared-backend/tests/test_soft_delete.py
+++ b/packages/shared-backend/tests/test_soft_delete.py
@@ -1,0 +1,147 @@
+"""Tests for ``platform_shared.repositories.soft_delete``.
+
+Covers the full public contract:
+  * Idempotency — already-deleted rows are not mutated; returns False.
+  * First-delete — sets the timestamp, returns True.
+  * Explicit ``deleted_at`` — caller-supplied timestamp is used verbatim.
+  * Default timestamp — when no explicit timestamp is given, a UTC-aware
+    datetime is stored.
+  * Custom field name — ``deleted_at_field`` kwarg is honoured.
+  * Session not flushed — the helper never calls ``db.flush()`` so the
+    caller owns transaction control.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, call
+
+import pytest
+
+from platform_shared.repositories.soft_delete import soft_delete
+
+
+# ---------------------------------------------------------------------------
+# Minimal stand-in for an ORM model instance
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeRow:
+    """Minimal ORM-row substitute with a nullable ``deleted_at`` field."""
+
+    deleted_at: datetime | None = None
+    archived_at: datetime | None = None  # used by custom-field-name tests
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_FIXED_TS = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestSoftDeleteContract:
+    """Core contract tests — no session interaction needed."""
+
+    @pytest.mark.anyio
+    async def test_returns_true_on_first_delete(self) -> None:
+        row = _FakeRow(deleted_at=None)
+        result = await soft_delete(MagicMock(), row)
+        assert result is True
+
+    @pytest.mark.anyio
+    async def test_sets_deleted_at_on_first_delete(self) -> None:
+        row = _FakeRow(deleted_at=None)
+        await soft_delete(MagicMock(), row)
+        assert row.deleted_at is not None
+
+    @pytest.mark.anyio
+    async def test_deleted_at_is_utc_aware(self) -> None:
+        row = _FakeRow(deleted_at=None)
+        await soft_delete(MagicMock(), row)
+        assert row.deleted_at is not None
+        assert row.deleted_at.tzinfo is not None
+
+    @pytest.mark.anyio
+    async def test_returns_false_when_already_deleted(self) -> None:
+        row = _FakeRow(deleted_at=_FIXED_TS)
+        result = await soft_delete(MagicMock(), row)
+        assert result is False
+
+    @pytest.mark.anyio
+    async def test_does_not_overwrite_existing_timestamp(self) -> None:
+        row = _FakeRow(deleted_at=_FIXED_TS)
+        await soft_delete(MagicMock(), row)
+        assert row.deleted_at == _FIXED_TS
+
+    @pytest.mark.anyio
+    async def test_idempotent_multiple_calls(self) -> None:
+        row = _FakeRow(deleted_at=None)
+
+        first = await soft_delete(MagicMock(), row)
+        assert first is True
+        stamp_after_first = row.deleted_at
+
+        second = await soft_delete(MagicMock(), row)
+        assert second is False
+        assert row.deleted_at == stamp_after_first
+
+
+class TestExplicitTimestamp:
+    @pytest.mark.anyio
+    async def test_uses_caller_supplied_deleted_at(self) -> None:
+        row = _FakeRow(deleted_at=None)
+        custom_ts = datetime(2025, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+        await soft_delete(MagicMock(), row, deleted_at=custom_ts)
+        assert row.deleted_at == custom_ts
+
+    @pytest.mark.anyio
+    async def test_caller_ts_not_used_when_already_deleted(self) -> None:
+        row = _FakeRow(deleted_at=_FIXED_TS)
+        later = _FIXED_TS + timedelta(hours=1)
+        await soft_delete(MagicMock(), row, deleted_at=later)
+        # Original timestamp preserved, NOT overwritten
+        assert row.deleted_at == _FIXED_TS
+
+
+class TestCustomFieldName:
+    @pytest.mark.anyio
+    async def test_sets_custom_field(self) -> None:
+        row = _FakeRow(archived_at=None)
+        result = await soft_delete(MagicMock(), row, deleted_at_field="archived_at")
+        assert result is True
+        assert row.archived_at is not None
+
+    @pytest.mark.anyio
+    async def test_idempotent_on_custom_field(self) -> None:
+        row = _FakeRow(archived_at=_FIXED_TS)
+        result = await soft_delete(MagicMock(), row, deleted_at_field="archived_at")
+        assert result is False
+        assert row.archived_at == _FIXED_TS
+
+
+class TestSessionNotFlushed:
+    """The helper must never call db.flush() or db.commit() — callers own
+    transaction boundaries."""
+
+    @pytest.mark.anyio
+    async def test_flush_never_called_on_first_delete(self) -> None:
+        db = AsyncMock()
+        row = _FakeRow(deleted_at=None)
+        await soft_delete(db, row)
+        db.flush.assert_not_called()
+        db.commit.assert_not_called()
+
+    @pytest.mark.anyio
+    async def test_flush_never_called_on_already_deleted(self) -> None:
+        db = AsyncMock()
+        row = _FakeRow(deleted_at=_FIXED_TS)
+        await soft_delete(db, row)
+        db.flush.assert_not_called()
+        db.commit.assert_not_called()


### PR DESCRIPTION
## Summary

Extracts the soft-delete pattern (\`set deleted_at = now() if not already set\`) into a single shared helper in \`platform_shared/repositories/soft_delete.py\`. Refactors 7 call sites across MBK + MJH to delegate to it.

## What's shared

\`packages/shared-backend/platform_shared/repositories/soft_delete.py\`:
- Idempotent \`deleted_at\` flip on a SQLAlchemy instance
- Optional caller-supplied \`deleted_at\` value (for consistent timestamps across batch operations)
- Returns True if newly soft-deleted, False if already deleted
- 12 unit tests cover the contract

## Call sites refactored

**MJH (2):**
- \`repositories/application/application_repository.py::soft_delete\`
- \`repositories/documents/document_repo.py::soft_delete\`

**MBK (5):**
- \`repositories/documents/document_repo.py::delete\`
- \`repositories/transactions/transaction_repo.py::soft_delete_by_document_id\` (loop body)
- \`repositories/transactions/transaction_repo.py::soft_delete_by_external_id\`
- \`repositories/transactions/transaction_repo.py::mark_deleted\`
- \`repositories/calendar/review_queue_repo.py::soft_delete\`

## Divergent semantics — intentionally NOT delegated

1. **7 MBK SQL-UPDATE repos** (\`applicant_repo\`, \`inquiry_repo\`, \`insurance_policy_repo\`, \`lease_template_repo\`, \`signed_lease_repo\`, \`listing_repo\`, \`vendor_repo\`) — these issue \`UPDATE ... WHERE deleted_at IS NULL\` as a single atomic statement. No pre-loaded instance; the helper's contract doesn't fit. Left as-is.

2. **\`status = "duplicate"\` / \`status = "deleted"\` mutations** in MBK transaction + document repos — app-specific business rules that must co-occur with the deleted_at flip. The flip delegates to the helper; the extra field assignments remain in the per-repo function.

3. **\`review_queue_repo.soft_delete\`** accepts a caller-supplied \`deleted_at\` so the service layer stamps a consistent \`now\` across multiple queue ops. The helper's \`deleted_at\` kwarg passes this through verbatim.

## Test results

- Shared-backend suite: **352 passed** (includes 12 new tests)
- MBK targeted suite (review_queue_repo, transaction_repo, transaction_service, extraction_to_transactions): **61 passed**
- MBK full suite: **2,623 passed, 5 skipped** (5 are pre-existing)

## From audit

Resolves the High-priority "Soft-delete pattern reimplemented in 12+ repos" item from the 2026-05-08 monorepo refactor audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)