### PR TITLE
fix(mbk): align docker-compose restart + pg start_period with canonical pattern

### DIFF
--- a/apps/mybookkeeper/docker-compose.yml
+++ b/apps/mybookkeeper/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   postgres:
     image: postgres:16-alpine
-    restart: always
+    restart: unless-stopped
     environment:
       POSTGRES_USER: mybookkeeper
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -12,7 +12,13 @@ services:
       test: ["CMD-SHELL", "pg_isready -U mybookkeeper"]
       interval: 5s
       timeout: 3s
-      retries: 5
+      retries: 10
+      # initdb on a cold start can take 10–20s; without start_period the
+      # early pg_isready failures count toward retries and Docker reports
+      # the container "unhealthy" before postgres has bound the socket.
+      # Dependent services (migrate, api) then bail before postgres is ready.
+      # Mirrors apps/myjobhunter/docker-compose.yml.
+      start_period: 30s
 
   migrate:
     build:
@@ -36,7 +42,7 @@ services:
       # apps/mybookkeeper/. Mirrors apps/myjobhunter/docker/backend.Dockerfile.
       context: ../..
       dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
-    restart: always
+    restart: unless-stopped
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
@@ -72,7 +78,7 @@ services:
       # apps/mybookkeeper/. Mirrors apps/myjobhunter/docker/backend.Dockerfile.
       context: ../..
       dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
-    restart: always
+    restart: unless-stopped
     command: ["python", "-m", "app.workers.upload_processor_worker"]
     env_file: backend/.env.docker
     environment:
@@ -91,7 +97,7 @@ services:
       # apps/mybookkeeper/. Mirrors apps/myjobhunter/docker/backend.Dockerfile.
       context: ../..
       dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
-    restart: always
+    restart: unless-stopped
     command: ["python", "-m", "app.workers.scheduler_worker"]
     env_file: backend/.env.docker
     environment:
@@ -117,7 +123,7 @@ services:
         # returns null and registration silently 400s — see the
         # caddy.Dockerfile comment for the full failure mode.
         VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
-    restart: always
+    restart: unless-stopped
     ports:
       # Bind only to localhost — host Caddy is the public front door and proxies here.
       # Port 80/443 on the host are owned by host Caddy; this container is HTTP-only on 8094.


### PR DESCRIPTION
## Summary

Pre-work for Tier 3 of the `platform_shared` real-platform plan (`infra/templates/` Jinja templates). Per the **monorepo-parity-discipline** rule, drift in the canonical app must be fixed BEFORE extracting templates from it — otherwise the drift gets mirrored into every future app.

Two pre-existing divergences between MBK and MJH/MGA in `apps/mybookkeeper/docker-compose.yml`:

### 1. `restart: always` → `restart: unless-stopped` (5 services)

MJH and MGA both use `unless-stopped`. The `unless-stopped` policy is preferable — it stops respawning a container that the operator has explicitly stopped (e.g. for a manual maintenance window). Updated on `postgres`, `api`, `upload-processor`, `scheduler`, `caddy`.

### 2. Postgres healthcheck `start_period: 30s` + `retries: 10`

MBK's postgres healthcheck has `retries: 5` and no `start_period`. initdb on a cold start can take 10–20s; without `start_period` the early `pg_isready` failures count toward retries and Docker reports the container "unhealthy" before postgres has bound the socket. Dependent services (`migrate`, `api`) then bail before postgres is ready. Aligned to MJH/MGA values.

No behavior change in steady-state; eliminates a class of cold-start deploy flake.

## Test plan

- [ ] CI green
- [ ] Next MBK deploy completes without the dependent-service-bails-before-postgres flake (if you've seen this; if not, the change is preventative)

## Follow-up (separate PR)

The follow-up PR — `infra/templates/` Jinja templates + `platform_shared/infra/render.py` + `TestInfraTemplateDrift` conformance test — will land on top of this commit. Architecture proposal already in hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)