### PR TITLE
fix(mga): send RTK Query request bodies via data: (axiosBaseQuery)

### DIFF
--- a/apps/mygamingassistant/frontend/src/store/gamesApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/gamesApi.ts
@@ -36,7 +36,7 @@ const gamesApi = baseApi.injectEndpoints({
       query: ({ mapId, objectKey }) => ({
         url: `/maps/${mapId}/minimap`,
         method: "POST",
-        body: { object_key: objectKey },
+        data: { object_key: objectKey },
       }),
     }),
     // Bulk-update polygon_points across zones for a single map. On success
@@ -49,7 +49,7 @@ const gamesApi = baseApi.injectEndpoints({
       query: ({ mapId, body }) => ({
         url: `/maps/${mapId}/zones`,
         method: "PATCH",
-        body,
+        data: body,
       }),
       // The map-detail query is keyed by (gameSlug, mapSlug), so we can't
       // invalidate by mapId. Caller fires a refetch via the query's

--- a/apps/mygamingassistant/frontend/src/store/lineupPackagesApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/lineupPackagesApi.ts
@@ -43,7 +43,7 @@ const lineupPackagesApi = lineupPackagesBaseApi.injectEndpoints({
       query: (payload) => ({
         url: "/lineup-packages",
         method: "POST",
-        body: payload,
+        data: payload,
       }),
       invalidatesTags: ["LineupPackageList"],
     }),
@@ -55,7 +55,7 @@ const lineupPackagesApi = lineupPackagesBaseApi.injectEndpoints({
       query: ({ id, patch }) => ({
         url: `/lineup-packages/${id}`,
         method: "PATCH",
-        body: patch,
+        data: patch,
       }),
       invalidatesTags: (_result, _err, { id }) => [
         { type: "LineupPackage", id },

--- a/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
@@ -79,7 +79,7 @@ const lineupsApi = lineupsBaseApi.injectEndpoints({
       query: ({ payload, lineup_id }) => ({
         url: lineup_id ? `/lineups?lineup_id=${lineup_id}` : "/lineups",
         method: "POST",
-        body: payload,
+        data: payload,
       }),
       invalidatesTags: ["LineupList", "ZoneDensity"],
     }),
@@ -88,7 +88,7 @@ const lineupsApi = lineupsBaseApi.injectEndpoints({
       query: ({ id, patch }) => ({
         url: `/lineups/${id}`,
         method: "PATCH",
-        body: patch,
+        data: patch,
       }),
       invalidatesTags: (_result, _err, { id }) => [
         { type: "Lineup", id },
@@ -135,7 +135,7 @@ const lineupsApi = lineupsBaseApi.injectEndpoints({
       query: ({ id, body }) => ({
         url: `/lineups/${id}/accept`,
         method: "POST",
-        body: body ?? {},
+        data: body ?? {},
       }),
       invalidatesTags: (_result, _err, { id }) => [
         { type: "Lineup", id },
@@ -155,7 +155,7 @@ const lineupsApi = lineupsBaseApi.injectEndpoints({
     }),
 
     bulkAcceptLineups: build.mutation<Lineup[], BulkAcceptBody>({
-      query: (body) => ({ url: "/lineups/bulk-accept", method: "POST", body }),
+      query: (body) => ({ url: "/lineups/bulk-accept", method: "POST", data: body }),
       invalidatesTags: ["LineupList", "PendingLineups", "ZoneDensity"],
     }),
 

--- a/apps/mygamingassistant/frontend/src/store/sourcesApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/sourcesApi.ts
@@ -28,7 +28,7 @@ const sourcesApi = sourcesBaseApi.injectEndpoints({
       query: (payload) => ({
         url: "/sources",
         method: "POST",
-        body: payload,
+        data: payload,
       }),
       invalidatesTags: ["SourceList"],
     }),


### PR DESCRIPTION
## Summary

`@platform/ui`'s `baseApi` uses `axiosBaseQuery`, which destructures **only** `data` from the RTK Query request descriptor (`Args` type: `{ url; method?; data?; params? }` — there is no `body`). Every MyGamingAssistant RTK Query mutation passed `body:`, so axios sent an **empty request body**. The backend rejected creates/updates with FastAPI 422 `"Field required"`.

This is the real, systemic root cause behind the `/sources` failure that #671 made graceful (it surfaced the 422 instead of a white screen, but the request was still empty). No MGA mutation carrying a payload has worked since the slices were written (#608–#611) — `/sources` is just the one the operator exercised.

## Change

Renamed the request-descriptor key `body:` → `data:` across all 4 MGA RTK Query slices — **9 mutations**:

- `sourcesApi.ts` — `createSource`
- `lineupsApi.ts` — `createLineup`, `updateLineup`, `acceptLineup`, `bulkAcceptLineups`
- `gamesApi.ts` — `confirmMinimapUpload`, `bulkUpdateMapZones`
- `lineupPackagesApi.ts` — `createLineupPackage`, `patchLineupPackage`

Public mutation **argument** names/types named `body` (e.g. `acceptLineup({ id, body })`, `bulkUpdateMapZones({ mapId, body })`) are intentionally unchanged, so **no call sites change**. Scope is strictly `apps/mygamingassistant/` — no shared-package, MBK, or MJH files touched.

## Verification

- [x] `tsc --noEmit` clean
- [x] `vitest run` — 246/246 passing (20 files); no test asserted the old (broken) `body:` shape
- [ ] CI build (`tsc -b && vite build`)
- [ ] Operator smoke: create a source on `/sources` returns 201 (was 422 "Field required")

## Operational migration

None — pure frontend transport fix. No env, schema, or deploy-config changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)