### PR TITLE
chore(deps): github actions bundle (upload-artifact 4→7, codeql-action 4.35.4)

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -184,7 +184,7 @@ jobs:
 
       - name: Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: apps/mybookkeeper/frontend/e2e/test-results/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,12 +29,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/init@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        uses: github/codeql-action/analyze@68bde559dea0fdcac2102bfdf6230c5f70eb485e # v4.35.4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary

Bundled bump of 2 open dependabot PRs against `.github/workflows/` to ship as one. Replaces #437, #438.

## Bumps

| Package | From | To | Original PR |
|---|---|---|---|
| `actions/upload-artifact` | 4.6.2 | 7.0.1 | #438 |
| `github/codeql-action` | 4.35.2 | 4.35.4 | #437 |

## Migration notes

- **upload-artifact 4 → 7** is a major bump. v7 runs on Node 24 (requires runner ≥ 2.327.1; GitHub-hosted runners are current) and adds an optional unzipped-upload `archive: false` mode. Our only usage in `ci-mybookkeeper.yml` (Playwright report upload on failure) passes only `name` / `path` / `retention-days` — those params are unchanged in v7. No workflow code changes needed.
- **codeql-action 4.35.2 → 4.35.4** is a patch bump; bundle 2.25.2 → 2.25.4.

## SHA verification

Both SHAs verified via `gh api repos/<owner>/<repo>/git/commits/<sha>` per `rules/verify-action-sha.md`:
- `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (actions/upload-artifact v7.0.1)
- `68bde559dea0fdcac2102bfdf6230c5f70eb485e` (github/codeql-action v4.35.4)

## Test plan

- [ ] CI green
- [ ] CodeQL workflow runs on this PR and uploads results