### PR TITLE
fix(mbk/demo): align demo router prefix to /admin/demo + EmailStr (audit C4)

### DIFF
--- a/apps/mybookkeeper/backend/app/api/demo.py
+++ b/apps/mybookkeeper/backend/app/api/demo.py
@@ -15,7 +15,7 @@ from app.schemas.demo.demo import (
 )
 from app.services.demo import demo_service
 
-router = APIRouter(prefix="/demo", tags=["demo"])
+router = APIRouter(prefix="/admin/demo", tags=["admin", "demo"])
 
 
 @router.post("/create", response_model=DemoCreateResponse)

--- a/apps/mybookkeeper/backend/app/schemas/demo/demo.py
+++ b/apps/mybookkeeper/backend/app/schemas/demo/demo.py
@@ -1,17 +1,17 @@
 import uuid
 from datetime import datetime
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, EmailStr, Field
 
 
 class DemoCredentials(BaseModel):
-    email: str
+    email: EmailStr
     password: str
 
 
 class DemoCreateRequest(BaseModel):
     tag: str = Field(min_length=1, max_length=100, pattern=r"^[\w\s\-\.]+$")
-    recipient_email: str | None = Field(default=None, description="Email address to send login invite to")
+    recipient_email: EmailStr | None = Field(default=None, description="Email address to send login invite to")
 
 
 class DemoCreateResponse(BaseModel):
@@ -22,13 +22,13 @@ class DemoCreateResponse(BaseModel):
 
 class DemoResetResponse(BaseModel):
     message: str
-    email: str
+    email: EmailStr
     password: str
 
 
 class DemoUserSummary(BaseModel):
     user_id: uuid.UUID
-    email: str
+    email: EmailStr
     tag: str
     organization_id: uuid.UUID
     organization_name: str

--- a/apps/mybookkeeper/frontend/e2e/demo-management.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/demo-management.spec.ts
@@ -6,12 +6,12 @@ async function cleanupDemoUsersByTag(
   api: import("@playwright/test").APIRequestContext,
   tag: string,
 ): Promise<void> {
-  const res = await api.get("/demo/users");
+  const res = await api.get("/admin/demo/users");
   if (res.ok()) {
     const data = await res.json();
     for (const user of data.users ?? []) {
       if (user.tag === tag) {
-        await api.delete(`/demo/users/${user.user_id}`).catch(() => {});
+        await api.delete(`/admin/demo/users/${user.user_id}`).catch(() => {});
       }
     }
   }
@@ -92,7 +92,7 @@ test.describe("Demo Management (Admin)", () => {
 
     // Ensure the user exists
     await cleanupDemoUsersByTag(api, tag);
-    await api.post("/demo/create", { data: { tag } });
+    await api.post("/admin/demo/create", { data: { tag } });
 
     // Reload to pick up the new user
     await page.reload();
@@ -200,7 +200,7 @@ test.describe("Demo Seed Data Verification", () => {
     await cleanupDemoUsersByTag(api, SEED_TAG);
 
     // Create a demo user
-    const createRes = await api.post("/demo/create", {
+    const createRes = await api.post("/admin/demo/create", {
       data: { tag: SEED_TAG },
     });
     if (createRes.ok()) {

--- a/apps/mybookkeeper/frontend/e2e/demo-seed-data.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/demo-seed-data.spec.ts
@@ -6,12 +6,12 @@ async function cleanupDemoUsersByTag(
   api: import("@playwright/test").APIRequestContext,
   tag: string,
 ): Promise<void> {
-  const res = await api.get("/demo/users");
+  const res = await api.get("/admin/demo/users");
   if (res.ok()) {
     const data = await res.json();
     for (const user of data.users ?? []) {
       if (user.tag === tag) {
-        await api.delete(`/demo/users/${user.user_id}`).catch(() => {});
+        await api.delete(`/admin/demo/users/${user.user_id}`).catch(() => {});
       }
     }
   }
@@ -26,7 +26,7 @@ test.describe("Demo Seed Data Verification", () => {
 
   test.beforeAll(async ({ api }) => {
     await cleanupDemoUsersByTag(api, TAG);
-    const createRes = await api.post("/demo/create", { data: { tag: TAG } });
+    const createRes = await api.post("/admin/demo/create", { data: { tag: TAG } });
     if (createRes.ok()) {
       const createData = await createRes.json();
       const loginRes = await fetch(`${BACKEND_URL}/auth/jwt/login`, {

--- a/apps/mybookkeeper/frontend/e2e/demo-users.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/demo-users.spec.ts
@@ -53,11 +53,11 @@ test.describe("Demo Users Management (consolidated page)", () => {
   });
 
   test("table shows correct columns when users exist", async ({ authedPage: page, api }) => {
-    const res = await api.get("/demo/users");
+    const res = await api.get("/admin/demo/users");
     const data = await res.json();
 
     if (data.total === 0) {
-      await api.post("/demo/create", { data: { tag: "E2E Column Test" } });
+      await api.post("/admin/demo/create", { data: { tag: "E2E Column Test" } });
       await page.reload();
       await expect(page.getByRole("heading", { name: "Demo Management" })).toBeVisible({ timeout: 15000 });
     }
@@ -70,7 +70,7 @@ test.describe("Demo Users Management (consolidated page)", () => {
 
   test("delete demo user removes from table", async ({ authedPage: page, api }) => {
     const tag = `E2E Delete ${Date.now()}`;
-    await api.post("/demo/create", { data: { tag } });
+    await api.post("/admin/demo/create", { data: { tag } });
     await page.reload();
     await expect(page.getByRole("heading", { name: "Demo Management" })).toBeVisible({ timeout: 15000 });
     await expect(page.getByText(tag)).toBeVisible({ timeout: 10000 });
@@ -87,12 +87,12 @@ test.describe("Demo Users Management (consolidated page)", () => {
   });
 
   test.afterAll(async ({ api }) => {
-    const res = await api.get("/demo/users");
+    const res = await api.get("/admin/demo/users");
     if (res.ok()) {
       const data = await res.json();
       for (const user of data.users) {
         if (user.tag.startsWith("E2E")) {
-          await api.delete(`/demo/users/${user.user_id}`).catch(() => {});
+          await api.delete(`/admin/demo/users/${user.user_id}`).catch(() => {});
         }
       }
     }

--- a/apps/mybookkeeper/frontend/src/shared/store/demoApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/demoApi.ts
@@ -7,12 +7,12 @@ import type { DemoResetUserResponse } from "@/shared/types/demo/demo-reset-user"
 export const demoApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
     listDemoUsers: build.query<DemoUserListResponse, void>({
-      query: () => ({ url: "/demo/users", method: "GET" }),
+      query: () => ({ url: "/admin/demo/users", method: "GET" }),
       providesTags: ["Demo"],
     }),
     createTaggedDemo: build.mutation<DemoCreateTaggedResponse, DemoCreateTaggedRequest>({
       query: (body) => ({
-        url: "/demo/create",
+        url: "/admin/demo/create",
         method: "POST",
         data: body,
       }),
@@ -20,14 +20,14 @@ export const demoApi = baseApi.injectEndpoints({
     }),
     deleteDemoUser: build.mutation<DemoDeleteResponse, string>({
       query: (userId) => ({
-        url: `/demo/users/${userId}`,
+        url: `/admin/demo/users/${userId}`,
         method: "DELETE",
       }),
       invalidatesTags: ["Demo"],
     }),
     resetDemoUser: build.mutation<DemoResetUserResponse, string>({
       query: (userId) => ({
-        url: `/demo/reset/${userId}`,
+        url: `/admin/demo/reset/${userId}`,
         method: "POST",
       }),
       invalidatesTags: ["Demo"],


### PR DESCRIPTION
## Summary

Two reconciliations between MBK's demo router and MJH's:

1. **URL prefix `/demo` → `/admin/demo`** — MJH already uses `/admin/demo`; convention follows REST + admin-namespacing. Routes inside the prefix are unchanged (`/create`, `/users`, `/users/{id}`, `/reset/{id}`), so MBK keeps its create/reset ergonomics. Frontend RTK Query slice + 3 E2E spec files updated.

2. **`EmailStr` instead of `str`** for every email field in the demo schemas (`DemoCredentials.email`, `DemoCreateRequest.recipient_email`, `DemoResetResponse.email`, `DemoUserSummary.email`). MJH already uses EmailStr; tightens validation at the API boundary so a non-email string can't propagate into demo-invite emails.

## Per the design review

- **Pass-through admin guard** — kept. MBK retains `current_admin`, MJH retains `current_superuser`. No role-system migration in MJH.
- **MBK `/reset/{user_id}` stays MBK-only** — not extracted to MJH. MJH's demo data model is different and "reset" (without the seed-recompute step) is a Tier-3 feature it doesn't yet need.

## Why

Audit C4 flagged the `/demo` vs `/admin/demo` prefix divergence and the missing EmailStr validation in MBK as inconsistencies vs MJH. This PR closes both gaps in the minimal way.

## Files

| File | Change |
|---|---|
| `app/api/demo.py` | Router prefix `/demo` → `/admin/demo` |
| `app/schemas/demo/demo.py` | `str` → `EmailStr` on 4 fields |
| `frontend/src/shared/store/demoApi.ts` | All 4 endpoint URLs prefix-updated |
| `frontend/e2e/demo-{management,seed-data,users}.spec.ts` | Helper API calls prefix-updated |

## Test plan

- [x] Backend: 54 MBK demo-related tests pass locally (`pytest tests/test_demo_*`)
- [x] Frontend RTK URLs updated; E2E URL helpers updated
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)