### PR TITLE
fix(mjh): persistent banner when an Add Application JD link needs a login

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/AddApplicationDialog.tsx
@@ -110,6 +110,7 @@ export default function AddApplicationDialog({ open, onOpenChange }: AddApplicat
               onTextChange={flow.setTextValue}
               onTextSubmit={flow.handleTextSubmit}
               onSetInputMode={flow.setInputMode}
+              notice={flow.urlBlockedNotice}
             />
           ) : null}
 

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/AddApplicationDialog.test.tsx
@@ -16,18 +16,13 @@ import AddApplicationDialog from "../AddApplicationDialog";
 
 // ---- mocks ----
 
-vi.mock("lucide-react", () => ({
-  X: () => null,
-  Plus: () => null,
-  Sparkles: () => null,
-  ChevronDown: () => null,
-  ChevronUp: () => null,
-  Download: () => null,
-  FileText: () => null,
-  Link: () => null,
-  Loader2: () => null,
-  Building2: () => null,
-}));
+// lucide-react is intentionally NOT mocked. The @platform/ui mock below
+// spreads the real barrel (importOriginal), which transitively renders
+// real icons anyway (e.g. ThemeToggle's Sun/Moon, AlertBox's barrel
+// siblings); a hard-coded icon stub map just breaks the whole file with
+// "No <Icon> export" the moment a new component is pulled in. Real icons
+// render as harmless <svg> in jsdom — tests query by text/role, never by
+// icon.
 
 vi.mock("@/lib/companiesApi", () => ({
   useListCompaniesQuery: vi.fn(),
@@ -379,6 +374,202 @@ describe("AddApplicationDialog — text-paste path", () => {
     await waitFor(() => {
       expect(screen.getByText(/review and adjust before saving/i)).toBeInTheDocument();
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Auth-walled URL → persistent banner (NOT a vanishing toast)
+//
+// Regression for the "it looks broken" defect: pasting a LinkedIn /
+// Glassdoor URL returned 422 auth_required, the dialog fired a transient
+// toast and silently swapped to the blank text tab. The toast faded and
+// left the user staring at an empty textarea with no idea why. The fix
+// replaces the toast (auth-required case only) with a persistent
+// AlertBox on the text tab; it clears on tab-switch-to-url / text parse
+// / dialog reset.
+// ---------------------------------------------------------------------------
+
+describe("AddApplicationDialog — auth-walled URL banner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCreateApplicationMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useCreateApplicationMutation>>(),
+    );
+    mockUseListCompaniesQuery.mockReturnValue(emptyCompanies);
+    mockUseCreateCompanyMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useCreateCompanyMutation>>(),
+    );
+    mockUseParseJobDescriptionMutation.mockReturnValue(
+      defaultMutation<ReturnType<typeof useParseJobDescriptionMutation>>(),
+    );
+  });
+
+  function mockAuthWalledExtract() {
+    const mockExtract = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.reject({ status: 422, data: { detail: "auth_required" } }),
+    });
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      [mockExtract, { isLoading: false }] as unknown as ReturnType<
+        typeof useExtractJdFromUrlMutation
+      >,
+    );
+    return mockExtract;
+  }
+
+  it("shows a persistent banner (not a vanishing toast) when the URL is auth-walled", async () => {
+    const { showError } = await import("@platform/ui");
+    mockAuthWalledExtract();
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByLabelText(/job posting url/i),
+      "https://www.linkedin.com/jobs/view/123",
+    );
+    await user.click(screen.getByRole("button", { name: /auto-fill/i }));
+
+    // Switched to the text tab AND a persistent explanation is shown.
+    expect(
+      await screen.findByLabelText(/job description text/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/couldn't read that link/i),
+    ).toBeInTheDocument();
+    // The auth-required case must NOT use the transient toast — that
+    // vanishing was the whole "it seems broken" complaint.
+    expect(showError).not.toHaveBeenCalled();
+  });
+
+  it("clears the blocked-link banner when the user switches back to the URL tab", async () => {
+    mockAuthWalledExtract();
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByLabelText(/job posting url/i),
+      "https://www.linkedin.com/jobs/view/123",
+    );
+    await user.click(screen.getByRole("button", { name: /auto-fill/i }));
+
+    await screen.findByText(/couldn't read that link/i);
+
+    await user.click(
+      screen.getByText(/have a url instead\? paste it here/i),
+    );
+
+    expect(screen.getByLabelText(/job posting url/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't read that link/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("clears the blocked-link banner after a text parse is started", async () => {
+    mockAuthWalledExtract();
+    const mockParse = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          title: "Senior Engineer",
+          company: "Acme Corp",
+          location: "Remote",
+          remote_type: "remote",
+          salary_min: null,
+          salary_max: null,
+          salary_currency: null,
+          salary_period: null,
+          seniority: null,
+          must_have_requirements: [],
+          nice_to_have_requirements: [],
+          responsibilities: [],
+          summary: "Great role.",
+        }),
+    });
+    const mockCreateCompany = vi.fn().mockReturnValue({
+      unwrap: () =>
+        Promise.resolve({
+          id: "co-new",
+          user_id: "u1",
+          name: "Acme Corp",
+          primary_domain: null,
+          logo_url: null,
+          industry: null,
+          size_range: null,
+          hq_location: null,
+          description: null,
+          external_ref: null,
+          external_source: null,
+          crunchbase_id: null,
+          created_at: "",
+          updated_at: "",
+        }),
+    });
+    mockUseParseJobDescriptionMutation.mockReturnValue(
+      [mockParse, { isLoading: false }] as unknown as ReturnType<
+        typeof useParseJobDescriptionMutation
+      >,
+    );
+    mockUseCreateCompanyMutation.mockReturnValue(
+      [mockCreateCompany, { isLoading: false }] as unknown as ReturnType<
+        typeof useCreateCompanyMutation
+      >,
+    );
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByLabelText(/job posting url/i),
+      "https://www.linkedin.com/jobs/view/123",
+    );
+    await user.click(screen.getByRole("button", { name: /auto-fill/i }));
+
+    await screen.findByText(/couldn't read that link/i);
+
+    await user.type(
+      screen.getByLabelText(/job description text/i),
+      "Pasted JD text for Acme Corp",
+    );
+    await user.click(screen.getByRole("button", { name: /parse with ai/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/review and adjust before saving/i)).toBeInTheDocument();
+    });
+    expect(
+      screen.queryByText(/couldn't read that link/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("keeps the transient toast for a generic (non-auth) URL failure", async () => {
+    const { showError } = await import("@platform/ui");
+    const mockExtract = vi.fn().mockReturnValue({
+      unwrap: () => Promise.reject({ status: 502, data: {} }),
+    });
+    mockUseExtractJdFromUrlMutation.mockReturnValue(
+      [mockExtract, { isLoading: false }] as unknown as ReturnType<
+        typeof useExtractJdFromUrlMutation
+      >,
+    );
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.type(
+      screen.getByLabelText(/job posting url/i),
+      "https://jobs.example.com/x",
+    );
+    await user.click(screen.getByRole("button", { name: /auto-fill/i }));
+
+    // Generic failure → stays on the URL tab and DOES use the toast;
+    // no persistent blocked-link banner (that copy is auth-only).
+    await waitFor(() => {
+      expect(showError).toHaveBeenCalled();
+    });
+    expect(screen.getByLabelText(/job posting url/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/couldn't read that link/i),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/PasteTextStep.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/PasteTextStep.tsx
@@ -4,7 +4,7 @@
  * Used when the operator doesn't have a URL (e.g. LinkedIn auth-walled
  * postings, copy-pasted email job descriptions).
  */
-import { LoadingButton } from "@platform/ui";
+import { AlertBox, LoadingButton } from "@platform/ui";
 import type { DialogInputMode } from "../useAddApplicationDialogState";
 
 interface PasteTextStepProps {
@@ -12,6 +12,13 @@ interface PasteTextStepProps {
   onTextChange: (next: string) => void;
   onTextSubmit: () => void;
   onSetInputMode: (mode: DialogInputMode) => void;
+  /**
+   * Persistent explanation shown above the textarea after a URL fetch
+   * was blocked (auth-walled site, 401/403). Survives until the user
+   * acts — unlike the old transient toast, which vanished and made the
+   * silent tab-switch look like the app had broken.
+   */
+  notice?: string | null;
 }
 
 export default function PasteTextStep({
@@ -19,11 +26,13 @@ export default function PasteTextStep({
   onTextChange,
   onTextSubmit,
   onSetInputMode,
+  notice,
 }: PasteTextStepProps) {
   const canSubmit = textValue.trim().length > 0;
 
   return (
     <div className="space-y-3">
+      {notice && <AlertBox variant="warning">{notice}</AlertBox>}
       <label htmlFor="add-app-text" className="block text-sm font-medium">
         Paste the job description text
       </label>

--- a/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/useAddApplicationFlow.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/add-application-dialog/useAddApplicationFlow.ts
@@ -71,6 +71,14 @@ interface UseAddApplicationFlowReturn {
   companyNameValue: string;
   pendingCompanyName: string | null;
   submittedJdText: string;
+  /**
+   * Persistent "we couldn't read that link" explanation shown on the
+   * text tab after a URL fetch was blocked (auth-walled site, 401/403).
+   * Replaces the old transient toast, which vanished and left the user
+   * on a blank text tab with no idea why — it looked like the app broke.
+   * Null when there's nothing to explain.
+   */
+  urlBlockedNotice: string | null;
   companies: Company[];
   creatingApplication: boolean;
 
@@ -118,6 +126,12 @@ export function useAddApplicationFlow(
   const [companyNameValue, setCompanyNameValue] = useState("");
   const [pendingCompanyName, setPendingCompanyName] = useState<string | null>(null);
   const [submittedJdText, setSubmittedJdText] = useState<string>("");
+  // Persistent "we couldn't read that link" explanation. Replaces the
+  // old transient toast, which vanished and left the user on a blank
+  // text tab with no idea why — it looked like the app had broken.
+  const [urlBlockedNotice, setUrlBlockedNotice] = useState<string | null>(
+    null,
+  );
 
   const companies = companiesData?.items ?? [];
 
@@ -131,12 +145,16 @@ export function useAddApplicationFlow(
     setCompanyNameValue("");
     setPendingCompanyName(null);
     setSubmittedJdText("");
+    setUrlBlockedNotice(null);
   }
 
   // -------------------------------------------------------------------------
   // Step 1 — input mode switching + paste-and-go.
   // -------------------------------------------------------------------------
   function setInputMode(mode: DialogInputMode) {
+    // Returning to the URL field means the blocked-link notice is no
+    // longer relevant; keep it while the user is on the text tab.
+    if (mode === "url") setUrlBlockedNotice(null);
     setState({ kind: "input", inputMode: mode });
   }
 
@@ -223,16 +241,21 @@ export function useAddApplicationFlow(
   // Step 2 — processing.
   // -------------------------------------------------------------------------
   async function runUrlExtract(url: string) {
+    setUrlBlockedNotice(null);
     setState({ kind: "processing", sourcePath: "url", longRunning: false });
     try {
       const result = await extractJdFromUrl({ url }).unwrap();
       await applyExtractResult(result);
     } catch (err) {
       if (isAuthRequiredError(err)) {
-        showError(
-          "That page requires sign-in or blocked our request. Paste the description text instead.",
-        );
+        // Persistent in-context banner on the text tab — NOT a toast.
+        // The toast faded and the silent tab-switch read as "broken".
         setInputMode("text");
+        setUrlBlockedNotice(
+          "We couldn't read that link — it needs a sign-in. Sites like " +
+            "LinkedIn and Glassdoor block automated access. Paste the job " +
+            "description text below and we'll auto-fill from it.",
+        );
         return;
       }
       showError(`Couldn't auto-fill: ${describeExtractError(err)}`);
@@ -241,6 +264,7 @@ export function useAddApplicationFlow(
   }
 
   async function runTextParse(text: string) {
+    setUrlBlockedNotice(null);
     setState({ kind: "processing", sourcePath: "text", longRunning: false });
     setSubmittedJdText(text);
     try {
@@ -491,6 +515,7 @@ export function useAddApplicationFlow(
     companyNameValue,
     pendingCompanyName,
     submittedJdText,
+    urlBlockedNotice,
     companies,
     creatingApplication,
     setInputMode,


### PR DESCRIPTION
## Summary

Issue 6 — the parity follow-up to #670. The Add Application dialog had
the identical defect #670 fixed for /analyze: an auth-walled JD URL
showed a vanishing toast then silently swapped to a blank text tab,
looking broken. Built via the pipeline (`g-troubleshoot`).

Mirrors #670's pattern exactly — persistent `AlertBox` (warning) on the
text step instead of the toast, for the auth-required case only; clears
on switch-to-URL / successful parse / dialog reset. No shared-input
refactor (deliberately deferred — the dialog's 3-step state machine).

Branch carries a merge of latest `main`; squash-merge collapses it to
the 4-file diff.

## Test plan

- [x] 4 new regression tests (persistent banner not toast on auth-walled URL; clears on tab switch; clears after parse; generic 502 still toasts) — `AddApplicationDialog.test.tsx` 13/13
- [x] typecheck + lint clean on changed files; no new suite failures (+13 passing)
- [ ] Pre-existing unrelated failures noted (shared-signature drift on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)