### PR TITLE
fix(mjh/discover): capture Anthropic error codes + circuit-break score loop

### DIFF
--- a/apps/myjobhunter/backend/app/services/discovery/discovery_score_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_score_service.py
@@ -18,6 +18,33 @@ runaway cost we:
 3. The hard ceiling lives in env (``DISCOVERY_DAILY_BUDGET_USD_HARD_CAP``,
    default $2.00). The per-user setting may not exceed this.
 
+Error handling and circuit-breaker
+===================================
+
+Transient Anthropic errors (``rate_limit_error``, ``overloaded_error``,
+``api_error``, ``connection_error``) are treated as per-row failures:
+
+- Each failure increments the consecutive-failure counter.
+- If three rows in a row fail, the loop aborts with a Sentry warning
+  so the operator can diagnose from the dashboard alone, without grepping
+  logs. Remaining rows stay with ``score IS NULL`` — the next scheduled
+  pass picks them up.
+
+Permanent Anthropic errors (``authentication_error``,
+``invalid_request_error``) indicate a configuration bug — the loop
+fails-loud immediately by re-raising, so a broken deploy doesn't
+silently produce zero scores forever.
+
+Non-Anthropic failures (validation errors, malformed JSON) are treated
+as transient per-row failures (``retryable=True`` on JobAnalysisError
+when ``code`` is None) so a single bad posting doesn't abort the batch.
+
+Sentry tags emitted on every failure:
+
+- ``discovery.score_error_type``  — Anthropic ``error.type`` or ``None``
+- ``discovery.score_error_message`` — first 200 chars of the error message
+- ``discovery.score_attempt_index`` — 0-based index of the failed posting
+
 Async + isolated session
 ========================
 
@@ -37,6 +64,7 @@ import logging
 import uuid
 from datetime import datetime, time, timezone
 
+import sentry_sdk
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -46,6 +74,7 @@ from app.models.system.extraction_log import ExtractionLog
 from app.repositories.discovery import discovery_repository
 from app.services.job_analysis.job_analysis_service import (
     JobAnalysisError,
+    PERMANENT_ANTHROPIC_CODES,
     score as score_jd,
 )
 
@@ -55,13 +84,23 @@ logger = logging.getLogger(__name__)
 DEFAULT_SCORE_BATCH = 20
 DEFAULT_DAILY_BUDGET_USD = 0.30
 
+# Abort the scoring loop after this many consecutive failures so a
+# sustained Anthropic outage doesn't waste the full batch budget and
+# spams logs. Remaining rows stay unscored for the next pass.
+_CIRCUIT_BREAKER_THRESHOLD = 3
+
 
 async def score_user_inbox(user_id: uuid.UUID, *, batch: int = DEFAULT_SCORE_BATCH) -> None:
     """Score up to ``batch`` unscored postings for ``user_id``.
 
-    Stops early when the per-user daily budget is exhausted. Per-call
-    failures are logged + swallowed; one bad posting does not abort the
-    rest of the batch.
+    Stops early when the per-user daily budget is exhausted. Per-row
+    transient failures are logged + counted toward the circuit-breaker;
+    one bad posting does not abort the rest of the batch unless three
+    consecutive rows fail (circuit-breaker trips).
+
+    Permanent config-bug errors (``authentication_error``,
+    ``invalid_request_error``) are re-raised immediately — a deploy with
+    a broken API key should fail loud, not silently produce zero scores.
 
     Designed to run as a FastAPI ``BackgroundTask`` after /refresh
     returns. No-op when there are no unscored postings or the budget
@@ -96,8 +135,10 @@ async def score_user_inbox(user_id: uuid.UUID, *, batch: int = DEFAULT_SCORE_BAT
         # without an extra round-trip.
         scored = 0
         budget_hits = False
+        consecutive_failures = 0
+        last_failure_code: str | None = None
 
-        for job in candidates:
+        for attempt_index, job in enumerate(candidates):
             if spent_today >= daily_cap:
                 budget_hits = True
                 break
@@ -117,12 +158,49 @@ async def score_user_inbox(user_id: uuid.UUID, *, batch: int = DEFAULT_SCORE_BAT
                     discovered_job=job,
                 )
             except JobAnalysisError as exc:
-                logger.warning(
-                    "discovery score: failed user=%s job=%s err=%s",
-                    user_id, job.id, exc,
+                _emit_sentry_failure(
+                    exc=exc,
+                    user_id=user_id,
+                    job_id=job.id,
+                    attempt_index=attempt_index,
                 )
+
+                # Permanent errors are config bugs — fail-loud so the operator
+                # sees a crash on the next Sentry alert instead of a silent
+                # zero-score inbox. The BackgroundTask runner will log the
+                # exception; the current iteration's remaining rows stay
+                # unscored for the next pass.
+                if exc.code in PERMANENT_ANTHROPIC_CODES:
+                    logger.error(
+                        "discovery score: permanent error — aborting loop "
+                        "user=%s job=%s code=%s err=%s",
+                        user_id, job.id, exc.code, exc,
+                    )
+                    raise
+
+                # Transient failure — count toward the circuit-breaker.
+                consecutive_failures += 1
+                last_failure_code = exc.code
+                logger.warning(
+                    "discovery score: transient failure user=%s job=%s "
+                    "code=%s consecutive=%d err=%s",
+                    user_id, job.id, exc.code, consecutive_failures, exc,
+                )
+
+                if consecutive_failures >= _CIRCUIT_BREAKER_THRESHOLD:
+                    _emit_circuit_break_warning(
+                        user_id=user_id,
+                        consecutive=consecutive_failures,
+                        last_code=last_failure_code,
+                        attempt_index=attempt_index,
+                    )
+                    break
+
                 continue
 
+            # Successful score — reset the consecutive-failure counter.
+            consecutive_failures = 0
+            last_failure_code = None
             spent_today += float(analysis.total_cost_usd or 0)
             scored += 1
 
@@ -130,6 +208,63 @@ async def score_user_inbox(user_id: uuid.UUID, *, batch: int = DEFAULT_SCORE_BAT
             "discovery score: complete user=%s scored=%d budget_hit=%s spent_session=%.4f",
             user_id, scored, budget_hits, spent_today,
         )
+
+
+def _emit_sentry_failure(
+    *,
+    exc: JobAnalysisError,
+    user_id: uuid.UUID,
+    job_id: uuid.UUID,
+    attempt_index: int,
+) -> None:
+    """Capture a per-row scoring failure to Sentry with structured tags.
+
+    Tags are specific enough to filter by error type in the Sentry dashboard
+    without grepping logs — operators can diagnose a scoring outage from
+    Sentry alone (per feedback_check_sentry_first.md).
+    """
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag("discovery.score_error_type", str(exc.code or "unknown"))
+        scope.set_tag(
+            "discovery.score_error_message",
+            str(exc)[:200],
+        )
+        scope.set_tag("discovery.score_attempt_index", str(attempt_index))
+        scope.set_tag("discovery.score_retryable", str(exc.retryable))
+        scope.set_extra("user_id", str(user_id))
+        scope.set_extra("job_id", str(job_id))
+        sentry_sdk.capture_exception(exc)
+
+
+def _emit_circuit_break_warning(
+    *,
+    user_id: uuid.UUID,
+    consecutive: int,
+    last_code: str | None,
+    attempt_index: int,
+) -> None:
+    """Emit a Sentry warning event when the circuit-breaker trips.
+
+    This is a separate event (not an exception) because the loop is aborting
+    gracefully — remaining rows stay unscored for the next pass.  The warning
+    is detectable in Sentry dashboards for alerting on sustained outages.
+    """
+    with sentry_sdk.new_scope() as scope:
+        scope.set_tag("discovery.circuit_break", "true")
+        scope.set_tag("discovery.circuit_break_code", str(last_code or "unknown"))
+        scope.set_tag("discovery.circuit_break_at_index", str(attempt_index))
+        scope.set_extra("user_id", str(user_id))
+        scope.set_extra("consecutive_failures", consecutive)
+        sentry_sdk.capture_message(
+            f"discovery score loop aborted: {consecutive} consecutive failures, "
+            f"type={last_code or 'unknown'}",
+            level="warning",
+        )
+    logger.warning(
+        "discovery score: circuit breaker tripped user=%s "
+        "consecutive=%d last_code=%s — remaining postings deferred to next pass",
+        user_id, consecutive, last_code,
+    )
 
 
 def _resolve_daily_budget() -> float:

--- a/apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py
+++ b/apps/myjobhunter/backend/app/services/job_analysis/job_analysis_service.py
@@ -104,7 +104,29 @@ __all__ = [
     "JobAnalysisFetchAuthRequiredError",
     "JobAnalysisFetchTimeoutError",
     "JobAnalysisInvalidUrlError",
+    # Error classification helpers (used by score loop + tests)
+    "TRANSIENT_ANTHROPIC_CODES",
+    "PERMANENT_ANTHROPIC_CODES",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Error classification constants — used by the score loop and tests.
+# ---------------------------------------------------------------------------
+
+#: Anthropic error.type values that are transient — the score loop should
+#: count them toward the circuit-breaker but not fail-loud. The next
+#: scheduled pass will retry the affected postings.
+TRANSIENT_ANTHROPIC_CODES: frozenset[str] = frozenset(
+    ("rate_limit_error", "overloaded_error", "api_error", "connection_error"),
+)
+
+#: Anthropic error.type values that indicate a permanent config bug —
+#: the score loop should raise immediately so a broken deploy doesn't
+#: silently produce zero scores forever.
+PERMANENT_ANTHROPIC_CODES: frozenset[str] = frozenset(
+    ("authentication_error", "invalid_request_error"),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -113,7 +135,60 @@ __all__ = [
 
 
 class JobAnalysisError(RuntimeError):
-    """Generic analysis failure — HTTP 502."""
+    """Generic analysis failure — HTTP 502.
+
+    Carries structured Anthropic error metadata so the discovery score
+    loop (and any future caller) can differentiate transient errors
+    (rate-limit, overloaded) from permanent config bugs
+    (authentication, invalid-request) without parsing the message string.
+
+    ``code`` mirrors Anthropic's documented ``error.type`` values:
+        - ``rate_limit_error``     — transient; retry at next scheduled pass
+        - ``overloaded_error``     — transient; retry at next scheduled pass
+        - ``authentication_error`` — config bug; fail-loud immediately
+        - ``invalid_request_error``— config bug; fail-loud immediately
+        - ``api_error``            — generic server error; treat as transient
+        - None                     — non-Anthropic failure (validation, JSON)
+
+    ``retryable`` is pre-computed from ``code`` so the loop doesn't need
+    to know the full code taxonomy — just check this flag.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str | None = None,
+        retryable: bool = True,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.retryable = retryable
+
+    @classmethod
+    def from_anthropic(cls, exc: Exception) -> "JobAnalysisError":
+        """Wrap an ``anthropic.APIError`` into a ``JobAnalysisError``.
+
+        Extracts ``error.type`` from the Anthropic response body, maps it
+        to ``retryable``, and preserves it as ``code``.  Called from the
+        ``score()`` function's except block so every Anthropic failure path
+        produces a ``JobAnalysisError`` with structured metadata.
+        """
+        code: str | None = None
+        retryable: bool = True
+
+        if isinstance(exc, anthropic.APIStatusError):
+            # ``exc.type`` is the Anthropic ``error.type`` string or None.
+            code = str(exc.type) if exc.type else None
+            # Permanent config bugs — fail-loud immediately so a broken deploy
+            # does not silently produce zero scores forever.
+            if code in PERMANENT_ANTHROPIC_CODES:
+                retryable = False
+        elif isinstance(exc, (anthropic.APIConnectionError, anthropic.APITimeoutError)):
+            code = "connection_error"
+            retryable = True
+
+        return cls(str(exc), code=code, retryable=retryable)
 
 
 class JobAnalysisFetchAuthRequiredError(JobAnalysisError):
@@ -301,9 +376,16 @@ async def score(
             user_id=user_id,
             context_id=discovered_job_id,
         )
-    except (anthropic.APIError, ValueError) as exc:
-        logger.warning("Claude job-analysis call failed: %s", exc)
-        raise JobAnalysisError(f"AI analysis failed: {exc}") from exc
+    except anthropic.APIError as exc:
+        wrapped = JobAnalysisError.from_anthropic(exc)
+        logger.warning(
+            "Claude job-analysis call failed: code=%s retryable=%s err=%s",
+            wrapped.code, wrapped.retryable, exc,
+        )
+        raise wrapped from exc
+    except ValueError as exc:
+        logger.warning("Claude job-analysis response invalid: %s", exc)
+        raise JobAnalysisError(str(exc), code=None, retryable=False) from exc
 
     validated = _validate_response(meta["parsed"])
 

--- a/apps/myjobhunter/backend/tests/test_discovery_score_service.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_score_service.py
@@ -3,8 +3,11 @@
 Covers:
 - Budget exhausted before any scoring: no score_jd calls made.
 - Happy path: budget allows N postings → score_jd called N times.
-- Per-posting error swallowing: one bad posting does not abort the loop.
-- Idempotency: already-scored postings excluded from list_unscored_for_user.
+- Transient per-row failure: loop continues after a single transient error.
+- Circuit-breaker: 3 consecutive transient failures abort the loop.
+- Permanent error: authentication_error / invalid_request_error re-raised immediately.
+- Sentry events: emitted on every failure + on circuit-break.
+- Error classification: retryable flag correctly set on JobAnalysisError.
 
 score_jd is mocked with AsyncMock throughout (no real Claude calls).
 All tests use the standard conftest DB fixtures.
@@ -13,13 +16,17 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.discovery.discovered_job import DiscoveredJob
-from app.services.job_analysis.job_analysis_service import JobAnalysisError
+from app.services.job_analysis.job_analysis_service import (
+    JobAnalysisError,
+    PERMANENT_ANTHROPIC_CODES,
+    TRANSIENT_ANTHROPIC_CODES,
+)
 
 
 _SCORE_JD_PATH = "app.services.discovery.discovery_score_service.score_jd"
@@ -29,6 +36,9 @@ _LIST_UNSCORED_PATH = (
     "app.services.discovery.discovery_score_service."
     "discovery_repository.list_unscored_for_user"
 )
+_SENTRY_CAPTURE_EXC_PATH = "app.services.discovery.discovery_score_service.sentry_sdk.capture_exception"
+_SENTRY_CAPTURE_MSG_PATH = "app.services.discovery.discovery_score_service.sentry_sdk.capture_message"
+_SENTRY_NEW_SCOPE_PATH = "app.services.discovery.discovery_score_service.sentry_sdk.new_scope"
 
 
 def _make_job(user_id: uuid.UUID) -> DiscoveredJob:
@@ -48,6 +58,26 @@ def _make_analysis(cost: float = 0.005) -> MagicMock:
     analysis.verdict_summary = "Great match."
     analysis.total_cost_usd = cost
     return analysis
+
+
+def _make_transient_error(code: str = "rate_limit_error") -> JobAnalysisError:
+    """Create a transient JobAnalysisError (retryable=True)."""
+    return JobAnalysisError(f"Anthropic error: {code}", code=code, retryable=True)
+
+
+def _make_permanent_error(code: str = "authentication_error") -> JobAnalysisError:
+    """Create a permanent JobAnalysisError (retryable=False)."""
+    return JobAnalysisError(f"Anthropic error: {code}", code=code, retryable=False)
+
+
+def _noop_scope_cm() -> MagicMock:
+    """Return a MagicMock context-manager that does nothing — stands in for
+    sentry_sdk.new_scope() so we don't need real Sentry in tests."""
+    scope = MagicMock()
+    cm = MagicMock()
+    cm.__enter__ = MagicMock(return_value=scope)
+    cm.__exit__ = MagicMock(return_value=False)
+    return cm
 
 
 class TestBudgetExhausted:
@@ -192,10 +222,10 @@ class TestHappyPath:
         assert mock_score.call_count == 1
 
 
-class TestPerPostingErrorSwallowing:
+class TestTransientErrorHandling:
     @pytest.mark.asyncio
-    async def test_job_analysis_error_is_caught_and_loop_continues(self) -> None:
-        """A JobAnalysisError on one posting logs + continues; other postings score."""
+    async def test_single_transient_error_does_not_abort_loop(self) -> None:
+        """A single transient failure logs a warning; the loop continues for other rows."""
         user_id = uuid.uuid4()
         jobs = [_make_job(user_id) for _ in range(3)]
 
@@ -205,10 +235,13 @@ class TestPerPostingErrorSwallowing:
         mock_cm.__aexit__ = AsyncMock(return_value=None)
 
         good_analysis = _make_analysis(cost=0.005)
-
-        # 2nd call raises; 1st and 3rd succeed.
+        # 2nd call raises a transient error; 1st and 3rd succeed.
         mock_score = AsyncMock(
-            side_effect=[good_analysis, JobAnalysisError("Claude error"), good_analysis]
+            side_effect=[
+                good_analysis,
+                _make_transient_error("rate_limit_error"),
+                good_analysis,
+            ]
         )
 
         with (
@@ -216,9 +249,435 @@ class TestPerPostingErrorSwallowing:
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
             patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
             patch(_SCORE_JD_PATH, new=mock_score),
+            patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
+            patch(_SENTRY_CAPTURE_EXC_PATH),
+            patch(_SENTRY_CAPTURE_MSG_PATH),
         ):
             from app.services.discovery import discovery_score_service
-            # Should NOT raise — errors are swallowed per-posting.
+            # Should NOT raise — transient errors are swallowed per-posting.
             await discovery_score_service.score_user_inbox(user_id, batch=10)
 
         assert mock_score.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_all_transient_error_codes_trigger_continue(self) -> None:
+        """Every code in TRANSIENT_ANTHROPIC_CODES causes a continue, not a raise."""
+        for code in TRANSIENT_ANTHROPIC_CODES:
+            user_id = uuid.uuid4()
+            job = _make_job(user_id)
+
+            mock_db = AsyncMock()
+            mock_cm = AsyncMock()
+            mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+            mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with (
+                patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+                patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+                patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+                patch(_SCORE_JD_PATH, new=AsyncMock(side_effect=_make_transient_error(code))),
+                patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
+                patch(_SENTRY_CAPTURE_EXC_PATH),
+                patch(_SENTRY_CAPTURE_MSG_PATH),
+            ):
+                from app.services.discovery import discovery_score_service
+                # None of these should raise out of score_user_inbox.
+                await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+    @pytest.mark.asyncio
+    async def test_sentry_tags_emitted_on_transient_failure(self) -> None:
+        """Sentry capture_exception is called with structured tags on each per-row failure."""
+        user_id = uuid.uuid4()
+        job = _make_job(user_id)
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        scope_mock = MagicMock()
+        scope_cm = MagicMock()
+        scope_cm.__enter__ = MagicMock(return_value=scope_mock)
+        scope_cm.__exit__ = MagicMock(return_value=False)
+
+        err = _make_transient_error("overloaded_error")
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+            patch(_SCORE_JD_PATH, new=AsyncMock(side_effect=err)),
+            patch(_SENTRY_NEW_SCOPE_PATH, return_value=scope_cm),
+            patch(_SENTRY_CAPTURE_EXC_PATH) as mock_capture_exc,
+            patch(_SENTRY_CAPTURE_MSG_PATH),
+        ):
+            from app.services.discovery import discovery_score_service
+            await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+        # capture_exception was called with the error
+        mock_capture_exc.assert_called_once_with(err)
+        # Scope tags were set
+        scope_mock.set_tag.assert_any_call("discovery.score_error_type", "overloaded_error")
+        scope_mock.set_tag.assert_any_call("discovery.score_retryable", "True")
+
+
+class TestCircuitBreaker:
+    @pytest.mark.asyncio
+    async def test_three_consecutive_failures_trips_circuit_breaker(self) -> None:
+        """3 consecutive transient failures abort the loop; Sentry warning emitted."""
+        user_id = uuid.uuid4()
+        # 5 jobs available — only 3 should be attempted before circuit break.
+        jobs = [_make_job(user_id) for _ in range(5)]
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(
+                _SCORE_JD_PATH,
+                new=AsyncMock(side_effect=_make_transient_error("rate_limit_error")),
+            ) as mock_score,
+            patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
+            patch(_SENTRY_CAPTURE_EXC_PATH),
+            patch(_SENTRY_CAPTURE_MSG_PATH) as mock_capture_msg,
+        ):
+            from app.services.discovery import discovery_score_service
+            # Should NOT raise — circuit break is a graceful abort.
+            await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+        # Only 3 attempts (threshold) — loop aborted before the 4th.
+        assert mock_score.call_count == 3
+        # A warning message event was sent to Sentry.
+        mock_capture_msg.assert_called_once()
+        msg_arg = mock_capture_msg.call_args.args[0]
+        assert "aborted" in msg_arg
+        assert "rate_limit_error" in msg_arg
+
+    @pytest.mark.asyncio
+    async def test_consecutive_counter_resets_on_success(self) -> None:
+        """A successful score resets the consecutive-failure counter.
+
+        Pattern: fail, fail, succeed, fail, fail, fail → circuit breaks at
+        the 3rd consecutive failure AFTER the reset (i.e., after the success).
+        Total calls = 2 + 1 + 3 = 6.
+        """
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(10)]
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        good_analysis = _make_analysis(cost=0.005)
+        err = _make_transient_error("rate_limit_error")
+
+        mock_score = AsyncMock(
+            side_effect=[
+                err,           # consecutive=1
+                err,           # consecutive=2
+                good_analysis, # reset → consecutive=0
+                err,           # consecutive=1
+                err,           # consecutive=2
+                err,           # consecutive=3 → circuit break
+            ]
+        )
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_SCORE_JD_PATH, new=mock_score),
+            patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
+            patch(_SENTRY_CAPTURE_EXC_PATH),
+            patch(_SENTRY_CAPTURE_MSG_PATH),
+        ):
+            from app.services.discovery import discovery_score_service
+            await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+        assert mock_score.call_count == 6
+
+    @pytest.mark.asyncio
+    async def test_circuit_breaker_emits_sentry_warning_with_last_code(self) -> None:
+        """The Sentry warning message includes the failure code and attempt index."""
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(5)]
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        scope_mock = MagicMock()
+        scope_cm = MagicMock()
+        scope_cm.__enter__ = MagicMock(return_value=scope_mock)
+        scope_cm.__exit__ = MagicMock(return_value=False)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(
+                _SCORE_JD_PATH,
+                new=AsyncMock(side_effect=_make_transient_error("overloaded_error")),
+            ),
+            patch(_SENTRY_NEW_SCOPE_PATH, return_value=scope_cm),
+            patch(_SENTRY_CAPTURE_EXC_PATH),
+            patch(_SENTRY_CAPTURE_MSG_PATH) as mock_capture_msg,
+        ):
+            from app.services.discovery import discovery_score_service
+            await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+        # Sentry warning event includes circuit-break tag
+        scope_mock.set_tag.assert_any_call("discovery.circuit_break", "true")
+        scope_mock.set_tag.assert_any_call(
+            "discovery.circuit_break_code", "overloaded_error"
+        )
+        mock_capture_msg.assert_called_once()
+        assert "overloaded_error" in mock_capture_msg.call_args.args[0]
+
+
+class TestPermanentErrors:
+    @pytest.mark.asyncio
+    async def test_authentication_error_re_raises_immediately(self) -> None:
+        """authentication_error is a config bug — loop re-raises without continuing."""
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(3)]
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(
+                _SCORE_JD_PATH,
+                new=AsyncMock(side_effect=_make_permanent_error("authentication_error")),
+            ) as mock_score,
+            patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
+            patch(_SENTRY_CAPTURE_EXC_PATH),
+            patch(_SENTRY_CAPTURE_MSG_PATH),
+        ):
+            from app.services.discovery import discovery_score_service
+            with pytest.raises(JobAnalysisError) as exc_info:
+                await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+        # Only 1 attempt before the raise — remaining 2 jobs untouched.
+        assert mock_score.call_count == 1
+        assert exc_info.value.code == "authentication_error"
+        assert exc_info.value.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_invalid_request_error_re_raises_immediately(self) -> None:
+        """invalid_request_error is a config bug — loop re-raises without continuing."""
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(3)]
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(
+                _SCORE_JD_PATH,
+                new=AsyncMock(side_effect=_make_permanent_error("invalid_request_error")),
+            ) as mock_score,
+            patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
+            patch(_SENTRY_CAPTURE_EXC_PATH),
+            patch(_SENTRY_CAPTURE_MSG_PATH),
+        ):
+            from app.services.discovery import discovery_score_service
+            with pytest.raises(JobAnalysisError) as exc_info:
+                await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+        assert mock_score.call_count == 1
+        assert exc_info.value.code == "invalid_request_error"
+        assert exc_info.value.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_all_permanent_error_codes_re_raise(self) -> None:
+        """Every code in PERMANENT_ANTHROPIC_CODES triggers an immediate re-raise."""
+        for code in PERMANENT_ANTHROPIC_CODES:
+            user_id = uuid.uuid4()
+            job = _make_job(user_id)
+
+            mock_db = AsyncMock()
+            mock_cm = AsyncMock()
+            mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+            mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+            with (
+                patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+                patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+                patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+                patch(
+                    _SCORE_JD_PATH,
+                    new=AsyncMock(side_effect=_make_permanent_error(code)),
+                ),
+                patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
+                patch(_SENTRY_CAPTURE_EXC_PATH),
+                patch(_SENTRY_CAPTURE_MSG_PATH),
+            ):
+                from app.services.discovery import discovery_score_service
+                with pytest.raises(JobAnalysisError) as exc_info:
+                    await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+            assert exc_info.value.code == code
+            assert exc_info.value.retryable is False
+
+    @pytest.mark.asyncio
+    async def test_sentry_capture_called_before_re_raise_on_permanent_error(self) -> None:
+        """Sentry capture_exception fires even for permanent errors before re-raise."""
+        user_id = uuid.uuid4()
+        job = _make_job(user_id)
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        err = _make_permanent_error("authentication_error")
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+            patch(_SCORE_JD_PATH, new=AsyncMock(side_effect=err)),
+            patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
+            patch(_SENTRY_CAPTURE_EXC_PATH) as mock_capture_exc,
+            patch(_SENTRY_CAPTURE_MSG_PATH),
+        ):
+            from app.services.discovery import discovery_score_service
+            with pytest.raises(JobAnalysisError):
+                await discovery_score_service.score_user_inbox(user_id, batch=10)
+
+        # Sentry was still notified even though we re-raised.
+        mock_capture_exc.assert_called_once_with(err)
+
+
+class TestJobAnalysisErrorStructure:
+    """Tests for JobAnalysisError field semantics and from_anthropic() factory."""
+
+    def test_default_is_retryable(self) -> None:
+        """JobAnalysisError with no kwargs defaults to retryable=True, code=None."""
+        err = JobAnalysisError("generic error")
+        assert err.retryable is True
+        assert err.code is None
+
+    def test_retryable_false_when_explicit(self) -> None:
+        err = JobAnalysisError("permanent", code="authentication_error", retryable=False)
+        assert err.retryable is False
+        assert err.code == "authentication_error"
+
+    def test_from_anthropic_rate_limit_is_transient(self) -> None:
+        """RateLimitError maps to retryable=True."""
+        import anthropic
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.headers = {}
+        mock_response.request = MagicMock()
+        mock_response.status_code = 429
+        exc = anthropic.RateLimitError(
+            "rate limit",
+            response=mock_response,
+            body={"error": {"type": "rate_limit_error"}},
+        )
+        wrapped = JobAnalysisError.from_anthropic(exc)
+        assert wrapped.code == "rate_limit_error"
+        assert wrapped.retryable is True
+
+    def test_from_anthropic_authentication_error_is_permanent(self) -> None:
+        """AuthenticationError maps to retryable=False."""
+        import anthropic
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.headers = {}
+        mock_response.request = MagicMock()
+        mock_response.status_code = 401
+        exc = anthropic.AuthenticationError(
+            "bad key",
+            response=mock_response,
+            body={"error": {"type": "authentication_error"}},
+        )
+        wrapped = JobAnalysisError.from_anthropic(exc)
+        assert wrapped.code == "authentication_error"
+        assert wrapped.retryable is False
+
+    def test_from_anthropic_invalid_request_is_permanent(self) -> None:
+        """BadRequestError with invalid_request_error type maps to retryable=False."""
+        import anthropic
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.headers = {}
+        mock_response.request = MagicMock()
+        mock_response.status_code = 400
+        exc = anthropic.BadRequestError(
+            "bad request",
+            response=mock_response,
+            body={"error": {"type": "invalid_request_error"}},
+        )
+        wrapped = JobAnalysisError.from_anthropic(exc)
+        assert wrapped.code == "invalid_request_error"
+        assert wrapped.retryable is False
+
+    def test_from_anthropic_overloaded_is_transient(self) -> None:
+        """InternalServerError with overloaded_error type maps to retryable=True.
+
+        Anthropic signals "overloaded" via HTTP 529 which is caught by
+        ``anthropic.InternalServerError`` (the public subclass of
+        ``APIStatusError``). ``OverloadedError`` exists in the private module
+        but is not exported — we test the public class with the correct body.
+        """
+        import anthropic
+        from unittest.mock import MagicMock
+
+        mock_response = MagicMock()
+        mock_response.headers = {}
+        mock_response.request = MagicMock()
+        mock_response.status_code = 529
+        # InternalServerError is the public subclass that catches 529 responses.
+        exc = anthropic.InternalServerError(
+            "overloaded",
+            response=mock_response,
+            body={"error": {"type": "overloaded_error"}},
+        )
+        wrapped = JobAnalysisError.from_anthropic(exc)
+        assert wrapped.code == "overloaded_error"
+        assert wrapped.retryable is True
+
+    def test_from_anthropic_connection_error_is_transient(self) -> None:
+        """APIConnectionError maps to code='connection_error', retryable=True."""
+        import anthropic
+        from unittest.mock import MagicMock
+
+        exc = anthropic.APIConnectionError(request=MagicMock())
+        wrapped = JobAnalysisError.from_anthropic(exc)
+        assert wrapped.code == "connection_error"
+        assert wrapped.retryable is True
+
+    def test_error_codes_in_transient_set_are_retryable(self) -> None:
+        """Every code in TRANSIENT_ANTHROPIC_CODES produces retryable=True."""
+        for code in TRANSIENT_ANTHROPIC_CODES:
+            err = JobAnalysisError("test", code=code, retryable=True)
+            assert err.retryable is True, f"Expected retryable for code={code}"
+
+    def test_error_codes_in_permanent_set_are_not_retryable(self) -> None:
+        """Every code in PERMANENT_ANTHROPIC_CODES produces retryable=False."""
+        for code in PERMANENT_ANTHROPIC_CODES:
+            err = JobAnalysisError("test", code=code, retryable=False)
+            assert err.retryable is False, f"Expected not-retryable for code={code}"


### PR DESCRIPTION
## Summary

Fixes the silent `except JobAnalysisError: continue` swallow in the discovery scoring loop (`discovery_score_service.score_user_inbox`). Before this PR, every Anthropic failure was logged at WARNING level and silently skipped — the operator had no way to distinguish a transient rate-limit blip from a permanent authentication misconfiguration, and a broken API key would produce zero scores forever with no alert.

## What changed

**`JobAnalysisError` (in `job_analysis_service.py`)**

Before:
```python
class JobAnalysisError(RuntimeError):
    """Generic analysis failure — HTTP 502."""
```

After:
```python
class JobAnalysisError(RuntimeError):
    def __init__(self, message: str, *, code: str | None = None, retryable: bool = True): ...

    @classmethod
    def from_anthropic(cls, exc: Exception) -> "JobAnalysisError": ...
```

`code` carries the Anthropic `error.type` string. `retryable` is pre-computed from `code`. `from_anthropic()` wraps any `APIStatusError` / `APIConnectionError` into the structured shape.

**`score()` function** now calls `JobAnalysisError.from_anthropic(exc)` instead of `JobAnalysisError(str(exc))` so structured codes propagate to every caller.

**`score_user_inbox` loop** — four error classes handled differently:

| Anthropic error.type | Was | Now |
|---|---|---|
| `rate_limit_error` | `continue` (silent) | Counted toward circuit-breaker; Sentry `capture_exception` with structured tags |
| `overloaded_error` | `continue` (silent) | Same as rate_limit_error |
| `authentication_error` | `continue` (silent) | **Re-raise immediately** — config bug, fail-loud |
| `invalid_request_error` | `continue` (silent) | **Re-raise immediately** — config bug, fail-loud |

Circuit-breaker: 3 consecutive transient failures abort the loop with a Sentry warning event (`discovery score loop aborted: 3 consecutive failures, type=X`). Remaining rows stay unscored for the next scheduled pass.

**Sentry tags emitted on every per-row failure:**
- `discovery.score_error_type` — Anthropic `error.type` or `unknown`
- `discovery.score_error_message` — first 200 chars of error message
- `discovery.score_attempt_index` — 0-based index in the batch
- `discovery.score_retryable` — `True` / `False`

**New constants exported from `job_analysis_service`:**
- `TRANSIENT_ANTHROPIC_CODES` — `frozenset` of retry-safe codes
- `PERMANENT_ANTHROPIC_CODES` — `frozenset` of fail-loud codes

## Tests

24 tests in `test_discovery_score_service.py` covering:

- Budget exhausted / no candidates (existing)
- Happy path — N candidates scored, single-commit guarantee, mid-batch budget stop (existing)
- Transient error handling: single failure continues loop, all transient codes trigger continue, Sentry tags emitted
- Circuit-breaker: 3 consecutive failures trips the breaker + Sentry warning, consecutive counter resets on success
- Permanent errors: `authentication_error` and `invalid_request_error` re-raise immediately (1 attempt, not 3), Sentry capture fires before re-raise
- `JobAnalysisError` structure: `from_anthropic()` for each SDK error subclass (RateLimitError, AuthenticationError, BadRequestError/invalid_request, InternalServerError/overloaded, APIConnectionError)

All 24 pass.

## Rules referenced

- `rules/check-third-party-error-codes.md` — every `APIStatusError` failure now surfaces `error.type` via Sentry tags
- `rules/no-bandaid-solutions.md` — `except: continue` was the bandaid; this is the clean shape
- `project_silent_fail_audit_followup.md` — MBK PR #205 is the reference pattern for removing silent-fail catches

🤖 Generated with [Claude Code](https://claude.com/claude-code)