### PR TITLE
refactor(shared): consolidate StorageNotConfiguredError to platform_shared

### DIFF
--- a/apps/mybookkeeper/backend/app/services/leases/_lease_helpers.py
+++ b/apps/mybookkeeper/backend/app/services/leases/_lease_helpers.py
@@ -9,6 +9,8 @@ import datetime as _dt
 import uuid
 from typing import Any
 
+from platform_shared.core.storage import StorageNotConfiguredError  # noqa: F401
+
 from app.models.applicants.applicant import Applicant
 from app.models.inquiries.inquiry import Inquiry
 from app.models.properties.property import Property
@@ -23,6 +25,7 @@ from app.repositories.leases import (
 from app.repositories.listings import listing_repo
 from app.repositories.properties import property_repo
 from app.repositories.user import user_repo
+
 from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
@@ -43,10 +46,6 @@ class SignedLeaseNotFoundError(LookupError):
 
 
 class AttachmentNotFoundError(LookupError):
-    pass
-
-
-class StorageNotConfiguredError(RuntimeError):
     pass
 
 


### PR DESCRIPTION
## Summary

- Removes the last local `class StorageNotConfiguredError(RuntimeError): pass` declaration from `apps/mybookkeeper/backend/app/services/leases/_lease_helpers.py`
- Replaces it with `from platform_shared.core.storage import StorageNotConfiguredError  # noqa: F401`
- `platform_shared.core.storage` is now the single source of truth for this exception class

## Context

The 2026-05-08 monorepo refactor audit flagged 5 identical declarations. At the time of this PR, 4 of the 5 had already been converted to re-exports:
- `apps/mybookkeeper/backend/app/core/storage.py` — already re-exported
- `apps/mybookkeeper/backend/app/services/listings/listing_photo_service.py` — already re-exported
- `apps/mybookkeeper/backend/app/services/listings/blackout_service.py` — already re-exported
- `apps/mybookkeeper/backend/app/services/screening/screening_service.py` — already re-exported
- `apps/myjobhunter/backend/app/core/storage.py` — already re-exported

This PR eliminates the remaining one in `_lease_helpers.py`.

## Verification

- `grep -rn "class StorageNotConfiguredError" apps/ packages/` returns only the canonical definition in `platform_shared/core/storage.py`
- Import identity smoke test confirmed all 5 consumer paths (`app.core.storage`, `_lease_helpers`, `signed_lease_service`, `listing_photo_service`, `screening_service`) resolve to the exact same class object (`is` identity)
- 133 targeted tests pass: `test_storage.py`, `test_bucket_initializer.py`, `test_listing_photo_service.py`, `test_screening.py`, `test_lease_templates_api.py`, `test_lease_import_api.py`, `test_suggest_placeholders_api.py`
- No consumer import paths changed — all callers that imported from `_lease_helpers` or any intermediate re-export continue to work unchanged

## Test plan

- [x] `grep -rn "class StorageNotConfiguredError" apps/ packages/` returns exactly 1 result (canonical)
- [x] Import identity smoke test passes
- [x] 133 targeted tests pass with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)