### PR TITLE
fix(mjh/discovery): reap stuck discovery_fetches on startup

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -361,7 +361,7 @@ Column-width alignment (`applications.role_title` 200 vs `discovered_jobs.title`
 
 ---
 
-### [Backend / Discovery] No reaper for `status='running'` fetches stuck >30 min
+### ~~[Backend / Discovery] No reaper for `status='running'` fetches stuck >30 min~~ RESOLVED
 
 **Severity:** Low
 **Effort:** M
@@ -372,6 +372,8 @@ Column-width alignment (`applications.role_title` 200 vs `discovered_jobs.title`
 **Recommendation:** Add a Dramatiq periodic task (or app-startup check) that updates `discovery_fetches` rows with `status='running' AND started_at < NOW() - interval '30 minutes'` to `status='error', error_message='reaped: server restart'`.
 
 **Why Low:** Audit-trail issue only — doesn't block functionality. But the migration documents it as a feature; ship-as-described.
+
+**Resolved:** Chose Option A (startup hook) — MJH has no Dramatiq scheduler. Added `discovery_fetch_reaper.py` + wired via `create_app_lifespan(on_startup=_on_startup)` in `main.py`. 5 unit tests added (`test_discovery_fetch_reaper.py`). On next deploy, any zombie `running` rows are reaped to `error` at boot.
 
 ---
 

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -22,7 +22,19 @@ from app.core.rate_limit import (
     require_turnstile,
 )
 from app.schemas.user import UserCreate, UserRead, UserUpdate
+from app.db.session import AsyncSessionLocal
+from app.services.discovery.discovery_fetch_reaper import reap_stale_running_fetches
 from app.services.storage.bucket_initializer import ensure_bucket
+
+
+async def _on_startup() -> None:
+    """Run once at backend boot — reap discovery_fetches stuck in 'running'."""
+    async with AsyncSessionLocal() as db:
+        reaped = await reap_stale_running_fetches(db)
+        if reaped > 0:
+            logger.info(
+                "discovery_fetch_reaper: reaped %d stale rows on startup", reaped
+            )
 
 
 def _resolve_git_commit() -> str:
@@ -60,6 +72,7 @@ lifespan = create_app_lifespan(
     settings=settings,
     init_sentry=init_sentry,
     bucket_init=ensure_bucket,
+    on_startup=_on_startup,
 )
 
 
@@ -193,7 +206,6 @@ app.include_router(discover.router)
 # mount alongside this under the same /admin prefix.
 from platform_shared.api.admin_router import build_admin_router
 from app.core.permissions import current_admin
-from app.db.session import AsyncSessionLocal
 from app.services.system.admin_user_service_factory import shared_admin_user_service
 from app.services.user.totp_service import verify_totp_code as _verify_totp_code
 

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
@@ -168,6 +168,32 @@ async def complete_fetch(
     await db.flush()
 
 
+async def reap_stale_fetches(
+    db: AsyncSession,
+    *,
+    cutoff: datetime,
+) -> int:
+    """Bulk-update discovery_fetches stuck in 'running' before ``cutoff`` to 'error'.
+
+    Called at startup to clean up zombie rows left by a crashed backend.
+    Returns the number of rows updated so the caller can log it.
+    """
+    stmt = (
+        update(DiscoveryFetch)
+        .where(
+            DiscoveryFetch.status == "running",
+            DiscoveryFetch.started_at < cutoff,
+        )
+        .values(
+            status="error",
+            error_message="reaped: server restart or stuck >30min",
+        )
+    )
+    result = await db.execute(stmt)
+    await db.flush()
+    return result.rowcount or 0
+
+
 # ===========================================================================
 # discovered_jobs
 # ===========================================================================

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_reaper.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_reaper.py
@@ -1,0 +1,57 @@
+"""Reaper for discovery_fetches rows stuck in ``status='running'``.
+
+A backend crash mid-fetch leaves the audit row in ``status='running'``
+indefinitely. Nothing in the normal fetch cycle will ever touch it again
+because every new fetch creates a new row — so the zombie row stays
+``running`` forever and corrupts per-source fetch-history views.
+
+The reaper is intentionally run once at startup (rather than as a periodic
+task) because:
+
+- The most common cause is a server restart / deploy crash, so startup is
+  exactly the right time to clean up.
+- MJH has no periodic-task infrastructure (no Dramatiq scheduler, no Celery
+  beat). Wiring a one-line startup hook is lower complexity than adding a
+  scheduling layer.
+- Even for rows that got stuck while the backend was alive (e.g. a slow
+  adapter held the lock for >30 min), they are unreachable: the next deploy
+  cleans them up rather than requiring operator intervention.
+
+``REAP_AFTER_MINUTES = 30`` matches the threshold documented in the
+``discovery_fetches`` model docstring.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.discovery.discovery_fetch import DiscoveryFetch
+
+logger = logging.getLogger(__name__)
+
+REAP_AFTER_MINUTES = 30
+
+
+async def reap_stale_running_fetches(db: AsyncSession) -> int:
+    """Update discovery_fetches stuck in ``'running'`` for >30 min to ``'error'``.
+
+    Returns the number of rows reaped so the caller can log it.
+    """
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=REAP_AFTER_MINUTES)
+    stmt = (
+        update(DiscoveryFetch)
+        .where(
+            DiscoveryFetch.status == "running",
+            DiscoveryFetch.started_at < cutoff,
+        )
+        .values(
+            status="error",
+            error_message="reaped: server restart or stuck >30min",
+        )
+    )
+    result = await db.execute(stmt)
+    await db.commit()
+    return result.rowcount or 0

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_reaper.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_reaper.py
@@ -25,10 +25,9 @@ from __future__ import annotations
 import logging
 from datetime import datetime, timedelta, timezone
 
-from sqlalchemy import update
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.models.discovery.discovery_fetch import DiscoveryFetch
+from app.repositories.discovery import discovery_repository
 
 logger = logging.getLogger(__name__)
 
@@ -41,17 +40,6 @@ async def reap_stale_running_fetches(db: AsyncSession) -> int:
     Returns the number of rows reaped so the caller can log it.
     """
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=REAP_AFTER_MINUTES)
-    stmt = (
-        update(DiscoveryFetch)
-        .where(
-            DiscoveryFetch.status == "running",
-            DiscoveryFetch.started_at < cutoff,
-        )
-        .values(
-            status="error",
-            error_message="reaped: server restart or stuck >30min",
-        )
-    )
-    result = await db.execute(stmt)
+    count = await discovery_repository.reap_stale_fetches(db, cutoff=cutoff)
     await db.commit()
-    return result.rowcount or 0
+    return count

--- a/apps/myjobhunter/backend/tests/test_discovery_fetch_reaper.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_fetch_reaper.py
@@ -1,0 +1,166 @@
+"""Unit tests for the discovery_fetch_reaper.
+
+Scenarios covered:
+
+1. Stale running row (started_at > 30 min ago) → reaped to error.
+2. Fresh running row (started_at < 30 min ago) → left untouched.
+3. Non-running rows (pending / success / error) → left untouched regardless
+   of age.
+4. Reaper returns the correct reaped count.
+5. Idempotency — running the reaper twice leaves rows in their post-first-run
+   state (an already-reaped error row is not double-touched).
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.discovery.discovery_fetch import DiscoveryFetch
+from app.models.discovery.discovery_source import DiscoverySource
+from app.services.discovery.discovery_fetch_reaper import (
+    REAP_AFTER_MINUTES,
+    reap_stale_running_fetches,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _uid(user: dict) -> uuid.UUID:
+    return uuid.UUID(user["id"])
+
+
+async def _make_source(db: AsyncSession, user_id: uuid.UUID) -> DiscoverySource:
+    src = DiscoverySource(user_id=user_id, source="jsearch", config={})
+    db.add(src)
+    await db.flush()
+    return src
+
+
+def _fetch(
+    user_id: uuid.UUID,
+    source_id: uuid.UUID,
+    started_at: datetime,
+    status: str = "running",
+) -> DiscoveryFetch:
+    return DiscoveryFetch(
+        user_id=user_id,
+        discovery_source_id=source_id,
+        source="jsearch",
+        started_at=started_at,
+        status=status,
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_running_row_is_reaped(db: AsyncSession, user_factory):
+    user = await user_factory()
+    uid = _uid(user)
+    src = await _make_source(db, uid)
+
+    stale_started = _now() - timedelta(minutes=REAP_AFTER_MINUTES + 1)
+    row = _fetch(uid, src.id, started_at=stale_started)
+    db.add(row)
+    await db.flush()
+    row_id = row.id
+
+    count = await reap_stale_running_fetches(db)
+
+    result = await db.execute(
+        select(DiscoveryFetch).where(DiscoveryFetch.id == row_id)
+    )
+    updated = result.scalar_one()
+
+    assert count == 1
+    assert updated.status == "error"
+    assert updated.error_message == "reaped: server restart or stuck >30min"
+
+
+@pytest.mark.asyncio
+async def test_fresh_running_row_is_untouched(db: AsyncSession, user_factory):
+    user = await user_factory()
+    uid = _uid(user)
+    src = await _make_source(db, uid)
+
+    fresh_started = _now() - timedelta(minutes=REAP_AFTER_MINUTES - 1)
+    row = _fetch(uid, src.id, started_at=fresh_started)
+    db.add(row)
+    await db.flush()
+    row_id = row.id
+
+    count = await reap_stale_running_fetches(db)
+
+    result = await db.execute(
+        select(DiscoveryFetch).where(DiscoveryFetch.id == row_id)
+    )
+    untouched = result.scalar_one()
+
+    assert count == 0
+    assert untouched.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_non_running_rows_are_untouched(db: AsyncSession, user_factory):
+    """Rows already in success / error are never touched, regardless of age."""
+    user = await user_factory()
+    uid = _uid(user)
+    src = await _make_source(db, uid)
+
+    very_old = _now() - timedelta(hours=24)
+    for terminal_status in ("success", "error", "partial"):
+        db.add(_fetch(uid, src.id, started_at=very_old, status=terminal_status))
+    await db.flush()
+
+    count = await reap_stale_running_fetches(db)
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_returns_correct_count_for_multiple_stale_rows(
+    db: AsyncSession, user_factory
+):
+    user = await user_factory()
+    uid = _uid(user)
+    src = await _make_source(db, uid)
+
+    very_old = _now() - timedelta(hours=2)
+    for _ in range(3):
+        db.add(_fetch(uid, src.id, started_at=very_old))
+    # One fresh running row that should NOT be reaped.
+    fresh_started = _now() - timedelta(minutes=5)
+    db.add(_fetch(uid, src.id, started_at=fresh_started))
+    await db.flush()
+
+    count = await reap_stale_running_fetches(db)
+    assert count == 3
+
+
+@pytest.mark.asyncio
+async def test_reaper_is_idempotent(db: AsyncSession, user_factory):
+    """Running the reaper twice on the same data produces no additional changes."""
+    user = await user_factory()
+    uid = _uid(user)
+    src = await _make_source(db, uid)
+
+    stale_started = _now() - timedelta(hours=1)
+    row = _fetch(uid, src.id, started_at=stale_started)
+    db.add(row)
+    await db.flush()
+    row_id = row.id
+
+    first_count = await reap_stale_running_fetches(db)
+    second_count = await reap_stale_running_fetches(db)
+
+    result = await db.execute(
+        select(DiscoveryFetch).where(DiscoveryFetch.id == row_id)
+    )
+    final_row = result.scalar_one()
+
+    assert first_count == 1
+    assert second_count == 0
+    assert final_row.status == "error"


### PR DESCRIPTION
## Summary

- Adds `discovery_repository.reap_stale_fetches(db, *, cutoff)` — bulk UPDATE with `WHERE status='running' AND started_at < cutoff`, returns rowcount (ORM in repo layer per arch rule)
- Adds `discovery_fetch_reaper.py` service — computes the 30-min cutoff, delegates to the repo, commits; returns count for logging
- Wires via `create_app_lifespan(on_startup=_on_startup)` in `main.py`; logs at INFO if any rows were reaped
- Resolves TECH_DEBT.md LOW entry "No reaper for `status='running'` fetches stuck >30 min"

**Why startup hook over Dramatiq:** MJH has no scheduler worker. The crash-restart scenario is exactly what startup covers. No new infra needed.

## Test plan

- `test_stale_running_row_is_reaped` — stale `running` row (>30 min old) → `error` ✓
- `test_fresh_running_row_is_untouched` — `running` row 29 min old → untouched ✓
- `test_non_running_rows_are_untouched` — `success`/`error`/`partial` ignored regardless of age ✓
- `test_returns_correct_count_for_multiple_stale_rows` — 3 stale + 1 fresh → count 3 ✓
- `test_reaper_is_idempotent` — second pass returns 0, row stays `error` ✓

All 5 pass.

## Operational migration

None. On the next deploy, any zombie `running` rows are reaped to `error` at startup — desired behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)