### PR TITLE
fix(mjh/alembic): merge discemb260511 and discnam260511 heads

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/discmrg260511_merge_embedding_and_name_heads.py
+++ b/apps/myjobhunter/backend/alembic/versions/discmrg260511_merge_embedding_and_name_heads.py
@@ -1,0 +1,29 @@
+"""Merge ``discemb260511`` and ``discnam260511`` heads.
+
+PR #568 (embeddings) and PR #574 (source name) were both authored against
+``discsrc260511`` as their parent and merged in parallel, leaving the
+migration graph with two heads. ``alembic upgrade head`` fails with
+"Multiple head revisions are present" until the heads are merged.
+
+This is a no-op merge migration — no schema changes, just unifies the
+graph so future migrations have a single canonical parent.
+
+Revision ID: discmrg260511
+Revises: discemb260511, discnam260511
+Create Date: 2026-05-11
+"""
+from typing import Sequence, Union
+
+
+revision: str = "discmrg260511"
+down_revision: Union[str, Sequence[str], None] = ("discemb260511", "discnam260511")
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass


### PR DESCRIPTION
## Summary

PR #568 (embeddings) and PR #574 (source name) both branched from `discsrc260511` and merged in parallel, leaving the migration graph with two heads. `alembic upgrade head` fails with "Multiple head revisions are present" — this no-op merge migration unifies the graph.

## Why this is urgent

**Production-blocking.** Any environment that has applied prior migrations cannot run `alembic upgrade head` until this lands. Today's MJH deploys will fail at lifespan startup once one of #568 or #574's migrations lands ahead of the other.

## Operational migration

After this PR merges, the next deploy runs `alembic upgrade head` which now sees a single head (`discmrg260511`). No env changes, no data changes. The merge migration is a no-op.

## Verify

```bash
cd apps/myjobhunter/backend
alembic heads   # before: 2 heads, after: 1 head (discmrg260511)
alembic upgrade head   # was failing, now succeeds
```

## Test plan
- [x] Migration file is a valid no-op merge (revises tuple with both heads)
- [ ] CI runs `alembic upgrade head` successfully (verifies the merge resolves the heads)