### PR TITLE
fix(mjh/e2e): sync auth, totp, admin-demo, account-deletion specs with current source

### DIFF
--- a/apps/myjobhunter/frontend/e2e/account-deletion.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/account-deletion.spec.ts
@@ -46,7 +46,7 @@ test.describe("MyJobHunter account deletion + data export", () => {
       const tokenCookie = await page.evaluate(() => localStorage.getItem("token"));
       expect(tokenCookie).not.toBeNull();
       const exportResponse = await request.get(
-        `${process.env.BACKEND_URL ?? "http://localhost:8004"}/api/users/me/export`,
+        `${process.env.BACKEND_URL ?? "http://localhost:8002"}/api/users/me/export`,
         {
           headers: { Authorization: `Bearer ${tokenCookie}` },
         },

--- a/apps/myjobhunter/frontend/e2e/admin-demo.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/admin-demo.spec.ts
@@ -190,7 +190,7 @@ test.describe("Admin demo accounts", () => {
 
       // Step 7: Back on the admin page, delete the demo account.
       await page
-        .getByRole("button", { name: new RegExp(`Delete ${demoEmail}`, "i") })
+        .getByRole("button", { name: `Delete ${demoEmail}` })
         .click();
 
       const confirmDialog = page.getByRole("dialog", {

--- a/apps/myjobhunter/frontend/e2e/auth.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/auth.spec.ts
@@ -46,7 +46,7 @@ test.describe("Email verification at registration", () => {
 
       // 5. Force-verify via the test helper (simulates the user clicking the email link)
       await request.post(
-        `${process.env.BACKEND_URL ?? "http://localhost:8004"}/api/_test/verify-email`,
+        `${process.env.BACKEND_URL ?? "http://localhost:8002"}/api/_test/verify-email`,
         { data: { email: user.email } },
       );
 

--- a/apps/myjobhunter/frontend/e2e/totp.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/totp.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 import { authenticator } from "otplib";
 import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
 
-const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8004";
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8002";
 
 /**
  * End-to-end TOTP enrollment + login challenge.


### PR DESCRIPTION
## Summary

Four stale Playwright E2E specs updated — no source UI changes.

- **auth.spec.ts** — `8004` → `8002` backend port default on the `_test/verify-email` helper call (step 5). When `BACKEND_URL` env var is unset, the force-verify request hit the wrong port, causing step 6's verified login to fail.
- **totp.spec.ts** — `8004` → `8002` backend port default on `BACKEND_URL` constant used in cleanup. Same mismatch as auth.spec.ts.
- **account-deletion.spec.ts** — `8004` → `8002` backend port default on the export `GET` request. Unlike the TOTP case, this is in the main test flow (not cleanup), so a wrong port causes the export assertion to fail with a connection error.
- **admin-demo.spec.ts** — `new RegExp(\`Delete \${demoEmail}\`, "i")` → `\`Delete \${demoEmail}\`` (plain string). Demo emails have the shape `demo+<uuid>@myjobhunter.local`. When that string is passed as a `RegExp` constructor argument, the `+` becomes a quantifier (one-or-more `o`) and `.` becomes a wildcard, so the pattern doesn't match the literal `aria-label`. Playwright's string `name` match is exact and safe for arbitrary email addresses.

## Test plan

- [ ] Run `npx playwright test e2e/auth.spec.ts e2e/totp.spec.ts e2e/admin-demo.spec.ts e2e/account-deletion.spec.ts` locally with backend on `:8002`
- [ ] Confirm all 4 specs pass end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)