### PR TITLE
fix(mjh/discover): default JSearch fetch to 5 pages (~50 postings) instead of 1

### DIFF
--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -50,6 +50,14 @@ DISCOVERY_DAILY_BUDGET_USD_HARD_CAP=2.00
 # dominates. Optional — defaults to 20 in code if unset.
 DISCOVERY_SCORE_TOP_N=20
 
+# /discover JSearch pagination depth. JSearch charges 1 RapidAPI request per
+# page; each page returns ~10 postings. The default of 5 pages (~50 postings
+# per fetch) gives good result diversity while keeping costs well within Pro:
+#   5 searches × 5 pages × 1 fetch/day = 750 req/month (Pro cap: 10k req/mo)
+# Tune up for more result breadth; tune down if you want to minimize API cost.
+# Valid range: 1–20. Optional — defaults to 5 in code if unset.
+DISCOVERY_JSEARCH_PAGES_PER_FETCH=5
+
 # /discover embeddings (PR 4a). No env var required — the embedding
 # model (sentence-transformers/all-MiniLM-L6-v2) is local fastembed
 # baked into the backend Docker image at build time. Listed here only

--- a/apps/myjobhunter/backend/app/core/config.py
+++ b/apps/myjobhunter/backend/app/core/config.py
@@ -7,6 +7,8 @@ platform_shared.core.settings.BaseAppSettings. Only MJH-specific fields
 limits) live here.
 """
 
+from pydantic import Field
+
 from platform_shared.core.settings import BaseAppSettings
 
 
@@ -55,6 +57,17 @@ class Settings(BaseAppSettings):
     # mirror the previous hardcoded values in api/discover.py.
     discovery_refresh_rate_limit_threshold: int = 30
     discovery_refresh_rate_limit_window_seconds: int = 300
+
+    # Number of JSearch pages to retrieve per saved-search fetch cycle.
+    # JSearch charges 1 RapidAPI request per page; each page returns ~10
+    # postings. At the default of 5 pages (~50 postings per fetch), one
+    # operator with 5 saved searches fetching once per day uses ~750
+    # req/month — well within the Pro tier ($9.99/mo, 10k req/mo).
+    # Floor: 1 (minimum useful fetch). Ceiling: 20 (hard cost guard;
+    # 20 pages × 10 searches × 2 fetches/day = 4k req/month, still
+    # within Pro). Tune down if you want to conserve budget; tune up if
+    # you want deeper result diversity.
+    discovery_jsearch_pages_per_fetch: int = Field(default=5, ge=1, le=20)
 
     # ------------------------------------------------------------------
     # Google OAuth (Gmail integration — Phase 3)

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
@@ -27,6 +27,7 @@ from typing import Any, Awaitable, Callable
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.core.config import settings
 from app.models.discovery.discovery_source import DiscoverySource
 from app.repositories.discovery import discovery_repository
 from app.schemas.discovery.greenhouse_source_config import (
@@ -101,7 +102,7 @@ async def _run_jsearch(config: dict[str, Any]) -> list[dict]:
     return await jsearch.search(
         query=query,
         page=1,
-        num_pages=1,
+        num_pages=settings.discovery_jsearch_pages_per_fetch,
         date_posted=typed.date_posted,
         country=typed.country,
         remote_jobs_only=typed.remote_jobs_only,

--- a/apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py
@@ -13,8 +13,11 @@ Pricing tiers (RapidAPI):
 - Ultra:       $49.99/mo for 100k req
 - Mega:        $149.99/mo for 400k req
 
-Usage at MJH's expected volume (~600 req/mo for one user with 10 saved
-searches × 2 pages × 1 fetch/day) fits comfortably in Pro.
+Usage at MJH's expected volume (~750 req/mo for one user with 5 saved
+searches × 5 pages × 1 fetch/day, i.e. ``DISCOVERY_JSEARCH_PAGES_PER_FETCH=5``)
+fits comfortably in Pro. 10 searches × 5 pages × 2 fetches/day is 3 k req/mo —
+still within Pro. See ``app.core.config.Settings.discovery_jsearch_pages_per_fetch``
+to tune.
 
 Adapter shape — pure function. Returns ``list[RawPosting]`` ready for
 the worker to upsert. No DB writes here; the worker owns persistence.

--- a/apps/myjobhunter/backend/tests/test_discovery_jsearch_pages_setting.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_jsearch_pages_setting.py
@@ -1,0 +1,138 @@
+"""Unit tests for Settings.discovery_jsearch_pages_per_fetch and its wiring
+into the JSearch fetch call.
+
+Two concerns tested here:
+
+1. **Settings default** — the field exists, defaults to 5, and accepts values
+   in [1, 20] while rejecting out-of-range integers.
+
+2. **Fetch-service wiring** — ``_run_jsearch`` passes
+   ``settings.discovery_jsearch_pages_per_fetch`` as ``num_pages`` to the
+   JSearch adapter instead of the old hard-coded 1.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from pydantic import Field, ValidationError
+from pydantic_settings import BaseSettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal settings stub (avoids triggering the full Settings()
+# singleton which requires DATABASE_URL + other required env vars)
+# ---------------------------------------------------------------------------
+
+
+class _PagesSettings(BaseSettings):
+    """Minimal stand-in that mirrors only the field under test."""
+
+    discovery_jsearch_pages_per_fetch: int = Field(default=5, ge=1, le=20)
+
+    model_config = {"env_file": None, "extra": "ignore"}
+
+
+# ---------------------------------------------------------------------------
+# Settings field tests
+# ---------------------------------------------------------------------------
+
+
+class TestDiscoveryJSearchPagesPerFetchSetting:
+    def test_default_is_five(self) -> None:
+        s = _PagesSettings()
+        assert s.discovery_jsearch_pages_per_fetch == 5
+
+    def test_accepts_minimum_value_one(self) -> None:
+        s = _PagesSettings(discovery_jsearch_pages_per_fetch=1)
+        assert s.discovery_jsearch_pages_per_fetch == 1
+
+    def test_accepts_maximum_value_twenty(self) -> None:
+        s = _PagesSettings(discovery_jsearch_pages_per_fetch=20)
+        assert s.discovery_jsearch_pages_per_fetch == 20
+
+    def test_accepts_mid_range_value(self) -> None:
+        s = _PagesSettings(discovery_jsearch_pages_per_fetch=10)
+        assert s.discovery_jsearch_pages_per_fetch == 10
+
+    def test_rejects_zero(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            _PagesSettings(discovery_jsearch_pages_per_fetch=0)
+        errors = exc_info.value.errors()
+        assert any(
+            e["loc"] == ("discovery_jsearch_pages_per_fetch",) for e in errors
+        ), f"Expected validation error on discovery_jsearch_pages_per_fetch, got: {errors}"
+
+    def test_rejects_twenty_one(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            _PagesSettings(discovery_jsearch_pages_per_fetch=21)
+        errors = exc_info.value.errors()
+        assert any(
+            e["loc"] == ("discovery_jsearch_pages_per_fetch",) for e in errors
+        ), f"Expected validation error on discovery_jsearch_pages_per_fetch, got: {errors}"
+
+    def test_rejects_negative(self) -> None:
+        with pytest.raises(ValidationError):
+            _PagesSettings(discovery_jsearch_pages_per_fetch=-1)
+
+
+# ---------------------------------------------------------------------------
+# Fetch-service wiring test — _run_jsearch must forward
+# settings.discovery_jsearch_pages_per_fetch as num_pages
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_jsearch_passes_pages_per_fetch_setting() -> None:
+    """_run_jsearch must pass settings.discovery_jsearch_pages_per_fetch
+    as num_pages to jsearch.search, not the old hard-coded 1."""
+    from app.services.discovery import discovery_fetch_service
+    from app.services.discovery.discovery_fetch_service import _run_jsearch
+
+    mock_search = AsyncMock(return_value=[])
+
+    # Patch settings so the test is deterministic regardless of local env.
+    with (
+        patch.object(
+            discovery_fetch_service.settings,
+            "discovery_jsearch_pages_per_fetch",
+            7,
+        ),
+        patch(
+            "app.services.discovery.discovery_fetch_service.jsearch.search",
+            mock_search,
+        ),
+    ):
+        config = {"query": "python engineer remote"}
+        await _run_jsearch(config)
+
+    mock_search.assert_awaited_once()
+    call_kwargs = mock_search.call_args.kwargs
+    assert call_kwargs["num_pages"] == 7, (
+        f"Expected num_pages=7 (from patched setting), got {call_kwargs.get('num_pages')!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_jsearch_default_setting_is_five() -> None:
+    """When the setting is at its default (5), _run_jsearch passes num_pages=5."""
+    from app.core.config import settings as real_settings
+    from app.services.discovery import discovery_fetch_service
+    from app.services.discovery.discovery_fetch_service import _run_jsearch
+
+    mock_search = AsyncMock(return_value=[])
+
+    # Only patch the adapter call — use the real settings singleton so we
+    # verify the actual default wiring in production code.
+    with patch(
+        "app.services.discovery.discovery_fetch_service.jsearch.search",
+        mock_search,
+    ):
+        config = {"query": "backend engineer"}
+        await _run_jsearch(config)
+
+    expected = real_settings.discovery_jsearch_pages_per_fetch
+    call_kwargs = mock_search.call_args.kwargs
+    assert call_kwargs["num_pages"] == expected, (
+        f"Expected num_pages={expected} (real settings), got {call_kwargs.get('num_pages')!r}"
+    )


### PR DESCRIPTION
## Summary

**Symptom:** Operator sees the same job postings on every fetch ("same results every time").

**Root cause:** `discovery_fetch_service._run_jsearch` hard-coded `num_pages=1`. JSearch returns ~10 postings per page, so every fetch retrieved only the top 10 results — identical across fetches because those listings are always at the top of search ranking. Layer 1 dedup then correctly marked them all as `updated` (already seen), leaving the inbox with nothing net-new.

The original `jsearch.py` module docstring even anticipated multi-page fetches:
> "Usage at MJH's expected volume (~600 req/mo for one user with 10 saved searches × 2 pages × 1 fetch/day) fits comfortably in Pro."

But the wiring shipped with 1 page. This PR fixes that gap.

## Changes

- **`app/core/config.py`** — new `Settings.discovery_jsearch_pages_per_fetch: int = Field(default=5, ge=1, le=20)` field. Typed, bounded, documented.
- **`app/services/discovery/discovery_fetch_service.py`** — `_run_jsearch` now reads `settings.discovery_jsearch_pages_per_fetch` instead of the hard-coded `1`.
- **`app/services/discovery/sources/jsearch.py`** — module docstring updated with corrected cost math (was based on 2-page assumption; now reflects the 5-page default).
- **`backend/.env.docker.example`** — `DISCOVERY_JSEARCH_PAGES_PER_FETCH=5` documented with cost math.
- **`tests/test_discovery_jsearch_pages_setting.py`** — 9 new unit tests: settings floor/ceiling/default validation + fetch-service wiring assertion.

## Cost math

| Scenario | Req/month | vs Pro cap (10k) |
|---|---|---|
| 5 searches × 5 pages × 1 fetch/day (default) | 750 | 7.5% |
| 10 searches × 5 pages × 2 fetches/day | 3,000 | 30% |
| 10 searches × 20 pages × 2 fetches/day (ceiling) | 12,000 | 120% — would need Ultra |

The default of 5 keeps the operator safely within Pro at any reasonable usage pattern.

## ⚠️ Operational migration

**No action required.** The new env var is fully optional — the code defaults to 5 if `DISCOVERY_JSEARCH_PAGES_PER_FETCH` is unset. Existing deployments continue working without any `.env.docker` changes.

**Optional tuning:** To change the pagination depth, add/update in `apps/myjobhunter/backend/.env.docker`:

```
# Valid range: 1–20. Default: 5.
DISCOVERY_JSEARCH_PAGES_PER_FETCH=5
```

Each page = 1 RapidAPI request = ~10 postings. Pro tier ($9.99/mo) = 10k req/month.

### How to verify the setting is active

```bash
docker compose -f apps/myjobhunter/docker-compose.yml exec api \
  python -c "from app.core.config import settings; print(settings.discovery_jsearch_pages_per_fetch)"
# Should print: 5 (or whatever value you set)
```

### Rollback path

Revert this PR. The previous image had `num_pages=1` hard-coded; no env var cleanup needed on rollback.