### PR TITLE
fix(mjh/auth): defer recovery codes to confirm step (audit C3)

### DIFF
--- a/apps/myjobhunter/backend/app/api/totp.py
+++ b/apps/myjobhunter/backend/app/api/totp.py
@@ -59,22 +59,17 @@ async def setup_totp(
 ) -> TotpSetupResponse:
     """Begin TOTP enrollment.
 
-    Generates a fresh secret + provisioning URI + 8 recovery codes and stashes
-    all three on the user row (encrypted at rest by the column type). Does
-    NOT yet flip ``totp_enabled`` — the user must call ``/verify`` with a
-    valid code first.
-
-    Recovery codes are returned exactly once. The user is responsible for
-    saving them — the backend never re-displays individual codes.
+    Generates a fresh secret + provisioning URI and stashes them on the
+    user row (encrypted at rest by the column type). Does NOT yet flip
+    ``totp_enabled`` and does NOT issue recovery codes — the user must
+    call ``/verify`` with a valid code first. Recovery codes are emitted
+    only after the authenticator is proven to work, so the user never
+    walks away with codes for an enrollment that doesn't actually work.
     """
     if user.totp_enabled:
         raise HTTPException(400, "2FA is already enabled")
-    secret, uri, recovery = await totp_service.setup_totp(user.id)
-    return TotpSetupResponse(
-        secret=secret,
-        provisioning_uri=uri,
-        recovery_codes=recovery,
-    )
+    secret, uri = await totp_service.setup_totp(user.id)
+    return TotpSetupResponse(secret=secret, provisioning_uri=uri)
 
 
 @router.post("/verify", response_model=TotpVerifyResponse)
@@ -86,11 +81,13 @@ async def verify_totp(
 ) -> TotpVerifyResponse:
     """Confirm enrollment by validating the first 6-digit code.
 
-    On success: ``totp_enabled`` is set to True and a TOTP_ENABLED auth event
-    is logged. On failure: returns 400 — the user can try again without
-    losing their pending secret.
+    On success: ``totp_enabled`` is set to True, recovery codes are
+    generated + persisted, and the response carries them so the user can
+    save them. The codes are emitted exactly once — the backend never
+    re-displays individual codes. On failure: returns 400 — the user can
+    try again without losing their pending secret.
     """
-    verified = await totp_service.confirm_totp(user.id, body.code)
+    verified, recovery_codes = await totp_service.confirm_totp(user.id, body.code)
     if not verified:
         raise HTTPException(400, "Invalid verification code")
     await log_auth_event(
@@ -104,7 +101,7 @@ async def verify_totp(
     # handler is the natural commit boundary for audit-only writes that
     # don't share a transaction with any business write.
     await db.commit()
-    return TotpVerifyResponse(verified=True)
+    return TotpVerifyResponse(verified=True, recovery_codes=recovery_codes)
 
 
 @router.post("/disable", response_model=TotpDisableResponse)

--- a/apps/myjobhunter/backend/app/schemas/totp.py
+++ b/apps/myjobhunter/backend/app/schemas/totp.py
@@ -13,12 +13,11 @@ class TotpSetupResponse(BaseModel):
 
     The plaintext secret + provisioning URI are shown to the user in the
     enrollment UI (manual-entry fallback + QR code). Recovery codes are
-    surfaced once at enrollment and never re-displayed — the user must save
-    them or they're lost.
+    NOT issued here — they're returned by ``POST /auth/totp/verify`` once
+    the user has proven the authenticator works.
     """
     secret: str
     provisioning_uri: str
-    recovery_codes: list[str]
 
 
 class TotpVerifyRequest(BaseModel):
@@ -27,7 +26,14 @@ class TotpVerifyRequest(BaseModel):
 
 
 class TotpVerifyResponse(BaseModel):
+    """Returned from ``POST /auth/totp/verify``.
+
+    On successful confirmation, the response carries the freshly-generated
+    recovery codes. The user is responsible for saving them — the backend
+    never re-displays individual codes.
+    """
     verified: bool
+    recovery_codes: list[str] = Field(default_factory=list)
 
 
 class TotpDisableRequest(BaseModel):

--- a/apps/myjobhunter/backend/app/services/user/totp_service.py
+++ b/apps/myjobhunter/backend/app/services/user/totp_service.py
@@ -74,42 +74,55 @@ def get_provisioning_uri(
 # DB-coupled coordinators
 # ---------------------------------------------------------------------------
 
-async def setup_totp(user_id: uuid.UUID) -> tuple[str, str, list[str]]:
-    """Generate a fresh SHA-256 TOTP enrollment and stash it on the user row.
+async def setup_totp(user_id: uuid.UUID) -> tuple[str, str]:
+    """Generate a fresh SHA-256 TOTP enrollment and stash the secret + URI.
+
+    Returns ``(secret, provisioning_uri)``. Recovery codes are NOT generated
+    here — they're issued by :func:`confirm_totp` once the user has proven
+    their authenticator can produce a valid code, so the user never walks
+    away with codes for an enrollment that doesn't actually work.
 
     Writes ``users.totp_algorithm = "sha256"`` alongside the new secret so
-    subsequent verifications use the correct HMAC digest.
+    subsequent verifications use the correct HMAC digest. ``totp_enabled``
+    stays False — the user still has to call :func:`confirm_totp`.
     """
     async with unit_of_work() as db:
         user = await user_repo.get_by_id(db, user_id)
         if user is None:
             raise ValueError("User not found")
-        secret, uri, recovery = _shared_enroll_totp(
-            label=user.email,
-            issuer=settings.totp_issuer,
-            algorithm=DEFAULT_TOTP_ALGORITHM,
-        )
+        secret = generate_secret()
         user.totp_secret = secret
-        user.totp_recovery_codes = ",".join(recovery)
+        user.totp_recovery_codes = None
         user.totp_algorithm = DEFAULT_TOTP_ALGORITHM
-        return secret, uri, recovery
+        uri = get_provisioning_uri(
+            secret, user.email, algorithm=DEFAULT_TOTP_ALGORITHM,
+        )
+        return secret, uri
 
 
-async def confirm_totp(user_id: uuid.UUID, code: str) -> bool:
-    """Verify the first TOTP code from a freshly-enrolled user.
+async def confirm_totp(user_id: uuid.UUID, code: str) -> tuple[bool, list[str]]:
+    """Verify a TOTP code and, on success, enable 2FA + issue recovery codes.
 
-    Flips ``totp_enabled`` on success. Uses ``user.totp_algorithm`` so
-    grandfathered SHA-1 users can still confirm during their grace period.
+    Returns ``(verified, recovery_codes)``. On failure or unknown user,
+    returns ``(False, [])`` and leaves all flags unchanged. Recovery codes
+    are emitted only after the authenticator is proven to work — this
+    matches MBK's posture and prevents the user from saving codes for a
+    secret they typed wrong.
+
+    Uses the algorithm stored in ``user.totp_algorithm`` so grandfathered
+    SHA-1 users can still confirm during their grace period.
     """
     async with unit_of_work() as db:
         user = await user_repo.get_by_id(db, user_id)
         if user is None or not user.totp_secret:
-            return False
+            return False, []
         algorithm: TotpAlgorithm = user.totp_algorithm  # type: ignore[assignment]
         if not verify_code(user.totp_secret, code, algorithm=algorithm):
-            return False
+            return False, []
+        recovery = generate_recovery_codes()
         user.totp_enabled = True
-        return True
+        user.totp_recovery_codes = ",".join(recovery)
+        return True, recovery
 
 
 async def disable_totp(user_id: uuid.UUID, code: str) -> bool:

--- a/apps/myjobhunter/backend/tests/test_totp_login.py
+++ b/apps/myjobhunter/backend/tests/test_totp_login.py
@@ -148,11 +148,11 @@ async def test_recovery_code_accepted_and_consumed(
     async with await as_user(user) as authed:
         setup = await authed.post("/auth/totp/setup")
         secret = setup.json()["secret"]
-        recovery_codes = setup.json()["recovery_codes"]
-        await authed.post(
+        verify = await authed.post(
             "/auth/totp/verify",
             json={"code": pyotp.TOTP(secret, digest=hashlib.sha256).now()},
         )
+        recovery_codes = verify.json()["recovery_codes"]
 
     # Use the first recovery code
     first_code = recovery_codes[0]
@@ -239,11 +239,11 @@ async def test_auth_events_written_on_totp_recovery_used(
     async with await as_user(user) as authed:
         setup = await authed.post("/auth/totp/setup")
         secret = setup.json()["secret"]
-        recovery_codes = setup.json()["recovery_codes"]
-        await authed.post(
+        verify = await authed.post(
             "/auth/totp/verify",
             json={"code": pyotp.TOTP(secret, digest=hashlib.sha256).now()},
         )
+        recovery_codes = verify.json()["recovery_codes"]
     await client.post(
         "/auth/totp/login",
         json={

--- a/apps/myjobhunter/backend/tests/test_totp_setup.py
+++ b/apps/myjobhunter/backend/tests/test_totp_setup.py
@@ -24,9 +24,10 @@ from app.core.config import settings
 
 
 @pytest.mark.asyncio
-async def test_setup_returns_secret_uri_and_recovery_codes(
+async def test_setup_returns_secret_and_uri_only(
     client: AsyncClient, user_factory, as_user,
 ) -> None:
+    """Setup returns secret + URI; recovery codes come from /verify (post-confirm)."""
     user = await user_factory()
     async with await as_user(user) as authed:
         resp = await authed.post("/auth/totp/setup")
@@ -36,12 +37,45 @@ async def test_setup_returns_secret_uri_and_recovery_codes(
     assert "secret" in body
     assert body["provisioning_uri"].startswith("otpauth://totp/")
     assert "issuer=MyJobHunter" in body["provisioning_uri"]
+    # Recovery codes are NOT issued at setup — only after /verify confirms.
+    assert "recovery_codes" not in body
+
+
+@pytest.mark.asyncio
+async def test_verify_returns_recovery_codes_on_success(
+    client: AsyncClient, user_factory, as_user,
+) -> None:
+    """First successful /verify call returns the freshly-generated recovery codes."""
+    user = await user_factory()
+    async with await as_user(user) as authed:
+        setup = await authed.post("/auth/totp/setup")
+        secret = setup.json()["secret"]
+        verify = await authed.post(
+            "/auth/totp/verify",
+            json={"code": pyotp.TOTP(secret, digest=hashlib.sha256).now()},
+        )
+
+    assert verify.status_code == 200
+    body = verify.json()
+    assert body["verified"] is True
     assert isinstance(body["recovery_codes"], list)
     assert len(body["recovery_codes"]) == 8
-    # Recovery codes are 8 uppercase hex characters
     for code in body["recovery_codes"]:
         assert len(code) == 8
-        assert code.isupper() or code.isdigit() or all(c in "0123456789ABCDEF" for c in code)
+        assert all(c in "0123456789ABCDEF" for c in code)
+
+
+@pytest.mark.asyncio
+async def test_verify_failed_returns_no_recovery_codes(
+    client: AsyncClient, user_factory, as_user,
+) -> None:
+    """Failed /verify must not leak recovery codes."""
+    user = await user_factory()
+    async with await as_user(user) as authed:
+        await authed.post("/auth/totp/setup")
+        verify = await authed.post("/auth/totp/verify", json={"code": "000000"})
+
+    assert verify.status_code == 400
 
 
 @pytest.mark.asyncio
@@ -86,7 +120,9 @@ async def test_verify_with_correct_code_enables_totp(
         status = await authed.get("/auth/totp/status")
 
     assert verify.status_code == 200
-    assert verify.json() == {"verified": True}
+    body = verify.json()
+    assert body["verified"] is True
+    assert len(body["recovery_codes"]) == 8
     assert status.json()["enabled"] is True
 
 
@@ -168,13 +204,18 @@ async def test_totp_secret_encrypted_at_rest(
     """Read the raw column bytes and confirm they are NOT the plaintext secret.
 
     This is the contract that justifies storing the secret in the DB at all —
-    a leaked database dump must not yield usable TOTP secrets.
+    a leaked database dump must not yield usable TOTP secrets. Recovery codes
+    are issued on /verify (post-confirm) and verified the same way.
     """
     user = await user_factory()
     async with await as_user(user) as authed:
         setup = await authed.post("/auth/totp/setup")
         plaintext_secret = setup.json()["secret"]
-        plaintext_recovery = setup.json()["recovery_codes"]
+        verify = await authed.post(
+            "/auth/totp/verify",
+            json={"code": pyotp.TOTP(plaintext_secret, digest=hashlib.sha256).now()},
+        )
+        plaintext_recovery = verify.json()["recovery_codes"]
 
     eng = create_async_engine(settings.database_url, poolclass=NullPool)
     factory = async_sessionmaker(eng, expire_on_commit=False)

--- a/apps/myjobhunter/frontend/src/features/security/TwoFactorSetup.tsx
+++ b/apps/myjobhunter/frontend/src/features/security/TwoFactorSetup.tsx
@@ -49,7 +49,6 @@ export default function TwoFactorSetup() {
       .unwrap()
       .then((data) => {
         setSetup(data);
-        setRecoveryCodes(data.recovery_codes);
         setStep("verify");
       })
       .catch((err: unknown) => setError(extractErrorMessage(err)));
@@ -61,6 +60,7 @@ export default function TwoFactorSetup() {
       .unwrap()
       .then((data) => {
         if (data.verified) {
+          setRecoveryCodes(data.recovery_codes);
           setStep("recovery");
           showSuccess("2FA enabled successfully");
         }

--- a/apps/myjobhunter/frontend/src/features/security/__tests__/TwoFactorSetup.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/security/__tests__/TwoFactorSetup.test.tsx
@@ -132,7 +132,6 @@ describe("TwoFactorSetup — enrollment flow", () => {
         Promise.resolve({
           secret: "MYSECRET123",
           provisioning_uri: "otpauth://totp/test?secret=MYSECRET123",
-          recovery_codes: ["AAAA1111", "BBBB2222"],
         }),
     });
 
@@ -153,11 +152,14 @@ describe("TwoFactorSetup — enrollment flow", () => {
         Promise.resolve({
           secret: "ABCDEF",
           provisioning_uri: "otpauth://totp/test",
-          recovery_codes: ["CODE0001", "CODE0002", "CODE0003"],
         }),
     });
     mockVerifyTotp.mockReturnValue({
-      unwrap: () => Promise.resolve({ verified: true }),
+      unwrap: () =>
+        Promise.resolve({
+          verified: true,
+          recovery_codes: ["CODE0001", "CODE0002", "CODE0003"],
+        }),
     });
 
     renderComponent();
@@ -183,7 +185,6 @@ describe("TwoFactorSetup — enrollment flow", () => {
         Promise.resolve({
           secret: "ABCDEF",
           provisioning_uri: "otpauth://totp/test",
-          recovery_codes: ["X1", "X2"],
         }),
     });
 
@@ -208,7 +209,6 @@ describe("TwoFactorSetup — enrollment flow", () => {
         Promise.resolve({
           secret: "ABC",
           provisioning_uri: "otpauth://totp/test",
-          recovery_codes: ["A1"],
         }),
     });
 
@@ -231,7 +231,6 @@ describe("TwoFactorSetup — enrollment flow", () => {
         Promise.resolve({
           secret: "X",
           provisioning_uri: "otpauth://totp/test",
-          recovery_codes: ["a"],
         }),
     });
     mockVerifyTotp.mockReturnValue({

--- a/apps/myjobhunter/frontend/src/types/security/totp-setup.ts
+++ b/apps/myjobhunter/frontend/src/types/security/totp-setup.ts
@@ -1,5 +1,4 @@
 export interface TotpSetup {
   secret: string;
   provisioning_uri: string;
-  recovery_codes: string[];
 }

--- a/apps/myjobhunter/frontend/src/types/security/totp-verify-response.ts
+++ b/apps/myjobhunter/frontend/src/types/security/totp-verify-response.ts
@@ -1,3 +1,4 @@
 export interface TotpVerifyResponse {
   verified: boolean;
+  recovery_codes: string[];
 }


### PR DESCRIPTION
## Summary

MJH was emitting recovery codes from `POST /auth/totp/setup` — **before** the user had proven their authenticator can produce a valid code. If the user typed the secret wrong into their authenticator app but saved the codes, they walk away with codes for an enrollment that doesn't actually work.

MBK already has the right pattern: setup returns secret + URI; verify returns recovery codes after a real code is accepted. This PR aligns MJH.

## Wire-shape change

| Endpoint | Before | After |
|---|---|---|
| `POST /auth/totp/setup` | `{ secret, provisioning_uri, recovery_codes }` | `{ secret, provisioning_uri }` |
| `POST /auth/totp/verify` | `{ verified }` | `{ verified, recovery_codes }` |

## Service-layer change

```diff
- async def setup_totp(user_id) -> tuple[str, str, list[str]]
+ async def setup_totp(user_id) -> tuple[str, str]

- async def confirm_totp(user_id, code) -> bool
+ async def confirm_totp(user_id, code) -> tuple[bool, list[str]]
```

## Frontend

`TwoFactorSetup.tsx` captures `recovery_codes` from the verify response, not the setup response. The 3-step UX (status → verify → recovery) is unchanged — the codes just arrive one step later.

## Why

A user who scans the QR code wrong and "saves" their recovery codes anyway has effectively no 2FA. They couldn't use their authenticator (wrong secret), and the recovery codes unlock an account whose 2FA was never functioning. The MBK pattern prevents this — recovery codes are only emitted after a real auth-code verification proves the secret round-trips correctly.

## Test plan

- [x] Backend: `pytest tests/test_totp_setup.py tests/test_totp_login.py` — 23/23 pass
- [x] Frontend mock fixtures updated (recovery_codes moved from setup to verify)
- [ ] CI green

## Files

| File | Change |
|---|---|
| `app/services/user/totp_service.py` | setup drops recovery; confirm generates + returns recovery |
| `app/schemas/totp.py` | TotpSetupResponse drops recovery_codes; TotpVerifyResponse adds it |
| `app/api/totp.py` | Route handlers updated to match service signatures |
| `tests/test_totp_setup.py` | Split into setup-returns-no-codes + verify-returns-codes + verify-failed-no-codes |
| `tests/test_totp_login.py` | Helpers grab recovery codes from verify response |
| `frontend/src/types/security/totp-setup.ts` | Drop recovery_codes |
| `frontend/src/types/security/totp-verify-response.ts` | Add recovery_codes |
| `frontend/src/features/security/TwoFactorSetup.tsx` | setRecoveryCodes moved to handleVerify |
| `frontend/src/features/security/__tests__/TwoFactorSetup.test.tsx` | Mock fixtures updated |

🤖 Generated with [Claude Code](https://claude.com/claude-code)