### PR TITLE
feat(mjh/discover): two-stage scoring — cosine prefilter then top-N Anthropic

### DIFF
--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -42,6 +42,14 @@ JSEARCH_API_KEY=
 DISCOVERY_DAILY_BUDGET_USD=0.30
 DISCOVERY_DAILY_BUDGET_USD_HARD_CAP=2.00
 
+# /discover scoring top-N (PR 4b). After the cosine-similarity
+# prefilter ranks unscored postings by relevance to the user's
+# profile embedding, only the top N are sent to Anthropic per pass.
+# 20 is a sweet spot: ~25x cost reduction at 500 postings/day. Tune
+# up for more scored rows per pass; tune down if Anthropic latency
+# dominates. Optional — defaults to 20 in code if unset.
+DISCOVERY_SCORE_TOP_N=20
+
 # /discover embeddings (PR 4a). No env var required — the embedding
 # model (sentence-transformers/all-MiniLM-L6-v2) is local fastembed
 # baked into the backend Docker image at build time. Listed here only

--- a/apps/myjobhunter/backend/app/core/config.py
+++ b/apps/myjobhunter/backend/app/core/config.py
@@ -39,6 +39,16 @@ class Settings(BaseAppSettings):
     discovery_daily_budget_usd: float = 0.30
     discovery_daily_budget_usd_hard_cap: float = 2.00
 
+    # /discover scoring top-N (PR 4b). After the cosine-similarity
+    # prefilter ranks unscored postings by relevance to the user's
+    # profile embedding, only the top N are sent to Anthropic per
+    # scoring pass. 20 is a sweet spot: ~25x cost reduction at 500
+    # postings/day while keeping a deep-enough cut that the operator
+    # rarely runs out of fresh high-relevance scored rows. Tune up if
+    # the budget headroom is available and the operator wants more
+    # scored rows per pass; tune down if Anthropic latency dominates.
+    discovery_score_top_n: int = 20
+
     # /discover refresh rate-limit (per IP). JSearch is paid; cap how
     # often an operator can hit /refresh in a window to bound runaway
     # cost from a stuck retry loop or a leaked credential. Defaults

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_prefilter_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_prefilter_repository.py
@@ -1,0 +1,146 @@
+"""Repository for the two-stage-scoring prefilter (PR 4b).
+
+Per the layered-architecture rule (``apps/myjobhunter/CLAUDE.md``):
+routes never touch the ORM, services orchestrate, repositories return
+ORM rows. ``discovery_prefilter_service`` orchestrates the
+embedding-vs-FIFO branch; this module owns the SQL.
+
+The ``embedding`` branch uses pgvector's cosine-distance operator
+``<=>``. The ``ix_discovered_jobs_embedding`` ivfflat index (added in
+PR 4a) covers this query. The FIFO branch is used when the user has
+no profile embedding yet — order by ``discovered_at DESC`` so the
+operator at least scores their freshest postings while the profile
+ripens.
+
+Both functions filter out the same triaged set as
+``list_unscored_for_user`` (dismissed / saved / promoted / already-scored)
+plus an additional ``embedding IS NOT NULL`` filter on the
+embedding-ranked branch (we can't compute cosine distance against a
+NULL vector).
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import desc, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.discovery.discovered_job import DiscoveredJob
+from app.models.profile.profile import Profile
+
+
+async def list_unscored_with_embedding_ranked(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    profile_embedding: list[float],
+    top_n: int,
+) -> list[DiscoveredJob]:
+    """Return up to ``top_n`` unscored postings ranked by cosine similarity.
+
+    Uses pgvector's ``<=>`` cosine-distance operator (smaller = more
+    similar). The ``embedding IS NOT NULL`` filter is required: ``<=>``
+    on a NULL vector evaluates to NULL and would silently exclude rows
+    via the ORDER BY; making the filter explicit also lets the planner
+    use the partial index where it exists.
+
+    Filters:
+        ``user_id`` matches (tenant scoping — mandatory)
+        ``dismissed_at IS NULL`` — operator has not rejected this row
+        ``saved_at IS NULL`` — operator has not saved-for-later this row
+        ``promoted_application_id IS NULL`` — not yet promoted to apps
+        ``score IS NULL`` — not yet scored (this pass produces a score)
+        ``embedding IS NOT NULL`` — needed for the cosine ranking
+    """
+    stmt = (
+        select(DiscoveredJob)
+        .where(
+            DiscoveredJob.user_id == user_id,
+            DiscoveredJob.dismissed_at.is_(None),
+            DiscoveredJob.saved_at.is_(None),
+            DiscoveredJob.promoted_application_id.is_(None),
+            DiscoveredJob.score.is_(None),
+            DiscoveredJob.embedding.isnot(None),
+        )
+        .order_by(DiscoveredJob.embedding.cosine_distance(profile_embedding))
+        .limit(top_n)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def list_unscored_fifo_fallback(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    top_n: int,
+) -> list[DiscoveredJob]:
+    """Return up to ``top_n`` unscored postings ordered by ``discovered_at DESC``.
+
+    Used when the user does NOT have a profile embedding yet (newly
+    onboarded operator hasn't filled in skills / work history / resume
+    yet). Without an embedding to rank against, falling back to FIFO
+    means the operator at least gets *some* scoring on their freshest
+    postings while their profile ripens.
+
+    No ``embedding IS NOT NULL`` filter here — a posting without an
+    embedding is still a valid scoring candidate when we have nothing
+    to rank against.
+    """
+    stmt = (
+        select(DiscoveredJob)
+        .where(
+            DiscoveredJob.user_id == user_id,
+            DiscoveredJob.dismissed_at.is_(None),
+            DiscoveredJob.saved_at.is_(None),
+            DiscoveredJob.promoted_application_id.is_(None),
+            DiscoveredJob.score.is_(None),
+        )
+        .order_by(desc(DiscoveredJob.discovered_at))
+        .limit(top_n)
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def count_unscored_with_embedding(
+    db: AsyncSession, user_id: uuid.UUID,
+) -> int:
+    """Return the number of eligible unscored postings that have an embedding.
+
+    Used by the prefilter service for the Sentry breadcrumb so the
+    operator can see ``prefilter_eligible_count`` vs
+    ``prefilter_returned_count`` on every score pass. Cheap count —
+    one scalar query, indexed on ``user_id`` + the partial
+    ``ix_discovered_score_pending``.
+    """
+    stmt = select(func.count(DiscoveredJob.id)).where(
+        DiscoveredJob.user_id == user_id,
+        DiscoveredJob.dismissed_at.is_(None),
+        DiscoveredJob.saved_at.is_(None),
+        DiscoveredJob.promoted_application_id.is_(None),
+        DiscoveredJob.score.is_(None),
+        DiscoveredJob.embedding.isnot(None),
+    )
+    result = await db.execute(stmt)
+    return int(result.scalar_one() or 0)
+
+
+async def get_profile_embedding(
+    db: AsyncSession, user_id: uuid.UUID,
+) -> list[float] | None:
+    """Return the user's profile embedding vector, or None if absent.
+
+    Returns the raw vector (not the Profile row) — the prefilter service
+    only needs the vector for the cosine query. Returns None when the
+    profile row doesn't exist OR when it exists but ``embedding IS NULL``
+    (e.g., the operator hasn't filled in skills / work history yet).
+    """
+    stmt = select(Profile.embedding).where(Profile.user_id == user_id)
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is None:
+        return None
+    # pgvector returns numpy arrays; coerce to list[float] so callers
+    # don't have to import numpy.
+    return list(row)

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_prefilter_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_prefilter_service.py
@@ -1,0 +1,202 @@
+"""Two-stage scoring prefilter (PR 4b).
+
+The discovery scoring loop used to iterate every unscored posting
+(``list_unscored_for_user``) and call Anthropic on each one. At
+500-2000 postings/day per user this hit the per-user daily budget cap
+fast and silently dropped the tail.
+
+This service narrows the candidate set via cosine similarity to the
+user's profile embedding BEFORE the loop hits Anthropic. With
+``top_n=20`` and typical fetch volumes, the budget covers the same
+20 highest-relevance postings every pass — a ~25x cost reduction at
+the same end-user-visible score quality.
+
+Two branches
+============
+
+1. **Embedding branch** (preferred): the user has a profile embedding
+   (``profiles.embedding IS NOT NULL``). Rank unscored postings with
+   embeddings by pgvector ``<=>`` cosine distance, return top N.
+2. **FIFO fallback**: the user has no profile embedding yet (newly
+   onboarded — hasn't filled in skills / work history / resume). Fall
+   back to ``discovered_at DESC`` so the operator at least gets *some*
+   scoring on their freshest postings while their profile ripens.
+   The embedding becomes load-bearing only once the profile is rich
+   enough to embed.
+
+Postings with ``embedding IS NULL`` (race between fetch and embed
+backfill) are skipped on the embedding branch and picked up by the
+next pass once the embedding lands. On the FIFO branch, embedding-less
+postings are eligible because we have nothing to rank against anyway.
+
+Observability
+=============
+
+Each call emits a Sentry breadcrumb summarising the branch taken,
+the eligible-count, and the returned-count. The score service reads
+the returned set and sets per-pass tags
+(``discovery.score_prefilter_top_n``,
+``discovery.score_prefilter_branch``) so operators can see at a glance
+how the score loop sized its work for each user without grepping
+logs (per ``feedback_check_sentry_first.md``).
+
+Failure shape
+=============
+
+If pgvector is not loaded or the cosine query raises, the exception
+propagates — per ``rules/no-bandaid-solutions.md`` we do NOT catch
+and degrade to FIFO. A failing prefilter is an infrastructure bug
+(the PR 4a boot guard should have caught this) and silently degrading
+would hide that. The score loop's caller is a BackgroundTask, so the
+exception goes to Sentry rather than the request response.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass
+from typing import Literal
+
+import sentry_sdk
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.discovery.discovered_job import DiscoveredJob
+from app.repositories.discovery import discovery_prefilter_repository
+
+logger = logging.getLogger(__name__)
+
+
+PrefilterBranch = Literal["embedding", "fifo_fallback"]
+
+
+@dataclass(frozen=True)
+class PrefilterResult:
+    """Output shape for ``rank_unscored_for_user``.
+
+    Carries both the chosen rows and the branch metadata so the score
+    service can attach the right Sentry tags without re-querying.
+
+    Attributes:
+        rows: Up to ``top_n`` unscored DiscoveredJob rows, ranked by
+            cosine similarity (embedding branch) or recency
+            (FIFO branch). May be fewer than ``top_n`` when there are
+            fewer eligible postings.
+        branch: Which path produced ``rows`` — drives the Sentry tag
+            ``discovery.score_prefilter_branch``.
+        eligible_count: How many rows were eligible BEFORE the limit
+            was applied. On the embedding branch, this is the count of
+            unscored postings with embeddings (so the operator can see
+            embed/fetch lag in Sentry). On the FIFO branch this is the
+            same count returned by the FIFO query — we don't run a
+            separate COUNT(*) because the FIFO path is the rare case.
+    """
+
+    rows: list[DiscoveredJob]
+    branch: PrefilterBranch
+    eligible_count: int
+
+
+async def rank_unscored_for_user(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    top_n: int = 20,
+) -> PrefilterResult:
+    """Return up to ``top_n`` unscored postings, ranked by best-available signal.
+
+    Picks the embedding branch when the user has a profile embedding;
+    falls back to FIFO when they don't. Both branches return rows in
+    the same shape — the caller iterates them identically.
+
+    Args:
+        db: An open AsyncSession. The caller owns the session lifecycle.
+        user_id: Tenant-scoping identifier; every read is filtered by it.
+        top_n: Maximum rows to return. Defaults to 20 — the cost-tuned
+            sweet spot for a ~$0.30/day budget at ~$0.005/score.
+
+    Returns:
+        A ``PrefilterResult`` describing the chosen rows + branch metadata.
+        ``rows`` is empty when there are no eligible postings — the score
+        service treats that as a no-op pass.
+
+    Raises:
+        Any exception from pgvector / the DB driver propagates. Per
+        ``rules/no-bandaid-solutions.md`` we do not catch and degrade —
+        a failing prefilter is an infrastructure bug worth surfacing.
+    """
+    profile_embedding = (
+        await discovery_prefilter_repository.get_profile_embedding(
+            db, user_id,
+        )
+    )
+
+    if profile_embedding is None:
+        rows = await discovery_prefilter_repository.list_unscored_fifo_fallback(
+            db, user_id, top_n=top_n,
+        )
+        result = PrefilterResult(
+            rows=rows,
+            branch="fifo_fallback",
+            eligible_count=len(rows),
+        )
+        _emit_breadcrumb(user_id=user_id, result=result, top_n=top_n)
+        logger.info(
+            "discovery prefilter: branch=fifo_fallback user=%s "
+            "returned=%d top_n=%d (no profile embedding)",
+            user_id, len(rows), top_n,
+        )
+        return result
+
+    eligible_count = (
+        await discovery_prefilter_repository.count_unscored_with_embedding(
+            db, user_id,
+        )
+    )
+    rows = await discovery_prefilter_repository.list_unscored_with_embedding_ranked(
+        db,
+        user_id,
+        profile_embedding=profile_embedding,
+        top_n=top_n,
+    )
+    result = PrefilterResult(
+        rows=rows,
+        branch="embedding",
+        eligible_count=eligible_count,
+    )
+    _emit_breadcrumb(user_id=user_id, result=result, top_n=top_n)
+    logger.info(
+        "discovery prefilter: branch=embedding user=%s "
+        "eligible=%d returned=%d top_n=%d",
+        user_id, eligible_count, len(rows), top_n,
+    )
+    return result
+
+
+def _emit_breadcrumb(
+    *,
+    user_id: uuid.UUID,
+    result: PrefilterResult,
+    top_n: int,
+) -> None:
+    """Emit a structured Sentry breadcrumb summarising the prefilter pass.
+
+    Per ``feedback_check_sentry_first.md``: every operationally-interesting
+    decision in the discovery pipeline leaves a Sentry breadcrumb so the
+    operator can reconstruct what happened from the dashboard alone.
+
+    Breadcrumbs are scoped to the current Sentry hub — when the score
+    service later captures an exception or message, the breadcrumb
+    appears in the event's trail.
+    """
+    sentry_sdk.add_breadcrumb(
+        category="discovery.prefilter",
+        message=f"prefilter branch={result.branch} returned={len(result.rows)}",
+        level="info",
+        data={
+            "user_id": str(user_id),
+            "prefilter_branch": result.branch,
+            "prefilter_eligible_count": result.eligible_count,
+            "prefilter_returned_count": len(result.rows),
+            "prefilter_top_n": top_n,
+        },
+    )

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_score_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_score_service.py
@@ -1,10 +1,25 @@
 """Discovery scoring loop — runs after a fetch cycle to rate new postings.
 
 After ``discovery_fetch_service.fetch_source`` upserts new rows, this
-loop pulls the freshest unscored postings for the user, calls the
-shared ``job_analysis_service.score()`` against the operator's profile
-snapshot, and persists the score + reasoning back onto the
-``discovered_jobs`` row.
+loop calls the two-stage prefilter
+(``discovery_prefilter_service.rank_unscored_for_user``) to narrow the
+candidate set, then calls the shared ``job_analysis_service.score()``
+against the operator's profile snapshot for each remaining row, and
+persists the score + reasoning back onto the ``discovered_jobs`` row.
+
+Two-stage scoring (PR 4b)
+=========================
+
+Before PR 4b, the loop iterated every unscored row in
+``discovered_at DESC`` order until the daily budget ran out. At
+500-2000 postings/day per user this hit the per-user budget cap fast
+and silently dropped the tail.
+
+Now the prefilter narrows the candidate set to ``top_n=20`` rows
+(default; tunable via ``settings.discovery_score_top_n``) before this
+loop ever calls Anthropic. The cosine-similarity ranking ensures the
+operator's budget is spent on the postings most likely to be a good
+fit; the budget cap and circuit-breaker still apply on top.
 
 Cost guard
 ==========
@@ -12,10 +27,12 @@ Cost guard
 Each scoring call costs ~$0.005-$0.01 in Anthropic tokens. To bound
 runaway cost we:
 
-1. Cap how many postings we score per cycle (``DEFAULT_SCORE_BATCH``).
-2. Aggregate today's spend from ``extraction_logs`` and stop the loop
+1. Prefilter to top-N by cosine similarity (PR 4b).
+2. Cap how many postings we score per cycle (``DEFAULT_SCORE_BATCH``;
+   acts as a safety ceiling even if the prefilter returns more).
+3. Aggregate today's spend from ``extraction_logs`` and stop the loop
    when it exceeds the per-user daily budget.
-3. The hard ceiling lives in env (``DISCOVERY_DAILY_BUDGET_USD_HARD_CAP``,
+4. The hard ceiling lives in env (``DISCOVERY_DAILY_BUDGET_USD_HARD_CAP``,
    default $2.00). The per-user setting may not exceed this.
 
 Error handling and circuit-breaker
@@ -54,9 +71,9 @@ We open a fresh ``AsyncSessionLocal`` here so DB work is owned by the
 loop and cleaned up cleanly.
 
 If the FastAPI process restarts mid-loop, unscored postings just stay
-unscored. The next /refresh picks them up because
-``list_unscored_for_user`` orders by ``discovered_at DESC`` and the
-loop is idempotent (only writes ``score`` when it was previously NULL).
+unscored. The next /refresh picks them up because the prefilter
+re-ranks by ``score IS NULL`` and the loop is idempotent (only writes
+``score`` when it was previously NULL).
 """
 from __future__ import annotations
 
@@ -71,7 +88,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.core.config import settings
 from app.db.session import AsyncSessionLocal
 from app.models.system.extraction_log import ExtractionLog
-from app.repositories.discovery import discovery_repository
+from app.services.discovery import discovery_prefilter_service
 from app.services.job_analysis.job_analysis_service import (
     JobAnalysisError,
     PERMANENT_ANTHROPIC_CODES,
@@ -91,7 +108,16 @@ _CIRCUIT_BREAKER_THRESHOLD = 3
 
 
 async def score_user_inbox(user_id: uuid.UUID, *, batch: int = DEFAULT_SCORE_BATCH) -> None:
-    """Score up to ``batch`` unscored postings for ``user_id``.
+    """Score up to ``top_n`` prefiltered postings for ``user_id``.
+
+    The prefilter (``discovery_prefilter_service.rank_unscored_for_user``)
+    selects the top N candidates by cosine similarity to the user's
+    profile embedding (or by ``discovered_at DESC`` when the user has
+    no profile embedding yet). This loop then scores each via Anthropic.
+
+    ``batch`` is the legacy upper bound on per-pass scoring — kept as a
+    safety ceiling. The prefilter's ``top_n`` (default 20) is the real
+    governor; in practice ``min(top_n, batch)`` rows are scored.
 
     Stops early when the per-user daily budget is exhausted. Per-row
     transient failures are logged + counted toward the circuit-breaker;
@@ -103,10 +129,11 @@ async def score_user_inbox(user_id: uuid.UUID, *, batch: int = DEFAULT_SCORE_BAT
     a broken API key should fail loud, not silently produce zero scores.
 
     Designed to run as a FastAPI ``BackgroundTask`` after /refresh
-    returns. No-op when there are no unscored postings or the budget
+    returns. No-op when there are no eligible postings or the budget
     is already spent.
     """
     daily_cap = _resolve_daily_budget()
+    top_n = _resolve_top_n(batch)
 
     async with AsyncSessionLocal() as db:
         spent_today = await _spent_today(db, user_id)
@@ -117,15 +144,33 @@ async def score_user_inbox(user_id: uuid.UUID, *, batch: int = DEFAULT_SCORE_BAT
             )
             return
 
-        candidates = await discovery_repository.list_unscored_for_user(
-            db, user_id, limit=batch,
+        prefilter_result = (
+            await discovery_prefilter_service.rank_unscored_for_user(
+                db, user_id, top_n=top_n,
+            )
         )
+        candidates = prefilter_result.rows
         if not candidates:
             return
 
+        # Attach per-pass Sentry tags so the operator can filter by branch
+        # and top_n in the dashboard. The tags live on the current scope
+        # so any per-row failure inherits them.
+        sentry_sdk.set_tag(
+            "discovery.score_prefilter_branch", prefilter_result.branch,
+        )
+        sentry_sdk.set_tag(
+            "discovery.score_prefilter_top_n", str(top_n),
+        )
+
         logger.info(
-            "discovery score: starting user=%s candidates=%d budget_remaining=%.4f",
-            user_id, len(candidates), daily_cap - spent_today,
+            "discovery score: starting user=%s candidates=%d "
+            "prefilter_branch=%s prefilter_eligible=%d budget_remaining=%.4f",
+            user_id,
+            len(candidates),
+            prefilter_result.branch,
+            prefilter_result.eligible_count,
+            daily_cap - spent_today,
         )
 
         # Track in-loop spend locally instead of re-querying
@@ -265,6 +310,25 @@ def _emit_circuit_break_warning(
         "consecutive=%d last_code=%s — remaining postings deferred to next pass",
         user_id, consecutive, last_code,
     )
+
+
+def _resolve_top_n(batch: int) -> int:
+    """Resolve the effective prefilter top-N for this pass.
+
+    The prefilter respects ``settings.discovery_score_top_n`` (default
+    20) but never exceeds the legacy ``batch`` ceiling — so a misconfigured
+    env (e.g. ``DISCOVERY_SCORE_TOP_N=10000``) can't bypass the per-pass
+    safety cap. Returns the smaller of the two, clamped to >= 1 so an
+    operator setting 0 or negative doesn't silently disable scoring.
+    """
+    raw = getattr(settings, "discovery_score_top_n", 20)
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        value = 20
+    if value < 1:
+        value = 20
+    return min(value, batch)
 
 
 def _resolve_daily_budget() -> float:

--- a/apps/myjobhunter/backend/tests/test_discovery_prefilter_service.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_prefilter_service.py
@@ -1,0 +1,324 @@
+"""Tests for discovery_prefilter_service.rank_unscored_for_user (PR 4b).
+
+Covers:
+
+- Happy path (embedding branch): profile has an embedding, prefilter
+  returns rows from the cosine-similarity ranked query.
+- FIFO fallback: profile has no embedding, prefilter returns rows from
+  the FIFO query.
+- Zero eligible postings: prefilter returns an empty list (no error).
+- Sentry breadcrumb emitted with the correct branch + counts.
+- top_n is forwarded to both repository functions verbatim.
+- Embedding branch reports eligible_count from the dedicated COUNT(*)
+  query (not just len(rows)), so the operator can see embed-vs-fetch
+  lag in Sentry.
+
+The repository layer is mocked at the
+``discovery_prefilter_repository`` import inside the service module —
+no real DB. The Sentry SDK is also mocked so the test doesn't depend
+on the SDK being initialized.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.models.discovery.discovered_job import DiscoveredJob
+from app.services.discovery import discovery_prefilter_service
+
+
+_PROFILE_EMB_PATH = (
+    "app.services.discovery.discovery_prefilter_service."
+    "discovery_prefilter_repository.get_profile_embedding"
+)
+_RANKED_PATH = (
+    "app.services.discovery.discovery_prefilter_service."
+    "discovery_prefilter_repository.list_unscored_with_embedding_ranked"
+)
+_FIFO_PATH = (
+    "app.services.discovery.discovery_prefilter_service."
+    "discovery_prefilter_repository.list_unscored_fifo_fallback"
+)
+_COUNT_PATH = (
+    "app.services.discovery.discovery_prefilter_service."
+    "discovery_prefilter_repository.count_unscored_with_embedding"
+)
+_BREADCRUMB_PATH = (
+    "app.services.discovery.discovery_prefilter_service.sentry_sdk.add_breadcrumb"
+)
+
+
+def _make_job(user_id: uuid.UUID) -> DiscoveredJob:
+    return DiscoveredJob(
+        user_id=user_id,
+        source="jsearch",
+        source_external_id=str(uuid.uuid4()),
+        title="Senior Engineer",
+        company_name="Acme",
+        remote_type="remote",
+    )
+
+
+def _profile_embedding() -> list[float]:
+    """Stand-in 384-dim profile vector — actual values irrelevant to tests."""
+    return [0.1] * 384
+
+
+# ---------------------------------------------------------------------------
+# Embedding branch
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingBranch:
+    @pytest.mark.asyncio
+    async def test_returns_ranked_rows_when_profile_has_embedding(self) -> None:
+        """Happy path: profile has an embedding → embedding branch is taken."""
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(5)]
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=_profile_embedding())),
+            patch(_COUNT_PATH, new=AsyncMock(return_value=12)),
+            patch(_RANKED_PATH, new=AsyncMock(return_value=jobs)) as mock_ranked,
+            patch(_FIFO_PATH, new=AsyncMock()) as mock_fifo,
+            patch(_BREADCRUMB_PATH),
+        ):
+            result = await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=5,
+            )
+
+        assert result.branch == "embedding"
+        assert result.rows == jobs
+        assert result.eligible_count == 12
+        mock_ranked.assert_awaited_once()
+        mock_fifo.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_top_n_forwarded_to_ranked_query(self) -> None:
+        """top_n is passed to the ranked repository function verbatim."""
+        user_id = uuid.uuid4()
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=_profile_embedding())),
+            patch(_COUNT_PATH, new=AsyncMock(return_value=0)),
+            patch(_RANKED_PATH, new=AsyncMock(return_value=[])) as mock_ranked,
+            patch(_BREADCRUMB_PATH),
+        ):
+            await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=42,
+            )
+
+        call_kwargs = mock_ranked.await_args.kwargs
+        assert call_kwargs["top_n"] == 42
+        assert call_kwargs["profile_embedding"] == _profile_embedding()
+
+    @pytest.mark.asyncio
+    async def test_eligible_count_reflects_count_query_not_rows_len(self) -> None:
+        """eligible_count reports the distinct COUNT(*), not just len(rows).
+
+        This lets the operator see embed/fetch lag in Sentry: if
+        eligible=200 but returned=20, the prefilter is doing its job.
+        If eligible=2 and returned=2 over many passes, fetches are
+        thin / embeddings are stuck.
+        """
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(20)]  # capped at top_n
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=_profile_embedding())),
+            patch(_COUNT_PATH, new=AsyncMock(return_value=500)),
+            patch(_RANKED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_BREADCRUMB_PATH),
+        ):
+            result = await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=20,
+            )
+
+        assert result.eligible_count == 500
+        assert len(result.rows) == 20
+
+    @pytest.mark.asyncio
+    async def test_zero_eligible_returns_empty_list(self) -> None:
+        """No eligible rows → empty list, branch=embedding (profile had an embedding)."""
+        user_id = uuid.uuid4()
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=_profile_embedding())),
+            patch(_COUNT_PATH, new=AsyncMock(return_value=0)),
+            patch(_RANKED_PATH, new=AsyncMock(return_value=[])),
+            patch(_BREADCRUMB_PATH),
+        ):
+            result = await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=20,
+            )
+
+        assert result.rows == []
+        assert result.branch == "embedding"
+        assert result.eligible_count == 0
+
+
+# ---------------------------------------------------------------------------
+# FIFO fallback branch
+# ---------------------------------------------------------------------------
+
+
+class TestFifoFallbackBranch:
+    @pytest.mark.asyncio
+    async def test_no_profile_embedding_falls_back_to_fifo(self) -> None:
+        """When profile embedding is None, FIFO query is used."""
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(3)]
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=None)),
+            patch(_RANKED_PATH, new=AsyncMock()) as mock_ranked,
+            patch(_FIFO_PATH, new=AsyncMock(return_value=jobs)) as mock_fifo,
+            patch(_COUNT_PATH, new=AsyncMock()) as mock_count,
+            patch(_BREADCRUMB_PATH),
+        ):
+            result = await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=20,
+            )
+
+        assert result.branch == "fifo_fallback"
+        assert result.rows == jobs
+        # The eligible_count COUNT(*) query is NOT run on the FIFO path —
+        # it would return rows with NULL embeddings too and would mislead
+        # the operator. eligible_count mirrors len(rows) for FIFO.
+        assert result.eligible_count == len(jobs)
+        mock_fifo.assert_awaited_once()
+        mock_ranked.assert_not_called()
+        mock_count.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_fifo_top_n_forwarded(self) -> None:
+        """top_n is passed to the FIFO repository function verbatim."""
+        user_id = uuid.uuid4()
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=None)),
+            patch(_FIFO_PATH, new=AsyncMock(return_value=[])) as mock_fifo,
+            patch(_BREADCRUMB_PATH),
+        ):
+            await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=7,
+            )
+
+        assert mock_fifo.await_args.kwargs["top_n"] == 7
+
+    @pytest.mark.asyncio
+    async def test_fifo_zero_eligible_returns_empty_list(self) -> None:
+        """FIFO branch with zero eligible rows returns an empty list."""
+        user_id = uuid.uuid4()
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=None)),
+            patch(_FIFO_PATH, new=AsyncMock(return_value=[])),
+            patch(_BREADCRUMB_PATH),
+        ):
+            result = await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=20,
+            )
+
+        assert result.rows == []
+        assert result.branch == "fifo_fallback"
+        assert result.eligible_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Sentry breadcrumb
+# ---------------------------------------------------------------------------
+
+
+class TestSentryBreadcrumb:
+    @pytest.mark.asyncio
+    async def test_embedding_branch_emits_breadcrumb(self) -> None:
+        """Embedding branch emits a breadcrumb with branch=embedding."""
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(5)]
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=_profile_embedding())),
+            patch(_COUNT_PATH, new=AsyncMock(return_value=42)),
+            patch(_RANKED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_BREADCRUMB_PATH) as mock_breadcrumb,
+        ):
+            await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=5,
+            )
+
+        mock_breadcrumb.assert_called_once()
+        kwargs = mock_breadcrumb.call_args.kwargs
+        assert kwargs["category"] == "discovery.prefilter"
+        assert kwargs["data"]["prefilter_branch"] == "embedding"
+        assert kwargs["data"]["prefilter_eligible_count"] == 42
+        assert kwargs["data"]["prefilter_returned_count"] == 5
+        assert kwargs["data"]["prefilter_top_n"] == 5
+        assert kwargs["data"]["user_id"] == str(user_id)
+
+    @pytest.mark.asyncio
+    async def test_fifo_branch_emits_breadcrumb(self) -> None:
+        """FIFO branch emits a breadcrumb with branch=fifo_fallback."""
+        user_id = uuid.uuid4()
+        jobs = [_make_job(user_id) for _ in range(3)]
+        mock_db = AsyncMock()
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=None)),
+            patch(_FIFO_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_BREADCRUMB_PATH) as mock_breadcrumb,
+        ):
+            await discovery_prefilter_service.rank_unscored_for_user(
+                mock_db, user_id, top_n=20,
+            )
+
+        mock_breadcrumb.assert_called_once()
+        kwargs = mock_breadcrumb.call_args.kwargs
+        assert kwargs["data"]["prefilter_branch"] == "fifo_fallback"
+        assert kwargs["data"]["prefilter_returned_count"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Error propagation — no silent bandaid
+# ---------------------------------------------------------------------------
+
+
+class TestErrorPropagation:
+    @pytest.mark.asyncio
+    async def test_db_error_propagates_not_swallowed(self) -> None:
+        """A DB-level exception (e.g. pgvector unloaded) propagates.
+
+        Per ``rules/no-bandaid-solutions.md``: the prefilter does NOT
+        catch and degrade to FIFO when the ranked query raises. A
+        failing cosine query is an infrastructure bug worth surfacing
+        — the PR 4a boot guard should have caught it earlier.
+        """
+        user_id = uuid.uuid4()
+        mock_db = AsyncMock()
+
+        class _PgvectorMissing(RuntimeError):
+            pass
+
+        with (
+            patch(_PROFILE_EMB_PATH, new=AsyncMock(return_value=_profile_embedding())),
+            patch(_COUNT_PATH, new=AsyncMock(return_value=10)),
+            patch(
+                _RANKED_PATH,
+                new=AsyncMock(side_effect=_PgvectorMissing("operator <=> not found")),
+            ),
+            patch(_BREADCRUMB_PATH),
+        ):
+            with pytest.raises(_PgvectorMissing):
+                await discovery_prefilter_service.rank_unscored_for_user(
+                    mock_db, user_id, top_n=20,
+                )

--- a/apps/myjobhunter/backend/tests/test_discovery_score_service.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_score_service.py
@@ -32,13 +32,17 @@ from app.services.job_analysis.job_analysis_service import (
 _SCORE_JD_PATH = "app.services.discovery.discovery_score_service.score_jd"
 _SPENT_TODAY_PATH = "app.services.discovery.discovery_score_service._spent_today"
 _SESSION_LOCAL_PATH = "app.services.discovery.discovery_score_service.AsyncSessionLocal"
-_LIST_UNSCORED_PATH = (
+# PR 4b: the score loop now reads its candidate list from the prefilter
+# service rather than from ``discovery_repository.list_unscored_for_user``.
+# Tests patch the prefilter to return a fixed candidate set.
+_PREFILTER_PATH = (
     "app.services.discovery.discovery_score_service."
-    "discovery_repository.list_unscored_for_user"
+    "discovery_prefilter_service.rank_unscored_for_user"
 )
 _SENTRY_CAPTURE_EXC_PATH = "app.services.discovery.discovery_score_service.sentry_sdk.capture_exception"
 _SENTRY_CAPTURE_MSG_PATH = "app.services.discovery.discovery_score_service.sentry_sdk.capture_message"
 _SENTRY_NEW_SCOPE_PATH = "app.services.discovery.discovery_score_service.sentry_sdk.new_scope"
+_SENTRY_SET_TAG_PATH = "app.services.discovery.discovery_score_service.sentry_sdk.set_tag"
 
 
 def _make_job(user_id: uuid.UUID) -> DiscoveredJob:
@@ -68,6 +72,21 @@ def _make_transient_error(code: str = "rate_limit_error") -> JobAnalysisError:
 def _make_permanent_error(code: str = "authentication_error") -> JobAnalysisError:
     """Create a permanent JobAnalysisError (retryable=False)."""
     return JobAnalysisError(f"Anthropic error: {code}", code=code, retryable=False)
+
+
+def _prefilter_result(rows: list[DiscoveredJob], *, branch: str = "embedding"):
+    """Build a PrefilterResult stand-in matching the service contract.
+
+    The score service reads ``.rows``, ``.branch``, and
+    ``.eligible_count`` — we mimic those attributes on a MagicMock so
+    tests don't import the real dataclass (keeps the patch surface
+    narrow and avoids forcing every test to construct the typed object).
+    """
+    result = MagicMock()
+    result.rows = rows
+    result.branch = branch
+    result.eligible_count = len(rows)
+    return result
 
 
 def _noop_scope_cm() -> MagicMock:
@@ -114,7 +133,7 @@ class TestBudgetExhausted:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[])),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result([]))),
             patch(_SCORE_JD_PATH, new=AsyncMock()) as mock_score,
         ):
             from app.services.discovery import discovery_score_service
@@ -140,7 +159,7 @@ class TestHappyPath:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result(jobs))),
             patch(_SCORE_JD_PATH, new=AsyncMock(return_value=analysis)) as mock_score,
         ):
             from app.services.discovery import discovery_score_service
@@ -171,7 +190,7 @@ class TestHappyPath:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result([job]))),
             patch(_SCORE_JD_PATH, new=AsyncMock(return_value=analysis)) as mock_score,
         ):
             from app.services.discovery import discovery_score_service
@@ -203,7 +222,7 @@ class TestHappyPath:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.15)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result(jobs))),
             patch(_SCORE_JD_PATH, new=AsyncMock(return_value=analysis)) as mock_score,
             patch.object(
                 __import__(
@@ -247,7 +266,7 @@ class TestTransientErrorHandling:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result(jobs))),
             patch(_SCORE_JD_PATH, new=mock_score),
             patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
             patch(_SENTRY_CAPTURE_EXC_PATH),
@@ -274,7 +293,7 @@ class TestTransientErrorHandling:
             with (
                 patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
                 patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-                patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+                patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result([job]))),
                 patch(_SCORE_JD_PATH, new=AsyncMock(side_effect=_make_transient_error(code))),
                 patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
                 patch(_SENTRY_CAPTURE_EXC_PATH),
@@ -305,7 +324,7 @@ class TestTransientErrorHandling:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result([job]))),
             patch(_SCORE_JD_PATH, new=AsyncMock(side_effect=err)),
             patch(_SENTRY_NEW_SCOPE_PATH, return_value=scope_cm),
             patch(_SENTRY_CAPTURE_EXC_PATH) as mock_capture_exc,
@@ -337,7 +356,7 @@ class TestCircuitBreaker:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result(jobs))),
             patch(
                 _SCORE_JD_PATH,
                 new=AsyncMock(side_effect=_make_transient_error("rate_limit_error")),
@@ -391,7 +410,7 @@ class TestCircuitBreaker:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result(jobs))),
             patch(_SCORE_JD_PATH, new=mock_score),
             patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
             patch(_SENTRY_CAPTURE_EXC_PATH),
@@ -421,7 +440,7 @@ class TestCircuitBreaker:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result(jobs))),
             patch(
                 _SCORE_JD_PATH,
                 new=AsyncMock(side_effect=_make_transient_error("overloaded_error")),
@@ -457,7 +476,7 @@ class TestPermanentErrors:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result(jobs))),
             patch(
                 _SCORE_JD_PATH,
                 new=AsyncMock(side_effect=_make_permanent_error("authentication_error")),
@@ -489,7 +508,7 @@ class TestPermanentErrors:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=jobs)),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result(jobs))),
             patch(
                 _SCORE_JD_PATH,
                 new=AsyncMock(side_effect=_make_permanent_error("invalid_request_error")),
@@ -521,7 +540,7 @@ class TestPermanentErrors:
             with (
                 patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
                 patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-                patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+                patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result([job]))),
                 patch(
                     _SCORE_JD_PATH,
                     new=AsyncMock(side_effect=_make_permanent_error(code)),
@@ -553,7 +572,7 @@ class TestPermanentErrors:
         with (
             patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
             patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
-            patch(_LIST_UNSCORED_PATH, new=AsyncMock(return_value=[job])),
+            patch(_PREFILTER_PATH, new=AsyncMock(return_value=_prefilter_result([job]))),
             patch(_SCORE_JD_PATH, new=AsyncMock(side_effect=err)),
             patch(_SENTRY_NEW_SCOPE_PATH, return_value=_noop_scope_cm()),
             patch(_SENTRY_CAPTURE_EXC_PATH) as mock_capture_exc,
@@ -565,6 +584,180 @@ class TestPermanentErrors:
 
         # Sentry was still notified even though we re-raised.
         mock_capture_exc.assert_called_once_with(err)
+
+
+class TestPrefilterIntegration:
+    """PR 4b: the score loop reads from the prefilter and emits per-pass Sentry tags."""
+
+    @pytest.mark.asyncio
+    async def test_score_loop_calls_prefilter_with_resolved_top_n(self) -> None:
+        """``settings.discovery_score_top_n`` flows through to the prefilter call."""
+        user_id = uuid.uuid4()
+        job = _make_job(user_id)
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        analysis = _make_analysis(cost=0.005)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(
+                _PREFILTER_PATH,
+                new=AsyncMock(return_value=_prefilter_result([job])),
+            ) as mock_prefilter,
+            patch(_SCORE_JD_PATH, new=AsyncMock(return_value=analysis)),
+            patch(_SENTRY_SET_TAG_PATH),
+            patch.object(
+                __import__(
+                    "app.services.discovery.discovery_score_service",
+                    fromlist=["settings"],
+                ).settings,
+                "discovery_score_top_n",
+                15,
+            ),
+        ):
+            from app.services.discovery import discovery_score_service
+            # batch=50 is the legacy cap; top_n=15 should be the
+            # effective value passed to the prefilter (min(top_n, batch)).
+            await discovery_score_service.score_user_inbox(user_id, batch=50)
+
+        assert mock_prefilter.await_args.kwargs["top_n"] == 15
+
+    @pytest.mark.asyncio
+    async def test_score_loop_caps_top_n_to_batch(self) -> None:
+        """A misconfigured DISCOVERY_SCORE_TOP_N can't exceed the batch ceiling.
+
+        Defense in depth: even if env sets top_n=10000, the per-pass
+        safety cap (``batch``) still applies. ``_resolve_top_n`` returns
+        ``min(top_n, batch)``.
+        """
+        user_id = uuid.uuid4()
+        job = _make_job(user_id)
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(
+                _PREFILTER_PATH,
+                new=AsyncMock(return_value=_prefilter_result([job])),
+            ) as mock_prefilter,
+            patch(_SCORE_JD_PATH, new=AsyncMock(return_value=_make_analysis())),
+            patch(_SENTRY_SET_TAG_PATH),
+            patch.object(
+                __import__(
+                    "app.services.discovery.discovery_score_service",
+                    fromlist=["settings"],
+                ).settings,
+                "discovery_score_top_n",
+                10000,
+            ),
+        ):
+            from app.services.discovery import discovery_score_service
+            await discovery_score_service.score_user_inbox(user_id, batch=20)
+
+        # 10000 misconfigured top_n is clamped down to batch=20.
+        assert mock_prefilter.await_args.kwargs["top_n"] == 20
+
+    @pytest.mark.asyncio
+    async def test_score_loop_only_iterates_prefilter_rows(self) -> None:
+        """The loop scores exactly the rows the prefilter returned, no more.
+
+        Even when the legacy batch ceiling is higher than the prefilter
+        output, the loop should stop at len(prefilter.rows). This is
+        what produces the cost reduction.
+        """
+        user_id = uuid.uuid4()
+        prefilter_jobs = [_make_job(user_id) for _ in range(3)]
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(
+                _PREFILTER_PATH,
+                new=AsyncMock(return_value=_prefilter_result(prefilter_jobs)),
+            ),
+            patch(
+                _SCORE_JD_PATH,
+                new=AsyncMock(return_value=_make_analysis()),
+            ) as mock_score,
+            patch(_SENTRY_SET_TAG_PATH),
+        ):
+            from app.services.discovery import discovery_score_service
+            # batch=20 is plenty of headroom; only 3 prefilter rows
+            # exist, so only 3 should be scored.
+            await discovery_score_service.score_user_inbox(user_id, batch=20)
+
+        assert mock_score.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_score_loop_sets_prefilter_branch_tag_on_sentry(self) -> None:
+        """The per-pass tag ``discovery.score_prefilter_branch`` is set."""
+        user_id = uuid.uuid4()
+        job = _make_job(user_id)
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(
+                _PREFILTER_PATH,
+                new=AsyncMock(return_value=_prefilter_result([job], branch="fifo_fallback")),
+            ),
+            patch(_SCORE_JD_PATH, new=AsyncMock(return_value=_make_analysis())),
+            patch(_SENTRY_SET_TAG_PATH) as mock_set_tag,
+        ):
+            from app.services.discovery import discovery_score_service
+            await discovery_score_service.score_user_inbox(user_id, batch=20)
+
+        mock_set_tag.assert_any_call(
+            "discovery.score_prefilter_branch", "fifo_fallback",
+        )
+        # top_n tag is set too — value depends on env but always present
+        tag_keys = {call.args[0] for call in mock_set_tag.call_args_list}
+        assert "discovery.score_prefilter_top_n" in tag_keys
+
+    @pytest.mark.asyncio
+    async def test_score_loop_skips_when_prefilter_returns_empty(self) -> None:
+        """Empty prefilter result → score_jd is never called."""
+        user_id = uuid.uuid4()
+
+        mock_db = AsyncMock()
+        mock_cm = AsyncMock()
+        mock_cm.__aenter__ = AsyncMock(return_value=mock_db)
+        mock_cm.__aexit__ = AsyncMock(return_value=None)
+
+        with (
+            patch(_SESSION_LOCAL_PATH, return_value=mock_cm),
+            patch(_SPENT_TODAY_PATH, new=AsyncMock(return_value=0.0)),
+            patch(
+                _PREFILTER_PATH,
+                new=AsyncMock(return_value=_prefilter_result([])),
+            ),
+            patch(_SCORE_JD_PATH, new=AsyncMock()) as mock_score,
+            patch(_SENTRY_SET_TAG_PATH),
+        ):
+            from app.services.discovery import discovery_score_service
+            await discovery_score_service.score_user_inbox(user_id, batch=20)
+
+        mock_score.assert_not_called()
 
 
 class TestJobAnalysisErrorStructure:

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
@@ -54,10 +54,23 @@ export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps
     );
   }
 
+  // PR 4b: when ANY card in the inbox is unscored, the inbox polls
+  // every 4s (INBOX_POLL_INTERVAL_MS) until scores fill in. Pass that
+  // signal to each unscored card so it can render a spinner in the
+  // verdict-badge slot instead of an empty space — the operator sees
+  // their fresh postings are being rated, not silently ignored.
+  // Once every card has a verdict, polling continues but the spinner
+  // simply has nothing to attach to.
+  const hasUnscored = items.some((job) => job.score === null);
+
   return (
     <div className="space-y-3">
       {items.map((job) => (
-        <DiscoveredJobCard key={job.id} job={job} />
+        <DiscoveredJobCard
+          key={job.id}
+          job={job}
+          isScoringInFlight={hasUnscored}
+        />
       ))}
     </div>
   );

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Bookmark, Briefcase, Check, ExternalLink, X } from "lucide-react";
+import { Bookmark, Briefcase, Check, ExternalLink, Loader2, X } from "lucide-react";
 import {
   Badge,
   Button,
@@ -22,6 +22,18 @@ import DismissReasonPopover from "./DismissReasonPopover";
 
 interface DiscoveredJobCardProps {
   job: DiscoveredJob;
+  /**
+   * True when the inbox view is currently polling for fresh scores
+   * (i.e. another card in the same list has score=null). Lets the
+   * unscored card show a small spinner in the verdict-badge slot so
+   * the operator knows the rating is in flight, not stuck. When
+   * false, an unscored card shows a static "Awaiting AI score" pill
+   * — same information, lower visual noise once polling stops.
+   *
+   * Optional for backward compatibility — defaults to false so
+   * existing callers (and tests) keep their current behaviour.
+   */
+  isScoringInFlight?: boolean;
 }
 
 const REMOTE_LABEL: Record<string, string> = {
@@ -43,7 +55,10 @@ const VERDICT_VISUAL: Record<JobAnalysisVerdict, VerdictVisual> = {
   mismatch: { label: "Mismatch", color: "red" },
 };
 
-export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
+export default function DiscoveredJobCard({
+  job,
+  isScoringInFlight = false,
+}: DiscoveredJobCardProps) {
   const [dismiss, { isLoading: isDismissing }] = useDismissDiscoveredJobMutation();
   const [save, { isLoading: isSaving }] = useSaveDiscoveredJobMutation();
   const [promote, { isLoading: isPromoting }] = usePromoteDiscoveredJobMutation();
@@ -88,6 +103,7 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
   const isAlreadySaved = !!job.saved_at;
   const isAlreadyPromoted = !!job.promoted_application_id;
   const verdictVisual = job.verdict ? VERDICT_VISUAL[job.verdict] ?? null : null;
+  const isUnscored = job.verdict === null && job.score === null;
 
   return (
     <Card className="p-4 sm:p-5 space-y-3">
@@ -103,6 +119,26 @@ export default function DiscoveredJobCard({ job }: DiscoveredJobCardProps) {
         </div>
         <div className="flex items-start gap-1.5 shrink-0">
           {verdictVisual && <Badge label={verdictVisual.label} color={verdictVisual.color} />}
+          {!verdictVisual && isUnscored && isScoringInFlight && (
+            <span
+              className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground border border-muted rounded"
+              role="status"
+              aria-live="polite"
+              aria-label="Scoring in progress"
+              data-testid="discovered-job-scoring-spinner"
+            >
+              <Loader2 className="w-3 h-3 animate-spin" aria-hidden="true" />
+              <span>Scoring</span>
+            </span>
+          )}
+          {!verdictVisual && isUnscored && !isScoringInFlight && (
+            <span
+              className="px-2 py-0.5 text-xs text-muted-foreground border border-muted rounded"
+              data-testid="discovered-job-awaiting-score"
+            >
+              Awaiting AI score
+            </span>
+          )}
           {job.source_publisher && (
             <Badge label={job.source_publisher} color="gray" />
           )}

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
@@ -12,6 +12,7 @@ vi.mock("lucide-react", () => ({
   Briefcase: () => null,
   Check: () => null,
   ExternalLink: () => null,
+  Loader2: () => null,
   X: () => null,
 }));
 
@@ -95,5 +96,60 @@ describe("DiscoveredJobCard — verdict badge", () => {
     render(<DiscoveredJobCard job={makeJob()} />);
     expect(screen.getByText("Senior Backend Engineer")).toBeInTheDocument();
     expect(screen.getByText(/Acme Corp/)).toBeInTheDocument();
+  });
+});
+
+describe("DiscoveredJobCard — unscored visual signal (PR 4b)", () => {
+  it("shows 'Awaiting AI score' pill when unscored and polling is idle", () => {
+    render(
+      <DiscoveredJobCard
+        job={makeJob({ verdict: null, score: null })}
+        isScoringInFlight={false}
+      />,
+    );
+    expect(
+      screen.getByTestId("discovered-job-awaiting-score"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("discovered-job-scoring-spinner"),
+    ).toBeNull();
+  });
+
+  it("shows a spinner when unscored and polling is in flight", () => {
+    render(
+      <DiscoveredJobCard
+        job={makeJob({ verdict: null, score: null })}
+        isScoringInFlight={true}
+      />,
+    );
+    expect(
+      screen.getByTestId("discovered-job-scoring-spinner"),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("discovered-job-awaiting-score"),
+    ).toBeNull();
+  });
+
+  it("shows neither pill nor spinner when the job already has a verdict", () => {
+    render(
+      <DiscoveredJobCard
+        job={makeJob({ verdict: "strong_fit", score: 90 })}
+        isScoringInFlight={true}
+      />,
+    );
+    expect(
+      screen.queryByTestId("discovered-job-awaiting-score"),
+    ).toBeNull();
+    expect(
+      screen.queryByTestId("discovered-job-scoring-spinner"),
+    ).toBeNull();
+  });
+
+  it("defaults isScoringInFlight to false when omitted", () => {
+    render(<DiscoveredJobCard job={makeJob({ verdict: null, score: null })} />);
+    // Default falsy → static pill, not the spinner.
+    expect(
+      screen.getByTestId("discovered-job-awaiting-score"),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

PR 4b of the MJH job discovery delta-plan sequence — wires the embedding infrastructure landed in #568 into the score loop.

- Replaces the "list every unscored row and call Anthropic on each" loop with a two-stage flow: rank unscored postings by pgvector cosine similarity to the user's profile embedding, then call Anthropic only on the top N (default 20).
- ~25x cost reduction at typical fetch volumes (500-2000 postings/day per user). Budget cap + circuit breaker still apply on top.
- Fallback: when a user has no profile embedding yet (newly onboarded, no skills/work history/resume), rank by ``discovered_at DESC`` so the operator still gets *some* scoring while the profile ripens.
- Frontend: unscored cards now show either a small spinner (when polling is in flight) or an "Awaiting AI score" pill so the missing verdict badge doesn't look like a bug.

Foundation: #568 (embedding infrastructure — pgvector + fastembed)

## What's in this PR

**Backend**
- New ``app/services/discovery/discovery_prefilter_service.py`` — orchestrator returning a structured ``PrefilterResult`` (rows + branch + eligible_count)
- New ``app/repositories/discovery/discovery_prefilter_repository.py`` — all SQL for cosine ranking, FIFO fallback, eligible-count, profile-embedding lookup (per the layered-architecture rule)
- ``discovery_score_service.score_user_inbox`` rewritten to call the prefilter and attach per-pass Sentry tags (``discovery.score_prefilter_branch``, ``discovery.score_prefilter_top_n``)
- Sentry breadcrumb emitted on every prefilter pass with branch + eligible_count + returned_count
- New ``Settings.discovery_score_top_n: int = 20`` (clamped to per-pass batch ceiling)
- Preserved: PR #566 circuit breaker (3 consecutive transient failures abort), permanent-error re-raise, structured Anthropic error capture

**Frontend**
- ``DiscoveredJobCard`` accepts a new optional ``isScoringInFlight`` prop; renders a spinner when true + unscored, a static "Awaiting AI score" pill when false + unscored, nothing when verdict exists
- ``DiscoverInboxView`` computes ``hasUnscored`` from the inbox items and passes it down — the existing 4-second polling fills scores in over time

**Tests**
- 10 new prefilter-service unit tests (happy path, FIFO fallback, top_n forwarding, Sentry breadcrumb, error propagation)
- 5 new prefilter-integration tests on the score service (top_n resolution, batch ceiling clamp, only-prefilter-rows iteration, per-pass Sentry tag, empty-prefilter short-circuit)
- Existing score-service tests retargeted from ``list_unscored_for_user`` to the prefilter — all 24 still pass
- 4 new DiscoveredJobCard tests covering both unscored visual signals

All 39 discovery-score + discovery-prefilter tests pass. Frontend ``discover`` tests all pass (54/54). Frontend typecheck clean.

## ⚠️ Operational migration required

After this PR merges and before/at the next deploy, the operator MAY optionally tune the new env var. The default (20) requires no operator action.

### What to set (optional)

Edit ``apps/myjobhunter/backend/.env.docker`` to override the default top-N if you want to tune it:

\`\`\`
DISCOVERY_SCORE_TOP_N=20
\`\`\`

### How to verify

\`\`\`bash
grep -E "^DISCOVERY_SCORE_TOP_N=" apps/myjobhunter/backend/.env.docker
\`\`\`

If empty/unset, the backend uses 20 (sensible default). Tune up for more scored rows per pass; tune down if Anthropic latency dominates. The value is clamped to the per-pass ``batch`` ceiling (currently 20) defensively — a misconfigured ``DISCOVERY_SCORE_TOP_N=10000`` cannot bypass the safety cap.

### How to recover if a deploy fails

This PR does not add any boot guard or required field, so the deploy cannot fail because of this env var. If something else fails:

\`\`\`bash
docker compose -f apps/myjobhunter/docker-compose.yml logs api --tail=50 | grep -iE "error|exception"
\`\`\`

### Rollback path

Safe to revert; the previous score loop still works as long as PR #568 (embedding infrastructure) remains in place.

## Test plan

- [ ] CI passes: backend pytest + frontend vitest + typecheck
- [ ] After merge + deploy: run a discovery refresh on the production VPS; check Sentry for the ``discovery.prefilter`` breadcrumb on the first scoring background task and confirm ``prefilter_branch`` reflects whether the operator's profile has an embedding
- [ ] After scoring runs, check the inbox shows fresh verdict badges only on the prefilter's top-N — older unscored rows remain ``Awaiting AI score`` until the next pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)