### PR TITLE
fix(deploy): serialize VPS deploys with flock to stop git-ref race

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -29,9 +29,33 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          command_timeout: 10m
+          # Generous: deploys are serialized via the flock below, so a
+          # later app can wait through several earlier app deploys before
+          # its own runs. 10m was too tight once deploys serialize.
+          command_timeout: 30m
           script: |
             set -e
+
+            # Serialize deploys across ALL apps on this shared VPS.
+            # Every app's deploy SSHes here and `git pull`s the SAME
+            # /srv/myfreeapps checkout; a `packages/**` change fans out
+            # to every app's deploy workflow at once. Without this lock
+            # they race on the shared git refs — observed failures:
+            #   error: cannot lock ref 'refs/remotes/origin/main'
+            #   fatal: Cannot fast-forward to multiple branches
+            # flock gives mutual exclusion WITHOUT dropping any app's
+            # deploy. A shared GitHub `concurrency` group can't be used
+            # here: it cancels intermediate *pending* runs, silently
+            # skipping some apps. So `concurrency.group` stays per-app
+            # (GitHub runs all of them) and this lock orders them. The
+            # lock auto-releases when this SSH script exits, even on
+            # failure (FD closed on process exit).
+            exec 9>/tmp/myfreeapps-deploy.lock
+            if ! flock -w 1500 9; then
+              echo "::error::Timed out (25m) waiting for the VPS deploy lock — an earlier app deploy is wedged. Investigate before retrying."
+              exit 1
+            fi
+
             cd /srv/myfreeapps
 
             echo "--- Pull latest code ---"

--- a/.github/workflows/deploy-mygamingassistant.yml
+++ b/.github/workflows/deploy-mygamingassistant.yml
@@ -29,9 +29,33 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          command_timeout: 10m
+          # Generous: deploys are serialized via the flock below, so a
+          # later app can wait through several earlier app deploys before
+          # its own runs. 10m was too tight once deploys serialize.
+          command_timeout: 30m
           script: |
             set -e
+
+            # Serialize deploys across ALL apps on this shared VPS.
+            # Every app's deploy SSHes here and `git pull`s the SAME
+            # /srv/myfreeapps checkout; a `packages/**` change fans out
+            # to every app's deploy workflow at once. Without this lock
+            # they race on the shared git refs — observed failures:
+            #   error: cannot lock ref 'refs/remotes/origin/main'
+            #   fatal: Cannot fast-forward to multiple branches
+            # flock gives mutual exclusion WITHOUT dropping any app's
+            # deploy. A shared GitHub `concurrency` group can't be used
+            # here: it cancels intermediate *pending* runs, silently
+            # skipping some apps. So `concurrency.group` stays per-app
+            # (GitHub runs all of them) and this lock orders them. The
+            # lock auto-releases when this SSH script exits, even on
+            # failure (FD closed on process exit).
+            exec 9>/tmp/myfreeapps-deploy.lock
+            if ! flock -w 1500 9; then
+              echo "::error::Timed out (25m) waiting for the VPS deploy lock — an earlier app deploy is wedged. Investigate before retrying."
+              exit 1
+            fi
+
             cd /srv/myfreeapps
 
             echo "--- Pull latest code ---"

--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -29,9 +29,33 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          command_timeout: 10m
+          # Generous: deploys are serialized via the flock below, so a
+          # later app can wait through several earlier app deploys before
+          # its own runs. 10m was too tight once deploys serialize.
+          command_timeout: 30m
           script: |
             set -e
+
+            # Serialize deploys across ALL apps on this shared VPS.
+            # Every app's deploy SSHes here and `git pull`s the SAME
+            # /srv/myfreeapps checkout; a `packages/**` change fans out
+            # to every app's deploy workflow at once. Without this lock
+            # they race on the shared git refs — observed failures:
+            #   error: cannot lock ref 'refs/remotes/origin/main'
+            #   fatal: Cannot fast-forward to multiple branches
+            # flock gives mutual exclusion WITHOUT dropping any app's
+            # deploy. A shared GitHub `concurrency` group can't be used
+            # here: it cancels intermediate *pending* runs, silently
+            # skipping some apps. So `concurrency.group` stays per-app
+            # (GitHub runs all of them) and this lock orders them. The
+            # lock auto-releases when this SSH script exits, even on
+            # failure (FD closed on process exit).
+            exec 9>/tmp/myfreeapps-deploy.lock
+            if ! flock -w 1500 9; then
+              echo "::error::Timed out (25m) waiting for the VPS deploy lock — an earlier app deploy is wedged. Investigate before retrying."
+              exit 1
+            fi
+
             cd /srv/myfreeapps
 
             echo "--- Pull latest code ---"

--- a/.github/workflows/deploy-mypizzatracker.yml
+++ b/.github/workflows/deploy-mypizzatracker.yml
@@ -29,9 +29,33 @@ jobs:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
-          command_timeout: 10m
+          # Generous: deploys are serialized via the flock below, so a
+          # later app can wait through several earlier app deploys before
+          # its own runs. 10m was too tight once deploys serialize.
+          command_timeout: 30m
           script: |
             set -e
+
+            # Serialize deploys across ALL apps on this shared VPS.
+            # Every app's deploy SSHes here and `git pull`s the SAME
+            # /srv/myfreeapps checkout; a `packages/**` change fans out
+            # to every app's deploy workflow at once. Without this lock
+            # they race on the shared git refs — observed failures:
+            #   error: cannot lock ref 'refs/remotes/origin/main'
+            #   fatal: Cannot fast-forward to multiple branches
+            # flock gives mutual exclusion WITHOUT dropping any app's
+            # deploy. A shared GitHub `concurrency` group can't be used
+            # here: it cancels intermediate *pending* runs, silently
+            # skipping some apps. So `concurrency.group` stays per-app
+            # (GitHub runs all of them) and this lock orders them. The
+            # lock auto-releases when this SSH script exits, even on
+            # failure (FD closed on process exit).
+            exec 9>/tmp/myfreeapps-deploy.lock
+            if ! flock -w 1500 9; then
+              echo "::error::Timed out (25m) waiting for the VPS deploy lock — an earlier app deploy is wedged. Investigate before retrying."
+              exit 1
+            fi
+
             cd /srv/myfreeapps
 
             echo "--- Pull latest code ---"

--- a/infra/templates/.github/workflows/deploy.yml.j2
+++ b/infra/templates/.github/workflows/deploy.yml.j2
@@ -29,9 +29,33 @@ jobs:
           host: ${{ '{{' }} secrets.SSH_HOST {{ '}}' }}
           username: ${{ '{{' }} secrets.SSH_USER {{ '}}' }}
           key: ${{ '{{' }} secrets.SSH_PRIVATE_KEY {{ '}}' }}
-          command_timeout: 10m
+          # Generous: deploys are serialized via the flock below, so a
+          # later app can wait through several earlier app deploys before
+          # its own runs. 10m was too tight once deploys serialize.
+          command_timeout: 30m
           script: |
             set -e
+
+            # Serialize deploys across ALL apps on this shared VPS.
+            # Every app's deploy SSHes here and `git pull`s the SAME
+            # /srv/myfreeapps checkout; a `packages/**` change fans out
+            # to every app's deploy workflow at once. Without this lock
+            # they race on the shared git refs — observed failures:
+            #   error: cannot lock ref 'refs/remotes/origin/main'
+            #   fatal: Cannot fast-forward to multiple branches
+            # flock gives mutual exclusion WITHOUT dropping any app's
+            # deploy. A shared GitHub `concurrency` group can't be used
+            # here: it cancels intermediate *pending* runs, silently
+            # skipping some apps. So `concurrency.group` stays per-app
+            # (GitHub runs all of them) and this lock orders them. The
+            # lock auto-releases when this SSH script exits, even on
+            # failure (FD closed on process exit).
+            exec 9>/tmp/myfreeapps-deploy.lock
+            if ! flock -w 1500 9; then
+              echo "::error::Timed out (25m) waiting for the VPS deploy lock — an earlier app deploy is wedged. Investigate before retrying."
+              exit 1
+            fi
+
             cd /srv/myfreeapps
 
             echo "--- Pull latest code ---"


### PR DESCRIPTION
## Summary

A `packages/**` change triggers **all 4** app deploy workflows simultaneously (shared-code blast radius). Each SSHes into the **same** VPS and `git pull`s the **same** `/srv/myfreeapps` checkout. With per-app concurrency groups they ran in parallel and raced on the shared git refs:

```
error: cannot lock ref 'refs/remotes/origin/main'
fatal: Cannot fast-forward to multiple branches
```

This intermittently flaps otherwise-healthy production apps — concretely, **MyJobHunter was green on #664 and broke on #665 purely from this race** (not a code regression). MyBookkeeper happened to win the race that round; next time it could be the one that fails.

## Fix

Wrap the VPS deploy script in `flock /tmp/myfreeapps-deploy.lock` so only one app deploy mutates the shared checkout at a time. The lock auto-releases when the SSH script exits (even on failure — FD closed on process exit).

**Deliberately NOT a shared GitHub `concurrency` group:** GitHub cancels intermediate *pending* runs within a group, so 4 simultaneous deploys would silently **drop 2 apps**. So `concurrency.group` stays per-app (GitHub runs all 4) and the flock orders them. `command_timeout` bumped 10m → 30m since a later app now waits through earlier deploys.

This is the canonical primitive for mutual exclusion on a shared host resource across independent CI jobs — not a workaround.

## Changes

- `infra/templates/.github/workflows/deploy.yml.j2` — the single source change (flock + timeout + a comment explaining why-not-concurrency-group so it isn't "simplified" back into a broken state).
- `.github/workflows/deploy-{mybookkeeper,myjobhunter,mygamingassistant,mypizzatracker}.yml` — re-rendered output (`python -m platform_shared.infra.render --all`), per the generated-file contract.

## Test plan

- [x] All 4 workflows re-rendered; per-app slug substitution + per-app `concurrency.group` intact; flock + 30m applied uniformly; clean +26/-2 per file (no line-ending churn — the 12 unrelated render-touched files were LF-only and reverted)
- [ ] **CI-gated:** `shared-backend-tests` → `TestInfraTemplateDrift` is the authoritative no-drift check (green on #664/#665; local run skips because jinja2 isn't in the local pytest env)
- [ ] **Real-world validation:** next `packages/**` merge will fan out to all 4 deploys — they should serialize cleanly instead of racing

## Note

Separately, MGA + MPT still fail their deploys for an *independent* reason (their VPS `.env` / `backend/.env.docker` were never created). That's operator setup, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)