### PR TITLE
fix(mbk/frontend): clear 4 lint errors blocking @eslint/js 10 bump

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/LeaseNew.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/LeaseNew.test.tsx
@@ -87,12 +87,6 @@ const TEMPLATE_SUMMARY: LeaseTemplateSummary = {
   updated_at: "2026-05-01T00:00:00Z",
 };
 
-const TEMPLATE_DETAIL = {
-  ...TEMPLATE_SUMMARY,
-  files: [],
-  placeholders: [],
-};
-
 const APPLICANTS: ApplicantSummary[] = [
   {
     id: "app-approved",

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseDetail.tsx
@@ -77,9 +77,13 @@ export default function LeaseDetail() {
   // Match backend ``UNDO_WINDOW_DAYS``. Kept inline (single use) so the
   // 30-day rule lives next to the button it gates.
   const UNDO_WINDOW_DAYS = 30;
+  // Freeze "now" at first render — React 19's hooks/purity rule forbids
+  // calling Date.now() during render. The 30-day undo window doesn't need
+  // sub-second accuracy; freezing at mount is fine.
+  const [nowMs] = useState(() => Date.now());
   const latestExtension = lease?.latest_extension ?? null;
   const ageMs = latestExtension
-    ? Date.now() - new Date(latestExtension.created_at).getTime()
+    ? nowMs - new Date(latestExtension.created_at).getTime()
     : null;
   const canUndoExtension =
     canExtend

--- a/apps/mybookkeeper/frontend/src/app/pages/LeaseNew.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/LeaseNew.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { ArrowLeft } from "lucide-react";
 import SectionHeader from "@/shared/components/ui/SectionHeader";
@@ -55,15 +55,6 @@ export default function LeaseNew() {
     initialTemplateIds,
   );
   const [pickedApplicantId, setPickedApplicantId] = useState<string | null>(null);
-
-  // Re-sync once if the URL provided initial templates after mount.
-  useEffect(() => {
-    if (initialTemplateIds.length > 0 && selectedTemplateIds.length === 0) {
-      setSelectedTemplateIds(initialTemplateIds);
-    }
-    // Only fires once when initialTemplateIds is non-empty on first render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
 
   const resolvedApplicantId = pickedApplicantId ?? urlApplicantId;
 

--- a/apps/mybookkeeper/frontend/src/shared/auth/StepUpModal.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/auth/StepUpModal.tsx
@@ -9,6 +9,7 @@ import {
   submitCode,
   subscribe,
 } from "@/shared/auth/stepUpController";
+import type { StepUpControllerState } from "@/shared/auth/types/StepUpControllerState";
 
 const HEADLINE = "Confirm your identity";
 const BODY =
@@ -17,7 +18,7 @@ const BODY =
 /**
  * MBK fork — byte-identical to packages/shared-frontend/src/auth/
  * StepUpModal.tsx, using MBK's local UI components. Will be deleted
- * once MBK migrates to React 19 and consumes from @platform/ui.
+ * once MBK migrates its auth-store to @platform/ui.
  *
  * Mount once at the app root (``App.tsx``). Subscribes to the
  * step-up controller and renders the modal whenever an axios response
@@ -25,51 +26,13 @@ const BODY =
  */
 export default function StepUpModal() {
   const state = useSyncExternalStore(subscribe, getState, getState);
-  const [code, setCode] = useState("");
-  const inputRef = useRef<HTMLInputElement | null>(null);
-
-  useEffect(() => {
-    if (state.pending) {
-      setCode("");
-    }
-  }, [state.pending, state.attempt]);
-
-  useEffect(() => {
-    if (state.pending && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [state.pending, state.attempt]);
-
   const open = state.pending !== null;
-  const submitDisabled =
-    state.submitting || code.length !== 6 || !/^\d{6}$/.test(code);
-
-  function handleSubmit(): void {
-    if (submitDisabled) return;
-    submitCode(code);
-  }
-
-  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
-    if (e.key === "Enter") {
-      e.preventDefault();
-      handleSubmit();
-    }
-  }
-
-  function handleCancel(): void {
-    controllerCancel("user_cancelled");
-  }
-
-  function handleCodeChange(e: React.ChangeEvent<HTMLInputElement>): void {
-    const next = e.target.value.replace(/\D/g, "").slice(0, 6);
-    setCode(next);
-  }
 
   return (
     <Dialog.Root
       open={open}
       onOpenChange={(isOpen) => {
-        if (!isOpen) handleCancel();
+        if (!isOpen) controllerCancel("user_cancelled");
       }}
     >
       <Dialog.Portal>
@@ -87,62 +50,109 @@ export default function StepUpModal() {
           >
             {BODY}
           </Dialog.Description>
-
-          <div className="mt-4 space-y-3">
-            <label
-              htmlFor="step-up-totp-code"
-              className="block text-sm font-medium"
-            >
-              6-digit code
-            </label>
-            <input
-              id="step-up-totp-code"
-              ref={inputRef}
-              type="text"
-              inputMode="numeric"
-              autoComplete="one-time-code"
-              pattern="[0-9]{6}"
-              maxLength={6}
-              value={code}
-              onChange={handleCodeChange}
-              onKeyDown={handleKeyDown}
-              disabled={state.submitting}
-              className="w-full rounded-md border bg-background px-3 py-2 text-center font-mono text-lg tracking-widest focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
-              aria-invalid={state.errorMessage != null ? "true" : undefined}
-              aria-describedby={
-                state.errorMessage != null ? "step-up-error" : undefined
-              }
+          {state.pending !== null && (
+            <StepUpForm
+              key={`${state.pending}-${state.attempt}`}
+              state={state}
             />
-            {state.errorMessage != null && (
-              <AlertBox variant="error" className="mt-2">
-                <span id="step-up-error" role="alert">
-                  {state.errorMessage}
-                </span>
-              </AlertBox>
-            )}
-          </div>
-
-          <div className="mt-6 flex justify-end gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={handleCancel}
-              disabled={state.submitting}
-            >
-              Cancel
-            </Button>
-            <LoadingButton
-              size="sm"
-              isLoading={state.submitting}
-              loadingText="Verifying..."
-              onClick={handleSubmit}
-              disabled={submitDisabled}
-            >
-              Verify
-            </LoadingButton>
-          </div>
+          )}
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
+  );
+}
+
+interface StepUpFormProps {
+  state: StepUpControllerState;
+}
+
+// Keyed on `${state.pending}-${state.attempt}` so a new challenge or a
+// retry remounts this component, resetting `code` to "" via the useState
+// initializer. This replaces a setState-in-effect anti-pattern that
+// React 19's `react-hooks/set-state-in-effect` rule rejects.
+function StepUpForm({ state }: StepUpFormProps) {
+  const [code, setCode] = useState("");
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const submitDisabled =
+    state.submitting || code.length !== 6 || !/^\d{6}$/.test(code);
+
+  function handleSubmit(): void {
+    if (submitDisabled) return;
+    submitCode(code);
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>): void {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleSubmit();
+    }
+  }
+
+  function handleCodeChange(e: React.ChangeEvent<HTMLInputElement>): void {
+    const next = e.target.value.replace(/\D/g, "").slice(0, 6);
+    setCode(next);
+  }
+
+  return (
+    <>
+      <div className="mt-4 space-y-3">
+        <label
+          htmlFor="step-up-totp-code"
+          className="block text-sm font-medium"
+        >
+          6-digit code
+        </label>
+        <input
+          id="step-up-totp-code"
+          ref={inputRef}
+          type="text"
+          inputMode="numeric"
+          autoComplete="one-time-code"
+          pattern="[0-9]{6}"
+          maxLength={6}
+          value={code}
+          onChange={handleCodeChange}
+          onKeyDown={handleKeyDown}
+          disabled={state.submitting}
+          className="w-full rounded-md border bg-background px-3 py-2 text-center font-mono text-lg tracking-widest focus:outline-none focus:ring-2 focus:ring-primary disabled:opacity-60"
+          aria-invalid={state.errorMessage != null ? "true" : undefined}
+          aria-describedby={
+            state.errorMessage != null ? "step-up-error" : undefined
+          }
+        />
+        {state.errorMessage != null && (
+          <AlertBox variant="error" className="mt-2">
+            <span id="step-up-error" role="alert">
+              {state.errorMessage}
+            </span>
+          </AlertBox>
+        )}
+      </div>
+
+      <div className="mt-6 flex justify-end gap-2">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => controllerCancel("user_cancelled")}
+          disabled={state.submitting}
+        >
+          Cancel
+        </Button>
+        <LoadingButton
+          size="sm"
+          isLoading={state.submitting}
+          loadingText="Verifying..."
+          onClick={handleSubmit}
+          disabled={submitDisabled}
+        >
+          Verify
+        </LoadingButton>
+      </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Resolves the four React 19 / react-hooks lint errors that have been blocking MBK's frontend `npm run lint` and the `@eslint/js 10` dependabot PR (#445, closed-and-deferred per `project_mbk_react_19_migration_plan.md`).

**Lint:** 4 errors → 0 errors. 8 warnings unchanged (all framework-level — TanStack Table `useReactTable()` + RHF `useForm().watch()` can't be memoized per React Compiler's documented limitations).

## The four fixes

| # | File | Rule | Fix |
|---|---|---|---|
| 1 | `__tests__/LeaseNew.test.tsx` | `@typescript-eslint/no-unused-vars` | Remove unused `TEMPLATE_DETAIL` fixture |
| 2 | `app/pages/LeaseDetail.tsx` | `react-hooks/purity` | `Date.now()` during render → `useState(() => Date.now())` initializer. 30-day undo-window doesn't need sub-second accuracy. |
| 3 | `app/pages/LeaseNew.tsx` | `react-hooks/set-state-in-effect` | Delete redundant "re-sync templateIds" effect. `useSearchParams` is synchronous; the useState initializer already captures URL params. |
| 4 | `shared/auth/StepUpModal.tsx` | `react-hooks/set-state-in-effect` | Extract keyed `StepUpForm` child. Code state now resets via remount on each new challenge/retry — React 19's idiomatic "remount-on-key-change" pattern. |

## Unblocks

- `@eslint/js 10` bump for MBK frontend (dependabot #445 deferred awaiting this)
- Future eslint co-bump (eslint 9 → 10) for MBK to match MJH (which shipped in PR #602)

## Test plan

- [x] `npm run lint` → exit 0, 0 errors
- [x] `npm run build` → builds clean
- [x] LeaseNew test (22 tests) → all passing
- [x] LeaseDetail tests (3 files, 24 tests) → all passing
- [ ] CI green

## Not addressed (pre-existing tech debt)

- 5x TanStack Table / RHF `watch()` warnings — framework-level React Compiler limitations
- 1x `react-refresh/only-export-components` in `PaymentDocumentCard.tsx`
- 1x `react-hooks/exhaustive-deps` useMemo recommendation in `ColumnFilter.tsx`

These do not block lint and would each be their own focused PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)