### PR TITLE
feat(mjh/discover): score-staleness UI signal after profile change

### DIFF
--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
@@ -87,6 +87,11 @@ export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps
   // simply has nothing to attach to.
   const hasUnscored = items.some((job) => job.score === null);
 
+  // Pass profile.updated_at to each card so the card can detect
+  // when its score was computed against an older profile snapshot
+  // (profile changed after scored_at → "Re-scoring soon" pill).
+  const profileUpdatedAt = profile?.updated_at ?? null;
+
   return (
     <div className="space-y-3">
       {profileBanner}
@@ -95,6 +100,7 @@ export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps
           key={job.id}
           job={job}
           isScoringInFlight={hasUnscored}
+          profileUpdatedAt={profileUpdatedAt}
         />
       ))}
     </div>

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
@@ -36,6 +36,16 @@ interface DiscoveredJobCardProps {
    * existing callers (and tests) keep their current behaviour.
    */
   isScoringInFlight?: boolean;
+  /**
+   * ISO timestamp of the last profile update (from GET /profile
+   * ``updated_at``). When this is more recent than ``job.scored_at``,
+   * the card's existing score was computed against an older profile
+   * snapshot and the worker will re-score on its next pass.
+   *
+   * Optional — defaults to null so callers that don't have the
+   * profile loaded yet show no staleness signal.
+   */
+  profileUpdatedAt?: string | null;
 }
 
 const REMOTE_LABEL: Record<string, string> = {
@@ -60,6 +70,7 @@ const VERDICT_VISUAL: Record<JobAnalysisVerdict, VerdictVisual> = {
 export default function DiscoveredJobCard({
   job,
   isScoringInFlight = false,
+  profileUpdatedAt = null,
 }: DiscoveredJobCardProps) {
   const [dismiss, { isLoading: isDismissing }] = useDismissDiscoveredJobMutation();
   const [save, { isLoading: isSaving }] = useSaveDiscoveredJobMutation();
@@ -109,6 +120,18 @@ export default function DiscoveredJobCard({
   const verdictVisual = job.verdict ? VERDICT_VISUAL[job.verdict] ?? null : null;
   const isUnscored = job.verdict === null && job.score === null;
 
+  // A scored card is "stale" when the operator has updated their profile
+  // AFTER the score was computed. The worker will re-score on its next pass;
+  // this pill lets the operator know the current score may not reflect their
+  // latest skills/experience without waiting for the worker to run.
+  // Only applies when the card actually has a score — truly unscored cards
+  // already show "Awaiting AI score" / the scoring spinner.
+  const isScoreStale =
+    !isUnscored &&
+    job.scored_at !== null &&
+    profileUpdatedAt !== null &&
+    new Date(profileUpdatedAt) > new Date(job.scored_at);
+
   return (
     <>
     <UndoDismissToast
@@ -129,6 +152,15 @@ export default function DiscoveredJobCard({
         </div>
         <div className="flex items-start gap-1.5 shrink-0">
           {verdictVisual && <Badge label={verdictVisual.label} color={verdictVisual.color} />}
+          {isScoreStale && (
+            <span
+              className="px-2 py-0.5 text-xs text-amber-700 dark:text-amber-400 border border-amber-300 dark:border-amber-700 rounded"
+              data-testid="discovered-job-score-stale"
+              title="Your profile changed after this score was computed. It will be re-scored on the next pass."
+            >
+              Re-scoring soon
+            </span>
+          )}
           {!verdictVisual && isUnscored && isScoringInFlight && (
             <span
               className="inline-flex items-center gap-1 px-2 py-0.5 text-xs text-muted-foreground border border-muted rounded"

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
@@ -163,6 +163,108 @@ describe("DiscoveredJobCard — unscored visual signal (PR 4b)", () => {
   });
 });
 
+describe("DiscoveredJobCard — score-staleness pill (score-staleness-signal PR)", () => {
+  // A scored job with a profile-updated-at that is NEWER than scored_at
+  // → the score is stale, the "Re-scoring soon" pill should appear.
+  it("shows 'Re-scoring soon' pill when scored_at is older than profileUpdatedAt", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({
+          verdict: "strong_fit",
+          score: 90,
+          scored_at: "2026-05-08T10:00:00Z",
+        })}
+        profileUpdatedAt="2026-05-09T12:00:00Z"
+      />,
+    );
+    expect(
+      screen.getByTestId("discovered-job-score-stale"),
+    ).toBeInTheDocument();
+  });
+
+  it("does NOT show the staleness pill when scored_at is newer than profileUpdatedAt", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({
+          verdict: "strong_fit",
+          score: 90,
+          scored_at: "2026-05-10T10:00:00Z",
+        })}
+        profileUpdatedAt="2026-05-09T12:00:00Z"
+      />,
+    );
+    expect(
+      screen.queryByTestId("discovered-job-score-stale"),
+    ).toBeNull();
+  });
+
+  it("does NOT show the staleness pill when profileUpdatedAt is null", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({
+          verdict: "strong_fit",
+          score: 90,
+          scored_at: "2026-05-08T10:00:00Z",
+        })}
+        profileUpdatedAt={null}
+      />,
+    );
+    expect(
+      screen.queryByTestId("discovered-job-score-stale"),
+    ).toBeNull();
+  });
+
+  it("does NOT show the staleness pill when profileUpdatedAt is omitted (default)", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({
+          verdict: "strong_fit",
+          score: 90,
+          scored_at: "2026-05-08T10:00:00Z",
+        })}
+      />,
+    );
+    expect(
+      screen.queryByTestId("discovered-job-score-stale"),
+    ).toBeNull();
+  });
+
+  it("does NOT show the staleness pill for a truly unscored card (score=null) even if profile is newer", () => {
+    // An unscored card already shows "Awaiting AI score". The staleness pill
+    // is only meaningful when there IS an existing score to call stale.
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({ verdict: null, score: null, scored_at: null })}
+        profileUpdatedAt="2026-05-09T12:00:00Z"
+      />,
+    );
+    expect(
+      screen.queryByTestId("discovered-job-score-stale"),
+    ).toBeNull();
+    // The regular "Awaiting AI score" pill should still be there.
+    expect(
+      screen.getByTestId("discovered-job-awaiting-score"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows both the verdict badge AND the staleness pill for a stale scored card", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({
+          verdict: "worth_considering",
+          score: 70,
+          scored_at: "2026-05-08T10:00:00Z",
+        })}
+        profileUpdatedAt="2026-05-09T12:00:00Z"
+      />,
+    );
+    // Verdict badge rendered (via the mocked Badge)
+    expect(screen.getByTestId("badge")).toHaveTextContent("Worth considering");
+    // Staleness pill also rendered
+    expect(screen.getByTestId("discovered-job-score-stale")).toBeInTheDocument();
+  });
+});
+
 describe("DiscoveredJobCard — post-promote view application link (PR 7)", () => {
   it("shows 'Applied' badge when job is promoted", () => {
     renderInRouter(


### PR DESCRIPTION
## Summary

- Closes the gap noted in the 2026-05-11 discovery design pass: when the operator updates their profile (skills, work history, resume) after job cards have been scored, there was no UI signal that existing scores may be stale.
- Adds a small amber **"Re-scoring soon"** informational pill to `DiscoveredJobCard` when `scored_at < profile.updated_at`. The worker's next pass will re-score those rows automatically; this pill just surfaces that the score the operator is seeing was computed against an older snapshot.
- No backend changes: `scored_at` was already in `DiscoveredJobResponse`; `profile.updated_at` was already fetched in `DiscoverInboxView` via `useGetProfileQuery()`. Zero new API calls.

## Design decisions

- **Frontend comparison instead of `is_score_stale` backend field.** The data was already available at the parent level (`DiscoverInboxView` already calls `useGetProfileQuery`). Keeping the comparison on the frontend avoids a backend serializer change and keeps the `DiscoveredJobResponse` schema stable. If staleness logic ever needs to account for things the frontend can't see (e.g. skills sub-resources updated_at vs profile.updated_at), that's when an `is_score_stale` backend field would be worth adding.
- **Pill only appears for scored cards.** Truly unscored cards (`score === null`) already show "Awaiting AI score" / the scoring spinner. Staleness is only meaningful when there's an existing score to call stale.
- Amber color (`text-amber-700 / border-amber-300`) distinguishes this from the verdict badges (colored) and the "Awaiting" pill (muted gray). Informational-only — no click handler.

## Scope

**MJH-only.** Does not touch MBK, `packages/shared-backend`, or `packages/shared-frontend`. Safe to merge in parallel with the MBK React 19 migration sequence.

## Test plan

- [x] `DiscoveredJobCard.test.tsx` — 6 new unit tests covering all state combinations (stale, fresh, null profileUpdatedAt, omitted prop, unscored card, stale with verdict badge)
- [x] `npm run typecheck` — clean (0 errors)
- [x] `npm run lint` — 0 errors, 9 pre-existing warnings (not in touched files)
- [x] `npm run build` — clean production build

🤖 Generated with [Claude Code](https://claude.com/claude-code)