### PR TITLE
refactor(mjh/discover): bundle 5 audit MEDIUM cleanup items

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -280,17 +280,9 @@ EXPLAIN ANALYZE before/after.
 
 ---
 
-### [Frontend / Discover] `SavedSearchesPanel` query extraction is an inline IIFE — extract to named helper
+### ~~[Frontend / Discover] `SavedSearchesPanel` query extraction is an inline IIFE — extract to named helper~~
 
-**Severity:** Medium
-**Effort:** XS
-**Location:** `apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx:51-61`
-
-**Problem:** An IIFE `const query = (() => { ... })();` resolves the legacy `config.query` vs new `config.roles` shape. The IIFE pattern obscures the logic.
-
-**Recommendation:** Extract `summarizeSearchQuery(config)` to `features/discover/saved-search-summary.ts` (or `saved-search-display.ts`) so it's testable and reusable. Add a unit test for both shapes.
-
-**Why Medium:** Combined with `source.config` being typed `Record<string, unknown>`, this is the kind of weakly-typed extraction that should have a single source of truth.
+**Resolved:** PR #BUNDLE5 (2026-05-08). Extracted `summarizeSearchQuery(config)` to `features/discover/saved-search-summary.ts`. Eight-case unit test added in `features/discover/__tests__/saved-search-summary.test.ts`. IIFE removed from `SavedSearchesPanel.tsx`.
 
 ---
 
@@ -345,31 +337,15 @@ EXPLAIN ANALYZE before/after.
 
 ---
 
-### [Frontend / Discover] `DiscoveredJobCard` mixes posting render + dismissal popover — split popover
+### ~~[Frontend / Discover] `DiscoveredJobCard` mixes posting render + dismissal popover — split popover~~
 
-**Severity:** Medium
-**Effort:** S
-**Location:** `apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx:150-183`
-
-**Problem:** Dismissal-reason popover is 33 lines of inline JSX inside the card component. Owns its own conditional render (`showReasons` ternary at line 150); trigger lives in another action bar (line 227). Mixes two concerns.
-
-**Recommendation:** Extract `DismissReasonPopover.tsx` (props: `onDismiss(reason?)`, `onCancel()`, `isLoading`). Card swaps between action-bar and popover via single `mode` state.
-
-**Why Medium:** Card is 238 lines, on the edge of the ~200-line maintainability threshold.
+**Resolved:** PR #BUNDLE5 (2026-05-08). Extracted `DismissReasonPopover.tsx` with props `onDismiss(reason?)`, `onCancel()`, `isLoading`. Five-case unit test added in `features/discover/__tests__/DismissReasonPopover.test.tsx`. Card now swaps via single `showReasons` state.
 
 ---
 
-### [Frontend / Discover] `bandForScore` hardcodes thresholds that mirror backend `_verdict_to_score` — duplicated logic
+### ~~[Frontend / Discover] `bandForScore` hardcodes thresholds that mirror backend `_verdict_to_score` — duplicated logic~~
 
-**Severity:** Medium
-**Effort:** S
-**Location:** `apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx:48-54` + `apps/myjobhunter/backend/app/services/discovery/discovery_score_service.py:140-147`
-
-**Problem:** Backend maps verdict → score: `strong_fit=90, worth_considering=70, stretch=40, mismatch=15`. Frontend maps score → band: `>=85 strong, >=60 good, >=30 stretch, else low`. Both must agree on thresholds.
-
-**Recommendation:** Add `verdict: string` to `DiscoveredJobResponse` schema (already on JobAnalysis row), serialize on score worker write, render directly in card. Remove `bandForScore`. `_verdict_to_score` is single source of truth.
-
-**Why Medium:** Cross-stack coupling on numeric thresholds. Per `feedback_enum_changes_cross_stack`, this is exactly what typed unions exist to prevent.
+**Resolved:** PR #BUNDLE5 (2026-05-08). Added `verdict: str | None` as a `@computed_field` on `DiscoveredJobResponse` (derived from `_SCORE_TO_VERDICT` inverse map). Frontend `DiscoveredJob` type updated with `verdict: JobAnalysisVerdict | null`. `bandForScore` helper removed; `VERDICT_VISUAL` record now drives badge rendering. Six-case unit test in `features/discover/__tests__/DiscoveredJobCard.test.tsx`.
 
 ---
 
@@ -417,17 +393,9 @@ EXPLAIN ANALYZE before/after.
 
 ---
 
-### [Frontend / Discover] No skeleton on dialog while profile loads — fields jump from blank to populated
+### ~~[Frontend / Discover] No skeleton on dialog while profile loads — fields jump from blank to populated~~
 
-**Severity:** Medium
-**Effort:** S
-**Location:** `apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx:51-55, 104-151`
-
-**Problem:** Three queries fire on dialog open with `skip: !open`. While loading, form renders empty. When data arrives, prefill effect populates fields — operator sees a sudden "fields fill in" jump.
-
-**Recommendation:** Either (a) gate form fields behind `isLoading` and show a small skeleton, or (b) prefetch profile when dialog mounts (not opens) so cache is warm. Option (a) is the smaller change.
-
-**Why Medium:** Direct violation of `visible-loading-feedback` — not catastrophic but jarring on first open.
+**Resolved:** PR #BUNDLE5 (2026-05-08). `useDiscoveryDefaultsPrefill` now exposes `isPrefillLoading`. `NewSavedSearchDialog` gates form behind `isPrefillLoading` and shows a 5-row skeleton while the three queries (profile, skills, work history) are in flight.
 
 ---
 
@@ -491,15 +459,9 @@ No state, no effect, no risk of double-open.
 
 ---
 
-### [Frontend / Tech Debt] Inline `renderInlineMarkdown` in NewSavedSearchDialog — extract or use existing markdown lib
+### ~~[Frontend / Tech Debt] Inline `renderInlineMarkdown` in NewSavedSearchDialog — extract or use existing markdown lib~~
 
-**Severity:** Low
-**Effort:** XS
-**Location:** `apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx:445-462`
-
-**Problem:** 18-line inline regex-based bold parser at the bottom of a 462-line component. Operator-controlled summary text uses `**bold**` markers.
-
-**Recommendation:** Extract to `packages/shared-frontend/src/lib/inline-markdown.tsx` or use react-markdown (already in package.json for resume refinement).
+**Resolved:** PR #501 (2026-05-08). `InlineBoldText` component added to `@platform/ui`; `renderInlineMarkdown` helper removed from `NewSavedSearchDialog.tsx`; import updated to `{ InlineBoldText } from "@platform/ui"`.
 
 ---
 

--- a/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
@@ -5,7 +5,7 @@ import uuid
 from datetime import datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
 from app.schemas.discovery.jsearch_source_config import JSearchSourceConfig
 
@@ -92,6 +92,14 @@ class DiscoveryFetchResultResponse(BaseModel):
     error_message: str | None
 
 
+_SCORE_TO_VERDICT: dict[int, str] = {
+    90: "strong_fit",
+    70: "worth_considering",
+    40: "stretch",
+    15: "mismatch",
+}
+
+
 class DiscoveredJobResponse(BaseModel):
     """One DiscoveredJob row in the inbox view."""
 
@@ -117,6 +125,18 @@ class DiscoveredJobResponse(BaseModel):
     dismissed_reason: str | None = None
     saved_at: datetime | None
     promoted_application_id: uuid.UUID | None
+
+    @computed_field  # type: ignore[prop-decorator]
+    @property
+    def verdict(self) -> str | None:
+        """Human-readable verdict label derived from the numeric score.
+
+        ``_verdict_to_score`` in discovery_score_service is the single
+        source of truth; this is the inverse mapping so the frontend
+        renders the label directly without duplicating the thresholds.
+        Returns None for unscored rows.
+        """
+        return _SCORE_TO_VERDICT.get(self.score) if self.score is not None else None
 
     model_config = ConfigDict(from_attributes=True)
 

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
@@ -17,6 +17,8 @@ import {
   type DismissalReason,
 } from "@/store/discoverApi";
 import type { DiscoveredJob } from "@/types/discovery/discovered-job";
+import type { JobAnalysisVerdict } from "@/types/job-analysis/job-analysis-verdict";
+import DismissReasonPopover from "./DismissReasonPopover";
 
 interface DiscoveredJobCardProps {
   job: DiscoveredJob;
@@ -29,29 +31,17 @@ const REMOTE_LABEL: Record<string, string> = {
   unknown: "",
 };
 
-const DISMISS_REASONS: { value: DismissalReason; label: string }[] = [
-  { value: "wrong_stack", label: "Wrong tech stack" },
-  { value: "too_small_company", label: "Company too small" },
-  { value: "wrong_sector", label: "Wrong industry / sector" },
-  { value: "wrong_comp", label: "Compensation mismatch" },
-  { value: "not_remote", label: "Not actually remote" },
-  { value: "not_interested", label: "Not interested" },
-  { value: "other", label: "Other" },
-];
-
-interface ScoreVisual {
-  band: "strong" | "good" | "stretch" | "low";
+interface VerdictVisual {
   label: string;
   color: "green" | "blue" | "yellow" | "red";
 }
 
-function bandForScore(score: number | null): ScoreVisual | null {
-  if (score === null) return null;
-  if (score >= 85) return { band: "strong", label: "Strong fit", color: "green" };
-  if (score >= 60) return { band: "good", label: "Worth considering", color: "blue" };
-  if (score >= 30) return { band: "stretch", label: "Stretch", color: "yellow" };
-  return { band: "low", label: "Mismatch", color: "red" };
-}
+const VERDICT_VISUAL: Record<JobAnalysisVerdict, VerdictVisual> = {
+  strong_fit: { label: "Strong fit", color: "green" },
+  worth_considering: { label: "Worth considering", color: "blue" },
+  stretch: { label: "Stretch", color: "yellow" },
+  mismatch: { label: "Mismatch", color: "red" },
+};
 
 export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
   const [dismiss, { isLoading: isDismissing }] = useDismissDiscoveredJobMutation();
@@ -97,7 +87,7 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
   const postedLabel = job.posted_at ? timeAgo(job.posted_at) : null;
   const isAlreadySaved = !!job.saved_at;
   const isAlreadyPromoted = !!job.promoted_application_id;
-  const scoreVisual = bandForScore(job.score);
+  const verdictVisual = job.verdict ? VERDICT_VISUAL[job.verdict] ?? null : null;
 
   return (
     <Card className="p-4 sm:p-5 space-y-3">
@@ -112,7 +102,7 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
           </p>
         </div>
         <div className="flex items-start gap-1.5 shrink-0">
-          {scoreVisual && <Badge label={scoreVisual.label} color={scoreVisual.color} />}
+          {verdictVisual && <Badge label={verdictVisual.label} color={verdictVisual.color} />}
           {job.source_publisher && (
             <Badge label={job.source_publisher} color="gray" />
           )}
@@ -148,39 +138,11 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
       )}
 
       {showReasons ? (
-        <div className="border rounded-md p-3 space-y-2">
-          <p className="text-xs font-medium">Why are you dismissing this?</p>
-          <div className="flex flex-wrap gap-1.5">
-            {DISMISS_REASONS.map((r) => (
-              <button
-                key={r.value}
-                type="button"
-                onClick={() => doDismiss(r.value)}
-                disabled={isDismissing}
-                className="px-2 py-1 text-xs border rounded hover:bg-muted"
-              >
-                {r.label}
-              </button>
-            ))}
-          </div>
-          <div className="flex items-center gap-2 pt-1">
-            <button
-              type="button"
-              onClick={() => doDismiss()}
-              disabled={isDismissing}
-              className="text-xs text-muted-foreground hover:underline"
-            >
-              Skip — dismiss without a reason
-            </button>
-            <button
-              type="button"
-              onClick={() => setShowReasons(false)}
-              className="text-xs text-muted-foreground hover:underline ml-auto"
-            >
-              Cancel
-            </button>
-          </div>
-        </div>
+        <DismissReasonPopover
+          onDismiss={doDismiss}
+          onCancel={() => setShowReasons(false)}
+          isLoading={isDismissing}
+        />
       ) : (
         <div className="flex items-center gap-2 pt-1 flex-wrap">
           {job.source_url && (

--- a/apps/myjobhunter/frontend/src/features/discover/DismissReasonPopover.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DismissReasonPopover.tsx
@@ -1,0 +1,59 @@
+import type { DismissalReason } from "@/store/discoverApi";
+
+const DISMISS_REASONS: { value: DismissalReason; label: string }[] = [
+  { value: "wrong_stack", label: "Wrong tech stack" },
+  { value: "too_small_company", label: "Company too small" },
+  { value: "wrong_sector", label: "Wrong industry / sector" },
+  { value: "wrong_comp", label: "Compensation mismatch" },
+  { value: "not_remote", label: "Not actually remote" },
+  { value: "not_interested", label: "Not interested" },
+  { value: "other", label: "Other" },
+];
+
+interface DismissReasonPopoverProps {
+  onDismiss: (reason?: DismissalReason) => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+
+export default function DismissReasonPopover({
+  onDismiss,
+  onCancel,
+  isLoading,
+}: DismissReasonPopoverProps) {
+  return (
+    <div className="border rounded-md p-3 space-y-2">
+      <p className="text-xs font-medium">Why are you dismissing this?</p>
+      <div className="flex flex-wrap gap-1.5">
+        {DISMISS_REASONS.map((r) => (
+          <button
+            key={r.value}
+            type="button"
+            onClick={() => onDismiss(r.value)}
+            disabled={isLoading}
+            className="px-2 py-1 text-xs border rounded hover:bg-muted"
+          >
+            {r.label}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center gap-2 pt-1">
+        <button
+          type="button"
+          onClick={() => onDismiss()}
+          disabled={isLoading}
+          className="text-xs text-muted-foreground hover:underline"
+        >
+          Skip — dismiss without a reason
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="text-xs text-muted-foreground hover:underline ml-auto"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -4,11 +4,12 @@ import {
   showError,
   showSuccess,
   extractErrorMessage,
+  InlineBoldText,
+  Skeleton,
 } from "@platform/ui";
 import { useCreateDiscoverySourceMutation } from "@/store/discoverApi";
 import { useUpdateProfileMutation } from "@/lib/profileApi";
 import { buildSavedSearchSummary } from "./saved-search-summary";
-import { InlineBoldText } from "@platform/ui";
 import { useDiscoveryDefaultsPrefill } from "./useDiscoveryDefaultsPrefill";
 import SearchInputsSection from "./dialog-sections/SearchInputsSection";
 import WhereWhenSection from "./dialog-sections/WhereWhenSection";
@@ -76,6 +77,7 @@ export default function NewSavedSearchDialog({
     profile,
     recentRoleSuggestions,
     skillSuggestions,
+    isPrefillLoading,
     didPrefill,
     resetPrefill,
   } = useDiscoveryDefaultsPrefill(open, {
@@ -205,6 +207,16 @@ export default function NewSavedSearchDialog({
       onCancel={handleCancel}
     >
       <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
+        {isPrefillLoading ? (
+          <div className="space-y-3" aria-busy="true">
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-9 w-3/4" />
+            <Skeleton className="h-9 w-full" />
+            <Skeleton className="h-9 w-1/2" />
+          </div>
+        ) : (
+          <>
         {didPrefill && (
           <p className="text-xs text-muted-foreground bg-muted/40 px-3 py-2 rounded">
             Pre-filled from your profile. Edit anything below.
@@ -275,6 +287,8 @@ export default function NewSavedSearchDialog({
               <InlineBoldText text={summary} />
             </p>
           </div>
+        )}
+          </>
         )}
       </div>
     </ConfirmDialog>

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
@@ -16,6 +16,7 @@ import {
   useRefreshDiscoverySourceMutation,
 } from "@/store/discoverApi";
 import type { DiscoverySource } from "@/types/discovery/discovery-source";
+import { summarizeSearchQuery } from "./saved-search-summary";
 
 export default function SavedSearchesPanel() {
   const { data: sources, isLoading } = useListDiscoverySourcesQuery();
@@ -43,19 +44,7 @@ function SavedSearchRow({ source }: { source: DiscoverySource }) {
   const [refresh, { isLoading: isRefreshing }] = useRefreshDiscoverySourceMutation();
   const [deactivate, { isLoading: isDeactivating }] = useDeactivateDiscoverySourceMutation();
 
-  // New saved searches use ``roles`` (list); legacy ones use ``query`` (string).
-  // Show whatever's available with a sensible fallback.
-  const query = (() => {
-    const roles = source.config?.roles;
-    if (Array.isArray(roles) && roles.length > 0) {
-      const validRoles = roles.filter((r): r is string => typeof r === "string");
-      if (validRoles.length > 0) return validRoles.join(" / ");
-    }
-    if (typeof source.config?.query === "string" && source.config.query) {
-      return source.config.query;
-    }
-    return "(no query)";
-  })();
+  const query = summarizeSearchQuery(source.config ?? {});
   const lastFetched = source.last_fetched_at
     ? `Last fetched ${timeAgo(source.last_fetched_at)}`
     : "Never fetched";

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * Tests for DiscoveredJobCard — specifically the verdict-based badge render
+ * introduced in the audit cleanup (replaces the old bandForScore helper).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DiscoveredJobCard from "../DiscoveredJobCard";
+import type { DiscoveredJob } from "@/types/discovery/discovered-job";
+
+vi.mock("lucide-react", () => ({
+  Bookmark: () => null,
+  Briefcase: () => null,
+  Check: () => null,
+  ExternalLink: () => null,
+  X: () => null,
+}));
+
+vi.mock("@platform/ui", () => ({
+  Badge: ({ label }: { label: string }) => <span data-testid="badge">{label}</span>,
+  Button: ({ children, onClick, disabled }: { children: React.ReactNode; onClick?: () => void; disabled?: boolean }) => (
+    <button onClick={onClick} disabled={disabled}>{children}</button>
+  ),
+  Card: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+  formatSalaryRange: () => "—",
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+  timeAgo: () => "2 hours ago",
+  extractErrorMessage: vi.fn(),
+}));
+
+vi.mock("@/store/discoverApi", () => ({
+  useDismissDiscoveredJobMutation: () => [vi.fn(), { isLoading: false }],
+  useSaveDiscoveredJobMutation: () => [vi.fn(), { isLoading: false }],
+  usePromoteDiscoveredJobMutation: () => [vi.fn(), { isLoading: false }],
+}));
+
+function makeJob(overrides: Partial<DiscoveredJob> = {}): DiscoveredJob {
+  return {
+    id: "job-1",
+    source: "jsearch",
+    source_publisher: null,
+    source_url: null,
+    title: "Senior Backend Engineer",
+    company_name: "Acme Corp",
+    location: "Remote",
+    remote_type: "remote",
+    description: null,
+    posted_at: null,
+    discovered_at: "2026-05-08T10:00:00Z",
+    salary_min: null,
+    salary_max: null,
+    salary_currency: "USD",
+    salary_period: null,
+    score: null,
+    score_reason: null,
+    scored_at: null,
+    dismissed_at: null,
+    dismissed_reason: null,
+    saved_at: null,
+    promoted_application_id: null,
+    verdict: null,
+    ...overrides,
+  };
+}
+
+describe("DiscoveredJobCard — verdict badge", () => {
+  it("shows no verdict badge when verdict is null (unscored)", () => {
+    render(<DiscoveredJobCard job={makeJob({ verdict: null })} />);
+    expect(screen.queryByTestId("badge")).toBeNull();
+  });
+
+  it("shows 'Strong fit' badge for strong_fit verdict", () => {
+    render(<DiscoveredJobCard job={makeJob({ verdict: "strong_fit", score: 90 })} />);
+    expect(screen.getByTestId("badge")).toHaveTextContent("Strong fit");
+  });
+
+  it("shows 'Worth considering' badge for worth_considering verdict", () => {
+    render(<DiscoveredJobCard job={makeJob({ verdict: "worth_considering", score: 70 })} />);
+    expect(screen.getByTestId("badge")).toHaveTextContent("Worth considering");
+  });
+
+  it("shows 'Stretch' badge for stretch verdict", () => {
+    render(<DiscoveredJobCard job={makeJob({ verdict: "stretch", score: 40 })} />);
+    expect(screen.getByTestId("badge")).toHaveTextContent("Stretch");
+  });
+
+  it("shows 'Mismatch' badge for mismatch verdict", () => {
+    render(<DiscoveredJobCard job={makeJob({ verdict: "mismatch", score: 15 })} />);
+    expect(screen.getByTestId("badge")).toHaveTextContent("Mismatch");
+  });
+
+  it("renders the job title and company name", () => {
+    render(<DiscoveredJobCard job={makeJob()} />);
+    expect(screen.getByText("Senior Backend Engineer")).toBeInTheDocument();
+    expect(screen.getByText(/Acme Corp/)).toBeInTheDocument();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DismissReasonPopover.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DismissReasonPopover.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import DismissReasonPopover from "../DismissReasonPopover";
+
+describe("DismissReasonPopover", () => {
+  it("renders all reason buttons", () => {
+    render(
+      <DismissReasonPopover
+        onDismiss={vi.fn()}
+        onCancel={vi.fn()}
+        isLoading={false}
+      />,
+    );
+    expect(screen.getByText("Wrong tech stack")).toBeInTheDocument();
+    expect(screen.getByText("Not interested")).toBeInTheDocument();
+    expect(screen.getByText("Other")).toBeInTheDocument();
+  });
+
+  it("calls onDismiss with the correct reason when a reason button is clicked", async () => {
+    const onDismiss = vi.fn();
+    render(
+      <DismissReasonPopover
+        onDismiss={onDismiss}
+        onCancel={vi.fn()}
+        isLoading={false}
+      />,
+    );
+    await userEvent.click(screen.getByText("Wrong tech stack"));
+    expect(onDismiss).toHaveBeenCalledWith("wrong_stack");
+  });
+
+  it("calls onDismiss with no argument when skip is clicked", async () => {
+    const onDismiss = vi.fn();
+    render(
+      <DismissReasonPopover
+        onDismiss={onDismiss}
+        onCancel={vi.fn()}
+        isLoading={false}
+      />,
+    );
+    await userEvent.click(screen.getByText(/dismiss without a reason/i));
+    expect(onDismiss).toHaveBeenCalledWith();
+  });
+
+  it("calls onCancel when Cancel is clicked", async () => {
+    const onCancel = vi.fn();
+    render(
+      <DismissReasonPopover
+        onDismiss={vi.fn()}
+        onCancel={onCancel}
+        isLoading={false}
+      />,
+    );
+    await userEvent.click(screen.getByText("Cancel"));
+    expect(onCancel).toHaveBeenCalled();
+  });
+
+  it("disables reason buttons and skip when isLoading is true", () => {
+    render(
+      <DismissReasonPopover
+        onDismiss={vi.fn()}
+        onCancel={vi.fn()}
+        isLoading={true}
+      />,
+    );
+    expect(screen.getByText("Wrong tech stack")).toBeDisabled();
+    expect(screen.getByText(/dismiss without a reason/i)).toBeDisabled();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/saved-search-summary.test.ts
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/saved-search-summary.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { summarizeSearchQuery } from "../saved-search-summary";
+
+describe("summarizeSearchQuery", () => {
+  it("renders roles from new-style config (roles array)", () => {
+    expect(
+      summarizeSearchQuery({ roles: ["Software Engineer", "Backend Engineer"] }),
+    ).toBe("Software Engineer / Backend Engineer");
+  });
+
+  it("renders a single role without a slash", () => {
+    expect(summarizeSearchQuery({ roles: ["Frontend Developer"] })).toBe(
+      "Frontend Developer",
+    );
+  });
+
+  it("falls back to legacy query string when roles is absent", () => {
+    expect(
+      summarizeSearchQuery({ query: "senior backend engineer python remote" }),
+    ).toBe("senior backend engineer python remote");
+  });
+
+  it("prefers roles over query when both are present", () => {
+    expect(
+      summarizeSearchQuery({
+        roles: ["Staff Engineer"],
+        query: "old query string",
+      }),
+    ).toBe("Staff Engineer");
+  });
+
+  it("ignores non-string entries in the roles array", () => {
+    expect(summarizeSearchQuery({ roles: [null, 42, "SRE"] })).toBe("SRE");
+  });
+
+  it("returns (no query) for empty roles array and absent query", () => {
+    expect(summarizeSearchQuery({ roles: [] })).toBe("(no query)");
+  });
+
+  it("returns (no query) for empty config", () => {
+    expect(summarizeSearchQuery({})).toBe("(no query)");
+  });
+
+  it("returns (no query) when query is an empty string", () => {
+    expect(summarizeSearchQuery({ query: "" })).toBe("(no query)");
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/discover/saved-search-summary.ts
+++ b/apps/myjobhunter/frontend/src/features/discover/saved-search-summary.ts
@@ -1,5 +1,24 @@
 import { INDUSTRY_CHIPS } from "./industry-chips";
 
+/**
+ * Render a ``DiscoverySource.config`` object as a short display string
+ * for the SavedSearchesPanel row.
+ *
+ * New configs store ``roles`` (string[]); legacy configs store ``query``
+ * (string). Falls back to "(no query)" when neither is present.
+ */
+export function summarizeSearchQuery(config: Record<string, unknown>): string {
+  const roles = config?.roles;
+  if (Array.isArray(roles) && roles.length > 0) {
+    const validRoles = roles.filter((r): r is string => typeof r === "string");
+    if (validRoles.length > 0) return validRoles.join(" / ");
+  }
+  if (typeof config?.query === "string" && config.query) {
+    return config.query;
+  }
+  return "(no query)";
+}
+
 interface SummaryInput {
   roles: string[];
   skills: string[];

--- a/apps/myjobhunter/frontend/src/features/discover/useDiscoveryDefaultsPrefill.ts
+++ b/apps/myjobhunter/frontend/src/features/discover/useDiscoveryDefaultsPrefill.ts
@@ -31,6 +31,8 @@ interface PrefillResult {
   recentRoleSuggestions: string[];
   /** Top profile.skills (autocomplete suggestions). */
   skillSuggestions: string[];
+  /** True while any of the three prefill queries is in flight. */
+  isPrefillLoading: boolean;
   /** True after the one-shot prefill has run for this open session. */
   didPrefill: boolean;
   /** Reset the prefill latch on dialog close. */
@@ -63,11 +65,12 @@ export function useDiscoveryDefaultsPrefill(
   open: boolean,
   setters: PrefillSetters,
 ): PrefillResult {
-  const { data: profile } = useGetProfileQuery(undefined, { skip: !open });
-  const { data: skillsData } = useListSkillsQuery(undefined, { skip: !open });
-  const { data: workHistoryData } = useListWorkHistoryQuery(undefined, {
+  const { data: profile, isLoading: profileLoading } = useGetProfileQuery(undefined, { skip: !open });
+  const { data: skillsData, isLoading: skillsLoading } = useListSkillsQuery(undefined, { skip: !open });
+  const { data: workHistoryData, isLoading: workHistoryLoading } = useListWorkHistoryQuery(undefined, {
     skip: !open,
   });
+  const isPrefillLoading = open && (profileLoading || skillsLoading || workHistoryLoading);
 
   // useRef instead of useState — flipping this latch shouldn't trigger
   // a re-render. The dialog reads the value to decide whether to show
@@ -119,6 +122,7 @@ export function useDiscoveryDefaultsPrefill(
     profile,
     recentRoleSuggestions,
     skillSuggestions,
+    isPrefillLoading,
     didPrefill: didPrefillRef.current,
     resetPrefill,
   };

--- a/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
@@ -1,3 +1,5 @@
+import type { JobAnalysisVerdict } from "@/types/job-analysis/job-analysis-verdict";
+
 /** A single discovered posting in the inbox. Mirrors backend DiscoveredJobResponse. */
 export interface DiscoveredJob {
   id: string;
@@ -22,6 +24,8 @@ export interface DiscoveredJob {
   dismissed_reason: string | null;
   saved_at: string | null;
   promoted_application_id: string | null;
+  /** Derived by the backend from ``score``. Null for unscored rows. */
+  verdict: JobAnalysisVerdict | null;
 }
 
 export interface DiscoveredJobListResponse {


### PR DESCRIPTION
## Summary

Bundles 5 MEDIUM audit cleanup items that share file overlap on `DiscoveredJobCard.tsx` and `NewSavedSearchDialog.tsx`. Each is its own logical change; bundled to avoid merge conflicts.

- **Item 1** — `SavedSearchesPanel` IIFE → `summarizeSearchQuery(config)` named helper in `saved-search-summary.ts` (8-case unit test)
- **Item 2** — Inline 33-line dismissal popover → `DismissReasonPopover.tsx` (5-case unit test)
- **Item 3** — `bandForScore` removed; `verdict: JobAnalysisVerdict | null` added as `@computed_field` on backend `DiscoveredJobResponse` + to frontend `DiscoveredJob` type (6-case unit test for badge render)
- **Item 4** — `NewSavedSearchDialog` skeleton while profile/skills/work-history queries load (exposes `isPrefillLoading` from `useDiscoveryDefaultsPrefill`)
- **Item 5** — Already resolved in PR #501; `TECH_DEBT.md` entry corrected with that PR reference

## Test plan

- [ ] `vitest run src/features/discover` — 19 tests pass (all new)
- [ ] `tsc --noEmit` — clean
- [ ] Backend `DiscoveredJobResponse.verdict` verified against all 5 score values via inline Python smoke check (strong_fit/worth_considering/stretch/mismatch/None)
- [ ] Pre-existing backend discover endpoint failures (6) are Anthropic-API-key-in-test-env, unrelated to this PR

## Files modified

- `backend/app/schemas/discovery/discovery_schemas.py` — adds `verdict` computed field
- `frontend/src/types/discovery/discovered-job.ts` — adds `verdict: JobAnalysisVerdict | null`
- `frontend/src/features/discover/saved-search-summary.ts` — adds `summarizeSearchQuery`
- `frontend/src/features/discover/SavedSearchesPanel.tsx` — uses named helper instead of IIFE
- `frontend/src/features/discover/DismissReasonPopover.tsx` — new extracted component
- `frontend/src/features/discover/DiscoveredJobCard.tsx` — uses `DismissReasonPopover` + `VERDICT_VISUAL` instead of `bandForScore`
- `frontend/src/features/discover/useDiscoveryDefaultsPrefill.ts` — exposes `isPrefillLoading`
- `frontend/src/features/discover/NewSavedSearchDialog.tsx` — skeleton gate on `isPrefillLoading`
- `apps/myjobhunter/TECH_DEBT.md` — all 5 entries resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)