### PR TITLE
fix(mbk): restore Monthly Overview revenue bar click -> drill-down

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/chart-utils.test.ts
+++ b/apps/mybookkeeper/frontend/src/__tests__/chart-utils.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { mergeData, buildFilter, formatMonthLabel } from "@/shared/utils/chart-utils";
+import {
+  mergeData,
+  buildFilter,
+  formatMonthLabel,
+  type PropertyBarKey,
+} from "@/shared/utils/chart-utils";
 import type { MonthSummary } from "@/shared/types/summary/month-summary";
 import type { MonthExpenseSummary } from "@/shared/types/summary/month-expense-summary";
 
@@ -168,5 +173,84 @@ describe("buildFilter", () => {
   it("formats multi-word category keys in the label", () => {
     const filter = buildFilter("mortgage_interest", entryJanuary);
     expect(filter.label).toBe("Mortgage Interest — January 2025");
+  });
+
+  // Regression for MonthlyOverviewChart bar-click drill-down (recharts 2->3 bump
+  // in PR #584 stopped passing the right row to buildFilter — handlers used to
+  // do `chartData[_index]` which drifted in recharts 3 when any bar in the
+  // displayed slice was filtered out, so click silently swallowed). The fix
+  // reads `data.payload` from the recharts BarRectangleItem the click was on
+  // and forwards that MergedRow straight into buildFilter. These tests pin
+  // the buildFilter contract for every dataKey the four bar-click handlers
+  // can produce, so the contract stays stable if recharts changes again.
+  describe("payload-driven dataKeys (MonthlyOverviewChart bar-click contract)", () => {
+    const entry = {
+      displayMonth: "Mar 25",
+      rawMonth: "2025-03",
+      revenue: 5000,
+      profit: 2000,
+      rev_prop1: 3000,
+      exp_prop1: 1500,
+      rev_prop2: 2000,
+      exp_prop2: 1500,
+      maintenance: 800,
+    };
+    const propertyKeys: PropertyBarKey[] = [
+      {
+        dataKey: "prop1",
+        name: "Lakeside Cabin",
+        propertyId: "prop1",
+        revenueColor: "#22c55e",
+        expenseColor: "#ef4444",
+      },
+      {
+        dataKey: "prop2",
+        name: "Downtown Loft",
+        propertyId: "prop2",
+        revenueColor: "#3b82f6",
+        expenseColor: "#f97316",
+      },
+    ];
+
+    it("builds a property revenue filter from a rev_<propertyId> dataKey", () => {
+      const filter = buildFilter("rev_prop1", entry, propertyKeys);
+      expect(filter.propertyId).toBe("prop1");
+      expect(filter.type).toBe("revenue");
+      expect(filter.startDate).toBe("2025-03-01");
+      expect(filter.endDate).toBe("2025-03-31");
+      expect(filter.label).toBe("Lakeside Cabin Revenue — March 2025");
+    });
+
+    it("builds a property expense filter from an exp_<propertyId> dataKey", () => {
+      const filter = buildFilter("exp_prop2", entry, propertyKeys);
+      expect(filter.propertyId).toBe("prop2");
+      expect(filter.type).toBe("expenses");
+      expect(filter.startDate).toBe("2025-03-01");
+      expect(filter.endDate).toBe("2025-03-31");
+      expect(filter.label).toBe("Downtown Loft Expenses — March 2025");
+    });
+
+    it("falls back to propertyId in the label when no PropertyBarKey matches", () => {
+      const filter = buildFilter("rev_unknownProp", entry, propertyKeys);
+      expect(filter.propertyId).toBe("unknownProp");
+      expect(filter.type).toBe("revenue");
+      expect(filter.label).toBe("unknownProp Revenue — March 2025");
+    });
+
+    it("builds a plain revenue filter from the 'revenue' dataKey", () => {
+      const filter = buildFilter("revenue", entry);
+      expect(filter.type).toBe("revenue");
+      expect(filter.category).toBeUndefined();
+      expect(filter.propertyId).toBeUndefined();
+      expect(filter.label).toBe("Revenue — March 2025");
+    });
+
+    it("builds a category expense filter from a category dataKey", () => {
+      const filter = buildFilter("maintenance", entry);
+      expect(filter.category).toBe("maintenance");
+      expect(filter.type).toBeUndefined();
+      expect(filter.propertyId).toBeUndefined();
+      expect(filter.label).toBe("Maintenance — March 2025");
+    });
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/MonthlyOverviewChart.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/MonthlyOverviewChart.tsx
@@ -22,6 +22,7 @@ import type { MonthSummary } from "@/shared/types/summary/month-summary";
 import type { MonthExpenseSummary } from "@/shared/types/summary/month-expense-summary";
 import type { DrillDownFilter } from "@/shared/types/dashboard/drill-down-filter";
 import type { DateRange } from "@/shared/types/dashboard/date-range";
+import type { MergedRow } from "@/shared/types/dashboard/merged-row";
 import type { PropertyMonthlySummary } from "@/shared/types/summary/property-monthly-summary";
 import { mergeData, buildFilter } from "@/shared/utils/chart-utils";
 
@@ -150,9 +151,9 @@ export default function MonthlyOverviewChart({
                 fill={pk.revenueColor}
                 radius={[2, 2, 0, 0]}
                 cursor="pointer"
-                onClick={(_data, _index, e) => {
+                onClick={(data, _index, e) => {
                   if (!isDragging.current) {
-                    const entry = chartData[_index];
+                    const entry = data.payload as MergedRow | undefined;
                     if (entry) onBarClick(buildFilter(`rev_${pk.propertyId}`, entry, propertyKeys));
                   }
                   e.stopPropagation();
@@ -166,9 +167,9 @@ export default function MonthlyOverviewChart({
                 fill="#22c55e"
                 radius={[2, 2, 0, 0]}
                 cursor="pointer"
-                onClick={(_data, _index, e) => {
+                onClick={(data, _index, e) => {
                   if (!isDragging.current) {
-                    const entry = chartData[_index];
+                    const entry = data.payload as MergedRow | undefined;
                     if (entry) onBarClick(buildFilter("revenue", entry));
                   }
                   e.stopPropagation();
@@ -184,9 +185,9 @@ export default function MonthlyOverviewChart({
                 fill={pk.expenseColor}
                 radius={[2, 2, 0, 0]}
                 cursor="pointer"
-                onClick={(_data, _index, e) => {
+                onClick={(data, _index, e) => {
                   if (!isDragging.current) {
-                    const entry = chartData[_index];
+                    const entry = data.payload as MergedRow | undefined;
                     if (entry) onBarClick(buildFilter(`exp_${pk.propertyId}`, entry, propertyKeys));
                   }
                   e.stopPropagation();
@@ -201,9 +202,9 @@ export default function MonthlyOverviewChart({
                 stackId="expenses"
                 fill={TAG_COLORS[cat] ?? "#94a3b8"}
                 cursor="pointer"
-                onClick={(_data, _index, e) => {
+                onClick={(data, _index, e) => {
                   if (!isDragging.current) {
-                    const entry = chartData[_index];
+                    const entry = data.payload as MergedRow | undefined;
                     if (entry) onBarClick(buildFilter(cat, entry));
                   }
                   e.stopPropagation();


### PR DESCRIPTION
## Summary
- Restores clicks on the green **Revenue** bar (and per-property revenue, per-property expense, and stacked-category expense bars) in the Dashboard's "Monthly Overview" chart so they once again open the `DrillDownPanel`.
- Root cause: recharts 2 -> 3 bump (PR #584) changed `Bar.onClick`'s `index` argument to point at the *post-filter rendered-rectangles* array, not the chart's source `data`. Every month with a zero/null bar value drops a rectangle, the index drifts, `chartData[_index]` returns `undefined`, and the `if (entry)` guard swallowed the click silently.
- PR #584 applied the correct fix (`data.payload` read) to `CategoryChart.tsx` but missed `MonthlyOverviewChart.tsx`'s 4 handlers. This PR applies the same fix uniformly.
- Drag-to-select date range is untouched (lives on the parent `ComposedChart` mouse handlers, not the individual bars).

### The exact recharts 3 cause
`recharts/es6/cartesian/Bar.js`:
```js
// line 685: rectangles are filtered before render
}).filter(Boolean);
// line 309-319: BarRectangles map iterates the filtered array
data.map((entry, i) => ...
  onClick: onClickFromContext(entry, i)
```
And the type explicitly documents it:
```ts
// recharts/types/cartesian/Bar.d.ts
originalDataIndex: number;
/** Stable pre-filter index within the currently displayed data slice. */
```

### The fix
For each of the 4 bar `onClick` handlers, read the source row from the recharts-attached `payload` (set on line 675 of `Bar.js` as `payload: entry`) instead of indexing back into `chartData`:

```diff
- onClick={(_data, _index, e) => {
-   if (!isDragging.current) {
-     const entry = chartData[_index];
+ onClick={(data, _index, e) => {
+   if (!isDragging.current) {
+     const entry = data.payload as MergedRow | undefined;
      if (entry) onBarClick(buildFilter("revenue", entry));
    }
    e.stopPropagation();
  }}
```

Pattern matches the already-shipped `CategoryChart.tsx` handler. Applied to all four code paths:
1. Plain `revenue` bar (the green one in the bug report)
2. Per-property `rev_<propertyId>` bars (property-breakdown mode)
3. Per-property `exp_<propertyId>` bars (property-breakdown mode)
4. Stacked-category expense bars (when not in property-breakdown mode)

### Why drag-to-select still works
The fix only touches `<Bar onClick>`. Drag-to-select lives on the parent `<ComposedChart onMouseDown / onMouseMove / onMouseUp>` and is structurally untouched. Verified by code reading: `handleMouseUp` only clears `isDragging.current` once `dragStart && dragEnd` are both set, and the bar's `onClick` still gates on `!isDragging.current` so a real drag (where `dragStart !== dragEnd`) still suppresses spurious drill-downs.

### Tests
Added 5 regression tests in `chart-utils.test.ts` pinning the `buildFilter` contract for every `dataKey` the four bar-click handlers can produce: `rev_<propertyId>`, `exp_<propertyId>`, `revenue`, category strings, and the fallback when no `PropertyBarKey` matches. The handlers are now thin pass-throughs to `buildFilter(payload)` — the test covers the contract those handlers depend on.

## Test plan
- [x] `npx vitest run src/__tests__/chart-utils.test.ts` — 23/23 pass (5 new + 18 existing)
- [x] `npx vitest run src/__tests__/Dashboard.test.tsx src/__tests__/Analytics.test.tsx src/__tests__/CostMonitoring.test.tsx` — 69/69 pass
- [x] `npx tsc -b --noEmit` — clean
- [x] `npx eslint src/app/features/dashboard/MonthlyOverviewChart.tsx src/__tests__/chart-utils.test.ts` — clean
- [ ] Manual: click green Revenue bar on `/dashboard` -> `DrillDownPanel` opens with that month's revenue rows
- [ ] Manual: drag across multiple month bars -> selects date range (no drill-down fires)
- [ ] Manual: with multiple properties enabled, click any per-property revenue or expense bar -> `DrillDownPanel` opens with property-scoped filter

Pre-existing failures (`Documents.test`, `hourly-rate.test`, `LeaseTemplateUploadDialog`, `PromoteFromInquiryPanel`, `PublicInquiryForm`) on origin/main are unrelated and unchanged — same list documented in PR #584. The dramatiq/uv.lock CI failure is being handled in a separate worktree.

[Claude Code](https://claude.com/claude-code)