### PR TITLE
refactor(platform): extract build_jwt_auth_backend factory (incremental H3)

### DIFF
--- a/apps/mybookkeeper/backend/app/core/auth.py
+++ b/apps/mybookkeeper/backend/app/core/auth.py
@@ -6,7 +6,6 @@ from typing import Any, Optional, Union
 from fastapi import Depends, Request
 from fastapi.security import OAuth2PasswordRequestForm
 from fastapi_users import BaseUserManager, FastAPIUsers, InvalidPasswordException, UUIDIDMixin, exceptions, models, schemas
-from fastapi_users.authentication import AuthenticationBackend, BearerTransport, JWTStrategy
 from fastapi_users.db import SQLAlchemyUserDatabase
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -374,18 +373,19 @@ async def get_user_manager(user_db: SQLAlchemyUserDatabase = Depends(get_user_db
     yield UserManager(user_db)
 
 
-bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
+from platform_shared.auth.jwt_backend import build_jwt_auth_backend
 
-
-def get_jwt_strategy() -> JWTStrategy:
-    return JWTStrategy(secret=settings.secret_key, lifetime_seconds=settings.jwt_lifetime_seconds)
-
-
-auth_backend = AuthenticationBackend(
-    name="jwt",
-    transport=bearer_transport,
-    get_strategy=get_jwt_strategy,
+# Constructed via the shared factory so future apps inherit the wiring.
+# Destructure into module-level names so existing
+# ``from app.core.auth import bearer_transport / get_jwt_strategy / auth_backend``
+# imports keep resolving unchanged.
+_jwt = build_jwt_auth_backend(
+    secret_key=settings.secret_key,
+    lifetime_seconds=settings.jwt_lifetime_seconds,
 )
+bearer_transport = _jwt.bearer_transport
+get_jwt_strategy = _jwt.get_jwt_strategy
+auth_backend = _jwt.auth_backend
 
 fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
 

--- a/apps/myjobhunter/backend/app/core/auth.py
+++ b/apps/myjobhunter/backend/app/core/auth.py
@@ -27,11 +27,6 @@ from fastapi_users import (
     exceptions,
     models,
 )
-from fastapi_users.authentication import (
-    AuthenticationBackend,
-    BearerTransport,
-    JWTStrategy,
-)
 from fastapi_users.db import SQLAlchemyUserDatabase
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -314,21 +309,19 @@ async def get_user_manager(user_db=Depends(get_user_db)):
     yield UserManager(user_db)
 
 
-bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
+from platform_shared.auth.jwt_backend import build_jwt_auth_backend
 
-
-def get_jwt_strategy() -> JWTStrategy:
-    return JWTStrategy(
-        secret=settings.secret_key,
-        lifetime_seconds=settings.jwt_lifetime_seconds,
-    )
-
-
-auth_backend = AuthenticationBackend(
-    name="jwt",
-    transport=bearer_transport,
-    get_strategy=get_jwt_strategy,
+# Constructed via the shared factory so future apps inherit the wiring.
+# Destructure into module-level names so existing
+# ``from app.core.auth import bearer_transport / get_jwt_strategy / auth_backend``
+# imports keep resolving unchanged.
+_jwt = build_jwt_auth_backend(
+    secret_key=settings.secret_key,
+    lifetime_seconds=settings.jwt_lifetime_seconds,
 )
+bearer_transport = _jwt.bearer_transport
+get_jwt_strategy = _jwt.get_jwt_strategy
+auth_backend = _jwt.auth_backend
 
 fastapi_users = FastAPIUsers[User, uuid.UUID](get_user_manager, [auth_backend])
 current_active_user = fastapi_users.current_user(active=True, verified=True)

--- a/packages/shared-backend/platform_shared/auth/jwt_backend.py
+++ b/packages/shared-backend/platform_shared/auth/jwt_backend.py
@@ -1,0 +1,81 @@
+"""Shared JWT authentication backend for fastapi-users.
+
+Both MBK and MJH wire fastapi-users with the same shape:
+
+    bearer_transport = BearerTransport(tokenUrl="auth/jwt/login")
+    def get_jwt_strategy() -> JWTStrategy:
+        return JWTStrategy(secret=settings.secret_key, lifetime_seconds=...)
+    auth_backend = AuthenticationBackend(
+        name="jwt", transport=bearer_transport, get_strategy=get_jwt_strategy
+    )
+
+Extracted to a factory so future apps inherit the wiring with one
+function call. Apps thin-wrap by binding their own settings. Existing
+imports of ``bearer_transport``, ``get_jwt_strategy``, and ``auth_backend``
+from each app's ``app.core.auth`` continue to resolve unchanged.
+"""
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from fastapi_users.authentication import (
+    AuthenticationBackend,
+    BearerTransport,
+    JWTStrategy,
+)
+
+
+class JwtAuthBackend(NamedTuple):
+    """Bundle of the three fastapi-users auth wiring objects.
+
+    Apps destructure this at module level so existing imports (e.g.
+    ``from app.core.auth import auth_backend``) keep working.
+    """
+
+    bearer_transport: BearerTransport
+    get_jwt_strategy: object  # Callable[[], JWTStrategy] — mypy-friendly
+    auth_backend: AuthenticationBackend
+
+
+def build_jwt_auth_backend(
+    *,
+    secret_key: str,
+    lifetime_seconds: int,
+    token_url: str = "auth/jwt/login",
+    backend_name: str = "jwt",
+) -> JwtAuthBackend:
+    """Construct the fastapi-users JWT auth wiring.
+
+    Args:
+        secret_key: HMAC secret for token signing. Apps pass
+            ``settings.secret_key``.
+        lifetime_seconds: Token TTL. Apps pass
+            ``settings.jwt_lifetime_seconds``.
+        token_url: ``BearerTransport`` token URL. Defaults to the
+            convention both apps use today (``"auth/jwt/login"``).
+        backend_name: ``AuthenticationBackend`` name. Defaults to
+            ``"jwt"`` matching both apps.
+
+    Returns:
+        ``JwtAuthBackend(bearer_transport, get_jwt_strategy, auth_backend)``
+        — apps destructure into module-level names.
+    """
+    bearer_transport = BearerTransport(tokenUrl=token_url)
+
+    def get_jwt_strategy() -> JWTStrategy:
+        return JWTStrategy(secret=secret_key, lifetime_seconds=lifetime_seconds)
+
+    auth_backend = AuthenticationBackend(
+        name=backend_name,
+        transport=bearer_transport,
+        get_strategy=get_jwt_strategy,
+    )
+
+    return JwtAuthBackend(
+        bearer_transport=bearer_transport,
+        get_jwt_strategy=get_jwt_strategy,
+        auth_backend=auth_backend,
+    )
+
+
+__all__ = ["JwtAuthBackend", "build_jwt_auth_backend"]


### PR DESCRIPTION
## Why

Audit finding **H3** (incremental, 2026-05-09): both apps had near-identical fastapi-users JWT auth backend setups (`BearerTransport` + `get_jwt_strategy` + `AuthenticationBackend`). Bodies were byte-identical except formatting; only the per-app `secret_key` + `lifetime` varied.

The audit explicitly recommended extracting these primitives **first**, before tackling the larger `UserManager` extraction:

> Extract incrementally — first `_lock_duration_for`, `get_jwt_strategy`, `bearer_transport`, `auth_backend`, `fastapi_users` construction. Then the `authenticate`/`authenticate_password` body. Defer `UserManager` subclass dance until both apps have the same `on_after_request_verify` shape.

## What

- **New `platform_shared/auth/jwt_backend.py::build_jwt_auth_backend`** — factory returning a `JwtAuthBackend` NamedTuple (`bearer_transport`, `get_jwt_strategy`, `auth_backend`).
- **Apps thin-wrap** by destructuring into module-level names so existing imports keep working:

```python
_jwt = build_jwt_auth_backend(
    secret_key=settings.secret_key,
    lifetime_seconds=settings.jwt_lifetime_seconds,
)
bearer_transport = _jwt.bearer_transport
get_jwt_strategy = _jwt.get_jwt_strategy
auth_backend = _jwt.auth_backend
```

- Removed now-unused `BearerTransport / JWTStrategy / AuthenticationBackend` imports from both apps' `app/core/auth.py`.

## Intentional divergences NOT touched

- `current_active_user` stays per-app:
  - MBK: `fastapi_users.current_user(active=True)`
  - MJH: `fastapi_users.current_user(active=True, verified=True)` — refuses unverified users at the dependency layer (defense-in-depth on top of MBK's verification check at the `/auth/totp/login` route)
- `fastapi_users` instantiation stays per-app (each binds its own User class)

These are conscious design choices, not drift. Future H3 work can decide whether MBK should also enforce `verified=True`.

## Regression

- **MBK targeted** (test_totp_routes + test_login_ip_rate_limit + test_auth_events_integration): 34/34 pass
- **MJH targeted** (test_auth + test_login_ip_rate_limit + test_totp_login + test_totp_setup): 31/31 pass
- **Full MBK pytest**: was at 54% with all-dots when I killed it (slow but progressing — CI will verify the full suite)
- Smoke imports for both apps confirm `bearer_transport`, `get_jwt_strategy`, `auth_backend` resolve to the right types with correct lifetimes (MBK: 86400s = 24h, MJH: 1800s = 30min)

## Operational migration

None required. No env vars, no schema changes, no API contract changes. The factory threads each app's `settings.secret_key` + `settings.jwt_lifetime_seconds` through unchanged.

## Test plan

- [x] All 34 MBK + 31 MJH targeted auth tests pass
- [x] Both apps' `current_active_user` import resolves correctly
- [x] No alembic migrations needed
- [x] No deploy workflow / Caddyfile / docker-compose changes
- [ ] CI full regression — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)