### PR TITLE
feat(mga): bulk update endpoint for map zone polygons

### DIFF
--- a/apps/mygamingassistant/backend/app/api/games.py
+++ b/apps/mygamingassistant/backend/app/api/games.py
@@ -6,13 +6,14 @@ anyone can browse the lineup library, only the operator can manage content.
 
 Routes:
     PUBLIC (no auth):
-        GET  /api/games                                — list all games
-        GET  /api/games/{game_slug}/maps               — list maps for a game
-        GET  /api/games/{game_slug}/maps/{map_slug}    — map detail with zones + sites + utility types
+        GET   /api/games                                — list all games
+        GET   /api/games/{game_slug}/maps               — list maps for a game
+        GET   /api/games/{game_slug}/maps/{map_slug}    — map detail with zones + sites + utility types
 
     AUTH (operator only):
-        POST /api/maps/{map_id}/minimap-upload-url     — presigned PUT for minimap
-        POST /api/maps/{map_id}/minimap                — confirm upload, update Map.minimap_url
+        POST  /api/maps/{map_id}/minimap-upload-url     — presigned PUT for minimap
+        POST  /api/maps/{map_id}/minimap                — confirm upload, update Map.minimap_url
+        PATCH /api/maps/{map_id}/zones                  — bulk update zone polygons
 
 See ``apps/mygamingassistant/CLAUDE.md`` → Authentication Model for the
 public-read/auth-write rationale (MGA-specific Tier 3 divergence).
@@ -32,10 +33,14 @@ from app.models.game.map_zone import MapZone  # noqa: F401 — used via selectin
 from app.models.game.site import Site  # noqa: F401 — used via selectinload
 from app.models.game.utility_type import UtilityType
 from app.models.user.user import User
+from app.repositories.game import game_repo
 from app.schemas.game.map_schemas import (
+    BulkUpdateZonesBody,
+    BulkUpdateZonesResult,
     MapMinimapUpdated,
     MinimapConfirmBody,
     MinimapUploadUrlResponse,
+    ZonePolygonFailure,
 )
 from app.services.game import map_service
 
@@ -208,4 +213,41 @@ async def confirm_minimap_upload(
     return MapMinimapUpdated(
         map_id=map_id,
         minimap_url=map_service.sign_minimap_url(map_obj.minimap_url),
+    )
+
+
+@auth_router.patch(
+    "/maps/{map_id}/zones",
+    response_model=BulkUpdateZonesResult,
+)
+async def update_map_zones(
+    map_id: uuid.UUID,
+    body: BulkUpdateZonesBody,
+    db: AsyncSession = Depends(get_db),
+    _user: User = Depends(current_active_user),
+) -> BulkUpdateZonesResult:
+    """Bulk-update polygon_points for one or more zones on a map.
+
+    Per-zone validation failures are returned in the ``failed`` array (HTTP
+    200) rather than 422-ing the whole request — operators commonly leave
+    a 1-2 point polygon mid-draw, and we shouldn't make them lose the rest
+    of their session because one zone is half-finished. Whole-request
+    errors (auth, unknown map) still use the standard HTTP error codes.
+    """
+    map_obj = await db.get(Map, map_id)
+    if map_obj is None:
+        raise HTTPException(status_code=404, detail="Map not found")
+
+    updates = [
+        (z.slug, [{"x": p.x, "y": p.y} for p in z.polygon_points])
+        for z in body.zones
+    ]
+    updated, failed = await game_repo.update_zone_polygons_bulk(
+        db, map_id=map_id, updates=updates
+    )
+    await db.commit()
+
+    return BulkUpdateZonesResult(
+        updated=updated,
+        failed=[ZonePolygonFailure(slug=s, reason=r) for s, r in failed],
     )

--- a/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
@@ -175,6 +175,49 @@ async def upsert_map_zone(
     return zone
 
 
+async def update_zone_polygons_bulk(
+    db: AsyncSession,
+    *,
+    map_id: uuid.UUID,
+    updates: list[tuple[str, list[dict[str, float]]]],
+) -> tuple[list[str], list[tuple[str, str]]]:
+    """Bulk-update polygon_points across multiple MapZones for one map.
+
+    Validation rules (per-zone, failures recorded — never raise):
+    - The zone slug must exist within this map (cross-map slugs rejected).
+    - ``polygon_points`` may be empty (clears the polygon, zone becomes
+      invisible/unclickable in plan mode) OR have >=3 entries.
+    - 1 or 2 points → rejected as "polygon needs 3+ vertices".
+
+    Caller is responsible for committing.
+
+    Returns
+    -------
+    tuple[list[str], list[tuple[str, str]]]
+        ``(updated_slugs, [(failed_slug, reason)])`` — partial successes are
+        normal and reflected by both lists having entries.
+    """
+    result = await db.execute(select(MapZone).where(MapZone.map_id == map_id))
+    zones_by_slug = {z.slug: z for z in result.scalars().all()}
+
+    updated: list[str] = []
+    failed: list[tuple[str, str]] = []
+
+    for slug, points in updates:
+        zone = zones_by_slug.get(slug)
+        if zone is None:
+            failed.append((slug, "zone slug not found on this map"))
+            continue
+        if 0 < len(points) < 3:
+            failed.append((slug, f"polygon needs 3+ vertices (got {len(points)})"))
+            continue
+        zone.polygon_points = points
+        updated.append(slug)
+
+    await db.flush()
+    return updated, failed
+
+
 # ---------------------------------------------------------------------------
 # Site
 # ---------------------------------------------------------------------------

--- a/apps/mygamingassistant/backend/app/schemas/game/map_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/map_schemas.py
@@ -1,4 +1,4 @@
-"""Pydantic schemas for map-related operator endpoints (minimap upload).
+"""Pydantic schemas for map-related operator endpoints (minimap upload, zone polygons).
 
 The map read endpoints in api/games.py return a dict — kept that way to
 preserve existing API shape. These schemas are only for the new auth-gated
@@ -9,7 +9,7 @@ from __future__ import annotations
 import uuid
 from typing import Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class MinimapUploadUrlResponse(BaseModel):
@@ -38,3 +38,65 @@ class MapMinimapUpdated(BaseModel):
 
     map_id: uuid.UUID
     minimap_url: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Zone polygon bulk update (operator-only)
+# ---------------------------------------------------------------------------
+
+class PolygonPoint(BaseModel):
+    """A single vertex of a zone polygon, in 0-1 normalized coords.
+
+    The frontend stores points in this object shape so it can pass them
+    directly into MapZoneOverlay's `pointsToSvg` helper. Pydantic enforces
+    the [0, 1] range at the API boundary; the editor canvas already clamps
+    locally but a malformed client should still 422.
+    """
+
+    x: float = Field(ge=0.0, le=1.0)
+    y: float = Field(ge=0.0, le=1.0)
+
+
+class ZonePolygonUpdate(BaseModel):
+    """One zone's new polygon for a bulk update.
+
+    ``polygon_points``: an empty list clears the polygon (zone becomes
+    invisible/unclickable in plan mode); otherwise must contain >=3 points.
+    The 3-point minimum is enforced server-side rather than via Pydantic
+    so the failure surfaces in the per-zone ``failed`` list rather than
+    422-ing the whole request — operators routinely leave a 1-2 point
+    polygon mid-draw and we shouldn't fail the entire save.
+    """
+
+    slug: str = Field(min_length=1, max_length=100)
+    polygon_points: list[PolygonPoint]
+
+
+class BulkUpdateZonesBody(BaseModel):
+    """Body for PATCH /api/maps/{map_id}/zones.
+
+    Last-write-wins semantics — single-operator app, no optimistic
+    concurrency check. Zones not included in this body are untouched.
+    """
+
+    zones: list[ZonePolygonUpdate] = Field(min_length=1)
+
+
+class ZonePolygonFailure(BaseModel):
+    """Per-zone failure detail returned alongside the ``updated`` list."""
+
+    slug: str
+    reason: str
+
+
+class BulkUpdateZonesResult(BaseModel):
+    """Response from PATCH /api/maps/{map_id}/zones.
+
+    Partial successes are returned with status 200; the operator UI inspects
+    ``failed`` to highlight broken zones in the editor without losing the
+    saved ones. Whole-request errors (404 map, 401 auth) still use HTTP
+    status codes.
+    """
+
+    updated: list[str]
+    failed: list[ZonePolygonFailure]

--- a/apps/mygamingassistant/backend/tests/test_zone_polygon_api.py
+++ b/apps/mygamingassistant/backend/tests/test_zone_polygon_api.py
@@ -148,7 +148,6 @@ async def test_patch_zones_updates_polygons(
     assert payload["failed"] == []
 
     # Read back from DB and confirm shape.
-    db.expire_all()
     result = await db.execute(
         select(MapZone).where(MapZone.map_id == seeded_map_with_zones.id)
     )
@@ -187,7 +186,6 @@ async def test_patch_zones_empty_polygon_clears(
     assert resp.status_code == 200, resp.text
     assert resp.json()["updated"] == ["a-site"]
 
-    db.expire_all()
     result = await db.execute(
         select(MapZone).where(
             MapZone.map_id == seeded_map_with_zones.id, MapZone.slug == "a-site"
@@ -247,7 +245,6 @@ async def test_patch_zones_partial_failure(
 
     # B-site should still be empty in DB — the failure rolled the per-zone
     # change but committed the successful one.
-    db.expire_all()
     result = await db.execute(
         select(MapZone).where(
             MapZone.map_id == seeded_map_with_zones.id, MapZone.slug == "b-site"
@@ -287,7 +284,6 @@ async def test_patch_zones_cannot_cross_map_boundary(
     assert resp.status_code == 200, resp.text
     assert resp.json()["updated"] == ["a-site"]
 
-    db.expire_all()
     result = await db.execute(
         select(MapZone).where(
             MapZone.map_id == second_map_with_zone.id, MapZone.slug == "a-site"

--- a/apps/mygamingassistant/backend/tests/test_zone_polygon_api.py
+++ b/apps/mygamingassistant/backend/tests/test_zone_polygon_api.py
@@ -148,7 +148,7 @@ async def test_patch_zones_updates_polygons(
     assert payload["failed"] == []
 
     # Read back from DB and confirm shape.
-    await db.expire_all()
+    db.expire_all()
     result = await db.execute(
         select(MapZone).where(MapZone.map_id == seeded_map_with_zones.id)
     )
@@ -187,7 +187,7 @@ async def test_patch_zones_empty_polygon_clears(
     assert resp.status_code == 200, resp.text
     assert resp.json()["updated"] == ["a-site"]
 
-    await db.expire_all()
+    db.expire_all()
     result = await db.execute(
         select(MapZone).where(
             MapZone.map_id == seeded_map_with_zones.id, MapZone.slug == "a-site"
@@ -247,7 +247,7 @@ async def test_patch_zones_partial_failure(
 
     # B-site should still be empty in DB — the failure rolled the per-zone
     # change but committed the successful one.
-    await db.expire_all()
+    db.expire_all()
     result = await db.execute(
         select(MapZone).where(
             MapZone.map_id == seeded_map_with_zones.id, MapZone.slug == "b-site"
@@ -287,7 +287,7 @@ async def test_patch_zones_cannot_cross_map_boundary(
     assert resp.status_code == 200, resp.text
     assert resp.json()["updated"] == ["a-site"]
 
-    await db.expire_all()
+    db.expire_all()
     result = await db.execute(
         select(MapZone).where(
             MapZone.map_id == second_map_with_zone.id, MapZone.slug == "a-site"

--- a/apps/mygamingassistant/backend/tests/test_zone_polygon_api.py
+++ b/apps/mygamingassistant/backend/tests/test_zone_polygon_api.py
@@ -1,0 +1,350 @@
+"""Tests for PATCH /api/maps/{map_id}/zones — bulk zone polygon update.
+
+Covers:
+- Endpoint requires auth (401 unauth)
+- Successful bulk update sets polygon_points and is persisted
+- Partial failure: missing slug, 1-2 point polygon → reported in `failed`
+  while valid zones in the same request are still applied
+- Cross-map slug rejected (slug exists in OTHER map, not this one)
+- Empty polygon (clears) accepted
+- Coords out of [0,1] range rejected at Pydantic boundary (422)
+- Unknown map returns 404
+- Empty zones list rejected at Pydantic boundary (422)
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.game import Game
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.models.user.user import User
+
+
+@pytest_asyncio.fixture
+async def auth_client(client: AsyncClient, db: AsyncSession) -> AsyncClient:
+    """Create a test user and log in; return an authed AsyncClient.
+
+    Inlined per the test_minimap_upload.py pattern so this module is
+    self-contained.
+    """
+    from fastapi_users.password import PasswordHelper
+
+    TEST_EMAIL = "zone-polygon-test@example.com"
+    TEST_PASSWORD = "testpassword123!"
+
+    result = await db.execute(select(User).where(User.email == TEST_EMAIL))
+    user = result.scalar_one_or_none()
+    if user is None:
+        helper = PasswordHelper()
+        user = User(
+            email=TEST_EMAIL,
+            hashed_password=helper.hash(TEST_PASSWORD),
+            is_verified=True,
+            is_active=True,
+        )
+        db.add(user)
+        await db.flush()
+
+    login = await client.post(
+        "/auth/jwt/login",
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
+    )
+    assert login.status_code == 200, login.text
+    token = login.json()["access_token"]
+    client.headers["Authorization"] = f"Bearer {token}"
+    return client
+
+
+@pytest_asyncio.fixture
+async def seeded_map_with_zones(db: AsyncSession) -> Map:
+    """Seed a CS2-test game + Mirage-test map + 3 zones with empty polygons."""
+    game = Game(slug="cs2-zonetest", name="CS2 ZoneTest", side_a_label="T", side_b_label="CT")
+    db.add(game)
+    await db.flush()
+    map_obj = Map(game_id=game.id, slug="mirage-zonetest", name="Mirage ZoneTest")
+    db.add(map_obj)
+    await db.flush()
+    for slug, name in [("a-site", "A Site"), ("b-site", "B Site"), ("mid", "Mid")]:
+        zone = MapZone(map_id=map_obj.id, slug=slug, name=name, polygon_points=[])
+        db.add(zone)
+    await db.flush()
+    return map_obj
+
+
+@pytest_asyncio.fixture
+async def second_map_with_zone(db: AsyncSession) -> Map:
+    """Seed a second map with its own zone slug to test cross-map isolation."""
+    game = Game(slug="cs2-zonetest-2", name="CS2 ZoneTest 2", side_a_label="T", side_b_label="CT")
+    db.add(game)
+    await db.flush()
+    map_obj = Map(game_id=game.id, slug="inferno-zonetest", name="Inferno ZoneTest")
+    db.add(map_obj)
+    await db.flush()
+    # Same slug "a-site" lives in this map too — should NOT collide with
+    # the first map's "a-site" when patching.
+    db.add(MapZone(map_id=map_obj.id, slug="a-site", name="A Site", polygon_points=[]))
+    await db.flush()
+    return map_obj
+
+
+# ---------------------------------------------------------------------------
+# Auth gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_zones_requires_auth(client: AsyncClient, seeded_map_with_zones: Map):
+    """Unauthenticated callers must get 401."""
+    resp = await client.patch(
+        f"/api/maps/{seeded_map_with_zones.id}/zones",
+        json={"zones": [{"slug": "a-site", "polygon_points": []}]},
+    )
+    assert resp.status_code == 401, resp.text
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_zones_updates_polygons(
+    auth_client: AsyncClient, db: AsyncSession, seeded_map_with_zones: Map
+):
+    """Valid bulk update: all zones land in `updated`, polygon_points
+    persisted in the object-shape the frontend reads."""
+    body = {
+        "zones": [
+            {
+                "slug": "a-site",
+                "polygon_points": [
+                    {"x": 0.7, "y": 0.3},
+                    {"x": 0.9, "y": 0.3},
+                    {"x": 0.9, "y": 0.5},
+                    {"x": 0.7, "y": 0.5},
+                ],
+            },
+            {
+                "slug": "mid",
+                "polygon_points": [
+                    {"x": 0.4, "y": 0.4},
+                    {"x": 0.6, "y": 0.4},
+                    {"x": 0.5, "y": 0.6},
+                ],
+            },
+        ]
+    }
+    resp = await auth_client.patch(
+        f"/api/maps/{seeded_map_with_zones.id}/zones", json=body
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert sorted(payload["updated"]) == ["a-site", "mid"]
+    assert payload["failed"] == []
+
+    # Read back from DB and confirm shape.
+    await db.expire_all()
+    result = await db.execute(
+        select(MapZone).where(MapZone.map_id == seeded_map_with_zones.id)
+    )
+    zones = {z.slug: z for z in result.scalars().all()}
+    assert zones["a-site"].polygon_points == [
+        {"x": 0.7, "y": 0.3},
+        {"x": 0.9, "y": 0.3},
+        {"x": 0.9, "y": 0.5},
+        {"x": 0.7, "y": 0.5},
+    ]
+    assert len(zones["mid"].polygon_points) == 3
+    # Untouched zone stays empty.
+    assert zones["b-site"].polygon_points == []
+
+
+@pytest.mark.asyncio
+async def test_patch_zones_empty_polygon_clears(
+    auth_client: AsyncClient, db: AsyncSession, seeded_map_with_zones: Map
+):
+    """`polygon_points: []` clears any previous polygon — used by the
+    editor's `Clear polygon` action."""
+    # First, seed a polygon directly.
+    result = await db.execute(
+        select(MapZone).where(
+            MapZone.map_id == seeded_map_with_zones.id, MapZone.slug == "a-site"
+        )
+    )
+    zone = result.scalar_one()
+    zone.polygon_points = [{"x": 0.1, "y": 0.1}, {"x": 0.2, "y": 0.1}, {"x": 0.2, "y": 0.2}]
+    await db.flush()
+
+    resp = await auth_client.patch(
+        f"/api/maps/{seeded_map_with_zones.id}/zones",
+        json={"zones": [{"slug": "a-site", "polygon_points": []}]},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["updated"] == ["a-site"]
+
+    await db.expire_all()
+    result = await db.execute(
+        select(MapZone).where(
+            MapZone.map_id == seeded_map_with_zones.id, MapZone.slug == "a-site"
+        )
+    )
+    assert result.scalar_one().polygon_points == []
+
+
+# ---------------------------------------------------------------------------
+# Partial failure
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_zones_partial_failure(
+    auth_client: AsyncClient, db: AsyncSession, seeded_map_with_zones: Map
+):
+    """A 2-point polygon AND an unknown slug both land in `failed`, but
+    the valid zone in the same request still saves."""
+    body = {
+        "zones": [
+            {
+                "slug": "a-site",
+                "polygon_points": [
+                    {"x": 0.1, "y": 0.1},
+                    {"x": 0.2, "y": 0.1},
+                    {"x": 0.2, "y": 0.2},
+                ],
+            },
+            {
+                "slug": "b-site",
+                "polygon_points": [
+                    {"x": 0.5, "y": 0.5},
+                    {"x": 0.6, "y": 0.5},
+                ],
+            },
+            {
+                "slug": "ghost-zone",
+                "polygon_points": [
+                    {"x": 0.1, "y": 0.1},
+                    {"x": 0.2, "y": 0.1},
+                    {"x": 0.2, "y": 0.2},
+                ],
+            },
+        ]
+    }
+    resp = await auth_client.patch(
+        f"/api/maps/{seeded_map_with_zones.id}/zones", json=body
+    )
+    assert resp.status_code == 200, resp.text
+    payload = resp.json()
+    assert payload["updated"] == ["a-site"]
+    by_slug = {f["slug"]: f["reason"] for f in payload["failed"]}
+    assert "b-site" in by_slug
+    assert "3+" in by_slug["b-site"]
+    assert "ghost-zone" in by_slug
+    assert "not found" in by_slug["ghost-zone"]
+
+    # B-site should still be empty in DB — the failure rolled the per-zone
+    # change but committed the successful one.
+    await db.expire_all()
+    result = await db.execute(
+        select(MapZone).where(
+            MapZone.map_id == seeded_map_with_zones.id, MapZone.slug == "b-site"
+        )
+    )
+    assert result.scalar_one().polygon_points == []
+
+
+# ---------------------------------------------------------------------------
+# Cross-map isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_zones_cannot_cross_map_boundary(
+    auth_client: AsyncClient,
+    db: AsyncSession,
+    seeded_map_with_zones: Map,
+    second_map_with_zone: Map,
+):
+    """Map B has its own `a-site` zone. Patching map A's `/zones` with
+    slug `a-site` must touch map A's zone only — map B's stays empty."""
+    body = {
+        "zones": [
+            {
+                "slug": "a-site",
+                "polygon_points": [
+                    {"x": 0.1, "y": 0.1},
+                    {"x": 0.2, "y": 0.1},
+                    {"x": 0.2, "y": 0.2},
+                ],
+            }
+        ]
+    }
+    resp = await auth_client.patch(
+        f"/api/maps/{seeded_map_with_zones.id}/zones", json=body
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["updated"] == ["a-site"]
+
+    await db.expire_all()
+    result = await db.execute(
+        select(MapZone).where(
+            MapZone.map_id == second_map_with_zone.id, MapZone.slug == "a-site"
+        )
+    )
+    assert result.scalar_one().polygon_points == []
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_patch_zones_rejects_out_of_range_coords(
+    auth_client: AsyncClient, seeded_map_with_zones: Map
+):
+    """x or y outside [0, 1] is a Pydantic-boundary 422."""
+    body = {
+        "zones": [
+            {
+                "slug": "a-site",
+                "polygon_points": [
+                    {"x": 0.1, "y": 0.1},
+                    {"x": 1.2, "y": 0.1},
+                    {"x": 0.2, "y": 0.2},
+                ],
+            }
+        ]
+    }
+    resp = await auth_client.patch(
+        f"/api/maps/{seeded_map_with_zones.id}/zones", json=body
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_patch_zones_rejects_empty_zones_list(
+    auth_client: AsyncClient, seeded_map_with_zones: Map
+):
+    """An empty `zones` array is 422 (Pydantic min_length=1).
+
+    Rationale: the caller meant to send at least one update; an empty
+    body is almost certainly a client bug, not a deliberate no-op.
+    """
+    resp = await auth_client.patch(
+        f"/api/maps/{seeded_map_with_zones.id}/zones",
+        json={"zones": []},
+    )
+    assert resp.status_code == 422, resp.text
+
+
+@pytest.mark.asyncio
+async def test_patch_zones_unknown_map_404(auth_client: AsyncClient):
+    """Patching a map that doesn't exist returns 404 (whole-request)."""
+    bogus_id = uuid.uuid4()
+    resp = await auth_client.patch(
+        f"/api/maps/{bogus_id}/zones",
+        json={"zones": [{"slug": "a-site", "polygon_points": []}]},
+    )
+    assert resp.status_code == 404, resp.text


### PR DESCRIPTION
## Summary

Backend half of the plan-mode zone editor feature. Adds `PATCH /api/maps/{map_id}/zones` so operators can author/clear `MapZone.polygon_points` from the upcoming editor UI.

## Why now

Today every zone in `cs2_maps.json` + `valorant_maps.json` ships with `polygon_points: []`. The frontend `MapPage` already wires a clickable SVG overlay via `MapZoneOverlay`, but zero-point polygons render invisible — so the map looks static and unclickable. The original project plan flagged ~30 min/map manual calibration as deferred work. This PR is the backend that unblocks an editor UI.

## What changes

| File | What |
|---|---|
| `app/schemas/game/map_schemas.py` | `PolygonPoint` (Pydantic 0-1 range), `ZonePolygonUpdate`, `BulkUpdateZonesBody`, `BulkUpdateZonesResult` |
| `app/repositories/game/game_repo.py` | `update_zone_polygons_bulk()` — per-zone validation captures failures rather than raising |
| `app/api/games.py` | `PATCH /api/maps/{map_id}/zones` on the existing `auth_router` (operator-only) |
| `tests/test_zone_polygon_api.py` | 8 test cases (auth, happy path, clear, partial-failure, cross-map isolation, 422 boundary, 404) |

## Design call: partial failures return HTTP 200, not 422

A 2-point polygon (in-progress draw) returns `{"updated": [...], "failed": [{"slug": "b-site", "reason": "polygon needs 3+ vertices"}]}` rather than failing the whole request. Operators routinely leave one zone half-drawn while the others are valid — making them lose 9 saved zones because of 1 half-finished one would be hostile UX. Pydantic-boundary issues (coords outside [0, 1], empty zones list) still return 422 because those are client bugs.

## Cross-map isolation

The same zone slug (e.g. `a-site`) lives on every CS2 map. The repo scopes lookups to `map_id`, and there's an explicit test (`test_patch_zones_cannot_cross_map_boundary`) verifying that patching Map A's `/zones` with slug `a-site` only touches Map A's row, never Map B's.

## Operational migration

None. Pure additive — new endpoint, no env vars, no DB schema changes (`polygon_points` JSON column already exists), existing read paths unaffected. Rollback removes the endpoint without consequence.

## Test plan

- [ ] CI green (backend-tests / mygamingassistant runs `pytest -q --timeout=60`)
- [ ] CodeQL + secret scan pass
- [ ] No regressions on the existing `test_minimap_upload.py` (same module, same auth router)

## What's next

Stacked frontend PR will add:
- `/{gameSlug}/{mapSlug}/zones/edit` route (operator-only)
- Polygon editor reusing `ZoneEditorCanvas` from the CV-calibration page
- localStorage draft persistence keyed by `map_id`
- "Edit zones" button + "not yet drawn" banner in `MapPage`
- E2E coverage end-to-end (operator draws polygon, saves, sees it clickable on `MapPage`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)