### PR TITLE
feat(mga): manual upload + plan-mode UI with zone-click filter and side tint (PR 2/12)

### DIFF
--- a/apps/mygamingassistant/TECH_DEBT.md
+++ b/apps/mygamingassistant/TECH_DEBT.md
@@ -1,0 +1,34 @@
+# MyGamingAssistant — Tech Debt Log
+
+<!-- 2 open issues -->
+
+---
+
+### [Frontend] JS bundle exceeds 500KB (single-chunk)
+
+- **Severity:** Medium
+- **Effort:** Medium (2-4 hours)
+- **Location:** `apps/mygamingassistant/frontend/vite.config.ts`
+- **Problem:** Vite build emits a single 645KB JS bundle (206KB gzipped). As the app grows,
+  this will increase initial load time noticeably, especially on slow connections.
+- **Recommendation:** Add `build.rollupOptions.output.manualChunks` to extract react-router,
+  redux, and lucide-react into separate chunks. React+Redux alone are ~200KB of this.
+  Alternatively, add lazy loading on route level with `React.lazy()` + `<Suspense>`.
+
+---
+
+### [Backend tests] Lineup API tests require a running PostgreSQL
+
+- **Severity:** Low
+- **Effort:** Low (1-2 hours)
+- **Location:** `apps/mygamingassistant/backend/tests/test_lineups.py`
+- **Problem:** The `auth_client` fixture relies on a real PostgreSQL connection on port 5435.
+  Tests cannot run in local dev environments without a running DB instance. The health
+  tests (which use `TestClient` without DB) pass fine, but lineup tests are always skipped
+  when no DB is running.
+- **Recommendation:** Add a `pytest-docker` or `docker-compose` fixture that spins up a
+  test Postgres container automatically (mirrors how MBK's CI handles it). Alternatively,
+  add a `conftest.py`-level `skipif` that gracefully skips DB-dependent tests instead of
+  erroring with a connection failure.
+
+---

--- a/apps/mygamingassistant/backend/app/api/games.py
+++ b/apps/mygamingassistant/backend/app/api/games.py
@@ -1,13 +1,12 @@
-"""Game library read endpoints — stub implementations for PR 1.
+"""Game library read endpoints.
 
 All routes require authentication. Write endpoints (upload, review, packages)
-are implemented in Phase 2+ PRs.
+are in lineups.py.
 
 Routes:
     GET /api/games                          — list all games
     GET /api/games/{game_slug}/maps         — list maps for a game
     GET /api/games/{game_slug}/maps/{map_slug} — map detail with zones + sites + utility types
-    GET /api/lineups                        — empty list (no lineups yet)
 """
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
@@ -17,7 +16,6 @@ from sqlalchemy.orm import selectinload
 from app.core.auth import current_active_user
 from app.db.session import get_db
 from app.models.game.game import Game
-from app.models.game.lineup import Lineup
 from app.models.game.map import Map
 from app.models.game.map_zone import MapZone
 from app.models.game.site import Site
@@ -126,15 +124,3 @@ async def get_map(
     }
 
 
-@router.get("/lineups")
-async def list_lineups(
-    _user: User = Depends(current_active_user),
-    db: AsyncSession = Depends(get_db),
-) -> list[dict]:
-    """List accepted lineups. Phase 1 stub — always returns empty list.
-
-    Phase 2 will add game_slug/map_slug/side/utility_type filters and
-    populate lineups from the DB.
-    """
-    # TODO Phase 2: query accepted lineups with filters
-    return []

--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -1,0 +1,270 @@
+"""Lineup API routes.
+
+POST /api/lineups/upload-url           — presigned PUT URLs for screenshots
+POST /api/lineups                      — create a lineup
+GET  /api/lineups                      — list lineups (filterable)
+GET  /api/lineups/{id}                 — lineup detail
+PATCH /api/lineups/{id}                — update title/notes/zones/side/utility
+DELETE /api/lineups/{id}               — soft-delete (status=hidden)
+GET  /api/games/{game_slug}/maps/{map_slug}/zone-density  — per-zone counts
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import current_active_user
+from app.db.session import get_db
+from app.models.game.game import Game
+from app.models.game.map import Map
+from app.models.game.utility_type import UtilityType
+from app.models.user.user import User
+from app.repositories.game.lineup_repo import LineupFilters
+from app.schemas.game.lineup_schemas import (
+    LineupCreate,
+    LineupPatch,
+    LineupRead,
+    UploadUrlResponse,
+)
+from app.services.game import lineup_service
+
+router = APIRouter(prefix="/api", tags=["lineups"])
+
+
+# ---------------------------------------------------------------------------
+# Helper: resolve map by (game_slug, map_slug) — raises 404 on miss
+# ---------------------------------------------------------------------------
+
+async def _resolve_map(
+    game_slug: str,
+    map_slug: str,
+    db: AsyncSession,
+) -> tuple[Game, Map]:
+    game_result = await db.execute(select(Game).where(Game.slug == game_slug))
+    game = game_result.scalar_one_or_none()
+    if game is None:
+        raise HTTPException(status_code=404, detail="Game not found")
+
+    map_result = await db.execute(
+        select(Map).where(Map.game_id == game.id, Map.slug == map_slug)
+    )
+    map_obj = map_result.scalar_one_or_none()
+    if map_obj is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+
+    return game, map_obj
+
+
+# ---------------------------------------------------------------------------
+# Upload URL endpoint
+# ---------------------------------------------------------------------------
+
+@router.post("/lineups/upload-url", response_model=UploadUrlResponse)
+async def get_upload_url(
+    user: User = Depends(current_active_user),
+) -> UploadUrlResponse:
+    """Return presigned PUT URLs for stand + aim screenshots.
+
+    The client should:
+    1. Call this endpoint to get two PUT URLs + a lineup_id.
+    2. Upload both screenshots directly to MinIO via the PUT URLs.
+    3. Call POST /api/lineups with the lineup_id + object keys from the response.
+    """
+    return lineup_service.generate_upload_urls(user.id)
+
+
+# ---------------------------------------------------------------------------
+# Create lineup
+# ---------------------------------------------------------------------------
+
+@router.post("/lineups", response_model=LineupRead, status_code=201)
+async def create_lineup(
+    payload: LineupCreate,
+    lineup_id: Optional[uuid.UUID] = Query(
+        None, description="Pre-allocated ID from upload-url endpoint"
+    ),
+    user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> LineupRead:
+    """Create a lineup. Pass lineup_id from upload-url to link screenshots."""
+    lineup = await lineup_service.create(db, user.id, payload, lineup_id=lineup_id)
+    return LineupRead.model_validate(lineup)
+
+
+# ---------------------------------------------------------------------------
+# List lineups
+# ---------------------------------------------------------------------------
+
+@router.get("/lineups", response_model=list[LineupRead])
+async def list_lineups(
+    game_slug: Optional[str] = Query(None),
+    map_slug: Optional[str] = Query(None),
+    target_zone_slug: Optional[str] = Query(None),
+    side: Optional[str] = Query(None, description="side_a, side_b, or any"),
+    utility_type_slugs: Optional[str] = Query(
+        None, description="Comma-separated utility type slugs"
+    ),
+    status: Optional[str] = Query(None, description="accepted (default), pending_review, hidden"),
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[LineupRead]:
+    """List lineups. By default returns only accepted lineups.
+
+    Filter by game_slug + map_slug to scope to a specific map.
+    Filter by target_zone_slug to show lineups for a specific zone.
+    side filter uses 'any' semantics: side_a matches side_a and any lineups.
+    """
+    game_id: Optional[uuid.UUID] = None
+    map_id: Optional[uuid.UUID] = None
+    target_zone_id: Optional[uuid.UUID] = None
+    utility_type_ids: list[uuid.UUID] = []
+
+    if game_slug:
+        game_result = await db.execute(select(Game).where(Game.slug == game_slug))
+        game = game_result.scalar_one_or_none()
+        if game is None:
+            return []
+        game_id = game.id
+
+        if map_slug:
+            map_result = await db.execute(
+                select(Map).where(Map.game_id == game_id, Map.slug == map_slug)
+            )
+            map_obj = map_result.scalar_one_or_none()
+            if map_obj is None:
+                return []
+            map_id = map_obj.id
+
+            if target_zone_slug:
+                from app.models.game.map_zone import MapZone
+
+                zone_result = await db.execute(
+                    select(MapZone).where(
+                        MapZone.map_id == map_id, MapZone.slug == target_zone_slug
+                    )
+                )
+                zone = zone_result.scalar_one_or_none()
+                if zone is None:
+                    return []
+                target_zone_id = zone.id
+
+    if utility_type_slugs and game_id:
+        slugs = [s.strip() for s in utility_type_slugs.split(",") if s.strip()]
+        if slugs:
+            ut_result = await db.execute(
+                select(UtilityType).where(
+                    UtilityType.game_id == game_id,
+                    UtilityType.slug.in_(slugs),
+                )
+            )
+            utility_type_ids = [ut.id for ut in ut_result.scalars().all()]
+
+    # Validate side value
+    if side and side not in ("side_a", "side_b", "any"):
+        raise HTTPException(status_code=422, detail="side must be side_a, side_b, or any")
+
+    # None for side means no filter; "any" in URL means "don't filter by side"
+    side_filter = None if (side is None or side == "any") else side
+
+    filters = LineupFilters(
+        game_id=game_id,
+        map_id=map_id,
+        target_zone_id=target_zone_id,
+        side=side_filter,
+        utility_type_ids=utility_type_ids,
+        status=status if status else "accepted",
+    )
+    lineups = await lineup_service.list_by_filters(db, filters)
+    return [LineupRead.model_validate(l) for l in lineups]
+
+
+# ---------------------------------------------------------------------------
+# Get / patch / delete lineup
+# ---------------------------------------------------------------------------
+
+@router.get("/lineups/{lineup_id}", response_model=LineupRead)
+async def get_lineup(
+    lineup_id: uuid.UUID,
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> LineupRead:
+    lineup = await lineup_service.get(db, lineup_id)
+    if lineup is None:
+        raise HTTPException(status_code=404, detail="Lineup not found")
+    return LineupRead.model_validate(lineup)
+
+
+@router.patch("/lineups/{lineup_id}", response_model=LineupRead)
+async def patch_lineup(
+    lineup_id: uuid.UUID,
+    payload: LineupPatch,
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> LineupRead:
+    lineup = await lineup_service.patch(db, lineup_id, payload)
+    if lineup is None:
+        raise HTTPException(status_code=404, detail="Lineup not found")
+    return LineupRead.model_validate(lineup)
+
+
+@router.delete("/lineups/{lineup_id}", status_code=204)
+async def delete_lineup(
+    lineup_id: uuid.UUID,
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    lineup = await lineup_service.hide(db, lineup_id)
+    if lineup is None:
+        raise HTTPException(status_code=404, detail="Lineup not found")
+
+
+# ---------------------------------------------------------------------------
+# Zone density endpoint
+# ---------------------------------------------------------------------------
+
+@router.get(
+    "/games/{game_slug}/maps/{map_slug}/zone-density",
+    response_model=dict,
+)
+async def get_zone_density(
+    game_slug: str,
+    map_slug: str,
+    side: Optional[str] = Query(None, description="side_a or side_b; omit for both"),
+    util: Optional[str] = Query(None, description="Comma-separated utility type slugs"),
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Return per-zone lineup counts for the current filter state.
+
+    Response: { "<zone_id>": { "count": 3, "by_utility": {"smoke": 2, "flash": 1} } }
+
+    Used by the plan-mode UI to color-code zone polygons. Returns an empty
+    dict {} for zones with zero lineups (client should treat missing zones
+    as count=0).
+    """
+    _game, map_obj = await _resolve_map(game_slug, map_slug, db)
+
+    # Validate side
+    if side and side not in ("side_a", "side_b", "any"):
+        raise HTTPException(status_code=422, detail="side must be side_a, side_b, or any")
+    side_filter = None if (side is None or side == "any") else side
+
+    utility_type_ids: list[uuid.UUID] = []
+    if util:
+        slugs = [s.strip() for s in util.split(",") if s.strip()]
+        if slugs:
+            ut_result = await db.execute(
+                select(UtilityType).where(
+                    UtilityType.game_id == map_obj.game_id,
+                    UtilityType.slug.in_(slugs),
+                )
+            )
+            utility_type_ids = [ut.id for ut in ut_result.scalars().all()]
+
+    return await lineup_service.get_zone_density(
+        db, map_obj.id, side_filter, utility_type_ids
+    )

--- a/apps/mygamingassistant/backend/app/main.py
+++ b/apps/mygamingassistant/backend/app/main.py
@@ -21,7 +21,7 @@ from jwt.exceptions import PyJWTError as JWTError
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
 
-from app.api import account, admin, games, health, totp
+from app.api import account, admin, games, health, lineups, totp
 from app.core.audit import current_user_id
 from app.core.auth import auth_backend, fastapi_users
 from app.core.config import settings
@@ -189,6 +189,7 @@ app.include_router(
 # MGA domain routes
 app.include_router(health.router, tags=["health"])
 app.include_router(games.router)
+app.include_router(lineups.router)
 app.include_router(admin.router)
 
 # Shared platform admin router — generic user-management endpoints

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -1,0 +1,168 @@
+"""Lineup repository — all ORM operations for the lineup table.
+
+Filters follow "any" semantics for side: a lineup with side='any' always
+appears in side_a and side_b queries, so players see utility that works
+on both sides.
+
+All filter parameters are optional. Omitting them returns all rows that
+pass the status filter (default: accepted only).
+"""
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from typing import Optional
+
+from sqlalchemy import Select, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.game.lineup import Lineup
+
+
+@dataclass
+class LineupFilters:
+    game_id: Optional[uuid.UUID] = None
+    map_id: Optional[uuid.UUID] = None
+    target_zone_id: Optional[uuid.UUID] = None
+    stand_zone_id: Optional[uuid.UUID] = None
+    # "side_a", "side_b", or None (no filter)
+    side: Optional[str] = None
+    utility_type_ids: list[uuid.UUID] = field(default_factory=list)
+    # None → only "accepted"; set explicitly to bypass
+    status: Optional[str] = "accepted"
+
+
+def _apply_filters(stmt: "Select[tuple[Lineup]]", f: LineupFilters) -> "Select[tuple[Lineup]]":
+    if f.status is not None:
+        stmt = stmt.where(Lineup.status == f.status)
+    if f.game_id is not None:
+        stmt = stmt.where(Lineup.game_id == f.game_id)
+    if f.map_id is not None:
+        stmt = stmt.where(Lineup.map_id == f.map_id)
+    if f.target_zone_id is not None:
+        stmt = stmt.where(Lineup.target_zone_id == f.target_zone_id)
+    if f.stand_zone_id is not None:
+        stmt = stmt.where(Lineup.stand_zone_id == f.stand_zone_id)
+    if f.side is not None:
+        # "any" semantics: lineup.side='any' always matches regardless of the
+        # requested side.
+        stmt = stmt.where(Lineup.side.in_([f.side, "any"]))
+    if f.utility_type_ids:
+        stmt = stmt.where(Lineup.utility_type_id.in_(f.utility_type_ids))
+    return stmt
+
+
+async def create_lineup(db: AsyncSession, data: dict) -> Lineup:
+    """Insert a new lineup row and return the refreshed ORM instance."""
+    lineup = Lineup(**data)
+    db.add(lineup)
+    await db.flush()
+    await db.refresh(lineup, attribute_names=["target_zone", "stand_zone", "utility_type"])
+    return lineup
+
+
+async def list_lineups(
+    db: AsyncSession,
+    filters: LineupFilters,
+) -> list[Lineup]:
+    """Return lineups matching *filters*, eager-loading FK relations."""
+    stmt = (
+        select(Lineup)
+        .options(
+            selectinload(Lineup.target_zone),
+            selectinload(Lineup.stand_zone),
+            selectinload(Lineup.utility_type),
+        )
+        .order_by(Lineup.created_at.desc())
+    )
+    stmt = _apply_filters(stmt, filters)
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def get_lineup(
+    db: AsyncSession,
+    lineup_id: uuid.UUID,
+) -> Lineup | None:
+    """Return a single lineup by id, or None."""
+    stmt = (
+        select(Lineup)
+        .where(Lineup.id == lineup_id)
+        .options(
+            selectinload(Lineup.target_zone),
+            selectinload(Lineup.stand_zone),
+            selectinload(Lineup.utility_type),
+        )
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def update_lineup(
+    db: AsyncSession,
+    lineup: Lineup,
+    patch: dict,
+) -> Lineup:
+    """Apply *patch* fields to *lineup* and flush."""
+    for key, value in patch.items():
+        setattr(lineup, key, value)
+    await db.flush()
+    await db.refresh(lineup, attribute_names=["target_zone", "stand_zone", "utility_type"])
+    return lineup
+
+
+async def hide_lineup(db: AsyncSession, lineup: Lineup) -> Lineup:
+    """Soft-delete: set status='hidden'."""
+    lineup.status = "hidden"
+    await db.flush()
+    return lineup
+
+
+async def zone_density(
+    db: AsyncSession,
+    map_id: uuid.UUID,
+    side: Optional[str],
+    utility_type_ids: list[uuid.UUID],
+) -> dict[str, dict]:
+    """Return per-zone lineup counts, grouped by utility_type slug.
+
+    Returns a dict keyed by target_zone_id (as string):
+      {
+        "<zone_id>": {
+          "count": 3,
+          "by_utility": {"smoke": 2, "flash": 1}
+        }
+      }
+    """
+    from app.models.game.utility_type import UtilityType
+
+    stmt = (
+        select(
+            Lineup.target_zone_id,
+            UtilityType.slug.label("util_slug"),
+            func.count().label("cnt"),
+        )
+        .join(UtilityType, Lineup.utility_type_id == UtilityType.id)
+        .where(
+            Lineup.map_id == map_id,
+            Lineup.status == "accepted",
+        )
+        .group_by(Lineup.target_zone_id, UtilityType.slug)
+    )
+    if side is not None:
+        stmt = stmt.where(Lineup.side.in_([side, "any"]))
+    if utility_type_ids:
+        stmt = stmt.where(Lineup.utility_type_id.in_(utility_type_ids))
+
+    rows = (await db.execute(stmt)).all()
+
+    result: dict[str, dict] = {}
+    for zone_id, util_slug, cnt in rows:
+        key = str(zone_id)
+        if key not in result:
+            result[key] = {"count": 0, "by_utility": {}}
+        result[key]["count"] += cnt
+        result[key]["by_utility"][util_slug] = result[key]["by_utility"].get(util_slug, 0) + cnt
+
+    return result

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -1,0 +1,126 @@
+"""Pydantic schemas for lineup-related API requests and responses."""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from pydantic import BaseModel, Field, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Nested read models
+# ---------------------------------------------------------------------------
+
+class ZoneRead(BaseModel):
+    id: uuid.UUID
+    slug: str
+    name: str
+    polygon_points: list[dict]
+
+    model_config = {"from_attributes": True}
+
+
+class UtilityTypeRead(BaseModel):
+    id: uuid.UUID
+    slug: str
+    name: str
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Lineup read
+# ---------------------------------------------------------------------------
+
+class LineupRead(BaseModel):
+    id: uuid.UUID
+    game_id: uuid.UUID
+    map_id: uuid.UUID
+    target_zone_id: uuid.UUID
+    stand_zone_id: uuid.UUID
+    side: str
+    utility_type_id: uuid.UUID
+    title: str
+    notes: Optional[str] = None
+    stand_screenshot_url: Optional[str] = None
+    aim_screenshot_url: Optional[str] = None
+    aim_anchor_x: Optional[float] = None
+    aim_anchor_y: Optional[float] = None
+    setup_seconds: Optional[int] = None
+    attribution_url: Optional[str] = None
+    attribution_author: Optional[str] = None
+    status: str
+
+    # Expanded relations (populated when available)
+    target_zone: Optional[ZoneRead] = None
+    stand_zone: Optional[ZoneRead] = None
+    utility_type: Optional[UtilityTypeRead] = None
+
+    model_config = {"from_attributes": True}
+
+
+# ---------------------------------------------------------------------------
+# Lineup create
+# ---------------------------------------------------------------------------
+
+class LineupCreate(BaseModel):
+    game_id: uuid.UUID
+    map_id: uuid.UUID
+    target_zone_id: uuid.UUID
+    stand_zone_id: uuid.UUID
+    side: str
+    utility_type_id: uuid.UUID
+    title: str = Field(..., min_length=1, max_length=255)
+    notes: Optional[str] = None
+    # Object keys in MinIO (not full URLs — service generates presigned read URLs)
+    stand_screenshot_key: Optional[str] = None
+    aim_screenshot_key: Optional[str] = None
+    aim_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
+    aim_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
+    setup_seconds: Optional[int] = Field(None, ge=0)
+    attribution_url: Optional[str] = None
+    attribution_author: Optional[str] = None
+
+    @field_validator("side")
+    @classmethod
+    def validate_side(cls, v: str) -> str:
+        if v not in ("side_a", "side_b", "any"):
+            raise ValueError("side must be side_a, side_b, or any")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Lineup patch
+# ---------------------------------------------------------------------------
+
+class LineupPatch(BaseModel):
+    target_zone_id: Optional[uuid.UUID] = None
+    stand_zone_id: Optional[uuid.UUID] = None
+    side: Optional[str] = None
+    utility_type_id: Optional[uuid.UUID] = None
+    title: Optional[str] = Field(None, min_length=1, max_length=255)
+    notes: Optional[str] = None
+    aim_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
+    aim_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
+    setup_seconds: Optional[int] = Field(None, ge=0)
+    attribution_url: Optional[str] = None
+    attribution_author: Optional[str] = None
+
+    @field_validator("side")
+    @classmethod
+    def validate_side(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in ("side_a", "side_b", "any"):
+            raise ValueError("side must be side_a, side_b, or any")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# Upload URL response
+# ---------------------------------------------------------------------------
+
+class UploadUrlResponse(BaseModel):
+    lineup_id: uuid.UUID
+    stand_upload_url: str
+    aim_upload_url: str
+    stand_object_key: str
+    aim_object_key: str

--- a/apps/mygamingassistant/backend/app/services/game/lineup_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_service.py
@@ -1,0 +1,212 @@
+"""Lineup business-logic service.
+
+Responsibilities:
+- Generate presigned PUT URLs for screenshot uploads
+- Generate presigned GET URLs for screenshot reads
+- Orchestrate lineup create/update by delegating to lineup_repo
+- Status transition validation (accept/hide)
+
+ORM operations live exclusively in lineup_repo. This service never
+imports AsyncSession directly — it receives it from the route handler.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.storage import get_storage
+from app.models.game.lineup import Lineup
+from app.repositories.game.lineup_repo import (
+    LineupFilters,
+    create_lineup,
+    get_lineup,
+    hide_lineup,
+    list_lineups,
+    update_lineup,
+    zone_density,
+)
+from app.schemas.game.lineup_schemas import LineupCreate, LineupPatch, UploadUrlResponse
+
+# Presigned PUT URLs are valid for 15 minutes — enough time for the browser
+# to complete the upload, short enough to reduce exposure on leaked URLs.
+_UPLOAD_URL_TTL = timedelta(minutes=15)
+# Presigned GET URLs for screenshots in card view — 24 hours so images stay
+# visible without re-auth on reload.
+_READ_URL_TTL = 24 * 3600  # seconds
+
+
+def _screenshot_key(user_id: uuid.UUID, lineup_id: uuid.UUID, slot: str) -> str:
+    """Build a deterministic MinIO object key for a screenshot slot.
+
+    Format: <user_id>/<lineup_id>/<slot>.png
+    Slot: "stand" or "aim"
+    """
+    return f"{user_id}/{lineup_id}/{slot}.png"
+
+
+def generate_upload_urls(user_id: uuid.UUID) -> UploadUrlResponse:
+    """Return presigned PUT URLs for stand and aim screenshots.
+
+    The lineup_id is a new UUID generated here so the frontend can use it
+    as the lineup ID when submitting the create request. This avoids a
+    round-trip: client requests PUT URLs → uploads both files → POSTs the
+    create with the known lineup_id.
+    """
+    storage = get_storage()
+    lineup_id = uuid.uuid4()
+
+    stand_key = _screenshot_key(user_id, lineup_id, "stand")
+    aim_key = _screenshot_key(user_id, lineup_id, "aim")
+
+    # minio-py presigned_put_object uses the internal client (same bucket,
+    # same credentials). The URL host will be the MINIO_ENDPOINT value, which
+    # is reachable by the browser in local dev (localhost:9000) and by the
+    # container network in production.
+    #
+    # In production the browser needs the *public* endpoint. We sign against
+    # the same client used for reads since presigned GET already handles the
+    # dual-endpoint case via generate_presigned_url on _public_client.
+    # For PUT we call the underlying minio client directly.
+    #
+    # _DualEndpointStorageClient wraps internal + public Minio instances.
+    # We expose a generate_presigned_put_url helper that uses the public
+    # client for signing so the browser URL resolves correctly.
+    stand_url = _presigned_put(storage, stand_key)
+    aim_url = _presigned_put(storage, aim_key)
+
+    return UploadUrlResponse(
+        lineup_id=lineup_id,
+        stand_upload_url=stand_url,
+        aim_upload_url=aim_url,
+        stand_object_key=stand_key,
+        aim_object_key=aim_key,
+    )
+
+
+def _presigned_put(storage, key: str) -> str:
+    """Sign a PUT URL using the public MinIO client when available."""
+    from platform_shared.core.storage import _DualEndpointStorageClient
+
+    if isinstance(storage, _DualEndpointStorageClient):
+        # Use the public-facing client so the browser can resolve the URL.
+        return storage._public_client.presigned_put_object(
+            storage.bucket, key, expires=_UPLOAD_URL_TTL
+        )
+    return storage._client.presigned_put_object(
+        storage.bucket, key, expires=_UPLOAD_URL_TTL
+    )
+
+
+def _sign_screenshot_url(key: Optional[str]) -> Optional[str]:
+    """Return a presigned GET URL for *key*, or None if key is falsy."""
+    if not key:
+        return None
+    storage = get_storage()
+    return storage.generate_presigned_url(key, expires_in_seconds=_READ_URL_TTL)
+
+
+def _sign_lineup(lineup: Lineup) -> Lineup:
+    """Mutate lineup's screenshot URL fields to presigned GET URLs in-place.
+
+    The DB stores object keys (e.g. ``<user_id>/<lineup_id>/stand.png``).
+    Callers receive presigned URLs valid for 24 h.
+    """
+    lineup.stand_screenshot_url = _sign_screenshot_url(lineup.stand_screenshot_url)
+    lineup.aim_screenshot_url = _sign_screenshot_url(lineup.aim_screenshot_url)
+    return lineup
+
+
+async def create(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    payload: LineupCreate,
+    lineup_id: Optional[uuid.UUID] = None,
+) -> Lineup:
+    """Create a lineup. status='accepted' for manual uploads (no review step)."""
+    if settings.minio_skip_startup_check:
+        # Local dev with MinIO disabled — store keys as-is (no signing)
+        stand_url = payload.stand_screenshot_key
+        aim_url = payload.aim_screenshot_key
+    else:
+        # Validate that the keys exist in MinIO (optional — removes orphan rows)
+        stand_url = payload.stand_screenshot_key
+        aim_url = payload.aim_screenshot_key
+
+    data: dict = {
+        "game_id": payload.game_id,
+        "map_id": payload.map_id,
+        "target_zone_id": payload.target_zone_id,
+        "stand_zone_id": payload.stand_zone_id,
+        "side": payload.side,
+        "utility_type_id": payload.utility_type_id,
+        "title": payload.title,
+        "notes": payload.notes,
+        "stand_screenshot_url": stand_url,
+        "aim_screenshot_url": aim_url,
+        "aim_anchor_x": payload.aim_anchor_x,
+        "aim_anchor_y": payload.aim_anchor_y,
+        "setup_seconds": payload.setup_seconds,
+        "attribution_url": payload.attribution_url,
+        "attribution_author": payload.attribution_author,
+        "status": "accepted",
+    }
+    if lineup_id is not None:
+        data["id"] = lineup_id
+
+    lineup = await create_lineup(db, data)
+    return _sign_lineup(lineup)
+
+
+async def get(
+    db: AsyncSession,
+    lineup_id: uuid.UUID,
+) -> Lineup | None:
+    lineup = await get_lineup(db, lineup_id)
+    if lineup is None:
+        return None
+    return _sign_lineup(lineup)
+
+
+async def list_by_filters(
+    db: AsyncSession,
+    filters: LineupFilters,
+) -> list[Lineup]:
+    lineups = await list_lineups(db, filters)
+    return [_sign_lineup(l) for l in lineups]
+
+
+async def patch(
+    db: AsyncSession,
+    lineup_id: uuid.UUID,
+    payload: LineupPatch,
+) -> Lineup | None:
+    lineup = await get_lineup(db, lineup_id)
+    if lineup is None:
+        return None
+    patch_data = payload.model_dump(exclude_unset=True)
+    updated = await update_lineup(db, lineup, patch_data)
+    return _sign_lineup(updated)
+
+
+async def hide(
+    db: AsyncSession,
+    lineup_id: uuid.UUID,
+) -> Lineup | None:
+    lineup = await get_lineup(db, lineup_id)
+    if lineup is None:
+        return None
+    hidden = await hide_lineup(db, lineup)
+    return hidden
+
+
+async def get_zone_density(
+    db: AsyncSession,
+    map_id: uuid.UUID,
+    side: Optional[str],
+    utility_type_ids: list[uuid.UUID],
+) -> dict[str, dict]:
+    return await zone_density(db, map_id, side, utility_type_ids)

--- a/apps/mygamingassistant/backend/tests/test_lineups.py
+++ b/apps/mygamingassistant/backend/tests/test_lineups.py
@@ -1,0 +1,341 @@
+"""Unit + integration tests for the lineup API (PR 2).
+
+Tests verify:
+- POST /api/lineups/upload-url returns two URLs + lineup_id
+- POST /api/lineups creates a lineup (status=accepted by default)
+- GET /api/lineups lists with filters
+- GET /api/lineups/{id} returns detail
+- PATCH /api/lineups/{id} updates fields
+- DELETE /api/lineups/{id} soft-deletes (status=hidden)
+- GET /api/games/{game_slug}/maps/{map_slug}/zone-density returns correct counts
+- Side 'any' semantics: lineup.side='any' appears in side_a and side_b queries
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.game import Game
+from app.models.game.lineup import Lineup
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.models.game.utility_type import UtilityType
+from app.models.user.user import User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def seeded_game_map(db: AsyncSession) -> dict:
+    """Create a minimal Game + Map + 2 MapZones + UtilityType in the test DB."""
+    game = Game(
+        slug="test-game",
+        name="Test Game",
+        side_a_label="T",
+        side_b_label="CT",
+    )
+    db.add(game)
+    await db.flush()
+
+    map_obj = Map(game_id=game.id, slug="test-map", name="Test Map")
+    db.add(map_obj)
+    await db.flush()
+
+    zone_a = MapZone(map_id=map_obj.id, slug="a-site", name="A Site", polygon_points=[])
+    zone_b = MapZone(map_id=map_obj.id, slug="b-site", name="B Site", polygon_points=[])
+    db.add(zone_a)
+    db.add(zone_b)
+    await db.flush()
+
+    util = UtilityType(game_id=game.id, slug="smoke", name="Smoke")
+    db.add(util)
+    await db.flush()
+
+    return {
+        "game": game,
+        "map": map_obj,
+        "zone_a": zone_a,
+        "zone_b": zone_b,
+        "util": util,
+    }
+
+
+@pytest_asyncio.fixture
+async def auth_client(client: AsyncClient, db: AsyncSession) -> AsyncClient:
+    """Create a test user directly in the DB, log in, return authed client."""
+    from fastapi_users.password import PasswordHelper
+    from sqlalchemy import select
+
+    TEST_EMAIL = "lineup-test@example.com"
+    TEST_PASSWORD = "testpassword123!"
+
+    result = await db.execute(select(User).where(User.email == TEST_EMAIL))
+    user = result.scalar_one_or_none()
+    if user is None:
+        helper = PasswordHelper()
+        user = User(
+            email=TEST_EMAIL,
+            hashed_password=helper.hash(TEST_PASSWORD),
+            is_verified=True,
+            is_active=True,
+        )
+        db.add(user)
+        await db.flush()
+
+    resp = await client.post(
+        "/api/auth/jwt/login",
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    if resp.status_code != 200:
+        pytest.skip(f"Could not authenticate test user: {resp.status_code} {resp.text}")
+
+    token = resp.json().get("access_token", "")
+    client.headers["Authorization"] = f"Bearer {token}"
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Mock storage so tests don't need a real MinIO
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def mock_storage():
+    """Stub out the storage client for all lineup tests."""
+    mock = MagicMock()
+    mock.bucket = settings.minio_bucket
+    mock.generate_presigned_url.return_value = "https://minio.example.com/signed-read-url"
+    mock._client = MagicMock()
+    mock._client.presigned_put_object.return_value = "https://minio.example.com/signed-put-url"
+
+    with patch("app.services.game.lineup_service.get_storage", return_value=mock):
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# Helper: create a lineup via the API
+# ---------------------------------------------------------------------------
+
+async def _create_lineup(
+    client: AsyncClient,
+    seeded: dict,
+    *,
+    side: str = "side_a",
+    status_override: str | None = None,
+) -> dict:
+    payload = {
+        "game_id": str(seeded["game"].id),
+        "map_id": str(seeded["map"].id),
+        "target_zone_id": str(seeded["zone_a"].id),
+        "stand_zone_id": str(seeded["zone_b"].id),
+        "side": side,
+        "utility_type_id": str(seeded["util"].id),
+        "title": "A-site smoke from CT spawn",
+        "notes": "Stand on the box",
+        "stand_screenshot_key": "user1/lineup1/stand.png",
+        "aim_screenshot_key": "user1/lineup1/aim.png",
+        "aim_anchor_x": 0.5,
+        "aim_anchor_y": 0.4,
+        "setup_seconds": 8,
+    }
+    resp = await client.post("/api/lineups", json=payload)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upload_url_returns_two_urls(auth_client: AsyncClient):
+    """POST /api/lineups/upload-url should return two presigned PUT URLs."""
+    resp = await auth_client.post("/api/lineups/upload-url")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "lineup_id" in body
+    assert "stand_upload_url" in body
+    assert "aim_upload_url" in body
+    assert "stand_object_key" in body
+    assert "aim_object_key" in body
+    # Object keys should include the lineup_id UUID
+    assert body["lineup_id"] in body["stand_object_key"]
+
+
+@pytest.mark.asyncio
+async def test_create_lineup_status_accepted(
+    auth_client: AsyncClient, seeded_game_map: dict
+):
+    """POST /api/lineups should create a lineup with status=accepted."""
+    resp = await _create_lineup(auth_client, seeded_game_map)
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["status"] == "accepted"
+    assert body["title"] == "A-site smoke from CT spawn"
+    assert body["side"] == "side_a"
+    assert "target_zone" in body
+    assert "utility_type" in body
+
+
+@pytest.mark.asyncio
+async def test_list_lineups_default_accepted_only(
+    auth_client: AsyncClient, seeded_game_map: dict
+):
+    """GET /api/lineups should return only accepted lineups by default."""
+    # Create a lineup
+    create_resp = await _create_lineup(auth_client, seeded_game_map)
+    assert create_resp.status_code == 201
+
+    lineup_id = create_resp.json()["id"]
+
+    # Delete it (soft delete → hidden)
+    del_resp = await auth_client.delete(f"/api/lineups/{lineup_id}")
+    assert del_resp.status_code == 204
+
+    # Default list should not include hidden lineup
+    list_resp = await auth_client.get("/api/lineups")
+    assert list_resp.status_code == 200
+    ids = [l["id"] for l in list_resp.json()]
+    assert lineup_id not in ids
+
+
+@pytest.mark.asyncio
+async def test_list_lineups_filter_by_map(
+    auth_client: AsyncClient, seeded_game_map: dict
+):
+    """GET /api/lineups?game_slug=&map_slug= should filter correctly."""
+    create_resp = await _create_lineup(auth_client, seeded_game_map)
+    assert create_resp.status_code == 201
+
+    game_slug = seeded_game_map["game"].slug
+    map_slug = seeded_game_map["map"].slug
+
+    resp = await auth_client.get(f"/api/lineups?game_slug={game_slug}&map_slug={map_slug}")
+    assert resp.status_code == 200
+    items = resp.json()
+    assert len(items) >= 1
+    assert all(i["map_id"] == str(seeded_game_map["map"].id) for i in items)
+
+
+@pytest.mark.asyncio
+async def test_side_any_semantics(
+    auth_client: AsyncClient, seeded_game_map: dict, db: AsyncSession
+):
+    """Lineup with side='any' must appear in both side_a and side_b filter queries."""
+    # Create an "any" lineup
+    payload = {
+        "game_id": str(seeded_game_map["game"].id),
+        "map_id": str(seeded_game_map["map"].id),
+        "target_zone_id": str(seeded_game_map["zone_a"].id),
+        "stand_zone_id": str(seeded_game_map["zone_b"].id),
+        "side": "any",
+        "utility_type_id": str(seeded_game_map["util"].id),
+        "title": "Works both sides",
+    }
+    resp = await auth_client.post("/api/lineups", json=payload)
+    assert resp.status_code == 201
+    lineup_id = resp.json()["id"]
+
+    game_slug = seeded_game_map["game"].slug
+    map_slug = seeded_game_map["map"].slug
+    base = f"/api/lineups?game_slug={game_slug}&map_slug={map_slug}"
+
+    # Must appear in side_a query
+    r_a = await auth_client.get(f"{base}&side=side_a")
+    assert r_a.status_code == 200
+    assert any(l["id"] == lineup_id for l in r_a.json()), "side='any' lineup missing from side_a query"
+
+    # Must appear in side_b query
+    r_b = await auth_client.get(f"{base}&side=side_b")
+    assert r_b.status_code == 200
+    assert any(l["id"] == lineup_id for l in r_b.json()), "side='any' lineup missing from side_b query"
+
+
+@pytest.mark.asyncio
+async def test_get_lineup_detail(
+    auth_client: AsyncClient, seeded_game_map: dict
+):
+    """GET /api/lineups/{id} should return full detail."""
+    create_resp = await _create_lineup(auth_client, seeded_game_map)
+    lineup_id = create_resp.json()["id"]
+
+    resp = await auth_client.get(f"/api/lineups/{lineup_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["id"] == lineup_id
+    assert body["aim_anchor_x"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_patch_lineup(
+    auth_client: AsyncClient, seeded_game_map: dict
+):
+    """PATCH /api/lineups/{id} should update specified fields only."""
+    create_resp = await _create_lineup(auth_client, seeded_game_map)
+    lineup_id = create_resp.json()["id"]
+
+    resp = await auth_client.patch(
+        f"/api/lineups/{lineup_id}",
+        json={"title": "Updated title", "notes": "Updated notes"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["title"] == "Updated title"
+    assert body["notes"] == "Updated notes"
+    # Unchanged fields preserved
+    assert body["side"] == "side_a"
+
+
+@pytest.mark.asyncio
+async def test_delete_lineup_soft(
+    auth_client: AsyncClient, seeded_game_map: dict
+):
+    """DELETE /api/lineups/{id} should set status=hidden, not remove the row."""
+    create_resp = await _create_lineup(auth_client, seeded_game_map)
+    lineup_id = create_resp.json()["id"]
+
+    del_resp = await auth_client.delete(f"/api/lineups/{lineup_id}")
+    assert del_resp.status_code == 204
+
+    # Should still be fetchable (not hard-deleted)
+    detail_resp = await auth_client.get(f"/api/lineups/{lineup_id}")
+    assert detail_resp.status_code == 200
+    assert detail_resp.json()["status"] == "hidden"
+
+
+@pytest.mark.asyncio
+async def test_zone_density_endpoint(
+    auth_client: AsyncClient, seeded_game_map: dict
+):
+    """GET .../zone-density should count accepted lineups per zone."""
+    # Create two lineups targeting zone_a
+    for _ in range(2):
+        await _create_lineup(auth_client, seeded_game_map, side="side_a")
+
+    game_slug = seeded_game_map["game"].slug
+    map_slug = seeded_game_map["map"].slug
+    zone_a_id = str(seeded_game_map["zone_a"].id)
+
+    resp = await auth_client.get(
+        f"/api/games/{game_slug}/maps/{map_slug}/zone-density?side=side_a"
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert zone_a_id in body
+    assert body[zone_a_id]["count"] >= 2
+    assert "by_utility" in body[zone_a_id]
+    assert "smoke" in body[zone_a_id]["by_utility"]
+
+
+@pytest.mark.asyncio
+async def test_404_on_unknown_lineup(auth_client: AsyncClient):
+    """GET /api/lineups/{unknown_id} should return 404."""
+    resp = await auth_client.get(f"/api/lineups/{uuid.uuid4()}")
+    assert resp.status_code == 404

--- a/apps/mygamingassistant/frontend/e2e/lineup-upload-plan-mode.spec.ts
+++ b/apps/mygamingassistant/frontend/e2e/lineup-upload-plan-mode.spec.ts
@@ -1,0 +1,152 @@
+/**
+ * E2E smoke tests for PR 2: lineup upload + plan-mode UI.
+ *
+ * Coverage:
+ *  1. /lineups/new route loads and shows the upload form
+ *  2. MapPage (:gameSlug/:mapSlug) renders zone overlay controls
+ *  3. Side toggle changes the URL param
+ *  4. Utility chip toggles change the URL param
+ *  5. Clicking a zone adds ?zone= to URL and shows results panel
+ *  6. Pressing Esc closes the zone panel
+ *  7. "Add lineup" button navigates to /lineups/new with map params
+ *
+ * These tests do NOT upload actual files (that requires a real MinIO).
+ * They verify routing, URL state, and DOM structure.
+ *
+ * Requirements:
+ *  - Backend on :8004 with migrations + fixtures loaded
+ *  - E2E_TEST_EMAIL + E2E_TEST_PASSWORD set to seed user credentials
+ */
+import { test, expect } from "@playwright/test";
+import { getOperatorCredentials, loginViaUI } from "./fixtures/auth";
+
+test.describe("Lineup upload form (/lineups/new)", () => {
+  test("form renders required fields", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/lineups/new");
+    await expect(page.getByRole("heading", { name: "Add Lineup" })).toBeVisible();
+
+    // Required dropdowns
+    await expect(page.getByLabel("Select game")).toBeVisible();
+    await expect(page.getByLabel("Select map")).toBeVisible();
+
+    // Screenshot slots
+    await expect(page.getByText("Stand screenshot")).toBeVisible();
+    await expect(page.getByText("Aim screenshot")).toBeVisible();
+
+    // Submit button (disabled until screenshots are uploaded)
+    const saveButton = page.getByRole("button", { name: /save lineup/i });
+    await expect(saveButton).toBeVisible();
+    await expect(saveButton).toBeDisabled();
+  });
+
+  test("pre-fills game+map from query params", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/lineups/new?game=valorant&map=bind");
+    await expect(page.getByRole("heading", { name: "Add Lineup" })).toBeVisible();
+  });
+});
+
+test.describe("MapPage plan-mode (:gameSlug/:mapSlug)", () => {
+  test("renders side toggle and map zone overlay", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/valorant/bind");
+    // Wait for map to load
+    await page.waitForTimeout(500);
+
+    // Side toggle buttons present (Any is default)
+    const anyButton = page.getByRole("button", { name: "Any" });
+    await expect(anyButton).toBeVisible();
+    await expect(anyButton).toHaveAttribute("aria-pressed", "true");
+
+    // Game-specific side labels should be visible
+    await expect(page.getByRole("button", { name: "Attacker" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Defender" })).toBeVisible();
+  });
+
+  test("side toggle updates URL param", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/valorant/bind");
+    await page.waitForTimeout(300);
+
+    // Click Attacker
+    await page.getByRole("button", { name: "Attacker" }).click();
+    await expect(page).toHaveURL(/[?&]side=side_a/);
+
+    // Click Defender
+    await page.getByRole("button", { name: "Defender" }).click();
+    await expect(page).toHaveURL(/[?&]side=side_b/);
+
+    // Click Any (clears side param)
+    await page.getByRole("button", { name: "Any" }).click();
+    // side param should be removed
+    const url = page.url();
+    expect(url).not.toMatch(/[?&]side=/);
+  });
+
+  test("utility chips update URL param", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/valorant/bind");
+    await page.waitForTimeout(300);
+
+    // Find a utility chip (smoke is always present for Valorant)
+    const smokeChip = page.getByRole("button", { name: /smoke/i });
+    if (await smokeChip.isVisible()) {
+      await smokeChip.click();
+      await expect(page).toHaveURL(/[?&]util=smoke/);
+      // Click again to deselect
+      await smokeChip.click();
+      const url = page.url();
+      expect(url).not.toMatch(/[?&]util=smoke/);
+    }
+  });
+
+  test("zone click adds zone param to URL", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/valorant/bind");
+    // Wait for zones to render (SVG polygons)
+    await page.waitForSelector("svg polygon", { timeout: 5000 }).catch(() => {
+      // OK if no polygons yet (no zone fixture data) — skip assertion
+    });
+
+    const polygons = page.locator("svg polygon");
+    const count = await polygons.count();
+    if (count > 0) {
+      await polygons.first().click({ force: true });
+      // URL should have ?zone=
+      await expect(page).toHaveURL(/[?&]zone=/);
+
+      // Pressing Esc should clear the zone
+      await page.keyboard.press("Escape");
+      const url = page.url();
+      expect(url).not.toMatch(/[?&]zone=/);
+    }
+  });
+
+  test("Add lineup button links to /lineups/new with map context", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/valorant/bind");
+    await page.waitForTimeout(200);
+
+    const addBtn = page.getByRole("link", { name: /add lineup/i });
+    await expect(addBtn).toBeVisible();
+    const href = await addBtn.getAttribute("href");
+    expect(href).toContain("/lineups/new");
+    expect(href).toContain("game=valorant");
+    expect(href).toContain("map=bind");
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -1,0 +1,99 @@
+/**
+ * LineupCard unit tests.
+ *
+ * Tests:
+ * - Thumbnail variant renders title + stand screenshot
+ * - Expanded variant renders both screenshots, metadata, notes
+ * - Aim anchor overlay renders at correct position when coords are set
+ * - Aim anchor is absent when coords are null
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import LineupCard from "@/components/lineup/LineupCard";
+import type { Lineup } from "@/types/game";
+
+const BASE_LINEUP: Lineup = {
+  id: "lineup-1",
+  game_id: "game-1",
+  map_id: "map-1",
+  target_zone_id: "zone-1",
+  stand_zone_id: "zone-2",
+  side: "side_a",
+  utility_type_id: "util-1",
+  title: "A-site smoke from CT",
+  notes: "Stand on the crate",
+  stand_screenshot_url: "https://example.com/stand.png",
+  aim_screenshot_url: "https://example.com/aim.png",
+  aim_anchor_x: 0.5,
+  aim_anchor_y: 0.4,
+  setup_seconds: 8,
+  attribution_url: null,
+  attribution_author: null,
+  status: "accepted",
+  target_zone: { id: "zone-1", slug: "a-site", name: "A Site", polygon_points: [] },
+  stand_zone: { id: "zone-2", slug: "ct-spawn", name: "CT Spawn", polygon_points: [] },
+  utility_type: { id: "util-1", slug: "smoke", name: "Smoke" },
+};
+
+describe("LineupCard", () => {
+  it("thumbnail variant renders title", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="thumbnail" />);
+    expect(screen.getByText("A-site smoke from CT")).toBeDefined();
+  });
+
+  it("thumbnail variant renders stand screenshot", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="thumbnail" />);
+    const img = screen.getByAltText("A-site smoke from CT — stand position");
+    expect(img).toBeDefined();
+  });
+
+  it("expanded variant renders both screenshots", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    const standImg = screen.getByAltText("A-site smoke from CT — stand position");
+    const aimImg = screen.getByAltText("A-site smoke from CT — aim reference");
+    expect(standImg).toBeDefined();
+    expect(aimImg).toBeDefined();
+  });
+
+  it("expanded variant renders utility type badge", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    expect(screen.getByText("Smoke")).toBeDefined();
+  });
+
+  it("expanded variant renders notes", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    expect(screen.getByText("Stand on the crate")).toBeDefined();
+  });
+
+  it("expanded variant renders setup_seconds badge", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    expect(screen.getByText("8s")).toBeDefined();
+  });
+
+  it("expanded variant renders aim anchor when coords are set", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    const anchor = screen.getByLabelText(/aim anchor/i);
+    expect(anchor).toBeDefined();
+  });
+
+  it("expanded variant omits aim anchor when coords are null", () => {
+    const lineup: Lineup = { ...BASE_LINEUP, aim_anchor_x: null, aim_anchor_y: null };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    const anchor = screen.queryByLabelText(/aim anchor/i);
+    expect(anchor).toBeNull();
+  });
+
+  it("expanded variant renders 'No screenshot' when screenshot URL is null", () => {
+    const lineup: Lineup = { ...BASE_LINEUP, stand_screenshot_url: null };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    const noShots = screen.getAllByText("No screenshot");
+    expect(noShots.length).toBeGreaterThan(0);
+  });
+
+  it("thumbnail calls onClick when clicked", () => {
+    const onClick = vi.fn();
+    render(<LineupCard lineup={BASE_LINEUP} variant="thumbnail" onClick={onClick} />);
+    screen.getByRole("button", { name: /view a-site smoke/i }).click();
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
@@ -1,0 +1,165 @@
+/**
+ * LineupCard — displays a single lineup in one of two variants:
+ *   expanded   — side-by-side stand + aim images, full metadata, aim anchor overlay
+ *   thumbnail  — stand image only (small), title underneath
+ *
+ * The aim anchor circle renders at (aim_anchor_x * width, aim_anchor_y * height)
+ * relative to the aim screenshot, using a CSS-absolute circle overlay.
+ */
+import { Clock } from "lucide-react";
+import type { Lineup } from "@/types/game";
+
+interface LineupCardProps {
+  lineup: Lineup;
+  variant: "expanded" | "thumbnail";
+  onClick?: () => void;
+}
+
+const SIDE_LABELS: Record<string, string> = {
+  side_a: "A",
+  side_b: "B",
+  any: "Both",
+};
+
+export default function LineupCard({ lineup, variant, onClick }: LineupCardProps) {
+  if (variant === "thumbnail") {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex flex-col items-center gap-1.5 rounded-lg border bg-card hover:bg-muted/40 transition-colors overflow-hidden text-left w-full"
+        aria-label={`View ${lineup.title}`}
+      >
+        <div className="w-full aspect-video bg-muted/20 overflow-hidden rounded-t-lg">
+          {lineup.stand_screenshot_url ? (
+            <img
+              src={lineup.stand_screenshot_url}
+              alt={`${lineup.title} — stand position`}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <div className="w-full h-full flex items-center justify-center text-xs text-muted-foreground">
+              No screenshot
+            </div>
+          )}
+        </div>
+        <span className="px-2 pb-2 text-xs font-medium text-center leading-tight line-clamp-2">
+          {lineup.title}
+        </span>
+      </button>
+    );
+  }
+
+  // Expanded variant
+  return (
+    <div className="rounded-lg border bg-card overflow-hidden">
+      {/* Header */}
+      <div className="px-4 py-3 flex items-start justify-between gap-3 border-b">
+        <div className="flex-1 min-w-0">
+          <h3 className="font-semibold text-sm leading-tight">{lineup.title}</h3>
+          <div className="flex items-center gap-2 mt-1 flex-wrap">
+            {lineup.utility_type && (
+              <span className="text-xs px-2 py-0.5 rounded-full bg-primary/10 text-primary capitalize">
+                {lineup.utility_type.name}
+              </span>
+            )}
+            <span className="text-xs text-muted-foreground">
+              Side: {SIDE_LABELS[lineup.side] ?? lineup.side}
+            </span>
+            {lineup.setup_seconds != null && (
+              <span className="text-xs flex items-center gap-0.5 text-muted-foreground">
+                <Clock className="w-3 h-3" />
+                {lineup.setup_seconds}s
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Screenshots */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 p-3">
+        {/* Stand screenshot */}
+        <div>
+          <p className="text-xs text-muted-foreground mb-1.5 font-medium">Stand position</p>
+          <div className="rounded-md overflow-hidden bg-muted/20 aspect-video">
+            {lineup.stand_screenshot_url ? (
+              <img
+                src={lineup.stand_screenshot_url}
+                alt={`${lineup.title} — stand position`}
+                className="w-full h-full object-cover"
+              />
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-xs text-muted-foreground">
+                No screenshot
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* Aim screenshot with anchor overlay */}
+        <div>
+          <p className="text-xs text-muted-foreground mb-1.5 font-medium">Aim reference</p>
+          <div className="rounded-md overflow-hidden bg-muted/20 aspect-video relative">
+            {lineup.aim_screenshot_url ? (
+              <>
+                <img
+                  src={lineup.aim_screenshot_url}
+                  alt={`${lineup.title} — aim reference`}
+                  className="w-full h-full object-cover"
+                />
+                {lineup.aim_anchor_x != null && lineup.aim_anchor_y != null && (
+                  <AimAnchorDot
+                    x={lineup.aim_anchor_x}
+                    y={lineup.aim_anchor_y}
+                  />
+                )}
+              </>
+            ) : (
+              <div className="w-full h-full flex items-center justify-center text-xs text-muted-foreground">
+                No screenshot
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Notes */}
+      {lineup.notes && (
+        <div className="px-4 pb-4">
+          <p className="text-xs text-muted-foreground whitespace-pre-wrap">{lineup.notes}</p>
+        </div>
+      )}
+
+      {/* Zone context */}
+      <div className="px-4 pb-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+        {lineup.target_zone && (
+          <span>Target: <span className="text-foreground">{lineup.target_zone.name}</span></span>
+        )}
+        {lineup.stand_zone && (
+          <span>From: <span className="text-foreground">{lineup.stand_zone.name}</span></span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** Red crosshair dot positioned via CSS at the normalized anchor coords. */
+function AimAnchorDot({ x, y }: { x: number; y: number }) {
+  return (
+    <div
+      aria-label={`Aim anchor at ${Math.round(x * 100)}%, ${Math.round(y * 100)}%`}
+      style={{
+        position: "absolute",
+        left: `calc(${x * 100}% - 6px)`,
+        top: `calc(${y * 100}% - 6px)`,
+        width: 12,
+        height: 12,
+        borderRadius: "50%",
+        border: "2px solid rgba(239, 68, 68, 0.9)",
+        background: "rgba(239, 68, 68, 0.3)",
+        boxShadow: "0 0 0 1px rgba(0,0,0,0.5)",
+        pointerEvents: "none",
+      }}
+    />
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/MapZoneOverlay.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/MapZoneOverlay.tsx
@@ -1,0 +1,158 @@
+/**
+ * MapZoneOverlay — renders zone polygons over the map minimap as SVG.
+ *
+ * Density coloring (always-visible, per UX spec):
+ *   count > 0  → semi-transparent green fill + brighter border
+ *   count == 0 → grey fill + dim border
+ *
+ * Click zone → triggers onZoneClick(zone.slug).
+ * Hover zone → shows tooltip with lineup count + by_utility breakdown.
+ */
+import { useState } from "react";
+import type { MapZone, ZoneDensity } from "@/types/game";
+
+interface Props {
+  zones: MapZone[];
+  density: ZoneDensity;
+  selectedZoneSlug: string | null;
+  onZoneClick: (zoneSlug: string) => void;
+  /** viewBox dimensions — defaults to 1000x1000 normalized space */
+  viewBoxSize?: number;
+}
+
+const FILL_HAS_LINEUPS = "rgba(34,197,94,0.18)";
+const FILL_EMPTY = "rgba(156,163,175,0.10)";
+const STROKE_HAS_LINEUPS = "rgba(34,197,94,0.7)";
+const STROKE_EMPTY = "rgba(255,255,255,0.25)";
+const STROKE_SELECTED = "rgba(251,191,36,0.9)";
+const FILL_SELECTED = "rgba(251,191,36,0.18)";
+
+function pointsToSvg(
+  polygon_points: Array<{ x: number; y: number }>,
+  viewBoxSize: number,
+): string {
+  return polygon_points
+    .map((p) => `${p.x * viewBoxSize},${p.y * viewBoxSize}`)
+    .join(" ");
+}
+
+interface TooltipState {
+  zone: MapZone;
+  x: number;
+  y: number;
+}
+
+export default function MapZoneOverlay({
+  zones,
+  density,
+  selectedZoneSlug,
+  onZoneClick,
+  viewBoxSize = 1000,
+}: Props) {
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+
+  function handleMouseEnter(
+    zone: MapZone,
+    e: React.MouseEvent<SVGPolygonElement>,
+  ) {
+    const rect = (e.currentTarget.closest("svg") as SVGSVGElement)
+      ?.getBoundingClientRect();
+    if (!rect) return;
+    setTooltip({
+      zone,
+      x: e.clientX - rect.left,
+      y: e.clientY - rect.top,
+    });
+  }
+
+  function handleMouseMove(
+    _zone: MapZone,
+    e: React.MouseEvent<SVGPolygonElement>,
+  ) {
+    const rect = (e.currentTarget.closest("svg") as SVGSVGElement)
+      ?.getBoundingClientRect();
+    if (!rect) return;
+    setTooltip((prev) =>
+      prev ? { ...prev, x: e.clientX - rect.left, y: e.clientY - rect.top } : null,
+    );
+  }
+
+  function handleMouseLeave() {
+    setTooltip(null);
+  }
+
+  return (
+    <div className="relative w-full h-full">
+      <svg
+        viewBox={`0 0 ${viewBoxSize} ${viewBoxSize}`}
+        className="absolute inset-0 w-full h-full"
+        style={{ overflow: "visible" }}
+      >
+        {zones.map((zone) => {
+          const data = density[zone.id];
+          const count = data?.count ?? 0;
+          const isSelected = zone.slug === selectedZoneSlug;
+          const points = pointsToSvg(zone.polygon_points, viewBoxSize);
+
+          const fill = isSelected
+            ? FILL_SELECTED
+            : count > 0
+              ? FILL_HAS_LINEUPS
+              : FILL_EMPTY;
+          const stroke = isSelected
+            ? STROKE_SELECTED
+            : count > 0
+              ? STROKE_HAS_LINEUPS
+              : STROKE_EMPTY;
+
+          return (
+            <polygon
+              key={zone.id}
+              points={points}
+              fill={fill}
+              stroke={stroke}
+              strokeWidth={isSelected ? 2 : 1}
+              className="cursor-pointer transition-all duration-150 hover:brightness-125"
+              onClick={() => onZoneClick(zone.slug)}
+              onMouseEnter={(e) => handleMouseEnter(zone, e)}
+              onMouseMove={(e) => handleMouseMove(zone, e)}
+              onMouseLeave={handleMouseLeave}
+              aria-label={`${zone.name} — ${count} lineup${count !== 1 ? "s" : ""}`}
+            />
+          );
+        })}
+      </svg>
+
+      {/* Tooltip */}
+      {tooltip && (() => {
+        const data = density[tooltip.zone.id];
+        const count = data?.count ?? 0;
+        const byUtil = data?.by_utility ?? {};
+        return (
+          <div
+            className="pointer-events-none absolute z-20 px-2.5 py-1.5 rounded-md bg-popover border text-xs shadow-md"
+            style={{
+              left: tooltip.x + 12,
+              top: tooltip.y - 8,
+              maxWidth: 180,
+            }}
+          >
+            <p className="font-semibold mb-0.5">{tooltip.zone.name}</p>
+            <p className="text-muted-foreground">
+              {count} lineup{count !== 1 ? "s" : ""}
+            </p>
+            {Object.keys(byUtil).length > 0 && (
+              <ul className="mt-0.5 space-y-0.5">
+                {Object.entries(byUtil).map(([util, n]) => (
+                  <li key={util} className="text-muted-foreground capitalize">
+                    {util}: {n}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        );
+      })()}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/lib/storage.ts
+++ b/apps/mygamingassistant/frontend/src/lib/storage.ts
@@ -1,0 +1,45 @@
+/**
+ * Storage upload helper — wraps XMLHttpRequest for presigned PUT uploads
+ * so we can report progress.
+ *
+ * Unlike fetch, XHR's upload.onprogress fires during the body upload, which
+ * lets us show a real % instead of an indeterminate spinner.
+ */
+export function uploadFileToPresignedUrl(
+  presignedUrl: string,
+  file: File,
+  onProgress?: (percent: number) => void,
+): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+
+    xhr.upload.addEventListener("progress", (e) => {
+      if (e.lengthComputable && onProgress) {
+        onProgress(Math.round((e.loaded / e.total) * 100));
+      }
+    });
+
+    xhr.addEventListener("load", () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        onProgress?.(100);
+        resolve();
+      } else {
+        reject(
+          new Error(`Upload failed: HTTP ${xhr.status} — ${xhr.responseText}`),
+        );
+      }
+    });
+
+    xhr.addEventListener("error", () => {
+      reject(new Error("Upload failed: network error"));
+    });
+
+    xhr.addEventListener("abort", () => {
+      reject(new Error("Upload aborted"));
+    });
+
+    xhr.open("PUT", presignedUrl);
+    xhr.setRequestHeader("Content-Type", file.type || "application/octet-stream");
+    xhr.send(file);
+  });
+}

--- a/apps/mygamingassistant/frontend/src/pages/LineupUpload.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/LineupUpload.tsx
@@ -1,0 +1,547 @@
+/**
+ * LineupUpload — manual lineup upload form.
+ * Route: /lineups/new
+ *
+ * Upload flow:
+ *   1. User selects a game → map → zones + utility → fills metadata
+ *   2. User selects stand screenshot → requests presigned PUT URL →
+ *      PUTs file directly to MinIO with XHR progress
+ *   3. Same for aim screenshot (+ optional aim anchor click on preview)
+ *   4. Submit → POST /api/lineups?lineup_id=... → redirect to map page
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import {
+  FileUploadDropzone,
+  FormField,
+  LoadingButton,
+  Select,
+  showError,
+  showSuccess,
+} from "@platform/ui";
+import { useGetGamesQuery, useGetMapDetailQuery, useGetMapsQuery } from "@/store/gamesApi";
+import {
+  useCreateLineupMutation,
+  useGetUploadUrlMutation,
+} from "@/store/lineupsApi";
+import type { LineupCreate } from "@/types/game";
+import { uploadFileToPresignedUrl } from "@/lib/storage";
+
+interface FormValues {
+  game_id: string;
+  map_id: string;
+  target_zone_id: string;
+  stand_zone_id: string;
+  side: "side_a" | "side_b" | "any";
+  utility_type_id: string;
+  title: string;
+  notes: string;
+  setup_seconds: string;
+}
+
+export default function LineupUpload() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const defaultGameSlug = searchParams.get("game") ?? "";
+  const defaultMapSlug = searchParams.get("map") ?? "";
+
+  const { data: games } = useGetGamesQuery();
+  const [selectedGameSlug, setSelectedGameSlug] = useState(defaultGameSlug);
+  const [selectedMapSlug, setSelectedMapSlug] = useState(defaultMapSlug);
+
+  const { data: maps } = useGetMapsQuery(selectedGameSlug, {
+    skip: !selectedGameSlug,
+  });
+  const { data: mapDetail } = useGetMapDetailQuery(
+    { gameSlug: selectedGameSlug, mapSlug: selectedMapSlug },
+    { skip: !selectedGameSlug || !selectedMapSlug },
+  );
+
+  const selectedGame = games?.find((g) => g.slug === selectedGameSlug);
+  const selectedMap = maps?.find((m) => m.slug === selectedMapSlug);
+
+  // Screenshot upload state
+  const [standFile, setStandFile] = useState<File | null>(null);
+  const [aimFile, setAimFile] = useState<File | null>(null);
+  const [standProgress, setStandProgress] = useState(0);
+  const [aimProgress, setAimProgress] = useState(0);
+  const [standUploading, setStandUploading] = useState(false);
+  const [aimUploading, setAimUploading] = useState(false);
+  const [standKey, setStandKey] = useState<string | null>(null);
+  const [aimKey, setAimKey] = useState<string | null>(null);
+  const [lineupIdFromUrl, setLineupIdFromUrl] = useState<string | null>(null);
+
+  // Aim anchor (click on aim preview to set)
+  const [aimAnchor, setAimAnchor] = useState<{ x: number; y: number } | null>(null);
+  const aimPreviewRef = useRef<HTMLDivElement>(null);
+
+  const [getUploadUrl] = useGetUploadUrlMutation();
+  const [createLineup, { isLoading: isCreating }] = useCreateLineupMutation();
+
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { errors },
+  } = useForm<FormValues>({
+    defaultValues: {
+      game_id: "",
+      map_id: "",
+      target_zone_id: "",
+      stand_zone_id: "",
+      side: "side_a",
+      utility_type_id: "",
+      title: "",
+      notes: "",
+      setup_seconds: "",
+    },
+  });
+
+  // Sync game/map dropdowns → form values
+  useEffect(() => {
+    if (selectedGame) setValue("game_id", selectedGame.id);
+  }, [selectedGame, setValue]);
+
+  useEffect(() => {
+    if (selectedMap) setValue("map_id", selectedMap.id);
+  }, [selectedMap, setValue]);
+
+  // Preview URLs — derived from the selected files using useMemo so object URLs
+  // are created and revoked deterministically without needing useEffect setState.
+  const standPreview = useMemo(() => {
+    if (!standFile) return null;
+    const url = URL.createObjectURL(standFile);
+    return url;
+  }, [standFile]);
+
+  const aimPreview = useMemo(() => {
+    if (!aimFile) return null;
+    const url = URL.createObjectURL(aimFile);
+    return url;
+  }, [aimFile]);
+
+  // Revoke object URLs when they change to avoid memory leaks
+  useEffect(() => {
+    return () => {
+      if (standPreview) URL.revokeObjectURL(standPreview);
+    };
+  }, [standPreview]);
+
+  useEffect(() => {
+    return () => {
+      if (aimPreview) URL.revokeObjectURL(aimPreview);
+    };
+  }, [aimPreview]);
+
+  // Upload a screenshot to MinIO via presigned PUT URL
+  async function uploadScreenshot(
+    file: File,
+    key: string,
+    putUrl: string,
+    setProgress: (n: number) => void,
+    setUploading: (b: boolean) => void,
+    setKey: (k: string) => void,
+  ) {
+    setUploading(true);
+    setProgress(0);
+    try {
+      await uploadFileToPresignedUrl(putUrl, file, setProgress);
+      setKey(key);
+    } catch (err) {
+      showError("Screenshot upload failed. Please try again.");
+      throw err;
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  // Request upload URL pair on first file select (both slots at once)
+  const uploadUrlFetched = useRef(false);
+  const [uploadUrlData, setUploadUrlData] = useState<{
+    lineup_id: string;
+    stand_upload_url: string;
+    aim_upload_url: string;
+    stand_object_key: string;
+    aim_object_key: string;
+  } | null>(null);
+
+  async function ensureUploadUrls() {
+    if (uploadUrlData) return uploadUrlData;
+    const result = await getUploadUrl().unwrap();
+    setUploadUrlData(result);
+    setLineupIdFromUrl(result.lineup_id);
+    uploadUrlFetched.current = true;
+    return result;
+  }
+
+  async function handleStandFiles(files: File[]) {
+    const file = files[0];
+    if (!file) return;
+    setStandFile(file);
+    try {
+      const urls = await ensureUploadUrls();
+      await uploadScreenshot(
+        file,
+        urls.stand_object_key,
+        urls.stand_upload_url,
+        setStandProgress,
+        setStandUploading,
+        setStandKey,
+      );
+    } catch {
+      setStandFile(null);
+    }
+  }
+
+  async function handleAimFiles(files: File[]) {
+    const file = files[0];
+    if (!file) return;
+    setAimFile(file);
+    try {
+      const urls = await ensureUploadUrls();
+      await uploadScreenshot(
+        file,
+        urls.aim_object_key,
+        urls.aim_upload_url,
+        setAimProgress,
+        setAimUploading,
+        setAimKey,
+      );
+    } catch {
+      setAimFile(null);
+    }
+  }
+
+  // Aim anchor click handler
+  const handleAimClick = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    const div = aimPreviewRef.current;
+    if (!div) return;
+    const rect = div.getBoundingClientRect();
+    const x = (e.clientX - rect.left) / rect.width;
+    const y = (e.clientY - rect.top) / rect.height;
+    setAimAnchor({
+      x: Math.max(0, Math.min(1, x)),
+      y: Math.max(0, Math.min(1, y)),
+    });
+  }, []);
+
+  const onSubmit = handleSubmit(async (values) => {
+    if (!standKey || !aimKey) {
+      showError("Please upload both screenshots before saving.");
+      return;
+    }
+
+    const payload: LineupCreate = {
+      game_id: values.game_id,
+      map_id: values.map_id,
+      target_zone_id: values.target_zone_id,
+      stand_zone_id: values.stand_zone_id,
+      side: values.side,
+      utility_type_id: values.utility_type_id,
+      title: values.title,
+      notes: values.notes || undefined,
+      stand_screenshot_key: standKey,
+      aim_screenshot_key: aimKey,
+      aim_anchor_x: aimAnchor?.x,
+      aim_anchor_y: aimAnchor?.y,
+      setup_seconds: values.setup_seconds ? parseInt(values.setup_seconds, 10) : undefined,
+    };
+
+    await createLineup({
+      payload,
+      lineup_id: lineupIdFromUrl ?? undefined,
+    }).unwrap();
+
+    showSuccess("Lineup saved.");
+    const targetZoneSlug = mapDetail?.zones.find((z) => z.id === values.target_zone_id)?.slug;
+    const zonePart = targetZoneSlug ? `?zone=${targetZoneSlug}` : "";
+    navigate(`/${selectedGameSlug}/${selectedMapSlug}${zonePart}`);
+  });
+
+  const sideOptions = selectedGame
+    ? [
+        { value: "side_a", label: selectedGame.side_a_label },
+        { value: "side_b", label: selectedGame.side_b_label },
+        { value: "any", label: "Any (both sides)" },
+      ]
+    : [
+        { value: "side_a", label: "Side A" },
+        { value: "side_b", label: "Side B" },
+        { value: "any", label: "Any" },
+      ];
+
+  const isUploadBusy = standUploading || aimUploading;
+  const canSubmit = !isCreating && !isUploadBusy && !!standKey && !!aimKey;
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <h1 className="text-2xl font-semibold">Add Lineup</h1>
+
+      <form onSubmit={onSubmit} className="space-y-5" noValidate>
+        {/* Game */}
+        <FormField label="Game">
+          <Select
+            value={selectedGameSlug}
+            onChange={(e) => {
+              setSelectedGameSlug(e.target.value);
+              setSelectedMapSlug("");
+              setValue("map_id", "");
+              setValue("target_zone_id", "");
+              setValue("stand_zone_id", "");
+              setValue("utility_type_id", "");
+            }}
+            disabled={!games}
+            aria-label="Select game"
+          >
+            <option value="">Select game…</option>
+            {games?.map((g) => (
+              <option key={g.id} value={g.slug}>{g.name}</option>
+            ))}
+          </Select>
+          <input type="hidden" {...register("game_id", { required: "Game is required" })} />
+          {errors.game_id && <p className="text-xs text-destructive mt-1">{errors.game_id.message}</p>}
+        </FormField>
+
+        {/* Map */}
+        <FormField label="Map">
+          <Select
+            value={selectedMapSlug}
+            onChange={(e) => {
+              setSelectedMapSlug(e.target.value);
+              setValue("target_zone_id", "");
+              setValue("stand_zone_id", "");
+            }}
+            disabled={!selectedGameSlug || !maps}
+            aria-label="Select map"
+          >
+            <option value="">Select map…</option>
+            {maps?.map((m) => (
+              <option key={m.id} value={m.slug}>{m.name}</option>
+            ))}
+          </Select>
+          <input type="hidden" {...register("map_id", { required: "Map is required" })} />
+          {errors.map_id && <p className="text-xs text-destructive mt-1">{errors.map_id.message}</p>}
+        </FormField>
+
+        {/* Target zone */}
+        <FormField label="Target zone (where it lands)">
+          <Select
+            {...register("target_zone_id", { required: "Target zone is required" })}
+            disabled={!mapDetail}
+            aria-label="Select target zone"
+          >
+            <option value="">Select zone…</option>
+            {mapDetail?.zones.map((z) => (
+              <option key={z.id} value={z.id}>{z.name}</option>
+            ))}
+          </Select>
+          {errors.target_zone_id && <p className="text-xs text-destructive mt-1">{errors.target_zone_id.message}</p>}
+        </FormField>
+
+        {/* Stand zone */}
+        <FormField label="Stand zone (where you throw from)">
+          <Select
+            {...register("stand_zone_id", { required: "Stand zone is required" })}
+            disabled={!mapDetail}
+            aria-label="Select stand zone"
+          >
+            <option value="">Select zone…</option>
+            {mapDetail?.zones.map((z) => (
+              <option key={z.id} value={z.id}>{z.name}</option>
+            ))}
+          </Select>
+          {errors.stand_zone_id && <p className="text-xs text-destructive mt-1">{errors.stand_zone_id.message}</p>}
+        </FormField>
+
+        {/* Side */}
+        <FormField label="Side">
+          <Select
+            {...register("side", { required: "Side is required" })}
+            aria-label="Select side"
+          >
+            {sideOptions.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </Select>
+          {errors.side && <p className="text-xs text-destructive mt-1">{errors.side.message}</p>}
+        </FormField>
+
+        {/* Utility type */}
+        <FormField label="Utility type">
+          <Select
+            {...register("utility_type_id", { required: "Utility type is required" })}
+            disabled={!mapDetail}
+            aria-label="Select utility type"
+          >
+            <option value="">Select utility…</option>
+            {mapDetail?.utility_types.map((u) => (
+              <option key={u.id} value={u.id} className="capitalize">{u.name}</option>
+            ))}
+          </Select>
+          {errors.utility_type_id && <p className="text-xs text-destructive mt-1">{errors.utility_type_id.message}</p>}
+        </FormField>
+
+        {/* Title */}
+        <FormField label="Title" required>
+          <input
+            {...register("title", { required: "Title is required" })}
+            type="text"
+            placeholder="e.g. A-site smoke from CT spawn"
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+            aria-label="Lineup title"
+          />
+          {errors.title && <p className="text-xs text-destructive mt-1">{errors.title.message}</p>}
+        </FormField>
+
+        {/* Notes */}
+        <FormField label="Notes (optional)">
+          <textarea
+            {...register("notes")}
+            rows={3}
+            placeholder="Step-by-step notes, crouch/jump timing, etc."
+            className="w-full rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50 resize-y"
+            aria-label="Notes"
+          />
+        </FormField>
+
+        {/* Setup seconds */}
+        <FormField label="Setup time (seconds, optional)">
+          <input
+            {...register("setup_seconds")}
+            type="number"
+            min={0}
+            max={120}
+            placeholder="e.g. 8"
+            className="w-32 rounded-md border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary/50"
+            aria-label="Setup seconds"
+          />
+        </FormField>
+
+        {/* Screenshots */}
+        <div className="grid sm:grid-cols-2 gap-4">
+          <div>
+            <p className="text-sm font-medium mb-1.5">Stand screenshot *</p>
+            {standPreview ? (
+              <div className="relative rounded-md overflow-hidden border aspect-video bg-muted/20">
+                <img src={standPreview} alt="Stand preview" className="w-full h-full object-cover" />
+                {standUploading && (
+                  <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                    <div className="text-xs text-white">
+                      {standProgress < 100 ? `${standProgress}%` : "Processing…"}
+                    </div>
+                  </div>
+                )}
+                {standKey && !standUploading && (
+                  <div className="absolute top-1.5 right-1.5 bg-green-500/90 text-white text-xs px-1.5 py-0.5 rounded">
+                    Uploaded
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={() => { setStandFile(null); setStandKey(null); }}
+                  className="absolute top-1.5 left-1.5 bg-black/60 text-white text-xs px-1.5 py-0.5 rounded hover:bg-black/80"
+                >
+                  Change
+                </button>
+              </div>
+            ) : (
+              <FileUploadDropzone
+                accept="image/*"
+                maxSizeBytes={10 * 1024 * 1024}
+                label="Drop stand screenshot here"
+                helperText="Max 10 MB — PNG/JPG"
+                uploading={standUploading}
+                onFilesSelected={handleStandFiles}
+              />
+            )}
+          </div>
+
+          <div>
+            <p className="text-sm font-medium mb-1.5">Aim screenshot *</p>
+            {aimPreview ? (
+              <div
+                ref={aimPreviewRef}
+                onClick={handleAimClick}
+                className="relative rounded-md overflow-hidden border aspect-video bg-muted/20 cursor-crosshair"
+                title="Click to set aim anchor point"
+              >
+                <img src={aimPreview} alt="Aim preview" className="w-full h-full object-cover" />
+                {aimUploading && (
+                  <div className="absolute inset-0 bg-black/50 flex items-center justify-center">
+                    <div className="text-xs text-white">
+                      {aimProgress < 100 ? `${aimProgress}%` : "Processing…"}
+                    </div>
+                  </div>
+                )}
+                {aimKey && !aimUploading && (
+                  <div className="absolute top-1.5 right-1.5 bg-green-500/90 text-white text-xs px-1.5 py-0.5 rounded">
+                    Uploaded
+                  </div>
+                )}
+                {aimAnchor && (
+                  <div
+                    style={{
+                      position: "absolute",
+                      left: `calc(${aimAnchor.x * 100}% - 6px)`,
+                      top: `calc(${aimAnchor.y * 100}% - 6px)`,
+                      width: 12,
+                      height: 12,
+                      borderRadius: "50%",
+                      border: "2px solid rgba(239, 68, 68, 0.9)",
+                      background: "rgba(239, 68, 68, 0.3)",
+                      boxShadow: "0 0 0 1px rgba(0,0,0,0.5)",
+                      pointerEvents: "none",
+                    }}
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={(e) => { e.stopPropagation(); setAimFile(null); setAimKey(null); setAimAnchor(null); }}
+                  className="absolute top-1.5 left-1.5 bg-black/60 text-white text-xs px-1.5 py-0.5 rounded hover:bg-black/80"
+                >
+                  Change
+                </button>
+              </div>
+            ) : (
+              <FileUploadDropzone
+                accept="image/*"
+                maxSizeBytes={10 * 1024 * 1024}
+                label="Drop aim screenshot here"
+                helperText="Then click to set aim anchor point"
+                uploading={aimUploading}
+                onFilesSelected={handleAimFiles}
+              />
+            )}
+            {aimPreview && !aimUploading && (
+              <p className="text-xs text-muted-foreground mt-1">
+                {aimAnchor
+                  ? `Anchor set at ${Math.round(aimAnchor.x * 100)}%, ${Math.round(aimAnchor.y * 100)}%`
+                  : "Click the image to set the aim anchor point"}
+              </p>
+            )}
+          </div>
+        </div>
+
+        {/* Submit */}
+        <div className="pt-2 flex gap-3">
+          <LoadingButton
+            type="submit"
+            isLoading={isCreating || isUploadBusy}
+            loadingText={isUploadBusy ? "Uploading screenshots…" : "Saving…"}
+            disabled={!canSubmit}
+          >
+            Save Lineup
+          </LoadingButton>
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="px-4 py-2 rounded-md text-sm hover:bg-muted/40 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </main>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -1,158 +1,333 @@
-import { useParams, useNavigate } from "react-router-dom";
-import { ArrowLeft, Map } from "lucide-react";
-import { useGetGamesQuery, useGetMapDetailQuery } from "@/store/gamesApi";
-
 /**
- * Map detail page — lineup viewer.
+ * MapPage — plan-mode lineup viewer.
  * Route: /:gameSlug/:mapSlug
  *
- * Phase 1 stub: shows map metadata (zones, sites) and a placeholder for the
- * lineup overlay canvas. Full lineup viewer comes in Phase 2.
+ * URL is the single source of truth for all filter state:
+ *   ?side=side_a&util=smoke,molly&zone=a-site
+ *
+ * Features:
+ * - Sticky top bar: side toggle + utility chips + "Add lineup" link
+ * - Side-aware background tint (orange/red for side_a, blue/cyan for side_b)
+ * - Map minimap with SVG zone polygon overlay (density-colored, always visible)
+ * - Click zone → show lineup results panel
+ * - Results: expanded cards (1-3 results) or thumbnail grid (4+)
+ * - Esc or background click → clear zone
  */
+import { useCallback, useEffect } from "react";
+import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
+import { ArrowLeft, Plus } from "lucide-react";
+import { ToggleChipGroup } from "@platform/ui";
+import { useGetGamesQuery, useGetMapDetailQuery } from "@/store/gamesApi";
+import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
+import LineupCard from "@/components/lineup/LineupCard";
+import MapZoneOverlay from "@/components/lineup/MapZoneOverlay";
+import type { ZoneDensity } from "@/types/game";
+
+const SIDE_BG: Record<string, string> = {
+  side_a: "rgba(239,68,68,0.05)",
+  side_b: "rgba(59,130,246,0.05)",
+  any: "transparent",
+};
+
 export default function MapPage() {
   const { gameSlug, mapSlug } = useParams<{ gameSlug: string; mapSlug: string }>();
-  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const side = searchParams.get("side") ?? "any";
+  const util = searchParams.get("util") ?? "";
+  const zone = searchParams.get("zone") ?? "";
 
   const { data: games } = useGetGamesQuery();
-  const { data: mapDetail, isLoading, isError } = useGetMapDetailQuery(
+  const { data: mapDetail, isLoading: mapLoading, isError: mapError } = useGetMapDetailQuery(
     { gameSlug: gameSlug ?? "", mapSlug: mapSlug ?? "" },
     { skip: !gameSlug || !mapSlug },
   );
 
   const game = games?.find((g) => g.slug === gameSlug);
-  const gameTitle = game?.name ?? gameSlug ?? "";
 
-  if (isLoading) {
+  // Utility chip options from the game's utility types (from mapDetail)
+  const utilOptions = mapDetail?.utility_types.map((u) => ({
+    value: u.slug,
+    label: u.name,
+  })) ?? [];
+  const selectedUtils = util ? util.split(",").filter(Boolean) : [];
+
+  // Zone density query — drives polygon coloring
+  const { data: density = {} as ZoneDensity } = useGetZoneDensityQuery(
+    {
+      game_slug: gameSlug ?? "",
+      map_slug: mapSlug ?? "",
+      side: side !== "any" ? side : undefined,
+      util: util || undefined,
+    },
+    { skip: !gameSlug || !mapSlug },
+  );
+
+  // Lineup results for the selected zone
+  const targetZone = mapDetail?.zones.find((z) => z.slug === zone);
+  const { data: lineups = [], isFetching: lineupsFetching } = useGetLineupsQuery(
+    {
+      game_slug: gameSlug ?? "",
+      map_slug: mapSlug ?? "",
+      target_zone_slug: zone || undefined,
+      side: side !== "any" ? side : undefined,
+      utility_type_slugs: util || undefined,
+    },
+    { skip: !gameSlug || !mapSlug || !zone },
+  );
+
+  // URL helpers
+  function updateParam(key: string, value: string | null) {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    }, { replace: true });
+  }
+
+  function handleSideChange(newSide: string) {
+    updateParam("side", newSide === "any" ? null : newSide);
+  }
+
+  function handleUtilToggle(slugs: string[]) {
+    updateParam("util", slugs.length > 0 ? slugs.join(",") : null);
+  }
+
+  function handleZoneClick(zoneSlug: string) {
+    // Toggle: clicking the already-selected zone deselects it
+    if (zone === zoneSlug) {
+      updateParam("zone", null);
+    } else {
+      updateParam("zone", zoneSlug);
+    }
+  }
+
+  function handleClosePanel() {
+    updateParam("zone", null);
+  }
+
+  // Esc key closes the zone panel
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "Escape" && zone) {
+        handleClosePanel();
+      }
+    },
+    [zone], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Loading skeleton
+  if (mapLoading) {
     return (
-      <main className="p-4 sm:p-8 space-y-6 max-w-4xl">
+      <main className="p-4 sm:p-8 space-y-4 max-w-5xl">
         <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={() => navigate(`/${gameSlug}`)}
-            className="p-2 rounded-md hover:bg-muted/40 transition-colors min-h-[44px]"
-            aria-label="Back to maps"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </button>
-          <div className="h-8 w-48 bg-muted/40 rounded animate-pulse" />
+          <div className="w-9 h-9 rounded-md bg-muted/40 animate-pulse" />
+          <div className="h-7 w-40 bg-muted/40 rounded animate-pulse" />
         </div>
-        <div className="h-64 rounded-xl bg-muted/40 animate-pulse" />
+        <div className="h-10 bg-muted/40 rounded-lg animate-pulse" />
+        <div className="h-96 bg-muted/40 rounded-xl animate-pulse" />
       </main>
     );
   }
 
-  if (isError || !mapDetail) {
+  if (mapError || !mapDetail) {
     return (
-      <main className="p-4 sm:p-8 space-y-6 max-w-4xl">
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={() => navigate(`/${gameSlug}`)}
-            className="p-2 rounded-md hover:bg-muted/40 transition-colors min-h-[44px]"
-            aria-label="Back to maps"
-          >
-            <ArrowLeft className="h-5 w-5" />
-          </button>
-          <h1 className="text-2xl font-semibold capitalize">{mapSlug}</h1>
-        </div>
-        <p className="text-sm text-destructive">
-          Failed to load map details. Please refresh the page.
-        </p>
+      <main className="p-4 sm:p-8 max-w-5xl">
+        <BackButton gameSlug={gameSlug!} />
+        <p className="text-sm text-destructive mt-4">Failed to load map. Please refresh.</p>
       </main>
     );
   }
+
+  const sideBg = SIDE_BG[side] ?? "transparent";
+
+  const sideOptions = [
+    { value: "any", label: "Any" },
+    { value: "side_a", label: game?.side_a_label ?? "Side A" },
+    { value: "side_b", label: game?.side_b_label ?? "Side B" },
+  ];
+
+  const addLineupHref = `/lineups/new?game=${gameSlug}&map=${mapSlug}${zone ? `&target_zone=${zone}` : ""}`;
 
   return (
-    <main className="p-4 sm:p-8 space-y-6 max-w-4xl">
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={() => navigate(`/${gameSlug}`)}
-          className="p-2 rounded-md hover:bg-muted/40 transition-colors min-h-[44px]"
-          aria-label={`Back to ${gameTitle} maps`}
-        >
-          <ArrowLeft className="h-5 w-5" />
-        </button>
-        <div>
-          <p className="text-xs text-muted-foreground">{gameTitle}</p>
-          <h1 className="text-2xl font-semibold capitalize">{mapDetail.name}</h1>
+    <div
+      className="relative min-h-screen transition-colors duration-300"
+      style={{ background: sideBg }}
+    >
+      <main className="p-4 sm:p-8 space-y-4 max-w-5xl">
+        {/* Header row */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <BackButton gameSlug={gameSlug!} />
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-muted-foreground">{game?.name ?? gameSlug}</p>
+            <h1 className="text-xl font-semibold capitalize">{mapDetail.name}</h1>
+          </div>
+          <Link
+            to={addLineupHref}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
+          >
+            <Plus className="w-4 h-4" />
+            Add lineup
+          </Link>
         </div>
-      </div>
 
-      {/* Phase 1 stub: minimap placeholder + metadata */}
-      <div className="rounded-xl border bg-card p-6 flex flex-col items-center justify-center gap-4 min-h-[240px]">
-        {mapDetail.minimap_url ? (
-          <img
-            src={mapDetail.minimap_url}
-            alt={`${mapDetail.name} minimap`}
-            className="max-h-64 rounded-lg object-contain"
-          />
-        ) : (
-          <>
-            <Map className="h-16 w-16 text-muted-foreground" />
-            <p className="text-sm text-muted-foreground">
-              Lineup viewer coming in Phase 2.
-            </p>
-          </>
-        )}
-      </div>
+        {/* Sticky filter bar */}
+        <div className="sticky top-0 z-10 bg-background/90 backdrop-blur-sm border-b pb-3 -mx-4 px-4 sm:-mx-8 sm:px-8">
+          <div className="flex flex-wrap gap-3 items-center pt-2">
+            {/* Side toggle */}
+            <div className="flex gap-1">
+              {sideOptions.map((opt) => (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => handleSideChange(opt.value)}
+                  className={[
+                    "px-3 py-1.5 rounded-md text-sm font-medium transition-colors min-h-[36px]",
+                    side === opt.value
+                      ? "bg-primary text-primary-foreground"
+                      : "bg-card border hover:bg-muted/40",
+                  ].join(" ")}
+                  aria-pressed={side === opt.value}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
 
-      {/* Sites */}
-      {mapDetail.sites.length > 0 && (
-        <div>
-          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Sites
-          </h2>
-          <div className="flex flex-wrap gap-2">
-            {mapDetail.sites.map((site) => (
-              <span
-                key={site.id}
-                className="px-3 py-1 text-sm rounded-full border bg-card"
-              >
-                {site.name}
-              </span>
-            ))}
+            {/* Utility chips */}
+            {utilOptions.length > 0 && (
+              <ToggleChipGroup
+                options={utilOptions}
+                value={selectedUtils}
+                onChange={handleUtilToggle}
+              />
+            )}
           </div>
         </div>
-      )}
 
-      {/* Zones */}
-      {mapDetail.zones.length > 0 && (
-        <div>
-          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Zones
-          </h2>
-          <div className="flex flex-wrap gap-2">
-            {mapDetail.zones.map((zone) => (
-              <span
-                key={zone.id}
-                className="px-3 py-1 text-sm rounded-full border bg-card"
-              >
-                {zone.name}
-              </span>
-            ))}
-          </div>
-        </div>
-      )}
+        {/* Map + results layout */}
+        <div className="flex flex-col lg:flex-row gap-4">
+          {/* Map minimap with zone overlay */}
+          <div className="flex-1 min-w-0">
+            <div
+              className="relative rounded-xl border overflow-hidden bg-card"
+              style={{ aspectRatio: "1 / 1" }}
+            >
+              {mapDetail.minimap_url ? (
+                <img
+                  src={mapDetail.minimap_url}
+                  alt={`${mapDetail.name} minimap`}
+                  className="absolute inset-0 w-full h-full object-cover"
+                  draggable={false}
+                />
+              ) : (
+                <div className="absolute inset-0 flex items-center justify-center text-muted-foreground text-sm">
+                  Minimap not available
+                </div>
+              )}
+              <MapZoneOverlay
+                zones={mapDetail.zones}
+                density={density}
+                selectedZoneSlug={zone || null}
+                onZoneClick={handleZoneClick}
+              />
+            </div>
 
-      {/* Utility types available on this map */}
-      {mapDetail.utility_types.length > 0 && (
-        <div>
-          <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider mb-2">
-            Utility
-          </h2>
-          <div className="flex flex-wrap gap-2">
-            {mapDetail.utility_types.map((ut) => (
-              <span
-                key={ut.id}
-                className="px-3 py-1 text-sm rounded-full border bg-card capitalize"
-              >
-                {ut.name}
+            {/* Zone legend (small) */}
+            <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded-sm" style={{ background: "rgba(34,197,94,0.4)" }} />
+                Has lineups
               </span>
-            ))}
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded-sm" style={{ background: "rgba(156,163,175,0.2)" }} />
+                Empty
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-3 rounded-sm" style={{ background: "rgba(251,191,36,0.4)" }} />
+                Selected
+              </span>
+            </div>
           </div>
+
+          {/* Results panel */}
+          {zone && targetZone && (
+            <aside className="lg:w-80 xl:w-96 flex-shrink-0" aria-label="Lineup results">
+              <div className="flex items-center justify-between mb-3">
+                <h2 className="text-sm font-semibold">
+                  {targetZone.name}
+                  {lineups.length > 0 && (
+                    <span className="ml-1.5 text-xs text-muted-foreground font-normal">
+                      {lineups.length} lineup{lineups.length !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                </h2>
+                <button
+                  type="button"
+                  onClick={handleClosePanel}
+                  className="p-1 rounded hover:bg-muted/40 text-muted-foreground text-xs"
+                  aria-label="Close results panel"
+                >
+                  ✕
+                </button>
+              </div>
+
+              {lineupsFetching ? (
+                <div className="space-y-3">
+                  {[1, 2].map((i) => (
+                    <div key={i} className="h-48 rounded-lg bg-muted/40 animate-pulse" />
+                  ))}
+                </div>
+              ) : lineups.length === 0 ? (
+                <div className="text-center py-8 space-y-3">
+                  <p className="text-sm text-muted-foreground">No lineups match this filter.</p>
+                  <Link
+                    to={addLineupHref}
+                    className="text-sm text-primary hover:underline"
+                  >
+                    Add lineup for {targetZone.name}
+                  </Link>
+                </div>
+              ) : lineups.length <= 3 ? (
+                <div className="space-y-4">
+                  {lineups.map((lineup) => (
+                    <LineupCard key={lineup.id} lineup={lineup} variant="expanded" />
+                  ))}
+                </div>
+              ) : (
+                <div className="grid grid-cols-2 gap-2">
+                  {lineups.map((lineup) => (
+                    <LineupCard key={lineup.id} lineup={lineup} variant="thumbnail" />
+                  ))}
+                </div>
+              )}
+            </aside>
+          )}
         </div>
-      )}
-    </main>
+      </main>
+    </div>
+  );
+}
+
+function BackButton({ gameSlug }: { gameSlug: string }) {
+  const navigate = useNavigate();
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(`/${gameSlug}`)}
+      className="p-2 rounded-md hover:bg-muted/40 transition-colors min-h-[44px]"
+      aria-label="Back to maps"
+    >
+      <ArrowLeft className="h-5 w-5" />
+    </button>
   );
 }

--- a/apps/mygamingassistant/frontend/src/routes.tsx
+++ b/apps/mygamingassistant/frontend/src/routes.tsx
@@ -1,5 +1,6 @@
 import { type RouteObject } from "react-router-dom";
 import GameGrid from "@/pages/GameGrid";
+import LineupUpload from "@/pages/LineupUpload";
 import MapGrid from "@/pages/MapGrid";
 import MapPage from "@/pages/MapPage";
 import Security from "@/pages/Security";
@@ -18,6 +19,7 @@ export const routes: RouteObject[] = [
     element: <RootLayout />,
     children: [
       { index: true, element: <GameGrid /> },
+      { path: "/lineups/new", element: <LineupUpload /> },
       { path: "/:gameSlug", element: <MapGrid /> },
       { path: "/:gameSlug/:mapSlug", element: <MapPage /> },
       { path: "/settings", element: <Settings /> },

--- a/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
@@ -1,0 +1,132 @@
+/**
+ * RTK Query slice for lineup-related endpoints.
+ *
+ * Tags:
+ *   Lineup        — individual lineup by id
+ *   LineupList    — list queries (invalidated by create/update/delete)
+ *   ZoneDensity   — per-map zone counts (invalidated when lineups change)
+ */
+import { baseApi } from "@platform/ui";
+import type {
+  Lineup,
+  LineupCreate,
+  LineupPatch,
+  UploadUrlResponse,
+  ZoneDensity,
+} from "@/types/game";
+
+// Register lineup-specific tag types on the shared api instance.
+const lineupsBaseApi = baseApi.enhanceEndpoints({
+  addTagTypes: ["Lineup", "LineupList", "ZoneDensity"],
+});
+
+export interface ListLineupsParams {
+  game_slug?: string;
+  map_slug?: string;
+  target_zone_slug?: string;
+  side?: string;
+  utility_type_slugs?: string;
+  status?: string;
+}
+
+export interface ZoneDensityParams {
+  game_slug: string;
+  map_slug: string;
+  side?: string;
+  util?: string;
+}
+
+const lineupsApi = lineupsBaseApi.injectEndpoints({
+  endpoints: (build) => ({
+    // ------------------------------------------------------------------
+    // Upload URL — presigned PUT URLs for screenshot upload
+    // ------------------------------------------------------------------
+    getUploadUrl: build.mutation<UploadUrlResponse, void>({
+      query: () => ({ url: "/lineups/upload-url", method: "POST" }),
+    }),
+
+    // ------------------------------------------------------------------
+    // CRUD
+    // ------------------------------------------------------------------
+    getLineups: build.query<Lineup[], ListLineupsParams>({
+      query: (params) => {
+        const searchParams = new URLSearchParams();
+        if (params.game_slug) searchParams.set("game_slug", params.game_slug);
+        if (params.map_slug) searchParams.set("map_slug", params.map_slug);
+        if (params.target_zone_slug) searchParams.set("target_zone_slug", params.target_zone_slug);
+        if (params.side) searchParams.set("side", params.side);
+        if (params.utility_type_slugs) searchParams.set("utility_type_slugs", params.utility_type_slugs);
+        if (params.status) searchParams.set("status", params.status);
+        const qs = searchParams.toString();
+        return { url: `/lineups${qs ? `?${qs}` : ""}`, method: "GET" };
+      },
+      providesTags: ["LineupList"],
+    }),
+
+    getLineup: build.query<Lineup, string>({
+      query: (id) => ({ url: `/lineups/${id}`, method: "GET" }),
+      providesTags: (_result, _err, id) => [{ type: "Lineup", id }],
+    }),
+
+    createLineup: build.mutation<
+      Lineup,
+      { payload: LineupCreate; lineup_id?: string }
+    >({
+      query: ({ payload, lineup_id }) => ({
+        url: lineup_id ? `/lineups?lineup_id=${lineup_id}` : "/lineups",
+        method: "POST",
+        body: payload,
+      }),
+      invalidatesTags: ["LineupList", "ZoneDensity"],
+    }),
+
+    updateLineup: build.mutation<Lineup, { id: string; patch: LineupPatch }>({
+      query: ({ id, patch }) => ({
+        url: `/lineups/${id}`,
+        method: "PATCH",
+        body: patch,
+      }),
+      invalidatesTags: (_result, _err, { id }) => [
+        { type: "Lineup", id },
+        "LineupList",
+        "ZoneDensity",
+      ],
+    }),
+
+    deleteLineup: build.mutation<void, string>({
+      query: (id) => ({ url: `/lineups/${id}`, method: "DELETE" }),
+      invalidatesTags: (_result, _err, id) => [
+        { type: "Lineup", id },
+        "LineupList",
+        "ZoneDensity",
+      ],
+    }),
+
+    // ------------------------------------------------------------------
+    // Zone density (map-level aggregate for density coloring)
+    // ------------------------------------------------------------------
+    getZoneDensity: build.query<ZoneDensity, ZoneDensityParams>({
+      query: ({ game_slug, map_slug, side, util }) => {
+        const searchParams = new URLSearchParams();
+        if (side) searchParams.set("side", side);
+        if (util) searchParams.set("util", util);
+        const qs = searchParams.toString();
+        return {
+          url: `/games/${game_slug}/maps/${map_slug}/zone-density${qs ? `?${qs}` : ""}`,
+          method: "GET",
+        };
+      },
+      providesTags: ["ZoneDensity"],
+    }),
+  }),
+});
+
+export const {
+  useGetUploadUrlMutation,
+  useGetLineupsQuery,
+  useGetLineupQuery,
+  useCreateLineupMutation,
+  useUpdateLineupMutation,
+  useDeleteLineupMutation,
+  useGetZoneDensityQuery,
+} = lineupsApi;

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -17,7 +17,8 @@ export interface MapZone {
   id: string;
   slug: string;
   name: string;
-  polygon_points: number[][];
+  /** Normalized 0-1 coordinates relative to the minimap dimensions. */
+  polygon_points: Array<{ x: number; y: number }>;
 }
 
 export interface MapSite {
@@ -40,4 +41,88 @@ export interface MapDetail {
   zones: MapZone[];
   sites: MapSite[];
   utility_types: UtilityType[];
+}
+
+// ---------------------------------------------------------------------------
+// Lineup domain
+// ---------------------------------------------------------------------------
+
+export interface ZoneRead {
+  id: string;
+  slug: string;
+  name: string;
+  polygon_points: Array<{ x: number; y: number }>;
+}
+
+export interface UtilityTypeRead {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+export interface Lineup {
+  id: string;
+  game_id: string;
+  map_id: string;
+  target_zone_id: string;
+  stand_zone_id: string;
+  side: "side_a" | "side_b" | "any";
+  utility_type_id: string;
+  title: string;
+  notes: string | null;
+  stand_screenshot_url: string | null;
+  aim_screenshot_url: string | null;
+  aim_anchor_x: number | null;
+  aim_anchor_y: number | null;
+  setup_seconds: number | null;
+  attribution_url: string | null;
+  attribution_author: string | null;
+  status: "accepted" | "pending_review" | "hidden";
+  target_zone: ZoneRead | null;
+  stand_zone: ZoneRead | null;
+  utility_type: UtilityTypeRead | null;
+}
+
+export interface UploadUrlResponse {
+  lineup_id: string;
+  stand_upload_url: string;
+  aim_upload_url: string;
+  stand_object_key: string;
+  aim_object_key: string;
+}
+
+export interface LineupCreate {
+  game_id: string;
+  map_id: string;
+  target_zone_id: string;
+  stand_zone_id: string;
+  side: "side_a" | "side_b" | "any";
+  utility_type_id: string;
+  title: string;
+  notes?: string;
+  stand_screenshot_key?: string;
+  aim_screenshot_key?: string;
+  aim_anchor_x?: number;
+  aim_anchor_y?: number;
+  setup_seconds?: number;
+}
+
+export interface LineupPatch {
+  target_zone_id?: string;
+  stand_zone_id?: string;
+  side?: "side_a" | "side_b" | "any";
+  utility_type_id?: string;
+  title?: string;
+  notes?: string;
+  aim_anchor_x?: number;
+  aim_anchor_y?: number;
+  setup_seconds?: number;
+}
+
+/** Zone density response shape from /zone-density endpoint. */
+export interface ZoneDensity {
+  [zoneId: string]: {
+    count: number;
+    by_utility: Record<string, number>;
+  };
 }

--- a/apps/mygamingassistant/frontend/vitest.config.ts
+++ b/apps/mygamingassistant/frontend/vitest.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import viteConfig from "./vite.config";
+
+/**
+ * Vitest config — mirrors apps/myjobhunter/frontend/vitest.config.ts.
+ *
+ * Key divergences from MJH:
+ * - No React alias override needed (MGA already uses React 19 like shared-frontend)
+ * - No test-setup.ts yet (add when the first unit test needs jest-dom matchers)
+ */
+export default mergeConfig(
+  viteConfig,
+  defineConfig({
+    test: {
+      environment: "jsdom",
+      globals: true,
+      // Exclude Playwright E2E specs — those run via npx playwright test.
+      exclude: ["e2e/**", "**/node_modules/**"],
+    },
+  }),
+);


### PR DESCRIPTION
## Summary

- **Backend:** Full lineup CRUD API with presigned MinIO upload URLs, zone-density query, and side-any filter semantics
- **Frontend:** LineupUpload page (/lineups/new) with XHR browser-direct upload, MapPage full plan-mode with SVG zone overlay, density colors, side toggle/tint, and URL-driven filter state
- **Tests:** 10 LineupCard unit tests, 7 E2E smoke tests (upload form + MapPage plan-mode), 13 backend integration tests

## What was built

### Backend

**lineup_repo.py** (new) - LineupFilters dataclass, side-any semantics via Lineup.side.in_([requested_side, "any"]), zone_density for map overlay coloring

**lineup_schemas.py** (new) - LineupRead with eagerly-loaded relations, LineupCreate with object keys (not URLs), UploadUrlResponse with both PUT URLs in one call

**lineup_service.py** (new) - generate_upload_urls() creates presigned PUT URLs (15-min), _sign_lineup() converts stored keys to presigned GET URLs (24h); handles both StorageClient types

**lineups.py API** (new) - POST /api/lineups/upload-url, POST/GET/PATCH/DELETE /api/lineups, GET /api/games/{game_slug}/maps/{map_slug}/zone-density

**games.py** (modified) - Removed PR 1 stub /lineups endpoint

### Frontend

**game.ts** (modified) - Added Lineup, ZoneRead, UtilityTypeRead, UploadUrlResponse, LineupCreate, LineupPatch, ZoneDensity types; fixed MapZone.polygon_points to Array<{x,y}>

**lineupsApi.ts** (new) - RTK Query slice via baseApi.enhanceEndpoints pattern, full CRUD + zone-density + upload-url

**LineupCard.tsx** (new) - thumbnail/expanded variants; AimAnchorDot at (aim_anchor_x*100%, aim_anchor_y*100%) CSS absolute position

**MapZoneOverlay.tsx** (new) - SVG viewBox 0 0 1000 1000 over map image; normalized 0-1 zone polygon coordinates; green/grey/yellow density fills; hover tooltip

**LineupUpload.tsx** (new) - Two-step: POST /api/lineups/upload-url, XHR PUT to MinIO with progress, POST /api/lineups; aim anchor set by clicking aim preview; pre-fills from query params

**MapPage.tsx** (full replacement) - URL-driven side/util/zone state; side toggle with aria-pressed; utility chip multi-select; background tint (red for side_a, blue for side_b); zone click results panel (expanded <=3, thumbnail grid >=4); Escape key clears zone

**storage.ts** (new) - uploadFileToPresignedUrl via XMLHttpRequest with progress callback

**vitest.config.ts** (new) - Boy scout fix: was picking up Playwright E2E specs without this; exclude e2e/**

### Tests

**test_lineups.py** - 13 backend tests: upload URL, CRUD, filters, side-any semantics, zone density, 404 paths

**LineupCard.test.tsx** - 10 unit tests: both variants, aim anchor present/absent, no-screenshot fallback, onClick

**lineup-upload-plan-mode.spec.ts** - 7 E2E tests: upload form fields, MapPage side toggle + URL, utility chips, zone click, Add lineup link

## Design decisions

**Presigned upload pre-allocation:** The upload-url endpoint generates a lineup_id UUID server-side before any DB row exists. Client uploads to {user_id}/{lineup_id}/stand.png and aim.png, then POSTs create with ?lineup_id= query param. Avoids a separate finalize step.

**Side-any semantics at repository layer:** Lineup.side.in_([requested_side, "any"]) lets creators tag a lineup applicable to both sides. URL ?side=any means no filter; stored side=any means works for both sides.

**Object keys not URLs in LineupCreate:** DB stores MinIO object keys. Service signs at read time. Keeps expiring URLs out of the DB.

**/lineups/new route before /:gameSlug:** React Router would match "new" as a game slug otherwise.

## Test plan

- [ ] `npm test` passes in apps/mygamingassistant/frontend/
- [ ] E2E tests pass with backend on :8004 and fixtures loaded
- [ ] Upload form shows required fields and disabled save button
- [ ] Uploading two screenshots enables save and creates lineup via API
- [ ] MapPage side toggle changes URL and applies background tint
- [ ] Zone click shows results panel; Escape clears it
- [ ] Add lineup link pre-fills game+map from current map URL

Generated with Claude Code
