### PR TITLE
fix(shared): surface Cloudflare Turnstile error-codes

### DIFF
--- a/apps/mybookkeeper/backend/app/api/public_inquiries.py
+++ b/apps/mybookkeeper/backend/app/api/public_inquiries.py
@@ -115,13 +115,13 @@ async def submit_public_inquiry(
         raise
 
     # Step 2: Turnstile (no-op when secret is empty).
-    turnstile_passed = await verify_turnstile_token(
+    # Don't reject on failure here — pass the result into the spam pipeline so
+    # it can log the assessment row + flip spam_status. The bot still sees a 200.
+    turnstile_passed, _ = await verify_turnstile_token(
         payload.turnstile_token,
         client_ip,
         secret_key=settings.turnstile_secret_key,
     )
-    # Don't reject on turnstile fail here — let the pipeline log the
-    # assessment row + flip spam_status. The bot still sees a 200 success.
 
     # Steps 3-11 happen in the service.
     result = await public_inquiry_service.submit_public_inquiry(

--- a/apps/mybookkeeper/backend/app/core/rate_limit.py
+++ b/apps/mybookkeeper/backend/app/core/rate_limit.py
@@ -161,13 +161,19 @@ async def require_turnstile(request: Request) -> None:
     token = request.headers.get("X-Turnstile-Token", "")
     if not token:
         raise HTTPException(status_code=400, detail="Captcha token required")
-    valid = await verify_turnstile_token(
+    success, error_codes = await verify_turnstile_token(
         token,
         get_client_ip(request),
         secret_key=settings.turnstile_secret_key,
     )
-    if not valid:
-        raise HTTPException(status_code=400, detail="Captcha verification failed")
+    if not success:
+        # Config bug — alert ops, don't blame the user.
+        if any(c in error_codes for c in ("invalid-input-secret", "missing-input-secret")):
+            raise HTTPException(status_code=503, detail="captcha_service_misconfigured")
+        # User-recoverable: token reused or expired.
+        if "timeout-or-duplicate" in error_codes:
+            raise HTTPException(status_code=400, detail="captcha_expired_please_retry")
+        raise HTTPException(status_code=400, detail="captcha_verification_failed")
 
 
 async def check_register_rate_limit(request: Request) -> None:

--- a/apps/mybookkeeper/backend/tests/test_auth_events_integration.py
+++ b/apps/mybookkeeper/backend/tests/test_auth_events_integration.py
@@ -162,7 +162,7 @@ async def test_password_reset_request_creates_event(db: AsyncSession) -> None:
 
     with (
         patch("app.core.auth.send_password_reset_email", return_value=True),
-        patch("app.core.rate_limit.verify_turnstile_token", new_callable=AsyncMock, return_value=True),
+        patch("app.core.rate_limit.verify_turnstile_token", new_callable=AsyncMock, return_value=(True, [])),
     ):
         transport = ASGITransport(app=app)
         async with AsyncClient(transport=transport, base_url="http://test") as client:

--- a/apps/mybookkeeper/backend/tests/test_turnstile.py
+++ b/apps/mybookkeeper/backend/tests/test_turnstile.py
@@ -5,6 +5,7 @@ Covers:
 - POST /auth/forgot-password with a valid token (mocked) → 202
 - POST /auth/forgot-password with an invalid token (mocked) → 400
 - Dev mode (turnstile_secret_key="") → no CAPTCHA check, succeeds without header
+- Error-code routing: invalid-input-secret → 503, timeout-or-duplicate → 400
 """
 from unittest.mock import AsyncMock, patch
 
@@ -65,13 +66,13 @@ class TestRequireTurnstile:
         with patch.object(settings, "turnstile_secret_key", "test-secret"):
             with patch(
                 "app.core.rate_limit.verify_turnstile_token",
-                new=AsyncMock(return_value=False),
+                new=AsyncMock(return_value=(False, [])),
             ):
                 request = _make_request({"x-turnstile-token": "bad-token"})
                 with pytest.raises(HTTPException) as exc_info:
                     await require_turnstile(request)
                 assert exc_info.value.status_code == 400
-                assert exc_info.value.detail == "Captcha verification failed"
+                assert exc_info.value.detail == "captcha_verification_failed"
 
     @pytest.mark.anyio
     async def test_valid_token_passes(self) -> None:
@@ -79,7 +80,7 @@ class TestRequireTurnstile:
         with patch.object(settings, "turnstile_secret_key", "test-secret"):
             with patch(
                 "app.core.rate_limit.verify_turnstile_token",
-                new=AsyncMock(return_value=True),
+                new=AsyncMock(return_value=(True, [])),
             ):
                 request = _make_request({"x-turnstile-token": "good-token"})
                 await require_turnstile(request)  # must not raise
@@ -90,7 +91,7 @@ class TestRequireTurnstile:
         with patch.object(settings, "turnstile_secret_key", "test-secret"):
             with patch(
                 "app.core.rate_limit.verify_turnstile_token",
-                new=AsyncMock(return_value=True),
+                new=AsyncMock(return_value=(True, [])),
             ) as mock_verify:
                 request = _make_request({
                     "x-turnstile-token": "good-token",
@@ -100,6 +101,34 @@ class TestRequireTurnstile:
                 mock_verify.assert_awaited_once_with(
                     "good-token", "9.9.9.9", secret_key="test-secret",
                 )
+
+    @pytest.mark.anyio
+    async def test_invalid_input_secret_raises_503(self) -> None:
+        """Config bug (invalid-input-secret) surfaces as 503, not a user-facing 400."""
+        with patch.object(settings, "turnstile_secret_key", "test-secret"):
+            with patch(
+                "app.core.rate_limit.verify_turnstile_token",
+                new=AsyncMock(return_value=(False, ["invalid-input-secret"])),
+            ):
+                request = _make_request({"x-turnstile-token": "any-token"})
+                with pytest.raises(HTTPException) as exc_info:
+                    await require_turnstile(request)
+                assert exc_info.value.status_code == 503
+                assert exc_info.value.detail == "captcha_service_misconfigured"
+
+    @pytest.mark.anyio
+    async def test_timeout_or_duplicate_raises_400_retry(self) -> None:
+        """Token reuse / expiry surfaces as 400 with a user-actionable detail."""
+        with patch.object(settings, "turnstile_secret_key", "test-secret"):
+            with patch(
+                "app.core.rate_limit.verify_turnstile_token",
+                new=AsyncMock(return_value=(False, ["timeout-or-duplicate"])),
+            ):
+                request = _make_request({"x-turnstile-token": "spent-token"})
+                with pytest.raises(HTTPException) as exc_info:
+                    await require_turnstile(request)
+                assert exc_info.value.status_code == 400
+                assert exc_info.value.detail == "captcha_expired_please_retry"
 
 
 # ---------------------------------------------------------------------------
@@ -132,7 +161,7 @@ class TestRegisterRateLimitStillVerifies:
         with patch.object(settings, "turnstile_secret_key", "test-secret"):
             with patch(
                 "app.core.rate_limit.verify_turnstile_token",
-                new=AsyncMock(return_value=True),
+                new=AsyncMock(return_value=(True, [])),
             ):
                 request = _make_request({"x-turnstile-token": "good-token"})
                 await check_register_rate_limit(request)  # must not raise

--- a/apps/myjobhunter/backend/app/core/rate_limit.py
+++ b/apps/myjobhunter/backend/app/core/rate_limit.py
@@ -73,13 +73,19 @@ async def require_turnstile(request: Request) -> None:
     token = request.headers.get("X-Turnstile-Token", "")
     if not token:
         raise HTTPException(status_code=400, detail="Captcha token required")
-    valid = await verify_turnstile_token(
+    success, error_codes = await verify_turnstile_token(
         token,
         get_client_ip(request),
         secret_key=settings.turnstile_secret_key,
     )
-    if not valid:
-        raise HTTPException(status_code=400, detail="Captcha verification failed")
+    if not success:
+        # Config bug — alert ops, don't blame the user.
+        if any(c in error_codes for c in ("invalid-input-secret", "missing-input-secret")):
+            raise HTTPException(status_code=503, detail="captcha_service_misconfigured")
+        # User-recoverable: token reused or expired.
+        if "timeout-or-duplicate" in error_codes:
+            raise HTTPException(status_code=400, detail="captcha_expired_please_retry")
+        raise HTTPException(status_code=400, detail="captcha_verification_failed")
 
 
 # ---------------------------------------------------------------------------

--- a/apps/myjobhunter/backend/tests/test_turnstile.py
+++ b/apps/myjobhunter/backend/tests/test_turnstile.py
@@ -37,11 +37,11 @@ async def test_register_succeeds_without_token_when_secret_empty(client: AsyncCl
 async def test_register_succeeds_with_valid_turnstile_token(
     client: AsyncClient, monkeypatch,
 ) -> None:
-    """When the secret is set, a valid token (verifier returns True) lets the request through."""
+    """When the secret is set, a valid token (verifier returns (True, [])) lets the request through."""
     monkeypatch.setattr(settings, "turnstile_secret_key", "test-secret")
     with patch(
         "app.core.rate_limit.verify_turnstile_token",
-        new=AsyncMock(return_value=True),
+        new=AsyncMock(return_value=(True, [])),
     ):
         resp = await client.post(
             "/auth/register",
@@ -55,11 +55,11 @@ async def test_register_succeeds_with_valid_turnstile_token(
 async def test_register_rejected_with_invalid_turnstile_token(
     client: AsyncClient, monkeypatch,
 ) -> None:
-    """When the verifier returns False, the request is rejected with 400."""
+    """When the verifier returns (False, []), the request is rejected with 400."""
     monkeypatch.setattr(settings, "turnstile_secret_key", "test-secret")
     with patch(
         "app.core.rate_limit.verify_turnstile_token",
-        new=AsyncMock(return_value=False),
+        new=AsyncMock(return_value=(False, [])),
     ):
         resp = await client.post(
             "/auth/register",
@@ -67,7 +67,7 @@ async def test_register_rejected_with_invalid_turnstile_token(
             headers={"X-Turnstile-Token": "bad-token"},
         )
     assert resp.status_code == 400
-    assert resp.json()["detail"] == "Captcha verification failed"
+    assert resp.json()["detail"] == "captcha_verification_failed"
 
 
 @pytest.mark.asyncio
@@ -82,6 +82,44 @@ async def test_register_rejected_when_token_missing(
     )
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Captcha token required"
+
+
+@pytest.mark.asyncio
+async def test_register_rejected_with_invalid_input_secret(
+    client: AsyncClient, monkeypatch,
+) -> None:
+    """Config bug (invalid-input-secret) surfaces as 503 so ops can distinguish it from user errors."""
+    monkeypatch.setattr(settings, "turnstile_secret_key", "bad-config-secret")
+    with patch(
+        "app.core.rate_limit.verify_turnstile_token",
+        new=AsyncMock(return_value=(False, ["invalid-input-secret"])),
+    ):
+        resp = await client.post(
+            "/auth/register",
+            json={"email": _email(), "password": "long-enough-password-1234"},
+            headers={"X-Turnstile-Token": "any-token"},
+        )
+    assert resp.status_code == 503
+    assert resp.json()["detail"] == "captcha_service_misconfigured"
+
+
+@pytest.mark.asyncio
+async def test_register_rejected_with_timeout_or_duplicate(
+    client: AsyncClient, monkeypatch,
+) -> None:
+    """Token reuse/expiry surfaces as 400 with a user-actionable retry detail."""
+    monkeypatch.setattr(settings, "turnstile_secret_key", "test-secret")
+    with patch(
+        "app.core.rate_limit.verify_turnstile_token",
+        new=AsyncMock(return_value=(False, ["timeout-or-duplicate"])),
+    ):
+        resp = await client.post(
+            "/auth/register",
+            json={"email": _email(), "password": "long-enough-password-1234"},
+            headers={"X-Turnstile-Token": "spent-token"},
+        )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "captcha_expired_please_retry"
 
 
 # ---------------------------------------------------------------------------
@@ -123,7 +161,7 @@ async def test_forgot_password_succeeds_with_valid_token(
     monkeypatch.setattr(settings, "turnstile_secret_key", "test-secret")
     with patch(
         "app.core.rate_limit.verify_turnstile_token",
-        new=AsyncMock(return_value=True),
+        new=AsyncMock(return_value=(True, [])),
     ):
         resp = await client.post(
             "/auth/forgot-password",
@@ -153,4 +191,4 @@ async def test_reset_password_does_not_require_turnstile(
     )
     assert resp.status_code == 400
     assert resp.json().get("detail") != "Captcha token required"
-    assert resp.json().get("detail") != "Captcha verification failed"
+    assert resp.json().get("detail") != "captcha_verification_failed"

--- a/packages/shared-backend/platform_shared/core/rate_limit.py
+++ b/packages/shared-backend/platform_shared/core/rate_limit.py
@@ -19,11 +19,14 @@ In-process state — ``_buckets`` is a module-local dict on each
 ``RateLimiter`` instance, so the limiter is per-worker. Multi-worker /
 multi-host coordination (Redis backend) is intentionally out of scope.
 """
+import logging
 import time
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger(__name__)
 
 from fastapi import HTTPException, Request
 from fastapi.security import OAuth2PasswordRequestForm
@@ -141,7 +144,7 @@ UserLookup = Callable[[AsyncSession, str], Awaitable[Any]]
 def make_require_turnstile(
     secret_key_provider: SecretKeyProvider,
     *,
-    verify: Callable[..., Awaitable[bool]] = verify_turnstile_token,
+    verify: Callable[..., Awaitable[tuple[bool, list[str]]]] = verify_turnstile_token,
 ) -> Callable[[Request], Awaitable[None]]:
     """Build a FastAPI dependency that enforces Turnstile CAPTCHA.
 
@@ -156,13 +159,20 @@ def make_require_turnstile(
         token = request.headers.get("X-Turnstile-Token", "")
         if not token:
             raise HTTPException(status_code=400, detail="Captcha token required")
-        valid = await verify(
+        success, error_codes = await verify(
             token,
             get_client_ip(request),
             secret_key=secret_key,
         )
-        if not valid:
-            raise HTTPException(status_code=400, detail="Captcha verification failed")
+        if not success:
+            # Config bug — alert ops, don't blame the user.
+            if any(c in error_codes for c in ("invalid-input-secret", "missing-input-secret")):
+                logger.error("Turnstile misconfigured: %s", error_codes)
+                raise HTTPException(status_code=503, detail="captcha_service_misconfigured")
+            # User-recoverable: token reused or expired.
+            if "timeout-or-duplicate" in error_codes:
+                raise HTTPException(status_code=400, detail="captcha_expired_please_retry")
+            raise HTTPException(status_code=400, detail="captcha_verification_failed")
 
     return _require_turnstile
 

--- a/packages/shared-backend/platform_shared/services/turnstile_service.py
+++ b/packages/shared-backend/platform_shared/services/turnstile_service.py
@@ -5,7 +5,11 @@ config layer) and pass it to ``verify_turnstile_token``. When the secret is
 empty (dev/CI mode) the verifier short-circuits to True so local development
 does not require a Cloudflare account.
 """
+import logging
+
 import httpx
+
+logger = logging.getLogger(__name__)
 
 TURNSTILE_VERIFY_URL = "https://challenges.cloudflare.com/turnstile/v0/siteverify"
 TURNSTILE_TIMEOUT_S = 10
@@ -16,14 +20,15 @@ async def verify_turnstile_token(
     remote_ip: str | None = None,
     *,
     secret_key: str | None,
-) -> bool:
+) -> tuple[bool, list[str]]:
     """Verify a Turnstile token against Cloudflare's siteverify endpoint.
 
-    Returns True when ``secret_key`` is empty/None — the no-op dev mode.
-    Otherwise POSTs to Cloudflare and returns ``result["success"]``.
+    Returns ``(True, [])`` when ``secret_key`` is empty/None — the no-op dev mode.
+    Otherwise POSTs to Cloudflare and returns ``(success, error_codes)`` so
+    callers can route on specific codes per rules/check-third-party-error-codes.md.
     """
     if not secret_key:
-        return True
+        return True, []
 
     payload: dict[str, str] = {
         "secret": secret_key,
@@ -35,4 +40,17 @@ async def verify_turnstile_token(
     async with httpx.AsyncClient(timeout=TURNSTILE_TIMEOUT_S) as client:
         resp = await client.post(TURNSTILE_VERIFY_URL, data=payload)
         result = resp.json()
-        return result.get("success", False)
+
+    success = bool(result.get("success", False))
+    error_codes: list[str] = list(result.get("error-codes") or [])
+
+    if not success:
+        # WARNING + structured kwargs so Sentry/log aggregator can group by failure reason.
+        logger.warning(
+            "Turnstile verify failed: codes=%s hostname=%s action=%s",
+            error_codes,
+            result.get("hostname"),
+            result.get("action"),
+        )
+
+    return success, error_codes

--- a/packages/shared-backend/tests/test_turnstile_service.py
+++ b/packages/shared-backend/tests/test_turnstile_service.py
@@ -1,9 +1,11 @@
 """Unit tests for platform_shared.services.turnstile_service.
 
 The verifier is decoupled from any app config — apps pass ``secret_key`` in.
-An empty/None key is the documented dev-mode no-op (returns True without
+An empty/None key is the documented dev-mode no-op (returns (True, []) without
 contacting Cloudflare).
 """
+import logging
+
 import httpx
 import pytest
 
@@ -30,7 +32,7 @@ class TestNoOpDevMode:
     async def test_empty_secret_returns_true_without_network(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """When secret_key is empty, the function must short-circuit to True."""
+        """When secret_key is empty, the function must short-circuit to (True, [])."""
         called = {"hit": False}
 
         def handler(_: httpx.Request) -> httpx.Response:
@@ -39,7 +41,8 @@ class TestNoOpDevMode:
 
         _install_mock_transport(monkeypatch, handler)
 
-        assert await verify_turnstile_token("any-token", secret_key="") is True
+        result = await verify_turnstile_token("any-token", secret_key="")
+        assert result == (True, [])
         assert called["hit"] is False, "Empty secret must not contact Cloudflare"
 
     @pytest.mark.anyio
@@ -54,7 +57,8 @@ class TestNoOpDevMode:
 
         _install_mock_transport(monkeypatch, handler)
 
-        assert await verify_turnstile_token("any-token", secret_key=None) is True
+        result = await verify_turnstile_token("any-token", secret_key=None)
+        assert result == (True, [])
         assert called["hit"] is False
 
 
@@ -69,10 +73,11 @@ class TestVerification:
             return httpx.Response(200, json={"success": True})
 
         _install_mock_transport(monkeypatch, handler)
-        ok = await verify_turnstile_token(
+        success, error_codes = await verify_turnstile_token(
             "abc123", remote_ip="9.9.9.9", secret_key="real-secret",
         )
-        assert ok is True
+        assert success is True
+        assert error_codes == []
         assert captured["url"] == TURNSTILE_VERIFY_URL
         # Body is form-encoded — confirm secret + token + remote IP all flow through.
         assert "secret=real-secret" in captured["body"]
@@ -80,7 +85,10 @@ class TestVerification:
         assert "remoteip=9.9.9.9" in captured["body"]
 
     @pytest.mark.anyio
-    async def test_failure_response(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_failure_response_with_error_codes(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Failure response with error-codes returns (False, [...codes...])."""
         def handler(_: httpx.Request) -> httpx.Response:
             return httpx.Response(
                 200,
@@ -88,7 +96,45 @@ class TestVerification:
             )
 
         _install_mock_transport(monkeypatch, handler)
-        assert await verify_turnstile_token("bad", secret_key="real-secret") is False
+        success, error_codes = await verify_turnstile_token("bad", secret_key="real-secret")
+        assert success is False
+        assert error_codes == ["invalid-input-response"]
+
+    @pytest.mark.anyio
+    async def test_failure_response_without_error_codes_field(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the response has no error-codes field, returns (False, [])."""
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"success": False})
+
+        _install_mock_transport(monkeypatch, handler)
+        success, error_codes = await verify_turnstile_token("bad", secret_key="real-secret")
+        assert success is False
+        assert error_codes == []
+
+    @pytest.mark.anyio
+    async def test_failure_emits_warning_log(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A failed verification must log at WARNING with the error codes."""
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={
+                    "success": False,
+                    "error-codes": ["timeout-or-duplicate"],
+                    "hostname": "example.com",
+                    "action": "register",
+                },
+            )
+
+        _install_mock_transport(monkeypatch, handler)
+        with caplog.at_level(logging.WARNING, logger="platform_shared.services.turnstile_service"):
+            await verify_turnstile_token("expired", secret_key="real-secret")
+
+        assert any("timeout-or-duplicate" in r.message for r in caplog.records)
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
 
     @pytest.mark.anyio
     async def test_remote_ip_optional(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -113,4 +159,6 @@ class TestVerification:
             return httpx.Response(200, json={"unexpected": "shape"})
 
         _install_mock_transport(monkeypatch, handler)
-        assert await verify_turnstile_token("abc", secret_key="real-secret") is False
+        success, error_codes = await verify_turnstile_token("abc", secret_key="real-secret")
+        assert success is False
+        assert error_codes == []


### PR DESCRIPTION
## Summary

- `verify_turnstile_token` now returns `tuple[bool, list[str]]` instead of bare `bool`, surfacing Cloudflare's documented `error-codes` array to every caller
- `require_turnstile` in both apps routes on specific codes: `invalid-input-secret` / `missing-input-secret` → 503 (config bug, alert ops); `timeout-or-duplicate` → 400 with retry detail; everything else → generic 400
- Failures log structured `codes=` / `hostname=` / `action=` at WARNING so Sentry can group by failure reason — previously the operator had zero diagnostic signal beyond \"captcha failed\"
- `public_inquiries.py` (spam pipeline path) uses `success, _ = await verify_turnstile_token(...)` — intentionally does not reject on failure, passes the bool to the pipeline scorer as before
- `test_auth_events_integration.py` mock updated from `return_value=True` → `return_value=(True, [])` to match new return type

## No operational migration required

On VPSes where `TURNSTILE_SECRET_KEY` is correctly set, call-site behavior is identical on the happy path. If the key was misconfigured today, the route returned a generic 400; it now returns 503 — a more honest failure, not a regression. No `.env.docker` changes needed before deploy.

## Resolves

CRITICAL silent-fail finding from the 2026-05-08 Silent-fail audit (`TECH_DEBT.md`). Root cause of the 2026-05-05 production incident where the operator spent ~90 minutes diagnosing a `timeout-or-duplicate` token reuse that would have been immediately visible with error-code logging.

## Test plan

- [x] `packages/shared-backend/tests/test_turnstile_service.py` — 8 tests: dev-mode short-circuit, success path, failure with codes, failure without codes field, WARNING log emission, remote IP optional, malformed response
- [x] `apps/mybookkeeper/backend/tests/test_turnstile.py` — 9 tests: all prior cases updated + 2 new (503 on `invalid-input-secret`, 400 retry on `timeout-or-duplicate`)
- [x] `apps/myjobhunter/backend/tests/test_turnstile.py` — 10 tests: all prior cases updated + 2 new (same code-routing coverage)
- [x] `apps/mybookkeeper/backend/tests/test_auth_events_integration.py` — 8 tests: all pass with updated mock return value

🤖 Generated with [Claude Code](https://claude.com/claude-code)