### PR TITLE
fix(mjh): wrap Tavily response.json() ValueError in typed error

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 40 (Critical: 1 / High: 3 / Medium: 22 / Low: 15)**
+**Open issues: 38 (Critical: 1 / High: 3 / Medium: 20 / Low: 15)**
 
 > Last comprehensive audit: 2026-05-07 (post-discovery feature ship). All Critical and 7 of 8 audit-High findings RESOLVED in PRs #421-#432 (2026-05-07). Remaining audit findings preserved below under "## High (audit 2026-05-07)" / "## Medium (audit 2026-05-07)" / "## Low (audit 2026-05-07)" sections; pre-existing findings preserved under "## Pre-existing".
 
@@ -157,21 +157,13 @@ Failures log structured `error-codes` at WARNING so Sentry can group by reason. 
 
 **Fix:** Catch only `SQLAlchemyError`, log the actual exception type, surface to caller via `(prompt, error)` tuple so a user-facing error toast can fire.
 
-### MEDIUM — JSearch `response.json()` uncaught ValueError on malformed 200
+### ~~MEDIUM — JSearch `response.json()` uncaught ValueError on malformed 200~~ RESOLVED
 
-**Location:** `apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py:217`
-**Effort:** XS
-**Problem:** Otherwise-good typed exception hierarchy (`JSearchAuthError`, `JSearchTransientError`, `JSearchInvalidResponseError`), but `response.json()` is unwrapped. A 200 with truncated body raises `ValueError` outside the hierarchy → retry decorator treats it as fatal.
+**Resolved:** PR fix/jsearch-tavily-json-error (2026-05-08). `response.json()` at jsearch.py:217 was already wrapped in `try/except ValueError as e: raise JSearchInvalidResponseError(...) from e` — the TECH_DEBT entry pre-dated the fix. Confirmed by `test_search_raises_on_non_json_body` in `test_jsearch_adapter.py`.
 
-**Fix:** Wrap the `.json()` call in `try/except ValueError as e: raise JSearchInvalidResponseError(...) from e`.
+### ~~MEDIUM — Tavily `response.json()` uncaught ValueError on malformed 200~~ RESOLVED
 
-### MEDIUM — Tavily `response.json()` uncaught ValueError on malformed 200
-
-**Location:** `apps/myjobhunter/backend/app/services/integrations/tavily_service.py:136, 194`
-**Effort:** XS
-**Problem:** Identical shape to the JSearch one above. `response.json()` outside the typed-error hierarchy. Two call sites (search + extract).
-
-**Fix:** Wrap both `.json()` calls; raise `TavilyInvalidResponseError`.
+**Resolved:** PR fix/jsearch-tavily-json-error (2026-05-08). Added `TavilyInvalidResponseError` class and wrapped both `response.json()` call sites in `search_company` and `search_company_overview` with `try/except ValueError as e: raise TavilyInvalidResponseError(...) from e`. Tests: `TestTavilyMalformedBody` in `test_tavily_service.py` (two cases, one per call site).
 
 ### MEDIUM — Gmail discovery lacks transient-vs-fatal categorization
 

--- a/apps/myjobhunter/backend/app/services/integrations/tavily_service.py
+++ b/apps/myjobhunter/backend/app/services/integrations/tavily_service.py
@@ -31,6 +31,10 @@ class TavilyNotConfiguredError(RuntimeError):
     """Raised when TAVILY_API_KEY is absent in a non-development environment."""
 
 
+class TavilyInvalidResponseError(RuntimeError):
+    """Raised when Tavily returns a 2xx with a non-JSON or unparseable body."""
+
+
 class TavilyResult(TypedDict):
     url: str
     title: str | None
@@ -133,7 +137,13 @@ async def search_company(company_name: str, domain: str | None = None) -> list[T
             },
         )
         response.raise_for_status()
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise TavilyInvalidResponseError(
+                f"Tavily search returned 2xx but body could not be parsed as JSON"
+                f" (len={len(response.content)}): {exc}"
+            ) from exc
 
     results = data.get("results", [])
     return [
@@ -191,7 +201,13 @@ async def search_company_overview(
             },
         )
         response.raise_for_status()
-        data = response.json()
+        try:
+            data = response.json()
+        except ValueError as exc:
+            raise TavilyInvalidResponseError(
+                f"Tavily extract returned 2xx but body could not be parsed as JSON"
+                f" (len={len(response.content)}): {exc}"
+            ) from exc
 
     results = data.get("results", [])
     return [

--- a/apps/myjobhunter/backend/tests/test_tavily_service.py
+++ b/apps/myjobhunter/backend/tests/test_tavily_service.py
@@ -17,8 +17,10 @@ import httpx
 import pytest
 
 from app.services.integrations.tavily_service import (
+    TavilyInvalidResponseError,
     TavilyNotConfiguredError,
     search_company,
+    search_company_overview,
 )
 
 
@@ -159,3 +161,56 @@ class TestTavilyHappyPath:
 
         assert len(results) == 1
         assert results[0]["url"] == "https://glassdoor.com/reviews/acme"
+
+
+# ---------------------------------------------------------------------------
+# Malformed-body handling — 2xx with non-JSON body raises typed error
+# ---------------------------------------------------------------------------
+
+
+class TestTavilyMalformedBody:
+    @pytest.mark.asyncio
+    async def test_search_company_raises_typed_error_on_non_json_body(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """search_company raises TavilyInvalidResponseError (not bare ValueError) on truncated body."""
+        from app.core.config import settings
+        monkeypatch.setattr(settings, "tavily_api_key", "test-key-abc")
+        monkeypatch.delenv("MYJOBHUNTER_ENV", raising=False)
+
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError("No JSON object could be decoded")
+        mock_response.content = b"not-json"
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.integrations.tavily_service.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(TavilyInvalidResponseError):
+                await search_company("Acme Corp")
+
+    @pytest.mark.asyncio
+    async def test_search_company_overview_raises_typed_error_on_non_json_body(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """search_company_overview raises TavilyInvalidResponseError (not bare ValueError) on truncated body."""
+        from app.core.config import settings
+        monkeypatch.setattr(settings, "tavily_api_key", "test-key-abc")
+        monkeypatch.delenv("MYJOBHUNTER_ENV", raising=False)
+
+        mock_response = MagicMock()
+        mock_response.json.side_effect = ValueError("No JSON object could be decoded")
+        mock_response.content = b"not-json"
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+
+        with patch("app.services.integrations.tavily_service.httpx.AsyncClient", return_value=mock_client):
+            with pytest.raises(TavilyInvalidResponseError):
+                await search_company_overview("Acme Corp")


### PR DESCRIPTION
## Summary

- Added `TavilyInvalidResponseError` class to `tavily_service.py`
- Wrapped `response.json()` in both call sites (`search_company` + `search_company_overview`) with `try/except ValueError as e: raise TavilyInvalidResponseError(...) from e`
- Two new tests in `TestTavilyMalformedBody` covering each call site
- TECH_DEBT.md: both silent-fail audit entries (JSearch + Tavily) marked RESOLVED; open count 40 → 38

**Note on JSearch:** The TECH_DEBT entry said JSearch was unwrapped, but `jsearch.py:216-221` already had the correct `try/except ValueError` wrapping in place (the entry pre-dated the fix). Confirmed by `test_search_raises_on_non_json_body` in `test_jsearch_adapter.py`. No code change needed there.

Per `rules/check-third-party-error-codes.md`. Closes the two MEDIUM items from the silent-fail audit (2026-05-08).

## Test plan

- [ ] `pytest tests/test_tavily_service.py -v` — all existing tests pass + 2 new `TestTavilyMalformedBody` tests pass
- [ ] `pytest tests/test_jsearch_adapter.py -v` — confirms `test_search_raises_on_non_json_body` was already green

🤖 Generated with [Claude Code](https://claude.com/claude-code)