### PR TITLE
chore(mjh/e2e): add storageState isolation to Playwright config

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -492,27 +492,17 @@ or documenting the gap prominently in `auth.py`.
 
 ---
 
-### [E2E Tests] E2E spec files shared a browser context with no isolation between tests
+### ~~[E2E Tests] E2E spec files shared a browser context with no isolation between tests~~
 
-**Severity:** Medium
+**Severity:** Medium — RESOLVED
 **Effort:** S
-**Location:** `apps/myjobhunter/frontend/e2e/playwright.config.ts` — missing `storageState`
+**Location:** `apps/myjobhunter/frontend/e2e/playwright.config.ts`
 **Discovered:** PR profile-wiring — `2026-05-02`
+**Resolved:** PR#TBD — `2026-05-08`
 
-**Problem:** All E2E specs share the same Playwright browser context. Tests that log in leave
-a JWT in `localStorage`. If a subsequent test navigates to `/login` while a token is still
-present, the Login page's `useIsAuthenticated` `useEffect` immediately redirects to `/dashboard`,
-bypassing the test's intended flow. The `auth.spec.ts` "unverified user" test was failing for
-this reason — it had to navigate to `/verify-email` (a public route) first to clear the token.
-
-**Recommendation:** Either:
-1. Add `storageState: { cookies: [], origins: [] }` to the playwright config's `use` block
-   to start each test with a clean context. This is the simplest fix and aligns with best
-   practices.
-2. Or configure `use.actionTimeout` and ensure every test that modifies auth state calls
-   `localStorage.removeItem("token")` via a shared `beforeEach` fixture.
-
-Option 1 is preferred — zero per-test overhead and prevents the class of bug entirely.
+Added `storageState: { cookies: [], origins: [] }` to the playwright config `use` block.
+Each test now starts with a clean browser context. No per-test changes needed — all specs
+already called `loginViaUI` explicitly.
 
 ---
 

--- a/apps/myjobhunter/frontend/e2e/playwright.config.ts
+++ b/apps/myjobhunter/frontend/e2e/playwright.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
     baseURL: process.env.BASE_URL ?? "http://localhost:5174",
     trace: "on-first-retry",
     screenshot: "only-on-failure",
+    storageState: { cookies: [], origins: [] },
   },
   projects: [
     {


### PR DESCRIPTION
## Summary

- Adds `storageState: { cookies: [], origins: [] }` to the `use` block in `apps/myjobhunter/frontend/e2e/playwright.config.ts`
- Each test now starts with a clean browser context — no JWT inherited from a previous test
- Resolves the MEDIUM tech-debt item (discovered PR profile-wiring 2026-05-02): shared context caused `useIsAuthenticated` to redirect `/login` → `/dashboard` if a prior test left a token in `localStorage`

## No per-test changes needed

All 15 spec files already call `loginViaUI` explicitly before any authenticated action. The `auth.spec.ts` tests that manually cleared `localStorage` before navigating to `/login` are now protected by the config-level isolation instead — those defensive calls remain harmless.

## Test plan

- [ ] All existing E2E tests pass with the config change (no test was implicitly relying on inherited auth state)
- [ ] `auth.spec.ts` "unverified user" test no longer needs the `/verify-email` workaround (but it remains as a harmless no-op)
- [ ] TECH_DEBT.md MEDIUM item marked RESOLVED