### PR TITLE
fix(mbk/auth): make password_reset_email fail-loud (sister to H6)

### DIFF
--- a/apps/mybookkeeper/backend/app/core/auth.py
+++ b/apps/mybookkeeper/backend/app/core/auth.py
@@ -263,11 +263,16 @@ class UserManager(UUIDIDMixin, BaseUserManager[User, uuid.UUID]):
     async def on_after_forgot_password(
         self, user: User, token: str, request: Optional[Request] = None,
     ) -> None:
-        success = send_password_reset_email(user.email, token)
-        if success:
-            logger.info("Password reset email sent to %s", user.email)
-        else:
-            logger.warning("Failed to send password reset email to %s", user.email)
+        """Send password-reset email when a token is generated.
+
+        Raises on any send failure so the forgot-password HTTP request
+        fails 5xx and the user retries — never returns 2xx with the reset
+        email lost. The pre-2026-05-09 bool-returning version silently
+        swallowed failures (sister to the kennethmontgo@gmail.com
+        verification-email gap fixed in PR #540).
+        """
+        send_password_reset_email(user.email, token)
+        logger.info("Password reset email sent to %s", user.email)
         await log_auth_event(
             self.user_db.session,
             event_type=AuthEventType.PASSWORD_RESET_REQUEST,

--- a/apps/mybookkeeper/backend/app/services/system/password_reset_email.py
+++ b/apps/mybookkeeper/backend/app/services/system/password_reset_email.py
@@ -6,7 +6,7 @@ from platform_shared.services.email_templates import build_password_reset_html
 
 from app.core.branding import MBK_BRANDING
 from app.core.config import settings
-from app.services.system import email_service
+from app.services.system.email_service import send_email_or_raise
 
 logger = logging.getLogger(__name__)
 
@@ -15,12 +15,27 @@ def _build_reset_html(reset_url: str) -> str:
     return build_password_reset_html(reset_url=reset_url, branding=MBK_BRANDING)
 
 
-def send_password_reset_email(recipient_email: str, token: str) -> bool:
+def send_password_reset_email(recipient_email: str, token: str) -> None:
+    """Send the password-reset message to a user who initiated forgot-password.
+
+    Critical-path transactional email — raises rather than returning a
+    bool so any failure propagates to the request handler. The pre-2026-05-09
+    bool-returning version silently logged a warning on failure, which
+    meant POST /auth/forgot-password could return 202 to the caller while
+    the reset link never reached their inbox — same bug class as the
+    kennethmontgo@gmail.com verification-email gap fixed in PR #540.
+
+    Sister fix to H6 (verification email fail-loud, #540). H7 added MJH's
+    password-reset-email service in fail-loud shape (#541); this PR brings
+    MBK's existing service to the same fail-loud contract so both apps
+    behave identically.
+
+    Raises:
+        ValueError, EmailNotConfiguredError, EmailSendError — see
+        ``send_email_or_raise`` for semantics.
+    """
     base_url = settings.frontend_url.rstrip("/")
     reset_url = f"{base_url}/reset-password?token={token}"
     html = _build_reset_html(reset_url)
     subject = "Reset your MyBookkeeper password"
-    success = email_service.send_email([recipient_email], subject, html)
-    if not success:
-        logger.warning("Failed to send password reset email to %s", recipient_email)
-    return success
+    send_email_or_raise([recipient_email], subject, html)

--- a/apps/mybookkeeper/backend/tests/test_password_reset.py
+++ b/apps/mybookkeeper/backend/tests/test_password_reset.py
@@ -39,40 +39,45 @@ class TestPasswordResetEmailTemplate:
 class TestSendPasswordResetEmail:
     """send_password_reset_email function tests."""
 
-    @patch("app.services.system.password_reset_email.email_service")
+    @patch("app.services.system.password_reset_email.send_email_or_raise")
     @patch("app.services.system.password_reset_email.settings")
-    def test_sends_email_with_correct_params(self, mock_settings, mock_email_svc):
+    def test_sends_email_with_correct_params(self, mock_settings, mock_send):
         mock_settings.frontend_url = "https://app.example.com"
-        mock_email_svc.send_email.return_value = True
 
         result = send_password_reset_email("user@example.com", "token123")
 
-        assert result is True
-        mock_email_svc.send_email.assert_called_once()
-        args = mock_email_svc.send_email.call_args
+        assert result is None  # fail-loud contract: returns None on success, raises on failure
+        mock_send.assert_called_once()
+        args = mock_send.call_args
         assert args[0][0] == ["user@example.com"]
         assert "Reset" in args[0][1] or "reset" in args[0][1]
         assert "token123" in args[0][2]
 
-    @patch("app.services.system.password_reset_email.email_service")
+    @patch("app.services.system.password_reset_email.send_email_or_raise")
     @patch("app.services.system.password_reset_email.settings")
-    def test_returns_false_on_failure(self, mock_settings, mock_email_svc):
+    def test_raises_on_send_failure(self, mock_settings, mock_send):
+        """Critical-path email — failures must propagate, never be swallowed.
+
+        Regression contract for the kennethmontgo@gmail.com bug class
+        applied to the password-reset path (sister to H6's verification
+        email fix in #540).
+        """
+        from app.services.system.email_service import EmailSendError
+
         mock_settings.frontend_url = "https://app.example.com"
-        mock_email_svc.send_email.return_value = False
+        mock_send.side_effect = EmailSendError("smtp connect failed")
 
-        result = send_password_reset_email("user@example.com", "token123")
+        with pytest.raises(EmailSendError, match="smtp connect failed"):
+            send_password_reset_email("user@example.com", "token123")
 
-        assert result is False
-
-    @patch("app.services.system.password_reset_email.email_service")
+    @patch("app.services.system.password_reset_email.send_email_or_raise")
     @patch("app.services.system.password_reset_email.settings")
-    def test_reset_url_uses_frontend_url(self, mock_settings, mock_email_svc):
+    def test_reset_url_uses_frontend_url(self, mock_settings, mock_send):
         mock_settings.frontend_url = "https://mybookkeeper.app/"
-        mock_email_svc.send_email.return_value = True
 
         send_password_reset_email("user@example.com", "abc")
 
-        html = mock_email_svc.send_email.call_args[0][2]
+        html = mock_send.call_args[0][2]
         assert "https://mybookkeeper.app/reset-password?token=abc" in html
 
 


### PR DESCRIPTION
## Why

Sister fix to **H6** (#540 — verification email fail-loud). MBK's `send_password_reset_email` returned `bool` and only logged a WARNING on SMTP failure. `POST /auth/forgot-password` would return 202 to the user even though the reset email never went out — same bug class as the kennethmontgo@gmail.com gap that H6 fixed for verification emails.

After this PR, both apps have all critical-path transactional emails fail-loud:

| App | Verification | Password Reset |
|---|---|---|
| MBK | #540 ✓ | **this PR** |
| MJH | already fail-loud | #541 ✓ |

## What

- **`send_password_reset_email`** returns `None` and uses `send_email_or_raise`. Failures propagate to the request handler so the HTTP request fails 5xx and the user retries.
- **`on_after_forgot_password`** is the same shape as `on_after_request_verify` after #540: call, log info, emit auth_event. The `PASSWORD_RESET_REQUEST` event is only written on the success path — previously it was logged with `succeeded=True` even on send failure (misleading audit trail).
- **Test file**: replaced 3 tests that exercised the bool/silent-fail behavior with tests for the new fail-loud contract:
  - `test_returns_false_on_failure` → `test_raises_on_send_failure` (verifies `EmailSendError` propagates)
  - `test_sends_email_with_correct_params` + `test_reset_url_uses_frontend_url` now patch `send_email_or_raise` (the new dependency).

## ⚠️ Operational migration required

After this PR merges and before the next deploy, the operator MUST verify SMTP is configured correctly on the VPS, or `POST /auth/forgot-password` will start failing 5xx instead of silently swallowing.

### What to verify

```bash
grep -E "^EMAIL_BACKEND=|^SMTP_HOST=|^SMTP_PORT=|^SMTP_USER=|^SMTP_PASSWORD=" apps/mybookkeeper/backend/.env.docker
```

`EMAIL_BACKEND=smtp` and the four SMTP_* values should be populated. (MBK's prod has been on SMTP since PR #293's boot guard, so this is already the case — the change is just that misconfigurations would now bubble up rather than silently swallow.)

### How to recover if a deploy already failed

```bash
docker compose -f apps/mybookkeeper/docker-compose.yml logs api --tail=100 | grep -iE "EmailSendError|EmailNotConfiguredError"
```

If you see those errors after a deploy, fix the SMTP env vars in `.env.docker` and re-deploy.

### Rollback path

If the operational migration can't be done immediately, revert this PR — the previous (silent) behavior is restored. Note that this brings back the silent-forgot-password gap for MBK.

## Regression

- **MBK backend pytest**: 2,644 passed / 5 skipped / 0 failed (full suite, 6:13)
- 11/11 password-reset tests pass with the new fail-loud contract
- All other email-flow tests untouched

## Test plan

- [x] Full MBK backend pytest passes
- [x] Targeted password-reset tests cover both success path + EmailSendError propagation
- [x] No alembic migrations needed
- [x] No deploy workflow / Caddyfile / docker-compose changes
- [x] MBK's password-reset flow is now at parity with MJH's (both fail-loud)

🤖 Generated with [Claude Code](https://claude.com/claude-code)