### PR TITLE
feat(mpt): customer DB + "the usual" lookup (Phase 1 PR 10)

### DIFF
--- a/.github/workflows/ci-mypizzatracker.yml
+++ b/.github/workflows/ci-mypizzatracker.yml
@@ -1,0 +1,168 @@
+name: MyPizzaTracker CI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'apps/mypizzatracker/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ci-mypizzatracker.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mypizzatracker/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/ci-mypizzatracker.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-mypizzatracker-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  backend-deps-resolve:
+    name: backend-deps-resolve / mypizzatracker
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: apps/mypizzatracker/backend/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Verify lockfile is consistent with pyproject.toml
+        working-directory: apps/mypizzatracker/backend
+        run: uv lock --check
+
+      - name: Sync backend dependencies from lockfile
+        working-directory: apps/mypizzatracker/backend
+        run: uv sync --frozen
+
+  backend-tests:
+    name: backend-tests / mypizzatracker
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    services:
+      postgres:
+        # Stock postgres:16 — MPT does NOT use pgvector.
+        # Mirrors apps/mypizzatracker/docker-compose.yml.
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql+asyncpg://postgres:postgres@localhost:5432/test
+      DATABASE_URL_SYNC: postgresql://postgres:postgres@localhost:5432/test
+      SECRET_KEY: "ci-placeholder-secret-key-not-real-32chars" # gitleaks:allow
+      ENCRYPTION_KEY: "ci-placeholder-encryption-key-not-real-32" # gitleaks:allow
+      # Environment kept at default ("development") so production boot
+      # guards (seed user, Sentry, SMS) stay off in CI.
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          enable-cache: true
+          cache-dependency-glob: apps/mypizzatracker/backend/uv.lock
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Sync backend dependencies (incl. dev group)
+        # The `dev` dependency-group in pyproject.toml carries pytest +
+        # pytest-asyncio + pytest-timeout. ``uv sync --frozen --group dev``
+        # installs both runtime deps and dev tools from the lockfile.
+        working-directory: apps/mypizzatracker/backend
+        run: uv sync --frozen --group dev
+
+      - name: Run alembic migrations
+        working-directory: apps/mypizzatracker/backend
+        run: PYTHONPATH=. uv run alembic upgrade head
+
+      - name: Run pytest
+        working-directory: apps/mypizzatracker/backend
+        # PYTHONPATH=. so pytest can import `app` — uv's venv-aware `uv run`
+        # doesn't add CWD to sys.path the way `python -m pytest` would, and
+        # this project is `package = false` (no installed entry point).
+        # --timeout=60 (pytest-timeout) is a safety net so a future teardown
+        # bug can't consume the whole job timeout silently.
+        run: PYTHONPATH=. uv run pytest -q --timeout=60
+
+  frontend-build:
+    name: frontend-build / mypizzatracker
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install workspace dependencies
+        # Root package.json is an npm workspace covering all apps' frontends.
+        # Use `npm install` rather than `npm ci`: there is a known npm bug
+        # (https://github.com/npm/cli/issues/4828) where workspace + optional
+        # platform-specific deps (rollup, esbuild) interact badly with `npm ci`'s
+        # strict lockfile validation, producing
+        # `Cannot find module '@rollup/rollup-linux-x64-gnu'` failures even when
+        # the lockfile has the entry. `npm install` is more lenient + self-heals.
+        run: npm install
+
+      - name: Build frontend
+        run: npm run build --workspace=mypizzatracker-frontend
+
+  caddy-image:
+    name: caddy-image / mypizzatracker
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Build caddy image (bakes frontend dist in)
+        run: |
+          docker build \
+            -f apps/mypizzatracker/docker/caddy.Dockerfile \
+            -t mypizzatracker-caddy:ci \
+            .
+
+      - name: Verify frontend dist is baked into image
+        # Confirms the multi-stage build produced /srv/frontend/index.html
+        # inside the caddy image. If this fails, the bake step silently didn't
+        # copy the dist (wrong COPY path, wrong build stage, etc.).
+        run: docker run --rm mypizzatracker-caddy:ci test -f /srv/frontend/index.html

--- a/apps/mypizzatracker/backend/app/api/customers.py
+++ b/apps/mypizzatracker/backend/app/api/customers.py
@@ -1,0 +1,79 @@
+"""Operator customer-DB routes.
+
+  GET    /customers                            -- list customers with rollup stats
+  PATCH  /customers/{customer_id}/notes        -- replace the operator notes field
+
+Auth is enforced at the router level (single-user app). Paths register
+without ``/api`` per the project's router-prefix convention.
+
+The customer list is sorted by most-recent-order desc; the operator uses
+it to find a customer by name or partial phone before/after a drop. Notes
+are operator-only freeform text the customer never sees -- things like
+"prefers extra crispy crust", "gluten sensitive", or "always shows up 20m
+late".
+"""
+from __future__ import annotations
+
+import uuid
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth import current_active_user
+from app.db.session import get_db
+from app.schemas.customer.customer_schemas import (
+    CustomerListItem,
+    CustomerNotesUpdate,
+    CustomerRead,
+)
+from app.services.customer import customer_service
+from app.services.customer.customer_service import CustomerServiceError
+
+router = APIRouter(
+    prefix="/customers",
+    tags=["customers"],
+    dependencies=[Depends(current_active_user)],
+)
+
+
+def _service_error(exc: CustomerServiceError) -> HTTPException:
+    return HTTPException(status_code=exc.http_status, detail=str(exc))
+
+
+@router.get("", response_model=list[CustomerListItem])
+async def list_customers(
+    search: str | None = Query(None, max_length=100),
+    limit: int = Query(200, ge=1, le=1000),
+    db: AsyncSession = Depends(get_db),
+) -> list[CustomerListItem]:
+    rows = await customer_service.list_with_stats(
+        db, search=search, limit=limit,
+    )
+    return [
+        CustomerListItem(
+            id=row["customer"].id,
+            name=row["customer"].name,
+            phone=row["customer"].phone,
+            notes=row["customer"].notes,
+            order_count=row["order_count"],
+            last_order_at=row["last_order_at"],
+        )
+        for row in rows
+    ]
+
+
+@router.patch(
+    "/{customer_id}/notes", response_model=CustomerRead,
+)
+async def update_customer_notes(
+    customer_id: uuid.UUID,
+    body: CustomerNotesUpdate,
+    db: AsyncSession = Depends(get_db),
+) -> CustomerRead:
+    try:
+        customer = await customer_service.update_notes(
+            db, customer_id, body.notes,
+        )
+    except CustomerServiceError as exc:
+        raise _service_error(exc) from exc
+    return CustomerRead.model_validate(customer)

--- a/apps/mypizzatracker/backend/app/api/public.py
+++ b/apps/mypizzatracker/backend/app/api/public.py
@@ -13,17 +13,19 @@ Endpoints (production URLs prepend ``/api``):
   GET    /public/drops/current            -- current active drop + slots w/ remaining capacity
   POST   /public/orders                   -- place an order; returns confirmation
   GET    /public/orders/{order_id}        -- look up an existing order (status check)
+  GET    /public/customers/lookup         -- "welcome back" + "the usual" by phone
 """
 from __future__ import annotations
 
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import get_db
 from app.repositories.order import order_repo
 from app.schemas.public.public_schemas import (
+    PublicCustomerLookup,
     PublicDropRead,
     PublicMenuRead,
     PublicOrderConfirmation,
@@ -93,6 +95,27 @@ async def place_public_order(
         raise _service_error(exc) from exc
 
     return await public_service.build_order_confirmation(db, order)
+
+
+@router.get("/customers/lookup", response_model=PublicCustomerLookup)
+async def lookup_public_customer(
+    phone: str = Query(..., min_length=1, max_length=30),
+    db: AsyncSession = Depends(get_db),
+) -> PublicCustomerLookup:
+    """Phone-keyed "welcome back" lookup for the public order page.
+
+    The customer's phone is the only secret here; the response only
+    includes the name they typed in last time plus the pizza-line shape
+    of their most recent non-no-show order (no IDs they couldn't already
+    see in the public menu, no PII beyond their own first name).
+
+    404 when no customer matches -- the frontend swallows it silently so
+    the lookup is a no-op for first-time orderers.
+    """
+    payload = await public_service.build_customer_lookup(db, phone)
+    if payload is None:
+        raise HTTPException(status_code=404, detail="No customer with that phone.")
+    return payload
 
 
 @router.get("/orders/{order_id}", response_model=PublicOrderConfirmation)

--- a/apps/mypizzatracker/backend/app/main.py
+++ b/apps/mypizzatracker/backend/app/main.py
@@ -20,7 +20,18 @@ from jwt.exceptions import PyJWTError as JWTError
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
 
-from app.api import account, admin, drops, financials, health, menu, public, service, totp
+from app.api import (
+    account,
+    admin,
+    customers,
+    drops,
+    financials,
+    health,
+    menu,
+    public,
+    service,
+    totp,
+)
 from app.core.audit import current_user_id
 from app.core.auth import auth_backend, fastapi_users
 from app.core.config import settings
@@ -192,6 +203,7 @@ app.include_router(menu.router)
 app.include_router(public.router)
 app.include_router(service.router)
 app.include_router(financials.router)
+app.include_router(customers.router)
 
 # Shared platform admin router -- generic user-management endpoints
 # (list/role/activate/deactivate/superuser/stats-users).

--- a/apps/mypizzatracker/backend/app/repositories/customer/customer_repo.py
+++ b/apps/mypizzatracker/backend/app/repositories/customer/customer_repo.py
@@ -5,13 +5,17 @@ responsibility -- the repo just takes the already-normalized value.
 """
 from __future__ import annotations
 
+import re
 import uuid
 from typing import Optional
 
-from sqlalchemy import select
+from sqlalchemy import func, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from app.models.customer.customer import Customer
+from app.models.order.order import Order
+from app.models.order.order_pizza import OrderPizza
 
 
 async def get_customer_by_phone(
@@ -44,3 +48,83 @@ async def update_customer(
         setattr(customer, key, value)
     await db.flush()
     return customer
+
+
+async def get_recent_order_for_customer(
+    db: AsyncSession, customer_id: uuid.UUID,
+) -> Optional[Order]:
+    """Return the customer's most recent non-no-show order, eager-loaded.
+
+    ``no_show`` orders are excluded so "the usual" reflects pizzas the
+    customer actually picked up, not ones they ghosted on.
+    """
+    stmt = (
+        select(Order)
+        .where(Order.customer_id == customer_id)
+        .where(Order.status != "no_show")
+        .options(selectinload(Order.pizzas).selectinload(OrderPizza.toppings))
+        .order_by(Order.created_at.desc())
+        .limit(1)
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def list_customers_with_stats(
+    db: AsyncSession,
+    *,
+    search: Optional[str] = None,
+    limit: int = 200,
+) -> list[dict]:
+    """Return customers with order_count + last_order_at.
+
+    Sorted by most-recent-order desc (customers who never ordered come last,
+    alphabetised by name within each bucket).
+
+    ``search`` matches case-insensitively against name and against the
+    digits-only phone substring, so ``"512"`` matches both ``"512-555-1234"``
+    and a customer named ``"512 Pizza Co"``.
+
+    The shape is a list of dicts (not Customer rows) so callers don't need
+    to know about the underlying join + subquery.
+    """
+    order_agg = (
+        select(
+            Order.customer_id.label("customer_id"),
+            func.count(Order.id).label("order_count"),
+            func.max(Order.created_at).label("last_order_at"),
+        )
+        .group_by(Order.customer_id)
+        .subquery()
+    )
+
+    stmt = (
+        select(
+            Customer,
+            order_agg.c.order_count,
+            order_agg.c.last_order_at,
+        )
+        .outerjoin(order_agg, Customer.id == order_agg.c.customer_id)
+    )
+
+    if search and search.strip():
+        digits = re.sub(r"\D+", "", search)
+        clauses = [Customer.name.ilike(f"%{search.strip()}%")]
+        if digits:
+            clauses.append(Customer.phone.like(f"%{digits}%"))
+        stmt = stmt.where(or_(*clauses))
+
+    stmt = stmt.order_by(
+        order_agg.c.last_order_at.desc().nullslast(),
+        Customer.name,
+    ).limit(limit)
+
+    result = await db.execute(stmt)
+    return [
+        {
+            "customer": row[0],
+            "order_count": int(row[1] or 0),
+            "last_order_at": row[2],
+        }
+        for row in result.all()
+    ]

--- a/apps/mypizzatracker/backend/app/schemas/customer/customer_schemas.py
+++ b/apps/mypizzatracker/backend/app/schemas/customer/customer_schemas.py
@@ -1,8 +1,10 @@
 """Pydantic schemas for Customer.
 
 The customer-facing order entry doesn't expose customer ID -- the order
-endpoint takes ``CustomerCreate`` inline and the service upserts. These
-schemas are reused by future owner-facing customer DB views (PR 10).
+endpoint takes ``CustomerCreate`` inline and the service upserts. The
+owner-facing customer DB views surface :class:`CustomerListItem` (with
+order rollup stats) and accept :class:`CustomerNotesUpdate` for inline
+notes editing.
 """
 from __future__ import annotations
 
@@ -34,3 +36,27 @@ class CustomerRead(BaseModel):
     updated_at: datetime
 
     model_config = {"from_attributes": True}
+
+
+class CustomerListItem(BaseModel):
+    """Operator-facing row for the /customers list view.
+
+    ``order_count`` excludes nothing -- it counts every order the customer
+    has ever placed, including no-shows. ``last_order_at`` is the timestamp
+    of the most recent order (any status); ``None`` for customers who
+    somehow have a row but no orders (shouldn't happen in normal flow but
+    the outer join tolerates it).
+    """
+
+    id: uuid.UUID
+    name: str
+    phone: str
+    notes: Optional[str] = None
+    order_count: int
+    last_order_at: Optional[datetime] = None
+
+
+class CustomerNotesUpdate(BaseModel):
+    """Owner-only patch shape for the ``notes`` column."""
+
+    notes: Optional[str] = Field(None, max_length=2000)

--- a/apps/mypizzatracker/backend/app/schemas/public/public_schemas.py
+++ b/apps/mypizzatracker/backend/app/schemas/public/public_schemas.py
@@ -102,3 +102,30 @@ class PublicOrderConfirmation(BaseModel):
     pizzas: list[PublicOrderPizzaConfirmation]
     total: Decimal
     created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Customer "the usual" lookup
+# ---------------------------------------------------------------------------
+
+class PublicTheUsualPizza(BaseModel):
+    """One pizza line from the customer's most recent non-no-show order,
+    filtered to items still active in today's menu."""
+
+    pizza_type_id: uuid.UUID
+    topping_type_ids: list[uuid.UUID] = Field(default_factory=list)
+    modifications_text: Optional[str] = None
+
+
+class PublicCustomerLookup(BaseModel):
+    """Response for ``GET /public/customers/lookup?phone=...``.
+
+    Returned only when a customer matches the phone. The "the usual" field
+    is the filtered pizza-line list from their most recent non-no-show
+    order; it may be empty if the menu has changed enough that none of
+    their prior items are still on offer (the frontend then shows the
+    welcome banner but suppresses the "Order the usual" button).
+    """
+
+    customer_name: str
+    the_usual: list[PublicTheUsualPizza] = Field(default_factory=list)

--- a/apps/mypizzatracker/backend/app/services/customer/customer_service.py
+++ b/apps/mypizzatracker/backend/app/services/customer/customer_service.py
@@ -19,6 +19,8 @@ public order route can translate them to HTTP 400 with a friendly message.
 from __future__ import annotations
 
 import re
+import uuid
+from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -31,6 +33,10 @@ class CustomerServiceError(Exception):
     """Base for customer rule violations."""
 
     http_status: int = 400
+
+
+class CustomerNotFoundError(CustomerServiceError):
+    http_status = 404
 
 
 _PHONE_DIGITS_RE = re.compile(r"\D+")
@@ -71,3 +77,45 @@ async def upsert_by_phone(
         return await customer_repo.update_customer(db, existing, {"name": name})
 
     return existing
+
+
+async def find_by_normalized_phone(
+    db: AsyncSession, raw_phone: str,
+) -> Optional[Customer]:
+    """Lookup a customer by phone with normalization.
+
+    Returns ``None`` if either the phone is unparseable (no digits) or the
+    customer doesn't exist -- callers map both to "not found" for the
+    public lookup endpoint.
+    """
+    try:
+        phone = normalize_phone(raw_phone)
+    except CustomerServiceError:
+        return None
+    return await customer_repo.get_customer_by_phone(db, phone)
+
+
+async def update_notes(
+    db: AsyncSession, customer_id: uuid.UUID, notes: Optional[str],
+) -> Customer:
+    """Replace the customer's ``notes`` field.
+
+    Empty string is normalised to ``None`` so the table doesn't accumulate
+    blank rows. Notes are operator-only freeform text; no length validation
+    beyond the schema's max_length.
+    """
+    customer = await customer_repo.get_customer_by_id(db, customer_id)
+    if customer is None:
+        raise CustomerNotFoundError(f"Customer {customer_id} not found.")
+
+    cleaned: Optional[str] = (notes or "").strip() or None
+    return await customer_repo.update_customer(db, customer, {"notes": cleaned})
+
+
+async def list_with_stats(
+    db: AsyncSession, *, search: Optional[str] = None, limit: int = 200,
+) -> list[dict]:
+    """Return list of customers with order_count + last_order_at."""
+    return await customer_repo.list_customers_with_stats(
+        db, search=search, limit=limit,
+    )

--- a/apps/mypizzatracker/backend/app/services/public/public_service.py
+++ b/apps/mypizzatracker/backend/app/services/public/public_service.py
@@ -18,16 +18,20 @@ from app.models.drop.drop import Drop
 from app.models.menu.pizza_type import PizzaType
 from app.models.menu.topping_type import ToppingType
 from app.models.order.order import Order
+from app.repositories.customer import customer_repo
 from app.repositories.menu import menu_repo
 from app.schemas.public.public_schemas import (
+    PublicCustomerLookup,
     PublicDropRead,
     PublicMenuRead,
     PublicOrderConfirmation,
     PublicOrderPizzaConfirmation,
     PublicPizzaRead,
     PublicSlotRead,
+    PublicTheUsualPizza,
     PublicToppingRead,
 )
+from app.services.customer import customer_service
 from app.services.order import order_service
 
 
@@ -142,6 +146,57 @@ async def build_order_confirmation(
         pizzas=pizza_lines,
         total=total,
         created_at=order.created_at,
+    )
+
+
+async def build_customer_lookup(
+    db: AsyncSession, raw_phone: str,
+) -> PublicCustomerLookup | None:
+    """Return a "welcome back" + "the usual" payload for a phone, or ``None``.
+
+    "The usual" is built from the customer's most recent non-no-show order,
+    filtered to only pizzas / toppings still ``active`` in the menu. If
+    every line had its pizza 86'd, the_usual is an empty list -- the
+    frontend treats that as "show welcome banner, hide the usual button".
+    """
+    customer = await customer_service.find_by_normalized_phone(db, raw_phone)
+    if customer is None:
+        return None
+
+    recent = await customer_repo.get_recent_order_for_customer(db, customer.id)
+    if recent is None:
+        return PublicCustomerLookup(customer_name=customer.name, the_usual=[])
+
+    pizza_type_ids = {p.pizza_type_id for p in recent.pizzas}
+    topping_type_ids: set[uuid.UUID] = set()
+    for pizza in recent.pizzas:
+        topping_type_ids.update(t.topping_type_id for t in pizza.toppings)
+
+    pizza_types = await _load_pizza_types(db, pizza_type_ids)
+    topping_types = await _load_topping_types(db, topping_type_ids)
+
+    the_usual: list[PublicTheUsualPizza] = []
+    for pizza in recent.pizzas:
+        pizza_type = pizza_types.get(pizza.pizza_type_id)
+        if pizza_type is None or not pizza_type.active:
+            continue
+        active_toppings: list[uuid.UUID] = []
+        for topping_row in pizza.toppings:
+            topping = topping_types.get(topping_row.topping_type_id)
+            if topping is None or not topping.active:
+                continue
+            active_toppings.append(topping.id)
+        the_usual.append(
+            PublicTheUsualPizza(
+                pizza_type_id=pizza_type.id,
+                topping_type_ids=active_toppings,
+                modifications_text=pizza.modifications_text,
+            ),
+        )
+
+    return PublicCustomerLookup(
+        customer_name=customer.name,
+        the_usual=the_usual,
     )
 
 

--- a/apps/mypizzatracker/backend/tests/test_customers.py
+++ b/apps/mypizzatracker/backend/tests/test_customers.py
@@ -1,0 +1,499 @@
+"""Tests for the operator-facing /customers routes + the public
+/public/customers/lookup endpoint that drives the order page's "the usual"
+button.
+
+Covers:
+- GET    /customers requires auth
+- GET    /customers returns rows with order_count + last_order_at
+- GET    /customers?search=... matches name (case-insensitive) and phone digits
+- GET    /customers returns customers without orders too (count=0)
+- PATCH  /customers/{id}/notes requires auth
+- PATCH  /customers/{id}/notes normalises blank string to None
+- PATCH  /customers/{id}/notes returns 404 for unknown id
+
+- GET    /public/customers/lookup returns 404 when no customer matches
+- GET    /public/customers/lookup returns name + the_usual on match
+- "The usual" excludes pizzas that have since been 86'd
+- "The usual" excludes toppings that have since been 86'd
+- "The usual" prefers the most recent non-no-show order over no-shows
+- Phone normalisation: "(512) 555-1234" matches "5125551234"
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from httpx import AsyncClient
+from sqlalchemy import select, update
+from sqlalchemy.ext.asyncio import AsyncSession
+from fastapi_users.password import PasswordHelper
+
+from app.models.customer.customer import Customer
+from app.models.menu.pizza_type import PizzaType
+from app.models.menu.topping_type import ToppingType
+from app.models.order.order import Order
+from app.models.user.user import User
+
+
+TEST_EMAIL = "customers-test@example.com"
+TEST_PASSWORD = "testpassword123!"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures + helpers (mirror test_public_orders.py)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def auth_client(client: AsyncClient, db: AsyncSession) -> AsyncClient:
+    result = await db.execute(select(User).where(User.email == TEST_EMAIL))
+    user = result.scalar_one_or_none()
+    if user is None:
+        helper = PasswordHelper()
+        user = User(
+            email=TEST_EMAIL,
+            hashed_password=helper.hash(TEST_PASSWORD),
+            is_verified=True,
+            is_active=True,
+        )
+        db.add(user)
+        await db.flush()
+
+    resp = await client.post(
+        "/auth/jwt/login",
+        data={"username": TEST_EMAIL, "password": TEST_PASSWORD},
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    if resp.status_code != 200:
+        pytest.skip(f"Auth failed: {resp.status_code} {resp.text}")
+    token = resp.json().get("access_token", "")
+    client.headers["Authorization"] = f"Bearer {token}"
+    return client
+
+
+async def _create_pizza(
+    auth_client: AsyncClient, name: str, price: str, active: bool = True,
+) -> str:
+    resp = await auth_client.post(
+        "/menu/pizzas",
+        json={"name": name, "price": price, "description": None, "active": active},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_topping(
+    auth_client: AsyncClient, name: str, price_delta: str, active: bool = True,
+) -> str:
+    resp = await auth_client.post(
+        "/menu/toppings",
+        json={"name": name, "price_delta": price_delta, "active": active},
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+async def _create_active_drop(
+    auth_client: AsyncClient,
+    *,
+    pickup_time: str = "12:00:00",
+    max_pizzas: int = 6,
+    name: str = "Dec 25th",
+    date: str = "2026-12-25",
+) -> tuple[str, str]:
+    drop_resp = await auth_client.post(
+        "/drops",
+        json={
+            "date": date,
+            "name": name,
+            "slot_window_start": "11:00:00",
+            "slot_window_end": "15:30:00",
+        },
+    )
+    assert drop_resp.status_code == 201, drop_resp.text
+    drop_id = drop_resp.json()["id"]
+    slot_resp = await auth_client.post(
+        f"/drops/{drop_id}/slots",
+        json={"pickup_time": pickup_time, "max_pizzas": max_pizzas},
+    )
+    assert slot_resp.status_code == 201, slot_resp.text
+    slot_id = slot_resp.json()["id"]
+    activate = await auth_client.patch(
+        f"/drops/{drop_id}", json={"status": "active"},
+    )
+    assert activate.status_code == 200, activate.text
+    return drop_id, slot_id
+
+
+async def _place_order(
+    client: AsyncClient,
+    *,
+    drop_id: str,
+    slot_id: str,
+    customer_name: str,
+    customer_phone: str,
+    pizza_id: str,
+    topping_ids: list[str] | None = None,
+    modifications_text: str | None = None,
+) -> str:
+    resp = await client.post(
+        "/public/orders",
+        json={
+            "drop_id": drop_id,
+            "slot_id": slot_id,
+            "customer_name": customer_name,
+            "customer_phone": customer_phone,
+            "payment_method_tag": "venmo",
+            "pizzas": [
+                {
+                    "pizza_type_id": pizza_id,
+                    "topping_type_ids": topping_ids or [],
+                    "modifications_text": modifications_text,
+                },
+            ],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()["order_id"]
+
+
+async def _set_pizza_active(db: AsyncSession, pizza_id: str, active: bool) -> None:
+    await db.execute(
+        update(PizzaType).where(PizzaType.id == pizza_id).values(active=active),
+    )
+    await db.flush()
+
+
+async def _set_topping_active(db: AsyncSession, topping_id: str, active: bool) -> None:
+    await db.execute(
+        update(ToppingType).where(ToppingType.id == topping_id).values(active=active),
+    )
+    await db.flush()
+
+
+# ---------------------------------------------------------------------------
+# Operator /customers list
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_customers_requires_auth(client: AsyncClient):
+    client.headers.pop("Authorization", None)
+    resp = await client.get("/customers")
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_list_customers_returns_rollup_stats(
+    client: AsyncClient, auth_client: AsyncClient,
+):
+    drop_id, slot_id = await _create_active_drop(auth_client, max_pizzas=10)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+
+    public_client = AsyncClient(
+        transport=client._transport, base_url=client.base_url,
+    )
+    try:
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Jane Doe", customer_phone="(512) 555-1234",
+            pizza_id=pizza_id,
+        )
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Jane Doe", customer_phone="(512) 555-1234",
+            pizza_id=pizza_id,
+        )
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Bob Burger", customer_phone="(415) 222-3333",
+            pizza_id=pizza_id,
+        )
+    finally:
+        await public_client.aclose()
+
+    resp = await auth_client.get("/customers")
+    assert resp.status_code == 200, resp.text
+    rows = resp.json()
+    by_phone = {r["phone"]: r for r in rows}
+
+    jane = by_phone["5125551234"]
+    assert jane["name"] == "Jane Doe"
+    assert jane["order_count"] == 2
+    assert jane["last_order_at"] is not None
+
+    bob = by_phone["4152223333"]
+    assert bob["order_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_list_customers_search_by_name_and_phone(
+    client: AsyncClient, auth_client: AsyncClient,
+):
+    drop_id, slot_id = await _create_active_drop(auth_client, max_pizzas=10)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+
+    public_client = AsyncClient(
+        transport=client._transport, base_url=client.base_url,
+    )
+    try:
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Maria Jaramillo", customer_phone="5125551234",
+            pizza_id=pizza_id,
+        )
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Henny P", customer_phone="9998887777",
+            pizza_id=pizza_id,
+        )
+    finally:
+        await public_client.aclose()
+
+    # Case-insensitive name search.
+    resp = await auth_client.get("/customers", params={"search": "maria"})
+    assert resp.status_code == 200
+    names = [r["name"] for r in resp.json()]
+    assert "Maria Jaramillo" in names
+    assert "Henny P" not in names
+
+    # Phone-digit substring search ignores formatting.
+    resp = await auth_client.get("/customers", params={"search": "(512) 555"})
+    assert resp.status_code == 200
+    phones = [r["phone"] for r in resp.json()]
+    assert "5125551234" in phones
+    assert "9998887777" not in phones
+
+
+# ---------------------------------------------------------------------------
+# Operator PATCH /customers/{id}/notes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_notes_requires_auth(client: AsyncClient):
+    client.headers.pop("Authorization", None)
+    resp = await client.patch(
+        "/customers/00000000-0000-0000-0000-000000000000/notes",
+        json={"notes": "anything"},
+    )
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_update_notes_404_for_unknown_customer(auth_client: AsyncClient):
+    resp = await auth_client.patch(
+        "/customers/00000000-0000-0000-0000-000000000000/notes",
+        json={"notes": "x"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_update_notes_persists_and_blank_becomes_null(
+    client: AsyncClient, auth_client: AsyncClient, db: AsyncSession,
+):
+    drop_id, slot_id = await _create_active_drop(auth_client, max_pizzas=10)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+    public_client = AsyncClient(
+        transport=client._transport, base_url=client.base_url,
+    )
+    try:
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Tyra Gibson", customer_phone="5121112222",
+            pizza_id=pizza_id,
+        )
+    finally:
+        await public_client.aclose()
+
+    listing = await auth_client.get("/customers")
+    customer_id = next(
+        r["id"] for r in listing.json() if r["phone"] == "5121112222"
+    )
+
+    resp = await auth_client.patch(
+        f"/customers/{customer_id}/notes",
+        json={"notes": "  prefers extra crispy crust  "},
+    )
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["notes"] == "prefers extra crispy crust"
+
+    # Blank notes => null.
+    resp = await auth_client.patch(
+        f"/customers/{customer_id}/notes",
+        json={"notes": "   "},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["notes"] is None
+
+    # Persisted in DB.
+    db_row = await db.execute(
+        select(Customer).where(Customer.phone == "5121112222"),
+    )
+    assert db_row.scalar_one().notes is None
+
+
+# ---------------------------------------------------------------------------
+# Public /public/customers/lookup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_lookup_404_when_no_customer(client: AsyncClient):
+    client.headers.pop("Authorization", None)
+    resp = await client.get(
+        "/public/customers/lookup", params={"phone": "5125550000"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_lookup_returns_name_and_the_usual(
+    client: AsyncClient, auth_client: AsyncClient,
+):
+    drop_id, slot_id = await _create_active_drop(auth_client, max_pizzas=10)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+    topping_id = await _create_topping(auth_client, "Mushrooms", "0")
+
+    public_client = AsyncClient(
+        transport=client._transport, base_url=client.base_url,
+    )
+    try:
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Jonathan Castillo",
+            customer_phone="5125551234",
+            pizza_id=pizza_id,
+            topping_ids=[topping_id],
+            modifications_text="extra crispy",
+        )
+    finally:
+        await public_client.aclose()
+
+    client.headers.pop("Authorization", None)
+    resp = await client.get(
+        "/public/customers/lookup", params={"phone": "(512) 555-1234"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["customer_name"] == "Jonathan Castillo"
+    assert len(body["the_usual"]) == 1
+    line = body["the_usual"][0]
+    assert line["pizza_type_id"] == pizza_id
+    assert line["topping_type_ids"] == [topping_id]
+    assert line["modifications_text"] == "extra crispy"
+
+
+@pytest.mark.asyncio
+async def test_lookup_filters_out_inactive_pizza_from_the_usual(
+    client: AsyncClient, auth_client: AsyncClient, db: AsyncSession,
+):
+    drop_id, slot_id = await _create_active_drop(auth_client, max_pizzas=10)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+
+    public_client = AsyncClient(
+        transport=client._transport, base_url=client.base_url,
+    )
+    try:
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Janette", customer_phone="5125559999",
+            pizza_id=pizza_id,
+        )
+    finally:
+        await public_client.aclose()
+
+    # 86 the pizza after the order.
+    await _set_pizza_active(db, pizza_id, False)
+
+    client.headers.pop("Authorization", None)
+    resp = await client.get(
+        "/public/customers/lookup", params={"phone": "5125559999"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["customer_name"] == "Janette"
+    assert body["the_usual"] == []  # filtered out
+
+
+@pytest.mark.asyncio
+async def test_lookup_filters_out_inactive_topping_keeps_pizza(
+    client: AsyncClient, auth_client: AsyncClient, db: AsyncSession,
+):
+    drop_id, slot_id = await _create_active_drop(auth_client, max_pizzas=10)
+    pizza_id = await _create_pizza(auth_client, "La Clasica", "17.00")
+    keep_topping = await _create_topping(auth_client, "Mushrooms", "0")
+    drop_topping = await _create_topping(auth_client, "Truffle", "5.00")
+
+    public_client = AsyncClient(
+        transport=client._transport, base_url=client.base_url,
+    )
+    try:
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Bryan Ruezga", customer_phone="5125557777",
+            pizza_id=pizza_id, topping_ids=[keep_topping, drop_topping],
+        )
+    finally:
+        await public_client.aclose()
+
+    await _set_topping_active(db, drop_topping, False)
+
+    client.headers.pop("Authorization", None)
+    resp = await client.get(
+        "/public/customers/lookup", params={"phone": "5125557777"},
+    )
+    assert resp.status_code == 200
+    line = resp.json()["the_usual"][0]
+    assert line["topping_type_ids"] == [keep_topping]
+
+
+@pytest.mark.asyncio
+async def test_lookup_excludes_no_show_orders_from_the_usual(
+    client: AsyncClient, auth_client: AsyncClient, db: AsyncSession,
+):
+    drop_id, slot_id = await _create_active_drop(auth_client, max_pizzas=10)
+    earlier_pizza = await _create_pizza(auth_client, "La Clasica", "17.00")
+    later_pizza = await _create_pizza(auth_client, "La Toxica", "19.00")
+
+    public_client = AsyncClient(
+        transport=client._transport, base_url=client.base_url,
+    )
+    try:
+        # First order -- will become the "usual"; second order is marked no_show.
+        await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Kevlin Ware", customer_phone="5125558888",
+            pizza_id=earlier_pizza,
+        )
+        no_show_id = await _place_order(
+            public_client,
+            drop_id=drop_id, slot_id=slot_id,
+            customer_name="Kevlin Ware", customer_phone="5125558888",
+            pizza_id=later_pizza,
+        )
+    finally:
+        await public_client.aclose()
+
+    await db.execute(
+        update(Order).where(Order.id == no_show_id).values(status="no_show"),
+    )
+    await db.flush()
+
+    client.headers.pop("Authorization", None)
+    resp = await client.get(
+        "/public/customers/lookup", params={"phone": "5125558888"},
+    )
+    assert resp.status_code == 200
+    line = resp.json()["the_usual"][0]
+    assert line["pizza_type_id"] == earlier_pizza

--- a/apps/mypizzatracker/frontend/src/RootLayout.tsx
+++ b/apps/mypizzatracker/frontend/src/RootLayout.tsx
@@ -1,5 +1,5 @@
 import { Outlet, ScrollRestoration } from "react-router-dom";
-import { ChefHat, DollarSign, Home, Pizza, Settings, Shield, UtensilsCrossed } from "lucide-react";
+import { ChefHat, DollarSign, Home, Pizza, Settings, Shield, Users, UtensilsCrossed } from "lucide-react";
 import { AppShell, RequireAuth, StepUpModal, Toaster, useIsAuthenticated } from "@platform/ui";
 import { buildNav } from "@/constants/nav";
 import { signOut } from "@/lib/auth";
@@ -25,6 +25,7 @@ const ICONS: Record<string, React.ReactNode> = {
   UtensilsCrossed: <UtensilsCrossed className="w-5 h-5" />,
   ChefHat: <ChefHat className="w-5 h-5" />,
   DollarSign: <DollarSign className="w-5 h-5" />,
+  Users: <Users className="w-5 h-5" />,
   Settings: <Settings className="w-5 h-5" />,
   Shield: <Shield className="w-5 h-5" />,
 };

--- a/apps/mypizzatracker/frontend/src/__tests__/applyTheUsual.test.ts
+++ b/apps/mypizzatracker/frontend/src/__tests__/applyTheUsual.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  countPhoneDigits,
+  selectOrderableTheUsual,
+} from "@/features/public-order/applyTheUsual";
+import type {
+  PublicMenu,
+  PublicTheUsualPizza,
+} from "@/types/public/public";
+
+const PIZZA_ID_A = "pizza-a";
+const PIZZA_ID_B = "pizza-b";
+const TOPPING_ID_X = "topping-x";
+const TOPPING_ID_Y = "topping-y";
+
+function menu(opts: {
+  pizzas?: string[];
+  toppings?: string[];
+}): PublicMenu {
+  return {
+    pizzas: (opts.pizzas ?? []).map((id) => ({
+      id,
+      name: id,
+      price: "10.00",
+      description: null,
+    })),
+    toppings: (opts.toppings ?? []).map((id) => ({
+      id,
+      name: id,
+      price_delta: "0",
+    })),
+  };
+}
+
+function line(
+  pizza_type_id: string,
+  topping_type_ids: string[] = [],
+  modifications_text: string | null = null,
+): PublicTheUsualPizza {
+  return { pizza_type_id, topping_type_ids, modifications_text };
+}
+
+describe("selectOrderableTheUsual", () => {
+  it("returns empty when menu has none of the prior pizzas", () => {
+    const result = selectOrderableTheUsual(
+      [line(PIZZA_ID_A)],
+      menu({ pizzas: [PIZZA_ID_B] }),
+    );
+    expect(result).toEqual([]);
+  });
+
+  it("passes through pizzas that are still active", () => {
+    const result = selectOrderableTheUsual(
+      [line(PIZZA_ID_A, [TOPPING_ID_X], "extra crispy")],
+      menu({ pizzas: [PIZZA_ID_A], toppings: [TOPPING_ID_X] }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({
+      pizza_type_id: PIZZA_ID_A,
+      topping_type_ids: [TOPPING_ID_X],
+      modifications_text: "extra crispy",
+    });
+  });
+
+  it("strips toppings that are no longer on the menu", () => {
+    const result = selectOrderableTheUsual(
+      [line(PIZZA_ID_A, [TOPPING_ID_X, TOPPING_ID_Y])],
+      menu({ pizzas: [PIZZA_ID_A], toppings: [TOPPING_ID_X] }),
+    );
+    expect(result[0].topping_type_ids).toEqual([TOPPING_ID_X]);
+  });
+
+  it("normalises null modifications_text to an empty string", () => {
+    const result = selectOrderableTheUsual(
+      [line(PIZZA_ID_A)],
+      menu({ pizzas: [PIZZA_ID_A] }),
+    );
+    expect(result[0].modifications_text).toBe("");
+  });
+
+  it("drops 86'd pizzas but keeps remaining orderable lines", () => {
+    const result = selectOrderableTheUsual(
+      [line(PIZZA_ID_A), line(PIZZA_ID_B)],
+      menu({ pizzas: [PIZZA_ID_B] }),
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0].pizza_type_id).toBe(PIZZA_ID_B);
+  });
+});
+
+describe("countPhoneDigits", () => {
+  it("counts only digit characters", () => {
+    expect(countPhoneDigits("(512) 555-1234")).toBe(10);
+    expect(countPhoneDigits("abc")).toBe(0);
+    expect(countPhoneDigits("")).toBe(0);
+    expect(countPhoneDigits("5")).toBe(1);
+  });
+});

--- a/apps/mypizzatracker/frontend/src/constants/nav.ts
+++ b/apps/mypizzatracker/frontend/src/constants/nav.ts
@@ -18,6 +18,7 @@ const NAV_DESCRIPTORS: NavDescriptor[] = [
   { path: "/menu", label: "Menu", iconName: "UtensilsCrossed" },
   { path: "/service", label: "Service", iconName: "ChefHat" },
   { path: "/financials", label: "Financials", iconName: "DollarSign" },
+  { path: "/customers", label: "Customers", iconName: "Users" },
   { path: "/settings", label: "Settings", iconName: "Settings" },
   { path: "/security", label: "Security", iconName: "Shield" },
 ];

--- a/apps/mypizzatracker/frontend/src/features/public-order/applyTheUsual.ts
+++ b/apps/mypizzatracker/frontend/src/features/public-order/applyTheUsual.ts
@@ -1,0 +1,52 @@
+import type {
+  PublicMenu,
+  PublicTheUsualPizza,
+} from "@/types/public/public";
+
+export interface TheUsualLine {
+  pizza_type_id: string;
+  topping_type_ids: string[];
+  modifications_text: string;
+}
+
+/**
+ * Take a "the usual" payload from the backend and the current public menu,
+ * and return the lines that can actually be ordered today.
+ *
+ * The backend already filters out 86'd pizzas / toppings, but the menu the
+ * customer sees could have shifted again between the lookup and the
+ * "Order the usual" click. Defensive double-filter — drop lines whose pizza
+ * isn't in ``menu.pizzas`` and remove toppings not in ``menu.toppings``.
+ *
+ * Returns an empty array when none of the prior items are orderable; the
+ * caller suppresses the "Order the usual" button in that case.
+ */
+export function selectOrderableTheUsual(
+  theUsual: PublicTheUsualPizza[],
+  menu: PublicMenu,
+): TheUsualLine[] {
+  const pizzaIds = new Set(menu.pizzas.map((p) => p.id));
+  const toppingIds = new Set(menu.toppings.map((t) => t.id));
+
+  const lines: TheUsualLine[] = [];
+  for (const line of theUsual) {
+    if (!pizzaIds.has(line.pizza_type_id)) continue;
+    lines.push({
+      pizza_type_id: line.pizza_type_id,
+      topping_type_ids: line.topping_type_ids.filter((id) =>
+        toppingIds.has(id),
+      ),
+      modifications_text: line.modifications_text ?? "",
+    });
+  }
+  return lines;
+}
+
+/**
+ * Count digits in a free-form phone string. Used to gate when the
+ * customer-lookup query should fire (we want at least a usable number,
+ * not a single keystroke).
+ */
+export function countPhoneDigits(raw: string): number {
+  return (raw.match(/\d/g) || []).length;
+}

--- a/apps/mypizzatracker/frontend/src/features/public-order/useDebouncedValue.ts
+++ b/apps/mypizzatracker/frontend/src/features/public-order/useDebouncedValue.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Debounce a value: returns the latest input after ``delayMs`` of quiet.
+ * Used by the public order page so the phone-keyed "the usual" lookup
+ * doesn't fire on every keystroke while the customer is typing.
+ */
+export function useDebouncedValue<T>(value: T, delayMs: number): T {
+  const [debounced, setDebounced] = useState<T>(value);
+
+  useEffect(() => {
+    const id = window.setTimeout(() => setDebounced(value), delayMs);
+    return () => window.clearTimeout(id);
+  }, [value, delayMs]);
+
+  return debounced;
+}

--- a/apps/mypizzatracker/frontend/src/pages/Customers.tsx
+++ b/apps/mypizzatracker/frontend/src/pages/Customers.tsx
@@ -1,0 +1,246 @@
+import { useMemo, useState } from "react";
+import {
+  Card,
+  Button,
+  LoadingButton,
+  Skeleton,
+  EmptyState,
+  showError,
+  showSuccess,
+  extractErrorMessage,
+} from "@platform/ui";
+import { Check, Pencil, Phone, Search, X } from "lucide-react";
+import {
+  useListCustomersQuery,
+  useUpdateCustomerNotesMutation,
+} from "@/store/customersApi";
+import { useDebouncedValue } from "@/features/public-order/useDebouncedValue";
+import type { CustomerListItem } from "@/types/customer/customer";
+
+/**
+ * Operator-only customer DB view. Single-screen workflow:
+ *   1. Type into the search box to filter (name OR phone digits, debounced).
+ *   2. Each row shows name, phone, order count, last-seen date.
+ *   3. Notes column is inline-editable -- click pencil to edit, save/cancel
+ *      to commit/back out. Saved notes are operator-only ("prefers extra
+ *      crispy", "gluten sensitive", "always shows up 20m late").
+ *
+ * Notes are never shown to the customer -- they live for the operator's
+ * own memory and surface here only.
+ */
+export default function CustomersPage() {
+  const [searchInput, setSearchInput] = useState("");
+  const debouncedSearch = useDebouncedValue(searchInput.trim(), 300);
+
+  const query = useListCustomersQuery(
+    debouncedSearch ? { search: debouncedSearch } : undefined,
+  );
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-5xl">
+      <header>
+        <h1 className="text-2xl font-semibold">Customers</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Everyone who has ever placed an order. Use the notes column to
+          remember preferences -- the customer never sees them.
+        </p>
+      </header>
+
+      <Card>
+        <label className="flex items-center gap-2 text-sm">
+          <Search className="h-4 w-4 text-muted-foreground" />
+          <input
+            type="search"
+            value={searchInput}
+            onChange={(e) => setSearchInput(e.target.value)}
+            placeholder="Search by name or phone..."
+            className="flex-1 px-3 py-2 rounded border bg-background text-sm"
+          />
+        </label>
+      </Card>
+
+      {query.isLoading ? <ListSkeleton /> : null}
+
+      {query.isError ? (
+        <EmptyState
+          heading="Could not load customers"
+          body={extractErrorMessage(query.error) || "Please try again."}
+          action={{ label: "Retry", onClick: () => query.refetch() }}
+        />
+      ) : null}
+
+      {query.data ? (
+        query.data.length === 0 ? (
+          <EmptyState
+            heading={
+              debouncedSearch
+                ? `No customers match "${debouncedSearch}"`
+                : "No customers yet"
+            }
+            body={
+              debouncedSearch
+                ? "Try a different name or phone fragment."
+                : "Customers show up here after their first order."
+            }
+          />
+        ) : (
+          <CustomerList rows={query.data} />
+        )
+      ) : null}
+    </main>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <div className="space-y-3">
+      {[0, 1, 2].map((i) => (
+        <Card key={i}>
+          <Skeleton className="h-4 w-1/3 mb-2" />
+          <Skeleton className="h-3 w-1/2" />
+        </Card>
+      ))}
+    </div>
+  );
+}
+
+interface CustomerListProps {
+  rows: CustomerListItem[];
+}
+
+function CustomerList({ rows }: CustomerListProps) {
+  return (
+    <ul className="space-y-3">
+      {rows.map((row) => (
+        <li key={row.id}>
+          <CustomerCard row={row} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+interface CustomerCardProps {
+  row: CustomerListItem;
+}
+
+function CustomerCard({ row }: CustomerCardProps) {
+  const [editing, setEditing] = useState(false);
+  const [draftNotes, setDraftNotes] = useState(row.notes ?? "");
+  const [updateNotes, { isLoading }] = useUpdateCustomerNotesMutation();
+
+  const formattedPhone = useMemo(() => formatPhone(row.phone), [row.phone]);
+  const lastSeen = useMemo(() => formatLastSeen(row.last_order_at), [
+    row.last_order_at,
+  ]);
+
+  const save = async () => {
+    try {
+      await updateNotes({
+        customerId: row.id,
+        body: { notes: draftNotes },
+      }).unwrap();
+      showSuccess("Notes saved");
+      setEditing(false);
+    } catch (err) {
+      showError(extractErrorMessage(err) || "Could not save notes");
+    }
+  };
+
+  const cancel = () => {
+    setDraftNotes(row.notes ?? "");
+    setEditing(false);
+  };
+
+  return (
+    <Card>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-base font-medium truncate">{row.name}</h3>
+          <p className="text-xs text-muted-foreground flex items-center gap-1 mt-0.5">
+            <Phone className="h-3 w-3" />
+            {formattedPhone}
+          </p>
+        </div>
+        <div className="text-right text-xs text-muted-foreground shrink-0">
+          <div>{row.order_count} order{row.order_count === 1 ? "" : "s"}</div>
+          <div>Last: {lastSeen}</div>
+        </div>
+      </div>
+
+      <div className="mt-3">
+        {editing ? (
+          <div className="space-y-2">
+            <textarea
+              value={draftNotes}
+              onChange={(e) => setDraftNotes(e.target.value)}
+              rows={3}
+              maxLength={2000}
+              placeholder="e.g. prefers extra crispy crust"
+              className="w-full px-3 py-2 rounded border bg-background text-sm"
+            />
+            <div className="flex gap-2">
+              <LoadingButton
+                size="sm"
+                isLoading={isLoading}
+                loadingText="Saving..."
+                onClick={save}
+              >
+                <Check className="h-4 w-4 mr-1" /> Save
+              </LoadingButton>
+              <Button size="sm" variant="ghost" onClick={cancel}>
+                <X className="h-4 w-4 mr-1" /> Cancel
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className="flex items-start justify-between gap-3">
+            <p className="text-sm text-muted-foreground flex-1 whitespace-pre-wrap">
+              {row.notes ? row.notes : <em className="text-xs">No notes yet</em>}
+            </p>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setDraftNotes(row.notes ?? "");
+                setEditing(true);
+              }}
+              aria-label={`Edit notes for ${row.name}`}
+            >
+              <Pencil className="h-4 w-4" />
+            </Button>
+          </div>
+        )}
+      </div>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatPhone(digits: string): string {
+  // Render US-style 10-digit phones as (XXX) XXX-XXXX; pass anything else through.
+  if (/^\d{10}$/.test(digits)) {
+    return `(${digits.slice(0, 3)}) ${digits.slice(3, 6)}-${digits.slice(6)}`;
+  }
+  return digits;
+}
+
+function formatLastSeen(iso: string | null): string {
+  if (!iso) return "never";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "never";
+  const now = new Date();
+  const sameDay =
+    d.getFullYear() === now.getFullYear()
+    && d.getMonth() === now.getMonth()
+    && d.getDate() === now.getDate();
+  if (sameDay) return "today";
+  const diffDays = Math.floor((now.getTime() - d.getTime()) / (1000 * 60 * 60 * 24));
+  if (diffDays === 1) return "yesterday";
+  if (diffDays < 7) return `${diffDays}d ago`;
+  if (diffDays < 30) return `${Math.floor(diffDays / 7)}w ago`;
+  return d.toLocaleDateString();
+}

--- a/apps/mypizzatracker/frontend/src/pages/PublicOrder.tsx
+++ b/apps/mypizzatracker/frontend/src/pages/PublicOrder.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import {
   Card,
@@ -10,10 +10,11 @@ import {
   showError,
   extractErrorMessage,
 } from "@platform/ui";
-import { Plus, Trash2, Pizza, ArrowRight } from "lucide-react";
+import { Plus, Trash2, Pizza, ArrowRight, Sparkles } from "lucide-react";
 import {
   useGetCurrentPublicDropQuery,
   useGetPublicMenuQuery,
+  useLookupPublicCustomerQuery,
   usePlacePublicOrderMutation,
 } from "@/store/publicApi";
 import type {
@@ -33,6 +34,11 @@ import {
   paymentMethodLabel,
 } from "@/features/public-order/formatters";
 import { saveOrder } from "@/features/public-order/savedOrders";
+import {
+  countPhoneDigits,
+  selectOrderableTheUsual,
+} from "@/features/public-order/applyTheUsual";
+import { useDebouncedValue } from "@/features/public-order/useDebouncedValue";
 
 /**
  * Customer-facing order placement page (mounted at /order, no auth).
@@ -200,7 +206,57 @@ function OrderBuilder({ drop, menu, onPlaced }: OrderBuilderProps) {
   const [paymentMethod, setPaymentMethod] = useState<string>(
     PAYMENT_METHOD_OPTIONS[0]?.tag ?? "venmo",
   );
+  // Once the customer has applied "the usual", they shouldn't be re-prompted
+  // every time they tweak the phone. Locking the banner after one apply keeps
+  // the page calm; clearing the phone field resets it.
+  const [usualApplied, setUsualApplied] = useState(false);
   const [placeOrder, { isLoading }] = usePlacePublicOrderMutation();
+
+  // Debounce + gate the customer lookup. Only fire when the customer has
+  // typed something that could realistically match a phone (>=7 digits) and
+  // when the value has been still for 400ms.
+  const debouncedPhone = useDebouncedValue(customerPhone, 400);
+  const debouncedDigits = countPhoneDigits(debouncedPhone);
+  const lookupQuery = useLookupPublicCustomerQuery(debouncedPhone, {
+    skip: debouncedDigits < 7 || usualApplied,
+  });
+
+  // If the customer name field is empty when a match returns, pre-fill it.
+  // Never overwrite something the customer typed.
+  useEffect(() => {
+    if (
+      lookupQuery.data?.customer_name
+      && customerName.trim() === ""
+    ) {
+      setCustomerName(lookupQuery.data.customer_name);
+    }
+  }, [lookupQuery.data, customerName]);
+
+  // Clearing the phone resets the "applied" lock so a different customer
+  // on a shared device can get their own "welcome back".
+  useEffect(() => {
+    if (countPhoneDigits(customerPhone) < 7 && usualApplied) {
+      setUsualApplied(false);
+    }
+  }, [customerPhone, usualApplied]);
+
+  const orderableTheUsual = useMemo(() => {
+    if (!lookupQuery.data) return [];
+    return selectOrderableTheUsual(lookupQuery.data.the_usual, menu);
+  }, [lookupQuery.data, menu]);
+
+  const applyTheUsual = () => {
+    if (orderableTheUsual.length === 0) return;
+    setLines(
+      orderableTheUsual.map((line) => ({
+        localId: cryptoRandomId(),
+        pizza_type_id: line.pizza_type_id,
+        topping_type_ids: new Set(line.topping_type_ids),
+        modifications_text: line.modifications_text,
+      })),
+    );
+    setUsualApplied(true);
+  };
 
   const selectedSlot = drop.slots.find((s) => s.id === selectedSlotId);
   const slotsWithCapacity = drop.slots.filter((s) => s.remaining_pizzas > 0);
@@ -342,6 +398,15 @@ function OrderBuilder({ drop, menu, onPlaced }: OrderBuilderProps) {
               autoComplete="tel"
             />
           </FormField>
+
+          {lookupQuery.data ? (
+            <WelcomeBack
+              name={lookupQuery.data.customer_name}
+              theUsualCount={orderableTheUsual.length}
+              applied={usualApplied}
+              onApply={applyTheUsual}
+            />
+          ) : null}
           <FormField label="How will you pay?" required>
             <div className="flex flex-wrap gap-2">
               {PAYMENT_METHOD_OPTIONS.map((opt) => (
@@ -544,6 +609,48 @@ function ToppingChip({ topping, selected, onClick }: ToppingChipProps) {
       {topping.name}
       {priceSuffix}
     </button>
+  );
+}
+
+interface WelcomeBackProps {
+  name: string;
+  theUsualCount: number;
+  applied: boolean;
+  onApply: () => void;
+}
+
+function WelcomeBack({ name, theUsualCount, applied, onApply }: WelcomeBackProps) {
+  return (
+    <div className="rounded border border-primary/40 bg-primary/5 px-3 py-2 flex items-start gap-3">
+      <Sparkles className="h-4 w-4 mt-0.5 text-primary shrink-0" />
+      <div className="flex-1">
+        <p className="text-sm font-medium">Welcome back, {name}!</p>
+        {applied ? (
+          <p className="text-xs text-muted-foreground mt-0.5">
+            Your usual order has been loaded -- adjust the pizzas below as needed.
+          </p>
+        ) : theUsualCount > 0 ? (
+          <>
+            <p className="text-xs text-muted-foreground mt-0.5">
+              Want to order your usual? We can fill in your last order's{" "}
+              {theUsualCount === 1 ? "pizza" : `${theUsualCount} pizzas`} for you.
+            </p>
+            <Button
+              size="sm"
+              className="mt-2"
+              onClick={onApply}
+              aria-label="Order the usual"
+            >
+              Order the usual
+            </Button>
+          </>
+        ) : (
+          <p className="text-xs text-muted-foreground mt-0.5">
+            (Your previous picks aren't on the current menu -- pick fresh below.)
+          </p>
+        )}
+      </div>
+    </div>
   );
 }
 

--- a/apps/mypizzatracker/frontend/src/routes.tsx
+++ b/apps/mypizzatracker/frontend/src/routes.tsx
@@ -4,6 +4,7 @@ import Drops from "@/pages/Drops";
 import Menu from "@/pages/Menu";
 import Service from "@/pages/Service";
 import Financials from "@/pages/Financials";
+import Customers from "@/pages/Customers";
 import Security from "@/pages/Security";
 import Settings from "@/pages/Settings";
 import Login from "@/pages/Login";
@@ -29,6 +30,7 @@ export const routes: RouteObject[] = [
       { path: "/menu", element: <Menu /> },
       { path: "/service", element: <Service /> },
       { path: "/financials", element: <Financials /> },
+      { path: "/customers", element: <Customers /> },
       { path: "/settings", element: <Settings /> },
       { path: "/security", element: <Security /> },
     ],

--- a/apps/mypizzatracker/frontend/src/store/customersApi.ts
+++ b/apps/mypizzatracker/frontend/src/store/customersApi.ts
@@ -1,0 +1,48 @@
+import { baseApi } from "@platform/ui";
+import type {
+  CustomerListItem,
+  CustomerNotesUpdate,
+  CustomerRead,
+} from "@/types/customer/customer";
+
+const apiWithTags = baseApi.enhanceEndpoints({
+  addTagTypes: ["Customer"],
+});
+
+const customersApi = apiWithTags.injectEndpoints({
+  endpoints: (build) => ({
+    listCustomers: build.query<CustomerListItem[], { search?: string } | void>({
+      query: (arg) => ({
+        url: "/customers",
+        method: "GET",
+        params: arg?.search ? { search: arg.search } : undefined,
+      }),
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.map((c) => ({ type: "Customer" as const, id: c.id })),
+              { type: "Customer" as const, id: "LIST" },
+            ]
+          : [{ type: "Customer" as const, id: "LIST" }],
+    }),
+    updateCustomerNotes: build.mutation<
+      CustomerRead,
+      { customerId: string; body: CustomerNotesUpdate }
+    >({
+      query: ({ customerId, body }) => ({
+        url: `/customers/${customerId}/notes`,
+        method: "PATCH",
+        data: body,
+      }),
+      invalidatesTags: (_result, _err, { customerId }) => [
+        { type: "Customer", id: customerId },
+        { type: "Customer", id: "LIST" },
+      ],
+    }),
+  }),
+});
+
+export const {
+  useListCustomersQuery,
+  useUpdateCustomerNotesMutation,
+} = customersApi;

--- a/apps/mypizzatracker/frontend/src/store/publicApi.ts
+++ b/apps/mypizzatracker/frontend/src/store/publicApi.ts
@@ -1,5 +1,6 @@
 import { baseApi } from "@platform/ui";
 import type {
+  PublicCustomerLookup,
   PublicDrop,
   PublicMenu,
   PublicOrderConfirmation,
@@ -32,6 +33,13 @@ const publicApi = baseApi.injectEndpoints({
         method: "GET",
       }),
     }),
+    lookupPublicCustomer: build.query<PublicCustomerLookup, string>({
+      query: (phone) => ({
+        url: "/public/customers/lookup",
+        method: "GET",
+        params: { phone },
+      }),
+    }),
   }),
 });
 
@@ -40,4 +48,5 @@ export const {
   useGetCurrentPublicDropQuery,
   usePlacePublicOrderMutation,
   useGetPublicOrderQuery,
+  useLookupPublicCustomerQuery,
 } = publicApi;

--- a/apps/mypizzatracker/frontend/src/types/customer/customer.ts
+++ b/apps/mypizzatracker/frontend/src/types/customer/customer.ts
@@ -1,0 +1,26 @@
+/**
+ * Customer-DB types -- mirrors backend schemas at
+ * apps/mypizzatracker/backend/app/schemas/customer/customer_schemas.py
+ */
+
+export interface CustomerListItem {
+  id: string;
+  name: string;
+  phone: string;
+  notes: string | null;
+  order_count: number;
+  last_order_at: string | null; // ISO timestamp
+}
+
+export interface CustomerRead {
+  id: string;
+  name: string;
+  phone: string;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface CustomerNotesUpdate {
+  notes: string | null;
+}

--- a/apps/mypizzatracker/frontend/src/types/public/public.ts
+++ b/apps/mypizzatracker/frontend/src/types/public/public.ts
@@ -114,3 +114,24 @@ export const PAYMENT_METHOD_OPTIONS: { tag: string; label: string }[] = [
   { tag: "applepay", label: "Apple Pay" },
   { tag: "cash", label: "Cash" },
 ];
+
+// ---------------------------------------------------------------------------
+// "The usual" lookup
+// ---------------------------------------------------------------------------
+
+export interface PublicTheUsualPizza {
+  pizza_type_id: string;
+  topping_type_ids: string[];
+  modifications_text: string | null;
+}
+
+/**
+ * Returned by GET /public/customers/lookup?phone=... when a customer
+ * matches. ``the_usual`` is the customer's most recent non-no-show order's
+ * pizza lines, filtered to items still active in today's menu -- the list
+ * may be empty if every prior item has since been 86'd.
+ */
+export interface PublicCustomerLookup {
+  customer_name: string;
+  the_usual: PublicTheUsualPizza[];
+}


### PR DESCRIPTION
## Summary

Phase 1's last MyPizzaTracker feature. Wires the Customer model (created in PR 5) into both customer-facing and owner-facing surfaces.

- **Public order page** does a debounced phone lookup (>=7 digits, 400ms quiet). On match it shows a *Welcome back, {name}!* banner with an *Order the usual* button that pre-fills pizza lines from the customer's most recent non-no-show order, filtered to only items still active in today's menu (server-side filter + client-side double-check).
- **/customers operator page** with substring search by name OR phone digits, per-row order count + last-seen, inline-editable notes (operator-only freeform; never shown to the customer).

Bundled in this PR: `.github/workflows/ci-mypizzatracker.yml`. MPT had no CI for backend pytest — the 326 LOC from PR 9 (and the 11 new tests here) wouldn't have caught regressions. Mirrors `ci-mygamingassistant.yml`: deps-resolve, backend-tests with Postgres service, frontend-build, caddy-image.

## What's in it

Backend:
- `GET /public/customers/lookup?phone=...` — 404 when no customer, else `{customer_name, the_usual: [{pizza_type_id, topping_type_ids[], modifications_text}]}`. Filters out pizzas/toppings that have since been 86'd; excludes no-show orders.
- `GET /customers?search=...` (operator) — list with `order_count` + `last_order_at` rollup via outerjoin subquery; case-insensitive name match, digits-only phone substring match.
- `PATCH /customers/{id}/notes` (operator) — replaces notes, normalises blank string to NULL.
- `customer_service.find_by_normalized_phone()`, `update_notes()`, `list_with_stats()`.

Frontend:
- `useDebouncedValue` hook + `selectOrderableTheUsual` + `countPhoneDigits` helpers.
- `Customers` page with search, list, inline notes editor.
- `WelcomeBack` banner inside `PublicOrder`'s details card, below the phone input.
- `customersApi` (operator) + `lookupPublicCustomer` (public) RTK Query slices.

Tests:
- Backend: 11 new pytest in `test_customers.py` covering lookup 404/200, the_usual filtering (86'd pizza, 86'd topping, no-show exclusion), phone normalisation, owner list rollup stats, search by name + phone digits, notes blank-to-null normalisation, auth gating.
- Frontend: 6 new vitest in `applyTheUsual.test.ts`. Existing 15 still green (21 total).

## Test plan

- [ ] CI: `ci-mypizzatracker.yml` runs backend-tests against Postgres service and reports all green
- [ ] CI: frontend-build + caddy-image jobs green
- [ ] Existing 5 CodeQL/secret/dep checks still green
- [ ] Manual: customer-facing — type a returning customer's phone, banner appears, "Order the usual" pre-fills pizzas correctly
- [ ] Manual: customer-facing — type a new phone, no banner
- [ ] Manual: operator — `/customers` page lists customers, search filters by name and phone, notes save/cancel work

🤖 Generated with [Claude Code](https://claude.com/claude-code)