### PR TITLE
refactor(mbk/frontend): clean up null/undefined patterns in shared/

### DIFF
--- a/apps/mybookkeeper/frontend/src/shared/lib/listing-labels.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/listing-labels.ts
@@ -63,7 +63,7 @@ const USD_FORMATTER = new Intl.NumberFormat("en-US", {
 });
 
 export function formatRate(rate: string | null | undefined): string {
-  if (rate === null || rate === undefined || rate === "") return "—";
+  if (!rate) return "—";
   const value = Number(rate);
   if (!Number.isFinite(value)) return "—";
   return USD_FORMATTER.format(value);

--- a/apps/mybookkeeper/frontend/src/shared/store/applicantsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/applicantsApi.ts
@@ -26,12 +26,10 @@ const applicantsApi = baseApi.injectEndpoints({
       query: (args) => ({
         url: "/applicants",
         params: {
-          ...(args?.stage ? { stage: args.stage } : {}),
-          ...(args?.include_deleted !== undefined
-            ? { include_deleted: args.include_deleted }
-            : {}),
-          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
-          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+          stage: args?.stage,
+          include_deleted: args?.include_deleted,
+          limit: args?.limit,
+          offset: args?.offset,
         },
       }),
       providesTags: (result) =>
@@ -84,11 +82,9 @@ const applicantsApi = baseApi.injectEndpoints({
       query: (args) => ({
         url: "/applicants/tenants",
         params: {
-          ...(args?.include_ended !== undefined
-            ? { include_ended: args.include_ended }
-            : {}),
-          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
-          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+          include_ended: args?.include_ended,
+          limit: args?.limit,
+          offset: args?.offset,
         },
       }),
       providesTags: (result) =>

--- a/apps/mybookkeeper/frontend/src/shared/store/inquiriesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/inquiriesApi.ts
@@ -29,10 +29,10 @@ const inquiriesApi = baseApi.injectEndpoints({
       query: (args) => ({
         url: "/inquiries",
         params: {
-          ...(args?.stage ? { stage: args.stage } : {}),
-          ...(args?.spam_status ? { spam_status: args.spam_status } : {}),
-          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
-          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+          stage: args?.stage,
+          spam_status: args?.spam_status,
+          limit: args?.limit,
+          offset: args?.offset,
         },
       }),
       providesTags: (result) =>

--- a/apps/mybookkeeper/frontend/src/shared/store/insurancePoliciesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/insurancePoliciesApi.ts
@@ -29,10 +29,10 @@ const insurancePoliciesApi = baseApi.injectEndpoints({
       query: (args) => ({
         url: "/insurance-policies",
         params: {
-          ...(args?.listing_id ? { listing_id: args.listing_id } : {}),
-          ...(args?.expiring_before ? { expiring_before: args.expiring_before } : {}),
-          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
-          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+          listing_id: args?.listing_id,
+          expiring_before: args?.expiring_before,
+          limit: args?.limit,
+          offset: args?.offset,
         },
       }),
       providesTags: (result) =>

--- a/apps/mybookkeeper/frontend/src/shared/store/leaseTemplatesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/leaseTemplatesApi.ts
@@ -28,8 +28,8 @@ const leaseTemplatesApi = baseApi.injectEndpoints({
       query: (args) => ({
         url: "/lease-templates",
         params: {
-          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
-          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+          limit: args?.limit,
+          offset: args?.offset,
         },
       }),
       providesTags: (result) =>

--- a/apps/mybookkeeper/frontend/src/shared/store/listingsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/listingsApi.ts
@@ -19,9 +19,9 @@ const listingsApi = baseApi.injectEndpoints({
       query: (args) => ({
         url: "/listings",
         params: {
-          ...(args?.status ? { status: args.status } : {}),
-          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
-          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+          status: args?.status,
+          limit: args?.limit,
+          offset: args?.offset,
         },
       }),
       providesTags: (result) =>
@@ -100,10 +100,7 @@ const listingsApi = baseApi.injectEndpoints({
       query: ({ listingId, photoId, caption, display_order }) => ({
         url: `/listings/${listingId}/photos/${photoId}`,
         method: "PATCH",
-        data: {
-          ...(caption !== undefined ? { caption } : {}),
-          ...(display_order !== undefined ? { display_order } : {}),
-        },
+        data: { caption, display_order },
       }),
       invalidatesTags: (_result, _err, arg) => [
         { type: "Listing", id: arg.listingId },

--- a/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
@@ -25,11 +25,11 @@ const signedLeasesApi = baseApi.injectEndpoints({
       query: (args) => ({
         url: "/signed-leases",
         params: {
-          ...(args?.applicant_id ? { applicant_id: args.applicant_id } : {}),
-          ...(args?.listing_id ? { listing_id: args.listing_id } : {}),
-          ...(args?.status ? { status: args.status } : {}),
-          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
-          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+          applicant_id: args?.applicant_id,
+          listing_id: args?.listing_id,
+          status: args?.status,
+          limit: args?.limit,
+          offset: args?.offset,
         },
       }),
       providesTags: (result) =>

--- a/apps/mybookkeeper/frontend/src/shared/store/vendorsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/vendorsApi.ts
@@ -20,13 +20,11 @@ const vendorsApi = baseApi.injectEndpoints({
       query: (args) => ({
         url: "/vendors",
         params: {
-          ...(args?.category ? { category: args.category } : {}),
-          ...(args?.preferred !== undefined ? { preferred: args.preferred } : {}),
-          ...(args?.include_deleted !== undefined
-            ? { include_deleted: args.include_deleted }
-            : {}),
-          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
-          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+          category: args?.category,
+          preferred: args?.preferred,
+          include_deleted: args?.include_deleted,
+          limit: args?.limit,
+          offset: args?.offset,
         },
       }),
       providesTags: (result) =>

--- a/apps/mybookkeeper/frontend/src/shared/utils/errorMessage.ts
+++ b/apps/mybookkeeper/frontend/src/shared/utils/errorMessage.ts
@@ -1,13 +1,13 @@
 export function extractErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null) {
+  if (err && typeof err === "object") {
     const obj = err as Record<string, unknown>;
-    if (typeof obj.data === "object" && obj.data !== null) {
+    if (obj.data && typeof obj.data === "object") {
       const data = obj.data as Record<string, unknown>;
       if (typeof data.detail === "string") return data.detail;
       // fastapi-users validation errors: { detail: { code: "...", reason: "..." } }
-      if (typeof data.detail === "object" && data.detail !== null) {
+      if (data.detail && typeof data.detail === "object") {
         const detail = data.detail as Record<string, unknown>;
         if (typeof detail.reason === "string") return detail.reason;
       }

--- a/apps/mybookkeeper/frontend/src/shared/utils/hourly-rate.ts
+++ b/apps/mybookkeeper/frontend/src/shared/utils/hourly-rate.ts
@@ -1,16 +1,17 @@
 /**
  * Format a backend Decimal-as-string hourly rate for display.
  *
- * Returns the em-dash fallback when the rate is null or unparseable,
- * matching the project-wide convention for "no value" cells in tables
- * and detail views (cf. shared/utils/currency.ts, shared/utils/date.ts).
+ * Returns the em-dash fallback when the rate is null, undefined, an empty
+ * string, or unparseable, matching the project-wide convention for "no
+ * value" cells in tables and detail views (cf. shared/utils/currency.ts,
+ * shared/utils/date.ts).
  *
  * Use the abbreviated `/hr` suffix everywhere — the long-form
  * "$X.XX / hour" was an outlier on VendorDetail.tsx and has been
  * removed in favour of consistency.
  */
 export function formatHourlyRate(rate: string | null | undefined): string {
-  if (rate === null || rate === undefined) return "—";
+  if (!rate) return "—";
   const num = Number(rate);
   if (Number.isNaN(num)) return "—";
   return `$${num.toFixed(2)}/hr`;


### PR DESCRIPTION
## Summary

Three related cleanups in MBK's frontend shared utility/store layer, surfaced by the TECH_DEBT \`=== null\` audit:

1. **Drop dead conditional spreads in 7 RTK Query slices.** The pattern \`...(args?.limit !== undefined ? { limit: args.limit } : {})\` is defensive code — axios's default param serializer already drops \`undefined\` values from query strings, and \`JSON.stringify\` drops them from PATCH bodies. Simplified to \`params: { limit: args?.limit, ... }\`.
2. **Tighten \`typeof === \"object\" && x !== null\`** in \`shared/utils/errorMessage.ts\` to the cleaner \`x && typeof === \"object\"\` form.
3. **Fix latent bug in \`formatHourlyRate\`.** The function used \`=== null || === undefined\` which missed empty strings; \`Number(\"\")\` returns 0 (not NaN), so \`formatHourlyRate(\"\")\` was producing \`\"$0.00/hr\"\` instead of \`\"—\"\`. Switched to \`if (!rate)\` which catches null + undefined + empty string. Same fix applied to \`formatRate\` in \`shared/lib/listing-labels.ts\`.

## Test impact

A pre-existing failing test (\`formatHourlyRate(\"\") === \"—\"\`) now passes — 1 fewer failing test on main. Three pre-existing failures remain (2 Documents.test.tsx, 1 hourly-rate IEEE 754 toFixed quirk) — all unrelated to this PR.

## MJH parity note (for follow-up session)

The same cleanup is applicable to \`apps/myjobhunter/frontend\` — its RTK Query slices have the same defensive \`!== undefined\` spreads, and its frontend has parallel \`=== null\` patterns. Deferred per session coordination — another session is currently touching MJH frontend, so MJH parity is queued as a follow-up after this lands.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm test --run\` — 1712 pass / 3 pre-existing failures (was 4)
- [x] Verified axios drops \`undefined\` query/body params (axios 1.7+, default \`paramsSerializer\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)