### PR TITLE
fix(auth): reconcile TOTP login flows between MBK and MJH (audit C2)

### DIFF
--- a/apps/mybookkeeper/backend/app/api/totp.py
+++ b/apps/mybookkeeper/backend/app/api/totp.py
@@ -169,7 +169,7 @@ async def totp_login(
                 succeeded=False,
             )
             await db.commit()
-            raise HTTPException(status_code=401, detail="Invalid authentication code")
+            raise HTTPException(status_code=401, detail="invalid_totp")
 
         event_type = AuthEventType.TOTP_RECOVERY_USED if used_recovery else AuthEventType.TOTP_VERIFY_SUCCESS
         await log_auth_event(
@@ -190,4 +190,9 @@ async def totp_login(
         request=request,
         succeeded=True,
     )
+    # Persist the LOGIN_SUCCESS event — without this commit the row is
+    # discarded when the get_db dependency tears down the session, and
+    # the credential-stuffing detection signal is lost. Failure paths
+    # already commit explicitly above; success was missing parity.
+    await db.commit()
     return TotpLoginResponse(access_token=token, token_type="bearer")

--- a/apps/mybookkeeper/backend/tests/test_totp_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_totp_routes.py
@@ -389,7 +389,7 @@ class TestTotpLogin:
         finally:
             app.dependency_overrides.clear()
         assert resp.status_code == 401
-        assert "Invalid" in resp.json()["detail"]
+        assert resp.json()["detail"] == "invalid_totp"
 
     @pytest.mark.asyncio
     async def test_login_with_valid_recovery_code_returns_token(

--- a/apps/mybookkeeper/frontend/src/app/pages/Login.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Login.tsx
@@ -101,7 +101,12 @@ export default function Login() {
         setNeedsVerification(true);
         setResendStatus("idle");
       } else {
-        setError(needsTotp ? extractErrorMessage(err) : "Invalid email or password");
+        const detail = extractErrorMessage(err);
+        const totpMsg =
+          detail === "invalid_totp"
+            ? "Invalid authentication code. Please try again."
+            : detail;
+        setError(needsTotp ? totpMsg : "Invalid email or password");
       }
       setIsLoading(false);
     }

--- a/apps/myjobhunter/backend/app/api/totp.py
+++ b/apps/myjobhunter/backend/app/api/totp.py
@@ -30,6 +30,11 @@ from app.core.auth import (
     get_jwt_strategy,
     get_user_manager,
 )
+from app.core.rate_limit import (
+    check_login_rate_limit,
+    check_totp_account_not_locked,
+    check_totp_rate_limit,
+)
 from app.db.session import get_db
 from app.models.user.user import User
 from app.schemas.totp import (
@@ -141,6 +146,11 @@ async def totp_status(
 
 @router.post(
     "/login",
+    dependencies=[
+        Depends(check_login_rate_limit),
+        Depends(check_totp_rate_limit),
+        Depends(check_totp_account_not_locked),
+    ],
     response_model=TotpLoginResponse,
     response_model_exclude_none=True,
 )
@@ -223,7 +233,7 @@ async def totp_login(
                 succeeded=False,
             )
             await db.commit()
-            raise HTTPException(status_code=400, detail="invalid_totp")
+            raise HTTPException(status_code=401, detail="invalid_totp")
 
         event_type = (
             AuthEventType.TOTP_RECOVERY_USED if used_recovery

--- a/apps/myjobhunter/backend/app/core/rate_limit.py
+++ b/apps/myjobhunter/backend/app/core/rate_limit.py
@@ -41,8 +41,11 @@ __all__ = [
     "RATE_LIMIT_GENERIC_DETAIL",
     "get_user_by_email",
     "login_limiter",
+    "totp_limiter",
     "check_login_rate_limit",
+    "check_totp_rate_limit",
     "check_account_not_locked",
+    "check_totp_account_not_locked",
     "verify_turnstile_token",
     "require_turnstile",
 ]
@@ -56,6 +59,11 @@ login_limiter = RateLimiter(
     max_attempts=settings.login_rate_limit_threshold,
     window_seconds=settings.login_rate_limit_window_seconds,
 )
+
+# Mirrors MBK's totp_limiter (20 / 300s) — separate from login_limiter so
+# the TOTP path can be tuned independently. Hardcoded to match MBK exactly;
+# move to settings if MJH ever needs operator-tunable TOTP throttle.
+totp_limiter = RateLimiter(max_attempts=20, window_seconds=300)
 
 
 # ---------------------------------------------------------------------------
@@ -123,6 +131,38 @@ async def check_login_rate_limit(
         raise
 
 
+async def check_totp_rate_limit(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Per-IP rate limit for the TOTP login endpoint with audit logging.
+
+    Mirrors ``check_login_rate_limit`` — on block, writes a
+    ``LOGIN_BLOCKED_RATE_LIMIT`` auth event with ``gate="totp"`` so SOC/admin
+    tooling can distinguish TOTP-path credential stuffing from standard-login
+    stuffing. The 429 body is intentionally identical to all other
+    rate-limit / lockout responses.
+    """
+    ip = get_client_ip(request)
+    try:
+        totp_limiter.check(ip)
+    except HTTPException:
+        metadata: dict[str, str] = {"ip": ip, "gate": "totp"}
+        domain = email_domain_from_request(request)
+        if domain is not None:
+            metadata["email_domain"] = domain
+        await log_auth_event(
+            db,
+            event_type=AuthEventType.LOGIN_BLOCKED_RATE_LIMIT,
+            user_id=None,
+            request=request,
+            succeeded=False,
+            metadata=metadata,
+        )
+        await db.commit()
+        raise
+
+
 async def check_account_not_locked(
     credentials: OAuth2PasswordRequestForm = Depends(),
     db: AsyncSession = Depends(get_db),
@@ -132,6 +172,45 @@ async def check_account_not_locked(
     if user is None:
         return
     if user.locked_until and user.locked_until > datetime.now(tz=timezone.utc):
+        raise HTTPException(
+            status_code=429,
+            detail=RATE_LIMIT_GENERIC_DETAIL,
+        )
+
+
+async def check_totp_account_not_locked(
+    request: Request,
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Reject ``POST /auth/totp/login`` attempts for locked accounts.
+
+    Parallel to ``check_account_not_locked`` for the form-encoded JWT login
+    path, but reads ``email`` from the JSON ``TotpLoginRequest`` body instead
+    of an ``OAuth2PasswordRequestForm``.
+
+    On block, writes a ``LOGIN_BLOCKED_LOCKED`` auth event so SOC/admin
+    tooling sees the same signal whether the attacker uses the JWT or TOTP
+    login endpoint. The 429 body is intentionally identical to all other
+    rate-limit / lockout responses — callers cannot infer which gate fired.
+    """
+    body = await request.json()
+    email: str = body.get("email", "")
+    if not email:
+        return
+
+    user = await get_user_by_email(db, email)
+    if user is None:
+        return
+
+    if user.locked_until and user.locked_until > datetime.now(tz=timezone.utc):
+        await log_auth_event(
+            db,
+            event_type=AuthEventType.LOGIN_BLOCKED_LOCKED,
+            user_id=user.id,
+            request=request,
+            succeeded=False,
+        )
+        await db.commit()
         raise HTTPException(
             status_code=429,
             detail=RATE_LIMIT_GENERIC_DETAIL,

--- a/apps/myjobhunter/backend/tests/test_totp_login.py
+++ b/apps/myjobhunter/backend/tests/test_totp_login.py
@@ -121,7 +121,7 @@ async def test_login_with_invalid_totp_returns_invalid_totp(
             "totp_code": "000000",
         },
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 401
     assert resp.json()["detail"] == "invalid_totp"
 
 
@@ -176,7 +176,7 @@ async def test_recovery_code_accepted_and_consumed(
             "totp_code": first_code,
         },
     )
-    assert resp_reuse.status_code == 400
+    assert resp_reuse.status_code == 401
     assert resp_reuse.json()["detail"] == "invalid_totp"
 
     # A different recovery code should still work

--- a/apps/myjobhunter/frontend/src/pages/Login.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Login.tsx
@@ -131,7 +131,12 @@ export default function Login() {
         setTotpError("Authentication code didn't go through. Please try again.");
       }
     } catch (err) {
-      setTotpError(extractErrorMessage(err));
+      const detail = extractErrorMessage(err);
+      setTotpError(
+        detail === "invalid_totp"
+          ? "Invalid authentication code. Please try again."
+          : detail,
+      );
     } finally {
       setIsVerifyingTotp(false);
     }


### PR DESCRIPTION
## Summary

Three TOTP-login reconciliations between MBK (canonical) and MJH:

1. **Failure response shape** — both apps now return `401` + `detail="invalid_totp"`. MBK previously returned 401 + "Invalid authentication code"; MJH returned 400 + "invalid_totp". The `invalid_totp` code is the canonical API contract; the friendly message is the frontend's job. Both Login pages now map the code to "Invalid authentication code. Please try again."

2. **MBK audit-event commit on success** — MBK was **silently losing LOGIN_SUCCESS events** in production. The TOTP-login success path called `log_auth_event()` but never committed; `get_db`'s session teardown discards uncommitted state, so the row never reached `auth_events`. Failure paths already committed explicitly. Adding the success commit closes a credential-stuffing detection gap.

3. **MJH gains 2 missing TOTP rate-limit deps** — `check_totp_rate_limit` (per-IP throttle, separate from the standard login limiter) and `check_totp_account_not_locked` (rejects locked accounts at the route layer before the password check). Both mirror MBK's implementations exactly. With this PR the `/auth/totp/login` dependency stack on both apps is identical:

   ```python
   dependencies=[
       Depends(check_login_rate_limit),
       Depends(check_totp_rate_limit),
       Depends(check_totp_account_not_locked),
   ]
   ```

   The TOTP rate limiter is hardcoded at MBK's defaults (20 req / 300s) for parity; can move to settings if MJH ever needs operator tuning.

## Why each change

- **(1)** Codes survive translation; English error strings drift between apps and break i18n later. The audit decision (Decision 2 of C2) was 401 + `invalid_totp`.
- **(2)** Was originally proposed as "MJH drops its success commit" — analysis showed that path would *propagate* an MBK bug instead of fixing it. Reconciliation goes the other way.
- **(3)** Defense-in-depth requested in audit Decision 3.

## Test plan

- [x] `pytest -k "totp or rate_limit or login or auth"` — 160 MBK + 43 MJH pass locally
- [x] Frontend Login UX preserved — "invalid_totp" → human-readable message
- [ ] CI green

## Files

| App | File | Change |
|---|---|---|
| MBK | `app/api/totp.py` | Detail = `invalid_totp`; add success commit |
| MJH | `app/api/totp.py` | Wire 3 deps; status 400 → 401 |
| MJH | `app/core/rate_limit.py` | + `totp_limiter`, `check_totp_rate_limit`, `check_totp_account_not_locked` |
| MBK | `tests/test_totp_routes.py` | Detail assertion |
| MJH | `tests/test_totp_login.py` | Status assertions |
| MBK | `frontend/src/app/pages/Login.tsx` | Code → friendly message |
| MJH | `frontend/src/pages/Login.tsx` | Code → friendly message |

🤖 Generated with [Claude Code](https://claude.com/claude-code)