### PR TITLE
feat(mjh): filter discovered jobs by saved search + source badge

### DIFF
--- a/apps/myjobhunter/backend/app/api/discover.py
+++ b/apps/myjobhunter/backend/app/api/discover.py
@@ -273,11 +273,12 @@ async def list_discovered(
     state: str = Query(default="inbox", pattern="^(inbox|saved|all)$"),
     limit: int = Query(default=50, ge=1, le=200),
     offset: int = Query(default=0, ge=0),
+    source_id: uuid.UUID | None = Query(default=None),
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
 ) -> DiscoveredJobListResponse:
     rows = await discovery_repository.list_discovered(
-        db, user.id, state=state, limit=limit, offset=offset,
+        db, user.id, state=state, limit=limit, offset=offset, source_id=source_id,
     )
     return DiscoveredJobListResponse(
         items=[DiscoveredJobResponse.model_validate(r) for r in rows],

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import desc, nulls_last, select, update
+from sqlalchemy import desc, nulls_last, outerjoin, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -334,6 +334,7 @@ async def list_discovered(
     state: str = "inbox",
     limit: int = 50,
     offset: int = 0,
+    source_id: uuid.UUID | None = None,
 ) -> list[DiscoveredJob]:
     """List discovered jobs scoped to user.
 
@@ -341,8 +342,27 @@ async def list_discovered(
       - "inbox": not dismissed, not saved, not promoted (the triage view)
       - "saved": saved_at IS NOT NULL AND dismissed_at IS NULL
       - "all": every non-expired row
+
+    source_id:
+      When provided, restricts results to rows whose fetch_id points to a
+      DiscoveryFetch whose discovery_source_id matches.  Uses a LEFT JOIN
+      on discovery_fetches to also populate ``discovery_source_id`` on
+      every returned row (no N+1).
     """
-    stmt = select(DiscoveredJob).where(DiscoveredJob.user_id == user_id)
+    # Always join discovery_fetches so we can populate discovery_source_id
+    # on each row without a second round-trip.  LEFT JOIN keeps rows whose
+    # fetch_id is NULL (legacy rows or fetch reaped after SET NULL cascade).
+    stmt = (
+        select(DiscoveredJob, DiscoveryFetch.discovery_source_id.label("_dsrc_id"))
+        .select_from(
+            outerjoin(
+                DiscoveredJob,
+                DiscoveryFetch,
+                DiscoveredJob.fetch_id == DiscoveryFetch.id,
+            )
+        )
+        .where(DiscoveredJob.user_id == user_id)
+    )
     if state == "inbox":
         stmt = stmt.where(
             DiscoveredJob.dismissed_at.is_(None),
@@ -355,18 +375,26 @@ async def list_discovered(
             DiscoveredJob.dismissed_at.is_(None),
         )
     # else "all": no extra filter
-    stmt = (
-        stmt.order_by(
-            # Highest score first; unscored rows fall to the bottom
-            # (nulls_last so an unscored row never beats a scored one).
-            nulls_last(desc(DiscoveredJob.score)),
-            desc(DiscoveredJob.discovered_at),
-        )
-        .limit(limit)
-        .offset(offset)
-    )
+
+    if source_id is not None:
+        stmt = stmt.where(DiscoveryFetch.discovery_source_id == source_id)
+
+    stmt = stmt.order_by(
+        # Highest score first; unscored rows fall to the bottom
+        # (nulls_last so an unscored row never beats a scored one).
+        nulls_last(desc(DiscoveredJob.score)),
+        desc(DiscoveredJob.discovered_at),
+    ).limit(limit).offset(offset)
+
     result = await db.execute(stmt)
-    return list(result.scalars().all())
+    rows = []
+    for job, dsrc_id in result.all():
+        # Attach discovery_source_id as a plain Python attribute so the
+        # Pydantic schema (from_attributes=True, discovery_source_id field)
+        # can read it without an ORM relationship.
+        job.discovery_source_id = dsrc_id
+        rows.append(job)
+    return rows
 
 
 async def get_discovered(

--- a/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
@@ -251,6 +251,10 @@ class DiscoveredJobResponse(BaseModel):
     dismissed_reason: str | None = None
     saved_at: datetime | None
     promoted_application_id: uuid.UUID | None
+    # Derived from the fetch FK: which saved search produced this posting.
+    # Null for legacy rows fetched before the fetch_id column was added, or
+    # for rows whose fetch row has been reaped.
+    discovery_source_id: uuid.UUID | None = None
 
     @computed_field  # type: ignore[prop-decorator]
     @property

--- a/apps/myjobhunter/backend/tests/test_discover_source_filter.py
+++ b/apps/myjobhunter/backend/tests/test_discover_source_filter.py
@@ -1,0 +1,266 @@
+"""Tests for ?source_id= filter on GET /discover.
+
+Verifies:
+- Unfiltered list returns postings from all sources
+- source_id filter restricts to postings from the matching saved search
+- Unknown / wrong-tenant source_id returns empty list (not 404)
+- discovery_source_id is populated on every returned item
+- Tenant isolation still holds when source_id is provided
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.discovery.discovered_job import DiscoveredJob
+from app.models.discovery.discovery_fetch import DiscoveryFetch
+from app.models.discovery.discovery_source import DiscoverySource
+
+
+_SEARCH_PATH = "app.services.discovery.discovery_fetch_service.jsearch.search"
+_SCORE_PATH = "app.services.discovery.discovery_score_service.score_user_inbox"
+_EMBED_PATH = "app.services.discovery.discovery_embedding_service.embed_pending_for_user_background"
+
+
+def _posting(**overrides) -> dict:
+    base = {
+        "source": "jsearch",
+        "source_external_id": f"ext-{uuid.uuid4()}",
+        "source_publisher": None,
+        "source_url": "https://example.com/job/1",
+        "title": "Backend Engineer",
+        "company_name": "Acme",
+        "location": "Remote",
+        "remote_type": "remote",
+        "description": "Python role",
+        "description_normalized": None,
+        "content_hash": None,
+        "posted_at": datetime(2026, 5, 6, 19, 0, tzinfo=timezone.utc),
+        "salary_min": None,
+        "salary_max": None,
+        "salary_currency": "USD",
+        "salary_period": None,
+        "raw_payload": {},
+    }
+    base.update(overrides)
+    return base
+
+
+async def _create_source_and_refresh(
+    client,
+    *,
+    query: str = "python remote",
+    name: str = "",
+    posting_overrides: dict | None = None,
+) -> tuple[str, str]:
+    """Create a saved search, refresh it once, return (source_id, job_id)."""
+    created = await client.post(
+        "/discover/sources",
+        json={"source": "jsearch", "name": name, "config": {"query": query}},
+    )
+    assert created.status_code == 201, created.text
+    source_id = created.json()["id"]
+
+    posting = _posting(**(posting_overrides or {}))
+    with (
+        patch(_SEARCH_PATH, new_callable=AsyncMock, return_value=[posting]),
+        patch(_SCORE_PATH, new_callable=AsyncMock, return_value=None),
+        patch(_EMBED_PATH, new_callable=AsyncMock, return_value=None),
+    ):
+        resp = await client.post(f"/discover/sources/{source_id}/refresh")
+    assert resp.status_code == 200, resp.text
+
+    listed = await client.get("/discover")
+    assert listed.status_code == 200
+    items = listed.json()["items"]
+    assert len(items) >= 1
+    # The most recently discovered posting for this source.
+    job_id = items[0]["id"]
+    return source_id, job_id
+
+
+# ===========================================================================
+# discovery_source_id is populated on all list paths
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_list_discovered_includes_discovery_source_id(
+    client: AsyncClient, user_factory, as_user,
+):
+    """Every item in the inbox response carries a non-null discovery_source_id
+    when the job was created via a fetch."""
+    user = await user_factory()
+    async with await as_user(user) as a:
+        source_id, job_id = await _create_source_and_refresh(a)
+
+        resp = await a.get("/discover")
+    assert resp.status_code == 200
+    item = resp.json()["items"][0]
+    assert item["id"] == job_id
+    assert item["discovery_source_id"] == source_id
+
+
+@pytest.mark.asyncio
+async def test_list_discovered_null_discovery_source_id_for_legacy_row(
+    db: AsyncSession, user_factory, as_user, client: AsyncClient,
+):
+    """A row inserted without a fetch_id (legacy / direct insertion) gets
+    discovery_source_id = null in the response — not a serialisation error."""
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+
+    job = DiscoveredJob(
+        user_id=user_id,
+        source="jsearch",
+        source_external_id="legacy-no-fetch",
+        title="Legacy Job",
+        company_name="OldCo",
+        fetch_id=None,  # no fetch → no source linkage
+    )
+    db.add(job)
+    await db.flush()
+
+    async with await as_user(user) as a:
+        resp = await a.get("/discover", params={"state": "all"})
+
+    assert resp.status_code == 200
+    items = resp.json()["items"]
+    legacy = next((i for i in items if i["id"] == str(job.id)), None)
+    assert legacy is not None, "legacy row not in response"
+    assert legacy["discovery_source_id"] is None
+
+
+# ===========================================================================
+# source_id filter — happy path
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_source_id_filter_returns_only_matching_postings(
+    client: AsyncClient, user_factory, as_user,
+):
+    """When ?source_id=<uuid> is given, only postings from that search appear."""
+    user = await user_factory()
+    async with await as_user(user) as a:
+        source_a_id, job_a_id = await _create_source_and_refresh(
+            a,
+            query="python backend remote",
+            name="Search A",
+            posting_overrides={"source_external_id": "ext-A", "title": "Backend A"},
+        )
+        source_b_id, job_b_id = await _create_source_and_refresh(
+            a,
+            query="frontend react remote",
+            name="Search B",
+            posting_overrides={"source_external_id": "ext-B", "title": "Frontend B"},
+        )
+
+        # Unfiltered: both postings visible
+        unfiltered = await a.get("/discover")
+        assert unfiltered.json()["total"] == 2
+
+        # Filtered to source A: only job A
+        filtered_a = await a.get("/discover", params={"source_id": source_a_id})
+        assert filtered_a.status_code == 200
+        items_a = filtered_a.json()["items"]
+        assert len(items_a) == 1
+        assert items_a[0]["id"] == job_a_id
+        assert items_a[0]["discovery_source_id"] == source_a_id
+
+        # Filtered to source B: only job B
+        filtered_b = await a.get("/discover", params={"source_id": source_b_id})
+        assert filtered_b.status_code == 200
+        items_b = filtered_b.json()["items"]
+        assert len(items_b) == 1
+        assert items_b[0]["id"] == job_b_id
+        assert items_b[0]["discovery_source_id"] == source_b_id
+
+
+# ===========================================================================
+# source_id filter — unknown / wrong-tenant source returns empty
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_source_id_filter_unknown_source_returns_empty(
+    client: AsyncClient, user_factory, as_user,
+):
+    """A source_id that doesn't exist (or belongs to another user) yields
+    an empty list — not a 404 or 422.  The frontend treats empty the same
+    as 'no results for this filter'."""
+    user = await user_factory()
+    async with await as_user(user) as a:
+        # Seed one posting so the user's inbox is not empty.
+        await _create_source_and_refresh(a)
+
+        unknown_id = str(uuid.uuid4())
+        resp = await a.get("/discover", params={"source_id": unknown_id})
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 0
+    assert body["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_source_id_filter_cross_tenant_isolation(
+    client: AsyncClient, user_factory, as_user,
+):
+    """User B supplying user A's source_id sees an empty list (tenant isolation)."""
+    owner = await user_factory()
+    attacker = await user_factory()
+
+    async with await as_user(owner) as a:
+        source_id, _ = await _create_source_and_refresh(a)
+
+    # Attacker tries to filter by owner's source_id.
+    async with await as_user(attacker) as a:
+        resp = await a.get("/discover", params={"source_id": source_id})
+
+    assert resp.status_code == 200
+    assert resp.json()["total"] == 0
+
+
+# ===========================================================================
+# source_id filter works with state parameter
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_source_id_filter_with_state_saved(
+    client: AsyncClient, user_factory, as_user,
+):
+    """source_id filter is honoured in the 'saved' state view too."""
+    user = await user_factory()
+    async with await as_user(user) as a:
+        source_a_id, job_a_id = await _create_source_and_refresh(
+            a,
+            query="python backend",
+            name="Search A",
+            posting_overrides={"source_external_id": "sa-1", "title": "A saved"},
+        )
+        source_b_id, job_b_id = await _create_source_and_refresh(
+            a,
+            query="frontend react",
+            name="Search B",
+            posting_overrides={"source_external_id": "sb-1", "title": "B saved"},
+        )
+
+        # Save both jobs.
+        await a.post(f"/discover/{job_a_id}/save")
+        await a.post(f"/discover/{job_b_id}/save")
+
+        # Filter saved by source A.
+        resp = await a.get(
+            "/discover", params={"state": "saved", "source_id": source_a_id},
+        )
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert items[0]["id"] == job_a_id

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
@@ -4,7 +4,7 @@ import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
 import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
 import DiscoveredJobsSkeleton from "@/features/discover/DiscoveredJobsSkeleton";
 import ProfileCompletenessBanner from "@/features/discover/ProfileCompletenessBanner";
-import { useListDiscoveredJobsQuery } from "@/store/discoverApi";
+import { useListDiscoveredJobsQuery, useListDiscoverySourcesQuery } from "@/store/discoverApi";
 import { useGetProfileQuery } from "@/lib/profileApi";
 import { useListSkillsQuery } from "@/lib/skillsApi";
 
@@ -15,14 +15,26 @@ const INBOX_POLL_INTERVAL_MS = 4000;
 
 interface DiscoverInboxViewProps {
   hasSources: boolean;
+  /** Active source filter from ?source= URL param. Null = no filter (show all). */
+  activeSourceId: string | null;
 }
 
-export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps) {
+export default function DiscoverInboxView({
+  hasSources,
+  activeSourceId,
+}: DiscoverInboxViewProps) {
+  // Include source_id in query args so RTK Query uses it as part of the cache key.
+  // When source_id changes the cache key changes → fresh fetch, no stale data.
+  const queryArgs = activeSourceId
+    ? { state: "inbox" as const, source_id: activeSourceId }
+    : { state: "inbox" as const };
+
   const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery(
-    { state: "inbox" },
+    queryArgs,
     { pollingInterval: INBOX_POLL_INTERVAL_MS },
   );
 
+  const { data: sources } = useListDiscoverySourcesQuery();
   const { data: profile } = useGetProfileQuery();
   const { data: skillsData } = useListSkillsQuery();
 
@@ -101,6 +113,7 @@ export default function DiscoverInboxView({ hasSources }: DiscoverInboxViewProps
           job={job}
           isScoringInFlight={hasUnscored}
           profileUpdatedAt={profileUpdatedAt}
+          sources={sources ?? []}
         />
       ))}
     </div>

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
@@ -18,6 +18,7 @@ import {
   type DismissalReason,
 } from "@/store/discoverApi";
 import type { DiscoveredJob } from "@/types/discovery/discovered-job";
+import type { DiscoverySource } from "@/types/discovery/discovery-source";
 import type { JobAnalysisVerdict } from "@/types/job-analysis/job-analysis-verdict";
 import DismissReasonPopover from "./DismissReasonPopover";
 import UndoDismissToast from "./UndoDismissToast";
@@ -46,6 +47,14 @@ interface DiscoveredJobCardProps {
    * profile loaded yet show no staleness signal.
    */
   profileUpdatedAt?: string | null;
+  /**
+   * All saved searches for the current user. Used to derive the
+   * source-name badge from ``job.discovery_source_id``.
+   *
+   * Optional — defaults to empty array so tests and callers that
+   * don't thread sources show no source badge.
+   */
+  sources?: DiscoverySource[];
 }
 
 const REMOTE_LABEL: Record<string, string> = {
@@ -71,6 +80,7 @@ export default function DiscoveredJobCard({
   job,
   isScoringInFlight = false,
   profileUpdatedAt = null,
+  sources = [],
 }: DiscoveredJobCardProps) {
   const [dismiss, { isLoading: isDismissing }] = useDismissDiscoveredJobMutation();
   const [save, { isLoading: isSaving }] = useSaveDiscoveredJobMutation();
@@ -132,6 +142,16 @@ export default function DiscoveredJobCard({
     profileUpdatedAt !== null &&
     new Date(profileUpdatedAt) > new Date(job.scored_at);
 
+  // Resolve the source name for the secondary badge. Look up by
+  // discovery_source_id against the already-fetched sources list — no
+  // extra network call. Falls back to null (no badge) for legacy rows.
+  const matchedSource = job.discovery_source_id
+    ? sources.find((s) => s.id === job.discovery_source_id) ?? null
+    : null;
+  const sourceBadgeLabel = matchedSource
+    ? matchedSource.name || matchedSource.source
+    : null;
+
   return (
     <>
     <UndoDismissToast
@@ -183,6 +203,11 @@ export default function DiscoveredJobCard({
           )}
           {job.source_publisher && (
             <Badge label={job.source_publisher} color="gray" />
+          )}
+          {sourceBadgeLabel && (
+            <span data-testid="source-name-badge">
+              <Badge label={sourceBadgeLabel} color="gray" />
+            </span>
           )}
         </div>
       </div>

--- a/apps/myjobhunter/frontend/src/features/discover/SourceFilterChips.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/SourceFilterChips.tsx
@@ -1,0 +1,73 @@
+import type { DiscoverySource } from "@/types/discovery/discovery-source";
+
+interface SourceFilterChipsProps {
+  sources: DiscoverySource[];
+  activeSourceId: string | null;
+  onSelect: (sourceId: string | null) => void;
+}
+
+/**
+ * Horizontal filter-chip strip for filtering the discover inbox by saved search.
+ * "All" chip is selected by default (activeSourceId === null).
+ * On narrow viewports the strip is horizontally scrollable rather than wrapping.
+ */
+export default function SourceFilterChips({
+  sources,
+  activeSourceId,
+  onSelect,
+}: SourceFilterChipsProps) {
+  if (sources.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex gap-2 overflow-x-auto pb-1"
+      role="group"
+      aria-label="Filter by saved search"
+    >
+      <Chip
+        label="All"
+        isActive={activeSourceId === null}
+        onClick={() => onSelect(null)}
+        testId="source-chip-all"
+      />
+      {sources.map((source) => (
+        <Chip
+          key={source.id}
+          label={source.name || source.source}
+          isActive={activeSourceId === source.id}
+          onClick={() => onSelect(source.id)}
+          testId={`source-chip-${source.id}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface ChipProps {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  testId: string;
+}
+
+function Chip({ label, isActive, onClick, testId }: ChipProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      aria-pressed={isActive}
+      className={[
+        "shrink-0 px-3 py-1 text-sm rounded-full border transition-colors",
+        "whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        isActive
+          ? "bg-primary text-primary-foreground border-primary"
+          : "bg-background text-foreground border-border hover:bg-muted",
+      ].join(" ")}
+    >
+      {label}
+    </button>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
@@ -1,12 +1,13 @@
 /**
- * Tests for DiscoveredJobCard — verdict badge, promoted state, and
- * "View application" link introduced in PR 7.
+ * Tests for DiscoveredJobCard — verdict badge, promoted state, source badge,
+ * and "View application" link introduced in PR 7.
  */
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import DiscoveredJobCard from "../DiscoveredJobCard";
 import type { DiscoveredJob } from "@/types/discovery/discovered-job";
+import type { DiscoverySource } from "@/types/discovery/discovery-source";
 
 vi.mock("lucide-react", () => ({
   Bookmark: () => null,
@@ -71,6 +72,7 @@ function makeJob(overrides: Partial<DiscoveredJob> = {}): DiscoveredJob {
     saved_at: null,
     promoted_application_id: null,
     verdict: null,
+    discovery_source_id: null,
     ...overrides,
   };
 }
@@ -293,5 +295,81 @@ describe("DiscoveredJobCard — post-promote view application link (PR 7)", () =
     );
     expect(screen.queryByTestId("view-application-link")).toBeNull();
     expect(screen.queryByTestId("promoted-applied-badge")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Source-name badge (filter chips feature)
+// ---------------------------------------------------------------------------
+
+function makeSource(overrides: Partial<DiscoverySource> = {}): DiscoverySource {
+  return {
+    id: "src-1",
+    source: "jsearch",
+    name: "Python remote",
+    config: {},
+    is_active: true,
+    fetch_interval_minutes: 1440,
+    last_fetched_at: null,
+    last_success_at: null,
+    last_error_at: null,
+    last_error_message: null,
+    consecutive_failures: 0,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("DiscoveredJobCard — source-name badge", () => {
+  it("shows no source badge when discovery_source_id is null", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({ discovery_source_id: null })}
+        sources={[makeSource()]}
+      />,
+    );
+    expect(screen.queryByTestId("source-name-badge")).toBeNull();
+  });
+
+  it("shows no source badge when sources list is empty (default)", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({ discovery_source_id: "src-1" })}
+      />,
+    );
+    expect(screen.queryByTestId("source-name-badge")).toBeNull();
+  });
+
+  it("shows the source name badge when discovery_source_id matches a source", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({ discovery_source_id: "src-1" })}
+        sources={[makeSource({ id: "src-1", name: "Python remote" })]}
+      />,
+    );
+    const badge = screen.getByTestId("source-name-badge");
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveTextContent("Python remote");
+  });
+
+  it("falls back to source.source when source name is empty", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({ discovery_source_id: "src-1" })}
+        sources={[makeSource({ id: "src-1", name: "", source: "jsearch" })]}
+      />,
+    );
+    expect(screen.getByTestId("source-name-badge")).toHaveTextContent("jsearch");
+  });
+
+  it("shows no badge when discovery_source_id does not match any source", () => {
+    renderInRouter(
+      <DiscoveredJobCard
+        job={makeJob({ discovery_source_id: "unknown-id" })}
+        sources={[makeSource({ id: "src-1" })]}
+      />,
+    );
+    expect(screen.queryByTestId("source-name-badge")).toBeNull();
   });
 });

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/SourceFilterChips.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/SourceFilterChips.test.tsx
@@ -1,0 +1,101 @@
+/**
+ * Tests for SourceFilterChips — filter-chip strip on the Discover page.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import SourceFilterChips from "../SourceFilterChips";
+import type { DiscoverySource } from "@/types/discovery/discovery-source";
+
+function makeSource(overrides: Partial<DiscoverySource> = {}): DiscoverySource {
+  return {
+    id: "src-1",
+    source: "jsearch",
+    name: "Python remote",
+    config: {},
+    is_active: true,
+    fetch_interval_minutes: 1440,
+    last_fetched_at: null,
+    last_success_at: null,
+    last_error_at: null,
+    last_error_message: null,
+    consecutive_failures: 0,
+    created_at: "2026-05-01T00:00:00Z",
+    updated_at: "2026-05-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("SourceFilterChips", () => {
+  it("renders nothing when sources list is empty", () => {
+    const { container } = render(
+      <SourceFilterChips sources={[]} activeSourceId={null} onSelect={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders an 'All' chip plus one chip per source", () => {
+    const sources = [
+      makeSource({ id: "src-1", name: "Python backend" }),
+      makeSource({ id: "src-2", name: "Frontend React" }),
+    ];
+    render(
+      <SourceFilterChips sources={sources} activeSourceId={null} onSelect={vi.fn()} />,
+    );
+
+    expect(screen.getByTestId("source-chip-all")).toBeInTheDocument();
+    expect(screen.getByTestId("source-chip-src-1")).toBeInTheDocument();
+    expect(screen.getByTestId("source-chip-src-2")).toBeInTheDocument();
+    expect(screen.getByText("Python backend")).toBeInTheDocument();
+    expect(screen.getByText("Frontend React")).toBeInTheDocument();
+  });
+
+  it("uses source.source as fallback label when name is empty", () => {
+    const sources = [makeSource({ id: "src-1", name: "", source: "jsearch" })];
+    render(
+      <SourceFilterChips sources={sources} activeSourceId={null} onSelect={vi.fn()} />,
+    );
+    expect(screen.getByText("jsearch")).toBeInTheDocument();
+  });
+
+  it("marks 'All' chip as active (aria-pressed=true) when activeSourceId is null", () => {
+    const sources = [makeSource()];
+    render(
+      <SourceFilterChips sources={sources} activeSourceId={null} onSelect={vi.fn()} />,
+    );
+    expect(screen.getByTestId("source-chip-all")).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("source-chip-src-1")).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("marks the matching source chip as active when activeSourceId is set", () => {
+    const sources = [
+      makeSource({ id: "src-1" }),
+      makeSource({ id: "src-2" }),
+    ];
+    render(
+      <SourceFilterChips sources={sources} activeSourceId="src-2" onSelect={vi.fn()} />,
+    );
+    expect(screen.getByTestId("source-chip-all")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("source-chip-src-1")).toHaveAttribute("aria-pressed", "false");
+    expect(screen.getByTestId("source-chip-src-2")).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("calls onSelect with null when 'All' chip is clicked", () => {
+    const onSelect = vi.fn();
+    const sources = [makeSource()];
+    render(
+      <SourceFilterChips sources={sources} activeSourceId="src-1" onSelect={onSelect} />,
+    );
+    fireEvent.click(screen.getByTestId("source-chip-all"));
+    expect(onSelect).toHaveBeenCalledWith(null);
+  });
+
+  it("calls onSelect with the source id when a source chip is clicked", () => {
+    const onSelect = vi.fn();
+    const sources = [makeSource({ id: "src-42" })];
+    render(
+      <SourceFilterChips sources={sources} activeSourceId={null} onSelect={onSelect} />,
+    );
+    fireEvent.click(screen.getByTestId("source-chip-src-42"));
+    expect(onSelect).toHaveBeenCalledWith("src-42");
+  });
+});

--- a/apps/myjobhunter/frontend/src/pages/Discover.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Discover.tsx
@@ -7,6 +7,7 @@ import DiscoverSavedView from "@/features/discover/DiscoverSavedView";
 import DiscoverViewTabs from "@/features/discover/DiscoverViewTabs";
 import NewSavedSearchDialog from "@/features/discover/NewSavedSearchDialog";
 import SavedSearchesPanel from "@/features/discover/SavedSearchesPanel";
+import SourceFilterChips from "@/features/discover/SourceFilterChips";
 import { useListDiscoverySourcesQuery } from "@/store/discoverApi";
 import type { DiscoverView } from "@/types/discovery/discover-view";
 
@@ -20,14 +21,9 @@ import type { DiscoverView } from "@/types/discovery/discover-view";
  * Tab state lives in ?view=inbox (default) | ?view=saved so deep-linking
  * and back-button work correctly.
  *
- * MVP scope (PR 5):
- * - Inbox / Saved tab toggle
- * - Saved-search creation via inline dialog (no separate /preferences page)
- * - Manual "Refresh" per saved search (no auto-scheduler yet)
- * - No scoring UI (backend score() endpoint not yet wired in v1)
- * - No promote-to-application yet (operator clicks the external Open
- *   link, applies on the source, manually creates an Application via
- *   /applications when ready)
+ * Source filter lives in ?source=<uuid> — selecting a chip sets the param,
+ * selecting "All" deletes it. Uses replace: true so back-button goes to the
+ * previous page rather than cycling through chip selections.
  */
 export default function Discover() {
   const [dialogOpen, setDialogOpen] = useState(false);
@@ -35,6 +31,8 @@ export default function Discover() {
 
   const rawView = searchParams.get("view");
   const activeView: DiscoverView = rawView === "saved" ? "saved" : "inbox";
+
+  const activeSourceId = searchParams.get("source");
 
   function setView(view: DiscoverView) {
     setSearchParams(
@@ -44,6 +42,21 @@ export default function Discover() {
           next.delete("view");
         } else {
           next.set("view", view);
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  }
+
+  function setSourceFilter(sourceId: string | null) {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (sourceId === null) {
+          next.delete("source");
+        } else {
+          next.set("source", sourceId);
         }
         return next;
       },
@@ -72,10 +85,21 @@ export default function Discover() {
 
       <SavedSearchesPanel />
 
+      {hasSources && (
+        <SourceFilterChips
+          sources={sources ?? []}
+          activeSourceId={activeSourceId}
+          onSelect={setSourceFilter}
+        />
+      )}
+
       <DiscoverViewTabs activeView={activeView} onSelect={setView} />
 
       {activeView === "inbox" ? (
-        <DiscoverInboxView hasSources={hasSources} />
+        <DiscoverInboxView
+          hasSources={hasSources}
+          activeSourceId={activeSourceId}
+        />
       ) : (
         <DiscoverSavedView />
       )}

--- a/apps/myjobhunter/frontend/src/store/discoverApi.ts
+++ b/apps/myjobhunter/frontend/src/store/discoverApi.ts
@@ -56,13 +56,20 @@ const discoverApi = apiWithTags.injectEndpoints({
     }),
     listDiscoveredJobs: build.query<
       DiscoveredJobListResponse,
-      { state?: "inbox" | "saved" | "all"; limit?: number; offset?: number }
+      {
+        state?: "inbox" | "saved" | "all";
+        limit?: number;
+        offset?: number;
+        source_id?: string;
+      }
     >({
-      query: ({ state = "inbox", limit = 50, offset = 0 } = {}) => ({
-        url: "/discover",
-        method: "GET",
-        params: { state, limit, offset },
-      }),
+      query: ({ state = "inbox", limit = 50, offset = 0, source_id } = {}) => {
+        const params: Record<string, string | number> = { state, limit, offset };
+        if (source_id) {
+          params.source_id = source_id;
+        }
+        return { url: "/discover", method: "GET", params };
+      },
       providesTags: ["DiscoveredJob"],
     }),
     dismissDiscoveredJob: build.mutation<

--- a/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovered-job.ts
@@ -26,4 +26,6 @@ export interface DiscoveredJob {
   promoted_application_id: string | null;
   /** Derived by the backend from ``score``. Null for unscored rows. */
   verdict: JobAnalysisVerdict | null;
+  /** Which saved search produced this posting. Null for legacy rows. */
+  discovery_source_id: string | null;
 }


### PR DESCRIPTION
## Summary

Issue 4 of a 5-issue MJH QA pass. The /discover inbox was one flat list
mixing every saved search's results with no attribution — after a new
search, results appended into the score-ranked stream and the user
couldn't tell which posting came from which search.

Built via the pipeline (`g-build-feature`). UX design decided up front
(filter chips + per-card source badge).

**Backend**
- `GET /discover` accepts `?source_id=<uuid>` — filters inbox/saved/all
- `discovery_repository.list_discovered()` LEFT JOINs `discovery_fetches`
  to derive `discovery_source_id` (no N+1; legacy `fetch_id=NULL` → null)
- `DiscoveredJobResponse.discovery_source_id` added; tenant scoping intact

**Frontend**
- `SourceFilterChips` — horizontal scrollable chip strip, "All" default,
  `?source=<uuid>` URL param (`replace: true`, mirrors `?view=`)
- `DiscoveredJobCard` — gray source-name `Badge` resolved from sources
- `discoverApi` cache keyed per source filter; polling preserved

## Test plan

- [x] 6 backend pytest (filter, legacy null, cross-tenant isolation, state=saved, unknown id → empty)
- [x] 7 `SourceFilterChips` + 5 `DiscoveredJobCard` Vitest tests
- [x] typecheck + lint clean
- [ ] Pre-existing unrelated: `test_discover_endpoints.py` (6) fail on main (unmocked score path → real Anthropic call); shared-frontend `InlineBoldText`

🤖 Generated with [Claude Code](https://claude.com/claude-code)