### PR TITLE
fix(mbk): remove unused dramatiq dep (unblocks backend-deps-resolve CI)

### DIFF
--- a/apps/mybookkeeper/backend/pyproject.toml
+++ b/apps/mybookkeeper/backend/pyproject.toml
@@ -20,7 +20,6 @@ dependencies = [
     "google-api-python-client==2.196.0",
     "google-auth-httplib2==0.4.0",
     "google-auth-oauthlib==1.4.0",
-    "dramatiq[postgres]==1.17.0",
     "cryptography>=48",
     "python-multipart==0.0.28",
     "passlib[bcrypt]==1.7.4",

--- a/apps/mybookkeeper/backend/requirements.txt
+++ b/apps/mybookkeeper/backend/requirements.txt
@@ -73,8 +73,6 @@ dnspython==2.8.0
     # via email-validator
 docstring-parser==0.18.0
     # via anthropic
-dramatiq==1.17.0
-    # via mybookkeeper-backend
 email-validator==2.3.0
     # via
     #   fastapi-users
@@ -173,8 +171,6 @@ pillow==12.2.0
     #   reportlab
 pluggy==1.6.0
     # via pytest
-prometheus-client==0.25.0
-    # via dramatiq
 proto-plus==1.27.2
     # via google-api-core
 protobuf==7.34.1

--- a/apps/mybookkeeper/backend/uv.lock
+++ b/apps/mybookkeeper/backend/uv.lock
@@ -334,18 +334,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dramatiq"
-version = "1.17.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "prometheus-client" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/37/a2/e5fd290620f75cea5e84e0199c82cb08334d54b4d102353fb93bb5fab572/dramatiq-1.17.0.tar.gz", hash = "sha256:7621280160b2f0dcb9cdd20eeee41e009d42bc7cc75a2c4b9b944c641dadd4df", size = 98573, upload-time = "2024-05-09T14:59:28.462Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/f5/8699390dd1ca34039c6eb7d9e3e22c4adb64eb39f437aac900d0b0365f7f/dramatiq-1.17.0-py3-none-any.whl", hash = "sha256:5c103de1b2f1d3dbca4f80fa7d32312f5253234a14a33277d48b7b2ca9498456", size = 120085, upload-time = "2024-05-09T14:59:26.402Z" },
-]
-
-[[package]]
 name = "email-validator"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -746,7 +734,6 @@ dependencies = [
     { name = "asyncpg" },
     { name = "clamd" },
     { name = "cryptography" },
-    { name = "dramatiq" },
     { name = "email-validator" },
     { name = "fastapi" },
     { name = "fastapi-users", extra = ["sqlalchemy"] },
@@ -795,7 +782,6 @@ requires-dist = [
     { name = "asyncpg", specifier = "==0.31.0" },
     { name = "clamd", specifier = "==1.0.2" },
     { name = "cryptography", specifier = ">=48" },
-    { name = "dramatiq", extras = ["postgres"], specifier = "==1.17.0" },
     { name = "email-validator", specifier = "==2.3.0" },
     { name = "fastapi", specifier = ">=0.118,<0.140" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = "==15.0.5" },
@@ -925,6 +911,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "httpx", specifier = ">=0.27.0" },
+    { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.1.0" },
     { name = "minio", specifier = ">=7.2.0" },
     { name = "pydantic", extras = ["email"], specifier = ">=2.9.0" },
     { name = "pydantic-settings", specifier = ">=2.5.0" },
@@ -932,6 +919,7 @@ requires-dist = [
     { name = "pyotp", specifier = ">=2.9.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "qrcode", specifier = ">=7.4.2" },
     { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
@@ -945,15 +933,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
-]
-
-[[package]]
-name = "prometheus-client"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Removes `dramatiq[postgres]==1.17.0` from `apps/mybookkeeper/backend/pyproject.toml`. dramatiq is not imported anywhere in MBK runtime code — the workers are plain asyncio loops invoked directly by Docker as `python -m app.workers.*`.

## Why

`backend-deps-resolve / mybookkeeper` has been failing on every PR (including the just-merged #640 and #644) with:

```
warning: The package `dramatiq==1.17.0` does not have an extra named `postgres`
##[error]Process completed with exit code 1.
```

dramatiq 1.17.0 has no `postgres` extra — the Postgres-broker functionality lives in the separate `dramatiq-pg` package. Since nothing in MBK actually imports dramatiq (verified by grep across `app/`), the cleanest fix is to drop the dep entirely. The transitive `prometheus-client` (only pulled in by dramatiq) is also gone.

Verified with `uv lock --check` — lockfile is consistent.

## Out of scope (follow-up cleanup PR)

These are pre-Docker legacy artifacts that reference dramatiq but are not exercised by the current prod deploy:

- `apps/mybookkeeper/deploy/dramatiq-worker.service` + `dramatiq-scheduler.service` (systemd files; prod is on Docker)
- `apps/mybookkeeper/deploy/{setup,update}.sh` + `docker/cleanup-old-deploy.sh` reference those services
- `apps/mybookkeeper/backend/app/cli/workers.py` references `dramatiq-worker` / `dramatiq-scheduler` service names + queries a `dramatiq_messages` table that doesn't exist
- `apps/mybookkeeper/CLAUDE.md` describes background jobs as "Dramatiq + PostgreSQL broker"

Worth a separate cleanup PR; intentionally kept narrow here so this can land as a small unblocker.

## Test plan

- [x] `uv lock --check` clean (lockfile consistent with pyproject.toml)
- [x] `dramatiq` and `prometheus-client` no longer present in `requirements.txt`
- [ ] CI: `backend-deps-resolve / mybookkeeper` should now pass
- [ ] CI: `backend-tests / mybookkeeper` should still pass (no runtime dramatiq usage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)