### PR TITLE
feat(mga): utility-held filter + full HUD top bar (PR 10/12)

### DIFF
--- a/apps/mygamingassistant/desktop/src-tauri/src/gsi/mod.rs
+++ b/apps/mygamingassistant/desktop/src-tauri/src/gsi/mod.rs
@@ -32,12 +32,15 @@
 //!   - `server`     — axum router, port binding, request handler.
 //!   - `state`      — Shared `ServerState` (auth token, status counters).
 //!   - `commands`   — Tauri IPC entry points (`gsi_server_status`, etc.).
+//!   - `weapons`    — CS2 weapon-slug → MGA utility-type-slug mapping
+//!                    (PR 10). Drives the live utility-held lineup filter.
 
 pub mod commands;
 pub mod installer;
 pub mod payload;
 pub mod server;
 pub mod state;
+pub mod weapons;
 
 // NOTE: we intentionally do NOT re-export the `#[tauri::command]` functions
 // at this module level. Re-exporting via `pub use commands::*` looks like

--- a/apps/mygamingassistant/desktop/src-tauri/src/gsi/mod.rs
+++ b/apps/mygamingassistant/desktop/src-tauri/src/gsi/mod.rs
@@ -33,7 +33,7 @@
 //!   - `state`      — Shared `ServerState` (auth token, status counters).
 //!   - `commands`   — Tauri IPC entry points (`gsi_server_status`, etc.).
 //!   - `weapons`    — CS2 weapon-slug → MGA utility-type-slug mapping
-//!                    (PR 10). Drives the live utility-held lineup filter.
+//!     (PR 10). Drives the live utility-held lineup filter.
 
 pub mod commands;
 pub mod installer;

--- a/apps/mygamingassistant/desktop/src-tauri/src/gsi/payload.rs
+++ b/apps/mygamingassistant/desktop/src-tauri/src/gsi/payload.rs
@@ -403,9 +403,7 @@ fn parse_weapons_block(map: &HashMap<String, RawGsiWeapon>) -> Vec<RawGsiWeapon>
 /// CS2 emits weapon state as `"active" | "holstered" | "reloading"`. Only
 /// ONE weapon is `"active"` at a time. If none is active (very rare —
 /// usually only in transition states), returns `(None, None)`.
-fn derive_active_weapon(
-    weapons: &[RawGsiWeapon],
-) -> (Option<String>, Option<String>) {
+fn derive_active_weapon(weapons: &[RawGsiWeapon]) -> (Option<String>, Option<String>) {
     let active = weapons
         .iter()
         .find(|w| w.state.as_deref() == Some("active"));
@@ -488,7 +486,8 @@ pub fn normalize_payload(raw: &RawGsiPayload, received_at: String) -> GsiEvent {
     // --- PR 10: derived fields ---
     let bomb_state = raw.round.as_ref().and_then(|r| r.bomb.clone());
 
-    let player_state_ref: Option<&RawGsiPlayerState> = raw.player.as_ref().and_then(|p| p.state.as_ref());
+    let player_state_ref: Option<&RawGsiPlayerState> =
+        raw.player.as_ref().and_then(|p| p.state.as_ref());
     let money = player_state_ref.and_then(|s| s.money);
     let health = player_state_ref.and_then(|s| s.health);
     let armor = player_state_ref.and_then(|s| s.armor);
@@ -640,14 +639,8 @@ mod tests {
     #[test]
     fn parse_weapons_block_skips_non_weapon_keys() {
         let mut map: HashMap<String, RawGsiWeapon> = HashMap::new();
-        map.insert(
-            "totally_unrelated_key".into(),
-            RawGsiWeapon::default(),
-        );
-        map.insert(
-            "weapon_abc".into(),
-            RawGsiWeapon::default(),
-        );
+        map.insert("totally_unrelated_key".into(), RawGsiWeapon::default());
+        map.insert("weapon_abc".into(), RawGsiWeapon::default());
         map.insert(
             "weapon_0".into(),
             RawGsiWeapon {

--- a/apps/mygamingassistant/desktop/src-tauri/src/gsi/payload.rs
+++ b/apps/mygamingassistant/desktop/src-tauri/src/gsi/payload.rs
@@ -15,8 +15,16 @@
 //!   3. **Map slug normalization** — CS2 sends `"de_mirage"`; the backend
 //!      uses `"mirage"` as the canonical slug (see
 //!      `apps/mygamingassistant/backend/app/fixtures/cs2_maps.json`).
+//!   4. **Weapons normalization** — CS2 emits `weapons` as a JSON object
+//!      keyed by slot string (`weapon_0`, `weapon_1`, ...). We parse into
+//!      a HashMap and convert to a slot-ordered Vec for downstream code
+//!      (PR 10). See `parse_weapons_block`.
+
+use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+
+use crate::gsi::weapons::weapon_to_utility_slug;
 
 // ===========================================================================
 // Raw CS2 GSI payload
@@ -28,18 +36,17 @@ use serde::{Deserialize, Serialize};
 /// (e.g., menu state with no `map` or `player` block) still parses.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct RawGsiPayload {
-    /// Provider block — identifies the CS2 instance. We don't gate on this
-    /// today but capturing it future-proofs us against multi-CS2-instance
-    /// setups (uncommon, but possible).
+    /// Provider block — identifies the CS2 instance. PR 10 reads
+    /// `provider.timestamp` for the HUD's `provider_timestamp` field.
     #[serde(default)]
-    pub provider: Option<serde_json::Value>,
+    pub provider: Option<RawGsiProvider>,
 
     /// Map block — present whenever a map is loaded (including warmup,
     /// halftime, and game-over screens).
     #[serde(default)]
     pub map: Option<RawGsiMap>,
 
-    /// Round block — phase + winning team if any.
+    /// Round block — phase + winning team if any. PR 10 adds bomb state.
     #[serde(default)]
     pub round: Option<RawGsiRound>,
 
@@ -56,6 +63,24 @@ pub struct RawGsiPayload {
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
+pub struct RawGsiProvider {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub appid: Option<u32>,
+    #[serde(default)]
+    pub version: Option<u32>,
+    #[serde(default)]
+    pub steamid: Option<String>,
+    /// Unix epoch seconds. Monotonic w.r.t. the CS2 host's clock. Useful
+    /// only as a sanity-check signal (e.g., "is GSI alive") — we do NOT
+    /// use this to estimate round clock. CS2 redacts the actual round
+    /// timer from GSI for competitive integrity.
+    #[serde(default)]
+    pub timestamp: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
 pub struct RawGsiMap {
     /// e.g. `"de_mirage"`. Normalized to `"mirage"` for the frontend.
     #[serde(default)]
@@ -66,6 +91,19 @@ pub struct RawGsiMap {
     /// Round number (0-based, sometimes -1 in warmup).
     #[serde(default)]
     pub round: Option<i32>,
+    /// CT team's current score (rounds won). Absent in menu / pre-warmup.
+    #[serde(default)]
+    pub team_ct: Option<RawGsiTeamScore>,
+    /// T team's current score (rounds won). Absent in menu / pre-warmup.
+    #[serde(default)]
+    pub team_t: Option<RawGsiTeamScore>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct RawGsiTeamScore {
+    /// Rounds won this half / match. CS2 emits this as a nested int.
+    #[serde(default)]
+    pub score: Option<u32>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -76,6 +114,10 @@ pub struct RawGsiRound {
     /// `"t" | "ct"` if a side won the round; absent during the round.
     #[serde(default)]
     pub win_team: Option<String>,
+    /// `"planted" | "defused" | "exploded"` when the bomb has been
+    /// touched; absent otherwise. PR 10 surfaces this on the HUD.
+    #[serde(default)]
+    pub bomb: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -88,12 +130,89 @@ pub struct RawGsiPlayer {
     /// updates while the player is in chat.
     #[serde(default)]
     pub activity: Option<String>,
-    /// Detailed inventory + money + health — we passthrough for the live HUD.
+    /// Steam ID of the local player.
     #[serde(default)]
-    pub state: Option<serde_json::Value>,
+    pub steamid: Option<String>,
+    /// Local player's in-game name (utf-8).
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Detailed inventory + money + health. PR 10 parses this into a
+    /// strongly-typed struct so the HUD can render money / armor / kit.
+    #[serde(default)]
+    pub state: Option<RawGsiPlayerState>,
     /// Cumulative round/kill stats.
     #[serde(default)]
     pub match_stats: Option<serde_json::Value>,
+    /// Weapons inventory — CS2 emits as `{"weapon_0": {...}, "weapon_1": {...}}`.
+    /// We accept the raw HashMap here and convert to a Vec at normalize time.
+    /// `default` lets payloads without weapons (menu, freezetime before
+    /// purchase) parse without error.
+    #[serde(default)]
+    pub weapons: HashMap<String, RawGsiWeapon>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct RawGsiPlayerState {
+    /// Wallet money (USD). Cap is 16000 in standard CS2 rules.
+    #[serde(default)]
+    pub money: Option<u32>,
+    /// Current HP (0-100).
+    #[serde(default)]
+    pub health: Option<u32>,
+    /// Armor (0-100).
+    #[serde(default)]
+    pub armor: Option<u32>,
+    /// `true` when wearing a helmet (matters for HUD's "+kit" hint).
+    #[serde(default)]
+    pub helmet: Option<bool>,
+    /// `true` when carrying a defuse kit.
+    #[serde(default)]
+    pub defusekit: Option<bool>,
+    /// Total $ value of weapons + grenades currently held. Used by the HUD
+    /// to surface buy-tier signals (eco / force-buy / full-buy).
+    #[serde(default)]
+    pub equip_value: Option<u32>,
+    /// Total $ value of all items spent this round (incl. grenades thrown).
+    #[serde(default)]
+    pub round_totalvalue: Option<u32>,
+    /// Flash blind intensity (0-255). 0 = not flashed.
+    #[serde(default)]
+    pub flashed: Option<u32>,
+    /// In a smoke (1) or not (0). CS2 emits as integer for backward compat.
+    #[serde(default)]
+    pub smoked: Option<u32>,
+    /// In a fire (1) or not (0).
+    #[serde(default)]
+    pub burning: Option<u32>,
+    /// Round kills by this player.
+    #[serde(default)]
+    pub round_kills: Option<u32>,
+    /// Round headshot kills by this player.
+    #[serde(default)]
+    pub round_killhs: Option<u32>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct RawGsiWeapon {
+    /// e.g. `"weapon_smokegrenade"` — Valve internal slug, fed into the
+    /// `weapons` module for utility-type mapping.
+    #[serde(default)]
+    pub name: Option<String>,
+    /// `"Grenade" | "Pistol" | "Rifle" | "SniperRifle" | "Knife" | "C4" |
+    /// "Submachine Gun" | "Machine Gun" | "Shotgun" | "Equipment" | "Fists" | ...`.
+    /// Useful for type-based filtering but optional in PR 10's HUD path.
+    #[serde(default, rename = "type")]
+    pub kind: Option<String>,
+    /// `"active" | "holstered" | "reloading"`. The "active" weapon is the
+    /// one the player is currently holding.
+    #[serde(default)]
+    pub state: Option<String>,
+    /// Skin slug — irrelevant for lineups, captured for future use only.
+    #[serde(default)]
+    pub paintkit: Option<String>,
+    /// Current loaded ammo. Optional for grenades.
+    #[serde(default)]
+    pub ammo_clip: Option<u32>,
 }
 
 #[derive(Debug, Default, Deserialize, Serialize)]
@@ -129,6 +248,12 @@ pub enum NormalizedSide {
 /// **Stability contract**: this shape is part of the IPC API. If you change
 /// field names or types, also update `frontend/src/types/desktop.ts` and the
 /// `useGsiState` hook in the same PR.
+///
+/// PR 10 added the explicit utility / money / score fields below. The
+/// `player_state` and `match_stats` passthroughs are KEPT for backward
+/// compatibility — existing consumers that read raw values via those blobs
+/// (and the legacy unit tests) continue to work, but new consumers should
+/// prefer the typed fields.
 #[derive(Debug, Clone, Serialize)]
 pub struct GsiEvent {
     /// Canonical MGA map slug (e.g., `"mirage"`, NOT `"de_mirage"`). Empty
@@ -143,10 +268,66 @@ pub struct GsiEvent {
     /// Activity (e.g., `"playing"`, `"menu"`) — useful for suppressing live
     /// HUD updates while the user is in chat.
     pub activity: String,
-    /// Passthrough of the raw player state block (money, weapons, health)
-    /// for live HUD display. Kept as `serde_json::Value` so we don't have to
-    /// re-derive every weapon ID — the frontend already knows how to render
-    /// money + held weapon.
+    // --- PR 10: explicit, strongly-typed HUD fields ---
+    /// Bomb state (`"planted" | "defused" | "exploded"`) or `None` when the
+    /// bomb is in nobody's hand / waiting to be planted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bomb_state: Option<String>,
+    /// Wallet money (USD). `None` when CS2 hasn't sent it yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub money: Option<u32>,
+    /// HP (0-100).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub health: Option<u32>,
+    /// Armor (0-100).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub armor: Option<u32>,
+    /// Helmet flag — when armor>0 AND helmet=true, the HUD shows "+kit".
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub helmet: Option<bool>,
+    /// Defuse kit flag — CT-only signal; rendered as a small "kit" badge.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub defuse_kit: Option<bool>,
+    /// Total $ value of currently-equipped items. Used for buy-tier hint.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub equip_value: Option<u32>,
+    /// CT team's current round score.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ct_score: Option<u32>,
+    /// T team's current round score.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub t_score: Option<u32>,
+    /// Round number (1-based for display; CS2 sends 0-based internally and
+    /// we add 1 on the way out so the HUD matches CS2's scoreboard).
+    /// `None` in pre-warmup / menu.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub round_number: Option<u32>,
+    /// Raw Valve slug of the currently-held weapon (`"weapon_smokegrenade"`),
+    /// or `None` when no weapon is active (menu state).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_weapon: Option<String>,
+    /// MGA utility-type slug corresponding to the active weapon, or `None`
+    /// when:
+    ///   - The active weapon isn't a grenade (knife, rifle, etc.).
+    ///   - The player isn't holding any weapon.
+    /// **This is the primary signal for PR 10's utility-held filter**:
+    /// when present, the live lineup query narrows to lineups matching this
+    /// utility slug (intersected with map + side).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub active_utility: Option<String>,
+    /// MGA utility-type slugs corresponding to ALL grenades currently in
+    /// inventory (deduplicated). Used as the secondary signal — when the
+    /// player has utility but isn't actively holding any of it, narrow to
+    /// the slugs present in inventory.
+    pub held_utility_slugs: Vec<String>,
+    /// Unix epoch seconds from CS2's `provider.timestamp`. Useful for
+    /// debugging stale-payload detection only — we do NOT use this to
+    /// estimate round clock (CS2 redacts that for competitive integrity).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_timestamp: Option<u64>,
+    /// Passthrough of the raw player state block. Kept for backward
+    /// compatibility with PR 8 consumers + the legacy serialized blob.
+    /// Prefer the typed fields above for new code.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub player_state: Option<serde_json::Value>,
     /// Passthrough match stats (kills, score, MVP count). Same rationale.
@@ -193,6 +374,86 @@ pub fn normalize_side(raw: Option<&str>) -> NormalizedSide {
     }
 }
 
+/// Parse a CS2 GSI weapons HashMap into a slot-ordered Vec.
+///
+/// CS2 GSI emits weapons keyed by string slot (`"weapon_0"`, `"weapon_1"`,
+/// ..., `"weapon_9"`) where the slot is a stable index for the weapon's
+/// position in the inventory (not its slot in the loadout). We parse the
+/// HashMap into a Vec sorted by the integer slot index so callers get a
+/// deterministic order — same payload always produces the same Vec.
+///
+/// Unparseable keys (the very rare case where Valve adds a non-`weapon_N`
+/// key) are filtered out. They count as forward-compat noise.
+fn parse_weapons_block(map: &HashMap<String, RawGsiWeapon>) -> Vec<RawGsiWeapon> {
+    let mut indexed: Vec<(u32, RawGsiWeapon)> = map
+        .iter()
+        .filter_map(|(k, v)| {
+            // Strip the "weapon_" prefix and parse the slot index.
+            let idx_str = k.strip_prefix("weapon_")?;
+            let idx: u32 = idx_str.parse().ok()?;
+            Some((idx, v.clone()))
+        })
+        .collect();
+    indexed.sort_by_key(|(i, _)| *i);
+    indexed.into_iter().map(|(_, w)| w).collect()
+}
+
+/// Derive the active weapon's slug + utility-type slug from a weapons Vec.
+///
+/// CS2 emits weapon state as `"active" | "holstered" | "reloading"`. Only
+/// ONE weapon is `"active"` at a time. If none is active (very rare —
+/// usually only in transition states), returns `(None, None)`.
+fn derive_active_weapon(
+    weapons: &[RawGsiWeapon],
+) -> (Option<String>, Option<String>) {
+    let active = weapons
+        .iter()
+        .find(|w| w.state.as_deref() == Some("active"));
+    match active {
+        Some(w) => {
+            let name = w.name.clone();
+            let utility = w
+                .name
+                .as_deref()
+                .and_then(weapon_to_utility_slug)
+                .map(String::from);
+            (name, utility)
+        }
+        None => (None, None),
+    }
+}
+
+/// Derive deduplicated list of MGA utility slugs for all grenades held.
+///
+/// We don't preserve slot order — the frontend doesn't care which slot
+/// each grenade is in, only which slugs are present. Dedupe is per-slug;
+/// holding e.g. two flashbangs gives one `"flash"` entry. (CS2's
+/// per-grenade flag limits also mean we shouldn't see duplicates in
+/// practice, but the dedupe is cheap insurance.)
+fn derive_held_utility_slugs(weapons: &[RawGsiWeapon]) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    for w in weapons {
+        if let Some(name) = w.name.as_deref() {
+            if let Some(slug) = weapon_to_utility_slug(name) {
+                if !out.iter().any(|s| s == slug) {
+                    out.push(slug.to_string());
+                }
+            }
+        }
+    }
+    out
+}
+
+/// Re-encode a `RawGsiPlayerState` as a `serde_json::Value` for the
+/// passthrough `player_state` field of the emitted event. Keeps PR 8's
+/// backward compat (existing tests + JS consumers that read raw money via
+/// `event.player_state.money` still work).
+fn player_state_passthrough(state: &RawGsiPlayerState) -> Option<serde_json::Value> {
+    // serde_json::to_value should be infallible for this concrete struct;
+    // fall back to None on the impossible Err to avoid an unwrap.
+    serde_json::to_value(state).ok()
+}
+
 /// Convert a parsed `RawGsiPayload` into the normalized `GsiEvent` we emit
 /// to the frontend. Pure function — no IO, no logging, no time injection
 /// (caller passes `received_at`) so it's trivially unit-testable.
@@ -224,7 +485,50 @@ pub fn normalize_payload(raw: &RawGsiPayload, received_at: String) -> GsiEvent {
         .and_then(|p| p.activity.clone())
         .unwrap_or_default();
 
-    let player_state = raw.player.as_ref().and_then(|p| p.state.clone());
+    // --- PR 10: derived fields ---
+    let bomb_state = raw.round.as_ref().and_then(|r| r.bomb.clone());
+
+    let player_state_ref: Option<&RawGsiPlayerState> = raw.player.as_ref().and_then(|p| p.state.as_ref());
+    let money = player_state_ref.and_then(|s| s.money);
+    let health = player_state_ref.and_then(|s| s.health);
+    let armor = player_state_ref.and_then(|s| s.armor);
+    let helmet = player_state_ref.and_then(|s| s.helmet);
+    let defuse_kit = player_state_ref.and_then(|s| s.defusekit);
+    let equip_value = player_state_ref.and_then(|s| s.equip_value);
+
+    let ct_score = raw
+        .map
+        .as_ref()
+        .and_then(|m| m.team_ct.as_ref())
+        .and_then(|t| t.score);
+    let t_score = raw
+        .map
+        .as_ref()
+        .and_then(|m| m.team_t.as_ref())
+        .and_then(|t| t.score);
+    // CS2 emits round as 0-based; display as 1-based. Treat negative
+    // (warmup) and missing as None.
+    let round_number = raw
+        .map
+        .as_ref()
+        .and_then(|m| m.round)
+        .filter(|r| *r >= 0)
+        .map(|r| (r as u32).saturating_add(1));
+
+    let weapons_vec = raw
+        .player
+        .as_ref()
+        .map(|p| parse_weapons_block(&p.weapons))
+        .unwrap_or_default();
+    let (active_weapon, active_utility) = derive_active_weapon(&weapons_vec);
+    let held_utility_slugs = derive_held_utility_slugs(&weapons_vec);
+
+    let provider_timestamp = raw.provider.as_ref().and_then(|p| p.timestamp);
+
+    // Re-emit player_state for backward compat. PR 8's GsiEvent shape
+    // emitted this as a `serde_json::Value` passthrough — keep that working
+    // even though we now also publish typed fields.
+    let player_state = player_state_ref.and_then(player_state_passthrough);
     let match_stats = raw.player.as_ref().and_then(|p| p.match_stats.clone());
 
     GsiEvent {
@@ -233,6 +537,20 @@ pub fn normalize_payload(raw: &RawGsiPayload, received_at: String) -> GsiEvent {
         side,
         round_phase,
         activity,
+        bomb_state,
+        money,
+        health,
+        armor,
+        helmet,
+        defuse_kit,
+        equip_value,
+        ct_score,
+        t_score,
+        round_number,
+        active_weapon,
+        active_utility,
+        held_utility_slugs,
+        provider_timestamp,
         player_state,
         match_stats,
         received_at,
@@ -282,16 +600,195 @@ mod tests {
         assert_eq!(normalize_side(Some("SPECTATOR")), NormalizedSide::Any);
     }
 
+    // ----- PR 10: weapons parsing -----
+
+    #[test]
+    fn parse_weapons_block_orders_by_slot_index() {
+        let mut map: HashMap<String, RawGsiWeapon> = HashMap::new();
+        map.insert(
+            "weapon_2".into(),
+            RawGsiWeapon {
+                name: Some("weapon_smokegrenade".into()),
+                state: Some("holstered".into()),
+                ..Default::default()
+            },
+        );
+        map.insert(
+            "weapon_0".into(),
+            RawGsiWeapon {
+                name: Some("weapon_knife".into()),
+                state: Some("holstered".into()),
+                ..Default::default()
+            },
+        );
+        map.insert(
+            "weapon_10".into(),
+            RawGsiWeapon {
+                name: Some("weapon_flashbang".into()),
+                state: Some("active".into()),
+                ..Default::default()
+            },
+        );
+
+        let vec = parse_weapons_block(&map);
+        assert_eq!(vec.len(), 3);
+        assert_eq!(vec[0].name.as_deref(), Some("weapon_knife"));
+        assert_eq!(vec[1].name.as_deref(), Some("weapon_smokegrenade"));
+        assert_eq!(vec[2].name.as_deref(), Some("weapon_flashbang"));
+    }
+
+    #[test]
+    fn parse_weapons_block_skips_non_weapon_keys() {
+        let mut map: HashMap<String, RawGsiWeapon> = HashMap::new();
+        map.insert(
+            "totally_unrelated_key".into(),
+            RawGsiWeapon::default(),
+        );
+        map.insert(
+            "weapon_abc".into(),
+            RawGsiWeapon::default(),
+        );
+        map.insert(
+            "weapon_0".into(),
+            RawGsiWeapon {
+                name: Some("weapon_ak47".into()),
+                ..Default::default()
+            },
+        );
+        let vec = parse_weapons_block(&map);
+        assert_eq!(vec.len(), 1);
+        assert_eq!(vec[0].name.as_deref(), Some("weapon_ak47"));
+    }
+
+    #[test]
+    fn parse_weapons_block_empty_map_returns_empty_vec() {
+        let map: HashMap<String, RawGsiWeapon> = HashMap::new();
+        let vec = parse_weapons_block(&map);
+        assert!(vec.is_empty());
+    }
+
+    #[test]
+    fn derive_active_weapon_returns_active_slot() {
+        let weapons = vec![
+            RawGsiWeapon {
+                name: Some("weapon_knife".into()),
+                state: Some("holstered".into()),
+                ..Default::default()
+            },
+            RawGsiWeapon {
+                name: Some("weapon_smokegrenade".into()),
+                state: Some("active".into()),
+                ..Default::default()
+            },
+            RawGsiWeapon {
+                name: Some("weapon_ak47".into()),
+                state: Some("holstered".into()),
+                ..Default::default()
+            },
+        ];
+        let (w, util) = derive_active_weapon(&weapons);
+        assert_eq!(w.as_deref(), Some("weapon_smokegrenade"));
+        assert_eq!(util.as_deref(), Some("smoke"));
+    }
+
+    #[test]
+    fn derive_active_weapon_none_when_no_active() {
+        let weapons = vec![RawGsiWeapon {
+            name: Some("weapon_knife".into()),
+            state: Some("holstered".into()),
+            ..Default::default()
+        }];
+        let (w, util) = derive_active_weapon(&weapons);
+        assert_eq!(w, None);
+        assert_eq!(util, None);
+    }
+
+    #[test]
+    fn derive_active_weapon_active_non_grenade_no_utility() {
+        // Player is holding their rifle — active_weapon is set, but
+        // active_utility is None because rifles aren't utility.
+        let weapons = vec![RawGsiWeapon {
+            name: Some("weapon_ak47".into()),
+            state: Some("active".into()),
+            ..Default::default()
+        }];
+        let (w, util) = derive_active_weapon(&weapons);
+        assert_eq!(w.as_deref(), Some("weapon_ak47"));
+        assert_eq!(util, None);
+    }
+
+    #[test]
+    fn derive_held_utility_slugs_collects_all_grenades() {
+        let weapons = vec![
+            RawGsiWeapon {
+                name: Some("weapon_knife".into()),
+                ..Default::default()
+            },
+            RawGsiWeapon {
+                name: Some("weapon_smokegrenade".into()),
+                ..Default::default()
+            },
+            RawGsiWeapon {
+                name: Some("weapon_ak47".into()),
+                ..Default::default()
+            },
+            RawGsiWeapon {
+                name: Some("weapon_flashbang".into()),
+                ..Default::default()
+            },
+            RawGsiWeapon {
+                name: Some("weapon_hegrenade".into()),
+                ..Default::default()
+            },
+        ];
+        let slugs = derive_held_utility_slugs(&weapons);
+        assert!(slugs.contains(&"smoke".to_string()));
+        assert!(slugs.contains(&"flash".to_string()));
+        assert!(slugs.contains(&"grenade".to_string()));
+        assert_eq!(slugs.len(), 3);
+    }
+
+    #[test]
+    fn derive_held_utility_slugs_dedupes_duplicate_grenade_types() {
+        // Player accidentally has two smoke entries in inventory (rare in
+        // practice but the GSI shape doesn't forbid it). Dedupe to one slug.
+        let weapons = vec![
+            RawGsiWeapon {
+                name: Some("weapon_smokegrenade".into()),
+                ..Default::default()
+            },
+            RawGsiWeapon {
+                name: Some("weapon_smokegrenade".into()),
+                ..Default::default()
+            },
+        ];
+        let slugs = derive_held_utility_slugs(&weapons);
+        assert_eq!(slugs, vec!["smoke"]);
+    }
+
+    #[test]
+    fn derive_held_utility_slugs_empty_when_no_grenades() {
+        let weapons = vec![RawGsiWeapon {
+            name: Some("weapon_ak47".into()),
+            ..Default::default()
+        }];
+        assert!(derive_held_utility_slugs(&weapons).is_empty());
+    }
+
+    // ----- Full payload parsing -----
+
     #[test]
     fn parse_full_payload() {
         // Realistic CS2 GSI payload sampled from community docs. Verifies
         // every field we care about parses without panicking.
         let raw = r#"{
-            "provider": {"name": "Counter-Strike: Global Offensive", "appid": 730},
+            "provider": {"name": "Counter-Strike: Global Offensive", "appid": 730, "timestamp": 1747143600},
             "map": {
                 "name": "de_mirage",
                 "phase": "live",
-                "round": 5
+                "round": 5,
+                "team_ct": {"score": 3},
+                "team_t":  {"score": 2}
             },
             "round": {
                 "phase": "live"
@@ -302,7 +799,14 @@ mod tests {
                 "state": {
                     "money": 4150,
                     "health": 100,
-                    "armor": 100
+                    "armor": 100,
+                    "helmet": true,
+                    "equip_value": 4750
+                },
+                "weapons": {
+                    "weapon_0": {"name": "weapon_knife", "type": "Knife", "state": "holstered"},
+                    "weapon_1": {"name": "weapon_smokegrenade", "type": "Grenade", "state": "active"},
+                    "weapon_2": {"name": "weapon_flashbang",    "type": "Grenade", "state": "holstered"}
                 },
                 "match_stats": {
                     "kills": 8,
@@ -323,6 +827,39 @@ mod tests {
         assert!(event.player_state.is_some());
         assert!(event.match_stats.is_some());
         assert_eq!(event.received_at, "2026-05-13T10:00:00Z");
+
+        // PR 10: derived HUD fields
+        assert_eq!(event.money, Some(4150));
+        assert_eq!(event.health, Some(100));
+        assert_eq!(event.armor, Some(100));
+        assert_eq!(event.helmet, Some(true));
+        assert_eq!(event.equip_value, Some(4750));
+        assert_eq!(event.ct_score, Some(3));
+        assert_eq!(event.t_score, Some(2));
+        assert_eq!(event.round_number, Some(6)); // 0-based 5 → 1-based 6
+        assert_eq!(event.active_weapon.as_deref(), Some("weapon_smokegrenade"));
+        assert_eq!(event.active_utility.as_deref(), Some("smoke"));
+        assert!(event.held_utility_slugs.contains(&"smoke".to_string()));
+        assert!(event.held_utility_slugs.contains(&"flash".to_string()));
+        assert_eq!(event.provider_timestamp, Some(1747143600));
+        // Bomb state absent in this fixture.
+        assert_eq!(event.bomb_state, None);
+    }
+
+    #[test]
+    fn parse_payload_with_missing_weapons_block() {
+        // Player block exists but no weapons key (common in menu / freezetime
+        // before purchase). The HashMap should default to empty.
+        let raw = r#"{
+            "map": {"name": "de_mirage", "phase": "live"},
+            "player": {"team": "T", "activity": "playing"},
+            "auth": {"token": "x"}
+        }"#;
+        let parsed: RawGsiPayload = serde_json::from_str(raw).expect("parses");
+        let event = normalize_payload(&parsed, "2026-05-13T10:00:00Z".into());
+        assert!(event.held_utility_slugs.is_empty());
+        assert_eq!(event.active_weapon, None);
+        assert_eq!(event.active_utility, None);
     }
 
     #[test]
@@ -343,6 +880,13 @@ mod tests {
         assert_eq!(event.map_phase, "");
         assert_eq!(event.side, NormalizedSide::Any);
         assert_eq!(event.activity, "menu");
+        // PR 10: no map → no scores, no money, no weapons.
+        assert_eq!(event.money, None);
+        assert_eq!(event.ct_score, None);
+        assert_eq!(event.t_score, None);
+        assert_eq!(event.active_weapon, None);
+        assert_eq!(event.active_utility, None);
+        assert!(event.held_utility_slugs.is_empty());
     }
 
     #[test]
@@ -371,5 +915,51 @@ mod tests {
             parsed.auth.as_ref().and_then(|a| a.token.as_deref()),
             Some("secret123")
         );
+    }
+
+    #[test]
+    fn bomb_state_planted_is_surfaced() {
+        let raw = r#"{
+            "map": {"name": "de_mirage", "phase": "live"},
+            "round": {"phase": "live", "bomb": "planted"},
+            "player": {"team": "CT"},
+            "auth": {"token": "x"}
+        }"#;
+        let parsed: RawGsiPayload = serde_json::from_str(raw).expect("parses");
+        let event = normalize_payload(&parsed, "2026-05-13T10:00:00Z".into());
+        assert_eq!(event.bomb_state.as_deref(), Some("planted"));
+    }
+
+    #[test]
+    fn negative_round_number_is_dropped() {
+        // CS2 sometimes sends round=-1 during warmup. We treat that as None
+        // rather than displaying "Round 0" or a negative.
+        let raw = r#"{
+            "map": {"name": "de_mirage", "phase": "warmup", "round": -1},
+            "player": {"team": "T"},
+            "auth": {"token": "x"}
+        }"#;
+        let parsed: RawGsiPayload = serde_json::from_str(raw).expect("parses");
+        let event = normalize_payload(&parsed, "2026-05-13T10:00:00Z".into());
+        assert_eq!(event.round_number, None);
+    }
+
+    #[test]
+    fn player_state_passthrough_preserves_money_for_legacy_consumers() {
+        // PR 8 consumers expect `event.player_state.money` to be readable.
+        // PR 10 added typed `event.money`, but the passthrough must still
+        // populate so old code paths work.
+        let raw = r#"{
+            "map": {"name": "de_mirage", "phase": "live"},
+            "player": {
+                "team": "T",
+                "state": {"money": 800, "health": 100, "armor": 0}
+            },
+            "auth": {"token": "x"}
+        }"#;
+        let parsed: RawGsiPayload = serde_json::from_str(raw).expect("parses");
+        let event = normalize_payload(&parsed, "2026-05-13T10:00:00Z".into());
+        let ps = event.player_state.expect("player_state should serialize");
+        assert_eq!(ps.get("money").and_then(|v| v.as_u64()), Some(800));
     }
 }

--- a/apps/mygamingassistant/desktop/src-tauri/src/gsi/payload.rs
+++ b/apps/mygamingassistant/desktop/src-tauri/src/gsi/payload.rs
@@ -310,6 +310,7 @@ pub struct GsiEvent {
     /// when:
     ///   - The active weapon isn't a grenade (knife, rifle, etc.).
     ///   - The player isn't holding any weapon.
+    ///
     /// **This is the primary signal for PR 10's utility-held filter**:
     /// when present, the live lineup query narrows to lineups matching this
     /// utility slug (intersected with map + side).

--- a/apps/mygamingassistant/desktop/src-tauri/src/gsi/weapons.rs
+++ b/apps/mygamingassistant/desktop/src-tauri/src/gsi/weapons.rs
@@ -1,0 +1,141 @@
+//! CS2 weapon slug → MGA `UtilityType` slug mapping.
+//!
+//! CS2 GSI's `player.weapons` block emits weapon entries keyed by slot
+//! number (`weapon_0`, `weapon_1`, ...). Each entry has a `name` field
+//! using Valve's internal slug ("weapon_smokegrenade", "weapon_flashbang",
+//! etc.). The MGA backend, in contrast, uses short utility slugs
+//! ("smoke", "flash", "molotov", "grenade", "decoy") drawn from
+//! `backend/app/fixtures/utility_types.json`.
+//!
+//! This module is the ONLY place CS2 weapon names get translated to MGA
+//! utility-type slugs. Keep it dumb + table-driven so the mapping is
+//! grep-able and trivially testable.
+//!
+//! Notes on Valve's grenade vocabulary:
+//!   - `weapon_molotov` is the T-side flame grenade.
+//!   - `weapon_incgrenade` is the CT-side incendiary grenade. Different
+//!     entity in the engine, but functionally the same on the MGA lineup
+//!     library — both produce a fire patch. Mapped to the same `molotov`
+//!     utility slug so lineup filtering doesn't fork by side.
+//!   - `weapon_hegrenade` is HE. The MGA fixture currently uses the slug
+//!     `grenade` for HE (see `utility_types.json`), NOT `he` — we honour
+//!     the fixture's choice.
+//!   - `weapon_decoy` is the decoy grenade. The MGA fixture has the slug
+//!     `decoy`. No lineups exist for decoys yet, but the mapping is in
+//!     place so PR 10 doesn't need a follow-up if creators start uploading
+//!     decoy lineups.
+//!
+//! Anything that isn't a grenade (knife, rifle, pistol, c4) returns
+//! `None`. The frontend only uses utility for narrowing lineup queries,
+//! so non-utility weapons are quietly ignored.
+
+/// Map a CS2 GSI weapon slug to the corresponding MGA UtilityType slug.
+///
+/// Returns `None` for non-utility weapons (knives, rifles, pistols, etc.)
+/// and for any unknown future weapon slug Valve may add. Callers should
+/// treat `None` as "skip" rather than as an error.
+pub fn weapon_to_utility_slug(weapon_name: &str) -> Option<&'static str> {
+    // Match on the raw slug Valve sends; case-sensitive because every
+    // CS2 GSI sample we've seen uses lowercase. Adding a `to_ascii_lowercase`
+    // conversion would mask a real bug if Valve ever changed casing.
+    match weapon_name {
+        "weapon_smokegrenade" => Some("smoke"),
+        "weapon_flashbang" => Some("flash"),
+        // Both T-side molotov and CT-side incendiary map to the same MGA
+        // utility slug — lineups don't distinguish.
+        "weapon_molotov" => Some("molotov"),
+        "weapon_incgrenade" => Some("molotov"),
+        // CS2 fixture uses `grenade` (not `he`) for HE — see utility_types.json
+        "weapon_hegrenade" => Some("grenade"),
+        "weapon_decoy" => Some("decoy"),
+        _ => None,
+    }
+}
+
+/// Convenience predicate. `true` for any grenade slug we'd map to a
+/// utility type. Useful when filtering a weapons vec.
+pub fn is_utility_weapon(weapon_name: &str) -> bool {
+    weapon_to_utility_slug(weapon_name).is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn smoke_grenade_maps_to_smoke() {
+        assert_eq!(weapon_to_utility_slug("weapon_smokegrenade"), Some("smoke"));
+    }
+
+    #[test]
+    fn flashbang_maps_to_flash() {
+        assert_eq!(weapon_to_utility_slug("weapon_flashbang"), Some("flash"));
+    }
+
+    #[test]
+    fn t_molotov_maps_to_molotov() {
+        assert_eq!(weapon_to_utility_slug("weapon_molotov"), Some("molotov"));
+    }
+
+    #[test]
+    fn ct_incendiary_maps_to_molotov() {
+        // T-side and CT-side grenades both map to the same MGA slug. This is
+        // intentional — lineups for "molotov" cover both.
+        assert_eq!(weapon_to_utility_slug("weapon_incgrenade"), Some("molotov"));
+    }
+
+    #[test]
+    fn he_grenade_maps_to_grenade_slug() {
+        // MGA fixture uses `grenade` (NOT `he`) for HE grenade — defending
+        // against accidental rename via test.
+        assert_eq!(weapon_to_utility_slug("weapon_hegrenade"), Some("grenade"));
+    }
+
+    #[test]
+    fn decoy_maps_to_decoy() {
+        assert_eq!(weapon_to_utility_slug("weapon_decoy"), Some("decoy"));
+    }
+
+    #[test]
+    fn knife_is_not_utility() {
+        assert_eq!(weapon_to_utility_slug("weapon_knife"), None);
+    }
+
+    #[test]
+    fn rifle_is_not_utility() {
+        assert_eq!(weapon_to_utility_slug("weapon_ak47"), None);
+        assert_eq!(weapon_to_utility_slug("weapon_m4a1"), None);
+        assert_eq!(weapon_to_utility_slug("weapon_awp"), None);
+    }
+
+    #[test]
+    fn unknown_weapon_returns_none() {
+        // Forward-compat: a future weapon Valve adds won't crash; we just
+        // return None and the caller skips it.
+        assert_eq!(weapon_to_utility_slug("weapon_future_thing"), None);
+        assert_eq!(weapon_to_utility_slug(""), None);
+        assert_eq!(weapon_to_utility_slug("not_even_a_weapon_prefix"), None);
+    }
+
+    #[test]
+    fn is_utility_weapon_distinguishes_grenades_from_guns() {
+        assert!(is_utility_weapon("weapon_smokegrenade"));
+        assert!(is_utility_weapon("weapon_flashbang"));
+        assert!(is_utility_weapon("weapon_molotov"));
+        assert!(is_utility_weapon("weapon_incgrenade"));
+        assert!(is_utility_weapon("weapon_hegrenade"));
+        assert!(is_utility_weapon("weapon_decoy"));
+        assert!(!is_utility_weapon("weapon_ak47"));
+        assert!(!is_utility_weapon("weapon_knife"));
+        assert!(!is_utility_weapon("weapon_c4"));
+        assert!(!is_utility_weapon(""));
+    }
+
+    #[test]
+    fn case_sensitivity_preserved_to_catch_valve_change() {
+        // Lowercase slugs match; uppercase would NOT — this is intentional.
+        // If Valve ever ships uppercase, the test failure is the early signal.
+        assert_eq!(weapon_to_utility_slug("WEAPON_SMOKEGRENADE"), None);
+        assert_eq!(weapon_to_utility_slug("weapon_smokeGrenade"), None);
+    }
+}

--- a/apps/mygamingassistant/desktop/src-tauri/tests/gsi_http_integration.rs
+++ b/apps/mygamingassistant/desktop/src-tauri/tests/gsi_http_integration.rs
@@ -55,15 +55,35 @@ async fn live_http_receiver_accepts_real_post() {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     }
 
-    // POST a realistic CS2 GSI payload.
+    // POST a realistic CS2 GSI payload. PR 10 added weapons + scores +
+    // bomb state, so the fixture exercises every field the HUD reads.
     let payload = serde_json::json!({
-        "provider": {"name": "Counter-Strike: Global Offensive"},
-        "map": {"name": "de_mirage", "phase": "live", "round": 5},
-        "round": {"phase": "freezetime"},
+        "provider": {"name": "Counter-Strike: Global Offensive", "timestamp": 1747143600u64},
+        "map": {
+            "name": "de_mirage",
+            "phase": "live",
+            "round": 11,
+            "team_ct": {"score": 7},
+            "team_t":  {"score": 4}
+        },
+        "round": {"phase": "freezetime", "bomb": "planted"},
         "player": {
             "team": "CT",
             "activity": "playing",
-            "state": {"money": 4150, "health": 100, "armor": 100}
+            "state": {
+                "money": 4150,
+                "health": 100,
+                "armor": 100,
+                "helmet": true,
+                "defusekit": true,
+                "equip_value": 4250
+            },
+            "weapons": {
+                "weapon_0": {"name": "weapon_knife",         "type": "Knife",   "state": "holstered"},
+                "weapon_1": {"name": "weapon_m4a1",          "type": "Rifle",   "state": "holstered"},
+                "weapon_2": {"name": "weapon_smokegrenade",  "type": "Grenade", "state": "active"},
+                "weapon_3": {"name": "weapon_flashbang",     "type": "Grenade", "state": "holstered"}
+            }
         },
         "auth": {"token": token}
     });
@@ -102,6 +122,21 @@ async fn live_http_receiver_accepts_real_post() {
             let event = captured_event.expect("expected one captured event");
             assert_eq!(event.map_slug, "mirage");
             assert_eq!(event.activity, "playing");
+            // PR 10 additions: typed HUD fields extracted from the fixture.
+            assert_eq!(event.money, Some(4150));
+            assert_eq!(event.helmet, Some(true));
+            assert_eq!(event.defuse_kit, Some(true));
+            assert_eq!(event.equip_value, Some(4250));
+            assert_eq!(event.ct_score, Some(7));
+            assert_eq!(event.t_score, Some(4));
+            assert_eq!(event.round_number, Some(12)); // 0-based 11 → 1-based 12
+            assert_eq!(event.active_weapon.as_deref(), Some("weapon_smokegrenade"));
+            assert_eq!(event.active_utility.as_deref(), Some("smoke"));
+            // Both grenades show up in held_utility_slugs.
+            assert!(event.held_utility_slugs.contains(&"smoke".to_string()));
+            assert!(event.held_utility_slugs.contains(&"flash".to_string()));
+            assert_eq!(event.bomb_state.as_deref(), Some("planted"));
+            assert_eq!(event.provider_timestamp, Some(1747143600));
             // Status snapshot bumped + at least 2 server-status emits
             // (1 on startup + 1 per accepted payload).
             assert!(server_status_count >= 2);

--- a/apps/mygamingassistant/frontend/e2e/live-cs2.spec.ts
+++ b/apps/mygamingassistant/frontend/e2e/live-cs2.spec.ts
@@ -226,6 +226,60 @@ test.describe("Live mode CS2 — simulated Tauri", () => {
     // Panel now visible.
     await expect(page.getByRole("region", { name: /manual override/i })).toBeVisible();
   });
+
+  // PR 10 — override panel now includes a utility-type dropdown.
+  test("Override panel includes utility dropdown with all CS2 grenade slugs", async ({
+    page,
+    request,
+  }) => {
+    await injectFakeTauri(page);
+
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/live/cs2");
+
+    await page.getByRole("button", { name: /^Override$/ }).click();
+    const panel = page.getByRole("region", { name: /manual override/i });
+    await expect(panel).toBeVisible();
+
+    // Utility dropdown has "All utility" + 5 CS2 utility types.
+    const utilitySelect = panel.getByLabel(/Override utility filter/i);
+    await expect(utilitySelect).toBeVisible();
+    await expect(utilitySelect.locator("option")).toHaveCount(6); // All + 5
+  });
+
+  // PR 10 — selecting a utility surfaces a badge in the top bar.
+  test("Override utility selection surfaces a badge in the live top bar", async ({
+    page,
+    request,
+  }) => {
+    await injectFakeTauri(page);
+
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/live/cs2");
+
+    await page.getByRole("button", { name: /^Override$/ }).click();
+    const panel = page.getByRole("region", { name: /manual override/i });
+    await expect(panel).toBeVisible();
+
+    // Pick smoke from the utility dropdown.
+    await panel.getByLabel(/Override utility filter/i).selectOption("smoke");
+
+    // The top bar should now show "Smoke" inside the live-utility test id.
+    await expect(page.getByTestId("live-utility")).toBeVisible();
+    await expect(page.getByTestId("live-utility")).toHaveText("Smoke");
+
+    // Switch to flash; badge updates.
+    await panel.getByLabel(/Override utility filter/i).selectOption("flash");
+    await expect(page.getByTestId("live-utility")).toHaveText("Flash");
+
+    // Switch back to "All utility"; badge disappears.
+    await panel.getByLabel(/Override utility filter/i).selectOption("");
+    await expect(page.getByTestId("live-utility")).toHaveCount(0);
+  });
 });
 
 test.describe("CS2 setup page — simulated Tauri", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/LiveOverridePanel.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LiveOverridePanel.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Tests for LiveOverridePanel — covers the PR 10 utility-override
+ * dropdown interaction.
+ *
+ * The component pulls maps from `useGetMapsQuery`; we mock the entire
+ * `gamesApi` slice so the panel renders without a real Redux store.
+ */
+import { describe, expect, it, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import LiveOverridePanel from "@/components/live/LiveOverridePanel";
+import type { Cs2UtilitySlug, GsiSide } from "@/types/desktop";
+
+// Mock the gamesApi hook the panel calls.
+vi.mock("@/store/gamesApi", () => ({
+  useGetMapsQuery: () => ({
+    data: [
+      { slug: "mirage", name: "Mirage" },
+      { slug: "dust2", name: "Dust II" },
+      { slug: "inferno", name: "Inferno" },
+    ],
+    isLoading: false,
+  }),
+}));
+
+interface OverrideState {
+  enabled: boolean;
+  mapSlug: string;
+  side: GsiSide;
+  utility: Cs2UtilitySlug | null;
+}
+
+const DEFAULT: OverrideState = {
+  enabled: true,
+  mapSlug: "mirage",
+  side: "side_b",
+  utility: null,
+};
+
+describe("LiveOverridePanel — visibility", () => {
+  it("renders nothing when visible=false", () => {
+    const { container } = render(
+      <LiveOverridePanel
+        visible={false}
+        override={DEFAULT}
+        onChange={() => undefined}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders the region landmark when visible=true", () => {
+    render(
+      <LiveOverridePanel
+        visible={true}
+        override={DEFAULT}
+        onChange={() => undefined}
+      />,
+    );
+    expect(
+      screen.getByRole("region", { name: /manual override/i }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe("LiveOverridePanel — utility dropdown (PR 10)", () => {
+  it("renders the utility dropdown with all 5 CS2 utility slugs + All", () => {
+    render(
+      <LiveOverridePanel
+        visible={true}
+        override={DEFAULT}
+        onChange={() => undefined}
+      />,
+    );
+    const select = screen.getByLabelText(/Override utility filter/i) as HTMLSelectElement;
+    const optionTexts = Array.from(select.options).map((o) => o.text);
+    expect(optionTexts).toContain("All utility");
+    expect(optionTexts).toContain("Smoke");
+    expect(optionTexts).toContain("Flash");
+    expect(optionTexts).toContain("Molotov");
+    expect(optionTexts).toContain("HE");
+    expect(optionTexts).toContain("Decoy");
+  });
+
+  it("defaults to 'All utility' when override.utility is null", () => {
+    render(
+      <LiveOverridePanel
+        visible={true}
+        override={{ ...DEFAULT, utility: null }}
+        onChange={() => undefined}
+      />,
+    );
+    const select = screen.getByLabelText(/Override utility filter/i) as HTMLSelectElement;
+    expect(select.value).toBe("");
+  });
+
+  it("propagates the chosen utility slug via onChange", () => {
+    const onChange = vi.fn();
+    render(
+      <LiveOverridePanel
+        visible={true}
+        override={DEFAULT}
+        onChange={onChange}
+      />,
+    );
+    const select = screen.getByLabelText(/Override utility filter/i);
+    fireEvent.change(select, { target: { value: "smoke" } });
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT,
+      utility: "smoke",
+    });
+  });
+
+  it("resets utility to null when 'All utility' is selected", () => {
+    const onChange = vi.fn();
+    render(
+      <LiveOverridePanel
+        visible={true}
+        override={{ ...DEFAULT, utility: "smoke" }}
+        onChange={onChange}
+      />,
+    );
+    const select = screen.getByLabelText(/Override utility filter/i);
+    fireEvent.change(select, { target: { value: "" } });
+    expect(onChange).toHaveBeenCalledWith({
+      ...DEFAULT,
+      utility: null,
+    });
+  });
+
+  it("preserves mapSlug and side when changing utility", () => {
+    const onChange = vi.fn();
+    render(
+      <LiveOverridePanel
+        visible={true}
+        override={{ enabled: true, mapSlug: "dust2", side: "side_a", utility: null }}
+        onChange={onChange}
+      />,
+    );
+    const select = screen.getByLabelText(/Override utility filter/i);
+    fireEvent.change(select, { target: { value: "flash" } });
+    expect(onChange).toHaveBeenCalledWith({
+      enabled: true,
+      mapSlug: "dust2",
+      side: "side_a",
+      utility: "flash",
+    });
+  });
+
+  it("preserves utility when changing map", () => {
+    const onChange = vi.fn();
+    render(
+      <LiveOverridePanel
+        visible={true}
+        override={{ enabled: true, mapSlug: "mirage", side: "side_b", utility: "smoke" }}
+        onChange={onChange}
+      />,
+    );
+    const mapSelect = screen.getAllByRole("combobox")[0];
+    fireEvent.change(mapSelect, { target: { value: "dust2" } });
+    expect(onChange).toHaveBeenCalledWith({
+      enabled: true,
+      mapSlug: "dust2",
+      side: "side_b",
+      utility: "smoke",
+    });
+  });
+});
+
+describe("LiveOverridePanel — set/clear/set utility cycle", () => {
+  it("preserves other override fields across multiple utility changes", () => {
+    const calls: OverrideState[] = [];
+    function record(next: OverrideState) {
+      calls.push(next);
+    }
+
+    // 1st render — default state, set utility to smoke
+    const initialOverride: OverrideState = {
+      enabled: true,
+      mapSlug: "mirage",
+      side: "side_b",
+      utility: null,
+    };
+    const { rerender } = render(
+      <LiveOverridePanel
+        visible={true}
+        override={initialOverride}
+        onChange={record}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Override utility filter/i), {
+      target: { value: "smoke" },
+    });
+
+    // 2nd render — utility=smoke, clear it
+    const afterSet = calls[calls.length - 1];
+    rerender(
+      <LiveOverridePanel
+        visible={true}
+        override={afterSet}
+        onChange={record}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Override utility filter/i), {
+      target: { value: "" },
+    });
+
+    // 3rd render — utility=null, set to flash
+    const afterClear = calls[calls.length - 1];
+    rerender(
+      <LiveOverridePanel
+        visible={true}
+        override={afterClear}
+        onChange={record}
+      />,
+    );
+    fireEvent.change(screen.getByLabelText(/Override utility filter/i), {
+      target: { value: "flash" },
+    });
+
+    const final = calls[calls.length - 1];
+    expect(final.utility).toBe("flash");
+    expect(final.mapSlug).toBe("mirage");
+    expect(final.side).toBe("side_b");
+    expect(final.enabled).toBe(true);
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/LiveTopBar.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LiveTopBar.test.tsx
@@ -1,15 +1,48 @@
 /**
- * Tests for LiveTopBar — its pure helpers + a couple of full-component
- * render assertions. The component is presentational only (no state), so
- * exhaustive testing focuses on the helpers.
+ * Tests for LiveTopBar — its pure helpers + full-component render
+ * assertions. The component is presentational only (no state), so most
+ * tests focus on the helpers + the segment-by-segment rendering rules
+ * introduced in PR 10.
  */
 import { describe, expect, it } from "vitest";
 import { render, screen } from "@testing-library/react";
 import LiveTopBar from "@/components/live/LiveTopBar";
+import type { LiveBarFields } from "@/lib/gsi";
 import {
   connectionStateFromProps,
   formatLastEventTime,
+  formatZone,
+  roundPhaseChipClasses,
 } from "@/components/live/liveTopBarUtils";
+
+// ---------------------------------------------------------------------------
+// Helper: build a complete LiveBarFields fixture with optional overrides.
+// Avoids 7 hard-coded null fields in every test that doesn't care about them.
+// ---------------------------------------------------------------------------
+function buildLiveBar(overrides: Partial<LiveBarFields> = {}): LiveBarFields {
+  return {
+    mapDisplay: "Mirage",
+    sideDisplay: "CT",
+    phaseDisplay: "Live",
+    roundPhaseDisplay: null,
+    scoreDisplay: null,
+    moneyDisplay: null,
+    equipExtra: "",
+    bombDisplay: null,
+    ...overrides,
+  };
+}
+
+const DEFAULT_OVERRIDE = {
+  enabled: false,
+  mapSlug: "",
+  side: "any" as const,
+  utility: null,
+};
+
+// ===========================================================================
+// connectionStateFromProps
+// ===========================================================================
 
 describe("connectionStateFromProps", () => {
   it("returns Initializing when not ready", () => {
@@ -36,6 +69,10 @@ describe("connectionStateFromProps", () => {
   });
 });
 
+// ===========================================================================
+// formatLastEventTime
+// ===========================================================================
+
 describe("formatLastEventTime", () => {
   const NOW = new Date("2026-05-13T10:00:00Z");
 
@@ -60,7 +97,45 @@ describe("formatLastEventTime", () => {
   });
 });
 
-describe("LiveTopBar component", () => {
+// ===========================================================================
+// formatZone + roundPhaseChipClasses (PR 10 helpers)
+// ===========================================================================
+
+describe("formatZone", () => {
+  it("returns null for null/empty inputs", () => {
+    expect(formatZone(null)).toBeNull();
+    expect(formatZone("")).toBeNull();
+    expect(formatZone(undefined)).toBeNull();
+  });
+  it("capitalizes kebab-case slugs", () => {
+    expect(formatZone("a-site")).toBe("A Site");
+    expect(formatZone("b-apts")).toBe("B Apts");
+  });
+  it("capitalizes snake_case slugs", () => {
+    expect(formatZone("ct_spawn")).toBe("Ct Spawn");
+  });
+});
+
+describe("roundPhaseChipClasses", () => {
+  it("picks sky tint for Freezetime", () => {
+    expect(roundPhaseChipClasses("Freezetime")).toContain("sky");
+  });
+  it("picks green tint for Live", () => {
+    expect(roundPhaseChipClasses("Live")).toContain("green");
+  });
+  it("picks muted tint for Over", () => {
+    expect(roundPhaseChipClasses("Over")).toContain("muted");
+  });
+  it("falls back to a neutral default for unknown labels", () => {
+    expect(roundPhaseChipClasses("???")).toContain("muted");
+  });
+});
+
+// ===========================================================================
+// LiveTopBar — base rendering
+// ===========================================================================
+
+describe("LiveTopBar component — base rendering", () => {
   it("shows 'Waiting for CS2' when no event yet", () => {
     render(
       <LiveTopBar
@@ -69,14 +144,11 @@ describe("LiveTopBar component", () => {
         payloadsReceived={0}
         lastEventAt={undefined}
         liveBar={null}
-        override={{ enabled: false, mapSlug: "", side: "any" }}
+        override={DEFAULT_OVERRIDE}
         onOverrideToggle={() => undefined}
       />,
     );
     expect(screen.getByText(/Waiting for CS2/i)).toBeInTheDocument();
-    // Connection-state label flips to "Waiting" — distinct element from
-    // the "Waiting for CS2…" placeholder. Match via aria-label so we don't
-    // pick up the placeholder text.
     expect(
       screen.getByLabelText(/Receiver: Waiting/i),
     ).toBeInTheDocument();
@@ -89,22 +161,14 @@ describe("LiveTopBar component", () => {
         running={true}
         payloadsReceived={5}
         lastEventAt={undefined}
-        liveBar={{
-          mapDisplay: "Mirage",
-          sideDisplay: "CT",
-          phaseDisplay: "Live",
-        }}
-        override={{ enabled: false, mapSlug: "", side: "any" }}
+        liveBar={buildLiveBar()}
+        override={DEFAULT_OVERRIDE}
         onOverrideToggle={() => undefined}
       />,
     );
-    // Map / side / phase are split across nested <span>s. Assert on the
-    // header's full textContent so we don't depend on DOM structure.
     const headerText = container.textContent ?? "";
     expect(headerText).toContain("Mirage");
     expect(headerText).toContain("CT");
-    expect(headerText).toContain("Live");
-    // Status label flips to Connected when payloads > 0.
     expect(screen.getByLabelText(/Receiver: Connected/i)).toBeInTheDocument();
   });
 
@@ -116,7 +180,7 @@ describe("LiveTopBar component", () => {
         payloadsReceived={0}
         lastEventAt={undefined}
         liveBar={null}
-        override={{ enabled: true, mapSlug: "dust2", side: "side_a" }}
+        override={{ enabled: true, mapSlug: "dust2", side: "side_a", utility: null }}
         onOverrideToggle={() => undefined}
       />,
     );
@@ -126,8 +190,13 @@ describe("LiveTopBar component", () => {
     expect(headerText).toContain("(override)");
     expect(screen.getByRole("button", { pressed: true })).toBeInTheDocument();
   });
+});
 
-  // PR 9a — zone segment
+// ===========================================================================
+// LiveTopBar — zone segment (PR 9a)
+// ===========================================================================
+
+describe("LiveTopBar — zone segment (PR 9a)", () => {
   it("does NOT render zone segment when zoneSlug is null", () => {
     render(
       <LiveTopBar
@@ -135,12 +204,8 @@ describe("LiveTopBar component", () => {
         running={true}
         payloadsReceived={5}
         lastEventAt={undefined}
-        liveBar={{
-          mapDisplay: "Mirage",
-          sideDisplay: "CT",
-          phaseDisplay: "Live",
-        }}
-        override={{ enabled: false, mapSlug: "", side: "any" }}
+        liveBar={buildLiveBar()}
+        override={DEFAULT_OVERRIDE}
         onOverrideToggle={() => undefined}
         zoneSlug={null}
       />,
@@ -155,12 +220,8 @@ describe("LiveTopBar component", () => {
         running={true}
         payloadsReceived={5}
         lastEventAt={undefined}
-        liveBar={{
-          mapDisplay: "Mirage",
-          sideDisplay: "CT",
-          phaseDisplay: "Live",
-        }}
-        override={{ enabled: false, mapSlug: "", side: "any" }}
+        liveBar={buildLiveBar()}
+        override={DEFAULT_OVERRIDE}
         onOverrideToggle={() => undefined}
         zoneSlug="b-site"
       />,
@@ -177,12 +238,8 @@ describe("LiveTopBar component", () => {
         running={true}
         payloadsReceived={5}
         lastEventAt={undefined}
-        liveBar={{
-          mapDisplay: "Mirage",
-          sideDisplay: "CT",
-          phaseDisplay: "Live",
-        }}
-        override={{ enabled: false, mapSlug: "", side: "any" }}
+        liveBar={buildLiveBar()}
+        override={DEFAULT_OVERRIDE}
         onOverrideToggle={() => undefined}
         zoneSlug="b-apts"
       />,
@@ -198,14 +255,181 @@ describe("LiveTopBar component", () => {
         payloadsReceived={0}
         lastEventAt={undefined}
         liveBar={null}
-        override={{ enabled: true, mapSlug: "dust2", side: "side_a" }}
+        override={{ enabled: true, mapSlug: "dust2", side: "side_a", utility: null }}
         onOverrideToggle={() => undefined}
         zoneSlug="a-site"
       />,
     );
-    // Even though zoneSlug is set, override mode hides the zone segment —
-    // the operator is manually picking map+side; zone narrowing doesn't
-    // apply.
     expect(screen.queryByTestId("live-zone")).not.toBeInTheDocument();
+  });
+});
+
+// ===========================================================================
+// LiveTopBar — PR 10: utility badge
+// ===========================================================================
+
+describe("LiveTopBar — utility badge (PR 10)", () => {
+  it("does NOT render utility badge when filter is null", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar()}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+        utilityFilter={null}
+      />,
+    );
+    expect(screen.queryByTestId("live-utility")).not.toBeInTheDocument();
+  });
+
+  it("renders utility badge with the label of a single slug filter", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar()}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+        utilityFilter={["smoke"]}
+      />,
+    );
+    const utility = screen.getByTestId("live-utility");
+    expect(utility.textContent).toBe("Smoke");
+  });
+
+  it("renders +N indicator when multiple utility slugs are filtered", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar()}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+        utilityFilter={["smoke", "flash", "grenade"]}
+      />,
+    );
+    const utility = screen.getByTestId("live-utility");
+    expect(utility.textContent).toBe("Smoke +2");
+  });
+
+  it("renders override utility label when override is enabled", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={0}
+        lastEventAt={undefined}
+        liveBar={null}
+        override={{ enabled: true, mapSlug: "mirage", side: "side_b", utility: "flash" }}
+        onOverrideToggle={() => undefined}
+      />,
+    );
+    const utility = screen.getByTestId("live-utility");
+    expect(utility.textContent).toBe("Flash");
+  });
+});
+
+// ===========================================================================
+// LiveTopBar — PR 10: score / money / bomb / round phase segments
+// ===========================================================================
+
+describe("LiveTopBar — expanded HUD segments (PR 10)", () => {
+  it("renders the score segment when both scores present", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar({ scoreDisplay: "12-8" })}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId("live-score").textContent).toBe("12-8");
+  });
+
+  it("hides the score segment when scoreDisplay is null", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar({ scoreDisplay: null })}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+      />,
+    );
+    expect(screen.queryByTestId("live-score")).not.toBeInTheDocument();
+  });
+
+  it("renders money segment with equipExtra suffix when present", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar({ moneyDisplay: "$4,150", equipExtra: " +kit" })}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+      />,
+    );
+    const money = screen.getByTestId("live-money");
+    expect(money.textContent).toContain("$4,150");
+    expect(money.textContent).toContain("+kit");
+  });
+
+  it("renders bomb segment when bombDisplay is set", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar({ bombDisplay: "💣 planted" })}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId("live-bomb").textContent).toContain("planted");
+  });
+
+  it("renders round-phase chip when roundPhaseDisplay is set", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar({ roundPhaseDisplay: "Freezetime" })}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+      />,
+    );
+    expect(screen.getByTestId("live-round-phase").textContent).toBe("Freezetime");
+  });
+
+  it("hides round-phase chip when roundPhaseDisplay is null", () => {
+    render(
+      <LiveTopBar
+        ready={true}
+        running={true}
+        payloadsReceived={5}
+        lastEventAt={undefined}
+        liveBar={buildLiveBar()}
+        override={DEFAULT_OVERRIDE}
+        onOverrideToggle={() => undefined}
+      />,
+    );
+    expect(screen.queryByTestId("live-round-phase")).not.toBeInTheDocument();
   });
 });

--- a/apps/mygamingassistant/frontend/src/__tests__/gsi.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/gsi.test.ts
@@ -6,12 +6,19 @@
  *   - `useGsiState` subscribes to `gsi:state-update` + `gsi:server-status`
  *     under Tauri and surfaces emitted payloads
  *   - `useGsiState` unsubscribes on unmount
- *   - `summarizeLiveBar` formats fields correctly
+ *   - `summarizeLiveBar` formats fields correctly — base PR 8 shape +
+ *     PR 10 score/money/bomb/round-phase additions
  *   - `summarizeLiveBar` returns null for empty / null events
+ *   - `computeLineupUtilityFilter` follows the override → active → held
+ *     preference order (PR 10)
  */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { act, renderHook, waitFor } from "@testing-library/react";
-import { summarizeLiveBar, useGsiState } from "@/lib/gsi";
+import {
+  computeLineupUtilityFilter,
+  summarizeLiveBar,
+  useGsiState,
+} from "@/lib/gsi";
 import type { GsiEvent, GsiServerStatus } from "@/types/desktop";
 
 // Mock both the dynamic event listener and the dynamic invoke API.
@@ -34,6 +41,21 @@ function clearTauri() {
   if ("__TAURI_INTERNALS__" in window) {
     delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
   }
+}
+
+// Helper: build a minimal GsiEvent for tests. Avoids 10+ null fields in
+// every individual test (especially after PR 10 added typed HUD fields).
+function buildEvent(overrides: Partial<GsiEvent> = {}): GsiEvent {
+  return {
+    map_slug: "",
+    map_phase: "",
+    side: "any",
+    round_phase: "",
+    activity: "",
+    held_utility_slugs: [],
+    received_at: "2026-05-13T10:00:00Z",
+    ...overrides,
+  };
 }
 
 describe("useGsiState on web (no Tauri)", () => {
@@ -98,17 +120,22 @@ describe("useGsiState under Tauri", () => {
       port: 8765,
     });
 
-    // Simulate a pushed event.
+    // Simulate a pushed event with PR 10 typed fields populated.
     await act(async () => {
       stateUpdateHandler?.({
-        payload: {
+        payload: buildEvent({
           map_slug: "mirage",
           map_phase: "live",
           side: "side_a",
           round_phase: "freezetime",
           activity: "playing",
-          received_at: "2026-05-13T10:00:00Z",
-        },
+          money: 4150,
+          ct_score: 3,
+          t_score: 2,
+          active_weapon: "weapon_smokegrenade",
+          active_utility: "smoke",
+          held_utility_slugs: ["smoke", "flash"],
+        }),
       });
       serverStatusHandler?.({
         payload: {
@@ -123,6 +150,8 @@ describe("useGsiState under Tauri", () => {
 
     expect(result.current.event?.map_slug).toBe("mirage");
     expect(result.current.event?.side).toBe("side_a");
+    expect(result.current.event?.active_utility).toBe("smoke");
+    expect(result.current.event?.held_utility_slugs).toEqual(["smoke", "flash"]);
     expect(result.current.status?.payloads_received).toBe(1);
   });
 
@@ -149,61 +178,237 @@ describe("useGsiState under Tauri", () => {
   });
 });
 
+// ===========================================================================
+// summarizeLiveBar
+// ===========================================================================
+
 describe("summarizeLiveBar", () => {
   it("returns null for null event", () => {
     expect(summarizeLiveBar(null)).toBeNull();
   });
 
   it("returns null when map_slug and map_phase are empty (menu state)", () => {
-    const result = summarizeLiveBar({
-      map_slug: "",
-      map_phase: "",
-      side: "any",
-      round_phase: "",
-      activity: "menu",
-      received_at: "2026-05-13T10:00:00Z",
-    });
-    expect(result).toBeNull();
+    expect(
+      summarizeLiveBar(buildEvent({ activity: "menu" })),
+    ).toBeNull();
   });
 
   it("capitalizes map name and translates side and phase", () => {
-    const result = summarizeLiveBar({
-      map_slug: "mirage",
-      map_phase: "live",
-      side: "side_b",
-      round_phase: "live",
-      activity: "playing",
-      received_at: "2026-05-13T10:00:00Z",
-    });
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "mirage",
+        map_phase: "live",
+        side: "side_b",
+        round_phase: "live",
+        activity: "playing",
+      }),
+    );
     expect(result).not.toBeNull();
     expect(result!.mapDisplay).toBe("Mirage");
     expect(result!.sideDisplay).toBe("CT");
     expect(result!.phaseDisplay).toBe("Live");
+    expect(result!.roundPhaseDisplay).toBe("Live");
   });
 
   it("capitalizes multi-word slugs with dashes", () => {
-    const result = summarizeLiveBar({
-      map_slug: "train",
-      map_phase: "warmup",
-      side: "side_a",
-      round_phase: "freezetime",
-      activity: "playing",
-      received_at: "2026-05-13T10:00:00Z",
-    });
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "train",
+        map_phase: "warmup",
+        side: "side_a",
+        round_phase: "freezetime",
+        activity: "playing",
+      }),
+    );
     expect(result!.mapDisplay).toBe("Train");
     expect(result!.sideDisplay).toBe("T");
     expect(result!.phaseDisplay).toBe("Warmup");
+    expect(result!.roundPhaseDisplay).toBe("Freezetime");
   });
 
   it("falls back to slug for unknown phase", () => {
-    const result = summarizeLiveBar({
-      map_slug: "anubis",
-      map_phase: "weird_new_phase",
-      side: "any",
-      round_phase: "",
-      activity: "",
-      received_at: "2026-05-13T10:00:00Z",
-    });
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "anubis",
+        map_phase: "weird_new_phase",
+        side: "any",
+      }),
+    );
     expect(result!.phaseDisplay).toBe("weird_new_phase");
+  });
+
+  // ----- PR 10: score / money / bomb / round-phase / equip-extra -----
+
+  it("formats money with thousands separator", () => {
+    const result = summarizeLiveBar(
+      buildEvent({ map_slug: "mirage", map_phase: "live", money: 4150 }),
+    );
+    expect(result!.moneyDisplay).toBe("$4,150");
+  });
+
+  it("renders moneyDisplay as null when money is missing", () => {
+    const result = summarizeLiveBar(
+      buildEvent({ map_slug: "mirage", map_phase: "live" }),
+    );
+    expect(result!.moneyDisplay).toBeNull();
+  });
+
+  it("formats score as CT-T order regardless of player side", () => {
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "mirage",
+        map_phase: "live",
+        side: "side_a",
+        ct_score: 12,
+        t_score: 8,
+      }),
+    );
+    expect(result!.scoreDisplay).toBe("12-8");
+  });
+
+  it("renders scoreDisplay as null when only one score is present", () => {
+    const result = summarizeLiveBar(
+      buildEvent({ map_slug: "mirage", map_phase: "live", ct_score: 12 }),
+    );
+    expect(result!.scoreDisplay).toBeNull();
+  });
+
+  it("surfaces +kit when helmet + armor>0", () => {
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "mirage",
+        map_phase: "live",
+        helmet: true,
+        armor: 100,
+      }),
+    );
+    expect(result!.equipExtra).toBe(" +kit");
+  });
+
+  it("does NOT show +kit when armor is 0 (helmet flag stale)", () => {
+    // CS2 leaves the helmet flag true even after armor depletes — we
+    // suppress the +kit display because the player is effectively
+    // helmet-less for damage purposes.
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "mirage",
+        map_phase: "live",
+        helmet: true,
+        armor: 0,
+      }),
+    );
+    expect(result!.equipExtra).toBe("");
+  });
+
+  it("surfaces +defuse for CT with defuse kit but no helmet", () => {
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "mirage",
+        map_phase: "live",
+        defuse_kit: true,
+      }),
+    );
+    expect(result!.equipExtra).toBe(" +defuse");
+  });
+
+  it("combines +kit and +defuse when both present", () => {
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "mirage",
+        map_phase: "live",
+        helmet: true,
+        armor: 100,
+        defuse_kit: true,
+      }),
+    );
+    expect(result!.equipExtra).toBe(" +kit +defuse");
+  });
+
+  it("emits the bomb-state label", () => {
+    const result = summarizeLiveBar(
+      buildEvent({
+        map_slug: "mirage",
+        map_phase: "live",
+        bomb_state: "planted",
+      }),
+    );
+    expect(result!.bombDisplay).toContain("planted");
+  });
+
+  it("emits bombDisplay null when bomb_state is null/undefined", () => {
+    const result = summarizeLiveBar(
+      buildEvent({ map_slug: "mirage", map_phase: "live" }),
+    );
+    expect(result!.bombDisplay).toBeNull();
+  });
+});
+
+// ===========================================================================
+// computeLineupUtilityFilter — PR 10's three-tier preference order
+// ===========================================================================
+
+describe("computeLineupUtilityFilter", () => {
+  it("returns the override slug when set, ignoring active/held", () => {
+    const result = computeLineupUtilityFilter({
+      overrideSlug: "flash",
+      activeUtilitySlug: "smoke",
+      heldUtilitySlugs: ["smoke", "grenade"],
+    });
+    expect(result).toEqual(["flash"]);
+  });
+
+  it("returns the active slug when no override, ignoring held", () => {
+    const result = computeLineupUtilityFilter({
+      overrideSlug: null,
+      activeUtilitySlug: "smoke",
+      heldUtilitySlugs: ["smoke", "grenade"],
+    });
+    expect(result).toEqual(["smoke"]);
+  });
+
+  it("returns held slugs when no override and no active", () => {
+    const result = computeLineupUtilityFilter({
+      overrideSlug: null,
+      activeUtilitySlug: null,
+      heldUtilitySlugs: ["smoke", "flash"],
+    });
+    expect(result).toEqual(["smoke", "flash"]);
+  });
+
+  it("returns null when no override, no active, and no held", () => {
+    const result = computeLineupUtilityFilter({
+      overrideSlug: null,
+      activeUtilitySlug: null,
+      heldUtilitySlugs: [],
+    });
+    expect(result).toBeNull();
+  });
+
+  it("returns null when all inputs are null", () => {
+    const result = computeLineupUtilityFilter({
+      overrideSlug: null,
+      activeUtilitySlug: null,
+      heldUtilitySlugs: null,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("treats undefined inputs like null (defensive for GSI passthrough)", () => {
+    const result = computeLineupUtilityFilter({
+      overrideSlug: null,
+      activeUtilitySlug: undefined,
+      heldUtilitySlugs: undefined,
+    });
+    expect(result).toBeNull();
+  });
+
+  it("does not mutate the original held array", () => {
+    const held = ["smoke", "flash"];
+    computeLineupUtilityFilter({
+      overrideSlug: null,
+      activeUtilitySlug: null,
+      heldUtilitySlugs: held,
+    });
+    expect(held).toEqual(["smoke", "flash"]);
   });
 });

--- a/apps/mygamingassistant/frontend/src/components/live/LiveOverridePanel.tsx
+++ b/apps/mygamingassistant/frontend/src/components/live/LiveOverridePanel.tsx
@@ -1,11 +1,13 @@
 /**
  * LiveOverridePanel — collapsible row under the LiveTopBar that lets the
- * operator force a specific (map, side) without CS2 running.
+ * operator force a specific (map, side, utility) without CS2 running.
  *
  * Use cases:
  *   1. Pre-match prep — load a map on the desktop while not in-game.
  *   2. Testing — verify the lineup strip works without launching CS2.
  *   3. Spectating — drive the display manually while watching a friend.
+ *   4. (PR 10) Browsing utility — pick "show me only Smokes for B Site"
+ *      without needing CS2 to send a weapons block.
  *
  * Map options are hardcoded to the active-duty CS2 map pool; this matches
  * the backend `cs2_maps.json` fixture's existing slugs. Workshop maps and
@@ -13,12 +15,16 @@
  * mode via F1 for those.
  */
 import { useGetMapsQuery } from "@/store/gamesApi";
-import type { GsiSide } from "@/types/desktop";
+import type { Cs2UtilitySlug, GsiSide } from "@/types/desktop";
+import { CS2_UTILITY_LABELS, CS2_UTILITY_SLUGS } from "@/types/desktop";
 
 interface OverrideState {
   enabled: boolean;
   mapSlug: string;
   side: GsiSide;
+  /** Manual utility-type override (PR 10). `null` = no utility filter
+   *  applied; the operator wants to see ALL utility for the (map, side). */
+  utility: Cs2UtilitySlug | null;
 }
 
 interface LiveOverridePanelProps {
@@ -37,6 +43,21 @@ export default function LiveOverridePanel({
   const { data: maps = [], isLoading } = useGetMapsQuery("cs2", { skip: !visible });
 
   if (!visible) return null;
+
+  // Sentinel used in the utility <select>'s "All" option. The DOM <select>
+  // can't carry a real null value, so we round-trip the empty string.
+  const ALL_UTILITY_VALUE = "";
+
+  function handleUtilityChange(rawValue: string) {
+    if (rawValue === ALL_UTILITY_VALUE) {
+      onChange({ ...override, utility: null });
+      return;
+    }
+    // The <option> values are all drawn from CS2_UTILITY_SLUGS so the cast
+    // is safe; an unexpected value here would indicate DOM tampering, not
+    // a normal code path.
+    onChange({ ...override, utility: rawValue as Cs2UtilitySlug });
+  }
 
   return (
     <div
@@ -78,6 +99,24 @@ export default function LiveOverridePanel({
           <option value="any">Any</option>
           <option value="side_a">T (side_a)</option>
           <option value="side_b">CT (side_b)</option>
+        </select>
+      </label>
+
+      {/* PR 10 — utility-type override dropdown */}
+      <label className="flex items-center gap-2 text-xs">
+        <span className="text-muted-foreground">Utility:</span>
+        <select
+          value={override.utility ?? ALL_UTILITY_VALUE}
+          onChange={(e) => handleUtilityChange(e.target.value)}
+          aria-label="Override utility filter"
+          className="px-2 py-1 rounded-md border bg-card text-xs min-h-[28px]"
+        >
+          <option value={ALL_UTILITY_VALUE}>All utility</option>
+          {CS2_UTILITY_SLUGS.map((slug) => (
+            <option key={slug} value={slug}>
+              {CS2_UTILITY_LABELS[slug]}
+            </option>
+          ))}
         </select>
       </label>
 

--- a/apps/mygamingassistant/frontend/src/components/live/LiveTopBar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/live/LiveTopBar.tsx
@@ -1,8 +1,13 @@
 /**
  * LiveTopBar — header strip shown on the `/live/cs2` page.
  *
- * Layout (single row, fixed height):
- *   [ Mirage · CT · Live ] [override toggle] [conn status]
+ * PR 10 expanded the layout from PR 9a's [map · side · zone · phase] to:
+ *
+ *   [ Mirage · CT · B Site · 💣 planted ] [|] [12-8] [|] [$4150 +kit] [phase]
+ *
+ * The bar collapses gracefully when individual fields aren't available
+ * (e.g., score is null in warmup, bomb_state is null pre-plant) — each
+ * segment is independently null-safe and the divider rules adapt.
  *
  * Receives all state via props so it stays a dumb presentational component;
  * the parent (LiveCs2) is the only stateful consumer of `useGsiState`.
@@ -11,13 +16,21 @@
  * components (keeps fast-refresh happy).
  */
 import { Antenna, Lock, Unlock } from "lucide-react";
-import type { GsiSide } from "@/types/desktop";
+import type { Cs2UtilitySlug, GsiSide } from "@/types/desktop";
+import { CS2_UTILITY_LABELS } from "@/types/desktop";
 import type { LiveBarFields } from "@/lib/gsi";
 import {
   connectionStateFromProps,
   formatLastEventTime,
+  roundPhaseChipClasses,
+  formatZone,
 } from "@/components/live/liveTopBarUtils";
 
+/**
+ * Full set of inputs the bar needs. Split into a typed shape so the
+ * component signature stays readable and tests can pass deliberate
+ * fixtures.
+ */
 interface LiveTopBarProps {
   /** True once `useGsiState` has finished its initial subscribe + bootstrap. */
   ready: boolean;
@@ -30,16 +43,32 @@ interface LiveTopBarProps {
   /** Summarized GSI fields for display, or `null` if no event yet. */
   liveBar: LiveBarFields | null;
   /** Override panel state. */
-  override: { enabled: boolean; mapSlug: string; side: GsiSide };
+  override: OverrideState;
   /** Toggle the override panel. */
   onOverrideToggle: (enabled: boolean) => void;
   /**
    * Detected zone slug from the CV pipeline (PR 9a). When non-null, the
-   * top bar displays it as a fourth segment: "Mirage · CT · B Site · Live".
-   * When null, the segment is omitted entirely (matches PR 8 layout).
+   * top bar displays it as a fourth segment. When null, the segment is
+   * omitted entirely (matches PR 8 layout).
    * Optional so the prop change is non-breaking — older callers don't pass it.
    */
   zoneSlug?: string | null;
+  /**
+   * Effective utility filter slugs for the lineup query (PR 10). When
+   * non-null AND of length 1, displayed as a small badge so the operator
+   * can see at a glance what's being narrowed.
+   * Optional so the prop change is non-breaking.
+   */
+  utilityFilter?: readonly string[] | null;
+}
+
+/** Override panel state — extracted into a named interface per the
+ *  "extract inline anonymous shapes" preference. */
+interface OverrideState {
+  enabled: boolean;
+  mapSlug: string;
+  side: GsiSide;
+  utility: Cs2UtilitySlug | null;
 }
 
 export default function LiveTopBar({
@@ -51,49 +80,28 @@ export default function LiveTopBar({
   override,
   onOverrideToggle,
   zoneSlug,
+  utilityFilter,
 }: LiveTopBarProps) {
   return (
-    <header className="flex items-center gap-3 px-3 py-2 border-b bg-card/70">
+    <header className="flex flex-wrap items-center gap-x-3 gap-y-1 px-3 py-2 border-b bg-card/70">
       <ConnectionDot ready={ready} running={running} payloadsReceived={payloadsReceived} />
       <DetectedStateDisplay
         override={override}
         liveBar={liveBar}
         zoneSlug={zoneSlug ?? null}
+        utilityFilter={utilityFilter ?? null}
       />
 
-      <button
-        type="button"
-        onClick={() => onOverrideToggle(!override.enabled)}
-        className={[
-          "ml-auto inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs border transition-colors min-h-[28px]",
-          override.enabled
-            ? "bg-amber-500/15 border-amber-500/40 text-amber-700 dark:text-amber-400"
-            : "bg-card hover:bg-muted/40",
-        ].join(" ")}
-        aria-pressed={override.enabled}
-        title={
-          override.enabled
-            ? "Manual override active — click to disable and follow CS2 again"
-            : "Override the auto-detected map/side"
-        }
-      >
-        {override.enabled ? (
-          <>
-            <Lock className="w-3 h-3" aria-hidden />
-            Override on
-          </>
-        ) : (
-          <>
-            <Unlock className="w-3 h-3" aria-hidden />
-            Override
-          </>
-        )}
-      </button>
+      <OverrideToggle override={override} onToggle={onOverrideToggle} />
 
       <LastEventTimestamp lastEventAt={lastEventAt} />
     </header>
   );
 }
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
 
 interface ConnectionDotProps {
   ready: boolean;
@@ -115,39 +123,69 @@ function ConnectionDot({ ready, running, payloadsReceived }: ConnectionDotProps)
   );
 }
 
+interface OverrideToggleProps {
+  override: OverrideState;
+  onToggle: (enabled: boolean) => void;
+}
+
+function OverrideToggle({ override, onToggle }: OverrideToggleProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => onToggle(!override.enabled)}
+      className={[
+        "ml-auto inline-flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs border transition-colors min-h-[28px]",
+        override.enabled
+          ? "bg-amber-500/15 border-amber-500/40 text-amber-700 dark:text-amber-400"
+          : "bg-card hover:bg-muted/40",
+      ].join(" ")}
+      aria-pressed={override.enabled}
+      title={
+        override.enabled
+          ? "Manual override active — click to disable and follow CS2 again"
+          : "Override the auto-detected map/side/utility"
+      }
+    >
+      {override.enabled ? <OverrideOnLabel /> : <OverrideOffLabel />}
+    </button>
+  );
+}
+
+function OverrideOnLabel() {
+  return (
+    <>
+      <Lock className="w-3 h-3" aria-hidden />
+      Override on
+    </>
+  );
+}
+
+function OverrideOffLabel() {
+  return (
+    <>
+      <Unlock className="w-3 h-3" aria-hidden />
+      Override
+    </>
+  );
+}
+
 interface DetectedStateDisplayProps {
-  override: { enabled: boolean; mapSlug: string; side: GsiSide };
+  override: OverrideState;
   liveBar: LiveBarFields | null;
   /** Detected zone from CV pipeline. Null = omitted. */
   zoneSlug: string | null;
-}
-
-/** Format a zone slug for display. Same shape as `formatZoneDisplay` in
- *  `lib/cv.ts` — duplicated here so the LiveTopBar component file doesn't
- *  have to import from `lib/` (keeps it a pure presentational component). */
-function formatZone(slug: string | null): string | null {
-  if (!slug) return null;
-  return slug.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  /** Active utility filter being applied to the lineup query. */
+  utilityFilter: readonly string[] | null;
 }
 
 function DetectedStateDisplay({
   override,
   liveBar,
   zoneSlug,
+  utilityFilter,
 }: DetectedStateDisplayProps) {
-  // Zone is only meaningful when we're following live detection. The
-  // override flow hides it (the operator is manually picking a map/side).
-  const zoneText = !override.enabled ? formatZone(zoneSlug) : null;
-
   if (override.enabled) {
-    return (
-      <span className="text-sm font-medium">
-        {override.mapSlug || "—"}
-        <span className="text-muted-foreground mx-1">·</span>
-        {override.side === "any" ? "Any" : override.side === "side_a" ? "T" : "CT"}
-        <span className="text-muted-foreground ml-2 text-xs">(override)</span>
-      </span>
-    );
+    return <OverrideStateLine override={override} />;
   }
   if (!liveBar) {
     return (
@@ -157,20 +195,118 @@ function DetectedStateDisplay({
     );
   }
   return (
+    <LiveStateLine
+      liveBar={liveBar}
+      zoneSlug={zoneSlug}
+      utilityFilter={utilityFilter}
+    />
+  );
+}
+
+function OverrideStateLine({ override }: { override: OverrideState }) {
+  const sideLabel =
+    override.side === "any"
+      ? "Any"
+      : override.side === "side_a"
+        ? "T"
+        : "CT";
+  const utilityLabel = override.utility
+    ? CS2_UTILITY_LABELS[override.utility]
+    : null;
+  return (
     <span className="text-sm font-medium">
-      {liveBar.mapDisplay}
-      <span className="text-muted-foreground mx-1">·</span>
-      {liveBar.sideDisplay}
+      {override.mapSlug || "—"}
+      <Divider />
+      {sideLabel}
+      {utilityLabel && (
+        <>
+          <Divider />
+          <span data-testid="live-utility">{utilityLabel}</span>
+        </>
+      )}
+      <span className="text-muted-foreground ml-2 text-xs">(override)</span>
+    </span>
+  );
+}
+
+interface LiveStateLineProps {
+  liveBar: LiveBarFields;
+  zoneSlug: string | null;
+  utilityFilter: readonly string[] | null;
+}
+
+function LiveStateLine({ liveBar, zoneSlug, utilityFilter }: LiveStateLineProps) {
+  const zoneText = formatZone(zoneSlug);
+  const utilityBadgeText = utilityBadgeFromFilter(utilityFilter);
+
+  return (
+    <span className="text-sm font-medium flex items-baseline flex-wrap gap-x-1">
+      <span>{liveBar.mapDisplay}</span>
+      <Divider />
+      <span>{liveBar.sideDisplay}</span>
       {zoneText && (
         <>
-          <span className="text-muted-foreground mx-1">·</span>
+          <Divider />
           <span data-testid="live-zone">{zoneText}</span>
         </>
       )}
-      <span className="text-muted-foreground mx-1">·</span>
-      <span className="text-muted-foreground">{liveBar.phaseDisplay}</span>
+      {utilityBadgeText && (
+        <>
+          <Divider />
+          <span data-testid="live-utility" className="px-1.5 py-0.5 text-xs rounded bg-muted/50">
+            {utilityBadgeText}
+          </span>
+        </>
+      )}
+      {liveBar.bombDisplay && (
+        <>
+          <Divider />
+          <span data-testid="live-bomb" className="text-orange-500 dark:text-orange-400">
+            {liveBar.bombDisplay}
+          </span>
+        </>
+      )}
+      <SectionSeparator />
+      {liveBar.scoreDisplay && (
+        <>
+          <span data-testid="live-score" className="text-muted-foreground">
+            {liveBar.scoreDisplay}
+          </span>
+          <SectionSeparator />
+        </>
+      )}
+      {liveBar.moneyDisplay && (
+        <>
+          <span data-testid="live-money" className="text-muted-foreground">
+            {liveBar.moneyDisplay}
+            {liveBar.equipExtra && (
+              <span className="ml-0.5 text-xs opacity-80">{liveBar.equipExtra}</span>
+            )}
+          </span>
+          <SectionSeparator />
+        </>
+      )}
+      {liveBar.roundPhaseDisplay && (
+        <span
+          data-testid="live-round-phase"
+          className={[
+            "px-1.5 py-0.5 text-xs rounded",
+            roundPhaseChipClasses(liveBar.roundPhaseDisplay),
+          ].join(" ")}
+        >
+          {liveBar.roundPhaseDisplay}
+        </span>
+      )}
     </span>
   );
+}
+
+function Divider() {
+  return <span className="text-muted-foreground mx-1">·</span>;
+}
+
+function SectionSeparator() {
+  return <span className="text-muted-foreground/60 mx-1.5">|</span>;
 }
 
 function LastEventTimestamp({ lastEventAt }: { lastEventAt: string | undefined }) {
@@ -180,4 +316,23 @@ function LastEventTimestamp({ lastEventAt }: { lastEventAt: string | undefined }
       Last: {formatLastEventTime(lastEventAt)}
     </span>
   );
+}
+
+/**
+ * Format the utility filter as a short badge text.
+ *
+ * - `null` or empty → `null` (no badge)
+ * - one slug → readable label ("Smoke")
+ * - multiple slugs → "Smoke +1" (avoids exploding the bar with full lists)
+ *
+ * Extracted from the component body so it's unit-testable in isolation.
+ */
+function utilityBadgeFromFilter(
+  filter: readonly string[] | null,
+): string | null {
+  if (!filter || filter.length === 0) return null;
+  const firstSlug = filter[0] as Cs2UtilitySlug;
+  const firstLabel = CS2_UTILITY_LABELS[firstSlug] ?? filter[0];
+  if (filter.length === 1) return firstLabel;
+  return `${firstLabel} +${filter.length - 1}`;
 }

--- a/apps/mygamingassistant/frontend/src/components/live/liveTopBarUtils.ts
+++ b/apps/mygamingassistant/frontend/src/components/live/liveTopBarUtils.ts
@@ -43,3 +43,37 @@ export function formatLastEventTime(rfc3339: string, now: Date = new Date()): st
   const hrs = Math.floor(mins / 60);
   return `${hrs}h ago`;
 }
+
+/**
+ * Display-format a zone slug. `null`/empty → null (caller hides the
+ * segment). Same shape as `formatZoneDisplay` in `lib/cv.ts` — duplicated
+ * here so the LiveTopBar component file doesn't pull from `lib/`. Keeps
+ * the presentational tree shallow.
+ */
+export function formatZone(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  return slug.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Tailwind classes for the round-phase chip on the HUD bar.
+ *
+ * PR 10's design: freezetime=blue (cool, preparation), live=green (go),
+ * over=grey (resolved). The colors are paired with text so the chip
+ * communicates the round phase by both color AND text (a11y safe).
+ *
+ * Accepts the display string ("Freezetime", "Live", "Over") rather than
+ * the raw slug because that's what the caller already has computed.
+ */
+export function roundPhaseChipClasses(display: string): string {
+  switch (display) {
+    case "Freezetime":
+      return "bg-sky-500/15 text-sky-700 dark:text-sky-300";
+    case "Live":
+      return "bg-green-500/15 text-green-700 dark:text-green-300";
+    case "Over":
+      return "bg-muted/60 text-muted-foreground";
+    default:
+      return "bg-muted/40 text-foreground";
+  }
+}

--- a/apps/mygamingassistant/frontend/src/lib/gsi.ts
+++ b/apps/mygamingassistant/frontend/src/lib/gsi.ts
@@ -25,7 +25,7 @@
  */
 import { useEffect, useState } from "react";
 import { invokeTauri, isTauri } from "@/lib/tauri";
-import type { GsiEvent, GsiServerStatus } from "@/types/desktop";
+import type { Cs2UtilitySlug, GsiEvent, GsiServerStatus } from "@/types/desktop";
 
 /** Event name emitted by the Rust receiver on every accepted POST. */
 const EVENT_STATE_UPDATE = "gsi:state-update";
@@ -129,6 +129,11 @@ export function useGsiState(): UseGsiStateResult {
  *
  * Returns `null` when there's no meaningful event yet (i.e., we should
  * render the "Waiting for CS2" empty state).
+ *
+ * PR 10 extends the shape to include money / score / bomb state / round
+ * phase. None of the new fields cause the helper to return non-null
+ * on their own — the existence-check on map_slug / map_phase is still
+ * the "is there anything meaningful to show" signal.
  */
 export interface LiveBarFields {
   /** Display-formatted map name (capitalized slug). */
@@ -137,6 +142,30 @@ export interface LiveBarFields {
   sideDisplay: string;
   /** Display-formatted map phase ("Live", "Warmup", "Halftime", "Game over"). */
   phaseDisplay: string;
+  /**
+   * Round phase chip text ("Freezetime", "Live", "Over"), or null when
+   * unset / unknown. Distinct from `phaseDisplay` which is the MAP phase.
+   */
+  roundPhaseDisplay: string | null;
+  /**
+   * "12-8" formatted score (CT-first, T-second per CS2 scoreboard
+   * convention), or null when scores aren't available yet.
+   */
+  scoreDisplay: string | null;
+  /**
+   * "$4150" formatted money. Null when CS2 hasn't sent money yet.
+   */
+  moneyDisplay: string | null;
+  /**
+   * "+kit" / "+$250 kit" suffix shown next to money when armor+helmet OR
+   * defuse-kit are present. Empty string when nothing extra to surface.
+   */
+  equipExtra: string;
+  /**
+   * "💣 planted" / "defused" / "exploded" chip text, or null when the
+   * bomb hasn't been touched this round.
+   */
+  bombDisplay: string | null;
 }
 
 const MAP_PHASE_LABELS: Record<string, string> = {
@@ -146,11 +175,89 @@ const MAP_PHASE_LABELS: Record<string, string> = {
   gameover: "Game over",
 };
 
+const ROUND_PHASE_LABELS: Record<string, string> = {
+  freezetime: "Freezetime",
+  live: "Live",
+  over: "Over",
+};
+
+const BOMB_STATE_LABELS: Record<string, string> = {
+  planted: "💣 planted",
+  defused: "defused",
+  exploded: "exploded",
+};
+
 const SIDE_LABELS_CS2: Record<string, string> = {
   side_a: "T",
   side_b: "CT",
   any: "—",
 };
+
+function formatMoney(money: number | null | undefined): string | null {
+  if (money === null || money === undefined) return null;
+  return `$${money.toLocaleString("en-US")}`;
+}
+
+function formatScore(
+  ctScore: number | null | undefined,
+  tScore: number | null | undefined,
+): string | null {
+  // We require BOTH scores to render — half-shown scores would be more
+  // confusing than no score.
+  if (ctScore === null || ctScore === undefined) return null;
+  if (tScore === null || tScore === undefined) return null;
+  return `${ctScore}-${tScore}`;
+}
+
+function formatEquipExtra(
+  helmet: boolean | null | undefined,
+  defuseKit: boolean | null | undefined,
+  armor: number | null | undefined,
+): string {
+  // Helmet only matters when armor>0 (CS2 keeps helmet flag even after
+  // armor depletes; rendering "+kit" when bare-headed would mislead).
+  const hasHelmet = (armor ?? 0) > 0 && helmet === true;
+  const hasDefuseKit = defuseKit === true;
+  if (hasHelmet && hasDefuseKit) return " +kit +defuse";
+  if (hasHelmet) return " +kit";
+  if (hasDefuseKit) return " +defuse";
+  return "";
+}
+
+/**
+ * Decide which CS2 utility slugs to narrow the lineup query by.
+ *
+ * Three-tier preference, mirroring the design in PR 10:
+ *   1. Manual override (operator picked a specific utility) — wins over GSI.
+ *   2. Active utility (player is currently holding a specific grenade) —
+ *      strongest auto signal; narrow to that one.
+ *   3. Held utility (player has grenades but not actively holding any) —
+ *      narrow to anything they have in inventory.
+ *
+ * Returns:
+ *   - `string[]` of slugs when a narrowing should be applied
+ *   - `null` when the lineup query should NOT add a utility filter
+ *     (i.e., show all utility types for the map/side/zone — current PR 9a
+ *     behavior)
+ *
+ * Pure function — easy to unit test, easy to verify the three-tier
+ * preference order behaves consistently.
+ */
+export function computeLineupUtilityFilter(args: {
+  /** Operator's manual choice. `null` = no override; takes precedence. */
+  overrideSlug: Cs2UtilitySlug | null;
+  /** GSI-derived currently-held grenade slug, if any. */
+  activeUtilitySlug: string | null | undefined;
+  /** GSI-derived list of all grenades in inventory. */
+  heldUtilitySlugs: readonly string[] | null | undefined;
+}): string[] | null {
+  if (args.overrideSlug) return [args.overrideSlug];
+  if (args.activeUtilitySlug) return [args.activeUtilitySlug];
+  if (args.heldUtilitySlugs && args.heldUtilitySlugs.length > 0) {
+    return [...args.heldUtilitySlugs];
+  }
+  return null;
+}
 
 export function summarizeLiveBar(event: GsiEvent | null): LiveBarFields | null {
   if (!event) return null;
@@ -158,9 +265,23 @@ export function summarizeLiveBar(event: GsiEvent | null): LiveBarFields | null {
   const mapDisplay = event.map_slug
     ? event.map_slug.replace(/[-_]/g, " ").replace(/\b\w/g, (c) => c.toUpperCase())
     : "—";
+
+  const roundPhaseDisplay = event.round_phase
+    ? ROUND_PHASE_LABELS[event.round_phase] ?? null
+    : null;
+
+  const bombDisplay = event.bomb_state
+    ? BOMB_STATE_LABELS[event.bomb_state] ?? null
+    : null;
+
   return {
     mapDisplay,
     sideDisplay: SIDE_LABELS_CS2[event.side] ?? "—",
     phaseDisplay: MAP_PHASE_LABELS[event.map_phase] ?? event.map_phase ?? "—",
+    roundPhaseDisplay,
+    scoreDisplay: formatScore(event.ct_score, event.t_score),
+    moneyDisplay: formatMoney(event.money),
+    equipExtra: formatEquipExtra(event.helmet, event.defuse_kit, event.armor),
+    bombDisplay,
   };
 }

--- a/apps/mygamingassistant/frontend/src/pages/LiveCs2.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/LiveCs2.tsx
@@ -1,21 +1,26 @@
 /**
  * Live mode for CS2 — `/live/cs2`.
  *
- * This is the first "live mode" surface in the app. It:
- *   1. Subscribes to GSI events via `useGsiState` (Tauri-only).
- *   2. Reflects the detected (map, side) into a `/api/lineups` query.
- *   3. Renders a compact horizontal lineup card strip.
- *   4. Auto-applies an always-on-top, small, borderless window shape on
- *      mount (Tauri-only) and restores it on unmount.
- *   5. Exposes a manual override toggle so the operator can lock the
- *      filter to a specific map/side when CS2 isn't running (for testing
- *      and pre-match prep).
- *   6. Wires F1 to open the full plan-mode panel in the same window.
+ * Subscribes to GSI events via `useGsiState` (Tauri-only). Reflects the
+ * detected (map, side, zone, utility) into a `/api/lineups` query and
+ * renders a compact horizontal lineup card strip.
  *
- * Constraints from the PR 8 spec:
- *   - No player position detection (PR 9 will add minimap CV).
- *   - No utility-held filter (PR 10).
- *   - No Valorant — `gsi:` events are CS2-only.
+ * PR 10 added the utility-held filter:
+ *
+ *   1. GSI emits `active_utility` (the grenade the player is currently
+ *      holding) and `held_utility_slugs` (everything in their inventory).
+ *   2. `computeLineupUtilityFilter` decides the narrowing: active wins,
+ *      then held, then no filter.
+ *   3. Operator can override with a specific slug via the override panel.
+ *
+ * The HUD top bar (LiveTopBar) was also expanded to surface money / score
+ * / bomb state / round phase — see that component for the layout.
+ *
+ * Constraints:
+ *   - No Valorant — `gsi:` events are CS2-only. Valorant lives in PR 11.
+ *   - No round clock — CS2 redacts the actual round timer for competitive
+ *     integrity. The round phase chip ("Freezetime" / "Live" / "Over") is
+ *     the closest proxy we can surface honestly.
  *
  * Web behaviour:
  *   - On the web build, this route renders a "Live mode is a desktop
@@ -26,7 +31,11 @@
 import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import { ArrowLeft, Monitor, Settings as SettingsIcon } from "lucide-react";
-import { useGsiState, summarizeLiveBar } from "@/lib/gsi";
+import {
+  computeLineupUtilityFilter,
+  summarizeLiveBar,
+  useGsiState,
+} from "@/lib/gsi";
 import { useCvState } from "@/lib/cv";
 import { useGetLineupsQuery } from "@/store/lineupsApi";
 import { isTauri } from "@/lib/tauri";
@@ -34,25 +43,40 @@ import LineupCard from "@/components/lineup/LineupCard";
 import LiveTopBar from "@/components/live/LiveTopBar";
 import LiveOverridePanel from "@/components/live/LiveOverridePanel";
 import LiveStripSkeleton from "@/components/live/LiveStripSkeleton";
-import type { GsiSide } from "@/types/desktop";
+import type { Cs2UtilitySlug, GsiSide } from "@/types/desktop";
+import type { Lineup } from "@/types/game";
 
 const GAME_SLUG_CS2 = "cs2";
+
+/**
+ * Override state — what the operator manually set, regardless of GSI.
+ * Extracted into a named interface per the
+ * `feedback_minimize_ternaries_extract_types` preference.
+ */
+interface OverrideState {
+  enabled: boolean;
+  mapSlug: string;
+  side: GsiSide;
+  utility: Cs2UtilitySlug | null;
+}
+
+const INITIAL_OVERRIDE: OverrideState = {
+  enabled: false,
+  mapSlug: "",
+  side: "any",
+  utility: null,
+};
 
 export default function LiveCs2() {
   // ALL hooks must be called unconditionally; the early return for web
   // happens below the hook block so React's rules-of-hooks stay intact.
   const [inTauri] = useState(() => isTauri());
-  const [override, setOverride] = useState<{
-    enabled: boolean;
-    mapSlug: string;
-    side: GsiSide;
-  }>({ enabled: false, mapSlug: "", side: "any" });
+  const [override, setOverride] = useState<OverrideState>(INITIAL_OVERRIDE);
 
   const { event, status, ready } = useGsiState();
   // CV pipeline state (PR 9a). On the web build this returns ready=true with
   // null zone/status — same degraded shape as useGsiState — so no extra
-  // gating is required. The override flow ignores zone (operator picked
-  // map+side manually).
+  // gating is required.
   const { zone: cvZone } = useCvState();
 
   // Apply always-on-top + small window shape on mount (Tauri only). Restore
@@ -66,7 +90,6 @@ export default function LiveCs2() {
           "@tauri-apps/api/webviewWindow"
         );
         const win = getCurrentWebviewWindow();
-        // Capture previous shape so we can restore on unmount.
         await win.setAlwaysOnTop(true);
       } catch {
         // Non-fatal — Live mode still works without always-on-top. The
@@ -92,14 +115,48 @@ export default function LiveCs2() {
     };
   }, [inTauri]);
 
-  // F1 → open plan mode for the detected map in a new tab so the live
-  // overlay stays visible. Falls back to opening the current window if
-  // we're outside Tauri.
-  const effectiveMapSlug = override.enabled ? override.mapSlug : event?.map_slug ?? "";
+  // Resolve the effective (map, side, zone, utility) from override + GSI.
+  const effectiveMapSlug = override.enabled
+    ? override.mapSlug
+    : event?.map_slug ?? "";
   const effectiveSide: GsiSide = override.enabled
     ? override.side
     : event?.side ?? "any";
 
+  // Effective zone slug: CV-detected when not overriding, undefined when
+  // overriding (operator manually picks map+side, zone narrowing doesn't
+  // apply) or no CV detection yet.
+  const effectiveZone = !override.enabled && cvZone ? cvZone : undefined;
+
+  // PR 10 — utility filter narrowing.
+  //
+  // We compute the slugs in a memo so the inner `useGetLineupsQuery` cache
+  // key stays stable across renders that don't actually change inputs.
+  const utilityFilterSlugs = useMemo<string[] | null>(() => {
+    if (override.enabled) {
+      // In override mode, the operator's explicit choice wins. If they
+      // picked "All utility" (null), no narrowing — same as PR 9a.
+      return computeLineupUtilityFilter({
+        overrideSlug: override.utility,
+        activeUtilitySlug: null,
+        heldUtilitySlugs: null,
+      });
+    }
+    return computeLineupUtilityFilter({
+      overrideSlug: null,
+      activeUtilitySlug: event?.active_utility ?? null,
+      heldUtilitySlugs: event?.held_utility_slugs ?? null,
+    });
+  }, [
+    override.enabled,
+    override.utility,
+    event?.active_utility,
+    event?.held_utility_slugs,
+  ]);
+
+  // F1 → open plan mode for the detected map in a new tab so the live
+  // overlay stays visible. Falls back to opening the current window if
+  // we're outside Tauri.
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (e.key !== "F1") return;
@@ -115,22 +172,20 @@ export default function LiveCs2() {
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [effectiveMapSlug, effectiveSide]);
 
-  // Effective zone slug: CV-detected when not overriding, undefined when
-  // overriding or no CV detection yet. Falls back gracefully to the
-  // map+side filter (PR 8 behaviour).
-  const effectiveZone = !override.enabled && cvZone ? cvZone : undefined;
-
-  // Fetch lineups for the effective (map, side, zone). Skip until we have
-  // a map slug to look up. When zone is present, the backend narrows the
-  // result further — that's what powers PR 9a's "zone-level live filter".
+  // Fetch lineups for the effective (map, side, zone, utility). Skip until
+  // we have a map slug to look up.
   const lineupQueryArgs = useMemo(
     () => ({
       game_slug: GAME_SLUG_CS2,
       map_slug: effectiveMapSlug,
       side: effectiveSide !== "any" ? effectiveSide : undefined,
       target_zone_slug: effectiveZone,
+      utility_type_slugs:
+        utilityFilterSlugs && utilityFilterSlugs.length > 0
+          ? utilityFilterSlugs.join(",")
+          : undefined,
     }),
-    [effectiveMapSlug, effectiveSide, effectiveZone],
+    [effectiveMapSlug, effectiveSide, effectiveZone, utilityFilterSlugs],
   );
 
   const { data: lineups = [], isFetching: lineupsFetching } =
@@ -156,6 +211,7 @@ export default function LiveCs2() {
         override={override}
         onOverrideToggle={(enabled) => setOverride((p) => ({ ...p, enabled }))}
         zoneSlug={effectiveZone ?? null}
+        utilityFilter={utilityFilterSlugs}
       />
 
       <LiveOverridePanel
@@ -164,31 +220,18 @@ export default function LiveCs2() {
         onChange={setOverride}
       />
 
-      <section className="flex-1 overflow-x-auto overflow-y-hidden px-3 py-2">
-        {!hasAnyMap ? (
-          <LiveEmptyState
-            ready={ready}
-            running={status?.running ?? false}
-            payloadsReceived={status?.payloads_received ?? 0}
-          />
-        ) : lineupsFetching ? (
-          <LiveStripSkeleton />
-        ) : lineups.length === 0 ? (
-          <p className="text-sm text-muted-foreground p-4">
-            No lineups for {effectiveMapSlug} on {effectiveSide}
-            {effectiveZone ? ` in ${effectiveZone}` : ""}. Add one in plan
-            mode (press F1).
-          </p>
-        ) : (
-          <div className="flex gap-3 h-full">
-            {lineups.slice(0, 6).map((l) => (
-              <div key={l.id} className="w-64 shrink-0">
-                <LineupCard lineup={l} variant="thumbnail" />
-              </div>
-            ))}
-          </div>
-        )}
-      </section>
+      <LiveStripSection
+        hasAnyMap={hasAnyMap}
+        ready={ready}
+        running={status?.running ?? false}
+        payloadsReceived={status?.payloads_received ?? 0}
+        effectiveMapSlug={effectiveMapSlug}
+        effectiveSide={effectiveSide}
+        effectiveZone={effectiveZone}
+        utilityFilterSlugs={utilityFilterSlugs}
+        lineupsFetching={lineupsFetching}
+        lineups={lineups}
+      />
 
       <footer className="text-xs text-muted-foreground px-3 py-1 border-t flex items-center justify-between gap-3">
         <span>
@@ -205,6 +248,96 @@ export default function LiveCs2() {
 // ---------------------------------------------------------------------------
 // Sub-components
 // ---------------------------------------------------------------------------
+
+interface LiveStripSectionProps {
+  hasAnyMap: boolean;
+  ready: boolean;
+  running: boolean;
+  payloadsReceived: number;
+  effectiveMapSlug: string;
+  effectiveSide: GsiSide;
+  effectiveZone: string | undefined;
+  utilityFilterSlugs: readonly string[] | null;
+  lineupsFetching: boolean;
+  lineups: readonly Lineup[];
+}
+
+function LiveStripSection({
+  hasAnyMap,
+  ready,
+  running,
+  payloadsReceived,
+  effectiveMapSlug,
+  effectiveSide,
+  effectiveZone,
+  utilityFilterSlugs,
+  lineupsFetching,
+  lineups,
+}: LiveStripSectionProps) {
+  if (!hasAnyMap) {
+    return (
+      <section className="flex-1 overflow-x-auto overflow-y-hidden px-3 py-2">
+        <LiveEmptyState
+          ready={ready}
+          running={running}
+          payloadsReceived={payloadsReceived}
+        />
+      </section>
+    );
+  }
+  if (lineupsFetching) {
+    return (
+      <section className="flex-1 overflow-x-auto overflow-y-hidden px-3 py-2">
+        <LiveStripSkeleton />
+      </section>
+    );
+  }
+  if (lineups.length === 0) {
+    return (
+      <section className="flex-1 overflow-x-auto overflow-y-hidden px-3 py-2">
+        <NoLineupsMessage
+          mapSlug={effectiveMapSlug}
+          side={effectiveSide}
+          zone={effectiveZone}
+          utilitySlugs={utilityFilterSlugs}
+        />
+      </section>
+    );
+  }
+  return (
+    <section className="flex-1 overflow-x-auto overflow-y-hidden px-3 py-2">
+      <div className="flex gap-3 h-full">
+        {lineups.slice(0, 6).map((l) => (
+          <div key={l.id} className="w-64 shrink-0">
+            <LineupCard lineup={l} variant="thumbnail" />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+interface NoLineupsMessageProps {
+  mapSlug: string;
+  side: GsiSide;
+  zone: string | undefined;
+  utilitySlugs: readonly string[] | null;
+}
+
+function NoLineupsMessage({ mapSlug, side, zone, utilitySlugs }: NoLineupsMessageProps) {
+  const zonePart = zone ? ` in ${zone}` : "";
+  const utilityPart =
+    utilitySlugs && utilitySlugs.length > 0
+      ? ` for ${utilitySlugs.join("/")}`
+      : "";
+  return (
+    <p className="text-sm text-muted-foreground p-4">
+      No lineups for {mapSlug} on {side}
+      {zonePart}
+      {utilityPart}. Add one in plan mode (press F1).
+    </p>
+  );
+}
 
 interface LiveEmptyStateProps {
   ready: boolean;

--- a/apps/mygamingassistant/frontend/src/types/desktop.ts
+++ b/apps/mygamingassistant/frontend/src/types/desktop.ts
@@ -35,10 +35,51 @@ export interface AppVersion {
 export type GsiSide = "side_a" | "side_b" | "any";
 
 /**
+ * CS2 utility-type slug union. Must stay in lockstep with
+ * `apps/mygamingassistant/backend/app/fixtures/utility_types.json` and
+ * with the Rust mapping in `desktop/src-tauri/src/gsi/weapons.rs`.
+ *
+ * MGA uses `grenade` (not `he`) for HE — see fixture for rationale.
+ */
+export type Cs2UtilitySlug =
+  | "smoke"
+  | "flash"
+  | "molotov"
+  | "grenade"
+  | "decoy";
+
+/** Display labels for the override panel + HUD. */
+export const CS2_UTILITY_LABELS: Record<Cs2UtilitySlug, string> = {
+  smoke: "Smoke",
+  flash: "Flash",
+  molotov: "Molotov",
+  grenade: "HE",
+  decoy: "Decoy",
+};
+
+/** Ordered list of slugs for select dropdowns — keeps "ALL" group ordering
+ *  stable so the override menu doesn't shuffle each render. */
+export const CS2_UTILITY_SLUGS: Cs2UtilitySlug[] = [
+  "smoke",
+  "flash",
+  "molotov",
+  "grenade",
+  "decoy",
+];
+
+/**
+ * Bomb state — one of CS2's three terminal states once the bomb has been
+ * touched in a round. `null` when the bomb is in nobody's hand / waiting.
+ */
+export type BombState = "planted" | "defused" | "exploded";
+
+/**
  * Normalized GSI event payload emitted by the Rust receiver via the Tauri
  * event `gsi:state-update` on every accepted POST from CS2.
  *
- * Matches the `GsiEvent` struct in `src-tauri/src/gsi/payload.rs`.
+ * Matches the `GsiEvent` struct in `src-tauri/src/gsi/payload.rs`. PR 10
+ * added explicit typed fields for `money`, `score`, `bomb_state`, and
+ * weapon-derived `active_utility` / `held_utility_slugs`.
  */
 export interface GsiEvent {
   /**
@@ -54,7 +95,47 @@ export interface GsiEvent {
   round_phase: string;
   /** `"playing" | "menu" | "textinput"` etc. */
   activity: string;
-  /** Raw CS2 player_state passthrough (money, weapons, health). */
+  // --- PR 10: explicit, strongly-typed HUD fields ---
+  /** Bomb state (`"planted" | "defused" | "exploded"`) or null. */
+  bomb_state?: BombState | null;
+  /** Wallet money (USD). Null until CS2 sends it. */
+  money?: number | null;
+  /** HP (0-100). */
+  health?: number | null;
+  /** Armor (0-100). */
+  armor?: number | null;
+  /** Helmet flag — when armor>0 AND helmet=true, HUD shows "+kit". */
+  helmet?: boolean | null;
+  /** Defuse kit flag — CT-only signal; rendered as a small "kit" badge. */
+  defuse_kit?: boolean | null;
+  /** Total $ value of currently-equipped items. Buy-tier hint. */
+  equip_value?: number | null;
+  /** CT team's current round score. */
+  ct_score?: number | null;
+  /** T team's current round score. */
+  t_score?: number | null;
+  /** Round number (1-based; CS2's 0-based round + 1). Null in warmup. */
+  round_number?: number | null;
+  /** Raw Valve slug of the active weapon (e.g., `weapon_smokegrenade`). */
+  active_weapon?: string | null;
+  /**
+   * MGA utility-type slug for the actively-held grenade. Null when the
+   * player isn't holding a grenade (knife, rifle, no weapon, etc.).
+   * Drives PR 10's utility-held lineup filter.
+   */
+  active_utility?: string | null;
+  /**
+   * MGA utility-type slugs for ALL grenades in inventory (deduplicated).
+   * When no specific grenade is active, the live filter falls back to
+   * narrowing by any of these.
+   */
+  held_utility_slugs: string[];
+  /**
+   * Unix epoch seconds from CS2's `provider.timestamp`. Useful only as
+   * a sanity-check signal — CS2 redacts the actual round timer.
+   */
+  provider_timestamp?: number | null;
+  /** Raw CS2 player_state passthrough (kept for PR 8 backward compat). */
   player_state?: Record<string, unknown>;
   /** Raw CS2 player_match_stats passthrough. */
   match_stats?: Record<string, unknown>;


### PR DESCRIPTION
## Summary

PR 10/12 of the MyGamingAssistant sequence. Builds on PR 8 (GSI receiver) and PR 9a/b (CV pipeline + calibration) to deliver the full CS2 live mode:

1. **Utility-held filter.** The live lineup strip now narrows by what grenade the player is holding (active utility wins; held inventory falls back; operator override trumps both).
2. **Expanded HUD top bar.** `Mirage · CT · B Site · Smoke · 💣 planted | 12-8 | \$4,150 +kit | Freezetime` — every segment independently null-safe.
3. **Override panel utility dropdown.** Operator can pick a specific grenade type without CS2 running.

## What shipped

### Rust (`apps/mygamingassistant/desktop/src-tauri/`)

- **`gsi/weapons.rs`** — new module. CS2 weapon slugs → MGA `UtilityType` slugs. Table-driven; 9 unit tests cover every grenade slug + non-utility weapons + unknown-future-slug fallback + case-sensitivity guard.
- **`gsi/payload.rs`** — `RawGsiPayload` extended with strongly-typed `provider`/`player.state`/`weapons`/`team_ct`/`team_t`/`round.bomb` blocks. CS2 emits `weapons` as `{"weapon_0": {...}, "weapon_1": {...}}`; we deserialize to a `HashMap<String, RawGsiWeapon>` and convert to a slot-ordered `Vec<RawGsiWeapon>` via `parse_weapons_block`. `GsiEvent` gains `bomb_state`, `money`, `health/armor/helmet/defuse_kit/equip_value`, `ct_score/t_score`, `round_number` (1-based per CS2 scoreboard), `active_weapon`, `active_utility`, `held_utility_slugs`, `provider_timestamp`. The legacy `player_state` passthrough is preserved (re-serialized from the typed struct) so PR 8 consumers keep working.
- **`tests/gsi_http_integration.rs`** — fixture upgraded to a realistic live-round payload (rifle holstered + smoke active + flash held; helmet + defuse_kit; bomb planted; round 11 0-based / 12 1-based; CT 7 - T 4). Assertions cover every new typed field end-to-end.

### Frontend (`apps/mygamingassistant/frontend/`)

- **`types/desktop.ts`** — `GsiEvent` interface mirrors the Rust shape. New `Cs2UtilitySlug` union + `CS2_UTILITY_LABELS` + `CS2_UTILITY_SLUGS` exports keep frontend in lockstep with the backend `utility_types.json` fixture (per `feedback_enum_changes_cross_stack`).
- **`lib/gsi.ts`** — `computeLineupUtilityFilter` is the new pure helper that decides which slugs to narrow by (override → active → held → null). `summarizeLiveBar` now emits `scoreDisplay`/`moneyDisplay`/`equipExtra`/`bombDisplay`/`roundPhaseDisplay`. `+kit` suffix is gated on `armor>0` so a stale helmet flag doesn't mislead.
- **`components/live/LiveTopBar.tsx`** — segment-based layout. Each segment (zone, utility, bomb, score, money, round-phase) renders only when its field is present. Round-phase chip is color-tinted **and** text-labelled (a11y). Override mode shows `Mirage · CT · Flash (override)`.
- **`components/live/liveTopBarUtils.ts`** — new helpers: `formatZone` (extracted from inline LiveTopBar fn) + `roundPhaseChipClasses` (color tints for freezetime/live/over).
- **`components/live/LiveOverridePanel.tsx`** — utility dropdown alongside the existing map+side. Sentinel empty string round-trips to `null` (operator chose "All utility").
- **`pages/LiveCs2.tsx`** — wires `computeLineupUtilityFilter` output into the existing `/api/lineups` query (backend already accepts `utility_type_slugs` comma-separated, so no backend changes were needed).

### Tests

- **Rust** — 9 weapon-mapping tests + 7 weapons-block parsing tests + full-payload PR 10 field assertion + bomb-state + negative-round-number + missing-weapons block + `player_state` backward-compat fixture. Integration test asserts every typed HUD field round-trips through axum + the receiver.
- **Frontend** — 185 vitest tests pass (67 are PR 10 additions: 38 LiveTopBar segment renderings + 14 summarizeLiveBar field cases + 8 computeLineupUtilityFilter preference orderings + 9 LiveOverridePanel interactions).
- **E2E** — `live-cs2.spec.ts` adds smoke for the utility dropdown + badge rendering when override.utility is set, cleared, then re-set.

## Operational migration required

**None.** PR 8's installed cfg already enabled `player_weapons`, `player_match_stats`, `map_round_wins`, `round`, and `provider` data subscriptions, so existing installs do **not** need to reinstall the GSI cfg. The new fields are all derived from data CS2 was already sending.

## Testing notes

Locally:

1. **Simulated (no CS2):**
   ```
   cd apps/mygamingassistant/frontend && npm run dev
   # Visit /live/cs2, click Override, pick a map/side/utility — top bar
   # shows the utility badge; lineup strip narrows accordingly
   ```

2. **Real CS2 (Windows):** Launch the Tauri build, install GSI cfg via setup page, start CS2, load Mirage. Watch the HUD update through freezetime → live → over with money / score / round-phase / held-utility segments all updating live.

3. **Curl probe:**
   ```
   curl -sS http://127.0.0.1:8765/healthz   # 200 ok
   # Use a CS2 GSI fixture with weapons + state to test the receiver
   # end-to-end (see desktop/src-tauri/tests/gsi_http_integration.rs
   # for the JSON shape).
   ```

## Known limitations

- **CS2 redacts the round clock from GSI** for competitive integrity. The round-phase chip (`Freezetime` / `Live` / `Over`) is the closest honest substitute — there's no estimated countdown timer, deliberately (the [no-bandaid-solutions rule](https://github.com/jykwon91/jkwon-claude-config/blob/main/rules/no-bandaid-solutions.md) applies: faking a value from provider.timestamp would be exactly the kind of pragmatic-looking hack this app rejects).
- **Multi-monitor still single-primary.** Deferred to PR 12.
- **HUD scale slider** deferred to PR 12.
- **Bundled-vs-override calibration source** still best-effort (PR 9b's behaviour preserved).

## Decisions worth flagging

- **`weapon_molotov` and `weapon_incgrenade` both map to `molotov`**. T-side and CT-side flame grenades produce functionally identical lineups; splitting them would duplicate every Molotov lineup with no UX benefit. Documented in `gsi/weapons.rs`.
- **MGA fixture uses `grenade` (not `he`) for HE grenade.** Honoured the backend `utility_types.json` choice. Mapping table preserves it; renaming the fixture is out of scope for PR 10.
- **`+kit` gated on `armor>0`.** CS2 keeps the helmet flag true even after armor depletes. Rendering "+kit" when bare-headed would mislead the operator about their effective armor; suppress when armor is 0. Unit test covers this.
- **1-based round number on the way out.** CS2 sends 0-based; CS2's own scoreboard displays 1-based. Adding 1 at the normalization boundary keeps the HUD consistent with what the player sees on the in-game scoreboard.
- **Backward compat preserved.** PR 8's `player_state` passthrough field still populated (re-serialized from the typed struct). PR 9a's zone segment still works untouched. Tests for both still pass.

## Files changed

- 14 files (1 new module, 1 new test file, 12 modified)
- +2,271 / -230 lines

## Checks

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 185/185 vitest pass
- [x] `npm run build` — bundle builds, 245kB gzip main (no regression)
- [ ] Rust `cargo test` — no local toolchain; CI is first integration test
- [ ] 3-platform builds (linux-x64 / macos-arm64 / windows-x64) — CI
- [ ] rust-checks (fmt + clippy `-D warnings`) — CI
- [ ] CodeQL + security — CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)