### PR TITLE
fix(mga): channel sync produces 0 lineups — channel-root URL + tab-id (and #676 test-mock gap)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/youtube_fetcher.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/youtube_fetcher.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
@@ -78,6 +79,45 @@ def _source_url(source: Source) -> str:
     return cfg.get("url") or cfg.get("channel_url") or ""
 
 
+# A real YouTube video id is exactly 11 url-safe chars. Channel ids are 24
+# chars and start with "UC"; playlist ids start with "PL"/"UU"/etc. Filtering
+# on this shape stops a channel/tab id from masquerading as a video id.
+_VIDEO_ID_RE = re.compile(r"^[A-Za-z0-9_-]{11}$")
+
+# yt-dlp tab/segment suffixes that already point at a concrete listing — do
+# NOT rewrite these. Everything else that looks like a channel root gets
+# "/videos" appended.
+_EXPLICIT_TAB_SEGMENTS = frozenset(
+    {"videos", "shorts", "streams", "live", "playlists", "playlist", "watch"}
+)
+
+# Channel-root forms: youtube.com/@handle, /channel/UC..., /c/Name, /user/Name.
+_CHANNEL_ROOT_RE = re.compile(
+    r"^(https?://(?:www\.)?youtube\.com/(?:@[^/?#]+|channel/[^/?#]+|c/[^/?#]+|user/[^/?#]+))/?$",
+    re.IGNORECASE,
+)
+
+
+def _normalize_listing_url(url: str) -> str:
+    """Rewrite a bare channel URL to its /videos tab.
+
+    yt-dlp's ``extract_flat`` on a channel ROOT (``youtube.com/@Handle``)
+    returns the channel's *tab playlists* (Videos / Shorts / Live) as entries
+    — each carrying the **channel id**, not a video id. Downstream that id is
+    fed to ``watch?v=`` and yt-dlp reports "Video unavailable". Targeting the
+    ``/videos`` tab makes the single flat extraction return actual videos.
+
+    Playlist URLs (``playlist?list=``), ``watch?v=`` URLs, and channel URLs
+    that already name a tab are returned unchanged.
+    """
+    if "list=" in url or "watch?v=" in url:
+        return url
+    match = _CHANNEL_ROOT_RE.match(url.strip())
+    if not match:
+        return url
+    return f"{match.group(1)}/videos"
+
+
 async def list_videos(source: Source) -> list[VideoMeta]:
     """Return new video metadata for a Source without downloading anything.
 
@@ -88,13 +128,16 @@ async def list_videos(source: Source) -> list[VideoMeta]:
     exceptions are caught, logged at ERROR with structured context, and
     re-raised as YouTubeFetchError.
     """
-    url = _source_url(source)
-    if not url:
+    raw_url = _source_url(source)
+    if not raw_url:
         raise YouTubeFetchError(
             f"Source {source.id} has no URL in config_json",
             error_type="MissingURL",
             original=ValueError("missing URL"),
         )
+    # A bare channel URL flattens to tab-playlists, not videos — rewrite to
+    # the /videos tab so the flat extraction returns actual videos.
+    url = _normalize_listing_url(raw_url)
 
     ydl_opts = {
         "quiet": True,
@@ -110,18 +153,33 @@ async def list_videos(source: Source) -> list[VideoMeta]:
         if info is None:
             return []
 
-        entries = info.get("entries") or []
-        # Single video (not a playlist/channel) — wrap in a list.
-        # Only treat the root info as a video if it has no "entries" key at all
-        # (a playlist with 0 entries still has entries=[]).
-        if "entries" not in info and info.get("id"):
-            entries = [info]
+        # A channel can flatten to a playlist-of-playlists (the Videos/Shorts/
+        # Live tabs). Descend into any nested "entries" so we always end up at
+        # leaf video entries. A node with no "entries" key at all is the
+        # single watch?v= case — treat it as one leaf.
+        def _iter_leaf_entries(node: dict):
+            nested = node.get("entries")
+            if nested is None:
+                yield node
+                return
+            for child in nested:
+                if child is not None:
+                    yield from _iter_leaf_entries(child)
 
         results: list[VideoMeta] = []
-        for entry in entries:
-            vid_id = entry.get("id") or entry.get("url", "").split("v=")[-1]
-            if not vid_id:
+        seen: set[str] = set()
+        for entry in _iter_leaf_entries(info):
+            if entry.get("_type") == "playlist":
                 continue
+            vid_id = entry.get("id") or entry.get("url", "").split("v=")[-1]
+            # Reject anything that isn't a real 11-char video id — a channel
+            # id (UC…, 24 chars) or playlist id slipping through here is the
+            # exact bug that made channel syncs produce 0 lineups.
+            if not vid_id or not _VIDEO_ID_RE.match(vid_id):
+                continue
+            if vid_id in seen:
+                continue
+            seen.add(vid_id)
             results.append(
                 VideoMeta(
                     video_id=vid_id,

--- a/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
@@ -141,6 +141,7 @@ class TestIngestionWithClassifier:
 
         with (
             patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]),
+            patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO),
             patch("app.services.ingestion.ingestion_orchestrator.download_video", new_callable=AsyncMock, return_value=fake_video_path),
             patch("app.services.ingestion.ingestion_orchestrator.extract_frames", new_callable=AsyncMock, return_value=[_FAKE_PNG, _FAKE_PNG]),
             patch("app.services.ingestion.ingestion_orchestrator.get_storage") as mock_storage_factory,
@@ -189,6 +190,7 @@ class TestIngestionWithClassifier:
 
         with (
             patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]),
+            patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO),
             patch("app.services.ingestion.ingestion_orchestrator.download_video", new_callable=AsyncMock, return_value=fake_video_path),
             patch("app.services.ingestion.ingestion_orchestrator.extract_frames", new_callable=AsyncMock, return_value=[_FAKE_PNG, _FAKE_PNG]),
             patch("app.services.ingestion.ingestion_orchestrator.get_storage") as mock_storage_factory,
@@ -233,6 +235,7 @@ class TestIngestionWithClassifier:
 
         with (
             patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]),
+            patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO),
             patch("app.services.ingestion.ingestion_orchestrator.download_video", new_callable=AsyncMock, return_value=fake_video_path),
             patch("app.services.ingestion.ingestion_orchestrator.extract_frames", new_callable=AsyncMock, return_value=[_FAKE_PNG, _FAKE_PNG]),
             patch("app.services.ingestion.ingestion_orchestrator.get_storage") as mock_storage_factory,

--- a/apps/mygamingassistant/backend/tests/test_youtube_fetcher.py
+++ b/apps/mygamingassistant/backend/tests/test_youtube_fetcher.py
@@ -49,12 +49,14 @@ def _make_channel_source(url: str = "https://www.youtube.com/@testchannel") -> S
     )
 
 
+# Video ids MUST be realistic 11-char YouTube ids — list_videos rejects
+# anything that isn't, so a channel/tab id can never masquerade as a video.
 _FAKE_INFO = {
     "id": "PLtest",
     "title": "Test Playlist",
     "entries": [
         {
-            "id": "vid001",
+            "id": "vid00000001",
             "title": "A-site smokes",
             "description": "0:00 Intro\n1:00 A-site smoke from CT",
             "duration": 180,
@@ -66,7 +68,7 @@ _FAKE_INFO = {
             ],
         },
         {
-            "id": "vid002",
+            "id": "vid00000002",
             "title": "B-site post-plant",
             "description": "0:00 B-site smoke",
             "duration": 90,
@@ -95,12 +97,12 @@ class TestListVideos:
             videos = await list_videos(source)
 
         assert len(videos) == 2
-        assert videos[0].video_id == "vid001"
+        assert videos[0].video_id == "vid00000001"
         assert videos[0].title == "A-site smokes"
         assert videos[0].duration == 180
         assert videos[0].channel_name == "TestChannel"
         assert len(videos[0].chapters) == 2
-        assert videos[1].video_id == "vid002"
+        assert videos[1].video_id == "vid00000002"
 
     @pytest.mark.asyncio
     async def test_raises_on_download_error(self):
@@ -169,6 +171,90 @@ class TestListVideos:
             videos = await list_videos(source)
         # Successful call with channel_url source — no error
         assert isinstance(videos, list)
+
+
+# ---------------------------------------------------------------------------
+# Channel-URL normalization + tab-id rejection
+#
+# Regression guard for the bug where syncing a channel produced 0 lineups:
+# a bare channel URL flattens to its Videos/Shorts/Live TAB playlists, each
+# carrying the 24-char channel id (not a video id). That id was fed to
+# watch?v= -> "Video unavailable" -> error_count=N, video_count=0.
+# ---------------------------------------------------------------------------
+
+from app.services.ingestion.youtube_fetcher import _normalize_listing_url  # noqa: E402
+
+
+class TestChannelUrlNormalization:
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("https://www.youtube.com/@TigerrGG", "https://www.youtube.com/@TigerrGG/videos"),
+            ("https://www.youtube.com/@TigerrGG/", "https://www.youtube.com/@TigerrGG/videos"),
+            ("https://youtube.com/channel/UCabcdefghijklmnopqrstuv",
+             "https://youtube.com/channel/UCabcdefghijklmnopqrstuv/videos"),
+            ("https://www.youtube.com/c/SomeName", "https://www.youtube.com/c/SomeName/videos"),
+            ("https://www.youtube.com/user/OldStyle", "https://www.youtube.com/user/OldStyle/videos"),
+            # Already-explicit / non-channel URLs are left untouched.
+            ("https://www.youtube.com/@TigerrGG/videos", "https://www.youtube.com/@TigerrGG/videos"),
+            ("https://www.youtube.com/@TigerrGG/shorts", "https://www.youtube.com/@TigerrGG/shorts"),
+            ("https://www.youtube.com/playlist?list=PLabc", "https://www.youtube.com/playlist?list=PLabc"),
+            ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "https://www.youtube.com/watch?v=dQw4w9WgXcQ"),
+        ],
+    )
+    def test_normalization(self, raw: str, expected: str):
+        assert _normalize_listing_url(raw) == expected
+
+    @pytest.mark.asyncio
+    async def test_channel_tab_ids_are_rejected(self):
+        """yt-dlp flattening a channel yields tab-playlists carrying the
+        24-char channel id. None of them may become a VideoMeta."""
+        channel_tabs_info = {
+            "id": "UCX_C4FYHUIYPpLTCmJ5VVYA",
+            "title": "Tigerr",
+            "entries": [
+                {"id": "UCX_C4FYHUIYPpLTCmJ5VVYA", "title": "Tigerr - Videos", "_type": "playlist"},
+                {"id": "UCX_C4FYHUIYPpLTCmJ5VVYA", "title": "Tigerr - Shorts", "_type": "playlist"},
+                {"id": "UCX_C4FYHUIYPpLTCmJ5VVYA", "title": "Tigerr - Live"},
+            ],
+        }
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value=channel_tabs_info)
+
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            videos = await list_videos(_make_channel_source())
+
+        assert videos == []
+
+    @pytest.mark.asyncio
+    async def test_nested_playlist_entries_are_flattened(self):
+        """A playlist-of-playlists is descended to leaf video entries; only
+        valid 11-char ids survive."""
+        nested_info = {
+            "id": "UCsomechannelid000000001",
+            "entries": [
+                {
+                    "id": "UCsomechannelid000000001",
+                    "title": "Videos tab",
+                    "entries": [
+                        {"id": "realvideo01", "title": "Lineup 1", "duration": 100},
+                        {"id": "realvideo02", "title": "Lineup 2", "duration": 120},
+                        {"id": "PLnotavideoplaylist", "title": "nested playlist ref"},
+                    ],
+                },
+            ],
+        }
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value=nested_info)
+
+        with patch("yt_dlp.YoutubeDL", return_value=mock_ydl):
+            videos = await list_videos(_make_channel_source())
+
+        assert [v.video_id for v in videos] == ["realvideo01", "realvideo02"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the user-reported bug: **"still no lineups when I sync to a channel."** Two related defects in the channel/playlist ingestion path, one PR (same root story — channel sync → 0 lineups).

### 1. Real root cause — channel-root URL flattens to tab-playlists (prod bug)

Reproduced against a real channel (`@TigerrGG`). `list_videos()` extracted the **bare channel URL**. yt-dlp `extract_flat` on a channel *root* returns the channel's **Videos / Shorts / Live tab playlists** as entries — each carrying the **24-char channel id**, not a video id. `_process_video` fed that id to `watch?v=` → `Video unavailable`. The DB confirmed it exactly: the `@TigerrGG` source had `error_count=3, video_count=0, chapter_count=0`, zero `pending_review` rows.

#676 (`fetch_video_detail`) was necessary but **not sufficient** — it still fetched a channel id as if it were a video.

**Fix in `youtube_fetcher.list_videos()`:**
- `_normalize_listing_url()` — rewrite a bare channel URL (`@handle`, `/channel/UC…`, `/c/…`, `/user/…`) to its `/videos` tab so the single flat extraction returns actual videos. `playlist?list=` / `watch?v=` / already-tabbed URLs pass through unchanged.
- Descend nested `entries` (playlist-of-playlists) to leaf videos, and **reject any id that is not a real 11-char video id**. A channel/tab/playlist id can never masquerade as a video again.

Verified end-to-end against `@TigerrGG`: `list_videos` now returns **189 real videos** (was 3 fake tab ids); `fetch_video_detail` + `parse_chapters` yield 5–6 chapters each ("5 Cache Smokes…" → "A Site Smokes" / "B Site Smokes").

### 2. #676 test-mock gap (CI red on main)

#676 was admin-merged with `backend-tests / mygamingassistant` red: `test_ingestion_with_classifier.py` didn't mock the new `fetch_video_detail`, so 2 tests hit real yt-dlp. Added the same `fetch_video_detail → FAKE_VIDEO` mock #676 used in the sibling orchestrator test.

## Tests

- `test_youtube_fetcher.py`: realistic 11-char fixture ids + new `TestChannelUrlNormalization` (URL-rewrite matrix, channel-tab-id rejection, nested flatten). **21/21**.
- `test_ingestion_with_classifier.py`: `fetch_video_detail` mock restored.
- Local: full `youtube_fetcher` / `ingestion_orchestrator` / `ingestion_with_classifier` suites green.

## Operational migration

None — pure ingestion logic. No env/schema/deploy change. (Operator note: a long-running dev backend started before ffmpeg was installed must be restarted to pick ffmpeg up on PATH — unrelated to this code.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
