### PR TITLE
fix(mjh/invites): expose distinct 409 detail codes on admin invite route

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -403,26 +403,19 @@ Column-width alignment (`applications.role_title` 200 vs `discovered_jobs.title`
 
 ## Pre-existing entries (preserved from prior scans)
 
-### [Admin Invites UX] "Cannot send invite to this email." doesn't tell operator why
+### ~~[Admin Invites UX] "Cannot send invite to this email." doesn't tell operator why~~
 
-**Severity:** Low
+**Severity:** Low — **RESOLVED** (see PR feat/mjh-admin-invite-error-codes)
 **Effort:** S
-**Location:** `apps/myjobhunter/backend/app/services/platform/invite_service.py` (raises) + `apps/myjobhunter/frontend/src/features/invite/...` (renders error)
+**Location:** `apps/myjobhunter/backend/app/services/platform/invite_service.py` (raises) + `apps/myjobhunter/frontend/src/features/admin/invites/CreateInviteDialog.tsx` (renders error)
 **Discovered:** 2026-05-07 — operator hit it after deploying the discovery feature
 
-**Problem:** The 409 message is intentionally generic — fires when (a) the email is already a registered user OR (b) there's already a pending invite for that email. The privacy reasoning (don't leak "is this email registered?" via the invite form) is right for end users, but the operator on `/admin/invites` is the only one who sees this UI and would benefit from knowing which case fired so they can act:
-
-- Already-registered → "User already exists; nothing to invite"
-- Pending invite → "Invite already pending; cancel it from the row above to resend"
-
-**Recommendation:** Two options, in increasing scope:
-
-1. **Backend exposes a distinct error code only on the admin route.** Keep the generic message for any non-admin caller (via the existing `register` flow), but on `POST /admin/invites` map the two cases to specific 409 detail strings. The admin role gate already means leakage is bounded to operators.
-2. **Frontend pre-flight:** before submitting, check if the email already appears in the visible pending-invites list and short-circuit with a UI hint. Doesn't help the registered-user case.
-
-Pick option 1; it's the cleaner and more informative path.
-
-**Why Low:** Doesn't break functionality — the operator can re-look at the pending list or query the DB to figure out which case fired. Just a UX paper-cut on a low-volume admin surface.
+Option 1 was implemented: `InviteRecipientUnavailableError` was split into
+`InviteEmailAlreadyRegisteredError` and `InvitePendingAlreadyExistsError` (both
+subclass the parent). The admin route catches each subclass and returns a specific
+409 detail code (`user_already_exists` / `invite_already_pending`). The frontend
+`CreateInviteDialog` maps those codes to operator-friendly hint messages. Non-admin
+callers would still catch the parent and see the generic body.
 
 ---
 

--- a/apps/myjobhunter/backend/app/api/admin_invites.py
+++ b/apps/myjobhunter/backend/app/api/admin_invites.py
@@ -12,9 +12,11 @@ the appropriate HTTP status codes. No DB primitives in this file.
 Security shape (2026-05-05): the public ``GET /invites/{token}/info``
 endpoint is per-IP rate-limited so an attacker cannot use it as a
 free token-validity oracle. The 409-collision response on
-``POST /admin/invites`` returns a single generic body so even a
-compromised admin token cannot enumerate existing user accounts vs.
-in-flight invites.
+``POST /admin/invites`` now returns a specific detail code
+(``user_already_exists`` / ``invite_already_pending``) so the operator
+can act on it directly; leakage is acceptable because the admin role
+gate bounds visibility to operators. Any non-admin caller would still
+receive the parent-class generic 409 body.
 
 Status code conventions:
   * 201 — invite created
@@ -44,9 +46,11 @@ from app.services.platform import invite_service
 from app.services.platform.invite_email import send_invite_email
 from app.services.platform.invite_service import (
     InviteAlreadyAcceptedError,
+    InviteEmailAlreadyRegisteredError,
     InviteEmailMismatchError,
     InviteExpiredError,
     InviteNotFoundError,
+    InvitePendingAlreadyExistsError,
     InviteRecipientUnavailableError,
 )
 from platform_shared.core.request_utils import get_client_ip
@@ -97,6 +101,10 @@ async def create_invite(
         result = await invite_service.create_invite(
             email=body.email, admin_id=admin.id,
         )
+    except InviteEmailAlreadyRegisteredError as e:
+        raise HTTPException(status_code=409, detail="user_already_exists") from e
+    except InvitePendingAlreadyExistsError as e:
+        raise HTTPException(status_code=409, detail="invite_already_pending") from e
     except InviteRecipientUnavailableError as e:
         raise HTTPException(status_code=409, detail=str(e)) from e
 

--- a/apps/myjobhunter/backend/app/services/platform/invite_service.py
+++ b/apps/myjobhunter/backend/app/services/platform/invite_service.py
@@ -74,11 +74,21 @@ class InviteError(Exception):
 class InviteRecipientUnavailableError(InviteError):
     """The recipient email cannot accept a new invite.
 
-    Collapses two underlying causes — already-registered user OR pending
-    invite already in flight — into a single error so a compromised
-    admin token cannot enumerate which case applies. The route layer
-    maps this to a single generic 409 body.
+    Parent class for the two specific collision cases. Non-admin callers
+    (e.g. a hypothetical self-register flow) should catch this parent and
+    emit a single generic 409 so a compromised token cannot enumerate
+    which case applies. The admin route catches each subclass directly
+    and returns an operator-friendly detail string — the admin role gate
+    bounds that leakage to operators only.
     """
+
+
+class InviteEmailAlreadyRegisteredError(InviteRecipientUnavailableError):
+    """The recipient email already belongs to a registered user account."""
+
+
+class InvitePendingAlreadyExistsError(InviteRecipientUnavailableError):
+    """A pending (un-accepted) invite already exists for this email."""
 
 
 class InviteNotFoundError(InviteError):
@@ -185,13 +195,13 @@ async def create_invite(
     async with unit_of_work() as db:
         existing_user = await user_repo.get_by_email(db, normalized)
         if existing_user is not None:
-            raise InviteRecipientUnavailableError(
+            raise InviteEmailAlreadyRegisteredError(
                 "Cannot send invite to this email."
             )
 
         existing_invite = await invite_repo.get_pending_for_email(db, normalized)
         if existing_invite is not None:
-            raise InviteRecipientUnavailableError(
+            raise InvitePendingAlreadyExistsError(
                 "Cannot send invite to this email."
             )
 
@@ -358,10 +368,12 @@ __all__ = [
     "INVITE_CANCELLED",
     "INVITE_CREATED",
     "InviteAlreadyAcceptedError",
+    "InviteEmailAlreadyRegisteredError",
     "InviteEmailMismatchError",
     "InviteError",
     "InviteExpiredError",
     "InviteNotFoundError",
+    "InvitePendingAlreadyExistsError",
     "InviteRecipientUnavailableError",
     "accept_invite",
     "cancel_invite",

--- a/apps/myjobhunter/backend/tests/test_platform_invites.py
+++ b/apps/myjobhunter/backend/tests/test_platform_invites.py
@@ -6,8 +6,8 @@ landed in PR fix/myjobhunter-invite-security-hardening:
   State machine:
     * admin creates invite (201) → public preview returns email + status
     * non-admin POST /admin/invites → 403
-    * duplicate email while a pending invite exists → 409 (generic)
-    * email already a registered user → 409 (generic — same body)
+    * duplicate email while a pending invite exists → 409 "invite_already_pending"
+    * email already a registered user → 409 "user_already_exists"
     * accept with matching email → invite consumed (accepted_at set)
     * accept twice → 409 already accepted
     * accept after expiry → 410 gone
@@ -21,10 +21,18 @@ landed in PR fix/myjobhunter-invite-security-hardening:
     * The DB persists only the sha256 hash, never the raw value.
     * Audit-log metadata uses email_domain only on create — never
       the full recipient email.
-    * The 409 collision response collapses "user exists" / "pending
-      invite" into a single generic body, so an admin token compromise
-      cannot enumerate the auth state of an arbitrary email.
+    * The admin route returns specific 409 detail codes per collision
+      reason; the parent InviteRecipientUnavailableError still maps to
+      a generic body for any non-admin caller.
     * The public preview is per-IP rate-limited.
+
+  Service-layer unit tests:
+    * create_invite raises InviteEmailAlreadyRegisteredError for an
+      existing user account.
+    * create_invite raises InvitePendingAlreadyExistsError for a
+      duplicate pending invite.
+    * Both are subclasses of InviteRecipientUnavailableError so a
+      non-admin catcher can use the parent without code changes.
 
 The unit-of-work fixture in conftest commits user-factory rows in a
 fresh engine, so the `is_verified=True` flip persists across the
@@ -260,13 +268,11 @@ async def test_create_invite_lowercases_email(
 
 
 @pytest.mark.asyncio
-async def test_create_invite_for_existing_user_returns_generic_409(
+async def test_create_invite_for_existing_user_returns_specific_409(
     client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
-    """Generic body — no hint that the email is already a user.
-
-    Security invariant: a compromised admin session must not be able to
-    enumerate which arbitrary emails already have accounts.
+    """Admin route returns ``user_already_exists`` so the operator knows the
+    email already belongs to a registered account and no action is needed.
     """
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
@@ -276,15 +282,16 @@ async def test_create_invite_for_existing_user_returns_generic_409(
             "/admin/invites", json={"email": existing["email"]},
         )
     assert resp.status_code == 409
-    detail = resp.json()["detail"]
-    assert detail == "Cannot send invite to this email."
+    assert resp.json()["detail"] == "user_already_exists"
 
 
 @pytest.mark.asyncio
-async def test_create_invite_duplicate_pending_returns_generic_409(
+async def test_create_invite_duplicate_pending_returns_specific_409(
     client: AsyncClient, user_factory, as_user, captured_invites,
 ) -> None:
-    """Same generic body as the user-exists branch."""
+    """Admin route returns ``invite_already_pending`` so the operator knows
+    to cancel the existing row and re-send rather than creating a duplicate.
+    """
     admin = await user_factory()
     await _promote_to_admin(admin["email"])
     async with await as_user(admin) as authed:
@@ -296,7 +303,7 @@ async def test_create_invite_duplicate_pending_returns_generic_409(
             "/admin/invites", json={"email": "dupe@example.com"},
         )
     assert second.status_code == 409
-    assert second.json()["detail"] == "Cannot send invite to this email."
+    assert second.json()["detail"] == "invite_already_pending"
 
 
 # ---------------------------------------------------------------------------
@@ -614,6 +621,51 @@ async def test_create_invite_audit_log_uses_email_domain_only(
     assert "fred" not in str(metadata), (
         "local-part of recipient email must not leak"
     )
+
+
+# ---------------------------------------------------------------------------
+# Service exception hierarchy (no DB)
+# ---------------------------------------------------------------------------
+
+
+def test_email_already_registered_error_is_subclass_of_recipient_unavailable() -> None:
+    from app.services.platform.invite_service import (
+        InviteEmailAlreadyRegisteredError,
+        InviteRecipientUnavailableError,
+    )
+
+    err = InviteEmailAlreadyRegisteredError("msg")
+    assert isinstance(err, InviteRecipientUnavailableError)
+
+
+def test_pending_already_exists_error_is_subclass_of_recipient_unavailable() -> None:
+    from app.services.platform.invite_service import (
+        InvitePendingAlreadyExistsError,
+        InviteRecipientUnavailableError,
+    )
+
+    err = InvitePendingAlreadyExistsError("msg")
+    assert isinstance(err, InviteRecipientUnavailableError)
+
+
+def test_both_subclasses_caught_by_parent() -> None:
+    from app.services.platform.invite_service import (
+        InviteEmailAlreadyRegisteredError,
+        InvitePendingAlreadyExistsError,
+        InviteRecipientUnavailableError,
+    )
+
+    caught: list[str] = []
+    for exc in (InviteEmailAlreadyRegisteredError, InvitePendingAlreadyExistsError):
+        try:
+            raise exc("test")
+        except InviteRecipientUnavailableError:
+            caught.append(exc.__name__)
+
+    assert caught == [
+        "InviteEmailAlreadyRegisteredError",
+        "InvitePendingAlreadyExistsError",
+    ]
 
 
 # ---------------------------------------------------------------------------

--- a/apps/myjobhunter/frontend/src/features/admin/invites/CreateInviteDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/invites/CreateInviteDialog.tsx
@@ -1,11 +1,11 @@
 import { useState } from "react";
 import {
   LoadingButton,
-  extractErrorMessage,
   showError,
   showSuccess,
 } from "@platform/ui";
 import { useCreateInviteMutation } from "@/store/invitesApi";
+import { extractInviteCreateErrorMessage } from "./inviteErrorMessages";
 
 export interface CreateInviteDialogProps {
   open: boolean;
@@ -47,7 +47,7 @@ export default function CreateInviteDialog({
       setEmail("");
       onOpenChange(false);
     } catch (err) {
-      showError(`Couldn't send invite: ${extractErrorMessage(err)}`);
+      showError(extractInviteCreateErrorMessage(err));
     }
   }
 

--- a/apps/myjobhunter/frontend/src/features/admin/invites/__tests__/inviteErrorMessages.test.ts
+++ b/apps/myjobhunter/frontend/src/features/admin/invites/__tests__/inviteErrorMessages.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { extractInviteCreateErrorMessage } from "../inviteErrorMessages";
+
+function makeRtkError(detail: string): unknown {
+  return { data: { detail } };
+}
+
+describe("extractInviteCreateErrorMessage", () => {
+  it("returns user-already-exists hint for user_already_exists code", () => {
+    const msg = extractInviteCreateErrorMessage(makeRtkError("user_already_exists"));
+    expect(msg).toContain("User already exists");
+    expect(msg).toContain("log in directly");
+  });
+
+  it("returns invite-already-pending hint for invite_already_pending code", () => {
+    const msg = extractInviteCreateErrorMessage(makeRtkError("invite_already_pending"));
+    expect(msg).toContain("Invite already pending");
+    expect(msg).toContain("cancel");
+  });
+
+  it("returns fallback for an unrecognised detail code", () => {
+    const msg = extractInviteCreateErrorMessage(makeRtkError("some_unknown_code"));
+    expect(msg).toMatch(/couldn't send invite/i);
+  });
+
+  it("returns fallback when error has no data field", () => {
+    const msg = extractInviteCreateErrorMessage(new Error("network error"));
+    expect(msg).toMatch(/couldn't send invite/i);
+  });
+
+  it("returns fallback when error is null", () => {
+    const msg = extractInviteCreateErrorMessage(null);
+    expect(msg).toMatch(/couldn't send invite/i);
+  });
+
+  it("user_already_exists and invite_already_pending produce distinct messages", () => {
+    const a = extractInviteCreateErrorMessage(makeRtkError("user_already_exists"));
+    const b = extractInviteCreateErrorMessage(makeRtkError("invite_already_pending"));
+    expect(a).not.toEqual(b);
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/admin/invites/inviteErrorMessages.ts
+++ b/apps/myjobhunter/frontend/src/features/admin/invites/inviteErrorMessages.ts
@@ -1,0 +1,36 @@
+/**
+ * Maps backend 409 detail codes from POST /admin/invites into operator-
+ * friendly hint messages. The admin route exposes specific codes (rather
+ * than the single generic message used for non-admin callers) so the
+ * operator can take the right action immediately.
+ */
+
+const INVITE_409_MESSAGES: Record<string, string> = {
+  user_already_exists:
+    "User already exists — nothing to invite. They can log in directly.",
+  invite_already_pending:
+    "Invite already pending — cancel it from the row above to resend.",
+};
+
+function extractDetailCode(err: unknown): string | undefined {
+  if (
+    err != null &&
+    typeof err === "object" &&
+    "data" in err &&
+    err.data != null &&
+    typeof err.data === "object" &&
+    "detail" in err.data &&
+    typeof (err.data as { detail: unknown }).detail === "string"
+  ) {
+    return (err.data as { detail: string }).detail;
+  }
+  return undefined;
+}
+
+export function extractInviteCreateErrorMessage(err: unknown): string {
+  const code = extractDetailCode(err);
+  if (code !== undefined && code in INVITE_409_MESSAGES) {
+    return INVITE_409_MESSAGES[code];
+  }
+  return "Couldn't send invite — please try again.";
+}


### PR DESCRIPTION
## Summary

- Splits `InviteRecipientUnavailableError` into two specific subclasses — `InviteEmailAlreadyRegisteredError` and `InvitePendingAlreadyExistsError` — both inheriting from the parent
- Admin `POST /admin/invites` now catches each subclass and returns `"user_already_exists"` or `"invite_already_pending"` as the 409 detail string; the admin role gate bounds that information to operators only
- Non-admin callers would still catch the parent and receive a generic body (privacy preserved)
- Frontend `CreateInviteDialog` now maps the specific codes to operator-friendly messages: "User already exists — nothing to invite. They can log in directly." and "Invite already pending — cancel it from the row above to resend."
- Resolves the `TECH_DEBT.md` LOW entry "[Admin Invites UX] 'Cannot send invite to this email.' doesn't tell operator why"

## Test plan

- [ ] 3 new backend unit tests: `InviteEmailAlreadyRegisteredError` / `InvitePendingAlreadyExistsError` are subclasses of `InviteRecipientUnavailableError`; both caught by the parent
- [ ] 2 updated backend integration tests: assert `"user_already_exists"` and `"invite_already_pending"` detail codes (previously asserted the generic string)
- [ ] 6 new frontend unit tests in `inviteErrorMessages.test.ts`: specific code → specific hint; unknown code → fallback; null → fallback; two codes produce distinct messages
- [ ] All pre-existing passing backend tests remain passing (11 pass, 17 pre-existing failures on `_promote_to_admin` path are unchanged from `main`)
- [ ] All 6 new frontend tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)