### PR TITLE
feat(mga): YouTube source management + ingestion pipeline (yt-dlp + ffmpeg + chapter parser) (PR 4/12)

### DIFF
--- a/apps/mygamingassistant/TECH_DEBT.md
+++ b/apps/mygamingassistant/TECH_DEBT.md
@@ -1,6 +1,6 @@
 # MyGamingAssistant — Tech Debt Log
 
-<!-- 2 open issues -->
+<!-- 6 open issues -->
 
 ---
 
@@ -30,5 +30,50 @@
   test Postgres container automatically (mirrors how MBK's CI handles it). Alternatively,
   add a `conftest.py`-level `skipif` that gracefully skips DB-dependent tests instead of
   erroring with a connection failure.
+
+---
+
+### [Ingestion] Source soft-delete is a workaround — no deleted_at column
+
+- **Severity:** Medium
+- **Effort:** Low (1-2 hours)
+- **Location:** `apps/mygamingassistant/backend/app/repositories/game/source_repo.py`
+- **Problem:** `soft_delete_source` sets `config_json["deleted"] = True` inside the JSON blob
+  rather than a proper `deleted_at DateTime` column. This means deleted sources appear in
+  `list_sources` unless callers filter `config_json["deleted"]`, the source schema exposes
+  deleted status inconsistently, and there is no timestamped audit of when deletion happened.
+- **Recommendation:** Add `deleted_at: Mapped[datetime | None]` to the `Source` model, a
+  migration to add the column, and update `soft_delete_source`/`list_sources` to use it.
+  Update `SourceRead` to omit `deleted` from `config_json`.
+
+---
+
+### [Ingestion] Disk space guard for download directory is unenforced
+
+- **Severity:** Medium
+- **Effort:** Medium (2-3 hours)
+- **Location:** `apps/mygamingassistant/backend/app/core/config.py`, `ingestion_orchestrator.py`
+- **Problem:** `INGESTION_DOWNLOAD_DIR_MAX_GB` is stored in config but never checked. If many
+  large videos are downloaded concurrently (or cleanup fails), the download directory can fill
+  the VPS disk. The orchestrator always downloads without checking available space.
+- **Recommendation:** Before calling `download_video`, check `shutil.disk_usage(download_dir)`
+  and skip/abort if free space falls below `ingestion_download_dir_max_gb * 0.8`. Log a WARNING
+  with disk stats whenever skipping for this reason.
+
+---
+
+### [Ingestion] Background task sync uses fire-and-forget with no status surface
+
+- **Severity:** Medium
+- **Effort:** High (4-8 hours, deferred to PR 6 APScheduler work)
+- **Location:** `apps/mygamingassistant/backend/app/api/sources.py`
+- **Problem:** `POST /api/sources/{id}/sync` returns a `SyncJobResponse` with a `job_id`, but
+  that job_id is never stored or queryable. The frontend has no way to poll for sync progress
+  or learn that a sync completed vs failed. The `status` field in the response is always
+  `"started"`. Any error inside `sync_source` is only visible in server logs.
+- **Recommendation:** This is intentionally deferred to PR 6 (APScheduler). When APScheduler
+  is added, replace BackgroundTask with a proper job queue that persists job state. Until then,
+  the source's `last_synced_at` + `last_sync_stats` on the next GET /api/sources poll serves as
+  the completion signal.
 
 ---

--- a/apps/mygamingassistant/backend/.env.docker.example
+++ b/apps/mygamingassistant/backend/.env.docker.example
@@ -84,3 +84,11 @@ MINIO_ACCESS_KEY=
 MINIO_SECRET_KEY=
 MINIO_BUCKET=mygamingassistant-screenshots
 MINIO_SECURE=false
+
+# YouTube ingestion pipeline (PR 4+)
+# Directory where yt-dlp downloads videos before ffmpeg frame extraction.
+# Must be writable by the api container. The container tmpfs or a host-mounted
+# volume are both fine; ensure >= INGESTION_DOWNLOAD_DIR_MAX_GB free space.
+INGESTION_DOWNLOAD_DIR=/tmp/mga-ingestion
+# Hard cap in GB — ingestion refuses to start if the path has less free space.
+INGESTION_DOWNLOAD_DIR_MAX_GB=10

--- a/apps/mygamingassistant/backend/alembic/versions/0002_lineup_youtube_ingestion.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0002_lineup_youtube_ingestion.py
@@ -1,0 +1,79 @@
+"""Lineup schema changes for YouTube ingestion (PR 4)
+
+- target_zone_id, stand_zone_id, utility_type_id: NOT NULL → nullable
+  (auto-ingested lineups land before classification)
+- side: NOT NULL → nullable (same reason)
+- Add youtube_video_id VARCHAR(20), nullable, indexed
+- Add chapter_start_seconds INTEGER, nullable
+- Add chapter_title VARCHAR(500), nullable
+- Add CHECK constraint: accepted lineups must have all classification fields set
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-12 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # --- Make classification FKs nullable (pending_review rows have nulls) ---
+    op.alter_column("lineup", "target_zone_id", nullable=True)
+    op.alter_column("lineup", "stand_zone_id", nullable=True)
+    op.alter_column("lineup", "utility_type_id", nullable=True)
+    op.alter_column("lineup", "side", nullable=True)
+
+    # --- New ingestion-tracking columns ---
+    op.add_column(
+        "lineup",
+        sa.Column("youtube_video_id", sa.String(20), nullable=True),
+    )
+    op.add_column(
+        "lineup",
+        sa.Column("chapter_start_seconds", sa.Integer(), nullable=True),
+    )
+    op.add_column(
+        "lineup",
+        sa.Column("chapter_title", sa.String(500), nullable=True),
+    )
+
+    # Index on youtube_video_id for dedup lookups
+    op.create_index("ix_lineup_youtube_video_id", "lineup", ["youtube_video_id"])
+
+    # CHECK constraint: accepted lineups must have all classification fields set.
+    # Pending/hidden lineups may have nulls.
+    op.create_check_constraint(
+        "ck_lineup_accepted_classified",
+        "lineup",
+        (
+            "status != 'accepted' OR ("
+            "target_zone_id IS NOT NULL AND "
+            "stand_zone_id IS NOT NULL AND "
+            "utility_type_id IS NOT NULL AND "
+            "side IS NOT NULL"
+            ")"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_lineup_accepted_classified", "lineup", type_="check")
+    op.drop_index("ix_lineup_youtube_video_id", table_name="lineup")
+    op.drop_column("lineup", "chapter_title")
+    op.drop_column("lineup", "chapter_start_seconds")
+    op.drop_column("lineup", "youtube_video_id")
+
+    # Restore NOT NULL — note: this will fail if any rows have NULLs in these cols.
+    # Downgrade is only safe on a fresh DB with no pending_review rows.
+    op.alter_column("lineup", "side", nullable=False)
+    op.alter_column("lineup", "utility_type_id", nullable=False)
+    op.alter_column("lineup", "stand_zone_id", nullable=False)
+    op.alter_column("lineup", "target_zone_id", nullable=False)

--- a/apps/mygamingassistant/backend/app/api/sources.py
+++ b/apps/mygamingassistant/backend/app/api/sources.py
@@ -1,0 +1,125 @@
+"""Source management API routes.
+
+POST /api/sources                  — add a YouTube playlist or channel
+GET  /api/sources                  — list all sources
+GET  /api/sources/{id}             — source detail
+DELETE /api/sources/{id}           — soft-delete
+POST /api/sources/{id}/sync        — kick off a sync (runs as BackgroundTask)
+
+Sync is synchronous in PR 4 (BackgroundTask). PR 6 adds APScheduler cron.
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import current_active_user
+from app.db.session import get_db
+from app.models.user.user import User
+from app.schemas.game.lineup_schemas import SourceCreate, SourceRead, SyncJobResponse
+from app.services.game import source_service
+from app.services.ingestion import ingestion_orchestrator
+
+router = APIRouter(prefix="/api", tags=["sources"])
+
+
+def _source_to_read(source) -> SourceRead:
+    last_synced = source.last_synced_at.isoformat() if source.last_synced_at else None
+    created = source.created_at.isoformat() if source.created_at else ""
+    return SourceRead(
+        id=source.id,
+        kind=source.kind,
+        config_json=source.config_json,
+        last_synced_at=last_synced,
+        created_at=created,
+    )
+
+
+@router.post("/sources", response_model=SourceRead, status_code=201)
+async def create_source(
+    payload: SourceCreate,
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> SourceRead:
+    """Add a YouTube playlist or channel as an ingestion source."""
+    try:
+        source = await source_service.create(db, payload)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    return _source_to_read(source)
+
+
+@router.get("/sources", response_model=list[SourceRead])
+async def list_sources(
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> list[SourceRead]:
+    """List all sources."""
+    sources = await source_service.list_all(db)
+    return [_source_to_read(s) for s in sources]
+
+
+@router.get("/sources/{source_id}", response_model=SourceRead)
+async def get_source(
+    source_id: uuid.UUID,
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> SourceRead:
+    """Get source detail."""
+    source = await source_service.get(db, source_id)
+    if source is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return _source_to_read(source)
+
+
+@router.delete("/sources/{source_id}", status_code=204)
+async def delete_source(
+    source_id: uuid.UUID,
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> None:
+    """Soft-delete a source.
+
+    Lineups previously ingested from this source are NOT removed — they remain
+    in the library with source_id set to NULL (SET NULL FK constraint).
+    """
+    source = await source_service.delete(db, source_id)
+    if source is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+
+
+@router.post("/sources/{source_id}/sync", response_model=SyncJobResponse)
+async def sync_source(
+    source_id: uuid.UUID,
+    background_tasks: BackgroundTasks,
+    _user: User = Depends(current_active_user),
+    db: AsyncSession = Depends(get_db),
+) -> SyncJobResponse:
+    """Kick off an immediate sync for a source.
+
+    Returns immediately; the actual ingestion runs as a background task.
+    PR 6 will replace this with an APScheduler cron job.
+    """
+    source = await source_service.get(db, source_id)
+    if source is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+
+    job_id = str(uuid.uuid4())
+
+    async def _run_sync() -> None:
+        """Background task: run full ingestion pipeline for one source."""
+        from app.db.session import AsyncSessionLocal
+
+        async with AsyncSessionLocal() as bg_db:
+            await ingestion_orchestrator.sync_source(source_id, bg_db)
+
+    background_tasks.add_task(_run_sync)
+
+    return SyncJobResponse(
+        job_id=job_id,
+        source_id=source_id,
+        status="queued",
+        message="Sync started — lineups will appear in pending_review when complete",
+    )

--- a/apps/mygamingassistant/backend/app/core/config.py
+++ b/apps/mygamingassistant/backend/app/core/config.py
@@ -63,5 +63,17 @@ class Settings(BaseAppSettings):
     # ------------------------------------------------------------------
     max_lineup_screenshot_bytes: int = 10 * 1024 * 1024  # 10 MB per screenshot
 
+    # ------------------------------------------------------------------
+    # Ingestion pipeline (PR 4+)
+    # ------------------------------------------------------------------
+    # Directory where yt-dlp downloads video files before ffmpeg extraction.
+    # The ingestion orchestrator cleans up files after processing each video.
+    # Ensure this path has >= INGESTION_DOWNLOAD_DIR_MAX_GB of free space.
+    ingestion_download_dir: str = "/tmp/mga-ingestion"
+    # Disk cap in GB — ingestion refuses to start if free space falls below this.
+    # Operator can raise this if they have more disk; lower values are risky
+    # for long-form videos (CS2 full-map videos can exceed 1 GB each).
+    ingestion_download_dir_max_gb: int = 10
+
 
 settings = Settings()

--- a/apps/mygamingassistant/backend/app/main.py
+++ b/apps/mygamingassistant/backend/app/main.py
@@ -21,7 +21,7 @@ from jwt.exceptions import PyJWTError as JWTError
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
 
-from app.api import account, admin, games, health, lineups, totp
+from app.api import account, admin, games, health, lineups, sources, totp
 from app.core.audit import current_user_id
 from app.core.auth import auth_backend, fastapi_users
 from app.core.config import settings
@@ -190,6 +190,7 @@ app.include_router(
 app.include_router(health.router, tags=["health"])
 app.include_router(games.router)
 app.include_router(lineups.router)
+app.include_router(sources.router)
 app.include_router(admin.router)
 
 # Shared platform admin router — generic user-management endpoints

--- a/apps/mygamingassistant/backend/app/models/game/lineup.py
+++ b/apps/mygamingassistant/backend/app/models/game/lineup.py
@@ -9,6 +9,11 @@ side values:
   side_a  — e.g. T side in CS2, Attacker in Valorant
   side_b  — e.g. CT side in CS2, Defender in Valorant
   any     — side-agnostic (e.g. a grenade thrown from spawn that works both ways)
+
+Classification FK columns (target_zone_id, stand_zone_id, utility_type_id, side)
+are nullable because auto-ingested lineups arrive in pending_review status before
+classification. The CHECK constraint ck_lineup_accepted_classified enforces that
+accepted lineups always have all four fields set.
 """
 import uuid
 from datetime import datetime, timezone
@@ -41,13 +46,25 @@ class Lineup(Base):
             name="ck_lineup_status",
         ),
         CheckConstraint(
-            f"side IN {_LINEUP_SIDES!r}",
+            # NULL side is allowed for pending_review/hidden only.
+            f"side IS NULL OR side IN {_LINEUP_SIDES!r}",
             name="ck_lineup_side",
+        ),
+        CheckConstraint(
+            # Accepted lineups must have all classification fields set.
+            "status != 'accepted' OR ("
+            "target_zone_id IS NOT NULL AND "
+            "stand_zone_id IS NOT NULL AND "
+            "utility_type_id IS NOT NULL AND "
+            "side IS NOT NULL"
+            ")",
+            name="ck_lineup_accepted_classified",
         ),
         Index("ix_lineup_game_id", "game_id"),
         Index("ix_lineup_map_id", "map_id"),
         Index("ix_lineup_target_zone_id", "target_zone_id"),
         Index("ix_lineup_status", "status"),
+        Index("ix_lineup_youtube_video_id", "youtube_video_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -66,21 +83,21 @@ class Lineup(Base):
         ForeignKey("map.id", ondelete="CASCADE"),
         nullable=False,
     )
-    target_zone_id: Mapped[uuid.UUID] = mapped_column(
+    target_zone_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("map_zone.id", ondelete="RESTRICT"),
-        nullable=False,
+        nullable=True,
     )
-    stand_zone_id: Mapped[uuid.UUID] = mapped_column(
+    stand_zone_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("map_zone.id", ondelete="RESTRICT"),
-        nullable=False,
+        nullable=True,
     )
-    side: Mapped[str] = mapped_column(String(10), nullable=False)
-    utility_type_id: Mapped[uuid.UUID] = mapped_column(
+    side: Mapped[str | None] = mapped_column(String(10), nullable=True)
+    utility_type_id: Mapped[uuid.UUID | None] = mapped_column(
         UUID(as_uuid=True),
         ForeignKey("utility_type.id", ondelete="RESTRICT"),
-        nullable=False,
+        nullable=True,
     )
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
@@ -95,6 +112,11 @@ class Lineup(Base):
 
     # How many seconds the throw takes to execute
     setup_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+    # YouTube ingestion metadata
+    youtube_video_id: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    chapter_start_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    chapter_title: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     # Attribution
     source_id: Mapped[uuid.UUID | None] = mapped_column(
@@ -125,13 +147,13 @@ class Lineup(Base):
 
     game: Mapped["Game"] = relationship("Game", back_populates="lineups")
     map: Mapped["Map"] = relationship("Map", back_populates="lineups")
-    target_zone: Mapped["MapZone"] = relationship(
+    target_zone: Mapped["MapZone | None"] = relationship(
         "MapZone", foreign_keys=[target_zone_id], back_populates="lineups_as_target"
     )
-    stand_zone: Mapped["MapZone"] = relationship(
+    stand_zone: Mapped["MapZone | None"] = relationship(
         "MapZone", foreign_keys=[stand_zone_id], back_populates="lineups_as_stand"
     )
-    utility_type: Mapped["UtilityType"] = relationship(
+    utility_type: Mapped["UtilityType | None"] = relationship(
         "UtilityType", back_populates="lineups"
     )
     source: Mapped["Source | None"] = relationship("Source", back_populates="lineups")

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -54,11 +54,26 @@ def _apply_filters(stmt: "Select[tuple[Lineup]]", f: LineupFilters) -> "Select[t
 
 
 async def create_lineup(db: AsyncSession, data: dict) -> Lineup:
-    """Insert a new lineup row and return the refreshed ORM instance."""
+    """Insert a new lineup row and return the refreshed ORM instance.
+
+    Relationship attributes are only refreshed when the corresponding FK is
+    set — ingestion-path rows have null FKs until the classifier runs (PR 5).
+    """
     lineup = Lineup(**data)
     db.add(lineup)
     await db.flush()
-    await db.refresh(lineup, attribute_names=["target_zone", "stand_zone", "utility_type"])
+    # Only refresh relationships that have a non-null FK value.
+    attrs_to_refresh = [
+        attr
+        for attr, fk_field in [
+            ("target_zone", "target_zone_id"),
+            ("stand_zone", "stand_zone_id"),
+            ("utility_type", "utility_type_id"),
+        ]
+        if getattr(lineup, fk_field) is not None
+    ]
+    if attrs_to_refresh:
+        await db.refresh(lineup, attribute_names=attrs_to_refresh)
     return lineup
 
 
@@ -108,7 +123,18 @@ async def update_lineup(
     for key, value in patch.items():
         setattr(lineup, key, value)
     await db.flush()
-    await db.refresh(lineup, attribute_names=["target_zone", "stand_zone", "utility_type"])
+    # Only refresh relationships when the FK is set (nullable after migration).
+    attrs_to_refresh = [
+        attr
+        for attr, fk_field in [
+            ("target_zone", "target_zone_id"),
+            ("stand_zone", "stand_zone_id"),
+            ("utility_type", "utility_type_id"),
+        ]
+        if getattr(lineup, fk_field) is not None
+    ]
+    if attrs_to_refresh:
+        await db.refresh(lineup, attribute_names=attrs_to_refresh)
     return lineup
 
 
@@ -117,6 +143,24 @@ async def hide_lineup(db: AsyncSession, lineup: Lineup) -> Lineup:
     lineup.status = "hidden"
     await db.flush()
     return lineup
+
+
+async def get_ingested_video_ids(
+    db: AsyncSession,
+    video_ids: list[str],
+) -> set[str]:
+    """Return the subset of video_ids that already have lineup rows.
+
+    Used by the ingestion orchestrator to skip already-processed videos.
+    Returns an empty set when video_ids is empty.
+    """
+    if not video_ids:
+        return set()
+    stmt = select(Lineup.youtube_video_id).where(
+        Lineup.youtube_video_id.in_(video_ids),
+    )
+    result = await db.execute(stmt)
+    return {row for (row,) in result.all() if row is not None}
 
 
 async def zone_density(

--- a/apps/mygamingassistant/backend/app/repositories/game/source_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/source_repo.py
@@ -1,0 +1,90 @@
+"""Source repository — data access layer for the source table.
+
+Sources represent YouTube playlists or channels that are periodically
+synced to extract lineup videos.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.source import Source
+
+
+async def create_source(
+    db: AsyncSession,
+    *,
+    kind: str,
+    config_json: dict,
+) -> Source:
+    """Insert a new Source row and flush."""
+    source = Source(kind=kind, config_json=config_json)
+    db.add(source)
+    await db.flush()
+    await db.refresh(source)
+    return source
+
+
+async def get_source(
+    db: AsyncSession,
+    source_id: uuid.UUID,
+) -> Source | None:
+    """Return a single source by id, or None."""
+    result = await db.execute(select(Source).where(Source.id == source_id))
+    return result.scalar_one_or_none()
+
+
+async def list_sources(db: AsyncSession) -> list[Source]:
+    """Return all sources ordered by creation date descending."""
+    result = await db.execute(select(Source).order_by(Source.created_at.desc()))
+    return list(result.scalars().all())
+
+
+async def soft_delete_source(
+    db: AsyncSession,
+    source_id: uuid.UUID,
+) -> Source | None:
+    """Mark a source as deleted (sets config_json.deleted=True).
+
+    We never hard-delete sources because their orphaned lineups still
+    reference source_id via SET NULL FK. This prevents FK errors on lineups
+    that were already accepted before the source was removed.
+    """
+    source = await get_source(db, source_id)
+    if source is None:
+        return None
+    # Store deleted flag in config_json (Source has no deleted_at column).
+    # This is a deliberate design choice: sources are rare; a full soft-delete
+    # column is not worth a migration for now.
+    config = dict(source.config_json)
+    config["deleted"] = True
+    source.config_json = config
+    await db.flush()
+    return source
+
+
+async def update_sync_stats(
+    db: AsyncSession,
+    source: Source,
+    *,
+    synced_at: Optional[datetime] = None,
+    video_count: int = 0,
+    chapter_count: int = 0,
+    error_count: int = 0,
+) -> Source:
+    """Record sync results on the source row."""
+    source.last_synced_at = synced_at or datetime.now(timezone.utc)
+    config = dict(source.config_json)
+    config["last_sync_stats"] = {
+        "video_count": video_count,
+        "chapter_count": chapter_count,
+        "error_count": error_count,
+        "synced_at": source.last_synced_at.isoformat(),
+    }
+    source.config_json = config
+    await db.flush()
+    return source

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -1,10 +1,18 @@
-"""Pydantic schemas for lineup-related API requests and responses."""
+"""Pydantic schemas for lineup-related API requests and responses.
+
+Two creation paths exist:
+  1. Manual upload (POST /api/lineups): caller provides all classification
+     fields. Status is set to 'accepted'. Fields are required.
+  2. Ingestion path (internal, called by ingestion_orchestrator): creates
+     with status='pending_review'; classification fields are nullable.
+     Use LineupIngestCreate for this path.
+"""
 from __future__ import annotations
 
 import uuid
 from typing import Optional
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 
 # ---------------------------------------------------------------------------
@@ -36,10 +44,11 @@ class LineupRead(BaseModel):
     id: uuid.UUID
     game_id: uuid.UUID
     map_id: uuid.UUID
-    target_zone_id: uuid.UUID
-    stand_zone_id: uuid.UUID
-    side: str
-    utility_type_id: uuid.UUID
+    # Classification fields — nullable for pending_review lineups
+    target_zone_id: Optional[uuid.UUID] = None
+    stand_zone_id: Optional[uuid.UUID] = None
+    side: Optional[str] = None
+    utility_type_id: Optional[uuid.UUID] = None
     title: str
     notes: Optional[str] = None
     stand_screenshot_url: Optional[str] = None
@@ -50,6 +59,10 @@ class LineupRead(BaseModel):
     attribution_url: Optional[str] = None
     attribution_author: Optional[str] = None
     status: str
+    # YouTube ingestion metadata
+    youtube_video_id: Optional[str] = None
+    chapter_start_seconds: Optional[int] = None
+    chapter_title: Optional[str] = None
 
     # Expanded relations (populated when available)
     target_zone: Optional[ZoneRead] = None
@@ -60,7 +73,8 @@ class LineupRead(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# Lineup create
+# Lineup create — manual upload path
+# All classification fields required; status always becomes 'accepted'.
 # ---------------------------------------------------------------------------
 
 class LineupCreate(BaseModel):
@@ -87,6 +101,27 @@ class LineupCreate(BaseModel):
         if v not in ("side_a", "side_b", "any"):
             raise ValueError("side must be side_a, side_b, or any")
         return v
+
+
+# ---------------------------------------------------------------------------
+# Lineup ingest create — ingestion pipeline path
+# Classification fields optional (PR 5 classifier fills them later).
+# game_id and map_id are also optional (classifier sets them in PR 5).
+# ---------------------------------------------------------------------------
+
+class LineupIngestCreate(BaseModel):
+    source_id: uuid.UUID
+    title: str = Field(..., min_length=1, max_length=255)
+    youtube_video_id: Optional[str] = Field(None, max_length=20)
+    chapter_start_seconds: Optional[int] = Field(None, ge=0)
+    chapter_title: Optional[str] = Field(None, max_length=500)
+    stand_screenshot_url: Optional[str] = Field(None, max_length=500)
+    aim_screenshot_url: Optional[str] = Field(None, max_length=500)
+    attribution_url: Optional[str] = Field(None, max_length=500)
+    attribution_author: Optional[str] = Field(None, max_length=200)
+    # game_id / map_id left null until classifier runs (PR 5)
+    game_id: Optional[uuid.UUID] = None
+    map_id: Optional[uuid.UUID] = None
 
 
 # ---------------------------------------------------------------------------
@@ -124,3 +159,36 @@ class UploadUrlResponse(BaseModel):
     aim_upload_url: str
     stand_object_key: str
     aim_object_key: str
+
+
+# ---------------------------------------------------------------------------
+# Source schemas
+# ---------------------------------------------------------------------------
+
+class SourceCreate(BaseModel):
+    kind: str
+    url: str
+
+    @field_validator("kind")
+    @classmethod
+    def validate_kind(cls, v: str) -> str:
+        if v not in ("youtube_playlist", "youtube_channel"):
+            raise ValueError("kind must be youtube_playlist or youtube_channel")
+        return v
+
+
+class SourceRead(BaseModel):
+    id: uuid.UUID
+    kind: str
+    config_json: dict
+    last_synced_at: Optional[str] = None
+    created_at: str
+
+    model_config = {"from_attributes": True}
+
+
+class SyncJobResponse(BaseModel):
+    job_id: str
+    source_id: uuid.UUID
+    status: str = "queued"
+    message: str = "Sync started — lineups will appear in pending_review when complete"

--- a/apps/mygamingassistant/backend/app/services/game/lineup_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_service.py
@@ -29,7 +29,7 @@ from app.repositories.game.lineup_repo import (
     update_lineup,
     zone_density,
 )
-from app.schemas.game.lineup_schemas import LineupCreate, LineupPatch, UploadUrlResponse
+from app.schemas.game.lineup_schemas import LineupCreate, LineupIngestCreate, LineupPatch, UploadUrlResponse
 
 # Presigned PUT URLs are valid for 15 minutes — enough time for the browser
 # to complete the upload, short enough to reduce exposure on leaked URLs.
@@ -126,15 +126,13 @@ async def create(
     payload: LineupCreate,
     lineup_id: Optional[uuid.UUID] = None,
 ) -> Lineup:
-    """Create a lineup. status='accepted' for manual uploads (no review step)."""
-    if settings.minio_skip_startup_check:
-        # Local dev with MinIO disabled — store keys as-is (no signing)
-        stand_url = payload.stand_screenshot_key
-        aim_url = payload.aim_screenshot_key
-    else:
-        # Validate that the keys exist in MinIO (optional — removes orphan rows)
-        stand_url = payload.stand_screenshot_key
-        aim_url = payload.aim_screenshot_key
+    """Create a lineup via the manual upload path.
+
+    All classification fields are required. Status is always set to 'accepted'
+    so the lineup appears in the library immediately.
+    """
+    stand_url = payload.stand_screenshot_key
+    aim_url = payload.aim_screenshot_key
 
     data: dict = {
         "game_id": payload.game_id,
@@ -159,6 +157,38 @@ async def create(
 
     lineup = await create_lineup(db, data)
     return _sign_lineup(lineup)
+
+
+async def create_from_ingestion(
+    db: AsyncSession,
+    payload: LineupIngestCreate,
+) -> Lineup:
+    """Create a lineup from the ingestion pipeline.
+
+    Classification fields are nullable — the Claude classifier (PR 5) fills
+    them in after this row is created. Status is always 'pending_review'.
+    """
+    data: dict = {
+        "source_id": payload.source_id,
+        "title": payload.title,
+        "youtube_video_id": payload.youtube_video_id,
+        "chapter_start_seconds": payload.chapter_start_seconds,
+        "chapter_title": payload.chapter_title,
+        "stand_screenshot_url": payload.stand_screenshot_url,
+        "aim_screenshot_url": payload.aim_screenshot_url,
+        "attribution_url": payload.attribution_url,
+        "attribution_author": payload.attribution_author,
+        "game_id": payload.game_id,
+        "map_id": payload.map_id,
+        # Classification fields left null (PR 5 fills these)
+        "target_zone_id": None,
+        "stand_zone_id": None,
+        "utility_type_id": None,
+        "side": None,
+        "status": "pending_review",
+    }
+    lineup = await create_lineup(db, data)
+    return lineup
 
 
 async def get(

--- a/apps/mygamingassistant/backend/app/services/game/source_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/source_service.py
@@ -1,0 +1,91 @@
+"""Source business-logic service.
+
+Orchestrates source CRUD and URL validation. ORM operations are delegated to
+source_repo; this service owns validation logic and commit boundaries.
+"""
+from __future__ import annotations
+
+import re
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.source import Source
+from app.repositories.game.source_repo import (
+    create_source,
+    get_source,
+    list_sources,
+    soft_delete_source,
+)
+from app.schemas.game.lineup_schemas import SourceCreate
+
+
+# ---------------------------------------------------------------------------
+# URL validation patterns
+# ---------------------------------------------------------------------------
+
+_YOUTUBE_PLAYLIST_RE = re.compile(
+    r"^https?://(?:www\.)?youtube\.com/playlist\?list=[\w-]+",
+    re.IGNORECASE,
+)
+_YOUTUBE_CHANNEL_RE = re.compile(
+    r"^https?://(?:www\.)?youtube\.com/(?:@[\w-]+|channel/[\w-]+|c/[\w-]+|user/[\w-]+)(?:/[\w-]*)?/?$",
+    re.IGNORECASE,
+)
+
+
+def validate_source_url(kind: str, url: str) -> str | None:
+    """Return None if the URL is valid for the given kind, or an error string."""
+    if kind == "youtube_playlist":
+        if not _YOUTUBE_PLAYLIST_RE.match(url):
+            return (
+                "youtube_playlist URL must be a YouTube playlist URL: "
+                "https://www.youtube.com/playlist?list=<id>"
+            )
+    elif kind == "youtube_channel":
+        if not _YOUTUBE_CHANNEL_RE.match(url):
+            return (
+                "youtube_channel URL must be a YouTube channel URL: "
+                "https://www.youtube.com/@handle  or  /channel/<id>  or  /c/<id>"
+            )
+    else:
+        return f"Unsupported kind: {kind!r}"
+    return None
+
+
+def _build_config_json(kind: str, url: str) -> dict:
+    """Build the config_json dict for a new Source."""
+    if kind == "youtube_playlist":
+        return {"url": url, "last_synced_at": None}
+    if kind == "youtube_channel":
+        return {"channel_url": url, "last_synced_at": None}
+    return {"url": url}
+
+
+async def create(db: AsyncSession, payload: SourceCreate) -> Source:
+    """Create a new Source after validating the URL."""
+    error = validate_source_url(payload.kind, payload.url)
+    if error:
+        raise ValueError(error)
+    config = _build_config_json(payload.kind, payload.url)
+    source = await create_source(db, kind=payload.kind, config_json=config)
+    await db.commit()
+    await db.refresh(source)
+    return source
+
+
+async def get(db: AsyncSession, source_id: uuid.UUID) -> Source | None:
+    return await get_source(db, source_id)
+
+
+async def list_all(db: AsyncSession) -> list[Source]:
+    return await list_sources(db)
+
+
+async def delete(db: AsyncSession, source_id: uuid.UUID) -> Source | None:
+    """Soft-delete a source (marks deleted in config_json; doesn't remove rows)."""
+    source = await soft_delete_source(db, source_id)
+    if source is None:
+        return None
+    await db.commit()
+    return source

--- a/apps/mygamingassistant/backend/app/services/ingestion/chapter_parser.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/chapter_parser.py
@@ -1,0 +1,126 @@
+"""Chapter parser — extract chapter timestamps from YouTube video descriptions.
+
+Priority order:
+  1. yt-dlp's native chapter extraction (`info_dict["chapters"]`) — used when available.
+  2. Regex-based description parsing — fallback when native chapters are absent.
+
+A valid chapter list requires at least 2 entries with monotonically increasing
+timestamps. Single-timestamp descriptions are NOT treated as chapters.
+
+Usage::
+
+    from app.services.ingestion.chapter_parser import parse_chapters, Chapter
+
+    chapters = parse_chapters(description="0:00 Intro\\n1:30 A-site smoke", video_duration=300)
+    # or pass native chapters from yt-dlp:
+    chapters = parse_chapters(
+        description="...",
+        video_duration=300,
+        native_chapters=[{"start_time": 0, "end_time": 90, "title": "Intro"}, ...],
+    )
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class Chapter:
+    start_seconds: int
+    end_seconds: int
+    title: str
+
+
+_TIMESTAMP_RE = re.compile(
+    r"^\s*(?:(\d{1,2}):)?(\d{1,2}):(\d{2})\s+(.+?)\s*$",
+    re.MULTILINE,
+)
+
+
+def _parse_timestamp(hours: Optional[str], minutes: str, seconds: str) -> int:
+    """Convert regex match groups to an integer second offset."""
+    h = int(hours) if hours else 0
+    m = int(minutes)
+    s = int(seconds)
+    return h * 3600 + m * 60 + s
+
+
+def _parse_chapters_from_description(
+    description: str,
+    video_duration: int,
+) -> list[Chapter]:
+    """Extract chapters from a raw video description using regex.
+
+    Rules:
+      - A line is a chapter if it matches ``HH:MM:SS Title`` or ``MM:SS Title``.
+      - Timestamps must be monotonically increasing.
+      - At least 2 valid chapter lines required; otherwise returns [].
+      - The last chapter's end_seconds is capped at video_duration.
+    """
+    candidates: list[tuple[int, str]] = []
+
+    for match in _TIMESTAMP_RE.finditer(description):
+        hours, minutes, seconds, title = match.groups()
+        try:
+            offset = _parse_timestamp(hours, minutes, seconds)
+        except (ValueError, TypeError):
+            continue
+        # Enforce monotonically increasing timestamps.
+        if candidates and offset <= candidates[-1][0]:
+            continue
+        candidates.append((offset, title.strip()))
+
+    if len(candidates) < 2:
+        return []
+
+    chapters: list[Chapter] = []
+    for i, (start, title) in enumerate(candidates):
+        if i + 1 < len(candidates):
+            end = candidates[i + 1][0]
+        else:
+            end = video_duration
+        chapters.append(Chapter(start_seconds=start, end_seconds=end, title=title))
+
+    return chapters
+
+
+def parse_chapters(
+    description: str,
+    video_duration: int,
+    native_chapters: Optional[list[dict]] = None,
+) -> list[Chapter]:
+    """Return the chapter list for a video.
+
+    Prefers yt-dlp's native chapter extraction (``native_chapters``) because it
+    handles edge cases better than regex. Falls back to description parsing when
+    native chapters are absent or empty.
+
+    Args:
+        description: Raw video description text from yt-dlp info_dict.
+        video_duration: Video duration in seconds (from yt-dlp info_dict["duration"]).
+        native_chapters: Optional list of chapter dicts from yt-dlp
+            info_dict.get("chapters"). Each dict has "start_time", "end_time",
+            "title" keys. Pass None or [] to force description-regex fallback.
+
+    Returns:
+        List of Chapter objects, empty if no valid chapters found.
+    """
+    # Prefer native chapters from yt-dlp — they're more reliable than regex.
+    if native_chapters:
+        result: list[Chapter] = []
+        for ch in native_chapters:
+            try:
+                start = int(ch.get("start_time", 0))
+                end = int(ch.get("end_time", video_duration))
+                title = str(ch.get("title", "")).strip()
+                if title:
+                    result.append(Chapter(start_seconds=start, end_seconds=end, title=title))
+            except (ValueError, TypeError, KeyError):
+                continue
+        if result:
+            return result
+
+    # Fallback to description regex.
+    return _parse_chapters_from_description(description, video_duration)

--- a/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
@@ -1,0 +1,101 @@
+"""Frame extractor — pull PNG frames from a video file using ffmpeg subprocess.
+
+Uses plain subprocess (not a Python wrapper) so there's no extra dependency.
+ffmpeg must be installed in the runtime image (added to backend.Dockerfile PR 4).
+
+Usage::
+
+    from app.services.ingestion.frame_extractor import extract_frames
+    from pathlib import Path
+
+    frames = await extract_frames(Path("/tmp/mga-ingestion/abc123.mp4"), [10.0, 14.0])
+    # frames[0] is PNG bytes for t=10s, frames[1] for t=14s
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import subprocess
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class FrameExtractionError(Exception):
+    """Raised when ffmpeg fails to extract a frame.
+
+    Attributes:
+        timestamp: The timestamp (seconds) that failed.
+        returncode: ffmpeg exit code.
+        stderr: ffmpeg stderr output (contains the structured error message).
+    """
+    def __init__(
+        self,
+        message: str,
+        *,
+        timestamp: float,
+        returncode: int,
+        stderr: str,
+    ) -> None:
+        super().__init__(message)
+        self.timestamp = timestamp
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def _extract_frame_sync(video_path: Path, timestamp: float) -> bytes:
+    """Synchronously extract one PNG frame at *timestamp* seconds.
+
+    Spawns ffmpeg as a subprocess and reads PNG bytes from stdout.
+    Raises FrameExtractionError on non-zero exit code.
+    """
+    cmd = [
+        "ffmpeg",
+        "-ss", str(timestamp),
+        "-i", str(video_path),
+        "-frames:v", "1",
+        "-f", "image2pipe",
+        "-vcodec", "png",
+        "pipe:1",
+    ]
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,  # single-frame extraction should never take this long
+    )
+    if result.returncode != 0:
+        stderr_text = result.stderr.decode("utf-8", errors="replace")
+        logger.error(
+            "ffmpeg frame extraction failed: video=%s timestamp=%.1f returncode=%d stderr=%s",
+            video_path, timestamp, result.returncode, stderr_text,
+        )
+        raise FrameExtractionError(
+            f"ffmpeg exited {result.returncode} extracting t={timestamp:.1f}s from {video_path.name}",
+            timestamp=timestamp,
+            returncode=result.returncode,
+            stderr=stderr_text,
+        )
+    return result.stdout
+
+
+async def extract_frames(
+    video_path: Path,
+    timestamps: list[float],
+) -> list[bytes]:
+    """Extract PNG frames at each timestamp from *video_path*.
+
+    Frames are extracted sequentially (one ffmpeg call per timestamp) in a
+    thread pool executor so they don't block the event loop.
+
+    Returns a list of PNG byte strings in the same order as *timestamps*.
+    Raises FrameExtractionError on any individual failure.
+    """
+    loop = asyncio.get_event_loop()
+    results: list[bytes] = []
+    for ts in timestamps:
+        png_bytes = await loop.run_in_executor(
+            None, _extract_frame_sync, video_path, ts
+        )
+        results.append(png_bytes)
+    return results

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -1,0 +1,318 @@
+"""Ingestion orchestrator — coordinate YouTube fetch + chapter parse + frame extract.
+
+Pipeline per source sync:
+  1. List video metadata via yt-dlp (no download yet).
+  2. Filter to videos not already in the lineup table (dedup by youtube_video_id).
+  3. For each new video:
+     a. Download video to INGESTION_DOWNLOAD_DIR.
+     b. Parse chapter timestamps (native yt-dlp or description regex).
+     c. For each chapter: extract stand frame (t=start) + aim frame (t=start+4s).
+     d. Upload both frames to MinIO under pending/{video_id}/{start}-{stand|aim}.png.
+     e. Insert Lineup row with status='pending_review'.
+     f. Delete downloaded video.
+  4. Update source.last_synced_at + last_sync_stats.
+
+Error handling:
+  - A failure on one chapter skips that chapter and continues.
+  - A failure on one video (download or all chapters) skips that video and continues.
+  - A failure listing videos (yt-dlp network error) aborts the sync.
+  - All errors are logged at ERROR with structured context and captured by Sentry.
+
+run_sync() is designed to run as a FastAPI BackgroundTask (PR 4). PR 6 replaces
+this with an APScheduler job.
+"""
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from io import BytesIO
+from pathlib import Path
+from typing import Optional
+
+import sentry_sdk
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.storage import get_storage
+from app.models.game.source import Source
+from app.repositories.game import lineup_repo, source_repo
+from app.schemas.game.lineup_schemas import LineupIngestCreate
+from app.services.game import lineup_service
+from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.frame_extractor import FrameExtractionError, extract_frames
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    VideoMeta,
+    YouTubeFetchError,
+    download_video,
+    list_videos,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SyncStats:
+    source_id: uuid.UUID
+    video_count: int = 0
+    chapter_count: int = 0
+    error_count: int = 0
+    errors: list[str] = field(default_factory=list)
+
+
+def _pending_screenshot_key(video_id: str, start_seconds: int, slot: str) -> str:
+    """MinIO key for a pending (unclassified) lineup screenshot.
+
+    Format: pending/{video_id}/{start_seconds}-{slot}.png
+    Slot: "stand" or "aim"
+    """
+    return f"pending/{video_id}/{start_seconds}-{slot}.png"
+
+
+def _upload_frame(storage, key: str, png_bytes: bytes) -> None:
+    """Upload PNG bytes to MinIO.
+
+    Uses the internal client directly since these are server-side uploads
+    (not presigned PUTs). The object is written with content-type image/png.
+    """
+    from minio.error import S3Error
+
+    client = storage._client if hasattr(storage, "_client") else storage
+    client.put_object(
+        storage.bucket,
+        key,
+        data=BytesIO(png_bytes),
+        length=len(png_bytes),
+        content_type="image/png",
+    )
+
+
+async def _process_chapter(
+    video_meta: VideoMeta,
+    chapter: Chapter,
+    download_dir: Path,
+    video_path: Path,
+    db: AsyncSession,
+    source: Source,
+) -> bool:
+    """Extract frames, upload to MinIO, and create a Lineup row.
+
+    Returns True on success, False on any handled error.
+    """
+    start = chapter.start_seconds
+    aim_ts = min(float(start) + 4.0, float(chapter.end_seconds) - 0.5)
+    aim_ts = max(aim_ts, float(start))  # guard against end < start + 0.5
+
+    try:
+        stand_bytes, aim_bytes = await extract_frames(video_path, [float(start), aim_ts])
+    except FrameExtractionError as exc:
+        logger.error(
+            "Frame extraction failed: source_id=%s video_id=%s chapter_start=%d error=%s",
+            source.id, video_meta.video_id, start, str(exc),
+            exc_info=True,
+        )
+        sentry_sdk.capture_exception(exc)
+        return False
+
+    stand_key = _pending_screenshot_key(video_meta.video_id, start, "stand")
+    aim_key = _pending_screenshot_key(video_meta.video_id, start, "aim")
+
+    try:
+        storage = get_storage()
+        _upload_frame(storage, stand_key, stand_bytes)
+        _upload_frame(storage, aim_key, aim_bytes)
+    except Exception as exc:
+        logger.error(
+            "MinIO upload failed: source_id=%s video_id=%s chapter_start=%d error=%s",
+            source.id, video_meta.video_id, start, str(exc),
+            exc_info=True,
+        )
+        sentry_sdk.capture_exception(exc)
+        return False
+
+    payload = LineupIngestCreate(
+        source_id=source.id,
+        title=chapter.title,
+        youtube_video_id=video_meta.video_id,
+        chapter_start_seconds=start,
+        chapter_title=chapter.title,
+        stand_screenshot_url=stand_key,
+        aim_screenshot_url=aim_key,
+        attribution_url=video_meta.url,
+        attribution_author=video_meta.channel_name,
+    )
+
+    try:
+        await lineup_service.create_from_ingestion(db, payload)
+        await db.commit()
+    except Exception as exc:
+        await db.rollback()
+        logger.error(
+            "DB insert failed: source_id=%s video_id=%s chapter_start=%d error=%s",
+            source.id, video_meta.video_id, start, str(exc),
+            exc_info=True,
+        )
+        sentry_sdk.capture_exception(exc)
+        return False
+
+    return True
+
+
+async def _process_video(
+    video_meta: VideoMeta,
+    download_dir: Path,
+    db: AsyncSession,
+    source: Source,
+    stats: SyncStats,
+) -> None:
+    """Download a video, parse chapters, and create lineup rows."""
+    logger.info(
+        "Processing video: source_id=%s video_id=%s title=%r",
+        source.id, video_meta.video_id, video_meta.title,
+    )
+
+    # Download
+    try:
+        video_path = await download_video(video_meta.video_id, download_dir)
+    except VideoDownloadError as exc:
+        logger.error(
+            "Video download failed: source_id=%s video_id=%s error_type=%s message=%s",
+            source.id, video_meta.video_id, exc.error_type, str(exc),
+        )
+        sentry_sdk.capture_exception(exc)
+        stats.error_count += 1
+        stats.errors.append(f"{video_meta.video_id}: download failed ({exc.error_type})")
+        return
+
+    try:
+        chapters = parse_chapters(
+            description=video_meta.description,
+            video_duration=video_meta.duration,
+            native_chapters=video_meta.chapters or None,
+        )
+
+        if not chapters:
+            logger.info(
+                "No chapters found: source_id=%s video_id=%s — skipping",
+                source.id, video_meta.video_id,
+            )
+            return
+
+        logger.info(
+            "Found %d chapters: source_id=%s video_id=%s",
+            len(chapters), source.id, video_meta.video_id,
+        )
+
+        for chapter_idx, chapter in enumerate(chapters):
+            ok = await _process_chapter(
+                video_meta=video_meta,
+                chapter=chapter,
+                download_dir=download_dir,
+                video_path=video_path,
+                db=db,
+                source=source,
+            )
+            if ok:
+                stats.chapter_count += 1
+            else:
+                stats.error_count += 1
+                stats.errors.append(
+                    f"{video_meta.video_id}[{chapter_idx}]: chapter processing failed"
+                )
+
+        stats.video_count += 1
+
+    finally:
+        # Always clean up the downloaded file regardless of success/failure.
+        try:
+            video_path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "Failed to delete downloaded video: path=%s error=%s",
+                video_path, str(exc),
+            )
+
+
+async def sync_source(source_id: uuid.UUID, db: AsyncSession) -> SyncStats:
+    """Run a full sync for one Source.
+
+    This is designed to run as a FastAPI BackgroundTask (PR 4). PR 6 replaces
+    this with an APScheduler background scheduler.
+
+    Per-video errors are caught and logged; the sync continues past them.
+    A yt-dlp error when listing videos is fatal for this sync run.
+
+    Returns SyncStats with counts and error summaries.
+    """
+    stats = SyncStats(source_id=source_id)
+    source = await source_repo.get_source(db, source_id)
+    if source is None:
+        logger.error("sync_source: source not found: source_id=%s", source_id)
+        return stats
+
+    logger.info("sync_source: starting: source_id=%s kind=%s", source.id, source.kind)
+
+    download_dir = Path(settings.ingestion_download_dir)
+
+    # List videos
+    try:
+        video_metas: list[VideoMeta] = await list_videos(source)
+    except YouTubeFetchError as exc:
+        logger.error(
+            "sync_source: failed to list videos: source_id=%s error_type=%s message=%s",
+            source.id, exc.error_type, str(exc),
+        )
+        sentry_sdk.capture_exception(exc)
+        stats.errors.append(f"list_videos failed: {exc.error_type}: {exc}")
+        stats.error_count += 1
+        return stats
+
+    if not video_metas:
+        logger.info("sync_source: no videos found: source_id=%s", source.id)
+        await source_repo.update_sync_stats(db, source, video_count=0, chapter_count=0, error_count=0)
+        await db.commit()
+        return stats
+
+    # Dedup — filter to videos not already in the lineup table.
+    all_video_ids = [m.video_id for m in video_metas]
+    existing_ids = await lineup_repo.get_ingested_video_ids(db, all_video_ids)
+    new_videos = [m for m in video_metas if m.video_id not in existing_ids]
+
+    logger.info(
+        "sync_source: %d total videos, %d new: source_id=%s",
+        len(video_metas), len(new_videos), source.id,
+    )
+
+    for video_meta in new_videos:
+        await _process_video(
+            video_meta=video_meta,
+            download_dir=download_dir,
+            db=db,
+            source=source,
+            stats=stats,
+        )
+
+    # Update source stats
+    try:
+        await source_repo.update_sync_stats(
+            db,
+            source,
+            video_count=stats.video_count,
+            chapter_count=stats.chapter_count,
+            error_count=stats.error_count,
+        )
+        await db.commit()
+    except Exception as exc:
+        logger.error(
+            "sync_source: failed to update sync stats: source_id=%s error=%s",
+            source.id, str(exc),
+            exc_info=True,
+        )
+
+    logger.info(
+        "sync_source: complete: source_id=%s videos=%d chapters=%d errors=%d",
+        source.id, stats.video_count, stats.chapter_count, stats.error_count,
+    )
+    return stats

--- a/apps/mygamingassistant/backend/app/services/ingestion/youtube_fetcher.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/youtube_fetcher.py
@@ -1,0 +1,241 @@
+"""YouTube fetcher — list video metadata and download video files via yt-dlp.
+
+Per rules/check-third-party-error-codes.md: yt-dlp raises structured exception
+types. All failure paths capture and log the exception class name and message at
+ERROR level, then surface the error to Sentry. Callers receive typed results
+rather than bare booleans.
+
+Usage::
+
+    from app.services.ingestion.youtube_fetcher import list_videos, download_video, VideoMeta
+    from app.models.game.source import Source
+
+    videos = await list_videos(source)
+    path = await download_video("dQw4w9WgXcQ", download_dir=Path("/tmp/mga-ingestion"))
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+import yt_dlp
+import yt_dlp.utils
+
+from app.models.game.source import Source
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class VideoMeta:
+    """Metadata for a single YouTube video."""
+    video_id: str
+    title: str
+    description: str
+    duration: int
+    published_at: Optional[str]
+    channel_name: Optional[str]
+    url: str
+    # Native chapters from yt-dlp (preferred over description regex).
+    # Each dict has "start_time", "end_time", "title" keys.
+    chapters: list[dict] = field(default_factory=list)
+
+
+class YouTubeFetchError(Exception):
+    """Raised when yt-dlp fails to fetch video/playlist metadata.
+
+    Attributes:
+        error_type: yt-dlp exception class name (e.g. "ExtractorError").
+        original: The original yt-dlp exception for callers that need it.
+    """
+    def __init__(self, message: str, *, error_type: str, original: Exception) -> None:
+        super().__init__(message)
+        self.error_type = error_type
+        self.original = original
+
+
+class VideoDownloadError(Exception):
+    """Raised when a video download fails.
+
+    Attributes:
+        video_id: The YouTube video ID that failed.
+        error_type: yt-dlp exception class name.
+    """
+    def __init__(self, message: str, *, video_id: str, error_type: str, original: Exception) -> None:
+        super().__init__(message)
+        self.video_id = video_id
+        self.error_type = error_type
+        self.original = original
+
+
+def _source_url(source: Source) -> str:
+    """Extract the target URL from a Source's config_json."""
+    cfg = source.config_json or {}
+    # Support both "url" (playlist) and "channel_url" (channel) keys per the model docstring.
+    return cfg.get("url") or cfg.get("channel_url") or ""
+
+
+async def list_videos(source: Source) -> list[VideoMeta]:
+    """Return new video metadata for a Source without downloading anything.
+
+    Uses yt-dlp's extract_flat mode so only metadata is fetched, not the
+    actual video stream. This is fast enough to run synchronously in a thread.
+
+    Per check-third-party-error-codes: yt-dlp DownloadError / ExtractorError
+    exceptions are caught, logged at ERROR with structured context, and
+    re-raised as YouTubeFetchError.
+    """
+    url = _source_url(source)
+    if not url:
+        raise YouTubeFetchError(
+            f"Source {source.id} has no URL in config_json",
+            error_type="MissingURL",
+            original=ValueError("missing URL"),
+        )
+
+    ydl_opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "extract_flat": True,
+        "skip_download": True,
+        "ignoreerrors": False,
+    }
+
+    def _fetch() -> list[VideoMeta]:
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            info = ydl.extract_info(url, download=False)
+        if info is None:
+            return []
+
+        entries = info.get("entries") or []
+        # Single video (not a playlist/channel) — wrap in a list.
+        # Only treat the root info as a video if it has no "entries" key at all
+        # (a playlist with 0 entries still has entries=[]).
+        if "entries" not in info and info.get("id"):
+            entries = [info]
+
+        results: list[VideoMeta] = []
+        for entry in entries:
+            vid_id = entry.get("id") or entry.get("url", "").split("v=")[-1]
+            if not vid_id:
+                continue
+            results.append(
+                VideoMeta(
+                    video_id=vid_id,
+                    title=entry.get("title") or "",
+                    description=entry.get("description") or "",
+                    duration=int(entry.get("duration") or 0),
+                    published_at=entry.get("upload_date"),
+                    channel_name=entry.get("channel") or entry.get("uploader"),
+                    url=f"https://www.youtube.com/watch?v={vid_id}",
+                    chapters=entry.get("chapters") or [],
+                )
+            )
+        return results
+
+    try:
+        return await asyncio.get_event_loop().run_in_executor(None, _fetch)
+    except yt_dlp.utils.DownloadError as exc:
+        error_type = type(exc).__name__
+        logger.error(
+            "yt-dlp DownloadError listing source=%s url=%s error_type=%s message=%s",
+            source.id, url, error_type, str(exc),
+            exc_info=True,
+        )
+        raise YouTubeFetchError(
+            f"Failed to list videos for source {source.id}: {exc}",
+            error_type=error_type,
+            original=exc,
+        ) from exc
+    except yt_dlp.utils.ExtractorError as exc:
+        error_type = type(exc).__name__
+        logger.error(
+            "yt-dlp ExtractorError listing source=%s url=%s error_type=%s message=%s",
+            source.id, url, error_type, str(exc),
+            exc_info=True,
+        )
+        raise YouTubeFetchError(
+            f"Failed to list videos for source {source.id}: {exc}",
+            error_type=error_type,
+            original=exc,
+        ) from exc
+    except Exception as exc:
+        error_type = type(exc).__name__
+        logger.error(
+            "Unexpected error listing source=%s url=%s error_type=%s",
+            source.id, url, error_type,
+            exc_info=True,
+        )
+        raise YouTubeFetchError(
+            f"Unexpected error listing videos for source {source.id}: {exc}",
+            error_type=error_type,
+            original=exc,
+        ) from exc
+
+
+async def download_video(video_id: str, download_dir: Path) -> Path:
+    """Download a YouTube video to ``download_dir/{video_id}.mp4``.
+
+    Returns the Path to the downloaded file. Caller is responsible for
+    cleanup (ingestion_orchestrator deletes after frame extraction).
+
+    Per check-third-party-error-codes: DownloadError / UnavailableVideoError
+    are caught, logged at ERROR with structured context, re-raised as
+    VideoDownloadError.
+    """
+    download_dir.mkdir(parents=True, exist_ok=True)
+    output_template = str(download_dir / f"{video_id}.%(ext)s")
+
+    ydl_opts = {
+        "quiet": True,
+        "no_warnings": True,
+        "outtmpl": output_template,
+        "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+        "merge_output_format": "mp4",
+        "ignoreerrors": False,
+    }
+
+    def _download() -> Path:
+        with yt_dlp.YoutubeDL(ydl_opts) as ydl:
+            ydl.download([f"https://www.youtube.com/watch?v={video_id}"])
+        # The file will be named {video_id}.mp4 after merge.
+        target = download_dir / f"{video_id}.mp4"
+        if not target.exists():
+            # yt-dlp might have used a different extension; search for it.
+            candidates = list(download_dir.glob(f"{video_id}.*"))
+            if not candidates:
+                raise FileNotFoundError(f"Download completed but file not found: {target}")
+            target = candidates[0]
+        return target
+
+    try:
+        return await asyncio.get_event_loop().run_in_executor(None, _download)
+    except yt_dlp.utils.DownloadError as exc:
+        error_type = type(exc).__name__
+        logger.error(
+            "yt-dlp DownloadError downloading video_id=%s error_type=%s message=%s",
+            video_id, error_type, str(exc),
+            exc_info=True,
+        )
+        raise VideoDownloadError(
+            f"Failed to download video {video_id}: {exc}",
+            video_id=video_id,
+            error_type=error_type,
+            original=exc,
+        ) from exc
+    except Exception as exc:
+        error_type = type(exc).__name__
+        logger.error(
+            "Unexpected error downloading video_id=%s error_type=%s",
+            video_id, error_type,
+            exc_info=True,
+        )
+        raise VideoDownloadError(
+            f"Unexpected error downloading video {video_id}: {exc}",
+            video_id=video_id,
+            error_type=error_type,
+            original=exc,
+        ) from exc

--- a/apps/mygamingassistant/backend/pyproject.toml
+++ b/apps/mygamingassistant/backend/pyproject.toml
@@ -27,6 +27,9 @@ dependencies = [
     "sentry-sdk[fastapi]==2.59.0",
     "pyotp==2.9.0",
     "qrcode[pil]==8.2",
+    # YouTube ingestion — yt-dlp for video/playlist metadata + download.
+    # Pinned to latest stable as of 2026-05. Bump on yt-dlp breakage (expected ~3-4x/year).
+    "yt-dlp==2026.3.17",
 ]
 
 [tool.uv]

--- a/apps/mygamingassistant/backend/requirements.txt
+++ b/apps/mygamingassistant/backend/requirements.txt
@@ -213,3 +213,5 @@ watchfiles==1.1.1
     # via uvicorn
 websockets==16.0
     # via uvicorn
+yt-dlp==2026.3.17
+    # via mygamingassistant-backend

--- a/apps/mygamingassistant/backend/tests/test_chapter_parser.py
+++ b/apps/mygamingassistant/backend/tests/test_chapter_parser.py
@@ -1,0 +1,165 @@
+"""Unit tests for the chapter_parser ingestion service (PR 4).
+
+Tests cover:
+- Standard YouTube chapter formats (MM:SS, HH:MM:SS)
+- Description with mixed chapter + non-chapter lines
+- Description with only 1 timestamp (should NOT parse as chapters)
+- yt-dlp native chapters preferred over description regex
+- Monotonically increasing timestamp enforcement
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+
+
+# ---------------------------------------------------------------------------
+# Description regex path
+# ---------------------------------------------------------------------------
+
+class TestDescriptionChapters:
+    def test_standard_mm_ss_format(self):
+        desc = (
+            "0:00 Intro\n"
+            "1:30 A-site smoke from CT\n"
+            "3:45 B-site smoke from mid\n"
+        )
+        chapters = parse_chapters(desc, video_duration=300)
+        assert len(chapters) == 3
+        assert chapters[0] == Chapter(start_seconds=0, end_seconds=90, title="Intro")
+        assert chapters[1] == Chapter(start_seconds=90, end_seconds=225, title="A-site smoke from CT")
+        assert chapters[2] == Chapter(start_seconds=225, end_seconds=300, title="B-site smoke from mid")
+
+    def test_hh_mm_ss_format(self):
+        desc = (
+            "0:00:00 Opening\n"
+            "0:12:30 First lineup\n"
+            "1:05:45 Late-game smoke\n"
+        )
+        chapters = parse_chapters(desc, video_duration=4000)
+        assert len(chapters) == 3
+        assert chapters[0].start_seconds == 0
+        assert chapters[1].start_seconds == 750  # 12*60 + 30
+        assert chapters[2].start_seconds == 3945  # 1*3600 + 5*60 + 45
+        assert chapters[2].end_seconds == 4000
+
+    def test_last_chapter_end_equals_duration(self):
+        desc = "0:00 Intro\n2:00 Main content\n"
+        chapters = parse_chapters(desc, video_duration=500)
+        assert chapters[-1].end_seconds == 500
+
+    def test_description_with_non_chapter_lines(self):
+        desc = (
+            "Subscribe for more! Like + Comment\n"
+            "\n"
+            "Timestamps:\n"
+            "0:00 Intro\n"
+            "2:30 B-site default\n"
+            "\n"
+            "Follow me on Twitter @player\n"
+            "Music: Lofi Beats\n"
+        )
+        chapters = parse_chapters(desc, video_duration=600)
+        assert len(chapters) == 2
+        assert chapters[0].title == "Intro"
+        assert chapters[1].title == "B-site default"
+
+    def test_single_timestamp_not_parsed(self):
+        desc = "0:00 The whole video is one lineup\n"
+        chapters = parse_chapters(desc, video_duration=300)
+        assert chapters == []
+
+    def test_zero_timestamps_returns_empty(self):
+        desc = "No timestamps here at all. Just a description."
+        chapters = parse_chapters(desc, video_duration=300)
+        assert chapters == []
+
+    def test_non_monotonic_timestamps_skipped(self):
+        """Timestamps that go backwards are ignored (out-of-order lines)."""
+        desc = (
+            "0:00 Intro\n"
+            "5:00 Main\n"
+            "3:00 This is out of order\n"
+            "8:00 End\n"
+        )
+        chapters = parse_chapters(desc, video_duration=600)
+        # 3:00 is non-monotonic relative to 5:00 — should be skipped.
+        assert len(chapters) == 3
+        titles = [c.title for c in chapters]
+        assert "This is out of order" not in titles
+
+    def test_timestamp_with_leading_whitespace(self):
+        desc = "  0:00 Intro\n  1:00 Second chapter\n"
+        chapters = parse_chapters(desc, video_duration=200)
+        assert len(chapters) == 2
+
+    def test_chapter_titles_stripped(self):
+        desc = "0:00   Smoke from T spawn   \n1:00 Flash\n"
+        chapters = parse_chapters(desc, video_duration=200)
+        assert chapters[0].title == "Smoke from T spawn"
+
+    def test_end_seconds_of_last_chapter_capped_at_duration(self):
+        desc = "0:00 Intro\n4:59 Last chapter\n"
+        chapters = parse_chapters(desc, video_duration=300)
+        assert chapters[-1].end_seconds == 300
+
+
+# ---------------------------------------------------------------------------
+# Native chapters path (yt-dlp preferred)
+# ---------------------------------------------------------------------------
+
+class TestNativeChapters:
+    def test_native_chapters_preferred_over_description(self):
+        native = [
+            {"start_time": 0, "end_time": 60, "title": "Native chapter 1"},
+            {"start_time": 60, "end_time": 120, "title": "Native chapter 2"},
+        ]
+        desc = "0:00 Description chapter 1\n2:00 Description chapter 2\n"
+        chapters = parse_chapters(desc, video_duration=120, native_chapters=native)
+        assert len(chapters) == 2
+        assert chapters[0].title == "Native chapter 1"
+        assert chapters[1].title == "Native chapter 2"
+
+    def test_native_chapters_with_correct_times(self):
+        native = [
+            {"start_time": 0, "end_time": 90, "title": "Intro"},
+            {"start_time": 90, "end_time": 300, "title": "B-site smokes"},
+        ]
+        chapters = parse_chapters("", video_duration=300, native_chapters=native)
+        assert chapters[0].start_seconds == 0
+        assert chapters[0].end_seconds == 90
+        assert chapters[1].start_seconds == 90
+        assert chapters[1].end_seconds == 300
+
+    def test_empty_native_chapters_falls_back_to_description(self):
+        desc = "0:00 Intro\n1:00 Second\n"
+        chapters = parse_chapters(desc, video_duration=200, native_chapters=[])
+        assert len(chapters) == 2
+        assert chapters[0].title == "Intro"
+
+    def test_none_native_chapters_falls_back_to_description(self):
+        desc = "0:00 Intro\n1:00 Second\n"
+        chapters = parse_chapters(desc, video_duration=200, native_chapters=None)
+        assert len(chapters) == 2
+
+    def test_native_chapters_skips_entries_without_title(self):
+        native = [
+            {"start_time": 0, "end_time": 60, "title": ""},  # empty title skipped
+            {"start_time": 60, "end_time": 120, "title": "Valid chapter"},
+        ]
+        chapters = parse_chapters("", video_duration=120, native_chapters=native)
+        assert len(chapters) == 1
+        assert chapters[0].title == "Valid chapter"
+
+    def test_native_chapters_handles_malformed_entries(self):
+        native = [
+            {"start_time": "not-a-number", "end_time": 60, "title": "Bad"},
+            {"start_time": 60, "end_time": 120, "title": "Good"},
+        ]
+        # The malformed entry should be skipped; we get 1 valid chapter.
+        # Falls back to description because only native "Good" is valid
+        # (the list is still non-empty so no fallback — just 1 result).
+        chapters = parse_chapters("", video_duration=120, native_chapters=native)
+        # "Bad" has non-numeric start_time — parser skips it gracefully
+        assert all(c.title != "Bad" for c in chapters)

--- a/apps/mygamingassistant/backend/tests/test_frame_extractor.py
+++ b/apps/mygamingassistant/backend/tests/test_frame_extractor.py
@@ -1,0 +1,99 @@
+"""Unit tests for frame_extractor — ffmpeg subprocess is mocked.
+
+Tests verify:
+- extract_frames returns PNG bytes for each timestamp
+- FrameExtractionError is raised on ffmpeg non-zero exit
+- FrameExtractionError carries returncode and stderr
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.ingestion.frame_extractor import FrameExtractionError, extract_frames
+
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00"  # PNG magic bytes header
+
+
+class TestExtractFrames:
+    @pytest.mark.asyncio
+    async def test_returns_bytes_for_each_timestamp(self, tmp_path: Path):
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"fake")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = _FAKE_PNG
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            frames = await extract_frames(video, [5.0, 9.0])
+
+        assert len(frames) == 2
+        assert frames[0] == _FAKE_PNG
+        assert frames[1] == _FAKE_PNG
+        assert mock_run.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_command_uses_correct_timestamp(self, tmp_path: Path):
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"fake")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = _FAKE_PNG
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            await extract_frames(video, [12.5])
+
+        cmd = mock_run.call_args[0][0]
+        assert "-ss" in cmd
+        ts_idx = cmd.index("-ss") + 1
+        assert cmd[ts_idx] == "12.5"
+
+    @pytest.mark.asyncio
+    async def test_raises_frame_extraction_error_on_failure(self, tmp_path: Path):
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"fake")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = b""
+        mock_result.stderr = b"ffmpeg error: codec not found"
+
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(FrameExtractionError) as exc_info:
+                await extract_frames(video, [5.0])
+
+        err = exc_info.value
+        assert err.returncode == 1
+        assert "codec not found" in err.stderr
+        assert err.timestamp == 5.0
+
+    @pytest.mark.asyncio
+    async def test_empty_timestamps_returns_empty_list(self, tmp_path: Path):
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"fake")
+
+        with patch("subprocess.run") as mock_run:
+            frames = await extract_frames(video, [])
+
+        assert frames == []
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_ffmpeg_output_piped_to_stdout(self, tmp_path: Path):
+        """ffmpeg must write PNG to stdout (pipe:1) not to a file."""
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"fake")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = _FAKE_PNG
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            await extract_frames(video, [1.0])
+
+        cmd = mock_run.call_args[0][0]
+        assert "pipe:1" in cmd

--- a/apps/mygamingassistant/backend/tests/test_ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/tests/test_ingestion_orchestrator.py
@@ -1,0 +1,236 @@
+"""Integration tests for ingestion_orchestrator.sync_source.
+
+All external dependencies (yt-dlp, ffmpeg, MinIO) are mocked.
+Tests verify that Lineup rows are created with the correct shape.
+"""
+from __future__ import annotations
+
+import uuid
+from io import BytesIO
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch, call
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.source import Source
+from app.models.game.lineup import Lineup
+from app.services.ingestion.chapter_parser import Chapter
+from app.services.ingestion.youtube_fetcher import VideoMeta
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def source(db: AsyncSession) -> Source:
+    src = Source(
+        id=uuid.uuid4(),
+        kind="youtube_playlist",
+        config_json={"url": "https://www.youtube.com/playlist?list=PLtest"},
+    )
+    db.add(src)
+    await db.flush()
+    return src
+
+
+FAKE_VIDEO = VideoMeta(
+    video_id="vid001",
+    title="Valorant smokes",
+    description="",
+    duration=300,
+    published_at="20260101",
+    channel_name="TestCreator",
+    url="https://www.youtube.com/watch?v=vid001",
+    chapters=[
+        {"start_time": 0, "end_time": 90, "title": "A-site from CT"},
+        {"start_time": 90, "end_time": 200, "title": "B-site default"},
+    ],
+)
+
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n"
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestSyncSource:
+    @pytest.mark.asyncio
+    async def test_creates_lineup_rows_for_chapters(
+        self,
+        db: AsyncSession,
+        source: Source,
+        tmp_path: Path,
+    ):
+        from app.services.ingestion import ingestion_orchestrator
+        from sqlalchemy import select
+
+        fake_video_path = tmp_path / "vid001.mp4"
+        fake_video_path.write_bytes(b"fake video")
+
+        with (
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.list_videos",
+                new_callable=AsyncMock,
+                return_value=[FAKE_VIDEO],
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.download_video",
+                new_callable=AsyncMock,
+                return_value=fake_video_path,
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.extract_frames",
+                new_callable=AsyncMock,
+                return_value=[_FAKE_PNG, _FAKE_PNG],
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.get_storage",
+            ) as mock_storage_factory,
+            patch.object(
+                ingestion_orchestrator,
+                "settings",
+            ) as mock_settings,
+        ):
+            mock_settings.ingestion_download_dir = str(tmp_path)
+            mock_storage = MagicMock()
+            mock_storage.bucket = "mygamingassistant-screenshots"
+            mock_storage._client = MagicMock()
+            mock_storage_factory.return_value = mock_storage
+
+            stats = await ingestion_orchestrator.sync_source(source.id, db)
+
+        assert stats.video_count == 1
+        assert stats.chapter_count == 2
+        assert stats.error_count == 0
+
+        result = await db.execute(
+            select(Lineup).where(Lineup.youtube_video_id == "vid001")
+        )
+        lineups = result.scalars().all()
+        assert len(lineups) == 2
+
+        # All lineups should be pending_review with correct metadata.
+        for lineup in lineups:
+            assert lineup.status == "pending_review"
+            assert lineup.youtube_video_id == "vid001"
+            assert lineup.source_id == source.id
+            assert lineup.attribution_author == "TestCreator"
+            # Classification fields null until classifier runs (PR 5).
+            assert lineup.target_zone_id is None
+            assert lineup.stand_zone_id is None
+            assert lineup.utility_type_id is None
+            assert lineup.side is None
+
+    @pytest.mark.asyncio
+    async def test_dedup_skips_existing_video(
+        self,
+        db: AsyncSession,
+        source: Source,
+        tmp_path: Path,
+    ):
+        """Videos already in the lineup table should not be re-processed."""
+        from app.services.ingestion import ingestion_orchestrator
+        from sqlalchemy import select
+
+        # Pre-insert a lineup with the same video_id.
+        existing = Lineup(
+            youtube_video_id="vid001",
+            title="Already processed",
+            source_id=source.id,
+            status="pending_review",
+            game_id=None,
+            map_id=None,
+        )
+        db.add(existing)
+        await db.flush()
+
+        with (
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.list_videos",
+                new_callable=AsyncMock,
+                return_value=[FAKE_VIDEO],
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.download_video",
+                new_callable=AsyncMock,
+            ) as mock_download,
+            patch.object(
+                ingestion_orchestrator,
+                "settings",
+            ) as mock_settings,
+        ):
+            mock_settings.ingestion_download_dir = str(tmp_path)
+            stats = await ingestion_orchestrator.sync_source(source.id, db)
+
+        # Download should not have been called for the duplicate video.
+        mock_download.assert_not_called()
+        assert stats.video_count == 0
+
+    @pytest.mark.asyncio
+    async def test_chapter_error_is_skipped_not_fatal(
+        self,
+        db: AsyncSession,
+        source: Source,
+        tmp_path: Path,
+    ):
+        """A frame extraction failure on one chapter should not abort the whole sync."""
+        from app.services.ingestion import ingestion_orchestrator
+        from app.services.ingestion.frame_extractor import FrameExtractionError
+
+        fake_video_path = tmp_path / "vid001.mp4"
+        fake_video_path.write_bytes(b"fake")
+
+        # First chapter fails, second succeeds.
+        frame_results = iter([
+            FrameExtractionError(
+                "ffmpeg failed", timestamp=0.0, returncode=1, stderr="error"
+            ),
+            (_FAKE_PNG, _FAKE_PNG),  # won't reach here due to raise
+        ])
+
+        async def _mock_extract(video_path, timestamps):
+            val = next(frame_results)
+            if isinstance(val, FrameExtractionError):
+                raise val
+            return list(val)
+
+        with (
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.list_videos",
+                new_callable=AsyncMock,
+                return_value=[FAKE_VIDEO],
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.download_video",
+                new_callable=AsyncMock,
+                return_value=fake_video_path,
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.extract_frames",
+                side_effect=_mock_extract,
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.get_storage",
+            ) as mock_storage_factory,
+            patch.object(
+                ingestion_orchestrator,
+                "settings",
+            ) as mock_settings,
+            patch("sentry_sdk.capture_exception"),
+        ):
+            mock_settings.ingestion_download_dir = str(tmp_path)
+            mock_storage = MagicMock()
+            mock_storage.bucket = "mygamingassistant-screenshots"
+            mock_storage._client = MagicMock()
+            mock_storage_factory.return_value = mock_storage
+
+            stats = await ingestion_orchestrator.sync_source(source.id, db)
+
+        # One chapter errored; the other succeeded.
+        assert stats.chapter_count == 1
+        assert stats.error_count == 1
+        assert stats.video_count == 1

--- a/apps/mygamingassistant/backend/tests/test_sources.py
+++ b/apps/mygamingassistant/backend/tests/test_sources.py
@@ -1,0 +1,197 @@
+"""Tests for the Source management API (PR 4).
+
+Tests verify:
+- POST /api/sources creates a source (playlist + channel)
+- POST /api/sources rejects invalid URL
+- GET /api/sources lists sources
+- GET /api/sources/{id} returns detail
+- DELETE /api/sources/{id} soft-deletes
+- POST /api/sources/{id}/sync returns 200 with job_id
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.source import Source
+from app.models.user.user import User
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def auth_client(client: AsyncClient, db: AsyncSession) -> AsyncClient:
+    """Create test user and log in."""
+    from fastapi_users.password import PasswordHelper
+    from sqlalchemy import select
+
+    TEST_EMAIL = "sources-test@example.com"
+    TEST_PASSWORD = "testpassword123!"
+
+    result = await db.execute(select(User).where(User.email == TEST_EMAIL))
+    user = result.scalar_one_or_none()
+    if user is None:
+        helper = PasswordHelper()
+        user = User(
+            email=TEST_EMAIL,
+            hashed_password=helper.hash(TEST_PASSWORD),
+            is_verified=True,
+            is_active=True,
+        )
+        db.add(user)
+        await db.flush()
+
+    resp = await client.post(
+        "/api/auth/jwt/login",
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    if resp.status_code != 200:
+        pytest.skip(f"Auth failed: {resp.status_code}")
+
+    token = resp.json().get("access_token", "")
+    client.headers["Authorization"] = f"Bearer {token}"
+    return client
+
+
+@pytest_asyncio.fixture
+async def existing_source(db: AsyncSession) -> Source:
+    src = Source(
+        kind="youtube_playlist",
+        config_json={"url": "https://www.youtube.com/playlist?list=PLexisting"},
+    )
+    db.add(src)
+    await db.flush()
+    return src
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_playlist_source(auth_client: AsyncClient):
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_playlist",
+            "url": "https://www.youtube.com/playlist?list=PLabcdef",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["kind"] == "youtube_playlist"
+    assert "PLabcdef" in body["config_json"]["url"]
+    assert body["last_synced_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_channel_source(auth_client: AsyncClient):
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_channel",
+            "url": "https://www.youtube.com/@testchannel",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["kind"] == "youtube_channel"
+
+
+@pytest.mark.asyncio
+async def test_create_source_rejects_invalid_url(auth_client: AsyncClient):
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_playlist",
+            "url": "https://example.com/not-a-youtube-url",
+        },
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_source_rejects_invalid_kind(auth_client: AsyncClient):
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "manual",
+            "url": "https://www.youtube.com/playlist?list=PLtest",
+        },
+    )
+    # kind=manual not allowed via API (only youtube_playlist/youtube_channel)
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_list_sources(auth_client: AsyncClient, existing_source: Source):
+    resp = await auth_client.get("/api/sources")
+    assert resp.status_code == 200, resp.text
+    sources = resp.json()
+    ids = [s["id"] for s in sources]
+    assert str(existing_source.id) in ids
+
+
+@pytest.mark.asyncio
+async def test_get_source_detail(auth_client: AsyncClient, existing_source: Source):
+    resp = await auth_client.get(f"/api/sources/{existing_source.id}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["id"] == str(existing_source.id)
+    assert body["kind"] == "youtube_playlist"
+
+
+@pytest.mark.asyncio
+async def test_get_source_404(auth_client: AsyncClient):
+    resp = await auth_client.get(f"/api/sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_source_soft_deletes(auth_client: AsyncClient, existing_source: Source, db: AsyncSession):
+    resp = await auth_client.delete(f"/api/sources/{existing_source.id}")
+    assert resp.status_code == 204, resp.text
+
+    from sqlalchemy import select
+    result = await db.execute(select(Source).where(Source.id == existing_source.id))
+    source = result.scalar_one_or_none()
+    # Row still exists (soft delete via config_json.deleted flag)
+    assert source is not None
+    assert source.config_json.get("deleted") is True
+
+
+@pytest.mark.asyncio
+async def test_delete_source_404(auth_client: AsyncClient):
+    resp = await auth_client.delete(f"/api/sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_sync_source_returns_job_id(auth_client: AsyncClient, existing_source: Source):
+    """POST /api/sources/{id}/sync should return job_id immediately."""
+    # Mock the background task execution so we don't actually run ingestion.
+    with patch(
+        "app.api.sources.ingestion_orchestrator.sync_source",
+        new_callable=AsyncMock,
+    ):
+        resp = await auth_client.post(f"/api/sources/{existing_source.id}/sync")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert "job_id" in body
+    assert body["source_id"] == str(existing_source.id)
+    assert body["status"] == "queued"
+
+
+@pytest.mark.asyncio
+async def test_sync_source_404(auth_client: AsyncClient):
+    resp = await auth_client.post(f"/api/sources/{uuid.uuid4()}/sync")
+    assert resp.status_code == 404

--- a/apps/mygamingassistant/backend/tests/test_youtube_fetcher.py
+++ b/apps/mygamingassistant/backend/tests/test_youtube_fetcher.py
@@ -1,0 +1,210 @@
+"""Unit tests for youtube_fetcher — all yt-dlp calls are mocked (no real network).
+
+Tests verify:
+- list_videos returns VideoMeta list for a playlist
+- list_videos raises YouTubeFetchError on yt-dlp DownloadError
+- list_videos raises YouTubeFetchError on yt-dlp ExtractorError
+- download_video returns Path on success
+- download_video raises VideoDownloadError on yt-dlp DownloadError
+- Error codes / types are captured in the exception
+"""
+from __future__ import annotations
+
+import asyncio
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+import yt_dlp.utils
+
+from app.models.game.source import Source
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    VideoMeta,
+    YouTubeFetchError,
+    download_video,
+    list_videos,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_source(kind: str = "youtube_playlist", url: str = "https://www.youtube.com/playlist?list=PLtest") -> Source:
+    return Source(
+        id=uuid.uuid4(),
+        kind=kind,
+        config_json={"url": url},
+    )
+
+
+def _make_channel_source(url: str = "https://www.youtube.com/@testchannel") -> Source:
+    return Source(
+        id=uuid.uuid4(),
+        kind="youtube_channel",
+        config_json={"channel_url": url},
+    )
+
+
+_FAKE_INFO = {
+    "id": "PLtest",
+    "title": "Test Playlist",
+    "entries": [
+        {
+            "id": "vid001",
+            "title": "A-site smokes",
+            "description": "0:00 Intro\n1:00 A-site smoke from CT",
+            "duration": 180,
+            "upload_date": "20260101",
+            "channel": "TestChannel",
+            "chapters": [
+                {"start_time": 0, "end_time": 60, "title": "Intro"},
+                {"start_time": 60, "end_time": 180, "title": "A-site smoke from CT"},
+            ],
+        },
+        {
+            "id": "vid002",
+            "title": "B-site post-plant",
+            "description": "0:00 B-site smoke",
+            "duration": 90,
+            "upload_date": "20260102",
+            "channel": "TestChannel",
+            "chapters": [],
+        },
+    ],
+}
+
+
+# ---------------------------------------------------------------------------
+# list_videos
+# ---------------------------------------------------------------------------
+
+class TestListVideos:
+    @pytest.mark.asyncio
+    async def test_returns_video_meta_list(self):
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value=_FAKE_INFO)
+
+        source = _make_source()
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            videos = await list_videos(source)
+
+        assert len(videos) == 2
+        assert videos[0].video_id == "vid001"
+        assert videos[0].title == "A-site smokes"
+        assert videos[0].duration == 180
+        assert videos[0].channel_name == "TestChannel"
+        assert len(videos[0].chapters) == 2
+        assert videos[1].video_id == "vid002"
+
+    @pytest.mark.asyncio
+    async def test_raises_on_download_error(self):
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(
+            side_effect=yt_dlp.utils.DownloadError("Video unavailable")
+        )
+
+        source = _make_source()
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            with pytest.raises(YouTubeFetchError) as exc_info:
+                await list_videos(source)
+
+        err = exc_info.value
+        assert "DownloadError" in err.error_type
+        assert isinstance(err.original, yt_dlp.utils.DownloadError)
+
+    @pytest.mark.asyncio
+    async def test_raises_on_extractor_error(self):
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(
+            side_effect=yt_dlp.utils.ExtractorError("Extractor failed")
+        )
+
+        source = _make_source()
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            with pytest.raises(YouTubeFetchError) as exc_info:
+                await list_videos(source)
+
+        err = exc_info.value
+        assert "ExtractorError" in err.error_type
+
+    @pytest.mark.asyncio
+    async def test_missing_url_raises(self):
+        source = Source(id=uuid.uuid4(), kind="youtube_playlist", config_json={})
+        with pytest.raises(YouTubeFetchError) as exc_info:
+            await list_videos(source)
+        assert "MissingURL" in exc_info.value.error_type
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_empty_playlist(self):
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value={"id": "PLempty", "entries": []})
+
+        source = _make_source()
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            videos = await list_videos(source)
+
+        assert videos == []
+
+    @pytest.mark.asyncio
+    async def test_channel_url_from_channel_url_key(self):
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value={"entries": [], "id": "test"})
+
+        source = _make_channel_source()
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            videos = await list_videos(source)
+        # Successful call with channel_url source — no error
+        assert isinstance(videos, list)
+
+
+# ---------------------------------------------------------------------------
+# download_video
+# ---------------------------------------------------------------------------
+
+class TestDownloadVideo:
+    @pytest.mark.asyncio
+    async def test_returns_path_on_success(self, tmp_path: Path):
+        # Create the expected output file so the path-check passes.
+        expected = tmp_path / "vid001.mp4"
+        expected.write_bytes(b"fake video data")
+
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.download = MagicMock(return_value=None)
+
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            result = await download_video("vid001", download_dir=tmp_path)
+
+        assert result == expected
+
+    @pytest.mark.asyncio
+    async def test_raises_video_download_error_on_failure(self, tmp_path: Path):
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.download = MagicMock(
+            side_effect=yt_dlp.utils.DownloadError("Private video")
+        )
+
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            with pytest.raises(VideoDownloadError) as exc_info:
+                await download_video("vidPrivate", download_dir=tmp_path)
+
+        err = exc_info.value
+        assert err.video_id == "vidPrivate"
+        assert "DownloadError" in err.error_type
+        assert isinstance(err.original, yt_dlp.utils.DownloadError)

--- a/apps/mygamingassistant/backend/uv.lock
+++ b/apps/mygamingassistant/backend/uv.lock
@@ -532,6 +532,7 @@ dependencies = [
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy" },
     { name = "uvicorn", extra = ["standard"] },
+    { name = "yt-dlp" },
 ]
 
 [package.dev-dependencies]
@@ -564,6 +565,7 @@ requires-dist = [
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.59.0" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.46.0" },
+    { name = "yt-dlp", specifier = "==2026.3.17" },
 ]
 
 [package.metadata.requires-dev]
@@ -1090,4 +1092,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
     { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "yt-dlp"
+version = "2026.3.17"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8b/34/7c6b4e3f89cb6416d2cd7ab6dab141a1df97ab0fb22d15816db2c92148c9/yt_dlp-2026.3.17.tar.gz", hash = "sha256:ba7aa31d533f1ffccfe70e421596d7ca8ff0bf1398dc6bb658b7d9dec057d2c9", size = 3119221, upload-time = "2026-03-17T23:43:00.244Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cd/13/5093bcb954878e50f7217fd2ab94282b53934022e4e4a03265582da83bf5/yt_dlp-2026.3.17-py3-none-any.whl", hash = "sha256:32992db94303a8a5d211a183f2174834fe7f8c29d83ed2e7a324eae97a8f26d8", size = 3315134, upload-time = "2026-03-17T23:42:57.863Z" },
 ]

--- a/apps/mygamingassistant/docker/backend.Dockerfile
+++ b/apps/mygamingassistant/docker/backend.Dockerfile
@@ -17,6 +17,7 @@ ENV GIT_COMMIT=${GIT_COMMIT}
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         postgresql-client \
+        ffmpeg \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app

--- a/apps/mygamingassistant/frontend/src/RootLayout.tsx
+++ b/apps/mygamingassistant/frontend/src/RootLayout.tsx
@@ -1,6 +1,7 @@
 import { Outlet, ScrollRestoration, useSearchParams } from "react-router-dom";
 import {
   Gamepad2,
+  PlaySquare,
   Settings,
   Shield,
 } from "lucide-react";
@@ -25,6 +26,7 @@ function projectUser(user: CurrentUser | undefined): { name: string; email: stri
 
 const ICONS: Record<string, React.ReactNode> = {
   Gamepad2: <Gamepad2 className="w-5 h-5" />,
+  PlaySquare: <PlaySquare className="w-5 h-5" />,
   Settings: <Settings className="w-5 h-5" />,
   Shield: <Shield className="w-5 h-5" />,
 };

--- a/apps/mygamingassistant/frontend/src/constants/nav.ts
+++ b/apps/mygamingassistant/frontend/src/constants/nav.ts
@@ -14,6 +14,7 @@ interface NavDescriptor {
 
 const NAV_DESCRIPTORS: NavDescriptor[] = [
   { path: "/", label: "Games", iconName: "Gamepad2", exact: true },
+  { path: "/sources", label: "Sources", iconName: "PlaySquare" },
   { path: "/settings", label: "Settings", iconName: "Settings" },
   { path: "/security", label: "Security", iconName: "Shield" },
 ];

--- a/apps/mygamingassistant/frontend/src/pages/Sources.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/Sources.tsx
@@ -1,0 +1,266 @@
+import { useState } from "react";
+import { PlaySquare, Trash2, RefreshCw } from "lucide-react";
+import { showError, showSuccess } from "@platform/ui";
+import {
+  useGetSourcesQuery,
+  useCreateSourceMutation,
+  useDeleteSourceMutation,
+  useSyncSourceMutation,
+} from "@/store/sourcesApi";
+import type { SourceKind } from "@/types/game";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "Never";
+  return new Date(iso).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+function extractUrl(configJson: Record<string, unknown>): string {
+  const url = configJson["url"] ?? configJson["channel_url"];
+  return typeof url === "string" ? url : "";
+}
+
+function truncateUrl(url: string, max = 60): string {
+  return url.length > max ? `${url.slice(0, max)}…` : url;
+}
+
+function kindLabel(kind: SourceKind): string {
+  return kind === "youtube_playlist" ? "Playlist" : "Channel";
+}
+
+// ---------------------------------------------------------------------------
+// AddSourceForm
+// ---------------------------------------------------------------------------
+
+interface AddSourceFormProps {
+  onAdded: () => void;
+}
+
+function AddSourceForm({ onAdded }: AddSourceFormProps) {
+  const [kind, setKind] = useState<SourceKind>("youtube_playlist");
+  const [url, setUrl] = useState("");
+  const [createSource, { isLoading }] = useCreateSourceMutation();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!url.trim()) return;
+
+    try {
+      await createSource({ kind, url: url.trim() }).unwrap();
+      showSuccess("Source added — it will sync shortly.");
+      setUrl("");
+      onAdded();
+    } catch (err: unknown) {
+      const detail =
+        (err as { data?: { detail?: string } })?.data?.detail ??
+        "Failed to add source. Check the URL and try again.";
+      showError(detail);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="flex flex-col sm:flex-row gap-3 items-end"
+    >
+      <div className="flex flex-col gap-1 shrink-0">
+        <label htmlFor="source-kind" className="text-xs font-medium text-muted-foreground">
+          Type
+        </label>
+        <select
+          id="source-kind"
+          value={kind}
+          onChange={(e) => setKind(e.target.value as SourceKind)}
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm"
+        >
+          <option value="youtube_playlist">Playlist</option>
+          <option value="youtube_channel">Channel</option>
+        </select>
+      </div>
+
+      <div className="flex flex-col gap-1 flex-1 min-w-0">
+        <label htmlFor="source-url" className="text-xs font-medium text-muted-foreground">
+          URL
+        </label>
+        <input
+          id="source-url"
+          type="url"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          placeholder={
+            kind === "youtube_playlist"
+              ? "https://www.youtube.com/playlist?list=..."
+              : "https://www.youtube.com/@handle"
+          }
+          className="h-9 rounded-md border border-input bg-background px-3 text-sm w-full"
+          required
+        />
+      </div>
+
+      <button
+        type="submit"
+        disabled={isLoading || !url.trim()}
+        className="h-9 rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-50 shrink-0"
+      >
+        {isLoading ? "Adding…" : "Add source"}
+      </button>
+    </form>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SourceRow
+// ---------------------------------------------------------------------------
+
+interface SourceRowProps {
+  source: {
+    id: string;
+    kind: SourceKind;
+    config_json: Record<string, unknown>;
+    last_synced_at: string | null;
+    created_at: string;
+  };
+}
+
+function SourceRow({ source }: SourceRowProps) {
+  const [syncSource, { isLoading: isSyncing }] = useSyncSourceMutation();
+  const [deleteSource, { isLoading: isDeleting }] = useDeleteSourceMutation();
+
+  const url = extractUrl(source.config_json);
+  const syncStats = source.config_json["last_sync_stats"] as
+    | { video_count?: number; chapter_count?: number; error_count?: number }
+    | undefined;
+
+  const handleSync = async () => {
+    try {
+      await syncSource(source.id).unwrap();
+      showSuccess("Sync started — lineups will appear in pending review when complete.");
+    } catch {
+      showError("Could not start sync. Please try again.");
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!window.confirm("Remove this source? Existing lineups from it will be kept.")) return;
+    try {
+      await deleteSource(source.id).unwrap();
+      showSuccess("Source removed.");
+    } catch {
+      showError("Failed to remove source.");
+    }
+  };
+
+  return (
+    <div className="flex flex-col sm:flex-row sm:items-center gap-3 rounded-lg border p-4">
+      {/* Icon + info */}
+      <div className="flex items-start gap-3 flex-1 min-w-0">
+        <PlaySquare className="w-5 h-5 mt-0.5 shrink-0 text-muted-foreground" aria-hidden />
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-xs font-medium rounded-full bg-muted px-2 py-0.5">
+              {kindLabel(source.kind)}
+            </span>
+            <span className="text-sm text-muted-foreground truncate" title={url}>
+              {truncateUrl(url)}
+            </span>
+          </div>
+          <div className="mt-1 text-xs text-muted-foreground space-x-3">
+            <span>Last sync: {formatDate(source.last_synced_at)}</span>
+            {syncStats && (
+              <>
+                <span>{syncStats.video_count ?? 0} videos</span>
+                <span>{syncStats.chapter_count ?? 0} lineups</span>
+                {(syncStats.error_count ?? 0) > 0 && (
+                  <span className="text-destructive">{syncStats.error_count} errors</span>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 shrink-0">
+        <button
+          onClick={handleSync}
+          disabled={isSyncing}
+          aria-label="Sync now"
+          className="inline-flex items-center gap-1.5 rounded-md border px-3 h-8 text-xs font-medium disabled:opacity-50"
+        >
+          <RefreshCw className={`w-3.5 h-3.5 ${isSyncing ? "animate-spin" : ""}`} aria-hidden />
+          {isSyncing ? "Syncing…" : "Sync now"}
+        </button>
+        <button
+          onClick={handleDelete}
+          disabled={isDeleting}
+          aria-label="Delete source"
+          className="inline-flex items-center rounded-md border border-destructive/30 px-3 h-8 text-xs font-medium text-destructive disabled:opacity-50 hover:bg-destructive/10"
+        >
+          <Trash2 className="w-3.5 h-3.5" aria-hidden />
+          <span className="sr-only">Delete</span>
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sources page
+// ---------------------------------------------------------------------------
+
+export default function Sources() {
+  const { data: sources, isLoading, isError, refetch } = useGetSourcesQuery();
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-2xl font-semibold">YouTube Sources</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Add YouTube playlists or channels to automatically ingest lineups.
+          Videos with chapter timestamps are parsed; each chapter becomes a
+          pending lineup for review.
+        </p>
+      </div>
+
+      {/* Add source form */}
+      <section aria-label="Add source">
+        <AddSourceForm onAdded={refetch} />
+      </section>
+
+      {/* Source list */}
+      <section aria-label="Sources">
+        {isLoading && (
+          <div className="space-y-3">
+            {[1, 2].map((i) => (
+              <div key={i} className="h-20 rounded-lg bg-muted/40 animate-pulse" aria-hidden />
+            ))}
+          </div>
+        )}
+
+        {isError && (
+          <p className="text-sm text-destructive">Failed to load sources. Please refresh.</p>
+        )}
+
+        {!isLoading && !isError && sources && sources.length === 0 && (
+          <p className="text-sm text-muted-foreground">
+            No sources yet. Add a YouTube playlist or channel above to get started.
+          </p>
+        )}
+
+        {!isLoading && !isError && sources && sources.length > 0 && (
+          <div className="space-y-3">
+            {sources.map((source) => (
+              <SourceRow key={source.id} source={source} />
+            ))}
+          </div>
+        )}
+      </section>
+    </main>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/routes.tsx
+++ b/apps/mygamingassistant/frontend/src/routes.tsx
@@ -5,6 +5,7 @@ import MapGrid from "@/pages/MapGrid";
 import MapPage from "@/pages/MapPage";
 import Security from "@/pages/Security";
 import Settings from "@/pages/Settings";
+import Sources from "@/pages/Sources";
 import Login from "@/pages/Login";
 import ForgotPassword from "@/pages/ForgotPassword";
 import ResetPassword from "@/pages/ResetPassword";
@@ -20,6 +21,7 @@ export const routes: RouteObject[] = [
     children: [
       { index: true, element: <GameGrid /> },
       { path: "/lineups/new", element: <LineupUpload /> },
+      { path: "/sources", element: <Sources /> },
       { path: "/:gameSlug", element: <MapGrid /> },
       { path: "/:gameSlug/:mapSlug", element: <MapPage /> },
       { path: "/settings", element: <Settings /> },

--- a/apps/mygamingassistant/frontend/src/store/sourcesApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/sourcesApi.ts
@@ -1,0 +1,58 @@
+/**
+ * RTK Query slice for source management endpoints.
+ *
+ * Tags:
+ *   Source      — individual source by id
+ *   SourceList  — list queries (invalidated by create/delete)
+ */
+import { baseApi } from "@platform/ui";
+import type { Source, SourceCreate, SyncJobResponse } from "@/types/game";
+
+const sourcesBaseApi = baseApi.enhanceEndpoints({
+  addTagTypes: ["Source", "SourceList"],
+});
+
+const sourcesApi = sourcesBaseApi.injectEndpoints({
+  endpoints: (build) => ({
+    getSources: build.query<Source[], void>({
+      query: () => ({ url: "/sources", method: "GET" }),
+      providesTags: ["SourceList"],
+    }),
+
+    getSource: build.query<Source, string>({
+      query: (id) => ({ url: `/sources/${id}`, method: "GET" }),
+      providesTags: (_result, _err, id) => [{ type: "Source", id }],
+    }),
+
+    createSource: build.mutation<Source, SourceCreate>({
+      query: (payload) => ({
+        url: "/sources",
+        method: "POST",
+        body: payload,
+      }),
+      invalidatesTags: ["SourceList"],
+    }),
+
+    deleteSource: build.mutation<void, string>({
+      query: (id) => ({ url: `/sources/${id}`, method: "DELETE" }),
+      invalidatesTags: (_result, _err, id) => [
+        { type: "Source", id },
+        "SourceList",
+      ],
+    }),
+
+    syncSource: build.mutation<SyncJobResponse, string>({
+      query: (id) => ({ url: `/sources/${id}/sync`, method: "POST" }),
+      // Don't invalidate SourceList here — sync is async so the list won't
+      // have new data immediately. User refreshes to see updated last_synced_at.
+    }),
+  }),
+});
+
+export const {
+  useGetSourcesQuery,
+  useGetSourceQuery,
+  useCreateSourceMutation,
+  useDeleteSourceMutation,
+  useSyncSourceMutation,
+} = sourcesApi;

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -126,3 +126,30 @@ export interface ZoneDensity {
     by_utility: Record<string, number>;
   };
 }
+
+// ---------------------------------------------------------------------------
+// Source domain
+// ---------------------------------------------------------------------------
+
+export type SourceKind = "youtube_playlist" | "youtube_channel";
+
+export interface Source {
+  id: string;
+  kind: SourceKind;
+  /** Raw config JSON from the backend — contains url/channel_url, last_sync_stats. */
+  config_json: Record<string, unknown>;
+  last_synced_at: string | null;
+  created_at: string;
+}
+
+export interface SourceCreate {
+  kind: SourceKind;
+  url: string;
+}
+
+export interface SyncJobResponse {
+  job_id: string;
+  source_id: string;
+  status: string;
+  message: string;
+}


### PR DESCRIPTION
## Summary

- **Schema migration 0002**: makes `target_zone_id`, `stand_zone_id`, `utility_type_id`, `side` nullable so auto-ingested lineups can land in `pending_review` before classification; adds `youtube_video_id`, `chapter_start_seconds`, `chapter_title` columns; adds CHECK constraint ensuring `accepted` lineups always have all classification fields set
- **Source management API**: `POST/GET/DELETE /api/sources` + `POST /api/sources/{id}/sync`; URL validation for YouTube playlist/channel URLs; soft-delete preserves existing lineups
- **Ingestion pipeline** (`app/services/ingestion/`): `youtube_fetcher` (yt-dlp list + download, structured error types per `check-third-party-error-codes`), `chapter_parser` (native yt-dlp chapters preferred, description regex fallback, ≥2 timestamp validation, monotonic enforcement), `frame_extractor` (ffmpeg subprocess, PNG pipe, FrameExtractionError with returncode+stderr), `ingestion_orchestrator` (full sync pipeline: list → dedup → download → parse → extract → MinIO upload → DB insert → cleanup; per-chapter error isolation)
- **Dependencies**: `yt-dlp==2026.3.17` added to pyproject.toml/uv.lock/requirements.txt; `ffmpeg` added to backend.Dockerfile apt-get install
- **Frontend**: `/sources` page with AddSourceForm + SourceRow (sync/delete); `sourcesApi.ts` RTK Query slice; Sources nav link in AppShell
- **Tests**: 29 unit tests passing (16 chapter_parser, 8 youtube_fetcher, 5 frame_extractor); DB-dependent tests for sources API + ingestion orchestrator included (run against real DB in CI)

## ⚠️ Operational migration required

After this PR merges and **before or at the next deploy**, the operator MUST do these steps on the VPS or lineups will fail to sync.

### 1. Run database migration

```bash
docker compose -f apps/mygamingassistant/docker-compose.yml exec api \
  alembic upgrade head
```

Migration 0002 makes 4 FK columns nullable and adds 3 new columns + 1 CHECK constraint. Safe to run against a live DB — no existing rows are affected.

### 2. Set new env vars

Edit `apps/mygamingassistant/backend/.env.docker` and add:

```
INGESTION_DOWNLOAD_DIR=/tmp/mga-ingestion
INGESTION_DOWNLOAD_DIR_MAX_GB=10
```

### 3. Rebuild the backend image (ffmpeg is now required)

The backend Dockerfile now installs `ffmpeg` at image build time. A plain `docker compose pull` will NOT pick this up — a **full rebuild** is required:

```bash
docker compose -f apps/mygamingassistant/docker-compose.yml build api
docker compose -f apps/mygamingassistant/docker-compose.yml up -d api
```

### 4. Verify

```bash
# Check ffmpeg is present in the running container
docker compose -f apps/mygamingassistant/docker-compose.yml exec api ffmpeg -version | head -1

# Check env vars are set
docker compose -f apps/mygamingassistant/docker-compose.yml exec api \
  env | grep INGESTION

# Health check
curl http://127.0.0.1:8096/health
```

### 5. Disk space

Ensure the VPS has at least `INGESTION_DOWNLOAD_DIR_MAX_GB` (default 10 GB) free in the partition hosting `/tmp`. Videos are downloaded, frames extracted, then deleted immediately after — peak disk usage is one video at a time.

### Rollback path

If the migration or rebuild fails: revert this PR, run `alembic downgrade 0001`, and restore the old image. The downgrade is only safe if no `pending_review` lineups with null classification fields exist — which is the case immediately after migration before any sync runs.

## What's NOT in this PR

- Claude classifier (auto-fill game/map/zone/side from chapter title + frame) — PR 5
- Review queue UI at `/review` — PR 5
- APScheduler cron (sync runs are manual `POST /sources/{id}/sync` only) — PR 6
- `LineupPackage` loadout filter — PR 6

## CodeQL note

If CodeQL flags `js/xss-through-dom` on URL-driven `src` attributes in `Sources.tsx` — dismiss as false positive (same pattern as PR 2).