### PR TITLE
feat(mjh/discover): profile-completeness banner + dismiss-undo toast

### DIFF
--- a/apps/myjobhunter/backend/app/api/discover.py
+++ b/apps/myjobhunter/backend/app/api/discover.py
@@ -306,6 +306,26 @@ async def dismiss_job(
 
 
 @router.post(
+    "/{job_id}/undo-dismiss",
+    status_code=204,
+)
+async def undo_dismiss_job(
+    job_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> None:
+    """Reverse a dismiss, returning the job to the inbox.
+
+    Status codes:
+    - 204 — dismiss reversed successfully
+    - 404 — job not found, belongs to a different user, or was not dismissed
+    """
+    ok = await discovery_inbox_service.undo_dismiss_for_user(db, job_id, user.id)
+    if not ok:
+        raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
+
+
+@router.post(
     "/{job_id}/save",
     status_code=204,
 )

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
@@ -411,6 +411,34 @@ async def save_discovered(
     return True
 
 
+async def undo_dismiss_discovered(
+    db: AsyncSession,
+    job_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> DiscoveredJob | None:
+    """Clear dismissed_at / dismissed_reason so the job returns to the inbox.
+
+    Returns the updated row on success, or None when:
+    - The job doesn't exist or belongs to a different user (tenant isolation).
+    - The job is NOT currently dismissed (already active / saved / promoted).
+
+    Idempotency decision: a job that was never dismissed returns None (404) so
+    the frontend can distinguish "undo worked" from "nothing to undo". The
+    caller (service layer) translates None → 404.
+    """
+    job = await get_discovered(db, job_id, user_id)
+    if job is None:
+        return None
+    if job.dismissed_at is None:
+        # Not currently dismissed — nothing to undo.
+        return None
+    job.dismissed_at = None
+    job.dismissed_reason = None
+    await db.flush()
+    await db.refresh(job)
+    return job
+
+
 async def list_unscored_for_user(
     db: AsyncSession, user_id: uuid.UUID, *, limit: int = 20,
 ) -> list[DiscoveredJob]:

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_inbox_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_inbox_service.py
@@ -31,6 +31,24 @@ async def dismiss_discovered(
     return True
 
 
+async def undo_dismiss_for_user(
+    db: AsyncSession,
+    job_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> bool:
+    """Reverse a dismiss — clears dismissed_at and dismissed_reason.
+
+    Returns False (→ 404) when:
+    - The job doesn't exist / belongs to a different user.
+    - The job is not currently dismissed (never dismissed, or already active).
+    """
+    row = await discovery_repository.undo_dismiss_discovered(db, job_id, user_id)
+    if row is None:
+        return False
+    await db.commit()
+    return True
+
+
 async def save_discovered(
     db: AsyncSession,
     job_id: uuid.UUID,

--- a/apps/myjobhunter/backend/tests/test_discover_endpoints.py
+++ b/apps/myjobhunter/backend/tests/test_discover_endpoints.py
@@ -498,3 +498,114 @@ async def test_promote_job_cross_tenant_404(
     async with await as_user(attacker) as a:
         resp = await a.post(f"/discover/{job_id}/promote")
         assert resp.status_code == 404
+
+
+# ===========================================================================
+# Undo-dismiss endpoint (PR 8)
+# ===========================================================================
+
+_SCORE_PATH = "app.services.discovery.discovery_score_service.score_user_inbox"
+
+
+async def _seed_dismissed_job(
+    a,
+    source_id_resp,
+    *,
+    reason: str | None = None,
+) -> str:
+    """Helper: refresh to get one job then dismiss it. Returns job_id.
+
+    Patches score_user_inbox (Anthropic) so no real API call fires — the
+    scoring background task is exercised by test_discovery_score_service.py;
+    here we only care about the inbox state transitions.
+    """
+    source_id = source_id_resp.json()["id"]
+    with (
+        patch(_SEARCH_PATH, new_callable=AsyncMock, return_value=[_posting()]),
+        patch(_SCORE_PATH, new_callable=AsyncMock, return_value=None),
+    ):
+        await a.post(f"/discover/sources/{source_id}/refresh")
+    listed = await a.get("/discover")
+    job_id = listed.json()["items"][0]["id"]
+    dismiss_payload = {"reason": reason} if reason else {}
+    resp = await a.post(f"/discover/{job_id}/dismiss", json=dismiss_payload)
+    assert resp.status_code == 204
+    return job_id
+
+
+@pytest.mark.asyncio
+async def test_undo_dismiss_happy_path(
+    client: AsyncClient, user_factory, as_user,
+):
+    """POST /discover/{id}/undo-dismiss clears dismissed_at and dismissed_reason,
+    returning the job to the inbox."""
+    user = await user_factory()
+    async with await as_user(user) as a:
+        created = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "x"}},
+        )
+        job_id = await _seed_dismissed_job(a, created, reason="wrong_stack")
+
+        # Inbox should be empty after dismiss.
+        inbox_before = await a.get("/discover")
+        assert inbox_before.json()["total"] == 0
+
+        resp = await a.post(f"/discover/{job_id}/undo-dismiss")
+        assert resp.status_code == 204
+
+        # Job must reappear in the inbox after undo.
+        inbox_after = await a.get("/discover")
+        assert inbox_after.json()["total"] == 1
+        item = inbox_after.json()["items"][0]
+        assert item["id"] == job_id
+        assert item["dismissed_at"] is None
+        assert item["dismissed_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_undo_dismiss_on_never_dismissed_returns_404(
+    client: AsyncClient, user_factory, as_user,
+):
+    """Calling undo-dismiss on an inbox job (never dismissed) returns 404.
+
+    This is the idempotency decision: a job that was never dismissed has
+    nothing to undo, so we return 404 rather than silently succeeding.
+    """
+    user = await user_factory()
+    async with await as_user(user) as a:
+        created = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "x"}},
+        )
+        source_id = created.json()["id"]
+        with (
+            patch(_SEARCH_PATH, new_callable=AsyncMock, return_value=[_posting()]),
+            patch(_SCORE_PATH, new_callable=AsyncMock, return_value=None),
+        ):
+            await a.post(f"/discover/sources/{source_id}/refresh")
+        listed = await a.get("/discover")
+        job_id = listed.json()["items"][0]["id"]
+
+        resp = await a.post(f"/discover/{job_id}/undo-dismiss")
+        assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_undo_dismiss_cross_tenant_404(
+    client: AsyncClient, user_factory, as_user,
+):
+    """A user cannot undo another user's dismiss — tenant isolation."""
+    owner = await user_factory()
+    attacker = await user_factory()
+
+    async with await as_user(owner) as a:
+        created = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "x"}},
+        )
+        job_id = await _seed_dismissed_job(a, created)
+
+    async with await as_user(attacker) as a:
+        resp = await a.post(f"/discover/{job_id}/undo-dismiss")
+        assert resp.status_code == 404

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
@@ -3,7 +3,10 @@ import { EmptyState } from "@platform/ui";
 import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
 import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
 import DiscoveredJobsSkeleton from "@/features/discover/DiscoveredJobsSkeleton";
+import ProfileCompletenessBanner from "@/features/discover/ProfileCompletenessBanner";
 import { useListDiscoveredJobsQuery } from "@/store/discoverApi";
+import { useGetProfileQuery } from "@/lib/profileApi";
+import { useListSkillsQuery } from "@/lib/skillsApi";
 
 // Background scoring runs after /refresh as a FastAPI BackgroundTask
 // (~30s for 20 postings). Poll while the inbox is visible so score badges
@@ -20,6 +23,12 @@ export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps
     { pollingInterval: INBOX_POLL_INTERVAL_MS },
   );
 
+  const { data: profile } = useGetProfileQuery();
+  const { data: skillsData } = useListSkillsQuery();
+
+  const hasResume = profile?.resume_file_path != null;
+  const hasSkills = (skillsData?.total ?? 0) > 0;
+
   if (!hasSources) {
     return (
       <EmptyState
@@ -30,27 +39,42 @@ export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps
     );
   }
 
+  const profileBanner = (
+    <ProfileCompletenessBanner hasResume={hasResume} hasSkills={hasSkills} />
+  );
+
   if (isError) {
     return (
-      <p className="text-sm text-destructive">
-        Couldn't load the inbox — try refreshing the page.
-      </p>
+      <>
+        {profileBanner}
+        <p className="text-sm text-destructive">
+          Couldn't load the inbox — try refreshing the page.
+        </p>
+      </>
     );
   }
 
   if (isLoading) {
-    return <DiscoveredJobsSkeleton />;
+    return (
+      <>
+        {profileBanner}
+        <DiscoveredJobsSkeleton />
+      </>
+    );
   }
 
   const items = jobsData?.items ?? [];
 
   if (items.length === 0) {
     return (
-      <EmptyState
-        icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
-        heading={DISCOVER_EMPTY_STATES.inbox_empty.heading}
-        body={DISCOVER_EMPTY_STATES.inbox_empty.body}
-      />
+      <>
+        {profileBanner}
+        <EmptyState
+          icon={<Telescope className="w-12 h-12 text-muted-foreground" />}
+          heading={DISCOVER_EMPTY_STATES.inbox_empty.heading}
+          body={DISCOVER_EMPTY_STATES.inbox_empty.body}
+        />
+      </>
     );
   }
 
@@ -65,6 +89,7 @@ export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps
 
   return (
     <div className="space-y-3">
+      {profileBanner}
       {items.map((job) => (
         <DiscoveredJobCard
           key={job.id}

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
@@ -20,6 +20,7 @@ import {
 import type { DiscoveredJob } from "@/types/discovery/discovered-job";
 import type { JobAnalysisVerdict } from "@/types/job-analysis/job-analysis-verdict";
 import DismissReasonPopover from "./DismissReasonPopover";
+import UndoDismissToast from "./UndoDismissToast";
 
 interface DiscoveredJobCardProps {
   job: DiscoveredJob;
@@ -64,11 +65,13 @@ export default function DiscoveredJobCard({
   const [save, { isLoading: isSaving }] = useSaveDiscoveredJobMutation();
   const [promote, { isLoading: isPromoting }] = usePromoteDiscoveredJobMutation();
   const [showReasons, setShowReasons] = useState(false);
+  const [undoToastOpen, setUndoToastOpen] = useState(false);
 
   async function doDismiss(reason?: DismissalReason) {
     try {
       await dismiss({ jobId: job.id, reason }).unwrap();
       setShowReasons(false);
+      setUndoToastOpen(true);
     } catch (err) {
       showError(extractErrorMessage(err) ?? "Couldn't dismiss this posting");
     }
@@ -107,6 +110,12 @@ export default function DiscoveredJobCard({
   const isUnscored = job.verdict === null && job.score === null;
 
   return (
+    <>
+    <UndoDismissToast
+      jobId={job.id}
+      open={undoToastOpen}
+      onOpenChange={setUndoToastOpen}
+    />
     <Card className="p-4 sm:p-5 space-y-3">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
@@ -244,5 +253,6 @@ export default function DiscoveredJobCard({
         </div>
       )}
     </Card>
+    </>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/discover/ProfileCompletenessBanner.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/ProfileCompletenessBanner.tsx
@@ -1,0 +1,110 @@
+/**
+ * ProfileCompletenessBanner — shown at the top of the Discover inbox when the
+ * operator has no resume and no skills on their profile.
+ *
+ * Without a resume or skills the embedding + scoring service cannot produce
+ * meaningful match scores, so every discovered posting would show "Awaiting AI
+ * score" indefinitely. This banner surfaces that dependency early so the
+ * operator knows what to do, rather than wondering why the scores never fill in.
+ *
+ * Dismissal: clicking the X sets a localStorage flag so the banner stays hidden
+ * across sessions. The operator can still browse without scores — the banner is
+ * a soft nudge, not a hard gate.
+ */
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import { X } from "lucide-react";
+
+const STORAGE_KEY = "mjh_discover_profile_banner_dismissed";
+
+function readStoredDismissal(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function storeDismissal(): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, "true");
+  } catch {
+    // localStorage unavailable — best-effort; banner will reappear on reload
+  }
+}
+
+interface ProfileCompletenessBannerProps {
+  onDismiss: () => void;
+}
+
+/**
+ * Pure presentational banner — no localStorage awareness.
+ * Exported for unit testing without storage side-effects.
+ */
+export function ProfileCompletenessBannerContent({
+  onDismiss,
+}: ProfileCompletenessBannerProps) {
+  return (
+    <div
+      className="flex items-start gap-3 rounded-md border border-yellow-200 bg-yellow-50 px-4 py-3 text-sm dark:border-yellow-800 dark:bg-yellow-950"
+      role="alert"
+      data-testid="profile-completeness-banner"
+    >
+      <div className="flex-1">
+        <p className="font-medium text-yellow-800 dark:text-yellow-200">
+          Add your resume to see match scores
+        </p>
+        <p className="mt-0.5 text-yellow-700 dark:text-yellow-300">
+          Without a resume or skills, MyJobHunter can&#39;t rank discovered
+          postings. Add either to start seeing match scores.
+        </p>
+        <Link
+          to="/profile"
+          className="mt-2 inline-block font-medium text-yellow-800 underline hover:no-underline dark:text-yellow-200"
+        >
+          Set up profile
+        </Link>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="shrink-0 text-yellow-600 hover:text-yellow-800 dark:text-yellow-400 dark:hover:text-yellow-200"
+        aria-label="Dismiss this banner"
+        data-testid="profile-completeness-banner-dismiss"
+      >
+        <X className="h-4 w-4" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+interface ProfileCompletenessBannerContainerProps {
+  /** True when the profile has a parsed resume (resume_file_path is non-null). */
+  hasResume: boolean;
+  /** True when the profile has at least one skill. */
+  hasSkills: boolean;
+}
+
+/**
+ * Smart container: owns localStorage state and renders nothing when the profile
+ * is already complete or the operator has dismissed the banner.
+ */
+export default function ProfileCompletenessBanner({
+  hasResume,
+  hasSkills,
+}: ProfileCompletenessBannerContainerProps) {
+  const [dismissed, setDismissed] = useState(readStoredDismissal);
+
+  const profileIncomplete = !hasResume && !hasSkills;
+
+  if (!profileIncomplete || dismissed) {
+    return null;
+  }
+
+  function handleDismiss() {
+    storeDismissal();
+    setDismissed(true);
+  }
+
+  return <ProfileCompletenessBannerContent onDismiss={handleDismiss} />;
+}

--- a/apps/myjobhunter/frontend/src/features/discover/UndoDismissToast.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/UndoDismissToast.tsx
@@ -1,0 +1,77 @@
+/**
+ * UndoDismissToast — a 5-second action toast shown after a job is dismissed.
+ *
+ * Renders a Radix Toast.Root within the existing Toast.Provider that the shared
+ * Toaster mounts in RootLayout. The shared Toaster's Viewport at the top-right
+ * corner will display this toast alongside the normal success/error toasts.
+ *
+ * Clicking "Undo" fires the undo-dismiss mutation and closes the toast. If the
+ * toast expires without a click, the dismissal stands.
+ *
+ * Per `rules/visible-loading-feedback.md`: the Undo button is disabled while
+ * the mutation is in flight (the round-trip is usually < 200ms, but the
+ * disabled state prevents accidental double-fires).
+ *
+ * Design decision: self-contained here rather than extending the shared Toaster
+ * because the shared toast-store only supports string messages with no action
+ * button. If undo-style toasts become common across the app, extract the action
+ * button pattern into shared-frontend at that point.
+ */
+import * as Toast from "@radix-ui/react-toast";
+import { extractErrorMessage, showError } from "@platform/ui";
+import { useUndoDismissDiscoveredJobMutation } from "@/store/discoverApi";
+
+const UNDO_TOAST_DURATION_MS = 5000;
+
+interface UndoDismissToastProps {
+  /** The job that was just dismissed — used to call undo-dismiss. */
+  jobId: string;
+  /** Whether the toast is currently visible. */
+  open: boolean;
+  /** Called when the toast auto-expires or is manually closed. */
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function UndoDismissToast({
+  jobId,
+  open,
+  onOpenChange,
+}: UndoDismissToastProps) {
+  const [undoDismiss, { isLoading: isUndoing }] =
+    useUndoDismissDiscoveredJobMutation();
+
+  async function handleUndo() {
+    try {
+      await undoDismiss(jobId).unwrap();
+      onOpenChange(false);
+    } catch (err) {
+      showError(extractErrorMessage(err) ?? "Couldn't undo dismiss");
+      onOpenChange(false);
+    }
+  }
+
+  return (
+    <Toast.Root
+      open={open}
+      onOpenChange={onOpenChange}
+      duration={UNDO_TOAST_DURATION_MS}
+      className="flex items-center justify-between gap-4 rounded-lg border border-border bg-card px-4 py-3 text-sm shadow-lg"
+      data-testid="undo-dismiss-toast"
+    >
+      <Toast.Description className="flex-1 text-foreground">
+        Dismissed.
+      </Toast.Description>
+      <Toast.Action asChild altText="Undo dismiss">
+        <button
+          type="button"
+          onClick={handleUndo}
+          disabled={isUndoing}
+          className="shrink-0 font-medium text-primary underline hover:no-underline disabled:opacity-50"
+          data-testid="undo-dismiss-button"
+        >
+          {isUndoing ? "Undoing…" : "Undo"}
+        </button>
+      </Toast.Action>
+    </Toast.Root>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
@@ -36,6 +36,9 @@ vi.mock("@/store/discoverApi", () => ({
   useDismissDiscoveredJobMutation: () => [vi.fn(), { isLoading: false }],
   useSaveDiscoveredJobMutation: () => [vi.fn(), { isLoading: false }],
   usePromoteDiscoveredJobMutation: () => [vi.fn(), { isLoading: false }],
+  // Added in PR 8 (undo-dismiss toast). No-op here — toast rendering is
+  // tested separately in UndoDismissToast.test.tsx.
+  useUndoDismissDiscoveredJobMutation: () => [vi.fn(), { isLoading: false }],
 }));
 
 function renderInRouter(ui: React.ReactElement) {

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/ProfileCompletenessBanner.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/ProfileCompletenessBanner.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for ProfileCompletenessBanner.
+ *
+ * Uses the exported `ProfileCompletenessBannerContent` (pure presentational
+ * component) for most tests so they don't need to manage localStorage state.
+ * Container-level tests use `ProfileCompletenessBanner` directly.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MemoryRouter } from "react-router-dom";
+import ProfileCompletenessBanner, {
+  ProfileCompletenessBannerContent,
+} from "../ProfileCompletenessBanner";
+
+const STORAGE_KEY = "mjh_discover_profile_banner_dismissed";
+
+vi.mock("lucide-react", () => ({
+  X: () => <span data-testid="x-icon" />,
+}));
+
+function renderInRouter(ui: React.ReactElement) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return render(<MemoryRouter>{ui as any}</MemoryRouter>);
+}
+
+// ---------------------------------------------------------------------------
+// Presentational content
+// ---------------------------------------------------------------------------
+
+describe("ProfileCompletenessBannerContent", () => {
+  it("renders the heading, body, and CTA link", () => {
+    renderInRouter(<ProfileCompletenessBannerContent onDismiss={vi.fn()} />);
+    expect(
+      screen.getByText("Add your resume to see match scores"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Without a resume or skills/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Set up profile/i })).toHaveAttribute(
+      "href",
+      "/profile",
+    );
+  });
+
+  it("calls onDismiss when the X button is clicked", async () => {
+    const onDismiss = vi.fn();
+    renderInRouter(<ProfileCompletenessBannerContent onDismiss={onDismiss} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /Dismiss this banner/i }),
+    );
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Container — visibility logic
+// ---------------------------------------------------------------------------
+
+describe("ProfileCompletenessBanner (container)", () => {
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+  });
+
+  it("renders when both hasResume and hasSkills are false", () => {
+    renderInRouter(
+      <ProfileCompletenessBanner hasResume={false} hasSkills={false} />,
+    );
+    expect(screen.getByTestId("profile-completeness-banner")).toBeInTheDocument();
+  });
+
+  it("does not render when hasResume is true (profile complete enough)", () => {
+    renderInRouter(
+      <ProfileCompletenessBanner hasResume={true} hasSkills={false} />,
+    );
+    expect(screen.queryByTestId("profile-completeness-banner")).toBeNull();
+  });
+
+  it("does not render when hasSkills is true (profile complete enough)", () => {
+    renderInRouter(
+      <ProfileCompletenessBanner hasResume={false} hasSkills={true} />,
+    );
+    expect(screen.queryByTestId("profile-completeness-banner")).toBeNull();
+  });
+
+  it("does not render when localStorage flag is set", () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    renderInRouter(
+      <ProfileCompletenessBanner hasResume={false} hasSkills={false} />,
+    );
+    expect(screen.queryByTestId("profile-completeness-banner")).toBeNull();
+  });
+
+  it("hides after clicking dismiss and persists to localStorage", async () => {
+    renderInRouter(
+      <ProfileCompletenessBanner hasResume={false} hasSkills={false} />,
+    );
+    expect(screen.getByTestId("profile-completeness-banner")).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole("button", { name: /Dismiss this banner/i }),
+    );
+
+    expect(screen.queryByTestId("profile-completeness-banner")).toBeNull();
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/UndoDismissToast.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/UndoDismissToast.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * Unit tests for UndoDismissToast.
+ *
+ * Note: Radix UI toast components use pointer-capture internally, which JSDOM
+ * does not implement (hasPointerCapture is missing). To work around this, tests
+ * that need to simulate a click on the Undo button use fireEvent.click (which
+ * bypasses the pointer-capture path that userEvent.click triggers) and suppress
+ * the resulting jsdom error by adding the method to the prototype.
+ *
+ * Verifies:
+ * - The toast renders when open=true
+ * - The toast is hidden when open=false
+ * - Clicking Undo fires the mutation with the correct jobId
+ * - The toast is closed after a successful undo (onOpenChange called with false)
+ */
+import { describe, expect, it, vi, beforeAll } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import * as Toast from "@radix-ui/react-toast";
+import UndoDismissToast from "../UndoDismissToast";
+
+// Polyfill hasPointerCapture for JSDOM so Radix Toast doesn't throw.
+beforeAll(() => {
+  if (!Element.prototype.hasPointerCapture) {
+    Element.prototype.hasPointerCapture = () => false;
+  }
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = () => undefined;
+  }
+  if (!Element.prototype.releasePointerCapture) {
+    Element.prototype.releasePointerCapture = () => undefined;
+  }
+});
+
+const mockUndoFn = vi.fn();
+
+vi.mock("@/store/discoverApi", () => ({
+  useUndoDismissDiscoveredJobMutation: () => [
+    mockUndoFn,
+    { isLoading: false },
+  ],
+}));
+
+vi.mock("@platform/ui", () => ({
+  showError: vi.fn(),
+  extractErrorMessage: vi.fn((err) => String(err)),
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyChildren = { children: any };
+
+function Wrapper({ children }: AnyChildren) {
+  return (
+    <Toast.Provider>
+      {children}
+      <Toast.Viewport />
+    </Toast.Provider>
+  );
+}
+
+describe("UndoDismissToast", () => {
+  it("renders the toast and Undo button when open", () => {
+    render(
+      <Wrapper>
+        <UndoDismissToast jobId="job-1" open={true} onOpenChange={vi.fn()} />
+      </Wrapper>,
+    );
+    expect(screen.getByTestId("undo-dismiss-toast")).toBeInTheDocument();
+    expect(screen.getByText("Dismissed.")).toBeInTheDocument();
+    expect(screen.getByTestId("undo-dismiss-button")).toBeInTheDocument();
+  });
+
+  it("does not render when open is false", () => {
+    render(
+      <Wrapper>
+        <UndoDismissToast jobId="job-1" open={false} onOpenChange={vi.fn()} />
+      </Wrapper>,
+    );
+    expect(screen.queryByTestId("undo-dismiss-toast")).toBeNull();
+  });
+
+  it("calls undoDismiss mutation with the correct jobId on Undo click", async () => {
+    mockUndoFn.mockReturnValue({ unwrap: () => Promise.resolve() });
+    const onOpenChange = vi.fn();
+
+    render(
+      <Wrapper>
+        <UndoDismissToast jobId="job-abc" open={true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId("undo-dismiss-button"));
+    // Allow async state to settle.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockUndoFn).toHaveBeenCalledWith("job-abc");
+  });
+
+  it("calls onOpenChange(false) after a successful undo", async () => {
+    mockUndoFn.mockReturnValue({ unwrap: () => Promise.resolve() });
+    const onOpenChange = vi.fn();
+
+    render(
+      <Wrapper>
+        <UndoDismissToast jobId="job-1" open={true} onOpenChange={onOpenChange} />
+      </Wrapper>,
+    );
+
+    fireEvent.click(screen.getByTestId("undo-dismiss-button"));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/apps/myjobhunter/frontend/src/store/discoverApi.ts
+++ b/apps/myjobhunter/frontend/src/store/discoverApi.ts
@@ -76,6 +76,13 @@ const discoverApi = apiWithTags.injectEndpoints({
       }),
       invalidatesTags: ["DiscoveredJob"],
     }),
+    undoDismissDiscoveredJob: build.mutation<void, string>({
+      query: (jobId) => ({
+        url: `/discover/${jobId}/undo-dismiss`,
+        method: "POST",
+      }),
+      invalidatesTags: ["DiscoveredJob"],
+    }),
     saveDiscoveredJob: build.mutation<void, string>({
       query: (jobId) => ({
         url: `/discover/${jobId}/save`,
@@ -103,6 +110,7 @@ export const {
   useRefreshDiscoverySourceMutation,
   useListDiscoveredJobsQuery,
   useDismissDiscoveredJobMutation,
+  useUndoDismissDiscoveredJobMutation,
   useSaveDiscoveredJobMutation,
   usePromoteDiscoveredJobMutation,
 } = discoverApi;


### PR DESCRIPTION
## Summary

Two first-time-UX safety nets for the MJH Discover inbox, from the 2026-05-11 delta-plan (PR 8).

### Feature 1 — Profile-completeness banner

Contextual banner at the top of the Discover inbox when the user has neither a resume nor any skills. Without profile content, the AI scoring pipeline can't produce match scores, and new users would see every card with an empty verdict badge and no explanation.

- Renders only when `profile.resume_file_path` is null AND `skills.total === 0`
- Heading: "Add your resume to see match scores"; body explains the dependency; CTA navigates to `/profile`
- Dismissible — persists to `localStorage` under `mjh_discover_profile_banner_dismissed`; never re-appears after dismiss
- Frontend-only: consumes existing `useGetProfileQuery` + `useListSkillsQuery`
- Component: `features/discover/ProfileCompletenessBanner.tsx` (exports both presentational `ProfileCompletenessBannerContent` and smart container)

### Feature 2 — Dismiss-undo toast

5-second undo toast after every dismiss action so users can reverse an accidental swipe-away.

- "Dismissed. [Undo]" — Undo button calls `POST /discover/{id}/undo-dismiss`
- Backend: clears `dismissed_at` + `dismissed_reason`; returns 204 on success, 404 if job is not dismissed / not found / cross-tenant
- New service method `undo_dismiss_for_user` in `discovery_inbox_service`, new repo function `undo_dismiss_discovered` in `discovery_repository` — follows route→service→repo convention
- `UndoDismissToast` uses `@radix-ui/react-toast` directly (shared Toaster does not support action buttons)
- Undo button disabled while mutation is in flight (per `visible-loading-feedback` rule)

## Files changed

**Backend**
- `app/repositories/discovery/discovery_repository.py` — `undo_dismiss_discovered`
- `app/services/discovery/discovery_inbox_service.py` — `undo_dismiss_for_user`
- `app/api/discover.py` — `POST /{job_id}/undo-dismiss` (204/404)
- `tests/test_discover_endpoints.py` — 3 new tests (happy path, never-dismissed 404, cross-tenant 404)

**Frontend**
- `features/discover/ProfileCompletenessBanner.tsx` (new)
- `features/discover/UndoDismissToast.tsx` (new)
- `features/discover/DiscoverInboxView.tsx` — imports banner + profile/skills queries
- `features/discover/DiscoveredJobCard.tsx` — integrates undo toast after dismiss
- `store/discoverApi.ts` — `undoDismissDiscoveredJob` mutation + hook export
- `features/discover/__tests__/ProfileCompletenessBanner.test.tsx` (new)
- `features/discover/__tests__/UndoDismissToast.test.tsx` (new)
- `features/discover/__tests__/DiscoveredJobCard.test.tsx` — added missing mock export

## Test coverage

- 3 new backend endpoint tests (all passing; pre-existing failures are unrelated pgvector/Anthropic key gaps)
- 9 new frontend unit tests across the two new components (all passing)
- Pre-existing test failures confirmed pre-existing via git stash diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)