### PR TITLE
fix(mbk/alembic): rename gmail_skipped_messages migration — revision collision + parallel head

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/gskmsg260508_add_gmail_skipped_messages_table.py
+++ b/apps/mybookkeeper/backend/alembic/versions/gskmsg260508_add_gmail_skipped_messages_table.py
@@ -1,7 +1,7 @@
 """add gmail_skipped_messages table
 
-Revision ID: a1b2c3d4e5f6
-Revises: z0a1b2c3d4e5
+Revision ID: gskmsg260508
+Revises: chsync260508
 Create Date: 2026-05-08 00:00:00.000000
 
 Audit log table for Gmail message envelope fetches that fail during discovery.
@@ -9,6 +9,10 @@ Previously these were silently skipped (bare except + continue); now every skip
 lands a row here so the operator can see which user/message combinations are
 failing and at what frequency. Partial sync behavior is preserved — the sync
 continues with the remaining messages.
+
+Renamed from the original `a1b2c3d4e5f6` revision id (which collided with
+`a1b2c3d4e5f6_add_invoice_line_items.py`) and re-pointed off `chsync260508`
+to linearize the chain after the parallel head left by PR #508 + PR #526.
 """
 from typing import Sequence, Union
 
@@ -16,8 +20,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql
 
-revision: str = "a1b2c3d4e5f6"
-down_revision: Union[str, None] = "z0a1b2c3d4e5"
+revision: str = "gskmsg260508"
+down_revision: Union[str, None] = "chsync260508"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Summary

PR #526 (gmail_skipped_messages audit table) shipped with two latent migration defects that \`test_alembic_chain\` caught on the post-merge regression run:

1. **Revision id collision** — used \`a1b2c3d4e5f6\` which was already taken by \`a1b2c3d4e5f6_add_invoice_line_items.py\`. Alembic emits a UserWarning and degrades to indeterminate behavior on a fresh DB.

2. **Parallel alembic head** — \`down_revision\` pointed at \`z0a1b2c3d4e5\` which left two branches at the top of the chain (\`a1b2c3d4e5f6\` and \`chsync260508\` from PR #508) that were never merged. Two heads break \`alembic upgrade head\`.

## Fix

- Rename \`a1b2c3d4e5f6_add_gmail_skipped_messages_table.py\` → \`gskmsg260508_add_gmail_skipped_messages_table.py\`
- Update \`revision: str = \"gskmsg260508\"\`
- Re-point \`down_revision: str = \"chsync260508\"\` to linearize the chain

## Verification
- [x] \`alembic heads\` → single head \`gskmsg260508\`
- [x] \`tests/test_alembic_chain.py\` 3/3 pass
- [x] Full MBK backend suite 2644/2644

🤖 Generated with [Claude Code](https://claude.com/claude-code)