### PR TITLE
chore(shared-frontend): tighten react peerDep to ^19 (PR 7 of React 19 migration)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8948,7 +8948,7 @@
     },
     "packages/shared-frontend": {
       "name": "@platform/ui",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.1",
         "@radix-ui/react-dropdown-menu": "^2.1.1",
@@ -8979,8 +8979,8 @@
       },
       "peerDependencies": {
         "@reduxjs/toolkit": "^2",
-        "react": "^18 || ^19",
-        "react-dom": "^18 || ^19",
+        "react": "^19",
+        "react-dom": "^19",
         "react-redux": "^9",
         "react-router-dom": "^6 || ^7"
       }

--- a/packages/shared-frontend/package.json
+++ b/packages/shared-frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@platform/ui",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -10,8 +10,8 @@
     "test:watch": "vitest"
   },
   "peerDependencies": {
-    "react": "^18 || ^19",
-    "react-dom": "^18 || ^19",
+    "react": "^19",
+    "react-dom": "^19",
     "@reduxjs/toolkit": "^2",
     "react-redux": "^9",
     "react-router-dom": "^6 || ^7"


### PR DESCRIPTION
## Summary

Final mandatory PR (7 of 7) in the MBK React 19 migration sequence. Tightens the `@platform/ui` peerDep from the transitional `^18 || ^19` accommodation to strict `^19`.

The optionality was needed while MBK was still on React 18. As of PR #589, both MBK and MJH consume `@platform/ui` on React 19, so the optionality has zero remaining value and creates a confusing peer-resolution surface where a future regression to React 18 would not trigger an npm warning.

## Changes

- `packages/shared-frontend/package.json`:
  - `peerDependencies.react`: `^18 || ^19` -> `^19`
  - `peerDependencies.react-dom`: `^18 || ^19` -> `^19`
  - `version`: `0.1.0` -> `0.2.0` (breaking peerDep change)
- `package-lock.json` reflects the version + peerDep bump only (no resolution changes; both apps were already on React 19).

## Verification

- `npm install` from monorepo root: clean, no resolution changes
- `npm install` in `apps/mybookkeeper/frontend`: no react/react-dom peer warnings
- `npm install` in `apps/myjobhunter/frontend`: no react/react-dom peer warnings
- `npm run build --workspace=apps/mybookkeeper/frontend`: clean
- `npm run build --workspace=apps/myjobhunter/frontend`: clean

## Operational migration

No operational migration required. This is a build-time peerDep tighten; no runtime env or VPS config changes.

## Test plan

- [x] Monorepo root `npm install` produces a minimal lockfile diff (version + peerDeps only)
- [x] MBK frontend installs with no react/react-dom peer warnings
- [x] MJH frontend installs with no react/react-dom peer warnings
- [x] MBK frontend builds clean
- [x] MJH frontend builds clean