### PR TITLE
chore(mjh/frontend): bundle 4 frontend chore items

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -431,25 +431,9 @@ EXPLAIN ANALYZE before/after.
 
 ---
 
-### [Frontend / Profile] `ResumeUploadSection` opens download URL via useEffect-on-cached-query — re-fires on remount
+### ~~[Frontend / Profile] `ResumeUploadSection` opens download URL via useEffect-on-cached-query — re-fires on remount~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** S
-**Location:** `apps/myjobhunter/frontend/src/features/profile/ResumeUploadSection.tsx:43-54`
-
-**Problem:** Download flow uses a query with `skip: !downloadingJobId`, then `useEffect` watches `[downloadUrlData, downloadingJobId]` to call `window.open(...)` and clear the id. If component re-renders while URL is still cached, the effect re-fires opening another tab. Same imperative-action-via-effect anti-pattern as PR #418.
-
-**Recommendation:** Use RTK Query's `useLazyQuery`:
-
-    const [getDownloadUrl] = useGetResumeDownloadUrlQuery.useLazyQuery();
-    async function handleDownload(jobId: string) {
-      const result = await getDownloadUrl(jobId).unwrap();
-      window.open(result.url, "_blank", "noopener,noreferrer");
-    }
-
-No state, no effect, no risk of double-open.
-
-**Why Medium:** Same operator-flagged anti-pattern as PR #418 (useState+useEffect ping-pong for imperative side-effects).
+**Resolved:** PR (chore/mjh-test-and-empty-state-fixes). Replaced `useGetResumeDownloadUrlQuery` + `useEffect` pattern with `useLazyGetResumeDownloadUrlQuery`. `handleDownload` is now `async` — calls `getDownloadUrl(jobId).unwrap()` directly and opens the URL in the same handler. A minimal `downloadingJobId` state remains solely to drive `isDownloading` on `ResumeJobRow`'s download button (disabled state). The re-fire-on-remount risk is eliminated. `useLazyGetResumeDownloadUrlQuery` exported from `resumesApi.ts`. Test mock updated to stub the lazy hook signature.
 
 ---
 
@@ -529,15 +513,9 @@ No state, no effect, no risk of double-open.
 
 ---
 
-### [Frontend / Discover] Empty-state copy is inline — should live in `constants/empty-states.ts`
+### ~~[Frontend / Discover] Empty-state copy is inline — should live in `constants/empty-states.ts`~~ RESOLVED
 
-**Severity:** Low
-**Effort:** XS
-**Location:** `apps/myjobhunter/frontend/src/pages/Discover.tsx:60-65, 73-77` + `apps/myjobhunter/frontend/src/constants/empty-states.ts`
-
-**Problem:** Project CLAUDE.md says: "Exact approved copy lives in `src/constants/empty-states.ts`. Never change inline." Discover defines copy inline.
-
-**Recommendation:** Add `DISCOVER_EMPTY_STATES` to `constants/empty-states.ts` with two entries (no saved searches, inbox empty). Import in Discover.tsx.
+**Resolved:** PR (chore/mjh-test-and-empty-state-fixes). Added `DISCOVER_EMPTY_STATES` constant and `EmptyStateCopyNoAction` interface to `constants/empty-states.ts`. `Discover.tsx` now imports and uses the constants for both empty-state variants (no saved searches, inbox empty).
 
 ---
 
@@ -694,23 +672,9 @@ local test runs unreliable on Windows.
 
 ---
 
-### [Frontend Tests] Applications.test.tsx — "Applied" text collision between column header and status badge
+### ~~[Frontend Tests] Applications.test.tsx — "Applied" text collision between column header and status badge~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** XS
-**Location:** `apps/myjobhunter/frontend/src/pages/__tests__/Applications.test.tsx`
-**Discovered:** PR #170 (CompanyForm refactor) — `2026-05-02`
-
-**Problem:** Two unit tests use `screen.getByText("Applied")` but the DataTable
-renders an "Applied" column header (sortable button) alongside the "Applied" status
-badge. `getByText` finds both and throws "Found multiple elements". These tests have
-been failing since the status column was added in PR #167 — they were just masked by
-the Redux Provider crash (missing `companiesApi` mock) until this PR fixed that.
-
-**Recommendation:** Use `screen.getByRole("cell", { name: "Applied" })` or
-`within(row).getByText("Applied")` to scope the query to the badge cell. Also
-update the column header test to use `getByRole("columnheader", { name: "Applied" })`
-to avoid future collisions.
+**Resolved:** PR (chore/mjh-test-and-empty-state-fixes). Changed `screen.getByText("Applied")` to `screen.getByRole("cell", { name: "Applied" })` in both tests that check the "applied" status badge. Note: the remaining Applications.test.tsx failures are a separate pre-existing issue — the `companiesApi` mock is missing `useTriggerCompanyResearchMutation` (added after the test was written). That gap is distinct from this "Applied" text collision fix.
 
 ---
 
@@ -733,23 +697,9 @@ an example config if one exists.
 
 ---
 
-### [Frontend Tests] `auth.test.ts` — register call assertion is brittle
+### ~~[Frontend Tests] `auth.test.ts` — register call assertion is brittle~~ RESOLVED
 
-**Severity:** Low
-**Effort:** XS
-**Location:** `apps/myjobhunter/frontend/src/lib/__tests__/auth.test.ts:109`
-**Discovered:** PR #170 (CompanyForm refactor) — `2026-05-02`
-
-**Problem:** The test asserts `toHaveBeenCalledWith("/auth/register", { email, password })`
-but the underlying `api.post` call now passes a 3rd argument `{ headers: {} }`. The
-assertion fails because `toHaveBeenCalledWith` checks exact argument equality. Probably
-a recent upstream change to the shared axios wrapper in `@platform/ui` added default
-headers to all POST calls.
-
-**Recommendation:** Change the assertion to `toHaveBeenCalledWith("/auth/register",
-expect.objectContaining({ email, password }))` to ignore the extra headers argument,
-or use `toHaveBeenLastCalledWith` with `expect.objectContaining`. Also investigate
-whether the `{ headers: {} }` is intentional or a regression in `@platform/ui`.
+**Resolved:** PR (chore/mjh-test-and-empty-state-fixes). Investigation found the test was already correct — the register test assertions at lines 141-164 already use the 3-argument form with `{ headers: {} }` explicitly. All 16 auth tests pass. The TECH_DEBT entry was describing a state that was fixed when the test was initially written.
 
 ---
 

--- a/apps/myjobhunter/frontend/src/constants/empty-states.ts
+++ b/apps/myjobhunter/frontend/src/constants/empty-states.ts
@@ -8,6 +8,28 @@ export interface EmptyStateCopy {
   actionLabel: string;
 }
 
+export interface EmptyStateCopyNoAction {
+  iconName: string;
+  heading: string;
+  body: string;
+}
+
+export const DISCOVER_EMPTY_STATES: Record<"no_saved_searches" | "inbox_empty", EmptyStateCopyNoAction> = {
+  no_saved_searches: {
+    iconName: "Telescope",
+    heading: "No saved searches yet",
+    body:
+      "Create a saved search and I'll pull tailored postings from " +
+      "Google Jobs (LinkedIn, Indeed, Glassdoor, ZipRecruiter) every " +
+      "time you click Refresh.",
+  },
+  inbox_empty: {
+    iconName: "Telescope",
+    heading: "Inbox empty",
+    body: "Click Refresh on a saved search above to fetch the latest postings.",
+  },
+};
+
 export const EMPTY_STATES = {
   dashboard: {
     iconName: "Briefcase",

--- a/apps/myjobhunter/frontend/src/features/profile/ResumeUploadSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/ResumeUploadSection.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { FileText } from "lucide-react";
 import { FileUploadDropzone, showError, showSuccess, extractErrorMessage } from "@platform/ui";
 import ResumeJobRow from "@/features/profile/ResumeJobRow";
@@ -5,9 +6,8 @@ import ResumeUploadSectionSkeleton from "@/features/profile/ResumeUploadSectionS
 import {
   useUploadResumeMutation,
   useListResumeJobsQuery,
-  useGetResumeDownloadUrlQuery,
+  useLazyGetResumeDownloadUrlQuery,
 } from "@/lib/resumesApi";
-import { useState, useEffect } from "react";
 
 // Accepted MIME types — must match the backend allowlist in resume_validator.py
 const ACCEPTED_RESUME_TYPES =
@@ -37,21 +37,8 @@ export default function ResumeUploadSection({ profileId: _profileId }: ResumeUpl
   });
 
   const [uploadResume, { isLoading: isUploading }] = useUploadResumeMutation();
+  const [getDownloadUrl] = useLazyGetResumeDownloadUrlQuery();
   const [downloadingJobId, setDownloadingJobId] = useState<string | null>(null);
-
-  // We trigger download imperatively via a separate query; hold the job id to trigger.
-  const { data: downloadUrlData } = useGetResumeDownloadUrlQuery(downloadingJobId ?? "", {
-    skip: !downloadingJobId,
-  });
-
-  // Open the presigned URL in a new tab once the query resolves, then clear the
-  // pending job id so the query is not re-triggered on subsequent renders.
-  useEffect(() => {
-    if (downloadUrlData && downloadingJobId) {
-      window.open(downloadUrlData.url, "_blank", "noopener,noreferrer");
-      setDownloadingJobId(null);
-    }
-  }, [downloadUrlData, downloadingJobId]);
 
   if (isLoading) {
     return <ResumeUploadSectionSkeleton />;
@@ -72,8 +59,16 @@ export default function ResumeUploadSection({ profileId: _profileId }: ResumeUpl
     }
   }
 
-  function handleDownload(jobId: string) {
+  async function handleDownload(jobId: string) {
     setDownloadingJobId(jobId);
+    try {
+      const result = await getDownloadUrl(jobId).unwrap();
+      window.open(result.url, "_blank", "noopener,noreferrer");
+    } catch (err) {
+      showError(`Download failed: ${extractErrorMessage(err)}`);
+    } finally {
+      setDownloadingJobId(null);
+    }
   }
 
   const jobList = jobs ?? [];

--- a/apps/myjobhunter/frontend/src/features/profile/__tests__/ResumeUploadSection.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/__tests__/ResumeUploadSection.test.tsx
@@ -24,7 +24,7 @@ import type { ResumeUploadJob } from "@/types/resume-upload-job/resume-upload-jo
 vi.mock("@/lib/resumesApi", () => ({
   useUploadResumeMutation: vi.fn(),
   useListResumeJobsQuery: vi.fn(),
-  useGetResumeDownloadUrlQuery: vi.fn(),
+  useLazyGetResumeDownloadUrlQuery: vi.fn(),
 }));
 
 // ---------------------------------------------------------------------------
@@ -81,7 +81,7 @@ vi.mock("@platform/ui", () => ({
 import {
   useUploadResumeMutation,
   useListResumeJobsQuery,
-  useGetResumeDownloadUrlQuery,
+  useLazyGetResumeDownloadUrlQuery,
 } from "@/lib/resumesApi";
 import { showSuccess, showError } from "@platform/ui";
 import ResumeJobRow from "@/features/profile/ResumeJobRow";
@@ -90,7 +90,7 @@ import ResumeUploadSection from "@/features/profile/ResumeUploadSection";
 
 const mockUseUploadResume = vi.mocked(useUploadResumeMutation);
 const mockUseListResumeJobs = vi.mocked(useListResumeJobsQuery);
-const mockUseGetDownloadUrl = vi.mocked(useGetResumeDownloadUrlQuery);
+const mockUseLazyGetDownloadUrl = vi.mocked(useLazyGetResumeDownloadUrlQuery);
 const mockShowSuccess = vi.mocked(showSuccess);
 const mockShowError = vi.mocked(showError);
 const mockResumeJobRow = vi.mocked(ResumeJobRow);
@@ -119,16 +119,19 @@ const STUB_JOB: ResumeUploadJob = {
   updated_at: "2026-05-04T12:00:00Z",
 };
 
+const stubLazyDownloadTrigger = vi.fn().mockReturnValue({
+  unwrap: vi.fn().mockResolvedValue({ url: "https://example.com/resume.pdf" }),
+});
+
 function setupDefaultMocks() {
   mockUseListResumeJobs.mockReturnValue({
     data: [],
     isLoading: false,
   } as unknown as ReturnType<typeof useListResumeJobsQuery>);
   mockUseUploadResume.mockReturnValue(stubMutation);
-  mockUseGetDownloadUrl.mockReturnValue({
-    data: undefined,
-    isLoading: false,
-  } as unknown as ReturnType<typeof useGetResumeDownloadUrlQuery>);
+  mockUseLazyGetDownloadUrl.mockReturnValue(
+    [stubLazyDownloadTrigger, { isUninitialized: true }, vi.fn()] as unknown as ReturnType<typeof useLazyGetResumeDownloadUrlQuery>,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -160,10 +163,9 @@ describe("ResumeUploadSection", () => {
       isLoading: false,
     } as unknown as ReturnType<typeof useListResumeJobsQuery>);
     mockUseUploadResume.mockReturnValue(stubMutation);
-    mockUseGetDownloadUrl.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useGetResumeDownloadUrlQuery>);
+    mockUseLazyGetDownloadUrl.mockReturnValue(
+      [stubLazyDownloadTrigger, { isUninitialized: true }, vi.fn()] as unknown as ReturnType<typeof useLazyGetResumeDownloadUrlQuery>,
+    );
 
     render(<ResumeUploadSection profileId="profile-1" />);
 
@@ -247,10 +249,9 @@ describe("ResumeUploadSection", () => {
       isLoading: true,
     } as unknown as ReturnType<typeof useListResumeJobsQuery>);
     mockUseUploadResume.mockReturnValue(stubMutation);
-    mockUseGetDownloadUrl.mockReturnValue({
-      data: undefined,
-      isLoading: false,
-    } as unknown as ReturnType<typeof useGetResumeDownloadUrlQuery>);
+    mockUseLazyGetDownloadUrl.mockReturnValue(
+      [stubLazyDownloadTrigger, { isUninitialized: true }, vi.fn()] as unknown as ReturnType<typeof useLazyGetResumeDownloadUrlQuery>,
+    );
 
     render(<ResumeUploadSection profileId="profile-1" />);
 

--- a/apps/myjobhunter/frontend/src/lib/resumesApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/resumesApi.ts
@@ -42,4 +42,5 @@ export const {
   useListResumeJobsQuery,
   useGetResumeJobQuery,
   useGetResumeDownloadUrlQuery,
+  useLazyGetResumeDownloadUrlQuery,
 } = resumesApi;

--- a/apps/myjobhunter/frontend/src/pages/Discover.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Discover.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Plus, Telescope } from "lucide-react";
 import { Button, EmptyState } from "@platform/ui";
+import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
 import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
 import DiscoveredJobsSkeleton from "@/features/discover/DiscoveredJobsSkeleton";
 import NewSavedSearchDialog from "@/features/discover/NewSavedSearchDialog";
@@ -65,12 +66,8 @@ export default function Discover() {
       {!hasSources && (
         <EmptyState
           icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
-          heading="No saved searches yet"
-          body={
-            "Create a saved search and I'll pull tailored postings from " +
-            "Google Jobs (LinkedIn, Indeed, Glassdoor, ZipRecruiter) every " +
-            "time you click Refresh."
-          }
+          heading={DISCOVER_EMPTY_STATES.no_saved_searches.heading}
+          body={DISCOVER_EMPTY_STATES.no_saved_searches.body}
         />
       )}
 
@@ -79,8 +76,8 @@ export default function Discover() {
       {hasSources && !isLoading && !hasJobs && (
         <EmptyState
           icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
-          heading="Inbox empty"
-          body="Click Refresh on a saved search above to fetch the latest postings."
+          heading={DISCOVER_EMPTY_STATES.inbox_empty.heading}
+          body={DISCOVER_EMPTY_STATES.inbox_empty.body}
         />
       )}
 

--- a/apps/myjobhunter/frontend/src/pages/__tests__/Applications.test.tsx
+++ b/apps/myjobhunter/frontend/src/pages/__tests__/Applications.test.tsx
@@ -184,8 +184,9 @@ describe("Applications page", () => {
 
       renderApplications();
 
-      // The badge label for "applied" is "Applied"
-      expect(screen.getByText("Applied")).toBeInTheDocument();
+      // "Applied" also appears as a column header for the applied_at date column;
+      // scope to the table cell to avoid "found multiple elements" from getByText.
+      expect(screen.getByRole("cell", { name: "Applied" })).toBeInTheDocument();
     });
 
     it("renders a Status badge for an app with latest_status='interview_scheduled'", () => {
@@ -271,7 +272,7 @@ describe("Applications page", () => {
 
       renderApplications();
 
-      expect(screen.getByText("Applied")).toBeInTheDocument();
+      expect(screen.getByRole("cell", { name: "Applied" })).toBeInTheDocument();
       expect(screen.getByText("Rejected")).toBeInTheDocument();
       // The null row contributes at least one "—"
       expect(screen.getAllByText("—").length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary

- **Item 1 — Applications.test.tsx "Applied" text collision**: Changed `screen.getByText("Applied")` to `screen.getByRole("cell", { name: "Applied" })` in two tests. The DataTable renders both an "Applied" column header (for `applied_at`) and "Applied" status badges, so `getByText` was finding multiple elements and throwing.
- **Item 2 — auth.test.ts brittle assertion**: Investigated — the test was already written with the correct 3-argument form (`{ headers: {} }`). All 16 auth tests pass. TECH_DEBT entry pre-dated the fix; marked resolved.
- **Item 3 — Discover.tsx inline empty-state copy**: Added `DISCOVER_EMPTY_STATES` constant and `EmptyStateCopyNoAction` interface to `constants/empty-states.ts`. `Discover.tsx` now imports and references the constants instead of defining copy inline, per project CLAUDE.md convention.
- **Item 4 — ResumeUploadSection useLazyQuery refactor**: Replaced the `useGetResumeDownloadUrlQuery` + `useEffect` pattern with `useLazyGetResumeDownloadUrlQuery`. `handleDownload` is now `async` and calls `getDownloadUrl(jobId).unwrap()` directly, eliminating the re-fire-on-remount risk. Exported `useLazyGetResumeDownloadUrlQuery` from `resumesApi.ts`. Test mock updated to stub the lazy hook's `[trigger, lastResult, reset]` signature.

All 4 items marked RESOLVED in `apps/myjobhunter/TECH_DEBT.md`.

## Test plan

- [ ] All 7 `ResumeUploadSection.test.tsx` tests pass
- [ ] All 16 `auth.test.ts` tests pass
- [ ] Pre-existing baseline: 25 failed / 273 passed — no regression introduced
- [ ] TypeScript compilation clean (`tsc -b --noEmit` exits 0)
- [ ] CI green (pre-existing failures only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)