### PR TITLE
fix(mbk): trusted-sender allowlist + revert dashboard filter (PR #640)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/trustsndr260514_backfill_trusted_sender_approved.py
+++ b/apps/mybookkeeper/backend/alembic/versions/trustsndr260514_backfill_trusted_sender_approved.py
@@ -1,0 +1,82 @@
+"""backfill trusted-sender transactions from unverified to approved
+
+Email-body extractions from trusted payment senders (Airbnb, Zelle, VRBO,
+Booking.com, Vello, FurnishedFinder) are now auto-approved at extraction
+time. Existing rows created before that change still carry status
+``unverified``; this migration backfills them so the dashboard reflects
+the same totals new extractions would.
+
+Sender email is not stored on any persistent row, so the join uses the
+extraction/document link plus a vendor ILIKE on the Claude-extracted
+vendor name (which matches the platform brand in practice).
+
+Idempotent: re-running is a no-op once status flips to ``approved``.
+Reversible (best-effort): downgrade flips the same matching rows back to
+``unverified``. If a row was already ``approved`` before this migration
+ran, downgrade will incorrectly flip it — operator should rely on
+backups for an exact rollback.
+
+Revision ID: trustsndr260514
+Revises: rmplaid260511
+Create Date: 2026-05-14
+"""
+from alembic import op
+
+
+revision = "trustsndr260514"
+down_revision = "rmplaid260511"
+branch_labels = None
+depends_on = None
+
+
+_TRUSTED_VENDOR_PATTERNS = (
+    "%airbnb%",
+    "%zelle%",
+    "%vrbo%",
+    "%booking.com%",
+    "%vello%",
+    "%furnishedfinder%",
+)
+
+
+def _vendor_ilike_clause(alias: str) -> str:
+    parts = [f"{alias}.vendor ILIKE '{p}'" for p in _TRUSTED_VENDOR_PATTERNS]
+    return "(" + " OR ".join(parts) + ")"
+
+
+def upgrade() -> None:
+    op.execute(
+        f"""
+        UPDATE transactions AS t
+        SET status = 'approved'
+        WHERE t.status = 'unverified'
+          AND t.extraction_id IS NOT NULL
+          AND EXISTS (
+              SELECT 1
+              FROM extractions e
+              JOIN documents d ON d.id = e.document_id
+              WHERE e.id = t.extraction_id
+                AND d.source = 'email'
+          )
+          AND {_vendor_ilike_clause("t")}
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        f"""
+        UPDATE transactions AS t
+        SET status = 'unverified'
+        WHERE t.status = 'approved'
+          AND t.extraction_id IS NOT NULL
+          AND EXISTS (
+              SELECT 1
+              FROM extractions e
+              JOIN documents d ON d.id = e.document_id
+              WHERE e.id = t.extraction_id
+                AND d.source = 'email'
+          )
+          AND {_vendor_ilike_clause("t")}
+        """
+    )

--- a/apps/mybookkeeper/backend/app/core/trusted_email_senders.py
+++ b/apps/mybookkeeper/backend/app/core/trusted_email_senders.py
@@ -1,0 +1,47 @@
+"""Allowlist of sender domains whose email-body extractions can be auto-approved.
+
+Email-body extractions normally land as ``unverified`` so the user reviews
+them before they affect dashboard totals. For payment platforms whose
+emails are unambiguous structured receipts (Airbnb, Zelle, VRBO, etc.),
+that review step is friction without value — the sender domain is itself
+strong evidence the transaction is real.
+"""
+from __future__ import annotations
+
+TRUSTED_PAYMENT_SENDERS: frozenset[str] = frozenset({
+    "airbnb.com",
+    "zellepay.com",
+    "vrbo.com",
+    "booking.com",
+    "vello.app",
+    "furnishedfinder.com",
+})
+
+
+def _extract_domain(email: str) -> str | None:
+    """Return the lowercase domain portion of ``email`` or None."""
+    if "@" not in email:
+        return None
+    _, _, domain = email.rpartition("@")
+    domain = domain.strip().lower()
+    # Strip a trailing display-name angle bracket if present.
+    if domain.endswith(">"):
+        domain = domain[:-1].strip()
+    return domain or None
+
+
+def is_trusted_sender(email: str | None) -> bool:
+    """Return True if ``email`` is from a trusted payment sender domain.
+
+    Matches the domain exactly or as a subdomain (``noreply@auto.airbnb.com``
+    matches the ``airbnb.com`` entry).
+    """
+    if not email:
+        return False
+    domain = _extract_domain(email)
+    if not domain:
+        return False
+    for trusted in TRUSTED_PAYMENT_SENDERS:
+        if domain == trusted or domain.endswith("." + trusted):
+            return True
+    return False

--- a/apps/mybookkeeper/backend/app/repositories/transactions/summary_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/transactions/summary_repo.py
@@ -22,7 +22,7 @@ def _build_txn_filters(
     filters = [
         Transaction.organization_id == organization_id,
         Transaction.deleted_at.is_(None),
-        Transaction.status.in_(["approved", "unverified"]),
+        Transaction.status == "approved",
     ]
     if start_date is not None:
         filters.append(Transaction.transaction_date >= start_date)

--- a/apps/mybookkeeper/backend/app/services/email/email_extraction_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_extraction_service.py
@@ -120,9 +120,11 @@ async def _extract_next_fetched(ctx: RequestContext) -> ExtractResult:
 
     try:
         extraction: tuple[ExtractionResult, Attachment | None] | None
+        sender_email: str | None = None
         if attachment_id == "body":
             email_data = cast(EmailBodyData, json.loads(raw_content.decode("utf-8")))
             logger.info("Extracting body for email id=%s subject=%r", message_id, email_data.get("subject"))
+            sender_email = email_data.get("from_address")
 
             # --- Booking ingestion pre-check ---
             # Attempt to classify the email as a booking confirmation before
@@ -180,6 +182,7 @@ async def _extract_next_fetched(ctx: RequestContext) -> ExtractResult:
                     organization_id=ctx.organization_id,
                     user_id=ctx.user_id,
                     db=db,
+                    sender_email=sender_email,
                 )
 
             item_ref = await email_queue_repo.get_by_id(db, item_id)

--- a/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.parsers import safe_date, safe_decimal
 from app.core.tags import transaction_type_for_category
+from app.core.trusted_email_senders import is_trusted_sender
 from app.models.documents.document import Document
 from app.models.email.email_types import Attachment
 from app.models.extraction.extraction import Extraction
@@ -39,6 +40,7 @@ async def save_email_extraction(
     organization_id: uuid.UUID,
     user_id: uuid.UUID,
     db: AsyncSession,
+    sender_email: str | None = None,
 ) -> int:
     """Persist extracted documents from an email. Returns count added.
 
@@ -196,8 +198,13 @@ async def save_email_extraction(
             )
 
             # Email body extractions (no PDF attachment) are less reliable —
-            # mark transactions as "unverified" so users review them
-            if is_email_body and txn:
+            # mark transactions as "unverified" so users review them. Trusted
+            # payment senders (Airbnb, Zelle, etc.) are exempt: their emails
+            # are unambiguous structured receipts and the review step is
+            # friction without value.
+            if is_email_body and txn and not (
+                sender_email and is_trusted_sender(sender_email)
+            ):
                 txn.status = "unverified"
 
             surviving = await resolve_and_link(

--- a/apps/mybookkeeper/backend/tests/test_summary_from_transactions.py
+++ b/apps/mybookkeeper/backend/tests/test_summary_from_transactions.py
@@ -150,7 +150,7 @@ class TestGetSummary:
         assert by_tag.get("utilities") == 50.00
 
     @pytest.mark.asyncio
-    async def test_approved_and_unverified_included_other_statuses_excluded(self, db: AsyncSession) -> None:
+    async def test_only_approved_summed_other_statuses_excluded(self, db: AsyncSession) -> None:
         user, org_id = await _setup_org_and_user(db)
         prop = _make_property(org_id, user.id)
         db.add(prop)
@@ -191,10 +191,10 @@ class TestGetSummary:
         rows = await summary_repo.txn_sum_by_category(db, org_id)
         total = sum(float(row.total) for row in rows)
 
-        assert total == 900.00
+        assert total == 500.00
 
     @pytest.mark.asyncio
-    async def test_unverified_income_counted_in_revenue(self, db: AsyncSession) -> None:
+    async def test_unverified_income_excluded_from_revenue(self, db: AsyncSession) -> None:
         user, org_id = await _setup_org_and_user(db)
         prop = _make_property(org_id, user.id)
         db.add(prop)
@@ -215,10 +215,10 @@ class TestGetSummary:
         rows = await summary_repo.txn_sum_by_category(db, org_id)
         by_tag = {row.tag: float(row.total) for row in rows}
 
-        assert by_tag.get("rental_revenue") == 1200.00
+        assert by_tag.get("rental_revenue") is None
 
     @pytest.mark.asyncio
-    async def test_unverified_expense_counted_in_expenses(self, db: AsyncSession) -> None:
+    async def test_unverified_expense_excluded_from_expenses(self, db: AsyncSession) -> None:
         user, org_id = await _setup_org_and_user(db)
         prop = _make_property(org_id, user.id)
         db.add(prop)
@@ -238,10 +238,10 @@ class TestGetSummary:
         rows = await summary_repo.txn_sum_by_category(db, org_id)
         by_tag = {row.tag: float(row.total) for row in rows}
 
-        assert by_tag.get("maintenance") == 75.00
+        assert by_tag.get("maintenance") is None
 
     @pytest.mark.asyncio
-    async def test_unverified_deleted_still_excluded(self, db: AsyncSession) -> None:
+    async def test_unverified_excluded_even_if_not_deleted(self, db: AsyncSession) -> None:
         user, org_id = await _setup_org_and_user(db)
         prop = _make_property(org_id, user.id)
         db.add(prop)
@@ -571,7 +571,7 @@ class TestGetTaxSummary:
         assert by_tag["rental_revenue"] == 3000.00
 
     @pytest.mark.asyncio
-    async def test_tax_summary_includes_unverified_excludes_other_statuses(self, db: AsyncSession) -> None:
+    async def test_tax_summary_only_approved_other_statuses_excluded(self, db: AsyncSession) -> None:
         user, org_id = await _setup_org_and_user(db)
         prop = _make_property(org_id, user.id)
         db.add(prop)
@@ -637,7 +637,7 @@ class TestGetTaxSummary:
         )
         by_tag = {row.tag: float(row.total) for row in rows}
 
-        assert by_tag.get("rental_revenue") == 5500.00
+        assert by_tag.get("rental_revenue") == 4000.00
 
     @pytest.mark.asyncio
     async def test_empty_result_for_year_with_no_transactions(self, db: AsyncSession) -> None:

--- a/apps/mybookkeeper/backend/tests/test_trusted_email_senders.py
+++ b/apps/mybookkeeper/backend/tests/test_trusted_email_senders.py
@@ -1,0 +1,219 @@
+"""Trusted-sender allowlist: domain matching + email-body approve/unverify gate.
+
+The dashboard sums only ``status='approved'`` transactions. Email-body
+extractions land as ``unverified`` so the user reviews them — except when
+the sender domain is on the trusted payment allowlist (Airbnb, Zelle,
+etc.), in which case they auto-approve.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.trusted_email_senders import (
+    TRUSTED_PAYMENT_SENDERS,
+    _extract_domain,
+    is_trusted_sender,
+)
+from app.models.extraction.extraction_types import ExtractionData, ExtractionResult
+from app.models.organization.organization import Organization
+from app.models.transactions.transaction import Transaction
+from app.models.user.user import User
+from app.services.extraction.extraction_persistence import save_email_extraction
+from sqlalchemy import select
+
+
+class TestExtractDomain:
+    def test_simple_email(self) -> None:
+        assert _extract_domain("noreply@airbnb.com") == "airbnb.com"
+
+    def test_lowercases_domain(self) -> None:
+        assert _extract_domain("Receipt@Airbnb.COM") == "airbnb.com"
+
+    def test_subdomain_preserved(self) -> None:
+        assert _extract_domain("auto@mailer.airbnb.com") == "mailer.airbnb.com"
+
+    def test_no_at_sign_returns_none(self) -> None:
+        assert _extract_domain("not-an-email") is None
+
+    def test_strips_trailing_angle_bracket(self) -> None:
+        # "Airbnb <noreply@airbnb.com>" — caller may pass the raw header
+        assert _extract_domain("noreply@airbnb.com>") == "airbnb.com"
+
+    def test_empty_domain_returns_none(self) -> None:
+        assert _extract_domain("foo@") is None
+
+
+class TestIsTrustedSender:
+    def test_exact_domain_match(self) -> None:
+        assert is_trusted_sender("noreply@airbnb.com") is True
+        assert is_trusted_sender("payments@zellepay.com") is True
+        assert is_trusted_sender("receipt@vrbo.com") is True
+        assert is_trusted_sender("reservation@booking.com") is True
+        assert is_trusted_sender("hello@vello.app") is True
+        assert is_trusted_sender("noreply@furnishedfinder.com") is True
+
+    def test_subdomain_match(self) -> None:
+        assert is_trusted_sender("auto@mailer.airbnb.com") is True
+        assert is_trusted_sender("x@notifications.booking.com") is True
+
+    def test_case_insensitive(self) -> None:
+        assert is_trusted_sender("Noreply@Airbnb.COM") is True
+
+    def test_untrusted_domain(self) -> None:
+        assert is_trusted_sender("billing@comcast.com") is False
+        assert is_trusted_sender("info@randomvendor.com") is False
+
+    def test_lookalike_suffix_does_not_match(self) -> None:
+        # "evilairbnb.com" must NOT match "airbnb.com" — only proper subdomains
+        assert is_trusted_sender("phish@evilairbnb.com") is False
+        assert is_trusted_sender("x@notairbnb.com") is False
+
+    def test_none_returns_false(self) -> None:
+        assert is_trusted_sender(None) is False
+
+    def test_empty_string_returns_false(self) -> None:
+        assert is_trusted_sender("") is False
+
+    def test_malformed_returns_false(self) -> None:
+        assert is_trusted_sender("just-a-name") is False
+
+    def test_allowlist_membership(self) -> None:
+        assert "airbnb.com" in TRUSTED_PAYMENT_SENDERS
+        assert "zellepay.com" in TRUSTED_PAYMENT_SENDERS
+
+
+async def _seed_org_user(db: AsyncSession) -> tuple[uuid.UUID, uuid.UUID]:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"test-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="fakehash",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db.add(user)
+    org = Organization(id=uuid.uuid4(), name="Test Org", created_by=user.id)
+    db.add(org)
+    await db.commit()
+    await db.refresh(user)
+    await db.refresh(org)
+    return org.id, user.id
+
+
+def _make_extraction_result(amount: str = "150.00", vendor: str = "Airbnb") -> ExtractionResult:
+    data: ExtractionData = {
+        "vendor": vendor,
+        "amount": amount,
+        "date": "2025-06-15",
+        "document_type": "invoice",
+        "confidence": "high",
+        "tags": ["rental_revenue"],
+    }
+    return {
+        "data": [data],
+        "tokens": 100,
+        "input_tokens": 80,
+        "output_tokens": 20,
+        "model_name": "claude-test",
+    }
+
+
+class TestEmailBodyApprovalGate:
+    """End-to-end: save_email_extraction honors the trusted-sender gate."""
+
+    @pytest.mark.asyncio
+    async def test_trusted_sender_body_creates_approved_transaction(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = await _seed_org_user(db)
+
+        added = await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="Reservation confirmed",
+            result=_make_extraction_result(amount="425.00", vendor="Airbnb"),
+            source_att=None,  # body-only → would normally be "unverified"
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email="automated@airbnb.com",
+        )
+        assert added == 1
+
+        txn = (await db.execute(
+            select(Transaction).where(Transaction.organization_id == org_id)
+        )).scalar_one()
+        assert txn.status == "approved"
+        assert txn.amount == Decimal("425.00")
+
+    @pytest.mark.asyncio
+    async def test_trusted_subdomain_also_approved(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = await _seed_org_user(db)
+
+        await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="Payment sent",
+            result=_make_extraction_result(amount="700.00", vendor="Zelle"),
+            source_att=None,
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email="alerts@notifications.zellepay.com",
+        )
+
+        txn = (await db.execute(
+            select(Transaction).where(Transaction.organization_id == org_id)
+        )).scalar_one()
+        assert txn.status == "approved"
+
+    @pytest.mark.asyncio
+    async def test_unknown_sender_body_creates_unverified_transaction(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = await _seed_org_user(db)
+
+        await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="Random invoice",
+            result=_make_extraction_result(amount="99.00", vendor="Comcast"),
+            source_att=None,
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email="billing@comcast.com",
+        )
+
+        txn = (await db.execute(
+            select(Transaction).where(Transaction.organization_id == org_id)
+        )).scalar_one()
+        assert txn.status == "unverified"
+
+    @pytest.mark.asyncio
+    async def test_missing_sender_body_creates_unverified_transaction(
+        self, db: AsyncSession
+    ) -> None:
+        # Legacy emails fetched before from_address wiring will have no sender.
+        # Must fall back to the safe path: unverified.
+        org_id, user_id = await _seed_org_user(db)
+
+        await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="Legacy email",
+            result=_make_extraction_result(amount="42.00", vendor="Unknown"),
+            source_att=None,
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email=None,
+        )
+
+        txn = (await db.execute(
+            select(Transaction).where(Transaction.organization_id == org_id)
+        )).scalar_one()
+        assert txn.status == "unverified"

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -194,7 +194,8 @@
         "backend/app/models/extraction/",
         "backend/app/repositories/extraction/",
         "backend/app/schemas/extraction/",
-        "backend/app/mappers/extraction_mapper.py"
+        "backend/app/mappers/extraction_mapper.py",
+        "backend/app/core/trusted_email_senders.py"
       ],
       "backend_tests": [
         "test_dedup_resolution.py",
@@ -205,7 +206,8 @@
         "test_extraction_to_transactions.py",
         "test_prompt_service.py",
         "test_property_matcher.py",
-        "test_self_healing.py"
+        "test_self_healing.py",
+        "test_trusted_email_senders.py"
       ],
       "frontend_tests": [],
       "e2e_specs": [


### PR DESCRIPTION
## Summary

- Revert PR #640: dashboard summary repository again sums only `status='approved'` transactions instead of `approved` + `unverified`.
- Replace the symptom-level fix with the root cause: email-body extractions from trusted payment senders (`airbnb.com`, `zellepay.com`, `vrbo.com`, `booking.com`, `vello.app`, `furnishedfinder.com`) auto-approve at extraction time. Untrusted senders still land as `unverified` for user review.
- Sender match is domain-exact or proper-subdomain — `phish@evilairbnb.com` does **not** match `airbnb.com`.
- Alembic data migration `trustsndr260514` flips existing `unverified` rows whose linked Extraction is from an email Document and whose vendor matches a trusted platform.
- `DrillDownPanel.tsx` intentionally untouched — it stays on `status=approved`.

## Why a revert

Including `unverified` in dashboard totals double-counted income whenever an email body extracted a transaction that the user later reconciled with a bank import. The dashboard should only reflect rows the user has accepted (`approved`). Auto-approving the high-trust senders eliminates the friction PR #640 was trying to fix, without inflating numbers.

## Files

- `app/core/trusted_email_senders.py` — new helper + frozenset allowlist.
- `app/services/extraction/extraction_persistence.py` — accepts `sender_email`, gates the `unverified` write on `not is_trusted_sender(...)`.
- `app/services/email/email_extraction_service.py` — threads `email_data.from_address` into `save_email_extraction`.
- `app/repositories/transactions/summary_repo.py` — reverts to `Transaction.status == 'approved'`.
- `tests/test_trusted_email_senders.py` — unit tests for domain matching + integration tests covering trusted / untrusted / subdomain / missing-sender paths.
- `tests/test_summary_from_transactions.py` — 5 PR-#640 tests revised so `unverified` is no longer summed.
- `alembic/versions/trustsndr260514_backfill_trusted_sender_approved.py` — data migration (idempotent, best-effort reversible).

## Test plan

- [x] `bash apps/mybookkeeper/scripts/run-affected-tests.sh` — 192 backend tests pass (extraction domain + new trusted-sender tests). E2E playwright deps are not installed locally; CI runs them.
- [x] `pytest tests/test_summary_from_transactions.py` — 19 passed.
- [x] `pytest tests/test_trusted_email_senders.py` — 19 passed (helper + body-approval gate).
- [ ] CI green on the PR.