### PR TITLE
chore(mbk): parity cleanup — @dnd-kit/sortable, tailwind-merge, @eslint/js (PR 5 of React 19 migration)

### DIFF
--- a/apps/mybookkeeper/frontend/package-lock.json
+++ b/apps/mybookkeeper/frontend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dialog": "^1.1.2",
@@ -35,7 +35,7 @@
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.26.2",
         "recharts": "^3.8.1",
-        "tailwind-merge": "^2.5.2",
+        "tailwind-merge": "^3.5.0",
         "vaul": "^1.1.2"
       },
       "devDependencies": {
@@ -541,15 +541,15 @@
       }
     },
     "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
       },
       "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
+        "@dnd-kit/core": "^6.3.0",
         "react": ">=16.8.0"
       }
     },
@@ -6463,9 +6463,9 @@
       "dev": true
     },
     "node_modules/tailwind-merge": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
-      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/dcastil"

--- a/apps/mybookkeeper/frontend/package.json
+++ b/apps/mybookkeeper/frontend/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
-    "@dnd-kit/sortable": "^8.0.0",
+    "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-dialog": "^1.1.2",
@@ -41,7 +41,7 @@
     "react-redux": "^9.2.0",
     "react-router-dom": "^6.26.2",
     "recharts": "^3.8.1",
-    "tailwind-merge": "^2.5.2",
+    "tailwind-merge": "^3.5.0",
     "vaul": "^1.1.2"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
-        "@dnd-kit/sortable": "^8.0.0",
+        "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-dialog": "^1.1.2",
@@ -41,7 +41,7 @@
         "react-redux": "^9.2.0",
         "react-router-dom": "^6.26.2",
         "recharts": "^3.8.1",
-        "tailwind-merge": "^2.5.2",
+        "tailwind-merge": "^3.5.0",
         "vaul": "^1.1.2"
       },
       "devDependencies": {
@@ -66,6 +66,19 @@
         "typescript-eslint": "^8.59.1",
         "vite": "^8.0.12",
         "vitest": "^4.1.5"
+      }
+    },
+    "apps/mybookkeeper/frontend/node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
       }
     },
     "apps/mybookkeeper/frontend/node_modules/@vitejs/plugin-react": {
@@ -131,6 +144,15 @@
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "apps/mybookkeeper/frontend/node_modules/tailwind-merge": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.6.0.tgz",
+      "integrity": "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "apps/mybookkeeper/frontend/node_modules/typescript": {
@@ -988,19 +1010,6 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@dnd-kit/sortable": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-8.0.0.tgz",
-      "integrity": "sha512-U3jk5ebVXe1Lr7c2wU7SBZjcWdQP+j7peHJfCspnA81enlu88Mgd7CC8Q+pub9ubP7eKVETzJW+IBAhsqbSu/g==",
-      "dependencies": {
-        "@dnd-kit/utilities": "^3.2.2",
-        "tslib": "^2.0.0"
-      },
-      "peerDependencies": {
-        "@dnd-kit/core": "^6.1.0",
-        "react": ">=16.8.0"
       }
     },
     "node_modules/@dnd-kit/utilities": {
@@ -8237,15 +8246,6 @@
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
-    },
-    "node_modules/tailwind-merge": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
-      "integrity": "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==",
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/dcastil"
-      }
     },
     "node_modules/tailwindcss": {
       "version": "3.4.19",


### PR DESCRIPTION
## Summary

Brings MBK inline with MJH on two low-risk packages (three were targeted; `@eslint/js` held — see below):

| Package | Before | After | Notes |
|---------|--------|-------|-------|
| `@dnd-kit/sortable` | `^8.0.0` | `^10.0.0` | MJH already on 10.x |
| `tailwind-merge` | `^2.5.2` | `^3.5.0` | MJH + @platform/ui already on 3.x |
| `@eslint/js` | `^9.39.4` | **unchanged** | See note below |

### `@eslint/js` — intentionally held at 9.x

`@eslint/js@10` has `peerOptional eslint@"^10.0.0"`. MBK is on `eslint@9.x`. Running `npm install` with `@eslint/js@^10.0.1` produced `ERESOLVE` — the dependency conflict is real, not just a warning. Bumping it would require co-bumping `eslint` to 10, which is out of scope for this parity-only PR. Held at `^9.39.4`; MJH parity on this package deferred until an eslint-10 bump PR.

## Step 1: Usage survey

**`@dnd-kit/sortable`** — used in two files:
- `src/app/features/listings/ListingPhotoCard.tsx` — `useSortable({ id })`, reads `attributes`, `listeners`, `setNodeRef`, `transform`, `transition`, `isDragging`. All stable APIs, unchanged in v10.
- `src/app/features/listings/ListingPhotoManager.tsx` — `SortableContext`, `arrayMove`, `rectSortingStrategy`, `sortableKeyboardCoordinates`. All stable APIs, unchanged in v10.

MJH runs `@dnd-kit/core@6.3.1` + `@dnd-kit/sortable@10.0.0` without issues (verified via `npm ls`). MBK uses the same core version — peerDep `^6.3.0` is satisfied.

**`tailwind-merge`** — consumed via the `cn()` helper across ~50+ components. v3 dropped legacy Tailwind class name aliases (e.g., `text-opacity-*`). MBK uses no deprecated class names. Function signature is unchanged.

**Peer warnings**: none. `npm ci --no-workspaces` passes with no warnings.

## Validation

- Build: clean (`vite v8.0.12`, 13.5s)
- TypeScript: `npx tsc --noEmit` clean
- Lint: 4 pre-existing errors preserved (React Compiler rules: `Date.now` in render, `setState` in effect — pre-date this PR), 0 new errors
- Unit tests: 1732 passed | 11 failed — all failures are pre-existing (Documents, hourly-rate, LeaseTemplateUploadDialog, PromoteFromInquiryPanel, PublicInquiryForm). **All `ListingPhotoManager` tests pass** — these are the tests that exercise `@dnd-kit/sortable` directly.
- `npm ci --no-workspaces` passes — simulates the `frontend-lockfile-drift` CI check that Docker depends on

## Lockfiles

Both lockfiles updated: workspace root (`package-lock.json`) and per-app (`apps/mybookkeeper/frontend/package-lock.json`). The per-app lockfile is load-bearing for Docker's `npm ci` in `caddy.Dockerfile`.

## No operational migration required

Pure dev-dependency + library version bumps. No env vars changed, no API surface changed, no Docker changes required.