### PR TITLE
fix(mbk/auth): make verification email fail-loud (drop silent-fail bool)

### DIFF
--- a/apps/mybookkeeper/backend/app/core/auth.py
+++ b/apps/mybookkeeper/backend/app/core/auth.py
@@ -334,12 +334,17 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_request_verify(
         self, user: User, token: str, request=None,
     ) -> None:
-        """Send verification email when a token is generated (registration or resend)."""
-        success = send_verification_email(user.email, token)
-        if success:
-            logger.info("Verification email sent to %s", user.email)
-        else:
-            logger.warning("Failed to send verification email to %s", user.email)
+        """Send verification email when a token is generated (registration or resend).
+
+        Raises on any send failure so the registration / resend HTTP request
+        fails 5xx and the user retries — never returns a 2xx with the
+        verification email lost. The pre-2026-05-09 bool-returning version
+        silently swallowed failures, which produced the
+        kennethmontgo@gmail.com bug class (registered-but-unverified
+        account with no recovery path).
+        """
+        send_verification_email(user.email, token)
+        logger.info("Verification email sent to %s", user.email)
         await log_auth_event(
             self.user_db.session,
             event_type=AuthEventType.EMAIL_VERIFY_RESEND,

--- a/apps/mybookkeeper/backend/app/services/system/verification_email.py
+++ b/apps/mybookkeeper/backend/app/services/system/verification_email.py
@@ -6,7 +6,7 @@ from platform_shared.services.email_templates import build_verification_html
 
 from app.core.branding import MBK_BRANDING
 from app.core.config import settings
-from app.services.system import email_service
+from app.services.system.email_service import send_email_or_raise
 
 logger = logging.getLogger(__name__)
 
@@ -15,12 +15,23 @@ def _build_verification_html(verify_url: str) -> str:
     return build_verification_html(verify_url=verify_url, branding=MBK_BRANDING)
 
 
-def send_verification_email(recipient_email: str, token: str) -> bool:
+def send_verification_email(recipient_email: str, token: str) -> None:
+    """Send the email-verification message to a newly registered user.
+
+    Critical-path transactional email — raises rather than returning a
+    bool so any failure propagates to the request handler. The pre-2026-05-09
+    bool-returning version silently logged a warning on failure, which
+    is how kennethmontgo@gmail.com ended up with a registered-but-unverified
+    account and no recovery path. MJH was migrated to fail-loud post-PR
+    #205; MBK was the last remaining silent-fail path on this email per
+    the 2026-05-09 parity audit (H6).
+
+    Raises:
+        ValueError, EmailNotConfiguredError, EmailSendError — see
+        ``send_email_or_raise`` for semantics.
+    """
     base_url = settings.frontend_url.rstrip("/")
     verify_url = f"{base_url}/verify-email?token={token}"
     html = _build_verification_html(verify_url)
     subject = "Verify your MyBookkeeper email"
-    success = email_service.send_email([recipient_email], subject, html)
-    if not success:
-        logger.warning("Failed to send verification email to %s", recipient_email)
-    return success
+    send_email_or_raise([recipient_email], subject, html)

--- a/apps/mybookkeeper/backend/tests/test_email_verification.py
+++ b/apps/mybookkeeper/backend/tests/test_email_verification.py
@@ -103,40 +103,44 @@ class TestVerificationEmailTemplate:
 # ---------------------------------------------------------------------------
 
 class TestSendVerificationEmail:
-    @patch("app.services.system.verification_email.email_service")
+    @patch("app.services.system.verification_email.send_email_or_raise")
     @patch("app.services.system.verification_email.settings")
-    def test_sends_email_with_correct_params(self, mock_settings, mock_email_svc):
+    def test_sends_email_with_correct_params(self, mock_settings, mock_send):
         mock_settings.frontend_url = "https://app.example.com"
-        mock_email_svc.send_email.return_value = True
 
         result = send_verification_email("user@example.com", "token123")
 
-        assert result is True
-        mock_email_svc.send_email.assert_called_once()
-        args = mock_email_svc.send_email.call_args
+        assert result is None  # fail-loud contract: returns None on success, raises on failure
+        mock_send.assert_called_once()
+        args = mock_send.call_args
         assert args[0][0] == ["user@example.com"]
         assert "Verify" in args[0][1]
         assert "token123" in args[0][2]
 
-    @patch("app.services.system.verification_email.email_service")
+    @patch("app.services.system.verification_email.send_email_or_raise")
     @patch("app.services.system.verification_email.settings")
-    def test_returns_false_on_failure(self, mock_settings, mock_email_svc):
+    def test_raises_on_send_failure(self, mock_settings, mock_send):
+        """Critical-path email — failures must propagate, never be swallowed.
+
+        Regression contract for the kennethmontgo@gmail.com bug class
+        (registered-but-unverified account with no recovery path).
+        """
+        from app.services.system.email_service import EmailSendError
+
         mock_settings.frontend_url = "https://app.example.com"
-        mock_email_svc.send_email.return_value = False
+        mock_send.side_effect = EmailSendError("smtp connect failed")
 
-        result = send_verification_email("user@example.com", "token123")
+        with pytest.raises(EmailSendError, match="smtp connect failed"):
+            send_verification_email("user@example.com", "token123")
 
-        assert result is False
-
-    @patch("app.services.system.verification_email.email_service")
+    @patch("app.services.system.verification_email.send_email_or_raise")
     @patch("app.services.system.verification_email.settings")
-    def test_verify_url_uses_frontend_url(self, mock_settings, mock_email_svc):
+    def test_verify_url_uses_frontend_url(self, mock_settings, mock_send):
         mock_settings.frontend_url = "https://mybookkeeper.app/"
-        mock_email_svc.send_email.return_value = True
 
         send_verification_email("user@example.com", "abc")
 
-        html = mock_email_svc.send_email.call_args[0][2]
+        html = mock_send.call_args[0][2]
         assert "https://mybookkeeper.app/verify-email?token=abc" in html
 
 
@@ -159,17 +163,20 @@ class TestOnAfterRequestVerify:
 
     @pytest.mark.anyio
     @patch("app.core.auth.send_verification_email")
-    async def test_logs_warning_on_send_failure(self, mock_send, caplog):
-        import logging
-        mock_send.return_value = False
+    async def test_raises_on_send_failure(self, mock_send):
+        """Send failure must propagate so the registration HTTP request
+        fails 5xx and the user retries — never returns 2xx with the email
+        lost. Regression contract for kennethmontgo@gmail.com.
+        """
+        from app.services.system.email_service import EmailSendError
+
+        mock_send.side_effect = EmailSendError("smtp down")
         manager = UserManager.__new__(UserManager)
         manager.user_db = MagicMock()
 
         user = _make_user(email="fail@example.com")
-        with caplog.at_level(logging.WARNING, logger="app.core.auth"):
+        with pytest.raises(EmailSendError, match="smtp down"):
             await manager.on_after_request_verify(user, "token")
-
-        assert any("fail@example.com" in r.message for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

Audit finding H6 (2026-05-09 parity scan): MBK's `send_verification_email` returned `bool` and only logged a WARNING on SMTP failure. Registration would then return 201 to the user even though the verification email never went out — the kennethmontgo@gmail.com bug class (registered-but-unverified account with no recovery path).

MJH was migrated to fail-loud post-PR #205. MBK was the last remaining silent-fail path on this email.

## What

- **`send_verification_email`** now returns `None` and uses `send_email_or_raise`. Failures (ValueError / EmailNotConfiguredError / EmailSendError) propagate to the request handler so registration / resend HTTP requests fail 5xx and the user retries.
- **`on_after_request_verify`** is the same shape as MJH's now: call, log info, emit auth_event. The audit_event is only written on the success path (the raise short-circuits before it). Previously the event was written with `succeeded=True` even on send failure — misleading audit trail.
- **Test file**: replaced 4 tests that exercised the bool / silent-fail behavior with tests for the new fail-loud contract:
  - `test_returns_false_on_failure` → `test_raises_on_send_failure` (verifies `EmailSendError` propagates)
  - `test_logs_warning_on_send_failure` → `test_raises_on_send_failure` (verifies the registration HTTP request fails 5xx)
  - `test_sends_email_with_correct_params` + `test_verify_url_uses_frontend_url` now patch `send_email_or_raise` (the new dependency).

## ⚠️ Operational migration required

After this PR merges and before/at the next deploy, the operator MUST verify SMTP is configured correctly on the VPS, or registration / forgot-password resend will start failing 5xx.

### What to verify

```bash
grep -E "^EMAIL_BACKEND=|^SMTP_HOST=|^SMTP_PORT=|^SMTP_USER=|^SMTP_PASSWORD=" apps/mybookkeeper/backend/.env.docker
```

`EMAIL_BACKEND=smtp` and the four SMTP_* values should be populated. (MBK's prod has been on SMTP since the PR #293 boot guard landed, so this is already the case — the change is just that misconfigurations would now bubble up rather than silently swallow.)

### How to recover if a deploy already failed

```bash
docker compose -f apps/mybookkeeper/docker-compose.yml logs api --tail=100 | grep -iE "EmailSendError|EmailNotConfiguredError"
```

If you see those errors after a deploy, fix the SMTP env vars in `.env.docker` and re-deploy.

### Rollback path

If the operational migration can't be done immediately, revert this PR — the previous silent-fail behavior is restored. Note that this brings back the kennethmontgo@gmail.com bug class.

## Regression

- **MBK backend pytest**: 2,644 passed / 5 skipped / 0 failed (full suite, 7:07)
- 4 verification-email tests rewritten for the new fail-loud contract; all pass.
- All other email-flow tests (TOTP setup, password-reset, organization-invite) untouched and still pass.

## Test plan

- [x] Full MBK backend pytest passes
- [x] Verification email tests cover both success path and EmailSendError propagation
- [x] No alembic migrations needed
- [x] No deploy workflow / Caddyfile / docker-compose changes needed
- [x] MJH already fails loud — this PR brings MBK to parity

🤖 Generated with [Claude Code](https://claude.com/claude-code)