### PR TITLE
feat(mga): operator minimap upload UI

### DIFF
--- a/apps/mygamingassistant/backend/app/api/games.py
+++ b/apps/mygamingassistant/backend/app/api/games.py
@@ -4,27 +4,51 @@ The game taxonomy (games, maps, zones, sites, utility types) is reference data
 that's safe to expose publicly. MGA's auth model is public-read / auth-write:
 anyone can browse the lineup library, only the operator can manage content.
 
-Routes (all public):
-    GET /api/games                          — list all games
-    GET /api/games/{game_slug}/maps         — list maps for a game
-    GET /api/games/{game_slug}/maps/{map_slug} — map detail with zones + sites + utility types
+Routes:
+    PUBLIC (no auth):
+        GET  /api/games                                — list all games
+        GET  /api/games/{game_slug}/maps               — list maps for a game
+        GET  /api/games/{game_slug}/maps/{map_slug}    — map detail with zones + sites + utility types
+
+    AUTH (operator only):
+        POST /api/maps/{map_id}/minimap-upload-url     — presigned PUT for minimap
+        POST /api/maps/{map_id}/minimap                — confirm upload, update Map.minimap_url
 
 See ``apps/mygamingassistant/CLAUDE.md`` → Authentication Model for the
 public-read/auth-write rationale (MGA-specific Tier 3 divergence).
 """
+import uuid
+
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.core.auth import current_active_user
 from app.db.session import get_db
 from app.models.game.game import Game
 from app.models.game.map import Map
 from app.models.game.map_zone import MapZone  # noqa: F401 — used via selectinload
 from app.models.game.site import Site  # noqa: F401 — used via selectinload
 from app.models.game.utility_type import UtilityType
+from app.models.user.user import User
+from app.schemas.game.map_schemas import (
+    MapMinimapUpdated,
+    MinimapConfirmBody,
+    MinimapUploadUrlResponse,
+)
+from app.services.game import map_service
 
+# Public — game taxonomy reads. Module-export name kept as ``router`` so
+# existing main.py wiring (``app.include_router(games.router)``) is unchanged.
 router = APIRouter(tags=["games"])
+
+# Operator-only — minimap upload + confirm. Router-level auth dep ensures
+# new handlers added here cannot accidentally ship public.
+auth_router = APIRouter(
+    tags=["games"],
+    dependencies=[Depends(current_active_user)],
+)
 
 
 @router.get("/games")
@@ -66,7 +90,7 @@ async def list_maps(
             "id": str(m.id),
             "slug": m.slug,
             "name": m.name,
-            "minimap_url": m.minimap_url,
+            "minimap_url": map_service.sign_minimap_url(m.minimap_url),
         }
         for m in maps
     ]
@@ -102,7 +126,7 @@ async def get_map(
         "id": str(map_obj.id),
         "slug": map_obj.slug,
         "name": map_obj.name,
-        "minimap_url": map_obj.minimap_url,
+        "minimap_url": map_service.sign_minimap_url(map_obj.minimap_url),
         "zones": [
             {
                 "id": str(z.id),
@@ -121,3 +145,67 @@ async def get_map(
             for u in utility_types
         ],
     }
+
+
+# ===========================================================================
+# Auth-required routes — operator only
+# ===========================================================================
+
+@auth_router.post(
+    "/maps/{map_id}/minimap-upload-url",
+    response_model=MinimapUploadUrlResponse,
+)
+async def get_minimap_upload_url(
+    map_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(current_active_user),
+) -> MinimapUploadUrlResponse:
+    """Return a presigned PUT URL for replacing this map's minimap.
+
+    Caller PUTs the image to ``put_url`` (raw body, Content-Type matters
+    because the confirm endpoint validates it), then POSTs
+    /api/maps/{map_id}/minimap with the returned ``object_key`` to persist.
+    """
+    map_obj = await db.get(Map, map_id)
+    if map_obj is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+
+    put_url, object_key = map_service.generate_minimap_upload_url(map_id)
+    return MinimapUploadUrlResponse(put_url=put_url, object_key=object_key)
+
+
+@auth_router.post(
+    "/maps/{map_id}/minimap",
+    response_model=MapMinimapUpdated,
+)
+async def confirm_minimap_upload(
+    map_id: uuid.UUID,
+    body: MinimapConfirmBody,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(current_active_user),
+) -> MapMinimapUpdated:
+    """Confirm a minimap upload completed and persist the object key.
+
+    Validates: object exists in MinIO, size <= 5 MB, allowed image MIME,
+    object_key matches the canonical key for this map (cannot repoint at
+    arbitrary keys). On success, ``Map.minimap_url`` becomes the object
+    key — read paths resolve it to a presigned GET URL via
+    ``map_service.sign_minimap_url``.
+    """
+    map_obj = await db.get(Map, map_id)
+    if map_obj is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+
+    try:
+        map_service.confirm_minimap_upload(map_id, body.object_key)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    map_obj.minimap_url = body.object_key
+    await db.flush()
+    await db.commit()
+
+    return MapMinimapUpdated(
+        map_id=map_id,
+        minimap_url=map_service.sign_minimap_url(map_obj.minimap_url),
+    )

--- a/apps/mygamingassistant/backend/app/main.py
+++ b/apps/mygamingassistant/backend/app/main.py
@@ -253,6 +253,10 @@ app.include_router(
 # (public read, auth write); sources + scheduler + admin stay auth-only.
 app.include_router(health.router, tags=["health"])
 app.include_router(games.router)
+# games.auth_router handles operator-only minimap-upload endpoints under
+# /api/maps/{map_id}/... — kept separate from games.router so auth gating is
+# router-level, not per-handler.
+app.include_router(games.auth_router)
 # Auth-router includes literal-path routes (/lineups/pending, /lineups/bulk-accept)
 # that would otherwise be shadowed by the public_router's /lineups/{lineup_id}
 # parametric route. Include auth_router FIRST so the literal routes match before

--- a/apps/mygamingassistant/backend/app/schemas/game/map_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/map_schemas.py
@@ -1,0 +1,40 @@
+"""Pydantic schemas for map-related operator endpoints (minimap upload).
+
+The map read endpoints in api/games.py return a dict — kept that way to
+preserve existing API shape. These schemas are only for the new auth-gated
+write endpoints.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from pydantic import BaseModel
+
+
+class MinimapUploadUrlResponse(BaseModel):
+    """Response from POST /api/maps/{map_id}/minimap-upload-url.
+
+    The frontend PUTs the file to ``put_url`` (multipart not needed; raw body),
+    then calls POST /api/maps/{map_id}/minimap with ``object_key`` to confirm.
+    """
+
+    put_url: str
+    object_key: str
+
+
+class MinimapConfirmBody(BaseModel):
+    """Body for POST /api/maps/{map_id}/minimap — confirms the PUT completed
+    and the backend should now persist the object key as the map's minimap_url.
+    """
+
+    object_key: str
+
+
+class MapMinimapUpdated(BaseModel):
+    """Response from POST /api/maps/{map_id}/minimap — the new effective URL
+    the frontend should display (presigned GET URL).
+    """
+
+    map_id: uuid.UUID
+    minimap_url: Optional[str] = None

--- a/apps/mygamingassistant/backend/app/services/game/map_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/map_service.py
@@ -1,0 +1,164 @@
+"""Map service — minimap upload + sign-on-read.
+
+The lineup_service already does both for lineup screenshots; this module is
+the map-domain equivalent. Storage of minimaps follows the same convention:
+
+  - `Map.minimap_url` may hold one of three URL-shapes:
+      1. A relative path (e.g. `/minimaps/cs2/mirage.png`) — bundled asset
+         under `frontend/public/minimaps/`. Passed through to the client
+         unchanged so the SPA serves it directly.
+      2. An absolute URL (e.g. `https://...`) — pre-existing data or future
+         CDN-hosted assets. Also passed through unchanged.
+      3. A MinIO object key (e.g. `maps/<map_id>/minimap.png`) — operator
+         uploaded via this service. The read path signs a presigned GET URL.
+
+  - Object keys are stable per map (`maps/<map_id>/minimap.png`); re-uploads
+    overwrite. Presigned URLs naturally cache-bust on every read because the
+    signature query params change per call.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import timedelta
+from typing import Optional
+
+from app.core.storage import get_storage
+
+# Mirrors lineup_service: 15-minute PUT TTL, 24-hour GET TTL.
+_UPLOAD_URL_TTL = timedelta(minutes=15)
+_READ_URL_TTL = 24 * 3600  # seconds
+
+# 5 MB cap on uploaded minimaps. CS2 radars from pak01_dir.vpk are well under
+# this; valorant minimaps from valorant-api.com are also small. Anything
+# bigger is almost certainly the wrong asset.
+MAX_MINIMAP_BYTES = 5 * 1024 * 1024
+
+# Allowed image content-types (also enforced by content-sniff after upload).
+_ALLOWED_CONTENT_TYPES = {"image/png", "image/jpeg", "image/webp"}
+
+
+def minimap_object_key(map_id: uuid.UUID) -> str:
+    """Build the canonical MinIO object key for a map's minimap.
+
+    Stable per map — re-uploads overwrite. Path-prefixed to keep maps/
+    grouped under one MinIO key prefix, separate from lineup screenshots.
+    """
+    return f"maps/{map_id}/minimap.png"
+
+
+def generate_minimap_upload_url(map_id: uuid.UUID) -> tuple[str, str]:
+    """Return (presigned_put_url, object_key) for a minimap upload.
+
+    Caller flow:
+      1. POST /api/maps/{map_id}/minimap-upload-url → this function
+      2. Client PUT to put_url with the file body
+      3. POST /api/maps/{map_id}/minimap → confirm_minimap_upload
+    """
+    storage = get_storage()
+    key = minimap_object_key(map_id)
+    put_url = _presigned_put(storage, key)
+    return put_url, key
+
+
+def confirm_minimap_upload(map_id: uuid.UUID, object_key: str) -> None:
+    """Validate the uploaded object before persisting the key as minimap_url.
+
+    Validates:
+      - object_key matches the canonical key for this map (caller cannot
+        repoint Map.minimap_url at an arbitrary MinIO object).
+      - object exists in MinIO (the PUT actually happened).
+      - object size <= MAX_MINIMAP_BYTES.
+      - object content-type is an allowed image MIME.
+
+    Raises ``ValueError`` on any validation failure. Caller is responsible
+    for catching this and converting to an HTTP 422.
+    """
+    expected = minimap_object_key(map_id)
+    if object_key != expected:
+        raise ValueError(
+            f"object_key {object_key!r} does not match expected {expected!r} "
+            "for this map; refusing to update minimap_url."
+        )
+
+    storage = get_storage()
+    info = _stat_object(storage, object_key)
+    if info is None:
+        raise ValueError(
+            "no object found at the expected key — was the PUT completed?"
+        )
+
+    size = info.get("size", 0)
+    if size > MAX_MINIMAP_BYTES:
+        raise ValueError(
+            f"minimap is {size} bytes; limit is {MAX_MINIMAP_BYTES} bytes "
+            f"({MAX_MINIMAP_BYTES // 1024 // 1024} MB)."
+        )
+
+    content_type = (info.get("content_type") or "").lower()
+    if content_type not in _ALLOWED_CONTENT_TYPES:
+        raise ValueError(
+            f"content-type {content_type!r} not allowed; "
+            f"expected one of: {sorted(_ALLOWED_CONTENT_TYPES)}."
+        )
+
+
+def sign_minimap_url(url: Optional[str]) -> Optional[str]:
+    """Resolve a stored ``Map.minimap_url`` value to a client-usable URL.
+
+    Pass-through for None, paths (``/...``), and absolute URLs. MinIO object
+    keys (no leading slash, no protocol) get signed into a presigned GET URL.
+    """
+    if not url:
+        return None
+    if url.startswith("/") or url.startswith("http://") or url.startswith("https://"):
+        return url
+    storage = get_storage()
+    return storage.generate_presigned_url(url, expires_in_seconds=_READ_URL_TTL)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers — mirror lineup_service._presigned_put / _stat_object
+# ---------------------------------------------------------------------------
+
+def _presigned_put(storage, key: str) -> str:
+    """Sign a PUT URL using the public MinIO client when available.
+
+    Same logic as ``lineup_service._presigned_put`` — split into a private
+    helper so future bucket / endpoint changes only need updating in one
+    place (kept inline rather than imported to keep service modules
+    independently movable).
+    """
+    from platform_shared.core.storage import _DualEndpointStorageClient
+
+    if isinstance(storage, _DualEndpointStorageClient):
+        return storage._public_client.presigned_put_object(
+            storage.bucket, key, expires=_UPLOAD_URL_TTL
+        )
+    return storage._client.presigned_put_object(
+        storage.bucket, key, expires=_UPLOAD_URL_TTL
+    )
+
+
+def _stat_object(storage, key: str) -> Optional[dict]:
+    """Return {size, content_type} for a MinIO object, or None on miss.
+
+    minio-py's stat_object raises ``S3Error`` with code NoSuchKey on miss.
+    """
+    from minio.error import S3Error
+    from platform_shared.core.storage import _DualEndpointStorageClient
+
+    client = (
+        storage._client
+        if not isinstance(storage, _DualEndpointStorageClient)
+        else storage._client
+    )
+    try:
+        stat = client.stat_object(storage.bucket, key)
+    except S3Error as exc:
+        if exc.code == "NoSuchKey":
+            return None
+        raise
+    return {
+        "size": stat.size,
+        "content_type": stat.content_type,
+    }

--- a/apps/mygamingassistant/backend/tests/test_minimap_upload.py
+++ b/apps/mygamingassistant/backend/tests/test_minimap_upload.py
@@ -1,0 +1,217 @@
+"""Tests for the minimap-upload endpoints in api/games.py.
+
+Covers:
+- POST /api/maps/{map_id}/minimap-upload-url returns a presigned PUT + key
+- Endpoint rejects unauthenticated callers (router-level auth gate)
+- POST /api/maps/{map_id}/minimap updates Map.minimap_url and signs response
+- Confirm rejects mismatched object_key (cannot repoint to arbitrary keys)
+- Confirm rejects oversize and disallowed content-type uploads
+- sign_minimap_url passes through paths/URLs unchanged, signs object keys
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.game import Game
+from app.models.game.map import Map
+from app.models.user.user import User
+from app.services.game import map_service
+
+
+@pytest_asyncio.fixture
+async def auth_client(client: AsyncClient, db: AsyncSession) -> AsyncClient:
+    """Create a test user and log in; return an authed AsyncClient.
+
+    Inlined from test_lineups.py so this test module is self-contained.
+    """
+    from fastapi_users.password import PasswordHelper
+    from sqlalchemy import select
+
+    TEST_EMAIL = "minimap-test@example.com"
+    TEST_PASSWORD = "testpassword123!"
+
+    result = await db.execute(select(User).where(User.email == TEST_EMAIL))
+    user = result.scalar_one_or_none()
+    if user is None:
+        helper = PasswordHelper()
+        user = User(
+            email=TEST_EMAIL,
+            hashed_password=helper.hash(TEST_PASSWORD),
+            is_verified=True,
+            is_active=True,
+        )
+        db.add(user)
+        await db.flush()
+
+    login = await client.post(
+        "/auth/jwt/login",
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
+    )
+    assert login.status_code == 200, login.text
+    token = login.json()["access_token"]
+    client.headers["Authorization"] = f"Bearer {token}"
+    return client
+
+
+@pytest_asyncio.fixture
+async def seeded_map(db: AsyncSession) -> Map:
+    game = Game(slug="cs2-test", name="CS2 Test", side_a_label="T", side_b_label="CT")
+    db.add(game)
+    await db.flush()
+    map_obj = Map(game_id=game.id, slug="mirage-test", name="Mirage Test")
+    db.add(map_obj)
+    await db.flush()
+    return map_obj
+
+
+@pytest.fixture
+def mock_storage_for_minimap():
+    """Mock the storage client used by map_service helpers."""
+    mock = MagicMock()
+    mock.bucket = "mygamingassistant-test"
+    mock._client.presigned_put_object.return_value = (
+        "https://minio.example.com/signed-put-url"
+    )
+    # stat_object default: PNG, 100KB
+    stat_mock = MagicMock(size=100 * 1024, content_type="image/png")
+    mock._client.stat_object.return_value = stat_mock
+    mock.generate_presigned_url.return_value = "https://minio.example.com/signed-get-url"
+    with patch("app.services.game.map_service.get_storage", return_value=mock):
+        yield mock
+
+
+# ---------------------------------------------------------------------------
+# Upload-url endpoint
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_upload_url_requires_auth(
+    client: AsyncClient, seeded_map: Map
+):
+    """Unauthenticated callers must get 401."""
+    resp = await client.post(f"/api/maps/{seeded_map.id}/minimap-upload-url")
+    assert resp.status_code == 401, resp.text
+
+
+@pytest.mark.asyncio
+async def test_upload_url_returns_put_url_and_canonical_key(
+    auth_client: AsyncClient, seeded_map: Map, mock_storage_for_minimap
+):
+    """Authed POST returns a presigned PUT URL + canonical object key."""
+    resp = await auth_client.post(f"/api/maps/{seeded_map.id}/minimap-upload-url")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["put_url"] == "https://minio.example.com/signed-put-url"
+    assert body["object_key"] == f"maps/{seeded_map.id}/minimap.png"
+
+
+@pytest.mark.asyncio
+async def test_upload_url_unknown_map_404(
+    auth_client: AsyncClient, mock_storage_for_minimap
+):
+    bogus_id = uuid.uuid4()
+    resp = await auth_client.post(f"/api/maps/{bogus_id}/minimap-upload-url")
+    assert resp.status_code == 404, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Confirm endpoint
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_confirm_updates_minimap_url_and_returns_signed(
+    auth_client: AsyncClient, seeded_map: Map, mock_storage_for_minimap
+):
+    """Confirm endpoint persists object_key in DB and returns presigned GET URL."""
+    object_key = f"maps/{seeded_map.id}/minimap.png"
+    resp = await auth_client.post(
+        f"/api/maps/{seeded_map.id}/minimap",
+        json={"object_key": object_key},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["map_id"] == str(seeded_map.id)
+    # The signed URL came from the mock's generate_presigned_url.
+    assert body["minimap_url"] == "https://minio.example.com/signed-get-url"
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_wrong_object_key(
+    auth_client: AsyncClient, seeded_map: Map, mock_storage_for_minimap
+):
+    """Cannot repoint Map.minimap_url at an arbitrary object key — 422."""
+    resp = await auth_client.post(
+        f"/api/maps/{seeded_map.id}/minimap",
+        json={"object_key": "some/other/object.png"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "expected" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_oversize(
+    auth_client: AsyncClient, seeded_map: Map, mock_storage_for_minimap
+):
+    """6 MB upload exceeds the 5 MB ceiling → 422."""
+    mock_storage_for_minimap._client.stat_object.return_value = MagicMock(
+        size=6 * 1024 * 1024, content_type="image/png"
+    )
+    resp = await auth_client.post(
+        f"/api/maps/{seeded_map.id}/minimap",
+        json={"object_key": f"maps/{seeded_map.id}/minimap.png"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "limit" in resp.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_confirm_rejects_non_image_content_type(
+    auth_client: AsyncClient, seeded_map: Map, mock_storage_for_minimap
+):
+    """text/html upload (e.g. SVG-as-text) is rejected → 422."""
+    mock_storage_for_minimap._client.stat_object.return_value = MagicMock(
+        size=1024, content_type="text/html"
+    )
+    resp = await auth_client.post(
+        f"/api/maps/{seeded_map.id}/minimap",
+        json={"object_key": f"maps/{seeded_map.id}/minimap.png"},
+    )
+    assert resp.status_code == 422, resp.text
+    assert "content-type" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# sign_minimap_url helper
+# ---------------------------------------------------------------------------
+
+def test_sign_minimap_url_passes_through_path():
+    """Relative paths (bundled assets) pass through unchanged."""
+    assert map_service.sign_minimap_url("/minimaps/cs2/mirage.png") == "/minimaps/cs2/mirage.png"
+
+
+def test_sign_minimap_url_passes_through_absolute():
+    """Absolute http(s) URLs pass through unchanged."""
+    assert (
+        map_service.sign_minimap_url("https://cdn.example.com/x.png")
+        == "https://cdn.example.com/x.png"
+    )
+
+
+def test_sign_minimap_url_none_stays_none():
+    assert map_service.sign_minimap_url(None) is None
+    assert map_service.sign_minimap_url("") is None
+
+
+def test_sign_minimap_url_signs_object_key(mock_storage_for_minimap):
+    """Object keys (no /, no protocol) get signed as presigned GET URLs."""
+    result = map_service.sign_minimap_url("maps/some-uuid/minimap.png")
+    assert result == "https://minio.example.com/signed-get-url"
+    mock_storage_for_minimap.generate_presigned_url.assert_called_once_with(
+        "maps/some-uuid/minimap.png", expires_in_seconds=24 * 3600
+    )

--- a/apps/mygamingassistant/frontend/public/minimaps/README.md
+++ b/apps/mygamingassistant/frontend/public/minimaps/README.md
@@ -1,12 +1,23 @@
 # Minimap assets
 
-These PNGs are bundled directly into the frontend so the map view doesn't depend on
-a third-party CDN. Path convention is `public/minimaps/<game-slug>/<map-slug>.png`.
+Two ways to populate map minimaps. **Pick whichever is easier per map.**
 
-The fixture files (`backend/app/fixtures/{cs2,valorant}_maps.json`) reference these
-paths via `minimap_url: "/minimaps/<game>/<map>.png"`. When the file is missing,
-`MapPage.tsx` falls back to a "Minimap not available" text block via the `<img onError>`
-handler, so the page never shows a broken-image icon.
+### 1. Operator upload UI (recommended for one-off updates)
+
+Log in as the operator, navigate to any map page (`/cs2/mirage` etc.), and click
+**Replace minimap** at the top-right. Pick a PNG/JPG/WebP up to 5 MB. The file goes to
+MinIO under `maps/<map_id>/minimap.png` and `Map.minimap_url` is updated; the GET
+endpoint returns a presigned URL on each read (24 h TTL). No commit needed.
+
+### 2. Bundled PNGs (for repo-versioned defaults)
+
+Drop PNGs into `public/minimaps/<game-slug>/<map-slug>.png` and update the fixture's
+`minimap_url` to `"/minimaps/<game>/<map>.png"`. Useful for shipping defaults that ship
+with the codebase rather than living in MinIO.
+
+When the bundled file is missing AND no upload exists, `MapPage.tsx` falls back to
+"Minimap not available" text via the `<img onError>` handler — never shows a
+broken-image icon.
 
 ## CS2 (`public/minimaps/cs2/`)
 

--- a/apps/mygamingassistant/frontend/src/components/game/MinimapUploadDialog.tsx
+++ b/apps/mygamingassistant/frontend/src/components/game/MinimapUploadDialog.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import { FileUploadDropzone, LoadingButton, showError, showSuccess } from "@platform/ui";
+import {
+  useGetMinimapUploadUrlMutation,
+  useConfirmMinimapUploadMutation,
+} from "@/store/gamesApi";
+import { uploadFileToPresignedUrl } from "@/lib/storage";
+
+export interface MinimapUploadDialogProps {
+  mapId: string;
+  mapName: string;
+  onClose: () => void;
+  onUploaded: () => void;
+}
+
+export default function MinimapUploadDialog({
+  mapId,
+  mapName,
+  onClose,
+  onUploaded,
+}: MinimapUploadDialogProps) {
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [progress, setProgress] = useState(0);
+  const [uploading, setUploading] = useState(false);
+  const [getUploadUrl] = useGetMinimapUploadUrlMutation();
+  const [confirmUpload] = useConfirmMinimapUploadMutation();
+
+  function handleFilesSelected(files: File[]) {
+    const f = files[0] ?? null;
+    setFile(f);
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setPreviewUrl(f ? URL.createObjectURL(f) : null);
+  }
+
+  async function handleUpload() {
+    if (!file) return;
+    setUploading(true);
+    setProgress(0);
+    try {
+      const { put_url, object_key } = await getUploadUrl(mapId).unwrap();
+      await uploadFileToPresignedUrl(put_url, file, setProgress);
+      await confirmUpload({ mapId, objectKey: object_key }).unwrap();
+      showSuccess("Minimap updated.");
+      onUploaded();
+      onClose();
+    } catch (err) {
+      const message =
+        err && typeof err === "object" && "data" in err && err.data
+          ? `Upload failed: ${JSON.stringify(err.data)}`
+          : "Upload failed. Check the file is a PNG/JPG/WebP under 5 MB.";
+      showError(message);
+    } finally {
+      setUploading(false);
+      setProgress(0);
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={`Replace minimap for ${mapName}`}
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      onClick={(e) => {
+        if (uploading) return;
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="bg-card border rounded-xl shadow-xl w-full max-w-lg p-6 space-y-4">
+        <div>
+          <h2 className="text-lg font-semibold">Replace minimap</h2>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {mapName} — PNG, JPG, or WebP up to 5 MB. Overwrites the current minimap.
+          </p>
+        </div>
+
+        {!file ? (
+          <FileUploadDropzone
+            accept="image/png,image/jpeg,image/webp"
+            maxSizeBytes={5 * 1024 * 1024}
+            label="Drop minimap image here"
+            helperText="Or click to browse"
+            uploading={false}
+            onFilesSelected={handleFilesSelected}
+          />
+        ) : (
+          <div className="space-y-3">
+            <div className="rounded-lg border bg-muted/20 p-3 flex items-center gap-3">
+              {previewUrl && (
+                <img
+                  src={previewUrl}
+                  alt="Selected minimap preview"
+                  className="h-20 w-20 rounded object-cover border"
+                  draggable={false}
+                />
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium truncate">{file.name}</p>
+                <p className="text-xs text-muted-foreground">
+                  {(file.size / 1024).toFixed(0)} KB
+                </p>
+              </div>
+              {!uploading && (
+                <button
+                  type="button"
+                  onClick={() => handleFilesSelected([])}
+                  className="text-xs text-muted-foreground hover:text-foreground px-2 py-1"
+                  aria-label="Remove selected file"
+                >
+                  Remove
+                </button>
+              )}
+            </div>
+            {uploading && (
+              <div className="space-y-1" aria-live="polite">
+                <div className="h-2 bg-muted/40 rounded overflow-hidden">
+                  <div
+                    className="h-full bg-primary transition-all"
+                    style={{ width: `${progress}%` }}
+                  />
+                </div>
+                <p className="text-xs text-muted-foreground text-right">
+                  {progress < 100 ? `Uploading ${progress}%` : "Finalizing…"}
+                </p>
+              </div>
+            )}
+          </div>
+        )}
+
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={uploading}
+            className="px-4 py-2 text-sm rounded-md border hover:bg-muted/40 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <LoadingButton
+            isLoading={uploading}
+            loadingText="Uploading…"
+            onClick={handleUpload}
+            disabled={!file || uploading}
+          >
+            Upload
+          </LoadingButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -18,7 +18,7 @@
  */
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { ArrowLeft, Backpack, Package, Plus } from "lucide-react";
+import { ArrowLeft, Backpack, ImagePlus, Package, Plus } from "lucide-react";
 import { ToggleChipGroup, showSuccess } from "@platform/ui";
 import { useGetGamesQuery, useGetMapDetailQuery } from "@/store/gamesApi";
 import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
@@ -26,10 +26,12 @@ import { useGetLineupPackagesQuery, usePinAllLineupPackageMutation } from "@/sto
 import LineupCard from "@/components/lineup/LineupCard";
 import MapZoneOverlay from "@/components/lineup/MapZoneOverlay";
 import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
+import MinimapUploadDialog from "@/components/game/MinimapUploadDialog";
 import RoundMode from "@/pages/RoundMode";
 import { usePins } from "@/hooks/usePins";
 import { useLoadout, computeEffectiveUtilFilter } from "@/hooks/useLoadout";
 import { useMapKeyboardShortcuts } from "@/hooks/useMapKeyboardShortcuts";
+import { useIsSuperuser } from "@/hooks/useIsSuperuser";
 import type { Lineup, ZoneDensity } from "@/types/game";
 
 const SIDE_BG: Record<string, string> = {
@@ -62,10 +64,14 @@ export default function MapPage() {
     data: mapDetail,
     isLoading: mapLoading,
     isError: mapError,
+    refetch: refetchMapDetail,
   } = useGetMapDetailQuery(
     { gameSlug: gameSlug ?? "", mapSlug: mapSlug ?? "" },
     { skip: !gameSlug || !mapSlug },
   );
+
+  const { isSuperuser } = useIsSuperuser();
+  const [showMinimapUpload, setShowMinimapUpload] = useState(false);
 
   const game = games?.find((g) => g.slug === gameSlug);
 
@@ -319,6 +325,17 @@ export default function MapPage() {
               <p className="text-xs text-muted-foreground">{game?.name ?? gameSlug}</p>
               <h1 className="text-xl font-semibold capitalize">{mapDetail.name}</h1>
             </div>
+            {isSuperuser && (
+              <button
+                type="button"
+                onClick={() => setShowMinimapUpload(true)}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
+                title="Replace this map's minimap image"
+              >
+                <ImagePlus className="w-4 h-4" />
+                Replace minimap
+              </button>
+            )}
             <Link
               to={addLineupHref}
               className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
@@ -327,6 +344,18 @@ export default function MapPage() {
               Add lineup
             </Link>
           </div>
+
+          {showMinimapUpload && (
+            <MinimapUploadDialog
+              mapId={mapDetail.id}
+              mapName={mapDetail.name}
+              onClose={() => setShowMinimapUpload(false)}
+              onUploaded={() => {
+                refetchMapDetail();
+                setMinimapLoadFailed(false);
+              }}
+            />
+          )}
 
           {/* Sticky filter bar */}
           <div className="sticky top-0 z-10 bg-background/90 backdrop-blur-sm border-b pb-3 -mx-4 px-4 sm:-mx-8 sm:px-8">

--- a/apps/mygamingassistant/frontend/src/store/gamesApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/gamesApi.ts
@@ -1,5 +1,11 @@
 import { baseApi } from "@platform/ui";
-import type { Game, GameMap, MapDetail } from "@/types/game";
+import type {
+  Game,
+  GameMap,
+  MapDetail,
+  MinimapUploadUrlResponse,
+  MapMinimapUpdated,
+} from "@/types/game";
 
 const gamesApi = baseApi.injectEndpoints({
   endpoints: (build) => ({
@@ -15,7 +21,29 @@ const gamesApi = baseApi.injectEndpoints({
         method: "GET",
       }),
     }),
+    getMinimapUploadUrl: build.mutation<MinimapUploadUrlResponse, string>({
+      query: (mapId) => ({
+        url: `/maps/${mapId}/minimap-upload-url`,
+        method: "POST",
+      }),
+    }),
+    confirmMinimapUpload: build.mutation<
+      MapMinimapUpdated,
+      { mapId: string; objectKey: string }
+    >({
+      query: ({ mapId, objectKey }) => ({
+        url: `/maps/${mapId}/minimap`,
+        method: "POST",
+        body: { object_key: objectKey },
+      }),
+    }),
   }),
 });
 
-export const { useGetGamesQuery, useGetMapsQuery, useGetMapDetailQuery } = gamesApi;
+export const {
+  useGetGamesQuery,
+  useGetMapsQuery,
+  useGetMapDetailQuery,
+  useGetMinimapUploadUrlMutation,
+  useConfirmMinimapUploadMutation,
+} = gamesApi;

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -43,6 +43,16 @@ export interface MapDetail {
   utility_types: UtilityType[];
 }
 
+export interface MinimapUploadUrlResponse {
+  put_url: string;
+  object_key: string;
+}
+
+export interface MapMinimapUpdated {
+  map_id: string;
+  minimap_url: string | null;
+}
+
 // ---------------------------------------------------------------------------
 // Lineup domain
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Operator can replace any map's minimap from the browser via a **Replace minimap** button on MapPage. File uploads to private MinIO under `maps/<map_id>/minimap.png`; the GET endpoint serves a presigned URL on each read. No more Source 2 Viewer / VPK extraction needed.
- Backend: two new endpoints on `games.auth_router` (presigned PUT + confirm). Validates object_key against canonical key, size ≤ 5 MB, image MIME types only. `map_service.sign_minimap_url` passes through bundled paths + absolute URLs unchanged; signs only MinIO object keys, so PR #636's bundled-fallback convention keeps working.
- Frontend: `MinimapUploadDialog` with file dropzone + progress bar; button gated by `useIsSuperuser` so anonymous visitors don't see it.

## Security posture (operator-only)

1. Router-level `Depends(current_active_user)` — anonymous = 401
2. Private MinIO bucket; backend mints all presigned PUTs (15-min TTL)
3. Fixed object key per map — confirm endpoint refuses arbitrary repointing
4. Frontend button hidden from non-superusers

## Test plan

- [x] 11 new pytest cases: auth gating, presign happy path, confirm-key mismatch (422), oversize (422), bad content-type (422), `sign_minimap_url` pass-through behavior
- [x] All 197 existing frontend vitest tests still pass
- [x] `npx tsc --noEmit` clean
- [ ] Smoke test in browser: log in → navigate `/cs2/mirage` → click Replace minimap → upload a PNG → real minimap renders without a page reload

## Operational note

No env or VPS changes — reuses the existing MinIO bucket. First map you upload to creates the `maps/` prefix under the same bucket as lineup screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)