### PR TITLE
fix(mbk/auth): validate JWT audience claim in set_audit_user middleware

### DIFF
--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -119,7 +119,12 @@ async def set_audit_user(request: Request, call_next):
     user_id = None
     if token:
         try:
-            payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])
+            payload = jwt.decode(
+                token,
+                settings.secret_key,
+                algorithms=["HS256"],
+                audience="fastapi-users:auth",
+            )
             user_id = payload.get("sub")
             token_ctx = current_user_id.set(user_id)
             try:


### PR DESCRIPTION
## Why

Audit finding C9 (2026-05-09 parity scan): MBK's `set_audit_user` middleware was decoding JWTs **without** validating the `aud` claim while MJH's same middleware does. This is a silent security divergence — one app validates, the other doesn't, with no operational signal pointing to the gap.

## What

One-line tightening in `apps/mybookkeeper/backend/app/main.py:122`:

```python
# Before
payload = jwt.decode(token, settings.secret_key, algorithms=["HS256"])

# After
payload = jwt.decode(
    token,
    settings.secret_key,
    algorithms=["HS256"],
    audience="fastapi-users:auth",
)
```

## Why this is safe to ship

`fastapi-users` issues access tokens with `aud=["fastapi-users:auth"]` by default. Existing MBK tokens already have the claim. Verified via:

```python
strategy = JWTStrategy(secret=..., lifetime_seconds=300)
token = await strategy.write_token(user)
decoded = jwt.decode(token, secret, algorithms=["HS256"], audience="fastapi-users:auth")
# decoded["aud"] == ["fastapi-users:auth"]
```

So tightening the validation is a strict superset — no compatibility break. Tokens that fail the new check were never issued by fastapi-users in the first place.

## Why this matters

The "wrong audience" attack surface: any token signed with MBK's `secret_key` for a different purpose would have been accepted by `set_audit_user`. Examples in the codebase:

- Plaid OAuth state tokens (`core/plaid_webhook_verifier.py`)
- Integration OAuth state tokens (`services/integrations/integration_service.py:86`)

Today those tokens would set `current_user_id` based on whatever `sub` claim they carry. After this fix, only fastapi-users access tokens are accepted. Defense in depth.

## Regression

- **MBK backend pytest**: 2,644 passed / 5 skipped / 0 failed (full suite, 6:13)
- No test reissues a token without the audience claim, so nothing breaks.

## Operational migration

None required. No env vars added. No restart-required state. The code change takes effect on the next deploy.

## Test plan

- [x] Full MBK backend pytest passes
- [x] Verified fastapi-users tokens already carry the aud claim
- [x] No deploy workflow / Caddyfile / docker-compose changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)