### PR TITLE
fix(mjh/e2e): sync 3 stale Playwright specs with current UI

### DIFF
--- a/apps/myjobhunter/frontend/e2e/applications-inline-company.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/applications-inline-company.spec.ts
@@ -1,134 +1,15 @@
 /**
- * E2E: Inline company creation from AddApplicationDialog.
+ * E2E: Company creation flows related to the Add Application dialog.
  *
- * Covers the new flow: user opens "Add application" dialog, clicks "+ New"
- * next to the company dropdown, fills in a company name, submits the inline
- * form, and the new company auto-selects in the application dropdown so the
- * user can complete the application without leaving the dialog.
+ * The inline-company-from-dialog flow (dropdown + "+ New" panel) was removed
+ * when AddApplicationDialog was redesigned in PR #371 to a URL/text/manual
+ * state machine. Those tests have been deleted; the regression test for the
+ * standalone /companies page is retained.
  */
 import { test, expect } from "@playwright/test";
 import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
 
 test.describe("Applications — inline company create", () => {
-  test("create a company inline from the add-application dialog, then submit the application", async ({
-    page,
-    request,
-  }) => {
-    const user = await createTestUser(request);
-
-    try {
-      await loginViaUI(page, user);
-
-      // Navigate to Applications
-      await page.getByRole("link", { name: /applications/i }).first().click();
-      await page.waitForURL("**/applications");
-
-      // Empty state with "Add application" CTA
-      await expect(
-        page.getByRole("heading", { name: "No applications yet" }),
-      ).toBeVisible();
-
-      // Open the Add Application dialog via empty-state CTA
-      await page.getByRole("button", { name: /add application/i }).first().click();
-
-      // Dialog is visible
-      await expect(
-        page.getByRole("dialog", { name: /add application/i }),
-      ).toBeVisible();
-
-      // The company dropdown should be visible with no companies yet
-      await expect(page.getByText("No companies yet")).toBeVisible();
-
-      // Click "+ New" button to open the inline company form
-      await page.getByRole("button", { name: /add new company/i }).click();
-
-      // The inline form header is visible
-      await expect(page.getByText("New company")).toBeVisible();
-
-      // The dropdown is replaced by the inline form
-      await expect(page.getByText("No companies yet")).not.toBeVisible();
-
-      // Fill in the company name (required field)
-      await page.getByLabel(/^name/i).fill("Inline Test Corp");
-
-      // Also fill optional domain
-      await page.getByLabel(/domain/i).fill("inlinetest.example.com");
-
-      // Submit the inline company form
-      await page.getByRole("button", { name: /create company/i }).click();
-
-      // Success toast fires
-      await expect(
-        page.getByText(/Company "Inline Test Corp" created/i),
-      ).toBeVisible({ timeout: 5_000 });
-
-      // The inline panel closes — dropdown comes back
-      await expect(page.getByText("New company")).not.toBeVisible();
-
-      // The new company is auto-selected in the dropdown.
-      // Check that the <select> has the new company as a selected option.
-      const companySelect = page.locator("select[name='company_id']");
-      await expect(companySelect).toBeVisible({ timeout: 3_000 });
-      // The selected option text should be "Inline Test Corp"
-      await expect(companySelect).toHaveValue(/\w+/); // non-empty value = a company is selected
-
-      // Now fill in the role title and submit the application
-      await page.getByLabel(/role title/i).fill("Staff Engineer");
-
-      await page.getByRole("button", { name: /add application/i }).click();
-
-      // Dialog closes + success toast
-      await expect(
-        page.getByText(/application added/i),
-      ).toBeVisible({ timeout: 5_000 });
-
-      // The application row appears in the list
-      await expect(page.getByText("Staff Engineer")).toBeVisible();
-    } finally {
-      await deleteTestUser(request, user);
-    }
-  });
-
-  test("cancel on inline company form returns to dropdown without submitting", async ({
-    page,
-    request,
-  }) => {
-    const user = await createTestUser(request);
-
-    try {
-      await loginViaUI(page, user);
-
-      await page.getByRole("link", { name: /applications/i }).first().click();
-      await page.waitForURL("**/applications");
-
-      // Open dialog
-      await page.getByRole("button", { name: /add application/i }).first().click();
-      await expect(page.getByRole("dialog", { name: /add application/i })).toBeVisible();
-
-      // Open inline form
-      await page.getByRole("button", { name: /add new company/i }).click();
-      await expect(page.getByText("New company")).toBeVisible();
-
-      // Type something in the name field
-      await page.getByLabel(/^name/i).fill("Cancel Corp");
-
-      // Click Cancel — should close the inline panel
-      // There are two Cancel buttons when CompanyForm is open (one in form, one in dialog footer).
-      // Find the one inside the "New company" panel.
-      const companyPanel = page.locator("text=New company").locator("..").locator("..");
-      await companyPanel.getByRole("button", { name: /cancel/i }).click();
-
-      // Panel closed, dropdown visible again
-      await expect(page.getByText("New company")).not.toBeVisible();
-      await expect(page.getByRole("button", { name: /add new company/i })).toBeVisible();
-
-      // The application dialog is still open
-      await expect(page.getByRole("dialog", { name: /add application/i })).toBeVisible();
-    } finally {
-      await deleteTestUser(request, user);
-    }
-  });
-
   test("existing companies spec still passes — add company via /companies page (regression)", async ({
     page,
     request,

--- a/apps/myjobhunter/frontend/e2e/documents.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/documents.spec.ts
@@ -82,8 +82,8 @@ test.describe("Document CRUD — text document", () => {
       // Open the add document dialog
       await page.getByRole("button", { name: /add document/i }).click();
 
-      // The dialog should open
-      await expect(page.getByText("Add Document")).toBeVisible({ timeout: 5_000 });
+      // The dialog heading disambiguates from the trigger button (strict mode)
+      await expect(page.getByRole("heading", { name: "Add Document" })).toBeVisible({ timeout: 5_000 });
 
       // Switch to text mode
       await page.getByRole("button", { name: "Write text" }).click();
@@ -95,8 +95,8 @@ test.describe("Document CRUD — text document", () => {
       // Submit
       await page.getByRole("button", { name: /create/i }).click();
 
-      // Dialog should close and document should appear in the list
-      await expect(page.getByText("Add Document")).not.toBeVisible({ timeout: 5_000 });
+      // Dialog should close
+      await expect(page.getByRole("heading", { name: "Add Document" })).not.toBeVisible({ timeout: 5_000 });
       await expect(page.getByText("My E2E Cover Letter")).toBeVisible({ timeout: 5_000 });
     } finally {
       await deleteTestUser(request, user);

--- a/apps/myjobhunter/frontend/e2e/smoke.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/smoke.spec.ts
@@ -14,12 +14,9 @@ test.describe("MyJobHunter smoke tests", () => {
       await loginViaUI(page, user, request);
       await expect(page).toHaveURL(/\/dashboard/);
 
-      // 3. Dashboard — check heading and empty state
+      // 3. Dashboard — KanbanEmptyState heading (body copy changed in PR #371 redesign)
       await expect(
         page.getByRole("heading", { name: "Your hunt starts here" })
-      ).toBeVisible();
-      await expect(
-        page.getByText(/I don't have anything to track yet/)
       ).toBeVisible();
 
       // 4. Applications page


### PR DESCRIPTION
## Summary

- **smoke.spec.ts** — removed stale `getByText(/I don't have anything to track yet/)` assertion; `KanbanEmptyState` (introduced in PR #371 Kanban redesign) renders different body copy than the legacy `EMPTY_STATES.dashboard.body` constant. Heading assertion retained.
- **applications-inline-company.spec.ts** — deleted 2 tests for the inline-company-from-dialog flow (dropdown + \"+ New\" panel + `select[name='company_id']`) that was removed when `AddApplicationDialog` was redesigned in PR #480 to a URL/text/manual-entry state machine. The third test (regression for the `/companies` page add flow) is retained unchanged.
- **documents.spec.ts** — replaced `getByText('Add Document')` with `getByRole('heading', { name: 'Add Document' })` to resolve Playwright strict-mode ambiguity; the trigger button renders \"Add document\" (lowercase d) and the dialog `<h2>` renders \"Add Document\" (capital D), giving two matches. Applied to both the open-check and the close-check.

No source (`src/`) changes. Pure test maintenance.

The cross-tenant 404 test at `documents.spec.ts:224` was inspected — it makes API-only calls with no UI selectors and the assertion shape is correct; no changes needed.

## Test plan

- [ ] `npx playwright test e2e/smoke.spec.ts` — dashboard step no longer asserts stale body text
- [ ] `npx playwright test e2e/applications-inline-company.spec.ts` — 1 test remaining (companies page regression)
- [ ] `npx playwright test e2e/documents.spec.ts` — heading selector resolves unambiguously

🤖 Generated with [Claude Code](https://claude.com/claude-code)