### PR TITLE
fix(mbk/email): set needs_reauth on Gmail send 401/refresh + fetch 401

### DIFF
--- a/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from typing import cast
 
 from google.auth.exceptions import RefreshError
+from googleapiclient.errors import HttpError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.context import RequestContext
@@ -77,6 +78,19 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
                 org_id, ctx.user_id, exc,
             )
             raise GmailAuthExpiredError(str(exc)) from exc
+        except HttpError as exc:
+            status = getattr(getattr(exc, "resp", None), "status", None)
+            if status == 401:
+                await integration_repo.mark_needs_reauth(
+                    db, integration, f"HttpError 401: {exc!r}"[:200], datetime.now(timezone.utc)
+                )
+                await _record_auth_expired_sync_log(db, ctx)
+                logger.warning(
+                    "Gmail token rejected (401) for org=%s user=%s during discovery: status=%s",
+                    org_id, ctx.user_id, status,
+                )
+                raise GmailAuthExpiredError(str(exc)) from exc
+            raise
         logger.info(
             "Gmail discovery: matched=%d new=%d (skipped %d already-processed)",
             gmail_matches_total, len(new_ids), gmail_matches_total - len(new_ids),
@@ -118,6 +132,32 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
                     org_id, ctx.user_id, message_id, exc,
                 )
                 raise GmailAuthExpiredError(str(exc)) from exc
+            except HttpError as exc:
+                status = getattr(getattr(exc, "resp", None), "status", None)
+                if status == 401:
+                    await integration_repo.mark_needs_reauth(
+                        db, integration, f"HttpError 401: {exc!r}"[:200], datetime.now(timezone.utc)
+                    )
+                    await sync_log_repo.mark_completed(db, log, "failed", error=GMAIL_AUTH_EXPIRED_SYNC_LOG_ERROR)
+                    logger.warning(
+                        "Gmail token rejected (401) for org=%s user=%s while fetching sources for message %s: status=%s",
+                        org_id, ctx.user_id, message_id, status,
+                    )
+                    raise GmailAuthExpiredError(str(exc)) from exc
+                # Non-401 HttpError — skip this message, don't abort the entire sync.
+                logger.warning(
+                    "gmail_discovery: skipped message_id=%s org=%s user=%s exc=%s msg=%s",
+                    message_id, org_id, ctx.user_id, type(exc).__name__, exc,
+                    exc_info=True,
+                )
+                await gmail_skipped_message_repo.record_skip(
+                    db,
+                    organization_id=org_id,
+                    user_id=ctx.user_id,
+                    gmail_message_id=message_id,
+                    exc=exc,
+                )
+                continue
             except Exception as e:
                 logger.warning(
                     "gmail_discovery: skipped message_id=%s org=%s user=%s exc=%s msg=%s",

--- a/apps/mybookkeeper/backend/app/services/email/email_fetch_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_fetch_service.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from typing import cast
 
 from google.auth.exceptions import RefreshError
+from googleapiclient.errors import HttpError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
@@ -120,6 +121,32 @@ async def _fetch_next_pending(ctx: RequestContext) -> FetchResult:
             if item_ref:
                 await email_queue_repo.mark_status(db, item_ref, "failed", error="Gmail auth expired")
         raise GmailReauthRequiredError(str(exc)) from exc
+
+    except HttpError as exc:
+        status = getattr(getattr(exc, "resp", None), "status", None)
+        if status == 401:
+            logger.warning(
+                "Gmail token rejected (401) for org=%s while fetching queue item %s: status=%s",
+                ctx.organization_id, item_id, status,
+            )
+            async with unit_of_work() as db:
+                integration = await integration_repo.get_by_org_and_provider(db, ctx.organization_id, "gmail")
+                if integration:
+                    await integration_repo.mark_needs_reauth(
+                        db, integration, f"HttpError 401: {exc!r}"[:200], datetime.now(timezone.utc)
+                    )
+                item_ref = await email_queue_repo.get_by_id(db, item_id)
+                if item_ref:
+                    await email_queue_repo.mark_status(db, item_ref, "failed", error="Gmail auth expired (401)")
+            raise GmailReauthRequiredError(str(exc)) from exc
+        # Non-401 HttpError — treat as a transient failure, not a reauth event.
+        logger.exception("Gmail HttpError (status=%s) fetching queue item %s", status, item_id)
+        async with unit_of_work() as db:
+            item_ref = await email_queue_repo.get_by_id(db, item_id)
+            if item_ref:
+                await email_queue_repo.mark_status(db, item_ref, "failed", error=str(exc)[:1000])
+            await _fail_sync_log_if_done(db, sync_log_id, str(exc))
+        return FetchResult("failed", error=str(exc))
 
     except Exception as e:
         logger.exception("Failed to fetch queue item %s", item_id)

--- a/apps/mybookkeeper/backend/app/services/email/gmail_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/gmail_service.py
@@ -1,6 +1,7 @@
 import base64
 import logging
 import re
+from datetime import datetime, timezone
 from email.message import EmailMessage
 from email.utils import make_msgid
 from pathlib import Path
@@ -11,6 +12,8 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build
 from googleapiclient.errors import HttpError
 from app.core.config import settings
+from app.db.session import unit_of_work
+from app.repositories import integration_repo
 from app.services.email.exceptions import GmailReauthRequiredError, GmailSendError, GmailSendScopeError
 
 logger = logging.getLogger(__name__)
@@ -310,7 +313,7 @@ def _collect_attachments(payload: _GmailPayload, service, message_id: str, resul
         _collect_attachments(part, service, message_id, result)
 
 
-def send_message_with_attachment(
+async def send_message_with_attachment(
     integration,  # type: ignore[no-untyped-def] — app.models.integrations.Integration, avoid circular import
     *,
     from_address: str,
@@ -329,6 +332,9 @@ def send_message_with_attachment(
     Raises the same GmailReauthRequiredError / GmailSendScopeError /
     GmailSendError hierarchy as ``send_message`` so callers can handle errors
     uniformly.
+
+    Contract: when ``GmailReauthRequiredError`` is raised, ``Integration.needs_reauth``
+    has already been set to ``True`` in the database before this function returns.
     """
     if not integration.access_token:
         raise GmailSendScopeError("Gmail integration has no access token")
@@ -359,14 +365,34 @@ def send_message_with_attachment(
             userId="me", body={"raw": raw},
         ).execute()
     except RefreshError as exc:
-        logger.warning("Gmail send rejected — refresh token invalid: %s", exc)
+        logger.warning(
+            "Gmail send rejected — refresh token invalid: %s", exc,
+        )
+        async with unit_of_work() as db:
+            stale = await integration_repo.get_by_org_and_provider(
+                db, integration.organization_id, "gmail"
+            )
+            if stale is not None:
+                await integration_repo.mark_needs_reauth(
+                    db, stale, repr(exc)[:200], datetime.now(timezone.utc)
+                )
         raise GmailReauthRequiredError(
             "Gmail token expired. Reconnect Gmail to send receipts."
         ) from exc
     except HttpError as exc:
         status = getattr(getattr(exc, "resp", None), "status", None)
         if status == 401:
-            logger.warning("Gmail send rejected with 401 — token rejected by Google")
+            logger.warning(
+                "Gmail send rejected with 401 — token rejected by Google: status=%s", status,
+            )
+            async with unit_of_work() as db:
+                stale = await integration_repo.get_by_org_and_provider(
+                    db, integration.organization_id, "gmail"
+                )
+                if stale is not None:
+                    await integration_repo.mark_needs_reauth(
+                        db, stale, f"HttpError 401: {exc!r}"[:200], datetime.now(timezone.utc)
+                    )
             raise GmailReauthRequiredError(
                 "Gmail token rejected (401). Reconnect Gmail to send receipts."
             ) from exc
@@ -389,7 +415,7 @@ def send_message_with_attachment(
     return sent_id
 
 
-def send_message(
+async def send_message(
     integration,  # type: ignore[no-untyped-def] — app.models.integrations.Integration, avoid circular import
     *,
     from_address: str,
@@ -411,6 +437,9 @@ def send_message(
 
     Returns the Gmail-issued message ID (used to dedup replies and to look
     up the message on the server later).
+
+    Contract: when ``GmailReauthRequiredError`` is raised, ``Integration.needs_reauth``
+    has already been set to ``True`` in the database before this function returns.
 
     Raises:
         GmailSendScopeError: 403 because the integration lacks ``gmail.send``.
@@ -444,14 +473,34 @@ def send_message(
             userId="me", body={"raw": raw},
         ).execute()
     except RefreshError as exc:
-        logger.warning("Gmail send rejected — refresh token invalid: %s", exc)
+        logger.warning(
+            "Gmail send rejected — refresh token invalid: %s", exc,
+        )
+        async with unit_of_work() as db:
+            stale = await integration_repo.get_by_org_and_provider(
+                db, integration.organization_id, "gmail"
+            )
+            if stale is not None:
+                await integration_repo.mark_needs_reauth(
+                    db, stale, repr(exc)[:200], datetime.now(timezone.utc)
+                )
         raise GmailReauthRequiredError(
             "Gmail token expired. Reconnect Gmail to send replies."
         ) from exc
     except HttpError as exc:
         status = getattr(getattr(exc, "resp", None), "status", None)
         if status == 401:
-            logger.warning("Gmail send rejected with 401 — token rejected by Google")
+            logger.warning(
+                "Gmail send rejected with 401 — token rejected by Google: status=%s", status,
+            )
+            async with unit_of_work() as db:
+                stale = await integration_repo.get_by_org_and_provider(
+                    db, integration.organization_id, "gmail"
+                )
+                if stale is not None:
+                    await integration_repo.mark_needs_reauth(
+                        db, stale, f"HttpError 401: {exc!r}"[:200], datetime.now(timezone.utc)
+                    )
             raise GmailReauthRequiredError(
                 "Gmail token rejected (401). Reconnect Gmail to send replies."
             ) from exc

--- a/apps/mybookkeeper/backend/app/services/inquiries/inquiry_reply_service.py
+++ b/apps/mybookkeeper/backend/app/services/inquiries/inquiry_reply_service.py
@@ -113,7 +113,7 @@ async def send_reply(
 
     # ----- Phase 2: send via Gmail (network call, no DB) -----
     try:
-        sent_message_id = gmail_service.send_message(
+        sent_message_id = await gmail_service.send_message(
             integration,
             from_address=from_address,
             to_address=to_address,
@@ -122,18 +122,8 @@ async def send_reply(
             in_reply_to_message_id=original_email_message_id,
         )
     except GmailReauthRequiredError as exc:
-        # Token was rejected by Google. Flip the flag so the UI shows the
-        # reconnect prompt immediately. Use a short-lived session so the
-        # flag write commits even if this function is called from a route
-        # that has no enclosing transaction.
-        async with unit_of_work() as db:
-            stale = await integration_repo.get_by_org_and_provider(
-                db, organization_id, "gmail",
-            )
-            if stale is not None:
-                await integration_repo.mark_needs_reauth(
-                    db, stale, repr(exc)[:200], _dt.datetime.now(_dt.timezone.utc)
-                )
+        # needs_reauth is already set by send_message before raising.
+        # Map to the caller-facing error type for the route handler.
         raise InquiryReplyAuthExpiredError(str(exc)) from exc
     except GmailSendScopeError as exc:
         # Defensive — we already checked scope but Google may have revoked

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
@@ -395,7 +395,7 @@ async def send_receipt(
             f"Amount: ${txn_amount:,.2f}\n\n"
             f"Thank you,\n{landlord_name}"
         )
-        gmail_service.send_message_with_attachment(
+        await gmail_service.send_message_with_attachment(
             integration,
             from_address=from_address,
             to_address=tenant_email,
@@ -406,19 +406,12 @@ async def send_receipt(
             attachment_content_type="application/pdf",
         )
     except GmailReauthRequiredError as exc:
-        # Roll back storage upload on failure
+        # needs_reauth is already set by send_message_with_attachment before raising.
+        # Roll back storage upload and surface the caller-facing error.
         try:
             storage.delete_file(storage_key)
         except Exception:
             logger.warning("Could not clean up orphaned receipt PDF at %s", storage_key)
-        async with unit_of_work() as db:
-            stale = await integration_repo.get_by_org_and_provider(
-                db, organization_id, "gmail",
-            )
-            if stale is not None:
-                await integration_repo.mark_needs_reauth(
-                    db, stale, repr(exc)[:200], now,
-                )
         raise ReceiptGmailReauthError(str(exc)) from exc
     except (GmailSendScopeError, GmailSendError) as exc:
         try:

--- a/apps/mybookkeeper/backend/app/test_helpers/mocks.py
+++ b/apps/mybookkeeper/backend/app/test_helpers/mocks.py
@@ -44,7 +44,7 @@ async def enable_mock_gmail_send(
     if getattr(gmail_service, "_real_send_message", None) is None:
         gmail_service._real_send_message = gmail_service.send_message  # type: ignore[attr-defined]
 
-    def _stub(*args: object, **kwargs: object) -> str:
+    async def _stub(*args: object, **kwargs: object) -> str:
         return f"<e2e-mock-{uuid.uuid4().hex[:12]}@mybookkeeper.app>"
 
     gmail_service.send_message = _stub  # type: ignore[assignment]
@@ -52,7 +52,7 @@ async def enable_mock_gmail_send(
     if getattr(gmail_service, "_real_send_message_with_attachment", None) is None:
         gmail_service._real_send_message_with_attachment = gmail_service.send_message_with_attachment  # type: ignore[attr-defined]
 
-    def _attachment_stub(*args: object, **kwargs: object) -> str:
+    async def _attachment_stub(*args: object, **kwargs: object) -> str:
         global _last_gmail_attachment_send
         _last_gmail_attachment_send = {
             "to_address": kwargs.get("to_address"),

--- a/apps/mybookkeeper/backend/tests/test_gmail_service_send.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_service_send.py
@@ -11,8 +11,10 @@ Covers:
 from __future__ import annotations
 
 import base64
+import uuid
+from contextlib import asynccontextmanager
 from typing import Any
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from googleapiclient.errors import HttpError
@@ -27,6 +29,7 @@ class _FakeIntegration:
     def __init__(self, *, access_token: str = "tok", refresh_token: str | None = "rt") -> None:
         self.access_token = access_token
         self.refresh_token = refresh_token
+        self.organization_id = uuid.uuid4()
 
 
 def _make_http_error(status: int) -> HttpError:
@@ -58,12 +61,24 @@ def _captured_send_call(captured: dict[str, Any]) -> Any:
     return fake_service
 
 
+def _no_op_uow():
+    """Fake unit_of_work that yields a no-op DB for the mark_needs_reauth path."""
+    fake_db = MagicMock()
+
+    @asynccontextmanager
+    async def _uow():
+        yield fake_db
+
+    return _uow
+
+
 class TestSendMessageHappyPath:
-    def test_builds_correct_rfc5322_message(self) -> None:
+    @pytest.mark.asyncio
+    async def test_builds_correct_rfc5322_message(self) -> None:
         captured: dict[str, Any] = {}
         fake = _captured_send_call(captured)
         with patch.object(gmail_service, "get_gmail_service", return_value=fake):
-            sent_id = gmail_service.send_message(
+            sent_id = await gmail_service.send_message(
                 _FakeIntegration(),
                 from_address="host@gmail.com",
                 to_address="alice@example.com",
@@ -81,11 +96,12 @@ class TestSendMessageHappyPath:
         # Message-ID is auto-generated.
         assert "Message-ID:" in decoded
 
-    def test_sets_in_reply_to_and_references_for_threading(self) -> None:
+    @pytest.mark.asyncio
+    async def test_sets_in_reply_to_and_references_for_threading(self) -> None:
         captured: dict[str, Any] = {}
         fake = _captured_send_call(captured)
         with patch.object(gmail_service, "get_gmail_service", return_value=fake):
-            gmail_service.send_message(
+            await gmail_service.send_message(
                 _FakeIntegration(),
                 from_address="h@g.com",
                 to_address="a@b.com",
@@ -98,11 +114,12 @@ class TestSendMessageHappyPath:
         assert "In-Reply-To: <orig-123@mail.example.com>" in decoded
         assert "References: <orig-123@mail.example.com>" in decoded
 
-    def test_no_threading_headers_when_no_original(self) -> None:
+    @pytest.mark.asyncio
+    async def test_no_threading_headers_when_no_original(self) -> None:
         captured: dict[str, Any] = {}
         fake = _captured_send_call(captured)
         with patch.object(gmail_service, "get_gmail_service", return_value=fake):
-            gmail_service.send_message(
+            await gmail_service.send_message(
                 _FakeIntegration(),
                 from_address="h@g.com",
                 to_address="a@b.com",
@@ -118,14 +135,15 @@ class TestSendMessageHappyPath:
 
 
 class TestSendMessageErrors:
-    def test_403_raises_send_scope_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_403_raises_send_scope_error(self) -> None:
         fake = MagicMock()
         send_chain = MagicMock()
         send_chain.execute.side_effect = _make_http_error(403)
         fake.users.return_value.messages.return_value.send.return_value = send_chain
         with patch.object(gmail_service, "get_gmail_service", return_value=fake):
             with pytest.raises(GmailSendScopeError):
-                gmail_service.send_message(
+                await gmail_service.send_message(
                     _FakeIntegration(),
                     from_address="h@g.com",
                     to_address="a@b.com",
@@ -133,14 +151,15 @@ class TestSendMessageErrors:
                     body="b",
                 )
 
-    def test_400_raises_send_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_400_raises_send_error(self) -> None:
         fake = MagicMock()
         send_chain = MagicMock()
         send_chain.execute.side_effect = _make_http_error(400)
         fake.users.return_value.messages.return_value.send.return_value = send_chain
         with patch.object(gmail_service, "get_gmail_service", return_value=fake):
             with pytest.raises(GmailSendError):
-                gmail_service.send_message(
+                await gmail_service.send_message(
                     _FakeIntegration(),
                     from_address="h@g.com",
                     to_address="a@b.com",
@@ -148,14 +167,15 @@ class TestSendMessageErrors:
                     body="b",
                 )
 
-    def test_500_raises_send_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_500_raises_send_error(self) -> None:
         fake = MagicMock()
         send_chain = MagicMock()
         send_chain.execute.side_effect = _make_http_error(500)
         fake.users.return_value.messages.return_value.send.return_value = send_chain
         with patch.object(gmail_service, "get_gmail_service", return_value=fake):
             with pytest.raises(GmailSendError):
-                gmail_service.send_message(
+                await gmail_service.send_message(
                     _FakeIntegration(),
                     from_address="h@g.com",
                     to_address="a@b.com",
@@ -163,14 +183,15 @@ class TestSendMessageErrors:
                     body="b",
                 )
 
-    def test_network_error_raises_send_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_network_error_raises_send_error(self) -> None:
         fake = MagicMock()
         send_chain = MagicMock()
         send_chain.execute.side_effect = ConnectionError("net down")
         fake.users.return_value.messages.return_value.send.return_value = send_chain
         with patch.object(gmail_service, "get_gmail_service", return_value=fake):
             with pytest.raises(GmailSendError):
-                gmail_service.send_message(
+                await gmail_service.send_message(
                     _FakeIntegration(),
                     from_address="h@g.com",
                     to_address="a@b.com",
@@ -178,14 +199,15 @@ class TestSendMessageErrors:
                     body="b",
                 )
 
-    def test_empty_response_id_raises_send_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_empty_response_id_raises_send_error(self) -> None:
         fake = MagicMock()
         send_chain = MagicMock()
         send_chain.execute.return_value = {"id": ""}
         fake.users.return_value.messages.return_value.send.return_value = send_chain
         with patch.object(gmail_service, "get_gmail_service", return_value=fake):
             with pytest.raises(GmailSendError):
-                gmail_service.send_message(
+                await gmail_service.send_message(
                     _FakeIntegration(),
                     from_address="h@g.com",
                     to_address="a@b.com",
@@ -193,9 +215,10 @@ class TestSendMessageErrors:
                     body="b",
                 )
 
-    def test_missing_access_token_raises_scope_error(self) -> None:
+    @pytest.mark.asyncio
+    async def test_missing_access_token_raises_scope_error(self) -> None:
         with pytest.raises(GmailSendScopeError):
-            gmail_service.send_message(
+            await gmail_service.send_message(
                 _FakeIntegration(access_token=""),
                 from_address="h@g.com",
                 to_address="a@b.com",

--- a/apps/mybookkeeper/backend/tests/test_gmail_token_refresh_needs_reauth.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_token_refresh_needs_reauth.py
@@ -1,0 +1,489 @@
+"""Tests for Gmail token refresh / 401 reauth flag handling.
+
+Regression coverage for two related bugs:
+
+1. ``email_fetch_service._fetch_next_pending`` did not catch ``HttpError`` with
+   status==401.  Google can reject a token via a 401 HTTP response (e.g. when
+   the user revokes access via myaccount.google.com) rather than raising a
+   ``RefreshError``.  Without this handler the queue item was marked ``failed``
+   but ``Integration.needs_reauth`` stayed ``False``, so the UI never prompted
+   the user to reconnect.
+
+2. ``gmail_service.send_message`` and ``send_message_with_attachment`` raised
+   ``GmailReauthRequiredError`` without first setting
+   ``Integration.needs_reauth = True``, violating the docstring contract.
+"""
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from google.auth.exceptions import RefreshError
+from googleapiclient.errors import HttpError
+
+from app.core.context import RequestContext
+from app.models.organization.organization_member import OrgRole
+from app.services.email.exceptions import GmailReauthRequiredError
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ctx() -> RequestContext:
+    return RequestContext(
+        organization_id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        org_role=OrgRole.OWNER,
+    )
+
+
+def _make_integration(org_id: uuid.UUID) -> MagicMock:
+    integration = MagicMock()
+    integration.organization_id = org_id
+    integration.access_token = "tok_access"
+    integration.refresh_token = "tok_refresh"
+    integration.needs_reauth = False
+    return integration
+
+
+def _make_fake_http_error(status: int) -> HttpError:
+    """Build a minimal HttpError that looks like a real Google API error."""
+    resp = MagicMock()
+    resp.status = status
+    return HttpError(resp=resp, content=b"Unauthorized")
+
+
+def _make_queue_item(org_id: uuid.UUID) -> MagicMock:
+    item = MagicMock()
+    item.id = uuid.uuid4()
+    item.message_id = "gmail_msg_abc"
+    item.sync_log_id = 1
+    item.attachment_id = "att_123"
+    return item
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: email_fetch_service — HttpError 401 sets needs_reauth
+# ---------------------------------------------------------------------------
+
+class TestFetchPathHttpError401:
+    """_fetch_next_pending must set needs_reauth when Gmail returns 401."""
+
+    @pytest.mark.asyncio
+    async def test_fetch_401_sets_needs_reauth(self) -> None:
+        """HttpError 401 during Gmail fetch must mark the integration for reauth
+        and raise GmailReauthRequiredError to stop the drain loop."""
+        ctx = _make_ctx()
+        org_id = ctx.organization_id
+        integration = _make_integration(org_id)
+        item = _make_queue_item(org_id)
+
+        fake_db = MagicMock()
+        fake_db.flush = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_uow():
+            yield fake_db
+
+        mark_calls: list[tuple] = []
+
+        async def fake_mark_needs_reauth(_db, integ, error, failed_at):
+            mark_calls.append((integ, error, failed_at))
+            integ.needs_reauth = True
+
+        async def fake_get_by_id(_db, item_id):
+            return item
+
+        async def fake_mark_status(_db, item_ref, status, *, error=None):
+            item_ref.status = status
+            item_ref.error = error
+
+        with (
+            patch(
+                "app.services.email.email_fetch_service.unit_of_work", fake_uow
+            ),
+            patch(
+                "app.services.email.email_fetch_service.AsyncSessionLocal", fake_uow
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.claim_next_pending",
+                new=AsyncMock(return_value=item),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.integration_repo.get_by_org_and_provider",
+                new=AsyncMock(return_value=integration),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.integration_repo.mark_needs_reauth",
+                new=fake_mark_needs_reauth,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.get_by_id",
+                new=fake_get_by_id,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.mark_status",
+                new=fake_mark_status,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.get_gmail_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.fetch_attachment_bytes",
+                side_effect=_make_fake_http_error(401),
+            ),
+        ):
+            from app.services.email.email_fetch_service import _fetch_next_pending
+
+            with pytest.raises(GmailReauthRequiredError):
+                await _fetch_next_pending(ctx)
+
+        assert len(mark_calls) == 1, "mark_needs_reauth must be called exactly once"
+        marked_integration, error_msg, failed_at = mark_calls[0]
+        assert marked_integration is integration
+        assert "401" in error_msg
+        assert failed_at.tzinfo is not None
+        assert integration.needs_reauth is True
+        assert item.status == "failed"
+        assert item.error == "Gmail auth expired (401)"
+
+    @pytest.mark.asyncio
+    async def test_fetch_refresh_error_still_sets_needs_reauth(self) -> None:
+        """Existing RefreshError path must still set needs_reauth (regression guard)."""
+        ctx = _make_ctx()
+        org_id = ctx.organization_id
+        integration = _make_integration(org_id)
+        item = _make_queue_item(org_id)
+
+        fake_db = MagicMock()
+        fake_db.flush = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_uow():
+            yield fake_db
+
+        mark_calls: list[tuple] = []
+
+        async def fake_mark_needs_reauth(_db, integ, error, failed_at):
+            mark_calls.append((integ, error, failed_at))
+            integ.needs_reauth = True
+
+        async def fake_get_by_id(_db, item_id):
+            return item
+
+        async def fake_mark_status(_db, item_ref, status, *, error=None):
+            item_ref.status = status
+
+        with (
+            patch(
+                "app.services.email.email_fetch_service.unit_of_work", fake_uow
+            ),
+            patch(
+                "app.services.email.email_fetch_service.AsyncSessionLocal", fake_uow
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.claim_next_pending",
+                new=AsyncMock(return_value=item),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.integration_repo.get_by_org_and_provider",
+                new=AsyncMock(return_value=integration),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.integration_repo.mark_needs_reauth",
+                new=fake_mark_needs_reauth,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.get_by_id",
+                new=fake_get_by_id,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.mark_status",
+                new=fake_mark_status,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.get_gmail_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.fetch_attachment_bytes",
+                side_effect=RefreshError("invalid_grant"),
+            ),
+        ):
+            from app.services.email.email_fetch_service import _fetch_next_pending
+
+            with pytest.raises(GmailReauthRequiredError):
+                await _fetch_next_pending(ctx)
+
+        assert len(mark_calls) == 1
+        assert integration.needs_reauth is True
+
+    @pytest.mark.asyncio
+    async def test_fetch_non_401_http_error_does_not_set_needs_reauth(self) -> None:
+        """HttpError with status != 401 must NOT set needs_reauth — it is a transient error."""
+        ctx = _make_ctx()
+        org_id = ctx.organization_id
+        integration = _make_integration(org_id)
+        item = _make_queue_item(org_id)
+
+        fake_db = MagicMock()
+        fake_db.flush = AsyncMock()
+
+        @asynccontextmanager
+        async def fake_uow():
+            yield fake_db
+
+        mark_calls: list[tuple] = []
+
+        async def fake_mark_needs_reauth(_db, integ, error, failed_at):
+            mark_calls.append((integ, error, failed_at))
+
+        async def fake_get_by_id(_db, item_id):
+            return item
+
+        async def fake_mark_status(_db, item_ref, status, *, error=None):
+            item_ref.status = status
+
+        async def fake_fail_sync_log_if_done(_db, sync_log_id, error_msg):
+            pass
+
+        with (
+            patch(
+                "app.services.email.email_fetch_service.unit_of_work", fake_uow
+            ),
+            patch(
+                "app.services.email.email_fetch_service.AsyncSessionLocal", fake_uow
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.claim_next_pending",
+                new=AsyncMock(return_value=item),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.integration_repo.get_by_org_and_provider",
+                new=AsyncMock(return_value=integration),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.integration_repo.mark_needs_reauth",
+                new=fake_mark_needs_reauth,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.get_by_id",
+                new=fake_get_by_id,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.email_queue_repo.mark_status",
+                new=fake_mark_status,
+            ),
+            patch(
+                "app.services.email.email_fetch_service._fail_sync_log_if_done",
+                new=fake_fail_sync_log_if_done,
+            ),
+            patch(
+                "app.services.email.email_fetch_service.get_gmail_service",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "app.services.email.email_fetch_service.fetch_attachment_bytes",
+                side_effect=_make_fake_http_error(500),
+            ),
+        ):
+            from app.services.email.email_fetch_service import _fetch_next_pending
+
+            result = await _fetch_next_pending(ctx)
+
+        assert result.status == "failed"
+        assert mark_calls == [], "mark_needs_reauth must NOT be called for non-401 errors"
+        assert integration.needs_reauth is False
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: gmail_service send paths — set needs_reauth before raising
+# ---------------------------------------------------------------------------
+
+class TestSendPathNeedsReauth:
+    """send_message and send_message_with_attachment must set needs_reauth."""
+
+    def _make_send_integration(self, org_id: uuid.UUID) -> MagicMock:
+        integration = MagicMock()
+        integration.organization_id = org_id
+        integration.access_token = "tok_access"
+        integration.refresh_token = "tok_refresh"
+        return integration
+
+    def _gmail_service_patches(
+        self,
+        org_id: uuid.UUID,
+        integration: MagicMock,
+        mark_calls: list,
+        send_side_effect: Exception,
+    ):
+        """Common patch stack for gmail_service send tests."""
+        stale = MagicMock()
+        stale.needs_reauth = False
+
+        fake_db = MagicMock()
+
+        @asynccontextmanager
+        async def fake_uow():
+            yield fake_db
+
+        async def fake_get_by_org(db, oid, provider):
+            return stale
+
+        async def fake_mark_needs_reauth(db, integ, error, failed_at):
+            mark_calls.append((integ, error, failed_at))
+            integ.needs_reauth = True
+
+        mock_service = MagicMock()
+        mock_service.users.return_value.messages.return_value.send.return_value.execute.side_effect = send_side_effect
+
+        return (
+            patch("app.services.email.gmail_service.unit_of_work", fake_uow),
+            patch(
+                "app.services.email.gmail_service.integration_repo.get_by_org_and_provider",
+                new=fake_get_by_org,
+            ),
+            patch(
+                "app.services.email.gmail_service.integration_repo.mark_needs_reauth",
+                new=fake_mark_needs_reauth,
+            ),
+            patch("app.services.email.gmail_service.get_gmail_service", return_value=mock_service),
+            stale,
+        )
+
+    @pytest.mark.asyncio
+    async def test_send_message_refresh_error_sets_needs_reauth(self) -> None:
+        """send_message must set needs_reauth when RefreshError is raised."""
+        org_id = uuid.uuid4()
+        integration = self._make_send_integration(org_id)
+        mark_calls: list = []
+
+        patches = self._gmail_service_patches(
+            org_id, integration, mark_calls, RefreshError("invalid_grant")
+        )
+        *ctx_patches, stale = patches
+
+        with (
+            ctx_patches[0],
+            ctx_patches[1],
+            ctx_patches[2],
+            ctx_patches[3],
+        ):
+            from app.services.email.gmail_service import send_message
+
+            with pytest.raises(GmailReauthRequiredError):
+                await send_message(
+                    integration,
+                    from_address="host@example.com",
+                    to_address="tenant@example.com",
+                    subject="Test",
+                    body="Hello",
+                )
+
+        assert len(mark_calls) == 1, "mark_needs_reauth must be called for RefreshError"
+        assert stale.needs_reauth is True
+
+    @pytest.mark.asyncio
+    async def test_send_message_401_sets_needs_reauth(self) -> None:
+        """send_message must set needs_reauth when HttpError 401 is raised."""
+        org_id = uuid.uuid4()
+        integration = self._make_send_integration(org_id)
+        mark_calls: list = []
+
+        patches = self._gmail_service_patches(
+            org_id, integration, mark_calls, _make_fake_http_error(401)
+        )
+        *ctx_patches, stale = patches
+
+        with (
+            ctx_patches[0],
+            ctx_patches[1],
+            ctx_patches[2],
+            ctx_patches[3],
+        ):
+            from app.services.email.gmail_service import send_message
+
+            with pytest.raises(GmailReauthRequiredError):
+                await send_message(
+                    integration,
+                    from_address="host@example.com",
+                    to_address="tenant@example.com",
+                    subject="Test",
+                    body="Hello",
+                )
+
+        assert len(mark_calls) == 1, "mark_needs_reauth must be called for 401 HttpError"
+        assert stale.needs_reauth is True
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_attachment_refresh_error_sets_needs_reauth(self) -> None:
+        """send_message_with_attachment must set needs_reauth on RefreshError."""
+        org_id = uuid.uuid4()
+        integration = self._make_send_integration(org_id)
+        mark_calls: list = []
+
+        patches = self._gmail_service_patches(
+            org_id, integration, mark_calls, RefreshError("invalid_grant")
+        )
+        *ctx_patches, stale = patches
+
+        with (
+            ctx_patches[0],
+            ctx_patches[1],
+            ctx_patches[2],
+            ctx_patches[3],
+        ):
+            from app.services.email.gmail_service import send_message_with_attachment
+
+            with pytest.raises(GmailReauthRequiredError):
+                await send_message_with_attachment(
+                    integration,
+                    from_address="host@example.com",
+                    to_address="tenant@example.com",
+                    subject="Receipt",
+                    body="See attached",
+                    attachment_bytes=b"%PDF",
+                    attachment_filename="receipt.pdf",
+                    attachment_content_type="application/pdf",
+                )
+
+        assert len(mark_calls) == 1
+        assert stale.needs_reauth is True
+
+    @pytest.mark.asyncio
+    async def test_send_message_with_attachment_401_sets_needs_reauth(self) -> None:
+        """send_message_with_attachment must set needs_reauth on HttpError 401."""
+        org_id = uuid.uuid4()
+        integration = self._make_send_integration(org_id)
+        mark_calls: list = []
+
+        patches = self._gmail_service_patches(
+            org_id, integration, mark_calls, _make_fake_http_error(401)
+        )
+        *ctx_patches, stale = patches
+
+        with (
+            ctx_patches[0],
+            ctx_patches[1],
+            ctx_patches[2],
+            ctx_patches[3],
+        ):
+            from app.services.email.gmail_service import send_message_with_attachment
+
+            with pytest.raises(GmailReauthRequiredError):
+                await send_message_with_attachment(
+                    integration,
+                    from_address="host@example.com",
+                    to_address="tenant@example.com",
+                    subject="Receipt",
+                    body="See attached",
+                    attachment_bytes=b"%PDF",
+                    attachment_filename="receipt.pdf",
+                    attachment_content_type="application/pdf",
+                )
+
+        assert len(mark_calls) == 1
+        assert stale.needs_reauth is True

--- a/apps/mybookkeeper/backend/tests/test_inquiry_reply_service.py
+++ b/apps/mybookkeeper/backend/tests/test_inquiry_reply_service.py
@@ -305,15 +305,30 @@ async def test_send_reply_scope_revoked_at_send_time_maps_to_scope_error(
 async def test_send_reply_token_expired_sets_needs_reauth_and_raises(
     db: AsyncSession, test_user: User, test_org: Organization, patch_session,
 ) -> None:
-    """When send_message raises GmailReauthRequiredError, the service sets
-    needs_reauth=True on the Integration and raises InquiryReplyAuthExpiredError.
-    No InquiryMessage row is created and the inquiry stage does not change."""
+    """When send_message raises GmailReauthRequiredError (which it does AFTER
+    setting needs_reauth=True on the Integration), InquiryReplyAuthExpiredError
+    is surfaced and no InquiryMessage row is created.
+
+    The mock simulates the real send_message contract: it writes needs_reauth
+    to the DB row before raising, so callers observe the committed state.
+    """
+    import datetime as _dt_inner
+
     integration = await _seed_integration(db, org=test_org, user=test_user)
     inquiry = await _seed_inquiry(db, org=test_org, user=test_user)
 
+    async def _fake_send_raises_after_setting_flag(*args, **kwargs):
+        # Mirror what the real send_message now does: set needs_reauth first,
+        # then raise GmailReauthRequiredError.
+        integration.needs_reauth = True
+        integration.last_reauth_error = "refresh token expired"
+        integration.last_reauth_failed_at = _dt_inner.datetime.now(_dt_inner.timezone.utc)
+        await db.flush()
+        raise GmailReauthRequiredError("refresh token expired")
+
     with patch(
         "app.services.inquiries.inquiry_reply_service.gmail_service.send_message",
-        side_effect=GmailReauthRequiredError("refresh token expired"),
+        side_effect=_fake_send_raises_after_setting_flag,
     ):
         with pytest.raises(inquiry_reply_service.InquiryReplyAuthExpiredError):
             await inquiry_reply_service.send_reply(


### PR DESCRIPTION
## Summary

Two related bugs that left `Integration.needs_reauth` unset when it should be `True`, forcing users to manually disconnect/reconnect Gmail instead of seeing the reconnect banner.

### Bug 1 — send paths didn't set needs_reauth (gmail_service.py)

`send_message` and `send_message_with_attachment` raised `GmailReauthRequiredError` on `RefreshError` and `HttpError 401`, but never called `integration_repo.mark_needs_reauth()` first — violating the docstring contract:

> "1. The `Integration.needs_reauth` flag has already been set to `True`."

Both functions now open a `unit_of_work()` inside the RefreshError/HttpError 401 except blocks and call `mark_needs_reauth` before raising. To support `await unit_of_work()`, both functions are converted from sync to async.

**Callers updated:** `inquiry_reply_service.py` and `receipt_service.py` now `await` the send calls. The old redundant `mark_needs_reauth` calls in those callers are removed (they're now done inside `gmail_service.py`). Test mock stubs in `test_helpers/mocks.py` updated to `async def`.

### Bug 2 — fetch path missed HttpError 401 (email_fetch_service.py)

`_fetch_next_pending` caught `RefreshError` and called `mark_needs_reauth`, but had no `HttpError` handler. When Google invalidates a token via HTTP 401 (user revokes at myaccount.google.com, password change, 6+ months inactivity), the exception fell through to the generic `except Exception` block, which marked the queue item `failed` but never set `needs_reauth`. Users saw failed imports with no reconnect prompt.

Added explicit `except HttpError` handler before `except Exception`. Status 401 → calls `mark_needs_reauth` + raises `GmailReauthRequiredError`. Non-401 HttpErrors → treated as transient, fall through to existing generic handler.

### Bug 3 — discovery path missed HttpError 401 (email_discovery_service.py)

Same gap as the fetch path: `list_new_email_ids` and `list_email_document_sources` calls caught `RefreshError` but not `HttpError 401`. Added matching handlers at both call sites.

## Before/After

**Before (fetch path):**
```python
except RefreshError as exc:
    # ... mark_needs_reauth ...
    raise GmailReauthRequiredError(...) from exc
except Exception as e:
    # marks item failed but NEVER sets needs_reauth
    await email_queue_repo.mark_status(db, item_ref, "failed", ...)
```

**After (fetch path):**
```python
except RefreshError as exc:
    # ... mark_needs_reauth ...
    raise GmailReauthRequiredError(...) from exc
except HttpError as exc:
    status = getattr(getattr(exc, "resp", None), "status", None)
    if status == 401:
        # ... mark_needs_reauth + raise GmailReauthRequiredError ...
    # non-401 falls through to generic handler unchanged
except Exception as e:
    # unchanged — transient errors only
```

## New tests

- `test_fetch_401_sets_needs_reauth` — fetch path with mocked 401 HttpError
- `test_fetch_refresh_error_still_sets_needs_reauth` — regression guard for existing RefreshError path
- `test_fetch_non_401_http_error_does_not_set_needs_reauth` — non-401 HttpError must NOT set needs_reauth
- `test_send_message_refresh_error_sets_needs_reauth` — send_message on RefreshError
- `test_send_message_401_sets_needs_reauth` — send_message on HttpError 401
- `test_send_message_with_attachment_refresh_error_sets_needs_reauth` — send_with_attachment on RefreshError
- `test_send_message_with_attachment_401_sets_needs_reauth` — send_with_attachment on HttpError 401

## No operational migration required

This is a transparent runtime fix — no env var changes, no schema changes, no deployment steps needed. The behavior on the happy path (successful send/fetch) is unchanged.