### PR TITLE
fix(mga): source mgmt + review queue — 3 bugs blocking the ingest flow

### DIFF
--- a/apps/mygamingassistant/backend/app/repositories/game/source_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/source_repo.py
@@ -29,19 +29,39 @@ async def create_source(
     return source
 
 
+def _is_deleted(source: Source) -> bool:
+    return bool((source.config_json or {}).get("deleted"))
+
+
 async def get_source(
     db: AsyncSession,
     source_id: uuid.UUID,
+    *,
+    include_deleted: bool = False,
 ) -> Source | None:
-    """Return a single source by id, or None."""
+    """Return a single source by id, or None.
+
+    Soft-deleted sources (config_json.deleted=True) are hidden by default so
+    they can't be fetched, synced, or shown in detail. soft_delete_source
+    passes include_deleted=True so it can still locate the row to mark.
+    """
     result = await db.execute(select(Source).where(Source.id == source_id))
-    return result.scalar_one_or_none()
+    source = result.scalar_one_or_none()
+    if source is None:
+        return None
+    if not include_deleted and _is_deleted(source):
+        return None
+    return source
 
 
 async def list_sources(db: AsyncSession) -> list[Source]:
-    """Return all sources ordered by creation date descending."""
+    """Return all non-deleted sources, newest first.
+
+    config_json is JSON (not JSONB) and sources are few, so the deleted
+    filter is applied in Python rather than via a JSON-path WHERE clause.
+    """
     result = await db.execute(select(Source).order_by(Source.created_at.desc()))
-    return list(result.scalars().all())
+    return [s for s in result.scalars().all() if not _is_deleted(s)]
 
 
 async def soft_delete_source(
@@ -54,7 +74,7 @@ async def soft_delete_source(
     reference source_id via SET NULL FK. This prevents FK errors on lineups
     that were already accepted before the source was removed.
     """
-    source = await get_source(db, source_id)
+    source = await get_source(db, source_id, include_deleted=True)
     if source is None:
         return None
     # Store deleted flag in config_json (Source has no deleted_at column).

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -44,8 +44,11 @@ class UtilityTypeRead(BaseModel):
 
 class LineupRead(BaseModel):
     id: uuid.UUID
-    game_id: uuid.UUID
-    map_id: uuid.UUID
+    # game_id / map_id are NULL on pending_review lineups — populated only
+    # when the operator accepts (CHECK enforces non-null at status='accepted').
+    # The review queue serializes pre-accept rows, so these must be optional.
+    game_id: Optional[uuid.UUID] = None
+    map_id: Optional[uuid.UUID] = None
     # Classification fields — nullable for pending_review lineups
     target_zone_id: Optional[uuid.UUID] = None
     stand_zone_id: Optional[uuid.UUID] = None

--- a/apps/mygamingassistant/backend/app/services/game/source_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/source_service.py
@@ -24,23 +24,33 @@ from app.schemas.game.lineup_schemas import SourceCreate
 # URL validation patterns
 # ---------------------------------------------------------------------------
 
-_YOUTUBE_PLAYLIST_RE = re.compile(
-    r"^https?://(?:www\.)?youtube\.com/playlist\?list=[\w-]+",
-    re.IGNORECASE,
-)
+# A playlist id can ride on the canonical /playlist?list=ID URL OR on a
+# watch?v=VIDEO&list=ID URL (what YouTube hands you when you open a video
+# from within a playlist — the most common copy-paste form). Accept both;
+# we normalize to the canonical /playlist?list=ID form before storing.
+_YOUTUBE_PLAYLIST_ID_RE = re.compile(r"[?&]list=([\w-]+)", re.IGNORECASE)
 _YOUTUBE_CHANNEL_RE = re.compile(
     r"^https?://(?:www\.)?youtube\.com/(?:@[\w-]+|channel/[\w-]+|c/[\w-]+|user/[\w-]+)(?:/[\w-]*)?/?$",
     re.IGNORECASE,
 )
 
 
+def _extract_playlist_id(url: str) -> str | None:
+    """Return the playlist id from any YouTube URL carrying a list= param."""
+    if "youtube.com" not in url.lower() and "youtu.be" not in url.lower():
+        return None
+    match = _YOUTUBE_PLAYLIST_ID_RE.search(url)
+    return match.group(1) if match else None
+
+
 def validate_source_url(kind: str, url: str) -> str | None:
     """Return None if the URL is valid for the given kind, or an error string."""
     if kind == "youtube_playlist":
-        if not _YOUTUBE_PLAYLIST_RE.match(url):
+        if not _extract_playlist_id(url):
             return (
-                "youtube_playlist URL must be a YouTube playlist URL: "
-                "https://www.youtube.com/playlist?list=<id>"
+                "youtube_playlist URL must contain a playlist id, e.g. "
+                "https://www.youtube.com/playlist?list=<id> or "
+                "https://www.youtube.com/watch?v=<vid>&list=<id>"
             )
     elif kind == "youtube_channel":
         if not _YOUTUBE_CHANNEL_RE.match(url):
@@ -56,7 +66,9 @@ def validate_source_url(kind: str, url: str) -> str | None:
 def _build_config_json(kind: str, url: str) -> dict:
     """Build the config_json dict for a new Source."""
     if kind == "youtube_playlist":
-        return {"url": url, "last_synced_at": None}
+        pid = _extract_playlist_id(url)
+        canonical = f"https://www.youtube.com/playlist?list={pid}" if pid else url
+        return {"url": canonical, "last_synced_at": None}
     if kind == "youtube_channel":
         return {"channel_url": url, "last_synced_at": None}
     return {"url": url}

--- a/apps/mygamingassistant/backend/tests/test_sources.py
+++ b/apps/mygamingassistant/backend/tests/test_sources.py
@@ -238,7 +238,13 @@ async def test_deleted_source_excluded_from_list_and_detail(
 
 def test_lineup_read_serializes_pending_row_with_null_game_map():
     """pending_review lineups have NULL game_id/map_id — LineupRead must
-    accept them so the review queue can load (regression: 2 uuid errors)."""
+    accept them so the review queue can load (regression: 2 uuid errors).
+
+    Asserts BOTH directions: model_validate (input) AND model_dump(mode="json")
+    (output). FastAPI's ``response_model=PendingLineupsResponse`` re-serializes
+    via model_dump, which is when the @computed_field effective_* properties
+    run — that output path, not model_validate, is where the review-queue 500
+    actually lived. Testing only model_validate left this uncovered."""
     from app.schemas.game.lineup_schemas import LineupRead
 
     model = LineupRead.model_validate(
@@ -251,3 +257,12 @@ def test_lineup_read_serializes_pending_row_with_null_game_map():
         }
     )
     assert model.game_id is None and model.map_id is None
+
+    # The FastAPI response path: must not raise, and the centroid-fallback
+    # computed fields must degrade to None when zones are absent.
+    dumped = model.model_dump(mode="json")
+    assert dumped["game_id"] is None and dumped["map_id"] is None
+    assert dumped["effective_stand_x"] is None
+    assert dumped["effective_stand_y"] is None
+    assert dumped["effective_target_x"] is None
+    assert dumped["effective_target_y"] is None

--- a/apps/mygamingassistant/backend/tests/test_sources.py
+++ b/apps/mygamingassistant/backend/tests/test_sources.py
@@ -195,3 +195,59 @@ async def test_sync_source_returns_job_id(auth_client: AsyncClient, existing_sou
 async def test_sync_source_404(auth_client: AsyncClient):
     resp = await auth_client.post(f"/api/sources/{uuid.uuid4()}/sync")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Regressions: playlist watch?v=&list= URL, deleted-source exclusion,
+# LineupRead serialization of pending (null game_id/map_id) rows.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_playlist_accepts_watch_list_url(auth_client: AsyncClient):
+    """The common 'open a video inside a playlist' URL must be accepted and
+    normalized to the canonical /playlist?list= form."""
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_playlist",
+            "url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0&list=PLCv9jk0KUJ",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["config_json"]["url"] == (
+        "https://www.youtube.com/playlist?list=PLCv9jk0KUJ"
+    )
+
+
+@pytest.mark.asyncio
+async def test_deleted_source_excluded_from_list_and_detail(
+    auth_client: AsyncClient, existing_source: Source
+):
+    """A soft-deleted source must vanish from the list AND 404 on detail."""
+    sid = str(existing_source.id)
+    assert (await auth_client.delete(f"/api/sources/{sid}")).status_code == 204
+
+    listed = (await auth_client.get("/api/sources")).json()
+    assert sid not in [s["id"] for s in listed]
+    assert (await auth_client.get(f"/api/sources/{sid}")).status_code == 404
+    # DELETE is idempotent — re-deleting an already-deleted source is a clean
+    # 204 (soft_delete_source still locates the row via include_deleted=True),
+    # never a 500.
+    assert (await auth_client.delete(f"/api/sources/{sid}")).status_code == 204
+
+
+def test_lineup_read_serializes_pending_row_with_null_game_map():
+    """pending_review lineups have NULL game_id/map_id — LineupRead must
+    accept them so the review queue can load (regression: 2 uuid errors)."""
+    from app.schemas.game.lineup_schemas import LineupRead
+
+    model = LineupRead.model_validate(
+        {
+            "id": uuid.uuid4(),
+            "game_id": None,
+            "map_id": None,
+            "title": "B-site smoke",
+            "status": "pending_review",
+        }
+    )
+    assert model.game_id is None and model.map_id is None


### PR DESCRIPTION
## Summary

Three real bugs found while the operator tested **add source → sync → review** end-to-end (the flow #677 unblocked). All backend, all in the source/review path.

### 1. Can't add a playlist
`validate_source_url` only accepted the bare `youtube.com/playlist?list=ID` form and rejected `watch?v=VID&list=ID` — the most common copy-paste shape (opening a video from inside a playlist). Now any YouTube URL carrying a `list=` id is accepted and **normalized to the canonical `/playlist?list=ID`** before storing (consistent with `youtube_fetcher._normalize_listing_url`, which already passes `list=` URLs through).

### 2. Deleted source not removed from the list
`soft_delete_source` set `config_json.deleted=True` but `list_sources`/`get_source` never filtered it — deleted sources stayed listed and were still syncable/viewable. `get_source` now hides deleted (with `include_deleted=True` retained for `soft_delete_source` itself); `list_sources` excludes them. DELETE stays idempotent (re-delete → 204, never 500). Frontend already `invalidatesTags: ["SourceList"]`, so the list refetches and the row disappears.

### 3. Review queue "Failed to load pending lineups"
`LineupRead` typed `game_id`/`map_id` as required `uuid.UUID`, but `pending_review` rows have them **NULL by design** (the CHECK enforces non-null only at `status='accepted'`). `get_pending` raised `ValidationError: 2 uuid errors` → 500 → empty review queue even though rows existed. Both are `Optional` now, matching the DB and the "nullable for pending_review" intent already documented on the sibling classification fields.

## Tests

`test_sources.py` +3: `watch?v=&list=` accept+normalize, deleted-source exclusion from list/detail, `LineupRead` null game/map serialization. **14/14 green**; `test_youtube_fetcher` 21/21 still green.

## Follow-up (tracked, not blocking)

Frontend API `Lineup` type should mark `game_id`/`map_id` nullable for cross-stack parity. `ReviewCard` already tolerates null via `?? ""`, so there is no runtime impact — type-correctness refinement only.

## Operational migration

None — pure logic/schema-serialization. No DB migration, no env change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
