### PR TITLE
fix(shared/email): assert smtplib reply code survives in __cause__

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -150,13 +150,11 @@ Failures log structured `error-codes` at WARNING so Sentry can group by reason. 
 
 **Fix:** Either fail-loud (raise so the whole sync rolls back) or write an audit row to a `gmail_skipped_messages` table with the exception type. Per `rules/no-bandaid-solutions.md` the latter is the right shape — it preserves the partial sync but audits the gap.
 
-### HIGH — SMTP `send_or_raise` truncates exception chain to `f"{e}"`
+### ~~HIGH — SMTP `send_or_raise` truncates exception chain to `f"{e}"`~~ ✓ Resolved
 
 **Location:** `packages/shared-backend/platform_shared/services/email_service.py:154-162`
 **Effort:** XS
-**Problem:** `EmailSendError(f"SMTP send to {to} failed: {e}")` stringifies the exception, losing the structured smtplib reply code (e.g. `421 Service not available` vs `550 Mailbox unavailable`). Sentry sees a generic message; operator can't tell rate-limit from rejected-sender.
-
-**Fix:** Use `EmailSendError(...) from e` (already correct at line 160 — line 154 is the lossy site). One-line fix.
+**Resolved:** `from e` was already present; added `test_smtp_reply_code_survives_in_cause` asserting the smtplib reply code (smtp_code, smtp_error) survives on `__cause__`.
 
 ### MEDIUM — Claude prompt loading swallows DB errors during user-rule fetch
 

--- a/packages/shared-backend/tests/test_email_service.py
+++ b/packages/shared-backend/tests/test_email_service.py
@@ -8,6 +8,7 @@ Covers:
 - Critical-path send_or_raise() raising on any failure (for verification,
   password reset, and other emails where silent loss leaves the user broken).
 """
+import smtplib
 import ssl
 from unittest.mock import MagicMock, patch
 
@@ -148,6 +149,19 @@ class TestSendOrRaise:
             with pytest.raises(EmailSendError) as exc:
                 service.send_or_raise(["x@example.com"], "subj", "<p>body</p>")
         assert exc.value.__cause__ is underlying
+
+    def test_smtp_reply_code_survives_in_cause(self) -> None:
+        """smtplib reply code (smtp_code, smtp_error) must survive on __cause__
+        so Sentry can distinguish 550 Mailbox unavailable from 421 rate-limit."""
+        service = _configured_service()
+        underlying = smtplib.SMTPDataError(550, b"Mailbox unavailable")
+        with patch("smtplib.SMTP", side_effect=underlying):
+            with pytest.raises(EmailSendError) as exc:
+                service.send_or_raise(["x@example.com"], "subj", "<p>body</p>")
+        cause = exc.value.__cause__
+        assert isinstance(cause, smtplib.SMTPDataError)
+        assert cause.smtp_code == 550
+        assert b"Mailbox unavailable" in cause.smtp_error
 
     def test_returns_none_on_success(self) -> None:
         service = _configured_service()


### PR DESCRIPTION
## Summary

- The `from e` exception chain was already present in `email_service.py` — the audit finding predated its introduction
- Adds `test_smtp_reply_code_survives_in_cause` to `TestSendOrRaise`: raises `SMTPDataError(550, b"Mailbox unavailable")` and asserts `smtp_code` and `smtp_error` survive on `__cause__`
- Marks the MJH TECH_DEBT.md HIGH XS finding as resolved

## Why the test matters

The existing `test_chains_underlying_exception` used a generic `OSError` — it confirmed the chain was wired but said nothing about whether smtplib's structured reply tuple (`smtp_code`, `smtp_error`) was accessible post-wrap. The new test locks that in, so a future refactor that converts to `raise EmailSendError(...) from None` (or loses the cause in some other way) breaks CI instead of silently degrading Sentry's ability to distinguish rate-limits from rejected senders.

## Test plan

- [x] `pytest packages/shared-backend/tests/test_email_service.py -v` — 19 passed
- [x] No callers changed — `EmailSendError` public type is unchanged

Per `rules/check-third-party-error-codes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)