### PR TITLE
chore(mjh/tech-debt): mark job_analysis_service.py 786-LOC MEDIUM as resolved (PR #479)

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -101,11 +101,14 @@ See sister entry in MBK. MJH-side file: `features/admin/demo/DeleteDemoConfirmDi
 
 ---
 
-#### MEDIUM — `apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py` (786 LOC)
+#### ✅ RESOLVED — `apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py` (786 LOC)
 
-**Effort:** M
-**Problem:** Analyze + score + promote + extraction-log management all together.
-**Recommendation:** Split into `job_analysis_service.py` (analyze + score), `job_analysis_promote_service.py` (promote-to-application).
+Split on 2026-05-08 (PR #479) into:
+- `job_analysis_service.py` (~470 LOC): analyze/score/get_analysis/soft_delete_analysis + all validation/prompt helpers
+- `job_analysis_promote_service.py` (~115 LOC): apply_to_application + _find_or_create_company
+- `_job_analysis_utils.py` (~50 LOC): shared tiny utilities (_str_or_none, _safe_float, _safe_remote_type, _map_salary_period) to avoid circular imports
+
+`apply_to_application` re-exported from job_analysis_service for backward compat — no caller changes required. 37/37 tests pass.
 
 ---
 


### PR DESCRIPTION
## Summary

- The `job_analysis_service.py` (786 LOC) split was shipped in PR #479 on 2026-05-08
- The TECH_DEBT.md entry was left unupdated; this PR marks it ✅ RESOLVED
- No code changes — TECH_DEBT.md housekeeping only

## What was shipped in #479

- `job_analysis_service.py` (~470 LOC): analyze/score/get_analysis/soft_delete_analysis + validation/prompt helpers
- `job_analysis_promote_service.py` (~115 LOC): apply_to_application + _find_or_create_company
- `_job_analysis_utils.py` (~50 LOC): shared tiny utilities to break circular imports

`apply_to_application` re-exported from job_analysis_service for backward compat — no caller changes required. 37/37 tests passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)