### PR TITLE
feat(mypizzatracker): Public order status check (Phase 1 PR 6)

### DIFF
--- a/apps/mypizzatracker/backend/app/api/public.py
+++ b/apps/mypizzatracker/backend/app/api/public.py
@@ -1,7 +1,8 @@
 """Customer-facing (public) routes -- no authentication.
 
 These are the only routes the pizza app exposes without a JWT. Customers
-hit them anonymously to browse the menu, pick a slot, and place an order.
+hit them anonymously to browse the menu, pick a slot, place an order, and
+check on their order's status.
 
 Routes are registered without the ``/api`` prefix -- docker Caddy strips
 ``/api`` before forwarding to the backend (see drops.py / menu.py for the
@@ -11,15 +12,17 @@ Endpoints (production URLs prepend ``/api``):
   GET    /public/menu                     -- active pizzas + toppings
   GET    /public/drops/current            -- current active drop + slots w/ remaining capacity
   POST   /public/orders                   -- place an order; returns confirmation
-
-The order status check endpoint (GET /public/orders/{id}) lands in PR 6.
+  GET    /public/orders/{order_id}        -- look up an existing order (status check)
 """
 from __future__ import annotations
+
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
+from app.repositories.order import order_repo
 from app.schemas.public.public_schemas import (
     PublicDropRead,
     PublicMenuRead,
@@ -89,4 +92,28 @@ async def place_public_order(
     except OrderServiceError as exc:
         raise _service_error(exc) from exc
 
+    return await public_service.build_order_confirmation(db, order)
+
+
+@router.get("/orders/{order_id}", response_model=PublicOrderConfirmation)
+async def get_public_order(
+    order_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+) -> PublicOrderConfirmation:
+    """Look up an order by its UUID.
+
+    The order ID is the only secret; anyone holding it can read the order.
+    That mirrors the existing model -- the customer is handed it inline at
+    placement time and can revisit it to check status. There is no rate
+    limit on this endpoint by design: customers may reload the page while
+    waiting for pickup, and bots that guess UUIDs find nothing useful even
+    if they hit (only the customer's name + phone, which is what the
+    customer just typed in publicly anyway).
+    """
+    order = await order_repo.get_order(db, order_id)
+    if order is None:
+        raise HTTPException(
+            status_code=404,
+            detail="Order not found. Double-check the order link from your confirmation.",
+        )
     return await public_service.build_order_confirmation(db, order)

--- a/apps/mypizzatracker/backend/tests/test_public_orders.py
+++ b/apps/mypizzatracker/backend/tests/test_public_orders.py
@@ -1,4 +1,4 @@
-"""Tests for the customer-facing public order placement API.
+"""Tests for the customer-facing public order placement + status API.
 
 Covers:
 - GET  /public/menu surfaces only active pizzas + toppings
@@ -8,6 +8,7 @@ Covers:
 - POST /public/orders rejects: missing drop, drop not active, slot mismatch,
   capacity exceeded, empty pizza list, 86'd pizza, unknown topping, malformed phone
 - Customer upsert: same phone reuses the customer; name updates stick
+- GET  /public/orders/{id} returns the same confirmation shape; 404 when unknown
 - No auth header is needed for any /public/* route
 """
 from __future__ import annotations
@@ -489,3 +490,74 @@ async def test_order_rejected_with_no_digits_phone(
     )
     assert resp.status_code == 400
     assert "digit" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Status check (GET /public/orders/{id})
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_order_returns_same_shape_as_placement(
+    client: AsyncClient, auth_client: AsyncClient,
+):
+    drop_id, slot_id = await _create_active_drop(auth_client)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+    topping_id = await _create_topping(auth_client, "Mushrooms", "0")
+
+    client.headers.pop("Authorization", None)
+    placement = await client.post(
+        "/public/orders",
+        json={
+            "drop_id": drop_id,
+            "slot_id": slot_id,
+            "customer_name": "Tyra",
+            "customer_phone": "(512) 555-7777",
+            "payment_method_tag": "venmo",
+            "pizzas": [
+                {
+                    "pizza_type_id": pizza_id,
+                    "topping_type_ids": [topping_id],
+                    "modifications_text": "well done",
+                },
+            ],
+        },
+    )
+    assert placement.status_code == 201
+    placed = placement.json()
+    order_id = placed["order_id"]
+
+    lookup = await client.get(f"/public/orders/{order_id}")
+    assert lookup.status_code == 200
+    fetched = lookup.json()
+
+    # Status check must surface the exact same identity + state the customer
+    # saw on placement. ``created_at`` is included in both shapes.
+    assert fetched["order_id"] == order_id
+    assert fetched["customer_name"] == placed["customer_name"]
+    assert fetched["customer_phone"] == placed["customer_phone"]
+    assert fetched["status"] == placed["status"]
+    assert fetched["payment_status"] == placed["payment_status"]
+    assert fetched["total"] == placed["total"]
+    assert len(fetched["pizzas"]) == 1
+    assert fetched["pizzas"][0]["pizza_name"] == "La Clasica"
+    assert fetched["pizzas"][0]["toppings"] == ["Mushrooms"]
+    assert fetched["pizzas"][0]["modifications_text"] == "well done"
+
+
+@pytest.mark.asyncio
+async def test_get_order_404_when_unknown(client: AsyncClient):
+    """A random UUID should not leak existence."""
+    client.headers.pop("Authorization", None)
+    resp = await client.get(
+        "/public/orders/00000000-0000-0000-0000-000000000000",
+    )
+    assert resp.status_code == 404
+    assert "not found" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_get_order_invalid_uuid_422(client: AsyncClient):
+    """Malformed UUID is a 422 from FastAPI's path-param coercion."""
+    client.headers.pop("Authorization", None)
+    resp = await client.get("/public/orders/not-a-uuid")
+    assert resp.status_code == 422

--- a/apps/mypizzatracker/frontend/src/features/public-order/OrderStatusCard.tsx
+++ b/apps/mypizzatracker/frontend/src/features/public-order/OrderStatusCard.tsx
@@ -1,0 +1,147 @@
+/**
+ * Order confirmation / status display.
+ *
+ * Used in two places:
+ *   1. PublicOrder.tsx — after a customer submits a new order, the
+ *      placement response is rendered here in "confirmation" mode
+ *      (heading: "Order placed!").
+ *   2. PublicOrderStatus.tsx — when the customer revisits /order/status/:id,
+ *      the fetched order is rendered here in "status" mode
+ *      (heading: "Order status").
+ *
+ * Both modes show the same fields; only the heading + sub-copy differ.
+ */
+import { Card, StatusBadge } from "@platform/ui";
+import { CheckCircle2, Phone } from "lucide-react";
+import type {
+  PublicOrderConfirmation,
+} from "@/types/public/public";
+import {
+  PUBLIC_ORDER_STATUS_LABELS,
+  PUBLIC_PAYMENT_STATUS_LABELS,
+} from "@/types/public/public";
+import {
+  formatDateLong,
+  formatMoney,
+  formatPhoneDisplay,
+  formatTime,
+  paymentMethodLabel,
+  shortId,
+} from "./formatters";
+
+export interface OrderStatusCardProps {
+  order: PublicOrderConfirmation;
+  /**
+   * "fresh" -> just placed (confirmation tone, green check).
+   * "lookup" -> later status check (neutral tone, status-focused heading).
+   */
+  variant: "fresh" | "lookup";
+}
+
+export function OrderStatusCard({ order, variant }: OrderStatusCardProps) {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <div className="flex items-start gap-3">
+          {variant === "fresh" ? (
+            <div className="w-10 h-10 rounded-full bg-emerald-500/10 flex items-center justify-center shrink-0">
+              <CheckCircle2 className="h-5 w-5 text-emerald-600" />
+            </div>
+          ) : null}
+          <div>
+            <h2 className="text-xl font-semibold">
+              {variant === "fresh" ? "Order placed!" : "Order status"}
+            </h2>
+            <p className="text-sm text-muted-foreground">
+              Pickup at {formatTime(order.slot_pickup_time)} on {formatDateLong(order.drop_date)}
+            </p>
+          </div>
+        </div>
+        <div className="mt-4 space-y-1 text-sm">
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Order #</span>
+            <span className="font-mono">{shortId(order.order_id)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Name</span>
+            <span>{order.customer_name}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">
+              <Phone className="inline h-3 w-3 mr-1" />
+              Phone
+            </span>
+            <span>{formatPhoneDisplay(order.customer_phone)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Status</span>
+            <StatusBadge
+              tone={statusTone(order.status)}
+              label={PUBLIC_ORDER_STATUS_LABELS[order.status]}
+            />
+          </div>
+          <div className="flex justify-between">
+            <span className="text-muted-foreground">Payment</span>
+            <span>
+              {paymentMethodLabel(order.payment_method_tag)} (
+              {PUBLIC_PAYMENT_STATUS_LABELS[order.payment_status]})
+            </span>
+          </div>
+        </div>
+      </Card>
+
+      <Card>
+        <h3 className="text-lg font-semibold mb-3">Your order</h3>
+        <ul className="divide-y">
+          {order.pizzas.map((p, i) => (
+            <li key={i} className="py-2">
+              <div className="flex justify-between items-start gap-3">
+                <div>
+                  <div className="font-medium">{p.pizza_name}</div>
+                  {p.toppings.length > 0 ? (
+                    <div className="text-xs text-muted-foreground">
+                      + {p.toppings.join(", ")}
+                    </div>
+                  ) : null}
+                  {p.modifications_text ? (
+                    <div className="text-xs italic text-muted-foreground">
+                      "{p.modifications_text}"
+                    </div>
+                  ) : null}
+                </div>
+                <div className="text-sm shrink-0">
+                  ${formatMoney(p.line_total)}
+                </div>
+              </div>
+            </li>
+          ))}
+        </ul>
+        <div className="mt-3 pt-3 border-t flex justify-between text-base font-semibold">
+          <span>Total</span>
+          <span>${formatMoney(order.total)}</span>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+/**
+ * Map the order's status enum to a StatusBadge tone. ``ready_*`` is positive,
+ * ``picked_up`` is success-ish, ``no_show`` is warning, in-progress is info.
+ */
+function statusTone(
+  status: PublicOrderConfirmation["status"],
+): "info" | "success" | "warning" {
+  switch (status) {
+    case "ready_text_sent":
+    case "ready_waiting":
+    case "picked_up":
+      return "success";
+    case "no_show":
+      return "warning";
+    case "not_started":
+    case "cooking":
+    default:
+      return "info";
+  }
+}

--- a/apps/mypizzatracker/frontend/src/features/public-order/formatters.ts
+++ b/apps/mypizzatracker/frontend/src/features/public-order/formatters.ts
@@ -1,0 +1,51 @@
+/**
+ * Display formatters shared by the customer-facing order pages
+ * (PublicOrder.tsx, PublicOrderStatus.tsx, OrderStatusCard).
+ *
+ * Kept module-local because they are presentation concerns specific to
+ * this app's customer flow. The owner-facing screens use the @platform/ui
+ * money/time helpers where available.
+ */
+import { PAYMENT_METHOD_OPTIONS } from "@/types/public/public";
+
+export function formatMoney(value: string | number): string {
+  const n = typeof value === "number" ? value : Number(value);
+  if (Number.isNaN(n)) return String(value);
+  return n.toFixed(2);
+}
+
+export function formatTime(time: string): string {
+  // Expecting "HH:MM:SS" or "HH:MM"
+  const [hh = "00", mm = "00"] = time.split(":");
+  const h = Number(hh);
+  const period = h >= 12 ? "PM" : "AM";
+  const display = h === 0 ? 12 : h > 12 ? h - 12 : h;
+  return `${display}:${mm} ${period}`;
+}
+
+export function formatDateLong(iso: string): string {
+  // iso = "YYYY-MM-DD" -- build a local-date Date so we don't drift across TZ.
+  const [y, m, d] = iso.split("-").map(Number);
+  if (!y || !m || !d) return iso;
+  const date = new Date(y, m - 1, d);
+  return date.toLocaleDateString(undefined, {
+    weekday: "long",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+export function paymentMethodLabel(tag: string): string {
+  return PAYMENT_METHOD_OPTIONS.find((o) => o.tag === tag)?.label ?? tag;
+}
+
+export function formatPhoneDisplay(digits: string): string {
+  if (digits.length === 10) {
+    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+  }
+  return digits;
+}
+
+export function shortId(id: string): string {
+  return id.slice(0, 8).toUpperCase();
+}

--- a/apps/mypizzatracker/frontend/src/features/public-order/savedOrders.ts
+++ b/apps/mypizzatracker/frontend/src/features/public-order/savedOrders.ts
@@ -1,0 +1,74 @@
+/**
+ * localStorage-backed list of recent order placements so a customer can
+ * revisit /order/status (no id) and see the orders they've placed from
+ * this browser. The actual order data lives server-side -- this list is
+ * only the IDs + a snippet for display.
+ *
+ * Capped at 20 entries to bound storage growth. Oldest entries fall off.
+ * Each entry is keyed by orderId so re-saving an existing order is a
+ * no-op rather than a duplicate. Failures (storage disabled, parse
+ * errors) are swallowed -- the list is a convenience, not a system of
+ * record.
+ */
+const STORAGE_KEY = "mpt:saved-orders";
+const MAX_ENTRIES = 20;
+
+export interface SavedOrder {
+  order_id: string;
+  customer_name: string;
+  drop_name: string;
+  drop_date: string;
+  slot_pickup_time: string;
+  saved_at: string;
+}
+
+function isBrowser(): boolean {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+export function listSavedOrders(): SavedOrder[] {
+  if (!isBrowser()) return [];
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isValidSavedOrder);
+  } catch {
+    return [];
+  }
+}
+
+export function saveOrder(entry: SavedOrder): void {
+  if (!isBrowser()) return;
+  try {
+    const current = listSavedOrders().filter((o) => o.order_id !== entry.order_id);
+    const next = [entry, ...current].slice(0, MAX_ENTRIES);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Swallow: storage may be full or disabled.
+  }
+}
+
+export function removeSavedOrder(orderId: string): void {
+  if (!isBrowser()) return;
+  try {
+    const next = listSavedOrders().filter((o) => o.order_id !== orderId);
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // Swallow.
+  }
+}
+
+function isValidSavedOrder(v: unknown): v is SavedOrder {
+  if (typeof v !== "object" || v === null) return false;
+  const o = v as Record<string, unknown>;
+  return (
+    typeof o.order_id === "string" &&
+    typeof o.customer_name === "string" &&
+    typeof o.drop_name === "string" &&
+    typeof o.drop_date === "string" &&
+    typeof o.slot_pickup_time === "string" &&
+    typeof o.saved_at === "string"
+  );
+}

--- a/apps/mypizzatracker/frontend/src/pages/PublicOrder.tsx
+++ b/apps/mypizzatracker/frontend/src/pages/PublicOrder.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState } from "react";
+import { Link } from "react-router-dom";
 import {
   Card,
   Button,
@@ -6,11 +7,10 @@ import {
   Skeleton,
   EmptyState,
   FormField,
-  StatusBadge,
   showError,
   extractErrorMessage,
 } from "@platform/ui";
-import { Plus, Trash2, Pizza, Phone, CheckCircle2 } from "lucide-react";
+import { Plus, Trash2, Pizza, ArrowRight } from "lucide-react";
 import {
   useGetCurrentPublicDropQuery,
   useGetPublicMenuQuery,
@@ -24,11 +24,15 @@ import type {
   PublicSlot,
   PublicTopping,
 } from "@/types/public/public";
+import { PAYMENT_METHOD_OPTIONS } from "@/types/public/public";
+import { OrderStatusCard } from "@/features/public-order/OrderStatusCard";
 import {
-  PAYMENT_METHOD_OPTIONS,
-  PUBLIC_PAYMENT_STATUS_LABELS,
-  PUBLIC_ORDER_STATUS_LABELS,
-} from "@/types/public/public";
+  formatDateLong,
+  formatMoney,
+  formatTime,
+  paymentMethodLabel,
+} from "@/features/public-order/formatters";
+import { saveOrder } from "@/features/public-order/savedOrders";
 
 /**
  * Customer-facing order placement page (mounted at /order, no auth).
@@ -38,11 +42,9 @@ import {
  *   2. If no active drop, show an empty-state with a "check back later" message.
  *   3. Render the order builder: pick a slot, add 1+ pizzas (each with optional
  *      toppings + modifications), enter name + phone + payment method, submit.
- *   4. On success, swap the builder for the confirmation card. The customer
- *      can refresh the page to place another order.
- *
- * The status-check page (PR 6) will live at /order/status and reuse the
- * confirmation card layout.
+ *   4. On success, swap the builder for the confirmation card and persist the
+ *      order ID to localStorage so /order/status can list it later. The
+ *      customer can also jump to /order/status/:id directly from here.
  */
 export default function PublicOrderPage() {
   const dropQuery = useGetCurrentPublicDropQuery();
@@ -90,7 +92,7 @@ export default function PublicOrderPage() {
   if (confirmation) {
     return (
       <PageShell>
-        <Confirmation confirmation={confirmation} />
+        <FreshConfirmation order={confirmation} />
       </PageShell>
     );
   }
@@ -238,6 +240,14 @@ function OrderBuilder({ drop, menu, onPlaced }: OrderBuilderProps) {
     };
     try {
       const result = await placeOrder(body).unwrap();
+      saveOrder({
+        order_id: result.order_id,
+        customer_name: result.customer_name,
+        drop_name: result.drop_name,
+        drop_date: result.drop_date,
+        slot_pickup_time: result.slot_pickup_time,
+        saved_at: new Date().toISOString(),
+      });
       onPlaced(result);
     } catch (err) {
       showError(extractErrorMessage(err) || "Could not place your order");
@@ -562,93 +572,30 @@ function PaymentMethodChip({ label, selected, onClick }: PaymentMethodChipProps)
 }
 
 // ---------------------------------------------------------------------------
-// Confirmation
+// Fresh-confirmation wrapper (post-placement)
 // ---------------------------------------------------------------------------
 
-interface ConfirmationProps {
-  confirmation: PublicOrderConfirmation;
+interface FreshConfirmationProps {
+  order: PublicOrderConfirmation;
 }
 
-function Confirmation({ confirmation }: ConfirmationProps) {
+function FreshConfirmation({ order }: FreshConfirmationProps) {
   return (
     <div className="space-y-4">
+      <OrderStatusCard order={order} variant="fresh" />
       <Card>
-        <div className="flex items-start gap-3">
-          <div className="w-10 h-10 rounded-full bg-emerald-500/10 flex items-center justify-center shrink-0">
-            <CheckCircle2 className="h-5 w-5 text-emerald-600" />
-          </div>
-          <div>
-            <h2 className="text-xl font-semibold">Order placed!</h2>
-            <p className="text-sm text-muted-foreground">
-              Pickup at {formatTime(confirmation.slot_pickup_time)} on {formatDateLong(confirmation.drop_date)}
-            </p>
-          </div>
-        </div>
-        <div className="mt-4 space-y-1 text-sm">
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Order #</span>
-            <span className="font-mono">{shortId(confirmation.order_id)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Name</span>
-            <span>{confirmation.customer_name}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">
-              <Phone className="inline h-3 w-3 mr-1" />
-              Phone
-            </span>
-            <span>{formatPhoneDisplay(confirmation.customer_phone)}</span>
-          </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Status</span>
-            <StatusBadge tone="info" label={PUBLIC_ORDER_STATUS_LABELS[confirmation.status]} />
-          </div>
-          <div className="flex justify-between">
-            <span className="text-muted-foreground">Payment</span>
-            <span>
-              {paymentMethodLabel(confirmation.payment_method_tag)} (
-              {PUBLIC_PAYMENT_STATUS_LABELS[confirmation.payment_status]})
-            </span>
-          </div>
-        </div>
+        <p className="text-sm">
+          Save the link below so you can check your order status from any
+          device. We'll also text you when your pizza is ready.
+        </p>
+        <Link
+          to={`/order/status/${order.order_id}`}
+          className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-primary hover:underline"
+        >
+          Track this order
+          <ArrowRight className="h-3 w-3" />
+        </Link>
       </Card>
-
-      <Card>
-        <h3 className="text-lg font-semibold mb-3">Your order</h3>
-        <ul className="divide-y">
-          {confirmation.pizzas.map((p, i) => (
-            <li key={i} className="py-2">
-              <div className="flex justify-between items-start gap-3">
-                <div>
-                  <div className="font-medium">{p.pizza_name}</div>
-                  {p.toppings.length > 0 ? (
-                    <div className="text-xs text-muted-foreground">
-                      + {p.toppings.join(", ")}
-                    </div>
-                  ) : null}
-                  {p.modifications_text ? (
-                    <div className="text-xs italic text-muted-foreground">
-                      "{p.modifications_text}"
-                    </div>
-                  ) : null}
-                </div>
-                <div className="text-sm shrink-0">
-                  ${formatMoney(p.line_total)}
-                </div>
-              </div>
-            </li>
-          ))}
-        </ul>
-        <div className="mt-3 pt-3 border-t flex justify-between text-base font-semibold">
-          <span>Total</span>
-          <span>${formatMoney(confirmation.total)}</span>
-        </div>
-      </Card>
-
-      <p className="text-xs text-muted-foreground text-center">
-        Save your order # to check status later. We'll text you when your pizza is ready.
-      </p>
     </div>
   );
 }
@@ -687,48 +634,4 @@ function cryptoRandomId(): string {
     return crypto.randomUUID();
   }
   return Math.random().toString(36).slice(2);
-}
-
-function formatMoney(value: string | number): string {
-  const n = typeof value === "number" ? value : Number(value);
-  if (Number.isNaN(n)) return String(value);
-  return n.toFixed(2);
-}
-
-function formatTime(time: string): string {
-  // Expecting "HH:MM:SS" or "HH:MM"
-  const [hh = "00", mm = "00"] = time.split(":");
-  const h = Number(hh);
-  const period = h >= 12 ? "PM" : "AM";
-  const display = h === 0 ? 12 : h > 12 ? h - 12 : h;
-  return `${display}:${mm} ${period}`;
-}
-
-function formatDateLong(iso: string): string {
-  // iso = "YYYY-MM-DD" -- build a local-date Date so we don't drift across TZ.
-  const [y, m, d] = iso.split("-").map(Number);
-  if (!y || !m || !d) return iso;
-  const date = new Date(y, m - 1, d);
-  return date.toLocaleDateString(undefined, {
-    weekday: "long",
-    month: "long",
-    day: "numeric",
-  });
-}
-
-function paymentMethodLabel(tag: string): string {
-  return (
-    PAYMENT_METHOD_OPTIONS.find((o) => o.tag === tag)?.label ?? tag
-  );
-}
-
-function formatPhoneDisplay(digits: string): string {
-  if (digits.length === 10) {
-    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
-  }
-  return digits;
-}
-
-function shortId(id: string): string {
-  return id.slice(0, 8).toUpperCase();
 }

--- a/apps/mypizzatracker/frontend/src/pages/PublicOrderStatus.tsx
+++ b/apps/mypizzatracker/frontend/src/pages/PublicOrderStatus.tsx
@@ -1,0 +1,141 @@
+import { Link, useParams } from "react-router-dom";
+import { Card, EmptyState, Skeleton, extractErrorMessage } from "@platform/ui";
+import { Pizza, ArrowRight } from "lucide-react";
+import { useGetPublicOrderQuery } from "@/store/publicApi";
+import { OrderStatusCard } from "@/features/public-order/OrderStatusCard";
+import {
+  formatDateLong,
+  formatTime,
+  shortId,
+} from "@/features/public-order/formatters";
+import { listSavedOrders } from "@/features/public-order/savedOrders";
+
+/**
+ * Customer-facing order status page.
+ *
+ *   /order/status               -> list saved orders from this browser (or
+ *                                  an empty state pointing back to /order).
+ *   /order/status/:orderId      -> fetch + render the order via OrderStatusCard.
+ *
+ * Authentication: none. The order_id (UUID) is the access token. PR 5 hands
+ * it to the customer at placement time and persists it via savedOrders.
+ */
+export default function PublicOrderStatusPage() {
+  const { orderId } = useParams<{ orderId?: string }>();
+
+  return (
+    <main className="min-h-screen bg-background">
+      <div className="mx-auto max-w-2xl p-4 sm:p-8 space-y-6">
+        <header className="flex items-center gap-3">
+          <div className="w-10 h-10 rounded-full bg-primary/10 flex items-center justify-center">
+            <Pizza className="h-5 w-5" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold leading-tight">Desmadre Pizza Drop</h1>
+            <p className="text-xs text-muted-foreground">Order status</p>
+          </div>
+        </header>
+        {orderId ? <SingleOrderView orderId={orderId} /> : <RecentOrdersList />}
+      </div>
+    </main>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Single-order lookup
+// ---------------------------------------------------------------------------
+
+interface SingleOrderViewProps {
+  orderId: string;
+}
+
+function SingleOrderView({ orderId }: SingleOrderViewProps) {
+  const query = useGetPublicOrderQuery(orderId);
+
+  if (query.isLoading) {
+    return (
+      <div className="space-y-4">
+        <Skeleton className="h-32 w-full" />
+        <Skeleton className="h-48 w-full" />
+      </div>
+    );
+  }
+
+  if (query.isError && (query.error as { status?: number })?.status === 404) {
+    return (
+      <EmptyState
+        heading="Order not found"
+        body="The link may be wrong or the order was deleted. Double-check the URL from your confirmation."
+        action={{ label: "Place a new order", onClick: () => { window.location.href = "/order"; } }}
+      />
+    );
+  }
+
+  if (query.isError) {
+    return (
+      <EmptyState
+        heading="Could not load this order"
+        body={extractErrorMessage(query.error) || "Please try again."}
+        action={{ label: "Retry", onClick: () => query.refetch() }}
+      />
+    );
+  }
+
+  if (!query.data) return null;
+
+  return <OrderStatusCard order={query.data} variant="lookup" />;
+}
+
+// ---------------------------------------------------------------------------
+// Recent-orders list (no :orderId in URL)
+// ---------------------------------------------------------------------------
+
+function RecentOrdersList() {
+  const saved = listSavedOrders();
+
+  if (saved.length === 0) {
+    return (
+      <EmptyState
+        heading="No saved orders"
+        body="Orders placed from this browser will appear here. Place one to get started."
+        action={{
+          label: "Place an order",
+          onClick: () => { window.location.href = "/order"; },
+        }}
+      />
+    );
+  }
+
+  return (
+    <Card>
+      <h2 className="text-lg font-semibold mb-3">Your recent orders</h2>
+      <p className="text-xs text-muted-foreground mb-4">
+        Stored locally in this browser only -- clear your browser data and
+        this list goes away. The orders themselves are kept server-side.
+      </p>
+      <ul className="divide-y">
+        {saved.map((entry) => (
+          <li key={entry.order_id} className="py-3">
+            <Link
+              to={`/order/status/${entry.order_id}`}
+              className="flex items-center justify-between gap-3 hover:bg-muted/30 -mx-2 px-2 py-1 rounded"
+            >
+              <div className="min-w-0">
+                <div className="font-medium truncate">
+                  {entry.drop_name}
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {formatDateLong(entry.drop_date)} -- pickup {formatTime(entry.slot_pickup_time)}
+                </div>
+                <div className="text-xs font-mono text-muted-foreground">
+                  #{shortId(entry.order_id)} -- {entry.customer_name}
+                </div>
+              </div>
+              <ArrowRight className="h-4 w-4 text-muted-foreground shrink-0" />
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/apps/mypizzatracker/frontend/src/routes.tsx
+++ b/apps/mypizzatracker/frontend/src/routes.tsx
@@ -10,6 +10,7 @@ import ResetPassword from "@/pages/ResetPassword";
 import VerifyEmail from "@/pages/VerifyEmail";
 import NotFound from "@/pages/NotFound";
 import PublicOrder from "@/pages/PublicOrder";
+import PublicOrderStatus from "@/pages/PublicOrderStatus";
 import RootLayout from "@/RootLayout";
 
 // Scaffolded app -- single-user, no /register route.
@@ -29,6 +30,8 @@ export const routes: RouteObject[] = [
     ],
   },
   { path: "/order", element: <PublicOrder /> },
+  { path: "/order/status", element: <PublicOrderStatus /> },
+  { path: "/order/status/:orderId", element: <PublicOrderStatus /> },
   { path: "/login", element: <Login /> },
   { path: "/forgot-password", element: <ForgotPassword /> },
   { path: "/reset-password", element: <ResetPassword /> },

--- a/apps/mypizzatracker/frontend/src/store/publicApi.ts
+++ b/apps/mypizzatracker/frontend/src/store/publicApi.ts
@@ -26,6 +26,12 @@ const publicApi = baseApi.injectEndpoints({
     >({
       query: (body) => ({ url: "/public/orders", method: "POST", data: body }),
     }),
+    getPublicOrder: build.query<PublicOrderConfirmation, string>({
+      query: (orderId) => ({
+        url: `/public/orders/${orderId}`,
+        method: "GET",
+      }),
+    }),
   }),
 });
 
@@ -33,4 +39,5 @@ export const {
   useGetPublicMenuQuery,
   useGetCurrentPublicDropQuery,
   usePlacePublicOrderMutation,
+  useGetPublicOrderQuery,
 } = publicApi;


### PR DESCRIPTION
## Summary

Phase 1 PR 6 of the mypizzatracker plan: customers can revisit an order they placed via /order/status/:orderId and see its current state. No auth -- the order UUID handed out by PR 5 is the access token. /order/status (no id) shows a localStorage-backed list of recent orders placed from this browser.

## Backend

- `GET /public/orders/{order_id}` returns the same `PublicOrderConfirmation` shape as the placement endpoint; reuses `public_service.build_order_confirmation` so wire shape stays in lockstep.
- 3 new tests covering round-trip shape, 404 on unknown UUID, 422 on malformed UUID. Full backend suite: **53/53 passing** locally.

## Frontend

- Extracted the placement confirmation card into `features/public-order/OrderStatusCard.tsx` with a `variant` prop (`"fresh"` post-placement vs `"lookup"` on revisit). Status badge tone is now state-aware.
- `features/public-order/formatters.ts` hosts shared time/money/phone/id helpers used by both the placement and status pages.
- `features/public-order/savedOrders.ts` -- tiny localStorage-backed list (cap 20). `PublicOrder` writes on successful submit; `PublicOrderStatus` reads when there's no `:orderId`.
- New page `PublicOrderStatus.tsx` serves both routes: `/order/status/:orderId` fetches via `useGetPublicOrderQuery`, `/order/status` lists saved entries (or empty-state with a CTA back to `/order`).

## What lands later

- PR 7: owner-side service dashboard with the 6-status advance, which mutates the `status` field this page now reads.
- PR 8: Twilio SMS wiring on the `ready_text_sent` transition.

## Test plan

- [ ] CI green
- [ ] `pytest` 53/53 (50 from PR 5 + 3 new status tests)
- [ ] Frontend typecheck + lint + build clean
- [ ] Manual smoke when deployed: place an order, click "Track this order", refresh -- card persists. Bad UUID -> friendly 404. /order/status -> see the order in the list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)