### PR TITLE
fix(mbk/extraction): narrow bare except to SQLAlchemyError in get_extraction_prompt

### DIFF
--- a/apps/mybookkeeper/backend/app/services/extraction/claude_service.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/claude_service.py
@@ -8,6 +8,7 @@ from dataclasses import dataclass
 
 import anthropic
 from anthropic import Timeout
+from sqlalchemy.exc import SQLAlchemyError
 from app.core.config import settings
 from app.db.session import AsyncSessionLocal
 from app.repositories import extraction_prompt_repo
@@ -59,12 +60,15 @@ async def get_extraction_prompt(
     user_id: uuid.UUID | None = None,
     filename: str | None = None,
     property_classification: str | None = None,
-) -> str:
+) -> tuple[str, str | None]:
     """Assemble extraction prompt: base + document-type addendum + property context + user-specific rules.
 
     DEFAULT_PROMPT is always the foundation. Document-type addendums provide
     focused instructions for specific form types. Property context narrows
     tax_relevant decisions. DB-stored rules are additive.
+
+    Returns (prompt, error_tag) where error_tag is None on success or
+    "user_rules_db_error" when the DB call to load user rules fails.
     """
     prompt = DEFAULT_PROMPT
 
@@ -80,14 +84,18 @@ async def get_extraction_prompt(
 
     if user_id:
         try:
-            async with AsyncSessionLocal() as db:  # Read-only — matches codebase pattern for service reads
+            async with AsyncSessionLocal() as db:
                 user_rules = await extraction_prompt_repo.get_active_for_user(db, user_id)
                 if user_rules:
                     prompt = f"{prompt}\n\n# User-specific rules\n{user_rules.prompt_text}"
-        except Exception:
-            logger.warning("Failed to load user prompt rules, using base only", exc_info=True)
+        except SQLAlchemyError as e:
+            logger.warning(
+                "claude prompt: failed to load user rules type=%s msg=%s — falling back to base prompt",
+                type(e).__name__, str(e),
+            )
+            return prompt, "user_rules_db_error"
 
-    return prompt
+    return prompt, None
 
 
 async def _create_with_backoff(**kwargs) -> anthropic.types.Message:
@@ -130,7 +138,9 @@ async def _create_with_backoff(**kwargs) -> anthropic.types.Message:
 
 
 async def extract_from_text(text: str, user_id: uuid.UUID | None = None, filename: str | None = None, property_classification: str | None = None) -> dict:
-    prompt = await get_extraction_prompt(user_id, filename=filename, property_classification=property_classification)
+    prompt, err = await get_extraction_prompt(user_id, filename=filename, property_classification=property_classification)
+    if err:
+        logger.warning("extract_from_text: proceeding without user rules (error=%s user_id=%s)", err, user_id)
     message = await _create_with_backoff(
         model="claude-sonnet-4-6",
         max_tokens=16384,
@@ -141,7 +151,9 @@ async def extract_from_text(text: str, user_id: uuid.UUID | None = None, filenam
 
 
 async def extract_from_image(image_bytes: bytes, media_type: str, user_id: uuid.UUID | None = None, filename: str | None = None, property_classification: str | None = None) -> dict:
-    prompt = await get_extraction_prompt(user_id, filename=filename, property_classification=property_classification)
+    prompt, err = await get_extraction_prompt(user_id, filename=filename, property_classification=property_classification)
+    if err:
+        logger.warning("extract_from_image: proceeding without user rules (error=%s user_id=%s)", err, user_id)
     file_b64 = base64.standard_b64encode(image_bytes).decode()
 
     is_pdf = media_type == "application/pdf"

--- a/apps/mybookkeeper/backend/tests/test_claude_service_prompt.py
+++ b/apps/mybookkeeper/backend/tests/test_claude_service_prompt.py
@@ -1,0 +1,103 @@
+"""Tests for get_extraction_prompt — SQLAlchemy error handling and fallback behavior."""
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from app.services.extraction.claude_service import get_extraction_prompt
+from app.services.extraction.prompts.base_prompt import DEFAULT_PROMPT
+
+
+class TestGetExtractionPromptSuccess:
+    @pytest.mark.asyncio
+    async def test_returns_base_prompt_when_no_user_id(self) -> None:
+        prompt, err = await get_extraction_prompt()
+        assert prompt == DEFAULT_PROMPT
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_returns_prompt_with_user_rules_appended(self) -> None:
+        user_id = uuid.uuid4()
+        fake_rules = MagicMock()
+        fake_rules.prompt_text = "Always flag utilities as deductible."
+
+        with patch("app.services.extraction.claude_service.AsyncSessionLocal") as mock_session_cls, \
+             patch("app.services.extraction.claude_service.extraction_prompt_repo") as mock_repo:
+            mock_db = AsyncMock()
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_repo.get_active_for_user = AsyncMock(return_value=fake_rules)
+
+            prompt, err = await get_extraction_prompt(user_id=user_id)
+
+        assert "# User-specific rules" in prompt
+        assert "Always flag utilities as deductible." in prompt
+        assert err is None
+
+    @pytest.mark.asyncio
+    async def test_returns_base_prompt_when_user_has_no_rules(self) -> None:
+        user_id = uuid.uuid4()
+
+        with patch("app.services.extraction.claude_service.AsyncSessionLocal") as mock_session_cls, \
+             patch("app.services.extraction.claude_service.extraction_prompt_repo") as mock_repo:
+            mock_db = AsyncMock()
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_repo.get_active_for_user = AsyncMock(return_value=None)
+
+            prompt, err = await get_extraction_prompt(user_id=user_id)
+
+        assert prompt == DEFAULT_PROMPT
+        assert err is None
+
+
+class TestGetExtractionPromptDbError:
+    @pytest.mark.asyncio
+    async def test_sqlalchemy_error_returns_base_prompt_and_error_tag(self) -> None:
+        user_id = uuid.uuid4()
+        db_error = OperationalError("connection refused", None, None)
+
+        with patch("app.services.extraction.claude_service.AsyncSessionLocal") as mock_session_cls, \
+             patch("app.services.extraction.claude_service.extraction_prompt_repo") as mock_repo:
+            mock_db = AsyncMock()
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_repo.get_active_for_user = AsyncMock(side_effect=db_error)
+
+            prompt, err = await get_extraction_prompt(user_id=user_id)
+
+        assert prompt == DEFAULT_PROMPT
+        assert err == "user_rules_db_error"
+
+    @pytest.mark.asyncio
+    async def test_sqlalchemy_error_emits_warning_log(self, caplog) -> None:
+        user_id = uuid.uuid4()
+        db_error = OperationalError("disk I/O error", None, None)
+
+        with patch("app.services.extraction.claude_service.AsyncSessionLocal") as mock_session_cls, \
+             patch("app.services.extraction.claude_service.extraction_prompt_repo") as mock_repo:
+            mock_db = AsyncMock()
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_repo.get_active_for_user = AsyncMock(side_effect=db_error)
+
+            import logging
+            with caplog.at_level(logging.WARNING, logger="app.services.extraction.claude_service"):
+                await get_extraction_prompt(user_id=user_id)
+
+        assert any("user_rules_db_error" in r.message or "failed to load user rules" in r.message for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_non_sqlalchemy_exception_propagates(self) -> None:
+        user_id = uuid.uuid4()
+
+        with patch("app.services.extraction.claude_service.AsyncSessionLocal") as mock_session_cls, \
+             patch("app.services.extraction.claude_service.extraction_prompt_repo") as mock_repo:
+            mock_db = AsyncMock()
+            mock_session_cls.return_value.__aenter__ = AsyncMock(return_value=mock_db)
+            mock_session_cls.return_value.__aexit__ = AsyncMock(return_value=False)
+            mock_repo.get_active_for_user = AsyncMock(side_effect=RuntimeError("unexpected bug"))
+
+            with pytest.raises(RuntimeError, match="unexpected bug"):
+                await get_extraction_prompt(user_id=user_id)

--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -149,13 +149,11 @@ Failures log structured `error-codes` at WARNING so Sentry can group by reason. 
 **Effort:** XS
 **Resolved:** `from e` was already present; added `test_smtp_reply_code_survives_in_cause` asserting the smtplib reply code (smtp_code, smtp_error) survives on `__cause__`.
 
-### MEDIUM — Claude prompt loading swallows DB errors during user-rule fetch
+### ✅ MEDIUM — Claude prompt loading swallows DB errors during user-rule fetch
 
 **Location:** `apps/mybookkeeper/backend/app/services/extraction/claude_service.py:82-88`
 **Effort:** S
-**Problem:** Bare `except Exception:` when loading user-specific extraction rules. On DB failure, falls back to base prompt silently. Extraction proceeds with incomplete user customization; user thinks their rules apply when they don't.
-
-**Fix:** Catch only `SQLAlchemyError`, log the actual exception type, surface to caller via `(prompt, error)` tuple so a user-facing error toast can fire.
+**Resolved:** Fixed in PR #TBD — narrowed bare `except Exception:` to `except SQLAlchemyError`, added WARNING log with exception type + message, changed `get_extraction_prompt` return type to `tuple[str, str | None]` so callers receive an error tag (`"user_rules_db_error"`) when the DB call fails. Non-SQLAlchemy exceptions now propagate. Covered by `tests/test_claude_service_prompt.py` (6 tests).
 
 ### MEDIUM — JSearch `response.json()` uncaught ValueError on malformed 200
 


### PR DESCRIPTION
## Summary

- Narrows \`except Exception:\` to \`except SQLAlchemyError\` when loading user-specific extraction rules in \`get_extraction_prompt\`
- Changes return type from \`str\` to \`tuple[str, str | None]\` — error tag \`"user_rules_db_error"\` is returned on DB failure, \`None\` on success
- Logs exception type and message at WARNING so Sentry captures the exact failure reason
- Non-SQLAlchemy exceptions now propagate instead of being swallowed
- Updates \`extract_from_text\` and \`extract_from_image\` callers to unpack the tuple and emit their own WARNING if the error tag is set
- Marks the MEDIUM silent-fail audit item resolved in \`apps/myjobhunter/TECH_DEBT.md\`

## Test plan

- [x] \`tests/test_claude_service_prompt.py\` — 6 new tests: success paths, DB error fallback + warning log, non-SQLAlchemy propagation; all pass (\`94 passed\` including existing suite)
- [x] No changes to callers beyond unpacking the returned tuple — \`document_extraction_service\` and \`email_extraction_service\` are unaffected (they call \`extract_from_text\` / \`extract_from_image\`, not \`get_extraction_prompt\` directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)