### PR TITLE
fix(mjh/discovery): recreate ix_discovered_inbox with DESC NULLS LAST

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -241,25 +241,10 @@ Route handlers now delegate to services; no `db.commit()` remains in `discover.p
 
 ---
 
-### [Backend / Discovery] `ix_discovered_inbox` index column order doesn't match query sort — Postgres won't use it for sort
+### ~~[Backend / Discovery] `ix_discovered_inbox` index column order doesn't match query sort — Postgres won't use it for sort~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** S
-**Location:** `apps/myjobhunter/backend/app/models/discovery/discovered_job.py:222-232` + the migration
-
-**Problem:** Index defined as `(user_id, score, discovered_at)` (default ASC). Inbox query orders by `nulls_last(desc(score)), desc(discovered_at)`. Postgres CAN use the index for the user_id equality predicate but must do an in-memory sort for the score/discovered_at ordering — defeating the partial-index purpose.
-
-**Recommendation:** Follow-up migration drops the index and recreates with explicit DESC + NULLS LAST:
-
-    op.create_index(
-        "ix_discovered_inbox", "discovered_jobs",
-        [sa.text("user_id"), sa.text("score DESC NULLS LAST"), sa.text("discovered_at DESC")],
-        postgresql_where=sa.text("dismissed_at IS NULL AND saved_at IS NULL AND promoted_application_id IS NULL"),
-    )
-
-EXPLAIN ANALYZE before/after.
-
-**Why Medium:** At v1 scale (one user, < 1000 inbox rows) the planner won't blink; at 10× scale the in-memory sort dominates Discover page load.
+**Severity:** ~~Medium~~ RESOLVED
+**Resolved:** 2026-05-08 — PR #TBD (`ixinbox260508_recreate_ix_discovered_inbox_desc.py`)
 
 ---
 

--- a/apps/myjobhunter/backend/alembic/versions/ixinbox260508_recreate_ix_discovered_inbox_desc.py
+++ b/apps/myjobhunter/backend/alembic/versions/ixinbox260508_recreate_ix_discovered_inbox_desc.py
@@ -1,0 +1,53 @@
+"""Recreate ``ix_discovered_inbox`` with explicit DESC NULLS LAST column ordering.
+
+The original index defined columns as ``(user_id, score, discovered_at)`` with
+default ASC ordering.  The inbox query sorts by
+``nulls_last(desc(score)), desc(discovered_at)``, so Postgres could satisfy the
+``user_id`` equality predicate from the index but had to perform an in-memory
+sort for the score/discovered_at ordering — defeating the partial-index
+purpose.
+
+Recreating the index with ``score DESC NULLS LAST, discovered_at DESC`` lets
+the planner perform an index scan in the query's natural sort order, eliminating
+the sort node entirely.
+
+discovered_jobs is small at MJH v1 scale (<10K rows); regular CREATE INDEX is
+fast enough.  If the table grows beyond ~100K rows, switch to CONCURRENTLY in a
+follow-up migration.
+
+Revision ID: ixinbox260508
+Revises: extctx260507
+Create Date: 2026-05-08
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "ixinbox260508"
+down_revision: Union[str, None] = "extctx260507"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_WHERE = "dismissed_at IS NULL AND saved_at IS NULL AND promoted_application_id IS NULL"
+
+
+def upgrade() -> None:
+    op.drop_index("ix_discovered_inbox", table_name="discovered_jobs")
+    op.create_index(
+        "ix_discovered_inbox",
+        "discovered_jobs",
+        [sa.text("user_id"), sa.text("score DESC NULLS LAST"), sa.text("discovered_at DESC")],
+        postgresql_where=sa.text(_WHERE),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_discovered_inbox", table_name="discovered_jobs")
+    op.create_index(
+        "ix_discovered_inbox",
+        "discovered_jobs",
+        [sa.text("user_id"), sa.text("score"), sa.text("discovered_at")],
+        postgresql_where=sa.text(_WHERE),
+    )

--- a/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
+++ b/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
@@ -222,8 +222,8 @@ class DiscoveredJob(Base):
         Index(
             "ix_discovered_inbox",
             "user_id",
-            "score",
-            "discovered_at",
+            text("score DESC NULLS LAST"),
+            text("discovered_at DESC"),
             postgresql_where=text(
                 "dismissed_at IS NULL "
                 "AND saved_at IS NULL "


### PR DESCRIPTION
## Summary

- The original `ix_discovered_inbox` partial index defined columns as `(user_id, score, discovered_at)` with default ASC ordering
- The inbox query sorts by `nulls_last(desc(score)), desc(discovered_at)`, so Postgres could use the index for the `user_id` equality predicate but performed an in-memory sort for the ordering columns — defeating the partial-index purpose
- Migration `ixinbox260508` drops and recreates the index with `score DESC NULLS LAST, discovered_at DESC`
- Model `Index()` declaration updated to match so `alembic check` / autogenerate stays in sync
- `TECH_DEBT.md` MEDIUM entry marked RESOLVED

## No operational migration required

`discovered_jobs` is currently small (<10K rows); `CREATE INDEX` completes in milliseconds and takes no meaningful table lock.  If the table grows beyond ~100K rows in a future phase, switch to `CREATE INDEX CONCURRENTLY` via `op.get_context().autocommit_block()`.

## EXPLAIN ANALYZE

No local Postgres available in this session.  Expected result on staging/prod (run after deploy):

```sql
EXPLAIN ANALYZE
SELECT *
FROM discovered_jobs
WHERE user_id = '<uuid>'
  AND dismissed_at IS NULL
  AND saved_at IS NULL
  AND promoted_application_id IS NULL
ORDER BY score DESC NULLS LAST, discovered_at DESC
LIMIT 50;
```

- **Before**: plan includes `Sort` node (in-memory sort after index scan on `user_id`)
- **After**: plan shows `Index Scan` on `ix_discovered_inbox` with no `Sort` node

🤖 Generated with [Claude Code](https://claude.com/claude-code)