### PR TITLE
feat(mga): lineup minimap anchor coords + zone centroid fallback (PR 1/3)

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0006_lineup_minimap_anchors.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0006_lineup_minimap_anchors.py
@@ -1,0 +1,40 @@
+"""Add minimap anchor coordinates to lineup
+
+Revision ID: 0006
+Revises: 0005
+Create Date: 2026-05-14 22:00:00.000000
+
+Adds four nullable Float columns to lineup:
+
+  stand_anchor_x, stand_anchor_y   — normalized 0-1 minimap position where
+                                     the player stands to execute the throw
+  target_anchor_x, target_anchor_y — normalized 0-1 minimap position where
+                                     the utility lands
+
+When NULL (the default for ingestion and back-compat), the API falls back
+to the polygon centroid of stand_zone / target_zone for rendering. This
+gives existing lineups an immediately-usable pin location and lets the
+operator refine coordinates later via the review UI (PR 2 in this series).
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0006"
+down_revision = "0005"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("lineup", sa.Column("stand_anchor_x", sa.Float(), nullable=True))
+    op.add_column("lineup", sa.Column("stand_anchor_y", sa.Float(), nullable=True))
+    op.add_column("lineup", sa.Column("target_anchor_x", sa.Float(), nullable=True))
+    op.add_column("lineup", sa.Column("target_anchor_y", sa.Float(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lineup", "target_anchor_y")
+    op.drop_column("lineup", "target_anchor_x")
+    op.drop_column("lineup", "stand_anchor_y")
+    op.drop_column("lineup", "stand_anchor_x")

--- a/apps/mygamingassistant/backend/app/models/game/lineup.py
+++ b/apps/mygamingassistant/backend/app/models/game/lineup.py
@@ -114,6 +114,14 @@ class Lineup(Base):
     aim_anchor_x: Mapped[float | None] = mapped_column(Float, nullable=True)
     aim_anchor_y: Mapped[float | None] = mapped_column(Float, nullable=True)
 
+    # Normalized 0-1 minimap positions. NULL falls back to zone centroid at
+    # read time so existing lineups render without backfill (PR 1/3 in the
+    # lineup-pins series).
+    stand_anchor_x: Mapped[float | None] = mapped_column(Float, nullable=True)
+    stand_anchor_y: Mapped[float | None] = mapped_column(Float, nullable=True)
+    target_anchor_x: Mapped[float | None] = mapped_column(Float, nullable=True)
+    target_anchor_y: Mapped[float | None] = mapped_column(Float, nullable=True)
+
     # How many seconds the throw takes to execute
     setup_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
 

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -12,7 +12,9 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, computed_field, field_validator, model_validator
+
+from app.services.game.polygon import polygon_centroid
 
 
 # ---------------------------------------------------------------------------
@@ -55,6 +57,13 @@ class LineupRead(BaseModel):
     aim_screenshot_url: Optional[str] = None
     aim_anchor_x: Optional[float] = None
     aim_anchor_y: Optional[float] = None
+    # Minimap anchor positions — raw values from the DB. May be NULL; use the
+    # computed effective_* fields below to render pins (they fall back to the
+    # zone polygon centroid when the explicit anchor isn't set).
+    stand_anchor_x: Optional[float] = None
+    stand_anchor_y: Optional[float] = None
+    target_anchor_x: Optional[float] = None
+    target_anchor_y: Optional[float] = None
     setup_seconds: Optional[int] = None
     attribution_url: Optional[str] = None
     attribution_author: Optional[str] = None
@@ -82,6 +91,44 @@ class LineupRead(BaseModel):
 
     model_config = {"from_attributes": True}
 
+    @computed_field  # type: ignore[misc]
+    @property
+    def effective_stand_x(self) -> Optional[float]:
+        """Minimap x for the stand pin: explicit anchor or stand_zone centroid."""
+        if self.stand_anchor_x is not None:
+            return self.stand_anchor_x
+        if self.stand_zone is not None:
+            return polygon_centroid(self.stand_zone.polygon_points)[0]
+        return None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def effective_stand_y(self) -> Optional[float]:
+        if self.stand_anchor_y is not None:
+            return self.stand_anchor_y
+        if self.stand_zone is not None:
+            return polygon_centroid(self.stand_zone.polygon_points)[1]
+        return None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def effective_target_x(self) -> Optional[float]:
+        """Minimap x for the target pin: explicit anchor or target_zone centroid."""
+        if self.target_anchor_x is not None:
+            return self.target_anchor_x
+        if self.target_zone is not None:
+            return polygon_centroid(self.target_zone.polygon_points)[0]
+        return None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def effective_target_y(self) -> Optional[float]:
+        if self.target_anchor_y is not None:
+            return self.target_anchor_y
+        if self.target_zone is not None:
+            return polygon_centroid(self.target_zone.polygon_points)[1]
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Lineup create — manual upload path
@@ -102,6 +149,10 @@ class LineupCreate(BaseModel):
     aim_screenshot_key: Optional[str] = None
     aim_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
     aim_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
+    stand_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
+    stand_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
+    target_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
+    target_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
     setup_seconds: Optional[int] = Field(None, ge=0)
     attribution_url: Optional[str] = None
     attribution_author: Optional[str] = None
@@ -148,6 +199,10 @@ class LineupPatch(BaseModel):
     notes: Optional[str] = None
     aim_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
     aim_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
+    stand_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
+    stand_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
+    target_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
+    target_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
     setup_seconds: Optional[int] = Field(None, ge=0)
     attribution_url: Optional[str] = None
     attribution_author: Optional[str] = None
@@ -193,6 +248,10 @@ class LineupAcceptBody(BaseModel):
     notes: Optional[str] = None
     aim_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
     aim_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
+    stand_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
+    stand_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
+    target_anchor_x: Optional[float] = Field(None, ge=0.0, le=1.0)
+    target_anchor_y: Optional[float] = Field(None, ge=0.0, le=1.0)
     setup_seconds: Optional[int] = Field(None, ge=0)
 
     @field_validator("side")

--- a/apps/mygamingassistant/backend/app/services/game/lineup_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_service.py
@@ -156,6 +156,10 @@ async def create(
         "aim_screenshot_url": aim_url,
         "aim_anchor_x": payload.aim_anchor_x,
         "aim_anchor_y": payload.aim_anchor_y,
+        "stand_anchor_x": payload.stand_anchor_x,
+        "stand_anchor_y": payload.stand_anchor_y,
+        "target_anchor_x": payload.target_anchor_x,
+        "target_anchor_y": payload.target_anchor_y,
         "setup_seconds": payload.setup_seconds,
         "attribution_url": payload.attribution_url,
         "attribution_author": payload.attribution_author,
@@ -328,6 +332,14 @@ async def accept(
         overrides["aim_anchor_x"] = body.aim_anchor_x
     if body.aim_anchor_y is not None:
         overrides["aim_anchor_y"] = body.aim_anchor_y
+    if body.stand_anchor_x is not None:
+        overrides["stand_anchor_x"] = body.stand_anchor_x
+    if body.stand_anchor_y is not None:
+        overrides["stand_anchor_y"] = body.stand_anchor_y
+    if body.target_anchor_x is not None:
+        overrides["target_anchor_x"] = body.target_anchor_x
+    if body.target_anchor_y is not None:
+        overrides["target_anchor_y"] = body.target_anchor_y
     if body.setup_seconds is not None:
         overrides["setup_seconds"] = body.setup_seconds
 

--- a/apps/mygamingassistant/backend/app/services/game/polygon.py
+++ b/apps/mygamingassistant/backend/app/services/game/polygon.py
@@ -1,0 +1,52 @@
+"""Polygon geometry helpers for map zones.
+
+Pure functions over the normalized 0-1 polygon_points format used by MapZone:
+    [{"x": 0.12, "y": 0.34}, {"x": 0.45, "y": 0.67}, ...]
+
+Used to derive minimap fallback coordinates when a lineup has no explicit
+stand_anchor / target_anchor set: the API returns the zone centroid so the
+frontend can render a pin without per-lineup precision data.
+"""
+from __future__ import annotations
+
+from typing import Sequence
+
+
+def polygon_centroid(points: Sequence[dict]) -> tuple[float, float]:
+    """Return the geometric centroid (cx, cy) of the polygon.
+
+    Uses the shoelace formula so non-convex polygons return a centroid inside
+    (or near) the shape — vertex-mean would drift outside for L-shaped zones.
+
+    Falls back to vertex mean when the polygon is degenerate (collinear or
+    fewer than 3 vertices), and to the map midpoint (0.5, 0.5) when empty so
+    callers never have to null-check coordinates.
+    """
+    if not points:
+        return 0.5, 0.5
+
+    n = len(points)
+    if n < 3:
+        return (
+            sum(p["x"] for p in points) / n,
+            sum(p["y"] for p in points) / n,
+        )
+
+    a2 = 0.0  # twice the signed area
+    cx = 0.0
+    cy = 0.0
+    for i in range(n):
+        x0, y0 = points[i]["x"], points[i]["y"]
+        x1, y1 = points[(i + 1) % n]["x"], points[(i + 1) % n]["y"]
+        cross = x0 * y1 - x1 * y0
+        a2 += cross
+        cx += (x0 + x1) * cross
+        cy += (y0 + y1) * cross
+
+    if a2 == 0:
+        return (
+            sum(p["x"] for p in points) / n,
+            sum(p["y"] for p in points) / n,
+        )
+
+    return cx / (3 * a2), cy / (3 * a2)

--- a/apps/mygamingassistant/backend/tests/test_lineups.py
+++ b/apps/mygamingassistant/backend/tests/test_lineups.py
@@ -348,3 +348,185 @@ async def test_404_on_unknown_lineup(auth_client: AsyncClient):
     """GET /api/lineups/{unknown_id} should return 404."""
     resp = await auth_client.get(f"/api/lineups/{uuid.uuid4()}")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Minimap anchor fields + effective_* fallback (PR 1 of lineup-pins series)
+# ---------------------------------------------------------------------------
+
+@pytest_asyncio.fixture
+async def seeded_with_polygons(db: AsyncSession) -> dict:
+    """Like seeded_game_map but zones have real polygon_points so centroids
+    are non-trivial and effective_* can be exercised end-to-end."""
+    game = Game(
+        slug="anchors-game",
+        name="Anchors Game",
+        side_a_label="T",
+        side_b_label="CT",
+    )
+    db.add(game)
+    await db.flush()
+
+    map_obj = Map(game_id=game.id, slug="anchors-map", name="Anchors Map")
+    db.add(map_obj)
+    await db.flush()
+
+    # Square zone centered at (0.2, 0.3) — centroid is the midpoint of bounds.
+    zone_target = MapZone(
+        map_id=map_obj.id,
+        slug="target",
+        name="Target",
+        polygon_points=[
+            {"x": 0.1, "y": 0.2},
+            {"x": 0.3, "y": 0.2},
+            {"x": 0.3, "y": 0.4},
+            {"x": 0.1, "y": 0.4},
+        ],
+    )
+    # Square zone centered at (0.8, 0.7).
+    zone_stand = MapZone(
+        map_id=map_obj.id,
+        slug="stand",
+        name="Stand",
+        polygon_points=[
+            {"x": 0.7, "y": 0.6},
+            {"x": 0.9, "y": 0.6},
+            {"x": 0.9, "y": 0.8},
+            {"x": 0.7, "y": 0.8},
+        ],
+    )
+    db.add_all([zone_target, zone_stand])
+    await db.flush()
+
+    util = UtilityType(game_id=game.id, slug="smoke", name="Smoke")
+    db.add(util)
+    await db.flush()
+
+    return {
+        "game": game,
+        "map": map_obj,
+        "zone_target": zone_target,
+        "zone_stand": zone_stand,
+        "util": util,
+    }
+
+
+@pytest.mark.asyncio
+async def test_effective_anchors_fallback_to_zone_centroid(
+    auth_client: AsyncClient, seeded_with_polygons: dict
+):
+    """When stand/target anchors are NULL, effective_* must equal zone centroid."""
+    payload = {
+        "game_id": str(seeded_with_polygons["game"].id),
+        "map_id": str(seeded_with_polygons["map"].id),
+        "target_zone_id": str(seeded_with_polygons["zone_target"].id),
+        "stand_zone_id": str(seeded_with_polygons["zone_stand"].id),
+        "side": "side_a",
+        "utility_type_id": str(seeded_with_polygons["util"].id),
+        "title": "no-anchor lineup",
+        # No anchors set — falls back to centroid
+    }
+    create_resp = await auth_client.post("/api/lineups", json=payload)
+    assert create_resp.status_code == 201, create_resp.text
+    lineup_id = create_resp.json()["id"]
+
+    resp = await auth_client.get(f"/api/lineups/{lineup_id}")
+    body = resp.json()
+
+    # Raw anchors stay NULL
+    assert body["stand_anchor_x"] is None
+    assert body["target_anchor_x"] is None
+
+    # Effective coordinates match the zone centroids (square: midpoint of bounds)
+    assert body["effective_target_x"] == pytest.approx(0.2)
+    assert body["effective_target_y"] == pytest.approx(0.3)
+    assert body["effective_stand_x"] == pytest.approx(0.8)
+    assert body["effective_stand_y"] == pytest.approx(0.7)
+
+
+@pytest.mark.asyncio
+async def test_explicit_anchors_override_centroid(
+    auth_client: AsyncClient, seeded_with_polygons: dict
+):
+    """Explicit anchors must take precedence over the zone centroid fallback."""
+    payload = {
+        "game_id": str(seeded_with_polygons["game"].id),
+        "map_id": str(seeded_with_polygons["map"].id),
+        "target_zone_id": str(seeded_with_polygons["zone_target"].id),
+        "stand_zone_id": str(seeded_with_polygons["zone_stand"].id),
+        "side": "side_a",
+        "utility_type_id": str(seeded_with_polygons["util"].id),
+        "title": "explicit-anchor lineup",
+        "stand_anchor_x": 0.55,
+        "stand_anchor_y": 0.66,
+        "target_anchor_x": 0.11,
+        "target_anchor_y": 0.22,
+    }
+    create_resp = await auth_client.post("/api/lineups", json=payload)
+    assert create_resp.status_code == 201, create_resp.text
+    body = create_resp.json()
+
+    # Raw anchors preserved
+    assert body["stand_anchor_x"] == pytest.approx(0.55)
+    assert body["target_anchor_y"] == pytest.approx(0.22)
+
+    # Effective values equal the explicit anchors, NOT the centroids
+    assert body["effective_stand_x"] == pytest.approx(0.55)
+    assert body["effective_stand_y"] == pytest.approx(0.66)
+    assert body["effective_target_x"] == pytest.approx(0.11)
+    assert body["effective_target_y"] == pytest.approx(0.22)
+
+
+@pytest.mark.asyncio
+async def test_patch_anchors_updates_effective(
+    auth_client: AsyncClient, seeded_with_polygons: dict
+):
+    """PATCH must accept anchor fields and the effective_* response reflects them."""
+    create_resp = await auth_client.post(
+        "/api/lineups",
+        json={
+            "game_id": str(seeded_with_polygons["game"].id),
+            "map_id": str(seeded_with_polygons["map"].id),
+            "target_zone_id": str(seeded_with_polygons["zone_target"].id),
+            "stand_zone_id": str(seeded_with_polygons["zone_stand"].id),
+            "side": "side_a",
+            "utility_type_id": str(seeded_with_polygons["util"].id),
+            "title": "patchable lineup",
+        },
+    )
+    lineup_id = create_resp.json()["id"]
+
+    patch_resp = await auth_client.patch(
+        f"/api/lineups/{lineup_id}",
+        json={
+            "stand_anchor_x": 0.42,
+            "stand_anchor_y": 0.43,
+        },
+    )
+    assert patch_resp.status_code == 200
+    body = patch_resp.json()
+
+    assert body["stand_anchor_x"] == pytest.approx(0.42)
+    assert body["effective_stand_x"] == pytest.approx(0.42)
+    # Target anchor still NULL → effective_ still falls back to centroid
+    assert body["target_anchor_x"] is None
+    assert body["effective_target_x"] == pytest.approx(0.2)
+
+
+@pytest.mark.asyncio
+async def test_anchor_validation_rejects_out_of_range(
+    auth_client: AsyncClient, seeded_with_polygons: dict
+):
+    """Anchors must be in [0, 1] — Pydantic Field(ge=0.0, le=1.0) rejects others."""
+    payload = {
+        "game_id": str(seeded_with_polygons["game"].id),
+        "map_id": str(seeded_with_polygons["map"].id),
+        "target_zone_id": str(seeded_with_polygons["zone_target"].id),
+        "stand_zone_id": str(seeded_with_polygons["zone_stand"].id),
+        "side": "side_a",
+        "utility_type_id": str(seeded_with_polygons["util"].id),
+        "title": "bad-anchor lineup",
+        "stand_anchor_x": 1.5,  # out of range
+    }
+    resp = await auth_client.post("/api/lineups", json=payload)
+    assert resp.status_code == 422

--- a/apps/mygamingassistant/backend/tests/test_polygon_centroid.py
+++ b/apps/mygamingassistant/backend/tests/test_polygon_centroid.py
@@ -1,0 +1,80 @@
+"""Unit tests for app.services.game.polygon.polygon_centroid."""
+import pytest
+
+from app.services.game.polygon import polygon_centroid
+
+
+def test_empty_polygon_returns_map_midpoint():
+    cx, cy = polygon_centroid([])
+    assert (cx, cy) == (0.5, 0.5)
+
+
+def test_single_point_returns_itself():
+    cx, cy = polygon_centroid([{"x": 0.3, "y": 0.7}])
+    assert cx == pytest.approx(0.3)
+    assert cy == pytest.approx(0.7)
+
+
+def test_two_points_returns_midpoint():
+    cx, cy = polygon_centroid([{"x": 0.0, "y": 0.0}, {"x": 1.0, "y": 1.0}])
+    assert cx == pytest.approx(0.5)
+    assert cy == pytest.approx(0.5)
+
+
+def test_square_returns_center():
+    pts = [
+        {"x": 0.2, "y": 0.2},
+        {"x": 0.6, "y": 0.2},
+        {"x": 0.6, "y": 0.6},
+        {"x": 0.2, "y": 0.6},
+    ]
+    cx, cy = polygon_centroid(pts)
+    assert cx == pytest.approx(0.4)
+    assert cy == pytest.approx(0.4)
+
+
+def test_triangle_returns_geometric_centroid():
+    # Right triangle: vertices at (0,0), (3,0), (0,3) — centroid is (1, 1)
+    pts = [
+        {"x": 0.0, "y": 0.0},
+        {"x": 0.3, "y": 0.0},
+        {"x": 0.0, "y": 0.3},
+    ]
+    cx, cy = polygon_centroid(pts)
+    assert cx == pytest.approx(0.1)
+    assert cy == pytest.approx(0.1)
+
+
+def test_collinear_falls_back_to_vertex_mean():
+    # All on y=0.5 — zero signed area, shoelace would divide by zero.
+    pts = [
+        {"x": 0.1, "y": 0.5},
+        {"x": 0.4, "y": 0.5},
+        {"x": 0.7, "y": 0.5},
+    ]
+    cx, cy = polygon_centroid(pts)
+    assert cx == pytest.approx(0.4)
+    assert cy == pytest.approx(0.5)
+
+
+def test_l_shape_non_convex():
+    # L-shape: a vertex-mean would drift toward the inside corner — the
+    # shoelace geometric centroid stays in the actual shape.
+    pts = [
+        {"x": 0.0, "y": 0.0},
+        {"x": 0.6, "y": 0.0},
+        {"x": 0.6, "y": 0.2},
+        {"x": 0.2, "y": 0.2},
+        {"x": 0.2, "y": 0.6},
+        {"x": 0.0, "y": 0.6},
+    ]
+    cx, cy = polygon_centroid(pts)
+    # Both should land inside the L (not at the inside corner 0.2/0.2).
+    # Shoelace centroid for this shape is roughly (0.2, 0.2-ish on x, 0.2-ish on y);
+    # what matters is that it differs from the vertex mean (0.27, 0.27).
+    vertex_mean_x = sum(p["x"] for p in pts) / len(pts)
+    vertex_mean_y = sum(p["y"] for p in pts) / len(pts)
+    # Geometric centroid for L-shape with two equal arms is symmetric in x/y.
+    assert cx == pytest.approx(cy, abs=1e-6)
+    # And differs from vertex mean.
+    assert cx != pytest.approx(vertex_mean_x, abs=1e-3)


### PR DESCRIPTION
## Summary

First of three PRs adding **per-lineup pins to the MapPage minimap**, replacing the current "zone-density + click-zone-to-expand-cards" UX with "click-pin → side-panel detail."

This PR is the data + backend foundation:

- Migration **0006** adds four nullable `Float` columns to `lineup`: `stand_anchor_x/y`, `target_anchor_x/y` (normalized `[0, 1]` on the minimap).
- `LineupRead` exposes four `@computed_field` properties — `effective_stand_x/y`, `effective_target_x/y` — that **fall back to the polygon centroid** of `stand_zone` / `target_zone` when the explicit anchor is unset.
- `LineupCreate` / `LineupPatch` / `LineupAcceptBody` accept the new fields; `lineup_service.create` + `.accept` forward them; `.patch` is unchanged (it already setattrs every patch key).

## Why the centroid fallback

The 11 existing seed lineups have no anchors and never will (the seed bypassed MinIO + classifier). Centroid fallback gives every lineup an immediately-usable pin location, then **PR 2** (draggable review UI) lets the operator refine to per-pixel precision. The classifier prompt extension to extract minimap coords from the YouTube frame lands in PR 2 as well.

## Next PRs

- **PR 2** — ReviewCard minimap inset with draggable stand pin (blue) + target pin (orange). Classifier prompt extended to suggest coords.
- **PR 3** — `MapLineupPins` over the minimap, `?pins=stand|target|both` URL toggle, click-cluster expand, click-pin opens side panel sliding from right.

## Test plan

- [x] 7 unit tests for `polygon_centroid` (empty / 1pt / 2pts / square / triangle / collinear / non-convex L)
- [x] 4 integration tests: NULL anchors fall back to centroid · explicit anchors override · PATCH updates effective_* · `Field(ge=0, le=1)` rejects out-of-range
- [x] Existing 20+ tests in `test_lineups.py` still pass (no signature changes)
- [ ] CI green
- [ ] Smoke: `/cs2/mirage` once PR 3 lands — pins appear over Mirage at the 4 occupied zones

## Operational migration

**None.** Additive nullable columns, no env changes, no CHECK constraint changes. Migration is forward-compatible with rows lacking the new fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)