### PR TITLE
fix(mbk): drill-down on Monthly Overview bar click (drag-state stale-read)

### DIFF
--- a/apps/mybookkeeper/frontend/src/app/features/dashboard/MonthlyOverviewChart.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/dashboard/MonthlyOverviewChart.tsx
@@ -48,9 +48,17 @@ export default function MonthlyOverviewChart({
     chartData.map((r) => [r.displayMonth, r.rawMonth]),
   );
 
-  const [dragStart, setDragStart] = useState<string | null>(null);
-  const [dragEnd, setDragEnd] = useState<string | null>(null);
-  const isDragging = useRef(false);
+  // Drag state lives in a ref so handleMouseUp reads it synchronously —
+  // React 19 automatic batching can otherwise leave handleMouseUp seeing
+  // stale state from handleMouseDown's setState calls, which leaves
+  // `dragged` permanently true and silently swallows every Bar onClick.
+  const dragRef = useRef<{ start: string | null; end: string | null; dragged: boolean }>({
+    start: null,
+    end: null,
+    dragged: false,
+  });
+  // Only the visual overlay needs a re-render trigger.
+  const [dragOverlay, setDragOverlay] = useState<{ start: string; end: string } | null>(null);
 
   const showRevenue =
     !selectedCategories ||
@@ -64,43 +72,44 @@ export default function MonthlyOverviewChart({
   function handleMouseDown(e: { activeLabel?: string | number }) {
     if (e.activeLabel != null) {
       const label = String(e.activeLabel);
-      isDragging.current = true;
-      setDragStart(label);
-      setDragEnd(label);
+      dragRef.current = { start: label, end: label, dragged: false };
     }
   }
 
   function handleMouseMove(e: { activeLabel?: string | number }) {
-    if (isDragging.current && e.activeLabel != null) {
-      setDragEnd(String(e.activeLabel));
+    const { start } = dragRef.current;
+    if (start && e.activeLabel != null) {
+      const label = String(e.activeLabel);
+      dragRef.current.end = label;
+      if (label !== start) {
+        dragRef.current.dragged = true;
+        setDragOverlay({ start, end: label });
+      }
     }
   }
 
   function handleMouseUp() {
-    if (isDragging.current && dragStart && dragEnd) {
-      isDragging.current = false;
+    const { start, end, dragged } = dragRef.current;
+    dragRef.current.start = null;
+    dragRef.current.end = null;
+    setDragOverlay(null);
 
-      const startRaw = displayToRaw.get(dragStart);
-      const endRaw = displayToRaw.get(dragEnd);
+    if (dragged && start && end) {
+      const startRaw = displayToRaw.get(start);
+      const endRaw = displayToRaw.get(end);
       if (startRaw && endRaw) {
         const [first, last] =
           startRaw <= endRaw ? [startRaw, endRaw] : [endRaw, startRaw];
-
-        if (first !== last) {
-          const startDate = format(
-            startOfMonth(parse(first, "yyyy-MM", new Date())),
-            "yyyy-MM-dd",
-          );
-          const endDate = format(
-            endOfMonth(parse(last, "yyyy-MM", new Date())),
-            "yyyy-MM-dd",
-          );
-          onRangeSelect({ startDate, endDate });
-        }
+        const startDate = format(
+          startOfMonth(parse(first, "yyyy-MM", new Date())),
+          "yyyy-MM-dd",
+        );
+        const endDate = format(
+          endOfMonth(parse(last, "yyyy-MM", new Date())),
+          "yyyy-MM-dd",
+        );
+        onRangeSelect({ startDate, endDate });
       }
-
-      setDragStart(null);
-      setDragEnd(null);
     }
   }
 
@@ -113,10 +122,9 @@ export default function MonthlyOverviewChart({
         onMouseMove={handleMouseMove}
         onMouseUp={handleMouseUp}
         onMouseLeave={() => {
-          if (isDragging.current) {
-            isDragging.current = false;
-            setDragStart(null);
-            setDragEnd(null);
+          if (dragRef.current.start) {
+            dragRef.current = { start: null, end: null, dragged: false };
+            setDragOverlay(null);
           }
         }}
       >
@@ -152,7 +160,7 @@ export default function MonthlyOverviewChart({
                 radius={[2, 2, 0, 0]}
                 cursor="pointer"
                 onClick={(data, _index, e) => {
-                  if (!isDragging.current) {
+                  if (!dragRef.current.dragged) {
                     const entry = data.payload as MergedRow | undefined;
                     if (entry) onBarClick(buildFilter(`rev_${pk.propertyId}`, entry, propertyKeys));
                   }
@@ -168,7 +176,7 @@ export default function MonthlyOverviewChart({
                 radius={[2, 2, 0, 0]}
                 cursor="pointer"
                 onClick={(data, _index, e) => {
-                  if (!isDragging.current) {
+                  if (!dragRef.current.dragged) {
                     const entry = data.payload as MergedRow | undefined;
                     if (entry) onBarClick(buildFilter("revenue", entry));
                   }
@@ -186,7 +194,7 @@ export default function MonthlyOverviewChart({
                 radius={[2, 2, 0, 0]}
                 cursor="pointer"
                 onClick={(data, _index, e) => {
-                  if (!isDragging.current) {
+                  if (!dragRef.current.dragged) {
                     const entry = data.payload as MergedRow | undefined;
                     if (entry) onBarClick(buildFilter(`exp_${pk.propertyId}`, entry, propertyKeys));
                   }
@@ -203,7 +211,7 @@ export default function MonthlyOverviewChart({
                 fill={TAG_COLORS[cat] ?? "#94a3b8"}
                 cursor="pointer"
                 onClick={(data, _index, e) => {
-                  if (!isDragging.current) {
+                  if (!dragRef.current.dragged) {
                     const entry = data.payload as MergedRow | undefined;
                     if (entry) onBarClick(buildFilter(cat, entry));
                   }
@@ -218,10 +226,10 @@ export default function MonthlyOverviewChart({
           strokeWidth={2}
           dot={false}
         />
-        {dragStart && dragEnd && dragStart !== dragEnd ? (
+        {dragOverlay && dragOverlay.start !== dragOverlay.end ? (
           <ReferenceArea
-            x1={dragStart}
-            x2={dragEnd}
+            x1={dragOverlay.start}
+            x2={dragOverlay.end}
             fill="#6366f1"
             fillOpacity={0.15}
             stroke="#6366f1"


### PR DESCRIPTION
## Summary

PR #644 fixed the recharts-3 index-drift bug, but a second bug remained: the drag-detection state was read from React state inside `handleMouseUp`, which under React 19's automatic batching had not yet flushed from the `handleMouseDown` `setState` calls earlier in the same gesture. The `if (isDragging.current && dragStart && dragEnd)` block was skipped on every mouseUp, `isDragging.current` stayed `true` forever after the first click, and the bar's `if (!isDragging.current)` guard silently swallowed every subsequent click.

User symptom: clicked a Revenue bar, nothing happened, zero console output (handler was firing but the guard rejected).

## Fix

Collapse gesture state into a single `dragRef` whose `{ start, end, dragged }` fields are written and read synchronously. The bar `onClick` handlers now check `dragRef.current.dragged` — set true only when `mousemove` sees an activeLabel different from the `mousedown` label, and reset at the start of every new gesture (`mousedown`).

React state is retained only for the `<ReferenceArea>` visual overlay, which genuinely needs a re-render trigger to redraw during a drag.

## Behaviours preserved

- **Pure click on a bar** → mousedown sets `dragged=false`, no qualifying mousemove, mouseup sees `dragged=false`, bar `onClick` sees `dragged=false` → drill-down opens ✓
- **Real drag across bars** → mousemove flips `dragged=true`, mouseup sees `true` → `onRangeSelect` fires; subsequent click sees `dragged=true` → drill-down suppressed ✓
- **Mouse leaves chart mid-drag** → dragRef + overlay both cleared ✓

## Test plan

- [x] `tsc -b --noEmit` clean
- [x] `eslint` on changed file clean
- [x] `chart-utils.test.ts` (23/23) still pass — pure-utility tests, no chart-event coverage
- [ ] Manual smoke after deploy: click green Revenue bar → drill-down opens
- [ ] Manual smoke after deploy: drag across 2+ months → date range applies, no drill-down

🤖 Generated with [Claude Code](https://claude.com/claude-code)