### PR TITLE
test(mjh/discover): enforce INDUSTRY_CHIPS / INDUSTRY_DENYLISTS key parity via backend test

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 37 (Critical: 1 / High: 3 / Medium: 19 / Low: 15)**
+**Open issues: 36 (Critical: 1 / High: 3 / Medium: 18 / Low: 15)**
 
 > Last comprehensive audit: 2026-05-07 (post-discovery feature ship). All Critical and 7 of 8 audit-High findings RESOLVED in PRs #421-#432 (2026-05-07). Remaining audit findings preserved below under "## High (audit 2026-05-07)" / "## Medium (audit 2026-05-07)" / "## Low (audit 2026-05-07)" sections; pre-existing findings preserved under "## Pre-existing".
 
@@ -342,19 +342,9 @@ Updated consumers: `store/discoverApi.ts`, `types/profile/profile.ts`, `types/pr
 
 ---
 
-### [Cross-stack / Discover] `INDUSTRY_CHIPS` and backend `INDUSTRY_DENYLISTS` keys can drift silently
+### ~~[Cross-stack / Discover] `INDUSTRY_CHIPS` and backend `INDUSTRY_DENYLISTS` keys can drift silently~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** S
-**Location:**
-- `apps/myjobhunter/frontend/src/features/discover/industry-chips.ts:24-30`
-- `apps/myjobhunter/backend/app/services/discovery/industry_denylists.py:50-126`
-
-**Problem:** Both files document a manual mirroring contract but nothing enforces the keys agree. Frontend chip with no backend entry is silently a no-op (per `expand_excluded_keywords` swallow-on-unknown).
-
-**Recommendation:** Add a backend test that reads frontend's `industry-chips.ts` and asserts every value appears in `INDUSTRY_DENYLISTS`. Cheapest fix: a Python test importing a JSON-exported chip list.
-
-**Why Medium:** Silent feature degradation. Operator selects chip, expects defense contractors filtered out, no signal the chip's keyword list was never wired.
+**Resolved:** PR #TBD (2026-05-08). Added `test_every_frontend_chip_has_backend_denylist_entry` to `tests/test_discovery_industry_chips.py`. The test regex-parses `industry-chips.ts` at test time and asserts every `value` field appears as a key in `INDUSTRY_DENYLISTS`. No drift found at time of resolution — all 5 current chip keys have backend entries. If a chip is added to the frontend without a backend denylist entry, CI will fail loudly.
 
 ---
 

--- a/apps/myjobhunter/backend/tests/test_discovery_industry_chips.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_industry_chips.py
@@ -203,3 +203,62 @@ def test_staffing_chip_drops_via_dice_postings() -> None:
     result = _apply_post_fetch_filters(postings, config)
     assert len(result) == 1
     assert result[0]["company_name"] == "Real Company"
+
+
+# ===========================================================================
+# Frontend / backend key drift — industry-chips.ts vs INDUSTRY_DENYLISTS
+# ===========================================================================
+
+
+def _read_frontend_chip_keys() -> list[str]:
+    """Parse industry-chips.ts to extract every chip's ``value`` field.
+
+    The TS file declares ``INDUSTRY_CHIPS: IndustryChip[]`` where each
+    element is an object literal with ``value: "<key>"`` and ``label: "..."``.
+    We regex out the ``value`` strings because they are the keys that must
+    exist in ``INDUSTRY_DENYLISTS``.
+
+    If the TS file's shape changes (e.g. the field is renamed from ``value``
+    to ``key``), this regex stops matching and the test fails loudly with
+    "Frontend industry-chips.ts produced no keys" — which is the right signal
+    to update the regex here rather than to silently pass.
+    """
+    from pathlib import Path
+    import re
+
+    chips_ts = (
+        Path(__file__).parent.parent.parent
+        / "frontend"
+        / "src"
+        / "features"
+        / "discover"
+        / "industry-chips.ts"
+    )
+    text = chips_ts.read_text(encoding="utf-8")
+    return re.findall(r'\bvalue\s*:\s*"([^"]+)"', text)
+
+
+def test_every_frontend_chip_has_backend_denylist_entry() -> None:
+    """Every chip value in ``INDUSTRY_CHIPS`` (frontend) must appear as a key
+    in ``INDUSTRY_DENYLISTS`` (backend).
+
+    Without a backend entry, ``expand_excluded_keywords`` silently skips the
+    chip and the operator's selection becomes a no-op — they believe a filter
+    is active when it isn't.
+
+    If this test fails, the missing keys must be added to
+    ``industry_denylists.py`` OR the chip removed from ``industry-chips.ts``.
+    Do NOT auto-fix in this test — the human decides which side is canonical.
+    """
+    chip_keys = _read_frontend_chip_keys()
+    assert chip_keys, (
+        "Frontend industry-chips.ts produced no keys — "
+        "the value-field regex may be stale or the file has moved"
+    )
+    missing = [k for k in chip_keys if k not in INDUSTRY_DENYLISTS]
+    assert missing == [], (
+        f"Frontend INDUSTRY_CHIPS has keys with no backend entry in "
+        f"INDUSTRY_DENYLISTS: {missing}. "
+        f"Add them to apps/myjobhunter/backend/app/services/discovery/"
+        f"industry_denylists.py or remove from industry-chips.ts."
+    )


### PR DESCRIPTION
## Summary

- Adds `test_every_frontend_chip_has_backend_denylist_entry` to `tests/test_discovery_industry_chips.py`
- The test regex-parses `frontend/src/features/discover/industry-chips.ts` at test time and asserts every chip `value` field appears as a key in `INDUSTRY_DENYLISTS`
- Updates `TECH_DEBT.md` Medium entry to RESOLVED

## What this prevents

`expand_excluded_keywords` silently skips unknown chip keys. Without this test, a developer could add a chip to the frontend array and forget to wire the backend expansion — the operator's filter selection would appear to work but no keywords would be excluded.

## Test results

```
19 passed in 0.03s
```

No drift found: all 5 current chip keys (`government_defense`, `staffing_recruiting`, `consulting_big4`, `crypto_web3`, `adtech_gambling`) have backend entries.

## Test design

- Regex-parses the TS file directly — no JSON export build step needed
- If the TS file's `value` field is renamed, the regex produces no matches and the test fails loudly with a clear "regex may be stale" message (intended behavior — the human updates the regex)
- Does NOT auto-fix drift; reports missing keys and lets the human decide which side is canonical

## Resolves

TECH_DEBT.md Medium: `[Cross-stack / Discover] INDUSTRY_CHIPS and backend INDUSTRY_DENYLISTS keys can drift silently`

🤖 Generated with [Claude Code](https://claude.com/claude-code)