### PR TITLE
fix(mga): filter non-lineup chapters + offset frame sampling (Phase 1/2 ingestion quality)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/chapter_parser.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/chapter_parser.py
@@ -86,6 +86,74 @@ def _parse_chapters_from_description(
     return chapters
 
 
+# Chapter titles that are video *structure*, not lineup demonstrations. A
+# YouTube lineup tutorial interleaves real lineup chapters ("A smoke from T
+# spawn") with structural chapters (intro, outro, "Tip 3", "Subscribe"). The
+# structural ones become useless pending lineup rows AND waste a classifier
+# call, so drop them before ingestion. Matched case-insensitively, anchored to
+# the start of the stripped title so "Mid smoke (intro angle)" is NOT dropped.
+#
+# Phase-1 cheap win. Phase 2 (Strategy A: multi-frame extraction + a Claude
+# `is_lineup` decision) makes the classifier itself the lineup detector and
+# supersedes this title heuristic.
+_NON_LINEUP_TITLE_RE = re.compile(
+    r"^\s*(?:"
+    r"intro|outro|tips?|"
+    r"subscribe|like|smash|"
+    r"thanks|thank\s*you|thx|"
+    r"conclusion|summary|recap|wrap[\s-]?up|overview|"
+    r"sponsor|promo|shout[\s-]?out|"
+    r"credits|disclaimer|patreon|discord|socials?|links?|"
+    r"giveaway|announcement|update|news|donate|donation|"
+    r"the\s+end|bye|see\s*you"
+    r")\b",
+    re.IGNORECASE,
+)
+
+# Minimum chapter length for a plausible lineup demo. A real lineup
+# demonstration (walk to spot, line up the throw, throw, show result) is rarely
+# shorter than this; sub-15s chapters are almost always transitions/stings.
+_MIN_LINEUP_CHAPTER_SECONDS = 15
+
+
+def filter_lineup_chapters(
+    chapters: list[Chapter],
+    *,
+    min_duration_seconds: int = _MIN_LINEUP_CHAPTER_SECONDS,
+) -> list[Chapter]:
+    """Drop chapters that are video structure, not lineup demonstrations.
+
+    Two heuristics applied *after* ``parse_chapters``:
+
+      1. **Title denylist** — intro / outro / "tip N" / subscribe / sponsor /
+         credits / etc.
+      2. **Minimum duration** — chapters shorter than *min_duration_seconds*
+         are transitions/stings, not a walk-aim-throw demo.
+
+    ``parse_chapters`` stays a pure structural parser (its existing test
+    contract — "Intro" parses as a chapter — is intentionally preserved). This
+    is the separate "is this chapter plausibly a lineup" concern, kept as its
+    own function for single responsibility and isolated unit testing.
+
+    Args:
+        chapters: Parsed chapters from ``parse_chapters``.
+        min_duration_seconds: Chapters shorter than this are dropped.
+
+    Returns:
+        The subset of *chapters* that are plausibly real lineups, in order.
+        May be empty (the orchestrator already treats "no chapters" as
+        "skip this video").
+    """
+    kept: list[Chapter] = []
+    for ch in chapters:
+        if _NON_LINEUP_TITLE_RE.match(ch.title.strip()):
+            continue
+        if (ch.end_seconds - ch.start_seconds) < min_duration_seconds:
+            continue
+        kept.append(ch)
+    return kept
+
+
 def parse_chapters(
     description: str,
     video_duration: int,

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -40,7 +40,11 @@ from app.repositories.game import lineup_repo, source_repo
 from app.schemas.game.lineup_schemas import LineupIngestCreate
 from app.services.classification.classifier_service import classify_lineup
 from app.services.game import lineup_service
-from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.chapter_parser import (
+    Chapter,
+    filter_lineup_chapters,
+    parse_chapters,
+)
 from app.services.ingestion.frame_extractor import FrameExtractionError, extract_frames
 from app.services.ingestion.youtube_fetcher import (
     VideoDownloadError,
@@ -52,6 +56,15 @@ from app.services.ingestion.youtube_fetcher import (
 )
 
 logger = logging.getLogger(__name__)
+
+# Phase-1 frame-timing heuristic. The exact chapter boundary is the worst
+# possible sample point — it's a deterministic fade-in / transition / black
+# frame (a t=0 "Intro" chapter is *always* a black frame). Offsetting a few
+# seconds into the chapter avoids that deterministic failure. This is still a
+# blind heuristic; Phase 2 (Strategy A: extract a grid of candidate frames and
+# let Claude pick the best stand/aim + decide is_lineup) replaces it wholesale.
+_STAND_FRAME_OFFSET_SECONDS = 3.0
+_AIM_FRAME_GAP_SECONDS = 4.0
 
 
 @dataclass
@@ -103,11 +116,17 @@ async def _process_chapter(
     Returns True on success, False on any handled error.
     """
     start = chapter.start_seconds
-    aim_ts = min(float(start) + 4.0, float(chapter.end_seconds) - 0.5)
-    aim_ts = max(aim_ts, float(start))  # guard against end < start + 0.5
+    # Clamp all sampling strictly inside [start, end) — never the exact
+    # boundary (fade-in/transition/black). filter_lineup_chapters already
+    # drops <15s chapters, but keep the math safe on short ones anyway.
+    chapter_end = float(chapter.end_seconds)
+    last_safe_ts = max(float(start), chapter_end - 0.5)
+    stand_ts = min(float(start) + _STAND_FRAME_OFFSET_SECONDS, last_safe_ts)
+    aim_ts = min(stand_ts + _AIM_FRAME_GAP_SECONDS, last_safe_ts)
+    aim_ts = max(aim_ts, stand_ts)
 
     try:
-        stand_bytes, aim_bytes = await extract_frames(video_path, [float(start), aim_ts])
+        stand_bytes, aim_bytes = await extract_frames(video_path, [stand_ts, aim_ts])
     except FrameExtractionError as exc:
         logger.error(
             "Frame extraction failed: source_id=%s video_id=%s chapter_start=%d error=%s",
@@ -237,9 +256,30 @@ async def _process_video(
         )
         return
 
+    # Drop structural chapters (intro/outro/"tip N"/subscribe/short) before
+    # download + frame extraction + classifier calls — they only produce junk
+    # pending lineups and waste a Claude call each. See chapter_parser.
+    parsed_count = len(chapters)
+    chapters = filter_lineup_chapters(chapters)
+    dropped = parsed_count - len(chapters)
+    if dropped:
+        logger.info(
+            "Filtered %d/%d non-lineup chapters (intro/outro/tip/short): "
+            "source_id=%s video_id=%s",
+            dropped, parsed_count, source.id, video_meta.video_id,
+        )
+    if not chapters:
+        logger.info(
+            "All %d parsed chapters were non-lineup structure — source is "
+            "likely not a lineup tutorial: source_id=%s video_id=%s — skipping",
+            parsed_count, source.id, video_meta.video_id,
+        )
+        return
+
     logger.info(
-        "Found %d chapters: source_id=%s video_id=%s",
-        len(chapters), source.id, video_meta.video_id,
+        "Found %d lineup chapters (%d parsed, %d filtered): "
+        "source_id=%s video_id=%s",
+        len(chapters), parsed_count, dropped, source.id, video_meta.video_id,
     )
 
     # Download only now that we know there are chapters worth extracting.

--- a/apps/mygamingassistant/backend/tests/test_chapter_parser.py
+++ b/apps/mygamingassistant/backend/tests/test_chapter_parser.py
@@ -11,7 +11,11 @@ from __future__ import annotations
 
 import pytest
 
-from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.chapter_parser import (
+    Chapter,
+    filter_lineup_chapters,
+    parse_chapters,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -163,3 +167,129 @@ class TestNativeChapters:
         chapters = parse_chapters("", video_duration=120, native_chapters=native)
         # "Bad" has non-numeric start_time — parser skips it gracefully
         assert all(c.title != "Bad" for c in chapters)
+
+
+# ---------------------------------------------------------------------------
+# filter_lineup_chapters — denylist + min-duration (Phase-1 cheap win)
+# ---------------------------------------------------------------------------
+
+class TestFilterLineupChapters:
+    def _ch(self, title: str, start: int = 0, end: int = 120) -> Chapter:
+        return Chapter(start_seconds=start, end_seconds=end, title=title)
+
+    def test_keeps_real_lineup_titles(self):
+        chapters = [
+            self._ch("A-site smoke from T spawn", 0, 60),
+            self._ch("Mid window flash", 60, 120),
+            self._ch("CT smoke from B site", 120, 200),
+        ]
+        kept = filter_lineup_chapters(chapters)
+        assert [c.title for c in kept] == [
+            "A-site smoke from T spawn",
+            "Mid window flash",
+            "CT smoke from B site",
+        ]
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "Intro",
+            "intro",
+            "INTRO",
+            "Outro",
+            "Tip 1",
+            "Tip 2",
+            "Tip 3",
+            "Tips",
+            "Subscribe",
+            "Like and Subscribe",
+            "Smash that like button",
+            "Thanks for watching",
+            "Thank you",
+            "Conclusion",
+            "Summary",
+            "Recap",
+            "Wrap up",
+            "Wrap-up",
+            "Overview",
+            "Sponsor",
+            "Shoutout",
+            "Shout out",
+            "Credits",
+            "Disclaimer",
+            "Patreon",
+            "Discord",
+            "Socials",
+            "Links",
+            "Giveaway",
+            "Announcement",
+            "Update",
+            "News",
+            "Donate",
+            "The end",
+            "Bye",
+            "See you",
+        ],
+    )
+    def test_drops_structural_titles(self, title: str):
+        kept = filter_lineup_chapters([self._ch(title, 0, 120)])
+        assert kept == []
+
+    def test_observed_tigerr_video_all_dropped(self):
+        """The real video that surfaced this bug: Intro/Tip 1-3/Outro."""
+        chapters = [
+            self._ch("Intro", 0, 19),
+            self._ch("Tip 1", 19, 146),
+            self._ch("Tip 2", 146, 245),
+            self._ch("Tip 3", 245, 467),
+            self._ch("Outro", 467, 540),
+        ]
+        assert filter_lineup_chapters(chapters) == []
+
+    def test_denylist_anchored_at_start_not_substring(self):
+        """A real lineup whose title merely contains a denylist word mid-string
+        must NOT be dropped — the denylist is start-anchored."""
+        chapters = [
+            self._ch("Mid smoke (quick tip)", 0, 60),
+            self._ch("Smoke that blocks the news ticker", 60, 120),
+            self._ch("Flash for the subscribe-style peek", 120, 180),
+        ]
+        kept = filter_lineup_chapters(chapters)
+        assert len(kept) == 3
+
+    def test_min_duration_drops_short_chapters(self):
+        chapters = [
+            self._ch("A smoke", 0, 10),       # 10s — too short
+            self._ch("B smoke", 10, 30),      # 20s — kept
+            self._ch("Mid flash", 30, 44),    # 14s — too short
+            self._ch("CT smoke", 44, 200),    # long — kept
+        ]
+        kept = filter_lineup_chapters(chapters)
+        assert [c.title for c in kept] == ["B smoke", "CT smoke"]
+
+    def test_min_duration_boundary_is_inclusive(self):
+        """Exactly min_duration_seconds is kept (only strictly shorter drops)."""
+        kept = filter_lineup_chapters([self._ch("A smoke", 0, 15)])
+        assert len(kept) == 1
+
+    def test_custom_min_duration(self):
+        chapters = [self._ch("A smoke", 0, 20), self._ch("B smoke", 20, 60)]
+        kept = filter_lineup_chapters(chapters, min_duration_seconds=30)
+        assert [c.title for c in kept] == ["B smoke"]
+
+    def test_empty_input_returns_empty(self):
+        assert filter_lineup_chapters([]) == []
+
+    def test_mixed_real_and_structural(self):
+        chapters = [
+            self._ch("Intro", 0, 30),
+            self._ch("A-site smoke from CT", 30, 120),
+            self._ch("Tip 2", 120, 150),
+            self._ch("B-site flash from mid", 150, 240),
+            self._ch("Outro", 240, 300),
+        ]
+        kept = filter_lineup_chapters(chapters)
+        assert [c.title for c in kept] == [
+            "A-site smoke from CT",
+            "B-site flash from mid",
+        ]

--- a/apps/mygamingassistant/backend/tests/test_ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/tests/test_ingestion_orchestrator.py
@@ -50,6 +50,25 @@ FAKE_VIDEO = VideoMeta(
     ],
 )
 
+# A video whose chapter list mixes real lineups with structural chapters
+# (intro/outro) and a too-short chapter — exercises filter_lineup_chapters
+# wiring + the frame-offset heuristic.
+FILTERED_VIDEO = VideoMeta(
+    video_id="vid002",
+    title="Mirage lineups",
+    description="",
+    duration=400,
+    published_at="20260101",
+    channel_name="TestCreator",
+    url="https://www.youtube.com/watch?v=vid002",
+    chapters=[
+        {"start_time": 0, "end_time": 20, "title": "Intro"},            # structural
+        {"start_time": 20, "end_time": 200, "title": "A ramp smoke"},   # real → kept
+        {"start_time": 200, "end_time": 210, "title": "B short smoke"}, # 10s → too short
+        {"start_time": 210, "end_time": 400, "title": "Outro"},         # structural
+    ],
+)
+
 _FAKE_PNG = b"\x89PNG\r\n\x1a\n"
 
 
@@ -129,6 +148,82 @@ class TestSyncSource:
             assert lineup.stand_zone_id is None
             assert lineup.utility_type_id is None
             assert lineup.side is None
+
+    @pytest.mark.asyncio
+    async def test_structural_chapters_filtered_and_frames_offset(
+        self,
+        db: AsyncSession,
+        source: Source,
+        tmp_path: Path,
+    ):
+        """Intro/Outro/short chapters are dropped before extraction; the
+        surviving lineup's frames are sampled a few seconds INTO the chapter,
+        never at the exact boundary (the deterministic black/transition frame).
+        """
+        from app.services.ingestion import ingestion_orchestrator
+        from sqlalchemy import select
+
+        fake_video_path = tmp_path / "vid002.mp4"
+        fake_video_path.write_bytes(b"fake video")
+
+        with (
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.list_videos",
+                new_callable=AsyncMock,
+                return_value=[FILTERED_VIDEO],
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.fetch_video_detail",
+                new_callable=AsyncMock,
+                return_value=FILTERED_VIDEO,
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.download_video",
+                new_callable=AsyncMock,
+                return_value=fake_video_path,
+            ),
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.extract_frames",
+                new_callable=AsyncMock,
+                return_value=[_FAKE_PNG, _FAKE_PNG],
+            ) as mock_extract,
+            patch(
+                "app.services.ingestion.ingestion_orchestrator.get_storage",
+            ) as mock_storage_factory,
+            patch.object(
+                ingestion_orchestrator,
+                "settings",
+            ) as mock_settings,
+        ):
+            mock_settings.ingestion_download_dir = str(tmp_path)
+            mock_settings.enable_classifier = False  # isolate filtering/offset
+            mock_storage = MagicMock()
+            mock_storage.bucket = "mygamingassistant-screenshots"
+            mock_storage._client = MagicMock()
+            mock_storage_factory.return_value = mock_storage
+
+            stats = await ingestion_orchestrator.sync_source(source.id, db)
+
+        # Only "A ramp smoke" survives (Intro/Outro denylisted, "B short
+        # smoke" is 10s < 15s minimum).
+        assert stats.chapter_count == 1
+        assert stats.video_count == 1
+
+        result = await db.execute(
+            select(Lineup).where(Lineup.youtube_video_id == "vid002")
+        )
+        lineups = result.scalars().all()
+        assert len(lineups) == 1
+        assert lineups[0].title == "A ramp smoke"
+        assert lineups[0].chapter_start_seconds == 20  # keyed by chapter start
+
+        # extract_frames called exactly once (one surviving chapter), and the
+        # timestamps are offset INTO the chapter: stand = start+3, aim =
+        # stand+4 — never the exact boundary (start=20).
+        assert mock_extract.await_count == 1
+        _video_arg, timestamps = mock_extract.await_args.args
+        assert timestamps == [23.0, 27.0]
+        assert 20.0 not in timestamps  # never the chapter boundary
 
     @pytest.mark.asyncio
     async def test_dedup_skips_existing_video(


### PR DESCRIPTION
## What

**Phase 1 of 2** fixing MGA ingestion quality. The pipeline turned every
YouTube chapter into a pending lineup and sampled frames at the exact chapter
boundary, so the review queue filled with junk (Intro/Tip/Outro rows) and even
real chapters got fade-in/title-card/webcam frames instead of the lineup.

Diagnosis (a `g-debug-bug` pass on the live data): of one ingested source,
**0/5 chapters were lineups and 0/10 sampled screenshots usably depicted one**.
Root causes ranked: (1) source-quality — a tips/commentary video was ingested
(addressed by Phase 3 / source validation, not here); (2) zero chapter
filtering; (3) frame-timing samples the chapter boundary.

This PR ships the cheap, unambiguous wins (defects 2 + 3).

## Changes

- `chapter_parser.filter_lineup_chapters()` — new **pure** function: title
  denylist (intro/outro/tip N/subscribe/sponsor/credits/…) + 15s min-duration.
  Deliberately **not** folded into `parse_chapters()` so the parser stays a
  pure structural parser and its existing test contract (`"Intro"` parses) is
  untouched — single responsibility.
- `ingestion_orchestrator._process_video` — apply the filter after parse,
  **before** download/extract/classify (saves a wasted download + one Claude
  classify call per junk chapter), with structured logs that distinguish "no
  chapters" from "all chapters were structure — source likely isn't a lineup
  tutorial" (operator-actionable).
- `ingestion_orchestrator._process_chapter` — sample stand at
  `chapter_start + 3s`, aim at `+7s`, clamped strictly inside the chapter.
  Never the deterministic boundary frame (a `t=0` Intro chapter was *always* a
  black frame). Still a heuristic — explicitly superseded by Phase 2.

## Not in scope (follow-ups)

- **Phase 2 (Strategy A):** multi-frame extraction + Claude `is_lineup` /
  best-frame selection — the real structural fix. Recommended `/effort max`.
- **Phase 3:** source-kind validation at add-time (addresses the primary
  root cause: non-lineup-tutorial sources).
- `/api/users/me` 500 (`dev@localhost` fails `EmailStr`) — separate PR.

## Tests

- `+TestFilterLineupChapters` — denylist params, min-duration (incl. inclusive
  boundary + custom threshold), start-anchored-not-substring, the observed
  real-video case (all dropped).
- `+test_structural_chapters_filtered_and_frames_offset` — asserts only the
  real chapter survives and `extract_frames` is called with `[23.0, 27.0]`,
  never the `20.0` boundary.
- Full backend suite: **222 passed**. The 7 `test_classifier_service.py`
  errors are a **pre-existing** test-DB fixture collision on `main`
  (`game.slug='valorant'`) — reproduce when that file is run in isolation,
  unrelated to this change. Flagged separately for a fixture-isolation fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
