### PR TITLE
refactor(mjh/types): split 3 multi-interface files into one-per-file

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -263,20 +263,13 @@ EXPLAIN ANALYZE before/after.
 
 ---
 
-### [Frontend / Types] One-type-per-file convention violated in 3 files
+### ~~[Frontend / Types] One-type-per-file convention violated in 3 files~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** XS
-**Location:**
-- `apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts` (`DiscoveredJob` + `DiscoveredJobListResponse`)
-- `apps/myjobhunter/frontend/src/types/discovery/discovery-source.ts` (`DiscoverySource` + `DiscoverySourceCreate`)
-- `apps/myjobhunter/frontend/src/types/profile/profile.ts` (`Profile` + `DiscoveryDefaults`)
-
-**Problem:** Project CLAUDE.md requires one interface per file in `src/types/`. Six interfaces co-located in three files.
-
-**Recommendation:** Split each file. Example: `types/discovery/discovered-job.ts` (entity), `types/discovery/discovered-job-list-response.ts`, `types/discovery/discovery-source-create-request.ts`, `types/profile/discovery-defaults.ts`.
-
-**Why Medium:** Pure convention drift, but operator has called this out before.
+**Severity:** ~~Medium~~ RESOLVED
+**Resolved:** 2026-05-08 — PR TBD
+**How:** Split 3 multi-interface files into 6 single-interface files.
+New files: `discovered-job-list-response.ts`, `discovery-source-create-request.ts`, `profile/discovery-defaults.ts`.
+Updated consumers: `store/discoverApi.ts`, `types/profile/profile.ts`, `types/profile/profile-update-request.ts`.
 
 ---
 

--- a/apps/myjobhunter/frontend/src/store/discoverApi.ts
+++ b/apps/myjobhunter/frontend/src/store/discoverApi.ts
@@ -1,10 +1,8 @@
 import { baseApi } from "@platform/ui";
 import type { Application } from "@/types/application";
-import type { DiscoveredJobListResponse } from "@/types/discovery/discovered-job";
-import type {
-  DiscoverySource,
-  DiscoverySourceCreate,
-} from "@/types/discovery/discovery-source";
+import type { DiscoveredJobListResponse } from "@/types/discovery/discovered-job-list-response";
+import type { DiscoverySource } from "@/types/discovery/discovery-source";
+import type { DiscoverySourceCreate } from "@/types/discovery/discovery-source-create-request";
 import type { DiscoveryFetchResult } from "@/types/discovery/discovery-fetch-result";
 
 export type DismissalReason =

--- a/apps/myjobhunter/frontend/src/types/discovery/discovered-job-list-response.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovered-job-list-response.ts
@@ -1,0 +1,7 @@
+import type { DiscoveredJob } from "./discovered-job";
+
+export interface DiscoveredJobListResponse {
+  items: DiscoveredJob[];
+  total: number;
+  state: "inbox" | "saved" | "all";
+}

--- a/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
@@ -23,9 +23,3 @@ export interface DiscoveredJob {
   saved_at: string | null;
   promoted_application_id: string | null;
 }
-
-export interface DiscoveredJobListResponse {
-  items: DiscoveredJob[];
-  total: number;
-  state: "inbox" | "saved" | "all";
-}

--- a/apps/myjobhunter/frontend/src/types/discovery/discovery-source-create-request.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovery-source-create-request.ts
@@ -1,0 +1,6 @@
+/** Body for POST /discover/sources. */
+export interface DiscoverySourceCreate {
+  source: string;
+  config: Record<string, unknown>;
+  fetch_interval_minutes?: number;
+}

--- a/apps/myjobhunter/frontend/src/types/discovery/discovery-source.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovery-source.ts
@@ -13,10 +13,3 @@ export interface DiscoverySource {
   created_at: string;
   updated_at: string;
 }
-
-/** Body for POST /discover/sources. */
-export interface DiscoverySourceCreate {
-  source: string;
-  config: Record<string, unknown>;
-  fetch_interval_minutes?: number;
-}

--- a/apps/myjobhunter/frontend/src/types/profile/discovery-defaults.ts
+++ b/apps/myjobhunter/frontend/src/types/profile/discovery-defaults.ts
@@ -1,0 +1,12 @@
+export interface DiscoveryDefaults {
+  excluded_industry_chips?: string[];
+  excluded_keywords?: string[];
+  employment_type?: string;
+  experience?: string;
+  country?: string;
+  date_posted?: string;
+  // Phase C scoring inputs (written by Phase C).
+  preferred_industries?: string[];
+  preferred_stack?: string[];
+  rejected_stack?: string[];
+}

--- a/apps/myjobhunter/frontend/src/types/profile/profile-update-request.ts
+++ b/apps/myjobhunter/frontend/src/types/profile/profile-update-request.ts
@@ -1,4 +1,4 @@
-import type { DiscoveryDefaults } from "./profile";
+import type { DiscoveryDefaults } from "./discovery-defaults";
 
 /**
  * Body for PATCH /profile. All fields optional.

--- a/apps/myjobhunter/frontend/src/types/profile/profile.ts
+++ b/apps/myjobhunter/frontend/src/types/profile/profile.ts
@@ -1,3 +1,5 @@
+import type { DiscoveryDefaults } from "./discovery-defaults";
+
 /**
  * Profile as returned by GET /profile and PATCH /profile.
  * Mirrors ProfileResponse in backend/app/schemas/profile/profile_response.py.
@@ -30,17 +32,4 @@ export interface Profile {
 
   created_at: string;
   updated_at: string;
-}
-
-export interface DiscoveryDefaults {
-  excluded_industry_chips?: string[];
-  excluded_keywords?: string[];
-  employment_type?: string;
-  experience?: string;
-  country?: string;
-  date_posted?: string;
-  // Phase C scoring inputs (written by Phase C).
-  preferred_industries?: string[];
-  preferred_stack?: string[];
-  rejected_stack?: string[];
 }


### PR DESCRIPTION
## Summary

- Extracts `DiscoveredJobListResponse` from `discovered-job.ts` → new `discovered-job-list-response.ts`
- Extracts `DiscoverySourceCreate` from `discovery-source.ts` → new `discovery-source-create-request.ts`
- Extracts `DiscoveryDefaults` from `profile/profile.ts` → new `profile/discovery-defaults.ts`
- Updates 3 consumer import paths: `store/discoverApi.ts`, `types/profile/profile.ts`, `types/profile/profile-update-request.ts`
- Marks TECH_DEBT.md MEDIUM "One-type-per-file convention violated in 3 files" as RESOLVED

Zero behavior change — pure structural split.

## Test plan

- [ ] `npm run build` passes in `apps/myjobhunter/frontend/` (TypeScript + Vite)
- [ ] No import errors in `discoverApi.ts`, `profile.ts`, `profile-update-request.ts`
- [ ] Each of the 6 type files exports exactly one interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)