### PR TITLE
chore(mjh/tech-debt): mark AddApplicationDialog split as resolved

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -85,11 +85,9 @@ See sister entry in MBK. MJH-side file: `features/admin/demo/DeleteDemoConfirmDi
 
 ### Long files (>500 LOC) — MJH-side production code
 
-#### HIGH — `apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx` (1,070 LOC)
+#### ~~HIGH — `apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx` (1,070 LOC)~~
 
-**Effort:** M
-**Problem:** Multi-step dialog with paste-link / paste-text / manual / company-confirm states all inline.
-**Recommendation:** Extract per-step components (`PasteLinkStep`, `PasteTextStep`, `ManualEntryStep`, `CompanyConfirmStep`) and a state-machine hook (`useAddApplicationFlow`).
+**RESOLVED** by PR #480 (2026-05-08). Extracted `useAddApplicationFlow` hook (zero JSX, pure state-machine logic) and four per-step components (`PasteLinkStep`, `PasteTextStep`, `ManualEntryStep`, `CompanyConfirmStep`, `ProcessingStep`) into `add-application-dialog/`. `AddApplicationDialog.tsx` is now a thin orchestrator at 153 LOC.
 
 ---
 


### PR DESCRIPTION
## Summary

- Marks the `AddApplicationDialog.tsx (1,070 LOC)` HIGH entry in `apps/myjobhunter/TECH_DEBT.md` as RESOLVED
- The actual split was shipped in PR #480; the tech-debt entry was not updated at the time
- No code changes — documentation only

## What was done in PR #480

- Extracted `useAddApplicationFlow` hook (513 LOC, zero JSX — pure state-machine logic with discriminated-union `DialogState`)
- Extracted five per-step components into `add-application-dialog/`: `PasteLinkStep`, `PasteTextStep`, `ManualEntryStep`, `ProcessingStep`, `CompanyConfirmStep`
- `AddApplicationDialog.tsx` reduced from 1,070 LOC to 153 LOC (thin orchestrator)
- Public export unchanged — no consumer import changes needed
- 24 existing tests continue to pass

## Test plan

- [x] `npm test -- src/features/applications/` — 24 tests, 3 files, all pass
- [x] `tsc --noEmit` — no type errors