### PR TITLE
fix(mbk): persist Gmail access token after in-memory refresh

### DIFF
--- a/apps/mybookkeeper/backend/app/repositories/integrations/integration_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/integrations/integration_repo.py
@@ -1,6 +1,6 @@
 import uuid
 from collections.abc import Sequence
-from datetime import datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -106,6 +106,27 @@ async def update_last_synced(
     db: AsyncSession, integration: Integration, synced_at: datetime
 ) -> None:
     integration.last_synced_at = synced_at
+
+
+async def update_access_token(
+    db: AsyncSession,
+    integration: Integration,
+    access_token: str,
+    expiry: datetime | None,
+) -> None:
+    """Persist a refreshed access token (and its expiry) for this integration.
+
+    Called after Google's auth library mints a new access token in-memory.
+    Without this, every Gmail call would re-trigger a refresh because the
+    DB-stored access_token stays frozen at OAuth-callback time.
+
+    ``expiry`` is normalized to timezone-aware UTC because google-auth returns
+    naive UTC datetimes.
+    """
+    integration.access_token = access_token
+    if expiry is not None and expiry.tzinfo is None:
+        expiry = expiry.replace(tzinfo=timezone.utc)
+    integration.token_expiry = expiry
 
 
 async def get_gmail_user_ids(db: AsyncSession) -> list[str]:

--- a/apps/mybookkeeper/backend/app/services/documents/document_query_service.py
+++ b/apps/mybookkeeper/backend/app/services/documents/document_query_service.py
@@ -9,7 +9,7 @@ from app.db.session import AsyncSessionLocal
 from app.models.documents.document import Document
 from app.models.responses.download_result import DownloadResult
 from app.repositories import document_repo, integration_repo
-from app.services.email.gmail_service import get_gmail_service, fetch_email_by_id
+from app.services.email.gmail_service import get_gmail_service, fetch_email_by_id, persist_refreshed_token
 
 _RENDERABLE_MIME_TYPES = {"application/pdf", "image/jpeg", "image/png", "image/webp"}
 
@@ -110,10 +110,12 @@ async def get_document_download(
         if not integration:
             raise ValueError("Gmail integration not connected")
 
-        service = get_gmail_service(integration.access_token, integration.refresh_token)
+        service, creds = get_gmail_service(integration.access_token, integration.refresh_token)
+        prior_token = creds.token
         email_data = await asyncio.to_thread(fetch_email_by_id, service, doc.email_message_id)
         if not email_data:
             raise ValueError("Email no longer available in Gmail")
+        await persist_refreshed_token(integration, creds, prior_token)
 
         attachments = email_data.get("attachments", [])
         if attachments:

--- a/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
@@ -21,7 +21,12 @@ from app.services.email.constants import (
     GMAIL_AUTH_EXPIRED_SYNC_LOG_ERROR,
 )
 from app.services.email.exceptions import GmailAuthExpiredError
-from app.services.email.gmail_service import get_gmail_service, list_email_document_sources, list_new_email_ids
+from app.services.email.gmail_service import (
+    get_gmail_service,
+    list_email_document_sources,
+    list_new_email_ids,
+    persist_refreshed_token,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +62,8 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
 
         await email_queue_repo.reset_stuck(db, org_id, ["extracting"], "fetched")
 
-        service = get_gmail_service(integration.access_token, integration.refresh_token)
+        service, creds = get_gmail_service(integration.access_token, integration.refresh_token)
+        prior_token = creds.token
 
         queued_ids = await email_queue_repo.get_message_ids(db, org_id)
         doc_ids = await document_repo.get_email_message_ids(db, org_id)
@@ -105,6 +111,7 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
                 gmail_matches_total=gmail_matches_total,
             )
             await integration_repo.update_last_synced(db, integration, now)
+            await persist_refreshed_token(integration, creds, prior_token)
             return DiscoverResult("nothing_new")
 
         log = await sync_log_repo.create(
@@ -215,6 +222,7 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
                     "Gmail discovery: filtered %d bounce/auto-reply emails for org=%s",
                     filtered_count, org_id,
                 )
+            await persist_refreshed_token(integration, creds, prior_token)
             return DiscoverResult("nothing_new")
 
         log.total_items = total_sources
@@ -223,6 +231,7 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
             "Gmail discovery: queued %d document sources from %d emails under sync_log_id=%d (filtered %d bounces)",
             total_sources, len(new_ids), log.id, filtered_count,
         )
+        await persist_refreshed_token(integration, creds, prior_token)
         return DiscoverResult("queued", count=total_sources, sync_log_id=log.id)
 
 

--- a/apps/mybookkeeper/backend/app/services/email/email_fetch_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_fetch_service.py
@@ -15,7 +15,12 @@ from app.db.session import AsyncSessionLocal, unit_of_work
 from app.models.email.email_types import EmailBodyData, FetchResult
 from app.repositories import email_queue_repo, integration_repo, sync_log_repo
 from app.services.email.exceptions import GmailReauthRequiredError
-from app.services.email.gmail_service import fetch_attachment_bytes, fetch_email_body, get_gmail_service
+from app.services.email.gmail_service import (
+    fetch_attachment_bytes,
+    fetch_email_body,
+    get_gmail_service,
+    persist_refreshed_token,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,7 +88,8 @@ async def _fetch_next_pending(ctx: RequestContext) -> FetchResult:
         refresh_token: str | None = integration.refresh_token
 
     try:
-        service = get_gmail_service(access_token, refresh_token)
+        service, creds = get_gmail_service(access_token, refresh_token)
+        prior_token = creds.token
 
         raw_bytes: bytes
         if attachment_id == "body":
@@ -104,6 +110,7 @@ async def _fetch_next_pending(ctx: RequestContext) -> FetchResult:
 
             await _complete_sync_log_if_done(db, sync_log_id, ctx)
 
+        await persist_refreshed_token(integration, creds, prior_token)
         return FetchResult("fetched")
 
     except RefreshError as exc:

--- a/apps/mybookkeeper/backend/app/services/email/gmail_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/gmail_service.py
@@ -59,7 +59,47 @@ def _normalize_filename(raw: str) -> str:
     return cleaned
 
 
-def get_gmail_service(access_token: str, refresh_token: str | None = None):
+async def persist_refreshed_token(
+    integration,  # type: ignore[no-untyped-def] — app.models.integrations.Integration, avoid circular import
+    creds: Credentials,
+    prior_token: str | None,
+) -> None:
+    """Persist Google's in-memory refreshed access token back to the DB.
+
+    Google's auth library rotates the access token whenever it expires (~1h),
+    but the rotation lives only on the in-memory ``Credentials`` instance. If
+    we don't write it back, every subsequent sync re-uses the original stored
+    token, gets a 401, and pays for another refresh. With this helper, the
+    refresh only happens once per real expiry.
+
+    Opens its own ``unit_of_work`` so it isn't entangled with whatever
+    transaction shape the caller has.
+    """
+    if not creds.token or creds.token == prior_token:
+        return
+    async with unit_of_work() as db:
+        refreshed = await integration_repo.get_by_org_and_provider(
+            db, integration.organization_id, "gmail"
+        )
+        if refreshed is not None:
+            await integration_repo.update_access_token(
+                db, refreshed, creds.token, creds.expiry
+            )
+
+
+def get_gmail_service(
+    access_token: str, refresh_token: str | None = None,
+) -> tuple[object, Credentials]:
+    """Build a Gmail API client.
+
+    Returns ``(service, creds)``. Google's auth library auto-refreshes the
+    access token in-memory when it gets a 401 — but the refreshed value lives
+    only on ``creds``. Callers must inspect ``creds.token`` after each Gmail
+    call and persist via ``integration_repo.update_access_token`` if it
+    diverges from the value originally passed in. Without that step, every
+    sync re-uses the stale DB-stored access token and re-pays the refresh
+    roundtrip on the next call.
+    """
     creds = Credentials(
         token=access_token,
         refresh_token=refresh_token,
@@ -67,7 +107,7 @@ def get_gmail_service(access_token: str, refresh_token: str | None = None):
         client_id=settings.google_client_id,
         client_secret=settings.google_client_secret,
     )
-    return build("gmail", "v1", credentials=creds)
+    return build("gmail", "v1", credentials=creds), creds
 
 
 def list_new_email_ids(
@@ -366,7 +406,8 @@ async def send_message_with_attachment(
 
     raw = base64.urlsafe_b64encode(msg.as_bytes()).decode("ascii")
 
-    service = get_gmail_service(integration.access_token, integration.refresh_token)
+    service, creds = get_gmail_service(integration.access_token, integration.refresh_token)
+    prior_token = creds.token
     try:
         sent = service.users().messages().send(
             userId="me", body={"raw": raw},
@@ -419,6 +460,7 @@ async def send_message_with_attachment(
     sent_id = sent.get("id")
     if not isinstance(sent_id, str) or not sent_id:
         raise GmailSendError("Gmail did not return a message id")
+    await persist_refreshed_token(integration, creds, prior_token)
     return sent_id
 
 
@@ -474,7 +516,8 @@ async def send_message(
 
     raw = base64.urlsafe_b64encode(message.as_bytes()).decode("ascii")
 
-    service = get_gmail_service(integration.access_token, integration.refresh_token)
+    service, creds = get_gmail_service(integration.access_token, integration.refresh_token)
+    prior_token = creds.token
     try:
         sent = service.users().messages().send(
             userId="me", body={"raw": raw},
@@ -527,4 +570,5 @@ async def send_message(
     sent_id = sent.get("id")
     if not isinstance(sent_id, str) or not sent_id:
         raise GmailSendError("Gmail did not return a message id")
+    await persist_refreshed_token(integration, creds, prior_token)
     return sent_id

--- a/apps/mybookkeeper/backend/tests/services/email/test_discovery_bounce_filter.py
+++ b/apps/mybookkeeper/backend/tests/services/email/test_discovery_bounce_filter.py
@@ -107,7 +107,7 @@ async def test_discovery_filters_bounce_and_logs_it(
             return_value=_bounce_sources_data(),
         ),
     ):
-        mock_gmail.return_value = MagicMock()
+        mock_gmail.return_value = (MagicMock(), MagicMock(token="t0"))
 
         from app.services.email.email_discovery_service import discover_gmail_emails
 
@@ -164,7 +164,7 @@ async def test_discovery_queues_legit_email_alongside_filtered_bounce(
             side_effect=fake_list_sources,
         ),
     ):
-        mock_gmail.return_value = MagicMock()
+        mock_gmail.return_value = (MagicMock(), MagicMock(token="t0"))
 
         from app.services.email.email_discovery_service import discover_gmail_emails
 
@@ -223,7 +223,7 @@ async def test_discovery_does_not_call_extraction_for_filtered_bounce(
             "app.services.extraction.claude_service.extract_from_image"
         ) as mock_extract_image,
     ):
-        mock_gmail.return_value = MagicMock()
+        mock_gmail.return_value = (MagicMock(), MagicMock(token="t0"))
 
         from app.services.email.email_discovery_service import discover_gmail_emails
 

--- a/apps/mybookkeeper/backend/tests/test_email_discovery_last_synced.py
+++ b/apps/mybookkeeper/backend/tests/test_email_discovery_last_synced.py
@@ -86,7 +86,7 @@ def _patch_discovery_dependencies(
         ),
         patch(
             "app.services.email.email_discovery_service.get_gmail_service",
-            return_value=MagicMock(),
+            return_value=(MagicMock(), MagicMock(token="t0")),
         ),
         patch(
             "app.services.email.email_discovery_service.email_queue_repo.get_message_ids",

--- a/apps/mybookkeeper/backend/tests/test_email_queue_split.py
+++ b/apps/mybookkeeper/backend/tests/test_email_queue_split.py
@@ -109,7 +109,7 @@ class TestDrainGmailFetch:
             patch("app.services.email.email_fetch_service.get_gmail_service") as mock_gmail,
             patch("app.services.email.email_fetch_service.fetch_attachment_bytes", return_value=fake_bytes),
         ):
-            mock_gmail.return_value = MagicMock()
+            mock_gmail.return_value = (MagicMock(), MagicMock(token="t0"))
 
             from app.services.email.email_fetch_service import _fetch_next_pending
 

--- a/apps/mybookkeeper/backend/tests/test_gmail_auth_expired.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_auth_expired.py
@@ -75,7 +75,7 @@ async def test_discover_raises_gmail_auth_expired_on_refresh_error() -> None:
         ),
         patch(
             "app.services.email.email_discovery_service.get_gmail_service",
-            return_value=MagicMock(),
+            return_value=(MagicMock(), MagicMock(token="t0")),
         ),
         patch(
             "app.services.email.email_discovery_service.email_queue_repo.get_message_ids",
@@ -224,7 +224,7 @@ async def test_discovery_sets_needs_reauth_on_refresh_error() -> None:
         ),
         patch(
             "app.services.email.email_discovery_service.get_gmail_service",
-            return_value=MagicMock(),
+            return_value=(MagicMock(), MagicMock(token="t0")),
         ),
         patch(
             "app.services.email.email_discovery_service.email_queue_repo.get_message_ids",

--- a/apps/mybookkeeper/backend/tests/test_gmail_service_send.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_service_send.py
@@ -77,7 +77,7 @@ class TestSendMessageHappyPath:
     async def test_builds_correct_rfc5322_message(self) -> None:
         captured: dict[str, Any] = {}
         fake = _captured_send_call(captured)
-        with patch.object(gmail_service, "get_gmail_service", return_value=fake):
+        with patch.object(gmail_service, "get_gmail_service", return_value=(fake, MagicMock(token="t0"))):
             sent_id = await gmail_service.send_message(
                 _FakeIntegration(),
                 from_address="host@gmail.com",
@@ -100,7 +100,7 @@ class TestSendMessageHappyPath:
     async def test_sets_in_reply_to_and_references_for_threading(self) -> None:
         captured: dict[str, Any] = {}
         fake = _captured_send_call(captured)
-        with patch.object(gmail_service, "get_gmail_service", return_value=fake):
+        with patch.object(gmail_service, "get_gmail_service", return_value=(fake, MagicMock(token="t0"))):
             await gmail_service.send_message(
                 _FakeIntegration(),
                 from_address="h@g.com",
@@ -118,7 +118,7 @@ class TestSendMessageHappyPath:
     async def test_no_threading_headers_when_no_original(self) -> None:
         captured: dict[str, Any] = {}
         fake = _captured_send_call(captured)
-        with patch.object(gmail_service, "get_gmail_service", return_value=fake):
+        with patch.object(gmail_service, "get_gmail_service", return_value=(fake, MagicMock(token="t0"))):
             await gmail_service.send_message(
                 _FakeIntegration(),
                 from_address="h@g.com",
@@ -141,7 +141,7 @@ class TestSendMessageErrors:
         send_chain = MagicMock()
         send_chain.execute.side_effect = _make_http_error(403)
         fake.users.return_value.messages.return_value.send.return_value = send_chain
-        with patch.object(gmail_service, "get_gmail_service", return_value=fake):
+        with patch.object(gmail_service, "get_gmail_service", return_value=(fake, MagicMock(token="t0"))):
             with pytest.raises(GmailSendScopeError):
                 await gmail_service.send_message(
                     _FakeIntegration(),
@@ -157,7 +157,7 @@ class TestSendMessageErrors:
         send_chain = MagicMock()
         send_chain.execute.side_effect = _make_http_error(400)
         fake.users.return_value.messages.return_value.send.return_value = send_chain
-        with patch.object(gmail_service, "get_gmail_service", return_value=fake):
+        with patch.object(gmail_service, "get_gmail_service", return_value=(fake, MagicMock(token="t0"))):
             with pytest.raises(GmailSendError):
                 await gmail_service.send_message(
                     _FakeIntegration(),
@@ -173,7 +173,7 @@ class TestSendMessageErrors:
         send_chain = MagicMock()
         send_chain.execute.side_effect = _make_http_error(500)
         fake.users.return_value.messages.return_value.send.return_value = send_chain
-        with patch.object(gmail_service, "get_gmail_service", return_value=fake):
+        with patch.object(gmail_service, "get_gmail_service", return_value=(fake, MagicMock(token="t0"))):
             with pytest.raises(GmailSendError):
                 await gmail_service.send_message(
                     _FakeIntegration(),
@@ -189,7 +189,7 @@ class TestSendMessageErrors:
         send_chain = MagicMock()
         send_chain.execute.side_effect = ConnectionError("net down")
         fake.users.return_value.messages.return_value.send.return_value = send_chain
-        with patch.object(gmail_service, "get_gmail_service", return_value=fake):
+        with patch.object(gmail_service, "get_gmail_service", return_value=(fake, MagicMock(token="t0"))):
             with pytest.raises(GmailSendError):
                 await gmail_service.send_message(
                     _FakeIntegration(),
@@ -205,7 +205,7 @@ class TestSendMessageErrors:
         send_chain = MagicMock()
         send_chain.execute.return_value = {"id": ""}
         fake.users.return_value.messages.return_value.send.return_value = send_chain
-        with patch.object(gmail_service, "get_gmail_service", return_value=fake):
+        with patch.object(gmail_service, "get_gmail_service", return_value=(fake, MagicMock(token="t0"))):
             with pytest.raises(GmailSendError):
                 await gmail_service.send_message(
                     _FakeIntegration(),

--- a/apps/mybookkeeper/backend/tests/test_gmail_skipped_messages.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_skipped_messages.py
@@ -72,7 +72,7 @@ def _base_patches(
         ),
         patch(
             "app.services.email.email_discovery_service.get_gmail_service",
-            return_value=MagicMock(),
+            return_value=(MagicMock(), MagicMock(token="t0")),
         ),
         patch(
             "app.services.email.email_discovery_service.email_queue_repo.get_message_ids",

--- a/apps/mybookkeeper/backend/tests/test_gmail_token_persistence.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_token_persistence.py
@@ -1,0 +1,200 @@
+"""Tests for in-memory access-token refresh persistence.
+
+Google's auth library auto-refreshes the access token in-memory when the
+stored one expires. Without persisting the refreshed value, every subsequent
+sync would re-pay the refresh roundtrip. These tests cover the seam that
+writes the new token back to integration_repo.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.email import gmail_service
+
+
+def _fake_integration(org_id: uuid.UUID) -> MagicMock:
+    integration = MagicMock()
+    integration.organization_id = org_id
+    integration.access_token = "tok_old"
+    integration.refresh_token = "rt"
+    return integration
+
+
+def _send_service_returning(send_response: dict, *, on_execute=None) -> MagicMock:
+    """Build a Gmail service stub whose send().execute() returns ``send_response``.
+
+    Optional ``on_execute`` hook fires before the response is returned — used
+    to simulate Google's auth library mutating the credentials object during
+    the call.
+    """
+    def execute():
+        if on_execute is not None:
+            on_execute()
+        return send_response
+
+    service = MagicMock()
+    service.users.return_value.messages.return_value.send.return_value.execute = execute
+    return service
+
+
+@asynccontextmanager
+async def _fake_uow_yielding(db):
+    yield db
+
+
+class TestPersistRefreshedTokenHelper:
+    """Direct coverage for gmail_service.persist_refreshed_token."""
+
+    @pytest.mark.asyncio
+    async def test_no_persist_when_token_unchanged(self) -> None:
+        org_id = uuid.uuid4()
+        integration = _fake_integration(org_id)
+        creds = MagicMock(token="tok_old", expiry=None)
+
+        update_calls: list = []
+
+        async def fake_update(_db, integ, token, expiry):
+            update_calls.append((integ, token, expiry))
+
+        async def fake_get(_db, _oid, _provider):
+            return integration
+
+        with (
+            patch("app.services.email.gmail_service.unit_of_work", lambda: _fake_uow_yielding(MagicMock())),
+            patch("app.services.email.gmail_service.integration_repo.update_access_token", new=fake_update),
+            patch("app.services.email.gmail_service.integration_repo.get_by_org_and_provider", new=fake_get),
+        ):
+            await gmail_service.persist_refreshed_token(integration, creds, prior_token="tok_old")
+
+        assert update_calls == [], "no DB write when token is unchanged"
+
+    @pytest.mark.asyncio
+    async def test_persists_when_token_refreshed(self) -> None:
+        org_id = uuid.uuid4()
+        integration = _fake_integration(org_id)
+        # creds.token has been mutated by Google's library to a fresh value.
+        new_expiry = datetime(2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc)
+        creds = MagicMock(token="tok_new", expiry=new_expiry)
+
+        refreshed = MagicMock()  # what integration_repo.get returns inside the helper's uow
+        update_calls: list = []
+
+        async def fake_update(_db, integ, token, expiry):
+            update_calls.append((integ, token, expiry))
+
+        async def fake_get(_db, _oid, _provider):
+            return refreshed
+
+        with (
+            patch("app.services.email.gmail_service.unit_of_work", lambda: _fake_uow_yielding(MagicMock())),
+            patch("app.services.email.gmail_service.integration_repo.update_access_token", new=fake_update),
+            patch("app.services.email.gmail_service.integration_repo.get_by_org_and_provider", new=fake_get),
+        ):
+            await gmail_service.persist_refreshed_token(integration, creds, prior_token="tok_old")
+
+        assert len(update_calls) == 1
+        called_integ, called_token, called_expiry = update_calls[0]
+        assert called_integ is refreshed
+        assert called_token == "tok_new"
+        assert called_expiry == new_expiry
+
+    @pytest.mark.asyncio
+    async def test_no_persist_when_integration_missing(self) -> None:
+        org_id = uuid.uuid4()
+        integration = _fake_integration(org_id)
+        creds = MagicMock(token="tok_new", expiry=None)
+
+        update_calls: list = []
+
+        async def fake_update(_db, integ, token, expiry):
+            update_calls.append((integ, token, expiry))
+
+        async def fake_get(_db, _oid, _provider):
+            return None  # integration was deleted concurrently
+
+        with (
+            patch("app.services.email.gmail_service.unit_of_work", lambda: _fake_uow_yielding(MagicMock())),
+            patch("app.services.email.gmail_service.integration_repo.update_access_token", new=fake_update),
+            patch("app.services.email.gmail_service.integration_repo.get_by_org_and_provider", new=fake_get),
+        ):
+            await gmail_service.persist_refreshed_token(integration, creds, prior_token="tok_old")
+
+        assert update_calls == [], "no write attempted when integration is gone"
+
+
+class TestSendMessagePersistence:
+    """send_message integrates with persist_refreshed_token on the success path."""
+
+    @pytest.mark.asyncio
+    async def test_send_persists_token_when_refreshed_during_call(self) -> None:
+        org_id = uuid.uuid4()
+        integration = _fake_integration(org_id)
+        creds = MagicMock(token="tok_old", expiry=None)
+
+        def mutate_token_on_send():
+            creds.token = "tok_new"
+            creds.expiry = datetime(2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc)
+
+        service = _send_service_returning(
+            {"id": "sent_123"}, on_execute=mutate_token_on_send,
+        )
+
+        update_calls: list = []
+
+        async def fake_update(_db, integ, token, expiry):
+            update_calls.append((integ, token, expiry))
+
+        async def fake_get(_db, _oid, _provider):
+            return MagicMock()
+
+        with (
+            patch("app.services.email.gmail_service.get_gmail_service", return_value=(service, creds)),
+            patch("app.services.email.gmail_service.unit_of_work", lambda: _fake_uow_yielding(MagicMock())),
+            patch("app.services.email.gmail_service.integration_repo.update_access_token", new=fake_update),
+            patch("app.services.email.gmail_service.integration_repo.get_by_org_and_provider", new=fake_get),
+        ):
+            sent_id = await gmail_service.send_message(
+                integration,
+                from_address="host@example.com",
+                to_address="tenant@example.com",
+                subject="Test",
+                body="Hello",
+            )
+
+        assert sent_id == "sent_123"
+        assert len(update_calls) == 1
+        _, token, _ = update_calls[0]
+        assert token == "tok_new"
+
+    @pytest.mark.asyncio
+    async def test_send_does_not_persist_when_token_unchanged(self) -> None:
+        org_id = uuid.uuid4()
+        integration = _fake_integration(org_id)
+        creds = MagicMock(token="tok_old", expiry=None)
+
+        service = _send_service_returning({"id": "sent_456"})
+
+        update_calls: list = []
+
+        async def fake_update(_db, integ, token, expiry):
+            update_calls.append((integ, token, expiry))
+
+        with (
+            patch("app.services.email.gmail_service.get_gmail_service", return_value=(service, creds)),
+            patch("app.services.email.gmail_service.integration_repo.update_access_token", new=fake_update),
+        ):
+            sent_id = await gmail_service.send_message(
+                integration,
+                from_address="host@example.com",
+                to_address="tenant@example.com",
+                subject="Test",
+                body="Hello",
+            )
+
+        assert sent_id == "sent_456"
+        assert update_calls == []

--- a/apps/mybookkeeper/backend/tests/test_gmail_token_refresh_needs_reauth.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_token_refresh_needs_reauth.py
@@ -129,7 +129,7 @@ class TestFetchPathHttpError401:
             ),
             patch(
                 "app.services.email.email_fetch_service.get_gmail_service",
-                return_value=MagicMock(),
+                return_value=(MagicMock(), MagicMock(token="t0")),
             ),
             patch(
                 "app.services.email.email_fetch_service.fetch_attachment_bytes",
@@ -206,7 +206,7 @@ class TestFetchPathHttpError401:
             ),
             patch(
                 "app.services.email.email_fetch_service.get_gmail_service",
-                return_value=MagicMock(),
+                return_value=(MagicMock(), MagicMock(token="t0")),
             ),
             patch(
                 "app.services.email.email_fetch_service.fetch_attachment_bytes",
@@ -283,7 +283,7 @@ class TestFetchPathHttpError401:
             ),
             patch(
                 "app.services.email.email_fetch_service.get_gmail_service",
-                return_value=MagicMock(),
+                return_value=(MagicMock(), MagicMock(token="t0")),
             ),
             patch(
                 "app.services.email.email_fetch_service.fetch_attachment_bytes",
@@ -350,7 +350,7 @@ class TestSendPathNeedsReauth:
                 "app.services.email.gmail_service.integration_repo.mark_needs_reauth",
                 new=fake_mark_needs_reauth,
             ),
-            patch("app.services.email.gmail_service.get_gmail_service", return_value=mock_service),
+            patch("app.services.email.gmail_service.get_gmail_service", return_value=(mock_service, MagicMock(token="t0"))),
             stale,
         )
 

--- a/apps/mybookkeeper/backend/tests/test_integration_encryption.py
+++ b/apps/mybookkeeper/backend/tests/test_integration_encryption.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.integrations.integration import Integration
 from app.models.organization.organization import Organization
 from app.models.user.user import User
+from app.repositories import integration_repo
 
 
 class TestIntegrationTokenEncryption:
@@ -182,3 +183,75 @@ class TestIntegrationTokenEncryption:
 
         assert integration.access_token_encrypted != original_encrypted
         assert integration.access_token == "ya29.updated"
+
+
+class TestUpdateAccessToken:
+    """integration_repo.update_access_token writes a refreshed token + normalizes expiry."""
+
+    @pytest.mark.asyncio
+    async def test_persists_new_access_token_and_aware_expiry(
+        self, db: AsyncSession, test_user: User, test_org: Organization
+    ) -> None:
+        integration = Integration(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            provider="gmail_refresh1",
+            token_expiry=datetime(2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        integration.access_token = "ya29.old"
+        db.add(integration)
+        await db.flush()
+        old_encrypted = integration.access_token_encrypted
+
+        new_expiry = datetime(2026, 5, 13, 13, 0, 0, tzinfo=timezone.utc)
+        await integration_repo.update_access_token(db, integration, "ya29.new", new_expiry)
+        await db.flush()
+
+        assert integration.access_token == "ya29.new"
+        assert integration.access_token_encrypted != old_encrypted
+        assert integration.token_expiry == new_expiry
+
+    @pytest.mark.asyncio
+    async def test_normalizes_naive_expiry_to_utc(
+        self, db: AsyncSession, test_user: User, test_org: Organization
+    ) -> None:
+        """google-auth returns naive datetimes for expiry — repo helper must
+        add UTC tzinfo so the DB stores a timezone-aware value."""
+        integration = Integration(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            provider="gmail_refresh2",
+            token_expiry=datetime(2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        integration.access_token = "ya29.old"
+        db.add(integration)
+        await db.flush()
+
+        naive_expiry = datetime(2026, 5, 13, 14, 0, 0)  # no tzinfo
+        await integration_repo.update_access_token(db, integration, "ya29.new", naive_expiry)
+        await db.flush()
+
+        assert integration.token_expiry is not None
+        assert integration.token_expiry.tzinfo is not None
+        assert integration.token_expiry == datetime(2026, 5, 13, 14, 0, 0, tzinfo=timezone.utc)
+
+    @pytest.mark.asyncio
+    async def test_accepts_none_expiry(
+        self, db: AsyncSession, test_user: User, test_org: Organization
+    ) -> None:
+        """If google-auth returns no expiry, the repo helper should clear it."""
+        integration = Integration(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            provider="gmail_refresh3",
+            token_expiry=datetime(2026, 5, 13, 12, 0, 0, tzinfo=timezone.utc),
+        )
+        integration.access_token = "ya29.old"
+        db.add(integration)
+        await db.flush()
+
+        await integration_repo.update_access_token(db, integration, "ya29.new", None)
+        await db.flush()
+
+        assert integration.access_token == "ya29.new"
+        assert integration.token_expiry is None

--- a/apps/mybookkeeper/backend/tests/test_silent_fail_audit_fixes.py
+++ b/apps/mybookkeeper/backend/tests/test_silent_fail_audit_fixes.py
@@ -171,7 +171,7 @@ class TestEmailDiscoveryServiceExcInfo:
             ),
             patch(
                 "app.services.email.email_discovery_service.get_gmail_service",
-                return_value=fake_service,
+                return_value=(fake_service, MagicMock(token="t0")),
             ),
             patch(
                 "app.services.email.email_discovery_service.email_queue_repo.get_message_ids",


### PR DESCRIPTION
## Summary

When you (the operator) saw the **\"Sync failed: Gmail connection expired, please reconnect\"** banner, that's `RefreshError` from Google: the refresh_token itself was rejected. Most likely cause is the Google Cloud OAuth app being in **Testing** publishing status, which invalidates refresh tokens after **7 days**.

This PR does **not** fix that — it fixes an adjacent code bug that contributed to the load:

- `get_gmail_service` built a `Credentials` object from the DB-stored `access_token` on every call. Google's library auto-refreshed in-memory when the token expired, but the new token was discarded when the function returned. Every subsequent sync re-paid the refresh roundtrip.
- `Integration.token_expiry` in the DB was frozen at OAuth-callback time, so `Credentials.expired` was effectively meaningless for the production path.

### What changed

- `get_gmail_service` now returns `(service, creds)` so callers can detect when Google's library refreshed the access token in-memory.
- New helper `gmail_service.persist_refreshed_token(integration, creds, prior_token)` writes the new access_token + expiry back to `integrations` via a new repo method `integration_repo.update_access_token`. Opens its own `unit_of_work` so it isn't entangled with caller-side transactions.
- Wired into all 5 callers: `email_discovery_service` (success paths), `email_fetch_service._fetch_next_pending` (success path), `document_query_service` (Gmail download path), and both `gmail_service.send_message` / `send_message_with_attachment` (after Gmail returns the message id).
- Error paths (`RefreshError`, `HttpError 401`) intentionally do NOT persist — if the refresh-then-call sequence failed, the in-memory token is suspect and `needs_reauth=True` is set as before.
- Token expiry is normalized to timezone-aware UTC (google-auth returns naive datetimes).

### Tests

- New `tests/test_gmail_token_persistence.py` (5 cases) — direct coverage of `persist_refreshed_token` and `send_message` integration.
- Extended `tests/test_integration_encryption.py` with `TestUpdateAccessToken` (3 cases) covering the repo helper, including naive-datetime → UTC normalization.
- All 9 existing test files that mocked `get_gmail_service` updated to return the new `(service, creds)` tuple.
- Full backend suite: **2696 passed, 5 skipped, 0 failed**.

## ⚠️ Operational migration required

**This PR alone won't stop the banner from recurring.** To stop refresh tokens from expiring after 7 days, **publish the Google Cloud OAuth app**:

1. Open https://console.cloud.google.com/apis/credentials/consent
2. Select the OAuth project that hosts MyBookkeeper's `GOOGLE_CLIENT_ID`
3. Under **Publishing status**, click **Publish App**
4. You should not need Google verification — `gmail.readonly` + `gmail.send` are NOT \"restricted\" scopes, so the modal should confirm without asking for a verification audit
5. Refresh tokens then live ~6 months / until revoked

After publishing, click **Disconnect** then **Connect Gmail** in MBK once to get a fresh refresh token. From that point on, this PR's persistence logic will keep the access_token current with no further reconnects needed (until the 6-month refresh-token clock or a Google security event).

### Rollback path

Safe — no schema changes, no data migration. Revert and the prior behavior (silent in-memory refresh, no DB persistence) returns. The integration row is still readable because the new `token_expiry` values are forward-compatible with the old code path.

## Test plan

- [ ] After merge, publish the Google OAuth app per the steps above
- [ ] Disconnect + reconnect Gmail in MBK once
- [ ] Confirm Sync now succeeds and \"Last synced\" updates
- [ ] Wait >1 hour, click Sync again — should succeed without surfacing the reconnect banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)