### PR TITLE
refactor(platform): extract DELETE /users/me to shared (C1 + H9)

### DIFF
--- a/apps/mybookkeeper/backend/app/api/account.py
+++ b/apps/mybookkeeper/backend/app/api/account.py
@@ -1,62 +1,54 @@
 """User self-service account management endpoints.
 
-DELETE /users/me       — hard-delete account (requires password + email confirmation + TOTP if enabled)
-GET    /users/me/export — download full data export as JSON
+DELETE /users/me        — extracted to ``platform_shared.api.account_deletion_router``
+                          (audit C1+H9, 2026-05-09). This module wires the shared
+                          factory with MBK's auth/db/totp dependencies.
+GET    /users/me/export — MBK-specific (per-org context); stays inline.
 """
-import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from fastapi_users.password import PasswordHelper
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.api.account_deletion_router import (
+    build_account_deletion_router,
+)
 
 from app.core.auth import current_active_user
 from app.core.context import RequestContext
 from app.core.permissions import current_org_member
 from app.db.session import get_db, unit_of_work
 from app.models.user.user import User
-from app.schemas.user.account import DeleteAccountRequest
 from app.services.user import account_service
-from app.services.user.totp_service import validate_totp_for_login
+from app.services.user import totp_service
 
 router = APIRouter(tags=["account"])
 
-logger = logging.getLogger(__name__)
+# Shared three-factor account-deletion endpoint (DELETE /users/me).
+# Mirrors MJH's wiring; both apps now call the service-layer
+# verify_totp_code(db, user_id, code) for the TOTP gate (post-#547 H5).
+async def _verify_totp_late_lookup(db, user_id, code):
+    """Late-bound TOTP verifier so tests patching the underlying service take effect.
 
-
-@router.delete("/users/me", status_code=204)
-async def delete_my_account(
-    body: DeleteAccountRequest,
-    current_user: User = Depends(current_active_user),
-) -> None:
-    """Permanently delete the authenticated user's account and all their data.
-
-    Requires:
-    - Correct account password
-    - Email address matching the account (typed confirmation)
-    - TOTP code if 2FA is enabled
+    The shared `build_account_deletion_router` captures the verifier callable
+    at build time. Pass this thin wrapper that does an attribute lookup on
+    the ``totp_service`` module each call, so tests doing
+    ``patch("app.services.user.totp_service.verify_totp_code", ...)`` see
+    their stub on the next request.
     """
-    # Re-verify password to prevent CSRF and accidental deletion.
-    helper = PasswordHelper()
-    verified, _ = helper.verify_and_update(body.password, current_user.hashed_password)
-    if not verified:
-        raise HTTPException(status_code=403, detail="Incorrect password")
+    return await totp_service.verify_totp_code(db, user_id, code)
 
-    # Email confirmation must exactly match the account email.
-    if body.confirm_email.strip().lower() != current_user.email.lower():
-        raise HTTPException(status_code=400, detail="Email confirmation does not match")
 
-    # TOTP gate: if the user has 2FA enabled, require a valid code.
-    if current_user.totp_enabled:
-        if not body.totp_code:
-            raise HTTPException(status_code=400, detail="TOTP_CODE_REQUIRED")
-        valid, _ = await validate_totp_for_login(current_user.email, body.totp_code)
-        if not valid:
-            raise HTTPException(status_code=403, detail="Invalid TOTP code")
-
-    async with unit_of_work() as txn_db:
-        await account_service.delete_account(txn_db, current_user)
+router.include_router(
+    build_account_deletion_router(
+        current_active_user=current_active_user,
+        get_db_dependency=get_db,
+        verify_totp_step_up=_verify_totp_late_lookup,
+        # Lambda for late lookup so tests patching `unit_of_work` take effect.
+        unit_of_work_factory=lambda: unit_of_work(),
+    )
+)
 
 
 @router.get("/users/me/export")

--- a/apps/mybookkeeper/backend/app/schemas/user/account.py
+++ b/apps/mybookkeeper/backend/app/schemas/user/account.py
@@ -1,7 +1,7 @@
-from pydantic import BaseModel, Field
+"""Re-export of the shared ``DeleteAccountRequest`` schema.
 
-
-class DeleteAccountRequest(BaseModel):
-    password: str = Field(min_length=1)
-    confirm_email: str = Field(min_length=1)
-    totp_code: str | None = Field(default=None, min_length=6, max_length=8)
+Implementation lives in ``platform_shared.schemas.account``. Existing
+MBK call sites (route handler, tests) import from
+``app.schemas.user.account`` and reach the same class.
+"""
+from platform_shared.schemas.account import DeleteAccountRequest  # noqa: F401

--- a/apps/mybookkeeper/backend/tests/test_account_deletion.py
+++ b/apps/mybookkeeper/backend/tests/test_account_deletion.py
@@ -72,6 +72,10 @@ def _patch_session(db: AsyncSession):
         yield db
         await db.flush()
 
+    # The shared account-deletion router (audit C1+H9) opens
+    # `unit_of_work_factory()` for the cascade. The factory wraps a
+    # lambda that re-resolves `unit_of_work` from
+    # `app.api.account` at call time, so this patch still takes effect.
     with patch("app.api.account.unit_of_work", _fake_uow):
         yield
 
@@ -86,7 +90,7 @@ async def test_delete_requires_correct_password(db: AsyncSession) -> None:
     db.add(user)
     await db.flush()
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (False, None)
 
@@ -114,7 +118,7 @@ async def test_delete_requires_email_confirmation(db: AsyncSession) -> None:
     db.add(user)
     await db.flush()
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 
@@ -142,7 +146,7 @@ async def test_delete_requires_totp_when_enabled_missing_code(db: AsyncSession) 
     db.add(user)
     await db.flush()
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 
@@ -172,8 +176,8 @@ async def test_delete_requires_totp_when_enabled_wrong_code(db: AsyncSession) ->
     await db.flush()
 
     with (
-        patch("app.api.account.PasswordHelper") as mock_helper_cls,
-        patch("app.api.account.validate_totp_for_login", new_callable=AsyncMock, return_value=(False, False)),
+        patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls,
+        patch("app.services.user.totp_service.verify_totp_code", new_callable=AsyncMock, return_value=False),
     ):
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
@@ -215,7 +219,7 @@ async def test_delete_succeeds_with_correct_creds(db: AsyncSession) -> None:
     user_row = (await db.execute(select(User).where(User.id == user.id))).scalar_one_or_none()
     assert user_row is not None
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 

--- a/apps/mybookkeeper/backend/tests/test_auth_events_integration.py
+++ b/apps/mybookkeeper/backend/tests/test_auth_events_integration.py
@@ -305,7 +305,7 @@ async def test_account_delete_creates_event(db: AsyncSession) -> None:
 
     with (
         patch("app.api.account.unit_of_work", _fake_uow),
-        patch("app.api.account.PasswordHelper") as mock_helper_cls,
+        patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls,
     ):
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)

--- a/apps/myjobhunter/backend/app/api/account.py
+++ b/apps/myjobhunter/backend/app/api/account.py
@@ -1,64 +1,54 @@
 """User self-service account management endpoints.
 
-DELETE /users/me        — hard-delete account (requires password + email confirmation + TOTP if enabled)
-GET    /users/me/export — download full data export as JSON
+DELETE /users/me        — extracted to ``platform_shared.api.account_deletion_router``
+                          (audit C1+H9, 2026-05-09). This module wires the shared
+                          factory with MJH's auth/db/totp dependencies.
+GET    /users/me/export — MJH-specific shape; stays inline.
 
 Mounted BEFORE the fastapi-users users router in ``app.main`` so the
 ``DELETE /users/me`` matcher fires here rather than the fastapi-users
 ``DELETE /users/{id}`` matcher.
 """
-import logging
 from datetime import datetime, timezone
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends
 from fastapi.responses import JSONResponse
-from fastapi_users.password import PasswordHelper
 from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.api.account_deletion_router import (
+    build_account_deletion_router,
+)
 
 from app.core.auth import current_active_user
 from app.db.session import get_db, unit_of_work
 from app.models.user.user import User
-from app.schemas.user.account import DeleteAccountRequest
 from app.services.user import account_service
-from app.services.user.totp_service import verify_totp_code
+from app.services.user import totp_service
 
 router = APIRouter(tags=["account"])
 
-logger = logging.getLogger(__name__)
+# Shared three-factor account-deletion endpoint (DELETE /users/me).
+async def _verify_totp_late_lookup(db, user_id, code):
+    """Late-bound TOTP verifier so tests patching the underlying service take effect.
 
-
-@router.delete("/users/me", status_code=204)
-async def delete_my_account(
-    body: DeleteAccountRequest,
-    db: AsyncSession = Depends(get_db),
-    current_user: User = Depends(current_active_user),
-) -> None:
-    """Permanently delete the authenticated user's account and all their data.
-
-    Requires:
-    - Correct account password
-    - Email address matching the account (typed confirmation)
-    - TOTP code if 2FA is enabled
+    The shared `build_account_deletion_router` captures the verifier callable
+    at build time. Pass this thin wrapper that does an attribute lookup on
+    the ``totp_service`` module each call, so tests doing
+    ``patch("app.services.user.totp_service.verify_totp_code", ...)`` see
+    their stub on the next request.
     """
-    # Re-verify password to prevent CSRF and accidental deletion.
-    helper = PasswordHelper()
-    verified, _ = helper.verify_and_update(body.password, current_user.hashed_password)
-    if not verified:
-        raise HTTPException(status_code=403, detail="Incorrect password")
+    return await totp_service.verify_totp_code(db, user_id, code)
 
-    # Email confirmation must exactly match the account email (case-insensitive).
-    if body.confirm_email.strip().lower() != current_user.email.lower():
-        raise HTTPException(status_code=400, detail="Email confirmation does not match")
 
-    # TOTP gate: if the user has 2FA enabled, require a valid code.
-    if current_user.totp_enabled:
-        if not body.totp_code:
-            raise HTTPException(status_code=400, detail="TOTP_CODE_REQUIRED")
-        if not await verify_totp_code(db, current_user.id, body.totp_code):
-            raise HTTPException(status_code=403, detail="Invalid TOTP code")
-
-    async with unit_of_work() as txn_db:
-        await account_service.delete_account(txn_db, current_user)
+router.include_router(
+    build_account_deletion_router(
+        current_active_user=current_active_user,
+        get_db_dependency=get_db,
+        verify_totp_step_up=_verify_totp_late_lookup,
+        # Lambda for late lookup so tests patching `unit_of_work` take effect.
+        unit_of_work_factory=lambda: unit_of_work(),
+    )
+)
 
 
 @router.get("/users/me/export")

--- a/apps/myjobhunter/backend/app/schemas/user/account.py
+++ b/apps/myjobhunter/backend/app/schemas/user/account.py
@@ -1,19 +1,7 @@
-"""Request schemas for the account self-service endpoints."""
-from pydantic import BaseModel, Field
+"""Re-export of the shared ``DeleteAccountRequest`` schema.
 
-
-class DeleteAccountRequest(BaseModel):
-    """Body of ``DELETE /users/me``.
-
-    Three-factor confirmation:
-    - ``password`` is re-verified against the stored hash
-    - ``confirm_email`` must match the authenticated user's email (case-insensitive)
-    - ``totp_code`` is required only when the user has 2FA enabled
-
-    The minimum length on ``totp_code`` is 6 (a standard 6-digit RFC 6238 code)
-    and the max is 8 to allow recovery codes to be used as a fallback.
-    """
-
-    password: str = Field(min_length=1)
-    confirm_email: str = Field(min_length=1)
-    totp_code: str | None = Field(default=None, min_length=6, max_length=8)
+Implementation lives in ``platform_shared.schemas.account``. Existing
+MJH call sites (route handler, tests) import from
+``app.schemas.user.account`` and reach the same class.
+"""
+from platform_shared.schemas.account import DeleteAccountRequest  # noqa: F401

--- a/apps/myjobhunter/backend/tests/test_account_deletion.py
+++ b/apps/myjobhunter/backend/tests/test_account_deletion.py
@@ -112,7 +112,7 @@ async def test_delete_requires_correct_password(db: AsyncSession) -> None:
     db.add(user)
     await db.flush()
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (False, None)
 
@@ -141,7 +141,7 @@ async def test_delete_requires_email_confirmation(db: AsyncSession) -> None:
     db.add(user)
     await db.flush()
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 
@@ -170,7 +170,7 @@ async def test_delete_requires_totp_when_enabled_missing_code(db: AsyncSession) 
     db.add(user)
     await db.flush()
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 
@@ -201,9 +201,9 @@ async def test_delete_requires_totp_when_enabled_wrong_code(db: AsyncSession) ->
     await db.flush()
 
     with (
-        patch("app.api.account.PasswordHelper") as mock_helper_cls,
+        patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls,
         patch(
-            "app.api.account.verify_totp_code",
+            "app.services.user.totp_service.verify_totp_code",
             new_callable=AsyncMock,
             return_value=False,
         ),
@@ -238,9 +238,9 @@ async def test_delete_succeeds_with_valid_totp(db: AsyncSession) -> None:
     await db.flush()
 
     with (
-        patch("app.api.account.PasswordHelper") as mock_helper_cls,
+        patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls,
         patch(
-            "app.api.account.verify_totp_code",
+            "app.services.user.totp_service.verify_totp_code",
             new_callable=AsyncMock,
             return_value=True,
         ),
@@ -278,7 +278,7 @@ async def test_delete_succeeds_with_correct_creds(db: AsyncSession) -> None:
     ).scalar_one_or_none()
     assert user_row is not None
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 
@@ -315,7 +315,7 @@ async def test_delete_email_match_is_case_insensitive(db: AsyncSession) -> None:
     db.add(user)
     await db.flush()
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 
@@ -428,7 +428,7 @@ async def test_delete_cascades_all_domain_rows(db: AsyncSession) -> None:
     user_row = (await db.execute(select(User).where(User.id == user.id))).scalar_one_or_none()
     assert user_row is not None
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 
@@ -481,7 +481,7 @@ async def test_account_deleted_event_survives_cascade(db: AsyncSession) -> None:
     db.add(user)
     await db.flush()
 
-    with patch("app.api.account.PasswordHelper") as mock_helper_cls:
+    with patch("platform_shared.api.account_deletion_router.PasswordHelper") as mock_helper_cls:
         mock_helper = mock_helper_cls.return_value
         mock_helper.verify_and_update.return_value = (True, None)
 

--- a/packages/shared-backend/platform_shared/api/account_deletion_router.py
+++ b/packages/shared-backend/platform_shared/api/account_deletion_router.py
@@ -1,0 +1,99 @@
+"""Shared ``DELETE /users/me`` route — three-factor confirm + audit + cascade.
+
+Both MBK and MJH expose this endpoint with byte-identical semantics:
+password re-verification + email-match confirmation + TOTP step-up
+(when 2FA is enabled). Apps build the router via
+:func:`build_account_deletion_router` passing their own auth dependency,
+db-session dependency, and TOTP verifier callable. The included router
+has no prefix; parent app routers wire under their own root.
+
+The export endpoint (``GET /users/me/export``) is intentionally NOT
+shared — its response shape and dependency surface differ per app
+(MBK includes per-org context, MJH is single-tenant-per-user) and
+extracting it would be more friction than reuse value.
+"""
+from __future__ import annotations
+
+import uuid
+from collections.abc import AsyncIterator, Awaitable, Callable
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from fastapi_users.password import PasswordHelper
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.schemas.account import DeleteAccountRequest
+from platform_shared.services.account_deletion import delete_account
+
+
+def build_account_deletion_router(
+    *,
+    current_active_user: Callable[..., Awaitable[Any]],
+    get_db_dependency: Callable[..., AsyncIterator[AsyncSession]],
+    verify_totp_step_up: Callable[
+        [AsyncSession, uuid.UUID, str], Awaitable[bool]
+    ],
+    unit_of_work_factory: Callable[..., Any],
+) -> APIRouter:
+    """Build a router exposing ``DELETE /users/me``.
+
+    Args:
+        current_active_user: The app's fastapi-users
+            ``current_active_user`` dependency.
+        get_db_dependency: The app's ``get_db`` async-generator
+            dependency. Used by the TOTP-verify call inside the
+            request gate.
+        verify_totp_step_up: A callable matching MJH's / MBK's
+            ``verify_totp_code(db, user_id, code) -> bool``. The
+            implementation lives per-app (MBK and MJH have a
+            byte-identical service-layer function after audit H5).
+        unit_of_work_factory: The app's ``unit_of_work`` async context
+            manager. The route opens this scope around the
+            cascade-delete + audit-event write so they commit
+            atomically.
+
+    Returns:
+        An ``APIRouter`` with a single DELETE route at ``/users/me``.
+        Tagged ``account`` for OpenAPI grouping.
+    """
+    router = APIRouter(tags=["account"])
+
+    @router.delete("/users/me", status_code=204)
+    async def delete_my_account(
+        body: DeleteAccountRequest,
+        db: AsyncSession = Depends(get_db_dependency),
+        current_user: Any = Depends(current_active_user),
+    ) -> None:
+        """Permanently delete the authenticated user's account and all their data.
+
+        Requires:
+        - Correct account password
+        - Email address matching the account (typed confirmation)
+        - TOTP code if 2FA is enabled
+        """
+        # Re-verify password to prevent CSRF and accidental deletion.
+        helper = PasswordHelper()
+        verified, _ = helper.verify_and_update(
+            body.password, current_user.hashed_password
+        )
+        if not verified:
+            raise HTTPException(status_code=403, detail="Incorrect password")
+
+        # Email confirmation must exactly match the account email
+        # (case-insensitive).
+        if body.confirm_email.strip().lower() != current_user.email.lower():
+            raise HTTPException(
+                status_code=400, detail="Email confirmation does not match"
+            )
+
+        # TOTP gate: if the user has 2FA enabled, require a valid code.
+        if current_user.totp_enabled:
+            if not body.totp_code:
+                raise HTTPException(status_code=400, detail="TOTP_CODE_REQUIRED")
+            if not await verify_totp_step_up(db, current_user.id, body.totp_code):
+                raise HTTPException(status_code=403, detail="Invalid TOTP code")
+
+        async with unit_of_work_factory() as txn_db:
+            await delete_account(txn_db, current_user)
+
+    return router

--- a/packages/shared-backend/platform_shared/schemas/account.py
+++ b/packages/shared-backend/platform_shared/schemas/account.py
@@ -1,0 +1,25 @@
+"""Request schemas for the account self-service endpoints.
+
+Lives in ``platform_shared`` so MBK + MJH (and future apps) share the
+exact same wire-shape contract for ``DELETE /users/me``. Account
+deletion is the highest-impact write op in the system; drift between
+apps in the request shape would be a real bug.
+"""
+from pydantic import BaseModel, Field
+
+
+class DeleteAccountRequest(BaseModel):
+    """Body of ``DELETE /users/me``.
+
+    Three-factor confirmation:
+    - ``password`` is re-verified against the stored hash
+    - ``confirm_email`` must match the authenticated user's email (case-insensitive)
+    - ``totp_code`` is required only when the user has 2FA enabled
+
+    The minimum length on ``totp_code`` is 6 (a standard 6-digit RFC 6238 code)
+    and the max is 8 to allow recovery codes to be used as a fallback.
+    """
+
+    password: str = Field(min_length=1)
+    confirm_email: str = Field(min_length=1)
+    totp_code: str | None = Field(default=None, min_length=6, max_length=8)

--- a/packages/shared-backend/platform_shared/services/account_deletion.py
+++ b/packages/shared-backend/platform_shared/services/account_deletion.py
@@ -1,0 +1,62 @@
+"""Hard-delete service for ``DELETE /users/me`` — emits audit event + cascade.
+
+The route in :mod:`platform_shared.api.account_deletion_router` calls
+this after the password / email / TOTP gates pass.
+
+Order matters:
+
+1. ``log_auth_event(ACCOUNT_DELETED)`` writes the audit row in the same
+   transaction. The ``auth_events.user_id`` column has NO foreign key
+   to ``users.id`` (intentional — see
+   :mod:`platform_shared.db.models.auth_event`) so the row survives
+   the cascade and remains queryable for the admin audit log.
+
+2. ``db.delete(user)`` issues ``DELETE FROM users WHERE id=...``. Every
+   app-owned table has ``ON DELETE CASCADE`` on its ``user_id`` FK, so
+   the single statement wipes all the user's rows atomically.
+
+The caller (the route handler) is responsible for committing the
+surrounding transaction. This function does not flush or commit.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from platform_shared.core.auth_events import AuthEventType
+from platform_shared.services.auth_event_service import log_auth_event
+
+logger = logging.getLogger(__name__)
+
+
+async def delete_account(db: AsyncSession, user: Any) -> None:
+    """Hard-delete ``user``; all related rows cascade-delete via FK.
+
+    Args:
+        db: Session that owns the surrounding transaction.
+        user: A loaded User-like instance with ``.id`` and ``.email``.
+            The function refetches the row by ``type(user)`` so it works
+            with both apps' User class without needing the class as a
+            parameter. Detached instances are handled correctly.
+    """
+    logger.warning(
+        "Account deletion: user_id=%s email=%s",
+        user.id,
+        user.email,
+    )
+    # Refetch via the session so SQLAlchemy emits a real DELETE statement
+    # (rather than a no-op when the caller passed a detached instance).
+    loaded_user = await db.get(type(user), user.id)
+    if loaded_user is None:
+        return
+    # Log BEFORE delete — the auth_events table has no FK to users, so
+    # the event row is safe even after the user cascade completes.
+    await log_auth_event(
+        db,
+        event_type=AuthEventType.ACCOUNT_DELETED,
+        user_id=user.id,
+        succeeded=True,
+    )
+    await db.delete(loaded_user)


### PR DESCRIPTION
## Why

Audit findings **C1** (account-deletion route) + **H9** (delete_account service): both apps had byte-identical 50+ LOC route handlers and 25-LOC service functions for the highest-impact write op (account deletion). Extracted to `platform_shared` so the security boundary lives in one place.

This is the security-incident-review surface analog of C5 (auth-events route). Drift here would mean one app could let an account through with weaker confirmation than the other; central single source of truth eliminates the risk.

## What — 3 new shared modules

- **`platform_shared/schemas/account.py::DeleteAccountRequest`** — was byte-identical 17-line file in both apps (only docstring differed).
- **`platform_shared/services/account_deletion.py::delete_account`** — generic over the User model class via `type(user)`. Same audit-event-before-cascade ordering as before; behavior unchanged.
- **`platform_shared/api/account_deletion_router.py::build_account_deletion_router`** — factory takes app's auth dep, get_db dep, TOTP verifier callable, and unit_of_work factory. Returns a router with `DELETE /users/me` at root.

## Apps thin-wrap with late-lookup wrappers for testability

The shared factory captures all dependencies at build time. To preserve test patchability (~6 tests across both apps patch the underlying functions), apps wrap with late-lookup helpers:

```python
async def _verify_totp_late_lookup(db, user_id, code):
    return await totp_service.verify_totp_code(db, user_id, code)

router.include_router(
    build_account_deletion_router(
        current_active_user=current_active_user,
        get_db_dependency=get_db,
        verify_totp_step_up=_verify_totp_late_lookup,
        unit_of_work_factory=lambda: unit_of_work(),  # late lookup
    )
)
```

## Apps' export endpoints stay inline

`GET /users/me/export` has different shape — MBK has per-org context (`ctx: RequestContext = Depends(current_org_member)`), MJH is single-tenant-per-user. Only the deletion route is shared.

## TOTP gate parity (depends on H5)

Both apps now use service-layer `verify_totp_code` (post-#547 H5 reconciliation). Previously MBK called `validate_totp_for_login(email, code) → tuple` while MJH called `verify_totp_code(db, user_id, code) → bool`. With H5, both apps have the same signature, so the shared factory has a clean single contract.

## Test patch updates

| Was | Now |
|---|---|
| `app.api.account.PasswordHelper` | `platform_shared.api.account_deletion_router.PasswordHelper` |
| `app.api.account.validate_totp_for_login` | `app.services.user.totp_service.verify_totp_code` |

Updated in:
- `apps/mybookkeeper/backend/tests/test_account_deletion.py`
- `apps/mybookkeeper/backend/tests/test_auth_events_integration.py`
- `apps/myjobhunter/backend/tests/test_account_deletion.py`

## Regression

- **MBK targeted** (test_account_deletion + test_data_export + test_auth_events_integration): 28/28 pass
- **MJH targeted** (test_account_deletion): 10/10 pass
- **Full MBK backend pytest**: 2,644 passed / 5 skipped / 0 failed (post-test-patch fix)

## Operational migration

None required. Same wire shape. No env vars, no schema changes, no API contract changes.

## Test plan

- [x] All targeted tests pass for both apps
- [x] Full MBK backend pytest passes
- [x] No alembic migrations needed
- [x] No deploy workflow / Caddyfile / docker-compose changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)