### PR TITLE
fix(mjh): persistent banner when a JD link needs a login

### DIFF
--- a/apps/myjobhunter/frontend/src/features/analyze/AnalyzeJdInput.tsx
+++ b/apps/myjobhunter/frontend/src/features/analyze/AnalyzeJdInput.tsx
@@ -19,7 +19,7 @@
  * and the test surface is small.
  */
 import { useEffect, useRef } from "react";
-import { LoadingButton } from "@platform/ui";
+import { AlertBox, LoadingButton } from "@platform/ui";
 
 const URL_REGEX = /^https?:\/\/\S+$/i;
 
@@ -36,6 +36,13 @@ export interface AnalyzeJdInputProps {
   onSubmitUrl: () => void;
   onSubmitText: () => void;
   onPasteUrl: (pasted: string) => void;
+  /**
+   * Persistent explanation shown above the textarea after a URL fetch
+   * was blocked (auth-walled site, 401/403). Survives until the user
+   * acts — unlike the old transient toast, which vanished and made the
+   * silent tab-switch look like the app had broken.
+   */
+  notice?: string | null;
 }
 
 export default function AnalyzeJdInput(props: AnalyzeJdInputProps) {
@@ -121,10 +128,12 @@ function TextPanel({
   onChangeMode,
   onChangeText,
   onSubmitText,
+  notice,
 }: AnalyzeJdInputProps) {
   const canSubmit = !isSubmitting && textValue.trim().length > 0;
   return (
     <div className="space-y-3">
+      {notice && <AlertBox variant="warning">{notice}</AlertBox>}
       <label htmlFor="analyze-text" className="block text-sm font-medium">
         Paste the job description text
       </label>

--- a/apps/myjobhunter/frontend/src/pages/Analyze.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Analyze.tsx
@@ -62,34 +62,49 @@ export default function Analyze() {
   const [state, setState] = useState<PageState>(INITIAL_STATE);
   const [urlValue, setUrlValue] = useState("");
   const [textValue, setTextValue] = useState("");
+  // Persistent "we couldn't read that link" explanation. Replaces the
+  // old transient toast, which vanished and left the user on a blank
+  // text tab with no idea why — it looked like the app had broken.
+  const [urlBlockedNotice, setUrlBlockedNotice] = useState<string | null>(
+    null,
+  );
 
   // ---------------------------------------------------------------------
   // Step transitions
   // ---------------------------------------------------------------------
 
   function setInputMode(mode: AnalyzeInputMode) {
+    // Returning to the URL field means the blocked-link notice is no
+    // longer relevant; keep it while the user is on the text tab.
+    if (mode === "url") setUrlBlockedNotice(null);
     setState({ kind: "input", mode });
   }
 
   function resetToInput(mode: AnalyzeInputMode = "url") {
     setUrlValue("");
     setTextValue("");
+    setUrlBlockedNotice(null);
     setState({ kind: "input", mode });
   }
 
   async function runAnalyzeUrl(url: string) {
     const trimmed = url.trim();
     if (!trimmed) return;
+    setUrlBlockedNotice(null);
     setState({ kind: "processing", sourcePath: "url", longRunning: false });
     try {
       const result = await analyzeJob({ url: trimmed }).unwrap();
       setState({ kind: "result", analysis: result });
     } catch (err) {
       if (isAuthRequiredError(err)) {
-        showError(
-          "That page requires sign-in or blocked our request. Paste the description text instead.",
-        );
+        // Persistent in-context banner on the text tab — NOT a toast.
+        // The toast faded and the silent tab-switch read as "broken".
         setInputMode("text");
+        setUrlBlockedNotice(
+          "We couldn't read that link — it needs a sign-in. Sites like " +
+            "LinkedIn and Glassdoor block automated access. Paste the job " +
+            "description text below and we'll analyze it.",
+        );
         return;
       }
       showError(`Couldn't analyze: ${describeExtractError(err)}`);
@@ -100,6 +115,7 @@ export default function Analyze() {
   async function runAnalyzeText(text: string) {
     const trimmed = text.trim();
     if (!trimmed) return;
+    setUrlBlockedNotice(null);
     setState({ kind: "processing", sourcePath: "text", longRunning: false });
     try {
       const result = await analyzeJob({ jd_text: trimmed }).unwrap();
@@ -153,6 +169,7 @@ export default function Analyze() {
           urlValue={urlValue}
           textValue={textValue}
           analyzing={analyzing}
+          notice={urlBlockedNotice}
           onChangeMode={setInputMode}
           onChangeUrl={setUrlValue}
           onChangeText={setTextValue}
@@ -191,6 +208,7 @@ interface InputViewProps {
   urlValue: string;
   textValue: string;
   analyzing: boolean;
+  notice: string | null;
   onChangeMode: (mode: AnalyzeInputMode) => void;
   onChangeUrl: (next: string) => void;
   onChangeText: (next: string) => void;

--- a/apps/myjobhunter/frontend/src/pages/__tests__/Analyze.test.tsx
+++ b/apps/myjobhunter/frontend/src/pages/__tests__/Analyze.test.tsx
@@ -9,13 +9,12 @@ import type { JobAnalysis } from "@/types/job-analysis/job-analysis";
 // Mocks
 // ---------------------------------------------------------------------------
 
-vi.mock("lucide-react", () => ({
-  Loader2: () => null,
-  Sparkles: () => null,
-  ExternalLink: () => null,
-  AlertTriangle: () => null,
-  CheckCircle2: () => null,
-}));
+// lucide-react is intentionally NOT mocked. The @platform/ui mock below
+// spreads the real barrel (importOriginal), which transitively renders
+// real icons anyway; a hard-coded icon stub map just breaks the whole
+// file with "No <Icon> export" the moment a new component is pulled in.
+// Real icons render as harmless <svg> in jsdom — tests query by
+// text/role, never by icon.
 
 vi.mock("@/lib/jobAnalysisApi", () => ({
   useAnalyzeJobMutation: vi.fn(),
@@ -274,6 +273,83 @@ describe("Analyze page", () => {
 
     // Back to input
     expect(await screen.findByLabelText("Job posting URL")).toBeInTheDocument();
+  });
+
+  it("shows a persistent banner (not a vanishing toast) when the URL is auth-walled", async () => {
+    const { showError } = await import("@platform/ui");
+    const analyzeMock = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.reject({ status: 422, data: { detail: "auth_required" } }),
+    });
+    mockUseAnalyzeJobMutation.mockReturnValue([
+      analyzeMock,
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useAnalyzeJobMutation>);
+    mockUseApplyFromAnalysisMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useApplyFromAnalysisMutation>);
+
+    const user = userEvent.setup();
+    renderAnalyze();
+
+    await user.type(
+      screen.getByLabelText("Job posting URL"),
+      "https://www.linkedin.com/jobs/view/123",
+    );
+    const urlButtons = screen.getAllByRole("button", {
+      name: /Analyze this job/i,
+    });
+    await user.click(urlButtons[urlButtons.length - 1]!);
+
+    // Switched to the text tab AND a persistent explanation is shown.
+    expect(
+      await screen.findByLabelText("Job description text"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/couldn't read that link/i),
+    ).toBeInTheDocument();
+    // The auth-required case must NOT use the transient toast — that
+    // vanishing was the whole "it seems broken" complaint.
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it("clears the blocked-link banner when the user switches back to the URL tab", async () => {
+    const analyzeMock = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.reject({ status: 422, data: { detail: "auth_required" } }),
+    });
+    mockUseAnalyzeJobMutation.mockReturnValue([
+      analyzeMock,
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useAnalyzeJobMutation>);
+    mockUseApplyFromAnalysisMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useApplyFromAnalysisMutation>);
+
+    const user = userEvent.setup();
+    renderAnalyze();
+
+    await user.type(
+      screen.getByLabelText("Job posting URL"),
+      "https://www.linkedin.com/jobs/view/123",
+    );
+    const urlButtons = screen.getAllByRole("button", {
+      name: /Analyze this job/i,
+    });
+    await user.click(urlButtons[urlButtons.length - 1]!);
+
+    await screen.findByText(/couldn't read that link/i);
+
+    await user.click(
+      screen.getByText(/Have a URL\? Paste it instead/i),
+    );
+
+    expect(screen.getByLabelText("Job posting URL")).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't read that link/i),
+    ).not.toBeInTheDocument();
   });
 
   it("shows the 'saved — view applications' affordance for an analysis that's already applied", async () => {


### PR DESCRIPTION
## Summary

Issue 3 of a 5-issue MJH QA pass. Pasting a job URL that needs a login
(LinkedIn, Glassdoor, any 401/403) made the app **look broken**.

**Root cause** — not a logic bug. The backend correctly returns
`422 auth_required` and the frontend correctly detects it. But the only
feedback was a *transient `showError` toast*, after which the page
silently swapped to the blank "paste text" tab. The toast faded and the
user was left on an empty textarea with no idea what happened.

**Fix** — for the auth-required case, replace the toast with a
persistent `AlertBox` (warning, from `@platform/ui`) rendered on the
text tab, explaining the link needs a sign-in and to paste the text.
It clears when the user switches back to the URL tab, starts a text
analysis, or resets. The generic (non-auth) failure path keeps its
toast — that one isn't the confusing case.

## Notes

- Reused `@platform/ui`'s existing `AlertBox` — no new component.
- Test infra: dropped the hard-coded `lucide-react` icon stub map in
  `Analyze.test.tsx`. It broke the whole file the moment `AlertBox`'s
  barrel siblings pulled a new icon (`Sun`). Real icons render as
  harmless `<svg>` in jsdom; tests query by text/role.
- **Known follow-up (tracked):** the Add Application dialog
  (`useAddApplicationFlow.ts`) has the identical pattern. Left for a
  separate PR — its input panel is a tangled 3-step state machine and
  the code already flags the shared-input extraction as its own refactor.

## Test plan

- [x] `Analyze.test.tsx` — 7 tests incl. 2 new: persistent banner shown + no toast on auth-walled URL; banner cleared on tab switch back
- [x] `jdErrorRouting.test.ts` — 12 tests still green
- [x] `npm run typecheck` + ESLint clean
- [ ] Pre-existing unrelated failure: `InlineBoldText.test.tsx` (shared, 2) — fails on clean `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)