### PR TITLE
fix(ui): visible error when password is too short

### DIFF
--- a/packages/shared-frontend/src/__tests__/PasswordPair.test.tsx
+++ b/packages/shared-frontend/src/__tests__/PasswordPair.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import PasswordPair from "../components/auth/PasswordPair";
+
+function renderPair(
+  overrides: Partial<Parameters<typeof PasswordPair>[0]> = {},
+) {
+  const defaults = {
+    password: "",
+    onPasswordChange: vi.fn(),
+    confirmPassword: "",
+    onConfirmPasswordChange: vi.fn(),
+  };
+  return render(<PasswordPair {...defaults} {...overrides} />);
+}
+
+describe("PasswordPair — too-short feedback", () => {
+  it("shows a visible destructive alert when the password is too short", () => {
+    // Regression: previously only aria-invalid was set (screen-reader
+    // only) and the submit button silently disabled — sighted users
+    // saw no error at all.
+    renderPair({ password: "short" });
+    const alert = screen.getByRole("alert");
+    expect(alert).toHaveTextContent(/at least 12 characters/i);
+    expect(alert.className).toContain("text-destructive");
+  });
+
+  it("shows only the muted hint (no alert) before any input", () => {
+    renderPair({ password: "" });
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(screen.getByText(/at least 12 characters/i).className).toContain(
+      "text-muted-foreground",
+    );
+  });
+
+  it("drops the too-short alert once the minimum length is met", () => {
+    renderPair({ password: "abcdefghijkl", confirmPassword: "abcdefghijkl" });
+    const hint = screen.getByText(/at least 12 characters/i);
+    expect(hint.className).toContain("text-muted-foreground");
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("respects a custom minLength in the message", () => {
+    renderPair({ password: "abc", minLength: 8 });
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      /at least 8 characters/i,
+    );
+  });
+});

--- a/packages/shared-frontend/src/components/auth/PasswordPair.tsx
+++ b/packages/shared-frontend/src/components/auth/PasswordPair.tsx
@@ -114,9 +114,19 @@ export default function PasswordPair({
           aria-invalid={tooShort}
           disabled={disabled}
         />
-        <p id={hintId} className="text-xs text-muted-foreground mt-1">
-          At least {minLength} characters.
-        </p>
+        {tooShort ? (
+          <p
+            id={hintId}
+            role="alert"
+            className="text-xs text-destructive mt-1"
+          >
+            Password must be at least {minLength} characters.
+          </p>
+        ) : (
+          <p id={hintId} className="text-xs text-muted-foreground mt-1">
+            At least {minLength} characters.
+          </p>
+        )}
       </div>
       <div>
         <label className="block text-sm font-medium mb-1">{confirmLabel}</label>


### PR DESCRIPTION
## Summary

Issue 2 of a 5-issue MJH QA pass. Typing a password under 12 characters
showed **no error** — the submit button just silently disabled.

**Root cause** — `PasswordPair` (`@platform/ui`) computed `tooShort` and
set `aria-invalid` (screen-reader only) but rendered no visible message;
the "At least 12 characters" hint stayed muted grey regardless. Only the
password-*mismatch* error was ever visible.

When too short, the hint now renders in destructive styling with
`role="alert"` (mirrors the existing mismatch-error pattern). The muted
hint still shows before input and once the minimum is met.

## Scope / impact

- `PasswordPair` is a **Tier-1 shared primitive** — fixes the
  registration + reset-password forms in every consuming app
  (MBK + MJH today).
- No API change; purely additive rendering. `aria-describedby` still
  points at the same `hintId`.

## Test plan

- [x] New `PasswordPair.test.tsx` — 4 tests: visible destructive alert when
      short, muted hint before input, alert cleared when min met, custom minLength
- [x] `npm run typecheck` passes
- [ ] Pre-existing unrelated failure: `InlineBoldText.test.tsx` (2) — fails on clean `main` too

🤖 Generated with [Claude Code](https://claude.com/claude-code)