### PR TITLE
refactor(shared-frontend): add InlineBoldText tests + mark TECH_DEBT resolved

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 41 (Critical: 1 / High: 4 / Medium: 22 / Low: 15)**
+**Open issues: 40 (Critical: 1 / High: 3 / Medium: 22 / Low: 15)**
 
 > Last comprehensive audit: 2026-05-07 (post-discovery feature ship). All Critical and 7 of 8 audit-High findings RESOLVED in PRs #421-#432 (2026-05-07). Remaining audit findings preserved below under "## High (audit 2026-05-07)" / "## Medium (audit 2026-05-07)" / "## Low (audit 2026-05-07)" sections; pre-existing findings preserved under "## Pre-existing".
 
@@ -56,12 +56,9 @@ See sister entry in `apps/mybookkeeper/TECH_DEBT.md`. MJH side: `apps/myjobhunte
 
 > MJH already imports from `@platform/ui`, so these extractions are NOT blocked-on-react-19 from the MJH side. They become unblocked-for-MBK once MBK upgrades to React 19.
 
-#### HIGH — Extract `InlineBoldText` to `@platform/ui` now
+#### ~~HIGH — Extract `InlineBoldText` to `@platform/ui` now~~ RESOLVED
 
-**Effort:** S
-**Location:** `apps/myjobhunter/frontend/src/features/discover/InlineBoldText.tsx` (65 LOC).
-**Problem:** Generic markdown-bold renderer (parses `**text**`) living in a feature folder. MJH-only consumer today, but obviously reusable.
-**Recommendation:** Move to `packages/shared-frontend/src/components/InlineBoldText.tsx`. Re-export from `@platform/ui` index. Update MJH import.
+**Resolved:** PR #476 (2026-05-08). Component moved to `packages/shared-frontend/src/components/ui/InlineBoldText.tsx`, re-exported from `@platform/ui` index. MJH `NewSavedSearchDialog` import updated. Unit tests added in `packages/shared-frontend/src/__tests__/InlineBoldText.test.tsx`.
 
 ---
 

--- a/packages/shared-frontend/src/__tests__/InlineBoldText.test.tsx
+++ b/packages/shared-frontend/src/__tests__/InlineBoldText.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import InlineBoldText, { __INTERNAL__ } from "../components/ui/InlineBoldText";
+
+const { parseBoldSegments } = __INTERNAL__;
+
+describe("parseBoldSegments", () => {
+  it("returns a single plain segment for a string with no bold markers", () => {
+    expect(parseBoldSegments("hello world")).toEqual([
+      { text: "hello world", bold: false },
+    ]);
+  });
+
+  it("returns a single bold segment for a fully-wrapped string", () => {
+    expect(parseBoldSegments("**bold**")).toEqual([
+      { text: "bold", bold: true },
+    ]);
+  });
+
+  it("splits a string into plain + bold + plain", () => {
+    expect(parseBoldSegments("hello **world** today")).toEqual([
+      { text: "hello ", bold: false },
+      { text: "world", bold: true },
+      { text: " today", bold: false },
+    ]);
+  });
+
+  it("handles multiple bold segments", () => {
+    expect(parseBoldSegments("**a** and **b**")).toEqual([
+      { text: "a", bold: true },
+      { text: " and ", bold: false },
+      { text: "b", bold: true },
+    ]);
+  });
+
+  it("returns an empty array for an empty string", () => {
+    expect(parseBoldSegments("")).toEqual([]);
+  });
+
+  it("treats unbalanced opening markers as plain text", () => {
+    const result = parseBoldSegments("hello **world");
+    expect(result).toEqual([{ text: "hello **world", bold: false }]);
+  });
+
+  it("treats unbalanced closing markers as plain text", () => {
+    const result = parseBoldSegments("hello world**");
+    expect(result).toEqual([{ text: "hello world**", bold: false }]);
+  });
+
+  it("handles bold segment at the very start", () => {
+    expect(parseBoldSegments("**start** of the string")).toEqual([
+      { text: "start", bold: true },
+      { text: " of the string", bold: false },
+    ]);
+  });
+
+  it("handles bold segment at the very end", () => {
+    expect(parseBoldSegments("end of the **string**")).toEqual([
+      { text: "end of the ", bold: false },
+      { text: "string", bold: true },
+    ]);
+  });
+});
+
+describe("InlineBoldText", () => {
+  it("renders plain text without any strong elements", () => {
+    render(<InlineBoldText text="plain text only" />);
+    expect(screen.getByText("plain text only")).toBeInTheDocument();
+    expect(document.querySelector("strong")).toBeNull();
+  });
+
+  it("renders a bold segment inside a <strong> element", () => {
+    render(<InlineBoldText text="**bold word**" />);
+    expect(screen.getByText("bold word").tagName).toBe("STRONG");
+  });
+
+  it("renders interleaved plain and bold segments", () => {
+    render(<InlineBoldText text="hello **world** today" />);
+    expect(screen.getByText("world").tagName).toBe("STRONG");
+    expect(screen.getByText("hello ")).toBeInTheDocument();
+    expect(screen.getByText(" today")).toBeInTheDocument();
+  });
+
+  it("applies the default boldClassName to bold segments", () => {
+    render(<InlineBoldText text="**word**" />);
+    expect(screen.getByText("word")).toHaveClass("text-foreground");
+  });
+
+  it("applies a custom boldClassName to bold segments", () => {
+    render(<InlineBoldText text="**word**" boldClassName="font-semibold" />);
+    expect(screen.getByText("word")).toHaveClass("font-semibold");
+    expect(screen.getByText("word")).not.toHaveClass("text-foreground");
+  });
+
+  it("renders an empty string without errors", () => {
+    const { container } = render(<InlineBoldText text="" />);
+    expect(container.firstChild).toBeEmptyDOMElement();
+  });
+
+  it("renders multiple bold segments correctly", () => {
+    render(<InlineBoldText text="**first** and **second**" />);
+    const strongs = document.querySelectorAll("strong");
+    expect(strongs).toHaveLength(2);
+    expect(strongs[0].textContent).toBe("first");
+    expect(strongs[1].textContent).toBe("second");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds unit tests for `InlineBoldText` in `packages/shared-frontend/src/__tests__/InlineBoldText.test.tsx` — 16 tests covering `parseBoldSegments` (9 pure-TS cases) and React render behavior (7 cases)
- Marks the `TECH_DEBT.md` HIGH entry resolved; updates open-issues count from 41 → 40

## Background

The component itself and its `@platform/ui` re-export landed in PR #476. `NewSavedSearchDialog.tsx` already imports from `@platform/ui`. What was missing was the test file and the TECH_DEBT housekeeping.

## MBK adoption

Not in scope here. MBK is blocked-on-react-19 for `@platform/ui` imports (two-React-copies runtime crash). Adoption is queued for the React 19 bump per the existing TECH_DEBT note.

## Test note

The 7 React render tests in this file fail for the same pre-existing reason all other React render tests in `packages/shared-frontend` fail (two-React-copies in the vitest environment — `react-dom` resolves to two different versions). The 9 `parseBoldSegments` pure-TS tests pass. The React render failures are not introduced by this PR.

## Test plan

- [ ] CI green on `parseBoldSegments` tests (9/9 pass)
- [ ] React render tests fail at the same rate as pre-existing failures in `packages/shared-frontend` (pre-existing env issue, not introduced here)
- [ ] TECH_DEBT.md entry for InlineBoldText shows as resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)