### PR TITLE
feat(mjh/discover): Greenhouse + Lever source adapters

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/discsrc260511_add_greenhouse_lever_sources.py
+++ b/apps/myjobhunter/backend/alembic/versions/discsrc260511_add_greenhouse_lever_sources.py
@@ -1,0 +1,54 @@
+"""Extend discovery source CHECK constraints to permit 'greenhouse' and 'lever'.
+
+Both Greenhouse and Lever were already listed as valid source KIND values in the
+original ``disco260507`` migration (they were part of the intended set from day
+one), so this migration is a no-op from a DB perspective — the values are
+already in the CHECK constraint.
+
+Wait — let me re-check.  The original migration's ``_DISCOVERY_SOURCE_KINDS``
+tuple includes ``"greenhouse"`` and ``"lever"`` already.  The CHECK constraint
+on ``discovery_sources.source`` and ``discovered_jobs.source`` already permits
+those values.
+
+This migration therefore has NO constraint change to make.  It is kept as an
+explicit record in the revision chain to document that:
+
+1. The Greenhouse and Lever adapters are now implemented (PR adds them).
+2. No DB schema change is required — the existing CHECK constraints already
+   permit these values, as they were included in the original design.
+3. The migration applies and rolls back cleanly (it's a no-op migration).
+
+Revision ID: discsrc260511
+Revises: ixinbox260508
+Create Date: 2026-05-11
+"""
+from typing import Sequence, Union
+
+
+revision: str = "discsrc260511"
+down_revision: Union[str, None] = "ixinbox260508"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # No schema changes needed.  The 'greenhouse' and 'lever' values were
+    # already included in the CHECK constraints from the original
+    # disco260507 migration:
+    #
+    #   chk_discovery_source  on discovery_sources.source
+    #   chk_discovered_source on discovered_jobs.source
+    #
+    # Both constraints already include:
+    #   'greenhouse', 'lever', 'ashby', 'remoteok', 'hn_who_is_hiring',
+    #   'workatastartup', 'jsearch', 'other'
+    #
+    # This migration exists as a no-op revision in the chain so that:
+    # a) The alembic history clearly marks when the adapters shipped.
+    # b) Future migrations have an unambiguous prior revision to chain from.
+    pass
+
+
+def downgrade() -> None:
+    # No schema changes to revert.
+    pass

--- a/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
@@ -7,7 +7,9 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
+from app.schemas.discovery.greenhouse_source_config import GreenhouseSourceConfig
 from app.schemas.discovery.jsearch_source_config import JSearchSourceConfig
+from app.schemas.discovery.lever_source_config import LeverSourceConfig
 
 
 _VALID_SOURCES = (
@@ -51,13 +53,21 @@ class DiscoverySourceCreate(BaseModel):
 
     @model_validator(mode="after")
     def _validate_config_per_source(self) -> "DiscoverySourceCreate":
-        """Reject typo'd or out-of-enum config values for jsearch
-        sources at request time — operator gets a 422 with the field
-        name instead of a silently-no-op saved search."""
+        """Reject typo'd or out-of-enum config values at request time.
+
+        Each source with a shipped adapter gets strict config validation
+        here — the operator gets a 422 with the field name instead of a
+        silently-no-op saved search.  Sources that don't yet have an
+        adapter (``ashby``, ``remoteok``, etc.) still accept a loose dict.
+        """
         if self.source == "jsearch":
-            # ``model_validate`` raises ValidationError, FastAPI
-            # converts that to a 422 response automatically.
+            # ``model_validate`` raises ValidationError; FastAPI converts
+            # that to a 422 response automatically.
             JSearchSourceConfig.model_validate(self.config)
+        elif self.source == "greenhouse":
+            GreenhouseSourceConfig.model_validate(self.config)
+        elif self.source == "lever":
+            LeverSourceConfig.model_validate(self.config)
         return self
 
 

--- a/apps/myjobhunter/backend/app/schemas/discovery/greenhouse_source_config.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/greenhouse_source_config.py
@@ -1,0 +1,105 @@
+"""Typed config schema for Greenhouse saved searches.
+
+Greenhouse publishes a free, no-auth public job-board feed at:
+``GET https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs?content=true``
+
+The only required piece of operator configuration is ``board_token`` — the
+slug that appears in the board URL: ``boards.greenhouse.io/<board_token>``.
+
+Validation design
+=================
+
+- ``board_token`` is validated against a regex that mirrors the slug shape
+  Greenhouse accepts. This also provides SSRF protection: we reject any
+  value that contains ``../``, ``%``, ``@``, ``/``, or other characters
+  that could be used to construct a malicious URL. Per the security agent's
+  guidance: no user-supplied string should reach a URL template without
+  shape validation.
+
+- ``model_config = ConfigDict(extra="forbid")`` rejects typos at the API
+  boundary (the operator gets a 422 with the field name, not a silently
+  no-op saved search).
+
+- ``parse_or_default`` mirrors JSearchSourceConfig's pattern: used at
+  fetch time where we log + fall back to defaults rather than crashing the
+  worker on a malformed legacy row.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+logger = logging.getLogger(__name__)
+
+# Greenhouse board tokens are alphanumeric slugs.  We allow hyphens and
+# underscores (Greenhouse generates both) and cap at 64 chars to match
+# what Greenhouse actually accepts.  No slashes, dots, percent signs, or
+# @ signs allowed — any of those would be an SSRF attempt.
+_BOARD_TOKEN_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+
+
+class GreenhouseSourceConfig(BaseModel):
+    """Strict-typed config for a Greenhouse public job-board saved search.
+
+    The operator supplies the board_token from the Greenhouse board URL:
+    ``boards.greenhouse.io/<board_token>``.  That is the only config
+    needed — no API key, no authentication.
+    """
+
+    board_token: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "The board token from the Greenhouse URL: "
+            "boards.greenhouse.io/<board_token>"
+        ),
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("board_token")
+    @classmethod
+    def validate_board_token_shape(cls, v: str) -> str:
+        """Reject tokens that don't match the expected slug shape.
+
+        This is the primary SSRF guard — board_token is interpolated
+        directly into the fetch URL, so we must ensure it cannot contain
+        path-traversal sequences or URL-special characters.
+        """
+        if not _BOARD_TOKEN_RE.match(v):
+            raise ValueError(
+                "board_token must be an alphanumeric slug "
+                "(letters, digits, hyphens, underscores; 1-64 chars; "
+                "must start with a letter or digit). "
+                f"Got: {v!r}",
+            )
+        return v
+
+    @classmethod
+    def parse_or_default(cls, raw: dict | None) -> "GreenhouseSourceConfig":
+        """Validate raw config from a stored saved-search row.
+
+        Used at fetch time.  On validation failure we log + raise so the
+        fetch loop marks the source as errored with a clear message rather
+        than silently no-oping with a bad token.  Unlike JSearch (which
+        falls back to empty defaults and runs a zero-result search), a
+        Greenhouse source with an invalid board_token cannot run at all —
+        there is no meaningful default to fall back to.
+        """
+        if raw is None or not raw:
+            raise ValueError(
+                "Greenhouse source config is missing — board_token is required",
+            )
+        try:
+            return cls.model_validate(raw)
+        except ValidationError as exc:
+            logger.warning(
+                "Greenhouse source config validation failed: %s",
+                exc,
+            )
+            raise ValueError(
+                f"Greenhouse source config invalid: {exc}",
+            ) from exc

--- a/apps/myjobhunter/backend/app/schemas/discovery/lever_source_config.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/lever_source_config.py
@@ -1,0 +1,100 @@
+"""Typed config schema for Lever saved searches.
+
+Lever publishes a free, no-auth public job-board feed at:
+``GET https://api.lever.co/v0/postings/{company_slug}?mode=json``
+
+The only required piece of operator configuration is ``company_slug`` — the
+slug that appears in the Lever URL: ``jobs.lever.co/<company_slug>``.
+
+Validation design
+=================
+
+- ``company_slug`` is validated against a regex that mirrors the slug shape
+  Lever accepts.  This also provides SSRF protection — same rationale as
+  GreenhouseSourceConfig.  No user-supplied string should reach a URL
+  template without shape validation.
+
+- ``model_config = ConfigDict(extra="forbid")`` rejects typos at the API
+  boundary.
+
+- ``parse_or_default`` raises on invalid config (same reasoning as
+  GreenhouseSourceConfig — there is no meaningful default slug to fall
+  back to).
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+logger = logging.getLogger(__name__)
+
+# Lever company slugs are lowercase alphanumeric + hyphens.  Lever's own
+# URL convention uses lowercase only, but we normalize to lowercase in the
+# validator to be forgiving of case typos.  The regex enforces the post-
+# normalization shape.
+_COMPANY_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+
+
+class LeverSourceConfig(BaseModel):
+    """Strict-typed config for a Lever public job-board saved search.
+
+    The operator supplies the company_slug from the Lever URL:
+    ``jobs.lever.co/<company_slug>``.  That is the only config
+    needed — no API key, no authentication.
+    """
+
+    company_slug: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        description=(
+            "The company slug from the Lever URL: "
+            "jobs.lever.co/<company_slug>"
+        ),
+    )
+
+    model_config = ConfigDict(extra="forbid")
+
+    @field_validator("company_slug")
+    @classmethod
+    def validate_company_slug_shape(cls, v: str) -> str:
+        """Normalize to lowercase and reject non-slug shapes.
+
+        This is the primary SSRF guard — company_slug is interpolated
+        directly into the fetch URL.  Lowercase normalization lets operators
+        paste slugs without worrying about case.
+        """
+        normalized = v.lower()
+        if not _COMPANY_SLUG_RE.match(normalized):
+            raise ValueError(
+                "company_slug must be a lowercase alphanumeric slug "
+                "(letters, digits, hyphens; 1-64 chars; "
+                "must start with a letter or digit). "
+                f"Got: {v!r}",
+            )
+        return normalized
+
+    @classmethod
+    def parse_or_default(cls, raw: dict | None) -> "LeverSourceConfig":
+        """Validate raw config from a stored saved-search row.
+
+        Used at fetch time.  Raises on invalid config because there is no
+        meaningful default slug to fall back to (unlike JSearch which can
+        run a parameterless search).
+        """
+        if raw is None or not raw:
+            raise ValueError(
+                "Lever source config is missing — company_slug is required",
+            )
+        try:
+            return cls.model_validate(raw)
+        except ValidationError as exc:
+            logger.warning(
+                "Lever source config validation failed: %s",
+                exc,
+            )
+            raise ValueError(
+                f"Lever source config invalid: {exc}",
+            ) from exc

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
@@ -29,9 +29,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.discovery.discovery_source import DiscoverySource
 from app.repositories.discovery import discovery_repository
+from app.schemas.discovery.greenhouse_source_config import GreenhouseSourceConfig
 from app.schemas.discovery.jsearch_source_config import JSearchSourceConfig
+from app.schemas.discovery.lever_source_config import LeverSourceConfig
 from app.services.discovery.industry_denylists import expand_excluded_keywords
-from app.services.discovery.sources import jsearch
+from app.services.discovery.sources import greenhouse, jsearch, lever
 
 logger = logging.getLogger(__name__)
 
@@ -220,8 +222,31 @@ def _apply_post_fetch_filters(
     return kept
 
 
+async def _run_greenhouse(config: dict[str, Any]) -> list[dict]:
+    """Validate Greenhouse config and invoke the adapter.
+
+    Unlike JSearch, there is no meaningful default config to fall back to
+    if the board_token is missing — we let ``parse_or_default`` raise
+    and the fetch-service error handler marks the source as errored.
+    """
+    typed = GreenhouseSourceConfig.parse_or_default(config)
+    return await greenhouse.fetch_board(board_token=typed.board_token, config=typed)
+
+
+async def _run_lever(config: dict[str, Any]) -> list[dict]:
+    """Validate Lever config and invoke the adapter.
+
+    Same reasoning as _run_greenhouse: no meaningful default when
+    company_slug is missing.
+    """
+    typed = LeverSourceConfig.parse_or_default(config)
+    return await lever.fetch_postings(company_slug=typed.company_slug, config=typed)
+
+
 _ADAPTERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[dict]]]] = {
     "jsearch": _run_jsearch,
+    "greenhouse": _run_greenhouse,
+    "lever": _run_lever,
 }
 
 

--- a/apps/myjobhunter/backend/app/services/discovery/sources/greenhouse.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/greenhouse.py
@@ -1,0 +1,337 @@
+"""Greenhouse public job-board source adapter.
+
+Wraps the official Greenhouse Boards API:
+``GET https://boards-api.greenhouse.io/v1/boards/{board_token}/jobs?content=true``
+
+This is a free, no-auth, officially-supported feed.  Greenhouse explicitly
+publishes this endpoint for programmatic consumption.  See:
+https://developers.greenhouse.io/job-board.html
+
+Key design decisions
+====================
+
+- **No authentication required** — the boards API is intentionally public.
+  We only need the operator-supplied ``board_token`` from the board URL.
+- **404 = invalid board_token** — treated as ``GreenhouseInvalidBoardError``
+  (caller should pause the source and surface to the operator).
+- **429 / 5xx = transient** — retried up to 3 times with exponential
+  backoff via tenacity.
+- **HTML description stripping** — Greenhouse returns job content as raw
+  HTML (``content`` field).  We strip tags to get plain text so Claude
+  can score without noise.  A lightweight regex-based stripper is used to
+  avoid a heavy BeautifulSoup dependency; it handles the common patterns
+  (``<br>``, ``<p>``, ``<li>``, ``<h2>``...) Greenhouse emits.
+- **company_name derivation** — the jobs feed does not include the company
+  name directly.  We fetch it from the board metadata endpoint on the first
+  call and cache it per-adapter-call.
+- **source_publisher** — set to ``"Greenhouse"`` (the platform), not the
+  company name, to be consistent with JSearch's pattern (publisher = the
+  channel, not the employer).
+
+Per ``rules/check-third-party-error-codes.md``: HTTP status + response
+body excerpt are logged on every non-2xx so Sentry dashboards can show the
+failure reason without needing a debug endpoint.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+
+import httpx
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from app.schemas.discovery.greenhouse_source_config import GreenhouseSourceConfig
+
+logger = logging.getLogger(__name__)
+
+
+GREENHOUSE_BOARDS_BASE = "https://boards-api.greenhouse.io/v1/boards"
+
+USER_AGENT = "MyJobHunter/1.0 (+https://myjobhunter.myfreeapps.org)"
+
+# HTTP statuses that warrant exponential backoff + retry.
+_TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
+
+# Greenhouse JD HTML is well-structured but may contain inline styles,
+# scripts (rare), and nested tags.  This stripper handles the common
+# patterns; it is intentionally minimal so we don't take on BeautifulSoup
+# as a dep for a secondary concern.
+_HTML_TAG_RE = re.compile(r"<[^>]+>", re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r"\s{2,}")
+
+# Cap description length consistent with jsearch.py.
+_MAX_DESCRIPTION_CHARS = 12_000
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class GreenhouseError(RuntimeError):
+    """Generic Greenhouse failure."""
+
+
+class GreenhouseInvalidBoardError(GreenhouseError):
+    """404 — board_token doesn't exist or is private.  Fatal, do not retry."""
+
+
+class GreenhouseTransientError(GreenhouseError):
+    """429 / 5xx / network error — retry with backoff."""
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+@retry(
+    retry=retry_if_exception_type(GreenhouseTransientError),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=20),
+    reraise=True,
+)
+async def fetch_board(
+    *,
+    board_token: str,
+    config: GreenhouseSourceConfig | None = None,
+) -> list[dict]:
+    """Fetch all active postings from a Greenhouse public board.
+
+    Args:
+        board_token: The slug from ``boards.greenhouse.io/<board_token>``.
+        config: Validated GreenhouseSourceConfig (optional — used for
+            any future per-source overrides like date filtering).
+
+    Returns:
+        List of normalized posting dicts whose keys map directly onto
+        ``DiscoveredJob`` columns (plus ``raw_payload``).
+
+    Raises:
+        GreenhouseInvalidBoardError: 404 — board_token is unknown.
+            Caller should deactivate the source.
+        GreenhouseTransientError: 429 / 5xx / network — retried up to 3
+            times before propagating.
+        GreenhouseError: Any other non-2xx status.
+    """
+    jobs_url = f"{GREENHOUSE_BOARDS_BASE}/{board_token}/jobs"
+    params = {"content": "true"}
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(jobs_url, params=params, headers=headers)
+    except httpx.RequestError as exc:
+        logger.warning(
+            "Greenhouse network error: board_token=%s error=%s",
+            board_token,
+            exc,
+        )
+        raise GreenhouseTransientError(
+            f"Greenhouse network error for board {board_token!r}: {exc}",
+        ) from exc
+
+    if response.status_code == 404:
+        logger.warning(
+            "Greenhouse invalid board: board_token=%s status=404 body=%s",
+            board_token,
+            response.text[:300],
+        )
+        raise GreenhouseInvalidBoardError(
+            f"Greenhouse board {board_token!r} not found (404) — "
+            "check that the board token is correct and the board is public",
+        )
+
+    if response.status_code in _TRANSIENT_STATUS:
+        logger.warning(
+            "Greenhouse transient error: board_token=%s status=%s body=%s",
+            board_token,
+            response.status_code,
+            response.text[:300],
+        )
+        raise GreenhouseTransientError(
+            f"Greenhouse returned {response.status_code} for board {board_token!r}",
+        )
+
+    if not response.is_success:
+        logger.warning(
+            "Greenhouse unexpected status: board_token=%s status=%s body=%s",
+            board_token,
+            response.status_code,
+            response.text[:300],
+        )
+        raise GreenhouseError(
+            f"Greenhouse returned unexpected status {response.status_code} "
+            f"for board {board_token!r}",
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        logger.warning(
+            "Greenhouse non-JSON response: board_token=%s body=%s",
+            board_token,
+            response.text[:300],
+        )
+        raise GreenhouseError(
+            f"Greenhouse returned non-JSON body for board {board_token!r}: {exc}",
+        ) from exc
+
+    # Try to get company name from the board metadata endpoint.  This is a
+    # best-effort call — if it fails we fall back to the board_token as the
+    # company name (ugly but safe).
+    company_name = await _fetch_company_name(board_token, headers)
+
+    raw_jobs = body.get("jobs", [])
+    if not isinstance(raw_jobs, list):
+        logger.warning(
+            "Greenhouse unexpected jobs shape: board_token=%s type=%s",
+            board_token,
+            type(raw_jobs).__name__,
+        )
+        raise GreenhouseError(
+            f"Greenhouse jobs field is not a list for board {board_token!r}: "
+            f"{type(raw_jobs).__name__}",
+        )
+
+    normalized: list[dict] = []
+    for raw in raw_jobs:
+        if not isinstance(raw, dict):
+            continue
+        if not raw.get("id"):
+            continue
+        normalized.append(_normalize(raw, company_name=company_name))
+
+    logger.info(
+        "Greenhouse fetch ok: board_token=%s returned=%d",
+        board_token,
+        len(normalized),
+    )
+    return normalized
+
+
+async def _fetch_company_name(board_token: str, headers: dict) -> str:
+    """Fetch the company name from the Greenhouse board metadata.
+
+    Best-effort — falls back to board_token on any failure.  The board
+    metadata endpoint (no query params) returns a JSON object with a
+    ``name`` field containing the company's display name.
+    """
+    try:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            resp = await client.get(
+                f"{GREENHOUSE_BOARDS_BASE}/{board_token}",
+                headers=headers,
+            )
+        if resp.is_success:
+            data = resp.json()
+            name = data.get("name")
+            if name and isinstance(name, str):
+                return name.strip()[:300]
+    except Exception as exc:  # noqa: BLE001 — best-effort, swallow anything
+        logger.debug(
+            "Greenhouse company name fetch failed (using board_token): %s", exc,
+        )
+    return board_token
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+
+def _normalize(raw: dict, *, company_name: str) -> dict:
+    """Map one Greenhouse job object to the DiscoveredJob column shape."""
+    description_html = raw.get("content") or ""
+    description = _strip_html(description_html)
+    if len(description) > _MAX_DESCRIPTION_CHARS:
+        description = description[: _MAX_DESCRIPTION_CHARS - 1] + "…"
+    description = description or None
+
+    location_raw = raw.get("location") or {}
+    location_name: str | None = None
+    if isinstance(location_raw, dict):
+        loc = location_raw.get("name")
+        if loc and isinstance(loc, str):
+            location_name = loc.strip()[:300] or None
+    elif isinstance(location_raw, str):
+        location_name = location_raw.strip()[:300] or None
+
+    # Derive remote_type from location string since Greenhouse doesn't
+    # have a dedicated remote field.
+    remote_type = _infer_remote_type(location_name)
+
+    return {
+        "source": "greenhouse",
+        "source_external_id": str(raw["id"]),
+        "source_publisher": "Greenhouse",
+        "source_url": _str_or_none(raw.get("absolute_url")),
+        "title": (_str_or_none(raw.get("title")) or "Untitled role")[:300],
+        "company_name": company_name,
+        "location": location_name,
+        "remote_type": remote_type,
+        "description": description,
+        "posted_at": _parse_updated_at(raw.get("updated_at")),
+        "salary_min": None,
+        "salary_max": None,
+        "salary_currency": "USD",
+        "salary_period": None,
+        "raw_payload": raw,
+    }
+
+
+def _strip_html(html: str) -> str:
+    """Remove HTML tags and normalize whitespace to plain text."""
+    # Replace block-level closing tags with newlines so paragraphs
+    # become separate lines of plain text.
+    text = re.sub(r"</?(p|br|li|h[1-6]|div|section|article)[^>]*>",
+                  " ", html, flags=re.IGNORECASE)
+    # Remove remaining tags.
+    text = _HTML_TAG_RE.sub("", text)
+    # Collapse multiple whitespace characters.
+    text = _WHITESPACE_RE.sub(" ", text)
+    return text.strip()
+
+
+def _infer_remote_type(location: str | None) -> str:
+    if not location:
+        return "unknown"
+    loc_lower = location.lower()
+    if "hybrid" in loc_lower:
+        return "hybrid"
+    if "remote" in loc_lower:
+        return "remote"
+    return "onsite"
+
+
+def _parse_updated_at(value: object) -> datetime | None:
+    """Parse Greenhouse's ``updated_at`` field.
+
+    Greenhouse returns ISO 8601 timestamps in the form
+    ``2024-02-14T10:04:02-05:00``.  Python's fromisoformat handles this
+    natively in 3.11+; for 3.7-3.10 compat we do a light normalisation.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        # Python 3.11+ handles Z and ±HH:MM offsets natively.
+        # For 3.10 compat we normalise the trailing Z.
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _str_or_none(value: object) -> str | None:
+    if not value or not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned if cleaned else None

--- a/apps/myjobhunter/backend/app/services/discovery/sources/lever.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/lever.py
@@ -1,0 +1,312 @@
+"""Lever public job-board source adapter.
+
+Wraps the official Lever Postings API:
+``GET https://api.lever.co/v0/postings/{company_slug}?mode=json``
+
+This is a free, no-auth, officially-supported feed.  Lever explicitly
+publishes this endpoint for programmatic consumption.  See:
+https://hire.lever.co/developer/documentation
+
+Key design decisions
+====================
+
+- **No authentication required** — the v0 postings endpoint is public.
+  We only need the operator-supplied ``company_slug`` from the Lever URL.
+- **404 = unknown slug** — treated as ``LeverInvalidSlugError`` (caller
+  should pause the source and surface to the operator).
+- **429 / 5xx = transient** — retried up to 3 times with exponential
+  backoff via tenacity.
+- **Plain-text description** — Lever returns ``descriptionPlain`` so no
+  HTML stripping is needed.  We fall back to the HTML ``description``
+  field (stripping tags) if ``descriptionPlain`` is absent.
+- **company_name** — derived from the company_slug since the v0 postings
+  endpoint doesn't return the company display name directly.  We use
+  ``_humanize_slug()`` to produce a readable name (e.g. ``stripe-inc``
+  → ``Stripe Inc``).  Not perfect but better than the raw slug in the
+  card UI.  The operator can later link the job to a Company record which
+  has the canonical name.
+- **createdAt is epoch milliseconds** in Lever's v0 API.
+
+Per ``rules/check-third-party-error-codes.md``: HTTP status + response
+body excerpt are logged on every non-2xx so Sentry dashboards can surface
+the failure reason without a debug endpoint.
+"""
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime, timezone
+
+import httpx
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from app.schemas.discovery.lever_source_config import LeverSourceConfig
+
+logger = logging.getLogger(__name__)
+
+
+LEVER_POSTINGS_BASE = "https://api.lever.co/v0/postings"
+
+USER_AGENT = "MyJobHunter/1.0 (+https://myjobhunter.myfreeapps.org)"
+
+# HTTP statuses that warrant exponential backoff + retry.
+_TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
+
+# Lightweight HTML tag stripper for the fallback ``description`` field.
+_HTML_TAG_RE = re.compile(r"<[^>]+>", re.IGNORECASE)
+_WHITESPACE_RE = re.compile(r"\s{2,}")
+
+# Cap description length consistent with jsearch.py and greenhouse.py.
+_MAX_DESCRIPTION_CHARS = 12_000
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+
+class LeverError(RuntimeError):
+    """Generic Lever failure."""
+
+
+class LeverInvalidSlugError(LeverError):
+    """404 — company_slug doesn't exist.  Fatal, do not retry."""
+
+
+class LeverTransientError(LeverError):
+    """429 / 5xx / network error — retry with backoff."""
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+@retry(
+    retry=retry_if_exception_type(LeverTransientError),
+    stop=stop_after_attempt(3),
+    wait=wait_exponential(multiplier=1, min=2, max=20),
+    reraise=True,
+)
+async def fetch_postings(
+    *,
+    company_slug: str,
+    config: LeverSourceConfig | None = None,
+) -> list[dict]:
+    """Fetch all active postings from a Lever public job board.
+
+    Args:
+        company_slug: The slug from ``jobs.lever.co/<company_slug>``.
+        config: Validated LeverSourceConfig (optional — used for any future
+            per-source overrides).
+
+    Returns:
+        List of normalized posting dicts whose keys map directly onto
+        ``DiscoveredJob`` columns (plus ``raw_payload``).
+
+    Raises:
+        LeverInvalidSlugError: 404 — company_slug is unknown.
+            Caller should deactivate the source.
+        LeverTransientError: 429 / 5xx / network — retried up to 3 times.
+        LeverError: Any other non-2xx status.
+    """
+    url = f"{LEVER_POSTINGS_BASE}/{company_slug}"
+    params = {"mode": "json"}
+    headers = {
+        "User-Agent": USER_AGENT,
+        "Accept": "application/json",
+    }
+
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            response = await client.get(url, params=params, headers=headers)
+    except httpx.RequestError as exc:
+        logger.warning(
+            "Lever network error: company_slug=%s error=%s",
+            company_slug,
+            exc,
+        )
+        raise LeverTransientError(
+            f"Lever network error for slug {company_slug!r}: {exc}",
+        ) from exc
+
+    if response.status_code == 404:
+        logger.warning(
+            "Lever invalid slug: company_slug=%s status=404 body=%s",
+            company_slug,
+            response.text[:300],
+        )
+        raise LeverInvalidSlugError(
+            f"Lever company {company_slug!r} not found (404) — "
+            "check that the slug is correct and postings are public",
+        )
+
+    if response.status_code in _TRANSIENT_STATUS:
+        logger.warning(
+            "Lever transient error: company_slug=%s status=%s body=%s",
+            company_slug,
+            response.status_code,
+            response.text[:300],
+        )
+        raise LeverTransientError(
+            f"Lever returned {response.status_code} for slug {company_slug!r}",
+        )
+
+    if not response.is_success:
+        logger.warning(
+            "Lever unexpected status: company_slug=%s status=%s body=%s",
+            company_slug,
+            response.status_code,
+            response.text[:300],
+        )
+        raise LeverError(
+            f"Lever returned unexpected status {response.status_code} "
+            f"for slug {company_slug!r}",
+        )
+
+    try:
+        body = response.json()
+    except ValueError as exc:
+        logger.warning(
+            "Lever non-JSON response: company_slug=%s body=%s",
+            company_slug,
+            response.text[:300],
+        )
+        raise LeverError(
+            f"Lever returned non-JSON body for slug {company_slug!r}: {exc}",
+        ) from exc
+
+    # The v0 endpoint returns a JSON array at the top level (mode=json).
+    if not isinstance(body, list):
+        logger.warning(
+            "Lever unexpected response shape: company_slug=%s type=%s",
+            company_slug,
+            type(body).__name__,
+        )
+        raise LeverError(
+            f"Lever response for slug {company_slug!r} is not a list: "
+            f"{type(body).__name__}",
+        )
+
+    company_name = _humanize_slug(company_slug)
+
+    normalized: list[dict] = []
+    for raw in body:
+        if not isinstance(raw, dict):
+            continue
+        if not raw.get("id"):
+            continue
+        normalized.append(_normalize(raw, company_name=company_name))
+
+    logger.info(
+        "Lever fetch ok: company_slug=%s returned=%d",
+        company_slug,
+        len(normalized),
+    )
+    return normalized
+
+
+# ---------------------------------------------------------------------------
+# Normalization
+# ---------------------------------------------------------------------------
+
+
+def _normalize(raw: dict, *, company_name: str) -> dict:
+    """Map one Lever posting object to the DiscoveredJob column shape."""
+    # Prefer the plain-text description; fall back to stripped HTML.
+    description: str | None = _str_or_none(raw.get("descriptionPlain"))
+    if description is None:
+        html = _str_or_none(raw.get("description"))
+        if html:
+            description = _strip_html(html) or None
+
+    if description and len(description) > _MAX_DESCRIPTION_CHARS:
+        description = description[: _MAX_DESCRIPTION_CHARS - 1] + "…"
+
+    # categories is a dict containing commitment, department, location, team.
+    categories = raw.get("categories") or {}
+    location_name: str | None = None
+    if isinstance(categories, dict):
+        loc = categories.get("location")
+        if loc and isinstance(loc, str):
+            location_name = loc.strip()[:300] or None
+
+    remote_type = _infer_remote_type(location_name)
+
+    return {
+        "source": "lever",
+        "source_external_id": str(raw["id"]),
+        "source_publisher": "Lever",
+        "source_url": _str_or_none(raw.get("hostedUrl")),
+        "title": (_str_or_none(raw.get("text")) or "Untitled role")[:300],
+        "company_name": company_name,
+        "location": location_name,
+        "remote_type": remote_type,
+        "description": description,
+        "posted_at": _parse_epoch_ms(raw.get("createdAt")),
+        "salary_min": None,
+        "salary_max": None,
+        "salary_currency": "USD",
+        "salary_period": None,
+        "raw_payload": raw,
+    }
+
+
+def _humanize_slug(slug: str) -> str:
+    """Convert a company slug to a display name.
+
+    ``stripe-inc`` → ``Stripe Inc``
+    ``openai`` → ``Openai``  (no hyphen = capitalize one word)
+    ``acme-corp-ltd`` → ``Acme Corp Ltd``
+
+    This is a best-effort cosmetic transform.  The operator can later link
+    the job to a Company record that has the canonical name.
+    """
+    return " ".join(word.capitalize() for word in slug.split("-"))
+
+
+def _strip_html(html: str) -> str:
+    """Remove HTML tags and normalize whitespace to plain text."""
+    text = re.sub(
+        r"</?(p|br|li|h[1-6]|div|section|article)[^>]*>",
+        " ",
+        html,
+        flags=re.IGNORECASE,
+    )
+    text = _HTML_TAG_RE.sub("", text)
+    text = _WHITESPACE_RE.sub(" ", text)
+    return text.strip()
+
+
+def _infer_remote_type(location: str | None) -> str:
+    if not location:
+        return "unknown"
+    loc_lower = location.lower()
+    if "hybrid" in loc_lower:
+        return "hybrid"
+    if "remote" in loc_lower:
+        return "remote"
+    return "onsite"
+
+
+def _parse_epoch_ms(value: object) -> datetime | None:
+    """Parse Lever's ``createdAt`` field (Unix epoch milliseconds as int)."""
+    if value is None:
+        return None
+    try:
+        ms = int(value)  # type: ignore[arg-type]
+        return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc)
+    except (TypeError, ValueError, OSError):
+        return None
+
+
+def _str_or_none(value: object) -> str | None:
+    if not value or not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    return cleaned if cleaned else None

--- a/apps/myjobhunter/backend/tests/test_greenhouse_adapter.py
+++ b/apps/myjobhunter/backend/tests/test_greenhouse_adapter.py
@@ -1,0 +1,349 @@
+"""Tests for the Greenhouse public job-board source adapter.
+
+Mocks ``httpx.AsyncClient`` via ``httpx.MockTransport`` so no actual
+HTTP calls happen. Verifies:
+
+- Happy path: 200 OK with realistic Greenhouse envelope → normalized
+  RawPosting dicts
+- 404 → GreenhouseInvalidBoardError (invalid board_token)
+- 429 → GreenhouseTransientError with tenacity retry (3 attempts)
+- 500 → GreenhouseTransientError with retry
+- Success after one transient failure (retry recovers)
+- Non-JSON body → GreenhouseError
+- Unexpected jobs shape (not list) → GreenhouseError
+- HTML stripping: <p>, <br>, <li>, <h2> tags removed
+- Remote type derivation from location string
+- Description truncation at 12k char cap
+- company_name fetched from board metadata endpoint
+- Empty jobs array → empty result list
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services.discovery.sources import greenhouse
+from app.services.discovery.sources.greenhouse import (
+    GreenhouseError,
+    GreenhouseInvalidBoardError,
+    GreenhouseTransientError,
+    fetch_board,
+)
+
+# Capture original AsyncClient before any patching.
+_OriginalAsyncClient = httpx.AsyncClient
+
+
+def _client_with_handler(handler):
+    transport = httpx.MockTransport(handler)
+    return _OriginalAsyncClient(transport=transport, timeout=30.0)
+
+
+def _realistic_job(**overrides) -> dict:
+    """One realistic Greenhouse jobs-feed entry."""
+    base = {
+        "id": 4001234,
+        "title": "Senior Software Engineer",
+        "location": {"name": "San Francisco, CA"},
+        "absolute_url": "https://boards.greenhouse.io/stripe/jobs/4001234",
+        "content": "<p>We're looking for a <strong>senior engineer</strong>.</p><ul><li>5+ years Python</li><li>Distributed systems experience</li></ul>",
+        "updated_at": "2026-05-10T14:30:00-07:00",
+        "requisition_id": "REQ-1234",
+        "metadata": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def _board_response(jobs: list | None = None) -> dict:
+    return {"jobs": jobs if jobs is not None else [_realistic_job()], "meta": {"total": 1}}
+
+
+def _company_response() -> dict:
+    return {"name": "Stripe", "id": "stripe", "url": "https://www.stripe.com"}
+
+
+# Multi-handler helper: first call = company name, second call = jobs.
+# (fetch_board calls the metadata endpoint then the jobs endpoint)
+class _TwoCallHandler:
+    def __init__(self, company_resp, jobs_resp):
+        self._company_resp = company_resp
+        self._jobs_resp = jobs_resp
+        self._call_count = 0
+
+    def __call__(self, request: httpx.Request) -> httpx.Response:
+        self._call_count += 1
+        # The company name call hits /{board_token} (no query params).
+        # The jobs call hits /{board_token}/jobs?content=true.
+        if "jobs" in request.url.path:
+            return httpx.Response(200, json=self._jobs_resp)
+        return httpx.Response(200, json=self._company_resp)
+
+
+# ===========================================================================
+# Happy path
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_happy_path() -> None:
+    handler = _TwoCallHandler(_company_response(), _board_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    assert len(results) == 1
+    posting = results[0]
+    assert posting["source"] == "greenhouse"
+    assert posting["source_external_id"] == "4001234"
+    assert posting["source_publisher"] == "Greenhouse"
+    assert posting["title"] == "Senior Software Engineer"
+    assert posting["company_name"] == "Stripe"
+    assert posting["location"] == "San Francisco, CA"
+    assert posting["remote_type"] == "onsite"
+    assert posting["source_url"] == "https://boards.greenhouse.io/stripe/jobs/4001234"
+    assert posting["posted_at"] is not None
+    # Salary fields are None — Greenhouse feed doesn't include comp
+    assert posting["salary_min"] is None
+    assert posting["salary_max"] is None
+    # raw_payload preserved
+    assert posting["raw_payload"]["id"] == 4001234
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_strips_html_from_description() -> None:
+    job = _realistic_job(
+        content="<p>We're looking for a <strong>senior engineer</strong>.</p>"
+                "<ul><li>5+ years Python</li><li>Distributed systems</li></ul>",
+    )
+    handler = _TwoCallHandler(_company_response(), _board_response([job]))
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    desc = results[0]["description"]
+    assert desc is not None
+    assert "<p>" not in desc
+    assert "<ul>" not in desc
+    assert "<li>" not in desc
+    assert "senior engineer" in desc
+    assert "5+ years Python" in desc
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_returns_empty_list_for_empty_jobs() -> None:
+    handler = _TwoCallHandler(_company_response(), {"jobs": []})
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_skips_jobs_missing_id() -> None:
+    bad_job = _realistic_job()
+    del bad_job["id"]
+    good_job = _realistic_job(id=9999)
+    handler = _TwoCallHandler(_company_response(), _board_response([bad_job, good_job]))
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    assert len(results) == 1
+    assert results[0]["source_external_id"] == "9999"
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_truncates_long_description() -> None:
+    job = _realistic_job(content="x" * 50000)
+    handler = _TwoCallHandler(_company_response(), _board_response([job]))
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    desc = results[0]["description"]
+    assert desc is not None
+    assert len(desc) == 12_000
+    assert desc.endswith("…")
+
+
+# ===========================================================================
+# 404 — invalid board token
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_raises_invalid_board_error_on_404() -> None:
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        if "jobs" in request.url.path:
+            return httpx.Response(404, text="not found")
+        return httpx.Response(200, json=_company_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(GreenhouseInvalidBoardError) as exc_info:
+            await fetch_board(board_token="nonexistent-board")
+
+    assert "not found" in str(exc_info.value).lower() or "404" in str(exc_info.value)
+
+
+# ===========================================================================
+# Transient errors → tenacity retry, then propagate
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_retries_on_429_then_propagates(monkeypatch) -> None:
+    monkeypatch.setattr(
+        greenhouse, "fetch_board",
+        greenhouse.fetch_board.retry_with(wait=lambda _: 0),
+    )
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "jobs" in request.url.path:
+            call_count["n"] += 1
+            return httpx.Response(429, text="rate limited")
+        return httpx.Response(200, json=_company_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(GreenhouseTransientError):
+            await greenhouse.fetch_board(board_token="stripe")
+
+    assert call_count["n"] == 3  # 3 attempts before propagating
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_retries_on_500(monkeypatch) -> None:
+    monkeypatch.setattr(
+        greenhouse, "fetch_board",
+        greenhouse.fetch_board.retry_with(wait=lambda _: 0),
+    )
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "jobs" in request.url.path:
+            call_count["n"] += 1
+            return httpx.Response(500, text="internal server error")
+        return httpx.Response(200, json=_company_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(GreenhouseTransientError):
+            await greenhouse.fetch_board(board_token="stripe")
+
+    assert call_count["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_succeeds_after_one_transient(monkeypatch) -> None:
+    monkeypatch.setattr(
+        greenhouse, "fetch_board",
+        greenhouse.fetch_board.retry_with(wait=lambda _: 0),
+    )
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "jobs" in request.url.path:
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                return httpx.Response(429, text="rate limited")
+            return httpx.Response(200, json=_board_response())
+        return httpx.Response(200, json=_company_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await greenhouse.fetch_board(board_token="stripe")
+
+    assert len(results) == 1
+    assert call_count["n"] == 2
+
+
+# ===========================================================================
+# Malformed responses
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_raises_on_non_json_body() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "jobs" in request.url.path:
+            return httpx.Response(200, text="not json")
+        return httpx.Response(200, json=_company_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(GreenhouseError):
+            await fetch_board(board_token="stripe")
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_raises_when_jobs_not_list() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "jobs" in request.url.path:
+            return httpx.Response(200, json={"jobs": "not-a-list"})
+        return httpx.Response(200, json=_company_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(GreenhouseError):
+            await fetch_board(board_token="stripe")
+
+
+# ===========================================================================
+# Remote type derivation
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_remote_type_from_location_remote() -> None:
+    job = _realistic_job(location={"name": "Remote"})
+    handler = _TwoCallHandler(_company_response(), _board_response([job]))
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    assert results[0]["remote_type"] == "remote"
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_remote_type_hybrid() -> None:
+    job = _realistic_job(location={"name": "New York / Hybrid"})
+    handler = _TwoCallHandler(_company_response(), _board_response([job]))
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    assert results[0]["remote_type"] == "hybrid"
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_remote_type_unknown_when_no_location() -> None:
+    job = _realistic_job(location=None)
+    handler = _TwoCallHandler(_company_response(), _board_response([job]))
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    assert results[0]["remote_type"] == "unknown"
+
+
+# ===========================================================================
+# Company name fallback
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_falls_back_to_board_token_when_company_fetch_fails() -> None:
+    """If the company metadata endpoint fails, board_token is used as the name."""
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "jobs" in request.url.path:
+            return httpx.Response(200, json=_board_response())
+        # Company metadata endpoint fails
+        return httpx.Response(500, text="server error")
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_board(board_token="stripe")
+
+    assert results[0]["company_name"] == "stripe"

--- a/apps/myjobhunter/backend/tests/test_lever_adapter.py
+++ b/apps/myjobhunter/backend/tests/test_lever_adapter.py
@@ -1,0 +1,356 @@
+"""Tests for the Lever public job-board source adapter.
+
+Mocks ``httpx.AsyncClient`` via ``httpx.MockTransport`` so no actual
+HTTP calls happen. Verifies:
+
+- Happy path: 200 OK with realistic Lever envelope → normalized postings
+- 404 → LeverInvalidSlugError (invalid company_slug)
+- 429 → LeverTransientError with tenacity retry (3 attempts)
+- 500 → LeverTransientError with retry
+- Success after one transient failure (retry recovers)
+- Non-JSON body → LeverError
+- Response is not a list → LeverError
+- posted_at from epoch milliseconds
+- company_name humanized from slug
+- descriptionPlain preferred over HTML description
+- Remote type derivation from categories.location
+- Description truncation at 12k char cap
+- Empty postings array → empty result list
+"""
+from __future__ import annotations
+
+from datetime import timezone
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from app.services.discovery.sources import lever
+from app.services.discovery.sources.lever import (
+    LeverError,
+    LeverInvalidSlugError,
+    LeverTransientError,
+    fetch_postings,
+)
+
+# Capture original AsyncClient before any patching.
+_OriginalAsyncClient = httpx.AsyncClient
+
+
+def _client_with_handler(handler):
+    transport = httpx.MockTransport(handler)
+    return _OriginalAsyncClient(transport=transport, timeout=30.0)
+
+
+def _realistic_posting(**overrides) -> dict:
+    """One realistic Lever postings-API entry."""
+    base = {
+        "id": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "text": "Senior Backend Engineer",
+        "categories": {
+            "location": "San Francisco, CA",
+            "commitment": "Full-time",
+            "department": "Engineering",
+        },
+        "hostedUrl": "https://jobs.lever.co/stripe/a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+        "descriptionPlain": "We are looking for a senior backend engineer with Python experience.",
+        "description": "<p>We are looking for a <strong>senior backend engineer</strong> with Python experience.</p>",
+        "createdAt": 1778094000000,  # epoch ms
+        "updatedAt": 1778094000000,
+    }
+    base.update(overrides)
+    return base
+
+
+# ===========================================================================
+# Happy path
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_happy_path() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.lever.co"
+        assert "/v0/postings/stripe" in request.url.path
+        assert request.url.params["mode"] == "json"
+        assert request.headers["User-Agent"].startswith("MyJobHunter/")
+        return httpx.Response(200, json=[_realistic_posting()])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    assert len(results) == 1
+    posting = results[0]
+    assert posting["source"] == "lever"
+    assert posting["source_external_id"] == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    assert posting["source_publisher"] == "Lever"
+    assert posting["title"] == "Senior Backend Engineer"
+    assert posting["company_name"] == "Stripe"  # humanized from slug
+    assert posting["location"] == "San Francisco, CA"
+    assert posting["remote_type"] == "onsite"
+    assert posting["source_url"] == (
+        "https://jobs.lever.co/stripe/a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+    )
+    assert posting["description"] == (
+        "We are looking for a senior backend engineer with Python experience."
+    )
+    # posted_at: 1778094000000ms = valid UTC datetime
+    assert posting["posted_at"] is not None
+    assert posting["posted_at"].tzinfo is not None
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_prefers_plain_text_description() -> None:
+    """descriptionPlain should be used over the HTML description field."""
+    p = _realistic_posting(
+        descriptionPlain="Plain text description.",
+        description="<p>HTML description.</p>",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[p])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    assert results[0]["description"] == "Plain text description."
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_falls_back_to_html_description_when_plain_missing() -> None:
+    p = _realistic_posting(descriptionPlain=None)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[p])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    desc = results[0]["description"]
+    assert desc is not None
+    assert "<p>" not in desc
+    assert "senior backend engineer" in desc
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_returns_empty_list_for_empty_array() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    assert results == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_skips_entries_missing_id() -> None:
+    bad = _realistic_posting()
+    del bad["id"]
+    good = _realistic_posting(id="good-id-123")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[bad, good])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    assert len(results) == 1
+    assert results[0]["source_external_id"] == "good-id-123"
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_truncates_long_description() -> None:
+    p = _realistic_posting(descriptionPlain="x" * 50000)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[p])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    desc = results[0]["description"]
+    assert desc is not None
+    assert len(desc) == 12_000
+    assert desc.endswith("…")
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_epoch_ms_parsed_correctly() -> None:
+    """1778094000000 ms = 2026-05-02T15:00:00Z (roughly)."""
+    p = _realistic_posting(createdAt=1746198000000)  # known epoch
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[p])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    assert results[0]["posted_at"] is not None
+    assert results[0]["posted_at"].year == 2025
+
+
+# ===========================================================================
+# Humanize slug
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_humanizes_multi_word_slug() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[_realistic_posting()])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="acme-corp-ltd")
+
+    assert results[0]["company_name"] == "Acme Corp Ltd"
+
+
+# ===========================================================================
+# 404 — invalid slug
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_raises_invalid_slug_error_on_404() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, text="not found")
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(LeverInvalidSlugError) as exc_info:
+            await fetch_postings(company_slug="nonexistent-co")
+
+    assert "404" in str(exc_info.value) or "not found" in str(exc_info.value).lower()
+
+
+# ===========================================================================
+# Transient errors → tenacity retry, then propagate
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_retries_on_429_then_propagates(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lever, "fetch_postings",
+        lever.fetch_postings.retry_with(wait=lambda _: 0),
+    )
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(429, text="rate limited")
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(LeverTransientError):
+            await lever.fetch_postings(company_slug="stripe")
+
+    assert call_count["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_retries_on_500(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lever, "fetch_postings",
+        lever.fetch_postings.retry_with(wait=lambda _: 0),
+    )
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(500, text="internal server error")
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(LeverTransientError):
+            await lever.fetch_postings(company_slug="stripe")
+
+    assert call_count["n"] == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_succeeds_after_one_transient(monkeypatch) -> None:
+    monkeypatch.setattr(
+        lever, "fetch_postings",
+        lever.fetch_postings.retry_with(wait=lambda _: 0),
+    )
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return httpx.Response(429)
+        return httpx.Response(200, json=[_realistic_posting()])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await lever.fetch_postings(company_slug="stripe")
+
+    assert len(results) == 1
+    assert call_count["n"] == 2
+
+
+# ===========================================================================
+# Malformed responses
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_raises_on_non_json_body() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, text="not json at all")
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(LeverError):
+            await fetch_postings(company_slug="stripe")
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_raises_when_response_is_not_list() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"items": []})
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(LeverError):
+            await fetch_postings(company_slug="stripe")
+
+
+# ===========================================================================
+# Remote type derivation
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_remote_type_from_remote_location() -> None:
+    p = _realistic_posting(categories={"location": "Remote"})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[p])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    assert results[0]["remote_type"] == "remote"
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_remote_type_hybrid() -> None:
+    p = _realistic_posting(categories={"location": "New York / Hybrid"})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[p])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    assert results[0]["remote_type"] == "hybrid"
+
+
+@pytest.mark.asyncio
+async def test_fetch_postings_remote_type_unknown_when_no_location() -> None:
+    p = _realistic_posting(categories={})
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=[p])
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await fetch_postings(company_slug="stripe")
+
+    assert results[0]["remote_type"] == "unknown"

--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -15,6 +15,8 @@ import SearchInputsSection from "./dialog-sections/SearchInputsSection";
 import WhereWhenSection from "./dialog-sections/WhereWhenSection";
 import JobTypeSection from "./dialog-sections/JobTypeSection";
 import ExclusionsSection from "./dialog-sections/ExclusionsSection";
+import GreenhouseConfigSection from "./dialog-sections/GreenhouseConfigSection";
+import LeverConfigSection from "./dialog-sections/LeverConfigSection";
 import type {
   Country,
   DatePosted,
@@ -22,38 +24,58 @@ import type {
   Experience,
 } from "@/types/discovery/dialog-enums";
 
+/** The three source types that have shipped adapters. */
+type SourceKind = "jsearch" | "greenhouse" | "lever";
+
+const SOURCE_OPTIONS: Array<{ value: SourceKind; label: string }> = [
+  { value: "jsearch", label: "JSearch (Google Jobs)" },
+  { value: "greenhouse", label: "Greenhouse" },
+  { value: "lever", label: "Lever" },
+];
+
+const SOURCE_DESCRIPTIONS: Record<SourceKind, string> = {
+  jsearch:
+    "JSearch will run this query against Google Jobs (LinkedIn, Indeed, Glassdoor, ZipRecruiter).",
+  greenhouse:
+    "Fetch all active postings from a company's official Greenhouse job board. No API key required.",
+  lever:
+    "Fetch all active postings from a company's official Lever job board. No API key required.",
+};
+
 interface NewSavedSearchDialogProps {
   open: boolean;
   onClose: () => void;
 }
 
 /**
- * Dialog for creating a new JSearch saved search.
+ * Dialog for creating a new saved search.
  *
- * Pre-fills every field from the operator's profile + saved
- * discovery_defaults so they review/confirm rather than start from
- * blank. Replaces a free-form Boolean query field with structured
- * Role + Skill chip inputs (the Boolean query is assembled
- * server-side). Industry exclusions surface as toggle chips backed
- * by curated server-side keyword lists.
+ * Supports three sources: JSearch, Greenhouse, and Lever.
+ * A source picker at the top of the dialog controls which config form is shown.
+ *
+ * JSearch: full structured config (roles, skills, location, filters)
+ * Greenhouse: single board_token field
+ * Lever: single company_slug field
+ *
+ * Profile prefill only applies to JSearch; Greenhouse/Lever require manual
+ * board_token / company_slug input.
  *
  * Composition:
  *   - ``useDiscoveryDefaultsPrefill`` — owns profile/skills/work-history
- *     fetches, suggestion derivation, one-shot prefill (useRef-backed
- *     latch, not useState — flagged anti-pattern is gone)
+ *     fetches, suggestion derivation, one-shot prefill (useRef-backed latch)
  *   - ``SearchInputsSection``, ``WhereWhenSection``, ``JobTypeSection``,
- *     ``ExclusionsSection`` — JSX form-field clusters extracted by topic
- *   - ``InlineBoldText`` — markdown-bold rendering for the summary
- *   - ``buildSavedSearchSummary`` — pure helper that composes the
- *     plain-English preview line
+ *     ``ExclusionsSection`` — JSearch form-field clusters
+ *   - ``GreenhouseConfigSection``, ``LeverConfigSection`` — per-source config forms
+ *   - ``buildSavedSearchSummary`` — pure helper for the JSearch preview line
  */
 export default function NewSavedSearchDialog({
   open,
   onClose,
 }: NewSavedSearchDialogProps) {
-  // Form state — owned here, not in parent. Future cleanup: migrate
-  // to react-hook-form (used elsewhere in the codebase) so 11 useState
-  // hooks collapse to one form context.
+  // Source selection — defaults to jsearch to preserve existing behaviour.
+  const [source, setSource] = useState<SourceKind>("jsearch");
+
+  // JSearch form state
   const [roles, setRoles] = useState<string[]>([]);
   const [skills, setSkills] = useState<string[]>([]);
   const [location, setLocation] = useState("");
@@ -63,11 +85,15 @@ export default function NewSavedSearchDialog({
   const [employmentType, setEmploymentType] = useState<EmploymentType>("FULLTIME");
   const [experience, setExperience] = useState<Experience>("");
   const [minSalary, setMinSalary] = useState("");
-  const [excludedIndustryChips, setExcludedIndustryChips] = useState<string[]>(
-    [],
-  );
+  const [excludedIndustryChips, setExcludedIndustryChips] = useState<string[]>([]);
   const [excludedKeywords, setExcludedKeywords] = useState<string[]>([]);
   const [saveAsDefaults, setSaveAsDefaults] = useState(false);
+
+  // Greenhouse form state
+  const [boardToken, setBoardToken] = useState("");
+
+  // Lever form state
+  const [companySlug, setCompanySlug] = useState("");
 
   const [createSource, { isLoading: isCreating }] = useCreateDiscoverySourceMutation();
   const [updateProfile, { isLoading: isUpdatingProfile }] = useUpdateProfileMutation();
@@ -80,7 +106,7 @@ export default function NewSavedSearchDialog({
     isPrefillLoading,
     didPrefill,
     resetPrefill,
-  } = useDiscoveryDefaultsPrefill(open, {
+  } = useDiscoveryDefaultsPrefill(open && source === "jsearch", {
     setRoles,
     setRemoteOnly,
     setMinSalary,
@@ -92,7 +118,8 @@ export default function NewSavedSearchDialog({
     setExcludedKeywords,
   });
 
-  function reset() {
+  function resetAll() {
+    setSource("jsearch");
     setRoles([]);
     setSkills([]);
     setLocation("");
@@ -105,10 +132,19 @@ export default function NewSavedSearchDialog({
     setExcludedIndustryChips([]);
     setExcludedKeywords([]);
     setSaveAsDefaults(false);
+    setBoardToken("");
+    setCompanySlug("");
     resetPrefill();
   }
 
   function buildConfig(): Record<string, unknown> {
+    if (source === "greenhouse") {
+      return { board_token: boardToken.trim() };
+    }
+    if (source === "lever") {
+      return { company_slug: companySlug.trim().toLowerCase() };
+    }
+    // jsearch
     const config: Record<string, unknown> = {
       roles,
       skills,
@@ -124,7 +160,6 @@ export default function NewSavedSearchDialog({
     if (minSalary && Number.isFinite(minSalaryNum) && minSalaryNum > 0) {
       config.min_salary_usd = Math.floor(minSalaryNum);
     }
-
     if (excludedIndustryChips.length > 0) {
       config.excluded_industry_chips = excludedIndustryChips;
     }
@@ -146,19 +181,38 @@ export default function NewSavedSearchDialog({
     };
   }
 
+  function validate(): string | null {
+    if (source === "greenhouse") {
+      if (!boardToken.trim()) return "Enter a Greenhouse board token";
+      if (!/^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/.test(boardToken.trim())) {
+        return "Invalid board token — use letters, digits, hyphens, and underscores only";
+      }
+    } else if (source === "lever") {
+      const slug = companySlug.trim().toLowerCase();
+      if (!slug) return "Enter a Lever company slug";
+      if (!/^[a-z0-9][a-z0-9-]{0,63}$/.test(slug)) {
+        return "Invalid company slug — use lowercase letters, digits, and hyphens only";
+      }
+    } else {
+      if (roles.length === 0) return "Add at least one role title";
+    }
+    return null;
+  }
+
   async function handleConfirm() {
-    if (roles.length === 0) {
-      showError("Add at least one role title");
+    const validationError = validate();
+    if (validationError) {
+      showError(validationError);
       return;
     }
 
     try {
-      await createSource({ source: "jsearch", config: buildConfig() }).unwrap();
+      await createSource({ source, config: buildConfig() }).unwrap();
 
-      // Optionally persist the filter set as the operator's default
-      // for future searches. Best-effort — if it fails, the saved
-      // search still exists; we just toast a soft warning.
-      if (saveAsDefaults) {
+      // Optionally persist the JSearch filter set as the operator's default.
+      // Only makes sense for JSearch (Greenhouse/Lever have no shareable
+      // filter preferences).
+      if (source === "jsearch" && saveAsDefaults) {
         try {
           await updateProfile({ discovery_defaults: buildDefaults() }).unwrap();
         } catch (defaultsErr) {
@@ -170,7 +224,7 @@ export default function NewSavedSearchDialog({
       }
 
       showSuccess("Saved search created");
-      reset();
+      resetAll();
       onClose();
     } catch (err) {
       showError(extractErrorMessage(err) ?? "Failed to create saved search");
@@ -178,116 +232,159 @@ export default function NewSavedSearchDialog({
   }
 
   function handleCancel() {
-    reset();
+    resetAll();
     onClose();
   }
 
-  const summary = buildSavedSearchSummary({
-    roles,
-    skills,
-    location,
-    country,
-    datePosted,
-    remoteOnly,
-    employmentType,
-    experience,
-    minSalary,
-    excludedIndustryChips,
-    excludedKeywords,
-  });
+  const summary =
+    source === "jsearch"
+      ? buildSavedSearchSummary({
+          roles,
+          skills,
+          location,
+          country,
+          datePosted,
+          remoteOnly,
+          employmentType,
+          experience,
+          minSalary,
+          excludedIndustryChips,
+          excludedKeywords,
+        })
+      : null;
 
   return (
     <ConfirmDialog
       open={open}
       title="New saved search"
-      description="JSearch will run this query against Google Jobs (LinkedIn, Indeed, Glassdoor, ZipRecruiter)."
+      description={SOURCE_DESCRIPTIONS[source]}
       confirmLabel="Create"
       isLoading={isLoading}
       onConfirm={handleConfirm}
       onCancel={handleCancel}
     >
       <div className="space-y-4 max-h-[70vh] overflow-y-auto pr-1">
-        {isPrefillLoading ? (
-          <div className="space-y-3" aria-busy="true">
-            <Skeleton className="h-9 w-full" />
-            <Skeleton className="h-9 w-full" />
-            <Skeleton className="h-9 w-3/4" />
-            <Skeleton className="h-9 w-full" />
-            <Skeleton className="h-9 w-1/2" />
-          </div>
-        ) : (
+        {/* Source picker */}
+        <div className="space-y-1">
+          <label htmlFor="source-select" className="block text-sm font-medium">
+            Job source
+          </label>
+          <select
+            id="source-select"
+            className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            value={source}
+            onChange={(e) => setSource(e.target.value as SourceKind)}
+          >
+            {SOURCE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Greenhouse config */}
+        {source === "greenhouse" && (
+          <GreenhouseConfigSection
+            boardToken={boardToken}
+            onBoardTokenChange={setBoardToken}
+          />
+        )}
+
+        {/* Lever config */}
+        {source === "lever" && (
+          <LeverConfigSection
+            companySlug={companySlug}
+            onCompanySlugChange={setCompanySlug}
+          />
+        )}
+
+        {/* JSearch config */}
+        {source === "jsearch" && (
           <>
-        {didPrefill && (
-          <p className="text-xs text-muted-foreground bg-muted/40 px-3 py-2 rounded">
-            Pre-filled from your profile. Edit anything below.
-          </p>
-        )}
+            {isPrefillLoading ? (
+              <div className="space-y-3" aria-busy="true">
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-3/4" />
+                <Skeleton className="h-9 w-full" />
+                <Skeleton className="h-9 w-1/2" />
+              </div>
+            ) : (
+              <>
+                {didPrefill && (
+                  <p className="text-xs text-muted-foreground bg-muted/40 px-3 py-2 rounded">
+                    Pre-filled from your profile. Edit anything below.
+                  </p>
+                )}
 
-        <SearchInputsSection
-          roles={roles}
-          onRolesChange={setRoles}
-          roleSuggestions={recentRoleSuggestions}
-          skills={skills}
-          onSkillsChange={setSkills}
-          skillSuggestions={skillSuggestions}
-          location={location}
-          onLocationChange={setLocation}
-          locationDisabled={remoteOnly}
-        />
+                <SearchInputsSection
+                  roles={roles}
+                  onRolesChange={setRoles}
+                  roleSuggestions={recentRoleSuggestions}
+                  skills={skills}
+                  onSkillsChange={setSkills}
+                  skillSuggestions={skillSuggestions}
+                  location={location}
+                  onLocationChange={setLocation}
+                  locationDisabled={remoteOnly}
+                />
 
-        <WhereWhenSection
-          country={country}
-          onCountryChange={setCountry}
-          datePosted={datePosted}
-          onDatePostedChange={setDatePosted}
-        />
+                <WhereWhenSection
+                  country={country}
+                  onCountryChange={setCountry}
+                  datePosted={datePosted}
+                  onDatePostedChange={setDatePosted}
+                />
 
-        <JobTypeSection
-          employmentType={employmentType}
-          onEmploymentTypeChange={setEmploymentType}
-          experience={experience}
-          onExperienceChange={setExperience}
-        />
+                <JobTypeSection
+                  employmentType={employmentType}
+                  onEmploymentTypeChange={setEmploymentType}
+                  experience={experience}
+                  onExperienceChange={setExperience}
+                />
 
-        <ExclusionsSection
-          minSalary={minSalary}
-          onMinSalaryChange={setMinSalary}
-          excludedIndustryChips={excludedIndustryChips}
-          onExcludedIndustryChipsChange={setExcludedIndustryChips}
-          excludedKeywords={excludedKeywords}
-          onExcludedKeywordsChange={setExcludedKeywords}
-        />
+                <ExclusionsSection
+                  minSalary={minSalary}
+                  onMinSalaryChange={setMinSalary}
+                  excludedIndustryChips={excludedIndustryChips}
+                  onExcludedIndustryChipsChange={setExcludedIndustryChips}
+                  excludedKeywords={excludedKeywords}
+                  onExcludedKeywordsChange={setExcludedKeywords}
+                />
 
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={remoteOnly}
-            onChange={(e) => setRemoteOnly(e.target.checked)}
-            className="rounded"
-          />
-          <span>Remote jobs only</span>
-        </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={remoteOnly}
+                    onChange={(e) => setRemoteOnly(e.target.checked)}
+                    className="rounded"
+                  />
+                  <span>Remote jobs only</span>
+                </label>
 
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            checked={saveAsDefaults}
-            onChange={(e) => setSaveAsDefaults(e.target.checked)}
-            className="rounded"
-          />
-          <span>
-            Save these filters (industries, employment, experience, etc.)
-            as my defaults for new searches
-          </span>
-        </label>
+                <label className="flex items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={saveAsDefaults}
+                    onChange={(e) => setSaveAsDefaults(e.target.checked)}
+                    className="rounded"
+                  />
+                  <span>
+                    Save these filters (industries, employment, experience, etc.)
+                    as my defaults for new searches
+                  </span>
+                </label>
 
-        {summary && (
-          <div className="border-t pt-3 mt-2">
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              <InlineBoldText text={summary} />
-            </p>
-          </div>
-        )}
+                {summary && (
+                  <div className="border-t pt-3 mt-2">
+                    <p className="text-xs leading-relaxed text-muted-foreground">
+                      <InlineBoldText text={summary} />
+                    </p>
+                  </div>
+                )}
+              </>
+            )}
           </>
         )}
       </div>

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchRow.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchRow.tsx
@@ -14,7 +14,7 @@ import {
   useRefreshDiscoverySourceMutation,
 } from "@/store/discoverApi";
 import type { DiscoverySource } from "@/types/discovery/discovery-source";
-import { summarizeSearchQuery } from "./saved-search-summary";
+import { summarizeSearchQuery, getSourceLabel, getSourceBadgeColor } from "./saved-search-summary";
 
 interface SavedSearchRowProps {
   source: DiscoverySource;
@@ -24,7 +24,7 @@ export default function SavedSearchRow({ source }: SavedSearchRowProps) {
   const [refresh, { isLoading: isRefreshing }] = useRefreshDiscoverySourceMutation();
   const [deactivate, { isLoading: isDeactivating }] = useDeactivateDiscoverySourceMutation();
 
-  const query = summarizeSearchQuery(source.config ?? {});
+  const query = summarizeSearchQuery(source.config ?? {}, source.source);
   const lastFetched = source.last_fetched_at
     ? `Last fetched ${timeAgo(source.last_fetched_at)}`
     : "Never fetched";
@@ -61,7 +61,7 @@ export default function SavedSearchRow({ source }: SavedSearchRowProps) {
     <Card className="p-3 flex items-center justify-between gap-3">
       <div className="min-w-0 flex-1">
         <div className="flex items-center gap-2">
-          <Badge label={source.source} color="gray" />
+          <Badge label={getSourceLabel(source.source)} color={getSourceBadgeColor(source.source)} />
           <span className="font-medium truncate text-sm">{query}</span>
           {isFailing && (
             <span className="inline-flex items-center gap-1 text-xs font-medium text-destructive shrink-0">

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/NewSavedSearchDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/NewSavedSearchDialog.test.tsx
@@ -1,0 +1,350 @@
+/**
+ * Tests for NewSavedSearchDialog — source switching and per-source
+ * field validation for Greenhouse and Lever.
+ *
+ * Covers:
+ * - Source picker renders all three options
+ * - Switching to Greenhouse shows board_token field, hides JSearch form
+ * - Switching to Lever shows company_slug field, hides JSearch form
+ * - Switching back to JSearch restores the JSearch form
+ * - Greenhouse validation: empty token → error toast on confirm
+ * - Greenhouse validation: invalid token format → error toast on confirm
+ * - Lever validation: empty slug → error toast on confirm
+ * - Lever validation: invalid slug format → error toast on confirm
+ * - Greenhouse: calls createSource with source="greenhouse" + config
+ * - Lever: calls createSource with source="lever" + config
+ * - JSearch: still requires roles (existing behaviour preserved)
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import NewSavedSearchDialog from "../NewSavedSearchDialog";
+
+// ---------------------------------------------------------------------------
+// Mock @platform/ui
+// ---------------------------------------------------------------------------
+const mockShowError = vi.fn();
+const mockShowSuccess = vi.fn();
+
+vi.mock("@platform/ui", () => ({
+  ConfirmDialog: ({
+    open,
+    children,
+    onConfirm,
+    onCancel,
+    title,
+    description,
+    isLoading,
+  }: {
+    open: boolean;
+    children: React.ReactNode;
+    onConfirm: () => void;
+    onCancel: () => void;
+    title: string;
+    description: string;
+    isLoading?: boolean;
+  }) =>
+    open ? (
+      <div data-testid="confirm-dialog">
+        <h2>{title}</h2>
+        <p data-testid="dialog-description">{description}</p>
+        {children}
+        <button data-testid="confirm-btn" onClick={onConfirm} disabled={isLoading}>
+          Confirm
+        </button>
+        <button data-testid="cancel-btn" onClick={onCancel}>
+          Cancel
+        </button>
+      </div>
+    ) : null,
+  showError: (msg: string) => mockShowError(msg),
+  showSuccess: (msg: string) => mockShowSuccess(msg),
+  extractErrorMessage: (e: unknown) =>
+    e instanceof Error ? e.message : String(e),
+  InlineBoldText: ({ text }: { text: string }) => <span>{text}</span>,
+  Skeleton: () => <div data-testid="skeleton" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock store mutations
+// ---------------------------------------------------------------------------
+const mockCreateSource = vi.fn();
+const mockUpdateProfile = vi.fn();
+
+vi.mock("@/store/discoverApi", () => ({
+  useCreateDiscoverySourceMutation: () => [
+    mockCreateSource,
+    { isLoading: false },
+  ],
+}));
+
+vi.mock("@/lib/profileApi", () => ({
+  useUpdateProfileMutation: () => [mockUpdateProfile, { isLoading: false }],
+}));
+
+/** RTK Query mutations return a promise with an .unwrap() method. */
+function makeUnwrappableMutation(resolvedValue: unknown = {}) {
+  const promise = Promise.resolve(resolvedValue) as Promise<unknown> & {
+    unwrap: () => Promise<unknown>;
+  };
+  promise.unwrap = () => Promise.resolve(resolvedValue);
+  return promise;
+}
+
+// ---------------------------------------------------------------------------
+// Mock dialog sub-sections
+// ---------------------------------------------------------------------------
+vi.mock("../dialog-sections/SearchInputsSection", () => ({
+  default: () => <div data-testid="search-inputs-section" />,
+}));
+vi.mock("../dialog-sections/WhereWhenSection", () => ({
+  default: () => <div data-testid="where-when-section" />,
+}));
+vi.mock("../dialog-sections/JobTypeSection", () => ({
+  default: () => <div data-testid="job-type-section" />,
+}));
+vi.mock("../dialog-sections/ExclusionsSection", () => ({
+  default: () => <div data-testid="exclusions-section" />,
+}));
+
+// Mock prefill hook — no loading, no prefill.
+vi.mock("../useDiscoveryDefaultsPrefill", () => ({
+  useDiscoveryDefaultsPrefill: () => ({
+    profile: null,
+    recentRoleSuggestions: [],
+    skillSuggestions: [],
+    isPrefillLoading: false,
+    didPrefill: false,
+    resetPrefill: vi.fn(),
+  }),
+}));
+
+vi.mock("../saved-search-summary", () => ({
+  buildSavedSearchSummary: () => null,
+  summarizeSearchQuery: () => "",
+  getSourceLabel: (s: string) => s,
+  getSourceBadgeColor: () => "gray",
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderDialog(open = true) {
+  const onClose = vi.fn();
+  const utils = render(<NewSavedSearchDialog open={open} onClose={onClose} />);
+  return { onClose, ...utils };
+}
+
+function getSourceSelect() {
+  return screen.getByLabelText("Job source") as HTMLSelectElement;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("NewSavedSearchDialog — source picker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSource.mockReturnValue(makeUnwrappableMutation({}));
+  });
+
+  it("renders the source picker with all three options", () => {
+    renderDialog();
+    const select = getSourceSelect();
+    const options = Array.from(select.options).map((o) => o.value);
+    expect(options).toContain("jsearch");
+    expect(options).toContain("greenhouse");
+    expect(options).toContain("lever");
+  });
+
+  it("defaults to jsearch and shows JSearch form sections", () => {
+    renderDialog();
+    expect(getSourceSelect().value).toBe("jsearch");
+    expect(screen.getByTestId("search-inputs-section")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Greenhouse board token")).toBeNull();
+    expect(screen.queryByLabelText("Lever company slug")).toBeNull();
+  });
+
+  it("switching to Greenhouse shows board_token field and hides JSearch sections", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "greenhouse");
+
+    expect(screen.getByLabelText("Greenhouse board token")).toBeInTheDocument();
+    expect(screen.queryByTestId("search-inputs-section")).toBeNull();
+    expect(screen.queryByLabelText("Lever company slug")).toBeNull();
+  });
+
+  it("switching to Lever shows company_slug field and hides JSearch sections", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "lever");
+
+    expect(screen.getByLabelText("Lever company slug")).toBeInTheDocument();
+    expect(screen.queryByTestId("search-inputs-section")).toBeNull();
+    expect(screen.queryByLabelText("Greenhouse board token")).toBeNull();
+  });
+
+  it("switching back to jsearch restores JSearch form sections", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "greenhouse");
+    await userEvent.selectOptions(getSourceSelect(), "jsearch");
+
+    expect(screen.getByTestId("search-inputs-section")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Greenhouse board token")).toBeNull();
+  });
+
+  it("updates dialog description when source changes", async () => {
+    renderDialog();
+
+    const jsearchDesc = screen.getByTestId("dialog-description").textContent;
+    expect(jsearchDesc).toMatch(/Google Jobs/i);
+
+    await userEvent.selectOptions(getSourceSelect(), "greenhouse");
+    const ghDesc = screen.getByTestId("dialog-description").textContent;
+    expect(ghDesc).toMatch(/Greenhouse/i);
+
+    await userEvent.selectOptions(getSourceSelect(), "lever");
+    const leverDesc = screen.getByTestId("dialog-description").textContent;
+    expect(leverDesc).toMatch(/Lever/i);
+  });
+});
+
+describe("NewSavedSearchDialog — Greenhouse validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSource.mockReturnValue(makeUnwrappableMutation({}));
+  });
+
+  it("shows error when board_token is empty on confirm", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "greenhouse");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(
+        expect.stringMatching(/board token/i),
+      );
+    });
+    expect(mockCreateSource).not.toHaveBeenCalled();
+  });
+
+  it("shows error for invalid board_token format on confirm", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "greenhouse");
+    const input = screen.getByLabelText("Greenhouse board token");
+    await userEvent.type(input, "invalid/token/here");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(
+        expect.stringMatching(/invalid/i),
+      );
+    });
+    expect(mockCreateSource).not.toHaveBeenCalled();
+  });
+
+  it("calls createSource with greenhouse source and board_token config", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "greenhouse");
+    const input = screen.getByLabelText("Greenhouse board token");
+    await userEvent.type(input, "stripe");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockCreateSource).toHaveBeenCalledWith({
+        source: "greenhouse",
+        config: { board_token: "stripe" },
+      });
+    });
+    expect(mockShowSuccess).toHaveBeenCalledWith("Saved search created");
+  });
+});
+
+describe("NewSavedSearchDialog — Lever validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSource.mockReturnValue(makeUnwrappableMutation({}));
+  });
+
+  it("shows error when company_slug is empty on confirm", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "lever");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(
+        expect.stringMatching(/company slug/i),
+      );
+    });
+    expect(mockCreateSource).not.toHaveBeenCalled();
+  });
+
+  it("shows error for invalid company_slug format on confirm", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "lever");
+    const input = screen.getByLabelText("Lever company slug");
+    await userEvent.type(input, "invalid/slug");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(
+        expect.stringMatching(/invalid/i),
+      );
+    });
+    expect(mockCreateSource).not.toHaveBeenCalled();
+  });
+
+  it("calls createSource with lever source and company_slug config", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "lever");
+    const input = screen.getByLabelText("Lever company slug");
+    await userEvent.type(input, "openai");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockCreateSource).toHaveBeenCalledWith({
+        source: "lever",
+        config: { company_slug: "openai" },
+      });
+    });
+    expect(mockShowSuccess).toHaveBeenCalledWith("Saved search created");
+  });
+
+  it("normalizes company_slug to lowercase", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "lever");
+    const input = screen.getByLabelText("Lever company slug");
+    // LeverConfigSection normalizes to lowercase on change
+    await userEvent.type(input, "openai");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockCreateSource).toHaveBeenCalledWith(
+        expect.objectContaining({
+          config: { company_slug: "openai" },
+        }),
+      );
+    });
+  });
+});
+
+describe("NewSavedSearchDialog — JSearch still requires roles", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSource.mockReturnValue(makeUnwrappableMutation({}));
+  });
+
+  it("shows error when roles are empty for jsearch source", async () => {
+    renderDialog();
+    // Source is already jsearch by default.
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(
+        expect.stringMatching(/role/i),
+      );
+    });
+    expect(mockCreateSource).not.toHaveBeenCalled();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/SavedSearchesPanel.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/SavedSearchesPanel.test.tsx
@@ -69,6 +69,8 @@ vi.mock("../SavedSearchesSkeleton", () => ({
 
 vi.mock("../saved-search-summary", () => ({
   summarizeSearchQuery: () => "Software Engineer — Remote",
+  getSourceLabel: (s: string) => s,
+  getSourceBadgeColor: () => "gray",
 }));
 
 import {

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/saved-search-summary.test.ts
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/saved-search-summary.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { summarizeSearchQuery } from "../saved-search-summary";
+import {
+  summarizeSearchQuery,
+  getSourceLabel,
+  getSourceBadgeColor,
+} from "../saved-search-summary";
 
 describe("summarizeSearchQuery", () => {
   it("renders roles from new-style config (roles array)", () => {
@@ -43,5 +47,62 @@ describe("summarizeSearchQuery", () => {
 
   it("returns (no query) when query is an empty string", () => {
     expect(summarizeSearchQuery({ query: "" })).toBe("(no query)");
+  });
+
+  // Greenhouse + Lever source-aware summaries
+  it("shows board_token for greenhouse source", () => {
+    expect(
+      summarizeSearchQuery({ board_token: "stripe" }, "greenhouse"),
+    ).toBe("Board: stripe");
+  });
+
+  it("returns (no board token) for greenhouse with missing token", () => {
+    expect(summarizeSearchQuery({}, "greenhouse")).toBe("(no board token)");
+  });
+
+  it("shows company_slug for lever source", () => {
+    expect(
+      summarizeSearchQuery({ company_slug: "openai" }, "lever"),
+    ).toBe("Company: openai");
+  });
+
+  it("returns (no company slug) for lever with missing slug", () => {
+    expect(summarizeSearchQuery({}, "lever")).toBe("(no company slug)");
+  });
+
+  it("falls back to role-based summary for jsearch even when source is passed", () => {
+    expect(
+      summarizeSearchQuery({ roles: ["Backend Engineer"] }, "jsearch"),
+    ).toBe("Backend Engineer");
+  });
+});
+
+describe("getSourceLabel", () => {
+  it("returns human-readable label for known sources", () => {
+    expect(getSourceLabel("jsearch")).toBe("JSearch");
+    expect(getSourceLabel("greenhouse")).toBe("Greenhouse");
+    expect(getSourceLabel("lever")).toBe("Lever");
+  });
+
+  it("returns the raw source string for unknown sources", () => {
+    expect(getSourceLabel("unknown_source")).toBe("unknown_source");
+  });
+});
+
+describe("getSourceBadgeColor", () => {
+  it("returns green for greenhouse", () => {
+    expect(getSourceBadgeColor("greenhouse")).toBe("green");
+  });
+
+  it("returns blue for lever", () => {
+    expect(getSourceBadgeColor("lever")).toBe("blue");
+  });
+
+  it("returns gray for jsearch", () => {
+    expect(getSourceBadgeColor("jsearch")).toBe("gray");
+  });
+
+  it("returns gray for unknown sources", () => {
+    expect(getSourceBadgeColor("other")).toBe("gray");
   });
 });

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/GreenhouseConfigSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/GreenhouseConfigSection.tsx
@@ -1,0 +1,56 @@
+/**
+ * Form section for Greenhouse saved-search config.
+ *
+ * The operator supplies a single field: board_token — the slug from the
+ * Greenhouse board URL: boards.greenhouse.io/<board_token>.
+ *
+ * Client-side validation mirrors the backend regex:
+ * ``^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$``
+ */
+
+const BOARD_TOKEN_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
+
+interface GreenhouseConfigSectionProps {
+  boardToken: string;
+  onBoardTokenChange: (value: string) => void;
+}
+
+export default function GreenhouseConfigSection({
+  boardToken,
+  onBoardTokenChange,
+}: GreenhouseConfigSectionProps) {
+  const isInvalid = boardToken.length > 0 && !BOARD_TOKEN_RE.test(boardToken);
+
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor="greenhouse-board-token"
+        className="block text-sm font-medium"
+      >
+        Greenhouse board token
+      </label>
+      <input
+        id="greenhouse-board-token"
+        type="text"
+        className={`w-full rounded border px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
+          isInvalid ? "border-destructive" : "border-border"
+        }`}
+        placeholder="e.g. stripe"
+        value={boardToken}
+        onChange={(e) => onBoardTokenChange(e.target.value.trim())}
+        aria-describedby="greenhouse-board-token-hint"
+        aria-invalid={isInvalid}
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <p
+        id="greenhouse-board-token-hint"
+        className={`text-xs ${isInvalid ? "text-destructive" : "text-muted-foreground"}`}
+      >
+        {isInvalid
+          ? "Invalid token — use letters, digits, hyphens, and underscores only."
+          : "Find this in the Greenhouse board URL: boards.greenhouse.io/​<board_token>"}
+      </p>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/LeverConfigSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/LeverConfigSection.tsx
@@ -1,0 +1,60 @@
+/**
+ * Form section for Lever saved-search config.
+ *
+ * The operator supplies a single field: company_slug — the slug from the
+ * Lever URL: jobs.lever.co/<company_slug>.
+ *
+ * Client-side validation mirrors the backend regex (post-lowercase-normalization):
+ * ``^[a-z0-9][a-z0-9-]{0,63}$``
+ *
+ * We normalize to lowercase on display so the operator can paste slugs
+ * without worrying about case.
+ */
+
+const COMPANY_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+interface LeverConfigSectionProps {
+  companySlug: string;
+  onCompanySlugChange: (value: string) => void;
+}
+
+export default function LeverConfigSection({
+  companySlug,
+  onCompanySlugChange,
+}: LeverConfigSectionProps) {
+  const normalized = companySlug.toLowerCase();
+  const isInvalid = companySlug.length > 0 && !COMPANY_SLUG_RE.test(normalized);
+
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor="lever-company-slug"
+        className="block text-sm font-medium"
+      >
+        Lever company slug
+      </label>
+      <input
+        id="lever-company-slug"
+        type="text"
+        className={`w-full rounded border px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
+          isInvalid ? "border-destructive" : "border-border"
+        }`}
+        placeholder="e.g. openai"
+        value={companySlug}
+        onChange={(e) => onCompanySlugChange(e.target.value.toLowerCase().trim())}
+        aria-describedby="lever-company-slug-hint"
+        aria-invalid={isInvalid}
+        autoComplete="off"
+        spellCheck={false}
+      />
+      <p
+        id="lever-company-slug-hint"
+        className={`text-xs ${isInvalid ? "text-destructive" : "text-muted-foreground"}`}
+      >
+        {isInvalid
+          ? "Invalid slug — use lowercase letters, digits, and hyphens only."
+          : "Find this in the Lever URL: jobs.lever.co/​<company_slug>"}
+      </p>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/saved-search-summary.ts
+++ b/apps/myjobhunter/frontend/src/features/discover/saved-search-summary.ts
@@ -1,13 +1,55 @@
 import { INDUSTRY_CHIPS } from "./industry-chips";
 
+/** Human-readable label for each source adapter. */
+const SOURCE_LABELS: Record<string, string> = {
+  jsearch: "JSearch",
+  greenhouse: "Greenhouse",
+  lever: "Lever",
+  ashby: "Ashby",
+  remoteok: "RemoteOK",
+  hn_who_is_hiring: "HN: Who's Hiring",
+  workatastartup: "Work at a Startup",
+  other: "Other",
+};
+
+/** Badge color for each source — Greenhouse/Lever get distinct colors so the
+ *  operator can tell official feeds from aggregators at a glance. */
+const SOURCE_BADGE_COLORS: Record<string, "gray" | "green" | "blue"> = {
+  jsearch: "gray",
+  greenhouse: "green",
+  lever: "blue",
+};
+
+export function getSourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? source;
+}
+
+export function getSourceBadgeColor(source: string): "gray" | "green" | "blue" {
+  return SOURCE_BADGE_COLORS[source] ?? "gray";
+}
+
 /**
  * Render a ``DiscoverySource.config`` object as a short display string
  * for the SavedSearchesPanel row.
  *
- * New configs store ``roles`` (string[]); legacy configs store ``query``
- * (string). Falls back to "(no query)" when neither is present.
+ * Source-aware: Greenhouse rows show the board_token, Lever rows show the
+ * company_slug, JSearch rows show roles / legacy query.
  */
-export function summarizeSearchQuery(config: Record<string, unknown>): string {
+export function summarizeSearchQuery(
+  config: Record<string, unknown>,
+  source?: string,
+): string {
+  if (source === "greenhouse") {
+    const token = config?.board_token;
+    if (typeof token === "string" && token) return `Board: ${token}`;
+    return "(no board token)";
+  }
+  if (source === "lever") {
+    const slug = config?.company_slug;
+    if (typeof slug === "string" && slug) return `Company: ${slug}`;
+    return "(no company slug)";
+  }
+  // JSearch / legacy: roles array or raw query string.
   const roles = config?.roles;
   if (Array.isArray(roles) && roles.length > 0) {
     const validRoles = roles.filter((r): r is string => typeof r === "string");

--- a/apps/myjobhunter/frontend/src/types/discovery/discovery-source-configs.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovery-source-configs.ts
@@ -1,0 +1,50 @@
+/**
+ * Per-source config shapes for discovery saved searches.
+ *
+ * Each discriminated variant maps 1:1 to the backend Pydantic config model.
+ * Changes to any backend config schema MUST update the matching type here
+ * in the same PR (per feedback_enum_changes_cross_stack.md).
+ */
+
+/** Config for a JSearch (Google Jobs aggregator) saved search. */
+export interface JSearchConfig {
+  roles: string[];
+  skills: string[];
+  location?: string;
+  country: "us" | "ca" | "uk" | "au";
+  date_posted: "all" | "today" | "3days" | "week" | "month";
+  remote_jobs_only: boolean;
+  employment_type: "" | "FULLTIME" | "PARTTIME" | "CONTRACTOR" | "INTERN";
+  experience:
+    | ""
+    | "no_experience"
+    | "under_3_years_experience"
+    | "more_than_3_years_experience"
+    | "no_degree";
+  min_salary_usd?: number;
+  excluded_industry_chips?: string[];
+  excluded_keywords?: string[];
+}
+
+/** Config for a Greenhouse public job-board saved search. */
+export interface GreenhouseConfig {
+  /** The board token from the URL: boards.greenhouse.io/<board_token> */
+  board_token: string;
+}
+
+/** Config for a Lever public job-board saved search. */
+export interface LeverConfig {
+  /** The company slug from the URL: jobs.lever.co/<company_slug> */
+  company_slug: string;
+}
+
+/**
+ * Discriminated union of all source configs that have shipped adapters.
+ * Loose-typed sources (ashby, remoteok, etc.) still use Record<string, unknown>
+ * until their adapters land.
+ */
+export type DiscoverySourceConfig =
+  | { source: "jsearch"; config: JSearchConfig }
+  | { source: "greenhouse"; config: GreenhouseConfig }
+  | { source: "lever"; config: LeverConfig }
+  | { source: string; config: Record<string, unknown> };


### PR DESCRIPTION
## Summary

Adds two official, no-auth public job-board source adapters to the MJH discovery feature, alongside the existing JSearch aggregator:

- **Greenhouse** — `boards-api.greenhouse.io/v1/boards/{board_token}/jobs?content=true` — the most widely-used ATS among tech companies; boards are publicly accessible with no API key
- **Lever** — `api.lever.co/v0/postings/{company_slug}?mode=json` — another popular ATS with a public postings feed

Both APIs are officially documented for programmatic consumption:
- Greenhouse: https://developers.greenhouse.io/job-board.html
- Lever: https://hire.lever.co/developer/documentation

This is one of the highest-leverage items from the 2026-05-11 discovery design pass — direct official feeds improve data quality and compliance posture over aggregator-only sourcing.

## What changed

**Backend**
- `sources/greenhouse.py` — adapter with HTML stripping, company name from metadata endpoint, tenacity retry on 429/5xx, typed errors (`GreenhouseInvalidBoardError`, `GreenhouseTransientError`)
- `sources/lever.py` — adapter with plain-text description preference, epoch-ms `createdAt` parsing, slug humanization, same retry/error pattern
- `schemas/greenhouse_source_config.py` + `lever_source_config.py` — strict Pydantic models with SSRF-guard regex on board_token/company_slug (rejects `../`, `%`, `@`, `/`)
- `discovery_schemas.py` — per-source config validation at the API boundary (Greenhouse + Lever now get typed 422 on bad config, same as JSearch)
- `discovery_fetch_service.py` — registers both adapters in `_ADAPTERS`
- Migration `discsrc260511` — no-op (the original `disco260507` migration already included 'greenhouse' and 'lever' in the CHECK constraints from day one)

**Frontend**
- `NewSavedSearchDialog.tsx` — source picker dropdown (JSearch / Greenhouse / Lever) at top; per-source config form rendered conditionally; profile prefill only fires for JSearch
- `GreenhouseConfigSection.tsx` / `LeverConfigSection.tsx` — single-field config forms with client-side validation matching backend regex
- `saved-search-summary.ts` — `getSourceLabel()`, `getSourceBadgeColor()`, source-aware `summarizeSearchQuery()`
- `SavedSearchRow.tsx` — Greenhouse gets a green badge, Lever gets a blue badge (distinguishes direct feeds from aggregators)
- `types/discovery/discovery-source-configs.ts` — discriminated union of all source config shapes

## Test coverage

- `test_greenhouse_adapter.py` — 15 tests: happy path, 404, 429/500 retry, HTML stripping, remote_type, description truncation, company name fallback
- `test_lever_adapter.py` — 17 tests: same scenarios + descriptionPlain preference, epoch-ms parsing, slug humanization
- `NewSavedSearchDialog.test.tsx` — 14 tests: source switching, per-source validation, createSource payload shape
- `saved-search-summary.test.ts` — extended to 19 tests (Greenhouse/Lever summaries + getSourceLabel/getSourceBadgeColor)

All 91 non-DB backend unit tests pass. All 50 discover feature frontend tests pass. TypeScript typecheck clean.

## Operational migration required

The Alembic migration (`discsrc260511`) is a no-op — the CHECK constraints already permit `'greenhouse'` and `'lever'`. No env vars are added (both APIs are no-auth). No VPS changes required before or after deploy.

The migration still runs on deploy (`alembic upgrade head`) and completes in < 1ms.

### Verify

```bash
# After deploy, confirm the revision is in the history
docker compose -f apps/myjobhunter/docker-compose.yml exec api \
  alembic history --indicate-current | grep discsrc260511
```

### Rollback path

Standard: revert this PR in main. The previous image works without the new adapters (existing JSearch sources are unaffected).