### PR TITLE
fix(mbk/channel-sync): categorize iCal poll errors as transient/auth/config/unknown

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/chsync260508_add_channel_listing_error_category.py
+++ b/apps/mybookkeeper/backend/alembic/versions/chsync260508_add_channel_listing_error_category.py
@@ -1,0 +1,26 @@
+"""add last_import_error_category to channel_listings
+
+Revision ID: chsync260508
+Revises: noaut260507
+Create Date: 2026-05-08 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "chsync260508"
+down_revision: Union[str, None] = "noaut260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "channel_listings",
+        sa.Column("last_import_error_category", sa.String(length=20), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("channel_listings", "last_import_error_category")

--- a/apps/mybookkeeper/backend/app/models/listings/channel_listing.py
+++ b/apps/mybookkeeper/backend/app/models/listings/channel_listing.py
@@ -74,6 +74,9 @@ class ChannelListing(Base):
         DateTime(timezone=True), nullable=True,
     )
     last_import_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_import_error_category: Mapped[str | None] = mapped_column(
+        String(20), nullable=True,
+    )
 
     ical_export_token: Mapped[str] = mapped_column(
         String(64), nullable=False, default=_generate_export_token,

--- a/apps/mybookkeeper/backend/app/repositories/listings/channel_listing_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/listings/channel_listing_repo.py
@@ -188,6 +188,7 @@ async def mark_imported(
     *,
     last_imported_at: datetime,
     last_import_error: str | None,
+    last_import_error_category: str | None = None,
 ) -> None:
     """Update poll-status columns. Called by the iCal polling worker."""
     row = await get_by_channel_listing_id(db, channel_listing_id)
@@ -195,4 +196,5 @@ async def mark_imported(
         return
     row.last_imported_at = last_imported_at
     row.last_import_error = last_import_error
+    row.last_import_error_category = last_import_error_category
     await db.flush()

--- a/apps/mybookkeeper/backend/app/services/listings/channel_sync_service.py
+++ b/apps/mybookkeeper/backend/app/services/listings/channel_sync_service.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
+from typing import Literal
 
 import httpx
 
@@ -32,6 +33,8 @@ from app.repositories import channel_listing_repo, listing_blackout_repo
 from app.services.listings.ical_parser import parse_ical_blackouts
 
 logger = logging.getLogger(__name__)
+
+ImportErrorCategory = Literal["transient", "auth", "config", "unknown"]
 
 # Per-feed HTTP timeout. Channels' iCal exports are tiny (text), so 10s
 # is generous. Any longer and a slow channel could starve the scheduler
@@ -70,22 +73,62 @@ async def poll_one(
     if channel_listing.ical_import_url is None:
         return
 
+    category: ImportErrorCategory
     try:
         payload = await _fetch(channel_listing.ical_import_url, client=client)
         parsed = parse_ical_blackouts(payload)
-    except Exception as exc:  # noqa: BLE001 — we intentionally catch broadly
-        # HTTP error, timeout, or parse error — preserve existing data
-        # and surface the message to the operator via the UI.
+    except httpx.HTTPStatusError as exc:
+        status = exc.response.status_code
+        if status in (401, 403):
+            category = "auth"
+        elif 400 <= status < 500:
+            category = "config"
+        else:
+            category = "transient"
+        message = f"HTTPStatusError {status}: {exc}"
         logger.warning(
-            "iCal poll failed for channel_listing=%s url=%s: %s",
-            channel_listing.id, channel_listing.ical_import_url, exc,
+            "iCal poll %s for channel_listing=%s url=%s: %s",
+            category, channel_listing.id, channel_listing.ical_import_url, message,
         )
         async with unit_of_work() as db:
             await channel_listing_repo.mark_imported(
                 db,
                 channel_listing.id,
                 last_imported_at=datetime.now(timezone.utc),
-                last_import_error=str(exc)[:500],
+                last_import_error=message[:500],
+                last_import_error_category=category,
+            )
+        return
+    except httpx.RequestError as exc:
+        category = "transient"
+        message = f"{type(exc).__name__}: {exc}"
+        logger.warning(
+            "iCal poll transient for channel_listing=%s url=%s: %s",
+            channel_listing.id, channel_listing.ical_import_url, message,
+        )
+        async with unit_of_work() as db:
+            await channel_listing_repo.mark_imported(
+                db,
+                channel_listing.id,
+                last_imported_at=datetime.now(timezone.utc),
+                last_import_error=message[:500],
+                last_import_error_category=category,
+            )
+        return
+    except Exception as exc:  # noqa: BLE001 — parse errors, unexpected failures
+        category = "unknown"
+        message = f"{type(exc).__name__}: {exc}"
+        logger.exception(
+            "iCal poll unknown error for channel_listing=%s url=%s",
+            channel_listing.id, channel_listing.ical_import_url,
+        )
+        async with unit_of_work() as db:
+            await channel_listing_repo.mark_imported(
+                db,
+                channel_listing.id,
+                last_imported_at=datetime.now(timezone.utc),
+                last_import_error=message[:500],
+                last_import_error_category=category,
             )
         return
 

--- a/apps/mybookkeeper/backend/tests/test_channel_sync_service.py
+++ b/apps/mybookkeeper/backend/tests/test_channel_sync_service.py
@@ -9,6 +9,7 @@ Verifies:
 - Update in place when UID re-seen with new dates
 - Delete when UID disappears from feed
 - HTTP failure preserves existing rows + records last_import_error
+- Error category branching: transient / auth / config / unknown
 """
 from __future__ import annotations
 
@@ -206,6 +207,97 @@ class TestPollOne:
         assert refreshed is not None
         assert refreshed.last_import_error is not None
         assert "timeout" in refreshed.last_import_error.lower()
+        assert refreshed.last_import_error_category == "transient"
+
+    @pytest.mark.asyncio
+    async def test_request_error_recorded_as_transient(
+        self, db, seeded_channel_listing,
+    ) -> None:
+        cl = seeded_channel_listing
+        with _patched_uow(db):
+            await channel_sync_service.poll_one(
+                cl, client=_mock_client_raising(httpx.ConnectTimeout("connect timed out")),
+            )
+
+        refreshed = await channel_listing_repo.get_by_channel_listing_id(db, cl.id)
+        assert refreshed is not None
+        assert refreshed.last_import_error_category == "transient"
+        assert refreshed.last_import_error is not None
+
+    @pytest.mark.asyncio
+    async def test_http_401_recorded_as_auth(
+        self, db, seeded_channel_listing,
+    ) -> None:
+        cl = seeded_channel_listing
+        mock_response = MagicMock()
+        mock_response.status_code = 401
+        exc = httpx.HTTPStatusError("401", request=MagicMock(), response=mock_response)
+        with _patched_uow(db):
+            await channel_sync_service.poll_one(cl, client=_mock_client_raising(exc))
+
+        refreshed = await channel_listing_repo.get_by_channel_listing_id(db, cl.id)
+        assert refreshed is not None
+        assert refreshed.last_import_error_category == "auth"
+
+    @pytest.mark.asyncio
+    async def test_http_403_recorded_as_auth(
+        self, db, seeded_channel_listing,
+    ) -> None:
+        cl = seeded_channel_listing
+        mock_response = MagicMock()
+        mock_response.status_code = 403
+        exc = httpx.HTTPStatusError("403", request=MagicMock(), response=mock_response)
+        with _patched_uow(db):
+            await channel_sync_service.poll_one(cl, client=_mock_client_raising(exc))
+
+        refreshed = await channel_listing_repo.get_by_channel_listing_id(db, cl.id)
+        assert refreshed is not None
+        assert refreshed.last_import_error_category == "auth"
+
+    @pytest.mark.asyncio
+    async def test_http_400_recorded_as_config(
+        self, db, seeded_channel_listing,
+    ) -> None:
+        cl = seeded_channel_listing
+        mock_response = MagicMock()
+        mock_response.status_code = 400
+        exc = httpx.HTTPStatusError("400", request=MagicMock(), response=mock_response)
+        with _patched_uow(db):
+            await channel_sync_service.poll_one(cl, client=_mock_client_raising(exc))
+
+        refreshed = await channel_listing_repo.get_by_channel_listing_id(db, cl.id)
+        assert refreshed is not None
+        assert refreshed.last_import_error_category == "config"
+
+    @pytest.mark.asyncio
+    async def test_http_503_recorded_as_transient(
+        self, db, seeded_channel_listing,
+    ) -> None:
+        cl = seeded_channel_listing
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        exc = httpx.HTTPStatusError("503", request=MagicMock(), response=mock_response)
+        with _patched_uow(db):
+            await channel_sync_service.poll_one(cl, client=_mock_client_raising(exc))
+
+        refreshed = await channel_listing_repo.get_by_channel_listing_id(db, cl.id)
+        assert refreshed is not None
+        assert refreshed.last_import_error_category == "transient"
+
+    @pytest.mark.asyncio
+    async def test_unexpected_exception_recorded_as_unknown(
+        self, db, seeded_channel_listing,
+    ) -> None:
+        cl = seeded_channel_listing
+        with _patched_uow(db):
+            await channel_sync_service.poll_one(
+                cl, client=_mock_client_raising(RuntimeError("unexpected parse failure")),
+            )
+
+        refreshed = await channel_listing_repo.get_by_channel_listing_id(db, cl.id)
+        assert refreshed is not None
+        assert refreshed.last_import_error_category == "unknown"
+        assert refreshed.last_import_error is not None
 
     @pytest.mark.asyncio
     async def test_skip_when_url_is_none(


### PR DESCRIPTION
## Summary

- Adds `last_import_error_category` (`String(20)`, nullable) column to `channel_listings` via additive migration `chsync260508`
- Splits the bare `Exception` catch in `channel_sync_service.poll_one` into three typed branches so operators get a priority signal alongside the error message:
  - `httpx.HTTPStatusError` 401/403 → `"auth"` (user must reconnect OAuth)
  - `httpx.HTTPStatusError` other 4xx → `"config"` (bad URL / missing scope — operator must fix)
  - `httpx.HTTPStatusError` 5xx → `"transient"` (channel outage, retry next cycle)
  - `httpx.RequestError` (timeout, DNS, connect) → `"transient"`
  - Anything else → `"unknown"` (logged with full traceback for investigation)
- Extends `channel_listing_repo.mark_imported()` with `last_import_error_category` kwarg (defaults to `None` so the success path clears the category)
- Adds 6 new test cases covering all four categories; updates existing http-failure test to assert category

## Migration note

`chsync260508` adds a nullable column with no default and no data backfill — safe additive migration, no operational steps required before deploy.

## Test plan

- [x] 11/11 `test_channel_sync_service.py` tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)