### PR TITLE
feat(mpt): Twilio SMS ready-text on dashboard transition (Phase 1 PR 8)

### DIFF
--- a/apps/mypizzatracker/backend/.env.docker.example
+++ b/apps/mypizzatracker/backend/.env.docker.example
@@ -77,3 +77,22 @@ MINIO_ACCESS_KEY=
 MINIO_SECRET_KEY=
 MINIO_BUCKET=mypizzatracker-uploads
 MINIO_SECURE=false
+
+# SMS delivery -- Twilio.
+#
+# Production MUST use SMS_BACKEND=twilio with valid TWILIO_ACCOUNT_SID /
+# TWILIO_AUTH_TOKEN / TWILIO_FROM_NUMBER -- the platform_shared boot
+# guard crashes the lifespan if SMS_BACKEND=console in non-development
+# environments (MPT opted in via create_app_lifespan(sms_required=True)).
+#
+# For local dev / CI, set SMS_BACKEND=console and leave TWILIO_* empty.
+# Console mode logs the would-be SMS body to stdout so the operator can
+# inspect what the customer would have received.
+#
+# TWILIO_FROM_NUMBER must be a Twilio-provisioned number in E.164 format
+# (e.g. +15551234567). To buy a number: console.twilio.com -> Phone
+# Numbers -> Buy a Number.
+SMS_BACKEND=twilio
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_FROM_NUMBER=

--- a/apps/mypizzatracker/backend/app/api/service.py
+++ b/apps/mypizzatracker/backend/app/api/service.py
@@ -22,6 +22,7 @@ from app.db.session import get_db
 from app.schemas.order.order_schemas import OrderRead
 from app.schemas.service.service_schemas import (
     AdvanceOrderRequest,
+    AdvanceOrderResponse,
     MoveOrderRequest,
     ServiceDashboard,
 )
@@ -52,19 +53,23 @@ async def get_dashboard(
         raise _service_error(exc) from exc
 
 
-@router.post("/orders/{order_id}/advance", response_model=OrderRead)
+@router.post("/orders/{order_id}/advance", response_model=AdvanceOrderResponse)
 async def advance_order(
     order_id: uuid.UUID,
     body: AdvanceOrderRequest,
     db: AsyncSession = Depends(get_db),
-) -> OrderRead:
+) -> AdvanceOrderResponse:
     try:
-        order = await service_dashboard_service.advance_order_status(
+        result = await service_dashboard_service.advance_order_status(
             db, order_id, body.target_status,
         )
     except DashboardServiceError as exc:
         raise _service_error(exc) from exc
-    return OrderRead.model_validate(order)
+    return AdvanceOrderResponse(
+        order=OrderRead.model_validate(result.order),
+        sms_dispatched=result.sms_dispatched,
+        sms_error=result.sms_error,
+    )
 
 
 @router.post("/orders/{order_id}/move", response_model=OrderRead)

--- a/apps/mypizzatracker/backend/app/main.py
+++ b/apps/mypizzatracker/backend/app/main.py
@@ -77,6 +77,7 @@ lifespan = create_app_lifespan(
     settings=settings,
     init_sentry=init_sentry,
     bucket_init=ensure_bucket,
+    sms_required=True,
     on_startup=_on_startup,
 )
 

--- a/apps/mypizzatracker/backend/app/schemas/service/service_schemas.py
+++ b/apps/mypizzatracker/backend/app/schemas/service/service_schemas.py
@@ -13,6 +13,8 @@ from typing import Optional
 
 from pydantic import BaseModel, Field
 
+from app.schemas.order.order_schemas import OrderRead
+
 
 class DashboardCustomer(BaseModel):
     id: uuid.UUID
@@ -90,3 +92,25 @@ class AdvanceOrderRequest(BaseModel):
 
 class MoveOrderRequest(BaseModel):
     slot_id: uuid.UUID
+
+
+# ---------------------------------------------------------------------------
+# Mutation response schemas
+# ---------------------------------------------------------------------------
+
+class AdvanceOrderResponse(BaseModel):
+    """Response for ``POST /service/orders/{order_id}/advance``.
+
+    ``sms_dispatched`` is non-null only when the transition targeted
+    ``ready_text_sent``:
+
+    - ``True`` -- SMS sent successfully via Twilio (or console-logged in dev).
+    - ``False`` -- Twilio rejected the send or creds were missing;
+      ``sms_error`` carries the operator-facing reason so the dashboard
+      can prompt them to text the customer manually.
+    - ``None`` -- this transition didn't involve SMS.
+    """
+
+    order: OrderRead
+    sms_dispatched: Optional[bool] = None
+    sms_error: Optional[str] = None

--- a/apps/mypizzatracker/backend/app/services/service_dashboard/service_dashboard_service.py
+++ b/apps/mypizzatracker/backend/app/services/service_dashboard/service_dashboard_service.py
@@ -4,7 +4,8 @@ Owns:
 
 1. The order-status state machine -- which transitions are allowed,
    what side effects each one carries (e.g., setting
-   ``ready_text_sent_at`` on the SMS-prep transition).
+   ``ready_text_sent_at`` AND firing the Twilio SMS on the
+   ``ready_text_sent`` transition).
 2. The slot-move policy -- target slot must belong to the same drop and
    must have enough remaining capacity for the order's pizza count.
 3. The enriched dashboard payload -- a single read returns the drop +
@@ -20,18 +21,20 @@ The 6-status order state machine (from ``app/models/order/order.py``):
     picked_up: terminal
     no_show: terminal
 
-PR 7 exposes the full state machine in this service layer; the dashboard
-UI hides ``ready_text_sent`` until PR 8 wires Twilio. PR 8 will set
-``ready_text_sent_at`` AND fire the actual SMS; for now we just record
-the timestamp so the field is populated whenever the operator chooses
-that transition.
+Transitioning into ``ready_text_sent`` stamps ``ready_text_sent_at`` AND
+fires a Twilio SMS to the customer (best-effort: a Twilio outage logs +
+returns the failure to the operator but does NOT roll back the status
+change — the operator is the authoritative record of "order is ready",
+the SMS is a courtesy notification).
 
 Mutations are rejected entirely if the drop is in ``closed`` status --
 service is over, history is frozen.
 """
 from __future__ import annotations
 
+import logging
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal
 from typing import Optional
@@ -57,6 +60,14 @@ from app.schemas.service.service_schemas import (
     DashboardSlot,
     ServiceDashboard,
 )
+from app.services.sms import sms_sender
+from app.services.sms.order_ready_notification import render_order_ready_body
+from platform_shared.services.sms_service import (
+    SmsNotConfiguredError,
+    SmsSendError,
+)
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # State machine
@@ -132,6 +143,26 @@ class TargetSlotCapacityError(DashboardServiceError):
 
 
 # ---------------------------------------------------------------------------
+# Result shapes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AdvanceOrderResult:
+    """Outcome of an order-status transition.
+
+    ``sms_dispatched`` is ``None`` for every transition EXCEPT
+    ``ready_text_sent`` — the only transition that attempts an SMS. A
+    successful attempt sets it to True; a Twilio failure sets it to False
+    and populates ``sms_error`` with a short, operator-facing message so
+    the dashboard can prompt them to text manually.
+    """
+
+    order: Order
+    sms_dispatched: Optional[bool] = None
+    sms_error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
 # Dashboard read
 # ---------------------------------------------------------------------------
 
@@ -192,11 +223,18 @@ async def get_dashboard(db: AsyncSession, drop_id: uuid.UUID) -> ServiceDashboar
 
 async def advance_order_status(
     db: AsyncSession, order_id: uuid.UUID, target_status: str,
-) -> Order:
+) -> AdvanceOrderResult:
     """Transition an order to ``target_status``.
 
-    Sets ``ready_text_sent_at = now()`` when transitioning into
-    ``ready_text_sent`` (PR 8 will additionally fire the SMS).
+    Side effects for ``target_status == "ready_text_sent"``:
+      1. Stamp ``ready_text_sent_at = now()``.
+      2. Send the customer a Twilio SMS announcing the pickup. The SMS is
+         best-effort — if Twilio rejects the message, the status change
+         still commits and the failure is surfaced via
+         ``AdvanceOrderResult.sms_error`` so the operator can text the
+         customer manually.
+
+    All other transitions return ``AdvanceOrderResult(order, None, None)``.
     """
     order = await _get_order(db, order_id)
     drop = await _get_drop(db, order.drop_id)
@@ -207,7 +245,7 @@ async def advance_order_status(
 
     if target_status == order.status:
         # Idempotent no-op rather than 409; lets the UI safely re-fire.
-        return order
+        return AdvanceOrderResult(order=order)
 
     pair = (order.status, target_status)
     if pair not in _ALLOWED_TRANSITIONS:
@@ -222,7 +260,71 @@ async def advance_order_status(
     await db.flush()
     refreshed = await order_repo.get_order(db, order.id)
     assert refreshed is not None, "Order disappeared during transition"
-    return refreshed
+
+    if target_status != "ready_text_sent":
+        return AdvanceOrderResult(order=refreshed)
+
+    # Fire the SMS AFTER the flush so a Twilio outage doesn't roll back
+    # the operator's intent. The status is the source of truth; the SMS
+    # is a courtesy.
+    sms_dispatched, sms_error = await _send_ready_text(db, refreshed, drop)
+    return AdvanceOrderResult(
+        order=refreshed,
+        sms_dispatched=sms_dispatched,
+        sms_error=sms_error,
+    )
+
+
+async def _send_ready_text(
+    db: AsyncSession, order: Order, drop: Drop,
+) -> tuple[bool, Optional[str]]:
+    """Dispatch the order-ready SMS. Returns (sent_ok, error_message).
+
+    Best-effort: every failure path returns ``(False, "<reason>")`` and
+    logs at WARNING; the caller surfaces ``error_message`` to the
+    operator. We never re-raise — the operator already advanced the
+    order and a Twilio outage shouldn't block the dashboard.
+    """
+    customer = await db.get(Customer, order.customer_id)
+    slot = await db.get(Slot, order.slot_id)
+    if customer is None or slot is None:
+        # Should be impossible given the FK constraints, but the SMS
+        # path is best-effort by design — log + return rather than
+        # raise.
+        logger.warning(
+            "Skipping ready-text SMS: missing customer or slot for order %s",
+            order.id,
+        )
+        return False, "Customer or slot missing; cannot text"
+    if not customer.phone:
+        return False, "Customer has no phone number on file"
+
+    body = render_order_ready_body(
+        customer_name=customer.name,
+        drop_name=drop.name,
+        pickup_time=slot.pickup_time,
+    )
+    try:
+        sms_sender.send_sms_or_raise(customer.phone, body)
+    except SmsNotConfiguredError as e:
+        logger.warning(
+            "Ready-text SMS skipped (Twilio not configured) for order %s: %s",
+            order.id, e,
+        )
+        return False, "SMS service is not configured"
+    except SmsSendError as e:
+        logger.warning(
+            "Ready-text SMS rejected by Twilio for order %s: %s",
+            order.id, e,
+        )
+        return False, str(e)
+    except ValueError as e:
+        logger.warning(
+            "Ready-text SMS rejected (invalid args) for order %s: %s",
+            order.id, e,
+        )
+        return False, str(e)
+    return True, None
 
 
 async def move_order_to_slot(

--- a/apps/mypizzatracker/backend/app/services/sms/order_ready_notification.py
+++ b/apps/mypizzatracker/backend/app/services/sms/order_ready_notification.py
@@ -1,0 +1,34 @@
+"""Renders the ready-to-pick-up SMS body for a customer order.
+
+Kept tiny on purpose — Twilio bills per SMS *segment* (160 ASCII chars
+or ~70 unicode chars per segment), so the body is one segment for the
+common case. The operator can extend the template later if a longer
+pickup-instructions block is needed; for now the customer already knows
+the pickup location from the original confirmation page.
+"""
+from __future__ import annotations
+
+from datetime import time as _time
+
+
+def render_order_ready_body(
+    *,
+    customer_name: str,
+    drop_name: str,
+    pickup_time: _time | None,
+) -> str:
+    """Build the SMS body for an order-ready notification.
+
+    The first-name-only address keeps the segment under 160 chars while
+    still feeling personal. Pickup time is formatted as HH:MM so the
+    customer doesn't need to do timezone math.
+    """
+    first_name = customer_name.strip().split(" ", 1)[0] if customer_name else "there"
+    if pickup_time is not None:
+        pickup_str = f" Slot: {pickup_time.strftime('%H:%M')}."
+    else:
+        pickup_str = ""
+    return (
+        f"Hi {first_name}, your pizza is ready to pick up at {drop_name}!"
+        f"{pickup_str} See you soon."
+    )

--- a/apps/mypizzatracker/backend/app/services/sms/sms_sender.py
+++ b/apps/mypizzatracker/backend/app/services/sms/sms_sender.py
@@ -1,0 +1,82 @@
+"""SMS delivery wrapper for MyPizzaTracker.
+
+Mirrors ``app.services.email.email_sender`` shape — routes through
+``platform_shared.services.sms_service.SmsService`` for the live Twilio
+backend, or logs to stdout in console mode.
+
+Console mode exists so dev/CI runs don't need a Twilio account; the
+operator can still see the rendered SMS body in logs while testing
+service-dashboard transitions. The boot guard
+(``platform_shared.core.boot_guards.check_sms_configured``) blocks
+console mode in production.
+"""
+import logging
+
+from platform_shared.services.sms_service import (
+    SmsNotConfiguredError,
+    SmsSendError,
+    SmsService,
+)
+
+from app.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _twilio_service() -> SmsService:
+    return SmsService(
+        account_sid=settings.twilio_account_sid,
+        auth_token=settings.twilio_auth_token,
+        from_number=settings.twilio_from_number,
+    )
+
+
+def _log_console_send(to: str, body: str) -> None:
+    logger.info(
+        "[sms:console] to=%s body_chars=%d body=%r",
+        to,
+        len(body),
+        body,
+    )
+
+
+def send_sms(to: str, body: str) -> bool:
+    """Best-effort SMS send. Returns True on success, False on failure.
+
+    Used for the order-ready notification: the order status transition
+    is the authoritative record; the SMS is a courtesy. On failure the
+    caller logs / surfaces a warning so the operator can text the
+    customer manually.
+    """
+    if not to or not body:
+        return False
+    if settings.sms_backend == "twilio":
+        return _twilio_service().send(to, body)
+    _log_console_send(to, body)
+    return True
+
+
+def send_sms_or_raise(to: str, body: str) -> str | None:
+    """Fail-loud SMS send. Returns the Twilio SID on success (or None in
+    console mode). Raises on any failure.
+
+    Reserved for paths where the SMS is itself the security artifact
+    (2FA codes, account-recovery links) — for ready-text alerts use
+    ``send_sms`` so a Twilio outage doesn't block the order transition.
+    """
+    if not to:
+        raise ValueError("Recipient phone number cannot be empty")
+    if not body:
+        raise ValueError("SMS body cannot be empty")
+    if settings.sms_backend == "twilio":
+        return _twilio_service().send_or_raise(to, body)
+    _log_console_send(to, body)
+    return None
+
+
+__all__ = [
+    "send_sms",
+    "send_sms_or_raise",
+    "SmsNotConfiguredError",
+    "SmsSendError",
+]

--- a/apps/mypizzatracker/backend/pyproject.toml
+++ b/apps/mypizzatracker/backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "sentry-sdk[fastapi]==2.59.0",
     "pyotp==2.9.0",
     "qrcode[pil]==8.2",
+    "twilio==9.10.9",
 ]
 
 [tool.uv]

--- a/apps/mypizzatracker/backend/requirements.txt
+++ b/apps/mypizzatracker/backend/requirements.txt
@@ -2,6 +2,16 @@
 #    uv export --format requirements-txt --no-hashes --no-emit-project --output-file requirements.txt
 -e ../../../packages/shared-backend
     # via mypizzatracker-backend
+aiohappyeyeballs==2.6.1
+    # via aiohttp
+aiohttp==3.13.5
+    # via
+    #   aiohttp-retry
+    #   twilio
+aiohttp-retry==2.8.3
+    # via twilio
+aiosignal==1.4.0
+    # via aiohttp
 alembic==1.18.4
     # via mypizzatracker-backend
 annotated-doc==0.0.4
@@ -24,6 +34,8 @@ asyncpg==0.31.0
     # via
     #   mypizzatracker-backend
     #   platform-shared
+attrs==26.1.0
+    # via aiohttp
 bcrypt==5.0.0
     # via
     #   passlib
@@ -33,11 +45,14 @@ certifi==2026.4.22
     #   httpcore
     #   httpx
     #   minio
+    #   requests
     #   sentry-sdk
 cffi==2.0.0
     # via
     #   argon2-cffi-bindings
     #   cryptography
+charset-normalizer==3.4.7
+    # via requests
 click==8.3.3
     # via uvicorn
 colorama==0.4.6 ; sys_platform == 'win32'
@@ -70,6 +85,10 @@ fastapi-users==15.0.5
     #   mypizzatracker-backend
 fastapi-users-db-sqlalchemy==7.0.0
     # via fastapi-users
+frozenlist==1.8.0
+    # via
+    #   aiohttp
+    #   aiosignal
 greenlet==3.5.0
     # via sqlalchemy
 h11==0.16.0
@@ -89,6 +108,8 @@ idna==3.15
     #   anyio
     #   email-validator
     #   httpx
+    #   requests
+    #   yarl
 iniconfig==2.3.0
     # via pytest
 makefun==1.16.0
@@ -101,6 +122,10 @@ minio==7.2.20
     # via
     #   mypizzatracker-backend
     #   platform-shared
+multidict==6.7.1
+    # via
+    #   aiohttp
+    #   yarl
 packaging==26.2
     # via pytest
 passlib==1.7.4
@@ -109,6 +134,10 @@ pillow==12.2.0
     # via qrcode
 pluggy==1.6.0
     # via pytest
+propcache==0.5.2
+    # via
+    #   aiohttp
+    #   yarl
 psycopg2-binary==2.9.12
     # via mypizzatracker-backend
 pwdlib==0.3.0
@@ -136,6 +165,7 @@ pyjwt==2.12.1
     #   fastapi-users
     #   mypizzatracker-backend
     #   platform-shared
+    #   twilio
 pyotp==2.9.0
     # via
     #   mypizzatracker-backend
@@ -158,6 +188,8 @@ qrcode==8.2
     # via
     #   mypizzatracker-backend
     #   platform-shared
+requests==2.34.2
+    # via twilio
 sentry-sdk==2.59.0
     # via
     #   mypizzatracker-backend
@@ -170,8 +202,11 @@ sqlalchemy==2.0.49
     #   platform-shared
 starlette==1.0.0
     # via fastapi
+twilio==9.10.9
+    # via mypizzatracker-backend
 typing-extensions==4.15.0
     # via
+    #   aiosignal
     #   alembic
     #   anyio
     #   fastapi
@@ -190,6 +225,7 @@ typing-inspection==0.4.2
 urllib3==2.7.0
     # via
     #   minio
+    #   requests
     #   sentry-sdk
 uvicorn==0.46.0
     # via mypizzatracker-backend
@@ -199,3 +235,5 @@ watchfiles==1.1.1
     # via uvicorn
 websockets==16.0
     # via uvicorn
+yarl==1.23.0
+    # via aiohttp

--- a/apps/mypizzatracker/backend/tests/test_order_ready_notification.py
+++ b/apps/mypizzatracker/backend/tests/test_order_ready_notification.py
@@ -1,0 +1,59 @@
+"""Unit tests for the order-ready SMS body renderer."""
+from __future__ import annotations
+
+from datetime import time
+
+from app.services.sms.order_ready_notification import render_order_ready_body
+
+
+def test_renders_first_name_only() -> None:
+    body = render_order_ready_body(
+        customer_name="Jonathan Castillo",
+        drop_name="Dec 25th",
+        pickup_time=time(12, 30),
+    )
+    assert body.startswith("Hi Jonathan,")
+    # last name should not appear in the segment
+    assert "Castillo" not in body
+
+
+def test_renders_drop_name_and_pickup_time() -> None:
+    body = render_order_ready_body(
+        customer_name="Maria",
+        drop_name="Desmadre Pizza Drop",
+        pickup_time=time(13, 0),
+    )
+    assert "Desmadre Pizza Drop" in body
+    assert "13:00" in body
+
+
+def test_handles_empty_customer_name() -> None:
+    body = render_order_ready_body(
+        customer_name="",
+        drop_name="Dec 25th",
+        pickup_time=time(12, 0),
+    )
+    assert "Hi there," in body
+
+
+def test_handles_missing_pickup_time() -> None:
+    body = render_order_ready_body(
+        customer_name="Maria",
+        drop_name="Dec 25th",
+        pickup_time=None,
+    )
+    # No Slot: prefix when pickup_time is missing
+    assert "Slot:" not in body
+    assert "Hi Maria," in body
+    assert "Dec 25th" in body
+
+
+def test_body_fits_single_sms_segment() -> None:
+    """A common case should fit one 160-char SMS segment so Twilio
+    bills one segment per ready-text rather than two."""
+    body = render_order_ready_body(
+        customer_name="Jonathan",
+        drop_name="Dec 25th Drop",
+        pickup_time=time(12, 30),
+    )
+    assert len(body) <= 160

--- a/apps/mypizzatracker/backend/tests/test_service_dashboard.py
+++ b/apps/mypizzatracker/backend/tests/test_service_dashboard.py
@@ -303,21 +303,24 @@ async def test_advance_status_happy_forward_path(
         f"/service/orders/{order_id}/advance",
         json={"target_status": "cooking"},
     )
-    assert r.status_code == 200 and r.json()["status"] == "cooking"
+    assert r.status_code == 200 and r.json()["order"]["status"] == "cooking"
+    # Non-SMS transitions report sms_dispatched: null
+    assert r.json()["sms_dispatched"] is None
 
-    # cooking -> ready_waiting (PR 7 default, skipping ready_text_sent)
+    # cooking -> ready_waiting (the no-text branch of the cooking fork)
     r = await auth_client.post(
         f"/service/orders/{order_id}/advance",
         json={"target_status": "ready_waiting"},
     )
-    assert r.status_code == 200 and r.json()["status"] == "ready_waiting"
+    assert r.status_code == 200 and r.json()["order"]["status"] == "ready_waiting"
+    assert r.json()["sms_dispatched"] is None
 
     # ready_waiting -> picked_up
     r = await auth_client.post(
         f"/service/orders/{order_id}/advance",
         json={"target_status": "picked_up"},
     )
-    assert r.status_code == 200 and r.json()["status"] == "picked_up"
+    assert r.status_code == 200 and r.json()["order"]["status"] == "picked_up"
 
 
 @pytest.mark.asyncio
@@ -339,10 +342,86 @@ async def test_advance_to_ready_text_sent_sets_timestamp(
     )
     assert r.status_code == 200
     body = r.json()
-    assert body["status"] == "ready_text_sent"
-    assert body["ready_text_sent_at"] is not None
+    assert body["order"]["status"] == "ready_text_sent"
+    assert body["order"]["ready_text_sent_at"] is not None
     # Round-trip parseable
-    datetime.fromisoformat(body["ready_text_sent_at"].replace("Z", "+00:00"))
+    datetime.fromisoformat(body["order"]["ready_text_sent_at"].replace("Z", "+00:00"))
+    # Tests run with sms_backend="console" (default) so the SMS is just
+    # logged; dispatch succeeds.
+    assert body["sms_dispatched"] is True
+    assert body["sms_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_advance_to_ready_text_sent_surfaces_twilio_failure(
+    client: AsyncClient, auth_client: AsyncClient, monkeypatch,
+):
+    """When Twilio rejects the send, the order transition still commits
+    but the response surfaces sms_dispatched=False + sms_error so the
+    operator knows to text manually."""
+    from app.services.sms import sms_sender
+    from platform_shared.services.sms_service import SmsSendError
+
+    drop_id, slot_id = await _create_active_drop(auth_client)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+    order_id = await _place_order(
+        client, drop_id=drop_id, slot_id=slot_id, pizza_ids=[pizza_id],
+    )
+    await auth_client.post(
+        f"/service/orders/{order_id}/advance", json={"target_status": "cooking"},
+    )
+
+    def _raise(*args, **kwargs):
+        raise SmsSendError("Twilio rejected (code=21610): recipient opted out")
+
+    monkeypatch.setattr(sms_sender, "send_sms_or_raise", _raise)
+
+    r = await auth_client.post(
+        f"/service/orders/{order_id}/advance",
+        json={"target_status": "ready_text_sent"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    # Transition still committed
+    assert body["order"]["status"] == "ready_text_sent"
+    assert body["order"]["ready_text_sent_at"] is not None
+    # SMS failure surfaced to operator
+    assert body["sms_dispatched"] is False
+    assert "21610" in body["sms_error"]
+
+
+@pytest.mark.asyncio
+async def test_advance_to_ready_text_sent_handles_unconfigured_twilio(
+    client: AsyncClient, auth_client: AsyncClient, monkeypatch,
+):
+    """When Twilio creds are missing entirely the transition still
+    commits and the operator sees an operator-facing reason."""
+    from app.services.sms import sms_sender
+    from platform_shared.services.sms_service import SmsNotConfiguredError
+
+    drop_id, slot_id = await _create_active_drop(auth_client)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+    order_id = await _place_order(
+        client, drop_id=drop_id, slot_id=slot_id, pizza_ids=[pizza_id],
+    )
+    await auth_client.post(
+        f"/service/orders/{order_id}/advance", json={"target_status": "cooking"},
+    )
+
+    def _raise(*args, **kwargs):
+        raise SmsNotConfiguredError("Twilio creds missing")
+
+    monkeypatch.setattr(sms_sender, "send_sms_or_raise", _raise)
+
+    r = await auth_client.post(
+        f"/service/orders/{order_id}/advance",
+        json={"target_status": "ready_text_sent"},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["order"]["status"] == "ready_text_sent"
+    assert body["sms_dispatched"] is False
+    assert "not configured" in body["sms_error"].lower()
 
 
 @pytest.mark.asyncio
@@ -382,7 +461,7 @@ async def test_advance_no_show_from_any_non_terminal_state(
             json={"target_status": "no_show"},
         )
         assert r.status_code == 200, f"{current_state} -> no_show failed: {r.text}"
-        assert r.json()["status"] == "no_show"
+        assert r.json()["order"]["status"] == "no_show"
 
 
 @pytest.mark.asyncio
@@ -426,7 +505,7 @@ async def test_advance_same_status_is_idempotent(
         json={"target_status": "not_started"},
     )
     assert r.status_code == 200
-    assert r.json()["status"] == "not_started"
+    assert r.json()["order"]["status"] == "not_started"
 
 
 @pytest.mark.asyncio

--- a/apps/mypizzatracker/backend/tests/test_sms_sender.py
+++ b/apps/mypizzatracker/backend/tests/test_sms_sender.py
@@ -1,0 +1,69 @@
+"""Unit tests for the MPT app-level SMS routing wrapper.
+
+The shared SmsService is exercised in
+packages/shared-backend/tests/test_sms_service.py; here we cover the
+console-vs-twilio routing layer that the rest of the app uses.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+from app.core.config import settings
+from app.services.sms import sms_sender
+from app.services.sms.sms_sender import send_sms, send_sms_or_raise
+from platform_shared.services.sms_service import SmsNotConfiguredError
+
+
+class TestConsoleBackend:
+    """When sms_backend == 'console', sends log to stdout and return success."""
+
+    def test_send_logs_and_returns_true(self, caplog) -> None:
+        caplog.set_level(logging.INFO, logger=sms_sender.__name__)
+        with patch.object(settings, "sms_backend", "console"):
+            ok = send_sms("+15559876543", "Your pizza is ready!")
+        assert ok is True
+        joined = " ".join(r.getMessage() for r in caplog.records)
+        assert "[sms:console]" in joined
+        assert "+15559876543" in joined
+
+    def test_send_or_raise_returns_none(self) -> None:
+        with patch.object(settings, "sms_backend", "console"):
+            sid = send_sms_or_raise("+15559876543", "Your pizza is ready!")
+        assert sid is None
+
+    def test_send_empty_to_returns_false(self) -> None:
+        with patch.object(settings, "sms_backend", "console"):
+            assert send_sms("", "body") is False
+
+    def test_send_or_raise_empty_to_raises(self) -> None:
+        with patch.object(settings, "sms_backend", "console"):
+            with pytest.raises(ValueError):
+                send_sms_or_raise("", "body")
+
+
+class TestTwilioBackend:
+    """When sms_backend == 'twilio', sends delegate to SmsService."""
+
+    def test_send_calls_twilio_service(self) -> None:
+        with patch.object(settings, "sms_backend", "twilio"), \
+             patch.object(settings, "twilio_account_sid", "AC1"), \
+             patch.object(settings, "twilio_auth_token", "tok"), \
+             patch.object(settings, "twilio_from_number", "+15551234567"), \
+             patch(
+                 "platform_shared.services.sms_service.SmsService.send",
+                 return_value=True,
+             ) as mock_send:
+            ok = send_sms("+15559876543", "body")
+        assert ok is True
+        mock_send.assert_called_once_with("+15559876543", "body")
+
+    def test_send_or_raise_propagates_not_configured(self) -> None:
+        with patch.object(settings, "sms_backend", "twilio"), \
+             patch.object(settings, "twilio_account_sid", ""), \
+             patch.object(settings, "twilio_auth_token", ""), \
+             patch.object(settings, "twilio_from_number", ""):
+            with pytest.raises(SmsNotConfiguredError):
+                send_sms_or_raise("+15559876543", "body")

--- a/apps/mypizzatracker/backend/uv.lock
+++ b/apps/mypizzatracker/backend/uv.lock
@@ -3,6 +3,74 @@ revision = 3
 requires-python = "==3.12.*"
 
 [[package]]
+name = "aiohappyeyeballs"
+version = "2.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/30/f84a107a9c4331c14b2b586036f40965c128aa4fee4dda5d3d51cb14ad54/aiohappyeyeballs-2.6.1.tar.gz", hash = "sha256:c3f9d0113123803ccadfdf3f0faa505bc78e6a72d1cc4806cbd719826e943558", size = 22760, upload-time = "2025-03-12T01:42:48.764Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl", hash = "sha256:f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8", size = 15265, upload-time = "2025-03-12T01:42:47.083Z" },
+]
+
+[[package]]
+name = "aiohttp"
+version = "3.13.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohappyeyeballs" },
+    { name = "aiosignal" },
+    { name = "attrs" },
+    { name = "frozenlist" },
+    { name = "multidict" },
+    { name = "propcache" },
+    { name = "yarl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/6f/353954c29e7dcce7cf00280a02c75f30e133c00793c7a2ed3776d7b2f426/aiohttp-3.13.5-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:023ecba036ddd840b0b19bf195bfae970083fd7024ce1ac22e9bba90464620e9", size = 748876, upload-time = "2026-03-31T21:57:36.319Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1b/428a7c64687b3b2e9cd293186695affc0e1e54a445d0361743b231f11066/aiohttp-3.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:15c933ad7920b7d9a20de151efcd05a6e38302cbf0e10c9b2acb9a42210a2416", size = 499557, upload-time = "2026-03-31T21:57:38.236Z" },
+    { url = "https://files.pythonhosted.org/packages/29/47/7be41556bfbb6917069d6a6634bb7dd5e163ba445b783a90d40f5ac7e3a7/aiohttp-3.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ab2899f9fa2f9f741896ebb6fa07c4c883bfa5c7f2ddd8cf2aafa86fa981b2d2", size = 500258, upload-time = "2026-03-31T21:57:39.923Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/c9ecc5828cb0b3695856c07c0a6817a99d51e2473400f705275a2b3d9239/aiohttp-3.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a60eaa2d440cd4707696b52e40ed3e2b0f73f65be07fd0ef23b6b539c9c0b0b4", size = 1749199, upload-time = "2026-03-31T21:57:41.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d3/3c6d610e66b495657622edb6ae7c7fd31b2e9086b4ec50b47897ad6042a9/aiohttp-3.13.5-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:55b3bdd3292283295774ab585160c4004f4f2f203946997f49aac032c84649e9", size = 1721013, upload-time = "2026-03-31T21:57:43.904Z" },
+    { url = "https://files.pythonhosted.org/packages/49/a0/24409c12217456df0bae7babe3b014e460b0b38a8e60753d6cb339f6556d/aiohttp-3.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2b2355dc094e5f7d45a7bb262fe7207aa0460b37a0d87027dcf21b5d890e7d5", size = 1781501, upload-time = "2026-03-31T21:57:46.285Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9d/b65ec649adc5bccc008b0957a9a9c691070aeac4e41cea18559fef49958b/aiohttp-3.13.5-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b38765950832f7d728297689ad78f5f2cf79ff82487131c4d26fe6ceecdc5f8e", size = 1878981, upload-time = "2026-03-31T21:57:48.734Z" },
+    { url = "https://files.pythonhosted.org/packages/57/d8/8d44036d7eb7b6a8ec4c5494ea0c8c8b94fbc0ed3991c1a7adf230df03bf/aiohttp-3.13.5-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b18f31b80d5a33661e08c89e202edabf1986e9b49c42b4504371daeaa11b47c1", size = 1767934, upload-time = "2026-03-31T21:57:51.171Z" },
+    { url = "https://files.pythonhosted.org/packages/31/04/d3f8211f273356f158e3464e9e45484d3fb8c4ce5eb2f6fe9405c3273983/aiohttp-3.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:33add2463dde55c4f2d9635c6ab33ce154e5ecf322bd26d09af95c5f81cfa286", size = 1566671, upload-time = "2026-03-31T21:57:53.326Z" },
+    { url = "https://files.pythonhosted.org/packages/41/db/073e4ebe00b78e2dfcacff734291651729a62953b48933d765dc513bf798/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:327cc432fdf1356fb4fbc6fe833ad4e9f6aacb71a8acaa5f1855e4b25910e4a9", size = 1705219, upload-time = "2026-03-31T21:57:55.385Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/7dfba71a2f9fd97b15c95c06819de7eb38113d2cdb6319669195a7d64270/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:7c35b0bf0b48a70b4cb4fc5d7bed9b932532728e124874355de1a0af8ec4bc88", size = 1743049, upload-time = "2026-03-31T21:57:57.341Z" },
+    { url = "https://files.pythonhosted.org/packages/18/71/901db0061e0f717d226386a7f471bb59b19566f2cae5f0d93874b017271f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:df23d57718f24badef8656c49743e11a89fd6f5358fa8a7b96e728fda2abf7d3", size = 1749557, upload-time = "2026-03-31T21:57:59.626Z" },
+    { url = "https://files.pythonhosted.org/packages/08/d5/41eebd16066e59cd43728fe74bce953d7402f2b4ddfdfef2c0e9f17ca274/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:02e048037a6501a5ec1f6fc9736135aec6eb8a004ce48838cb951c515f32c80b", size = 1558931, upload-time = "2026-03-31T21:58:01.972Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e6/4a799798bf05740e66c3a1161079bda7a3dd8e22ca392481d7a7f9af82a6/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31cebae8b26f8a615d2b546fee45d5ffb76852ae6450e2a03f42c9102260d6fe", size = 1774125, upload-time = "2026-03-31T21:58:04.007Z" },
+    { url = "https://files.pythonhosted.org/packages/84/63/7749337c90f92bc2cb18f9560d67aa6258c7060d1397d21529b8004fcf6f/aiohttp-3.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:888e78eb5ca55a615d285c3c09a7a91b42e9dd6fc699b166ebd5dee87c9ccf14", size = 1732427, upload-time = "2026-03-31T21:58:06.337Z" },
+    { url = "https://files.pythonhosted.org/packages/98/de/cf2f44ff98d307e72fb97d5f5bbae3bfcb442f0ea9790c0bf5c5c2331404/aiohttp-3.13.5-cp312-cp312-win32.whl", hash = "sha256:8bd3ec6376e68a41f9f95f5ed170e2fcf22d4eb27a1f8cb361d0508f6e0557f3", size = 433534, upload-time = "2026-03-31T21:58:08.712Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ca/eadf6f9c8fa5e31d40993e3db153fb5ed0b11008ad5d9de98a95045bed84/aiohttp-3.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:110e448e02c729bcebb18c60b9214a87ba33bac4a9fa5e9a5f139938b56c6cb1", size = 460446, upload-time = "2026-03-31T21:58:10.945Z" },
+]
+
+[[package]]
+name = "aiohttp-retry"
+version = "2.8.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/c1/d57818a0ed5b0313ad8c620638225ddd44094d0d606ee33f3df5105572cd/aiohttp_retry-2.8.3.tar.gz", hash = "sha256:9a8e637e31682ad36e1ff9f8bcba912fcfc7d7041722bc901a4b948da4d71ea9", size = 10585, upload-time = "2022-08-11T21:13:41.945Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/57/af573003eca6248a5cbc538fc46bea5b249c2ac86f27140b0a621bcd3fde/aiohttp_retry-2.8.3-py3-none-any.whl", hash = "sha256:3aeeead8f6afe48272db93ced9440cf4eda8b6fd7ee2abb25357b7eb28525b45", size = 9773, upload-time = "2022-08-11T21:13:40.602Z" },
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "frozenlist" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
 name = "alembic"
 version = "1.18.4"
 source = { registry = "https://pypi.org/simple" }
@@ -97,6 +165,15 @@ wheels = [
 ]
 
 [[package]]
+name = "attrs"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32", size = 952055, upload-time = "2026-03-19T14:22:25.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309", size = 67548, upload-time = "2026-03-19T14:22:23.645Z" },
+]
+
+[[package]]
 name = "bcrypt"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -164,6 +241,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
     { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
     { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -297,6 +399,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/87/12/bc9e6146ae31564741cefc87ee6e37fa5b566933f0afe8aa030779d60e60/fastapi_users_db_sqlalchemy-7.0.0.tar.gz", hash = "sha256:6823eeedf8a92f819276a2b2210ef1dcfd71fe8b6e37f7b4da8d1c60e3dfd595", size = 10877, upload-time = "2025-01-04T13:09:05.086Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a6/08/9968963c1fb8c34627b7f1fbcdfe9438540f87dc7c9bfb59bb4fd19a4ecf/fastapi_users_db_sqlalchemy-7.0.0-py3-none-any.whl", hash = "sha256:5fceac018e7cfa69efc70834dd3035b3de7988eb4274154a0dbe8b14f5aa001e", size = 6891, upload-time = "2025-01-04T13:09:02.869Z" },
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/f5/c831fac6cc817d26fd54c7eaccd04ef7e0288806943f7cc5bbf69f3ac1f0/frozenlist-1.8.0.tar.gz", hash = "sha256:3ede829ed8d842f6cd48fc7081d7a41001a56f1f38603f9d49bf3020d59a31ad", size = 45875, upload-time = "2025-10-06T05:38:17.865Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/29/948b9aa87e75820a38650af445d2ef2b6b8a6fab1a23b6bb9e4ef0be2d59/frozenlist-1.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:78f7b9e5d6f2fdb88cdde9440dc147259b62b9d3b019924def9f6478be254ac1", size = 87782, upload-time = "2025-10-06T05:36:06.649Z" },
+    { url = "https://files.pythonhosted.org/packages/64/80/4f6e318ee2a7c0750ed724fa33a4bdf1eacdc5a39a7a24e818a773cd91af/frozenlist-1.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:229bf37d2e4acdaf808fd3f06e854a4a7a3661e871b10dc1f8f1896a3b05f18b", size = 50594, upload-time = "2025-10-06T05:36:07.69Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/94/5c8a2b50a496b11dd519f4a24cb5496cf125681dd99e94c604ccdea9419a/frozenlist-1.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f833670942247a14eafbb675458b4e61c82e002a148f49e68257b79296e865c4", size = 50448, upload-time = "2025-10-06T05:36:08.78Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/bd/d91c5e39f490a49df14320f4e8c80161cfcce09f1e2cde1edd16a551abb3/frozenlist-1.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:494a5952b1c597ba44e0e78113a7266e656b9794eec897b19ead706bd7074383", size = 242411, upload-time = "2025-10-06T05:36:09.801Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/83/f61505a05109ef3293dfb1ff594d13d64a2324ac3482be2cedc2be818256/frozenlist-1.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96f423a119f4777a4a056b66ce11527366a8bb92f54e541ade21f2374433f6d4", size = 243014, upload-time = "2025-10-06T05:36:11.394Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/cb/cb6c7b0f7d4023ddda30cf56b8b17494eb3a79e3fda666bf735f63118b35/frozenlist-1.8.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:3462dd9475af2025c31cc61be6652dfa25cbfb56cbbf52f4ccfe029f38decaf8", size = 234909, upload-time = "2025-10-06T05:36:12.598Z" },
+    { url = "https://files.pythonhosted.org/packages/31/c5/cd7a1f3b8b34af009fb17d4123c5a778b44ae2804e3ad6b86204255f9ec5/frozenlist-1.8.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c4c800524c9cd9bac5166cd6f55285957fcfc907db323e193f2afcd4d9abd69b", size = 250049, upload-time = "2025-10-06T05:36:14.065Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/01/2f95d3b416c584a1e7f0e1d6d31998c4a795f7544069ee2e0962a4b60740/frozenlist-1.8.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d6a5df73acd3399d893dafc71663ad22534b5aa4f94e8a2fabfe856c3c1b6a52", size = 256485, upload-time = "2025-10-06T05:36:15.39Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/03/024bf7720b3abaebcff6d0793d73c154237b85bdf67b7ed55e5e9596dc9a/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:405e8fe955c2280ce66428b3ca55e12b3c4e9c336fb2103a4937e891c69a4a29", size = 237619, upload-time = "2025-10-06T05:36:16.558Z" },
+    { url = "https://files.pythonhosted.org/packages/69/fa/f8abdfe7d76b731f5d8bd217827cf6764d4f1d9763407e42717b4bed50a0/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:908bd3f6439f2fef9e85031b59fd4f1297af54415fb60e4254a95f75b3cab3f3", size = 250320, upload-time = "2025-10-06T05:36:17.821Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/3c/b051329f718b463b22613e269ad72138cc256c540f78a6de89452803a47d/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:294e487f9ec720bd8ffcebc99d575f7eff3568a08a253d1ee1a0378754b74143", size = 246820, upload-time = "2025-10-06T05:36:19.046Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/ae/58282e8f98e444b3f4dd42448ff36fa38bef29e40d40f330b22e7108f565/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:74c51543498289c0c43656701be6b077f4b265868fa7f8a8859c197006efb608", size = 250518, upload-time = "2025-10-06T05:36:20.763Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/96/007e5944694d66123183845a106547a15944fbbb7154788cbf7272789536/frozenlist-1.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:776f352e8329135506a1d6bf16ac3f87bc25b28e765949282dcc627af36123aa", size = 239096, upload-time = "2025-10-06T05:36:22.129Z" },
+    { url = "https://files.pythonhosted.org/packages/66/bb/852b9d6db2fa40be96f29c0d1205c306288f0684df8fd26ca1951d461a56/frozenlist-1.8.0-cp312-cp312-win32.whl", hash = "sha256:433403ae80709741ce34038da08511d4a77062aa924baf411ef73d1146e74faf", size = 39985, upload-time = "2025-10-06T05:36:23.661Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/af/38e51a553dd66eb064cdf193841f16f077585d4d28394c2fa6235cb41765/frozenlist-1.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:34187385b08f866104f0c0617404c8eb08165ab1272e884abc89c112e9c00746", size = 44591, upload-time = "2025-10-06T05:36:24.958Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/06/1dc65480ab147339fecc70797e9c2f69d9cea9cf38934ce08df070fdb9cb/frozenlist-1.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:fe3c58d2f5db5fbd18c2987cba06d51b0529f52bc3a6cdc33d3f4eab725104bd", size = 40102, upload-time = "2025-10-06T05:36:26.333Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl", hash = "sha256:0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d", size = 13409, upload-time = "2025-10-06T05:38:16.721Z" },
 ]
 
 [[package]]
@@ -444,6 +571,33 @@ wheels = [
 ]
 
 [[package]]
+name = "multidict"
+version = "6.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/c2/c2d94cbe6ac1753f3fc980da97b3d930efe1da3af3c9f5125354436c073d/multidict-6.7.1.tar.gz", hash = "sha256:ec6652a1bee61c53a3e5776b6049172c53b6aaba34f18c9ad04f82712bac623d", size = 102010, upload-time = "2026-01-26T02:46:45.979Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9c/f20e0e2cf80e4b2e4b1c365bf5fe104ee633c751a724246262db8f1a0b13/multidict-6.7.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a90f75c956e32891a4eda3639ce6dd86e87105271f43d43442a3aedf3cddf172", size = 76893, upload-time = "2026-01-26T02:43:52.754Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/cf/18ef143a81610136d3da8193da9d80bfe1cb548a1e2d1c775f26b23d024a/multidict-6.7.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3fccb473e87eaa1382689053e4a4618e7ba7b9b9b8d6adf2027ee474597128cd", size = 45456, upload-time = "2026-01-26T02:43:53.893Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/65/1caac9d4cd32e8433908683446eebc953e82d22b03d10d41a5f0fefe991b/multidict-6.7.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b0fa96985700739c4c7853a43c0b3e169360d6855780021bfc6d0f1ce7c123e7", size = 43872, upload-time = "2026-01-26T02:43:55.041Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3b/d6bd75dc4f3ff7c73766e04e705b00ed6dbbaccf670d9e05a12b006f5a21/multidict-6.7.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb2a55f408c3043e42b40cc8eecd575afa27b7e0b956dfb190de0f8499a57a53", size = 251018, upload-time = "2026-01-26T02:43:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/80/c959c5933adedb9ac15152e4067c702a808ea183a8b64cf8f31af8ad3155/multidict-6.7.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eb0ce7b2a32d09892b3dd6cc44877a0d02a33241fafca5f25c8b6b62374f8b75", size = 258883, upload-time = "2026-01-26T02:43:57.499Z" },
+    { url = "https://files.pythonhosted.org/packages/86/85/7ed40adafea3d4f1c8b916e3b5cc3a8e07dfcdcb9cd72800f4ed3ca1b387/multidict-6.7.1-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c3a32d23520ee37bf327d1e1a656fec76a2edd5c038bf43eddfa0572ec49c60b", size = 242413, upload-time = "2026-01-26T02:43:58.755Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/57/b8565ff533e48595503c785f8361ff9a4fde4d67de25c207cd0ba3befd03/multidict-6.7.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:9c90fed18bffc0189ba814749fdcc102b536e83a9f738a9003e569acd540a733", size = 268404, upload-time = "2026-01-26T02:44:00.216Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/50/9810c5c29350f7258180dfdcb2e52783a0632862eb334c4896ac717cebcb/multidict-6.7.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:da62917e6076f512daccfbbde27f46fed1c98fee202f0559adec8ee0de67f71a", size = 269456, upload-time = "2026-01-26T02:44:02.202Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8d/5e5be3ced1d12966fefb5c4ea3b2a5b480afcea36406559442c6e31d4a48/multidict-6.7.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde23ef6ed9db7eaee6c37dcec08524cb43903c60b285b172b6c094711b3961", size = 256322, upload-time = "2026-01-26T02:44:03.56Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6e/d8a26d81ac166a5592782d208dd90dfdc0a7a218adaa52b45a672b46c122/multidict-6.7.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3758692429e4e32f1ba0df23219cd0b4fc0a52f476726fff9337d1a57676a582", size = 253955, upload-time = "2026-01-26T02:44:04.845Z" },
+    { url = "https://files.pythonhosted.org/packages/59/4c/7c672c8aad41534ba619bcd4ade7a0dc87ed6b8b5c06149b85d3dd03f0cd/multidict-6.7.1-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:398c1478926eca669f2fd6a5856b6de9c0acf23a2cb59a14c0ba5844fa38077e", size = 251254, upload-time = "2026-01-26T02:44:06.133Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/bd/84c24de512cbafbdbc39439f74e967f19570ce7924e3007174a29c348916/multidict-6.7.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:c102791b1c4f3ab36ce4101154549105a53dc828f016356b3e3bcae2e3a039d3", size = 252059, upload-time = "2026-01-26T02:44:07.518Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/ba/f5449385510825b73d01c2d4087bf6d2fccc20a2d42ac34df93191d3dd03/multidict-6.7.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:a088b62bd733e2ad12c50dad01b7d0166c30287c166e137433d3b410add807a6", size = 263588, upload-time = "2026-01-26T02:44:09.382Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/11/afc7c677f68f75c84a69fe37184f0f82fce13ce4b92f49f3db280b7e92b3/multidict-6.7.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:3d51ff4785d58d3f6c91bdbffcb5e1f7ddfda557727043aa20d20ec4f65e324a", size = 259642, upload-time = "2026-01-26T02:44:10.73Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/17/ebb9644da78c4ab36403739e0e6e0e30ebb135b9caf3440825001a0bddcb/multidict-6.7.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc5907494fccf3e7d3f94f95c91d6336b092b5fc83811720fae5e2765890dfba", size = 251377, upload-time = "2026-01-26T02:44:12.042Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/a4/840f5b97339e27846c46307f2530a2805d9d537d8b8bd416af031cad7fa0/multidict-6.7.1-cp312-cp312-win32.whl", hash = "sha256:28ca5ce2fd9716631133d0e9a9b9a745ad7f60bac2bccafb56aa380fc0b6c511", size = 41887, upload-time = "2026-01-26T02:44:14.245Z" },
+    { url = "https://files.pythonhosted.org/packages/80/31/0b2517913687895f5904325c2069d6a3b78f66cc641a86a2baf75a05dcbb/multidict-6.7.1-cp312-cp312-win_amd64.whl", hash = "sha256:fcee94dfbd638784645b066074b338bc9cc155d4b4bffa4adce1615c5a426c19", size = 46053, upload-time = "2026-01-26T02:44:15.371Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/5b/aba28e4ee4006ae4c7df8d327d31025d760ffa992ea23812a601d226e682/multidict-6.7.1-cp312-cp312-win_arm64.whl", hash = "sha256:ba0a9fb644d0c1a2194cf7ffb043bd852cea63a57f66fbd33959f7dae18517bf", size = 43307, upload-time = "2026-01-26T02:44:16.852Z" },
+    { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
 name = "mypizzatracker-backend"
 version = "0.1.0"
 source = { virtual = "." }
@@ -467,6 +621,7 @@ dependencies = [
     { name = "qrcode", extra = ["pil"] },
     { name = "sentry-sdk", extra = ["fastapi"] },
     { name = "sqlalchemy" },
+    { name = "twilio" },
     { name = "uvicorn", extra = ["standard"] },
 ]
 
@@ -498,6 +653,7 @@ requires-dist = [
     { name = "qrcode", extras = ["pil"], specifier = "==8.2" },
     { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.59.0" },
     { name = "sqlalchemy", specifier = "==2.0.49" },
+    { name = "twilio", specifier = "==9.10.9" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.46.0" },
 ]
 
@@ -588,6 +744,7 @@ requires-dist = [
     { name = "qrcode", specifier = ">=7.4.2" },
     { name = "sentry-sdk", specifier = ">=2.0.0" },
     { name = "sqlalchemy", specifier = ">=2.0.36" },
+    { name = "twilio", marker = "extra == 'dev'", specifier = ">=9.10.0" },
 ]
 provides-extras = ["dev"]
 
@@ -598,6 +755,32 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "propcache"
+version = "0.5.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ec/44/c87281c333769159c50594f22610f77398a47ccbfbbf23074e744e86f87c/propcache-0.5.2.tar.gz", hash = "sha256:01c4fc7480cd0598bb4b57022df55b9ca296da7fc5a8760bd8451a7e63a7d427", size = 50208, upload-time = "2026-05-08T21:02:12.199Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/cb/e27bc2b2737a0bb49962b275efa051e8f1c35a936df7d5139b6b658b7dc9/propcache-0.5.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:806719138ecd720339a12410fb9614ac9b2b2d3a5fdf8235d56981c36f4039ba", size = 95887, upload-time = "2026-05-08T21:00:11.277Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/13/b8ae04c59392f8d11c6cd9fb4011d1dc7c86b81225c770280300e259ffe1/propcache-0.5.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:db2b80ea58eab4f86b2beec3cc8b39e8ff9276ac20e96b7cce43c8ae84cd6b5a", size = 54654, upload-time = "2026-05-08T21:00:12.604Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/7d/49777a3e20b55863d4794384a38acd460c04157b0a00f8602b0d508b8431/propcache-0.5.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e5cbfac9f61484f7e9f3597775500cd3ebe8274e9b050c38f9525c77c97520bf", size = 55190, upload-time = "2026-05-08T21:00:13.935Z" },
+    { url = "https://files.pythonhosted.org/packages/44/c7/085d0cd63062e84044e3f05797749c3f8e3938ff3aeb0eb2f69d43fafc91/propcache-0.5.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbc581d2814337da56222fab8dc5f161cd798a434e49bac27930aaef798e144", size = 59995, upload-time = "2026-05-08T21:00:15.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/32cf8e3009e92b2645cf1e944f701e8ea4e924dffde1ee26db860bcbf7e4/propcache-0.5.2-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:857187f381f88c8e2fa2fe56ab94879d011b883d5a2ee5a1b60a8cd2a06846d9", size = 63422, upload-time = "2026-05-08T21:00:16.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1b/f112433f99fc979431b87a39ef169e3f8df070d99a72792c56d6937ac48b/propcache-0.5.2-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:178b4a2cdaac1818e2bf1c5a99b94383fa73ea5382e032a48dec07dc5668dc42", size = 64342, upload-time = "2026-05-08T21:00:18.362Z" },
+    { url = "https://files.pythonhosted.org/packages/14/15/5574111ae50dd6e879456888c0eadd4c5a869959775854e18e18a6b345f3/propcache-0.5.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6f328175a2cde1f0ff2c4ed8ce968b9dcfb55f3a7153f39e2957ed994da13476", size = 61639, upload-time = "2026-05-08T21:00:19.692Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/da/4d775080b1490c0ae604acda868bd71aabe3a89ed16f2aa4339eb8a283e7/propcache-0.5.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5671d09a36b06d0fd4a3da0fccbcae360e9b1570924171a15e9e0997f0249fba", size = 61588, upload-time = "2026-05-08T21:00:21.155Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ac/f076982cbe2195ee9cf32de5a1e46951d9fb399fc207f390562dd0fd8fb2/propcache-0.5.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:80168e2ebe4d3ec6599d10ad8f520304ae1cad9b6c5a95372aef1b66b7bfb53a", size = 60029, upload-time = "2026-05-08T21:00:22.713Z" },
+    { url = "https://files.pythonhosted.org/packages/70/60/189be62e0dd898dce3b331e1b8c7a543cd3a405ac0c81fe8ee8a9d5d77e1/propcache-0.5.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:45f11346f884bc47444f6e6647131055844134c3175b629f84952e2b5cd62b64", size = 56774, upload-time = "2026-05-08T21:00:24.001Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/9e/93377b9c7939c1ffae98f878dee955efadfd638078bc86dbc21f9d52f651/propcache-0.5.2-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e778ebd44ef4f66ed60a0416b06b489687db264a9c0b3620362f26489492913", size = 63532, upload-time = "2026-05-08T21:00:25.545Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f9/590ef6cfb9b8028d516d287812ece32bb0bc5f11fbb9c8bf6b2e6313fec8/propcache-0.5.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:c0cb9ed24c8964e172768d455a38254c2dd8a552905729ce006cad3d3dda59b1", size = 61592, upload-time = "2026-05-08T21:00:27.186Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/5e/70958b3034c297a630bba2f17ca7abc2d5f39a803ad7e370ab79d1ecd022/propcache-0.5.2-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:1d1ad32d9d4355e2be65574fd0bfd3677e7066b009cd5b9b2dee8aa6a6393b33", size = 64788, upload-time = "2026-05-08T21:00:28.8Z" },
+    { url = "https://files.pythonhosted.org/packages/12/fd/77fe5936d8c3086ca9048f7f415f122ed82e53884a9ec193646b42deef06/propcache-0.5.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c80f4ba3e8f00189165999a742ee526ebeccedf6c3f7beb0c7df821e9772435a", size = 62514, upload-time = "2026-05-08T21:00:30.098Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/74/66bd798b5b3be70aa1b391f5cc9d6a0a5532d7fd3b19ec0b213e72e6ad9d/propcache-0.5.2-cp312-cp312-win32.whl", hash = "sha256:8c7972d8f193740d9175f0998ab38717e6cd322d5935c5b0fef8c0d323fd9031", size = 39018, upload-time = "2026-05-08T21:00:31.622Z" },
+    { url = "https://files.pythonhosted.org/packages/61/7c/5c0d34aa3024694d6dcb9271cdbdd08c4e47c1c0ad95ec7e7bc74cdea145/propcache-0.5.2-cp312-cp312-win_amd64.whl", hash = "sha256:d9ee8826a7d47863a08ac44e1a5f611a462eefc3a194b492da242128bec75b42", size = 42322, upload-time = "2026-05-08T21:00:32.918Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/875812f1a3feb20ceba818ef39fbe4d92f1081e04ac815c822496d0d038b/propcache-0.5.2-cp312-cp312-win_arm64.whl", hash = "sha256:2800a4a8ead6b28cccd1ec54b59346f0def7922ee1c7598e8499c733cfbb7c84", size = 38172, upload-time = "2026-05-08T21:00:35.124Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl", hash = "sha256:be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe", size = 14036, upload-time = "2026-05-08T21:02:10.673Z" },
 ]
 
 [[package]]
@@ -855,6 +1038,21 @@ pil = [
 ]
 
 [[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
 name = "sentry-sdk"
 version = "2.59.0"
 source = { registry = "https://pypi.org/simple" }
@@ -908,6 +1106,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "twilio"
+version = "9.10.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "aiohttp-retry" },
+    { name = "pyjwt" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/af/275130be4783c6e2b2122d3b278b63da0007611d1dc073d6414adcc6be03/twilio-9.10.9.tar.gz", hash = "sha256:eb74fc026c85a89372836414f57e262119efaa160b9419cf4d05b59056b8e89d", size = 1762839, upload-time = "2026-05-07T17:34:38.162Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/6b/df08b499d01ba6b9f7f42f9dd51b82aab1eb26c93602f3b89179a520494f/twilio-9.10.9-py2.py3-none-any.whl", hash = "sha256:1c50bfb394b5dbc044bacab24b2e3b550bee0c08da51c4a1fa4816293303e66c", size = 2452983, upload-time = "2026-05-07T17:34:36.459Z" },
 ]
 
 [[package]]
@@ -1018,4 +1231,36 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
     { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
     { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "yarl"
+version = "1.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "multidict" },
+    { name = "propcache" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/23/6e/beb1beec874a72f23815c1434518bfc4ed2175065173fb138c3705f658d4/yarl-1.23.0.tar.gz", hash = "sha256:53b1ea6ca88ebd4420379c330aea57e258408dd0df9af0992e5de2078dc9f5d5", size = 194676, upload-time = "2026-03-01T22:07:53.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/8a/94615bc31022f711add374097ad4144d569e95ff3c38d39215d07ac153a0/yarl-1.23.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:1932b6b8bba8d0160a9d1078aae5838a66039e8832d41d2992daa9a3a08f7860", size = 124737, upload-time = "2026-03-01T22:05:12.897Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/6f/c6554045d59d64052698add01226bc867b52fe4a12373415d7991fdca95d/yarl-1.23.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:411225bae281f114067578891bc75534cfb3d92a3b4dfef7a6ca78ba354e6069", size = 87029, upload-time = "2026-03-01T22:05:14.376Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2a/725ecc166d53438bc88f76822ed4b1e3b10756e790bafd7b523fe97c322d/yarl-1.23.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:13a563739ae600a631c36ce096615fe307f131344588b0bc0daec108cdb47b25", size = 86310, upload-time = "2026-03-01T22:05:15.71Z" },
+    { url = "https://files.pythonhosted.org/packages/99/30/58260ed98e6ff7f90ba84442c1ddd758c9170d70327394a6227b310cd60f/yarl-1.23.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cbf44c5cb4a7633d078788e1b56387e3d3cf2b8139a3be38040b22d6c3221c8", size = 97587, upload-time = "2026-03-01T22:05:17.384Z" },
+    { url = "https://files.pythonhosted.org/packages/76/0a/8b08aac08b50682e65759f7f8dde98ae8168f72487e7357a5d684c581ef9/yarl-1.23.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:53ad387048f6f09a8969631e4de3f1bf70c50e93545d64af4f751b2498755072", size = 92528, upload-time = "2026-03-01T22:05:18.804Z" },
+    { url = "https://files.pythonhosted.org/packages/52/07/0b7179101fe5f8385ec6c6bb5d0cb9f76bd9fb4a769591ab6fb5cdbfc69a/yarl-1.23.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:4a59ba56f340334766f3a4442e0efd0af895fae9e2b204741ef885c446b3a1a8", size = 105339, upload-time = "2026-03-01T22:05:20.235Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8a/36d82869ab5ec829ca8574dfcb92b51286fcfb1e9c7a73659616362dc880/yarl-1.23.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:803a3c3ce4acc62eaf01eaca1208dcf0783025ef27572c3336502b9c232005e7", size = 105061, upload-time = "2026-03-01T22:05:22.268Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3e/868e5c3364b6cee19ff3e1a122194fa4ce51def02c61023970442162859e/yarl-1.23.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a3d2bff8f37f8d0f96c7ec554d16945050d54462d6e95414babaa18bfafc7f51", size = 100132, upload-time = "2026-03-01T22:05:23.638Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/26/9c89acf82f08a52cb52d6d39454f8d18af15f9d386a23795389d1d423823/yarl-1.23.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c75eb09e8d55bceb4367e83496ff8ef2bc7ea6960efb38e978e8073ea59ecb67", size = 99289, upload-time = "2026-03-01T22:05:25.749Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/54/5b0db00d2cb056922356104468019c0a132e89c8d3ab67d8ede9f4483d2a/yarl-1.23.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:877b0738624280e34c55680d6054a307aa94f7d52fa0e3034a9cc6e790871da7", size = 96950, upload-time = "2026-03-01T22:05:27.318Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/40/10fa93811fd439341fad7e0718a86aca0de9548023bbb403668d6555acab/yarl-1.23.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:b5405bb8f0e783a988172993cfc627e4d9d00432d6bbac65a923041edacf997d", size = 93960, upload-time = "2026-03-01T22:05:28.738Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d2/8ae2e6cd77d0805f4526e30ec43b6f9a3dfc542d401ac4990d178e4bf0cf/yarl-1.23.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:1c3a3598a832590c5a3ce56ab5576361b5688c12cb1d39429cf5dba30b510760", size = 104703, upload-time = "2026-03-01T22:05:30.438Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/0c/b3ceacf82c3fe21183ce35fa2acf5320af003d52bc1fcf5915077681142e/yarl-1.23.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:8419ebd326430d1cbb7efb5292330a2cf39114e82df5cc3d83c9a0d5ebeaf2f2", size = 98325, upload-time = "2026-03-01T22:05:31.835Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/e0/12900edd28bdab91a69bd2554b85ad7b151f64e8b521fe16f9ad2f56477a/yarl-1.23.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:be61f6fff406ca40e3b1d84716fde398fc08bc63dd96d15f3a14230a0973ed86", size = 105067, upload-time = "2026-03-01T22:05:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/15/61/74bb1182cf79c9bbe4eb6b1f14a57a22d7a0be5e9cedf8e2d5c2086474c3/yarl-1.23.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3ceb13c5c858d01321b5d9bb65e4cf37a92169ea470b70fec6f236b2c9dd7e34", size = 100285, upload-time = "2026-03-01T22:05:35.4Z" },
+    { url = "https://files.pythonhosted.org/packages/69/7f/cd5ef733f2550de6241bd8bd8c3febc78158b9d75f197d9c7baa113436af/yarl-1.23.0-cp312-cp312-win32.whl", hash = "sha256:fffc45637bcd6538de8b85f51e3df3223e4ad89bccbfca0481c08c7fc8b7ed7d", size = 82359, upload-time = "2026-03-01T22:05:36.811Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/be/25216a49daeeb7af2bec0db22d5e7df08ed1d7c9f65d78b14f3b74fd72fc/yarl-1.23.0-cp312-cp312-win_amd64.whl", hash = "sha256:f69f57305656a4852f2a7203efc661d8c042e6cc67f7acd97d8667fb448a426e", size = 87674, upload-time = "2026-03-01T22:05:38.171Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/35/aeab955d6c425b227d5b7247eafb24f2653fedc32f95373a001af5dfeb9e/yarl-1.23.0-cp312-cp312-win_arm64.whl", hash = "sha256:6e87a6e8735b44816e7db0b2fbc9686932df473c826b0d9743148432e10bb9b9", size = 81879, upload-time = "2026-03-01T22:05:40.006Z" },
+    { url = "https://files.pythonhosted.org/packages/69/68/c8739671f5699c7dc470580a4f821ef37c32c4cb0b047ce223a7f115757f/yarl-1.23.0-py3-none-any.whl", hash = "sha256:a2df6afe50dea8ae15fa34c9f824a3ee958d785fd5d089063d960bae1daa0a3f", size = 48288, upload-time = "2026-03-01T22:07:51.388Z" },
 ]

--- a/apps/mypizzatracker/frontend/src/__tests__/orderStatus.test.ts
+++ b/apps/mypizzatracker/frontend/src/__tests__/orderStatus.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Unit tests for the order-status helpers.
+ *
+ * `advanceChoices` is the source of truth for which buttons render on each
+ * OrderCard; the most critical case is the `cooking` fork (PR 8) which
+ * surfaces both the SMS path and the no-text path.
+ */
+import { describe, expect, it } from "vitest";
+
+import {
+  advanceChoices,
+  isTerminal,
+  ORDER_STATUS_LABELS,
+  ORDER_STATUS_TONES,
+} from "@/features/service/orderStatus";
+
+describe("advanceChoices", () => {
+  it("returns single 'cooking' option for not_started", () => {
+    expect(advanceChoices("not_started")).toEqual(["cooking"]);
+  });
+
+  it("forks cooking into ready_text_sent (primary) + ready_waiting (secondary)", () => {
+    // First element is the primary (SMS) action; second is the no-text fallback.
+    expect(advanceChoices("cooking")).toEqual([
+      "ready_text_sent",
+      "ready_waiting",
+    ]);
+  });
+
+  it("returns picked_up for ready_text_sent", () => {
+    expect(advanceChoices("ready_text_sent")).toEqual(["picked_up"]);
+  });
+
+  it("returns picked_up for ready_waiting", () => {
+    expect(advanceChoices("ready_waiting")).toEqual(["picked_up"]);
+  });
+
+  it("returns nothing for terminal states", () => {
+    expect(advanceChoices("picked_up")).toEqual([]);
+    expect(advanceChoices("no_show")).toEqual([]);
+  });
+});
+
+describe("isTerminal", () => {
+  it("returns true for picked_up", () => {
+    expect(isTerminal("picked_up")).toBe(true);
+  });
+
+  it("returns true for no_show", () => {
+    expect(isTerminal("no_show")).toBe(true);
+  });
+
+  it("returns false for all non-terminal states", () => {
+    for (const s of ["not_started", "cooking", "ready_text_sent", "ready_waiting"] as const) {
+      expect(isTerminal(s)).toBe(false);
+    }
+  });
+});
+
+describe("ORDER_STATUS_LABELS / TONES coverage", () => {
+  // Sanity check: every status has a label + tone so the dashboard never
+  // renders raw enum strings to the operator.
+  it("has a label for every status", () => {
+    for (const s of [
+      "not_started",
+      "cooking",
+      "ready_text_sent",
+      "ready_waiting",
+      "picked_up",
+      "no_show",
+    ] as const) {
+      expect(typeof ORDER_STATUS_LABELS[s]).toBe("string");
+      expect(ORDER_STATUS_LABELS[s].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("has a tone for every status", () => {
+    for (const s of [
+      "not_started",
+      "cooking",
+      "ready_text_sent",
+      "ready_waiting",
+      "picked_up",
+      "no_show",
+    ] as const) {
+      expect(typeof ORDER_STATUS_TONES[s]).toBe("string");
+    }
+  });
+});

--- a/apps/mypizzatracker/frontend/src/features/service/OrderCard.tsx
+++ b/apps/mypizzatracker/frontend/src/features/service/OrderCard.tsx
@@ -17,12 +17,13 @@ import {
 import type {
   DashboardOrder,
   DashboardSlot,
+  OrderStatus,
 } from "@/types/service/service";
 import {
   ORDER_STATUS_LABELS,
   ORDER_STATUS_TONES,
   isTerminal,
-  nextAdvanceStatus,
+  advanceChoices,
 } from "./orderStatus";
 
 interface OrderCardProps {
@@ -47,28 +48,37 @@ export function OrderCard({
   const [advance, { isLoading: isAdvancing }] = useAdvanceOrderMutation();
   const [move, { isLoading: isMoving }] = useMoveOrderMutation();
   const [confirmNoShow, setConfirmNoShow] = useState(false);
+  const [pendingChoice, setPendingChoice] = useState<OrderStatus | null>(null);
 
   const mutating = isAdvancing || isMoving;
   const terminal = isTerminal(order.status);
-  const next = nextAdvanceStatus(order.status);
+  const choices = advanceChoices(order.status);
 
   const stale = computeStale(order.updated_at, serverTime, order.status);
 
-  const onAdvance = async () => {
-    if (!next) return;
+  const onAdvance = async (target: OrderStatus) => {
+    setPendingChoice(target);
     try {
-      await advance({
+      const result = await advance({
         dropId,
         orderId: order.id,
-        targetStatus: next,
+        targetStatus: target,
       }).unwrap();
-      showSuccess(`Moved to ${ORDER_STATUS_LABELS[next]}`);
+      showSuccess(`Moved to ${ORDER_STATUS_LABELS[target]}`);
+      if (result.sms_dispatched === false) {
+        showError(
+          `SMS not sent (${result.sms_error || "unknown error"}). Please text ${order.customer.phone} manually.`,
+        );
+      }
     } catch (err) {
       showError(extractErrorMessage(err) || "Failed to advance order");
+    } finally {
+      setPendingChoice(null);
     }
   };
 
   const onNoShow = async () => {
+    setPendingChoice("no_show");
     try {
       await advance({
         dropId,
@@ -78,6 +88,8 @@ export function OrderCard({
       showSuccess("Marked no-show");
     } catch (err) {
       showError(extractErrorMessage(err) || "Failed to mark no-show");
+    } finally {
+      setPendingChoice(null);
     }
   };
 
@@ -160,17 +172,19 @@ export function OrderCard({
 
       {!readOnly && !terminal ? (
         <div className="flex items-center gap-2 flex-wrap">
-          {next ? (
+          {choices.map((choice, index) => (
             <LoadingButton
+              key={choice}
               size="sm"
-              isLoading={isAdvancing}
+              variant={index === 0 ? "primary" : "secondary"}
+              isLoading={isAdvancing && pendingChoice === choice}
               loadingText="Saving..."
-              onClick={onAdvance}
+              onClick={() => onAdvance(choice)}
               disabled={mutating}
             >
-              -&gt; {ORDER_STATUS_LABELS[next]}
+              -&gt; {ORDER_STATUS_LABELS[choice]}
             </LoadingButton>
-          ) : null}
+          ))}
           <MoveSelect
             currentSlotId={order.slot_id}
             slots={slots}

--- a/apps/mypizzatracker/frontend/src/features/service/orderStatus.ts
+++ b/apps/mypizzatracker/frontend/src/features/service/orderStatus.ts
@@ -20,29 +20,32 @@ export const ORDER_STATUS_TONES: Record<OrderStatus, BadgeTone> = {
 };
 
 /**
- * The single "happy path" next status surfaced in PR 7's advance button.
+ * Ordered list of "happy path" advance choices for a given current state.
  *
- * `ready_text_sent` is hidden from the advance UI in PR 7 (Twilio comes
- * in PR 8). From `cooking`, the operator skips straight to
- * `ready_waiting`. From `ready_text_sent` (only reachable post-PR-8 or
- * via direct API), the operator advances to `picked_up`.
+ * The first element is the recommended primary action; any additional
+ * elements are secondary (rendered as ghost buttons). Terminal states
+ * return an empty list. `no_show` is offered separately as a sad-path
+ * action on every non-terminal card and is not part of this list.
  *
- * Terminal states have no next; `no_show` is offered separately as a
- * sad-path secondary action on every non-terminal card.
+ * Cooking forks into two choices since PR 8 wired Twilio:
+ *   - `ready_text_sent` (primary) -- transition AND send the customer
+ *     a ready-pickup SMS via Twilio.
+ *   - `ready_waiting` (secondary) -- transition only; operator will
+ *     text manually or skip the text.
  */
-export function nextAdvanceStatus(current: OrderStatus): OrderStatus | null {
+export function advanceChoices(current: OrderStatus): OrderStatus[] {
   switch (current) {
     case "not_started":
-      return "cooking";
+      return ["cooking"];
     case "cooking":
-      return "ready_waiting";
+      return ["ready_text_sent", "ready_waiting"];
     case "ready_text_sent":
-      return "picked_up";
+      return ["picked_up"];
     case "ready_waiting":
-      return "picked_up";
+      return ["picked_up"];
     case "picked_up":
     case "no_show":
-      return null;
+      return [];
   }
 }
 

--- a/apps/mypizzatracker/frontend/src/store/serviceApi.ts
+++ b/apps/mypizzatracker/frontend/src/store/serviceApi.ts
@@ -1,5 +1,9 @@
 import { baseApi } from "@platform/ui";
-import type { ServiceDashboardPayload, OrderStatus } from "@/types/service/service";
+import type {
+  AdvanceOrderResponse,
+  ServiceDashboardPayload,
+  OrderStatus,
+} from "@/types/service/service";
 
 const apiWithTags = baseApi.enhanceEndpoints({
   addTagTypes: ["ServiceDashboard"],
@@ -17,7 +21,7 @@ const serviceApi = apiWithTags.injectEndpoints({
       ],
     }),
     advanceOrder: build.mutation<
-      { id: string; status: OrderStatus; slot_id: string },
+      AdvanceOrderResponse,
       { dropId: string; orderId: string; targetStatus: OrderStatus }
     >({
       query: ({ orderId, targetStatus }) => ({

--- a/apps/mypizzatracker/frontend/src/types/service/service.ts
+++ b/apps/mypizzatracker/frontend/src/types/service/service.ts
@@ -87,3 +87,23 @@ export interface ServiceDashboardPayload {
   slots: DashboardSlot[];
   server_time: string;
 }
+
+/**
+ * Response shape for ``POST /service/orders/{id}/advance``.
+ *
+ * ``sms_dispatched`` is non-null only when the transition targeted
+ * ``ready_text_sent``:
+ *   - ``true``  — SMS sent successfully (or console-logged in dev).
+ *   - ``false`` — Twilio rejected; ``sms_error`` carries the reason.
+ *   - ``null``  — transition didn't involve SMS.
+ */
+export interface AdvanceOrderResponse {
+  order: {
+    id: string;
+    status: OrderStatus;
+    slot_id: string;
+    ready_text_sent_at: string | null;
+  };
+  sms_dispatched: boolean | null;
+  sms_error: string | null;
+}

--- a/packages/shared-backend/platform_shared/core/boot_guards.py
+++ b/packages/shared-backend/platform_shared/core/boot_guards.py
@@ -123,3 +123,74 @@ def check_email_configured(
             "EmailService silently no-ops and transactional emails never "
             "reach users. Set the credentials or set ENVIRONMENT=development."
         )
+
+
+class SmsNotConfiguredError(RuntimeError):
+    """Raised at boot when SMS is required but Twilio is not configured."""
+
+
+def check_sms_configured(
+    *,
+    sms_backend: str,
+    twilio_account_sid: str,
+    twilio_auth_token: str,
+    twilio_from_number: str,
+    environment: str,
+) -> None:
+    """Fail loud at boot if SMS isn't usable in a non-dev environment.
+
+    Only apps that opt in to SMS (via ``create_app_lifespan(sms_required=True)``)
+    invoke this guard; apps that never text users (MBK, MJH) skip it
+    entirely so they don't need to set Twilio env vars.
+
+    Two failure modes guarded:
+
+    1. ``sms_backend == "console"`` in production / staging. Console-mode
+       SMS goes to stdout — useful for dev where the operator wants to
+       see the rendered body, broken in production where customers never
+       see the text.
+    2. ``sms_backend == "twilio"`` with any of ``TWILIO_ACCOUNT_SID`` /
+       ``TWILIO_AUTH_TOKEN`` / ``TWILIO_FROM_NUMBER`` empty. The
+       ``SmsService`` raises ``SmsNotConfiguredError`` on send when any
+       credential is empty — an operator who forgot one would only
+       notice when the first customer never gets their ready-text.
+
+    Args:
+        sms_backend: ``"console"`` (dev/CI default — log to stdout) or
+            ``"twilio"`` (production — send via Twilio).
+        twilio_account_sid: Twilio Account SID. Required when
+            ``sms_backend == "twilio"``.
+        twilio_auth_token: Twilio Auth Token. Required when
+            ``sms_backend == "twilio"``.
+        twilio_from_number: The E.164-formatted Twilio number to send
+            from (e.g. ``"+15551234567"``). Required when
+            ``sms_backend == "twilio"``.
+        environment: The deployment environment name. ``"development"``
+            and ``"test"`` allow any combination; everything else
+            requires a working ``twilio`` backend.
+
+    Raises:
+        SmsNotConfiguredError: If ``environment`` is not dev/test and
+            either (a) ``sms_backend == "console"``, or (b)
+            ``sms_backend == "twilio"`` with any empty Twilio credential.
+    """
+    if environment in _DEV_ENVIRONMENTS:
+        return
+    if sms_backend == "console":
+        raise SmsNotConfiguredError(
+            "SMS_BACKEND='console' is not allowed in non-development "
+            "environments — ready-text alerts would silently log to stdout "
+            "instead of reaching customers. Set SMS_BACKEND=twilio and "
+            "configure TWILIO_ACCOUNT_SID / TWILIO_AUTH_TOKEN / "
+            "TWILIO_FROM_NUMBER, or set ENVIRONMENT=development."
+        )
+    if sms_backend == "twilio" and not (
+        twilio_account_sid and twilio_auth_token and twilio_from_number
+    ):
+        raise SmsNotConfiguredError(
+            "SMS_BACKEND='twilio' requires TWILIO_ACCOUNT_SID, "
+            "TWILIO_AUTH_TOKEN, and TWILIO_FROM_NUMBER to all be set in "
+            "non-development environments. Without them the SmsService "
+            "raises on every send and customers never receive ready-texts. "
+            "Set the credentials or set ENVIRONMENT=development."
+        )

--- a/packages/shared-backend/platform_shared/core/lifespan.py
+++ b/packages/shared-backend/platform_shared/core/lifespan.py
@@ -69,6 +69,7 @@ from fastapi import FastAPI
 from platform_shared.core.audit import register_audit_listeners
 from platform_shared.core.boot_guards import (
     check_email_configured,
+    check_sms_configured,
     check_turnstile_configured,
 )
 
@@ -88,6 +89,10 @@ class _SettingsProtocol(Protocol):
     email_backend: str
     smtp_user: str
     smtp_password: str
+    sms_backend: str
+    twilio_account_sid: str
+    twilio_auth_token: str
+    twilio_from_number: str
 
 
 # init_sentry needs to be passed in as a callable rather than imported,
@@ -104,6 +109,7 @@ def create_app_lifespan(
     settings: _SettingsProtocol,
     init_sentry: InitSentryFn,
     bucket_init: BucketInitFn = lambda: None,
+    sms_required: bool = False,
     on_startup: LifecycleHook | None = None,
     on_shutdown: LifecycleHook | None = None,
 ) -> Callable[[FastAPI], Any]:
@@ -123,6 +129,10 @@ def create_app_lifespan(
             existence at startup. Defaults to a no-op for apps that
             don't use object storage. Most apps pass their
             ``services.storage.bucket_initializer.ensure_bucket``.
+        sms_required: When True, the lifespan also runs
+            ``check_sms_configured()`` so the app fails loud in
+            production if Twilio credentials are missing. Apps that
+            never text users (MBK, MJH) leave this False.
         on_startup: Optional async or sync callable invoked AFTER all
             shared boot steps but BEFORE the lifespan yields. Use for
             app-specific work like spawning background tasks.
@@ -155,6 +165,14 @@ def create_app_lifespan(
             smtp_password=settings.smtp_password,
             environment=settings.environment,
         )
+        if sms_required:
+            check_sms_configured(
+                sms_backend=settings.sms_backend,
+                twilio_account_sid=settings.twilio_account_sid,
+                twilio_auth_token=settings.twilio_auth_token,
+                twilio_from_number=settings.twilio_from_number,
+                environment=settings.environment,
+            )
 
         # 3. Side-effect inits — wire SQLAlchemy listeners before any
         #    request handler can run a write, and verify MinIO is

--- a/packages/shared-backend/platform_shared/core/settings.py
+++ b/packages/shared-backend/platform_shared/core/settings.py
@@ -122,6 +122,16 @@ class BaseAppSettings(BaseSettings):
     smtp_password: str = ""
 
     # ------------------------------------------------------------------
+    # SMS delivery (opt-in per app via create_app_lifespan(sms_required=True))
+    # sms_backend = "console" prints to stdout (dev/CI default);
+    # "twilio" sends via Twilio's REST API.
+    # ------------------------------------------------------------------
+    sms_backend: str = "console"
+    twilio_account_sid: str = ""
+    twilio_auth_token: str = ""
+    twilio_from_number: str = ""
+
+    # ------------------------------------------------------------------
     # MinIO object storage
     # Apps override minio_bucket with their per-app bucket name.
     # minio_skip_startup_check is dev-only — production should always

--- a/packages/shared-backend/platform_shared/services/sms_service.py
+++ b/packages/shared-backend/platform_shared/services/sms_service.py
@@ -1,0 +1,163 @@
+"""Twilio SMS service.
+
+Usage:
+    sms = SmsService(
+        account_sid="AC...",
+        auth_token="...",
+        from_number="+15551234567",
+    )
+
+    # Critical-path SMS (account-recovery 2FA, order-ready alerts where
+    # the customer is waiting in person) — caller MUST know if delivery
+    # failed:
+    sid = sms.send_or_raise("+15559876543", "Your pizza is ready!")
+
+    # Best-effort SMS (engagement nudges, marketing) — caller continues
+    # on failure:
+    ok = sms.send("+15559876543", "Tomorrow's drop opens at 11am.")
+
+Twilio's REST API returns structured error codes
+(https://www.twilio.com/docs/api/errors) on failure. Per
+rules/check-third-party-error-codes.md, we capture the code on every
+failure and log it at WARNING with structured kwargs so Sentry/log
+aggregators can group failures by reason. Common codes operators will
+see:
+
+    21211  invalid To phone number
+    21408  permission to send SMS to this region not enabled
+    21610  recipient has unsubscribed (STOP)
+    21614  To phone is not SMS-capable
+    30001  Twilio queue overflow
+    30003  unreachable destination handset
+    30005  unknown destination handset
+    30007  carrier filtered (spam blocker)
+
+The body of ``SmsSendError`` embeds the Twilio code + status so callers
+that re-raise via HTTP can surface a useful message in their 4xx body
+without needing to import the Twilio SDK exception types.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # twilio is an optional import — apps that don't use SMS don't need
+    # to install it, and platform_shared.services.sms_service stays
+    # importable for type-checking on those apps. The runtime imports
+    # happen inside send_or_raise() below.
+    from twilio.rest import Client as _TwilioClient
+
+logger = logging.getLogger(__name__)
+
+
+class SmsNotConfiguredError(RuntimeError):
+    """Raised when Twilio credentials are missing.
+
+    Use platform_shared.core.boot_guards.check_sms_configured() at
+    lifespan startup so deploys fail loud instead of operators silently
+    losing every ready-text in production.
+    """
+
+
+class SmsSendError(RuntimeError):
+    """Raised when Twilio rejects a send (invalid number, unsubscribed
+    recipient, carrier filtered, etc.). Distinct from SmsNotConfiguredError —
+    this is a transient or addressee-specific failure, not a deploy
+    misconfiguration. The Twilio error code is embedded in the message.
+    """
+
+    def __init__(self, message: str, *, code: int | None = None, status: int | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.status = status
+
+
+@dataclass
+class SmsService:
+    account_sid: str = ""
+    auth_token: str = ""
+    from_number: str = ""
+
+    def is_configured(self) -> bool:
+        return bool(self.account_sid and self.auth_token and self.from_number)
+
+    def send_or_raise(self, to: str, body: str) -> str:
+        """Send the SMS, raising on any failure.
+
+        Returns:
+            Twilio message SID on success.
+
+        Raises:
+            ValueError: If ``to`` or ``body`` is empty.
+            SmsNotConfiguredError: If Twilio creds are missing.
+            SmsSendError: If Twilio rejects the send.
+        """
+        if not to:
+            raise ValueError("Recipient phone number cannot be empty")
+        if not body:
+            raise ValueError("SMS body cannot be empty")
+        if not self.is_configured():
+            raise SmsNotConfiguredError(
+                "Twilio credentials are not configured (TWILIO_ACCOUNT_SID / "
+                "TWILIO_AUTH_TOKEN / TWILIO_FROM_NUMBER). The platform_shared."
+                "core.boot_guards.check_sms_configured() guard should have caught "
+                "this at lifespan startup — investigate why the runtime SmsService "
+                "instance has empty creds."
+            )
+
+        # Imports happen lazily so the twilio package is only required
+        # by apps that actually use SMS.
+        from twilio.base.exceptions import TwilioRestException
+        from twilio.rest import Client
+
+        client: _TwilioClient = Client(self.account_sid, self.auth_token)
+        try:
+            msg = client.messages.create(
+                to=to,
+                from_=self.from_number,
+                body=body,
+            )
+        except TwilioRestException as e:
+            logger.warning(
+                "Twilio send failed: code=%s status=%s to=%s body_chars=%d msg=%s",
+                e.code, e.status, to, len(body), e.msg,
+            )
+            raise SmsSendError(
+                f"Twilio rejected SMS (code={e.code} status={e.status}): {e.msg}",
+                code=e.code,
+                status=e.status,
+            ) from e
+        except Exception as e:
+            # Network errors, timeouts, malformed responses — not
+            # specifically Twilio-codeable but still a send failure.
+            logger.warning(
+                "Twilio send failed (non-Twilio exception): to=%s body_chars=%d err=%r",
+                to, len(body), e,
+            )
+            raise SmsSendError(f"Twilio send failed: {e}") from e
+
+        logger.info(
+            "SMS sent via Twilio: sid=%s to=%s body_chars=%d",
+            msg.sid, to, len(body),
+        )
+        return msg.sid
+
+    def send(self, to: str, body: str) -> bool:
+        """Best-effort send. Returns True on success, False on failure.
+
+        Use for non-critical SMS where the operator has another recovery
+        path. Critical-path callers (e.g. account-recovery 2FA) MUST use
+        send_or_raise() so the failure propagates to the HTTP response.
+        """
+        try:
+            self.send_or_raise(to, body)
+            return True
+        except (ValueError, SmsNotConfiguredError, SmsSendError):
+            logger.warning(
+                "Best-effort SMS send failed to %s",
+                to,
+                exc_info=True,
+            )
+            return False

--- a/packages/shared-backend/pyproject.toml
+++ b/packages/shared-backend/pyproject.toml
@@ -31,6 +31,10 @@ dev = [
     # Dev-only: never imported from request handlers.
     "jinja2>=3.1.0",
     "pyyaml>=6.0.0",
+    # Required for tests of platform_shared.services.sms_service that need to
+    # patch the Twilio Client / TwilioRestException. Runtime apps that use
+    # SMS pull twilio in via their own pyproject.toml deps.
+    "twilio>=9.10.0",
 ]
 
 [tool.pytest.ini_options]

--- a/packages/shared-backend/tests/test_boot_guards.py
+++ b/packages/shared-backend/tests/test_boot_guards.py
@@ -4,8 +4,10 @@ import pytest
 
 from platform_shared.core.boot_guards import (
     EmailNotConfiguredError,
+    SmsNotConfiguredError,
     TurnstileNotConfiguredError,
     check_email_configured,
+    check_sms_configured,
     check_turnstile_configured,
 )
 
@@ -117,3 +119,97 @@ class TestCheckEmailConfigured:
 
     def test_inherits_from_runtime_error(self) -> None:
         assert issubclass(EmailNotConfiguredError, RuntimeError)
+
+
+class TestCheckSmsConfigured:
+    def test_dev_with_console_passes(self) -> None:
+        check_sms_configured(
+            sms_backend="console",
+            twilio_account_sid="",
+            twilio_auth_token="",
+            twilio_from_number="",
+            environment="development",
+        )
+
+    def test_test_with_console_passes(self) -> None:
+        check_sms_configured(
+            sms_backend="console",
+            twilio_account_sid="",
+            twilio_auth_token="",
+            twilio_from_number="",
+            environment="test",
+        )
+
+    def test_dev_with_twilio_and_empty_creds_passes(self) -> None:
+        check_sms_configured(
+            sms_backend="twilio",
+            twilio_account_sid="",
+            twilio_auth_token="",
+            twilio_from_number="",
+            environment="development",
+        )
+
+    def test_production_with_console_raises(self) -> None:
+        with pytest.raises(SmsNotConfiguredError) as exc:
+            check_sms_configured(
+                sms_backend="console",
+                twilio_account_sid="",
+                twilio_auth_token="",
+                twilio_from_number="",
+                environment="production",
+            )
+        assert "console" in str(exc.value).lower()
+        assert "TWILIO_" in str(exc.value)
+
+    def test_staging_with_console_raises(self) -> None:
+        with pytest.raises(SmsNotConfiguredError):
+            check_sms_configured(
+                sms_backend="console",
+                twilio_account_sid="",
+                twilio_auth_token="",
+                twilio_from_number="",
+                environment="staging",
+            )
+
+    def test_production_with_twilio_and_missing_sid_raises(self) -> None:
+        with pytest.raises(SmsNotConfiguredError) as exc:
+            check_sms_configured(
+                sms_backend="twilio",
+                twilio_account_sid="",
+                twilio_auth_token="t",
+                twilio_from_number="+15551234567",
+                environment="production",
+            )
+        assert "TWILIO_ACCOUNT_SID" in str(exc.value)
+
+    def test_production_with_twilio_and_missing_token_raises(self) -> None:
+        with pytest.raises(SmsNotConfiguredError):
+            check_sms_configured(
+                sms_backend="twilio",
+                twilio_account_sid="AC1",
+                twilio_auth_token="",
+                twilio_from_number="+15551234567",
+                environment="production",
+            )
+
+    def test_production_with_twilio_and_missing_from_number_raises(self) -> None:
+        with pytest.raises(SmsNotConfiguredError):
+            check_sms_configured(
+                sms_backend="twilio",
+                twilio_account_sid="AC1",
+                twilio_auth_token="t",
+                twilio_from_number="",
+                environment="production",
+            )
+
+    def test_production_with_twilio_and_full_creds_passes(self) -> None:
+        check_sms_configured(
+            sms_backend="twilio",
+            twilio_account_sid="AC1",
+            twilio_auth_token="t",
+            twilio_from_number="+15551234567",
+            environment="production",
+        )
+
+    def test_inherits_from_runtime_error(self) -> None:
+        assert issubclass(SmsNotConfiguredError, RuntimeError)

--- a/packages/shared-backend/tests/test_lifespan.py
+++ b/packages/shared-backend/tests/test_lifespan.py
@@ -10,6 +10,7 @@ from fastapi import FastAPI
 
 from platform_shared.core.boot_guards import (
     EmailNotConfiguredError,
+    SmsNotConfiguredError,
     TurnstileNotConfiguredError,
 )
 from platform_shared.core.lifespan import create_app_lifespan
@@ -23,6 +24,10 @@ def _settings(
     email_backend: str = "console",
     smtp_user: str = "",
     smtp_password: str = "",
+    sms_backend: str = "console",
+    twilio_account_sid: str = "",
+    twilio_auth_token: str = "",
+    twilio_from_number: str = "",
 ) -> SimpleNamespace:
     """Build a settings-like namespace for tests."""
     return SimpleNamespace(
@@ -32,6 +37,10 @@ def _settings(
         email_backend=email_backend,
         smtp_user=smtp_user,
         smtp_password=smtp_password,
+        sms_backend=sms_backend,
+        twilio_account_sid=twilio_account_sid,
+        twilio_auth_token=twilio_auth_token,
+        twilio_from_number=twilio_from_number,
     )
 
 
@@ -259,3 +268,100 @@ class TestBucketInit:
         async with lifespan(app):
             pass
         assert bucket_called == ["bucket"]
+
+
+class TestSmsRequired:
+    """sms_required=True gates the check_sms_configured guard."""
+
+    @pytest.mark.asyncio
+    async def test_default_sms_not_required_passes_in_prod_without_twilio(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        """Apps that never SMS (default) don't need Twilio creds even in prod."""
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="present",
+                email_backend="smtp",
+                smtp_user="u",
+                smtp_password="p" * 16,
+            ),
+            init_sentry=MagicMock(),
+        )
+        async with lifespan(app):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_sms_required_with_empty_twilio_creds_raises_in_prod(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="present",
+                email_backend="smtp",
+                smtp_user="u",
+                smtp_password="p" * 16,
+                sms_backend="twilio",
+                # twilio creds intentionally empty
+            ),
+            init_sentry=MagicMock(),
+            sms_required=True,
+        )
+        with pytest.raises(SmsNotConfiguredError):
+            async with lifespan(app):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_sms_required_with_full_twilio_creds_passes(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="present",
+                email_backend="smtp",
+                smtp_user="u",
+                smtp_password="p" * 16,
+                sms_backend="twilio",
+                twilio_account_sid="AC1",
+                twilio_auth_token="t",
+                twilio_from_number="+15551234567",
+            ),
+            init_sentry=MagicMock(),
+            sms_required=True,
+        )
+        async with lifespan(app):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_sms_required_in_dev_with_empty_creds_passes(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        """Dev/test envs don't need Twilio creds even with sms_required=True."""
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(environment="development"),
+            init_sentry=MagicMock(),
+            sms_required=True,
+        )
+        async with lifespan(app):
+            pass

--- a/packages/shared-backend/tests/test_sms_service.py
+++ b/packages/shared-backend/tests/test_sms_service.py
@@ -1,0 +1,167 @@
+"""Tests for platform_shared.services.sms_service.
+
+Covers:
+- ``is_configured()`` truth table -- all three Twilio fields must be set.
+- Best-effort ``send()`` returning bool (caller continues on failure).
+- Critical-path ``send_or_raise()`` raising on any failure (caller handles).
+- Twilio error codes captured + embedded in SmsSendError per
+  rules/check-third-party-error-codes.md.
+- ValueError on empty inputs.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from platform_shared.services.sms_service import (
+    SmsNotConfiguredError,
+    SmsSendError,
+    SmsService,
+)
+
+
+def _configured_service() -> SmsService:
+    return SmsService(
+        account_sid="ACfake1234567890fake1234567890abcd",
+        auth_token="fake-auth-token-x" * 2,
+        from_number="+15551234567",
+    )
+
+
+class TestIsConfigured:
+    def test_all_three_fields_set_is_configured(self) -> None:
+        assert _configured_service().is_configured() is True
+
+    def test_missing_sid_is_not_configured(self) -> None:
+        s = _configured_service()
+        s.account_sid = ""
+        assert s.is_configured() is False
+
+    def test_missing_token_is_not_configured(self) -> None:
+        s = _configured_service()
+        s.auth_token = ""
+        assert s.is_configured() is False
+
+    def test_missing_from_number_is_not_configured(self) -> None:
+        s = _configured_service()
+        s.from_number = ""
+        assert s.is_configured() is False
+
+    def test_empty_default_is_not_configured(self) -> None:
+        assert SmsService().is_configured() is False
+
+
+class TestSendOrRaise:
+    def test_raises_value_error_for_empty_to(self) -> None:
+        service = _configured_service()
+        with pytest.raises(ValueError):
+            service.send_or_raise("", "body")
+
+    def test_raises_value_error_for_empty_body(self) -> None:
+        service = _configured_service()
+        with pytest.raises(ValueError):
+            service.send_or_raise("+15559876543", "")
+
+    def test_raises_not_configured_when_creds_missing(self) -> None:
+        service = SmsService()
+        with pytest.raises(SmsNotConfiguredError):
+            service.send_or_raise("+15559876543", "body")
+
+    def test_returns_sid_on_success(self) -> None:
+        service = _configured_service()
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = MagicMock(sid="SM-fake-sid-1234")
+
+        with patch("twilio.rest.Client", return_value=mock_client) as mock_cls:
+            sid = service.send_or_raise("+15559876543", "Your pizza is ready!")
+
+        mock_cls.assert_called_once_with(service.account_sid, service.auth_token)
+        mock_client.messages.create.assert_called_once_with(
+            to="+15559876543",
+            from_=service.from_number,
+            body="Your pizza is ready!",
+        )
+        assert sid == "SM-fake-sid-1234"
+
+    def test_raises_send_error_on_twilio_rejection(self) -> None:
+        from twilio.base.exceptions import TwilioRestException
+
+        service = _configured_service()
+        underlying = TwilioRestException(
+            status=400,
+            uri="/Messages",
+            msg="The 'To' number is not a valid mobile number.",
+            code=21211,
+        )
+
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = underlying
+
+        with patch("twilio.rest.Client", return_value=mock_client):
+            with pytest.raises(SmsSendError) as exc:
+                service.send_or_raise("+invalid", "body")
+
+        # Twilio error code embedded in the message per
+        # rules/check-third-party-error-codes.md so callers can route
+        # without importing the Twilio SDK.
+        assert "21211" in str(exc.value)
+        assert exc.value.code == 21211
+        assert exc.value.status == 400
+        # __cause__ chain preserved for Sentry diagnostics
+        assert exc.value.__cause__ is underlying
+
+    def test_raises_send_error_on_generic_exception(self) -> None:
+        """Non-Twilio exceptions (network errors, timeouts) still raise
+        SmsSendError so callers have a single exception type to handle."""
+        service = _configured_service()
+        underlying = OSError("connection refused")
+
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = underlying
+
+        with patch("twilio.rest.Client", return_value=mock_client):
+            with pytest.raises(SmsSendError) as exc:
+                service.send_or_raise("+15559876543", "body")
+
+        assert "connection refused" in str(exc.value)
+        assert exc.value.__cause__ is underlying
+
+
+class TestSend:
+    def test_returns_true_on_success(self) -> None:
+        service = _configured_service()
+        mock_client = MagicMock()
+        mock_client.messages.create.return_value = MagicMock(sid="SM-ok")
+
+        with patch("twilio.rest.Client", return_value=mock_client):
+            assert service.send("+15559876543", "body") is True
+
+    def test_returns_false_when_unconfigured(self) -> None:
+        assert SmsService().send("+15559876543", "body") is False
+
+    def test_returns_false_for_empty_to(self) -> None:
+        assert _configured_service().send("", "body") is False
+
+    def test_returns_false_for_empty_body(self) -> None:
+        assert _configured_service().send("+15559876543", "") is False
+
+    def test_returns_false_on_twilio_rejection(self) -> None:
+        from twilio.base.exceptions import TwilioRestException
+
+        service = _configured_service()
+        mock_client = MagicMock()
+        mock_client.messages.create.side_effect = TwilioRestException(
+            status=400, uri="/Messages", msg="rejected", code=21610,
+        )
+
+        with patch("twilio.rest.Client", return_value=mock_client):
+            assert service.send("+15559876543", "body") is False
+
+
+class TestInheritance:
+    def test_not_configured_is_runtime_error(self) -> None:
+        assert issubclass(SmsNotConfiguredError, RuntimeError)
+
+    def test_send_error_is_runtime_error(self) -> None:
+        assert issubclass(SmsSendError, RuntimeError)


### PR DESCRIPTION
## Summary

- Adds `platform_shared.services.sms_service.SmsService` (Twilio-backed, mirrors `EmailService`) plus `check_sms_configured` boot guard + `sms_required=True` opt-in on the lifespan factory.
- Wires `advance_order_status(target=ready_text_sent)` to render + send the ready-text SMS through Twilio (best-effort; status transition commits even if Twilio rejects).
- Replaces single-button advance with `advanceChoices()` so the **cooking** state forks into a primary **"→ Ready - text sent"** (SMS) button and secondary **"→ Ready - waiting"** (no-text) button on every order card.

## Operational migration required

Before/at the next deploy, on the VPS edit `apps/mypizzatracker/backend/.env.docker` and add:

\`\`\`
SMS_BACKEND=twilio
TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
TWILIO_AUTH_TOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
TWILIO_FROM_NUMBER=+1xxxxxxxxxx
\`\`\`

(get values from console.twilio.com → Account Info + Phone Numbers → buy / pick a number)

Verify on the VPS:

\`\`\`bash
grep -E "^SMS_BACKEND=|^TWILIO_" apps/mypizzatracker/backend/.env.docker
\`\`\`

If the next deploy fails with `SmsNotConfiguredError` in the api container logs, this is the cause — the boot guard is now enforced for MPT (`sms_required=True`). Rollback: revert this PR — the previous image still works without the new env vars.

## Why best-effort SMS, not transactional?

The order status is the operator's authoritative record of "this order is ready". An SMS gateway outage shouldn't block the dashboard or roll back a transition the operator just made. The response surfaces `sms_dispatched=false` + `sms_error=...` so the operator gets a toast prompting them to text manually when Twilio rejects.

## Test plan

- [x] `pytest packages/shared-backend/tests/test_sms_service.py` — 21 tests (is_configured truth table, send/send_or_raise happy + failure paths, Twilio code capture per `rules/check-third-party-error-codes.md`)
- [x] `pytest packages/shared-backend/tests/test_boot_guards.py::TestCheckSmsConfigured` — 10 tests (dev/prod × backend × cred-completeness combinations)
- [x] `pytest packages/shared-backend/tests/test_lifespan.py::TestSmsRequired` — 4 tests (default no-SMS prod path still works; sms_required=True crashes on missing creds; passes on full creds; dev skips guard)
- [x] `pytest apps/mypizzatracker/backend/tests/test_service_dashboard.py` — existing tests updated for new `AdvanceOrderResponse` shape, plus 3 new tests for ready_text_sent SMS dispatch / Twilio rejection / not-configured paths
- [x] `pytest apps/mypizzatracker/backend/tests/test_sms_sender.py` — 6 tests (console vs twilio routing)
- [x] `pytest apps/mypizzatracker/backend/tests/test_order_ready_notification.py` — 5 tests (first-name only, single-segment, drop name, missing pickup time)
- [x] `npm run typecheck && npm run lint && npm test` in MPT frontend — orderStatus.test.ts covers the cooking fork shape (10 assertions)
- [ ] Post-merge smoke: SSH to VPS, set env vars, deploy, click "Text + Ready" on a real cooking order, verify SMS arrives (operator to validate with their own Twilio account)

## Notable shape changes

- `POST /service/orders/{id}/advance` response is now `{order, sms_dispatched, sms_error}` (was bare `OrderRead`). Frontend type + 4 existing tests updated. The `move` endpoint is unchanged (still returns `OrderRead`).
- `nextAdvanceStatus()` → `advanceChoices()` in `orderStatus.ts`. Returns an ordered list; OrderCard renders index-0 as primary, the rest as secondary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)