### PR TITLE
fix(mjh/auth): wire on_after_forgot_password to send password-reset email

### DIFF
--- a/apps/myjobhunter/backend/app/core/auth.py
+++ b/apps/myjobhunter/backend/app/core/auth.py
@@ -49,6 +49,7 @@ from platform_shared.services.hibp_service import HIBPCheckError, is_password_pw
 from app.core.config import settings
 from app.db.session import get_db
 from app.models.user.user import User
+from app.services.email.password_reset_email import send_password_reset_email
 from app.services.email.verification_email import send_verification_email
 from app.services.system.auth_event_service import log_auth_event
 
@@ -287,6 +288,21 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
         """
         send_verification_email(user.email, token)
         logger.info("Verification email sent to user_id=%s", user.id)
+
+    async def on_after_forgot_password(
+        self, user: User, token: str, request: Optional[Request] = None,
+    ) -> None:
+        """Send password-reset email when a token is generated.
+
+        Without this hook wired, fastapi-users issues a token but never
+        delivers it — the operator's forgot-password flow is silently
+        broken. Identified in the 2026-05-09 parity audit (H7).
+
+        Raises on any send failure so the forgot-password HTTP request
+        fails 5xx and the user retries.
+        """
+        send_password_reset_email(user.email, token)
+        logger.info("Password-reset email sent to user_id=%s", user.id)
 
     async def on_after_verify(
         self, user: User, request: Optional[Request] = None,

--- a/apps/myjobhunter/backend/app/services/email/password_reset_email.py
+++ b/apps/myjobhunter/backend/app/services/email/password_reset_email.py
@@ -1,0 +1,36 @@
+"""Password-reset email template + sender for MyJobHunter."""
+import logging
+
+from platform_shared.services.email_templates import build_password_reset_html
+
+from app.core.branding import MJH_BRANDING
+from app.core.config import settings
+from app.services.email.email_sender import send_email_or_raise
+
+logger = logging.getLogger(__name__)
+
+
+def _build_reset_html(reset_url: str) -> str:
+    return build_password_reset_html(reset_url=reset_url, branding=MJH_BRANDING)
+
+
+def send_password_reset_email(recipient_email: str, token: str) -> None:
+    """Send the password-reset message to a user who initiated forgot-password.
+
+    Critical-path transactional email — raises rather than returning a
+    bool so any failure propagates to the request handler. Without this
+    wired, MJH's POST /auth/forgot-password endpoint issues a token via
+    fastapi-users but never delivers it (silent gap pre-2026-05-09).
+
+    Mirrors apps/myjobhunter/backend/app/services/email/verification_email.py
+    in fail-loud shape.
+
+    Raises:
+        ValueError, EmailNotConfiguredError, EmailSendError — see
+        ``send_email_or_raise`` for semantics.
+    """
+    base_url = settings.frontend_url.rstrip("/")
+    reset_url = f"{base_url}/reset-password?token={token}"
+    html = _build_reset_html(reset_url)
+    subject = "Reset your MyJobHunter password"
+    send_email_or_raise([recipient_email], subject, html)

--- a/apps/myjobhunter/backend/tests/test_password_reset.py
+++ b/apps/myjobhunter/backend/tests/test_password_reset.py
@@ -1,0 +1,112 @@
+"""Tests for the MJH password-reset email flow.
+
+Locks the contract:
+- Calling send_password_reset_email triggers the shared template renderer
+  with MJH branding and the right reset URL.
+- Failures (EmailSendError, EmailNotConfiguredError, ValueError) propagate
+  rather than being swallowed (mirrors verification_email's fail-loud
+  contract per the 2026-05-09 H6/H7 parity audit).
+- The UserManager.on_after_forgot_password hook is wired to the sender so
+  fastapi-users' forgot-password endpoint actually delivers the email.
+"""
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.core.auth import UserManager
+from app.services.email.email_sender import EmailSendError
+from app.services.email.password_reset_email import (
+    _build_reset_html,
+    send_password_reset_email,
+)
+
+
+class TestPasswordResetEmailTemplate:
+    def test_reset_url_included_in_html(self) -> None:
+        html = _build_reset_html("https://example.com/reset-password?token=abc123")
+        assert "https://example.com/reset-password?token=abc123" in html
+
+    def test_html_escapes_url(self) -> None:
+        html = _build_reset_html("https://example.com/r?token=a<b>c")
+        assert "<b>" not in html
+        assert "&lt;b&gt;" in html
+
+    def test_html_has_branded_header(self) -> None:
+        html = _build_reset_html("https://example.com")
+        assert "MyJobHunter" in html
+
+
+class TestSendPasswordResetEmail:
+    @patch("app.services.email.password_reset_email.send_email_or_raise")
+    @patch("app.services.email.password_reset_email.settings")
+    def test_sends_email_with_correct_params(self, mock_settings, mock_send) -> None:
+        mock_settings.frontend_url = "https://app.example.com"
+
+        result = send_password_reset_email("user@example.com", "token123")
+
+        assert result is None  # fail-loud contract: returns None on success
+        mock_send.assert_called_once()
+        args = mock_send.call_args
+        assert args[0][0] == ["user@example.com"]
+        assert "Reset" in args[0][1]
+        assert "MyJobHunter" in args[0][1]
+        assert "token123" in args[0][2]
+
+    @patch("app.services.email.password_reset_email.send_email_or_raise")
+    @patch("app.services.email.password_reset_email.settings")
+    def test_raises_on_send_failure(self, mock_settings, mock_send) -> None:
+        """Critical-path email — failures must propagate, never be swallowed.
+
+        Without this contract, MJH's POST /auth/forgot-password would
+        return 202 to the user even though the reset email never went out
+        — the user can never recover their account.
+        """
+        mock_settings.frontend_url = "https://app.example.com"
+        mock_send.side_effect = EmailSendError("smtp connect failed")
+
+        with pytest.raises(EmailSendError, match="smtp connect failed"):
+            send_password_reset_email("user@example.com", "token123")
+
+    @patch("app.services.email.password_reset_email.send_email_or_raise")
+    @patch("app.services.email.password_reset_email.settings")
+    def test_reset_url_uses_frontend_url(self, mock_settings, mock_send) -> None:
+        mock_settings.frontend_url = "https://myjobhunter.app/"
+
+        send_password_reset_email("user@example.com", "abc")
+
+        html = mock_send.call_args[0][2]
+        assert "https://myjobhunter.app/reset-password?token=abc" in html
+
+
+class TestOnAfterForgotPassword:
+    @pytest.mark.anyio
+    @patch("app.core.auth.send_password_reset_email")
+    async def test_sends_reset_email_with_token(self, mock_send) -> None:
+        manager = UserManager.__new__(UserManager)
+        manager.user_db = MagicMock()
+
+        user = MagicMock()
+        user.id = "u1"
+        user.email = "test@example.com"
+
+        await manager.on_after_forgot_password(user, "resettoken123")
+
+        mock_send.assert_called_once_with("test@example.com", "resettoken123")
+
+    @pytest.mark.anyio
+    @patch("app.core.auth.send_password_reset_email")
+    async def test_raises_on_send_failure(self, mock_send) -> None:
+        """Send failure must propagate so the forgot-password HTTP request
+        fails 5xx and the user retries — never returns a 2xx with the
+        reset email lost.
+        """
+        mock_send.side_effect = EmailSendError("smtp down")
+        manager = UserManager.__new__(UserManager)
+        manager.user_db = MagicMock()
+
+        user = MagicMock()
+        user.id = "u1"
+        user.email = "fail@example.com"
+
+        with pytest.raises(EmailSendError, match="smtp down"):
+            await manager.on_after_forgot_password(user, "token")


### PR DESCRIPTION
## Why

Audit finding H7 (2026-05-09 parity scan): **MJH's password-reset flow was silently broken in production.** fastapi-users issues a reset token via the `on_after_forgot_password` hook, but MJH's `UserManager` didn't override it. The token never reached the user's inbox. This is a security gap — users who lock themselves out have no recovery path.

## What

- **New `apps/myjobhunter/backend/app/services/email/password_reset_email.py`** — mirrors MJH's `verification_email` pattern: builds HTML via the shared `build_password_reset_html` template + `MJH_BRANDING`, uses `send_email_or_raise` (fail-loud per H6's reasoning).
- **`UserManager.on_after_forgot_password`** hook in `app/core/auth.py` calls `send_password_reset_email` and lets failures propagate so the forgot-password HTTP request fails 5xx and the user retries — never returns 2xx with the email lost.
- **New `tests/test_password_reset.py`** (8 tests): template rendering, fail-loud contract, URL formation, hook invocation. All pass locally.

## Note: MBK still on silent-fail

MBK's `send_password_reset_email` is still on the silent-fail bool shape (sister to H6's verification_email gap that just landed in #540). That is a separate follow-up — the parity-rule gap exists for a few PRs while we land fail-loud across both apps. Tracking that gap as a follow-up to H7 in TECH_DEBT.

## ⚠️ Operational migration required

After this PR merges and before/at the next deploy, the operator MUST verify SMTP is configured on the MJH VPS, or password-reset will start failing 5xx instead of silently swallowing.

### What to verify

```bash
grep -E "^EMAIL_BACKEND=|^SMTP_HOST=|^SMTP_PORT=|^SMTP_USER=|^SMTP_PASSWORD=" apps/myjobhunter/backend/.env.docker
```

`EMAIL_BACKEND=smtp` and the four SMTP_* values must be populated. Per the existing MJH CLAUDE.md, MJH defaults `email_backend: str = "console"` for local dev — flip to `smtp` in `.env.docker` before this PR's behavior matters in production.

### How to recover if a deploy already failed

```bash
docker compose -f apps/myjobhunter/docker-compose.yml logs api --tail=100 | grep -iE "EmailSendError|EmailNotConfiguredError"
```

If you see those errors after a deploy, fix the SMTP env vars in `.env.docker` and re-deploy.

### Rollback path

If the operational migration can't be done immediately, revert this PR — the previous (silent) behavior is restored. Note that this brings back the silent forgot-password gap.

## Test coverage

- 8 new unit tests for `password_reset_email.py` + the `on_after_forgot_password` hook (template rendering, URL formation, fail-loud propagation)
- Full MJH targeted suite (225+ tests excluding pre-existing failure files: `test_audit`, `test_audit_log_gaps`, `test_demo_service`, `test_discover_endpoints`, `test_company_research_routes` — all confirmed failing on main with same errors, not introduced by this PR)

## Test plan

- [x] 8 unit tests for password-reset flow pass
- [x] MJH targeted suite passes (excluding pre-existing failures, verified on main)
- [x] No alembic migrations needed
- [x] No deploy workflow / Caddyfile / docker-compose changes needed
- [ ] CI will run the full MJH suite — pre-existing failures will surface but they exist on main too

🤖 Generated with [Claude Code](https://claude.com/claude-code)