### PR TITLE
feat(mjh/discover): Saved tab + error branches

### DIFF
--- a/apps/myjobhunter/frontend/e2e/discover.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/discover.spec.ts
@@ -1,0 +1,91 @@
+import { test, expect } from "@playwright/test";
+import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
+
+test.describe("Discover page", () => {
+  test("shows Inbox and Saved tabs; Saved tab empty state is visible", async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request);
+
+    try {
+      await loginViaUI(page, user, request);
+
+      // Navigate to Discover
+      await page.goto("/discover");
+      await page.waitForURL("**/discover");
+
+      // Both tabs are visible
+      await expect(page.getByRole("tab", { name: "Inbox" })).toBeVisible();
+      await expect(page.getByRole("tab", { name: "Saved" })).toBeVisible();
+
+      // Inbox tab is active by default
+      await expect(page.getByRole("tab", { name: "Inbox" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      // No saved searches yet — inbox shows the no-saved-searches empty state
+      await expect(
+        page.getByRole("heading", { name: "No saved searches yet" }),
+      ).toBeVisible();
+
+      // Switch to Saved tab
+      await page.getByRole("tab", { name: "Saved" }).click();
+
+      // URL now has ?view=saved
+      await expect(page).toHaveURL(/\?view=saved/);
+
+      // Saved tab is now active
+      await expect(page.getByRole("tab", { name: "Saved" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      // Saved empty state is shown
+      await expect(
+        page.getByRole("heading", { name: "No saved jobs" }),
+      ).toBeVisible();
+      await expect(
+        page.getByText(/When you save a posting from the inbox/),
+      ).toBeVisible();
+
+      // Switch back to Inbox — URL param is removed
+      await page.getByRole("tab", { name: "Inbox" }).click();
+      await expect(page).not.toHaveURL(/\?view=saved/);
+      await expect(page.getByRole("tab", { name: "Inbox" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    } finally {
+      await deleteTestUser(request, user);
+    }
+  });
+
+  test("deep-linking to ?view=saved opens the Saved tab directly", async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request);
+
+    try {
+      await loginViaUI(page, user, request);
+
+      // Navigate directly to the saved view
+      await page.goto("/discover?view=saved");
+      await page.waitForURL("**/discover**");
+
+      // Saved tab is immediately active
+      await expect(page.getByRole("tab", { name: "Saved" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      await expect(
+        page.getByRole("heading", { name: "No saved jobs" }),
+      ).toBeVisible();
+    } finally {
+      await deleteTestUser(request, user);
+    }
+  });
+});

--- a/apps/myjobhunter/frontend/src/constants/empty-states.ts
+++ b/apps/myjobhunter/frontend/src/constants/empty-states.ts
@@ -14,7 +14,10 @@ export interface EmptyStateCopyNoAction {
   body: string;
 }
 
-export const DISCOVER_EMPTY_STATES: Record<"no_saved_searches" | "inbox_empty", EmptyStateCopyNoAction> = {
+export const DISCOVER_EMPTY_STATES: Record<
+  "no_saved_searches" | "inbox_empty" | "saved_empty",
+  EmptyStateCopyNoAction
+> = {
   no_saved_searches: {
     iconName: "Telescope",
     heading: "No saved searches yet",
@@ -27,6 +30,11 @@ export const DISCOVER_EMPTY_STATES: Record<"no_saved_searches" | "inbox_empty", 
     iconName: "Telescope",
     heading: "Inbox empty",
     body: "Click Refresh on a saved search above to fetch the latest postings.",
+  },
+  saved_empty: {
+    iconName: "Telescope",
+    heading: "No saved jobs",
+    body: "When you save a posting from the inbox it shows up here — hold it until you're ready to apply.",
   },
 };
 

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
@@ -1,0 +1,64 @@
+import { Telescope } from "lucide-react";
+import { EmptyState } from "@platform/ui";
+import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
+import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
+import DiscoveredJobsSkeleton from "@/features/discover/DiscoveredJobsSkeleton";
+import { useListDiscoveredJobsQuery } from "@/store/discoverApi";
+
+// Background scoring runs after /refresh as a FastAPI BackgroundTask
+// (~30s for 20 postings). Poll while the inbox is visible so score badges
+// fill in without the operator refreshing manually.
+const INBOX_POLL_INTERVAL_MS = 4000;
+
+interface DiscoverInboxViewProps {
+  hasSources: boolean;
+}
+
+export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps) {
+  const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery(
+    { state: "inbox" },
+    { pollingInterval: INBOX_POLL_INTERVAL_MS },
+  );
+
+  if (!hasSources) {
+    return (
+      <EmptyState
+        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+        heading={DISCOVER_EMPTY_STATES.no_saved_searches.heading}
+        body={DISCOVER_EMPTY_STATES.no_saved_searches.body}
+      />
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">
+        Couldn't load the inbox — try refreshing the page.
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return <DiscoveredJobsSkeleton />;
+  }
+
+  const items = jobsData?.items ?? [];
+
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+        heading={DISCOVER_EMPTY_STATES.inbox_empty.heading}
+        body={DISCOVER_EMPTY_STATES.inbox_empty.body}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((job) => (
+        <DiscoveredJobCard key={job.id} job={job} />
+      ))}
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverSavedView.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverSavedView.tsx
@@ -1,0 +1,44 @@
+import { Telescope } from "lucide-react";
+import { EmptyState } from "@platform/ui";
+import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
+import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
+import DiscoveredJobsSkeleton from "@/features/discover/DiscoveredJobsSkeleton";
+import { useListDiscoveredJobsQuery } from "@/store/discoverApi";
+
+export default function DiscoverSavedView() {
+  const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery({
+    state: "saved",
+  });
+
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">
+        Couldn't load saved jobs — try refreshing the page.
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return <DiscoveredJobsSkeleton />;
+  }
+
+  const items = jobsData?.items ?? [];
+
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+        heading={DISCOVER_EMPTY_STATES.saved_empty.heading}
+        body={DISCOVER_EMPTY_STATES.saved_empty.body}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((job) => (
+        <DiscoveredJobCard key={job.id} job={job} />
+      ))}
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverTabButton.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverTabButton.tsx
@@ -1,0 +1,32 @@
+import type { DiscoverView } from "@/types/discovery/discover-view";
+
+export interface DiscoverTabButtonProps {
+  label: string;
+  view: DiscoverView;
+  activeView: DiscoverView;
+  onSelect: (view: DiscoverView) => void;
+}
+
+export default function DiscoverTabButton({
+  label,
+  view,
+  activeView,
+  onSelect,
+}: DiscoverTabButtonProps) {
+  const isActive = view === activeView;
+  return (
+    <button
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => onSelect(view)}
+      className={[
+        "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+        isActive
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverViewTabs.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverViewTabs.tsx
@@ -1,11 +1,15 @@
+import DiscoverTabButton from "@/features/discover/DiscoverTabButton";
 import type { DiscoverView } from "@/types/discovery/discover-view";
 
-interface ViewTabsProps {
+interface DiscoverViewTabsProps {
   activeView: DiscoverView;
   onSelect: (view: DiscoverView) => void;
 }
 
-export default function DiscoverViewTabs({ activeView, onSelect }: ViewTabsProps) {
+export default function DiscoverViewTabs({
+  activeView,
+  onSelect,
+}: DiscoverViewTabsProps) {
   return (
     <div
       role="tablist"
@@ -25,31 +29,5 @@ export default function DiscoverViewTabs({ activeView, onSelect }: ViewTabsProps
         onSelect={onSelect}
       />
     </div>
-  );
-}
-
-interface TabButtonProps {
-  label: string;
-  view: DiscoverView;
-  activeView: DiscoverView;
-  onSelect: (view: DiscoverView) => void;
-}
-
-function DiscoverTabButton({ label, view, activeView, onSelect }: TabButtonProps) {
-  const isActive = view === activeView;
-  return (
-    <button
-      role="tab"
-      aria-selected={isActive}
-      onClick={() => onSelect(view)}
-      className={[
-        "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-        isActive
-          ? "border-primary text-foreground"
-          : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
-      ].join(" ")}
-    >
-      {label}
-    </button>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverViewTabs.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverViewTabs.tsx
@@ -1,0 +1,55 @@
+import type { DiscoverView } from "@/types/discovery/discover-view";
+
+interface ViewTabsProps {
+  activeView: DiscoverView;
+  onSelect: (view: DiscoverView) => void;
+}
+
+export default function DiscoverViewTabs({ activeView, onSelect }: ViewTabsProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Discover views"
+      className="flex gap-1 border-b border-border"
+    >
+      <DiscoverTabButton
+        label="Inbox"
+        view="inbox"
+        activeView={activeView}
+        onSelect={onSelect}
+      />
+      <DiscoverTabButton
+        label="Saved"
+        view="saved"
+        activeView={activeView}
+        onSelect={onSelect}
+      />
+    </div>
+  );
+}
+
+interface TabButtonProps {
+  label: string;
+  view: DiscoverView;
+  activeView: DiscoverView;
+  onSelect: (view: DiscoverView) => void;
+}
+
+function DiscoverTabButton({ label, view, activeView, onSelect }: TabButtonProps) {
+  const isActive = view === activeView;
+  return (
+    <button
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => onSelect(view)}
+      className={[
+        "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+        isActive
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchRow.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchRow.tsx
@@ -1,0 +1,101 @@
+import { AlertTriangle, RefreshCw, Trash2 } from "lucide-react";
+import {
+  Badge,
+  Button,
+  Card,
+  LoadingButton,
+  showError,
+  showSuccess,
+  timeAgo,
+  extractErrorMessage,
+} from "@platform/ui";
+import {
+  useDeactivateDiscoverySourceMutation,
+  useRefreshDiscoverySourceMutation,
+} from "@/store/discoverApi";
+import type { DiscoverySource } from "@/types/discovery/discovery-source";
+import { summarizeSearchQuery } from "./saved-search-summary";
+
+interface SavedSearchRowProps {
+  source: DiscoverySource;
+}
+
+export default function SavedSearchRow({ source }: SavedSearchRowProps) {
+  const [refresh, { isLoading: isRefreshing }] = useRefreshDiscoverySourceMutation();
+  const [deactivate, { isLoading: isDeactivating }] = useDeactivateDiscoverySourceMutation();
+
+  const query = summarizeSearchQuery(source.config ?? {});
+  const lastFetched = source.last_fetched_at
+    ? `Last fetched ${timeAgo(source.last_fetched_at)}`
+    : "Never fetched";
+
+  async function handleRefresh() {
+    try {
+      const result = await refresh(source.id).unwrap();
+      if (result.status === "success") {
+        showSuccess(
+          `Fetched ${result.fetched_count} posting${
+            result.fetched_count === 1 ? "" : "s"
+          } (${result.new_count} new)`,
+        );
+      } else if (result.error_message) {
+        showError(result.error_message);
+      }
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Refresh failed");
+    }
+  }
+
+  async function handleDeactivate() {
+    try {
+      await deactivate(source.id).unwrap();
+      showSuccess("Saved search removed");
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Couldn't remove saved search");
+    }
+  }
+
+  const isFailing = source.consecutive_failures > 0;
+
+  return (
+    <Card className="p-3 flex items-center justify-between gap-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <Badge label={source.source} color="gray" />
+          <span className="font-medium truncate text-sm">{query}</span>
+          {isFailing && (
+            <span className="inline-flex items-center gap-1 text-xs font-medium text-destructive shrink-0">
+              <AlertTriangle className="w-3 h-3" aria-hidden="true" />
+              Fetch failed
+            </span>
+          )}
+        </div>
+        <p className="text-xs text-muted-foreground mt-1">
+          {lastFetched}
+          {source.last_error_message ? ` — ${source.last_error_message}` : ""}
+        </p>
+      </div>
+      <div className="flex items-center gap-1 shrink-0">
+        <LoadingButton
+          size="sm"
+          variant="secondary"
+          isLoading={isRefreshing}
+          loadingText="Fetching…"
+          onClick={handleRefresh}
+        >
+          <RefreshCw className="w-4 h-4 mr-1" />
+          Refresh
+        </LoadingButton>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={handleDeactivate}
+          disabled={isDeactivating}
+          aria-label="Remove saved search"
+        >
+          <Trash2 className="w-4 h-4" />
+        </Button>
+      </div>
+    </Card>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
@@ -1,22 +1,6 @@
-import { AlertTriangle, RefreshCw, Trash2 } from "lucide-react";
-import {
-  Badge,
-  Button,
-  Card,
-  LoadingButton,
-  showError,
-  showSuccess,
-  timeAgo,
-  extractErrorMessage,
-} from "@platform/ui";
 import SavedSearchesSkeleton from "@/features/discover/SavedSearchesSkeleton";
-import {
-  useDeactivateDiscoverySourceMutation,
-  useListDiscoverySourcesQuery,
-  useRefreshDiscoverySourceMutation,
-} from "@/store/discoverApi";
-import type { DiscoverySource } from "@/types/discovery/discovery-source";
-import { summarizeSearchQuery } from "./saved-search-summary";
+import SavedSearchRow from "@/features/discover/SavedSearchRow";
+import { useListDiscoverySourcesQuery } from "@/store/discoverApi";
 
 export default function SavedSearchesPanel() {
   const { data: sources, isLoading, isError } = useListDiscoverySourcesQuery();
@@ -44,85 +28,5 @@ export default function SavedSearchesPanel() {
         <SavedSearchRow key={source.id} source={source} />
       ))}
     </div>
-  );
-}
-
-function SavedSearchRow({ source }: { source: DiscoverySource }) {
-  const [refresh, { isLoading: isRefreshing }] = useRefreshDiscoverySourceMutation();
-  const [deactivate, { isLoading: isDeactivating }] = useDeactivateDiscoverySourceMutation();
-
-  const query = summarizeSearchQuery(source.config ?? {});
-  const lastFetched = source.last_fetched_at
-    ? `Last fetched ${timeAgo(source.last_fetched_at)}`
-    : "Never fetched";
-
-  async function handleRefresh() {
-    try {
-      const result = await refresh(source.id).unwrap();
-      if (result.status === "success") {
-        showSuccess(
-          `Fetched ${result.fetched_count} posting${
-            result.fetched_count === 1 ? "" : "s"
-          } (${result.new_count} new)`,
-        );
-      } else if (result.error_message) {
-        showError(result.error_message);
-      }
-    } catch (err) {
-      showError(extractErrorMessage(err) ?? "Refresh failed");
-    }
-  }
-
-  async function handleDeactivate() {
-    try {
-      await deactivate(source.id).unwrap();
-      showSuccess("Saved search removed");
-    } catch (err) {
-      showError(extractErrorMessage(err) ?? "Couldn't remove saved search");
-    }
-  }
-
-  const isFailing = source.consecutive_failures > 0;
-
-  return (
-    <Card className="p-3 flex items-center justify-between gap-3">
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center gap-2">
-          <Badge label={source.source} color="gray" />
-          <span className="font-medium truncate text-sm">{query}</span>
-          {isFailing && (
-            <span className="inline-flex items-center gap-1 text-xs font-medium text-destructive shrink-0">
-              <AlertTriangle className="w-3 h-3" aria-hidden="true" />
-              Fetch failed
-            </span>
-          )}
-        </div>
-        <p className="text-xs text-muted-foreground mt-1">
-          {lastFetched}
-          {source.last_error_message ? ` — ${source.last_error_message}` : ""}
-        </p>
-      </div>
-      <div className="flex items-center gap-1 shrink-0">
-        <LoadingButton
-          size="sm"
-          variant="secondary"
-          isLoading={isRefreshing}
-          loadingText="Fetching…"
-          onClick={handleRefresh}
-        >
-          <RefreshCw className="w-4 h-4 mr-1" />
-          Refresh
-        </LoadingButton>
-        <Button
-          size="sm"
-          variant="ghost"
-          onClick={handleDeactivate}
-          disabled={isDeactivating}
-          aria-label="Remove saved search"
-        >
-          <Trash2 className="w-4 h-4" />
-        </Button>
-      </div>
-    </Card>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchesPanel.tsx
@@ -1,4 +1,4 @@
-import { RefreshCw, Trash2 } from "lucide-react";
+import { AlertTriangle, RefreshCw, Trash2 } from "lucide-react";
 import {
   Badge,
   Button,
@@ -19,10 +19,17 @@ import type { DiscoverySource } from "@/types/discovery/discovery-source";
 import { summarizeSearchQuery } from "./saved-search-summary";
 
 export default function SavedSearchesPanel() {
-  const { data: sources, isLoading } = useListDiscoverySourcesQuery();
+  const { data: sources, isLoading, isError } = useListDiscoverySourcesQuery();
 
   if (isLoading) {
     return <SavedSearchesSkeleton />;
+  }
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">
+        Couldn't load saved searches — try refreshing the page.
+      </p>
+    );
   }
   if (!sources || sources.length === 0) {
     return null;
@@ -75,16 +82,24 @@ function SavedSearchRow({ source }: { source: DiscoverySource }) {
     }
   }
 
+  const isFailing = source.consecutive_failures > 0;
+
   return (
     <Card className="p-3 flex items-center justify-between gap-3">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
           <Badge label={source.source} color="gray" />
           <span className="font-medium truncate text-sm">{query}</span>
+          {isFailing && (
+            <span className="inline-flex items-center gap-1 text-xs font-medium text-destructive shrink-0">
+              <AlertTriangle className="w-3 h-3" aria-hidden="true" />
+              Fetch failed
+            </span>
+          )}
         </div>
         <p className="text-xs text-muted-foreground mt-1">
           {lastFetched}
-          {source.last_error_message ? ` — error: ${source.last_error_message}` : ""}
+          {source.last_error_message ? ` — ${source.last_error_message}` : ""}
         </p>
       </div>
       <div className="flex items-center gap-1 shrink-0">

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/SavedSearchesPanel.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/SavedSearchesPanel.test.tsx
@@ -1,0 +1,188 @@
+/**
+ * Tests for SavedSearchesPanel — error state and "Fetch failed" badge
+ * when consecutive_failures > 0.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import SavedSearchesPanel from "../SavedSearchesPanel";
+import type { DiscoverySource } from "@/types/discovery/discovery-source";
+
+vi.mock("@/store/discoverApi", () => ({
+  useListDiscoverySourcesQuery: vi.fn(),
+  useRefreshDiscoverySourceMutation: vi.fn(),
+  useDeactivateDiscoverySourceMutation: vi.fn(),
+}));
+
+vi.mock("lucide-react", () => ({
+  AlertTriangle: () => <svg data-testid="alert-icon" />,
+  RefreshCw: () => null,
+  Trash2: () => null,
+}));
+
+vi.mock("@platform/ui", () => ({
+  Badge: ({ label }: { label: string }) => (
+    <span data-testid="badge">{label}</span>
+  ),
+  Button: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  Card: ({
+    children,
+    className,
+  }: {
+    children: React.ReactNode;
+    className?: string;
+  }) => <div className={className}>{children}</div>,
+  LoadingButton: ({
+    children,
+    onClick,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onClick?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button onClick={onClick} disabled={disabled}>
+      {children}
+    </button>
+  ),
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+  timeAgo: () => "2 hours ago",
+  extractErrorMessage: vi.fn(),
+  Skeleton: () => <div data-testid="skeleton" />,
+}));
+
+vi.mock("../SavedSearchesSkeleton", () => ({
+  default: () => <div data-testid="sources-skeleton" />,
+}));
+
+vi.mock("../saved-search-summary", () => ({
+  summarizeSearchQuery: () => "Software Engineer — Remote",
+}));
+
+import {
+  useListDiscoverySourcesQuery,
+  useRefreshDiscoverySourceMutation,
+  useDeactivateDiscoverySourceMutation,
+} from "@/store/discoverApi";
+
+const mockListSources = vi.mocked(useListDiscoverySourcesQuery);
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stubMutation = [vi.fn(), { isLoading: false }] as any;
+
+function makeSource(
+  overrides: Partial<DiscoverySource> = {},
+): DiscoverySource {
+  return {
+    id: "src-1",
+    source: "jsearch",
+    config: {},
+    is_active: true,
+    fetch_interval_minutes: 60,
+    last_fetched_at: null,
+    last_success_at: null,
+    last_error_at: null,
+    last_error_message: null,
+    consecutive_failures: 0,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("SavedSearchesPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useRefreshDiscoverySourceMutation).mockReturnValue(stubMutation);
+    vi.mocked(useDeactivateDiscoverySourceMutation).mockReturnValue(
+      stubMutation,
+    );
+  });
+
+  it("shows skeleton while loading", () => {
+    mockListSources.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+
+    render(<SavedSearchesPanel />);
+
+    expect(screen.getByTestId("sources-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows error message when sources query fails", () => {
+    mockListSources.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+
+    render(<SavedSearchesPanel />);
+
+    expect(
+      screen.getByText(/Couldn't load saved searches/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when sources list is empty", () => {
+    mockListSources.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+
+    const { container } = render(<SavedSearchesPanel />);
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders source rows when sources exist", () => {
+    mockListSources.mockReturnValue({
+      data: [makeSource()],
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+
+    render(<SavedSearchesPanel />);
+
+    expect(screen.getByText("Software Engineer — Remote")).toBeInTheDocument();
+  });
+
+  it("shows 'Fetch failed' badge when consecutive_failures > 0", () => {
+    mockListSources.mockReturnValue({
+      data: [makeSource({ consecutive_failures: 3 })],
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+
+    render(<SavedSearchesPanel />);
+
+    expect(screen.getByText("Fetch failed")).toBeInTheDocument();
+    expect(screen.getByTestId("alert-icon")).toBeInTheDocument();
+  });
+
+  it("does NOT show 'Fetch failed' badge when consecutive_failures is 0", () => {
+    mockListSources.mockReturnValue({
+      data: [makeSource({ consecutive_failures: 0 })],
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+
+    render(<SavedSearchesPanel />);
+
+    expect(screen.queryByText("Fetch failed")).toBeNull();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/SavedSearchesPanel.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/SavedSearchesPanel.test.tsx
@@ -79,8 +79,14 @@ import {
 
 const mockListSources = vi.mocked(useListDiscoverySourcesQuery);
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const stubMutation = [vi.fn(), { isLoading: false }] as any;
+// Stub mutations as unknown casts — the actual return type differs per hook
+// but the tests never invoke the trigger so the shape doesn't matter.
+const stubRefreshMutation = [vi.fn(), { isLoading: false }] as unknown as ReturnType<
+  typeof useRefreshDiscoverySourceMutation
+>;
+const stubDeactivateMutation = [vi.fn(), { isLoading: false }] as unknown as ReturnType<
+  typeof useDeactivateDiscoverySourceMutation
+>;
 
 function makeSource(
   overrides: Partial<DiscoverySource> = {},
@@ -105,9 +111,9 @@ function makeSource(
 describe("SavedSearchesPanel", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(useRefreshDiscoverySourceMutation).mockReturnValue(stubMutation);
+    vi.mocked(useRefreshDiscoverySourceMutation).mockReturnValue(stubRefreshMutation);
     vi.mocked(useDeactivateDiscoverySourceMutation).mockReturnValue(
-      stubMutation,
+      stubDeactivateMutation,
     );
   });
 

--- a/apps/myjobhunter/frontend/src/pages/Discover.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Discover.tsx
@@ -1,5 +1,5 @@
-import { useState } from "react";
 import { Plus, Telescope } from "lucide-react";
+import { useSearchParams } from "react-router-dom";
 import { Button, EmptyState } from "@platform/ui";
 import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
 import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
@@ -10,11 +10,15 @@ import {
   useListDiscoveredJobsQuery,
   useListDiscoverySourcesQuery,
 } from "@/store/discoverApi";
+import { useState } from "react";
 
 // Background scoring runs after /refresh as a FastAPI BackgroundTask
 // (~30s for 20 postings). Poll the inbox at 4s while the page is open
 // so score badges fill in without the operator refreshing manually.
+// Only poll when viewing the inbox — saved view is stable between refreshes.
 const INBOX_POLL_INTERVAL_MS = 4000;
+
+type DiscoverView = "inbox" | "saved";
 
 /**
  * /discover — proactive job-posting inbox.
@@ -23,27 +27,33 @@ const INBOX_POLL_INTERVAL_MS = 4000;
  * Google Jobs only) into a triage list. The operator clicks "Save",
  * "Dismiss", or the external "Open" link per posting.
  *
- * MVP scope (PR 5):
- * - Single inbox view (no master-detail, no keyboard shortcuts)
- * - Saved-search creation via inline dialog (no separate /preferences page)
- * - Manual "Refresh" per saved search (no auto-scheduler yet)
- * - No scoring UI (backend score() endpoint not yet wired in v1)
- * - No promote-to-application yet (operator clicks the external Open
- *   link, applies on the source, manually creates an Application via
- *   /applications when ready)
+ * Tab state lives in ?view=inbox (default) | ?view=saved so deep-linking
+ * and back-button work correctly.
  */
 export default function Discover() {
   const [dialogOpen, setDialogOpen] = useState(false);
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const rawView = searchParams.get("view");
+  const activeView: DiscoverView = rawView === "saved" ? "saved" : "inbox";
+
+  function setView(view: DiscoverView) {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (view === "inbox") {
+          next.delete("view");
+        } else {
+          next.set("view", view);
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  }
 
   const { data: sources } = useListDiscoverySourcesQuery();
-  const { data: jobsData, isLoading } = useListDiscoveredJobsQuery(
-    {},
-    { pollingInterval: INBOX_POLL_INTERVAL_MS },
-  );
-
   const hasSources = (sources?.length ?? 0) > 0;
-  const items = jobsData?.items ?? [];
-  const hasJobs = items.length > 0;
 
   return (
     <main className="p-4 sm:p-8 space-y-6">
@@ -63,30 +73,12 @@ export default function Discover() {
 
       <SavedSearchesPanel />
 
-      {!hasSources && (
-        <EmptyState
-          icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
-          heading={DISCOVER_EMPTY_STATES.no_saved_searches.heading}
-          body={DISCOVER_EMPTY_STATES.no_saved_searches.body}
-        />
-      )}
+      <ViewTabs activeView={activeView} onSelect={setView} />
 
-      {hasSources && isLoading && <DiscoveredJobsSkeleton />}
-
-      {hasSources && !isLoading && !hasJobs && (
-        <EmptyState
-          icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
-          heading={DISCOVER_EMPTY_STATES.inbox_empty.heading}
-          body={DISCOVER_EMPTY_STATES.inbox_empty.body}
-        />
-      )}
-
-      {hasJobs && (
-        <div className="space-y-3">
-          {items.map((job) => (
-            <DiscoveredJobCard key={job.id} job={job} />
-          ))}
-        </div>
+      {activeView === "inbox" ? (
+        <InboxView hasSources={hasSources} />
+      ) : (
+        <SavedView />
       )}
 
       <NewSavedSearchDialog
@@ -94,5 +86,162 @@ export default function Discover() {
         onClose={() => setDialogOpen(false)}
       />
     </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tab bar
+// ---------------------------------------------------------------------------
+
+interface ViewTabsProps {
+  activeView: DiscoverView;
+  onSelect: (view: DiscoverView) => void;
+}
+
+function ViewTabs({ activeView, onSelect }: ViewTabsProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Discover views"
+      className="flex gap-1 border-b border-border"
+    >
+      <TabButton
+        label="Inbox"
+        view="inbox"
+        activeView={activeView}
+        onSelect={onSelect}
+      />
+      <TabButton
+        label="Saved"
+        view="saved"
+        activeView={activeView}
+        onSelect={onSelect}
+      />
+    </div>
+  );
+}
+
+interface TabButtonProps {
+  label: string;
+  view: DiscoverView;
+  activeView: DiscoverView;
+  onSelect: (view: DiscoverView) => void;
+}
+
+function TabButton({ label, view, activeView, onSelect }: TabButtonProps) {
+  const isActive = view === activeView;
+  return (
+    <button
+      role="tab"
+      aria-selected={isActive}
+      onClick={() => onSelect(view)}
+      className={[
+        "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+        isActive
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inbox view
+// ---------------------------------------------------------------------------
+
+interface InboxViewProps {
+  hasSources: boolean;
+}
+
+function InboxView({ hasSources }: InboxViewProps) {
+  const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery(
+    { state: "inbox" },
+    { pollingInterval: INBOX_POLL_INTERVAL_MS },
+  );
+
+  if (!hasSources) {
+    return (
+      <EmptyState
+        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+        heading={DISCOVER_EMPTY_STATES.no_saved_searches.heading}
+        body={DISCOVER_EMPTY_STATES.no_saved_searches.body}
+      />
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">
+        Couldn't load the inbox — try refreshing the page.
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return <DiscoveredJobsSkeleton />;
+  }
+
+  const items = jobsData?.items ?? [];
+
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+        heading={DISCOVER_EMPTY_STATES.inbox_empty.heading}
+        body={DISCOVER_EMPTY_STATES.inbox_empty.body}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((job) => (
+        <DiscoveredJobCard key={job.id} job={job} />
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Saved view
+// ---------------------------------------------------------------------------
+
+function SavedView() {
+  const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery({
+    state: "saved",
+  });
+
+  if (isError) {
+    return (
+      <p className="text-sm text-destructive">
+        Couldn't load saved jobs — try refreshing the page.
+      </p>
+    );
+  }
+
+  if (isLoading) {
+    return <DiscoveredJobsSkeleton />;
+  }
+
+  const items = jobsData?.items ?? [];
+
+  if (items.length === 0) {
+    return (
+      <EmptyState
+        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+        heading={DISCOVER_EMPTY_STATES.saved_empty.heading}
+        body={DISCOVER_EMPTY_STATES.saved_empty.body}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      {items.map((job) => (
+        <DiscoveredJobCard key={job.id} job={job} />
+      ))}
+    </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/Discover.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Discover.tsx
@@ -1,24 +1,14 @@
-import { Plus, Telescope } from "lucide-react";
+import { useState } from "react";
+import { Plus } from "lucide-react";
 import { useSearchParams } from "react-router-dom";
-import { Button, EmptyState } from "@platform/ui";
-import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
-import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
-import DiscoveredJobsSkeleton from "@/features/discover/DiscoveredJobsSkeleton";
+import { Button } from "@platform/ui";
+import DiscoverInboxView from "@/features/discover/DiscoverInboxView";
+import DiscoverSavedView from "@/features/discover/DiscoverSavedView";
+import DiscoverViewTabs from "@/features/discover/DiscoverViewTabs";
 import NewSavedSearchDialog from "@/features/discover/NewSavedSearchDialog";
 import SavedSearchesPanel from "@/features/discover/SavedSearchesPanel";
-import {
-  useListDiscoveredJobsQuery,
-  useListDiscoverySourcesQuery,
-} from "@/store/discoverApi";
-import { useState } from "react";
-
-// Background scoring runs after /refresh as a FastAPI BackgroundTask
-// (~30s for 20 postings). Poll the inbox at 4s while the page is open
-// so score badges fill in without the operator refreshing manually.
-// Only poll when viewing the inbox — saved view is stable between refreshes.
-const INBOX_POLL_INTERVAL_MS = 4000;
-
-type DiscoverView = "inbox" | "saved";
+import { useListDiscoverySourcesQuery } from "@/store/discoverApi";
+import type { DiscoverView } from "@/types/discovery/discover-view";
 
 /**
  * /discover — proactive job-posting inbox.
@@ -29,6 +19,15 @@ type DiscoverView = "inbox" | "saved";
  *
  * Tab state lives in ?view=inbox (default) | ?view=saved so deep-linking
  * and back-button work correctly.
+ *
+ * MVP scope (PR 5):
+ * - Inbox / Saved tab toggle
+ * - Saved-search creation via inline dialog (no separate /preferences page)
+ * - Manual "Refresh" per saved search (no auto-scheduler yet)
+ * - No scoring UI (backend score() endpoint not yet wired in v1)
+ * - No promote-to-application yet (operator clicks the external Open
+ *   link, applies on the source, manually creates an Application via
+ *   /applications when ready)
  */
 export default function Discover() {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -73,12 +72,12 @@ export default function Discover() {
 
       <SavedSearchesPanel />
 
-      <ViewTabs activeView={activeView} onSelect={setView} />
+      <DiscoverViewTabs activeView={activeView} onSelect={setView} />
 
       {activeView === "inbox" ? (
-        <InboxView hasSources={hasSources} />
+        <DiscoverInboxView hasSources={hasSources} />
       ) : (
-        <SavedView />
+        <DiscoverSavedView />
       )}
 
       <NewSavedSearchDialog
@@ -86,162 +85,5 @@ export default function Discover() {
         onClose={() => setDialogOpen(false)}
       />
     </main>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Tab bar
-// ---------------------------------------------------------------------------
-
-interface ViewTabsProps {
-  activeView: DiscoverView;
-  onSelect: (view: DiscoverView) => void;
-}
-
-function ViewTabs({ activeView, onSelect }: ViewTabsProps) {
-  return (
-    <div
-      role="tablist"
-      aria-label="Discover views"
-      className="flex gap-1 border-b border-border"
-    >
-      <TabButton
-        label="Inbox"
-        view="inbox"
-        activeView={activeView}
-        onSelect={onSelect}
-      />
-      <TabButton
-        label="Saved"
-        view="saved"
-        activeView={activeView}
-        onSelect={onSelect}
-      />
-    </div>
-  );
-}
-
-interface TabButtonProps {
-  label: string;
-  view: DiscoverView;
-  activeView: DiscoverView;
-  onSelect: (view: DiscoverView) => void;
-}
-
-function TabButton({ label, view, activeView, onSelect }: TabButtonProps) {
-  const isActive = view === activeView;
-  return (
-    <button
-      role="tab"
-      aria-selected={isActive}
-      onClick={() => onSelect(view)}
-      className={[
-        "px-4 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
-        isActive
-          ? "border-primary text-foreground"
-          : "border-transparent text-muted-foreground hover:text-foreground hover:border-border",
-      ].join(" ")}
-    >
-      {label}
-    </button>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Inbox view
-// ---------------------------------------------------------------------------
-
-interface InboxViewProps {
-  hasSources: boolean;
-}
-
-function InboxView({ hasSources }: InboxViewProps) {
-  const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery(
-    { state: "inbox" },
-    { pollingInterval: INBOX_POLL_INTERVAL_MS },
-  );
-
-  if (!hasSources) {
-    return (
-      <EmptyState
-        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
-        heading={DISCOVER_EMPTY_STATES.no_saved_searches.heading}
-        body={DISCOVER_EMPTY_STATES.no_saved_searches.body}
-      />
-    );
-  }
-
-  if (isError) {
-    return (
-      <p className="text-sm text-destructive">
-        Couldn't load the inbox — try refreshing the page.
-      </p>
-    );
-  }
-
-  if (isLoading) {
-    return <DiscoveredJobsSkeleton />;
-  }
-
-  const items = jobsData?.items ?? [];
-
-  if (items.length === 0) {
-    return (
-      <EmptyState
-        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
-        heading={DISCOVER_EMPTY_STATES.inbox_empty.heading}
-        body={DISCOVER_EMPTY_STATES.inbox_empty.body}
-      />
-    );
-  }
-
-  return (
-    <div className="space-y-3">
-      {items.map((job) => (
-        <DiscoveredJobCard key={job.id} job={job} />
-      ))}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Saved view
-// ---------------------------------------------------------------------------
-
-function SavedView() {
-  const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery({
-    state: "saved",
-  });
-
-  if (isError) {
-    return (
-      <p className="text-sm text-destructive">
-        Couldn't load saved jobs — try refreshing the page.
-      </p>
-    );
-  }
-
-  if (isLoading) {
-    return <DiscoveredJobsSkeleton />;
-  }
-
-  const items = jobsData?.items ?? [];
-
-  if (items.length === 0) {
-    return (
-      <EmptyState
-        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
-        heading={DISCOVER_EMPTY_STATES.saved_empty.heading}
-        body={DISCOVER_EMPTY_STATES.saved_empty.body}
-      />
-    );
-  }
-
-  return (
-    <div className="space-y-3">
-      {items.map((job) => (
-        <DiscoveredJobCard key={job.id} job={job} />
-      ))}
-    </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/__tests__/Discover.test.tsx
+++ b/apps/myjobhunter/frontend/src/pages/__tests__/Discover.test.tsx
@@ -1,0 +1,391 @@
+/**
+ * Tests for Discover page — Saved tab, error branches, and tab navigation.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import Discover from "@/pages/Discover";
+
+// ---------------------------------------------------------------------------
+// Mock RTK Query hooks
+// ---------------------------------------------------------------------------
+
+vi.mock("@/store/discoverApi", () => ({
+  useListDiscoverySourcesQuery: vi.fn(),
+  useListDiscoveredJobsQuery: vi.fn(),
+  useCreateDiscoverySourceMutation: vi.fn(),
+  useDeactivateDiscoverySourceMutation: vi.fn(),
+  useRefreshDiscoverySourceMutation: vi.fn(),
+  useDismissDiscoveredJobMutation: vi.fn(),
+  useSaveDiscoveredJobMutation: vi.fn(),
+  usePromoteDiscoveredJobMutation: vi.fn(),
+}));
+
+// NewSavedSearchDialog and SavedSearchesPanel use RTK mutations + profileApi
+// not worth wiring in page-level unit tests — behaviour tested in their own files.
+vi.mock("@/features/discover/NewSavedSearchDialog", () => ({
+  default: ({ open }: { open: boolean; onClose: () => void }) =>
+    open ? <div data-testid="new-search-dialog" /> : null,
+}));
+
+vi.mock("@/features/discover/SavedSearchesPanel", () => ({
+  default: () => <div data-testid="saved-searches-panel" />,
+}));
+
+// Suppress radix-dialog portal errors in jsdom.
+vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@radix-ui/react-dialog")>();
+  return {
+    ...actual,
+    Portal: ({ children }: { children: React.ReactNode }) => children,
+  };
+});
+
+vi.mock("@platform/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@platform/ui")>();
+  return {
+    ...actual,
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+  };
+});
+
+import {
+  useListDiscoverySourcesQuery,
+  useListDiscoveredJobsQuery,
+  useCreateDiscoverySourceMutation,
+  useDeactivateDiscoverySourceMutation,
+  useRefreshDiscoverySourceMutation,
+  useDismissDiscoveredJobMutation,
+  useSaveDiscoveredJobMutation,
+  usePromoteDiscoveredJobMutation,
+} from "@/store/discoverApi";
+
+const mockListSources = vi.mocked(useListDiscoverySourcesQuery);
+const mockListJobs = vi.mocked(useListDiscoveredJobsQuery);
+
+// Stub mutations — none of the tests exercise them; they just need to not crash.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const stubMutation = [vi.fn(), { isLoading: false }] as any;
+
+function stubAllMutations() {
+  vi.mocked(useCreateDiscoverySourceMutation).mockReturnValue(stubMutation);
+  vi.mocked(useDeactivateDiscoverySourceMutation).mockReturnValue(stubMutation);
+  vi.mocked(useRefreshDiscoverySourceMutation).mockReturnValue(stubMutation);
+  vi.mocked(useDismissDiscoveredJobMutation).mockReturnValue(stubMutation);
+  vi.mocked(useSaveDiscoveredJobMutation).mockReturnValue(stubMutation);
+  vi.mocked(usePromoteDiscoveredJobMutation).mockReturnValue(stubMutation);
+}
+
+function renderDiscover(initialUrl = "/discover") {
+  return render(
+    <MemoryRouter initialEntries={[initialUrl]}>
+      <Routes>
+        <Route path="/discover" element={<Discover />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+// Minimal source fixture
+const aSource = {
+  id: "src-1",
+  source: "jsearch",
+  config: {},
+  is_active: true,
+  fetch_interval_minutes: 60,
+  last_fetched_at: null,
+  last_success_at: null,
+  last_error_at: null,
+  last_error_message: null,
+  consecutive_failures: 0,
+  created_at: "2026-05-01T00:00:00Z",
+  updated_at: "2026-05-01T00:00:00Z",
+};
+
+// Minimal discovered-job fixture
+const aJob = {
+  id: "job-1",
+  source: "jsearch",
+  source_publisher: null,
+  source_url: null,
+  title: "Senior Backend Engineer",
+  company_name: "Acme Corp",
+  location: "Remote",
+  remote_type: "remote",
+  description: null,
+  posted_at: null,
+  discovered_at: "2026-05-08T10:00:00Z",
+  salary_min: null,
+  salary_max: null,
+  salary_currency: "USD",
+  salary_period: null,
+  score: null,
+  score_reason: null,
+  scored_at: null,
+  dismissed_at: null,
+  dismissed_reason: null,
+  saved_at: "2026-05-09T10:00:00Z",
+  promoted_application_id: null,
+  verdict: null,
+};
+
+describe("Discover page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    stubAllMutations();
+  });
+
+  // -------------------------------------------------------------------------
+  // Tab rendering
+  // -------------------------------------------------------------------------
+
+  describe("tab bar", () => {
+    it("renders Inbox and Saved tabs", () => {
+      mockListSources.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: { items: [], total: 0 },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover();
+
+      expect(screen.getByRole("tab", { name: "Inbox" })).toBeInTheDocument();
+      expect(screen.getByRole("tab", { name: "Saved" })).toBeInTheDocument();
+    });
+
+    it("defaults to Inbox tab (no ?view param)", () => {
+      mockListSources.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: { items: [], total: 0 },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover();
+
+      expect(screen.getByRole("tab", { name: "Inbox" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByRole("tab", { name: "Saved" })).toHaveAttribute(
+        "aria-selected",
+        "false",
+      );
+    });
+
+    it("activates the Saved tab when ?view=saved is in the URL", () => {
+      mockListSources.mockReturnValue({
+        data: [aSource],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: { items: [], total: 0 },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover("/discover?view=saved");
+
+      expect(screen.getByRole("tab", { name: "Saved" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inbox tab — empty state
+  // -------------------------------------------------------------------------
+
+  describe("inbox tab — empty state", () => {
+    it("shows no-saved-searches empty state when there are no sources", () => {
+      mockListSources.mockReturnValue({
+        data: [],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: { items: [], total: 0 },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover();
+
+      expect(
+        screen.getByRole("heading", { name: "No saved searches yet" }),
+      ).toBeInTheDocument();
+    });
+
+    it("shows inbox-empty state when sources exist but inbox has no jobs", () => {
+      mockListSources.mockReturnValue({
+        data: [aSource],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: { items: [], total: 0 },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover();
+
+      expect(
+        screen.getByRole("heading", { name: "Inbox empty" }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inbox tab — error branch
+  // -------------------------------------------------------------------------
+
+  describe("inbox tab — error state", () => {
+    it("shows error message when inbox query fails", () => {
+      mockListSources.mockReturnValue({
+        data: [aSource],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover();
+
+      expect(
+        screen.getByText(/Couldn't load the inbox/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Saved tab — empty state
+  // -------------------------------------------------------------------------
+
+  describe("saved tab — empty state", () => {
+    it("shows saved-empty state when there are no saved jobs", async () => {
+      mockListSources.mockReturnValue({
+        data: [aSource],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: { items: [], total: 0 },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover("/discover?view=saved");
+
+      expect(
+        screen.getByRole("heading", { name: "No saved jobs" }),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/When you save a posting from the inbox/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Saved tab — populated state
+  // -------------------------------------------------------------------------
+
+  describe("saved tab — populated", () => {
+    it("renders saved job cards when saved jobs exist", () => {
+      mockListSources.mockReturnValue({
+        data: [aSource],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: { items: [aJob], total: 1 },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover("/discover?view=saved");
+
+      expect(screen.getByText("Senior Backend Engineer")).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Saved tab — error branch
+  // -------------------------------------------------------------------------
+
+  describe("saved tab — error state", () => {
+    it("shows error message when saved jobs query fails", () => {
+      mockListSources.mockReturnValue({
+        data: [aSource],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: undefined,
+        isLoading: false,
+        isError: true,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover("/discover?view=saved");
+
+      expect(
+        screen.getByText(/Couldn't load saved jobs/i),
+      ).toBeInTheDocument();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Tab switching
+  // -------------------------------------------------------------------------
+
+  describe("tab switching", () => {
+    it("switches to Saved tab when the Saved tab is clicked", async () => {
+      const user = userEvent.setup();
+
+      mockListSources.mockReturnValue({
+        data: [aSource],
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+      mockListJobs.mockReturnValue({
+        data: { items: [], total: 0 },
+        isLoading: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+
+      renderDiscover();
+
+      // Initially on Inbox
+      expect(screen.getByRole("tab", { name: "Inbox" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+
+      await user.click(screen.getByRole("tab", { name: "Saved" }));
+
+      expect(screen.getByRole("tab", { name: "Saved" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(
+        screen.getByRole("heading", { name: "No saved jobs" }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/myjobhunter/frontend/src/pages/__tests__/Discover.test.tsx
+++ b/apps/myjobhunter/frontend/src/pages/__tests__/Discover.test.tsx
@@ -8,22 +8,17 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import Discover from "@/pages/Discover";
 
 // ---------------------------------------------------------------------------
-// Mock RTK Query hooks
+// Mock RTK Query hooks — only the two query hooks are used directly by
+// Discover.tsx; mutations live in sub-components that are mocked below.
 // ---------------------------------------------------------------------------
 
 vi.mock("@/store/discoverApi", () => ({
   useListDiscoverySourcesQuery: vi.fn(),
   useListDiscoveredJobsQuery: vi.fn(),
-  useCreateDiscoverySourceMutation: vi.fn(),
-  useDeactivateDiscoverySourceMutation: vi.fn(),
-  useRefreshDiscoverySourceMutation: vi.fn(),
-  useDismissDiscoveredJobMutation: vi.fn(),
-  useSaveDiscoveredJobMutation: vi.fn(),
-  usePromoteDiscoveredJobMutation: vi.fn(),
 }));
 
-// NewSavedSearchDialog and SavedSearchesPanel use RTK mutations + profileApi
-// not worth wiring in page-level unit tests — behaviour tested in their own files.
+// Sub-components with their own RTK wiring are mocked so this test file
+// stays lean and doesn't need a Redux Provider.
 vi.mock("@/features/discover/NewSavedSearchDialog", () => ({
   default: ({ open }: { open: boolean; onClose: () => void }) =>
     open ? <div data-testid="new-search-dialog" /> : null,
@@ -33,14 +28,15 @@ vi.mock("@/features/discover/SavedSearchesPanel", () => ({
   default: () => <div data-testid="saved-searches-panel" />,
 }));
 
-// Suppress radix-dialog portal errors in jsdom.
-vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("@radix-ui/react-dialog")>();
-  return {
-    ...actual,
-    Portal: ({ children }: { children: React.ReactNode }) => children,
-  };
-});
+vi.mock("@/features/discover/DiscoverInboxView", () => ({
+  default: ({ hasSources }: { hasSources: boolean }) => (
+    <div data-testid="inbox-view" data-has-sources={String(hasSources)} />
+  ),
+}));
+
+vi.mock("@/features/discover/DiscoverSavedView", () => ({
+  default: () => <div data-testid="saved-view" />,
+}));
 
 vi.mock("@platform/ui", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@platform/ui")>();
@@ -54,29 +50,10 @@ vi.mock("@platform/ui", async (importOriginal) => {
 import {
   useListDiscoverySourcesQuery,
   useListDiscoveredJobsQuery,
-  useCreateDiscoverySourceMutation,
-  useDeactivateDiscoverySourceMutation,
-  useRefreshDiscoverySourceMutation,
-  useDismissDiscoveredJobMutation,
-  useSaveDiscoveredJobMutation,
-  usePromoteDiscoveredJobMutation,
 } from "@/store/discoverApi";
 
 const mockListSources = vi.mocked(useListDiscoverySourcesQuery);
 const mockListJobs = vi.mocked(useListDiscoveredJobsQuery);
-
-// Stub mutations — none of the tests exercise them; they just need to not crash.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const stubMutation = [vi.fn(), { isLoading: false }] as any;
-
-function stubAllMutations() {
-  vi.mocked(useCreateDiscoverySourceMutation).mockReturnValue(stubMutation);
-  vi.mocked(useDeactivateDiscoverySourceMutation).mockReturnValue(stubMutation);
-  vi.mocked(useRefreshDiscoverySourceMutation).mockReturnValue(stubMutation);
-  vi.mocked(useDismissDiscoveredJobMutation).mockReturnValue(stubMutation);
-  vi.mocked(useSaveDiscoveredJobMutation).mockReturnValue(stubMutation);
-  vi.mocked(usePromoteDiscoveredJobMutation).mockReturnValue(stubMutation);
-}
 
 function renderDiscover(initialUrl = "/discover") {
   return render(
@@ -104,37 +81,23 @@ const aSource = {
   updated_at: "2026-05-01T00:00:00Z",
 };
 
-// Minimal discovered-job fixture
-const aJob = {
-  id: "job-1",
-  source: "jsearch",
-  source_publisher: null,
-  source_url: null,
-  title: "Senior Backend Engineer",
-  company_name: "Acme Corp",
-  location: "Remote",
-  remote_type: "remote",
-  description: null,
-  posted_at: null,
-  discovered_at: "2026-05-08T10:00:00Z",
-  salary_min: null,
-  salary_max: null,
-  salary_currency: "USD",
-  salary_period: null,
-  score: null,
-  score_reason: null,
-  scored_at: null,
-  dismissed_at: null,
-  dismissed_reason: null,
-  saved_at: "2026-05-09T10:00:00Z",
-  promoted_application_id: null,
-  verdict: null,
-};
+function stubQueries(opts: { hasSources?: boolean } = {}) {
+  const sources = opts.hasSources ? [aSource] : [];
+  mockListSources.mockReturnValue({
+    data: sources,
+    isLoading: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
+  mockListJobs.mockReturnValue({
+    data: { items: [], total: 0 },
+    isLoading: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+}
 
 describe("Discover page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    stubAllMutations();
   });
 
   // -------------------------------------------------------------------------
@@ -143,17 +106,7 @@ describe("Discover page", () => {
 
   describe("tab bar", () => {
     it("renders Inbox and Saved tabs", () => {
-      mockListSources.mockReturnValue({
-        data: [],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: { items: [], total: 0 },
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
+      stubQueries();
       renderDiscover();
 
       expect(screen.getByRole("tab", { name: "Inbox" })).toBeInTheDocument();
@@ -161,17 +114,7 @@ describe("Discover page", () => {
     });
 
     it("defaults to Inbox tab (no ?view param)", () => {
-      mockListSources.mockReturnValue({
-        data: [],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: { items: [], total: 0 },
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
+      stubQueries();
       renderDiscover();
 
       expect(screen.getByRole("tab", { name: "Inbox" })).toHaveAttribute(
@@ -185,17 +128,7 @@ describe("Discover page", () => {
     });
 
     it("activates the Saved tab when ?view=saved is in the URL", () => {
-      mockListSources.mockReturnValue({
-        data: [aSource],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: { items: [], total: 0 },
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
+      stubQueries({ hasSources: true });
       renderDiscover("/discover?view=saved");
 
       expect(screen.getByRole("tab", { name: "Saved" })).toHaveAttribute(
@@ -206,147 +139,44 @@ describe("Discover page", () => {
   });
 
   // -------------------------------------------------------------------------
-  // Inbox tab — empty state
+  // View routing
   // -------------------------------------------------------------------------
 
-  describe("inbox tab — empty state", () => {
-    it("shows no-saved-searches empty state when there are no sources", () => {
-      mockListSources.mockReturnValue({
-        data: [],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: { items: [], total: 0 },
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
+  describe("view routing", () => {
+    it("renders InboxView when ?view is absent", () => {
+      stubQueries();
       renderDiscover();
 
-      expect(
-        screen.getByRole("heading", { name: "No saved searches yet" }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("inbox-view")).toBeInTheDocument();
+      expect(screen.queryByTestId("saved-view")).toBeNull();
     });
 
-    it("shows inbox-empty state when sources exist but inbox has no jobs", () => {
-      mockListSources.mockReturnValue({
-        data: [aSource],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: { items: [], total: 0 },
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
+    it("renders SavedView when ?view=saved", () => {
+      stubQueries({ hasSources: true });
+      renderDiscover("/discover?view=saved");
 
+      expect(screen.getByTestId("saved-view")).toBeInTheDocument();
+      expect(screen.queryByTestId("inbox-view")).toBeNull();
+    });
+
+    it("passes hasSources=true to InboxView when sources exist", () => {
+      stubQueries({ hasSources: true });
       renderDiscover();
 
-      expect(
-        screen.getByRole("heading", { name: "Inbox empty" }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("inbox-view")).toHaveAttribute(
+        "data-has-sources",
+        "true",
+      );
     });
-  });
 
-  // -------------------------------------------------------------------------
-  // Inbox tab — error branch
-  // -------------------------------------------------------------------------
-
-  describe("inbox tab — error state", () => {
-    it("shows error message when inbox query fails", () => {
-      mockListSources.mockReturnValue({
-        data: [aSource],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        isError: true,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
+    it("passes hasSources=false to InboxView when no sources", () => {
+      stubQueries({ hasSources: false });
       renderDiscover();
 
-      expect(
-        screen.getByText(/Couldn't load the inbox/i),
-      ).toBeInTheDocument();
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Saved tab — empty state
-  // -------------------------------------------------------------------------
-
-  describe("saved tab — empty state", () => {
-    it("shows saved-empty state when there are no saved jobs", async () => {
-      mockListSources.mockReturnValue({
-        data: [aSource],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: { items: [], total: 0 },
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
-      renderDiscover("/discover?view=saved");
-
-      expect(
-        screen.getByRole("heading", { name: "No saved jobs" }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(/When you save a posting from the inbox/i),
-      ).toBeInTheDocument();
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Saved tab — populated state
-  // -------------------------------------------------------------------------
-
-  describe("saved tab — populated", () => {
-    it("renders saved job cards when saved jobs exist", () => {
-      mockListSources.mockReturnValue({
-        data: [aSource],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: { items: [aJob], total: 1 },
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
-      renderDiscover("/discover?view=saved");
-
-      expect(screen.getByText("Senior Backend Engineer")).toBeInTheDocument();
-    });
-  });
-
-  // -------------------------------------------------------------------------
-  // Saved tab — error branch
-  // -------------------------------------------------------------------------
-
-  describe("saved tab — error state", () => {
-    it("shows error message when saved jobs query fails", () => {
-      mockListSources.mockReturnValue({
-        data: [aSource],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: undefined,
-        isLoading: false,
-        isError: true,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
-      renderDiscover("/discover?view=saved");
-
-      expect(
-        screen.getByText(/Couldn't load saved jobs/i),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("inbox-view")).toHaveAttribute(
+        "data-has-sources",
+        "false",
+      );
     });
   });
 
@@ -355,20 +185,9 @@ describe("Discover page", () => {
   // -------------------------------------------------------------------------
 
   describe("tab switching", () => {
-    it("switches to Saved tab when the Saved tab is clicked", async () => {
+    it("switches to Saved view when the Saved tab is clicked", async () => {
       const user = userEvent.setup();
-
-      mockListSources.mockReturnValue({
-        data: [aSource],
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoverySourcesQuery>);
-      mockListJobs.mockReturnValue({
-        data: { items: [], total: 0 },
-        isLoading: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useListDiscoveredJobsQuery>);
-
+      stubQueries({ hasSources: true });
       renderDiscover();
 
       // Initially on Inbox
@@ -376,6 +195,7 @@ describe("Discover page", () => {
         "aria-selected",
         "true",
       );
+      expect(screen.getByTestId("inbox-view")).toBeInTheDocument();
 
       await user.click(screen.getByRole("tab", { name: "Saved" }));
 
@@ -383,9 +203,25 @@ describe("Discover page", () => {
         "aria-selected",
         "true",
       );
-      expect(
-        screen.getByRole("heading", { name: "No saved jobs" }),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId("saved-view")).toBeInTheDocument();
+      expect(screen.queryByTestId("inbox-view")).toBeNull();
+    });
+
+    it("switches back to Inbox view when the Inbox tab is clicked from Saved", async () => {
+      const user = userEvent.setup();
+      stubQueries({ hasSources: true });
+      renderDiscover("/discover?view=saved");
+
+      // Initially on Saved
+      expect(screen.getByTestId("saved-view")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("tab", { name: "Inbox" }));
+
+      expect(screen.getByRole("tab", { name: "Inbox" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+      expect(screen.getByTestId("inbox-view")).toBeInTheDocument();
     });
   });
 });

--- a/apps/myjobhunter/frontend/src/types/discovery/discover-view.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discover-view.ts
@@ -1,0 +1,2 @@
+/** The two tabs on the /discover page. */
+export type DiscoverView = "inbox" | "saved";


### PR DESCRIPTION
## Summary

Closes four visible UX dead-ends on `/discover` surfaced in the 2026-05-11 design pass:

- **Saved tab** — adds Inbox/Saved tab bar. State lives in `?view=inbox` (default) / `?view=saved` so deep-linking and the back button work correctly. The Saved tab uses the existing `listDiscoveredJobs?state=saved` API (no backend change) and shows a Telescope empty state when the saved list is empty.
- **Inbox error branch** — `isError` on `listDiscoveredJobs` now renders a human-readable error message instead of a blank screen.
- **Sources error branch** — `isError` on `listDiscoverySources` now renders an error message in `SavedSearchesPanel` instead of silently rendering nothing.
- **Fetch-failed badge** — `consecutive_failures > 0` on a `SavedSearchRow` now shows an `AlertTriangle + "Fetch failed"` inline badge so repeated fetch failures are visible at a glance.

## Files changed

- `src/pages/Discover.tsx` — tab bar, URL param state (`?view=inbox|saved`), delegates to sub-components
- `src/features/discover/DiscoverInboxView.tsx` — inbox view with error + empty + loaded states (new file)
- `src/features/discover/DiscoverSavedView.tsx` — saved view with error + empty + loaded states (new file)
- `src/features/discover/DiscoverViewTabs.tsx` — tab bar component (new file)
- `src/features/discover/DiscoverTabButton.tsx` — individual tab button (new file)
- `src/features/discover/SavedSearchRow.tsx` — extracted row component with fetch-failed badge (new file)
- `src/features/discover/SavedSearchesPanel.tsx` — slimmed to panel + error branch; row extracted
- `src/types/discovery/discover-view.ts` — `DiscoverView = "inbox" | "saved"` type (new file)
- `src/constants/empty-states.ts` — `saved_empty` copy added
- `e2e/discover.spec.ts` — E2E tests: Saved tab empty state, deep-link via `?view=saved`, tab toggle
- `src/pages/__tests__/Discover.test.tsx` — 11 unit tests for tab bar, view routing, tab switching
- `src/features/discover/__tests__/SavedSearchesPanel.test.tsx` — 6 unit tests for loading/error/populated/fetch-failed badge

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (9 pre-existing warnings in unrelated files)
- [x] `npm run build` — clean
- [x] 17 new unit tests all pass
- [x] E2E spec covers Saved tab empty state, deep-link, and round-trip tab toggle (requires backend running on :8002)
- [x] Pre-existing test failures unchanged (25 failures all in unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)