### PR TITLE
feat(mbk/leases): New lease (successor) button + parent breadcrumbs (PR 4b)

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseAddTemplateModal.test.tsx
@@ -132,6 +132,8 @@ function buildLease(overrides: Partial<SignedLeaseDetail> = {}): SignedLeaseDeta
     updated_at: "2026-05-01T00:00:00Z",
     attachments: [],
     latest_extension: null,
+    parent_lease_id: null,
+    successor_lease_id: null,
     ...overrides,
   };
 }

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailEmailButton.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailEmailButton.test.tsx
@@ -102,6 +102,8 @@ function buildLease(overrides: Partial<SignedLeaseDetail> = {}): SignedLeaseDeta
     updated_at: "2026-05-07T00:00:00Z",
     attachments: [buildAttachment()],
     latest_extension: null,
+    parent_lease_id: null,
+    successor_lease_id: null,
     ...overrides,
   };
 }

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailRegenerate.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailRegenerate.test.tsx
@@ -75,6 +75,8 @@ function buildLease(overrides: Partial<SignedLeaseDetail> = {}): SignedLeaseDeta
     updated_at: "2026-05-01T00:00:00Z",
     attachments: [],
     latest_extension: null,
+    parent_lease_id: null,
+    successor_lease_id: null,
     ...overrides,
   };
 }

--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailSuccessorButton.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseDetailSuccessorButton.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Unit tests for the "New lease" successor button on LeaseDetail.
+ *
+ * Visibility contract (matches the backend's parent-status rules):
+ * - Visible when canWrite AND status ∈ {signed, active, ended} AND
+ *   ``successor_lease_id`` is null.
+ * - Hidden for draft / generated / sent / terminated.
+ * - Hidden when a live successor already exists (the backend would 409;
+ *   the button is the kinder UX).
+ * - Hidden for read-only users.
+ *
+ * Also asserts the parent-link / successor-link breadcrumbs render when
+ * the corresponding fields are set on the response.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Provider } from "react-redux";
+import { store } from "@/shared/store";
+import LeaseDetail from "@/app/pages/LeaseDetail";
+import type { SignedLeaseDetail } from "@/shared/types/lease/signed-lease-detail";
+import type { ApplicantDetailResponse } from "@/shared/types/applicant/applicant-detail-response";
+import type { SignedLeaseStatus } from "@/shared/types/lease/signed-lease-status";
+
+const navigateMock = vi.fn();
+let mockLease: SignedLeaseDetail | undefined;
+let mockApplicant: ApplicantDetailResponse | undefined;
+const useGetSignedLeaseByIdQueryMock = vi.fn();
+const useGetApplicantByIdQueryMock = vi.fn();
+
+vi.mock("@/shared/store/signedLeasesApi", () => ({
+  useGenerateSignedLeaseMutation: () => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve() })),
+    { isLoading: false },
+  ],
+  useUpdateSignedLeaseMutation: () => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve() })),
+    { isLoading: false },
+  ],
+  useEmailSignedLeaseToTenantMutation: () => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve() })),
+    { isLoading: false },
+  ],
+  useExtendSignedLeaseMutation: () => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve() })),
+    { isLoading: false },
+  ],
+  useUndoSignedLeaseExtensionMutation: () => [
+    vi.fn(() => ({ unwrap: () => Promise.resolve() })),
+    { isLoading: false },
+  ],
+  useUploadSignedLeaseAttachmentMutation: () => [
+    vi.fn(),
+    { isLoading: false },
+  ],
+  useDeleteSignedLeaseAttachmentMutation: () => [vi.fn(), {}],
+  useUpdateLeaseAttachmentMutation: () => [vi.fn(), {}],
+  useGetSignedLeaseByIdQuery: (...args: unknown[]) =>
+    useGetSignedLeaseByIdQueryMock(...args),
+}));
+
+vi.mock("@/shared/store/applicantsApi", () => ({
+  useGetApplicantByIdQuery: (...args: unknown[]) =>
+    useGetApplicantByIdQueryMock(...args),
+}));
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+let canWriteValue = true;
+vi.mock("@/shared/hooks/useOrgRole", () => ({
+  useCanWrite: () => canWriteValue,
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>(
+    "react-router-dom",
+  );
+  return { ...actual, useNavigate: () => navigateMock };
+});
+
+function buildLease(
+  overrides: Partial<SignedLeaseDetail> = {},
+): SignedLeaseDetail {
+  return {
+    id: "lease-1",
+    user_id: "user-1",
+    organization_id: "org-1",
+    templates: [],
+    applicant_id: "app-1",
+    listing_id: null,
+    kind: "imported",
+    values: {},
+    status: "signed",
+    starts_on: "2026-01-01",
+    ends_on: "2026-12-31",
+    notes: null,
+    generated_at: null,
+    sent_at: null,
+    signed_at: "2026-01-01T00:00:00Z",
+    ended_at: null,
+    auto_email_tenant: false,
+    last_emailed_to_tenant_at: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    attachments: [],
+    latest_extension: null,
+    parent_lease_id: null,
+    successor_lease_id: null,
+    ...overrides,
+  };
+}
+
+function buildApplicant(): ApplicantDetailResponse {
+  return {
+    id: "app-1",
+    organization_id: "org-1",
+    user_id: "user-1",
+    inquiry_id: null,
+    legal_name: "Jane Doe",
+    dob: null,
+    employer_or_hospital: null,
+    vehicle_make_model: null,
+    contact_email: "tenant@example.com",
+    contact_phone: null,
+    id_document_storage_key: null,
+    contract_start: null,
+    contract_end: null,
+    smoker: null,
+    pets: null,
+    referred_by: null,
+    stage: "lease_signed",
+    tenant_ended_at: null,
+    tenant_ended_reason: null,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    screening_results: [],
+    references: [],
+    video_call_notes: [],
+    events: [],
+  };
+}
+
+function renderDetail() {
+  useGetSignedLeaseByIdQueryMock.mockReturnValue({
+    data: mockLease,
+    isLoading: false,
+    isFetching: false,
+    isError: false,
+    refetch: vi.fn(),
+  });
+  useGetApplicantByIdQueryMock.mockReturnValue({ data: mockApplicant });
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/leases/lease-1"]}>
+        <Routes>
+          <Route path="/leases/:leaseId" element={<LeaseDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+beforeEach(() => {
+  navigateMock.mockClear();
+  canWriteValue = true;
+});
+
+describe("LeaseDetail — New lease (successor) button", () => {
+  it.each<[SignedLeaseStatus, "shown" | "hidden"]>([
+    ["signed", "shown"],
+    ["active", "shown"],
+    ["ended", "shown"],
+    ["draft", "hidden"],
+    ["generated", "hidden"],
+    ["sent", "hidden"],
+    ["terminated", "hidden"],
+  ])("status %s → button %s", (status, expectation) => {
+    mockLease = buildLease({ status });
+    mockApplicant = buildApplicant();
+    renderDetail();
+    const button = screen.queryByTestId("lease-new-successor-button");
+    if (expectation === "shown") {
+      expect(button).toBeInTheDocument();
+    } else {
+      expect(button).toBeNull();
+    }
+  });
+
+  it("is hidden when a live successor already exists", () => {
+    mockLease = buildLease({ successor_lease_id: "successor-1" });
+    mockApplicant = buildApplicant();
+    renderDetail();
+    expect(screen.queryByTestId("lease-new-successor-button")).toBeNull();
+  });
+
+  it("is hidden for read-only users", () => {
+    canWriteValue = false;
+    mockLease = buildLease();
+    mockApplicant = buildApplicant();
+    renderDetail();
+    expect(screen.queryByTestId("lease-new-successor-button")).toBeNull();
+  });
+
+  it("navigates to /leases/new with applicant_id + parent_lease_id when clicked", async () => {
+    mockLease = buildLease();
+    mockApplicant = buildApplicant();
+    renderDetail();
+    const button = screen.getByTestId("lease-new-successor-button");
+    await userEvent.click(button);
+    expect(navigateMock).toHaveBeenCalledWith(
+      "/leases/new?applicant_id=app-1&parent_lease_id=lease-1",
+    );
+  });
+
+  it("renders parent breadcrumb when this lease IS a successor", () => {
+    mockLease = buildLease({ parent_lease_id: "parent-99" });
+    mockApplicant = buildApplicant();
+    renderDetail();
+    const link = screen.getByTestId("lease-parent-link");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/leases/parent-99");
+  });
+
+  it("renders successor breadcrumb when this lease HAS a successor", () => {
+    mockLease = buildLease({ successor_lease_id: "successor-42" });
+    mockApplicant = buildApplicant();
+    renderDetail();
+    const link = screen.getByTestId("lease-successor-link");
+    expect(link).toBeInTheDocument();
+    expect(link.getAttribute("href")).toBe("/leases/successor-42");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/leases/LeaseGenerateForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/leases/LeaseGenerateForm.tsx
@@ -21,6 +21,8 @@ export interface LeaseGenerateFormProps {
   templateLabels?: Record<string, string>;
   applicantId: string;
   listingId?: string | null;
+  /** When set, the new lease is created as a successor to this parent. */
+  parentLeaseId?: string | null;
 }
 
 type ProvenanceMap = Record<string, PlaceholderProvenance>;
@@ -51,6 +53,7 @@ export default function LeaseGenerateForm({
   templateLabels,
   applicantId,
   listingId,
+  parentLeaseId,
 }: LeaseGenerateFormProps) {
   const navigate = useNavigate();
   const [createLease, { isLoading: isCreating }] = useCreateSignedLeaseMutation();
@@ -233,6 +236,7 @@ export default function LeaseGenerateForm({
         applicant_id: applicantId,
         listing_id: listingId ?? null,
         values,
+        ...(parentLeaseId ? { parent_lease_id: parentLeaseId } : {}),
       }).unwrap();
       showSuccess(
         submitTemplateIds.length > 1
@@ -241,9 +245,28 @@ export default function LeaseGenerateForm({
       );
       navigate(`/leases/${created.id}`);
     } catch (e: unknown) {
-      const status = (e as { status?: number }).status;
-      if (status === 422) showError("Some required fields are still missing.");
-      else showError("Couldn't create the lease. Want to try again?");
+      const err = e as {
+        status?: number;
+        data?: { detail?: unknown };
+      };
+      const detail = err.data?.detail;
+      const code =
+        detail && typeof detail === "object"
+          ? (detail as { code?: unknown }).code
+          : undefined;
+      if (code === "INVALID_PARENT_LEASE") {
+        showError(
+          "The parent lease can't have a successor in its current state.",
+        );
+      } else if (code === "SUCCESSOR_ALREADY_EXISTS") {
+        showError(
+          "That lease already has a successor — open the existing one instead.",
+        );
+      } else if (err.status === 422) {
+        showError("Some required fields are still missing.");
+      } else {
+        showError("Couldn't create the lease. Want to try again?");
+      }
     }
   }
 

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -1,6 +1,15 @@
 import { useState } from "react";
-import { Link, useParams } from "react-router-dom";
-import { ArrowLeft, CalendarPlus, FileText, Mail, Plus, Undo2, User } from "lucide-react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import {
+  ArrowLeft,
+  CalendarPlus,
+  FilePlus2,
+  FileText,
+  Mail,
+  Plus,
+  Undo2,
+  User,
+} from "lucide-react";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
 import AlertBox from "@/shared/components/ui/AlertBox";
 import Badge from "@/shared/components/ui/Badge";
@@ -28,6 +37,7 @@ type Tab = "files" | "details" | "notes";
 
 export default function LeaseDetail() {
   const { leaseId } = useParams<{ leaseId: string }>();
+  const navigate = useNavigate();
   const canWrite = useCanWrite();
   const [tab, setTab] = useState<Tab>("files");
   const [showAddTemplateModal, setShowAddTemplateModal] = useState(false);
@@ -77,6 +87,26 @@ export default function LeaseDetail() {
     && latestExtension !== null
     && ageMs !== null
     && ageMs < UNDO_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+  // A successor lease can be created when the parent is far enough along
+  // to be considered "real" (signed / active / ended) AND does not already
+  // have one. ``draft`` / ``generated`` / ``sent`` should still be edited
+  // in place; ``terminated`` is closed-and-final.
+  const canCreateSuccessor =
+    canWrite
+    && lease !== undefined
+    && (
+      lease.status === "signed"
+      || lease.status === "active"
+      || lease.status === "ended"
+    )
+    && lease.successor_lease_id === null;
+
+  function handleCreateSuccessor() {
+    if (!lease) return;
+    navigate(
+      `/leases/new?applicant_id=${lease.applicant_id}&parent_lease_id=${lease.id}`,
+    );
+  }
 
   async function handleGenerate() {
     if (!lease) return;
@@ -235,9 +265,43 @@ export default function LeaseDetail() {
                     Undo extension
                   </Button>
                 ) : null}
+                {canCreateSuccessor ? (
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    onClick={handleCreateSuccessor}
+                    data-testid="lease-new-successor-button"
+                    title="Create a new lease that supersedes this one (rent change, term change, etc.)"
+                  >
+                    <FilePlus2 size={16} className="mr-1" />
+                    New lease
+                  </Button>
+                ) : null}
               </div>
             }
           />
+
+          {lease.parent_lease_id ? (
+            <Link
+              to={`/leases/${lease.parent_lease_id}`}
+              data-testid="lease-parent-link"
+              className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+            >
+              <ArrowLeft className="h-3 w-3" aria-hidden="true" />
+              View prior lease this supersedes
+            </Link>
+          ) : null}
+
+          {lease.successor_lease_id ? (
+            <Link
+              to={`/leases/${lease.successor_lease_id}`}
+              data-testid="lease-successor-link"
+              className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+            >
+              <FilePlus2 className="h-3 w-3" aria-hidden="true" />
+              View successor lease
+            </Link>
+          ) : null}
 
           {showExtendDialog && lease?.ends_on ? (
             <ExtendLeaseDialog

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseNew.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseNew.tsx
@@ -33,6 +33,12 @@ export default function LeaseNew() {
   const urlTemplateIdsParam = searchParams.get("template_ids");
   const urlSingleTemplateId = searchParams.get("template_id");
   const urlApplicantId = searchParams.get("applicant_id");
+  // When the host clicked "New lease" from a parent lease's detail page,
+  // this URL param carries the parent's ID through to the create
+  // mutation. Surfaced via a small banner so the host knows what they're
+  // creating — and submitted to the backend so the new lease is wired
+  // up as a successor.
+  const urlParentLeaseId = searchParams.get("parent_lease_id");
 
   const initialTemplateIds: string[] = useMemo(() => {
     if (urlTemplateIdsParam) {
@@ -147,6 +153,23 @@ export default function LeaseNew() {
         subtitle="Pick one or more templates and an applicant, then fill in the placeholders."
       />
 
+      {urlParentLeaseId ? (
+        <div
+          className="rounded-md border bg-muted/50 px-3 py-2 text-xs"
+          data-testid="lease-new-successor-banner"
+        >
+          Creating a successor to{" "}
+          <Link
+            to={`/leases/${urlParentLeaseId}`}
+            className="font-medium text-primary hover:underline"
+            data-testid="lease-new-parent-link"
+          >
+            the prior lease
+          </Link>
+          . The original stays in place; this new draft becomes the successor.
+        </div>
+      ) : null}
+
       {/* ------------------------------------------------------------------ */}
       {/* Step 1 — Template multi-picker (always visible while picking)       */}
       {/* ------------------------------------------------------------------ */}
@@ -249,6 +272,7 @@ export default function LeaseNew() {
             templateIds={selectedTemplateIds}
             templateLabels={templateLabels}
             applicantId={resolvedApplicantId!}
+            parentLeaseId={urlParentLeaseId}
           />
         </section>
       ) : null}

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-create-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-create-request.ts
@@ -10,4 +10,9 @@ export interface SignedLeaseCreateRequest {
   applicant_id: string;
   listing_id?: string | null;
   values: Record<string, unknown>;
+  /** Optional successor pointer. When set, the parent must exist in the
+   *  caller's tenant, be in status signed/active/ended, and not already
+   *  have a live successor. The backend returns 422 INVALID_PARENT_LEASE
+   *  or 409 SUCCESSOR_ALREADY_EXISTS when the precondition fails. */
+  parent_lease_id?: string | null;
 }

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-detail.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-detail.ts
@@ -31,4 +31,10 @@ export interface SignedLeaseDetail {
   /** The most-recent live extension (seed excluded), or null when the lease
    *  is at its original term. Drives the Undo button's 30-day gating. */
   latest_extension: LeaseExtensionSummary | null;
+  /** When this lease IS a successor, references the prior lease it supersedes. */
+  parent_lease_id: string | null;
+  /** ID of the live successor (a lease whose parent_lease_id points at this
+   *  one). Null when no successor exists yet. Drives the "New lease"
+   *  button's enabled state. */
+  successor_lease_id: string | null;
 }

--- a/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-import-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/lease/signed-lease-import-request.ts
@@ -6,4 +6,6 @@ export interface SignedLeaseImportRequest {
   notes?: string;
   status?: string;
   files: File[];
+  /** Optional successor pointer (same semantics as the create flow). */
+  parent_lease_id?: string;
 }


### PR DESCRIPTION
## Summary

Frontend half of the successor-lease feature. Backend shipped in #563. Adds the "New lease" button on the lease detail page and threads `parent_lease_id` through the `/leases/new` flow.

This is **PR 4b** — the final PR in the 4-PR lease-extension sequence.

## What lands

- **`SignedLeaseDetail`** TS interface now exposes `parent_lease_id` and `successor_lease_id` (matching the backend response added in #563). `SignedLeaseCreateRequest` and `SignedLeaseImportRequest` accept an optional `parent_lease_id`.
- **`LeaseDetail`**:
  - **"New lease" button** on the action row, visible when `canWrite` + status in {signed, active, ended} + no live successor exists. Click navigates to `/leases/new?applicant_id=X&parent_lease_id=Y`.
  - **Breadcrumb links**: "View prior lease this supersedes" (when `parent_lease_id` set) and "View successor lease" (when `successor_lease_id` set).
- **`LeaseNew`** reads `parent_lease_id` from URL search params, renders an explanatory banner ("Creating a successor to the prior lease"), and forwards it to `LeaseGenerateForm`.
- **`LeaseGenerateForm`** accepts a new `parentLeaseId` prop, passes it on the create mutation, and translates the two backend conflict codes to friendly toasts:
  - `INVALID_PARENT_LEASE` → "The parent lease can't have a successor in its current state."
  - `SUCCESSOR_ALREADY_EXISTS` → "That lease already has a successor — open the existing one instead."

## Test plan

- [x] New **`LeaseDetailSuccessorButton.test`** — 10 cases: visibility across all 7 statuses (parametrised), hidden when successor exists, hidden for read-only users, click → navigate with correct URL, parent + successor breadcrumbs render with correct hrefs.
- [x] Existing fixtures updated with `parent_lease_id: null` / `successor_lease_id: null` so `tsc -b` passes.
- [ ] CI build / vitest (this PR — relies on CI to confirm)

## Closes the feature

This PR closes the 4-PR lease-extension sequence per `project_lease_extension_feature_design.md`:

| Sub-PR | Status |
|---|---|
| 1a (#556) — schema foundation | ✅ |
| 1b (#559) — contract_end derived | ✅ |
| 2a (#560) — extend backend | ✅ |
| 2b (#561) — extend UI | ✅ |
| 3 (#562) — 30-day undo | ✅ |
| 4a (#563) — successor backend | ✅ |
| 4b (this PR) — successor UI | 🟡 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)