### PR TITLE
feat(mbk/leases): Extend lease button + dialog (PR 2b frontend)

### DIFF
--- a/apps/mybookkeeper/backend/app/test_helpers/seed.py
+++ b/apps/mybookkeeper/backend/app/test_helpers/seed.py
@@ -585,6 +585,8 @@ class _SeedSignedLeaseRequest(BaseModel):
     applicant_id: uuid.UUID | None = None
     kind: str = "imported"
     status: str = "signed"
+    starts_on: _dt.date | None = None
+    ends_on: _dt.date | None = None
     attachments: list[_SeedAttachmentSpec] = []
 
 
@@ -619,6 +621,8 @@ async def seed_signed_lease(
             kind=payload.kind,
             values={},
             status=payload.status,
+            starts_on=payload.starts_on,
+            ends_on=payload.ends_on,
             signed_at=now,
             created_at=now,
             updated_at=now,

--- a/apps/mybookkeeper/frontend/e2e/lease-extend.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/lease-extend.spec.ts
@@ -1,0 +1,211 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+
+/**
+ * E2E tests for the lease extension feature (PR mbk-lease-extend-ui).
+ *
+ * Covers:
+ * 1. Backend smoke: POST /signed-leases/{id}/extend updates ends_on, creates
+ *    a signed_addendum attachment, returns the updated lease.
+ * 2. Frontend UI: Extend button on a signed lease detail page opens a dialog,
+ *    submitting it persists the new end date.
+ * 3. Frontend UI: Extend button is HIDDEN for a draft lease (status guard).
+ */
+
+async function seedApplicant(
+  api: APIRequestContext,
+  legalName: string,
+): Promise<string> {
+  const res = await api.post("/test/seed-applicant", {
+    data: { legal_name: legalName, stage: "lease_signed" },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedApplicant failed: ${res.status()} ${await res.text()}`);
+  }
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function seedSignedLease(
+  api: APIRequestContext,
+  applicantId: string,
+  opts: {
+    status?: string;
+    starts_on?: string;
+    ends_on?: string;
+  } = {},
+): Promise<string> {
+  const res = await api.post("/test/seed-signed-lease", {
+    data: {
+      applicant_id: applicantId,
+      kind: "imported",
+      status: opts.status ?? "signed",
+      starts_on: opts.starts_on ?? "2026-01-01",
+      ends_on: opts.ends_on ?? "2026-12-31",
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `seedSignedLease failed: ${res.status()} ${await res.text()}`,
+    );
+  }
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function getLease(
+  api: APIRequestContext,
+  id: string,
+): Promise<{
+  ends_on: string | null;
+  attachments: Array<{ kind: string; filename: string }>;
+}> {
+  const res = await api.get(`/signed-leases/${id}`);
+  if (!res.ok()) throw new Error(`getLease failed: ${res.status()}`);
+  return res.json() as Promise<{
+    ends_on: string | null;
+    attachments: Array<{ kind: string; filename: string }>;
+  }>;
+}
+
+async function deleteApplicant(
+  api: APIRequestContext, id: string,
+): Promise<void> {
+  await api.delete(`/test/applicants/${id}`).catch(() => {});
+}
+
+async function deleteSignedLease(
+  api: APIRequestContext, id: string,
+): Promise<void> {
+  await api.delete(`/test/signed-leases/${id}`).catch(() => {});
+}
+
+
+test.describe("Lease extension", () => {
+  test(
+    "API: POST /signed-leases/{id}/extend updates ends_on + creates addendum",
+    async ({ api }) => {
+      const runId = Date.now();
+      const applicantId = await seedApplicant(api, `E2E Extend ${runId}`);
+      let leaseId = "";
+      try {
+        leaseId = await seedSignedLease(api, applicantId, {
+          status: "signed",
+          starts_on: "2026-01-01",
+          ends_on: "2026-12-31",
+        });
+
+        const res = await api.post(`/signed-leases/${leaseId}/extend`, {
+          data: { new_ends_on: "2027-06-30", notes: "E2E extension" },
+        });
+        expect(res.status()).toBe(200);
+        const body = (await res.json()) as { ends_on: string };
+        expect(body.ends_on).toBe("2027-06-30");
+
+        const fetched = await getLease(api, leaseId);
+        expect(fetched.ends_on).toBe("2027-06-30");
+        const addendum = fetched.attachments.find(
+          (a) => a.kind === "signed_addendum",
+        );
+        expect(addendum).toBeDefined();
+        expect(addendum?.filename).toContain("2027-06-30");
+      } finally {
+        if (leaseId) await deleteSignedLease(api, leaseId);
+        await deleteApplicant(api, applicantId);
+      }
+    },
+  );
+
+  test(
+    "API: rejects extension when new_ends_on is on or before current",
+    async ({ api }) => {
+      const runId = Date.now();
+      const applicantId = await seedApplicant(api, `E2E Bad Date ${runId}`);
+      let leaseId = "";
+      try {
+        leaseId = await seedSignedLease(api, applicantId, {
+          status: "signed",
+          starts_on: "2026-01-01",
+          ends_on: "2026-12-31",
+        });
+
+        const res = await api.post(`/signed-leases/${leaseId}/extend`, {
+          data: { new_ends_on: "2026-12-31" },
+        });
+        expect(res.status()).toBe(409);
+        const body = (await res.json()) as {
+          detail: { code: string; message: string };
+        };
+        expect(body.detail.code).toBe("NEW_END_DATE_NOT_AFTER_CURRENT");
+      } finally {
+        if (leaseId) await deleteSignedLease(api, leaseId);
+        await deleteApplicant(api, applicantId);
+      }
+    },
+  );
+
+  test(
+    "UI: Extend button on signed lease opens dialog and persists new date",
+    async ({ authedPage: page, api }) => {
+      const runId = Date.now();
+      const applicantId = await seedApplicant(api, `E2E UI Extend ${runId}`);
+      let leaseId = "";
+      try {
+        leaseId = await seedSignedLease(api, applicantId, {
+          status: "signed",
+          starts_on: "2026-01-01",
+          ends_on: "2026-12-31",
+        });
+
+        await page.goto(`/leases/${leaseId}`);
+        await page.waitForLoadState("networkidle");
+
+        const extendButton = page.getByTestId("lease-extend-button");
+        await expect(extendButton).toBeVisible({ timeout: 10000 });
+        await extendButton.click();
+
+        await expect(page.getByTestId("extend-lease-dialog")).toBeVisible();
+        await page
+          .getByTestId("extend-lease-new-end")
+          .fill("2027-06-30");
+        await page
+          .getByTestId("extend-lease-notes")
+          .fill("Six-month renewal");
+        await page.getByTestId("extend-lease-confirm").click();
+
+        // Wait for the mutation + cache invalidation to settle.
+        await page.waitForLoadState("networkidle");
+
+        const updated = await getLease(api, leaseId);
+        expect(updated.ends_on).toBe("2027-06-30");
+        expect(
+          updated.attachments.some((a) => a.kind === "signed_addendum"),
+        ).toBe(true);
+      } finally {
+        if (leaseId) await deleteSignedLease(api, leaseId);
+        await deleteApplicant(api, applicantId);
+      }
+    },
+  );
+
+  test(
+    "UI: Extend button is hidden for a draft lease",
+    async ({ authedPage: page, api }) => {
+      const runId = Date.now();
+      const applicantId = await seedApplicant(api, `E2E No Extend ${runId}`);
+      let leaseId = "";
+      try {
+        leaseId = await seedSignedLease(api, applicantId, {
+          status: "draft",
+          starts_on: "2026-01-01",
+          ends_on: "2026-12-31",
+        });
+
+        await page.goto(`/leases/${leaseId}`);
+        await page.waitForLoadState("networkidle");
+
+        await expect(page.getByTestId("lease-extend-button")).toHaveCount(0);
+      } finally {
+        if (leaseId) await deleteSignedLease(api, leaseId);
+        await deleteApplicant(api, applicantId);
+      }
+    },
+  );
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/ExtendLeaseDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/ExtendLeaseDialog.test.tsx
@@ -1,0 +1,205 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import ExtendLeaseDialog from "@/app/features/leases/ExtendLeaseDialog";
+
+const mockExtendLease = vi.fn();
+
+vi.mock("@/shared/store/signedLeasesApi", () => ({
+  useExtendSignedLeaseMutation: vi.fn(() => [
+    mockExtendLease,
+    { isLoading: false },
+  ]),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+import { useExtendSignedLeaseMutation } from "@/shared/store/signedLeasesApi";
+import { showSuccess, showError } from "@/shared/lib/toast-store";
+
+function renderDialog(onClose = vi.fn(), currentEndsOn = "2026-12-31") {
+  return render(
+    <Provider store={store}>
+      <ExtendLeaseDialog
+        leaseId="lease-1"
+        currentEndsOn={currentEndsOn}
+        onClose={onClose}
+      />
+    </Provider>,
+  );
+}
+
+describe("ExtendLeaseDialog", () => {
+  beforeEach(() => {
+    vi.mocked(mockExtendLease).mockReset();
+    vi.mocked(showSuccess).mockReset();
+    vi.mocked(showError).mockReset();
+    vi.mocked(useExtendSignedLeaseMutation).mockReturnValue([
+      mockExtendLease,
+      { isLoading: false } as unknown as ReturnType<
+        typeof useExtendSignedLeaseMutation
+      >[1],
+    ]);
+  });
+
+  it("renders dialog with current end date and required form fields", () => {
+    renderDialog();
+    expect(
+      screen.getByRole("dialog", { name: "Extend lease" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2026-12-31/)).toBeInTheDocument();
+    expect(screen.getByTestId("extend-lease-new-end")).toBeInTheDocument();
+    expect(screen.getByTestId("extend-lease-notes")).toBeInTheDocument();
+    expect(screen.getByTestId("extend-lease-email-tenant")).toBeInTheDocument();
+    expect(screen.getByTestId("extend-lease-confirm")).toBeDisabled();
+  });
+
+  it("disables Confirm when new date is equal to or before current", () => {
+    renderDialog(undefined, "2026-12-31");
+    const input = screen.getByTestId("extend-lease-new-end");
+    fireEvent.change(input, { target: { value: "2026-12-31" } });
+    expect(screen.getByTestId("extend-lease-confirm")).toBeDisabled();
+    expect(
+      screen.getByTestId("extend-lease-new-end-error"),
+    ).toBeInTheDocument();
+  });
+
+  it("enables Confirm when new date is strictly after current", () => {
+    renderDialog(undefined, "2026-12-31");
+    fireEvent.change(screen.getByTestId("extend-lease-new-end"), {
+      target: { value: "2027-06-30" },
+    });
+    expect(screen.getByTestId("extend-lease-confirm")).not.toBeDisabled();
+  });
+
+  it("calls extend mutation with new_ends_on + notes + email_tenant", async () => {
+    mockExtendLease.mockReturnValueOnce({ unwrap: () => Promise.resolve({}) });
+    renderDialog();
+    fireEvent.change(screen.getByTestId("extend-lease-new-end"), {
+      target: { value: "2027-06-30" },
+    });
+    fireEvent.change(screen.getByTestId("extend-lease-notes"), {
+      target: { value: "Six-month renewal" },
+    });
+    fireEvent.click(screen.getByTestId("extend-lease-email-tenant"));
+    fireEvent.click(screen.getByTestId("extend-lease-confirm"));
+
+    await waitFor(() => {
+      expect(mockExtendLease).toHaveBeenCalledWith({
+        leaseId: "lease-1",
+        data: {
+          new_ends_on: "2027-06-30",
+          notes: "Six-month renewal",
+          email_tenant: true,
+        },
+      });
+    });
+  });
+
+  it("omits notes from payload when empty", async () => {
+    mockExtendLease.mockReturnValueOnce({ unwrap: () => Promise.resolve({}) });
+    renderDialog();
+    fireEvent.change(screen.getByTestId("extend-lease-new-end"), {
+      target: { value: "2027-06-30" },
+    });
+    fireEvent.click(screen.getByTestId("extend-lease-confirm"));
+
+    await waitFor(() => {
+      expect(mockExtendLease).toHaveBeenCalledWith({
+        leaseId: "lease-1",
+        data: {
+          new_ends_on: "2027-06-30",
+          notes: undefined,
+          email_tenant: false,
+        },
+      });
+    });
+  });
+
+  it("shows success toast and calls onClose on success", async () => {
+    mockExtendLease.mockReturnValueOnce({ unwrap: () => Promise.resolve({}) });
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.change(screen.getByTestId("extend-lease-new-end"), {
+      target: { value: "2027-06-30" },
+    });
+    fireEvent.click(screen.getByTestId("extend-lease-confirm"));
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith("Lease extended.");
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+
+  it("shows email-aware success message when email_tenant was checked", async () => {
+    mockExtendLease.mockReturnValueOnce({ unwrap: () => Promise.resolve({}) });
+    renderDialog();
+    fireEvent.change(screen.getByTestId("extend-lease-new-end"), {
+      target: { value: "2027-06-30" },
+    });
+    fireEvent.click(screen.getByTestId("extend-lease-email-tenant"));
+    fireEvent.click(screen.getByTestId("extend-lease-confirm"));
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith(
+        "Lease extended. I'll email the tenant shortly.",
+      );
+    });
+  });
+
+  it("surfaces a 409 INVALID_STATUS_FOR_EXTENSION as a friendly toast", async () => {
+    mockExtendLease.mockReturnValueOnce({
+      unwrap: () =>
+        Promise.reject({
+          status: 409,
+          data: {
+            detail: {
+              code: "INVALID_STATUS_FOR_EXTENSION",
+              message: "lease is in draft",
+            },
+          },
+        }),
+    });
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.change(screen.getByTestId("extend-lease-new-end"), {
+      target: { value: "2027-06-30" },
+    });
+    fireEvent.click(screen.getByTestId("extend-lease-confirm"));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        "Only signed or active leases can be extended.",
+      );
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it("surfaces a generic error toast on unknown failure", async () => {
+    mockExtendLease.mockReturnValueOnce({
+      unwrap: () => Promise.reject(new Error("network down")),
+    });
+    renderDialog();
+    fireEvent.change(screen.getByTestId("extend-lease-new-end"), {
+      target: { value: "2027-06-30" },
+    });
+    fireEvent.click(screen.getByTestId("extend-lease-confirm"));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        "Couldn't extend the lease. Please try again.",
+      );
+    });
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.click(screen.getByTestId("extend-lease-cancel"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/leases/ExtendLeaseDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/ExtendLeaseDialog.tsx
@@ -1,0 +1,204 @@
+import { useState } from "react";
+import Button from "@/shared/components/ui/Button";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useExtendSignedLeaseMutation } from "@/shared/store/signedLeasesApi";
+
+const NOTES_MAX_LENGTH = 2000;
+
+export interface ExtendLeaseDialogProps {
+  leaseId: string;
+  currentEndsOn: string;
+  onClose: () => void;
+}
+
+interface ConflictDetail {
+  code:
+    | "INVALID_STATUS_FOR_EXTENSION"
+    | "MISSING_CURRENT_END_DATE"
+    | "NEW_END_DATE_NOT_AFTER_CURRENT";
+  message: string;
+}
+
+function extractConflictDetail(err: unknown): ConflictDetail | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as { status?: number; data?: { detail?: unknown } };
+  if (e.status !== 409) return null;
+  const detail = e.data?.detail;
+  if (!detail || typeof detail !== "object") return null;
+  const code = (detail as { code?: unknown }).code;
+  if (
+    code === "INVALID_STATUS_FOR_EXTENSION"
+    || code === "MISSING_CURRENT_END_DATE"
+    || code === "NEW_END_DATE_NOT_AFTER_CURRENT"
+  ) {
+    return detail as ConflictDetail;
+  }
+  return null;
+}
+
+function describeConflict(detail: ConflictDetail): string {
+  switch (detail.code) {
+    case "INVALID_STATUS_FOR_EXTENSION":
+      return "Only signed or active leases can be extended.";
+    case "MISSING_CURRENT_END_DATE":
+      return "This lease has no current end date — fill in the original term before extending.";
+    case "NEW_END_DATE_NOT_AFTER_CURRENT":
+      return "The new end date must be after the current end date.";
+  }
+}
+
+/**
+ * Inline dialog to extend a signed or active lease's end date.
+ *
+ * Posts ``POST /signed-leases/{id}/extend`` with the new end date, optional
+ * notes, and an opt-in to email the tenant after commit. The backend renders
+ * the addendum PDF, attaches it, and updates ``ends_on`` atomically.
+ */
+export default function ExtendLeaseDialog({
+  leaseId,
+  currentEndsOn,
+  onClose,
+}: ExtendLeaseDialogProps) {
+  const [newEndsOn, setNewEndsOn] = useState("");
+  const [notes, setNotes] = useState("");
+  const [emailTenant, setEmailTenant] = useState(false);
+  const [extendLease, { isLoading }] = useExtendSignedLeaseMutation();
+
+  const isValid =
+    newEndsOn !== ""
+    && newEndsOn > currentEndsOn
+    && notes.length <= NOTES_MAX_LENGTH;
+
+  async function handleConfirm() {
+    if (!isValid) return;
+    try {
+      await extendLease({
+        leaseId,
+        data: {
+          new_ends_on: newEndsOn,
+          notes: notes.trim() || undefined,
+          email_tenant: emailTenant,
+        },
+      }).unwrap();
+      showSuccess(
+        emailTenant
+          ? "Lease extended. I'll email the tenant shortly."
+          : "Lease extended.",
+      );
+      onClose();
+    } catch (err) {
+      const conflict = extractConflictDetail(err);
+      if (conflict) {
+        showError(describeConflict(conflict));
+        return;
+      }
+      showError("Couldn't extend the lease. Please try again.");
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Extend lease"
+      aria-modal="true"
+      data-testid="extend-lease-dialog"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="bg-card rounded-lg shadow-lg p-6 w-full max-w-md space-y-4">
+        <div className="space-y-1">
+          <h2 className="text-base font-semibold">Extend lease</h2>
+          <p className="text-sm text-muted-foreground">
+            Current end date:{" "}
+            <span className="font-medium text-foreground">{currentEndsOn}</span>.
+            I'll auto-render an extension addendum PDF and attach it to the lease.
+          </p>
+        </div>
+
+        <div className="space-y-1">
+          <label
+            htmlFor="extend-lease-new-end"
+            className="block text-sm font-medium"
+          >
+            New end date
+          </label>
+          <input
+            id="extend-lease-new-end"
+            type="date"
+            data-testid="extend-lease-new-end"
+            value={newEndsOn}
+            min={currentEndsOn}
+            onChange={(e) => setNewEndsOn(e.target.value)}
+            className="w-full px-3 py-2 text-sm border rounded-md min-h-[44px]"
+          />
+          {newEndsOn !== "" && newEndsOn <= currentEndsOn ? (
+            <p
+              className="text-xs text-red-600"
+              data-testid="extend-lease-new-end-error"
+            >
+              New end date must be after {currentEndsOn}.
+            </p>
+          ) : null}
+        </div>
+
+        <div className="space-y-1">
+          <label
+            htmlFor="extend-lease-notes"
+            className="block text-sm font-medium"
+          >
+            Notes{" "}
+            <span className="text-muted-foreground font-normal">(optional)</span>
+          </label>
+          <textarea
+            id="extend-lease-notes"
+            data-testid="extend-lease-notes"
+            value={notes}
+            onChange={(e) => setNotes(e.target.value)}
+            maxLength={NOTES_MAX_LENGTH}
+            rows={3}
+            placeholder="e.g. Tenant requested 6-month extension at current rent"
+            className="w-full px-3 py-2 text-sm border rounded-md resize-none"
+          />
+          <p className="text-right text-xs text-muted-foreground">
+            {notes.length}/{NOTES_MAX_LENGTH}
+          </p>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            data-testid="extend-lease-email-tenant"
+            checked={emailTenant}
+            onChange={(e) => setEmailTenant(e.target.checked)}
+            className="h-4 w-4"
+          />
+          <span>Email the tenant the rendered addendum</span>
+        </label>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            data-testid="extend-lease-cancel"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <LoadingButton
+            type="button"
+            variant="primary"
+            size="sm"
+            data-testid="extend-lease-confirm"
+            isLoading={isLoading}
+            loadingText="Extending..."
+            disabled={!isValid}
+            onClick={() => void handleConfirm()}
+          >
+            Extend lease
+          </LoadingButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, FileText, Mail, Plus, User } from "lucide-react";
+import { ArrowLeft, CalendarPlus, FileText, Mail, Plus, User } from "lucide-react";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import Badge from "@/shared/components/ui/Badge";
@@ -18,6 +18,7 @@ import {
 import { useGetApplicantByIdQuery } from "@/shared/store/applicantsApi";
 import SignedLeaseStatusBadge from "@/app/features/leases/SignedLeaseStatusBadge";
 import SignedLeaseStatusPicker from "@/app/features/leases/SignedLeaseStatusPicker";
+import ExtendLeaseDialog from "@/app/features/leases/ExtendLeaseDialog";
 import LeaseAttachmentsSection from "@/app/features/leases/LeaseAttachmentsSection";
 import LeaseAddTemplateModal from "@/app/features/leases/LeaseAddTemplateModal";
 import type { SignedLeaseStatus } from "@/shared/types/lease/signed-lease-status";
@@ -29,6 +30,7 @@ export default function LeaseDetail() {
   const canWrite = useCanWrite();
   const [tab, setTab] = useState<Tab>("files");
   const [showAddTemplateModal, setShowAddTemplateModal] = useState(false);
+  const [showExtendDialog, setShowExtendDialog] = useState(false);
   const {
     data: lease,
     isLoading,
@@ -57,6 +59,10 @@ export default function LeaseDetail() {
     (a) => a.kind === "rendered_original" || a.kind === "signed_lease",
   );
   const showEmailButton = canWrite && hasEmailableAttachment;
+  const canExtend =
+    canWrite
+    && (lease?.status === "signed" || lease?.status === "active")
+    && Boolean(lease?.ends_on);
 
   async function handleGenerate() {
     if (!lease) return;
@@ -192,9 +198,28 @@ export default function LeaseDetail() {
                     Email to tenant
                   </LoadingButton>
                 ) : null}
+                {canExtend ? (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={() => setShowExtendDialog(true)}
+                    data-testid="lease-extend-button"
+                  >
+                    <CalendarPlus size={16} className="mr-1" />
+                    Extend lease
+                  </Button>
+                ) : null}
               </div>
             }
           />
+
+          {showExtendDialog && lease?.ends_on ? (
+            <ExtendLeaseDialog
+              leaseId={lease.id}
+              currentEndsOn={lease.ends_on}
+              onClose={() => setShowExtendDialog(false)}
+            />
+          ) : null}
 
           {showAddTemplateModal && lease ? (
             <LeaseAddTemplateModal

--- a/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
@@ -1,4 +1,5 @@
 import { baseApi } from "./baseApi";
+import type { ExtendLeaseRequest } from "@/shared/types/lease/extend-lease-request";
 import type { LeaseAttachmentKind } from "@/shared/types/lease/lease-attachment-kind";
 import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
 import type { SignedLeaseCreateRequest } from "@/shared/types/lease/signed-lease-create-request";
@@ -92,6 +93,21 @@ const signedLeasesApi = baseApi.injectEndpoints({
       // Invalidate so the UI refetches and reflects the new stamp
       // (next user navigation or polling will pick it up).
       invalidatesTags: (_r, _e, id) => [{ type: "SignedLease", id }],
+    }),
+
+    extendSignedLease: builder.mutation<
+      SignedLeaseDetail,
+      { leaseId: string; data: ExtendLeaseRequest }
+    >({
+      query: ({ leaseId, data }) => ({
+        url: `/signed-leases/${leaseId}/extend`,
+        method: "POST",
+        data,
+      }),
+      invalidatesTags: (_r, _e, { leaseId }) => [
+        { type: "SignedLease", id: leaseId },
+        { type: "SignedLease", id: "LIST" },
+      ],
     }),
 
     uploadSignedLeaseAttachment: builder.mutation<
@@ -204,6 +220,7 @@ export const {
   useDeleteSignedLeaseMutation,
   useGenerateSignedLeaseMutation,
   useEmailSignedLeaseToTenantMutation,
+  useExtendSignedLeaseMutation,
   useUploadSignedLeaseAttachmentMutation,
   useDeleteSignedLeaseAttachmentMutation,
   useImportSignedLeaseMutation,

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/extend-lease-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/extend-lease-request.ts
@@ -1,0 +1,15 @@
+/**
+ * Body for POST /signed-leases/{lease_id}/extend.
+ *
+ * Mirrors backend ``ExtendLeaseRequest``. ``new_ends_on`` is required and
+ * must be strictly after the lease's current ``ends_on`` (the backend
+ * enforces this and surfaces 409 ``NEW_END_DATE_NOT_AFTER_CURRENT``).
+ * ``notes`` is optional free-text (max 2000 chars) that lands on the
+ * rendered addendum. ``email_tenant`` triggers a best-effort tenant email
+ * after the DB commit.
+ */
+export interface ExtendLeaseRequest {
+  new_ends_on: string; // ISO-8601 YYYY-MM-DD
+  notes?: string;
+  email_tenant?: boolean;
+}


### PR DESCRIPTION
## Summary

Frontend half of the lease extension feature. Backend service + endpoint shipped in #560. This PR adds the **Extend lease** button to the signed-lease detail page and the dialog that collects the new end date, optional notes, and an email-tenant opt-in.

This is **PR 2b** of the 4-PR lease extension sequence.

## What lands

- **\`ExtendLeaseDialog\`** — inline dialog matching the existing \`EndTenancyDialog\` pattern. Validates \`new_ends_on > current ends_on\` client-side, disables Confirm until valid, surfaces 409 error codes from the backend as friendly toasts (INVALID_STATUS_FOR_EXTENSION / MISSING_CURRENT_END_DATE / NEW_END_DATE_NOT_AFTER_CURRENT).
- **Extend button** on the \`LeaseDetail\` action row. Visible when canWrite + status in {signed, active} + ends_on != null.
- **\`useExtendSignedLeaseMutation\`** RTK Query hook invalidating per-lease + LIST cache tags.
- **\`ExtendLeaseRequest\`** TypeScript type matching the backend Pydantic schema.

## Backend test-helper change

\`POST /test/seed-signed-lease\` now accepts optional \`starts_on\` / \`ends_on\` so the e2e can seed a lease eligible for extension. Test-only — no production impact.

## Test plan

- [x] Vitest: 10 cases (happy path, payload shape, success/error toasts including 409 code translation, validation gating, cancel, email-aware success)
- [x] Playwright: 4 e2e cases (API smoke 200 + 409, UI dialog happy path, button hidden for draft)
- [x] Backend suite re-run after seed helper change: 32 passed, no regressions

## Out of scope

- PR 3 — 30-day undo extension
- PR 4 — Successor-lease creation + auto-end scheduled job

🤖 Generated with [Claude Code](https://claude.com/claude-code)