### PR TITLE
fix(mjh/e2e): make full E2E suite green — domain, ORM, race fixes

### DIFF
--- a/apps/myjobhunter/backend/app/api/test_helpers.py
+++ b/apps/myjobhunter/backend/app/api/test_helpers.py
@@ -56,18 +56,31 @@ async def reset_rate_limit() -> None:
 
 @router.post("/_test/promote-to-admin", status_code=204)
 async def promote_to_admin(email: EmailStr = Body(..., embed=True)) -> None:
-    """Flip a user's role to admin.
+    """Flip a user's ``is_superuser`` flag to True.
 
     Used by E2E tests that exercise admin-gated routes (e.g.
     ``/admin/demo/users``) so a fresh test user can be granted the
-    role without seeding via SQL. Gated by
+    superuser bit without seeding via SQL. Gated by
     ``MYJOBHUNTER_ENABLE_TEST_HELPERS=1`` — never mounted in production.
+
+    The admin gate (``app.core.permissions.current_superuser``) reads
+    ``user.is_superuser``, so this is the column we flip. The legacy
+    ``role`` column on the user model is platform-level metadata and
+    is NOT what gates admin routes.
+
+    Caller ordering note: callers must promote AFTER any login the user
+    will perform during the test. fastapi-users' ``UserManager`` issues
+    an ORM ``user_db.update(...)`` on successful login flows, which can
+    overwrite a fresh promotion with the in-memory user copy that still
+    has ``is_superuser=False``. Promote last; subsequent requests use
+    the existing JWT and read ``is_superuser`` fresh from the DB on
+    every authenticated request.
     """
     async with AsyncSessionLocal() as session:
         async with session.begin():
             result = await session.execute(
                 text(
-                    "UPDATE users SET role = 'admin' "
+                    "UPDATE users SET is_superuser = TRUE "
                     "WHERE email = :email RETURNING id"
                 ),
                 {"email": email},

--- a/apps/myjobhunter/backend/app/schemas/demo/demo.py
+++ b/apps/myjobhunter/backend/app/schemas/demo/demo.py
@@ -40,16 +40,16 @@ class DemoCreateRequest(BaseModel):
     """Body of ``POST /admin/demo/users``.
 
     ``email`` is optional — when omitted the service auto-generates a
-    ``demo+<uuid>@myjobhunter.local`` address. ``display_name`` is
-    optional — when omitted the service synthesizes a plausible name
-    from the seed data.
+    ``demo+<uuid>@myjobhunter-demo.example.com`` address.
+    ``display_name`` is optional — when omitted the service
+    synthesizes a plausible name from the seed data.
     """
 
     email: EmailStr | None = Field(
         default=None,
         description=(
             "Optional. Demo account email. Auto-generated as "
-            "'demo+<uuid>@myjobhunter.local' when omitted."
+            "'demo+<uuid>@myjobhunter-demo.example.com' when omitted."
         ),
     )
     display_name: str | None = Field(

--- a/apps/myjobhunter/backend/app/services/demo/demo_constants.py
+++ b/apps/myjobhunter/backend/app/services/demo/demo_constants.py
@@ -31,7 +31,7 @@ import uuid
 from datetime import date, datetime, timedelta, timezone
 from typing import TypedDict
 
-DEMO_EMAIL_DOMAIN = "myjobhunter.local"
+DEMO_EMAIL_DOMAIN = "myjobhunter-demo.example.com"
 DEMO_EMAIL_PREFIX = "demo"
 DEMO_DEFAULT_DISPLAY_NAME = "Alex Demo"
 
@@ -48,12 +48,15 @@ def generate_demo_password() -> str:
 
 
 def make_demo_email() -> str:
-    """Generate a unique demo email under ``myjobhunter.local``.
+    """Generate a unique demo email under ``myjobhunter-demo.example.com``.
 
-    ``.local`` is RFC 6762 reserved (mDNS) so it will never collide
-    with a real deliverable inbox. The UUID slice keeps the email
-    short enough to display comfortably in the credentials modal but
-    long enough to avoid collisions across many demo accounts.
+    ``example.com`` is RFC 2606 reserved so it will never collide with
+    a real deliverable inbox, AND it passes Pydantic's ``EmailStr``
+    syntactic validation (unlike ``.local`` / ``.test`` / ``.invalid``
+    which ``email_validator`` rejects as special-use TLDs). The UUID
+    slice keeps the email short enough to display comfortably in the
+    credentials modal but long enough to avoid collisions across many
+    demo accounts.
     """
     slug = uuid.uuid4().hex[:12]
     return f"{DEMO_EMAIL_PREFIX}+{slug}@{DEMO_EMAIL_DOMAIN}"

--- a/apps/myjobhunter/backend/app/services/demo/demo_service.py
+++ b/apps/myjobhunter/backend/app/services/demo/demo_service.py
@@ -79,7 +79,7 @@ async def create_demo_user(
 
     Args:
         email: Optional override. When ``None`` the service auto-
-            generates ``demo+<uuid>@myjobhunter.local``.
+            generates ``demo+<uuid>@myjobhunter-demo.example.com``.
         display_name: Optional override. When ``None`` the service
             uses ``DEMO_DEFAULT_DISPLAY_NAME``.
 
@@ -147,8 +147,9 @@ async def create_demo_user(
         user_id = user.id
 
     # Log only the email domain — demo emails today are non-deliverable
-    # (`.local`), but the same log shape would copy-paste into a real
-    # signup flow if extracted later. PII redaction by default.
+    # (RFC 2606 ``example.com``), but the same log shape would copy-
+    # paste into a real signup flow if extracted later. PII redaction
+    # by default.
     _, _, _domain = final_email.rpartition("@")
     logger.info(
         "DEMO_ACTION created demo user user_id=%s email_domain=%s",

--- a/apps/myjobhunter/backend/tests/test_demo_service.py
+++ b/apps/myjobhunter/backend/tests/test_demo_service.py
@@ -63,7 +63,7 @@ async def test_create_demo_user_returns_credentials_and_seeds_data() -> None:
     """``create_demo_user`` writes a real user, profile, and applications."""
     response = await demo_service.create_demo_user()
 
-    assert response.credentials.email.endswith("@myjobhunter.local")
+    assert response.credentials.email.endswith("@myjobhunter-demo.example.com")
     assert len(response.credentials.password) >= 16
     assert response.user_id is not None
 
@@ -153,11 +153,11 @@ async def test_create_demo_user_returns_credentials_and_seeds_data() -> None:
 
 async def test_create_demo_user_rejects_duplicate_email() -> None:
     """Passing the same email twice raises ValueError (409)."""
-    first = await demo_service.create_demo_user(email="demo+dupe@myjobhunter.local")
-    assert first.credentials.email == "demo+dupe@myjobhunter.local"
+    first = await demo_service.create_demo_user(email="demo+dupe@myjobhunter-demo.example.com")
+    assert first.credentials.email == "demo+dupe@myjobhunter-demo.example.com"
 
     with pytest.raises(ValueError, match="already exists"):
-        await demo_service.create_demo_user(email="demo+dupe@myjobhunter.local")
+        await demo_service.create_demo_user(email="demo+dupe@myjobhunter-demo.example.com")
 
 
 async def test_list_demo_users_returns_only_demo_rows() -> None:
@@ -291,7 +291,7 @@ async def test_post_demo_users_admin_can_create(user_factory) -> None:
     assert resp.status_code == 201, resp.text
     body = resp.json()
     assert "credentials" in body
-    assert body["credentials"]["email"].endswith("@myjobhunter.local")
+    assert body["credentials"]["email"].endswith("@myjobhunter-demo.example.com")
     assert body["user_id"]
 
 

--- a/apps/myjobhunter/frontend/e2e/admin-demo.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/admin-demo.spec.ts
@@ -18,7 +18,7 @@
  * demo accounts from the page.
  */
 import { test, expect, type APIRequestContext } from "@playwright/test";
-import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+import { createTestUser, deleteTestUser, loginViaUI, resetRateLimit } from "./fixtures/auth";
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8002";
 
@@ -72,9 +72,18 @@ test.describe("Admin demo accounts", () => {
     let adminToken = "";
 
     try {
-      await promoteToAdmin(request, adminUser.email);
+      // Step 1: Log in first (both API and UI), THEN promote.
+      //
+      // Why this order matters: fastapi-users' UserManager.authenticate() calls
+      // user_db.update(result, clear_update) on every successful login, which
+      // issues session.commit() against an ORM-cached user object that still has
+      // is_superuser=False. That commit overwrites any raw-SQL promotion that
+      // happened before the login. Promoting AFTER all logins avoids the race.
 
-      // Get a token for cleanup later.
+      // Get a token for cleanup — this login happens before promotion so it
+      // won't interfere.
+      // Reset rate limit before API login to prevent 429s during parallel runs.
+      await resetRateLimit(request);
       const loginResp = await request.post(
         `${BACKEND_URL}/api/auth/jwt/login`,
         {
@@ -86,16 +95,25 @@ test.describe("Admin demo accounts", () => {
         (await loginResp.json()) as { access_token: string }
       ).access_token;
 
-      // Make sure no leftover demo accounts pollute the listing.
-      await bulkDeleteDemoUsers(request, adminToken);
-
-      // Step 1: Log in via UI as the admin and navigate to /admin/demo.
+      // Log in via UI so the browser has an auth session.
       await loginViaUI(page, adminUser, request);
       await expect(page).toHaveURL(/\/dashboard/);
 
+      // NOW promote — no more logins will happen for this user after this point,
+      // so the ORM-commit overwrite can't strike again.
+      await promoteToAdmin(request, adminUser.email);
+
+      // Clean up leftover demo accounts from previous broken runs.
+      // Must happen AFTER promotion — the JWT token is checked against DB
+      // is_superuser on every request, so the same token now grants admin access.
+      await bulkDeleteDemoUsers(request, adminToken);
+
+      // Navigate to /admin/demo. The page load triggers a fresh /users/me fetch
+      // which will see is_superuser=true. RequireSuperuser waits for that fetch
+      // before allowing or redirecting, so this is race-free.
       await page.goto("/admin/demo");
       await expect(
-        page.getByRole("heading", { name: "Demo accounts" }),
+        page.getByRole("heading", { name: "Demo accounts", exact: true }),
       ).toBeVisible({ timeout: 10_000 });
 
       // Step 2: Empty state shows the CTA.
@@ -125,7 +143,7 @@ test.describe("Admin demo accounts", () => {
       const credsText = await credsDialog.textContent();
       expect(credsText).toBeTruthy();
       const emailMatch = credsText!.match(
-        /demo\+[a-z0-9]+@myjobhunter\.local/i,
+        /demo\+[a-z0-9]+@myjobhunter-demo\.example\.com/i,
       );
       expect(emailMatch).not.toBeNull();
       const demoEmail = emailMatch![0];

--- a/apps/myjobhunter/frontend/e2e/applications-inline-company.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/applications-inline-company.spec.ts
@@ -44,11 +44,11 @@ test.describe("Applications — inline company create", () => {
       await page.getByRole("button", { name: /^add company$/i }).click();
 
       await expect(
-        page.getByText(/Regression Corp.*added|added.*Regression Corp/i),
+        page.getByText(/Regression Corp.*added|added.*Regression Corp/i).first(),
       ).toBeVisible({ timeout: 5_000 });
 
-      await expect(page.getByText("Regression Corp")).toBeVisible();
-      await expect(page.getByText("regression.example.com")).toBeVisible();
+      await expect(page.getByRole("button", { name: /Regression Corp/i }).first()).toBeVisible();
+      await expect(page.getByText("regression.example.com").first()).toBeVisible();
     } finally {
       await deleteTestUser(request, user);
     }

--- a/apps/myjobhunter/frontend/e2e/applications-jd-url-extract.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/applications-jd-url-extract.spec.ts
@@ -58,33 +58,30 @@ test.describe("Applications — paste-link JD URL extract", () => {
         page.getByRole("dialog", { name: /add application/i }),
       ).toBeVisible();
 
-      // Expand the auto-fill panel — the prompt is collapsed initially.
-      await page.getByRole("button", { name: /paste a link or job description to auto-fill/i }).click();
-
-      // URL tab is the default. Confirm by checking for the URL input.
+      // The URL input is the default (no expand step needed in the new dialog).
       const urlInput = page.getByLabel(/job posting url/i);
       await expect(urlInput).toBeVisible();
 
-      // Type a URL and click "Fetch and auto-fill".
+      // Type a URL and click "Auto-fill".
       await urlInput.fill("https://jobs.example.com/posting/abc");
-      await page.getByRole("button", { name: /fetch and auto-fill/i }).click();
+      await page.getByRole("button", { name: /auto-fill/i }).click();
 
-      // Success banner appears.
-      await expect(page.getByText(/fields pre-filled from jd/i)).toBeVisible({
+      // The dialog advances to the review step — "Review and adjust before saving"
+      // banner with the source URL.
+      await expect(page.getByText(/review and adjust before saving/i)).toBeVisible({
         timeout: 5_000,
       });
-      await expect(page.getByText(/fetched from/i)).toBeVisible();
+      await expect(page.getByText(/jobs\.example\.com/i)).toBeVisible();
 
-      // The role title is pre-filled.
-      await expect(page.getByLabel(/role title/i)).toHaveValue("Senior Backend Engineer");
+      // The role title field is pre-filled.
+      await expect(
+        page.getByPlaceholder(/senior backend engineer/i)
+      ).toHaveValue("Senior Backend Engineer");
 
-      // The location is pre-filled.
-      await expect(page.getByLabel(/^location/i)).toHaveValue("San Francisco, CA, US");
-
-      // The URL field is also pre-filled with the source URL.
-      await expect(page.locator("input[type='url']").first()).toHaveValue(
-        "https://jobs.example.com/posting/abc",
-      );
+      // The location field is pre-filled.
+      await expect(
+        page.getByPlaceholder(/sf, nyc/i)
+      ).toHaveValue("San Francisco, CA, US");
     } finally {
       await deleteTestUser(request, user);
     }
@@ -113,26 +110,17 @@ test.describe("Applications — paste-link JD URL extract", () => {
       await page.waitForURL("**/applications");
       await page.getByRole("button", { name: /add application/i }).first().click();
 
-      await page.getByRole("button", { name: /paste a link or job description to auto-fill/i }).click();
-
+      // The URL input is the default (no expand step in the new dialog).
       const urlInput = page.getByLabel(/job posting url/i);
       await urlInput.fill("https://www.linkedin.com/jobs/view/12345");
-      await page.getByRole("button", { name: /fetch and auto-fill/i }).click();
+      await page.getByRole("button", { name: /auto-fill/i }).click();
 
-      // Auth-required banner is shown — distinct from the generic "Couldn't auto-fill" banner.
-      await expect(page.getByText(/couldn't reach this page/i)).toBeVisible({
+      // Backend returns 422 auth_required → the dialog switches to the text panel
+      // and shows a toast explaining that the page required sign-in.
+      // The dialog now shows the text-paste panel with its textarea.
+      await expect(page.getByLabel(/job description text/i)).toBeVisible({
         timeout: 5_000,
       });
-
-      // The "paste the description text instead" button is offered.
-      const switchButton = page.getByRole("button", {
-        name: /paste the description text instead/i,
-      });
-      await expect(switchButton).toBeVisible();
-
-      // Clicking it switches the active tab to the text panel.
-      await switchButton.click();
-      await expect(page.getByLabel(/job description text/i)).toBeVisible();
     } finally {
       await deleteTestUser(request, user);
     }

--- a/apps/myjobhunter/frontend/e2e/applications-status.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/applications-status.spec.ts
@@ -6,9 +6,9 @@
  * the correct status badge.
  */
 import { test, expect } from "@playwright/test";
-import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+import { createTestUser, deleteTestUser, loginViaUI, resetRateLimit } from "./fixtures/auth";
 
-const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8004";
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8002";
 
 /**
  * Create a company via the API (faster than UI flow for test setup).
@@ -82,12 +82,14 @@ async function logEventViaApi(
 
 /**
  * Log in via the backend API and return the JWT token.
+ * Resets the per-IP rate limit first to prevent 429s during parallel runs.
  */
 async function getToken(
   request: import("@playwright/test").APIRequestContext,
   email: string,
   password: string,
 ): Promise<string> {
+  await resetRateLimit(request);
   const res = await request.post(`${BACKEND_URL}/api/auth/jwt/login`, {
     form: { username: email, password },
   });
@@ -145,7 +147,7 @@ test.describe("Applications list — Status column", () => {
     }
   });
 
-  test("shows em-dash for an application with no events", async ({
+  test("shows 'Applied' status for a new application (backend auto-logs initial event)", async ({
     page,
     request,
   }) => {
@@ -163,14 +165,12 @@ test.describe("Applications list — Status column", () => {
 
       await expect(page.getByText("No Events Role")).toBeVisible({ timeout: 8_000 });
 
-      // The Status column should show an em-dash for zero events.
-      // DataTable renders each row as a <button> (clickable), so use getByRole("button")
-      // scoped to the row, then assert the second cell (Status) contains "—".
+      // The backend auto-logs an "applied" event when an application is created,
+      // so the Status column always shows "Applied" for a new application even when
+      // no explicit events are logged via the API. The row uses role="button" so
+      // td.nth(1) targets the Status cell (column index 1).
       const row = page.getByRole("button").filter({ hasText: "No Events Role" });
-      // The Status cell is the second <td> (index 1: 0=role_title, 1=latest_status).
-      // getByRole("cell") doesn't work when the <tr> overrides to role="button",
-      // which breaks table semantics for the child <td> elements.
-      await expect(row.locator("td").nth(1)).toHaveText("—");
+      await expect(row.locator("td").nth(1)).toHaveText("Applied");
     } finally {
       await deleteTestUser(request, user);
     }

--- a/apps/myjobhunter/frontend/e2e/audit-perf-fixes.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/audit-perf-fixes.spec.ts
@@ -19,9 +19,9 @@
  * description).
  */
 import { test, expect } from "@playwright/test";
-import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+import { createTestUser, deleteTestUser, loginViaUI, resetRateLimit } from "./fixtures/auth";
 
-const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8004";
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8002";
 
 // ---------------------------------------------------------------------------
 // API helpers (mirrors applications-status.spec.ts)
@@ -32,6 +32,8 @@ async function getToken(
   email: string,
   password: string,
 ): Promise<string> {
+  // Reset per-IP rate limit before each API login to prevent 429s during parallel runs.
+  await resetRateLimit(request);
   const res = await request.post(`${BACKEND_URL}/api/auth/jwt/login`, {
     form: { username: email, password },
   });
@@ -228,7 +230,8 @@ test.describe("Applications list — status badge updates after logging event (a
 
       // Status badge should now show "Applied" — no manual refresh needed.
       // This verifies that logApplicationEvent invalidates the Applications list cache.
-      await expect(page.getByText("Applied")).toBeVisible({ timeout: 8_000 });
+      // Use .first() because the list may show multiple badge elements (strict-mode guard).
+      await expect(page.getByText("Applied").first()).toBeVisible({ timeout: 8_000 });
     } finally {
       await deleteTestUser(request, user);
     }

--- a/apps/myjobhunter/frontend/e2e/company-research.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/company-research.spec.ts
@@ -27,8 +27,8 @@ test.describe("Company Research panel", () => {
       await page.getByRole("link", { name: /companies/i }).first().click();
       await page.waitForURL("**/companies");
       await page.getByRole("button", { name: /add a company/i }).click();
-      await page.locator("#ac-name").fill("Research Test Corp");
-      await page.locator("#ac-domain").fill("researchtestcorp.example.com");
+      await page.getByLabel(/^name/i).fill("Research Test Corp");
+      await page.getByLabel(/domain/i).fill("researchtestcorp.example.com");
       await page.getByRole("button", { name: /^add company$/i }).click();
 
       // Navigate to the company detail page
@@ -60,7 +60,7 @@ test.describe("Company Research panel", () => {
       await page.getByRole("link", { name: /companies/i }).first().click();
       await page.waitForURL("**/companies");
       await page.getByRole("button", { name: /add a company/i }).click();
-      await page.locator("#ac-name").fill("Research Error Corp");
+      await page.getByLabel(/^name/i).fill("Research Error Corp");
       await page.getByRole("button", { name: /^add company$/i }).click();
 
       const row = page.getByRole("button").filter({ hasText: "Research Error Corp" }).first();

--- a/apps/myjobhunter/frontend/e2e/documents.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/documents.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+import { createTestUser, deleteTestUser, loginViaUI, resetRateLimit } from "./fixtures/auth";
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8002";
 
@@ -22,6 +22,8 @@ async function loginAndGetToken(
   request: import("@playwright/test").APIRequestContext,
   user: { email: string; password: string },
 ): Promise<string> {
+  // Reset per-IP rate limit before each API login to prevent 429s during parallel runs.
+  await resetRateLimit(request);
   const resp = await request.post(`${BACKEND_URL}/api/auth/jwt/login`, {
     form: { username: user.email, password: user.password },
   });
@@ -50,8 +52,8 @@ test.describe("Documents page", () => {
       await page.getByRole("link", { name: /documents/i }).first().click();
       await page.waitForURL("**/documents");
 
-      // Page heading
-      await expect(page.getByRole("heading", { name: /documents/i })).toBeVisible();
+      // Page heading — use exact match to avoid matching "No documents yet" heading
+      await expect(page.getByRole("heading", { name: "Documents", exact: true })).toBeVisible();
 
       // Empty state — no documents yet
       await expect(page.getByText(/No documents yet/i)).toBeVisible();

--- a/apps/myjobhunter/frontend/e2e/fixtures/auth.ts
+++ b/apps/myjobhunter/frontend/e2e/fixtures/auth.ts
@@ -22,11 +22,15 @@ export async function createTestUser(
   overrides: Partial<TestUser> & { verify?: boolean } = {},
 ): Promise<TestUser> {
   const timestamp = Date.now();
+  // Suffix a short random token so two parallel workers that hit Date.now()
+  // in the same millisecond don't collide on the unique email index.
+  const nonce = Math.random().toString(36).slice(2, 10);
   const verify = overrides.verify ?? true;
   const user: TestUser = {
     email:
-      overrides.email ?? `e2e-test-${timestamp}@myjobhunter-test.example.com`,
-    password: overrides.password ?? `TestPass${timestamp}!`,
+      overrides.email ??
+      `e2e-test-${timestamp}-${nonce}@myjobhunter-test.example.com`,
+    password: overrides.password ?? `TestPass${timestamp}-${nonce}!`,
   };
 
   const response = await request.post(`${BACKEND_URL}/api/auth/register`, {

--- a/apps/myjobhunter/frontend/e2e/profile.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/profile.spec.ts
@@ -159,9 +159,11 @@ test.describe("Skills", () => {
       await page.getByLabel("Skill name").fill("python");
       await page.getByLabel("Skill name").press("Enter");
 
-      // Error toast appears
+      // Error toast appears. Match the visible toast body, not the
+      // aria-live announcement (which renders a sibling element with the
+      // same substring and would trip strict-mode locators).
       await expect(
-        page.getByText(/already exists/i),
+        page.getByText(/already exists/i).first(),
       ).toBeVisible({ timeout: 5_000 });
     } finally {
       await deleteTestUser(request, user);

--- a/apps/myjobhunter/frontend/e2e/resumes.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/resumes.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+import { createTestUser, deleteTestUser, loginViaUI, resetRateLimit } from "./fixtures/auth";
 import path from "path";
 import fs from "fs";
 import os from "os";
@@ -26,6 +26,9 @@ async function loginAndGetToken(
   request: import("@playwright/test").APIRequestContext,
   user: { email: string; password: string },
 ): Promise<string> {
+  // Reset the per-IP rate limit before each login to prevent 429s when many
+  // tests share 127.0.0.1 as the client IP during parallel runs.
+  await resetRateLimit(request);
   const resp = await request.post(`${BACKEND_URL}/api/auth/jwt/login`, {
     form: { username: user.email, password: user.password },
   });

--- a/apps/myjobhunter/frontend/e2e/smoke.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/smoke.spec.ts
@@ -34,8 +34,8 @@ test.describe("MyJobHunter smoke tests", () => {
       await expect(
         page.getByRole("dialog", { name: /add application/i })
       ).toBeVisible({ timeout: 5_000 });
-      // Dismiss the dialog before continuing
-      await page.getByRole("button", { name: /cancel/i }).click();
+      // Dismiss via the X close button (the URL-input step has no Cancel button)
+      await page.getByRole("button", { name: /close/i }).click();
 
       // 6. Companies page
       await page.getByRole("link", { name: /companies/i }).first().click();
@@ -67,7 +67,7 @@ test.describe("MyJobHunter smoke tests", () => {
       await page.getByRole("link", { name: /documents/i }).first().click();
       await page.waitForURL("**/documents");
       await expect(
-        page.getByRole("heading", { name: /documents/i })
+        page.getByRole("heading", { name: "Documents", exact: true })
       ).toBeVisible();
       await expect(page.getByText(/No documents yet/i)).toBeVisible();
 
@@ -82,15 +82,12 @@ test.describe("MyJobHunter smoke tests", () => {
 
       // 10. Application detail error page — invalid/non-existent UUID
       await page.goto("/applications/non-existent-uuid");
-      // The app shows a 422/error state when the UUID is not found
+      // The app shows a 422 error state for an invalid UUID path param
       await expect(
         page.getByRole("heading", {
           name: /couldn't load that application/i,
         })
       ).toBeVisible({ timeout: 5_000 });
-      await expect(
-        page.getByText(/non-existent-uuid.*isn't available/i)
-      ).toBeVisible();
 
       // 11. Sign out
       // Desktop: user menu in sidebar — the button shows the truncated name,

--- a/apps/myjobhunter/frontend/e2e/totp.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/totp.spec.ts
@@ -1,6 +1,43 @@
 import { test, expect } from "@playwright/test";
-import { authenticator } from "otplib";
-import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+import { createHmac } from "crypto";
+import { createTestUser, deleteTestUser, loginViaUI, resetRateLimit } from "./fixtures/auth";
+
+// The backend enrolls TOTP with SHA-256 (platform_shared default since the
+// 2026-05-02 TOTP algorithm upgrade). Generate codes here with the same
+// algorithm so the challenge step doesn't fail with "Invalid verification code".
+//
+// otplib's default authenticator and its plugin-crypto/plugin-thirty-two
+// combination produce different codes than pyotp for SHA-256 due to
+// differences in base32 decoding. Using a direct implementation avoids that
+// mismatch entirely.
+function base32decode(secret: string): Buffer {
+  const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ234567";
+  let bits = 0;
+  let value = 0;
+  const output: number[] = [];
+  for (const ch of secret.toUpperCase().replace(/=/g, "")) {
+    const idx = ALPHABET.indexOf(ch);
+    if (idx < 0) throw new Error(`Invalid base32 character: ${ch}`);
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      output.push((value >>> (bits - 8)) & 255);
+      bits -= 8;
+    }
+  }
+  return Buffer.from(output);
+}
+
+function generateTotp256(secret: string): string {
+  const key = base32decode(secret);
+  const step = BigInt(Math.floor(Date.now() / 30_000));
+  const msg = Buffer.alloc(8);
+  msg.writeBigUInt64BE(step);
+  const h = createHmac("sha256", key).update(msg).digest();
+  const offset = h[h.length - 1] & 0x0f;
+  const code = (h.readUInt32BE(offset) & 0x7fff_ffff) % 1_000_000;
+  return code.toString().padStart(6, "0");
+}
 
 const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8002";
 
@@ -67,7 +104,7 @@ test.describe("MyJobHunter TOTP 2FA", () => {
       await expect(page.getByText(setup.secret)).toBeVisible();
 
       // 4. Enter a fresh 6-digit code derived from the same secret
-      const code = authenticator.generate(setup.secret);
+      const code = generateTotp256(setup.secret);
       await page.getByPlaceholder("000000").fill(code);
       await page.getByRole("button", { name: /verify & enable/i }).click();
 
@@ -86,7 +123,10 @@ test.describe("MyJobHunter TOTP 2FA", () => {
       await page.getByRole("menuitem", { name: /sign out/i }).click();
       await page.waitForURL("**/login", { timeout: 5_000 });
 
-      // 7. Sign in again — TOTP challenge should appear
+      // 7. Sign in again — TOTP challenge should appear.
+      // Reset rate limit first — prior loginViaUI call exhausts the per-IP
+      // throttle when all tests share 127.0.0.1 as the client IP.
+      await resetRateLimit(request);
       await page.getByLabel(/email/i).fill(user.email);
       await page.locator("#login-password").fill(user.password);
       await page.getByRole("button", { name: /^sign in$/i }).click();
@@ -96,7 +136,7 @@ test.describe("MyJobHunter TOTP 2FA", () => {
 
       // 8. Provide a fresh TOTP code (must regenerate — the previous one may
       //    have rolled past its 30s window during recovery-code display)
-      const challengeCode = authenticator.generate(setup.secret);
+      const challengeCode = generateTotp256(setup.secret);
       await page.getByLabel(/authentication code/i).fill(challengeCode);
       await page.getByRole("button", { name: /^verify$/i }).click();
       // After TOTP verify, navigate goes to the "from" state (last visited page
@@ -111,6 +151,10 @@ test.describe("MyJobHunter TOTP 2FA", () => {
       await page.locator("aside").getByRole("button").last().click();
       await page.getByRole("menuitem", { name: /sign out/i }).click();
       await page.waitForURL("**/login", { timeout: 5_000 });
+
+      // Reset rate limit — the previous TOTP challenge login exhausts the
+      // per-IP throttle when all tests share 127.0.0.1 as the client IP.
+      await resetRateLimit(request);
 
       await page.getByLabel(/email/i).fill(user.email);
       await page.locator("#login-password").fill(user.password);

--- a/apps/myjobhunter/frontend/src/features/admin/demo/CreateDemoDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/CreateDemoDialog.tsx
@@ -13,7 +13,7 @@ export interface CreateDemoDialogProps {
  * Modal for creating a new demo account.
  *
  * Both inputs (email + display name) are optional — the backend
- * generates sensible defaults when omitted (`demo+<uuid>@myjobhunter.local`
+ * generates sensible defaults when omitted (`demo+<uuid>@myjobhunter-demo.example.com`
  * and `Alex Demo` respectively). The form is intentionally minimal
  * because the seeded data does the heavy lifting.
  *
@@ -83,7 +83,7 @@ export default function CreateDemoDialog({
                 type="email"
                 value={email}
                 onChange={(e) => setEmail(e.target.value)}
-                placeholder="demo+<id>@myjobhunter.local (auto-generated)"
+                placeholder="demo+<id>@myjobhunter-demo.example.com (auto-generated)"
                 className="w-full border rounded-md px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-primary/50"
                 autoFocus
                 disabled={isLoading}

--- a/apps/myjobhunter/frontend/src/features/admin/demo/__tests__/CreateDemoDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/__tests__/CreateDemoDialog.test.tsx
@@ -91,13 +91,13 @@ describe("CreateDemoDialog", () => {
 
     await user.type(
       screen.getByLabelText(/email/i),
-      "  demo@myjobhunter.local  ",
+      "  demo@myjobhunter-demo.example.com  ",
     );
     await user.type(screen.getByLabelText(/display name/i), "  Demo Boss  ");
     await user.click(screen.getByRole("button", { name: /^create$/i }));
 
     expect(onSubmit).toHaveBeenCalledWith({
-      email: "demo@myjobhunter.local",
+      email: "demo@myjobhunter-demo.example.com",
       displayName: "Demo Boss",
     });
   });

--- a/apps/myjobhunter/frontend/src/features/admin/demo/__tests__/DemoUsersTable.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/admin/demo/__tests__/DemoUsersTable.test.tsx
@@ -21,7 +21,7 @@ vi.mock("@platform/ui", () => ({
 const SAMPLE_USERS: DemoUser[] = [
   {
     user_id: "11111111-1111-1111-1111-111111111111",
-    email: "demo+abc@myjobhunter.local",
+    email: "demo+abc@myjobhunter-demo.example.com",
     display_name: "Alex Demo",
     created_at: "2026-05-05T12:00:00Z",
     application_count: 4,
@@ -29,7 +29,7 @@ const SAMPLE_USERS: DemoUser[] = [
   },
   {
     user_id: "22222222-2222-2222-2222-222222222222",
-    email: "demo+xyz@myjobhunter.local",
+    email: "demo+xyz@myjobhunter-demo.example.com",
     display_name: "Jordan Sandbox",
     created_at: "2026-05-04T08:30:00Z",
     application_count: 0,
@@ -44,7 +44,7 @@ describe("DemoUsersTable", () => {
     expect(screen.getAllByTestId("demo-user-row")).toHaveLength(2);
     expect(screen.getByText("Alex Demo")).toBeInTheDocument();
     expect(screen.getByText("Jordan Sandbox")).toBeInTheDocument();
-    expect(screen.getByText("demo+abc@myjobhunter.local")).toBeInTheDocument();
+    expect(screen.getByText("demo+abc@myjobhunter-demo.example.com")).toBeInTheDocument();
   });
 
   it("invokes onDelete with the matching row when Delete is clicked", async () => {
@@ -55,7 +55,7 @@ describe("DemoUsersTable", () => {
 
     await user.click(
       screen.getByRole("button", {
-        name: /Delete demo\+abc@myjobhunter.local/i,
+        name: /Delete demo\+abc@myjobhunter-demo.example.com/i,
       }),
     );
 

--- a/apps/myjobhunter/frontend/src/types/demo/demo-create-request.ts
+++ b/apps/myjobhunter/frontend/src/types/demo/demo-create-request.ts
@@ -2,7 +2,7 @@
  * Body of `POST /admin/demo/users`.
  *
  * Both fields are optional. When `email` is omitted the backend
- * auto-generates `demo+<uuid>@myjobhunter.local`. When `display_name`
+ * auto-generates `demo+<uuid>@myjobhunter-demo.example.com`. When `display_name`
  * is omitted the backend defaults to "Alex Demo" — the seeded
  * profile's name.
  */


### PR DESCRIPTION
## Summary

Closes the MJH E2E backlog. Resolves the 13-spec failure inventory from the 2026-05-09 session handoff by fixing root causes instead of the bandaids that the WIP checkpoint reached for.

**Result: 45/45 passing, 3 skipped (Tavily-gated, intentional).**

## What changed

**Backend (5 files):**

- Demo email domain `myjobhunter.local` → `myjobhunter-demo.example.com`. `email_validator` rejects RFC 6762 special-use TLDs (`.local`/`.test`/`.invalid`) so `EmailStr` was failing on auto-generated demo addresses. `example.com` is RFC 2606 reserved AND passes syntax validation — same approach MBK uses. **No `EmailStr` → `str` schema downgrades.**
- `/_test/promote-to-admin`: flip `is_superuser` instead of `role='admin'`. The admin gate (`core/permissions.py`) reads `is_superuser`; the legacy `role` column does not gate admin routes. Stays on the ORM via `AsyncSessionLocal` / `unit_of_work` — **no asyncpg bypass.**

**E2E specs (12 files):**

- Sync stale selectors / copy / dialog flows with current source (PR #371 / #480 redesigns).
- `admin-demo`: log in first, THEN promote, so fastapi-users' `user_db.update` on successful login can't overwrite the `is_superuser=true` write with the in-memory copy.
- `totp`: replace `otplib` with a hand-rolled SHA-256 TOTP generator. Backend uses SHA-256 since the 2026-05-02 `platform_shared` upgrade; `otplib`'s defaults produced mismatched codes. Add `resetRateLimit` before re-login attempts to dodge per-IP 429s.

**E2E fixtures (1 file):**

- `createTestUser`: append a random nonce to email/password so two parallel workers calling `Date.now()` in the same millisecond don't collide on `ix_users_email`. Was producing 9 spurious `Failed to create test user: 500` failures per run.

**Misc (1 file):**

- `profile.spec.ts:146`: scope strict-mode locator with `.first()` so it doesn't trip on the toast body + aria-live announcement that both contain "already exists".

## What this PR does NOT do (intentional non-scope)

- Schema-level `EmailStr` → `str` downgrade (was bandaid; reverted).
- `asyncpg.connect()` raw bypass in `test_helpers.py` (was bandaid; replaced with ORM).
- `is_demo` exposure on `UserRead` schema (untouched; was unrelated agent override).

## Test plan

- [x] `pytest` passes for `tests/test_demo_service.py` (domain assertions updated)
- [x] `npx playwright test --config e2e/playwright.config.ts` → 45 passed, 3 skipped, 0 failed
- [x] Backend imports cleanly: `python -c "from app.api import test_helpers; from app.schemas.demo.demo import DemoCredentials; ..."`
- [x] EmailStr accepts the new domain: confirmed via Pydantic round-trip test