### PR TITLE
feat(mga): operator polygon editor for plan-mode map zones

### DIFF
--- a/apps/mygamingassistant/frontend/e2e/zone-editor.spec.ts
+++ b/apps/mygamingassistant/frontend/e2e/zone-editor.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * E2E for the plan-mode zone editor.
+ *
+ * Coverage:
+ *  1. /{game}/{map}/zones/edit requires auth — unauth caller sees the
+ *     AuthRequired sign-in CTA.
+ *  2. Operator landing on a not-yet-calibrated MapPage sees the "zones
+ *     not drawn yet" banner with Set up zones CTA.
+ *  3. Editor page renders top bar + zone list when authed.
+ *  4. Clicking an empty zone in the rail enters drawing mode (mode hint
+ *     above canvas reflects the change; floating action bar shows Cancel).
+ *  5. Save button is disabled when nothing is dirty.
+ *
+ * The full draw-save-roundtrip-render flow needs canvas mouse simulation
+ * which is brittle in headless Playwright; the underlying canvas
+ * mechanics are covered by the unit tests for ZoneEditorCanvas (already
+ * shipped) and useZoneEditorDraft (this PR). This spec focuses on the
+ * orchestration glue.
+ */
+import { test, expect } from "@playwright/test";
+import { getOperatorCredentials, loginViaUI } from "./fixtures/auth";
+
+test.describe("Zone editor — auth gate", () => {
+  test("unauth visit shows sign-in CTA", async ({ page }) => {
+    await page.goto("/cs2/mirage/zones/edit");
+    await expect(page.getByText(/edit map zones/i)).toBeVisible();
+    await expect(page.getByRole("link", { name: /sign in/i })).toBeVisible();
+  });
+});
+
+test.describe("MapPage — operator banner when zones not drawn", () => {
+  test("operator sees the not-yet-drawn banner + CTA", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/cs2/mirage");
+    // Banner copy from MapPage.tsx
+    await expect(
+      page.getByText(/this map's zones aren't drawn yet/i),
+    ).toBeVisible();
+    const cta = page.getByRole("link", { name: /set up zones/i });
+    await expect(cta).toBeVisible();
+    await cta.click();
+    await expect(page).toHaveURL(/\/cs2\/mirage\/zones\/edit$/);
+  });
+
+  test("operator sees Edit zones header button", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/cs2/mirage");
+    await expect(page.getByRole("link", { name: /edit zones/i })).toBeVisible();
+  });
+});
+
+test.describe("Zone editor page", () => {
+  test("authed editor shows top bar + zone list + Save disabled at start", async ({
+    page,
+    request,
+  }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/cs2/mirage/zones/edit");
+
+    // Top bar — page title
+    await expect(page.getByRole("heading", { name: /edit zones — mirage/i })).toBeVisible();
+
+    // Save button disabled when nothing is dirty
+    const saveButton = page.getByRole("button", { name: /^save$/i });
+    await expect(saveButton).toBeVisible();
+    await expect(saveButton).toBeDisabled();
+
+    // Zone list rendered (Mirage seed has 10 zones).
+    await expect(page.getByText(/zones \(10\)/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /a site/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /b site/i })).toBeVisible();
+  });
+
+  test("clicking an empty zone enters drawing mode", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/cs2/mirage/zones/edit");
+
+    // Click "A Site" (which has empty polygon_points after fresh seed) — should
+    // auto-enter `new` drawing mode per the design spec.
+    await page.getByRole("button", { name: /a site/i }).click();
+
+    // The action bar swaps to Cancel + the mode hint above the canvas
+    // mentions "Click to add vertices".
+    await expect(page.getByText(/click to add vertices/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /cancel/i })).toBeVisible();
+  });
+
+  test("Discard button disabled when no dirty changes", async ({ page, request }) => {
+    const credentials = getOperatorCredentials();
+    await loginViaUI(page, credentials, request);
+
+    await page.goto("/cs2/mirage/zones/edit");
+    const discardButton = page.getByRole("button", { name: /discard/i });
+    await expect(discardButton).toBeVisible();
+    await expect(discardButton).toBeDisabled();
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/useZoneEditorDraft.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/useZoneEditorDraft.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for hooks/useZoneEditorDraft.
+ *
+ * Covers the contracts the design review called out as load-bearing:
+ *  - Draft initializes from server zones on first hydrate.
+ *  - localStorage round-trip survives unmount/remount.
+ *  - Stale draft (matches server) is silently cleared, not flagged as restored.
+ *  - Dirty calc against baseline + per-slug dirtySlugs.
+ *  - Undo/redo invariants.
+ *  - discardChanges restores baseline + clears localStorage.
+ *  - markSaved updates baseline so isDirty becomes false.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { useZoneEditorDraft } from "@/hooks/useZoneEditorDraft";
+import type { MapZone } from "@/types/game";
+
+const MAP_ID = "11111111-1111-1111-1111-111111111111";
+
+function makeServerZones(): MapZone[] {
+  return [
+    { id: "z1", slug: "a-site", name: "A Site", polygon_points: [] },
+    { id: "z2", slug: "b-site", name: "B Site", polygon_points: [] },
+    {
+      id: "z3",
+      slug: "mid",
+      name: "Mid",
+      polygon_points: [
+        { x: 0.4, y: 0.4 },
+        { x: 0.6, y: 0.4 },
+        { x: 0.5, y: 0.6 },
+      ],
+    },
+  ];
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe("useZoneEditorDraft — initialization", () => {
+  it("is not ready until both mapId and serverZones arrive", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: undefined, serverZones: undefined }),
+    );
+    expect(result.current.ready).toBe(false);
+  });
+
+  it("hydrates from server zones when no stored draft exists", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    expect(result.current.ready).toBe(true);
+    expect(result.current.getPolygon("mid")).toEqual([
+      { x: 0.4, y: 0.4 },
+      { x: 0.6, y: 0.4 },
+      { x: 0.5, y: 0.6 },
+    ]);
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.restoredFromStorage).toBe(false);
+  });
+
+  it("ignores a stored draft that matches the server (no diff)", () => {
+    const server = makeServerZones();
+    localStorage.setItem(
+      `mga_zone_draft_${MAP_ID}`,
+      JSON.stringify({
+        __version: 1,
+        mapId: MAP_ID,
+        zones: {
+          "a-site": [],
+          "b-site": [],
+          mid: [
+            { x: 0.4, y: 0.4 },
+            { x: 0.6, y: 0.4 },
+            { x: 0.5, y: 0.6 },
+          ],
+        },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: server }),
+    );
+    expect(result.current.restoredFromStorage).toBe(false);
+    // Storage was cleared because draft matched server.
+    expect(localStorage.getItem(`mga_zone_draft_${MAP_ID}`)).toBeNull();
+  });
+
+  it("restores a meaningfully-different stored draft and flags it", () => {
+    localStorage.setItem(
+      `mga_zone_draft_${MAP_ID}`,
+      JSON.stringify({
+        __version: 1,
+        mapId: MAP_ID,
+        zones: {
+          "a-site": [
+            { x: 0.1, y: 0.1 },
+            { x: 0.2, y: 0.1 },
+            { x: 0.2, y: 0.2 },
+          ],
+          "b-site": [],
+          mid: [
+            { x: 0.4, y: 0.4 },
+            { x: 0.6, y: 0.4 },
+            { x: 0.5, y: 0.6 },
+          ],
+        },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    expect(result.current.restoredFromStorage).toBe(true);
+    expect(result.current.getPolygon("a-site")).toHaveLength(3);
+    expect(result.current.isDirty).toBe(true);
+    expect(result.current.dirtySlugs.has("a-site")).toBe(true);
+    expect(result.current.dirtySlugs.has("mid")).toBe(false);
+  });
+
+  it("ignores a stored draft from a different map_id", () => {
+    localStorage.setItem(
+      `mga_zone_draft_${MAP_ID}`,
+      JSON.stringify({
+        __version: 1,
+        mapId: "different-map",
+        zones: { "a-site": [{ x: 0.5, y: 0.5 }] },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    expect(result.current.restoredFromStorage).toBe(false);
+    expect(result.current.getPolygon("a-site")).toEqual([]);
+  });
+
+  it("ignores a stored draft from an old __version", () => {
+    localStorage.setItem(
+      `mga_zone_draft_${MAP_ID}`,
+      JSON.stringify({
+        __version: 0,
+        mapId: MAP_ID,
+        zones: { "a-site": [{ x: 0.5, y: 0.5 }] },
+      }),
+    );
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    expect(result.current.restoredFromStorage).toBe(false);
+    expect(result.current.getPolygon("a-site")).toEqual([]);
+  });
+});
+
+describe("useZoneEditorDraft — editing", () => {
+  it("setPolygon updates the zone + flags it dirty", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    act(() =>
+      result.current.setPolygon("a-site", [
+        { x: 0.7, y: 0.3 },
+        { x: 0.9, y: 0.3 },
+        { x: 0.9, y: 0.5 },
+      ]),
+    );
+    expect(result.current.isDirty).toBe(true);
+    expect(result.current.dirtySlugs.has("a-site")).toBe(true);
+    expect(result.current.getPolygon("a-site")).toHaveLength(3);
+  });
+
+  it("clearPolygon empties the zone polygon", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    expect(result.current.getPolygon("mid")).toHaveLength(3);
+    act(() => result.current.clearPolygon("mid"));
+    expect(result.current.getPolygon("mid")).toEqual([]);
+    expect(result.current.dirtySlugs.has("mid")).toBe(true);
+  });
+
+  it("persists changes to localStorage", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    act(() =>
+      result.current.setPolygon("a-site", [
+        { x: 0.7, y: 0.3 },
+        { x: 0.9, y: 0.3 },
+        { x: 0.9, y: 0.5 },
+      ]),
+    );
+    const stored = JSON.parse(
+      localStorage.getItem(`mga_zone_draft_${MAP_ID}`) ?? "{}",
+    );
+    expect(stored.mapId).toBe(MAP_ID);
+    expect(stored.zones["a-site"]).toHaveLength(3);
+  });
+
+  it("clears localStorage when draft returns to baseline", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    const triangle = [
+      { x: 0.7, y: 0.3 },
+      { x: 0.9, y: 0.3 },
+      { x: 0.9, y: 0.5 },
+    ];
+    act(() => result.current.setPolygon("a-site", triangle));
+    expect(localStorage.getItem(`mga_zone_draft_${MAP_ID}`)).not.toBeNull();
+    act(() => result.current.clearPolygon("a-site"));
+    // a-site is now [] which matches the server baseline of [].
+    expect(localStorage.getItem(`mga_zone_draft_${MAP_ID}`)).toBeNull();
+  });
+});
+
+describe("useZoneEditorDraft — undo / redo", () => {
+  it("undo reverts last change; redo replays it", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    expect(result.current.canUndo).toBe(false);
+    const triangle = [
+      { x: 0.7, y: 0.3 },
+      { x: 0.9, y: 0.3 },
+      { x: 0.9, y: 0.5 },
+    ];
+    act(() => result.current.setPolygon("a-site", triangle));
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.getPolygon("a-site")).toHaveLength(3);
+
+    act(() => result.current.undo());
+    expect(result.current.getPolygon("a-site")).toEqual([]);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => result.current.redo());
+    expect(result.current.getPolygon("a-site")).toHaveLength(3);
+  });
+
+  it("new edit clears the redo stack", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    act(() =>
+      result.current.setPolygon("a-site", [
+        { x: 0.1, y: 0.1 },
+        { x: 0.2, y: 0.1 },
+        { x: 0.2, y: 0.2 },
+      ]),
+    );
+    act(() => result.current.undo());
+    expect(result.current.canRedo).toBe(true);
+    act(() =>
+      result.current.setPolygon("b-site", [
+        { x: 0.5, y: 0.5 },
+        { x: 0.6, y: 0.5 },
+        { x: 0.6, y: 0.6 },
+      ]),
+    );
+    expect(result.current.canRedo).toBe(false);
+  });
+});
+
+describe("useZoneEditorDraft — discardChanges / markSaved", () => {
+  it("discardChanges resets to baseline and clears storage", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    act(() =>
+      result.current.setPolygon("a-site", [
+        { x: 0.1, y: 0.1 },
+        { x: 0.2, y: 0.1 },
+        { x: 0.2, y: 0.2 },
+      ]),
+    );
+    expect(result.current.isDirty).toBe(true);
+    act(() => result.current.discardChanges());
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.getPolygon("a-site")).toEqual([]);
+    expect(localStorage.getItem(`mga_zone_draft_${MAP_ID}`)).toBeNull();
+  });
+
+  it("markSaved promotes draft to baseline (isDirty -> false)", () => {
+    const { result } = renderHook(() =>
+      useZoneEditorDraft({ mapId: MAP_ID, serverZones: makeServerZones() }),
+    );
+    act(() =>
+      result.current.setPolygon("a-site", [
+        { x: 0.1, y: 0.1 },
+        { x: 0.2, y: 0.1 },
+        { x: 0.2, y: 0.2 },
+      ]),
+    );
+    expect(result.current.isDirty).toBe(true);
+    act(() => result.current.markSaved());
+    expect(result.current.isDirty).toBe(false);
+    expect(result.current.getPolygon("a-site")).toHaveLength(3);
+    expect(localStorage.getItem(`mga_zone_draft_${MAP_ID}`)).toBeNull();
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/zonePolygon.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/zonePolygon.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Tests for lib/zonePolygon.ts.
+ *
+ * The design review for the zone editor flagged a format mismatch
+ * between the editor canvas (tuple form) and the MapZoneOverlay consumer
+ * (object form) as a ship-blocker. These tests pin the conversion both
+ * ways so a future refactor can't silently re-introduce the bug.
+ */
+import { describe, expect, it } from "vitest";
+import {
+  tupleToObject,
+  objectToTuple,
+  tuplesToObjects,
+  objectsToTuples,
+  clampPoint,
+} from "@/lib/zonePolygon";
+
+describe("zonePolygon adapters", () => {
+  it("tupleToObject maps [x, y] to {x, y}", () => {
+    expect(tupleToObject([0.25, 0.75])).toEqual({ x: 0.25, y: 0.75 });
+  });
+
+  it("objectToTuple maps {x, y} to [x, y]", () => {
+    expect(objectToTuple({ x: 0.25, y: 0.75 })).toEqual([0.25, 0.75]);
+  });
+
+  it("round-trips through both directions without drift", () => {
+    const original: Array<[number, number]> = [
+      [0.1, 0.2],
+      [0.3, 0.4],
+      [0.5, 0.6],
+    ];
+    const out = objectsToTuples(tuplesToObjects(original));
+    expect(out).toEqual(original);
+  });
+
+  it("round-trips object→tuple→object preserving values", () => {
+    const original = [
+      { x: 0.7, y: 0.3 },
+      { x: 0.9, y: 0.3 },
+      { x: 0.9, y: 0.5 },
+      { x: 0.7, y: 0.5 },
+    ];
+    const out = tuplesToObjects(objectsToTuples(original));
+    expect(out).toEqual(original);
+  });
+
+  it("handles empty arrays in both directions", () => {
+    expect(tuplesToObjects([])).toEqual([]);
+    expect(objectsToTuples([])).toEqual([]);
+  });
+});
+
+describe("clampPoint", () => {
+  it("passes through in-range values", () => {
+    expect(clampPoint({ x: 0.5, y: 0.5 })).toEqual({ x: 0.5, y: 0.5 });
+  });
+
+  it("clamps negatives to 0", () => {
+    expect(clampPoint({ x: -0.3, y: -0.1 })).toEqual({ x: 0, y: 0 });
+  });
+
+  it("clamps >1 down to 1", () => {
+    expect(clampPoint({ x: 1.5, y: 2.0 })).toEqual({ x: 1, y: 1 });
+  });
+
+  it("coerces NaN to 0", () => {
+    expect(clampPoint({ x: Number.NaN, y: 0.5 })).toEqual({ x: 0, y: 0.5 });
+  });
+
+  it("preserves boundary values exactly", () => {
+    expect(clampPoint({ x: 0, y: 1 })).toEqual({ x: 0, y: 1 });
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/zone-editor/ZoneEditorActionBar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/zone-editor/ZoneEditorActionBar.tsx
@@ -1,0 +1,87 @@
+/**
+ * Floating action bar anchored bottom-right of the editor canvas.
+ *
+ * Replaces the right rail per the design review — eliminates the tablet
+ * scroll problem and keeps actions always visible without competing with
+ * the canvas for clicks.
+ *
+ * State machine (one button at a time):
+ *   no zone selected         → null (nothing renders)
+ *   zone selected, no polygon → "Draw"
+ *   zone selected, has polygon → "Clear"
+ *   currently drawing (mode='new') → "Cancel"
+ */
+import { Pencil, Trash2, X } from "lucide-react";
+
+export type ActionBarMode = "draw" | "clear" | "cancel" | null;
+
+export interface ZoneEditorActionBarProps {
+  mode: ActionBarMode;
+  selectedZoneName: string | null;
+  onDraw: () => void;
+  onClear: () => void;
+  onCancel: () => void;
+}
+
+export default function ZoneEditorActionBar({
+  mode,
+  selectedZoneName,
+  onDraw,
+  onClear,
+  onCancel,
+}: ZoneEditorActionBarProps) {
+  if (mode === null) return null;
+
+  if (mode === "draw") {
+    return (
+      <div className="absolute bottom-3 right-3 z-10 flex items-center gap-2 bg-card border rounded-lg shadow-lg p-1.5">
+        <span className="text-xs text-muted-foreground px-2">
+          {selectedZoneName ?? ""}
+        </span>
+        <button
+          type="button"
+          onClick={onDraw}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-primary text-primary-foreground text-sm hover:opacity-90 min-h-[36px]"
+        >
+          <Pencil className="w-4 h-4" aria-hidden />
+          Draw polygon
+        </button>
+      </div>
+    );
+  }
+
+  if (mode === "clear") {
+    return (
+      <div className="absolute bottom-3 right-3 z-10 flex items-center gap-2 bg-card border rounded-lg shadow-lg p-1.5">
+        <span className="text-xs text-muted-foreground px-2">
+          {selectedZoneName ?? ""}
+        </span>
+        <button
+          type="button"
+          onClick={onClear}
+          className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border bg-card hover:bg-muted/40 text-sm text-destructive min-h-[36px]"
+        >
+          <Trash2 className="w-4 h-4" aria-hidden />
+          Clear polygon
+        </button>
+      </div>
+    );
+  }
+
+  // mode === "cancel"
+  return (
+    <div className="absolute bottom-3 right-3 z-10 flex items-center gap-2 bg-card border rounded-lg shadow-lg p-1.5">
+      <span className="text-xs text-muted-foreground px-2">
+        Drawing — click first vertex or press Enter to close
+      </span>
+      <button
+        type="button"
+        onClick={onCancel}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md border bg-card hover:bg-muted/40 text-sm min-h-[36px]"
+      >
+        <X className="w-4 h-4" aria-hidden />
+        Cancel
+      </button>
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/zone-editor/ZoneEditorLeftRail.tsx
+++ b/apps/mygamingassistant/frontend/src/components/zone-editor/ZoneEditorLeftRail.tsx
@@ -1,0 +1,97 @@
+/**
+ * Left rail for the zone editor — zone list with status dots.
+ *
+ * Status dot meanings:
+ *   green  — polygon authored AND matches server baseline
+ *   amber  — polygon authored AND differs from server baseline (dirty)
+ *   grey   — no polygon yet (operator hasn't drawn this zone)
+ *
+ * Single-click on a zone with no polygon dispatches `onClickEmptyZone` so
+ * the parent can auto-enter `new` mode — saves 3 clicks per zone over a
+ * "click zone, look at right rail, click Draw" flow.
+ */
+import type { MapZone } from "@/types/game";
+import type { PointObject } from "@/lib/zonePolygon";
+
+export interface ZoneEditorLeftRailProps {
+  zones: MapZone[];
+  /** Draft polygon state keyed by slug. */
+  draftZones: Record<string, PointObject[]>;
+  /** Slugs whose draft differs from the server baseline. */
+  dirtySlugs: Set<string>;
+  selectedSlug: string | null;
+  onSelectFilledZone: (slug: string) => void;
+  onClickEmptyZone: (slug: string) => void;
+}
+
+export default function ZoneEditorLeftRail({
+  zones,
+  draftZones,
+  dirtySlugs,
+  selectedSlug,
+  onSelectFilledZone,
+  onClickEmptyZone,
+}: ZoneEditorLeftRailProps) {
+  return (
+    <aside className="w-full lg:w-60 border-b lg:border-b-0 lg:border-r bg-card flex flex-col">
+      <div className="px-3 py-2 border-b text-xs text-muted-foreground">
+        Zones ({zones.length})
+      </div>
+      <ul className="flex-1 overflow-y-auto">
+        {zones.map((z) => {
+          const points = draftZones[z.slug] ?? [];
+          const hasPolygon = points.length >= 3;
+          const isDirty = dirtySlugs.has(z.slug);
+          const isSelected = z.slug === selectedSlug;
+          const dotCls = dotClass({ hasPolygon, isDirty });
+          return (
+            <li key={z.id}>
+              <button
+                type="button"
+                onClick={() => {
+                  if (hasPolygon) {
+                    onSelectFilledZone(z.slug);
+                  } else {
+                    onClickEmptyZone(z.slug);
+                  }
+                }}
+                className={[
+                  "w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/40 transition-colors text-left",
+                  isSelected ? "bg-muted/50" : "",
+                ].join(" ")}
+                aria-current={isSelected ? "true" : undefined}
+              >
+                <span
+                  className={`inline-block w-2 h-2 rounded-full shrink-0 ${dotCls}`}
+                  aria-hidden
+                />
+                <span className="flex-1 truncate">{z.name}</span>
+                {!hasPolygon && (
+                  <span className="text-xs text-muted-foreground">
+                    Draw
+                  </span>
+                )}
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+      <div className="px-3 py-2 border-t text-[11px] text-muted-foreground">
+        Zone names are seeded from the fixture. New zones require an
+        admin update.
+      </div>
+    </aside>
+  );
+}
+
+function dotClass({
+  hasPolygon,
+  isDirty,
+}: {
+  hasPolygon: boolean;
+  isDirty: boolean;
+}): string {
+  if (isDirty) return "bg-amber-500";
+  if (hasPolygon) return "bg-emerald-500";
+  return "bg-muted-foreground/30";
+}

--- a/apps/mygamingassistant/frontend/src/components/zone-editor/ZoneEditorPreview.tsx
+++ b/apps/mygamingassistant/frontend/src/components/zone-editor/ZoneEditorPreview.tsx
@@ -1,0 +1,58 @@
+/**
+ * Preview-mode wrapper for the zone editor.
+ *
+ * When the operator toggles preview, swap the editor canvas for the same
+ * MapZoneOverlay end users see on MapPage. Density is empty (no lineup
+ * count tinting) — the point of preview is "where will the clickable
+ * areas land", not "how does the live coloring look".
+ */
+import MapZoneOverlay from "@/components/lineup/MapZoneOverlay";
+import type { MapZone } from "@/types/game";
+import type { PointObject } from "@/lib/zonePolygon";
+
+export interface ZoneEditorPreviewProps {
+  serverZones: MapZone[];
+  draftZones: Record<string, PointObject[]>;
+  minimapUrl: string | null;
+}
+
+export default function ZoneEditorPreview({
+  serverZones,
+  draftZones,
+  minimapUrl,
+}: ZoneEditorPreviewProps) {
+  // Build MapZone-shaped objects from server identity + draft polygons so
+  // the operator sees their in-progress edits as end users would.
+  const previewZones: MapZone[] = serverZones.map((z) => ({
+    ...z,
+    polygon_points: draftZones[z.slug] ?? z.polygon_points,
+  }));
+
+  return (
+    <div
+      className="relative rounded-md border bg-muted/20 overflow-hidden"
+      style={{ aspectRatio: "1 / 1" }}
+    >
+      {minimapUrl ? (
+        <img
+          src={minimapUrl}
+          alt="Minimap preview"
+          className="absolute inset-0 w-full h-full object-cover select-none pointer-events-none"
+          draggable={false}
+        />
+      ) : (
+        <div className="absolute inset-0 flex items-center justify-center text-muted-foreground text-sm">
+          Minimap not available
+        </div>
+      )}
+      <MapZoneOverlay
+        zones={previewZones}
+        density={{}}
+        selectedZoneSlug={null}
+        onZoneClick={() => {
+          /* preview only — no-op */
+        }}
+      />
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/zone-editor/ZoneEditorTopBar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/zone-editor/ZoneEditorTopBar.tsx
@@ -1,0 +1,69 @@
+/**
+ * Top bar for the plan-mode zone editor. Owns Back-to-map navigation,
+ * dirty indicator, Save, Discard, and the page title.
+ */
+import { Link } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+
+export interface ZoneEditorTopBarProps {
+  gameSlug: string;
+  mapSlug: string;
+  mapName: string;
+  isDirty: boolean;
+  isSaving: boolean;
+  onSave: () => void;
+  onDiscard: () => void;
+}
+
+export default function ZoneEditorTopBar({
+  gameSlug,
+  mapSlug,
+  mapName,
+  isDirty,
+  isSaving,
+  onSave,
+  onDiscard,
+}: ZoneEditorTopBarProps) {
+  const backHref = `/${gameSlug}/${mapSlug}`;
+  return (
+    <div className="flex items-center gap-3 px-4 sm:px-6 py-3 border-b bg-card">
+      <Link
+        to={backHref}
+        className="p-2 -ml-2 rounded-md hover:bg-muted/40 transition-colors min-h-[40px]"
+        aria-label="Back to map"
+      >
+        <ArrowLeft className="h-5 w-5" />
+      </Link>
+      <div className="flex-1 min-w-0">
+        <p className="text-xs text-muted-foreground capitalize">{gameSlug}</p>
+        <h1 className="text-base font-semibold capitalize truncate">
+          Edit zones — {mapName}
+        </h1>
+      </div>
+      {isDirty && (
+        <span
+          className="px-2 py-0.5 rounded-full text-xs bg-amber-500/15 text-amber-700 dark:text-amber-300 border border-amber-500/30"
+          aria-live="polite"
+        >
+          Unsaved changes
+        </span>
+      )}
+      <button
+        type="button"
+        onClick={onDiscard}
+        disabled={!isDirty || isSaving}
+        className="px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-muted/40 disabled:opacity-50 disabled:cursor-not-allowed min-h-[36px]"
+      >
+        Discard
+      </button>
+      <button
+        type="button"
+        onClick={onSave}
+        disabled={!isDirty || isSaving}
+        className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed min-h-[36px]"
+      >
+        {isSaving ? "Saving..." : "Save"}
+      </button>
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/hooks/useZoneEditorDraft.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/useZoneEditorDraft.ts
@@ -1,0 +1,280 @@
+/**
+ * useZoneEditorDraft — local draft state for the plan-mode zone editor.
+ *
+ * Responsibilities:
+ *  - Hold an editable `Record<slug, PointObject[]>` snapshot of the map's
+ *    zone polygons, initialized from the server-loaded zones.
+ *  - Persist the draft to localStorage keyed by `mga_zone_draft_<mapId>`
+ *    so an accidental tab close or session timeout doesn't lose 30 min of
+ *    work (the design review flagged this as worth the ~20 lines).
+ *  - Undo/redo via a simple snapshot stack.
+ *  - Compute `isDirty` and per-slug `dirtySlugs` against the server
+ *    baseline so the editor can show which zones still need saving.
+ *  - Discard restores baseline + clears localStorage.
+ *
+ * The hook does NOT own the save mutation — callers wire it up so they
+ * can pass loading state to the Save Bar and handle partial failures
+ * cleanly. After a successful save the caller MUST call `markSaved()` to
+ * reset the baseline and clear localStorage.
+ */
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { MapZone } from "@/types/game";
+import type { PointObject } from "@/lib/zonePolygon";
+
+const STORAGE_KEY_PREFIX = "mga_zone_draft_";
+const STORAGE_VERSION = 1;
+
+type ZoneMap = Record<string, PointObject[]>;
+
+interface StoredDraft {
+  __version: number;
+  mapId: string;
+  zones: ZoneMap;
+}
+
+function storageKey(mapId: string): string {
+  return `${STORAGE_KEY_PREFIX}${mapId}`;
+}
+
+function readStoredDraft(mapId: string): ZoneMap | null {
+  try {
+    const raw = localStorage.getItem(storageKey(mapId));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as StoredDraft;
+    if (parsed.__version !== STORAGE_VERSION) return null;
+    if (parsed.mapId !== mapId) return null;
+    return parsed.zones;
+  } catch {
+    // Quota exceeded / disabled / malformed JSON — fall back to server state.
+    return null;
+  }
+}
+
+function writeStoredDraft(mapId: string, zones: ZoneMap): void {
+  try {
+    const entry: StoredDraft = {
+      __version: STORAGE_VERSION,
+      mapId,
+      zones,
+    };
+    localStorage.setItem(storageKey(mapId), JSON.stringify(entry));
+  } catch {
+    // Quota exceeded or storage disabled — silently fall through. Worst
+    // case the operator loses the draft on tab close, which matches the
+    // pre-draft-persistence behavior.
+  }
+}
+
+function clearStoredDraft(mapId: string): void {
+  try {
+    localStorage.removeItem(storageKey(mapId));
+  } catch {
+    // ignore
+  }
+}
+
+function zonesToMap(zones: MapZone[]): ZoneMap {
+  const out: ZoneMap = {};
+  for (const z of zones) {
+    out[z.slug] = z.polygon_points;
+  }
+  return out;
+}
+
+// Stable JSON shape — keys sorted — so dirty checks don't flicker on
+// JS Object property-order differences.
+function hash(value: unknown): string {
+  return JSON.stringify(value, (_k, v) => {
+    if (v && typeof v === "object" && !Array.isArray(v)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(v as object).sort()) {
+        sorted[k] = (v as Record<string, unknown>)[k];
+      }
+      return sorted;
+    }
+    return v;
+  });
+}
+
+export interface UseZoneEditorDraftArgs {
+  mapId: string | undefined;
+  /** Server-loaded zones — undefined while the map detail query is in flight. */
+  serverZones: MapZone[] | undefined;
+}
+
+export interface ZoneEditorDraft {
+  zones: ZoneMap;
+  /** Convenience read for one zone's polygon. */
+  getPolygon: (slug: string) => PointObject[];
+  setPolygon: (slug: string, points: PointObject[]) => void;
+  clearPolygon: (slug: string) => void;
+  /** Discard the draft and revert to the server baseline. */
+  discardChanges: () => void;
+  /** Tell the hook "the server now reflects the current draft" — clears
+   *  localStorage and updates the baseline so isDirty becomes false. */
+  markSaved: () => void;
+  isDirty: boolean;
+  dirtySlugs: Set<string>;
+  canUndo: boolean;
+  canRedo: boolean;
+  undo: () => void;
+  redo: () => void;
+  /** True after the first server load has hydrated the draft. False while
+   *  the parent query is in flight. */
+  ready: boolean;
+  /** True if a localStorage draft was restored on init (used to surface a
+   *  one-time "We restored your in-progress draft" toast). */
+  restoredFromStorage: boolean;
+}
+
+export function useZoneEditorDraft({
+  mapId,
+  serverZones,
+}: UseZoneEditorDraftArgs): ZoneEditorDraft {
+  const [zones, setZones] = useState<ZoneMap>({});
+  const [baseline, setBaseline] = useState<ZoneMap>({});
+  const [undoStack, setUndoStack] = useState<ZoneMap[]>([]);
+  const [redoStack, setRedoStack] = useState<ZoneMap[]>([]);
+  const [ready, setReady] = useState(false);
+  const [restoredFromStorage, setRestoredFromStorage] = useState(false);
+
+  // Initialize once when both mapId and serverZones are available.
+  // useRef guards against double-init on re-renders.
+  const initRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!mapId || !serverZones) return;
+    if (initRef.current === mapId) return;
+    initRef.current = mapId;
+
+    const server = zonesToMap(serverZones);
+    const stored = readStoredDraft(mapId);
+    if (stored) {
+      // Only treat as a real restored draft if it actually differs from
+      // the server state. Otherwise it's just stale data to ignore.
+      const meaningful = hash(stored) !== hash(server);
+      if (meaningful) {
+        setZones(stored);
+        setRestoredFromStorage(true);
+      } else {
+        setZones(server);
+        clearStoredDraft(mapId);
+      }
+    } else {
+      setZones(server);
+    }
+    setBaseline(server);
+    setReady(true);
+  }, [mapId, serverZones]);
+
+  // Persist to localStorage on every change (but not during initial hydration).
+  useEffect(() => {
+    if (!mapId || !ready) return;
+    if (hash(zones) === hash(baseline)) {
+      // Draft matches baseline — no point storing.
+      clearStoredDraft(mapId);
+      return;
+    }
+    writeStoredDraft(mapId, zones);
+  }, [mapId, zones, baseline, ready]);
+
+  const pushUndo = useCallback((prev: ZoneMap) => {
+    setUndoStack((stack) => [...stack, prev]);
+    setRedoStack([]);
+  }, []);
+
+  const setPolygon = useCallback(
+    (slug: string, points: PointObject[]) => {
+      setZones((prev) => {
+        pushUndo(prev);
+        return { ...prev, [slug]: points };
+      });
+    },
+    [pushUndo],
+  );
+
+  const clearPolygon = useCallback(
+    (slug: string) => {
+      setZones((prev) => {
+        pushUndo(prev);
+        return { ...prev, [slug]: [] };
+      });
+    },
+    [pushUndo],
+  );
+
+  const discardChanges = useCallback(() => {
+    if (!mapId) return;
+    setZones(baseline);
+    setUndoStack([]);
+    setRedoStack([]);
+    clearStoredDraft(mapId);
+    setRestoredFromStorage(false);
+  }, [baseline, mapId]);
+
+  const markSaved = useCallback(() => {
+    if (!mapId) return;
+    setBaseline(zones);
+    setUndoStack([]);
+    setRedoStack([]);
+    clearStoredDraft(mapId);
+    setRestoredFromStorage(false);
+  }, [zones, mapId]);
+
+  const undo = useCallback(() => {
+    setUndoStack((stack) => {
+      if (stack.length === 0) return stack;
+      const last = stack[stack.length - 1];
+      setRedoStack((r) => [...r, zones]);
+      setZones(last);
+      return stack.slice(0, -1);
+    });
+  }, [zones]);
+
+  const redo = useCallback(() => {
+    setRedoStack((stack) => {
+      if (stack.length === 0) return stack;
+      const next = stack[stack.length - 1];
+      setUndoStack((u) => [...u, zones]);
+      setZones(next);
+      return stack.slice(0, -1);
+    });
+  }, [zones]);
+
+  const dirtySlugs = useMemo(() => {
+    const out = new Set<string>();
+    const allSlugs = new Set([
+      ...Object.keys(zones),
+      ...Object.keys(baseline),
+    ]);
+    for (const slug of allSlugs) {
+      if (hash(zones[slug] ?? []) !== hash(baseline[slug] ?? [])) {
+        out.add(slug);
+      }
+    }
+    return out;
+  }, [zones, baseline]);
+
+  const isDirty = dirtySlugs.size > 0;
+
+  const getPolygon = useCallback(
+    (slug: string): PointObject[] => zones[slug] ?? [],
+    [zones],
+  );
+
+  return {
+    zones,
+    getPolygon,
+    setPolygon,
+    clearPolygon,
+    discardChanges,
+    markSaved,
+    isDirty,
+    dirtySlugs,
+    canUndo: undoStack.length > 0,
+    canRedo: redoStack.length > 0,
+    undo,
+    redo,
+    ready,
+    restoredFromStorage,
+  };
+}

--- a/apps/mygamingassistant/frontend/src/lib/zonePolygon.ts
+++ b/apps/mygamingassistant/frontend/src/lib/zonePolygon.ts
@@ -1,0 +1,47 @@
+/**
+ * Coordinate format adapters between the polygon editor canvas and the
+ * MapZoneOverlay consumer.
+ *
+ * The shipped `ZoneEditorCanvas` (from the CV-calibration page) stores
+ * vertices as `Array<[number, number]>` tuples; `MapZoneOverlay` reads
+ * `Array<{x, y}>` objects from the backend's `MapZone.polygon_points`
+ * column. Without this serializer the two would silently disagree —
+ * tuples passed to MapZoneOverlay's `pointsToSvg` (which does `p.x *
+ * size`) would render as NaN at the origin.
+ *
+ * All coords are normalized 0-1. The clamp helper is included for
+ * defensive use at boundaries — the editor canvas already clamps
+ * locally on every pointer event, but a malformed external value
+ * (stale localStorage draft, hand-edited fixture) should not break
+ * downstream rendering.
+ */
+
+export type PointTuple = [number, number];
+export type PointObject = { x: number; y: number };
+
+export function tupleToObject(p: PointTuple): PointObject {
+  return { x: p[0], y: p[1] };
+}
+
+export function objectToTuple(p: PointObject): PointTuple {
+  return [p.x, p.y];
+}
+
+export function tuplesToObjects(points: PointTuple[]): PointObject[] {
+  return points.map(tupleToObject);
+}
+
+export function objectsToTuples(points: PointObject[]): PointTuple[] {
+  return points.map(objectToTuple);
+}
+
+export function clampPoint(p: PointObject): PointObject {
+  return { x: clamp01(p.x), y: clamp01(p.y) };
+}
+
+function clamp01(v: number): number {
+  if (Number.isNaN(v)) return 0;
+  if (v < 0) return 0;
+  if (v > 1) return 1;
+  return v;
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -18,7 +18,7 @@
  */
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { ArrowLeft, Backpack, ImagePlus, Package, Plus } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Backpack, ImagePlus, Package, Pencil, Plus } from "lucide-react";
 import { ToggleChipGroup, showSuccess } from "@platform/ui";
 import { useGetGamesQuery, useGetMapDetailQuery } from "@/store/gamesApi";
 import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
@@ -350,6 +350,16 @@ export default function MapPage() {
               <h1 className="text-xl font-semibold capitalize">{mapDetail.name}</h1>
             </div>
             {isSuperuser && (
+              <Link
+                to={`/${gameSlug}/${mapSlug}/zones/edit`}
+                className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
+                title="Author the clickable zone polygons for this map"
+              >
+                <Pencil className="w-4 h-4" />
+                Edit zones
+              </Link>
+            )}
+            {isSuperuser && (
               <button
                 type="button"
                 onClick={() => setShowMinimapUpload(true)}
@@ -368,6 +378,35 @@ export default function MapPage() {
               Add lineup
             </Link>
           </div>
+
+          {isSuperuser &&
+            mapDetail.zones.length > 0 &&
+            mapDetail.zones.every((z) => z.polygon_points.length === 0) && (
+              <div
+                className="flex items-start gap-2.5 px-3 py-2.5 rounded-md border bg-amber-500/10 border-amber-500/30 text-sm"
+                role="status"
+              >
+                <AlertTriangle
+                  className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
+                  aria-hidden
+                />
+                <div className="flex-1">
+                  <p className="font-medium">
+                    This map's zones aren't drawn yet.
+                  </p>
+                  <p className="text-xs text-muted-foreground">
+                    Visitors will see a static minimap until you author the
+                    clickable zone polygons.
+                  </p>
+                </div>
+                <Link
+                  to={`/${gameSlug}/${mapSlug}/zones/edit`}
+                  className="px-3 py-1 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 min-h-[32px] inline-flex items-center"
+                >
+                  Set up zones
+                </Link>
+              </div>
+            )}
 
           {showMinimapUpload && (
             <MinimapUploadDialog

--- a/apps/mygamingassistant/frontend/src/pages/ZoneEditPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/ZoneEditPage.tsx
@@ -1,0 +1,426 @@
+/**
+ * ZoneEditPage — operator-only polygon editor for a map's plan-mode zones.
+ * Route: /:gameSlug/:mapSlug/zones/edit
+ *
+ * Authors `MapZone.polygon_points` so MapPage's clickable SVG overlay can
+ * actually render. Without this page, every zone ships with empty
+ * polygon_points and the map appears as a static, unclickable image.
+ *
+ * Reuses `ZoneEditorCanvas` from the CV-calibration page (storage-agnostic
+ * pure-render polygon editor) but mounts a different orchestrator hook
+ * (`useZoneEditorDraft`) that talks to the backend instead of a Tauri file.
+ *
+ * Coord shape note: the canvas uses `[x, y]` tuples; the backend stores
+ * `{x, y}` objects. `lib/zonePolygon` adapts at the boundary — the
+ * mismatch was the design review's #1 ship-blocker.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useParams, useBlocker } from "react-router-dom";
+import { ConfirmDialog, showError, showSuccess } from "@platform/ui";
+import { useGetMapDetailQuery, useBulkUpdateMapZonesMutation } from "@/store/gamesApi";
+import { useZoneEditorDraft } from "@/hooks/useZoneEditorDraft";
+import { tuplesToObjects, objectsToTuples } from "@/lib/zonePolygon";
+import type { CvZonePolygon } from "@/types/desktop";
+import type { ZonePolygonUpdate } from "@/types/game";
+import ZoneEditorCanvas, { type EditorMode } from "@/components/calibrate/zones/ZoneEditorCanvas";
+import ZoneEditorTopBar from "@/components/zone-editor/ZoneEditorTopBar";
+import ZoneEditorLeftRail from "@/components/zone-editor/ZoneEditorLeftRail";
+import ZoneEditorActionBar, { type ActionBarMode } from "@/components/zone-editor/ZoneEditorActionBar";
+import ZoneEditorPreview from "@/components/zone-editor/ZoneEditorPreview";
+
+const COACHMARK_STORAGE_KEY = "mga_zone_editor_seen_v1";
+
+export default function ZoneEditPage() {
+  const { gameSlug, mapSlug } = useParams<{ gameSlug: string; mapSlug: string }>();
+
+  const {
+    data: mapDetail,
+    isLoading: mapLoading,
+    isError: mapError,
+    refetch: refetchMapDetail,
+  } = useGetMapDetailQuery(
+    { gameSlug: gameSlug ?? "", mapSlug: mapSlug ?? "" },
+    { skip: !gameSlug || !mapSlug },
+  );
+
+  const draft = useZoneEditorDraft({
+    mapId: mapDetail?.id,
+    serverZones: mapDetail?.zones,
+  });
+
+  const [bulkUpdate, { isLoading: isSaving }] = useBulkUpdateMapZonesMutation();
+
+  const [selectedSlug, setSelectedSlug] = useState<string | null>(null);
+  const [mode, setMode] = useState<EditorMode>("select");
+  const [drawingPoints, setDrawingPoints] = useState<Array<[number, number]>>([]);
+  const [previewMode, setPreviewMode] = useState(false);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
+  const [confirmLeave, setConfirmLeave] = useState(false);
+  const [showCoachmark, setShowCoachmark] = useState(false);
+
+  // ---- Draft → CvZonePolygon adapter for the canvas (tuples + names) ----
+  const canvasZones: CvZonePolygon[] = useMemo(() => {
+    if (!mapDetail) return [];
+    return mapDetail.zones
+      .map((z) => {
+        const points = draft.zones[z.slug] ?? [];
+        if (points.length < 3) return null;
+        return {
+          slug: z.slug,
+          name: z.name,
+          points: objectsToTuples(points),
+        };
+      })
+      .filter((z): z is CvZonePolygon => z !== null);
+  }, [mapDetail, draft.zones]);
+
+  // ---- Auto-select first zone once data loads ----
+  useEffect(() => {
+    if (!mapDetail || selectedSlug) return;
+    if (mapDetail.zones.length === 0) return;
+    setSelectedSlug(mapDetail.zones[0].slug);
+  }, [mapDetail, selectedSlug]);
+
+  // ---- Restored-from-storage one-time toast ----
+  const [restoreToastShown, setRestoreToastShown] = useState(false);
+  useEffect(() => {
+    if (draft.restoredFromStorage && !restoreToastShown) {
+      showSuccess("Restored your in-progress draft.");
+      setRestoreToastShown(true);
+    }
+  }, [draft.restoredFromStorage, restoreToastShown]);
+
+  // ---- Coachmark for first-time `new` mode ----
+  useEffect(() => {
+    if (mode !== "new") return;
+    try {
+      if (localStorage.getItem(COACHMARK_STORAGE_KEY)) return;
+      setShowCoachmark(true);
+      localStorage.setItem(COACHMARK_STORAGE_KEY, "1");
+    } catch {
+      // localStorage disabled — show coachmark anyway, accept that next
+      // session will show it again.
+      setShowCoachmark(true);
+    }
+  }, [mode]);
+
+  // ---- Dirty-leave guard (react-router blocker + beforeunload) ----
+  const blocker = useBlocker(
+    ({ currentLocation, nextLocation }) =>
+      draft.isDirty && currentLocation.pathname !== nextLocation.pathname,
+  );
+
+  useEffect(() => {
+    if (blocker.state === "blocked") {
+      setConfirmLeave(true);
+    }
+  }, [blocker.state]);
+
+  useEffect(() => {
+    function onBeforeUnload(e: BeforeUnloadEvent) {
+      if (!draft.isDirty) return;
+      e.preventDefault();
+      e.returnValue = "";
+    }
+    window.addEventListener("beforeunload", onBeforeUnload);
+    return () => window.removeEventListener("beforeunload", onBeforeUnload);
+  }, [draft.isDirty]);
+
+  // ---- Keyboard shortcuts ----
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      const target = e.target as HTMLElement | null;
+      if (target && ["INPUT", "TEXTAREA", "SELECT"].includes(target.tagName)) {
+        return;
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === "z" && !e.shiftKey) {
+        e.preventDefault();
+        draft.undo();
+      } else if ((e.ctrlKey || e.metaKey) && e.shiftKey && e.key.toLowerCase() === "z") {
+        e.preventDefault();
+        draft.redo();
+      } else if (e.key === "p" && mode !== "new" && !e.metaKey && !e.ctrlKey) {
+        e.preventDefault();
+        setPreviewMode((v) => !v);
+      } else if (e.key === "Escape" && mode === "new") {
+        e.preventDefault();
+        setDrawingPoints([]);
+        setMode("select");
+      } else if (e.key === "Enter" && mode === "new" && drawingPoints.length >= 3) {
+        e.preventDefault();
+        finalizeDrawing();
+      }
+    }
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+    // finalizeDrawing closes over drawingPoints + selectedSlug; the deps
+    // here are intentionally narrow to avoid binding a stale finalize.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [mode, drawingPoints.length, draft.undo, draft.redo]);
+
+  // ---- Drawing helpers ----
+  const startDrawing = useCallback((slug: string) => {
+    setSelectedSlug(slug);
+    setMode("new");
+    setDrawingPoints([]);
+    setPreviewMode(false);
+  }, []);
+
+  const cancelDrawing = useCallback(() => {
+    setDrawingPoints([]);
+    setMode("select");
+  }, []);
+
+  const finalizeDrawing = useCallback(() => {
+    if (!selectedSlug || drawingPoints.length < 3) return;
+    draft.setPolygon(selectedSlug, tuplesToObjects(drawingPoints));
+    setDrawingPoints([]);
+    setMode("select");
+  }, [selectedSlug, drawingPoints, draft]);
+
+  // ---- Canvas event handlers ----
+  const handleAppendVertex = useCallback((pt: [number, number]) => {
+    setDrawingPoints((prev) => [...prev, pt]);
+  }, []);
+
+  const handleCloseNewPolygon = useCallback(() => {
+    finalizeDrawing();
+  }, [finalizeDrawing]);
+
+  const handleUpdateZonePoints = useCallback(
+    (slug: string, pts: Array<[number, number]>) => {
+      draft.setPolygon(slug, tuplesToObjects(pts));
+    },
+    [draft],
+  );
+
+  const handleSelectZoneFromCanvas = useCallback((slug: string | null) => {
+    if (slug) setSelectedSlug(slug);
+  }, []);
+
+  // ---- Left rail click handlers ----
+  const handleSelectFilledZone = useCallback((slug: string) => {
+    setSelectedSlug(slug);
+    setMode("select");
+    setPreviewMode(false);
+  }, []);
+
+  // ---- Action bar handlers ----
+  const handleClearSelected = useCallback(() => {
+    if (!selectedSlug) return;
+    draft.clearPolygon(selectedSlug);
+  }, [selectedSlug, draft]);
+
+  // ---- Save ----
+  const handleSave = useCallback(async () => {
+    if (!mapDetail || !draft.isDirty) return;
+    const updates: ZonePolygonUpdate[] = Array.from(draft.dirtySlugs).map((slug) => ({
+      slug,
+      polygon_points: draft.zones[slug] ?? [],
+    }));
+    try {
+      const result = await bulkUpdate({
+        mapId: mapDetail.id,
+        body: { zones: updates },
+      }).unwrap();
+      if (result.failed.length > 0) {
+        const failedDetail = result.failed.map((f) => `${f.slug} (${f.reason})`).join(", ");
+        showError(`Saved ${result.updated.length}; failed: ${failedDetail}`);
+        // Don't markSaved — partial-success leaves draft dirty for the
+        // failed zones so the operator can see + fix them.
+        return;
+      }
+      draft.markSaved();
+      void refetchMapDetail();
+      showSuccess(`Saved ${result.updated.length} zone${result.updated.length !== 1 ? "s" : ""}.`);
+    } catch (e) {
+      const m = e instanceof Error ? e.message : String(e);
+      showError(`Save failed: ${m}`);
+    }
+  }, [mapDetail, draft, bulkUpdate, refetchMapDetail]);
+
+  const handleDiscardConfirmed = useCallback(() => {
+    draft.discardChanges();
+    setMode("select");
+    setDrawingPoints([]);
+    setConfirmDiscard(false);
+  }, [draft]);
+
+  // ---- Action bar mode derivation ----
+  const actionBarMode: ActionBarMode = useMemo(() => {
+    if (!selectedSlug) return null;
+    if (mode === "new") return "cancel";
+    const points = draft.zones[selectedSlug] ?? [];
+    if (points.length >= 3) return "clear";
+    return "draw";
+  }, [selectedSlug, mode, draft.zones]);
+
+  const selectedZone = useMemo(
+    () => mapDetail?.zones.find((z) => z.slug === selectedSlug) ?? null,
+    [mapDetail, selectedSlug],
+  );
+
+  // ---- Loading / error states ----
+  if (mapLoading || !draft.ready) {
+    return (
+      <main className="p-4 sm:p-6 space-y-4">
+        <div className="h-10 w-1/3 bg-muted/40 rounded animate-pulse" />
+        <div className="h-96 bg-muted/40 rounded-xl animate-pulse" />
+      </main>
+    );
+  }
+
+  if (mapError || !mapDetail) {
+    return (
+      <main className="p-4 sm:p-6">
+        <p className="text-sm text-destructive">Failed to load map. Please refresh.</p>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <main className="flex flex-col h-[calc(100vh-3.5rem)]">
+        <ZoneEditorTopBar
+          gameSlug={gameSlug ?? ""}
+          mapSlug={mapSlug ?? ""}
+          mapName={mapDetail.name}
+          isDirty={draft.isDirty}
+          isSaving={isSaving}
+          onSave={() => void handleSave()}
+          onDiscard={() => setConfirmDiscard(true)}
+        />
+
+        <div className="flex flex-col lg:flex-row flex-1 min-h-0 overflow-hidden">
+          <ZoneEditorLeftRail
+            zones={mapDetail.zones}
+            draftZones={draft.zones}
+            dirtySlugs={draft.dirtySlugs}
+            selectedSlug={selectedSlug}
+            onSelectFilledZone={handleSelectFilledZone}
+            onClickEmptyZone={startDrawing}
+          />
+
+          <section className="flex-1 overflow-auto p-4">
+            <div className="flex items-center justify-between mb-2">
+              <p className="text-xs text-muted-foreground">
+                {hintForMode(mode, drawingPoints.length, selectedZone?.name ?? null)}
+              </p>
+              <button
+                type="button"
+                onClick={() => setPreviewMode((v) => !v)}
+                className="text-xs px-2 py-1 rounded-md border hover:bg-muted/40"
+                disabled={mode === "new"}
+              >
+                {previewMode ? "Back to edit" : "Preview"}
+              </button>
+            </div>
+
+            <div className="relative max-w-3xl mx-auto">
+              {previewMode ? (
+                <ZoneEditorPreview
+                  serverZones={mapDetail.zones}
+                  draftZones={draft.zones}
+                  minimapUrl={mapDetail.minimap_url}
+                />
+              ) : (
+                <ZoneEditorCanvas
+                  backgroundSrc={mapDetail.minimap_url}
+                  backgroundIsFallback={false}
+                  zones={canvasZones}
+                  selectedSlug={selectedSlug}
+                  mode={mode}
+                  drawingSlug={mode === "new" ? selectedSlug : null}
+                  drawingPoints={drawingPoints}
+                  onSelectZone={handleSelectZoneFromCanvas}
+                  onUpdateZonePoints={handleUpdateZonePoints}
+                  onAppendNewVertex={handleAppendVertex}
+                  onCloseNewPolygon={handleCloseNewPolygon}
+                />
+              )}
+
+              {!previewMode && (
+                <ZoneEditorActionBar
+                  mode={actionBarMode}
+                  selectedZoneName={selectedZone?.name ?? null}
+                  onDraw={() => selectedSlug && startDrawing(selectedSlug)}
+                  onClear={handleClearSelected}
+                  onCancel={cancelDrawing}
+                />
+              )}
+
+              {showCoachmark && mode === "new" && (
+                <div
+                  className="absolute top-3 left-1/2 -translate-x-1/2 z-20 max-w-sm bg-popover border rounded-lg shadow-lg px-4 py-2.5 text-sm"
+                  role="status"
+                >
+                  <p className="font-medium mb-1">Drawing a polygon</p>
+                  <p className="text-xs text-muted-foreground">
+                    Click to add vertices. Click the first vertex (or press Enter)
+                    to close. Esc cancels.
+                  </p>
+                  <button
+                    type="button"
+                    onClick={() => setShowCoachmark(false)}
+                    className="mt-2 text-xs text-primary hover:underline"
+                  >
+                    Got it
+                  </button>
+                </div>
+              )}
+            </div>
+          </section>
+        </div>
+      </main>
+
+      <ConfirmDialog
+        open={confirmDiscard}
+        title="Discard unsaved changes?"
+        description="Your in-progress polygons will be lost. This cannot be undone."
+        confirmLabel="Discard"
+        variant="destructive"
+        onConfirm={handleDiscardConfirmed}
+        onCancel={() => setConfirmDiscard(false)}
+      />
+
+      <ConfirmDialog
+        open={confirmLeave}
+        title="Leave with unsaved changes?"
+        description="Your in-progress polygons won't be saved."
+        confirmLabel="Leave"
+        variant="destructive"
+        onConfirm={() => {
+          setConfirmLeave(false);
+          blocker.proceed?.();
+        }}
+        onCancel={() => {
+          setConfirmLeave(false);
+          blocker.reset?.();
+        }}
+      />
+    </>
+  );
+}
+
+function hintForMode(
+  mode: EditorMode,
+  drawingCount: number,
+  zoneName: string | null,
+): string {
+  if (mode === "new") {
+    if (drawingCount === 0) {
+      return zoneName
+        ? `Click to add vertices for ${zoneName}.`
+        : "Click to add vertices.";
+    }
+    if (drawingCount < 3) {
+      return `${drawingCount} of 3+ vertices. Keep clicking.`;
+    }
+    return `${drawingCount} vertices. Click the first vertex or press Enter to close.`;
+  }
+  if (mode === "select") {
+    if (!zoneName) return "Select a zone from the list to edit.";
+    return `Editing ${zoneName}. Drag the polygon to move; drag vertices to reshape.`;
+  }
+  return "";
+}

--- a/apps/mygamingassistant/frontend/src/routes.tsx
+++ b/apps/mygamingassistant/frontend/src/routes.tsx
@@ -11,6 +11,7 @@ import Review from "@/pages/Review";
 import Security from "@/pages/Security";
 import Settings from "@/pages/Settings";
 import Sources from "@/pages/Sources";
+import ZoneEditPage from "@/pages/ZoneEditPage";
 import Login from "@/pages/Login";
 import ForgotPassword from "@/pages/ForgotPassword";
 import ResetPassword from "@/pages/ResetPassword";
@@ -84,6 +85,16 @@ export const routes: RouteObject[] = [
         element: (
           <AuthRequired action="calibrate the minimap CV pipeline">
             <LiveCs2Calibrate />
+          </AuthRequired>
+        ),
+      },
+      {
+        // Note: this MUST come AFTER `/:gameSlug/:mapSlug` so the more
+        // specific path doesn't shadow the plan-mode map view.
+        path: "/:gameSlug/:mapSlug/zones/edit",
+        element: (
+          <AuthRequired action="edit map zones">
+            <ZoneEditPage />
           </AuthRequired>
         ),
       },

--- a/apps/mygamingassistant/frontend/src/store/gamesApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/gamesApi.ts
@@ -1,5 +1,7 @@
 import { baseApi } from "@platform/ui";
 import type {
+  BulkUpdateZonesBody,
+  BulkUpdateZonesResult,
   Game,
   GameMap,
   MapDetail,
@@ -37,6 +39,22 @@ const gamesApi = baseApi.injectEndpoints({
         body: { object_key: objectKey },
       }),
     }),
+    // Bulk-update polygon_points across zones for a single map. On success
+    // the page should refetch getMapDetail so MapPage's clickable overlay
+    // reflects the new polygons immediately on the next visit.
+    bulkUpdateMapZones: build.mutation<
+      BulkUpdateZonesResult,
+      { mapId: string; body: BulkUpdateZonesBody }
+    >({
+      query: ({ mapId, body }) => ({
+        url: `/maps/${mapId}/zones`,
+        method: "PATCH",
+        body,
+      }),
+      // The map-detail query is keyed by (gameSlug, mapSlug), so we can't
+      // invalidate by mapId. Caller fires a refetch via the query's
+      // refetch() helper after a successful save.
+    }),
   }),
 });
 
@@ -46,4 +64,5 @@ export const {
   useGetMapDetailQuery,
   useGetMinimapUploadUrlMutation,
   useConfirmMinimapUploadMutation,
+  useBulkUpdateMapZonesMutation,
 } = gamesApi;

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -53,6 +53,27 @@ export interface MapMinimapUpdated {
   minimap_url: string | null;
 }
 
+/** One zone's new polygon for the bulk PATCH /maps/{id}/zones request. */
+export interface ZonePolygonUpdate {
+  slug: string;
+  polygon_points: Array<{ x: number; y: number }>;
+}
+
+export interface BulkUpdateZonesBody {
+  zones: ZonePolygonUpdate[];
+}
+
+export interface ZonePolygonFailure {
+  slug: string;
+  reason: string;
+}
+
+/** Response from PATCH /maps/{id}/zones — partial successes are normal. */
+export interface BulkUpdateZonesResult {
+  updated: string[];
+  failed: ZonePolygonFailure[];
+}
+
 // ---------------------------------------------------------------------------
 // Lineup domain
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Frontend half of the plan-mode zone editor. Lets the operator author the `MapZone.polygon_points` that `MapZoneOverlay` needs to render clickable zones; without these, MapPage looks like a static unclickable image to end users.

**Stacked on #653** (backend PATCH endpoint). Retarget to main once the backend lands per `rules/stacked-pr-merge-base-trap.md`.

## What lands

| Piece | Where |
|---|---|
| Tuple↔object adapter for canvas/backend coord shapes (10 unit tests) | `lib/zonePolygon.ts` |
| Draft hook with localStorage persistence + undo/redo (14 unit tests) | `hooks/useZoneEditorDraft.ts` |
| Editor page reusing `ZoneEditorCanvas` | `pages/ZoneEditPage.tsx` |
| Floating action bar (replaces right rail per design review) | `components/zone-editor/ZoneEditorActionBar.tsx` |
| Top bar + left rail + preview wrapper | `components/zone-editor/Zone*.tsx` |
| Operator-only "Edit zones" header button + not-yet-drawn banner | `pages/MapPage.tsx` |
| Route registration | `routes.tsx` |
| E2E spec (auth gate, banner, top bar, single-click draw entry) | `e2e/zone-editor.spec.ts` |

## Design-review issues addressed (every CRITICAL/HIGH item)

- **Coord-format mismatch**: `lib/zonePolygon` is the single seam. Round-trip test pins both directions.
- **Single-click empty zone enters draw mode**: no separate "Draw" button click needed (saves ~3 clicks per zone × N zones × N maps).
- **localStorage draft persistence**: keyed by `mga_zone_draft_<map_id>`, restored on page load with a one-time toast, cleared on save.
- **Cache invalidation after save**: page calls `refetchMapDetail()` so MapPage's overlay reflects new polygons immediately.
- **Bulk-PATCH partial-failure handling**: failed slugs surfaced in the toast; `draft.markSaved` not called so failed zones stay dirty for fix-up.

## Architectural reuse notes

`ZoneEditorCanvas` is a pure-render polygon editor that was built for the Tauri-only `/live/cs2/calibrate` page. It's storage-agnostic — same canvas, different orchestrator hook. No fork; the new editor consumes it as-is via the coord adapter.

## Operational migration

None. Pure additive — new route, no env vars, no DB schema.

## Test plan

- [x] Unit: 24 tests pass (`zonePolygon.test.ts` + `useZoneEditorDraft.test.ts`)
- [x] Typecheck: clean
- [ ] E2E: 5 specs in `zone-editor.spec.ts` — CI runs them
- [ ] Manual: log in, navigate to /cs2/mirage, click "Set up zones" banner CTA, draw a polygon for A Site, save, return to /cs2/mirage, click A Site polygon, results panel opens

## Known gaps (deferred per design review)

- Cannot add new zones from the editor — slugs come from fixtures. Documented inline in the left rail. Adding zones is a known follow-up.
- No in-editor click simulation against live lineup data — preview swaps to MapZoneOverlay rendering only. Operator confirms by saving and looking at MapPage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)