### PR TITLE
fix(mjh): clear "account already exists" message on registration

### DIFF
--- a/apps/myjobhunter/frontend/src/features/auth/__tests__/registerErrorMessages.test.ts
+++ b/apps/myjobhunter/frontend/src/features/auth/__tests__/registerErrorMessages.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { describeRegisterError } from "../registerErrorMessages";
+
+/** axios rejection shape: server body at err.response.data, and the
+ *  object is an Error whose .message is the unhelpful status string. */
+function makeAxiosError(detail: unknown): unknown {
+  const err = new Error("Request failed with status code 400") as Error & {
+    response: { status: number; data: { detail: unknown } };
+  };
+  err.response = { status: 400, data: { detail } };
+  return err;
+}
+
+/** RTK Query fetchBaseQuery shape. */
+function makeRtkError(detail: unknown): unknown {
+  return { status: 400, data: { detail } };
+}
+
+describe("describeRegisterError", () => {
+  it("maps REGISTER_USER_ALREADY_EXISTS to a clear sign-in message (axios)", () => {
+    const msg = describeRegisterError(
+      makeAxiosError("REGISTER_USER_ALREADY_EXISTS"),
+    );
+    expect(msg).toContain("already exists");
+    expect(msg).toContain("Sign in");
+    // Must NOT leak the raw axios status message.
+    expect(msg).not.toMatch(/status code/i);
+  });
+
+  it("maps REGISTER_USER_ALREADY_EXISTS for the RTK Query shape too", () => {
+    const msg = describeRegisterError(
+      makeRtkError("REGISTER_USER_ALREADY_EXISTS"),
+    );
+    expect(msg).toContain("already exists");
+  });
+
+  it("surfaces the reason for an invalid-password object body", () => {
+    const msg = describeRegisterError(
+      makeAxiosError({
+        code: "REGISTER_INVALID_PASSWORD",
+        reason: "This password has appeared in a known data breach.",
+      }),
+    );
+    expect(msg).toMatch(/data breach/i);
+  });
+
+  it("falls back to extractErrorMessage for an unknown string code", () => {
+    const msg = describeRegisterError(makeAxiosError("SOME_OTHER_CODE"));
+    expect(msg).toBe("SOME_OTHER_CODE");
+  });
+
+  it("falls back to the Error message when there is no server body", () => {
+    const msg = describeRegisterError(new Error("network down"));
+    expect(msg).toBe("network down");
+  });
+
+  it("handles null / non-object input without throwing", () => {
+    expect(describeRegisterError(null)).toMatch(/unexpected error/i);
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/auth/registerErrorMessages.ts
+++ b/apps/myjobhunter/frontend/src/features/auth/registerErrorMessages.ts
@@ -1,0 +1,58 @@
+/**
+ * Maps fastapi-users ``POST /auth/register`` error bodies into clear,
+ * user-facing copy.
+ *
+ * fastapi-users returns two failure shapes on the register route:
+ *   - ``{detail: "REGISTER_USER_ALREADY_EXISTS"}`` — a bare string code
+ *   - ``{detail: {code: "REGISTER_INVALID_PASSWORD", reason: "..."}}`` —
+ *     a nested object whose ``reason`` is already human-readable
+ *
+ * Without this mapping the raw code (or, worse, axios's
+ * ``"Request failed with status code 400"``) is what the user sees.
+ * Mirrors the ``features/admin/invites/inviteErrorMessages.ts`` pattern.
+ */
+import { extractErrorMessage } from "@platform/ui";
+
+const REGISTER_CODE_MESSAGES: Record<string, string> = {
+  REGISTER_USER_ALREADY_EXISTS:
+    "An account with this email already exists. Sign in instead.",
+};
+
+function rawDetail(err: unknown): unknown {
+  if (err === null || typeof err !== "object") return undefined;
+  const obj = err as Record<string, unknown>;
+  // axios: body at err.response.data.detail
+  const response = obj.response;
+  if (response !== null && typeof response === "object") {
+    const data = (response as Record<string, unknown>).data;
+    if (data !== null && typeof data === "object") {
+      return (data as Record<string, unknown>).detail;
+    }
+  }
+  // RTK Query: body at err.data.detail
+  const data = obj.data;
+  if (data !== null && typeof data === "object") {
+    return (data as Record<string, unknown>).detail;
+  }
+  return undefined;
+}
+
+export function describeRegisterError(err: unknown): string {
+  const detail = rawDetail(err);
+
+  if (typeof detail === "string" && detail in REGISTER_CODE_MESSAGES) {
+    return REGISTER_CODE_MESSAGES[detail];
+  }
+
+  // Invalid-password failures carry an already-readable reason string
+  // (e.g. the HIBP breach message or the length rule).
+  if (
+    detail !== null &&
+    typeof detail === "object" &&
+    typeof (detail as Record<string, unknown>).reason === "string"
+  ) {
+    return (detail as { reason: string }).reason;
+  }
+
+  return extractErrorMessage(err);
+}

--- a/apps/myjobhunter/frontend/src/pages/Register.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Register.tsx
@@ -4,10 +4,10 @@ import {
   LoadingButton,
   PasswordPair,
   TurnstileWidget,
-  extractErrorMessage,
 } from "@platform/ui";
 import { Briefcase } from "lucide-react";
 import { register } from "@/lib/auth";
+import { describeRegisterError } from "@/features/auth/registerErrorMessages";
 import { useGetInviteInfoQuery } from "@/store/invitesApi";
 
 const INVITE_TOKEN_STORAGE_KEY = "myjobhunter.pendingInviteToken";
@@ -129,7 +129,7 @@ function RegisterWithInvite({ token }: RegisterWithInviteProps) {
       await register(invite!.email, password, turnstileToken);
       setRegistered(true);
     } catch (err) {
-      setSubmitError(extractErrorMessage(err));
+      setSubmitError(describeRegisterError(err));
     } finally {
       setIsSubmitting(false);
     }

--- a/packages/shared-frontend/src/__tests__/errorMessage.test.ts
+++ b/packages/shared-frontend/src/__tests__/errorMessage.test.ts
@@ -68,6 +68,44 @@ describe("extractErrorMessage", () => {
     ).toBe("An unexpected error occurred");
   });
 
+  it("reads axios err.response.data.detail BEFORE the Error.message fallback", () => {
+    // Regression: AxiosError IS an Error. A naive `err instanceof Error`
+    // check first returned "Request failed with status code 400" and
+    // never surfaced the server's {detail} body.
+    const axiosErr = new Error("Request failed with status code 400") as Error & {
+      response: { status: number; data: { detail: string } };
+    };
+    axiosErr.response = {
+      status: 400,
+      data: { detail: "REGISTER_USER_ALREADY_EXISTS" },
+    };
+    expect(extractErrorMessage(axiosErr)).toBe("REGISTER_USER_ALREADY_EXISTS");
+  });
+
+  it("reads RTK Query err.data.detail", () => {
+    expect(
+      extractErrorMessage({ status: 409, data: { detail: "invite_already_pending" } }),
+    ).toBe("invite_already_pending");
+  });
+
+  it("reads a string err.data body (axios timeout shape)", () => {
+    expect(extractErrorMessage({ status: 504, data: "Timeout" })).toBe("Timeout");
+  });
+
+  it("falls back to Error.message when there is no structured body", () => {
+    expect(extractErrorMessage(new Error("Email already exists"))).toBe(
+      "Email already exists",
+    );
+  });
+
+  it("ignores a blank/whitespace detail and falls through", () => {
+    const err = new Error("real message") as Error & {
+      response: { data: { detail: string } };
+    };
+    err.response = { data: { detail: "   " } };
+    expect(extractErrorMessage(err)).toBe("real message");
+  });
+
   it("falls back to a generic message for unknown shapes", () => {
     expect(extractErrorMessage(undefined)).toBe("An unexpected error occurred");
     expect(extractErrorMessage(null)).toBe("An unexpected error occurred");

--- a/packages/shared-frontend/src/utils/errorMessage.ts
+++ b/packages/shared-frontend/src/utils/errorMessage.ts
@@ -1,35 +1,81 @@
 /**
- * Normalize an unknown thrown/rejected value into a human-readable string.
+ * Extract a human-displayable message from an unknown thrown value.
  *
- * Critically, this MUST always return a string. FastAPI returns 422
- * validation failures as `{ detail: [{ type, loc, msg, input }, ...] }`.
- * If that array (or its objects) reaches JSX, React throws
- * "Objects are not valid as a React child" and the route crashes. Callers
- * pass the result straight into toasts/JSX, so the array shape is flattened
- * to its `msg` strings here, prefixed with the offending field from `loc`.
+ * Handles the error shapes this codebase produces:
+ *   - **axios** rejections — the server body is at ``err.response.data``
+ *     and ``err`` is itself an ``Error`` whose ``.message`` is the
+ *     useless ``"Request failed with status code 400"``.
+ *   - **RTK Query** (``fetchBaseQuery``) — the body is at ``err.data``.
+ *   - plain ``Error`` / string — used by some call sites and tests.
+ *
+ * The structured server ``detail`` is read BEFORE the ``Error.message``
+ * fallback. An ``AxiosError`` *is* an ``Error``, so a naive
+ * ``err instanceof Error`` check first would always return
+ * ``"Request failed with status code 400"`` and never surface the
+ * server's ``{detail: ...}`` body (this was the registration
+ * "generic 400" bug).
+ *
+ * This MUST always return a string. FastAPI 422 validation failures
+ * arrive as ``{ detail: [{ type, loc, msg, input }, ...] }``; if that
+ * array (or its objects) reaches JSX, React throws "Objects are not
+ * valid as a React child" and the route crashes. The array is flattened
+ * to its ``msg`` strings (prefixed with the offending ``loc`` field)
+ * via ``formatValidationDetail``.
  */
-export function extractErrorMessage(err: unknown): string {
-  if (err instanceof Error) return err.message;
-  if (typeof err === "string") return err;
-  if (typeof err === "object" && err !== null) {
-    const obj = err as Record<string, unknown>;
-    if (typeof obj.data === "object" && obj.data !== null) {
-      const data = obj.data as Record<string, unknown>;
-      if (typeof data.detail === "string") return data.detail;
-      if (Array.isArray(data.detail)) {
-        const msg = formatValidationDetail(data.detail);
-        if (msg) return msg;
-      }
+
+function readDetail(data: unknown): string | undefined {
+  if (typeof data === "string") return data.trim() || undefined;
+  if (data !== null && typeof data === "object") {
+    const detail = (data as Record<string, unknown>).detail;
+    if (typeof detail === "string") return detail.trim() || undefined;
+    if (Array.isArray(detail)) {
+      const msg = formatValidationDetail(detail);
+      if (msg) return msg;
     }
-    if (typeof obj.data === "string") return obj.data;
-    if (typeof obj.message === "string") return obj.message;
-    if (typeof obj.detail === "string") return obj.detail;
+  }
+  return undefined;
+}
+
+export function extractErrorMessage(err: unknown): string {
+  if (typeof err === "string") return err;
+
+  if (err !== null && typeof err === "object") {
+    const obj = err as Record<string, unknown>;
+
+    // axios: server body lives under err.response.data
+    const response = obj.response;
+    if (response !== null && typeof response === "object") {
+      const fromResponse = readDetail(
+        (response as Record<string, unknown>).data,
+      );
+      if (fromResponse) return fromResponse;
+    }
+
+    // RTK Query fetchBaseQuery: { status, data: { detail } | string }
+    const fromData = readDetail(obj.data);
+    if (fromData) return fromData;
+
+    if (typeof obj.detail === "string" && obj.detail.trim()) {
+      return obj.detail;
+    }
     if (Array.isArray(obj.detail)) {
       const msg = formatValidationDetail(obj.detail);
       if (msg) return msg;
     }
-    if (typeof obj.error === "string") return obj.error;
+    if (typeof obj.error === "string" && obj.error.trim()) {
+      return obj.error;
+    }
+
+    // Only now fall back to a raw Error.message — for an AxiosError
+    // this is the unhelpful "Request failed with status code N", so it
+    // must come AFTER the structured-detail extraction above.
+    if (err instanceof Error && err.message) return err.message;
+    if (typeof obj.message === "string" && obj.message.trim()) {
+      return obj.message;
+    }
   }
+
+  if (err instanceof Error && err.message) return err.message;
   return "An unexpected error occurred";
 }
 


### PR DESCRIPTION
## Summary

Issue 1 of a 5-issue MJH QA pass. Registration showed the generic
**"Request failed with status code 400"** instead of clearly stating the
email already had an account.

**Root cause** — shared `extractErrorMessage` (`@platform/ui`) checked
`err instanceof Error` first and returned `err.message`. An `AxiosError`
*is* an `Error`, so it always returned the useless axios status string
and never read the server's `{detail}` body. Reordered so structured
server detail (axios `response.data.detail` + RTK Query `data.detail`)
is extracted **before** the `Error.message` fallback.

Added `describeRegisterError` (mirrors the existing
`inviteErrorMessages.ts` mapper) translating the fastapi-users
`REGISTER_USER_ALREADY_EXISTS` code and the invalid-password `reason`
object into user-facing copy. The page already has a "Sign in" CTA.

## Scope / impact

- `extractErrorMessage` is a **Tier-1 shared primitive** — the fix
  benefits every app (MBK/MJH/MGA/MPT). Reorder preserves the
  `Error.message` fallback so existing callers/tests are unaffected.
- `InviteRegisterForm.tsx` is dead code (no references) — left untouched.

## Test plan

- [x] `errorMessage.test.ts` (shared) — 7 tests incl. the AxiosError regression shape
- [x] `registerErrorMessages.test.ts` (MJH) — 6 tests, axios + RTK shapes + fallbacks
- [x] `npm run typecheck` passes for both packages
- [x] ESLint clean on changed files
- [ ] Pre-existing unrelated failures: `InlineBoldText.test.tsx` (2) — fail on clean `main` too

🤖 Generated with [Claude Code](https://claude.com/claude-code)