### PR TITLE
feat(mjh): persist job-analysis result across navigation

### DIFF
--- a/apps/myjobhunter/frontend/src/features/analyze/AnalysisActions.tsx
+++ b/apps/myjobhunter/frontend/src/features/analyze/AnalysisActions.tsx
@@ -11,6 +11,11 @@
  *                 analysis already has an applied_application_id, in
  *                 place of (1) and (2).
  *
+ * Before the user has applied, a single line of bridging copy explains
+ * what adding to applications unlocks (tracking, contacts, documents).
+ * It is intentionally minimal — the verdict and dimensions already did
+ * the heavy analytical work; this just names the next step.
+ *
  * Everything is button-style for consistency. The primary action uses
  * LoadingButton so the operator sees the spinner during the round-trip.
  */
@@ -56,22 +61,27 @@ export default function AnalysisActions({
   }
 
   return (
-    <div className="flex flex-wrap items-center justify-end gap-3 pt-2">
-      <button
-        type="button"
-        onClick={onAnalyzeAnother}
-        className="rounded-md border bg-background px-4 py-2 text-sm font-medium hover:bg-muted min-h-[44px]"
-      >
-        Analyze another
-      </button>
-      <LoadingButton
-        type="button"
-        isLoading={applying}
-        loadingText="Adding…"
-        onClick={onApply}
-      >
-        Add to applications
-      </LoadingButton>
+    <div className="space-y-3 pt-2">
+      <p className="text-sm text-muted-foreground text-right">
+        Add to applications to track interviews, contacts, and documents for this role.
+      </p>
+      <div className="flex flex-wrap items-center justify-end gap-3">
+        <button
+          type="button"
+          onClick={onAnalyzeAnother}
+          className="rounded-md border bg-background px-4 py-2 text-sm font-medium hover:bg-muted min-h-[44px]"
+        >
+          Analyze another
+        </button>
+        <LoadingButton
+          type="button"
+          isLoading={applying}
+          loadingText="Adding…"
+          onClick={onApply}
+        >
+          Add to applications
+        </LoadingButton>
+      </div>
     </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/lib/store.ts
+++ b/apps/myjobhunter/frontend/src/lib/store.ts
@@ -1,9 +1,11 @@
 import { configureStore } from "@reduxjs/toolkit";
 import { baseApi } from "@platform/ui";
+import jobAnalysisReducer from "@/store/jobAnalysisSlice";
 
 export const store = configureStore({
   reducer: {
     [baseApi.reducerPath]: baseApi.reducer,
+    jobAnalysis: jobAnalysisReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware().concat(baseApi.middleware),

--- a/apps/myjobhunter/frontend/src/pages/Analyze.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Analyze.tsx
@@ -14,6 +14,14 @@
  * depending on whether Claude returned). This is the same shape the
  * Add Application dialog uses for its three-step flow.
  *
+ * Redux-slice persistence (in-app navigation only):
+ * When an analysis completes successfully, the result is written to the
+ * jobAnalysis slice so that navigating to another page and back does NOT
+ * lose the result — no second paid AI call needed.  On mount, if the
+ * slice holds a lastResult, the page initialises directly to RESULT
+ * (no flash of the input view).  When the user clicks "Analyze another"
+ * the slice is cleared so remounting shows the input view.
+ *
  * Operator workflow (verbatim from session notes):
  * > "the application page should not be the first step. when we paste
  *    a jd, it should be analysis. applying to the job should be the
@@ -25,6 +33,7 @@
  */
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 import { Loader2, Sparkles } from "lucide-react";
 import { EmptyState, showError, showSuccess, extractErrorMessage } from "@platform/ui";
 import AnalyzeJdInput, {
@@ -42,6 +51,8 @@ import {
   useAnalyzeJobMutation,
   useApplyFromAnalysisMutation,
 } from "@/lib/jobAnalysisApi";
+import { setLastAnalysis, clearLastAnalysis } from "@/store/jobAnalysisSlice";
+import type { RootState } from "@/lib/store";
 import type { JobAnalysis } from "@/types/job-analysis/job-analysis";
 
 const PROCESSING_LONG_RUNNING_THRESHOLD_MS = 3000;
@@ -51,15 +62,27 @@ type PageState =
   | { kind: "processing"; sourcePath: "url" | "text"; longRunning: boolean }
   | { kind: "result"; analysis: JobAnalysis };
 
-const INITIAL_STATE: PageState = { kind: "input", mode: "url" };
+function deriveInitialState(lastResult: JobAnalysis | null): PageState {
+  if (lastResult !== null) {
+    return { kind: "result", analysis: lastResult };
+  }
+  return { kind: "input", mode: "url" };
+}
 
 export default function Analyze() {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
+  const lastResult = useSelector((s: RootState) => s.jobAnalysis.lastResult);
+
   const [analyzeJob, { isLoading: analyzing }] = useAnalyzeJobMutation();
   const [applyFromAnalysis, { isLoading: applying }] =
     useApplyFromAnalysisMutation();
 
-  const [state, setState] = useState<PageState>(INITIAL_STATE);
+  // Initialise directly from the slice on first render — no post-mount
+  // useEffect — so the input view never flashes before the result appears.
+  const [state, setState] = useState<PageState>(() =>
+    deriveInitialState(lastResult),
+  );
   const [urlValue, setUrlValue] = useState("");
   const [textValue, setTextValue] = useState("");
   // Persistent "we couldn't read that link" explanation. Replaces the
@@ -84,6 +107,7 @@ export default function Analyze() {
     setUrlValue("");
     setTextValue("");
     setUrlBlockedNotice(null);
+    dispatch(clearLastAnalysis());
     setState({ kind: "input", mode });
   }
 
@@ -94,6 +118,7 @@ export default function Analyze() {
     setState({ kind: "processing", sourcePath: "url", longRunning: false });
     try {
       const result = await analyzeJob({ url: trimmed }).unwrap();
+      dispatch(setLastAnalysis(result));
       setState({ kind: "result", analysis: result });
     } catch (err) {
       if (isAuthRequiredError(err)) {
@@ -119,6 +144,7 @@ export default function Analyze() {
     setState({ kind: "processing", sourcePath: "text", longRunning: false });
     try {
       const result = await analyzeJob({ jd_text: trimmed }).unwrap();
+      dispatch(setLastAnalysis(result));
       setState({ kind: "result", analysis: result });
     } catch (err) {
       showError(
@@ -163,7 +189,7 @@ export default function Analyze() {
   // ---------------------------------------------------------------------
   return (
     <main className="p-4 sm:p-8 space-y-6">
-      {state.kind === "input" ? (
+      {state.kind === "input" && (
         <InputView
           mode={state.mode}
           urlValue={urlValue}
@@ -177,16 +203,16 @@ export default function Analyze() {
           onSubmitText={() => runAnalyzeText(textValue)}
           onPasteUrl={handlePasteUrl}
         />
-      ) : null}
+      )}
 
-      {state.kind === "processing" ? (
+      {state.kind === "processing" && (
         <ProcessingView
           sourcePath={state.sourcePath}
           longRunning={state.longRunning}
         />
-      ) : null}
+      )}
 
-      {state.kind === "result" ? (
+      {state.kind === "result" && (
         <ResultView
           analysis={state.analysis}
           applying={applying}
@@ -194,7 +220,7 @@ export default function Analyze() {
           onAnalyzeAnother={() => resetToInput("url")}
           onViewApplications={() => navigate("/applications")}
         />
-      ) : null}
+      )}
     </main>
   );
 }

--- a/apps/myjobhunter/frontend/src/pages/__tests__/Analyze.test.tsx
+++ b/apps/myjobhunter/frontend/src/pages/__tests__/Analyze.test.tsx
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { baseApi } from "@platform/ui";
+import jobAnalysisReducer from "@/store/jobAnalysisSlice";
 import Analyze from "@/pages/Analyze";
 import type { JobAnalysis } from "@/types/job-analysis/job-analysis";
 
@@ -62,6 +66,24 @@ const mockUseAnalyzeJobMutation = vi.mocked(useAnalyzeJobMutation);
 const mockUseApplyFromAnalysisMutation = vi.mocked(useApplyFromAnalysisMutation);
 
 // ---------------------------------------------------------------------------
+// Test store factory
+// ---------------------------------------------------------------------------
+
+function makeTestStore(preloadedJobAnalysis?: { lastResult: JobAnalysis | null }) {
+  return configureStore({
+    reducer: {
+      [baseApi.reducerPath]: baseApi.reducer,
+      jobAnalysis: jobAnalysisReducer,
+    },
+    middleware: (getDefaultMiddleware) =>
+      getDefaultMiddleware().concat(baseApi.middleware),
+    preloadedState: preloadedJobAnalysis
+      ? { jobAnalysis: preloadedJobAnalysis }
+      : undefined,
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
 
@@ -104,18 +126,28 @@ function makeAnalysis(overrides: Partial<JobAnalysis> = {}): JobAnalysis {
   };
 }
 
-function renderAnalyze() {
-  return render(
-    <MemoryRouter initialEntries={["/analyze"]}>
-      <Routes>
-        <Route path="/analyze" element={<Analyze />} />
-        <Route
-          path="/applications"
-          element={<div data-testid="applications-page">Applications</div>}
-        />
-      </Routes>
-    </MemoryRouter>,
-  );
+interface RenderOptions {
+  store?: ReturnType<typeof makeTestStore>;
+}
+
+function renderAnalyze({ store }: RenderOptions = {}) {
+  const testStore = store ?? makeTestStore();
+  return {
+    store: testStore,
+    ...render(
+      <Provider store={testStore}>
+        <MemoryRouter initialEntries={["/analyze"]}>
+          <Routes>
+            <Route path="/analyze" element={<Analyze />} />
+            <Route
+              path="/applications"
+              element={<div data-testid="applications-page">Applications</div>}
+            />
+          </Routes>
+        </MemoryRouter>
+      </Provider>,
+    ),
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -390,6 +422,160 @@ describe("Analyze page", () => {
     // Primary "Add to applications" should NOT render when already saved.
     expect(
       screen.queryByRole("button", { name: /Add to applications/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Slice persistence tests (new)
+  // ---------------------------------------------------------------------------
+
+  it("re-hydrates result view from slice on remount — no flash of input", () => {
+    // Arrange: pre-populate the store with a completed analysis.
+    const store = makeTestStore({ lastResult: makeAnalysis() });
+    mockUseAnalyzeJobMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useAnalyzeJobMutation>);
+    mockUseApplyFromAnalysisMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useApplyFromAnalysisMutation>);
+
+    // Mount Analyze with the pre-populated store (simulates returning after
+    // navigation away).
+    renderAnalyze({ store });
+
+    // Should render the result immediately — no input view visible.
+    expect(screen.queryByText("Analyze a job")).not.toBeInTheDocument();
+    expect(screen.getByText("Worth considering")).toBeInTheDocument();
+    expect(screen.getByText("Senior Backend Engineer")).toBeInTheDocument();
+  });
+
+  it("slice is cleared on 'Analyze another' so remount shows input", async () => {
+    const store = makeTestStore({ lastResult: makeAnalysis() });
+    mockUseAnalyzeJobMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useAnalyzeJobMutation>);
+    mockUseApplyFromAnalysisMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useApplyFromAnalysisMutation>);
+
+    const user = userEvent.setup();
+    renderAnalyze({ store });
+
+    // Starts in result view (pre-hydrated).
+    expect(screen.getByText("Worth considering")).toBeInTheDocument();
+
+    // Click "Analyze another" — should clear the slice.
+    await user.click(screen.getByRole("button", { name: /Analyze another/i }));
+
+    // Slice should now be null.
+    const sliceState = store.getState().jobAnalysis;
+    expect(sliceState.lastResult).toBeNull();
+
+    // Page should show input.
+    expect(await screen.findByLabelText("Job posting URL")).toBeInTheDocument();
+  });
+
+  it("slice is populated after a successful analysis", async () => {
+    const analysis = makeAnalysis();
+    const analyzeMock = vi.fn().mockReturnValue({
+      unwrap: () => Promise.resolve(analysis),
+    });
+    mockUseAnalyzeJobMutation.mockReturnValue([
+      analyzeMock,
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useAnalyzeJobMutation>);
+    mockUseApplyFromAnalysisMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useApplyFromAnalysisMutation>);
+
+    const user = userEvent.setup();
+    const { store } = renderAnalyze();
+
+    await user.click(
+      screen.getByText("No URL? Paste the description text instead."),
+    );
+    await user.type(
+      await screen.findByLabelText("Job description text"),
+      "Some JD.",
+    );
+    const submitButtons = screen.getAllByRole("button", {
+      name: /Analyze this job/i,
+    });
+    await user.click(submitButtons[submitButtons.length - 1]!);
+
+    await screen.findByText("Worth considering");
+
+    // Slice should now hold the result.
+    const sliceState = store.getState().jobAnalysis;
+    expect(sliceState.lastResult).not.toBeNull();
+    expect(sliceState.lastResult?.id).toBe("an-1");
+  });
+
+  it("shows bridging copy framing the next step before applying", async () => {
+    const analyzeMock = vi.fn().mockReturnValue({
+      unwrap: () => Promise.resolve(makeAnalysis()),
+    });
+    mockUseAnalyzeJobMutation.mockReturnValue([
+      analyzeMock,
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useAnalyzeJobMutation>);
+    mockUseApplyFromAnalysisMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useApplyFromAnalysisMutation>);
+
+    const user = userEvent.setup();
+    renderAnalyze();
+
+    await user.click(
+      screen.getByText("No URL? Paste the description text instead."),
+    );
+    await user.type(
+      await screen.findByLabelText("Job description text"),
+      "Some JD.",
+    );
+    const submitButtons = screen.getAllByRole("button", {
+      name: /Analyze this job/i,
+    });
+    await user.click(submitButtons[submitButtons.length - 1]!);
+
+    await screen.findByText("Worth considering");
+
+    // Bridging copy should be visible before applying.
+    expect(
+      screen.getByText(
+        /Add to applications to track interviews, contacts, and documents/i,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("bridging copy is absent once the analysis has been applied", async () => {
+    // Pre-populate store with an already-applied analysis.
+    const store = makeTestStore({
+      lastResult: makeAnalysis({ applied_application_id: "app-existing" }),
+    });
+    mockUseAnalyzeJobMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useAnalyzeJobMutation>);
+    mockUseApplyFromAnalysisMutation.mockReturnValue([
+      vi.fn(),
+      { isLoading: false, reset: vi.fn() },
+    ] as unknown as ReturnType<typeof useApplyFromAnalysisMutation>);
+
+    renderAnalyze({ store });
+
+    // "Saved to your applications." is shown instead of bridging copy.
+    expect(await screen.findByText(/Saved to your applications/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        /Add to applications to track interviews/i,
+      ),
     ).not.toBeInTheDocument();
   });
 });

--- a/apps/myjobhunter/frontend/src/store/jobAnalysisSlice.ts
+++ b/apps/myjobhunter/frontend/src/store/jobAnalysisSlice.ts
@@ -1,0 +1,41 @@
+/**
+ * Redux slice for the last job-analysis result.
+ *
+ * Scope: in-app navigation persistence only.
+ * The result is stored in Redux so it survives sidebar navigation
+ * without requiring a second paid AI call.  A full browser refresh
+ * clears the slice (by design — URL-param / backend-refetch is a
+ * separate future concern).
+ *
+ * Actions
+ *   setLastAnalysis(result)  — called when an analysis completes
+ *   clearLastAnalysis()      — called when the user resets to input
+ */
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import type { JobAnalysis } from "@/types/job-analysis/job-analysis";
+
+interface JobAnalysisState {
+  lastResult: JobAnalysis | null;
+}
+
+const initialState: JobAnalysisState = {
+  lastResult: null,
+};
+
+const jobAnalysisSlice = createSlice({
+  name: "jobAnalysis",
+  initialState,
+  reducers: {
+    setLastAnalysis(state, action: PayloadAction<JobAnalysis>) {
+      state.lastResult = action.payload;
+    },
+    clearLastAnalysis(state) {
+      state.lastResult = null;
+    },
+  },
+});
+
+export const { setLastAnalysis, clearLastAnalysis } =
+  jobAnalysisSlice.actions;
+
+export default jobAnalysisSlice.reducer;


### PR DESCRIPTION
## Summary

Issue 5 of a 5-issue MJH QA pass. After analyzing a job, navigating to
another page discarded the result — a 5–15s paid AI call lost on a
sidebar click. Built via the pipeline (`g-build-feature`).

Approach decided up front: **Redux-slice interim** (survives in-app
navigation). Full refresh-safety via a `?id=` URL param + backend
re-fetch is a deliberately separate future PR — not built here.

- New `jobAnalysisSlice` (`lastResult: JobAnalysis | null`,
  `setLastAnalysis` / `clearLastAnalysis`); registered in the store
- `Analyze.tsx` re-hydrates from the slice via a lazy `useState`
  initialiser (no input-view flash); dispatches on success; clears on
  "Analyze another"
- `AnalysisActions` — one-line bridging copy framing the next step
  before applying; absent once applied

## Test plan

- [x] 5 original Analyze tests pass + 5 new (re-hydrate no-flash, clear-on-another, slice populated, bridging copy present/absent)
- [x] typecheck + lint clean; full suite matches main baseline (no regressions)
- [ ] Pre-existing unrelated failures noted (ThemeToggle/shared-frontend partial-mock drift on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)