### PR TITLE
fix(mybookkeeper): allow theme-bootstrap inline script in CSP

### DIFF
--- a/apps/mybookkeeper/app.yaml
+++ b/apps/mybookkeeper/app.yaml
@@ -9,7 +9,7 @@ joins_minio_network: true
 block_api_docs: true
 include_bundle_tripwire: true
 env_seed_command: run setup.sh or create env files manually first
-csp: "default-src 'self'; script-src 'self' https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.{$DOMAIN} https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://storage.{$DOMAIN} https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+csp: "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.{$DOMAIN} https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://storage.{$DOMAIN} https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
 workers:
   - name: upload-processor
     command: ["python", "-m", "app.workers.upload_processor_worker"]

--- a/apps/mybookkeeper/docker/Caddyfile.docker
+++ b/apps/mybookkeeper/docker/Caddyfile.docker
@@ -65,7 +65,7 @@
             header {
                 defer
                 X-Frame-Options "DENY"
-                Content-Security-Policy "default-src 'self'; script-src 'self' https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.{$DOMAIN} https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://storage.{$DOMAIN} https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+                Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.{$DOMAIN} https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://storage.{$DOMAIN} https://us.posthog.com https://challenges.cloudflare.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
             }
 
             # Cache strategy:


### PR DESCRIPTION
## Summary

- MBK's `index.html` ships an inline `<script>` that bootstraps the dark-mode class before React hydrates (avoids flash-of-wrong-theme).
- Under MBK's existing `script-src 'self' ...` CSP — no `'unsafe-inline'`, no `sha256-` — that inline script was silently blocked in production.
- MJH and MGA both ship the **same script byte-for-byte** AND both have the SHA-256 hash in their CSP. MBK is the parity drift.

## What changes

Single hash added to `apps/mybookkeeper/app.yaml`:

```
'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk='
```

Caddyfile re-rendered via `python -m platform_shared.infra.render --app mybookkeeper` (template + render pattern, not direct edit of the generated `Caddyfile.docker`).

## Verification

Hash matches MJH/MGA on main byte-for-byte:

```
$ git show main:apps/myjobhunter/app.yaml | grep sha256-
csp: "... 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' ..."

$ git show main:apps/mygamingassistant/app.yaml | grep sha256-
csp: "... 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' ..."
```

## Operational migration

None. Pure CSP relaxation; rollback restores the previous CSP without breakage.

## Test plan

- [ ] CI green
- [ ] After deploy, no `Refused to execute inline script` errors in browser console for the theme bootstrap
- [ ] Dark-mode users no longer see a flash of light theme on first paint

Refs:
- `rules/inline-script-csp-hashes.md` — hash-pinned inline scripts policy
- `rules/monorepo-parity-discipline.md` — Tier 2 operational parity (MJH/MGA already shipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)