### PR TITLE
feat(mjh/discover): scheduled fetches via APScheduler

### DIFF
--- a/apps/myjobhunter/backend/app/main.py
+++ b/apps/myjobhunter/backend/app/main.py
@@ -23,24 +23,33 @@ from app.core.rate_limit import (
 )
 from app.schemas.user import UserCreate, UserRead, UserUpdate
 from app.db.session import AsyncSessionLocal
-from app.services.discovery import discovery_embedding_service
+from app.services.discovery import discovery_embedding_service, discovery_scheduler_service
 from app.services.discovery.discovery_fetch_reaper import reap_stale_running_fetches
 from app.services.storage.bucket_initializer import ensure_bucket
 
 
 async def _on_startup() -> None:
-    """Run once at backend boot — reap stale fetches + eager-load the
-    embedding model.
+    """Run once at backend boot — reap stale fetches, eager-load the
+    embedding model, then start the discovery scheduler.
 
-    The embedding model load runs FIRST so a missing / corrupt fastembed
-    cache fails the lifespan before we touch the DB — the failure mode
-    is then a clean "deploy rollback to previous image" rather than the
-    backend booting in a half-broken state where discovery fetches
-    succeed but the post-fetch embed task crashes for every user.
+    Order matters:
 
-    Per rules/no-bandaid-solutions.md: any embedding model failure
-    raises ``EmbeddingModelLoadError`` and crashes the lifespan. There
-    is no silent fallback.
+    1. Embedding model load — a missing / corrupt fastembed cache fails
+       the lifespan before we touch the DB. The failure mode is then a
+       clean "deploy rollback to previous image" rather than the backend
+       booting in a half-broken state where discovery fetches succeed
+       but the post-fetch embed task crashes for every user.
+    2. Reap stale ``discovery_fetches`` rows from a previous crash so
+       the operator's dashboard doesn't show zombie 'running' rows.
+    3. Start the APScheduler + register active sources. If APScheduler
+       cannot reach Postgres for its jobstore, this raises and the
+       lifespan crashes — the deploy rolls back to the previous image
+       and the operator sees a clear error in logs.
+
+    Per rules/no-bandaid-solutions.md: every failure here is fail-loud.
+    No silent fallback (a backend that booted without a scheduler would
+    silently degrade — operator would never know automatic refresh
+    stopped working).
     """
     discovery_embedding_service.load_model_eager()
 
@@ -50,6 +59,23 @@ async def _on_startup() -> None:
             logger.info(
                 "discovery_fetch_reaper: reaped %d stale rows on startup", reaped
             )
+
+    # Start the in-process scheduler and register one job per active
+    # discovery_source. See discovery_scheduler_service module docstring
+    # for the architecture rationale + Dramatiq migration triggers.
+    discovery_scheduler_service.start_scheduler(settings)
+    async with AsyncSessionLocal() as db:
+        await discovery_scheduler_service.register_source_jobs(db)
+
+
+async def _on_shutdown() -> None:
+    """Stop the APScheduler cleanly on lifespan teardown.
+
+    ``wait=False`` inside ``shutdown_scheduler`` so a long-running
+    scheduled job doesn't block process exit — the job is re-picked-up
+    on next start because the SQLAlchemyJobStore persists state.
+    """
+    discovery_scheduler_service.shutdown_scheduler()
 
 
 # Used by the deploy workflow's freshness tripwire and by /api/version +
@@ -70,6 +96,7 @@ lifespan = create_app_lifespan(
     init_sentry=init_sentry,
     bucket_init=ensure_bucket,
     on_startup=_on_startup,
+    on_shutdown=_on_shutdown,
 )
 
 

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_scheduler_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_scheduler_service.py
@@ -1,0 +1,407 @@
+"""APScheduler wiring for scheduled discovery passes (PR 5).
+
+The shipped /discover surface is manual-refresh only — the operator
+clicks Refresh per saved search. This module closes that gap by running
+``fetch + embed + score`` automatically per ``DiscoverySource`` row on
+the cadence stored in ``discovery_sources.fetch_interval_minutes``.
+
+Architecture rationale
+----------------------
+
+Single-VPS, single-process FastAPI app with ~10 saved searches per user.
+A full external queue (Dramatiq + Redis) would be over-engineered:
+
+- No multi-process coordination needed today
+- No cross-process retries needed today
+- Job state survives restarts because we use APScheduler's
+  ``SQLAlchemyJobStore`` pointed at the same Postgres the app already
+  uses (no new infra surface)
+
+The architecture-design pass on 2026-05-11 recommended in-process
+APScheduler with a Postgres jobstore. This module is the realisation.
+
+When to migrate to Dramatiq
+---------------------------
+
+Promote the discovery passes to a real queue when ANY of these are true:
+
+1. Multi-user concurrent fetches saturate one process (asyncio lag
+   exceeds 200ms p95 measured at the request layer)
+2. We need cross-process retries — e.g. one worker dies mid-fetch and a
+   second worker must pick it up. APScheduler's ``max_instances=1`` +
+   ``coalesce=True`` handles single-process restart; not multi-worker.
+3. Global scheduled-pass throughput exceeds 50/min (the per-user model
+   doesn't scale linearly because each pass holds a DB connection + an
+   adapter HTTP call + an Anthropic call)
+4. Job latency or jitter matters for the user (APScheduler is
+   best-effort, not real-time)
+
+Until any of those trip, in-process APScheduler is the right shape.
+
+Monorepo parity note
+--------------------
+
+APScheduler is currently MJH-only. When MyBookkeeper adds its first
+scheduled job (e.g. monthly rent reminders, weekly statement parsing
+cron, periodic backup verification), promote this scheduler factory to
+``platform_shared.core.scheduler`` per
+``rules/monorepo-parity-discipline.md`` (auto-promote rule). The shape
+of ``start_scheduler`` + ``register_*_jobs`` + ``add_*_job`` is generic
+enough to host MBK's future cron registrations alongside MJH's discovery
+passes.
+
+Lifecycle
+---------
+
+- ``start_scheduler(settings)`` — initializes the AsyncIOScheduler with a
+  SQLAlchemyJobStore pointed at the app's Postgres. Called from
+  the FastAPI lifespan startup hook AFTER the fetch reaper has cleared
+  stale running rows.
+- ``register_source_jobs(db)`` — scans ``discovery_sources WHERE
+  is_active=true`` and adds one IntervalTrigger job per source.
+  Idempotent (uses ``replace_existing=True``) so a deploy that restarts
+  the process re-establishes the schedule cleanly.
+- ``add_source_job`` / ``update_source_job`` / ``remove_source_job`` —
+  called from ``discovery_source_service`` on create / update / delete
+  so the in-memory schedule stays in sync with the DB.
+- ``shutdown_scheduler()`` — graceful shutdown from the lifespan
+  teardown.
+
+Failure mode posture
+--------------------
+
+Per ``rules/no-bandaid-solutions.md``: if APScheduler cannot initialize
+its jobstore (e.g. Postgres unreachable, schema missing), the lifespan
+startup must FAIL LOUDLY. We do NOT catch + ignore a startup failure.
+A backend that booted with no scheduler is silently degraded — the
+operator would never know automatic refresh stopped working.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any
+
+from apscheduler.jobstores.sqlalchemy import SQLAlchemyJobStore
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+from apscheduler.triggers.interval import IntervalTrigger
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import AsyncSessionLocal
+from app.models.discovery.discovery_source import DiscoverySource
+from app.services.discovery import (
+    discovery_embedding_service,
+    discovery_fetch_service,
+    discovery_score_service,
+)
+from app.services.discovery.discovery_fetch_service import (
+    DiscoveryFetchError,
+    DiscoverySourceInactiveError,
+    DiscoverySourceNotFoundError,
+    DiscoveryUnsupportedSourceError,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# Module-level scheduler reference. Populated by ``start_scheduler``,
+# consumed by ``add_source_job`` / ``update_source_job`` /
+# ``remove_source_job`` / ``register_source_jobs`` / ``shutdown_scheduler``.
+# Kept as a module global instead of threaded through the dependency
+# graph because the scheduler is a process-wide singleton — there is no
+# legitimate use case for two AsyncIOScheduler instances in one process.
+_scheduler: AsyncIOScheduler | None = None
+
+
+class SchedulerNotStartedError(RuntimeError):
+    """Raised when a CRUD helper is called before ``start_scheduler``."""
+
+
+class SchedulerSourceMismatchError(RuntimeError):
+    """Raised when a scheduled job's payload doesn't match the DB row.
+
+    Defensive assertion — catches scheduler-state bugs (e.g. a stale
+    job left over from a previous deploy referencing a deleted source)
+    BEFORE they can leak data cross-tenant.
+    """
+
+
+def _job_id(source_id: uuid.UUID) -> str:
+    """Stable job id derived from the source id.
+
+    APScheduler uses string ids; using ``str(source_id)`` directly is
+    fine but a prefix makes the jobs easy to grep in the ``apscheduler_jobs``
+    table when an operator is debugging.
+    """
+    return f"discovery:source:{source_id}"
+
+
+def start_scheduler(settings: Any) -> AsyncIOScheduler:
+    """Initialize the module-level AsyncIOScheduler.
+
+    The SQLAlchemyJobStore writes jobs to the same Postgres the app uses
+    (no separate DB / Redis). Job table name ``apscheduler_jobs`` is
+    auto-created on first run.
+
+    ``settings`` must expose ``database_url_sync`` — APScheduler's
+    SQLAlchemyJobStore wraps a synchronous SQLAlchemy Engine (it doesn't
+    know about asyncio). ``database_url_sync`` is the same DSN as
+    ``database_url`` minus the ``+asyncpg`` driver fragment, so both
+    layers talk to the same Postgres instance.
+
+    Idempotent: if already started (e.g. a unit test calls this twice),
+    returns the existing scheduler.
+
+    Raises:
+        Any APScheduler / SQLAlchemy startup error. The caller (lifespan)
+        does NOT swallow these — failure to start the scheduler must
+        fail the lifespan loudly per ``rules/no-bandaid-solutions.md``.
+    """
+    global _scheduler
+    if _scheduler is not None and _scheduler.running:
+        return _scheduler
+
+    jobstore = SQLAlchemyJobStore(
+        url=settings.database_url_sync,
+        tablename="apscheduler_jobs",
+    )
+    _scheduler = AsyncIOScheduler(
+        jobstores={"default": jobstore},
+        # UTC throughout so jobs fire on the same instant regardless of
+        # the host's local timezone. Matches the rest of MJH which uses
+        # ``datetime.now(timezone.utc)`` for every datetime column.
+        timezone="UTC",
+    )
+    _scheduler.start()
+    logger.info("discovery_scheduler_service: scheduler started")
+    return _scheduler
+
+
+def shutdown_scheduler() -> None:
+    """Stop the scheduler. Idempotent; safe to call multiple times.
+
+    Called from the FastAPI lifespan shutdown hook. ``wait=False`` so a
+    long-running scheduled job doesn't block the process from exiting —
+    the job will be picked up again on next start because the jobstore
+    is persistent.
+    """
+    global _scheduler
+    if _scheduler is not None and _scheduler.running:
+        _scheduler.shutdown(wait=False)
+        logger.info("discovery_scheduler_service: scheduler shut down")
+    _scheduler = None
+
+
+def _require_scheduler() -> AsyncIOScheduler:
+    if _scheduler is None or not _scheduler.running:
+        raise SchedulerNotStartedError(
+            "discovery_scheduler_service: scheduler not started — "
+            "call start_scheduler() from the FastAPI lifespan first",
+        )
+    return _scheduler
+
+
+def add_source_job(
+    source_id: uuid.UUID,
+    user_id: uuid.UUID,
+    interval_minutes: int,
+) -> None:
+    """Register / replace a scheduled fetch for one DiscoverySource.
+
+    Idempotent — ``replace_existing=True`` so create-then-update or
+    process-restart-after-create both end up with one job per source.
+
+    ``misfire_grace_time=900`` — if the scheduler is delayed by up to
+    15 minutes (e.g. a long fetch held the event loop, a deploy paused
+    execution), still run the job. Beyond that, skip the missed run and
+    wait for the next interval. ``coalesce=True`` collapses multiple
+    missed runs into one — we never want to backfill 12h of fetches
+    in a row after the process was down for 12h.
+
+    ``max_instances=1`` — never run two passes for the same source
+    concurrently. Prevents duplicate JSearch quota burn and DB
+    contention if a previous pass took longer than its interval.
+    """
+    scheduler = _require_scheduler()
+    scheduler.add_job(
+        _run_scheduled_fetch,
+        trigger=IntervalTrigger(minutes=interval_minutes),
+        id=_job_id(source_id),
+        kwargs={"source_id": source_id, "user_id": user_id},
+        replace_existing=True,
+        coalesce=True,
+        misfire_grace_time=900,
+        max_instances=1,
+        name=f"discovery_fetch:{source_id}",
+    )
+    logger.info(
+        "discovery_scheduler_service: added/updated job source=%s interval=%dm",
+        source_id, interval_minutes,
+    )
+
+
+def update_source_job(
+    source_id: uuid.UUID,
+    user_id: uuid.UUID,
+    interval_minutes: int,
+) -> None:
+    """Adjust an existing source's interval. Re-registers from scratch.
+
+    APScheduler exposes ``reschedule_job`` for trigger-only edits, but
+    re-adding with ``replace_existing=True`` is simpler and covers the
+    cases where the user_id payload also needs to refresh (e.g. ownership
+    changes — never happens today but a possible future).
+    """
+    add_source_job(source_id, user_id, interval_minutes)
+
+
+def remove_source_job(source_id: uuid.UUID) -> None:
+    """Cancel the scheduled fetch for a source. Idempotent.
+
+    Called when a source is deleted or deactivated. If the job is
+    already gone (e.g. the source was deactivated before the scheduler
+    was ever started — unlikely but defensible), this is a no-op.
+    """
+    scheduler = _require_scheduler()
+    job_id = _job_id(source_id)
+    job = scheduler.get_job(job_id)
+    if job is not None:
+        scheduler.remove_job(job_id)
+        logger.info(
+            "discovery_scheduler_service: removed job source=%s", source_id,
+        )
+
+
+async def register_source_jobs(db: AsyncSession) -> int:
+    """Sweep the DB and register a job per active DiscoverySource.
+
+    Called from lifespan startup so a fresh process picks up the
+    schedule from the DB. Returns the count of jobs registered so the
+    caller can log it.
+
+    Idempotent: each ``add_source_job`` call uses ``replace_existing=True``
+    so re-running this on a process that already has jobs registered is
+    safe.
+    """
+    stmt = select(DiscoverySource).where(DiscoverySource.is_active.is_(True))
+    result = await db.execute(stmt)
+    sources = list(result.scalars().all())
+
+    for src in sources:
+        add_source_job(
+            source_id=src.id,
+            user_id=src.user_id,
+            interval_minutes=src.fetch_interval_minutes,
+        )
+
+    logger.info(
+        "discovery_scheduler_service: registered %d scheduled fetch job(s) on startup",
+        len(sources),
+    )
+    return len(sources)
+
+
+async def _run_scheduled_fetch(source_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    """Job function executed by APScheduler on the schedule.
+
+    Re-loads the source from the DB rather than trusting the queue
+    payload — the payload is stable but stale (e.g. the operator may
+    have deactivated the source after the job was last scheduled).
+    Bails out cleanly when the source is gone or deactivated.
+
+    Tenant-isolation defensive assertion: verify ``source.user_id``
+    matches the ``user_id`` from the job payload. A mismatch means
+    scheduler state has drifted from DB state (e.g. a source id was
+    reused — extremely unlikely with UUIDs but the assertion is cheap
+    and the failure mode if it slipped through is cross-tenant data
+    leakage). Treat as a hard error rather than silently downgrading.
+
+    The fetch / embed / score chain mirrors the manual-refresh route
+    handler in ``app/api/discover.py``. Errors from the fetch (transient
+    JSearch outage, auth failure, etc.) are re-raised to APScheduler so
+    they surface in logs + Sentry. The fetch service already increments
+    ``consecutive_failures`` on the source row and logs structured
+    error context (per ``rules/check-third-party-error-codes.md``).
+    """
+    async with AsyncSessionLocal() as db:
+        src = await db.get(DiscoverySource, source_id)
+        if src is None:
+            # Source was deleted between scheduling and execution. Drop
+            # the job so we don't keep retrying — the source CRUD path
+            # also calls ``remove_source_job`` but a race is possible.
+            logger.warning(
+                "discovery_scheduler_service: source %s gone; removing job",
+                source_id,
+            )
+            try:
+                remove_source_job(source_id)
+            except SchedulerNotStartedError:
+                # Scheduler was shut down between job dispatch and this
+                # cleanup. Nothing to remove; safe to swallow.
+                pass
+            return
+
+        if src.user_id != user_id:
+            raise SchedulerSourceMismatchError(
+                f"discovery_scheduler_service: source {source_id} belongs to "
+                f"{src.user_id} but job payload says {user_id} — scheduler "
+                "state has drifted from DB",
+            )
+
+        if not src.is_active:
+            # Operator deactivated the source. Cancel the schedule so we
+            # don't keep firing — the deactivate path also calls
+            # ``remove_source_job`` but a race is possible.
+            logger.info(
+                "discovery_scheduler_service: source %s inactive; removing job",
+                source_id,
+            )
+            try:
+                remove_source_job(source_id)
+            except SchedulerNotStartedError:
+                pass
+            return
+
+        logger.info(
+            "discovery_scheduler_service: running scheduled fetch source=%s user=%s",
+            source_id, user_id,
+        )
+        try:
+            result = await discovery_fetch_service.fetch_source(
+                db, user_id, source_id,
+            )
+        except (
+            DiscoverySourceNotFoundError,
+            DiscoverySourceInactiveError,
+            DiscoveryUnsupportedSourceError,
+            DiscoveryFetchError,
+        ):
+            # These are surfaced + structured-logged by fetch_source;
+            # re-raise so APScheduler counts the job as failed and
+            # Sentry captures the traceback.
+            raise
+
+    # Embedding + scoring run in their own sessions (each opens its own
+    # AsyncSessionLocal context). Mirror the route layer's chain.
+    if result.get("new_count", 0) > 0:
+        try:
+            await discovery_embedding_service.embed_pending_for_user_background(
+                user_id,
+            )
+        except Exception:
+            # The fetch itself succeeded. Log + continue to scoring so a
+            # transient embed failure doesn't block the scoring pass.
+            # Exception propagates to Sentry via APScheduler's logger.
+            logger.exception(
+                "discovery_scheduler_service: embed failed user=%s source=%s",
+                user_id, source_id,
+            )
+        try:
+            await discovery_score_service.score_user_inbox(user_id)
+        except Exception:
+            logger.exception(
+                "discovery_scheduler_service: score failed user=%s source=%s",
+                user_id, source_id,
+            )

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_source_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_source_service.py
@@ -4,15 +4,29 @@ Owns the transaction boundary for create and deactivate operations so route
 handlers never call ``db.commit()`` directly.  Per the MJH layered-architecture
 convention: routes → services → repositories; services commit, repositories
 only ``add``/``flush``.
+
+Also owns the side-effects on the in-process APScheduler. Creates register a
+scheduled job; deactivates remove one. This keeps the DB row and the
+schedule in lockstep — there is no path that creates a source without
+scheduling it (or deactivates without unscheduling). See
+``discovery_scheduler_service`` for the scheduler design rationale.
 """
 from __future__ import annotations
 
+import logging
 import uuid
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.discovery.discovery_source import DiscoverySource
 from app.repositories.discovery import discovery_repository
+from app.services.discovery import discovery_scheduler_service
+from app.services.discovery.discovery_scheduler_service import (
+    SchedulerNotStartedError,
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 async def create_source(
@@ -23,7 +37,15 @@ async def create_source(
     config: dict | None = None,
     fetch_interval_minutes: int = 1440,
 ) -> DiscoverySource:
-    """Create a new active saved search and commit the transaction."""
+    """Create a new active saved search and commit the transaction.
+
+    After commit, registers a scheduled fetch with APScheduler so the
+    source is automatically refreshed on its configured cadence. A
+    scheduler-registration failure is logged but does NOT rollback the
+    create — the source row is still valid and the operator can use
+    manual refresh. The next process restart re-syncs the schedule via
+    ``register_source_jobs``.
+    """
     src = await discovery_repository.create_source(
         db,
         user_id=user_id,
@@ -33,6 +55,24 @@ async def create_source(
     )
     await db.commit()
     await db.refresh(src)
+
+    try:
+        discovery_scheduler_service.add_source_job(
+            source_id=src.id,
+            user_id=src.user_id,
+            interval_minutes=src.fetch_interval_minutes,
+        )
+    except SchedulerNotStartedError:
+        # Tests / scripts that exercise the service without booting the
+        # full lifespan won't have the scheduler running. Log + continue —
+        # the row is committed and the schedule will be picked up on
+        # next ``register_source_jobs`` sweep.
+        logger.warning(
+            "create_source: scheduler not started; source %s saved but "
+            "schedule will be picked up on next process start",
+            src.id,
+        )
+
     return src
 
 
@@ -41,9 +81,26 @@ async def deactivate_source(
     source_id: uuid.UUID,
     user_id: uuid.UUID,
 ) -> bool:
-    """Soft-deactivate a saved search.  Returns False when not found / wrong owner."""
+    """Soft-deactivate a saved search.  Returns False when not found / wrong owner.
+
+    Also removes the scheduled fetch from APScheduler so we don't keep
+    firing for an inactive source. The scheduler job-runner has a
+    defensive ``is_active`` check too, so a race between deactivate and
+    fire-time is harmless.
+    """
     ok = await discovery_repository.deactivate_source(db, source_id, user_id)
     if not ok:
         return False
     await db.commit()
+
+    try:
+        discovery_scheduler_service.remove_source_job(source_id)
+    except SchedulerNotStartedError:
+        # As above — tolerated when scheduler isn't running.
+        logger.warning(
+            "deactivate_source: scheduler not started; source %s deactivated "
+            "but no schedule removal needed",
+            source_id,
+        )
+
     return True

--- a/apps/myjobhunter/backend/pyproject.toml
+++ b/apps/myjobhunter/backend/pyproject.toml
@@ -49,6 +49,14 @@ dependencies = [
     # Both are wired in app.services.discovery.discovery_embedding_service.
     "fastembed>=0.8",
     "pgvector>=0.4",
+    # Scheduled discovery passes (PR 5). In-process AsyncIOScheduler with a
+    # Postgres SQLAlchemyJobStore so jobs survive restarts and are visible to
+    # the operator via the same DB. apscheduler[sqlalchemy] pulls in the
+    # SQLAlchemyJobStore variant. When MJH outgrows the single-process model
+    # (cross-process retries, >50 daily passes/min globally, asyncio lag >200ms
+    # p95) — promote to Dramatiq per the migration triggers documented in
+    # app/services/discovery/discovery_scheduler_service.py.
+    "apscheduler[sqlalchemy]>=3.11.2",
 ]
 
 [tool.uv]

--- a/apps/myjobhunter/backend/requirements.txt
+++ b/apps/myjobhunter/backend/requirements.txt
@@ -19,6 +19,8 @@ anyio==4.13.0
     #   myjobhunter-backend
     #   starlette
     #   watchfiles
+apscheduler==3.11.2
+    # via myjobhunter-backend
 argon2-cffi==25.1.0
     # via
     #   minio
@@ -261,6 +263,7 @@ soupsieve==2.8.3
 sqlalchemy==2.0.49
     # via
     #   alembic
+    #   apscheduler
     #   fastapi-users-db-sqlalchemy
     #   myjobhunter-backend
     #   platform-shared
@@ -302,6 +305,10 @@ typing-inspection==0.4.2
     #   fastapi
     #   pydantic
     #   pydantic-settings
+tzdata==2026.2 ; sys_platform == 'win32'
+    # via tzlocal
+tzlocal==5.3.1
+    # via apscheduler
 urllib3==2.6.3
     # via
     #   minio

--- a/apps/myjobhunter/backend/tests/conftest.py
+++ b/apps/myjobhunter/backend/tests/conftest.py
@@ -95,6 +95,47 @@ def _disable_discovery_embedding_background(monkeypatch: pytest.MonkeyPatch) -> 
 
 
 # ---------------------------------------------------------------------------
+# Default-mock the APScheduler wiring for the whole test session.
+#
+# discovery_scheduler_service spins up an AsyncIOScheduler with a
+# SQLAlchemyJobStore on every ``create_source`` call. Tests don't need
+# (or want) real scheduling — they want to assert behaviour at the
+# service / route layer. Mocking the scheduler at the module level keeps
+# every test that creates a source running in milliseconds rather than
+# hundreds of ms.
+#
+# Tests that genuinely need to verify scheduler behaviour
+# (test_discovery_scheduler_service.py) override these by re-patching
+# the module symbols with their own fakes inside the test function.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _disable_discovery_scheduler(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No-op the APScheduler CRUD helpers for every test by default."""
+    from app.services.discovery import discovery_scheduler_service
+
+    def _noop_add(*args, **kwargs) -> None:
+        return None
+
+    def _noop_remove(*args, **kwargs) -> None:
+        return None
+
+    def _noop_update(*args, **kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        discovery_scheduler_service, "add_source_job", _noop_add,
+    )
+    monkeypatch.setattr(
+        discovery_scheduler_service, "remove_source_job", _noop_remove,
+    )
+    monkeypatch.setattr(
+        discovery_scheduler_service, "update_source_job", _noop_update,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Reset module-level limiter state between tests (PR C3)
 # ---------------------------------------------------------------------------
 

--- a/apps/myjobhunter/backend/tests/test_discovery_scheduler_service.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_scheduler_service.py
@@ -1,0 +1,313 @@
+"""Tests for discovery_scheduler_service — APScheduler wiring (PR 5).
+
+The autouse ``_disable_discovery_scheduler`` fixture in conftest.py
+no-ops the CRUD helpers for every other test. These tests re-patch the
+relevant symbols back to the real implementations so they exercise
+actual scheduler behaviour.
+
+Real APScheduler is used (with MemoryJobStore instead of the production
+SQLAlchemyJobStore) so each test can spin up + tear down an isolated
+scheduler in-process without touching the database.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+import pytest_asyncio
+from apscheduler.jobstores.memory import MemoryJobStore
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from app.services.discovery import discovery_scheduler_service
+from app.services.discovery.discovery_scheduler_service import (
+    SchedulerNotStartedError,
+    SchedulerSourceMismatchError,
+    _job_id,
+    _run_scheduled_fetch,
+    add_source_job,
+    register_source_jobs,
+    remove_source_job,
+    update_source_job,
+)
+
+
+@pytest_asyncio.fixture
+async def real_scheduler(monkeypatch: pytest.MonkeyPatch):
+    """Spin up a real AsyncIOScheduler backed by MemoryJobStore.
+
+    Replaces the module-level ``_scheduler`` directly to bypass the
+    Postgres jobstore (which would require a live DB connection and slow
+    every test). Re-patches the autouse no-op mocks back to the real
+    implementations so this test exercises actual scheduler behaviour.
+
+    AsyncIOScheduler requires a running event loop on ``start``, which
+    is why this fixture is async.
+    """
+    # Restore real implementations (autouse fixture mocked them).
+    monkeypatch.setattr(
+        discovery_scheduler_service, "add_source_job", add_source_job,
+    )
+    monkeypatch.setattr(
+        discovery_scheduler_service, "remove_source_job", remove_source_job,
+    )
+    monkeypatch.setattr(
+        discovery_scheduler_service, "update_source_job", update_source_job,
+    )
+
+    sched = AsyncIOScheduler(
+        jobstores={"default": MemoryJobStore()}, timezone="UTC",
+    )
+    sched.start(paused=True)  # paused so jobs don't actually fire
+    monkeypatch.setattr(discovery_scheduler_service, "_scheduler", sched)
+
+    yield sched
+
+    sched.shutdown(wait=False)
+    monkeypatch.setattr(discovery_scheduler_service, "_scheduler", None)
+
+
+# ===========================================================================
+# add_source_job / remove_source_job / update_source_job
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_add_source_job_registers(real_scheduler):
+    source_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    add_source_job(source_id, user_id, interval_minutes=60)
+
+    job = real_scheduler.get_job(_job_id(source_id))
+    assert job is not None
+    assert job.kwargs == {"source_id": source_id, "user_id": user_id}
+
+
+@pytest.mark.asyncio
+async def test_add_source_job_is_idempotent(real_scheduler):
+    source_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    add_source_job(source_id, user_id, interval_minutes=60)
+    add_source_job(source_id, user_id, interval_minutes=120)  # replace
+
+    job = real_scheduler.get_job(_job_id(source_id))
+    assert job is not None
+    # Trigger should reflect the new interval. We can't introspect the
+    # raw minutes directly across APScheduler versions, but the job
+    # being still single confirms replace_existing worked.
+    jobs = real_scheduler.get_jobs()
+    assert len([j for j in jobs if j.id == _job_id(source_id)]) == 1
+
+
+@pytest.mark.asyncio
+async def test_update_source_job_round_trip(real_scheduler):
+    source_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    add_source_job(source_id, user_id, interval_minutes=60)
+    update_source_job(source_id, user_id, interval_minutes=720)
+
+    job = real_scheduler.get_job(_job_id(source_id))
+    assert job is not None
+
+
+@pytest.mark.asyncio
+async def test_remove_source_job_removes(real_scheduler):
+    source_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    add_source_job(source_id, user_id, interval_minutes=60)
+    assert real_scheduler.get_job(_job_id(source_id)) is not None
+
+    remove_source_job(source_id)
+    assert real_scheduler.get_job(_job_id(source_id)) is None
+
+
+@pytest.mark.asyncio
+async def test_remove_source_job_idempotent_when_missing(real_scheduler):
+    # No add — remove should be a no-op, not raise.
+    remove_source_job(uuid.uuid4())
+
+
+def test_add_source_job_raises_when_scheduler_not_started(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """If the scheduler hasn't been started, the CRUD helpers raise."""
+    monkeypatch.setattr(
+        discovery_scheduler_service, "add_source_job", add_source_job,
+    )
+    monkeypatch.setattr(discovery_scheduler_service, "_scheduler", None)
+
+    with pytest.raises(SchedulerNotStartedError):
+        add_source_job(uuid.uuid4(), uuid.uuid4(), interval_minutes=60)
+
+
+# ===========================================================================
+# register_source_jobs — startup sweep
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_register_source_jobs_picks_up_active_sources(
+    real_scheduler,
+    client,  # noqa: ARG001 — pulls in the test DB fixture
+    user_factory,
+    as_user,
+    db,
+):
+    """The startup sweep registers one job per active DiscoverySource.
+
+    Creates a source through the HTTP API (with the scheduler mock
+    bypassed via ``real_scheduler``), then runs ``register_source_jobs``
+    against the test DB and asserts one job was scheduled.
+    """
+    user = await user_factory()
+    async with await as_user(user) as a:
+        resp = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "test"}},
+        )
+        assert resp.status_code == 201
+        source_id = uuid.UUID(resp.json()["id"])
+
+    # ``register_source_jobs`` scans the DB for is_active=True rows.
+    # The test client's rolled-back transaction means we have to use
+    # the same session for the read.
+    count = await register_source_jobs(db)
+    assert count >= 1
+    assert real_scheduler.get_job(_job_id(source_id)) is not None
+
+
+# ===========================================================================
+# _run_scheduled_fetch — the actual job function
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_fetch_missing_source_removes_job(
+    real_scheduler, monkeypatch: pytest.MonkeyPatch,
+):
+    """When the source no longer exists in the DB, the job removes itself.
+
+    Patches ``AsyncSessionLocal`` so the function uses a session that
+    sees no matching row. Confirms ``remove_source_job`` was called.
+    """
+    # Patch the session factory to yield a session that returns None
+    # from db.get(DiscoverySource, ...).
+    fake_source_id = uuid.uuid4()
+    fake_user_id = uuid.uuid4()
+
+    # Pre-register a job so we can confirm it gets removed.
+    add_source_job(fake_source_id, fake_user_id, interval_minutes=60)
+    assert real_scheduler.get_job(_job_id(fake_source_id)) is not None
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, model, key):  # noqa: ARG002
+            return None
+
+    monkeypatch.setattr(
+        discovery_scheduler_service, "AsyncSessionLocal", _FakeSession,
+    )
+
+    await _run_scheduled_fetch(fake_source_id, fake_user_id)
+
+    # Job should have been removed by the missing-source cleanup branch.
+    assert real_scheduler.get_job(_job_id(fake_source_id)) is None
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_fetch_user_id_mismatch_raises(
+    real_scheduler, monkeypatch: pytest.MonkeyPatch,
+):
+    """A user_id mismatch between payload and DB row is a hard error.
+
+    Prevents cross-tenant leakage if scheduler state ever drifts.
+    """
+    from app.models.discovery.discovery_source import DiscoverySource
+
+    fake_source_id = uuid.uuid4()
+    real_user_id = uuid.uuid4()
+    payload_user_id = uuid.uuid4()
+    assert real_user_id != payload_user_id
+
+    stub_source = DiscoverySource(
+        id=fake_source_id,
+        user_id=real_user_id,
+        source="jsearch",
+        config={},
+        is_active=True,
+        fetch_interval_minutes=60,
+        consecutive_failures=0,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, model, key):  # noqa: ARG002
+            return stub_source
+
+    monkeypatch.setattr(
+        discovery_scheduler_service, "AsyncSessionLocal", _FakeSession,
+    )
+
+    with pytest.raises(SchedulerSourceMismatchError):
+        await _run_scheduled_fetch(fake_source_id, payload_user_id)
+
+
+@pytest.mark.asyncio
+async def test_run_scheduled_fetch_inactive_source_skips_and_removes(
+    real_scheduler, monkeypatch: pytest.MonkeyPatch,
+):
+    """An inactive source is skipped + the scheduled job is removed."""
+    from app.models.discovery.discovery_source import DiscoverySource
+
+    fake_source_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    add_source_job(fake_source_id, user_id, interval_minutes=60)
+    assert real_scheduler.get_job(_job_id(fake_source_id)) is not None
+
+    stub_source = DiscoverySource(
+        id=fake_source_id,
+        user_id=user_id,
+        source="jsearch",
+        config={},
+        is_active=False,
+        fetch_interval_minutes=60,
+        consecutive_failures=0,
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+    )
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args):
+            return None
+
+        async def get(self, model, key):  # noqa: ARG002
+            return stub_source
+
+    monkeypatch.setattr(
+        discovery_scheduler_service, "AsyncSessionLocal", _FakeSession,
+    )
+
+    # No fetch service is invoked because is_active=False short-circuits.
+    await _run_scheduled_fetch(fake_source_id, user_id)
+
+    assert real_scheduler.get_job(_job_id(fake_source_id)) is None

--- a/apps/myjobhunter/backend/uv.lock
+++ b/apps/myjobhunter/backend/uv.lock
@@ -67,6 +67,23 @@ wheels = [
 ]
 
 [[package]]
+name = "apscheduler"
+version = "3.11.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
+]
+
+[package.optional-dependencies]
+sqlalchemy = [
+    { name = "sqlalchemy" },
+]
+
+[[package]]
 name = "argon2-cffi"
 version = "25.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -811,6 +828,7 @@ dependencies = [
     { name = "alembic" },
     { name = "anthropic" },
     { name = "anyio" },
+    { name = "apscheduler", extra = ["sqlalchemy"] },
     { name = "asyncpg" },
     { name = "beautifulsoup4" },
     { name = "cryptography" },
@@ -849,6 +867,7 @@ requires-dist = [
     { name = "alembic", specifier = "==1.18.4" },
     { name = "anthropic", specifier = ">=0.49.0" },
     { name = "anyio", specifier = "==4.13.0" },
+    { name = "apscheduler", extras = ["sqlalchemy"], specifier = ">=3.11.2" },
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "cryptography", specifier = "==47.0.0" },
@@ -1546,6 +1565,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+]
+
+[[package]]
+name = "tzlocal"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]

--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -17,6 +17,10 @@ import JobTypeSection from "./dialog-sections/JobTypeSection";
 import ExclusionsSection from "./dialog-sections/ExclusionsSection";
 import GreenhouseConfigSection from "./dialog-sections/GreenhouseConfigSection";
 import LeverConfigSection from "./dialog-sections/LeverConfigSection";
+import {
+  DEFAULT_REFRESH_INTERVAL_MINUTES,
+  REFRESH_INTERVAL_OPTIONS,
+} from "./refresh-interval";
 import type {
   Country,
   DatePosted,
@@ -95,6 +99,13 @@ export default function NewSavedSearchDialog({
   // Lever form state
   const [companySlug, setCompanySlug] = useState("");
 
+  // Refresh-frequency picker (PR 5). Applies to every source type — the
+  // backend scheduler runs the same fetch chain for jsearch / greenhouse /
+  // lever. Defaults to daily.
+  const [fetchIntervalMinutes, setFetchIntervalMinutes] = useState<number>(
+    DEFAULT_REFRESH_INTERVAL_MINUTES,
+  );
+
   const [createSource, { isLoading: isCreating }] = useCreateDiscoverySourceMutation();
   const [updateProfile, { isLoading: isUpdatingProfile }] = useUpdateProfileMutation();
   const isLoading = isCreating || isUpdatingProfile;
@@ -134,6 +145,7 @@ export default function NewSavedSearchDialog({
     setSaveAsDefaults(false);
     setBoardToken("");
     setCompanySlug("");
+    setFetchIntervalMinutes(DEFAULT_REFRESH_INTERVAL_MINUTES);
     resetPrefill();
   }
 
@@ -207,7 +219,11 @@ export default function NewSavedSearchDialog({
     }
 
     try {
-      await createSource({ source, config: buildConfig() }).unwrap();
+      await createSource({
+        source,
+        config: buildConfig(),
+        fetch_interval_minutes: fetchIntervalMinutes,
+      }).unwrap();
 
       // Optionally persist the JSearch filter set as the operator's default.
       // Only makes sense for JSearch (Greenhouse/Lever have no shareable
@@ -281,6 +297,31 @@ export default function NewSavedSearchDialog({
               </option>
             ))}
           </select>
+        </div>
+
+        {/* Refresh frequency — applies to every source type. Sits
+            above the source-specific fields so it's the first thing
+            the operator sees after picking a source. */}
+        <div className="space-y-1">
+          <label htmlFor="refresh-frequency" className="block text-sm font-medium">
+            Refresh frequency
+          </label>
+          <select
+            id="refresh-frequency"
+            className="w-full rounded border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring"
+            value={fetchIntervalMinutes}
+            onChange={(e) => setFetchIntervalMinutes(Number(e.target.value))}
+          >
+            {REFRESH_INTERVAL_OPTIONS.map((opt) => (
+              <option key={opt.minutes} value={opt.minutes}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+          <p className="text-xs text-muted-foreground">
+            How often this saved search will fetch new postings automatically.
+            You can also refresh on demand from the saved-search list.
+          </p>
         </div>
 
         {/* Greenhouse config */}

--- a/apps/myjobhunter/frontend/src/features/discover/SavedSearchRow.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SavedSearchRow.tsx
@@ -15,6 +15,7 @@ import {
 } from "@/store/discoverApi";
 import type { DiscoverySource } from "@/types/discovery/discovery-source";
 import { summarizeSearchQuery, getSourceLabel, getSourceBadgeColor } from "./saved-search-summary";
+import { refreshIntervalShortLabel } from "./refresh-interval";
 
 interface SavedSearchRowProps {
   source: DiscoverySource;
@@ -25,9 +26,15 @@ export default function SavedSearchRow({ source }: SavedSearchRowProps) {
   const [deactivate, { isLoading: isDeactivating }] = useDeactivateDiscoverySourceMutation();
 
   const query = summarizeSearchQuery(source.config ?? {}, source.source);
+  // Schedule line: "Refreshes every 6h — last fetched 2h ago" (PR 5).
+  // Each source has an APScheduler job firing on its
+  // ``fetch_interval_minutes`` cadence. Surfacing the cadence here lets
+  // the operator see at a glance how often the search runs and how
+  // recent the last automatic run was.
+  const cadence = refreshIntervalShortLabel(source.fetch_interval_minutes);
   const lastFetched = source.last_fetched_at
-    ? `Last fetched ${timeAgo(source.last_fetched_at)}`
-    : "Never fetched";
+    ? `Refreshes ${cadence.toLowerCase()} — last fetched ${timeAgo(source.last_fetched_at)}`
+    : `Refreshes ${cadence.toLowerCase()} — never fetched yet`;
 
   async function handleRefresh() {
     try {

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/NewSavedSearchDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/NewSavedSearchDialog.test.tsx
@@ -255,6 +255,7 @@ describe("NewSavedSearchDialog — Greenhouse validation", () => {
       expect(mockCreateSource).toHaveBeenCalledWith({
         source: "greenhouse",
         config: { board_token: "stripe" },
+        fetch_interval_minutes: 1440,
       });
     });
     expect(mockShowSuccess).toHaveBeenCalledWith("Saved search created");
@@ -306,6 +307,7 @@ describe("NewSavedSearchDialog — Lever validation", () => {
       expect(mockCreateSource).toHaveBeenCalledWith({
         source: "lever",
         config: { company_slug: "openai" },
+        fetch_interval_minutes: 1440,
       });
     });
     expect(mockShowSuccess).toHaveBeenCalledWith("Saved search created");
@@ -325,6 +327,38 @@ describe("NewSavedSearchDialog — Lever validation", () => {
           config: { company_slug: "openai" },
         }),
       );
+    });
+  });
+});
+
+describe("NewSavedSearchDialog — refresh frequency (PR 5)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSource.mockReturnValue(makeUnwrappableMutation({}));
+  });
+
+  it("defaults the refresh-frequency picker to Daily (1440m)", async () => {
+    renderDialog();
+    const picker = screen.getByLabelText("Refresh frequency") as HTMLSelectElement;
+    expect(picker.value).toBe("1440");
+  });
+
+  it("sends the selected fetch_interval_minutes on create", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "greenhouse");
+    await userEvent.type(screen.getByLabelText("Greenhouse board token"), "stripe");
+    await userEvent.selectOptions(
+      screen.getByLabelText("Refresh frequency"),
+      "360",
+    );
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockCreateSource).toHaveBeenCalledWith({
+        source: "greenhouse",
+        config: { board_token: "stripe" },
+        fetch_interval_minutes: 360,
+      });
     });
   });
 });

--- a/apps/myjobhunter/frontend/src/features/discover/refresh-interval.ts
+++ b/apps/myjobhunter/frontend/src/features/discover/refresh-interval.ts
@@ -1,0 +1,51 @@
+/** Preset refresh-interval options for the "How often" picker.
+ *
+ * Cron strings are a footgun for non-technical operators (off-by-one,
+ * timezone confusion, "every 5 minutes" → quota burn). A small preset
+ * list covers the realistic cadence range:
+ *
+ * - ``Every 2 hours`` (120m) — aggressive; for hot-pipeline searches
+ * - ``Every 6 hours`` (360m) — balanced
+ * - ``Twice daily`` (720m)   — most operators
+ * - ``Daily`` (1440m)        — default; the right answer for most cases
+ *
+ * Backend allows 15-10080 minutes; we deliberately omit sub-hourly
+ * options to keep JSearch quota predictable. If an operator needs
+ * higher cadence, the backend's CHECK constraint floor (15 minutes)
+ * is the documented escape hatch — they can call the API directly.
+ */
+export interface RefreshIntervalOption {
+  /** Backend ``fetch_interval_minutes`` value. */
+  minutes: number;
+  /** Human-readable label for the picker. */
+  label: string;
+  /** Short human-readable form used in the SavedSearchRow status line. */
+  short: string;
+}
+
+export const REFRESH_INTERVAL_OPTIONS: ReadonlyArray<RefreshIntervalOption> = [
+  { minutes: 120, label: "Every 2 hours", short: "Every 2h" },
+  { minutes: 360, label: "Every 6 hours", short: "Every 6h" },
+  { minutes: 720, label: "Twice daily", short: "Twice daily" },
+  { minutes: 1440, label: "Daily", short: "Daily" },
+];
+
+export const DEFAULT_REFRESH_INTERVAL_MINUTES = 1440;
+
+/** Return the short human-readable label for a given interval.
+ *
+ * Falls back to a generic "Every Xh" / "Every Xd" form when the value
+ * isn't one of the presets (a future API change could land custom
+ * values from elsewhere).
+ */
+export function refreshIntervalShortLabel(minutes: number): string {
+  const preset = REFRESH_INTERVAL_OPTIONS.find((o) => o.minutes === minutes);
+  if (preset) return preset.short;
+  if (minutes < 60) return `Every ${minutes}m`;
+  if (minutes < 1440) {
+    const hours = Math.round(minutes / 60);
+    return `Every ${hours}h`;
+  }
+  const days = Math.round(minutes / 1440);
+  return days === 1 ? "Daily" : `Every ${days}d`;
+}

--- a/apps/myjobhunter/frontend/src/types/discovery/discovery-source-create-request.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovery-source-create-request.ts
@@ -1,4 +1,12 @@
-/** Body for POST /discover/sources. */
+/** Body for POST /discover/sources.
+ *
+ * ``fetch_interval_minutes`` controls how often the backend scheduler
+ * (APScheduler, per PR 5) runs an automatic fetch for this source.
+ * Backend validates ``ge=15, le=10080`` (15 minutes through 7 days). The
+ * frontend exposes preset values via ``REFRESH_INTERVAL_OPTIONS`` rather
+ * than a free-form input so an operator can't accidentally schedule a
+ * 1-minute fetch and burn JSearch quota.
+ */
 export interface DiscoverySourceCreate {
   source: string;
   config: Record<string, unknown>;


### PR DESCRIPTION
## Summary

PR 5 of the MJH job discovery delta-plan. Closes the manual-refresh-only gap — every `DiscoverySource` now has an in-process APScheduler job firing on its configured cadence (`fetch_interval_minutes`), running the same `fetch + embed + score` chain the manual `/refresh` route runs.

## Architecture decision: APScheduler over Dramatiq

- **APScheduler in-process** with `SQLAlchemyJobStore` pointed at the existing Postgres
- No new infra surface (Redis, dedicated workers) — fits the single-VPS, single-process FastAPI shape
- Jobs survive restarts because the jobstore is persistent; `register_source_jobs` re-syncs on boot
- `coalesce=True` + `misfire_grace_time=900` (15 min) + `max_instances=1` so a long fetch doesn't fan out into duplicates after a restart

### When to migrate to Dramatiq later

Documented in `discovery_scheduler_service.py` module docstring:

1. Multi-user concurrent fetches saturate one process (asyncio lag >200ms p95)
2. Need cross-process retries (one worker dies, another picks up)
3. Global scheduled-pass throughput exceeds 50/min
4. Job latency / jitter matters for the user

Until any of these trip, in-process APScheduler is the right shape.

### Monorepo parity note

APScheduler is MJH-only today. When MyBookkeeper adds its first scheduled job (rent reminders, statement parsing cron, backup verification), promote `discovery_scheduler_service` to `platform_shared.core.scheduler` per `rules/monorepo-parity-discipline.md` auto-promote rule. Module docstring spells this out.

## Backend changes

- **New** `app/services/discovery/discovery_scheduler_service.py`:
  - `start_scheduler(settings)` / `shutdown_scheduler()` — lifespan hooks
  - `register_source_jobs(db)` — startup sweep over active sources
  - `add_source_job` / `update_source_job` / `remove_source_job` — CRUD-side hooks
  - `_run_scheduled_fetch` — re-loads source from DB, asserts `user_id` matches payload (defensive tenant-isolation guard), runs fetch + embed + score chain
- **Lifespan** in `main.py` calls `start_scheduler` + `register_source_jobs` on startup, `shutdown_scheduler` on teardown (now uses `on_shutdown` hook of `create_app_lifespan`)
- **Source service** calls `add_source_job` on commit of a new source, `remove_source_job` on deactivate
- **No migration** — `fetch_interval_minutes SMALLINT NOT NULL DEFAULT 1440 CHECK (>= 15)` already exists on `discovery_sources` (shipped in PR `disco260507_discovery_tables`)
- **New dep** `apscheduler[sqlalchemy]>=3.11.2` (transitively `tzdata`, `tzlocal`)
- **Autouse pytest fixture** no-ops scheduler CRUD for existing tests so they don't try to spin one up

## Frontend changes

- **New** `features/discover/refresh-interval.ts` — preset options (Every 2h / Every 6h / Twice daily / Daily) + `refreshIntervalShortLabel(minutes)` helper
- **`NewSavedSearchDialog`** adds a "Refresh frequency" picker ABOVE the source-specific fields (per UX agent — cron strings are a footgun, presets only). Default: Daily. Applies to all three source kinds.
- **`SavedSearchRow`** surfaces the cadence inline: `Refreshes every 6h — last fetched 2h ago`. Edit-frequency affordance deferred — no PATCH endpoint exists yet for `fetch_interval_minutes`; left as a v2 follow-up to keep this PR scoped.

## Tests

- **10 new** backend unit tests in `test_discovery_scheduler_service.py`:
  - Scheduler register / update / remove round-trips
  - Add is idempotent (replace_existing)
  - Missing source removes the job
  - Inactive source skips + removes the job
  - `user_id` mismatch raises `SchedulerSourceMismatchError`
  - Startup sweep picks up active sources
  - Helpers raise `SchedulerNotStartedError` before `start_scheduler`
- **2 new** frontend tests in `NewSavedSearchDialog.test.tsx`:
  - Refresh-frequency picker defaults to Daily (1440m)
  - Selected interval is sent in the create payload
- **Adjacent contract updates**: existing `createSource(...)` assertions now expect `fetch_interval_minutes: 1440` in the payload

## Pre-existing test failures (not caused by this PR)

Confirmed by re-running the suite on `main`:

- **Backend**: 10 tests in `test_discover_endpoints.py` + 6 in `test_discovery_models.py` + 2 in `test_discovery_source_service.py` fail with `column discovered_jobs.embedding does not exist` — the test DB hasn't been re-migrated with `discemb260511_pgvector_embeddings`. Same on main. Unrelated to this PR.
- **Frontend**: 25 tests fail in unrelated areas (resume refinement, etc.) on both main and this branch. Net zero regressions; this PR adds 2 new passing tests (369 vs main's 367).

## Operational migration

**Not strictly required**, but worth noting:

- First boot of this PR creates the `apscheduler_jobs` table in the existing Postgres via SQLAlchemy DDL (the `SQLAlchemyJobStore` does this on connect). No manual migration step.
- Per `rules/no-bandaid-solutions.md`: if APScheduler cannot reach Postgres at boot, the lifespan **fails loudly** — deploy rolls back to the previous image; no silent fallback. The operator should see a clear error in `docker compose logs api` if this trips.
- Existing active `DiscoverySource` rows are auto-registered on boot via `register_source_jobs`. Operator does not need to recreate or touch their saved searches.

## Test plan

- [ ] Backend unit tests for the scheduler service pass (10/10)
- [ ] Backend tests for source service create/deactivate pass (verifies scheduler hooks fire)
- [ ] Frontend unit tests for NewSavedSearchDialog pass (56/56 in discover/)
- [ ] Frontend builds and typechecks clean
- [ ] On a fresh deploy: verify `apscheduler_jobs` table is created and existing active sources are registered as jobs
- [ ] Verify scheduler picks up a new saved search on creation (no restart needed)
- [ ] Verify deactivating a source unregisters its scheduled job

🤖 Generated with [Claude Code](https://claude.com/claude-code)