### PR TITLE
feat(infra): scaffolder runs npm install at monorepo root

### DIFF
--- a/packages/shared-backend/platform_shared/infra/new_app.py
+++ b/packages/shared-backend/platform_shared/infra/new_app.py
@@ -205,6 +205,33 @@ def _maybe_regenerate_requirements(backend_dir: Path) -> bool:
         return False
 
 
+def _maybe_npm_install(repo_root: Path) -> bool:
+    """Best-effort: run `npm install` at monorepo root so the new frontend
+    workspace lands in the root `package-lock.json`.
+
+    Without this step, the first CI run after every scaffold fails with
+    ``npm ci EUSAGE -- Missing: <slug>-frontend@0.0.1 from lock file``.
+    Hit on PR #624; see project_platform_shared_real_platform.md.
+
+    Returns True if npm install succeeded; False if npm is missing or failed.
+    """
+    npm_path = shutil.which("npm")
+    if npm_path is None:
+        return False
+
+    try:
+        subprocess.run(
+            [npm_path, "install"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
 def scaffold_app(
     *,
     slug: str,
@@ -217,6 +244,7 @@ def scaffold_app(
     repo_root: Path | None = None,
     skip_render: bool = False,
     skip_uv: bool = False,
+    skip_npm: bool = False,
 ) -> dict[str, object]:
     """Programmatic entry point. Used by both the CLI and the conformance test.
 
@@ -263,12 +291,17 @@ def scaffold_app(
     if not skip_uv:
         uv_ok = _maybe_regenerate_requirements(app_dir / "backend")
 
+    npm_ok = False
+    if not skip_npm:
+        npm_ok = _maybe_npm_install(root)
+
     return {
         "app_dir": str(app_dir),
         "files_written": file_count,
         "app_yaml": str(app_yaml_path),
         "rendered": rendered_paths,
         "uv_export_succeeded": uv_ok,
+        "npm_install_succeeded": npm_ok,
     }
 
 
@@ -294,6 +327,8 @@ def _cli() -> int:
                         help="Skip Tier 3 render after scaffolding (advanced).")
     parser.add_argument("--skip-uv", action="store_true",
                         help="Skip uv sync/export after scaffolding (advanced).")
+    parser.add_argument("--skip-npm", action="store_true",
+                        help="Skip npm install at monorepo root after scaffolding (advanced).")
     args = parser.parse_args()
 
     try:
@@ -307,6 +342,7 @@ def _cli() -> int:
             postgres_image=args.postgres_image,
             skip_render=args.skip_render,
             skip_uv=args.skip_uv,
+            skip_npm=args.skip_npm,
         )
     except ScaffoldError as exc:
         print(f"error: {exc}", file=sys.stderr)
@@ -321,6 +357,12 @@ def _cli() -> int:
             f"  cd {summary['app_dir']}/backend && uv sync && "
             "uv export --format requirements-txt --no-hashes --no-emit-project "
             "--output-file requirements.txt"
+        )
+    if not summary["npm_install_succeeded"]:
+        print(
+            "WARNING: npm install at monorepo root was skipped or failed.\n"
+            "  Run `npm install` from the monorepo root before pushing — "
+            "without it, CI fails on `npm ci EUSAGE` for the new workspace."
         )
     return 0
 

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -333,10 +333,11 @@ class TestScaffolderProducesBootableApp:
       2. Missing critical files. A trimmed include-list that drops, say,
          `backend/app/main.py` would scaffold an app that can't start.
 
-    Test runs the scaffolder with `skip_render=True` + `skip_uv=True` so it
-    doesn't depend on `.github/workflows/deploy.yml.j2` (which is monorepo-
-    relative and not copied into tmp_path) or on `uv` being installed.
-    Tier 3 render is covered by `TestInfraTemplateDrift`.
+    Test runs the scaffolder with skip_render=True + skip_uv=True + skip_npm=True
+    so it doesn't depend on `.github/workflows/deploy.yml.j2` (which is monorepo-
+    relative and not copied into tmp_path), uv being installed, or there being a
+    monorepo root npm workspace to sync against. Tier 3 render is covered by
+    `TestInfraTemplateDrift`.
     """
 
     def test_scaffolds_complete_substituted_skeleton(self, tmp_path) -> None:
@@ -366,6 +367,7 @@ class TestScaffolderProducesBootableApp:
             repo_root=tmp_path,
             skip_render=True,
             skip_uv=True,
+            skip_npm=True,
         )
 
         app_dir = tmp_path / "apps" / "scaffoldtest"
@@ -444,6 +446,7 @@ class TestScaffolderProducesBootableApp:
                 repo_root=tmp_path,
                 skip_render=True,
                 skip_uv=True,
+                skip_npm=True,
             )
 
     def test_rejects_invalid_slug(self, tmp_path) -> None:


### PR DESCRIPTION
## Summary

Closes the footgun hit on PR #624. The scaffolder writes `apps/<slug>/frontend/package.json` but never refreshed the monorepo's root `package-lock.json`, so the first CI run after every scaffold failed with `npm ci EUSAGE — Missing: <slug>-frontend@0.0.1 from lock file`. Now self-heals: same shape as the existing `uv sync && uv export` step.

## Changes

- New `_maybe_npm_install(repo_root)` helper in `new_app.py` — mirrors `_maybe_regenerate_requirements`. Returns False if npm is missing or fails.
- `scaffold_app()` calls it after the uv step, gated by a new `skip_npm: bool = False` kwarg.
- New `--skip-npm` CLI flag (advanced; for conformance test).
- `_cli()` prints a `WARNING:` with the manual command if npm install was skipped or failed.
- Conformance test passes `skip_npm=True` (tmp_path has no monorepo root npm workspace).

## Test plan

- [x] `pytest packages/shared-backend/tests/test_app_conformance.py` (63 pass)
- [ ] Next scaffold (Phase 1 PR 3 onward) self-heals the root lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)