### PR TITLE
feat(mbk/leases): foundation schema for lease extensions (PR 1a)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/ltvers260510_add_lease_term_versions.py
+++ b/apps/mybookkeeper/backend/alembic/versions/ltvers260510_add_lease_term_versions.py
@@ -1,0 +1,167 @@
+"""Add lease_term_versions table + signed_leases.parent_lease_id + ends_on partial index.
+
+Foundation schema for the lease extension / successor lease feature
+(see project memory: ``project_lease_extension_feature_design.md``).
+
+This migration is schema-only. It does NOT touch ``applicants.contract_end``;
+that refactor lands in a follow-up PR.
+
+Backfill: every existing ``signed_leases`` row with non-null ``starts_on`` AND
+``ends_on`` gets a seed ``lease_term_versions`` row capturing the original
+term. Leases that never had dates filled in (drafts) are skipped — the
+extension flow only runs from ``signed`` / ``active`` status anyway, so the
+seed will be created at signature time for those once the feature ships.
+
+Revision ID: ltvers260510
+Revises: gskmsg260508
+Create Date: 2026-05-10 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+
+revision: str = "ltvers260510"
+down_revision: Union[str, None] = "gskmsg260508"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "lease_term_versions",
+        sa.Column(
+            "id",
+            PGUUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "lease_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("signed_leases.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("starts_on", sa.Date(), nullable=False),
+        sa.Column("ends_on", sa.Date(), nullable=False),
+        sa.Column(
+            "source_attachment_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("signed_lease_attachments.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column(
+            "created_by_user_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("users.id", ondelete="RESTRICT"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_index(
+        "uq_lease_term_versions_lease_attachment",
+        "lease_term_versions",
+        ["lease_id", "source_attachment_id"],
+        unique=True,
+        postgresql_where=sa.text("source_attachment_id IS NOT NULL"),
+    )
+    op.create_index(
+        "uq_lease_term_versions_seed_per_lease",
+        "lease_term_versions",
+        ["lease_id"],
+        unique=True,
+        postgresql_where=sa.text(
+            "source_attachment_id IS NULL AND deleted_at IS NULL"
+        ),
+    )
+    op.create_index(
+        "ix_lease_term_versions_lease_active",
+        "lease_term_versions",
+        ["lease_id", "created_at"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+    # Successor-lease pointer on signed_leases.
+    op.add_column(
+        "signed_leases",
+        sa.Column(
+            "parent_lease_id",
+            PGUUID(as_uuid=True),
+            sa.ForeignKey("signed_leases.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+    op.create_index(
+        "ix_signed_leases_parent_lease_id",
+        "signed_leases",
+        ["parent_lease_id"],
+    )
+
+    # Drives "expiring lease" queries.
+    op.create_index(
+        "ix_signed_leases_org_ends_on_active",
+        "signed_leases",
+        ["organization_id", "ends_on"],
+        postgresql_where=sa.text(
+            "deleted_at IS NULL AND ends_on IS NOT NULL"
+        ),
+    )
+
+    # Backfill: seed one lease_term_versions row per signed lease with both
+    # dates populated. user_id from the lease's owner (FK RESTRICT means
+    # the user always exists for a non-deleted lease).
+    op.execute(
+        """
+        INSERT INTO lease_term_versions (
+            id, lease_id, starts_on, ends_on,
+            source_attachment_id, created_by_user_id, created_at, deleted_at
+        )
+        SELECT
+            gen_random_uuid(),
+            sl.id,
+            sl.starts_on,
+            sl.ends_on,
+            NULL,
+            sl.user_id,
+            COALESCE(sl.signed_at, sl.created_at),
+            NULL
+        FROM signed_leases sl
+        WHERE sl.starts_on IS NOT NULL
+          AND sl.ends_on IS NOT NULL
+          AND sl.deleted_at IS NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_signed_leases_org_ends_on_active",
+        table_name="signed_leases",
+    )
+    op.drop_index(
+        "ix_signed_leases_parent_lease_id",
+        table_name="signed_leases",
+    )
+    op.drop_column("signed_leases", "parent_lease_id")
+
+    op.drop_index(
+        "ix_lease_term_versions_lease_active",
+        table_name="lease_term_versions",
+    )
+    op.drop_index(
+        "uq_lease_term_versions_seed_per_lease",
+        table_name="lease_term_versions",
+    )
+    op.drop_index(
+        "uq_lease_term_versions_lease_attachment",
+        table_name="lease_term_versions",
+    )
+    op.drop_table("lease_term_versions")

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -34,6 +34,7 @@ from app.models.leases.lease_template_placeholder import LeaseTemplatePlaceholde
 from app.models.leases.signed_lease import SignedLease
 from app.models.leases.signed_lease_attachment import SignedLeaseAttachment
 from app.models.leases.signed_lease_template import SignedLeaseTemplate
+from app.models.leases.lease_term_version import LeaseTermVersion
 from app.models.insurance.insurance_policy import InsurancePolicy
 from app.models.insurance.insurance_policy_attachment import InsurancePolicyAttachment
 from app.models.vendors.vendor import Vendor

--- a/apps/mybookkeeper/backend/app/models/leases/lease_term_version.py
+++ b/apps/mybookkeeper/backend/app/models/leases/lease_term_version.py
@@ -1,0 +1,103 @@
+"""A versioned record of a signed lease's effective term (starts_on / ends_on).
+
+The seed row (``source_attachment_id IS NULL``) captures the lease's original
+term as signed. Each subsequent row records an extension addendum: a new
+``ends_on`` plus a pointer to the addendum attachment that produced it.
+
+Soft-deleted via ``deleted_at`` so an extension can be undone within the
+30-day window without losing the audit trail. The repo / service layer is
+responsible for recomputing ``signed_leases.ends_on`` from the latest
+non-deleted version after an undo.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from sqlalchemy import (
+    Date,
+    DateTime,
+    ForeignKey,
+    Index,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class LeaseTermVersion(Base):
+    __tablename__ = "lease_term_versions"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4,
+    )
+    lease_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("signed_leases.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+
+    starts_on: Mapped[_dt.date] = mapped_column(Date, nullable=False)
+    ends_on: Mapped[_dt.date] = mapped_column(Date, nullable=False)
+
+    # NULL on the seed row (the original term, no addendum). Set to the
+    # signed_lease_attachments row that captures the rendered/signed
+    # extension addendum for every extension version.
+    source_attachment_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("signed_lease_attachments.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+
+    created_by_user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("users.id", ondelete="RESTRICT"),
+        nullable=False,
+    )
+
+    created_at: Mapped[_dt.datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: _dt.datetime.now(_dt.timezone.utc),
+        server_default=func.now(),
+    )
+
+    # Soft-delete used by the 30-day extension undo path. Seed rows must
+    # never be soft-deleted (the partial unique index below enforces that
+    # exactly one live seed exists per lease).
+    deleted_at: Mapped[_dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    __table_args__ = (
+        # One version per addendum (idempotency: re-uploading the same
+        # addendum file does not create a duplicate version row). Partial
+        # so the seed row (source_attachment_id IS NULL) is excluded —
+        # otherwise two NULL seed rows on the same lease would collide
+        # only by accident of NULL semantics.
+        Index(
+            "uq_lease_term_versions_lease_attachment",
+            "lease_id", "source_attachment_id",
+            unique=True,
+            postgresql_where=text("source_attachment_id IS NOT NULL"),
+        ),
+        # Exactly one live seed row per lease — guards the invariant that
+        # a lease has a single canonical original term.
+        Index(
+            "uq_lease_term_versions_seed_per_lease",
+            "lease_id",
+            unique=True,
+            postgresql_where=text(
+                "source_attachment_id IS NULL AND deleted_at IS NULL"
+            ),
+        ),
+        # Lookup the latest live version for a given lease.
+        Index(
+            "ix_lease_term_versions_lease_active",
+            "lease_id", "created_at",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/models/leases/signed_lease.py
+++ b/apps/mybookkeeper/backend/app/models/leases/signed_lease.py
@@ -67,6 +67,21 @@ class SignedLease(Base):
         nullable=True,
     )
 
+    # Successor-lease pointer: when the host creates a new lease that
+    # supersedes this one (rent change, term change, occupants change),
+    # the new lease's ``parent_lease_id`` references the prior lease. The
+    # back-pointer is intentionally one-way — a bidirectional FK would
+    # encode an invariant the database cannot enforce. Forward navigation
+    # ("does this lease have a successor?") is a single indexed query.
+    # ``ondelete=SET NULL`` so deleting an old lease never blocks the
+    # successor; the historical link is best-effort.
+    parent_lease_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("signed_leases.id", ondelete="SET NULL"),
+        index=True,
+        nullable=True,
+    )
+
     # 'generated' = created via template substitution pipeline.
     # 'imported'  = uploaded externally-signed PDF(s) with no template.
     kind: Mapped[str] = mapped_column(
@@ -155,5 +170,17 @@ class SignedLease(Base):
             "ix_signed_leases_org_status_active",
             "organization_id", "status",
             postgresql_where=text("deleted_at IS NULL"),
+        ),
+        # Drives "expiring lease" queries (e.g. listing all leases ending
+        # within the next N days for a given org). ``ends_on`` only fills
+        # in once the lease is signed/active, so the partial predicate
+        # additionally scopes to the live-non-draft set the index is
+        # actually queried for.
+        Index(
+            "ix_signed_leases_org_ends_on_active",
+            "organization_id", "ends_on",
+            postgresql_where=text(
+                "deleted_at IS NULL AND ends_on IS NOT NULL"
+            ),
         ),
     )

--- a/apps/mybookkeeper/backend/tests/test_lease_term_version_model.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_term_version_model.py
@@ -1,0 +1,184 @@
+"""Schema tests for the LeaseTermVersion model + signed_leases.parent_lease_id.
+
+Foundation for the lease extension feature (PR 1, see project memory:
+``project_lease_extension_feature_design.md``). This test file verifies the
+model's basic shape — round-trip persistence, defaults, FK column wiring,
+and the table-level index declarations. Behavioural tests for the extension
+service land in PR 2.
+
+The in-memory SQLite session in ``conftest.py`` runs with foreign keys OFF,
+so FK enforcement is verified at the column-declaration level (presence +
+ondelete) rather than via runtime constraint failures.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy import select
+
+from app.models.leases.lease_term_version import LeaseTermVersion
+from app.models.leases.signed_lease import SignedLease
+
+
+@pytest.mark.asyncio
+async def test_lease_term_version_round_trip(db) -> None:
+    user_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    applicant_id = uuid.uuid4()
+
+    lease = SignedLease(
+        user_id=user_id,
+        organization_id=org_id,
+        applicant_id=applicant_id,
+        kind="generated",
+        status="signed",
+        starts_on=_dt.date(2026, 1, 1),
+        ends_on=_dt.date(2026, 12, 31),
+    )
+    db.add(lease)
+    await db.flush()
+
+    version = LeaseTermVersion(
+        lease_id=lease.id,
+        starts_on=lease.starts_on,
+        ends_on=lease.ends_on,
+        source_attachment_id=None,
+        created_by_user_id=user_id,
+    )
+    db.add(version)
+    await db.commit()
+
+    fetched = (
+        await db.execute(
+            select(LeaseTermVersion).where(LeaseTermVersion.lease_id == lease.id)
+        )
+    ).scalar_one()
+
+    assert fetched.id is not None
+    assert fetched.lease_id == lease.id
+    assert fetched.starts_on == _dt.date(2026, 1, 1)
+    assert fetched.ends_on == _dt.date(2026, 12, 31)
+    assert fetched.source_attachment_id is None
+    assert fetched.deleted_at is None
+    assert fetched.created_at is not None
+
+
+@pytest.mark.asyncio
+async def test_signed_lease_parent_lease_id_round_trip(db) -> None:
+    """Successor lease pointer round-trips through the column."""
+    user_id = uuid.uuid4()
+    org_id = uuid.uuid4()
+    applicant_id = uuid.uuid4()
+
+    parent = SignedLease(
+        user_id=user_id,
+        organization_id=org_id,
+        applicant_id=applicant_id,
+        kind="generated",
+        status="ended",
+        starts_on=_dt.date(2025, 1, 1),
+        ends_on=_dt.date(2025, 12, 31),
+    )
+    db.add(parent)
+    await db.flush()
+
+    successor = SignedLease(
+        user_id=user_id,
+        organization_id=org_id,
+        applicant_id=applicant_id,
+        kind="generated",
+        status="signed",
+        starts_on=_dt.date(2026, 1, 1),
+        ends_on=_dt.date(2026, 12, 31),
+        parent_lease_id=parent.id,
+    )
+    db.add(successor)
+    await db.commit()
+
+    fetched = (
+        await db.execute(
+            select(SignedLease).where(SignedLease.id == successor.id)
+        )
+    ).scalar_one()
+    assert fetched.parent_lease_id == parent.id
+
+
+def test_lease_term_versions_table_has_expected_indexes() -> None:
+    """The two partial unique indexes + the lookup index are declared.
+
+    Catches accidental removal of the seed-row uniqueness invariant or the
+    addendum-idempotency invariant in a future refactor.
+    """
+    table = LeaseTermVersion.__table__
+    index_names = {ix.name for ix in table.indexes}
+    assert "uq_lease_term_versions_lease_attachment" in index_names
+    assert "uq_lease_term_versions_seed_per_lease" in index_names
+    assert "ix_lease_term_versions_lease_active" in index_names
+
+    # Verify the seed-row index is unique + has the partial predicate.
+    seed_ix = next(
+        ix for ix in table.indexes
+        if ix.name == "uq_lease_term_versions_seed_per_lease"
+    )
+    assert seed_ix.unique is True
+    where = seed_ix.dialect_options["postgresql"].get("where")
+    assert where is not None
+    assert "source_attachment_id IS NULL" in str(where)
+    assert "deleted_at IS NULL" in str(where)
+
+    # Verify the addendum index is unique and excludes the seed row.
+    addendum_ix = next(
+        ix for ix in table.indexes
+        if ix.name == "uq_lease_term_versions_lease_attachment"
+    )
+    assert addendum_ix.unique is True
+    addendum_where = addendum_ix.dialect_options["postgresql"].get("where")
+    assert addendum_where is not None
+    assert "source_attachment_id IS NOT NULL" in str(addendum_where)
+
+
+def test_signed_leases_has_ends_on_active_index() -> None:
+    """Partial index on ``(organization_id, ends_on)`` for expiring-lease scans."""
+    table = SignedLease.__table__
+    index_names = {ix.name for ix in table.indexes}
+    assert "ix_signed_leases_org_ends_on_active" in index_names
+
+    ends_on_ix = next(
+        ix for ix in table.indexes
+        if ix.name == "ix_signed_leases_org_ends_on_active"
+    )
+    where = ends_on_ix.dialect_options["postgresql"].get("where")
+    assert where is not None
+    assert "deleted_at IS NULL" in str(where)
+    assert "ends_on IS NOT NULL" in str(where)
+
+
+def test_signed_leases_has_parent_lease_id_column() -> None:
+    """Successor pointer column is declared with the right FK shape."""
+    col = SignedLease.__table__.c.parent_lease_id
+    assert col is not None
+    assert col.nullable is True
+    fk = next(iter(col.foreign_keys), None)
+    assert fk is not None
+    assert fk.column.table.name == "signed_leases"
+    assert fk.ondelete == "SET NULL"
+
+
+def test_lease_term_version_lease_id_fk_cascades() -> None:
+    """Deleting a signed lease must cascade to its term versions."""
+    col = LeaseTermVersion.__table__.c.lease_id
+    fk = next(iter(col.foreign_keys), None)
+    assert fk is not None
+    assert fk.column.table.name == "signed_leases"
+    assert fk.ondelete == "CASCADE"
+
+
+def test_lease_term_version_attachment_fk_set_null() -> None:
+    """source_attachment_id must NOT cascade — losing the file shouldn't drop the version."""
+    col = LeaseTermVersion.__table__.c.source_attachment_id
+    fk = next(iter(col.foreign_keys), None)
+    assert fk is not None
+    assert fk.column.table.name == "signed_lease_attachments"
+    assert fk.ondelete == "SET NULL"


### PR DESCRIPTION
## Summary

Foundation schema for the MBK lease extension + successor lease feature. **Schema-only** — no service / API / UI surface yet, those land in PR 2-4.

Design context: `~/.claude/projects/.../memory/project_lease_extension_feature_design.md` (locked-in decisions from 2026-05-10).

This is **PR 1a** of a larger sequence. The original PR 1 plan also bundled an `applicant.contract_end` → derived-property refactor. That refactor's blast radius (~48 files) was too wide to safely combine with the new schema, so it's deferred to a separate follow-up before PR 2.

## What's added

- **`lease_term_versions` table** — one row per effective term of a signed lease. Seed row (`source_attachment_id IS NULL`) captures the original term; later rows record extension addenda. Soft-deleted via `deleted_at` for the 30-day undo path (PR 3).
- **`signed_leases.parent_lease_id` FK + index** — one-way successor pointer for material-change leases (rent / occupants / terms). Forward navigation is a single indexed query; bidirectional FK was rejected because it would encode an invariant the DB can't enforce.
- **`ix_signed_leases_org_ends_on_active` partial index** — drives "leases expiring within N days" queries for the dashboard / extension prompts.
- **Backfill** — every existing signed lease with both `starts_on` and `ends_on` populated gets a seed row at migration time. Drafts without dates are skipped — the extension flow only runs from `signed`/`active` and will create a seed at signature time when needed.

## Invariants enforced by partial unique indexes

| Index | Predicate | Guarantees |
|---|---|---|
| `uq_lease_term_versions_lease_attachment` | `source_attachment_id IS NOT NULL` | Re-uploading the same addendum is idempotent — no duplicate version row. |
| `uq_lease_term_versions_seed_per_lease` | `source_attachment_id IS NULL AND deleted_at IS NULL` | Exactly one live seed row per lease — guards the canonical "original term" invariant. |

## Out of scope (intentionally deferred)

- Extension service + `POST /signed-leases/{id}/extend` (PR 2)
- 30-day undo flow (PR 3)
- Successor lease creation + auto-end scheduled job (PR 4)
- `applicant.contract_end` refactor to derived `@property` (separate follow-up before PR 2)

## Test plan

- [x] New unit tests verify model round-trip, FK shape (CASCADE on `lease_id`, SET NULL on `source_attachment_id`), index declarations, and `parent_lease_id` round-trip
- [x] Existing lease test suite (`test_lease_template_repo`, `test_lease_filename`, `test_lease_import_heuristic`) still passes — 31/31 green locally
- [ ] Migration applies cleanly on staging (deploy verifies)
- [ ] Backfill produces one seed row per existing signed lease (sanity-check via `SELECT COUNT(*) FROM lease_term_versions` after deploy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)