### PR TITLE
refactor(platform): extract _resolve_git_commit to shared

### DIFF
--- a/apps/mybookkeeper/backend/app/main.py
+++ b/apps/mybookkeeper/backend/app/main.py
@@ -1,7 +1,5 @@
 import asyncio
 import logging
-import os
-import subprocess
 import time
 from datetime import datetime, timezone
 
@@ -12,6 +10,7 @@ import jwt
 from jwt.exceptions import PyJWTError as JWTError
 from sqlalchemy import text
 
+from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
 
 from app.core.auth import fastapi_users, auth_backend
@@ -19,21 +18,7 @@ from app.core.config import settings
 from app.core.observability import init_sentry
 
 
-def _resolve_git_commit() -> str:
-    env_commit = os.environ.get("GIT_COMMIT", "").strip()
-    if env_commit:
-        return env_commit
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-    except Exception:
-        return "unknown"
-
-
-GIT_COMMIT = _resolve_git_commit()
+GIT_COMMIT = resolve_git_commit()
 STARTUP_TIMESTAMP = datetime.now(timezone.utc).isoformat()
 
 from app.core.audit import current_user_id

--- a/apps/mybookkeeper/backend/tests/test_version_endpoint.py
+++ b/apps/mybookkeeper/backend/tests/test_version_endpoint.py
@@ -4,19 +4,19 @@ from unittest.mock import patch
 
 import pytest
 
+from platform_shared.core.git import resolve_git_commit
+
 
 def test_resolve_git_commit_from_env():
     """When GIT_COMMIT env var is set, it takes precedence."""
     with patch.dict(os.environ, {"GIT_COMMIT": "abc1234"}):
-        from app.main import _resolve_git_commit
-        assert _resolve_git_commit() == "abc1234"
+        assert resolve_git_commit() == "abc1234"
 
 
 def test_resolve_git_commit_falls_back_to_git():
     """When no env var, falls back to git rev-parse."""
     with patch.dict(os.environ, {"GIT_COMMIT": ""}):
-        from app.main import _resolve_git_commit
-        result = _resolve_git_commit()
+        result = resolve_git_commit()
         assert len(result) > 0
         assert result != "unknown"
 
@@ -24,16 +24,17 @@ def test_resolve_git_commit_falls_back_to_git():
 def test_resolve_git_commit_returns_unknown_when_no_git():
     """When both env var and git are unavailable, returns 'unknown'."""
     with patch.dict(os.environ, {"GIT_COMMIT": ""}):
-        with patch("subprocess.check_output", side_effect=FileNotFoundError):
-            from app.main import _resolve_git_commit
-            assert _resolve_git_commit() == "unknown"
+        with patch(
+            "platform_shared.core.git.subprocess.check_output",
+            side_effect=FileNotFoundError,
+        ):
+            assert resolve_git_commit() == "unknown"
 
 
 def test_resolve_git_commit_strips_whitespace():
     """Env var value is stripped of whitespace."""
     with patch.dict(os.environ, {"GIT_COMMIT": "  abc1234  "}):
-        from app.main import _resolve_git_commit
-        assert _resolve_git_commit() == "abc1234"
+        assert resolve_git_commit() == "abc1234"
 
 
 def test_git_commit_module_level_is_set():

--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import subprocess
 import time
 from datetime import datetime, timezone
 
@@ -9,6 +8,7 @@ from fastapi import Depends, FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from jwt.exceptions import PyJWTError as JWTError
 
+from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
 
 from app.api import account, admin, admin_invites, applications, companies, demo, discover, documents, health, integrations, job_analysis, profile, resume_refinement, resumes, totp
@@ -37,27 +37,9 @@ async def _on_startup() -> None:
             )
 
 
-def _resolve_git_commit() -> str:
-    """Resolve the deployed git commit short SHA.
-
-    Mirrors apps/mybookkeeper/backend/app/main.py — used by the deploy
-    workflow's freshness tripwire and by /api/version + /health for
-    deploy verification.
-    """
-    env_commit = os.environ.get("GIT_COMMIT", "").strip()
-    if env_commit:
-        return env_commit
-    try:
-        return subprocess.check_output(
-            ["git", "rev-parse", "--short", "HEAD"],
-            text=True,
-            stderr=subprocess.DEVNULL,
-        ).strip()
-    except Exception:
-        return "unknown"
-
-
-GIT_COMMIT = _resolve_git_commit()
+# Used by the deploy workflow's freshness tripwire and by /api/version +
+# /health for deploy verification.
+GIT_COMMIT = resolve_git_commit()
 STARTUP_TIMESTAMP = datetime.now(timezone.utc).isoformat()
 
 logging.basicConfig(

--- a/apps/myjobhunter/backend/tests/test_version_endpoint.py
+++ b/apps/myjobhunter/backend/tests/test_version_endpoint.py
@@ -1,4 +1,4 @@
-"""Tests for the deploy-verification surfaces — _resolve_git_commit, /version,
+"""Tests for the deploy-verification surfaces — resolve_git_commit, /version,
 and the version field on /health.
 
 Mirrors apps/mybookkeeper/backend/tests/test_version_endpoint.py — keep the
@@ -11,6 +11,10 @@ Note that MJH mounts FastAPI with ``root_path="/api"``, so:
   client at the bare path `/version` (the test client does NOT prepend the
   root_path — that's added by the upstream Caddy proxy in production).
 - The same applies to the `/health` route mounted via app/api/health.py.
+
+The ``resolve_git_commit`` helper itself lives in
+``platform_shared.core.git`` (extracted in PR after 2026-05-09 H4 audit) —
+both apps wire ``GIT_COMMIT = resolve_git_commit()`` at module load.
 """
 import os
 import subprocess  # noqa: F401 — used by patch path
@@ -20,19 +24,19 @@ from unittest.mock import patch
 import pytest
 from httpx import ASGITransport, AsyncClient
 
+from platform_shared.core.git import resolve_git_commit
+
 
 def test_resolve_git_commit_from_env() -> None:
     """When GIT_COMMIT env var is set, it takes precedence."""
     with patch.dict(os.environ, {"GIT_COMMIT": "abc1234"}):
-        from app.main import _resolve_git_commit
-        assert _resolve_git_commit() == "abc1234"
+        assert resolve_git_commit() == "abc1234"
 
 
 def test_resolve_git_commit_falls_back_to_git() -> None:
     """When no env var, falls back to git rev-parse."""
     with patch.dict(os.environ, {"GIT_COMMIT": ""}):
-        from app.main import _resolve_git_commit
-        result = _resolve_git_commit()
+        result = resolve_git_commit()
         assert len(result) > 0
         assert result != "unknown"
 
@@ -40,16 +44,17 @@ def test_resolve_git_commit_falls_back_to_git() -> None:
 def test_resolve_git_commit_returns_unknown_when_no_git() -> None:
     """When both env var and git are unavailable, returns 'unknown'."""
     with patch.dict(os.environ, {"GIT_COMMIT": ""}):
-        with patch("subprocess.check_output", side_effect=FileNotFoundError):
-            from app.main import _resolve_git_commit
-            assert _resolve_git_commit() == "unknown"
+        with patch(
+            "platform_shared.core.git.subprocess.check_output",
+            side_effect=FileNotFoundError,
+        ):
+            assert resolve_git_commit() == "unknown"
 
 
 def test_resolve_git_commit_strips_whitespace() -> None:
     """Env var value is stripped of whitespace."""
     with patch.dict(os.environ, {"GIT_COMMIT": "  abc1234  "}):
-        from app.main import _resolve_git_commit
-        assert _resolve_git_commit() == "abc1234"
+        assert resolve_git_commit() == "abc1234"
 
 
 def test_git_commit_module_level_is_set() -> None:

--- a/packages/shared-backend/platform_shared/core/git.py
+++ b/packages/shared-backend/platform_shared/core/git.py
@@ -1,0 +1,45 @@
+"""Shared git-commit resolver for deploy verification.
+
+Both apps' ``main.py`` modules expose a ``GIT_COMMIT`` constant that powers
+the ``/health`` and ``/version`` deploy-verification routes. The constant
+resolves to (in order):
+
+1. The ``GIT_COMMIT`` env var, set by the build pipeline at image build
+   time (Docker build arg → env var).
+2. ``git rev-parse --short HEAD`` from the working directory, useful in
+   local dev runs.
+3. The literal string ``"unknown"`` — last-resort fallback so the
+   constant always resolves to a non-empty string.
+
+This module is the single source of truth — both apps' ``main.py`` import
+``resolve_git_commit`` instead of carrying their own copy.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+
+def resolve_git_commit() -> str:
+    """Return the deployed git commit short SHA, or ``"unknown"`` if unavailable.
+
+    Read priority:
+        1. ``$GIT_COMMIT`` env var (set by the build pipeline)
+        2. ``git rev-parse --short HEAD`` (local dev fallback)
+        3. ``"unknown"`` literal (last-resort fallback)
+
+    Never raises — exceptions from the subprocess call are swallowed and
+    the literal ``"unknown"`` is returned. Callers can rely on the result
+    always being a non-empty string.
+    """
+    env_commit = os.environ.get("GIT_COMMIT", "").strip()
+    if env_commit:
+        return env_commit
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except Exception:
+        return "unknown"

--- a/packages/shared-backend/tests/test_git_resolve.py
+++ b/packages/shared-backend/tests/test_git_resolve.py
@@ -1,0 +1,68 @@
+"""Contract tests for ``platform_shared.core.git.resolve_git_commit``.
+
+Behavior precedence:
+  1. ``GIT_COMMIT`` env var (highest priority)
+  2. ``git rev-parse --short HEAD`` fallback
+  3. ``"unknown"`` literal (last resort)
+
+Never raises.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+from unittest.mock import patch
+
+from platform_shared.core.git import resolve_git_commit
+
+
+class TestResolveGitCommit:
+    def test_returns_env_var_when_set(self, monkeypatch) -> None:
+        monkeypatch.setenv("GIT_COMMIT", "deadbeef")
+        assert resolve_git_commit() == "deadbeef"
+
+    def test_strips_env_var_whitespace(self, monkeypatch) -> None:
+        monkeypatch.setenv("GIT_COMMIT", "  abc1234  \n")
+        assert resolve_git_commit() == "abc1234"
+
+    def test_falls_back_to_git_when_env_var_empty(self, monkeypatch) -> None:
+        monkeypatch.delenv("GIT_COMMIT", raising=False)
+        with patch(
+            "platform_shared.core.git.subprocess.check_output",
+            return_value="cafebabe\n",
+        ) as mock_check:
+            result = resolve_git_commit()
+        assert result == "cafebabe"
+        mock_check.assert_called_once_with(
+            ["git", "rev-parse", "--short", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+
+    def test_falls_back_to_unknown_when_git_fails(self, monkeypatch) -> None:
+        monkeypatch.delenv("GIT_COMMIT", raising=False)
+        with patch(
+            "platform_shared.core.git.subprocess.check_output",
+            side_effect=FileNotFoundError("git not on PATH"),
+        ):
+            assert resolve_git_commit() == "unknown"
+
+    def test_swallows_subprocess_error(self, monkeypatch) -> None:
+        """Any exception during the subprocess call → 'unknown', no raise."""
+        monkeypatch.delenv("GIT_COMMIT", raising=False)
+        with patch(
+            "platform_shared.core.git.subprocess.check_output",
+            side_effect=subprocess.CalledProcessError(128, ["git"]),
+        ):
+            assert resolve_git_commit() == "unknown"
+
+    def test_env_var_takes_precedence_over_git(self, monkeypatch) -> None:
+        """Env var wins even if `git rev-parse` would have returned a value."""
+        monkeypatch.setenv("GIT_COMMIT", "from_env")
+        with patch(
+            "platform_shared.core.git.subprocess.check_output",
+            return_value="from_git",
+        ) as mock_check:
+            result = resolve_git_commit()
+        assert result == "from_env"
+        mock_check.assert_not_called()


### PR DESCRIPTION
## Why

Audit finding M14 (2026-05-09 parity scan): both apps had byte-identical `_resolve_git_commit` functions in their `main.py` — env-var-first (`$GIT_COMMIT`), `git rev-parse --short HEAD` fallback, `"unknown"` last-resort. Extracted to `platform_shared.core.git` so the third app inherits.

The audit's broader **H4** (extract `/health` + `/version` routes too) is deferred — MBK has `@app.get("/api/version")` (hand-prefixed) while MJH has `@app.get("/version")` (with `root_path="/api"`), and changing the public path would touch frontend E2E tests, sidebar version display, and the deploy workflow. Out of scope for this PR.

## What

- **New `platform_shared/core/git.py::resolve_git_commit()`** — single source of truth. Always returns a non-empty string (`"unknown"` last-resort).
- **6 contract tests** covering env-var precedence, whitespace strip, git-rev-parse fallback, subprocess error swallowing, env-var-wins-over-git, and never-raises guarantee.
- Both apps' `main.py` drops the local `_resolve_git_commit` + `os`/`subprocess` imports (only MJH still imports `os` for the `MYJOBHUNTER_ENABLE_TEST_HELPERS` check). `GIT_COMMIT = resolve_git_commit()` at module load — same shape, fewer lines.
- Both apps' `test_version_endpoint.py` updated to import from shared and patch `platform_shared.core.git.subprocess.check_output`. The contract tests in shared cover the helper directly; the per-app tests still cover the `/health` and `/version` route shapes (unchanged).

## Regression

- **Shared backend pytest**: 425 passed (was 419; +6 new git tests)
- **MBK full pytest**: passed (exit 0)
- **MBK version endpoint tests**: 8/8 pass
- **MJH version endpoint tests**: 8/8 pass

## Operational migration

None required. No env vars added/renamed. The `GIT_COMMIT` env var contract is unchanged. No deploy workflow changes.

## Test plan

- [x] All 425 shared-backend tests pass
- [x] Full MBK backend pytest passes
- [x] MJH targeted version-endpoint tests pass
- [x] No alembic migrations needed
- [x] No deploy workflow / Caddyfile / docker-compose changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)