### PR TITLE
chore(mjh/discover): cache Greenhouse company_name + wire excluded_keywords to GH/Lever

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 16 (Critical: 0 / High: 2 blocked-on-react-19 / Medium: 7 deferred-or-blocked / Low: 7 deferred-or-environmental)**
+**Open issues: 14 (Critical: 0 / High: 2 blocked-on-react-19 / Medium: 5 deferred-or-blocked / Low: 7 deferred-or-environmental)**
 
 > Status (2026-05-08 PM): All actionable audit items resolved across batches PR #492-#528 (~30 PRs). Remaining open entries are either (a) blocked on the React 18→19 monorepo bump (5 items), (b) deferred-by-design conventions or follow-ups (4), (c) environmental issues unrelated to code (3: asyncpg Windows, test hang on Windows, Quality Gate false-positive), or (d) intentional accepted lint warnings (2).
 
@@ -651,20 +651,12 @@ keep lint green while the underlying patterns are fixed. These are warnings, not
 
 ## Discovery adapter follow-ups (2026-05-11)
 
-### [Discovery] Greenhouse/Lever postings not filtered by post_fetch_filters min_salary / excluded_keywords
+### ~~[Discovery] Greenhouse/Lever postings not filtered by post_fetch_filters min_salary / excluded_keywords~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** Low
-**Location:** `apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py`, `_apply_post_fetch_filters`
-**Problem:** `_apply_post_fetch_filters` runs for all sources including Greenhouse and Lever, but those sources never have `min_salary_usd` or `excluded_keywords` in their config (their configs only have `board_token` / `company_slug`). This is currently a no-op — correct behavior — but if we ever want to allow operators to set exclusion filters on Greenhouse/Lever sources, there's no UI path for it. The filter function would need to be made aware of per-source config shapes.
-**Recommendation:** When adding filter-by-keyword support to Greenhouse/Lever sources, add `excluded_keywords` as an optional field to `GreenhouseSourceConfig` / `LeverSourceConfig` (same field, same validation), add the UI field to `GreenhouseConfigSection` / `LeverConfigSection`, and the existing filter logic picks it up automatically. No backend service changes needed.
+**Resolved:** PR chore(mjh/discover): cache Greenhouse company_name + wire excluded_keywords to GH/Lever (2026-05-11). Added `excluded_keywords: list[str] = []` to `GreenhouseSourceConfig` and `LeverSourceConfig`. Added `excluded_keywords` `MultiChipInput` field to `GreenhouseConfigSection.tsx` and `LeverConfigSection.tsx`. Updated `NewSavedSearchDialog.tsx` state + `buildConfig()` to include the field when non-empty. The existing `_apply_post_fetch_filters` in the fetch service picks it up automatically — no service-layer changes needed. `min_salary_usd` intentionally omitted from both (Greenhouse/Lever feeds don't reliably include salary data). `GreenhouseFetchConfig` (fetch-time supertype) has `extra="ignore"` to allow the new `resolved_company_name` cache field to round-trip cleanly. 55 backend unit tests pass; 37 frontend tests pass (new tests in `test_greenhouse_adapter.py`, `test_lever_adapter.py`, `test_discovery_post_fetch_filters.py`, `GreenhouseConfigSection.test.tsx`, `LeverConfigSection.test.tsx`, `NewSavedSearchDialog.test.tsx`).
 
 ---
 
-### [Discovery] Greenhouse company_name is fetched in a second HTTP call per board fetch
+### ~~[Discovery] Greenhouse company_name is fetched in a second HTTP call per board fetch~~ RESOLVED
 
-**Severity:** Medium
-**Effort:** Low
-**Location:** `apps/myjobhunter/backend/app/services/discovery/sources/greenhouse.py`, `_fetch_company_name`
-**Problem:** Every `fetch_board()` call makes two HTTP requests: one for the company metadata (to get the display name) and one for the jobs list. This is correct behavior but doubles the per-source latency and Greenhouse API usage. For a single user with ~5 Greenhouse saved searches this is negligible; at scale it could matter.
-**Recommendation:** Cache the company name in the `DiscoverySource.config` JSONB column after the first successful fetch (same way `last_fetched_at` is updated). The fetch service already has a `mark_source_fetched` call that could also persist the resolved company name. Then skip the metadata call when the name is already cached. This is a low-priority optimization — only needed if Greenhouse sources become heavily used.
+**Resolved:** PR chore(mjh/discover): cache Greenhouse company_name + wire excluded_keywords to GH/Lever (2026-05-11). Added `resolved_company_name: str | None` to `GreenhouseFetchConfig` (fetch-time config supertype). `fetch_board()` now returns `tuple[list[dict], str | None]` — the second element is the resolved name for the caller to cache. `_run_greenhouse` in the fetch service unpacks the tuple and persists the name back to `source.config` JSONB via a direct ORM mutation (same DB transaction). On subsequent fetches `GreenhouseFetchConfig.resolved_company_name` is populated and the metadata HTTP call is skipped. The write-time `GreenhouseSourceConfig` (with `extra="forbid"`) does not expose `resolved_company_name` — callers cannot inject it. Tests: 3 new cache-specific tests in `test_greenhouse_adapter.py`.

--- a/apps/myjobhunter/backend/app/schemas/discovery/greenhouse_source_config.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/greenhouse_source_config.py
@@ -16,13 +16,20 @@ Validation design
   guidance: no user-supplied string should reach a URL template without
   shape validation.
 
-- ``model_config = ConfigDict(extra="forbid")`` rejects typos at the API
-  boundary (the operator gets a 422 with the field name, not a silently
-  no-op saved search).
+- ``model_config = ConfigDict(extra="forbid")`` on the write-time model
+  rejects typos at the API boundary (the operator gets a 422 with the
+  field name, not a silently no-op saved search).
 
 - ``parse_or_default`` mirrors JSearchSourceConfig's pattern: used at
-  fetch time where we log + fall back to defaults rather than crashing the
-  worker on a malformed legacy row.
+  fetch time where we log + raise on a missing board_token.
+
+- ``resolved_company_name`` is an optional field present only in the
+  fetch-time model (``GreenhouseFetchConfig``).  It caches the company
+  display name after the first successful metadata HTTP call so subsequent
+  fetches skip that round-trip.  The fetch service writes it back to the
+  JSONB config column via ``mark_source_fetched``.  API callers cannot set
+  it because the write-time ``GreenhouseSourceConfig`` has ``extra="forbid"``
+  and does not declare this field.
 """
 from __future__ import annotations
 
@@ -46,6 +53,10 @@ class GreenhouseSourceConfig(BaseModel):
     The operator supplies the board_token from the Greenhouse board URL:
     ``boards.greenhouse.io/<board_token>``.  That is the only config
     needed — no API key, no authentication.
+
+    Write-time model — ``extra="forbid"`` rejects any unknown field so
+    callers cannot inject ``resolved_company_name`` or other server-managed
+    fields.
     """
 
     board_token: str = Field(
@@ -55,6 +66,23 @@ class GreenhouseSourceConfig(BaseModel):
         description=(
             "The board token from the Greenhouse URL: "
             "boards.greenhouse.io/<board_token>"
+        ),
+    )
+
+    # Post-fetch keyword filter — case-insensitive substring match against
+    # title, company_name, description, and source_publisher.  Same
+    # semantics as JSearch's ``excluded_keywords`` field so the
+    # ``_apply_post_fetch_filters`` function in the fetch service picks
+    # it up automatically.
+    #
+    # ``min_salary_usd`` is intentionally omitted: Greenhouse's public
+    # board feed does not reliably include salary data, so filtering on it
+    # would silently drop legitimate postings.
+    excluded_keywords: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Case-insensitive substrings to drop from fetched postings. "
+            "Matched against title, company, description, and publisher."
         ),
     )
 
@@ -79,22 +107,20 @@ class GreenhouseSourceConfig(BaseModel):
         return v
 
     @classmethod
-    def parse_or_default(cls, raw: dict | None) -> "GreenhouseSourceConfig":
+    def parse_or_default(cls, raw: dict | None) -> "GreenhouseFetchConfig":
         """Validate raw config from a stored saved-search row.
 
-        Used at fetch time.  On validation failure we log + raise so the
-        fetch loop marks the source as errored with a clear message rather
-        than silently no-oping with a bad token.  Unlike JSearch (which
-        falls back to empty defaults and runs a zero-result search), a
-        Greenhouse source with an invalid board_token cannot run at all —
-        there is no meaningful default to fall back to.
+        Returns a ``GreenhouseFetchConfig`` (lenient supertype) so the
+        caller can read ``resolved_company_name`` if it was cached on a
+        prior fetch.  On validation failure we log + raise so the fetch
+        loop marks the source as errored with a clear message.
         """
         if raw is None or not raw:
             raise ValueError(
                 "Greenhouse source config is missing — board_token is required",
             )
         try:
-            return cls.model_validate(raw)
+            return GreenhouseFetchConfig.model_validate(raw)
         except ValidationError as exc:
             logger.warning(
                 "Greenhouse source config validation failed: %s",
@@ -103,3 +129,24 @@ class GreenhouseSourceConfig(BaseModel):
             raise ValueError(
                 f"Greenhouse source config invalid: {exc}",
             ) from exc
+
+
+class GreenhouseFetchConfig(GreenhouseSourceConfig):
+    """Fetch-time superset of ``GreenhouseSourceConfig``.
+
+    Adds ``resolved_company_name`` — the cached company display name
+    written by the fetch service after the first successful metadata call.
+    ``extra="ignore"`` lets legacy rows that contain unknown keys round-trip
+    without errors while the cache field is being populated over time.
+    """
+
+    resolved_company_name: str | None = Field(
+        default=None,
+        description=(
+            "Company display name cached from the Greenhouse board metadata "
+            "endpoint after the first successful fetch.  None on first run; "
+            "set by the fetch service and stored back into the JSONB config."
+        ),
+    )
+
+    model_config = ConfigDict(extra="ignore")

--- a/apps/myjobhunter/backend/app/schemas/discovery/lever_source_config.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/lever_source_config.py
@@ -55,6 +55,17 @@ class LeverSourceConfig(BaseModel):
         ),
     )
 
+    # Post-fetch keyword filter — same semantics as Greenhouse and JSearch.
+    # ``min_salary_usd`` is intentionally omitted: Lever's v0 postings feed
+    # does not reliably include salary data.
+    excluded_keywords: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Case-insensitive substrings to drop from fetched postings. "
+            "Matched against title, company, description, and publisher."
+        ),
+    )
+
     model_config = ConfigDict(extra="forbid")
 
     @field_validator("company_slug")

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
@@ -29,7 +29,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.discovery.discovery_source import DiscoverySource
 from app.repositories.discovery import discovery_repository
-from app.schemas.discovery.greenhouse_source_config import GreenhouseSourceConfig
+from app.schemas.discovery.greenhouse_source_config import (
+    GreenhouseSourceConfig,
+    GreenhouseFetchConfig,
+)
 from app.schemas.discovery.jsearch_source_config import JSearchSourceConfig
 from app.schemas.discovery.lever_source_config import LeverSourceConfig
 from app.services.discovery.industry_denylists import expand_excluded_keywords
@@ -222,12 +225,19 @@ def _apply_post_fetch_filters(
     return kept
 
 
-async def _run_greenhouse(config: dict[str, Any]) -> list[dict]:
+async def _run_greenhouse(
+    config: dict[str, Any],
+) -> tuple[list[dict], str | None]:
     """Validate Greenhouse config and invoke the adapter.
 
     Unlike JSearch, there is no meaningful default config to fall back to
     if the board_token is missing — we let ``parse_or_default`` raise
     and the fetch-service error handler marks the source as errored.
+
+    Returns a ``(postings, resolved_company_name)`` tuple.
+    ``resolved_company_name`` is non-None when the fetch service should
+    write it back to the source's config JSONB to skip the metadata call
+    on the next fetch.
     """
     typed = GreenhouseSourceConfig.parse_or_default(config)
     return await greenhouse.fetch_board(board_token=typed.board_token, config=typed)
@@ -245,9 +255,14 @@ async def _run_lever(config: dict[str, Any]) -> list[dict]:
 
 _ADAPTERS: dict[str, Callable[[dict[str, Any]], Awaitable[list[dict]]]] = {
     "jsearch": _run_jsearch,
-    "greenhouse": _run_greenhouse,
     "lever": _run_lever,
 }
+
+# Greenhouse gets a dedicated slot because its adapter returns a tuple
+# ``(postings, resolved_company_name)`` — the second element lets the
+# fetch service persist the company display name back to the JSONB config
+# so subsequent fetches skip the metadata round-trip.
+_GREENHOUSE_ADAPTER = _run_greenhouse
 
 
 # ---------------------------------------------------------------------------
@@ -291,8 +306,12 @@ async def fetch_source(
             f"discovery_source {source_id} is inactive",
         )
 
-    adapter = _ADAPTERS.get(source.source)
-    if adapter is None:
+    is_greenhouse = source.source == "greenhouse"
+    if is_greenhouse:
+        # Greenhouse adapter returns (postings, resolved_company_name) so it
+        # bypasses the generic _ADAPTERS dispatch.
+        pass
+    elif source.source not in _ADAPTERS:
         raise DiscoveryUnsupportedSourceError(
             f"no adapter registered for source kind {source.source!r}",
         )
@@ -312,9 +331,18 @@ async def fetch_source(
     status = "success"
     error_message: str | None = None
     max_posted_at = None
+    # Greenhouse: company name resolved from metadata or cache.  Non-None
+    # signals the fetch service should write it back to the config JSONB.
+    greenhouse_resolved_name: str | None = None
 
     try:
-        postings = await adapter(source.config or {})
+        if is_greenhouse:
+            postings, greenhouse_resolved_name = await _GREENHOUSE_ADAPTER(
+                source.config or {},
+            )
+        else:
+            adapter = _ADAPTERS[source.source]
+            postings = await adapter(source.config or {})
     except Exception as exc:
         # Persist the audit row + source-level failure, then re-raise
         # the ORIGINAL exception so the route layer can map typed
@@ -358,6 +386,22 @@ async def fetch_source(
                 max_posted_at is None or posted_at > max_posted_at
             ):
                 max_posted_at = posted_at
+
+    # ---- Persist Greenhouse company name cache ----
+    # When the adapter resolved a company display name that differs from
+    # whatever was previously cached (or it's the first fetch), write it
+    # back into the source's config JSONB so the next fetch can skip the
+    # metadata round-trip.  We mutate the ORM instance directly — the
+    # same db.commit() below will persist the change.
+    if is_greenhouse and greenhouse_resolved_name is not None:
+        current_cached = (source.config or {}).get("resolved_company_name")
+        if greenhouse_resolved_name != current_cached:
+            # SQLAlchemy won't detect in-place dict mutation on JSONB columns;
+            # replace the column reference entirely to trigger change detection.
+            updated_config = dict(source.config or {})
+            updated_config["resolved_company_name"] = greenhouse_resolved_name
+            source.config = updated_config
+            await db.flush()
 
     # ---- Audit complete + source watermark ----
     await discovery_repository.complete_fetch(

--- a/apps/myjobhunter/backend/app/services/discovery/sources/greenhouse.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/greenhouse.py
@@ -46,7 +46,10 @@ from tenacity import (
     wait_exponential,
 )
 
-from app.schemas.discovery.greenhouse_source_config import GreenhouseSourceConfig
+from app.schemas.discovery.greenhouse_source_config import (
+    GreenhouseFetchConfig,
+    GreenhouseSourceConfig,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -101,17 +104,26 @@ async def fetch_board(
     *,
     board_token: str,
     config: GreenhouseSourceConfig | None = None,
-) -> list[dict]:
+) -> tuple[list[dict], str | None]:
     """Fetch all active postings from a Greenhouse public board.
 
     Args:
         board_token: The slug from ``boards.greenhouse.io/<board_token>``.
-        config: Validated GreenhouseSourceConfig (optional — used for
-            any future per-source overrides like date filtering).
+        config: Validated GreenhouseSourceConfig (or GreenhouseFetchConfig
+            with a cached ``resolved_company_name``).  When a cached name
+            is present the metadata HTTP call is skipped, halving per-fetch
+            latency.
 
     Returns:
-        List of normalized posting dicts whose keys map directly onto
-        ``DiscoveredJob`` columns (plus ``raw_payload``).
+        A 2-tuple ``(postings, resolved_company_name)`` where:
+
+        - ``postings`` is a list of normalized posting dicts whose keys map
+          directly onto ``DiscoveredJob`` columns (plus ``raw_payload``).
+        - ``resolved_company_name`` is the company display name that was
+          used for this fetch — the caller should persist it back into the
+          source's ``config`` JSONB so the next fetch can skip the metadata
+          call.  ``None`` if the metadata call failed (board_token used
+          instead; still worth persisting to avoid retrying every time).
 
     Raises:
         GreenhouseInvalidBoardError: 404 — board_token is unknown.
@@ -186,10 +198,25 @@ async def fetch_board(
             f"Greenhouse returned non-JSON body for board {board_token!r}: {exc}",
         ) from exc
 
-    # Try to get company name from the board metadata endpoint.  This is a
-    # best-effort call — if it fails we fall back to the board_token as the
-    # company name (ugly but safe).
-    company_name = await _fetch_company_name(board_token, headers)
+    # Use cached company name when available to skip the metadata round-trip.
+    # ``config`` may be a ``GreenhouseFetchConfig`` (fetched from DB) or a
+    # plain ``GreenhouseSourceConfig`` (e.g. in tests).  Guard with getattr
+    # so both types are accepted without isinstance coupling.
+    cached_name: str | None = getattr(config, "resolved_company_name", None)
+    if cached_name:
+        company_name = cached_name
+        resolved_company_name: str | None = cached_name
+        logger.debug(
+            "Greenhouse company name from cache: board_token=%s name=%r",
+            board_token,
+            company_name,
+        )
+    else:
+        # First fetch for this source — call the metadata endpoint.
+        company_name = await _fetch_company_name(board_token, headers)
+        # Persist back if the name differs from the board_token (i.e. the
+        # metadata call succeeded and returned a real display name).
+        resolved_company_name = company_name if company_name != board_token else None
 
     raw_jobs = body.get("jobs", [])
     if not isinstance(raw_jobs, list):
@@ -212,11 +239,12 @@ async def fetch_board(
         normalized.append(_normalize(raw, company_name=company_name))
 
     logger.info(
-        "Greenhouse fetch ok: board_token=%s returned=%d",
+        "Greenhouse fetch ok: board_token=%s returned=%d cached_name=%s",
         board_token,
         len(normalized),
+        cached_name is not None,
     )
-    return normalized
+    return normalized, resolved_company_name
 
 
 async def _fetch_company_name(board_token: str, headers: dict) -> str:

--- a/apps/myjobhunter/backend/tests/test_discovery_post_fetch_filters.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_post_fetch_filters.py
@@ -128,3 +128,82 @@ def test_min_salary_invalid_raw_falls_back_to_no_filter() -> None:
         postings, {"min_salary_usd": "not a number"},
     )
     assert len(result) == 1
+
+
+# ===========================================================================
+# Greenhouse / Lever excluded_keywords integration (tech debt 2026-05-11)
+# ===========================================================================
+
+
+def _greenhouse_posting(**overrides):
+    """Greenhouse posting shape — no salary fields."""
+    base = {
+        "source": "greenhouse",
+        "source_external_id": "gh-123",
+        "source_publisher": "Greenhouse",
+        "title": "Senior Software Engineer",
+        "company_name": "Stripe",
+        "description": "We are looking for a strong engineer.",
+        "salary_min": None,
+        "salary_max": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_greenhouse_excluded_keywords_drops_matching_posting() -> None:
+    """excluded_keywords filter works for Greenhouse postings (same code path)."""
+    postings = [
+        _greenhouse_posting(title="Junior Software Engineer"),
+        _greenhouse_posting(title="Senior Software Engineer"),
+    ]
+    result = _apply_post_fetch_filters(postings, {"excluded_keywords": ["junior"]})
+    assert len(result) == 1
+    assert result[0]["title"] == "Senior Software Engineer"
+
+
+def test_greenhouse_excluded_keywords_matches_company_name() -> None:
+    """Company name is checked even for Greenhouse postings."""
+    postings = [
+        _greenhouse_posting(company_name="Palantir"),
+        _greenhouse_posting(company_name="Stripe"),
+    ]
+    result = _apply_post_fetch_filters(
+        postings, {"excluded_keywords": ["palantir"]},
+    )
+    assert len(result) == 1
+    assert result[0]["company_name"] == "Stripe"
+
+
+def test_greenhouse_no_excluded_keywords_passes_all() -> None:
+    """Greenhouse postings with no filter set are all kept."""
+    postings = [_greenhouse_posting(), _greenhouse_posting(title="Intern")]
+    result = _apply_post_fetch_filters(postings, {"board_token": "stripe"})
+    assert len(result) == 2
+
+
+def _lever_posting(**overrides):
+    """Lever posting shape — no salary fields."""
+    base = {
+        "source": "lever",
+        "source_external_id": "lv-456",
+        "source_publisher": "Lever",
+        "title": "Backend Engineer",
+        "company_name": "OpenAI",
+        "description": "Looking for a backend engineer.",
+        "salary_min": None,
+        "salary_max": None,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_lever_excluded_keywords_drops_matching_posting() -> None:
+    """excluded_keywords filter works for Lever postings (same code path)."""
+    postings = [
+        _lever_posting(title="Intern Backend Engineer"),
+        _lever_posting(title="Backend Engineer"),
+    ]
+    result = _apply_post_fetch_filters(postings, {"excluded_keywords": ["intern"]})
+    assert len(result) == 1
+    assert result[0]["title"] == "Backend Engineer"

--- a/apps/myjobhunter/backend/tests/test_greenhouse_adapter.py
+++ b/apps/myjobhunter/backend/tests/test_greenhouse_adapter.py
@@ -16,6 +16,9 @@ HTTP calls happen. Verifies:
 - Description truncation at 12k char cap
 - company_name fetched from board metadata endpoint
 - Empty jobs array → empty result list
+- company_name cache hit: skips metadata call, uses cached name
+- company_name cache miss: calls metadata, returns resolved name
+- resolved_company_name returned in result tuple
 """
 from __future__ import annotations
 
@@ -24,6 +27,10 @@ from unittest.mock import patch
 import httpx
 import pytest
 
+from app.schemas.discovery.greenhouse_source_config import (
+    GreenhouseFetchConfig,
+    GreenhouseSourceConfig,
+)
 from app.services.discovery.sources import greenhouse
 from app.services.discovery.sources.greenhouse import (
     GreenhouseError,
@@ -92,7 +99,7 @@ async def test_fetch_board_happy_path() -> None:
     handler = _TwoCallHandler(_company_response(), _board_response())
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, resolved_name = await fetch_board(board_token="stripe")
 
     assert len(results) == 1
     posting = results[0]
@@ -110,6 +117,8 @@ async def test_fetch_board_happy_path() -> None:
     assert posting["salary_max"] is None
     # raw_payload preserved
     assert posting["raw_payload"]["id"] == 4001234
+    # resolved name returned for caller to cache
+    assert resolved_name == "Stripe"
 
 
 @pytest.mark.asyncio
@@ -121,7 +130,7 @@ async def test_fetch_board_strips_html_from_description() -> None:
     handler = _TwoCallHandler(_company_response(), _board_response([job]))
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, _ = await fetch_board(board_token="stripe")
 
     desc = results[0]["description"]
     assert desc is not None
@@ -137,7 +146,7 @@ async def test_fetch_board_returns_empty_list_for_empty_jobs() -> None:
     handler = _TwoCallHandler(_company_response(), {"jobs": []})
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, _ = await fetch_board(board_token="stripe")
 
     assert results == []
 
@@ -150,7 +159,7 @@ async def test_fetch_board_skips_jobs_missing_id() -> None:
     handler = _TwoCallHandler(_company_response(), _board_response([bad_job, good_job]))
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, _ = await fetch_board(board_token="stripe")
 
     assert len(results) == 1
     assert results[0]["source_external_id"] == "9999"
@@ -162,7 +171,7 @@ async def test_fetch_board_truncates_long_description() -> None:
     handler = _TwoCallHandler(_company_response(), _board_response([job]))
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, _ = await fetch_board(board_token="stripe")
 
     desc = results[0]["description"]
     assert desc is not None
@@ -256,7 +265,7 @@ async def test_fetch_board_succeeds_after_one_transient(monkeypatch) -> None:
         return httpx.Response(200, json=_company_response())
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await greenhouse.fetch_board(board_token="stripe")
+        results, _ = await greenhouse.fetch_board(board_token="stripe")
 
     assert len(results) == 1
     assert call_count["n"] == 2
@@ -302,7 +311,7 @@ async def test_fetch_board_remote_type_from_location_remote() -> None:
     handler = _TwoCallHandler(_company_response(), _board_response([job]))
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, _ = await fetch_board(board_token="stripe")
 
     assert results[0]["remote_type"] == "remote"
 
@@ -313,7 +322,7 @@ async def test_fetch_board_remote_type_hybrid() -> None:
     handler = _TwoCallHandler(_company_response(), _board_response([job]))
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, _ = await fetch_board(board_token="stripe")
 
     assert results[0]["remote_type"] == "hybrid"
 
@@ -324,7 +333,7 @@ async def test_fetch_board_remote_type_unknown_when_no_location() -> None:
     handler = _TwoCallHandler(_company_response(), _board_response([job]))
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, _ = await fetch_board(board_token="stripe")
 
     assert results[0]["remote_type"] == "unknown"
 
@@ -344,6 +353,112 @@ async def test_fetch_board_falls_back_to_board_token_when_company_fetch_fails() 
         return httpx.Response(500, text="server error")
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        results = await fetch_board(board_token="stripe")
+        results, resolved_name = await fetch_board(board_token="stripe")
 
     assert results[0]["company_name"] == "stripe"
+    # Fallback name equals board_token, so resolved_company_name is None
+    # (nothing new to cache — it's already implied by the board_token).
+    assert resolved_name is None
+
+
+# ===========================================================================
+# Company name caching — Item 1 from tech debt cleanup (2026-05-11)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_uses_cached_name_and_skips_metadata_call() -> None:
+    """When resolved_company_name is cached in config, no metadata HTTP call."""
+    metadata_call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "jobs" in request.url.path:
+            return httpx.Response(200, json=_board_response())
+        # Should not be reached — metadata call should be skipped.
+        metadata_call_count["n"] += 1
+        return httpx.Response(200, json=_company_response())
+
+    config = GreenhouseFetchConfig(
+        board_token="stripe",
+        resolved_company_name="Stripe (cached)",
+    )
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results, resolved_name = await fetch_board(board_token="stripe", config=config)
+
+    # Cached name used; metadata endpoint never called.
+    assert metadata_call_count["n"] == 0
+    assert results[0]["company_name"] == "Stripe (cached)"
+    # resolved_name echoes the cache — no update needed.
+    assert resolved_name == "Stripe (cached)"
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_returns_resolved_name_for_caller_to_cache() -> None:
+    """On first fetch (no cached name), resolved_company_name is returned."""
+    handler = _TwoCallHandler(_company_response(), _board_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results, resolved_name = await fetch_board(board_token="stripe")
+
+    # The metadata endpoint returned "Stripe"; caller should cache it.
+    assert resolved_name == "Stripe"
+    assert results[0]["company_name"] == "Stripe"
+
+
+@pytest.mark.asyncio
+async def test_fetch_board_metadata_call_count_without_cache() -> None:
+    """Without a cached name exactly one metadata call is made per fetch_board."""
+    handler = _TwoCallHandler(_company_response(), _board_response())
+    calls = []
+
+    original_init = _OriginalAsyncClient.__init__
+
+    def tracking_handler(request: httpx.Request) -> httpx.Response:
+        calls.append(request.url.path)
+        if "jobs" in request.url.path:
+            return httpx.Response(200, json=_board_response())
+        return httpx.Response(200, json=_company_response())
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(tracking_handler)):
+        await fetch_board(board_token="stripe")
+
+    metadata_calls = [p for p in calls if "jobs" not in p]
+    jobs_calls = [p for p in calls if "jobs" in p]
+    assert len(metadata_calls) == 1
+    assert len(jobs_calls) == 1
+
+
+# ===========================================================================
+# excluded_keywords filter (Item 2 — Greenhouse config field)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_source_config_accepts_excluded_keywords() -> None:
+    """excluded_keywords is a valid field on GreenhouseSourceConfig."""
+    cfg = GreenhouseSourceConfig(
+        board_token="stripe",
+        excluded_keywords=["junior", "intern"],
+    )
+    assert cfg.excluded_keywords == ["junior", "intern"]
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_source_config_excluded_keywords_defaults_empty() -> None:
+    """excluded_keywords defaults to [] when not supplied."""
+    cfg = GreenhouseSourceConfig(board_token="stripe")
+    assert cfg.excluded_keywords == []
+
+
+@pytest.mark.asyncio
+async def test_greenhouse_fetch_config_round_trips_excluded_keywords() -> None:
+    """GreenhouseFetchConfig parses excluded_keywords from raw JSONB dict."""
+    raw = {
+        "board_token": "stripe",
+        "excluded_keywords": ["junior"],
+        "resolved_company_name": "Stripe",
+    }
+    cfg = GreenhouseFetchConfig.model_validate(raw)
+    assert cfg.excluded_keywords == ["junior"]
+    assert cfg.resolved_company_name == "Stripe"

--- a/apps/myjobhunter/backend/tests/test_lever_adapter.py
+++ b/apps/myjobhunter/backend/tests/test_lever_adapter.py
@@ -354,3 +354,36 @@ async def test_fetch_postings_remote_type_unknown_when_no_location() -> None:
         results = await fetch_postings(company_slug="stripe")
 
     assert results[0]["remote_type"] == "unknown"
+
+
+# ===========================================================================
+# excluded_keywords config field (tech debt 2026-05-11)
+# ===========================================================================
+
+
+def test_lever_source_config_accepts_excluded_keywords() -> None:
+    """excluded_keywords is a valid field on LeverSourceConfig."""
+    from app.schemas.discovery.lever_source_config import LeverSourceConfig
+
+    cfg = LeverSourceConfig(
+        company_slug="openai",
+        excluded_keywords=["junior", "intern"],
+    )
+    assert cfg.excluded_keywords == ["junior", "intern"]
+
+
+def test_lever_source_config_excluded_keywords_defaults_empty() -> None:
+    """excluded_keywords defaults to [] when not supplied."""
+    from app.schemas.discovery.lever_source_config import LeverSourceConfig
+
+    cfg = LeverSourceConfig(company_slug="openai")
+    assert cfg.excluded_keywords == []
+
+
+def test_lever_source_config_parse_or_default_accepts_excluded_keywords() -> None:
+    """parse_or_default round-trips excluded_keywords from raw JSONB."""
+    from app.schemas.discovery.lever_source_config import LeverSourceConfig
+
+    raw = {"company_slug": "openai", "excluded_keywords": ["junior"]}
+    cfg = LeverSourceConfig.parse_or_default(raw)
+    assert cfg.excluded_keywords == ["junior"]

--- a/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/NewSavedSearchDialog.tsx
@@ -98,9 +98,15 @@ export default function NewSavedSearchDialog({
 
   // Greenhouse form state
   const [boardToken, setBoardToken] = useState("");
+  const [greenhouseExcludedKeywords, setGreenhouseExcludedKeywords] = useState<
+    string[]
+  >([]);
 
   // Lever form state
   const [companySlug, setCompanySlug] = useState("");
+  const [leverExcludedKeywords, setLeverExcludedKeywords] = useState<string[]>(
+    [],
+  );
 
   // Refresh-frequency picker (PR 5). Applies to every source type — the
   // backend scheduler runs the same fetch chain for jsearch / greenhouse /
@@ -148,17 +154,31 @@ export default function NewSavedSearchDialog({
     setExcludedKeywords([]);
     setSaveAsDefaults(false);
     setBoardToken("");
+    setGreenhouseExcludedKeywords([]);
     setCompanySlug("");
+    setLeverExcludedKeywords([]);
     setFetchIntervalMinutes(DEFAULT_REFRESH_INTERVAL_MINUTES);
     resetPrefill();
   }
 
   function buildConfig(): Record<string, unknown> {
     if (source === "greenhouse") {
-      return { board_token: boardToken.trim() };
+      const ghConfig: Record<string, unknown> = {
+        board_token: boardToken.trim(),
+      };
+      if (greenhouseExcludedKeywords.length > 0) {
+        ghConfig.excluded_keywords = greenhouseExcludedKeywords;
+      }
+      return ghConfig;
     }
     if (source === "lever") {
-      return { company_slug: companySlug.trim().toLowerCase() };
+      const leverConfig: Record<string, unknown> = {
+        company_slug: companySlug.trim().toLowerCase(),
+      };
+      if (leverExcludedKeywords.length > 0) {
+        leverConfig.excluded_keywords = leverExcludedKeywords;
+      }
+      return leverConfig;
     }
     // jsearch
     const config: Record<string, unknown> = {
@@ -355,6 +375,8 @@ export default function NewSavedSearchDialog({
           <GreenhouseConfigSection
             boardToken={boardToken}
             onBoardTokenChange={setBoardToken}
+            excludedKeywords={greenhouseExcludedKeywords}
+            onExcludedKeywordsChange={setGreenhouseExcludedKeywords}
           />
         )}
 
@@ -363,6 +385,8 @@ export default function NewSavedSearchDialog({
           <LeverConfigSection
             companySlug={companySlug}
             onCompanySlugChange={setCompanySlug}
+            excludedKeywords={leverExcludedKeywords}
+            onExcludedKeywordsChange={setLeverExcludedKeywords}
           />
         )}
 

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/NewSavedSearchDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/NewSavedSearchDialog.test.tsx
@@ -63,6 +63,34 @@ vi.mock("@platform/ui", () => ({
     e instanceof Error ? e.message : String(e),
   InlineBoldText: ({ text }: { text: string }) => <span>{text}</span>,
   Skeleton: () => <div data-testid="skeleton" />,
+  // Used by GreenhouseConfigSection + LeverConfigSection
+  FormField: ({
+    label,
+    children,
+  }: {
+    label: string;
+    children: React.ReactNode;
+  }) => (
+    <div>
+      <label>{label}</label>
+      {children}
+    </div>
+  ),
+  MultiChipInput: ({
+    value,
+    ariaLabel,
+  }: {
+    value: string[];
+    onChange: (v: string[]) => void;
+    ariaLabel?: string;
+    placeholder?: string;
+  }) => (
+    <div data-testid="multi-chip-input" aria-label={ariaLabel}>
+      {value.map((v: string) => (
+        <span key={v}>{v}</span>
+      ))}
+    </div>
+  ),
 }));
 
 // ---------------------------------------------------------------------------
@@ -447,5 +475,49 @@ describe("NewSavedSearchDialog — name field (PR 6)", () => {
     fireEvent.click(screen.getByTestId("cancel-btn"));
     // After close the form is reset; re-open would show blank name
     // (tested at DOM level since open=true re-renders)
+  });
+});
+
+describe("NewSavedSearchDialog — Greenhouse excluded_keywords payload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateSource.mockReturnValue(makeUnwrappableMutation({}));
+  });
+
+  it("omits excluded_keywords from Greenhouse payload when none set", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "greenhouse");
+    const tokenInput = screen.getByLabelText("Greenhouse board token");
+    await userEvent.type(tokenInput, "stripe");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockCreateSource).toHaveBeenCalledWith({
+        source: "greenhouse",
+        config: { board_token: "stripe" },
+        fetch_interval_minutes: 1440,
+      });
+    });
+    // config should NOT have excluded_keywords key when empty
+    const callArgs = mockCreateSource.mock.calls[0][0];
+    expect(callArgs.config).not.toHaveProperty("excluded_keywords");
+  });
+
+  it("omits excluded_keywords from Lever payload when none set", async () => {
+    renderDialog();
+    await userEvent.selectOptions(getSourceSelect(), "lever");
+    const slugInput = screen.getByLabelText("Lever company slug");
+    await userEvent.type(slugInput, "openai");
+    fireEvent.click(screen.getByTestId("confirm-btn"));
+
+    await waitFor(() => {
+      expect(mockCreateSource).toHaveBeenCalledWith({
+        source: "lever",
+        config: { company_slug: "openai" },
+        fetch_interval_minutes: 1440,
+      });
+    });
+    const callArgs = mockCreateSource.mock.calls[0][0];
+    expect(callArgs.config).not.toHaveProperty("excluded_keywords");
   });
 });

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/GreenhouseConfigSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/GreenhouseConfigSection.tsx
@@ -1,56 +1,83 @@
 /**
  * Form section for Greenhouse saved-search config.
  *
- * The operator supplies a single field: board_token — the slug from the
- * Greenhouse board URL: boards.greenhouse.io/<board_token>.
+ * The operator supplies:
+ * - board_token — the slug from the Greenhouse board URL:
+ *   boards.greenhouse.io/<board_token>
+ * - excluded_keywords (optional) — case-insensitive substrings dropped
+ *   from fetched postings before they reach the inbox.
  *
- * Client-side validation mirrors the backend regex:
+ * Client-side validation for board_token mirrors the backend regex:
  * ``^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$``
+ *
+ * min_salary_usd is intentionally absent — Greenhouse's public board feed
+ * does not reliably include salary data, so filtering on it would silently
+ * hide legitimate postings.
  */
+import { MultiChipInput, FormField } from "@platform/ui";
 
 const BOARD_TOKEN_RE = /^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$/;
 
 interface GreenhouseConfigSectionProps {
   boardToken: string;
   onBoardTokenChange: (value: string) => void;
+  excludedKeywords: string[];
+  onExcludedKeywordsChange: (value: string[]) => void;
 }
 
 export default function GreenhouseConfigSection({
   boardToken,
   onBoardTokenChange,
+  excludedKeywords,
+  onExcludedKeywordsChange,
 }: GreenhouseConfigSectionProps) {
   const isInvalid = boardToken.length > 0 && !BOARD_TOKEN_RE.test(boardToken);
 
   return (
-    <div className="space-y-2">
-      <label
-        htmlFor="greenhouse-board-token"
-        className="block text-sm font-medium"
-      >
-        Greenhouse board token
-      </label>
-      <input
-        id="greenhouse-board-token"
-        type="text"
-        className={`w-full rounded border px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
-          isInvalid ? "border-destructive" : "border-border"
-        }`}
-        placeholder="e.g. stripe"
-        value={boardToken}
-        onChange={(e) => onBoardTokenChange(e.target.value.trim())}
-        aria-describedby="greenhouse-board-token-hint"
-        aria-invalid={isInvalid}
-        autoComplete="off"
-        spellCheck={false}
-      />
-      <p
-        id="greenhouse-board-token-hint"
-        className={`text-xs ${isInvalid ? "text-destructive" : "text-muted-foreground"}`}
-      >
-        {isInvalid
-          ? "Invalid token — use letters, digits, hyphens, and underscores only."
-          : "Find this in the Greenhouse board URL: boards.greenhouse.io/​<board_token>"}
-      </p>
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label
+          htmlFor="greenhouse-board-token"
+          className="block text-sm font-medium"
+        >
+          Greenhouse board token
+        </label>
+        <input
+          id="greenhouse-board-token"
+          type="text"
+          className={`w-full rounded border px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
+            isInvalid ? "border-destructive" : "border-border"
+          }`}
+          placeholder="e.g. stripe"
+          value={boardToken}
+          onChange={(e) => onBoardTokenChange(e.target.value.trim())}
+          aria-describedby="greenhouse-board-token-hint"
+          aria-invalid={isInvalid}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p
+          id="greenhouse-board-token-hint"
+          className={`text-xs ${isInvalid ? "text-destructive" : "text-muted-foreground"}`}
+        >
+          {isInvalid
+            ? "Invalid token — use letters, digits, hyphens, and underscores only."
+            : "Find this in the Greenhouse board URL: boards.greenhouse.io/​<board_token>"}
+        </p>
+      </div>
+
+      <FormField label="Exclude keywords (optional)">
+        <MultiChipInput
+          value={excludedKeywords}
+          onChange={onExcludedKeywordsChange}
+          placeholder="junior, intern, ad hoc company name…"
+          ariaLabel="Excluded keywords"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Case-insensitive substring match against title, company, description,
+          and publisher. Salary filtering is not available for Greenhouse sources.
+        </p>
+      </FormField>
     </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/LeverConfigSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/LeverConfigSection.tsx
@@ -1,60 +1,87 @@
 /**
  * Form section for Lever saved-search config.
  *
- * The operator supplies a single field: company_slug — the slug from the
- * Lever URL: jobs.lever.co/<company_slug>.
+ * The operator supplies:
+ * - company_slug — the slug from the Lever URL:
+ *   jobs.lever.co/<company_slug>
+ * - excluded_keywords (optional) — case-insensitive substrings dropped
+ *   from fetched postings before they reach the inbox.
  *
- * Client-side validation mirrors the backend regex (post-lowercase-normalization):
+ * Client-side validation for company_slug mirrors the backend regex
+ * (post-lowercase-normalization):
  * ``^[a-z0-9][a-z0-9-]{0,63}$``
  *
  * We normalize to lowercase on display so the operator can paste slugs
  * without worrying about case.
+ *
+ * min_salary_usd is intentionally absent — Lever's v0 postings feed does
+ * not reliably include salary data.
  */
+import { MultiChipInput, FormField } from "@platform/ui";
 
 const COMPANY_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
 
 interface LeverConfigSectionProps {
   companySlug: string;
   onCompanySlugChange: (value: string) => void;
+  excludedKeywords: string[];
+  onExcludedKeywordsChange: (value: string[]) => void;
 }
 
 export default function LeverConfigSection({
   companySlug,
   onCompanySlugChange,
+  excludedKeywords,
+  onExcludedKeywordsChange,
 }: LeverConfigSectionProps) {
   const normalized = companySlug.toLowerCase();
   const isInvalid = companySlug.length > 0 && !COMPANY_SLUG_RE.test(normalized);
 
   return (
-    <div className="space-y-2">
-      <label
-        htmlFor="lever-company-slug"
-        className="block text-sm font-medium"
-      >
-        Lever company slug
-      </label>
-      <input
-        id="lever-company-slug"
-        type="text"
-        className={`w-full rounded border px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
-          isInvalid ? "border-destructive" : "border-border"
-        }`}
-        placeholder="e.g. openai"
-        value={companySlug}
-        onChange={(e) => onCompanySlugChange(e.target.value.toLowerCase().trim())}
-        aria-describedby="lever-company-slug-hint"
-        aria-invalid={isInvalid}
-        autoComplete="off"
-        spellCheck={false}
-      />
-      <p
-        id="lever-company-slug-hint"
-        className={`text-xs ${isInvalid ? "text-destructive" : "text-muted-foreground"}`}
-      >
-        {isInvalid
-          ? "Invalid slug — use lowercase letters, digits, and hyphens only."
-          : "Find this in the Lever URL: jobs.lever.co/​<company_slug>"}
-      </p>
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <label
+          htmlFor="lever-company-slug"
+          className="block text-sm font-medium"
+        >
+          Lever company slug
+        </label>
+        <input
+          id="lever-company-slug"
+          type="text"
+          className={`w-full rounded border px-3 py-2 text-sm bg-background focus:outline-none focus:ring-2 focus:ring-ring ${
+            isInvalid ? "border-destructive" : "border-border"
+          }`}
+          placeholder="e.g. openai"
+          value={companySlug}
+          onChange={(e) => onCompanySlugChange(e.target.value.toLowerCase().trim())}
+          aria-describedby="lever-company-slug-hint"
+          aria-invalid={isInvalid}
+          autoComplete="off"
+          spellCheck={false}
+        />
+        <p
+          id="lever-company-slug-hint"
+          className={`text-xs ${isInvalid ? "text-destructive" : "text-muted-foreground"}`}
+        >
+          {isInvalid
+            ? "Invalid slug — use lowercase letters, digits, and hyphens only."
+            : "Find this in the Lever URL: jobs.lever.co/​<company_slug>"}
+        </p>
+      </div>
+
+      <FormField label="Exclude keywords (optional)">
+        <MultiChipInput
+          value={excludedKeywords}
+          onChange={onExcludedKeywordsChange}
+          placeholder="junior, intern, ad hoc company name…"
+          ariaLabel="Excluded keywords"
+        />
+        <p className="text-xs text-muted-foreground mt-1">
+          Case-insensitive substring match against title, company, description,
+          and publisher. Salary filtering is not available for Lever sources.
+        </p>
+      </FormField>
     </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/__tests__/GreenhouseConfigSection.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/__tests__/GreenhouseConfigSection.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Tests for GreenhouseConfigSection.
+ *
+ * Covers:
+ * - board_token input renders with correct label
+ * - excluded_keywords MultiChipInput renders
+ * - Invalid token format shows error hint
+ * - Valid token: no error hint shown
+ * - onExcludedKeywordsChange callback fires when chips change
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GreenhouseConfigSection from "../GreenhouseConfigSection";
+
+// ---------------------------------------------------------------------------
+// Mock @platform/ui — we only need FormField + MultiChipInput stubs
+// ---------------------------------------------------------------------------
+vi.mock("@platform/ui", () => ({
+  FormField: ({
+    label,
+    children,
+  }: {
+    label: string;
+    children: React.ReactNode;
+  }) => (
+    <div>
+      <label>{label}</label>
+      {children}
+    </div>
+  ),
+  MultiChipInput: ({
+    value,
+    onChange,
+    ariaLabel,
+  }: {
+    value: string[];
+    onChange: (v: string[]) => void;
+    ariaLabel?: string;
+    placeholder?: string;
+  }) => (
+    <div
+      data-testid="multi-chip-input"
+      aria-label={ariaLabel}
+      onClick={() => onChange([...value, "new-chip"])}
+    >
+      {value.map((v) => (
+        <span key={v} data-testid={`chip-${v}`}>
+          {v}
+        </span>
+      ))}
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GreenhouseConfigSection — board_token field", () => {
+  it("renders the board_token input with correct label", () => {
+    render(
+      <GreenhouseConfigSection
+        boardToken=""
+        onBoardTokenChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("Greenhouse board token")).toBeInTheDocument();
+  });
+
+  it("shows validation error hint for invalid token", () => {
+    render(
+      <GreenhouseConfigSection
+        boardToken="invalid/token"
+        onBoardTokenChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(
+      screen.getByText(/Invalid token/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows help text for valid token", () => {
+    render(
+      <GreenhouseConfigSection
+        boardToken="stripe"
+        onBoardTokenChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/boards\.greenhouse\.io/i)).toBeInTheDocument();
+  });
+});
+
+describe("GreenhouseConfigSection — excluded_keywords field", () => {
+  it("renders the excluded keywords MultiChipInput", () => {
+    render(
+      <GreenhouseConfigSection
+        boardToken="stripe"
+        onBoardTokenChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("multi-chip-input")).toBeInTheDocument();
+  });
+
+  it("renders existing excluded keyword chips", () => {
+    render(
+      <GreenhouseConfigSection
+        boardToken="stripe"
+        onBoardTokenChange={vi.fn()}
+        excludedKeywords={["junior", "intern"]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("chip-junior")).toBeInTheDocument();
+    expect(screen.getByTestId("chip-intern")).toBeInTheDocument();
+  });
+
+  it("calls onExcludedKeywordsChange when chip is added", async () => {
+    const onChange = vi.fn();
+    render(
+      <GreenhouseConfigSection
+        boardToken="stripe"
+        onBoardTokenChange={vi.fn()}
+        excludedKeywords={["junior"]}
+        onExcludedKeywordsChange={onChange}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("multi-chip-input"));
+    expect(onChange).toHaveBeenCalledWith(["junior", "new-chip"]);
+  });
+
+  it("renders the excluded keywords label", () => {
+    render(
+      <GreenhouseConfigSection
+        boardToken="stripe"
+        onBoardTokenChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Exclude keywords/i)).toBeInTheDocument();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/discover/dialog-sections/__tests__/LeverConfigSection.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/dialog-sections/__tests__/LeverConfigSection.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for LeverConfigSection.
+ *
+ * Covers:
+ * - company_slug input renders with correct label
+ * - excluded_keywords MultiChipInput renders
+ * - Invalid slug format shows error hint
+ * - Valid slug: no error hint shown
+ * - Input normalizes to lowercase
+ * - onExcludedKeywordsChange callback fires when chips change
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import LeverConfigSection from "../LeverConfigSection";
+
+// ---------------------------------------------------------------------------
+// Mock @platform/ui — we only need FormField + MultiChipInput stubs
+// ---------------------------------------------------------------------------
+vi.mock("@platform/ui", () => ({
+  FormField: ({
+    label,
+    children,
+  }: {
+    label: string;
+    children: React.ReactNode;
+  }) => (
+    <div>
+      <label>{label}</label>
+      {children}
+    </div>
+  ),
+  MultiChipInput: ({
+    value,
+    onChange,
+    ariaLabel,
+  }: {
+    value: string[];
+    onChange: (v: string[]) => void;
+    ariaLabel?: string;
+    placeholder?: string;
+  }) => (
+    <div
+      data-testid="multi-chip-input"
+      aria-label={ariaLabel}
+      onClick={() => onChange([...value, "new-chip"])}
+    >
+      {value.map((v) => (
+        <span key={v} data-testid={`chip-${v}`}>
+          {v}
+        </span>
+      ))}
+    </div>
+  ),
+}));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("LeverConfigSection — company_slug field", () => {
+  it("renders the company_slug input with correct label", () => {
+    render(
+      <LeverConfigSection
+        companySlug=""
+        onCompanySlugChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("Lever company slug")).toBeInTheDocument();
+  });
+
+  it("shows validation error hint for invalid slug", () => {
+    render(
+      <LeverConfigSection
+        companySlug="Invalid/Slug"
+        onCompanySlugChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Invalid slug/i)).toBeInTheDocument();
+  });
+
+  it("shows help text for valid slug", () => {
+    render(
+      <LeverConfigSection
+        companySlug="openai"
+        onCompanySlugChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/jobs\.lever\.co/i)).toBeInTheDocument();
+  });
+});
+
+describe("LeverConfigSection — excluded_keywords field", () => {
+  it("renders the excluded keywords MultiChipInput", () => {
+    render(
+      <LeverConfigSection
+        companySlug="openai"
+        onCompanySlugChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("multi-chip-input")).toBeInTheDocument();
+  });
+
+  it("renders existing excluded keyword chips", () => {
+    render(
+      <LeverConfigSection
+        companySlug="openai"
+        onCompanySlugChange={vi.fn()}
+        excludedKeywords={["junior", "intern"]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByTestId("chip-junior")).toBeInTheDocument();
+    expect(screen.getByTestId("chip-intern")).toBeInTheDocument();
+  });
+
+  it("calls onExcludedKeywordsChange when chip is added", async () => {
+    const onChange = vi.fn();
+    render(
+      <LeverConfigSection
+        companySlug="openai"
+        onCompanySlugChange={vi.fn()}
+        excludedKeywords={["junior"]}
+        onExcludedKeywordsChange={onChange}
+      />,
+    );
+    await userEvent.click(screen.getByTestId("multi-chip-input"));
+    expect(onChange).toHaveBeenCalledWith(["junior", "new-chip"]);
+  });
+
+  it("renders the excluded keywords label", () => {
+    render(
+      <LeverConfigSection
+        companySlug="openai"
+        onCompanySlugChange={vi.fn()}
+        excludedKeywords={[]}
+        onExcludedKeywordsChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Exclude keywords/i)).toBeInTheDocument();
+  });
+});

--- a/apps/myjobhunter/frontend/src/types/discovery/discovery-source-configs.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovery-source-configs.ts
@@ -30,12 +30,26 @@ export interface JSearchConfig {
 export interface GreenhouseConfig {
   /** The board token from the URL: boards.greenhouse.io/<board_token> */
   board_token: string;
+  /**
+   * Case-insensitive substrings to drop from fetched postings.
+   * Matched against title, company, description, and publisher.
+   * min_salary_usd is intentionally absent — Greenhouse feeds don't
+   * reliably include salary data.
+   */
+  excluded_keywords?: string[];
 }
 
 /** Config for a Lever public job-board saved search. */
 export interface LeverConfig {
   /** The company slug from the URL: jobs.lever.co/<company_slug> */
   company_slug: string;
+  /**
+   * Case-insensitive substrings to drop from fetched postings.
+   * Matched against title, company, description, and publisher.
+   * min_salary_usd is intentionally absent — Lever feeds don't
+   * reliably include salary data.
+   */
+  excluded_keywords?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary

Resolves two Medium-Low tech debt items from `apps/myjobhunter/TECH_DEBT.md` under **## Discovery adapter follow-ups (2026-05-11)**.

### Item 1 — Greenhouse company_name N+1 (was: every fetch_board() makes two HTTP requests)

- `fetch_board()` now returns `tuple[list[dict], str | None]`; the second element is the resolved company display name
- Added `GreenhouseFetchConfig` — a fetch-time supertype of `GreenhouseSourceConfig` with `resolved_company_name: str | None` field and `extra="ignore"` so legacy JSONB rows round-trip cleanly
- `_run_greenhouse` in the fetch service unpacks the tuple and writes `resolved_company_name` back to `source.config` JSONB in the same DB transaction — the next fetch sees the cached name and skips the metadata HTTP call
- Write-time `GreenhouseSourceConfig` keeps `extra="forbid"`; API callers cannot inject `resolved_company_name`

### Item 2 — excluded_keywords not wired to Greenhouse / Lever configs

- Added `excluded_keywords: list[str] = []` to `GreenhouseSourceConfig` and `LeverSourceConfig` — the existing `_apply_post_fetch_filters` in the fetch service reads this field from the raw config dict automatically (no service changes needed)
- Added `MultiChipInput` excluded-keywords field to `GreenhouseConfigSection.tsx` and `LeverConfigSection.tsx` — same UX as JSearch's exclusions section
- `NewSavedSearchDialog.tsx` wired: new state vars + `buildConfig()` includes the field when non-empty + `resetAll()` clears both
- `GreenhouseConfig` / `LeverConfig` TypeScript interfaces updated with `excluded_keywords?: string[]`
- `min_salary_usd` intentionally absent from both sources (Greenhouse/Lever public feeds don't reliably include salary data — filtering on it would silently hide legitimate postings)

## Tests

- **55 backend unit tests pass** (21 new/updated across `test_greenhouse_adapter.py`, `test_lever_adapter.py`, `test_discovery_post_fetch_filters.py`)
- **37 frontend tests pass** (2 new test files: `GreenhouseConfigSection.test.tsx`, `LeverConfigSection.test.tsx`; 2 new payload tests + FormField/MultiChipInput stubs added to `NewSavedSearchDialog.test.tsx`)
- TypeCheck: clean (`tsc --noEmit`)
- Lint: 0 errors, 9 pre-existing warnings (all documented in TECH_DEBT.md)

## Test plan

- [ ] Backend: `pytest tests/test_greenhouse_adapter.py tests/test_lever_adapter.py tests/test_discovery_post_fetch_filters.py` — 55 passed
- [ ] Frontend: all new test files pass; `npm run typecheck` clean; `npm run lint` 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)