### PR TITLE
feat(mbk/leases): undo extension within 30 days (PR 3)

### DIFF
--- a/apps/mybookkeeper/backend/app/api/signed_leases.py
+++ b/apps/mybookkeeper/backend/app/api/signed_leases.py
@@ -395,6 +395,56 @@ async def extend_lease(
 
 
 @router.post(
+    "/{lease_id}/extensions/{version_id}/undo",
+    response_model=SignedLeaseResponse,
+)
+async def undo_lease_extension(
+    lease_id: uuid.UUID,
+    version_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> SignedLeaseResponse:
+    """Undo a recent lease extension (within the 30-day window).
+
+    Soft-deletes the matching ``lease_term_versions`` row and recomputes
+    ``signed_leases.ends_on`` from the now-latest version. The rendered
+    addendum attachment is preserved as an audit trail.
+
+    Errors:
+        404 — lease not found, or version_id not on this lease.
+        409 — undo refused: version is the seed row, isn't the latest
+              extension, or the 30-day window has expired.
+    """
+    try:
+        return await lease_extension_service.undo_extension(
+            user_id=ctx.user_id,
+            organization_id=ctx.organization_id,
+            lease_id=lease_id,
+            version_id=version_id,
+        )
+    except lease_extension_service.SignedLeaseNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Lease not found") from exc
+    except lease_extension_service.ExtensionNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail="Extension not found",
+        ) from exc
+    except lease_extension_service.CannotUndoSeedRowError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "CANNOT_UNDO_SEED_ROW", "message": str(exc)},
+        ) from exc
+    except lease_extension_service.NotLatestExtensionError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "NOT_LATEST_EXTENSION", "message": str(exc)},
+        ) from exc
+    except lease_extension_service.UndoWindowExpiredError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={"code": "UNDO_WINDOW_EXPIRED", "message": str(exc)},
+        ) from exc
+
+
+@router.post(
     "/{lease_id}/attachments",
     response_model=SignedLeaseAttachmentResponse,
     status_code=201,

--- a/apps/mybookkeeper/backend/app/models/leases/lease_term_version.py
+++ b/apps/mybookkeeper/backend/app/models/leases/lease_term_version.py
@@ -83,6 +83,7 @@ class LeaseTermVersion(Base):
             "lease_id", "source_attachment_id",
             unique=True,
             postgresql_where=text("source_attachment_id IS NOT NULL"),
+            sqlite_where=text("source_attachment_id IS NOT NULL"),
         ),
         # Exactly one live seed row per lease — guards the invariant that
         # a lease has a single canonical original term.
@@ -93,11 +94,15 @@ class LeaseTermVersion(Base):
             postgresql_where=text(
                 "source_attachment_id IS NULL AND deleted_at IS NULL"
             ),
+            sqlite_where=text(
+                "source_attachment_id IS NULL AND deleted_at IS NULL"
+            ),
         ),
         # Lookup the latest live version for a given lease.
         Index(
             "ix_lease_term_versions_lease_active",
             "lease_id", "created_at",
             postgresql_where=text("deleted_at IS NULL"),
+            sqlite_where=text("deleted_at IS NULL"),
         ),
     )

--- a/apps/mybookkeeper/backend/app/repositories/leases/lease_term_version_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/leases/lease_term_version_repo.py
@@ -5,8 +5,11 @@ signed lease over time. The seed row (``source_attachment_id IS NULL``)
 captures the original term; later rows record extension addenda, each
 pointing at the rendered ``signed_lease_attachments`` row that produced it.
 
-Soft-delete (``deleted_at``) is reserved for the 30-day extension-undo
-flow that lands in a later PR — this PR only writes; it never deletes.
+Soft-delete (``deleted_at``) is the 30-day extension-undo gate: a row
+becomes invisible to the lease view but the audit trail (and the linked
+addendum attachment) remain. Seed rows MUST NEVER be soft-deleted — the
+``uq_lease_term_versions_seed_per_lease`` partial unique index enforces
+exactly one live seed per lease.
 """
 from __future__ import annotations
 
@@ -59,3 +62,66 @@ async def list_by_lease(
     stmt = stmt.order_by(desc(LeaseTermVersion.created_at))
     result = await db.execute(stmt)
     return list(result.scalars().all())
+
+
+async def get(
+    db: AsyncSession,
+    *,
+    version_id: uuid.UUID,
+    lease_id: uuid.UUID,
+    include_deleted: bool = False,
+) -> LeaseTermVersion | None:
+    """Fetch a single version scoped to its lease (IDOR guard).
+
+    Both ``version_id`` AND ``lease_id`` must match — preventing a caller
+    from undoing a version that doesn't belong to the lease they own.
+    """
+    stmt = select(LeaseTermVersion).where(
+        LeaseTermVersion.id == version_id,
+        LeaseTermVersion.lease_id == lease_id,
+    )
+    if not include_deleted:
+        stmt = stmt.where(LeaseTermVersion.deleted_at.is_(None))
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def get_latest_extension(
+    db: AsyncSession,
+    *,
+    lease_id: uuid.UUID,
+) -> LeaseTermVersion | None:
+    """Return the most-recent non-deleted extension (seed excluded).
+
+    Drives the Undo button's gating on the frontend: when this returns a
+    row whose ``created_at`` is within the undo window, the host can roll
+    back that extension. ``None`` means the lease has no live extensions
+    (only the seed row).
+    """
+    result = await db.execute(
+        select(LeaseTermVersion)
+        .where(
+            LeaseTermVersion.lease_id == lease_id,
+            LeaseTermVersion.deleted_at.is_(None),
+            LeaseTermVersion.source_attachment_id.is_not(None),
+        )
+        .order_by(desc(LeaseTermVersion.created_at))
+        .limit(1),
+    )
+    return result.scalar_one_or_none()
+
+
+async def soft_delete(
+    db: AsyncSession,
+    *,
+    version: LeaseTermVersion,
+    now: _dt.datetime,
+) -> None:
+    """Soft-delete a term version row.
+
+    Caller MUST have verified the row is not a seed (``source_attachment_id``
+    is not NULL) and is within the undo window. Soft-deleting a seed
+    would violate the one-live-seed-per-lease invariant and lose the
+    original term.
+    """
+    version.deleted_at = now

--- a/apps/mybookkeeper/backend/app/schemas/leases/lease_extension_summary.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/lease_extension_summary.py
@@ -1,0 +1,23 @@
+"""Summary of the latest non-deleted lease extension.
+
+Exposed on ``SignedLeaseResponse.latest_extension`` so the frontend can
+render the Undo button conditionally. Mirrors a ``lease_term_versions``
+row created with a non-null ``source_attachment_id`` (extensions only —
+the seed row is never surfaced as an "extension" to the host).
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+from pydantic import BaseModel, ConfigDict
+
+
+class LeaseExtensionSummary(BaseModel):
+    id: uuid.UUID
+    created_at: _dt.datetime
+    starts_on: _dt.date
+    ends_on: _dt.date
+    source_attachment_id: uuid.UUID
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/leases/signed_lease_response.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
+from app.schemas.leases.lease_extension_summary import LeaseExtensionSummary
 from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
@@ -37,5 +38,10 @@ class SignedLeaseResponse(BaseModel):
     created_at: _dt.datetime
     updated_at: _dt.datetime
     attachments: list[SignedLeaseAttachmentResponse]
+    # The most-recent live extension (seed excluded), or null when the lease
+    # is at its original term. Drives the Undo button on the frontend; the
+    # client checks ``created_at`` against the 30-day undo window to decide
+    # whether to render the button.
+    latest_extension: LeaseExtensionSummary | None = None
 
     model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/services/leases/_lease_helpers.py
+++ b/apps/mybookkeeper/backend/app/services/leases/_lease_helpers.py
@@ -19,6 +19,7 @@ from app.repositories.applicants import applicant_repo
 from app.repositories.inquiries.inquiry_repo import get_by_applicant_inquiry_id
 from app.repositories.leases import (
     lease_template_repo,
+    lease_term_version_repo,
     signed_lease_attachment_repo,
     signed_lease_template_repo,
 )
@@ -26,6 +27,7 @@ from app.repositories.listings import listing_repo
 from app.repositories.properties import property_repo
 from app.repositories.user import user_repo
 
+from app.schemas.leases.lease_extension_summary import LeaseExtensionSummary
 from app.schemas.leases.signed_lease_attachment_response import (
     SignedLeaseAttachmentResponse,
 )
@@ -136,7 +138,12 @@ def _attachment_responses(rows) -> list[SignedLeaseAttachmentResponse]:
     )
 
 
-def _to_detail(lease, attachments, template_links: list[SignedLeaseTemplateLink]) -> SignedLeaseResponse:
+def _to_detail(
+    lease,
+    attachments,
+    template_links: list[SignedLeaseTemplateLink],
+    latest_extension: "LeaseExtensionSummary | None" = None,
+) -> SignedLeaseResponse:
     return SignedLeaseResponse(
         id=lease.id,
         user_id=lease.user_id,
@@ -159,7 +166,20 @@ def _to_detail(lease, attachments, template_links: list[SignedLeaseTemplateLink]
         created_at=lease.created_at,
         updated_at=lease.updated_at,
         attachments=_attachment_responses(attachments),
+        latest_extension=latest_extension,
     )
+
+
+async def _resolve_latest_extension(
+    db,
+    *,
+    lease_id: uuid.UUID,
+) -> "LeaseExtensionSummary | None":
+    """Load the newest live extension (seed excluded) for inclusion in detail responses."""
+    row = await lease_term_version_repo.get_latest_extension(db, lease_id=lease_id)
+    if row is None:
+        return None
+    return LeaseExtensionSummary.model_validate(row)
 
 
 async def _resolve_template_links(

--- a/apps/mybookkeeper/backend/app/services/leases/lease_extension_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_extension_service.py
@@ -63,6 +63,28 @@ class MissingCurrentEndDateError(ValueError):
     """The lease has no ``ends_on`` set — cannot extend from an unknown date."""
 
 
+class ExtensionNotFoundError(LookupError):
+    """The requested ``lease_term_versions`` row is not in the lease's live set."""
+
+
+class CannotUndoSeedRowError(ValueError):
+    """Refused to undo the seed term (would lose the original lease term)."""
+
+
+class NotLatestExtensionError(ValueError):
+    """The requested version is not the latest extension — undo is FIFO only."""
+
+
+class UndoWindowExpiredError(ValueError):
+    """The extension was committed more than ``UNDO_WINDOW_DAYS`` ago."""
+
+
+# How long after an extension was committed the host can still undo it.
+# Generous window — tenants sometimes change their mind weeks after
+# signing the addendum. Undo is strictly reversible (re-extend if needed).
+UNDO_WINDOW_DAYS: int = 30
+
+
 # 1-page boilerplate. Placeholders match the addendum-aware keys already
 # present in ``default_source_map.py``. Unknown keys remain bracketed in
 # the rendered output (per ``render_md`` contract), which is the right
@@ -225,6 +247,109 @@ async def extend_lease(
         lease_id=lease_id,
     )
     return detail, now
+
+
+async def undo_extension(
+    *,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    lease_id: uuid.UUID,
+    version_id: uuid.UUID,
+) -> SignedLeaseResponse:
+    """Roll back a recent extension within the ``UNDO_WINDOW_DAYS`` window.
+
+    Soft-deletes the ``lease_term_versions`` row and recomputes
+    ``signed_leases.ends_on`` from the now-latest live version. The
+    rendered addendum attachment is intentionally preserved as an audit
+    trail — soft-deleted versions still reference it via
+    ``source_attachment_id``.
+
+    Raises:
+        SignedLeaseNotFoundError: lease not in (user_id, organization_id).
+        ExtensionNotFoundError: version_id is not a live row on this lease.
+        CannotUndoSeedRowError: version is the seed (would lose original term).
+        NotLatestExtensionError: a newer live extension exists; undo is FIFO.
+        UndoWindowExpiredError: version was committed >UNDO_WINDOW_DAYS ago.
+    """
+    now = _dt.datetime.now(_dt.timezone.utc)
+
+    async with unit_of_work() as db:
+        lease = await signed_lease_repo.get(
+            db,
+            lease_id=lease_id,
+            user_id=user_id,
+            organization_id=organization_id,
+        )
+        if lease is None:
+            raise SignedLeaseNotFoundError(f"Lease {lease_id} not found")
+
+        version = await lease_term_version_repo.get(
+            db,
+            version_id=version_id,
+            lease_id=lease_id,
+        )
+        if version is None:
+            raise ExtensionNotFoundError(
+                f"Extension {version_id} not found on lease {lease_id}",
+            )
+
+        if version.source_attachment_id is None:
+            raise CannotUndoSeedRowError(
+                "The original lease term cannot be undone — it's not an extension.",
+            )
+
+        latest = await lease_term_version_repo.get_latest_extension(
+            db, lease_id=lease_id,
+        )
+        if latest is None or latest.id != version.id:
+            raise NotLatestExtensionError(
+                "Only the most recent extension can be undone. "
+                "Undo the latest extension first if you need to roll back further.",
+            )
+
+        age = now - version.created_at
+        if age.days >= UNDO_WINDOW_DAYS:
+            raise UndoWindowExpiredError(
+                f"This extension was committed more than {UNDO_WINDOW_DAYS} "
+                "days ago and can no longer be undone.",
+            )
+
+        await lease_term_version_repo.soft_delete(db, version=version, now=now)
+
+        # Recompute lease.ends_on from the next-latest live version. If no
+        # other extension exists, fall back to the seed row (which always
+        # exists for an extended lease — the seed was created at the
+        # original signature time per PR 1a's backfill).
+        next_latest = await lease_term_version_repo.get_latest_extension(
+            db, lease_id=lease_id,
+        )
+        if next_latest is not None:
+            new_ends_on = next_latest.ends_on
+        else:
+            seed = next(
+                (
+                    v for v in await lease_term_version_repo.list_by_lease(
+                        db, lease_id=lease_id,
+                    )
+                    if v.source_attachment_id is None
+                ),
+                None,
+            )
+            new_ends_on = seed.ends_on if seed is not None else lease.ends_on
+
+        await signed_lease_repo.update_lease(
+            db,
+            lease_id=lease_id,
+            user_id=user_id,
+            organization_id=organization_id,
+            fields={"ends_on": new_ends_on, "updated_at": now},
+        )
+
+    return await get_lease(
+        user_id=user_id,
+        organization_id=organization_id,
+        lease_id=lease_id,
+    )
 
 
 def _addendum_filename(new_ends_on: _dt.date) -> str:

--- a/apps/mybookkeeper/backend/app/services/leases/lease_lifecycle_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_lifecycle_service.py
@@ -28,6 +28,7 @@ from app.services.leases._lease_helpers import (
     _attachment_responses,
     _build_summary,
     _denormalise_dates,
+    _resolve_latest_extension,
     _resolve_template_links,
     _to_detail,
     _validate_status_transition,
@@ -118,7 +119,8 @@ async def create_lease(
 
         attachments = await signed_lease_attachment_repo.list_by_lease(db, lease.id)
         template_links = await _resolve_template_links(db, lease_id=lease.id)
-    return _to_detail(lease, attachments, template_links)
+        latest_extension = await _resolve_latest_extension(db, lease_id=lease.id)
+    return _to_detail(lease, attachments, template_links, latest_extension)
 
 
 # ---------------------------------------------------------------------------
@@ -202,7 +204,8 @@ async def get_lease(
             db, lease.id,
         )
         template_links = await _resolve_template_links(db, lease_id=lease.id)
-    return _to_detail(lease, attachments, template_links)
+        latest_extension = await _resolve_latest_extension(db, lease_id=lease.id)
+    return _to_detail(lease, attachments, template_links, latest_extension)
 
 
 # ---------------------------------------------------------------------------
@@ -276,7 +279,8 @@ async def update_lease(
             organization_id=organization_id,
         )
         template_links = await _resolve_template_links(db, lease_id=lease_id)
-    return _to_detail(lease, attachments, template_links)
+        latest_extension = await _resolve_latest_extension(db, lease_id=lease_id)
+    return _to_detail(lease, attachments, template_links, latest_extension)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/mybookkeeper/backend/tests/test_lease_extension_undo_api.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_extension_undo_api.py
@@ -1,0 +1,188 @@
+"""Route tests for POST /signed-leases/{lease_id}/extensions/{version_id}/undo.
+
+Service behavior is covered in test_lease_extension_undo_service. This
+file isolates the route: status code + body translation, permission gating.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+from app.core.context import RequestContext
+from app.core.permissions import require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.leases.signed_lease_response import SignedLeaseResponse
+from app.services.leases import lease_extension_service
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(
+        organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER,
+    )
+
+
+def _stub_detail(lease_id: uuid.UUID, ends_on: _dt.date) -> SignedLeaseResponse:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    return SignedLeaseResponse(
+        id=lease_id,
+        user_id=uuid.uuid4(),
+        organization_id=uuid.uuid4(),
+        templates=[],
+        applicant_id=uuid.uuid4(),
+        kind="generated",
+        values={},
+        status="active",
+        starts_on=_dt.date(2026, 1, 1),
+        ends_on=ends_on,
+        created_at=now,
+        updated_at=now,
+        attachments=[],
+        latest_extension=None,
+    )
+
+
+class TestUndoExtensionRoute:
+    def test_happy_path_returns_200_with_rolled_back_lease(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        lease_id, version_id = uuid.uuid4(), uuid.uuid4()
+        detail = _stub_detail(lease_id, _dt.date(2026, 12, 31))
+
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.lease_extension_service.undo_extension",
+                new_callable=AsyncMock,
+                return_value=detail,
+            ) as mock_svc:
+                client = TestClient(app)
+                response = client.post(
+                    f"/signed-leases/{lease_id}/extensions/{version_id}/undo",
+                )
+            assert response.status_code == 200, response.text
+            assert response.json()["id"] == str(lease_id)
+            assert response.json()["ends_on"] == "2026-12-31"
+            kwargs = mock_svc.call_args.kwargs
+            assert kwargs["user_id"] == user_id
+            assert kwargs["organization_id"] == org_id
+            assert kwargs["lease_id"] == lease_id
+            assert kwargs["version_id"] == version_id
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_lease_not_found_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.lease_extension_service.undo_extension",
+                new_callable=AsyncMock,
+                side_effect=lease_extension_service.SignedLeaseNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/signed-leases/{uuid.uuid4()}/extensions/{uuid.uuid4()}/undo",
+                )
+            assert response.status_code == 404
+            assert response.json()["detail"] == "Lease not found"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_extension_not_found_returns_404(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.lease_extension_service.undo_extension",
+                new_callable=AsyncMock,
+                side_effect=lease_extension_service.ExtensionNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/signed-leases/{uuid.uuid4()}/extensions/{uuid.uuid4()}/undo",
+                )
+            assert response.status_code == 404
+            assert response.json()["detail"] == "Extension not found"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_seed_row_returns_409(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.lease_extension_service.undo_extension",
+                new_callable=AsyncMock,
+                side_effect=lease_extension_service.CannotUndoSeedRowError("seed"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/signed-leases/{uuid.uuid4()}/extensions/{uuid.uuid4()}/undo",
+                )
+            assert response.status_code == 409
+            assert response.json()["detail"]["code"] == "CANNOT_UNDO_SEED_ROW"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_not_latest_returns_409(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.lease_extension_service.undo_extension",
+                new_callable=AsyncMock,
+                side_effect=lease_extension_service.NotLatestExtensionError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/signed-leases/{uuid.uuid4()}/extensions/{uuid.uuid4()}/undo",
+                )
+            assert response.status_code == 409
+            assert response.json()["detail"]["code"] == "NOT_LATEST_EXTENSION"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_window_expired_returns_409(self) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+        try:
+            with patch(
+                "app.api.signed_leases.lease_extension_service.undo_extension",
+                new_callable=AsyncMock,
+                side_effect=lease_extension_service.UndoWindowExpiredError("expired"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/signed-leases/{uuid.uuid4()}/extensions/{uuid.uuid4()}/undo",
+                )
+            assert response.status_code == 409
+            assert response.json()["detail"]["code"] == "UNDO_WINDOW_EXPIRED"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_viewer_returns_403(self) -> None:
+        app.dependency_overrides[require_write_access] = lambda: (
+            (_ for _ in ()).throw(
+                __import__("fastapi").HTTPException(
+                    status_code=403, detail="Viewers have read-only access",
+                )
+            )
+        )
+        try:
+            client = TestClient(app)
+            response = client.post(
+                f"/signed-leases/{uuid.uuid4()}/extensions/{uuid.uuid4()}/undo",
+            )
+            assert response.status_code == 403
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_unauthenticated_returns_401(self) -> None:
+        client = TestClient(app)
+        response = client.post(
+            f"/signed-leases/{uuid.uuid4()}/extensions/{uuid.uuid4()}/undo",
+        )
+        assert response.status_code == 401

--- a/apps/mybookkeeper/backend/tests/test_lease_extension_undo_service.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_extension_undo_service.py
@@ -1,0 +1,306 @@
+"""Unit tests for lease_extension_service.undo_extension.
+
+Exercises the service against an in-memory SQLite session.
+
+Coverage:
+- Happy path: latest extension within window → soft-deleted, lease.ends_on
+  recomputes from the next-latest row (or seed when only one extension).
+- Refuses seed row.
+- Refuses non-latest extension when a newer live extension exists.
+- Refuses when the 30-day window has expired.
+- Refuses extension on a different lease (cross-tenant IDOR via composite WHERE).
+- Cross-tenant: lease in a different org → SignedLeaseNotFoundError.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.leases.lease_term_version import LeaseTermVersion
+from app.models.leases.signed_lease import SignedLease
+from app.services.leases.lease_extension_service import (
+    CannotUndoSeedRowError,
+    ExtensionNotFoundError,
+    NotLatestExtensionError,
+    SignedLeaseNotFoundError,
+    UNDO_WINDOW_DAYS,
+    UndoWindowExpiredError,
+    undo_extension,
+)
+
+
+def _fake_uow_for(session: AsyncSession):
+    @asynccontextmanager
+    async def _uow():
+        yield session
+    return _uow
+
+
+async def _seed_lease_with_seed_version(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    org_id: uuid.UUID,
+) -> SignedLease:
+    applicant = Applicant(
+        organization_id=org_id,
+        user_id=user_id,
+        stage="lease_signed",
+        legal_name="Tenant",
+    )
+    db.add(applicant)
+    await db.flush()
+
+    lease = SignedLease(
+        user_id=user_id,
+        organization_id=org_id,
+        applicant_id=applicant.id,
+        kind="generated",
+        status="signed",
+        starts_on=_dt.date(2026, 1, 1),
+        ends_on=_dt.date(2026, 12, 31),
+    )
+    db.add(lease)
+    await db.flush()
+
+    seed = LeaseTermVersion(
+        lease_id=lease.id,
+        starts_on=lease.starts_on,
+        ends_on=lease.ends_on,
+        source_attachment_id=None,
+        created_by_user_id=user_id,
+        created_at=_dt.datetime(2026, 1, 1, tzinfo=_dt.timezone.utc),
+    )
+    db.add(seed)
+    await db.flush()
+    return lease
+
+
+async def _seed_extension(
+    db: AsyncSession,
+    *,
+    lease: SignedLease,
+    user_id: uuid.UUID,
+    ends_on: _dt.date,
+    age_days: int = 1,
+) -> LeaseTermVersion:
+    now = _dt.datetime.now(_dt.timezone.utc)
+    version = LeaseTermVersion(
+        lease_id=lease.id,
+        starts_on=lease.starts_on,
+        ends_on=ends_on,
+        # FK is normally to signed_lease_attachments.id; for these unit tests
+        # we just need a non-null UUID — FK enforcement is OFF in conftest.
+        source_attachment_id=uuid.uuid4(),
+        created_by_user_id=user_id,
+        created_at=now - _dt.timedelta(days=age_days),
+    )
+    db.add(version)
+    await db.flush()
+    # Reflect the extension on the lease (the real service does this).
+    lease.ends_on = ends_on
+    await db.flush()
+    return version
+
+
+@pytest.mark.asyncio
+async def test_happy_path_undoes_single_extension(db: AsyncSession) -> None:
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_lease_with_seed_version(
+        db, user_id=user_id, org_id=org_id,
+    )
+    version = await _seed_extension(
+        db, lease=lease, user_id=user_id, ends_on=_dt.date(2027, 6, 30),
+    )
+
+    detail_stub = object()
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), patch(
+        "app.services.leases.lease_extension_service.get_lease",
+        AsyncMock(return_value=detail_stub),
+    ):
+        result = await undo_extension(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            version_id=version.id,
+        )
+
+    assert result is detail_stub
+
+    # The version was soft-deleted.
+    refreshed = (
+        await db.execute(
+            select(LeaseTermVersion).where(LeaseTermVersion.id == version.id)
+        )
+    ).scalar_one()
+    assert refreshed.deleted_at is not None
+
+    # Lease.ends_on rolled back to the seed's value.
+    await db.refresh(lease)
+    assert lease.ends_on == _dt.date(2026, 12, 31)
+
+
+@pytest.mark.asyncio
+async def test_undo_returns_to_previous_extension(db: AsyncSession) -> None:
+    """Two extensions stacked: undoing the latest returns ends_on to the prior one."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_lease_with_seed_version(
+        db, user_id=user_id, org_id=org_id,
+    )
+    await _seed_extension(
+        db, lease=lease, user_id=user_id,
+        ends_on=_dt.date(2027, 6, 30), age_days=10,
+    )
+    latest = await _seed_extension(
+        db, lease=lease, user_id=user_id,
+        ends_on=_dt.date(2028, 6, 30), age_days=1,
+    )
+
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), patch(
+        "app.services.leases.lease_extension_service.get_lease",
+        AsyncMock(return_value=object()),
+    ):
+        await undo_extension(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            version_id=latest.id,
+        )
+
+    await db.refresh(lease)
+    assert lease.ends_on == _dt.date(2027, 6, 30)
+
+
+@pytest.mark.asyncio
+async def test_refuses_seed_row(db: AsyncSession) -> None:
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_lease_with_seed_version(
+        db, user_id=user_id, org_id=org_id,
+    )
+    seed_row = (
+        await db.execute(
+            select(LeaseTermVersion).where(
+                LeaseTermVersion.lease_id == lease.id,
+            )
+        )
+    ).scalar_one()
+
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), pytest.raises(CannotUndoSeedRowError):
+        await undo_extension(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            version_id=seed_row.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_refuses_non_latest_extension(db: AsyncSession) -> None:
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_lease_with_seed_version(
+        db, user_id=user_id, org_id=org_id,
+    )
+    older = await _seed_extension(
+        db, lease=lease, user_id=user_id,
+        ends_on=_dt.date(2027, 6, 30), age_days=10,
+    )
+    await _seed_extension(
+        db, lease=lease, user_id=user_id,
+        ends_on=_dt.date(2028, 6, 30), age_days=1,
+    )
+
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), pytest.raises(NotLatestExtensionError):
+        await undo_extension(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            version_id=older.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_refuses_after_window_expired(db: AsyncSession) -> None:
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_lease_with_seed_version(
+        db, user_id=user_id, org_id=org_id,
+    )
+    version = await _seed_extension(
+        db, lease=lease, user_id=user_id,
+        ends_on=_dt.date(2027, 6, 30), age_days=UNDO_WINDOW_DAYS + 1,
+    )
+
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), pytest.raises(UndoWindowExpiredError):
+        await undo_extension(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            version_id=version.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_extension_not_found_for_different_lease(db: AsyncSession) -> None:
+    """Composite WHERE: version_id on lease A cannot be undone via lease B."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease_a = await _seed_lease_with_seed_version(
+        db, user_id=user_id, org_id=org_id,
+    )
+    lease_b = await _seed_lease_with_seed_version(
+        db, user_id=user_id, org_id=org_id,
+    )
+    version_on_a = await _seed_extension(
+        db, lease=lease_a, user_id=user_id, ends_on=_dt.date(2027, 6, 30),
+    )
+
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), pytest.raises(ExtensionNotFoundError):
+        await undo_extension(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease_b.id,
+            version_id=version_on_a.id,
+        )
+
+
+@pytest.mark.asyncio
+async def test_cross_tenant_lease_returns_not_found(db: AsyncSession) -> None:
+    org_a, user_a = uuid.uuid4(), uuid.uuid4()
+    org_b, user_b = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_lease_with_seed_version(
+        db, user_id=user_a, org_id=org_a,
+    )
+
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), pytest.raises(SignedLeaseNotFoundError):
+        await undo_extension(
+            user_id=user_b,
+            organization_id=org_b,
+            lease_id=lease.id,
+            version_id=uuid.uuid4(),
+        )

--- a/apps/mybookkeeper/frontend/e2e/lease-undo-extension.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/lease-undo-extension.spec.ts
@@ -1,0 +1,206 @@
+import { test, expect, type APIRequestContext } from "./fixtures/auth";
+
+/**
+ * E2E for the 30-day extension undo flow.
+ *
+ * Backend extension service in #560, frontend Extend button in #561, this
+ * PR adds the Undo button gated by the 30-day window.
+ */
+
+async function seedApplicant(
+  api: APIRequestContext,
+  legalName: string,
+): Promise<string> {
+  const res = await api.post("/test/seed-applicant", {
+    data: { legal_name: legalName, stage: "lease_signed" },
+  });
+  if (!res.ok()) {
+    throw new Error(`seedApplicant failed: ${res.status()} ${await res.text()}`);
+  }
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function seedSignedLease(
+  api: APIRequestContext,
+  applicantId: string,
+): Promise<string> {
+  const res = await api.post("/test/seed-signed-lease", {
+    data: {
+      applicant_id: applicantId,
+      kind: "imported",
+      status: "signed",
+      starts_on: "2026-01-01",
+      ends_on: "2026-12-31",
+    },
+  });
+  if (!res.ok()) {
+    throw new Error(
+      `seedSignedLease failed: ${res.status()} ${await res.text()}`,
+    );
+  }
+  return ((await res.json()) as { id: string }).id;
+}
+
+async function extendLease(
+  api: APIRequestContext,
+  leaseId: string,
+  newEndsOn: string,
+): Promise<{ versionId: string }> {
+  const res = await api.post(`/signed-leases/${leaseId}/extend`, {
+    data: { new_ends_on: newEndsOn },
+  });
+  if (!res.ok()) {
+    throw new Error(`extendLease failed: ${res.status()} ${await res.text()}`);
+  }
+  const body = (await res.json()) as {
+    latest_extension: { id: string } | null;
+  };
+  if (!body.latest_extension) {
+    throw new Error("extendLease: no latest_extension on response");
+  }
+  return { versionId: body.latest_extension.id };
+}
+
+async function getLease(
+  api: APIRequestContext,
+  id: string,
+): Promise<{
+  ends_on: string | null;
+  latest_extension: { id: string } | null;
+}> {
+  const res = await api.get(`/signed-leases/${id}`);
+  if (!res.ok()) throw new Error(`getLease failed: ${res.status()}`);
+  return res.json() as Promise<{
+    ends_on: string | null;
+    latest_extension: { id: string } | null;
+  }>;
+}
+
+async function deleteApplicant(
+  api: APIRequestContext, id: string,
+): Promise<void> {
+  await api.delete(`/test/applicants/${id}`).catch(() => {});
+}
+
+async function deleteSignedLease(
+  api: APIRequestContext, id: string,
+): Promise<void> {
+  await api.delete(`/test/signed-leases/${id}`).catch(() => {});
+}
+
+
+test.describe("Lease extension undo", () => {
+  test(
+    "API: POST .../extensions/{id}/undo rolls back ends_on",
+    async ({ api }) => {
+      const runId = Date.now();
+      const applicantId = await seedApplicant(api, `E2E Undo ${runId}`);
+      let leaseId = "";
+      try {
+        leaseId = await seedSignedLease(api, applicantId);
+        const { versionId } = await extendLease(api, leaseId, "2027-06-30");
+
+        const undoRes = await api.post(
+          `/signed-leases/${leaseId}/extensions/${versionId}/undo`,
+        );
+        expect(undoRes.status()).toBe(200);
+        const body = (await undoRes.json()) as {
+          ends_on: string;
+          latest_extension: unknown;
+        };
+        expect(body.ends_on).toBe("2026-12-31");
+        expect(body.latest_extension).toBeNull();
+
+        const fetched = await getLease(api, leaseId);
+        expect(fetched.ends_on).toBe("2026-12-31");
+        expect(fetched.latest_extension).toBeNull();
+      } finally {
+        if (leaseId) await deleteSignedLease(api, leaseId);
+        await deleteApplicant(api, applicantId);
+      }
+    },
+  );
+
+  test(
+    "API: undoing the same extension twice returns 404",
+    async ({ api }) => {
+      const runId = Date.now();
+      const applicantId = await seedApplicant(api, `E2E Undo Twice ${runId}`);
+      let leaseId = "";
+      try {
+        leaseId = await seedSignedLease(api, applicantId);
+        const { versionId } = await extendLease(api, leaseId, "2027-06-30");
+
+        const first = await api.post(
+          `/signed-leases/${leaseId}/extensions/${versionId}/undo`,
+        );
+        expect(first.status()).toBe(200);
+
+        const second = await api.post(
+          `/signed-leases/${leaseId}/extensions/${versionId}/undo`,
+        );
+        // After undo, the version is soft-deleted → not in the live set
+        // → 404 (route maps ExtensionNotFoundError).
+        expect(second.status()).toBe(404);
+      } finally {
+        if (leaseId) await deleteSignedLease(api, leaseId);
+        await deleteApplicant(api, applicantId);
+      }
+    },
+  );
+
+  test(
+    "UI: Undo button on an extended lease rolls back ends_on",
+    async ({ authedPage: page, api }) => {
+      const runId = Date.now();
+      const applicantId = await seedApplicant(api, `E2E Undo UI ${runId}`);
+      let leaseId = "";
+      try {
+        leaseId = await seedSignedLease(api, applicantId);
+        await extendLease(api, leaseId, "2027-06-30");
+
+        await page.goto(`/leases/${leaseId}`);
+        await page.waitForLoadState("networkidle");
+
+        const undoButton = page.getByTestId("lease-undo-extension-button");
+        await expect(undoButton).toBeVisible({ timeout: 10000 });
+        await undoButton.click();
+
+        await expect(
+          page.getByTestId("undo-extension-dialog"),
+        ).toBeVisible();
+        await page.getByTestId("undo-extension-confirm").click();
+
+        await page.waitForLoadState("networkidle");
+
+        const fetched = await getLease(api, leaseId);
+        expect(fetched.ends_on).toBe("2026-12-31");
+        expect(fetched.latest_extension).toBeNull();
+      } finally {
+        if (leaseId) await deleteSignedLease(api, leaseId);
+        await deleteApplicant(api, applicantId);
+      }
+    },
+  );
+
+  test(
+    "UI: Undo button is hidden on a lease with no extension",
+    async ({ authedPage: page, api }) => {
+      const runId = Date.now();
+      const applicantId = await seedApplicant(api, `E2E No Undo ${runId}`);
+      let leaseId = "";
+      try {
+        leaseId = await seedSignedLease(api, applicantId);
+        await page.goto(`/leases/${leaseId}`);
+        await page.waitForLoadState("networkidle");
+
+        await expect(
+          page.getByTestId("lease-undo-extension-button"),
+        ).toHaveCount(0);
+      } finally {
+        if (leaseId) await deleteSignedLease(api, leaseId);
+        await deleteApplicant(api, applicantId);
+      }
+    },
+  );
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
@@ -131,6 +131,7 @@ function buildLease(overrides: Partial<SignedLeaseDetail> = {}): SignedLeaseDeta
     created_at: "2026-05-01T00:00:00Z",
     updated_at: "2026-05-01T00:00:00Z",
     attachments: [],
+    latest_extension: null,
     ...overrides,
   };
 }

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailEmailButton.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailEmailButton.test.tsx
@@ -101,6 +101,7 @@ function buildLease(overrides: Partial<SignedLeaseDetail> = {}): SignedLeaseDeta
     created_at: "2026-05-07T00:00:00Z",
     updated_at: "2026-05-07T00:00:00Z",
     attachments: [buildAttachment()],
+    latest_extension: null,
     ...overrides,
   };
 }

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailRegenerate.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailRegenerate.test.tsx
@@ -74,6 +74,7 @@ function buildLease(overrides: Partial<SignedLeaseDetail> = {}): SignedLeaseDeta
     created_at: "2026-05-01T00:00:00Z",
     updated_at: "2026-05-01T00:00:00Z",
     attachments: [],
+    latest_extension: null,
     ...overrides,
   };
 }

--- a/apps/mybookkeeper/frontend/src/__tests__/UndoExtensionDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/UndoExtensionDialog.test.tsx
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import UndoExtensionDialog from "@/app/features/leases/UndoExtensionDialog";
+
+const mockUndoExtension = vi.fn();
+
+vi.mock("@/shared/store/signedLeasesApi", () => ({
+  useUndoSignedLeaseExtensionMutation: vi.fn(() => [
+    mockUndoExtension,
+    { isLoading: false },
+  ]),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+}));
+
+import { useUndoSignedLeaseExtensionMutation } from "@/shared/store/signedLeasesApi";
+import { showSuccess, showError } from "@/shared/lib/toast-store";
+
+function renderDialog(onClose = vi.fn()) {
+  return render(
+    <Provider store={store}>
+      <UndoExtensionDialog
+        leaseId="lease-1"
+        versionId="version-1"
+        currentExtendedEndsOn="2027-06-30"
+        onClose={onClose}
+      />
+    </Provider>,
+  );
+}
+
+describe("UndoExtensionDialog", () => {
+  beforeEach(() => {
+    vi.mocked(mockUndoExtension).mockReset();
+    vi.mocked(showSuccess).mockReset();
+    vi.mocked(showError).mockReset();
+    vi.mocked(useUndoSignedLeaseExtensionMutation).mockReturnValue([
+      mockUndoExtension,
+      { isLoading: false } as unknown as ReturnType<
+        typeof useUndoSignedLeaseExtensionMutation
+      >[1],
+    ]);
+  });
+
+  it("renders dialog with current extended date and confirm/cancel buttons", () => {
+    renderDialog();
+    expect(
+      screen.getByRole("dialog", { name: "Undo extension" }),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/2027-06-30/)).toBeInTheDocument();
+    expect(screen.getByTestId("undo-extension-confirm")).toBeInTheDocument();
+    expect(screen.getByTestId("undo-extension-cancel")).toBeInTheDocument();
+  });
+
+  it("calls onClose when Cancel is clicked", () => {
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.click(screen.getByTestId("undo-extension-cancel"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("calls undo mutation with leaseId + versionId on Confirm", async () => {
+    mockUndoExtension.mockReturnValueOnce({
+      unwrap: () => Promise.resolve({}),
+    });
+    renderDialog();
+    fireEvent.click(screen.getByTestId("undo-extension-confirm"));
+
+    await waitFor(() => {
+      expect(mockUndoExtension).toHaveBeenCalledWith({
+        leaseId: "lease-1",
+        versionId: "version-1",
+      });
+    });
+  });
+
+  it("shows success toast and closes on success", async () => {
+    mockUndoExtension.mockReturnValueOnce({
+      unwrap: () => Promise.resolve({}),
+    });
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.click(screen.getByTestId("undo-extension-confirm"));
+
+    await waitFor(() => {
+      expect(showSuccess).toHaveBeenCalledWith("Extension undone.");
+      expect(onClose).toHaveBeenCalledOnce();
+    });
+  });
+
+  it.each([
+    [
+      "CANNOT_UNDO_SEED_ROW",
+      "The original lease term can't be undone — it's not an extension.",
+    ],
+    [
+      "NOT_LATEST_EXTENSION",
+      "A newer extension exists. Undo the latest extension first.",
+    ],
+    [
+      "UNDO_WINDOW_EXPIRED",
+      "This extension is older than 30 days and can no longer be undone.",
+    ],
+  ])("surfaces 409 %s as a friendly toast", async (code, message) => {
+    mockUndoExtension.mockReturnValueOnce({
+      unwrap: () =>
+        Promise.reject({
+          status: 409,
+          data: { detail: { code, message: "from-backend" } },
+        }),
+    });
+    const onClose = vi.fn();
+    renderDialog(onClose);
+    fireEvent.click(screen.getByTestId("undo-extension-confirm"));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(message);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  it("surfaces a generic error toast on unknown failure", async () => {
+    mockUndoExtension.mockReturnValueOnce({
+      unwrap: () => Promise.reject(new Error("network")),
+    });
+    renderDialog();
+    fireEvent.click(screen.getByTestId("undo-extension-confirm"));
+
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalledWith(
+        "Couldn't undo the extension. Please try again.",
+      );
+    });
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/leases/UndoExtensionDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/UndoExtensionDialog.tsx
@@ -1,0 +1,124 @@
+import Button from "@/shared/components/ui/Button";
+import LoadingButton from "@/shared/components/ui/LoadingButton";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useUndoSignedLeaseExtensionMutation } from "@/shared/store/signedLeasesApi";
+
+export interface UndoExtensionDialogProps {
+  leaseId: string;
+  versionId: string;
+  /** The end date the latest extension carried — shown for context. */
+  currentExtendedEndsOn: string;
+  onClose: () => void;
+}
+
+interface ConflictDetail {
+  code:
+    | "CANNOT_UNDO_SEED_ROW"
+    | "NOT_LATEST_EXTENSION"
+    | "UNDO_WINDOW_EXPIRED";
+  message: string;
+}
+
+function extractConflictDetail(err: unknown): ConflictDetail | null {
+  if (!err || typeof err !== "object") return null;
+  const e = err as { status?: number; data?: { detail?: unknown } };
+  if (e.status !== 409) return null;
+  const detail = e.data?.detail;
+  if (!detail || typeof detail !== "object") return null;
+  const code = (detail as { code?: unknown }).code;
+  if (
+    code === "CANNOT_UNDO_SEED_ROW"
+    || code === "NOT_LATEST_EXTENSION"
+    || code === "UNDO_WINDOW_EXPIRED"
+  ) {
+    return detail as ConflictDetail;
+  }
+  return null;
+}
+
+function describeConflict(detail: ConflictDetail): string {
+  switch (detail.code) {
+    case "CANNOT_UNDO_SEED_ROW":
+      return "The original lease term can't be undone — it's not an extension.";
+    case "NOT_LATEST_EXTENSION":
+      return "A newer extension exists. Undo the latest extension first.";
+    case "UNDO_WINDOW_EXPIRED":
+      return "This extension is older than 30 days and can no longer be undone.";
+  }
+}
+
+/**
+ * Confirmation dialog for undoing a recent lease extension.
+ *
+ * Matches the EndTenancyDialog pattern (inline modal, no Radix dependency).
+ * The rendered addendum attachment is intentionally preserved as an audit
+ * record — the dialog copy makes that explicit so the host isn't surprised.
+ */
+export default function UndoExtensionDialog({
+  leaseId,
+  versionId,
+  currentExtendedEndsOn,
+  onClose,
+}: UndoExtensionDialogProps) {
+  const [undoExtension, { isLoading }] = useUndoSignedLeaseExtensionMutation();
+
+  async function handleConfirm() {
+    try {
+      await undoExtension({ leaseId, versionId }).unwrap();
+      showSuccess("Extension undone.");
+      onClose();
+    } catch (err) {
+      const conflict = extractConflictDetail(err);
+      if (conflict) {
+        showError(describeConflict(conflict));
+        return;
+      }
+      showError("Couldn't undo the extension. Please try again.");
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-label="Undo extension"
+      aria-modal="true"
+      data-testid="undo-extension-dialog"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4"
+    >
+      <div className="bg-card rounded-lg shadow-lg p-6 w-full max-w-md space-y-4">
+        <h2 className="text-base font-semibold">Undo extension</h2>
+        <p className="text-sm text-muted-foreground">
+          Roll the end date back from{" "}
+          <span className="font-medium text-foreground">
+            {currentExtendedEndsOn}
+          </span>
+          {" "}to the previous term. The rendered addendum stays attached to
+          the lease as an audit record.
+        </p>
+
+        <div className="flex items-center justify-end gap-2 pt-1">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            data-testid="undo-extension-cancel"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <LoadingButton
+            type="button"
+            variant="primary"
+            size="sm"
+            data-testid="undo-extension-confirm"
+            isLoading={isLoading}
+            loadingText="Undoing..."
+            onClick={() => void handleConfirm()}
+          >
+            Undo extension
+          </LoadingButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, CalendarPlus, FileText, Mail, Plus, User } from "lucide-react";
+import { ArrowLeft, CalendarPlus, FileText, Mail, Plus, Undo2, User } from "lucide-react";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import Badge from "@/shared/components/ui/Badge";
@@ -21,6 +21,7 @@ import SignedLeaseStatusPicker from "@/app/features/leases/SignedLeaseStatusPick
 import ExtendLeaseDialog from "@/app/features/leases/ExtendLeaseDialog";
 import LeaseAttachmentsSection from "@/app/features/leases/LeaseAttachmentsSection";
 import LeaseAddTemplateModal from "@/app/features/leases/LeaseAddTemplateModal";
+import UndoExtensionDialog from "@/app/features/leases/UndoExtensionDialog";
 import type { SignedLeaseStatus } from "@/shared/types/lease/signed-lease-status";
 
 type Tab = "files" | "details" | "notes";
@@ -31,6 +32,7 @@ export default function LeaseDetail() {
   const [tab, setTab] = useState<Tab>("files");
   const [showAddTemplateModal, setShowAddTemplateModal] = useState(false);
   const [showExtendDialog, setShowExtendDialog] = useState(false);
+  const [showUndoDialog, setShowUndoDialog] = useState(false);
   const {
     data: lease,
     isLoading,
@@ -63,6 +65,18 @@ export default function LeaseDetail() {
     canWrite
     && (lease?.status === "signed" || lease?.status === "active")
     && Boolean(lease?.ends_on);
+  // Match backend ``UNDO_WINDOW_DAYS``. Kept inline (single use) so the
+  // 30-day rule lives next to the button it gates.
+  const UNDO_WINDOW_DAYS = 30;
+  const latestExtension = lease?.latest_extension ?? null;
+  const ageMs = latestExtension
+    ? Date.now() - new Date(latestExtension.created_at).getTime()
+    : null;
+  const canUndoExtension =
+    canExtend
+    && latestExtension !== null
+    && ageMs !== null
+    && ageMs < UNDO_WINDOW_DAYS * 24 * 60 * 60 * 1000;
 
   async function handleGenerate() {
     if (!lease) return;
@@ -209,6 +223,18 @@ export default function LeaseDetail() {
                     Extend lease
                   </Button>
                 ) : null}
+                {canUndoExtension && latestExtension ? (
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setShowUndoDialog(true)}
+                    data-testid="lease-undo-extension-button"
+                    title="Roll back the latest extension (within 30 days)"
+                  >
+                    <Undo2 size={16} className="mr-1" />
+                    Undo extension
+                  </Button>
+                ) : null}
               </div>
             }
           />
@@ -218,6 +244,15 @@ export default function LeaseDetail() {
               leaseId={lease.id}
               currentEndsOn={lease.ends_on}
               onClose={() => setShowExtendDialog(false)}
+            />
+          ) : null}
+
+          {showUndoDialog && lease && latestExtension ? (
+            <UndoExtensionDialog
+              leaseId={lease.id}
+              versionId={latestExtension.id}
+              currentExtendedEndsOn={latestExtension.ends_on}
+              onClose={() => setShowUndoDialog(false)}
             />
           ) : null}
 

--- a/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/signedLeasesApi.ts
@@ -110,6 +110,20 @@ const signedLeasesApi = baseApi.injectEndpoints({
       ],
     }),
 
+    undoSignedLeaseExtension: builder.mutation<
+      SignedLeaseDetail,
+      { leaseId: string; versionId: string }
+    >({
+      query: ({ leaseId, versionId }) => ({
+        url: `/signed-leases/${leaseId}/extensions/${versionId}/undo`,
+        method: "POST",
+      }),
+      invalidatesTags: (_r, _e, { leaseId }) => [
+        { type: "SignedLease", id: leaseId },
+        { type: "SignedLease", id: "LIST" },
+      ],
+    }),
+
     uploadSignedLeaseAttachment: builder.mutation<
       SignedLeaseAttachment,
       { leaseId: string; file: File; kind: LeaseAttachmentKind }
@@ -221,6 +235,7 @@ export const {
   useGenerateSignedLeaseMutation,
   useEmailSignedLeaseToTenantMutation,
   useExtendSignedLeaseMutation,
+  useUndoSignedLeaseExtensionMutation,
   useUploadSignedLeaseAttachmentMutation,
   useDeleteSignedLeaseAttachmentMutation,
   useImportSignedLeaseMutation,

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/lease-extension-summary.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/lease-extension-summary.ts
@@ -1,0 +1,13 @@
+/**
+ * Mirrors backend ``LeaseExtensionSummary``.
+ *
+ * Exposed on ``SignedLeaseDetail.latest_extension`` for the lease detail
+ * page to gate the Undo button on the 30-day undo window.
+ */
+export interface LeaseExtensionSummary {
+  id: string;
+  created_at: string; // ISO-8601 timestamp
+  starts_on: string;  // YYYY-MM-DD
+  ends_on: string;    // YYYY-MM-DD
+  source_attachment_id: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-detail.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-detail.ts
@@ -1,3 +1,4 @@
+import type { LeaseExtensionSummary } from "@/shared/types/lease/lease-extension-summary";
 import type { SignedLeaseAttachment } from "@/shared/types/lease/signed-lease-attachment";
 import type { SignedLeaseStatus } from "@/shared/types/lease/signed-lease-status";
 import type { SignedLeaseTemplateLink } from "@/shared/types/lease/signed-lease-template-link";
@@ -27,4 +28,7 @@ export interface SignedLeaseDetail {
   created_at: string;
   updated_at: string;
   attachments: SignedLeaseAttachment[];
+  /** The most-recent live extension (seed excluded), or null when the lease
+   *  is at its original term. Drives the Undo button's 30-day gating. */
+  latest_extension: LeaseExtensionSummary | null;
 }


### PR DESCRIPTION
## Summary

Adds the 30-day undo flow for lease extensions. Soft-deletes the ``lease_term_versions`` row, recomputes ``signed_leases.ends_on`` from the now-latest version, and preserves the rendered addendum attachment as an audit record.

This is **PR 3** of the 4-PR lease extension sequence. PR 1a/1b/2a/2b shipped #556, #559, #560, #561.

Design context: ``project_lease_extension_feature_design.md`` decision #2.

## What lands

**Backend**
- ``POST /signed-leases/{lease_id}/extensions/{version_id}/undo`` route with structured 409 error codes:
  - ``CANNOT_UNDO_SEED_ROW`` — version is the original seed term
  - ``NOT_LATEST_EXTENSION`` — a newer extension exists; undo is FIFO
  - ``UNDO_WINDOW_EXPIRED`` — version is >30 days old
- ``lease_extension_service.undo_extension()`` — validates window, refuses seed rows and non-latest extensions, soft-deletes, recomputes ``ends_on`` from next-latest extension OR the seed row.
- ``lease_term_version_repo`` — ``get`` (composite WHERE IDOR guard), ``get_latest_extension``, ``soft_delete``.
- ``LeaseExtensionSummary`` schema + new ``SignedLeaseResponse.latest_extension`` field so the frontend gates the Undo button without a second API call.
- Partial unique indexes on ``lease_term_versions`` now declare ``sqlite_where`` alongside ``postgresql_where`` so the in-memory SQLite test DB enforces the same invariants as Postgres.

**Frontend**
- ``useUndoSignedLeaseExtensionMutation`` with per-lease + LIST cache invalidation.
- ``UndoExtensionDialog`` component (matches EndTenancyDialog pattern) surfaces 409 codes as friendly toasts.
- Undo button on the LeaseDetail action row. Visible when ``latest_extension != null`` AND created within the 30-day window.

## Test plan

- [x] Backend service: happy path, multi-extension rollback, seed-row rejection, non-latest rejection, window-expired rejection, cross-tenant 404, composite-WHERE IDOR guard (7 cases)
- [x] Backend API: 200, 404 (lease + version), 409 for all 3 error codes, 403 viewer, 401 unauth (8 cases)
- [x] Backend full suite: **2687 passed, 5 skipped** (no regressions)
- [x] Frontend vitest: 7 cases incl. parametrised 409 code translation
- [x] Playwright e2e: 4 cases (API roll-back, idempotent 404 on re-undo, UI dialog flow, button hidden when no extension)

## Out of scope

- **PR 4** — Successor-lease creation + auto-end scheduled job

🤖 Generated with [Claude Code](https://claude.com/claude-code)