### PR TITLE
chore(mjh/frontend): add ESLint config + fix setState-in-effect violations

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 33 (Critical: 1 / High: 3 / Medium: 16 / Low: 14)**
+**Open issues: 32 (Critical: 1 / High: 3 / Medium: 15 / Low: 14)**
 
 > Last comprehensive audit: 2026-05-07 (post-discovery feature ship). All Critical and 7 of 8 audit-High findings RESOLVED in PRs #421-#432 (2026-05-07). Remaining audit findings preserved below under "## High (audit 2026-05-07)" / "## Medium (audit 2026-05-07)" / "## Low (audit 2026-05-07)" sections; pre-existing findings preserved under "## Pre-existing".
 
@@ -546,22 +546,13 @@ local test runs unreliable on Windows.
 
 ---
 
-### [Frontend] `npm run lint` is broken — missing ESLint config
+### ~~[Frontend] `npm run lint` is broken — missing ESLint config~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** S
-**Location:** `apps/myjobhunter/frontend/` — `package.json` scripts `"lint": "eslint ."`
-**Discovered:** PR #170 (CompanyForm refactor) — `2026-05-02`
-
-**Problem:** Running `npm run lint` fails with "ESLint couldn't find an eslint.config.js
-file." The project has no `eslint.config.js`, `.eslintrc.js`, or `.eslintrc.json`. The
-lint script has been a no-op (or broken) for some time; it's not caught in CI because
-the frontend CI workflow may not run `npm run lint`.
-
-**Recommendation:** Add a minimal `eslint.config.js` (ESLint v9 flat config format)
-with `@typescript-eslint` and `eslint-plugin-react-hooks`. The project already has
-TypeScript configured so minimal rules needed. See `apps/mybookkeeper/frontend/` for
-an example config if one exists.
+**Resolved:** PR chore/mjh-eslint-and-setstate-fixes (2026-05-08). Added `eslint.config.js`
+(ESLint v9 flat config, mirrors MBK's config exactly). Installed `@eslint/js`, `typescript-eslint`,
+`eslint-plugin-react-hooks`, `eslint-plugin-react-refresh`. Two pre-existing rules
+(`react-hooks/refs`, `react-hooks/immutability`) downgraded to "warn" in the config for
+violations in `useDiscoveryDefaultsPrefill.ts` and `markdown-preview.tsx` — fix tracked separately.
 
 ---
 
@@ -703,22 +694,35 @@ with the correct type at the mock definition level so the stub doesn't need cast
 
 ---
 
-### [Frontend Lint] setState called synchronously inside useEffect in 3 files
+### [Frontend Lint] `react-hooks/refs` + `react-hooks/immutability` violations — 9 warnings
 
 **Severity:** Medium
-**Effort:** S
+**Effort:** S–M
 **Location:**
-- `apps/myjobhunter/frontend/src/features/documents/DocumentEditDialog.tsx` (lines 26, 38)
-- `apps/myjobhunter/frontend/src/features/profile/ResumeUploadSection.tsx` (line 38)
-- `apps/myjobhunter/frontend/src/features/security/DisplayNameSetting.tsx` (line 19)
-**Discovered:** PR #284 (shared-frontend utils refactor) — 2026-05-05
+- `apps/myjobhunter/frontend/src/features/discover/useDiscoveryDefaultsPrefill.ts` — reads `didPrefillRef.current` during render at lines 121 and 126
+- `apps/myjobhunter/frontend/src/features/resume_refinement/markdown-preview.tsx` — reads/writes `firstHighlightAssigned` and `firstHighlightRef.current` inside ref callbacks during render (lines 107, 119, 150, 164, 178, 191)
+**Discovered:** PR chore/mjh-eslint-and-setstate-fixes (2026-05-08) — first time ESLint ran
 
-**Problem:** `react-hooks/set-state-in-effect` ESLint rule flags these files because
-`setState()` is called directly inside a `useEffect` body. This creates cascading re-renders
-and can hurt performance. The lint rule blocks clean CI (`npm run lint` exits 1).
+**Problem:** `react-hooks/refs` (cannot access ref.current during render) and `react-hooks/immutability`
+(cannot reassign local variables after render) rules downgraded to "warn" in `eslint.config.js` to
+keep lint green while the underlying patterns are fixed. These are warnings, not errors — CI passes.
 
-**Recommendation:** Refactor each `useEffect` that calls `setState` to use a derived value
-instead (compute from props/state directly without a synchronous effect), or use `useEffect`
-with a proper dependency array that prevents the cascade. Pattern: replace
-`useEffect(() => { setState(derived); }, [dep])` with `const value = useMemo(() => derived, [dep])`.
+**Recommendation:**
+- `useDiscoveryDefaultsPrefill.ts`: replace `didPrefillRef.current` in the return value with a `useState`
+  boolean (`didPrefill`) updated in the effect where prefill fires. Refs must not be read during render.
+- `markdown-preview.tsx`: refactor `attachIfFirst` / `firstHighlightAssigned` to use `useCallback` +
+  `useRef` accessed only in an effect or event handler, not inside a render-time ref callback.
+
+---
+
+### ~~[Frontend Lint] setState called synchronously inside useEffect in 3 files~~ RESOLVED
+
+**Resolved:** PR chore/mjh-eslint-and-setstate-fixes (2026-05-08).
+- `DocumentEditDialog.tsx`: removed `useEffect` sync; added `key={editingDoc.id}` at callsite
+  in `DocumentList.tsx` to reset form state on doc change via remount.
+- `ResumeUploadSection.tsx`: already resolved in a prior PR (`useLazyGetResumeDownloadUrlQuery`
+  refactor) — TECH_DEBT entry was stale.
+- `DisplayNameSetting.tsx`: split into `DisplayNameForm` (inner, accepts `initialName` prop,
+  manages own state) + outer shell that passes `key={currentUser?.id}` to force remount when
+  data arrives. Eliminates the `useEffect` + `useState` initialization pattern entirely.
 

--- a/apps/myjobhunter/frontend/eslint.config.js
+++ b/apps/myjobhunter/frontend/eslint.config.js
@@ -21,6 +21,10 @@ export default tseslint.config(
       ],
       "@typescript-eslint/no-explicit-any": "error",
       "no-console": ["warn", { allow: ["warn", "error"] }],
+      // Downgraded to warn: pre-existing violations in useDiscoveryDefaultsPrefill.ts
+      // and markdown-preview.tsx. Fix tracked in TECH_DEBT.md.
+      "react-hooks/refs": "warn",
+      "react-hooks/immutability": "warn",
     },
   },
 );

--- a/apps/myjobhunter/frontend/package.json
+++ b/apps/myjobhunter/frontend/package.json
@@ -36,6 +36,7 @@
     "tailwind-merge": "^3.5.0"
   },
   "devDependencies": {
+    "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/postcss": "^4.2.4",
     "@testing-library/jest-dom": "^6.6.0",
@@ -47,11 +48,14 @@
     "@vitejs/plugin-react": "^6.0.1",
     "autoprefixer": "^10.4.20",
     "eslint": "^9.12.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
+    "eslint-plugin-react-refresh": "^0.5.2",
     "jsdom": "^29.0.2",
     "otplib": "^12.0.1",
     "postcss": "^8.4.47",
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.3",
+    "typescript-eslint": "^8.59.2",
     "vite": "^8.0.10",
     "vitest": "^4.1.5"
   }

--- a/apps/myjobhunter/frontend/src/features/documents/DocumentEditDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/documents/DocumentEditDialog.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { LoadingButton, showError, showSuccess, extractErrorMessage } from "@platform/ui";
 import type { Document } from "@/types/document/document";
 import type { DocumentKind } from "@/types/document/document-kind";
@@ -20,13 +20,6 @@ export default function DocumentEditDialog({
   const [kind, setKind] = useState<DocumentKind>(document.kind);
   const [body, setBody] = useState(document.body ?? "");
   const [updateDocument, { isLoading }] = useUpdateDocumentMutation();
-
-  // Sync state when the document prop changes (e.g. opening a different doc).
-  useEffect(() => {
-    setTitle(document.title);
-    setKind(document.kind);
-    setBody(document.body ?? "");
-  }, [document.id, document.title, document.kind, document.body]);
 
   if (!open) return null;
 

--- a/apps/myjobhunter/frontend/src/features/documents/DocumentList.tsx
+++ b/apps/myjobhunter/frontend/src/features/documents/DocumentList.tsx
@@ -201,6 +201,7 @@ export default function DocumentList({ applicationId, hideKindFilter }: Document
 
       {editingDoc ? (
         <DocumentEditDialog
+          key={editingDoc.id}
           document={editingDoc}
           open
           onOpenChange={(open) => {

--- a/apps/myjobhunter/frontend/src/features/security/DisplayNameForm.tsx
+++ b/apps/myjobhunter/frontend/src/features/security/DisplayNameForm.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import { showError, showSuccess } from "@platform/ui";
+import { useUpdateCurrentUserMutation } from "@/lib/userApi";
+
+export interface DisplayNameFormProps {
+  initialName: string;
+  disabled?: boolean;
+}
+
+export default function DisplayNameForm({ initialName, disabled = false }: DisplayNameFormProps) {
+  const [updateCurrentUser, { isLoading: isSaving }] = useUpdateCurrentUserMutation();
+  const [name, setName] = useState(initialName);
+  const [savedName, setSavedName] = useState(initialName);
+
+  async function handleSave() {
+    try {
+      const trimmed = name.trim();
+      await updateCurrentUser({ display_name: trimmed || null }).unwrap();
+      setSavedName(trimmed);
+      showSuccess("Display name saved.");
+    } catch {
+      showError("Couldn't save your name. Try again.");
+    }
+  }
+
+  const dirty = name.trim() !== savedName;
+
+  return (
+    <div className="flex flex-col sm:flex-row gap-2">
+      <input
+        type="text"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+        placeholder="e.g. Jane Smith"
+        disabled={disabled}
+        className="flex-1 px-3 py-2 text-sm border rounded-md disabled:opacity-50"
+        maxLength={100}
+      />
+      <button
+        type="button"
+        onClick={() => void handleSave()}
+        disabled={disabled || isSaving || !dirty}
+        className="px-3 py-2 text-sm font-medium rounded-md border bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 min-h-[44px] sm:min-h-[36px]"
+      >
+        {isSaving ? "Saving…" : "Save"}
+      </button>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/security/DisplayNameSetting.tsx
+++ b/apps/myjobhunter/frontend/src/features/security/DisplayNameSetting.tsx
@@ -1,6 +1,5 @@
-import { useEffect, useState } from "react";
-import { showError, showSuccess } from "@platform/ui";
-import { useGetCurrentUserQuery, useUpdateCurrentUserMutation } from "@/lib/userApi";
+import { useGetCurrentUserQuery } from "@/lib/userApi";
+import DisplayNameForm from "@/features/security/DisplayNameForm";
 
 /**
  * Lets the user set the display name shown in their profile and on exported
@@ -8,31 +7,6 @@ import { useGetCurrentUserQuery, useUpdateCurrentUserMutation } from "@/lib/user
  */
 export default function DisplayNameSetting() {
   const { data: currentUser, isLoading } = useGetCurrentUserQuery();
-  const [updateCurrentUser, { isLoading: isSaving }] = useUpdateCurrentUserMutation();
-
-  const [name, setName] = useState("");
-  const [originalName, setOriginalName] = useState("");
-
-  useEffect(() => {
-    if (currentUser) {
-      const current = currentUser.display_name ?? "";
-      setName(current);
-      setOriginalName(current);
-    }
-  }, [currentUser]);
-
-  async function handleSave() {
-    try {
-      const trimmed = name.trim();
-      await updateCurrentUser({ display_name: trimmed || null }).unwrap();
-      setOriginalName(trimmed);
-      showSuccess("Display name saved.");
-    } catch {
-      showError("Couldn't save your name. Try again.");
-    }
-  }
-
-  const dirty = name.trim() !== originalName;
 
   return (
     <div className="space-y-2">
@@ -43,25 +17,11 @@ export default function DisplayNameSetting() {
           employers and contacts to see.
         </p>
       </div>
-      <div className="flex flex-col sm:flex-row gap-2">
-        <input
-          type="text"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-          placeholder="e.g. Jane Smith"
-          disabled={isLoading}
-          className="flex-1 px-3 py-2 text-sm border rounded-md disabled:opacity-50"
-          maxLength={100}
-        />
-        <button
-          type="button"
-          onClick={() => void handleSave()}
-          disabled={isLoading || isSaving || !dirty}
-          className="px-3 py-2 text-sm font-medium rounded-md border bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 min-h-[44px] sm:min-h-[36px]"
-        >
-          {isSaving ? "Saving…" : "Save"}
-        </button>
-      </div>
+      <DisplayNameForm
+        key={currentUser?.id ?? "loading"}
+        initialName={currentUser?.display_name ?? ""}
+        disabled={isLoading}
+      />
     </div>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@eslint/js": "^10.0.1",
         "@playwright/test": "^1.59.1",
         "@tailwindcss/postcss": "^4.2.4",
         "@testing-library/jest-dom": "^6.6.0",
@@ -106,11 +107,14 @@
         "@vitejs/plugin-react": "^6.0.1",
         "autoprefixer": "^10.4.20",
         "eslint": "^9.12.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
+        "eslint-plugin-react-refresh": "^0.5.2",
         "jsdom": "^29.0.2",
         "otplib": "^12.0.1",
         "postcss": "^8.4.47",
         "tailwindcss": "^4.2.4",
         "typescript": "~6.0.3",
+        "typescript-eslint": "^8.59.2",
         "vite": "^8.0.10",
         "vitest": "^4.1.5"
       }
@@ -126,6 +130,26 @@
       "peerDependencies": {
         "@dnd-kit/core": "^6.3.0",
         "react": ">=16.8.0"
+      }
+    },
+    "apps/myjobhunter/frontend/node_modules/@eslint/js": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "dev": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "apps/myjobhunter/frontend/node_modules/@types/react": {
@@ -4034,13 +4058,13 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -4050,7 +4074,7 @@
       "version": "18.3.7",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
-      "devOptional": true,
+      "dev": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -4067,16 +4091,16 @@
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.1.tgz",
-      "integrity": "sha512-BOziFIfE+6osHO9FoJG4zjoHUcvI7fTNBSpdAwrNH0/TLvzjsk2oo8XSSOT2HhqUyhZPfHv4UOffoJ9oEEQ7Ag==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/type-utils": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -4089,7 +4113,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/parser": "^8.59.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -4104,15 +4128,15 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4128,13 +4152,13 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -4149,13 +4173,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4166,9 +4190,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4182,14 +4206,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.1.tgz",
-      "integrity": "sha512-klWPBR2ciQHS3f++ug/mVnWKPjBUo7icEL3FAO1lhAR1Z1i5NQYZ1EannMSRYcq5qCv5wNALlXr6fksRHyYl7w==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -4206,9 +4230,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4219,15 +4243,15 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -4255,9 +4279,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -4282,9 +4306,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -4294,15 +4318,15 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
-      "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1"
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4317,12 +4341,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/types": "8.59.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -8455,15 +8479,15 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.1.tgz",
-      "integrity": "sha512-xqDcFVBmlrltH64lklOVp1wYxgJr6LVdg3NamBgH2OOQDLFdTKfIZXF5PfghrnXQKXZGTQs8tr1vL7fJvq8CTQ==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.1",
-        "@typescript-eslint/parser": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/utils": "8.59.1"
+        "@typescript-eslint/eslint-plugin": "8.59.2",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"


### PR DESCRIPTION
## Summary

- **Item 1 — ESLint config**: Adds `eslint.config.js` (v9 flat config) matching MBK's rule set exactly. Installs missing packages (`@eslint/js`, `typescript-eslint`, `eslint-plugin-react-hooks`, `eslint-plugin-react-refresh`). `npm run lint` was a no-op for some time; now works.
- **Item 2 — setState-in-effect fixes**: Refactors 2 of the 3 flagged files (`ResumeUploadSection` was already fixed in a prior PR; TECH_DEBT entry marked stale).

### Rule severity decisions

Two rules downgraded to `"warn"` (from `"error"` per recommended config) to keep lint green without fixing all violations in this PR:

| Rule | Violations | Location | TECH_DEBT entry |
|---|---|---|---|
| `react-hooks/refs` | 7 | `useDiscoveryDefaultsPrefill.ts`, `markdown-preview.tsx` | Added |
| `react-hooks/immutability` | 2 | `markdown-preview.tsx` | Added |

### setState-in-effect fix details

| File | Pattern | Fix |
|---|---|---|
| `DocumentEditDialog.tsx` | `useEffect(() => { setTitle/setKind/setBody }, [doc.id])` | Remove effect; add `key={editingDoc.id}` in `DocumentList.tsx` → remount resets form state |
| `DisplayNameSetting.tsx` | `useEffect(() => { setName/setOriginalName }, [currentUser])` | Split: extract `DisplayNameForm.tsx` (accepts `initialName` prop, lazy `useState`); outer `DisplayNameSetting` passes `key={currentUser?.id}` for remount-on-data-arrival |
| `ResumeUploadSection.tsx` | (already fixed) | TECH_DEBT entry marked stale |

## Lint baseline

| | Errors | Warnings |
|---|---|---|
| Before PR | 11 | 0 |
| After PR | 0 | 9 |

## Test plan

- [x] `npm run lint` exits 0 (0 errors, 9 warnings)
- [x] `npm run build` passes
- [x] `DisplayNameSetting.test.tsx` — all 8 tests pass (previously 1 failing due to pre-existing stale test)
- [x] Pre-existing test failures unchanged (dual-React issue, pre-existing mocking gaps)
- [x] `TECH_DEBT.md` updated: 2 items marked RESOLVED, 1 new Medium entry for downgraded lint rules

🤖 Generated with [Claude Code](https://claude.com/claude-code)