### PR TITLE
fix(mga): stop /sources crash on FastAPI 422; surface real message

### DIFF
--- a/apps/mygamingassistant/frontend/src/components/review/ReviewCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/review/ReviewCard.tsx
@@ -7,7 +7,7 @@
  */
 import { useState } from "react";
 import { Check, EyeOff, RefreshCw } from "lucide-react";
-import { showError, showSuccess } from "@platform/ui";
+import { showError, showSuccess, extractErrorMessage } from "@platform/ui";
 import {
   useAcceptLineupMutation,
   useHideLineupMutation,
@@ -127,10 +127,7 @@ export default function ReviewCard({
       await acceptLineup({ id: lineup.id, body }).unwrap();
       showSuccess("Lineup accepted.");
     } catch (err: unknown) {
-      const detail =
-        (err as { data?: { detail?: string } })?.data?.detail ??
-        "Failed to accept lineup.";
-      showError(detail);
+      showError(extractErrorMessage(err));
     }
   };
 

--- a/apps/mygamingassistant/frontend/src/pages/Sources.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/Sources.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { PlaySquare, Trash2, RefreshCw } from "lucide-react";
-import { showError, showSuccess } from "@platform/ui";
+import { showError, showSuccess, extractErrorMessage } from "@platform/ui";
 import {
   useGetSourcesQuery,
   useCreateSourceMutation,
@@ -57,10 +57,7 @@ function AddSourceForm({ onAdded }: AddSourceFormProps) {
       setUrl("");
       onAdded();
     } catch (err: unknown) {
-      const detail =
-        (err as { data?: { detail?: string } })?.data?.detail ??
-        "Failed to add source. Check the URL and try again.";
-      showError(detail);
+      showError(extractErrorMessage(err));
     }
   };
 

--- a/packages/shared-frontend/src/__tests__/errorMessage.test.ts
+++ b/packages/shared-frontend/src/__tests__/errorMessage.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { extractErrorMessage } from "../utils/errorMessage";
+
+describe("extractErrorMessage", () => {
+  it("returns the message of an Error instance", () => {
+    expect(extractErrorMessage(new Error("boom"))).toBe("boom");
+  });
+
+  it("returns a plain string as-is", () => {
+    expect(extractErrorMessage("nope")).toBe("nope");
+  });
+
+  it("reads RTK-style data.detail string", () => {
+    expect(
+      extractErrorMessage({ data: { detail: "Source not found" } }),
+    ).toBe("Source not found");
+  });
+
+  // The bug this fixes: FastAPI 422 returns detail as an array of
+  // { type, loc, msg, input }. Rendering that array crashes React.
+  it("flattens a FastAPI 422 detail array and prefixes the field", () => {
+    const err = {
+      data: {
+        detail: [
+          {
+            type: "value_error",
+            loc: ["body", "url"],
+            msg: "youtube_playlist URL must be a YouTube playlist URL",
+            input: "https://youtu.be/abc",
+          },
+        ],
+      },
+    };
+    expect(extractErrorMessage(err)).toBe(
+      "url: youtube_playlist URL must be a YouTube playlist URL",
+    );
+  });
+
+  it("joins multiple validation errors with '; '", () => {
+    const err = {
+      data: {
+        detail: [
+          { loc: ["body", "url"], msg: "field required" },
+          { loc: ["body", "kind"], msg: "kind must be youtube_playlist or youtube_channel" },
+        ],
+      },
+    };
+    expect(extractErrorMessage(err)).toBe(
+      "url: field required; kind: kind must be youtube_playlist or youtube_channel",
+    );
+  });
+
+  it("omits the field prefix when loc only contains 'body'", () => {
+    expect(
+      extractErrorMessage({ data: { detail: [{ loc: ["body"], msg: "invalid body" }] } }),
+    ).toBe("invalid body");
+  });
+
+  it("handles a top-level detail array (non-RTK shape)", () => {
+    expect(
+      extractErrorMessage({ detail: [{ loc: ["body", "x"], msg: "bad" }] }),
+    ).toBe("x: bad");
+  });
+
+  it("falls back when the array has no usable msg", () => {
+    expect(
+      extractErrorMessage({ data: { detail: [{ type: "x", loc: ["body"] }] } }),
+    ).toBe("An unexpected error occurred");
+  });
+
+  it("falls back to a generic message for unknown shapes", () => {
+    expect(extractErrorMessage(undefined)).toBe("An unexpected error occurred");
+    expect(extractErrorMessage(null)).toBe("An unexpected error occurred");
+    expect(extractErrorMessage({ weird: true })).toBe("An unexpected error occurred");
+  });
+});

--- a/packages/shared-frontend/src/utils/errorMessage.ts
+++ b/packages/shared-frontend/src/utils/errorMessage.ts
@@ -1,3 +1,13 @@
+/**
+ * Normalize an unknown thrown/rejected value into a human-readable string.
+ *
+ * Critically, this MUST always return a string. FastAPI returns 422
+ * validation failures as `{ detail: [{ type, loc, msg, input }, ...] }`.
+ * If that array (or its objects) reaches JSX, React throws
+ * "Objects are not valid as a React child" and the route crashes. Callers
+ * pass the result straight into toasts/JSX, so the array shape is flattened
+ * to its `msg` strings here, prefixed with the offending field from `loc`.
+ */
 export function extractErrorMessage(err: unknown): string {
   if (err instanceof Error) return err.message;
   if (typeof err === "string") return err;
@@ -6,11 +16,44 @@ export function extractErrorMessage(err: unknown): string {
     if (typeof obj.data === "object" && obj.data !== null) {
       const data = obj.data as Record<string, unknown>;
       if (typeof data.detail === "string") return data.detail;
+      if (Array.isArray(data.detail)) {
+        const msg = formatValidationDetail(data.detail);
+        if (msg) return msg;
+      }
     }
     if (typeof obj.data === "string") return obj.data;
     if (typeof obj.message === "string") return obj.message;
     if (typeof obj.detail === "string") return obj.detail;
+    if (Array.isArray(obj.detail)) {
+      const msg = formatValidationDetail(obj.detail);
+      if (msg) return msg;
+    }
     if (typeof obj.error === "string") return obj.error;
   }
   return "An unexpected error occurred";
+}
+
+/**
+ * Flatten a FastAPI/Pydantic 422 `detail` array into one readable string.
+ * Each item is `{ type, loc, msg, input }`; `loc` is like `["body", "url"]`.
+ * Returns "" when nothing usable is present so the caller can fall through.
+ */
+function formatValidationDetail(detail: unknown[]): string {
+  const parts = detail
+    .map((item) => {
+      if (typeof item === "string") return item;
+      if (item && typeof item === "object") {
+        const o = item as Record<string, unknown>;
+        const msg = typeof o.msg === "string" ? o.msg : null;
+        if (!msg) return null;
+        const loc = Array.isArray(o.loc) ? o.loc : [];
+        const field = loc
+          .filter((p) => p !== "body" && typeof p !== "number")
+          .join(".");
+        return field ? `${field}: ${msg}` : msg;
+      }
+      return null;
+    })
+    .filter((p): p is string => Boolean(p));
+  return parts.join("; ");
 }


### PR DESCRIPTION
## Summary

Reported: adding a YouTube source on `/sources` produced a full-page **"Objects are not valid as a React child (found: object with keys {type, loc, msg, input})"** crash.

Root cause: a URL failing backend validation returns HTTP **422** whose `detail` is an **array** of Pydantic `{type, loc, msg, input}` objects. `Sources.tsx` and `ReviewCard.tsx` both typed `err.data.detail` as `string` and passed the array straight to `showError` → React render crash → the actual reason ("…must be a YouTube playlist URL…") was hidden.

## Fix (Tier 1 / shared)

- `extractErrorMessage` (`packages/shared-frontend`) now flattens a FastAPI 422 `detail` array to its `msg` strings, prefixed with the offending field from `loc` (e.g. `url: …`). Handles both RTK `{data:{detail:[…]}}` and top-level `{detail:[…]}`. **Purely additive** — that array previously fell through to the generic fallback, so existing string-`detail` callers (MBK / MJH / StepUp) are unchanged.
- `Sources.tsx` + `ReviewCard.tsx` drop the buggy local `(err as {data?:{detail?:string}}).data?.detail ?? "…"` and call the shared `extractErrorMessage`. (ReviewCard's was in `handleAccept` — a 422 from the `stand/target_anchor` range guard added in #667 would have crashed there too.)

Operators now see e.g. `url: youtube_playlist URL must be a YouTube playlist URL: https://www.youtube.com/playlist?list=<id>` instead of a white screen.

## Test plan

- [x] 9 new `extractErrorMessage` cases (string detail, 422 array w/ field prefix, multi-error join, top-level array, no-msg fallback, generic) — all pass
- [x] MGA `tsc` clean · MGA vitest 246/246 · `npm run build` (CI gate) green
- [ ] CI green
- [ ] Browser smoke at `/sources`: submit a bad URL → toast shows the backend message, no crash

## Operational migration

**None** — frontend-only; no backend/env/schema change.

## Out of scope (noted, not fixed here)

`packages/shared-frontend/src/__tests__/InlineBoldText.test.tsx` has 2 pre-existing failures (last touched in #501, unrelated to this change; not a CI gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)