### PR TITLE
refactor(shared): extract Pydantic ListResponse[ItemT] generic; refactor MBK list schemas

### DIFF
--- a/apps/mybookkeeper/backend/app/schemas/applicants/applicant_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/applicant_list_response.py
@@ -1,14 +1,10 @@
 """Paginated envelope for GET /applicants — same shape as InquiryListResponse."""
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from platform_shared.schemas.pagination import ListResponse
 
 from app.schemas.applicants.applicant_summary import ApplicantSummary
 
 
-class ApplicantListResponse(BaseModel):
-    items: list[ApplicantSummary]
-    total: int
-    has_more: bool
-
-    model_config = ConfigDict(from_attributes=True)
+class ApplicantListResponse(ListResponse[ApplicantSummary]):
+    pass

--- a/apps/mybookkeeper/backend/app/schemas/applicants/tenant_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/applicants/tenant_list_response.py
@@ -1,14 +1,10 @@
 """Paginated envelope for GET /applicants/tenants."""
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from platform_shared.schemas.pagination import ListResponse
 
 from app.schemas.applicants.applicant_summary import ApplicantSummary
 
 
-class TenantListResponse(BaseModel):
-    items: list[ApplicantSummary]
-    total: int
-    has_more: bool
-
-    model_config = ConfigDict(from_attributes=True)
+class TenantListResponse(ListResponse[ApplicantSummary]):
+    pass

--- a/apps/mybookkeeper/backend/app/schemas/inquiries/inquiry_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/inquiries/inquiry_list_response.py
@@ -1,14 +1,10 @@
 """Paginated envelope for GET /inquiries — same shape as ListingListResponse."""
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from platform_shared.schemas.pagination import ListResponse
 
 from app.schemas.inquiries.inquiry_summary import InquirySummary
 
 
-class InquiryListResponse(BaseModel):
-    items: list[InquirySummary]
-    total: int
-    has_more: bool
-
-    model_config = ConfigDict(from_attributes=True)
+class InquiryListResponse(ListResponse[InquirySummary]):
+    pass

--- a/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_list_response.py
@@ -1,14 +1,10 @@
 """Paginated list response for insurance policies."""
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from platform_shared.schemas.pagination import ListResponse
 
 from app.schemas.insurance.insurance_policy_summary import InsurancePolicySummary
 
 
-class InsurancePolicyListResponse(BaseModel):
-    items: list[InsurancePolicySummary]
-    total: int
-    has_more: bool
-
-    model_config = ConfigDict(from_attributes=True)
+class InsurancePolicyListResponse(ListResponse[InsurancePolicySummary]):
+    pass

--- a/apps/mybookkeeper/backend/app/schemas/leases/lease_template_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/lease_template_list_response.py
@@ -1,14 +1,10 @@
 """Paginated envelope for GET /lease-templates."""
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from platform_shared.schemas.pagination import ListResponse
 
 from app.schemas.leases.lease_template_summary import LeaseTemplateSummary
 
 
-class LeaseTemplateListResponse(BaseModel):
-    items: list[LeaseTemplateSummary]
-    total: int
-    has_more: bool
-
-    model_config = ConfigDict(from_attributes=True)
+class LeaseTemplateListResponse(ListResponse[LeaseTemplateSummary]):
+    pass

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_list_response.py
@@ -1,14 +1,10 @@
 """Paginated envelope for GET /signed-leases."""
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from platform_shared.schemas.pagination import ListResponse
 
 from app.schemas.leases.signed_lease_summary import SignedLeaseSummary
 
 
-class SignedLeaseListResponse(BaseModel):
-    items: list[SignedLeaseSummary]
-    total: int
-    has_more: bool
-
-    model_config = ConfigDict(from_attributes=True)
+class SignedLeaseListResponse(ListResponse[SignedLeaseSummary]):
+    pass

--- a/apps/mybookkeeper/backend/app/schemas/listings/listing_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/listings/listing_list_response.py
@@ -8,16 +8,10 @@ signal.
 """
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from platform_shared.schemas.pagination import ListResponse
 
 from app.schemas.listings.listing_summary import ListingSummary
 
 
-class ListingListResponse(BaseModel):
+class ListingListResponse(ListResponse[ListingSummary]):
     """Paginated response envelope for GET /listings."""
-
-    items: list[ListingSummary]
-    total: int
-    has_more: bool
-
-    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/vendors/vendor_list_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/vendors/vendor_list_response.py
@@ -1,14 +1,10 @@
 """Paginated envelope for GET /vendors — same shape as ApplicantListResponse."""
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict
+from platform_shared.schemas.pagination import ListResponse
 
 from app.schemas.vendors.vendor_summary import VendorSummary
 
 
-class VendorListResponse(BaseModel):
-    items: list[VendorSummary]
-    total: int
-    has_more: bool
-
-    model_config = ConfigDict(from_attributes=True)
+class VendorListResponse(ListResponse[VendorSummary]):
+    pass

--- a/packages/shared-backend/platform_shared/schemas/pagination.py
+++ b/packages/shared-backend/platform_shared/schemas/pagination.py
@@ -1,0 +1,22 @@
+"""Generic paginated list response shared across all apps."""
+from __future__ import annotations
+
+from typing import Generic, TypeVar
+
+from pydantic import BaseModel, ConfigDict
+
+ItemT = TypeVar("ItemT")
+
+
+class ListResponse(BaseModel, Generic[ItemT]):
+    """Generic paginated list response.
+
+    Use as ``class FooListResponse(ListResponse[FooResponse]): pass`` so the
+    OpenAPI schema name stays stable for SPA consumers.
+    """
+
+    model_config = ConfigDict(from_attributes=True)
+
+    items: list[ItemT]
+    total: int
+    has_more: bool

--- a/packages/shared-backend/tests/test_list_response.py
+++ b/packages/shared-backend/tests/test_list_response.py
@@ -1,0 +1,53 @@
+"""Unit tests for platform_shared.schemas.pagination.ListResponse."""
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+from platform_shared.schemas.pagination import ListResponse
+
+
+class _Item(BaseModel):
+    id: int
+    name: str
+
+
+class ItemListResponse(ListResponse[_Item]):
+    pass
+
+
+class TestListResponse:
+    def test_instantiates_with_items(self) -> None:
+        items = [_Item(id=1, name="a"), _Item(id=2, name="b")]
+        r = ItemListResponse(items=items, total=2, has_more=False)
+        assert r.items == items
+        assert r.total == 2
+        assert r.has_more is False
+
+    def test_empty_items(self) -> None:
+        r = ItemListResponse(items=[], total=0, has_more=False)
+        assert r.items == []
+        assert r.total == 0
+
+    def test_has_more_true(self) -> None:
+        r = ItemListResponse(items=[_Item(id=1, name="x")], total=100, has_more=True)
+        assert r.has_more is True
+
+    def test_serialises(self) -> None:
+        r = ItemListResponse(items=[_Item(id=1, name="z")], total=1, has_more=False)
+        dumped = r.model_dump()
+        assert dumped == {
+            "items": [{"id": 1, "name": "z"}],
+            "total": 1,
+            "has_more": False,
+        }
+
+    def test_subclass_preserves_name(self) -> None:
+        assert ItemListResponse.__name__ == "ItemListResponse"
+
+    def test_from_attributes_config(self) -> None:
+        assert ItemListResponse.model_config.get("from_attributes") is True
+
+    def test_kwarg_shape(self) -> None:
+        """Construction uses items, total, has_more — no positional surprises."""
+        r = ListResponse[_Item](items=[], total=0, has_more=False)
+        assert r.total == 0


### PR DESCRIPTION
## Summary

- Adds `platform_shared.schemas.pagination.ListResponse[ItemT]` — a Pydantic v2 generic with `{items, total, has_more}` and `from_attributes=True`
- Refactors 8 MBK `*ListResponse` schemas (all with the exact canonical shape) into one-line subclasses, eliminating 57 lines of boilerplate
- Adds 7 unit tests in `packages/shared-backend/tests/test_list_response.py`; 369 shared-backend tests pass

## Files refactored (8)

- `apps/mybookkeeper/backend/app/schemas/applicants/applicant_list_response.py`
- `apps/mybookkeeper/backend/app/schemas/applicants/tenant_list_response.py`
- `apps/mybookkeeper/backend/app/schemas/inquiries/inquiry_list_response.py`
- `apps/mybookkeeper/backend/app/schemas/vendors/vendor_list_response.py`
- `apps/mybookkeeper/backend/app/schemas/insurance/insurance_policy_list_response.py`
- `apps/mybookkeeper/backend/app/schemas/leases/signed_lease_list_response.py`
- `apps/mybookkeeper/backend/app/schemas/leases/lease_template_list_response.py`
- `apps/mybookkeeper/backend/app/schemas/listings/listing_list_response.py`

## Files skipped (intentionally not converted)

- `apps/mybookkeeper/backend/app/schemas/leases/receipt_response.py` — `PendingReceiptListResponse` has an extra `pending_count` field; not the canonical shape
- `apps/mybookkeeper/backend/app/schemas/demo/demo.py` — `DemoUserListResponse` uses a `users` field (not `items`) and has no `has_more`; different contract entirely

## No consumer changes needed

All 8 service-layer construction calls already use `(items=..., total=..., has_more=...)` kwargs. The generic preserves the class name and field names, so route handlers and RTK Query consumers are untouched.

## Test plan

- [x] `pytest packages/shared-backend/` — 369 passed
- [x] Import smoke-test of all 8 refactored schemas from the MBK venv
- [x] Verified construction kwargs match at each call site via grep

🤖 Generated with [Claude Code](https://claude.com/claude-code)