### PR TITLE
refactor(mjh/discover): move route-layer db.commit() into service wrappers

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 38 (Critical: 1 / High: 3 / Medium: 20 / Low: 15)**
+**Open issues: 37 (Critical: 1 / High: 3 / Medium: 19 / Low: 15)**
 
 > Last comprehensive audit: 2026-05-07 (post-discovery feature ship). All Critical and 7 of 8 audit-High findings RESOLVED in PRs #421-#432 (2026-05-07). Remaining audit findings preserved below under "## High (audit 2026-05-07)" / "## Medium (audit 2026-05-07)" / "## Low (audit 2026-05-07)" sections; pre-existing findings preserved under "## Pre-existing".
 
@@ -217,26 +217,13 @@ _Still open (downgraded from High to Medium since the immediate cost concern is 
 
 ## Medium (audit 2026-05-07)
 
-### [Backend / Discovery] Repository tenant scoping correct but route layer commits — service-layer commit convention violated
+### ~~[Backend / Discovery] Repository tenant scoping correct but route layer commits — service-layer commit convention violated~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** S
-**Location:** `apps/myjobhunter/backend/app/api/discover.py:97, 129, 246, 261`
+**Resolved:** PR (refactor/mjh-discover-service-layer-commits). Four `db.commit()` calls moved from route handlers into two new thin service modules:
+- `app/services/discovery/discovery_source_service.py` — `create_source`, `deactivate_source`
+- `app/services/discovery/discovery_inbox_service.py` — `dismiss_discovered`, `save_discovered`
 
-**Problem:** Per project CLAUDE.md and PreToolUse Check #3, MJH uses service-layer commits (services own transaction boundary, repositories only `add/flush`). `discover.py` violates this on four routes: `create_source`, `deactivate_source`, `dismiss_job`, `save_job` all call a repository function then `await db.commit()` in the route handler.
-
-**Recommendation:** Move each commit into a thin service wrapper:
-
-    # app/services/discovery/discovery_source_service.py
-    async def create_source(db, *, user_id, source, config, fetch_interval_minutes):
-        src = await discovery_repository.create_source(db, user_id=user_id, ...)
-        await db.commit()
-        await db.refresh(src)
-        return src
-
-Aligns with `discovery_fetch_service` and `discovery_promote_service` patterns already in place.
-
-**Why Medium:** Inconsistency rather than defect. Future refactors adding cross-table operations to dismiss/save will hit this seam and bandaid around it.
+Route handlers now delegate to services; no `db.commit()` remains in `discover.py`.
 
 ---
 

--- a/apps/myjobhunter/backend/app/api/discover.py
+++ b/apps/myjobhunter/backend/app/api/discover.py
@@ -47,8 +47,10 @@ from app.services.discovery.discovery_promote_service import (
 )
 from app.services.discovery import (
     discovery_fetch_service,
+    discovery_inbox_service,
     discovery_promote_service,
     discovery_score_service,
+    discovery_source_service,
 )
 from app.services.discovery.discovery_fetch_service import (
     DiscoveryFetchError,
@@ -92,15 +94,13 @@ async def create_source(
     user: User = Depends(current_active_user),
 ) -> DiscoverySourceResponse:
     """Create a new active saved search for the caller."""
-    src = await discovery_repository.create_source(
+    src = await discovery_source_service.create_source(
         db,
         user_id=user.id,
         source=payload.source,
         config=payload.config,
         fetch_interval_minutes=payload.fetch_interval_minutes,
     )
-    await db.commit()
-    await db.refresh(src)
     return DiscoverySourceResponse.model_validate(src)
 
 
@@ -128,10 +128,9 @@ async def deactivate_source(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
 ) -> None:
-    ok = await discovery_repository.deactivate_source(db, source_id, user.id)
+    ok = await discovery_source_service.deactivate_source(db, source_id, user.id)
     if not ok:
         raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
-    await db.commit()
 
 
 # ---------------------------------------------------------------------------
@@ -243,12 +242,11 @@ async def dismiss_job(
     """Dismiss a discovered job. Optional ``reason`` is captured as a
     teaching signal for future scoring."""
     reason = payload.reason if payload else None
-    ok = await discovery_repository.dismiss_discovered(
+    ok = await discovery_inbox_service.dismiss_discovered(
         db, job_id, user.id, reason=reason,
     )
     if not ok:
         raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
-    await db.commit()
 
 
 @router.post(
@@ -260,10 +258,9 @@ async def save_job(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
 ) -> None:
-    ok = await discovery_repository.save_discovered(db, job_id, user.id)
+    ok = await discovery_inbox_service.save_discovered(db, job_id, user.id)
     if not ok:
         raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
-    await db.commit()
 
 
 @router.post(

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_inbox_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_inbox_service.py
@@ -1,0 +1,44 @@
+"""Service wrappers for discovered-job inbox mutations.
+
+Owns the transaction boundary for dismiss and save operations so route
+handlers never call ``db.commit()`` directly.  Per the MJH layered-architecture
+convention: routes → services → repositories; services commit, repositories
+only ``add``/``flush``.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.repositories.discovery import discovery_repository
+
+
+async def dismiss_discovered(
+    db: AsyncSession,
+    job_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    reason: str | None = None,
+) -> bool:
+    """Dismiss a discovered job.  Returns False when not found / wrong owner."""
+    ok = await discovery_repository.dismiss_discovered(
+        db, job_id, user_id, reason=reason,
+    )
+    if not ok:
+        return False
+    await db.commit()
+    return True
+
+
+async def save_discovered(
+    db: AsyncSession,
+    job_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> bool:
+    """Save a discovered job for later.  Returns False when not found / wrong owner."""
+    ok = await discovery_repository.save_discovered(db, job_id, user_id)
+    if not ok:
+        return False
+    await db.commit()
+    return True

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_source_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_source_service.py
@@ -1,0 +1,49 @@
+"""Service wrappers for saved-search (DiscoverySource) mutations.
+
+Owns the transaction boundary for create and deactivate operations so route
+handlers never call ``db.commit()`` directly.  Per the MJH layered-architecture
+convention: routes → services → repositories; services commit, repositories
+only ``add``/``flush``.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.discovery.discovery_source import DiscoverySource
+from app.repositories.discovery import discovery_repository
+
+
+async def create_source(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    source: str,
+    config: dict | None = None,
+    fetch_interval_minutes: int = 1440,
+) -> DiscoverySource:
+    """Create a new active saved search and commit the transaction."""
+    src = await discovery_repository.create_source(
+        db,
+        user_id=user_id,
+        source=source,
+        config=config,
+        fetch_interval_minutes=fetch_interval_minutes,
+    )
+    await db.commit()
+    await db.refresh(src)
+    return src
+
+
+async def deactivate_source(
+    db: AsyncSession,
+    source_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> bool:
+    """Soft-deactivate a saved search.  Returns False when not found / wrong owner."""
+    ok = await discovery_repository.deactivate_source(db, source_id, user_id)
+    if not ok:
+        return False
+    await db.commit()
+    return True

--- a/apps/myjobhunter/backend/tests/test_discovery_source_service.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_source_service.py
@@ -1,0 +1,113 @@
+"""Unit tests for discovery_source_service and discovery_inbox_service.
+
+Exercises the transaction boundary (service commits, repo flushes only).
+Uses the HTTP client fixtures so the DB session lifecycle is exercised
+end-to-end — the same pattern used in test_discover_endpoints.py.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from httpx import AsyncClient
+
+
+# ===========================================================================
+# discovery_source_service
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_source_persists(client: AsyncClient, user_factory, as_user):
+    user = await user_factory()
+    async with await as_user(user) as a:
+        resp = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "python remote"}},
+        )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["source"] == "jsearch"
+    assert body["is_active"] is True
+    assert uuid.UUID(body["id"])
+
+
+@pytest.mark.asyncio
+async def test_create_source_default_fetch_interval(
+    client: AsyncClient, user_factory, as_user,
+):
+    user = await user_factory()
+    async with await as_user(user) as a:
+        resp = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "go engineer"}},
+        )
+    assert resp.status_code == 201
+    assert resp.json()["fetch_interval_minutes"] == 1440
+
+
+@pytest.mark.asyncio
+async def test_deactivate_source_returns_204(
+    client: AsyncClient, user_factory, as_user,
+):
+    user = await user_factory()
+    async with await as_user(user) as a:
+        created = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "x"}},
+        )
+        source_id = created.json()["id"]
+        resp = await a.delete(f"/discover/sources/{source_id}")
+    assert resp.status_code == 204
+
+
+@pytest.mark.asyncio
+async def test_deactivate_source_not_found_returns_404(
+    client: AsyncClient, user_factory, as_user,
+):
+    user = await user_factory()
+    async with await as_user(user) as a:
+        resp = await a.delete(f"/discover/sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_deactivate_source_cross_tenant_404(
+    client: AsyncClient, user_factory, as_user,
+):
+    owner = await user_factory()
+    attacker = await user_factory()
+    async with await as_user(owner) as a:
+        created = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "x"}},
+        )
+        source_id = created.json()["id"]
+    async with await as_user(attacker) as a:
+        resp = await a.delete(f"/discover/sources/{source_id}")
+    assert resp.status_code == 404
+
+
+# ===========================================================================
+# discovery_inbox_service
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_dismiss_not_found_returns_404(
+    client: AsyncClient, user_factory, as_user,
+):
+    user = await user_factory()
+    async with await as_user(user) as a:
+        resp = await a.post(f"/discover/{uuid.uuid4()}/dismiss")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_save_not_found_returns_404(
+    client: AsyncClient, user_factory, as_user,
+):
+    user = await user_factory()
+    async with await as_user(user) as a:
+        resp = await a.post(f"/discover/{uuid.uuid4()}/save")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

- Four routes in `discover.py` violated MJH's service-layer commit convention by calling a repo function then `await db.commit()` directly in the handler.
- Added two thin service modules that own the transaction boundary: `discovery_source_service.py` (`create_source`, `deactivate_source`) and `discovery_inbox_service.py` (`dismiss_discovered`, `save_discovered`).
- Route handlers now delegate to services; zero `db.commit()` remains in `discover.py`.
- No external behavior change — same HTTP contract, same status codes, same response shapes.

## Test plan

- [ ] `test_discovery_source_service.py` — 7 new tests covering create (persists, default interval), deactivate (204, 404, cross-tenant 404), dismiss (404), save (404)
- [ ] `test_discover_endpoints.py` — all pre-existing tests pass at same rate as `main` (6 pre-existing failures tied to Anthropic key not set in test env; confirmed identical on `main`)
- [ ] `grep -n "db.commit" apps/myjobhunter/backend/app/api/discover.py` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)