### PR TITLE
refactor(platform): extract bucket_initializer to shared with skip-check kwarg

### DIFF
--- a/apps/mybookkeeper/backend/app/services/storage/bucket_initializer.py
+++ b/apps/mybookkeeper/backend/app/services/storage/bucket_initializer.py
@@ -1,53 +1,44 @@
 """Eager bucket setup, called from FastAPI lifespan.
 
-Storage is a hard requirement for this app — listing photos, lease
-attachments, and applicant documents all depend on MinIO. If env vars
-are missing or MinIO is unreachable at boot, the app MUST refuse to
-start so the deploy healthcheck fails and the rollout aborts.
+Thin wrapper over ``platform_shared.services.storage.bucket_initializer``.
+The shared helper owns the skip-check + ``ensure_bucket`` call + logging
+contract; this module wires MBK's ``get_storage`` + skip predicate.
+
+MBK skip condition: requires BOTH ``allow_test_admin_promotion`` AND
+``minio_skip_startup_check`` to be true — stricter than MJH's, which
+checks only ``minio_skip_startup_check``. The double-flag form is a
+test-only escape hatch so production never accidentally skips bucket
+verification even if one flag leaks into the env.
+
+Storage is a hard requirement for MBK — listing photos, lease attachments,
+and applicant documents all depend on MinIO. If env vars are missing or
+MinIO is unreachable at boot, the app MUST refuse to start so the deploy
+healthcheck fails and the rollout aborts.
 
 Previous behavior (graceful degradation) hid environmental
-misconfiguration as `presigned_url=null` in API responses, with no
+misconfiguration as ``presigned_url=null`` in API responses, with no
 visible error path — see the postmortem after PRs #201–#204 for the
 two-week trail of bugs that pattern caused.
-
-Exception: when ``allow_test_admin_promotion=true`` AND
-``minio_skip_startup_check=true`` both appear in the environment the
-bucket check is skipped so E2E test suites can run against a backend
-that has no local MinIO. Storage is still mocked at the route level via
-``POST /test/mock-gmail-send/enable`` for any test that exercises the
-receipt-send path.
 """
-from __future__ import annotations
-
-import logging
+from platform_shared.services.storage.bucket_initializer import (
+    ensure_bucket as _shared_ensure_bucket,
+)
 
 from app.core.config import settings
-from app.core.storage import StorageNotConfiguredError, get_storage
-
-logger = logging.getLogger(__name__)
+from app.core.storage import get_storage
 
 
 def ensure_bucket() -> None:
-    """Ensure the configured bucket exists. Raises on any error.
+    """Ensure the configured MBK bucket exists. Raises on any error.
 
-    The lifespan calls this at startup. If `get_storage()` raises (env
-    vars missing, etc.) or `bucket_exists()` raises (MinIO unreachable),
-    the exception propagates and FastAPI startup fails. The deploy
-    healthcheck catches this and rolls back.
-
-    The check is intentionally skipped when both
-    ``ALLOW_TEST_ADMIN_PROMOTION=true`` and
-    ``MINIO_SKIP_STARTUP_CHECK=true`` are set — test-only escape hatch.
+    Skipped when ``ALLOW_TEST_ADMIN_PROMOTION=true`` AND
+    ``MINIO_SKIP_STARTUP_CHECK=true`` are both set in the environment —
+    test-only escape hatch.
     """
-    if settings.allow_test_admin_promotion and settings.minio_skip_startup_check:
-        logger.warning(
-            "MinIO startup check skipped (MINIO_SKIP_STARTUP_CHECK=true in test mode)"
-        )
-        return
-
-    try:
-        storage = get_storage()
-    except StorageNotConfiguredError:
-        raise
-    storage.ensure_bucket()
-    logger.info("MinIO bucket %s ready", storage.bucket)
+    _shared_ensure_bucket(
+        get_storage=get_storage,
+        skip_check=lambda: (
+            settings.allow_test_admin_promotion
+            and settings.minio_skip_startup_check
+        ),
+    )

--- a/apps/myjobhunter/backend/app/services/storage/bucket_initializer.py
+++ b/apps/myjobhunter/backend/app/services/storage/bucket_initializer.py
@@ -1,42 +1,32 @@
 """Eager bucket setup, called from FastAPI lifespan.
 
+Thin wrapper over ``platform_shared.services.storage.bucket_initializer``.
+The shared helper owns the skip-check + ``ensure_bucket`` call + logging
+contract; this module wires MJH's ``get_storage`` + skip predicate.
+
+MJH skip condition: ``minio_skip_startup_check`` alone — looser than MBK's
+which also requires ``allow_test_admin_promotion``. MJH doesn't have an
+admin-promotion test escape hatch so the single flag is enough.
+
 Storage is a hard requirement for MJH — resume files all depend on MinIO.
 If env vars are missing or MinIO is unreachable at boot, the app MUST refuse
 to start so the deploy healthcheck fails and the rollout aborts.
-
-Exception: when ``minio_skip_startup_check=True`` the bucket check is skipped
-so unit test suites can run against a backend that has no local MinIO.
 """
-from __future__ import annotations
-
-import logging
+from platform_shared.services.storage.bucket_initializer import (
+    ensure_bucket as _shared_ensure_bucket,
+)
 
 from app.core.config import settings
-from app.core.storage import StorageNotConfiguredError, get_storage
-
-logger = logging.getLogger(__name__)
+from app.core.storage import get_storage
 
 
 def ensure_bucket() -> None:
-    """Ensure the configured bucket exists. Raises on any error.
+    """Ensure the configured MJH bucket exists. Raises on any error.
 
-    The lifespan calls this at startup. If ``get_storage()`` raises (env
-    vars missing, etc.) or ``bucket_exists()`` raises (MinIO unreachable),
-    the exception propagates and FastAPI startup fails. The deploy
-    healthcheck catches this and rolls back.
-
-    The check is intentionally skipped when ``MINIO_SKIP_STARTUP_CHECK=true``
-    is set — test-only escape hatch.
+    Skipped when ``MINIO_SKIP_STARTUP_CHECK=true`` is set — test-only
+    escape hatch so unit-test suites without local MinIO can boot.
     """
-    if settings.minio_skip_startup_check:
-        logger.warning(
-            "MinIO startup check skipped (MINIO_SKIP_STARTUP_CHECK=true in test mode)"
-        )
-        return
-
-    try:
-        storage = get_storage()
-    except StorageNotConfiguredError:
-        raise
-    storage.ensure_bucket()
-    logger.info("MinIO bucket %s ready", storage.bucket)
+    _shared_ensure_bucket(
+        get_storage=get_storage,
+        skip_check=lambda: settings.minio_skip_startup_check,
+    )

--- a/packages/shared-backend/platform_shared/services/storage/bucket_initializer.py
+++ b/packages/shared-backend/platform_shared/services/storage/bucket_initializer.py
@@ -1,0 +1,85 @@
+"""Eager MinIO bucket setup, called from each app's FastAPI lifespan.
+
+Storage is a hard requirement for any consuming app — listing photos,
+lease attachments, applicant documents (MBK) or resume files (MJH) all
+depend on MinIO. If env vars are missing or MinIO is unreachable at boot,
+the app MUST refuse to start so the deploy healthcheck fails and the
+rollout aborts.
+
+Previous behavior (graceful degradation) hid environmental
+misconfiguration as ``presigned_url=null`` in API responses, with no
+visible error path — see the MBK PR #201–#204 postmortem for the
+two-week trail of bugs that pattern caused.
+
+Apps wire this via:
+
+    from platform_shared.services.storage.bucket_initializer import ensure_bucket
+    from app.core.config import settings
+    from app.core.storage import get_storage
+
+    def app_ensure_bucket() -> None:
+        ensure_bucket(
+            get_storage=get_storage,
+            skip_check=lambda: settings.minio_skip_startup_check,
+        )
+
+Each app picks its own skip predicate — MBK requires BOTH
+``allow_test_admin_promotion`` AND ``minio_skip_startup_check`` (stricter
+escape hatch); MJH requires only ``minio_skip_startup_check``.
+"""
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from platform_shared.core.storage import StorageClient, StorageNotConfiguredError
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_bucket(
+    *,
+    get_storage: Callable[[], StorageClient],
+    skip_check: Callable[[], bool],
+) -> None:
+    """Ensure the configured bucket exists. Raises on any error.
+
+    The lifespan calls this at startup. If ``get_storage()`` raises
+    (env vars missing, etc.) or ``ensure_bucket()`` raises (MinIO
+    unreachable), the exception propagates and FastAPI startup fails.
+    The deploy healthcheck catches this and rolls back.
+
+    Args:
+        get_storage: The app's storage-client builder (e.g.
+            ``app.core.storage.get_storage``). Called once per
+            invocation; the app is expected to cache.
+        skip_check: A callable returning ``True`` when bucket
+            verification should be skipped. Apps wire their own
+            test-mode escape hatch (e.g. ``lambda: settings.minio_skip_startup_check``).
+
+    Skip path: when ``skip_check()`` returns True, logs a warning and
+    returns without contacting MinIO. ``get_storage()`` is not called,
+    so missing env vars do NOT crash in skip mode either — useful for
+    unit-test suites that don't have MinIO available.
+
+    Raises:
+        StorageNotConfiguredError: when env vars are unset.
+        Exception: any other error from ``get_storage()`` or
+            ``ensure_bucket()`` (network, S3, etc.) propagates so the
+            lifespan boot fails.
+    """
+    if skip_check():
+        logger.warning(
+            "MinIO startup check skipped (skip_check returned True)",
+        )
+        return
+
+    try:
+        storage = get_storage()
+    except StorageNotConfiguredError:
+        raise
+    storage.ensure_bucket()
+    logger.info("MinIO bucket %s ready", storage.bucket)
+
+
+__all__ = ["ensure_bucket"]


### PR DESCRIPTION
## Why

Audit finding **H2** (2026-05-09 parity scan): natural follow-up to **H1** (#544 — storage client extraction). Both apps had near-identical `bucket_initializer.py` modules; only the skip-condition predicate differed.

| App | Skip condition |
|---|---|
| MBK | `ALLOW_TEST_ADMIN_PROMOTION=true` AND `MINIO_SKIP_STARTUP_CHECK=true` |
| MJH | `MINIO_SKIP_STARTUP_CHECK=true` alone |

Extracted to `platform_shared.services.storage.bucket_initializer.ensure_bucket` with the skip predicate passed as a callable. Apps thin-wrap and bind their own settings + storage builder.

## Why MBK's stricter skip

MBK's E2E test suite needs an escape hatch when no MinIO is locally available, but the admin-promotion flag must also be on so the test only runs in test mode. MJH's test suite doesn't have an admin-promotion test path so a single flag is enough. The double-flag form ensures production never accidentally skips bucket verification even if one flag leaks into the env.

## What

**New shared module:**

```python
# platform_shared/services/storage/bucket_initializer.py
def ensure_bucket(
    *,
    get_storage: Callable[[], StorageClient],
    skip_check: Callable[[], bool],
) -> None:
    if skip_check():
        logger.warning("MinIO startup check skipped (skip_check returned True)")
        return
    storage = get_storage()
    storage.ensure_bucket()
    logger.info("MinIO bucket %s ready", storage.bucket)
```

**Apps thin-wrap (~25 LOC saved per app):**

```python
# apps/mybookkeeper/backend/app/services/storage/bucket_initializer.py
def ensure_bucket() -> None:
    _shared_ensure_bucket(
        get_storage=get_storage,
        skip_check=lambda: (
            settings.allow_test_admin_promotion
            and settings.minio_skip_startup_check
        ),
    )

# apps/myjobhunter/backend/app/services/storage/bucket_initializer.py
def ensure_bucket() -> None:
    _shared_ensure_bucket(
        get_storage=get_storage,
        skip_check=lambda: settings.minio_skip_startup_check,
    )
```

Both lambda-bind their app-local settings to `skip_check` so the shared helper never imports any app's config.

## Regression

- **MBK backend pytest**: 2,644 passed / 5 skipped / 0 failed (full suite, 5:08)
- Smoke imports verified for both apps

## Operational migration

None required. No env vars added or renamed. The skip-check semantics are identical to before.

## Test plan

- [x] Full MBK backend pytest passes
- [x] Smoke import verifies `ensure_bucket()` signature unchanged in both apps
- [x] No alembic migrations needed
- [x] No deploy workflow / Caddyfile / docker-compose changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)