### PR TITLE
refactor(platform): extract auth-event repo + schema + admin route + user_repo getters

### DIFF
--- a/apps/mybookkeeper/backend/app/api/admin.py
+++ b/apps/mybookkeeper/backend/app/api/admin.py
@@ -2,27 +2,31 @@
 
 Generic admin user-management endpoints (list users, change role,
 activate/deactivate, toggle superuser, user-count stats) are mounted
-from ``platform_shared.api.admin_router`` in ``app.main``. This module
-owns only the MBK-specific admin surface area.
+from ``platform_shared.api.admin_router`` in ``app.main``. The auth-events
+listing route is mounted from ``platform_shared.api.admin_auth_events_router``
+in this file. This module owns only the MBK-specific admin surface area.
 """
-import uuid
-from datetime import datetime
-from typing import Optional
+from fastapi import APIRouter, Depends
 
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy.ext.asyncio import AsyncSession
+from platform_shared.api.admin_auth_events_router import (
+    build_admin_auth_events_router,
+)
 
 from app.core.config import settings
 from app.core.permissions import current_admin
 from app.core.storage import get_storage
 from app.db.session import get_db
 from app.models.user.user import User
-from app.repositories.system import auth_event_repo
 from app.schemas.system.admin import AdminOrgRead, CleanReExtractRequest, CleanReExtractResponse, PlatformStats
-from app.schemas.system.auth_event import AuthEventRead
 from app.services.system import admin_service
 
 router = APIRouter(prefix="/admin", tags=["admin"])
+router.include_router(
+    build_admin_auth_events_router(
+        admin_dependency=current_admin,
+        get_db_dependency=get_db,
+    ),
+)
 
 
 @router.get("/storage-health")
@@ -108,25 +112,3 @@ async def list_all_orgs(
     user: User = Depends(current_admin),
 ) -> list[AdminOrgRead]:
     return await admin_service.list_all_orgs()
-
-
-@router.get("/auth-events", response_model=list[AuthEventRead])
-async def list_auth_events(
-    user_id: Optional[uuid.UUID] = None,
-    event_type: Optional[str] = None,
-    since: Optional[datetime] = None,
-    limit: int = Query(100, le=500),
-    offset: int = 0,
-    admin: User = Depends(current_admin),
-    db: AsyncSession = Depends(get_db),
-) -> list[AuthEventRead]:
-    """List auth events. Superuser-only endpoint for security incident review."""
-    events = await auth_event_repo.list_filtered(
-        db,
-        user_id=user_id,
-        event_type=event_type,
-        since=since,
-        limit=limit,
-        offset=offset,
-    )
-    return list(events)

--- a/apps/mybookkeeper/backend/app/repositories/system/auth_event_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/system/auth_event_repo.py
@@ -5,6 +5,8 @@ from datetime import datetime
 from sqlalchemy import and_, func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from platform_shared.repositories.auth_event_repo import list_filtered  # noqa: F401
+
 from app.models.system.auth_event import AuthEvent
 
 
@@ -40,33 +42,3 @@ async def count_recent_failures(
         ),
     )
     return result.scalar_one()
-
-
-async def list_filtered(
-    db: AsyncSession,
-    *,
-    user_id: uuid.UUID | None = None,
-    event_type: str | None = None,
-    since: datetime | None = None,
-    limit: int = 100,
-    offset: int = 0,
-) -> Sequence[AuthEvent]:
-    filters: list = []
-    if user_id is not None:
-        filters.append(AuthEvent.user_id == user_id)
-    if event_type is not None:
-        filters.append(AuthEvent.event_type == event_type)
-    if since is not None:
-        filters.append(AuthEvent.created_at >= since)
-
-    query = (
-        select(AuthEvent)
-        .order_by(AuthEvent.created_at.desc())
-        .limit(limit)
-        .offset(offset)
-    )
-    if filters:
-        query = query.where(and_(*filters))
-
-    result = await db.execute(query)
-    return result.scalars().all()

--- a/apps/mybookkeeper/backend/app/repositories/user/user_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/user/user_repo.py
@@ -5,6 +5,12 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import load_only
 
+from platform_shared.repositories.user_repo import (
+    get_by_email as _shared_get_by_email,
+    get_by_id as _shared_get_by_id,
+    get_totp_enabled as _shared_get_totp_enabled,
+)
+
 from app.models.user.user import Role, User
 
 
@@ -21,19 +27,15 @@ async def list_all(db: AsyncSession) -> Sequence[User]:
 
 
 async def get_by_id(db: AsyncSession, user_id: uuid.UUID) -> User | None:
-    result = await db.execute(select(User).where(User.id == user_id))
-    return result.scalar_one_or_none()
+    return await _shared_get_by_id(db, user_id, user_model=User)
 
 
 async def get_by_email(db: AsyncSession, email: str) -> User | None:
-    result = await db.execute(select(User).where(User.email == email))
-    return result.scalar_one_or_none()
+    return await _shared_get_by_email(db, email, user_model=User)
 
 
 async def get_totp_enabled(db: AsyncSession, email: str) -> bool:
-    result = await db.execute(select(User.totp_enabled).where(User.email == email))
-    row = result.scalar_one_or_none()
-    return bool(row)
+    return await _shared_get_totp_enabled(db, email, user_model=User)
 
 
 async def update_role(db: AsyncSession, user: User, role: Role) -> User:

--- a/apps/mybookkeeper/backend/app/schemas/system/auth_event.py
+++ b/apps/mybookkeeper/backend/app/schemas/system/auth_event.py
@@ -1,17 +1,7 @@
-import uuid
-from datetime import datetime
+"""Re-export of the shared ``AuthEventRead`` schema.
 
-from pydantic import BaseModel, Field
-
-
-class AuthEventRead(BaseModel):
-    id: uuid.UUID
-    user_id: uuid.UUID | None = None
-    event_type: str
-    ip_address: str | None = None
-    user_agent: str | None = None
-    metadata: dict = Field(alias="event_metadata")
-    succeeded: bool
-    created_at: datetime
-
-    model_config = {"from_attributes": True, "populate_by_name": True}
+Implementation lives in ``platform_shared.schemas.auth_event``. Existing
+MBK call sites can import from ``app.schemas.system.auth_event`` and
+reach the same class.
+"""
+from platform_shared.schemas.auth_event import AuthEventRead  # noqa: F401

--- a/apps/myjobhunter/backend/app/api/admin.py
+++ b/apps/myjobhunter/backend/app/api/admin.py
@@ -1,8 +1,11 @@
 """Platform admin routes.
 
 Currently only auth-events listing — the security incident review tool.
-Other MBK admin endpoints (storage-health, platform stats) can land in
-this file as MJH grows; mirror the MBK shape when porting.
+The route lives in ``platform_shared.api.admin_auth_events_router``;
+this module wires it up with MJH's admin guard + db dependency.
+
+Other MBK admin endpoints (storage-health, platform stats, clean-re-extract)
+have not been ported to MJH yet — when they are, mirror the MBK shape.
 
 All routes here are gated by ``current_superuser`` — operator only.
 MJH does not have a multi-tier admin role; the platform is single-
@@ -10,46 +13,20 @@ operator with everyone else as a regular user.
 """
 from __future__ import annotations
 
-import uuid
-from datetime import datetime
-from typing import Optional
+from fastapi import APIRouter
 
-from fastapi import APIRouter, Depends, Query
-from sqlalchemy.ext.asyncio import AsyncSession
+from platform_shared.api.admin_auth_events_router import (
+    build_admin_auth_events_router,
+)
 
 from app.core.permissions import current_superuser
 from app.db.session import get_db
-from app.models.user.user import User
-from app.repositories.system import auth_event_repo
-from app.schemas.system.auth_event import AuthEventRead
 
 
 router = APIRouter(prefix="/admin", tags=["admin"])
-
-
-@router.get("/auth-events", response_model=list[AuthEventRead])
-async def list_auth_events(
-    user_id: Optional[uuid.UUID] = None,
-    event_type: Optional[str] = None,
-    since: Optional[datetime] = None,
-    limit: int = Query(100, le=500),
-    offset: int = 0,
-    admin: User = Depends(current_superuser),
-    db: AsyncSession = Depends(get_db),
-) -> list[AuthEventRead]:
-    """List auth events with optional filters, newest first.
-
-    Operator-only endpoint for security incident review. All filters AND
-    together. ``limit`` capped at 500 to avoid massive responses.
-
-    Mirrors MBK's GET /admin/auth-events shape exactly.
-    """
-    events = await auth_event_repo.list_filtered(
-        db,
-        user_id=user_id,
-        event_type=event_type,
-        since=since,
-        limit=limit,
-        offset=offset,
-    )
-    return list(events)
+router.include_router(
+    build_admin_auth_events_router(
+        admin_dependency=current_superuser,
+        get_db_dependency=get_db,
+    ),
+)

--- a/apps/myjobhunter/backend/app/repositories/system/auth_event_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/system/auth_event_repo.py
@@ -1,51 +1,9 @@
-"""Auth-event read repository for the admin auth-events route.
+"""Auth-event read repository — re-exports the shared ``list_filtered``.
 
-Mirrors apps/mybookkeeper/backend/app/repositories/system/auth_event_repo.py
-``list_filtered`` shape exactly. Writes go through
-``app/services/system/auth_event_service.log_auth_event`` (already shared).
+Writes go through ``platform_shared.services.auth_event_service.log_auth_event``.
+Reads (used by the admin auth-events listing route) go through
+``platform_shared.repositories.auth_event_repo.list_filtered`` —
+re-exported here so existing MJH call sites importing from
+``app.repositories.system.auth_event_repo`` keep working unchanged.
 """
-from __future__ import annotations
-
-import uuid
-from collections.abc import Sequence
-from datetime import datetime
-
-from sqlalchemy import and_, select
-from sqlalchemy.ext.asyncio import AsyncSession
-
-from app.models.system.auth_event import AuthEvent
-
-
-async def list_filtered(
-    db: AsyncSession,
-    *,
-    user_id: uuid.UUID | None = None,
-    event_type: str | None = None,
-    since: datetime | None = None,
-    limit: int = 100,
-    offset: int = 0,
-) -> Sequence[AuthEvent]:
-    """List auth events with optional filters, newest first.
-
-    All filters AND together. ``limit`` should be capped by the route
-    (MBK uses ``Query(100, le=500)``).
-    """
-    filters: list = []
-    if user_id is not None:
-        filters.append(AuthEvent.user_id == user_id)
-    if event_type is not None:
-        filters.append(AuthEvent.event_type == event_type)
-    if since is not None:
-        filters.append(AuthEvent.created_at >= since)
-
-    query = (
-        select(AuthEvent)
-        .order_by(AuthEvent.created_at.desc())
-        .limit(limit)
-        .offset(offset)
-    )
-    if filters:
-        query = query.where(and_(*filters))
-
-    result = await db.execute(query)
-    return result.scalars().all()
+from platform_shared.repositories.auth_event_repo import list_filtered  # noqa: F401

--- a/apps/myjobhunter/backend/app/repositories/user/user_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/user/user_repo.py
@@ -1,28 +1,32 @@
 """User-row data access used by TOTP and auth flows.
 
-Kept as bare functions (no class) to match the rest of MJH's repository
-layer and to make patching easy in tests. ``check_account_not_locked``
-(in :mod:`app.core.rate_limit`) reads the user row through here so that
-route-dependency module doesn't import ORM primitives directly.
+The three canonical lookups (by id, by email, totp-enabled probe) are
+shared via ``platform_shared.repositories.user_repo``; this module thin-
+wraps them and binds MJH's ``User`` class. Kept as bare functions (no
+class) to match the rest of MJH's repository layer and to make patching
+easy in tests.
 """
 import uuid
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.repositories.user_repo import (
+    get_by_email as _shared_get_by_email,
+    get_by_id as _shared_get_by_id,
+    get_totp_enabled as _shared_get_totp_enabled,
+)
 
 from app.models.user.user import User
 
 
 async def get_by_id(db: AsyncSession, user_id: uuid.UUID) -> User | None:
     """Return the user with ``user_id``, or ``None`` if not found."""
-    result = await db.execute(select(User).where(User.id == user_id))
-    return result.scalar_one_or_none()
+    return await _shared_get_by_id(db, user_id, user_model=User)
 
 
 async def get_by_email(db: AsyncSession, email: str) -> User | None:
     """Return the user with ``email``, or ``None`` if not found."""
-    result = await db.execute(select(User).where(User.email == email))
-    return result.scalar_one_or_none()
+    return await _shared_get_by_email(db, email, user_model=User)
 
 
 async def get_totp_enabled(db: AsyncSession, email: str) -> bool:
@@ -32,8 +36,4 @@ async def get_totp_enabled(db: AsyncSession, email: str) -> bool:
     "no such user" from "user without 2FA". The login flow uses this to
     decide whether to surface ``detail: totp_required``.
     """
-    result = await db.execute(
-        select(User.totp_enabled).where(User.email == email),
-    )
-    row = result.scalar_one_or_none()
-    return bool(row)
+    return await _shared_get_totp_enabled(db, email, user_model=User)

--- a/apps/myjobhunter/backend/app/schemas/system/auth_event.py
+++ b/apps/myjobhunter/backend/app/schemas/system/auth_event.py
@@ -1,24 +1,7 @@
-"""Read schema for the admin auth-events listing route.
+"""Re-export of the shared ``AuthEventRead`` schema.
 
-Mirrors apps/mybookkeeper/backend/app/schemas/system/auth_event.py exactly.
-The ``event_metadata`` alias maps to the model's ``event_metadata`` field
-(which itself maps to the SQL column ``metadata`` per the shared
-``platform_shared.db.models.auth_event.AuthEvent``).
+Implementation lives in ``platform_shared.schemas.auth_event``. Existing
+MJH call sites can import from ``app.schemas.system.auth_event`` and
+reach the same class.
 """
-import uuid
-from datetime import datetime
-
-from pydantic import BaseModel, Field
-
-
-class AuthEventRead(BaseModel):
-    id: uuid.UUID
-    user_id: uuid.UUID | None = None
-    event_type: str
-    ip_address: str | None = None
-    user_agent: str | None = None
-    metadata: dict = Field(alias="event_metadata")
-    succeeded: bool
-    created_at: datetime
-
-    model_config = {"from_attributes": True, "populate_by_name": True}
+from platform_shared.schemas.auth_event import AuthEventRead  # noqa: F401

--- a/packages/shared-backend/platform_shared/api/admin_auth_events_router.py
+++ b/packages/shared-backend/platform_shared/api/admin_auth_events_router.py
@@ -1,0 +1,84 @@
+"""Shared GET /admin/auth-events route — security incident review tool.
+
+Both MBK and MJH expose the same auth-events listing endpoint. Apps
+build the router via ``build_admin_auth_events_router(...)`` passing
+their own admin guard + db-session dependency, then include the
+returned router in their existing admin router (or root app):
+
+    from platform_shared.api.admin_auth_events_router import (
+        build_admin_auth_events_router,
+    )
+    from app.core.permissions import current_admin
+    from app.db.session import get_db
+
+    router = APIRouter(prefix="/admin", tags=["admin"])
+    router.include_router(
+        build_admin_auth_events_router(
+            admin_dependency=current_admin,
+            get_db_dependency=get_db,
+        ),
+    )
+
+The included router has no prefix of its own; the parent's ``/admin``
+prefix is applied so the final path is ``GET /admin/auth-events``.
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Callable
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.repositories.auth_event_repo import list_filtered
+from platform_shared.schemas.auth_event import AuthEventRead
+
+
+def build_admin_auth_events_router(
+    *,
+    admin_dependency: Callable[..., object],
+    get_db_dependency: Callable[..., AsyncIterator[AsyncSession]],
+) -> APIRouter:
+    """Build a router exposing ``GET /auth-events`` (admin-only).
+
+    Args:
+        admin_dependency: The app's admin-gate dependency (e.g.
+            ``current_admin`` for MBK, ``current_superuser`` for MJH).
+        get_db_dependency: The app's ``get_db`` async-generator
+            dependency. The route uses it to read auth_events; never
+            writes.
+
+    Returns:
+        An ``APIRouter`` with a single GET route. Tagged ``admin`` for
+        OpenAPI grouping. No prefix — wire under the app's existing
+        ``/admin`` parent router.
+    """
+    router = APIRouter(tags=["admin"])
+
+    @router.get("/auth-events", response_model=list[AuthEventRead])
+    async def list_auth_events(
+        user_id: uuid.UUID | None = None,
+        event_type: str | None = None,
+        since: datetime | None = None,
+        limit: int = Query(100, le=500),
+        offset: int = 0,
+        _admin: object = Depends(admin_dependency),
+        db: AsyncSession = Depends(get_db_dependency),
+    ) -> list[AuthEventRead]:
+        """List auth events with optional filters, newest first.
+
+        Operator-only endpoint for security incident review. All filters
+        AND together. ``limit`` capped at 500 to avoid massive responses.
+        """
+        events = await list_filtered(
+            db,
+            user_id=user_id,
+            event_type=event_type,
+            since=since,
+            limit=limit,
+            offset=offset,
+        )
+        return [AuthEventRead.model_validate(e) for e in events]
+
+    return router

--- a/packages/shared-backend/platform_shared/repositories/auth_event_repo.py
+++ b/packages/shared-backend/platform_shared/repositories/auth_event_repo.py
@@ -1,0 +1,51 @@
+"""Read repository for the auth_events audit table.
+
+Writes go through ``platform_shared.services.auth_event_service.log_auth_event``;
+reads go through here. Used by the admin auth-events listing route
+(``platform_shared.api.admin_auth_events_router``).
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime
+
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.db.models.auth_event import AuthEvent
+
+
+async def list_filtered(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID | None = None,
+    event_type: str | None = None,
+    since: datetime | None = None,
+    limit: int = 100,
+    offset: int = 0,
+) -> Sequence[AuthEvent]:
+    """List auth events with optional filters, newest first.
+
+    All filters AND together. ``limit`` should be capped by the route
+    (the shared admin router caps at 500).
+    """
+    filters: list = []
+    if user_id is not None:
+        filters.append(AuthEvent.user_id == user_id)
+    if event_type is not None:
+        filters.append(AuthEvent.event_type == event_type)
+    if since is not None:
+        filters.append(AuthEvent.created_at >= since)
+
+    query = (
+        select(AuthEvent)
+        .order_by(AuthEvent.created_at.desc())
+        .limit(limit)
+        .offset(offset)
+    )
+    if filters:
+        query = query.where(and_(*filters))
+
+    result = await db.execute(query)
+    return result.scalars().all()

--- a/packages/shared-backend/platform_shared/repositories/user_repo.py
+++ b/packages/shared-backend/platform_shared/repositories/user_repo.py
@@ -1,0 +1,69 @@
+"""User-row reads parameterized on the per-app User model.
+
+Each app's own ``User`` class differs in domain columns (MBK has
+``role``/``name``, MJH has ``display_name``/``is_demo``), but the three
+canonical lookups — by id, by email, totp-status — share the same shape
+across every app. Apps thin-wrap these and bind their own User class.
+
+Usage in ``apps/<app>/backend/app/repositories/user/user_repo.py``:
+
+    from platform_shared.repositories.user_repo import (
+        get_by_id as _shared_get_by_id,
+        get_by_email as _shared_get_by_email,
+        get_totp_enabled as _shared_get_totp_enabled,
+    )
+    from app.models.user.user import User
+
+    async def get_by_id(db, user_id):
+        return await _shared_get_by_id(db, user_id, user_model=User)
+
+    # ... same for get_by_email and get_totp_enabled
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def get_by_id(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    user_model: Any,
+) -> Any | None:
+    """Return the user row with ``user_id``, or ``None`` if not found."""
+    result = await db.execute(select(user_model).where(user_model.id == user_id))
+    return result.scalar_one_or_none()
+
+
+async def get_by_email(
+    db: AsyncSession,
+    email: str,
+    *,
+    user_model: Any,
+) -> Any | None:
+    """Return the user row with ``email``, or ``None`` if not found."""
+    result = await db.execute(select(user_model).where(user_model.email == email))
+    return result.scalar_one_or_none()
+
+
+async def get_totp_enabled(
+    db: AsyncSession,
+    email: str,
+    *,
+    user_model: Any,
+) -> bool:
+    """Cheap probe — does the user with ``email`` have TOTP 2FA enabled?
+
+    Returns ``False`` for unknown emails so callers don't have to
+    distinguish "no such user" from "user without 2FA". The login flow
+    uses this to decide whether to surface ``detail: totp_required``.
+    """
+    result = await db.execute(
+        select(user_model.totp_enabled).where(user_model.email == email),
+    )
+    row = result.scalar_one_or_none()
+    return bool(row)

--- a/packages/shared-backend/platform_shared/schemas/auth_event.py
+++ b/packages/shared-backend/platform_shared/schemas/auth_event.py
@@ -1,0 +1,24 @@
+"""Read schema for the admin auth-events listing route.
+
+The ``event_metadata`` alias maps the model's ``event_metadata`` field
+(which itself maps to the SQL column ``metadata`` per the shared
+``platform_shared.db.models.auth_event.AuthEvent``) to the wire field
+``metadata`` so admin clients see the natural name.
+"""
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class AuthEventRead(BaseModel):
+    id: uuid.UUID
+    user_id: uuid.UUID | None = None
+    event_type: str
+    ip_address: str | None = None
+    user_agent: str | None = None
+    metadata: dict = Field(alias="event_metadata")
+    succeeded: bool
+    created_at: datetime
+
+    model_config = {"from_attributes": True, "populate_by_name": True}


### PR DESCRIPTION
## Why

Audit findings **C5 + H11** (2026-05-09 parity scan): four byte-identical duplications across MBK and MJH. Extracting these to `platform_shared` eliminates ~60 LOC per app, reduces drift surface area for the third app, and means the security-incident-review surface is identical across all apps (no SOC tooling divergence).

## What — 4 new shared modules

- **`platform_shared/schemas/auth_event.py::AuthEventRead`** — was byte-identical 17-line file in both apps (only docstring differed).
- **`platform_shared/repositories/auth_event_repo.py::list_filtered`** — was byte-identical body in both apps.
- **`platform_shared/api/admin_auth_events_router.py::build_admin_auth_events_router`** — factory takes `admin_dependency` + `get_db_dependency`. The included router has no prefix; parent app routers wire under their own `/admin`.
- **`platform_shared/repositories/user_repo.py`** — three byte-identical getters (`get_by_id`, `get_by_email`, `get_totp_enabled`) parameterized on the per-app `User` model class.

## Apps now thin-wrap shared

- **`apps/{mbk,mjh}/backend/app/repositories/user/user_repo.py`** — bind `User` to shared getters. MBK keeps its 3 admin-only functions (`list_all`, `update_role`, `set_active`) inline since only MBK has them.
- **`apps/{mbk,mjh}/backend/app/repositories/system/auth_event_repo.py`** — re-export shared `list_filtered`. MBK keeps `list_by_user` + `count_recent_failures` inline (MBK-only).
- **`apps/{mbk,mjh}/backend/app/schemas/system/auth_event.py`** — re-export shared `AuthEventRead`.
- **`apps/{mbk,mjh}/backend/app/api/admin.py`** — replace inline `/auth-events` route block with `router.include_router(build_admin_auth_events_router(...))`.

## Why this matters

The auth-events route is the security-incident-review surface. Drift between apps (one admitting events the other denies, different limits, different filter shapes) would mean SOC tooling would diverge per app. By extracting to shared, the route is byte-identical across every app — only the admin-guard dependency varies (MBK uses `current_admin` for `Role.ADMIN`; MJH uses `current_superuser` for `is_superuser`).

## Regression

- **shared-backend pytest**: 419 passed
- **MBK backend pytest**: 2,644 passed / 5 skipped / 0 failed (full suite, 7:02)
- **MJH targeted slice**: passes for affected files (auth_events / totp / user_repo callers). Full MJH suite has the same ~10 pre-existing failures flagged in PRs #538/#540/#541 (anthropic API key, role/superuser test fixture bug, audit user_id assertions) — verified on main.

## Operational migration

None required. No env vars, no schema changes, no breaking API changes. The wire shape of `GET /admin/auth-events` is unchanged (FastAPI converts via `response_model` either way).

## Test plan

- [x] All 419 shared-backend tests pass
- [x] Full MBK backend pytest passes
- [x] Targeted MJH tests pass for affected files
- [x] No alembic migrations needed
- [x] No deploy workflow / Caddyfile / docker-compose changes needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)