### PR TITLE
fix(mga): fail loud on invalid SEED_USER_EMAIL instead of silent /users/me 500

### DIFF
--- a/apps/mygamingassistant/backend/app/main.py
+++ b/apps/mygamingassistant/backend/app/main.py
@@ -37,7 +37,9 @@ from app.core.rate_limit import (
 from app.schemas.user.user_base import UserCreate, UserRead, UserUpdate
 from app.services.storage.bucket_initializer import ensure_bucket
 from app.services.user.seed_user_service import (
+    SeedUserInvalidEmailError,
     SeedUserNotConfiguredError,
+    is_valid_seed_email,
     seed_operator_user,
 )
 
@@ -65,8 +67,12 @@ async def _on_startup() -> None:
 
     Boot guards:
       - production: SEED_USER_EMAIL + SEED_USER_PASSWORD_HASH required.
+      - production: SEED_USER_EMAIL must be a valid email (fastapi-users
+        serializes the operator via an EmailStr field; an invalid address
+        makes GET /users/me 500 on every authenticated request).
       - production + ENABLE_CLASSIFIER=true: ANTHROPIC_API_KEY required.
-      - development: missing vars log WARNING and seed/classifier are skipped.
+      - development: missing/invalid vars log WARNING and seed/classifier
+        are skipped.
     """
     email = settings.seed_user_email
     hashed_password = settings.seed_user_password_hash
@@ -80,6 +86,28 @@ async def _on_startup() -> None:
         logger.warning(
             "_on_startup: SEED_USER_EMAIL or SEED_USER_PASSWORD_HASH is empty "
             "— skipping seed in non-production environment."
+        )
+        return
+
+    # Email-format guard. fastapi-users' UserRead.email is EmailStr; seeding an
+    # operator with an invalid address (e.g. dev@localhost — no dot in domain)
+    # makes GET /users/me raise ResponseValidationError → 500 on every
+    # authenticated request. Fail loud in prod; in dev, log loudly and skip the
+    # seed rather than create a broken operator.
+    if not is_valid_seed_email(email):
+        if settings.environment == "production":
+            raise SeedUserInvalidEmailError(
+                f"SEED_USER_EMAIL={email!r} is not a valid email address. "
+                "fastapi-users serializes the operator through an EmailStr "
+                "field, so an invalid address makes GET /users/me return 500 "
+                "on every authenticated request. Set a valid SEED_USER_EMAIL "
+                "in apps/mygamingassistant/backend/.env.docker."
+            )
+        logger.error(
+            "_on_startup: SEED_USER_EMAIL=%r is not a valid email address "
+            "— skipping seed. GET /users/me would 500 for this operator. "
+            "Set a valid SEED_USER_EMAIL (e.g. dev@example.com).",
+            email,
         )
         return
 

--- a/apps/mygamingassistant/backend/app/services/user/seed_user_service.py
+++ b/apps/mygamingassistant/backend/app/services/user/seed_user_service.py
@@ -5,12 +5,18 @@ On every startup the lifespan calls ``seed_operator_user()`` to ensure the
 operator's account exists. The operation is idempotent — if the user already
 exists, it's a no-op.
 
-Boot guard (enforced in main.py _on_startup):
+Boot guards (enforced in main.py _on_startup):
   - In production (ENVIRONMENT=production): if SEED_USER_EMAIL or
     SEED_USER_PASSWORD_HASH is empty the startup raises SeedUserNotConfiguredError
     so the deploy healthcheck fails immediately rather than booting a server
     the operator can never log into.
-  - In development: if either var is empty, log a WARNING and skip the seed.
+  - In production: if SEED_USER_EMAIL is set but not a syntactically valid
+    email, the startup raises SeedUserInvalidEmailError. fastapi-users
+    serializes the operator through an ``EmailStr`` field (UserRead), so an
+    invalid address makes ``GET /users/me`` return 500 on every authenticated
+    request — a silent, hard-to-diagnose failure. Fail loud at boot instead.
+  - In development: if either var is empty OR the email is invalid, log and
+    skip the seed (do not create an operator that 500s /users/me).
 
 The password is stored as a bcrypt hash. Never store plaintext.
 
@@ -31,6 +37,38 @@ logger = logging.getLogger(__name__)
 
 class SeedUserNotConfiguredError(RuntimeError):
     """Raised in production when SEED_USER_EMAIL or SEED_USER_PASSWORD_HASH is empty."""
+
+
+class SeedUserInvalidEmailError(RuntimeError):
+    """Raised in production when SEED_USER_EMAIL is set but not a valid email."""
+
+
+def is_valid_seed_email(email: str) -> bool:
+    """Return True if *email* passes the same validation fastapi-users'
+    ``UserRead.email`` (Pydantic ``EmailStr``) applies at response time.
+
+    Pydantic v2 ``EmailStr`` delegates to ``email-validator`` with
+    ``check_deliverability=False`` (no DNS/network). We mirror that exactly so
+    this boot check accepts/rejects precisely what the response schema will —
+    catching ``dev@localhost``-style addresses (no dot in the domain) before
+    they seed an operator whose ``GET /users/me`` then 500s on every call.
+
+    The DNS check is deliberately disabled: it matches Pydantic, avoids a
+    network call on the startup path, and keeps the check deterministic in CI.
+    """
+    if not email:
+        return False
+    try:
+        from email_validator import EmailNotValidError, validate_email
+    except ImportError:  # pragma: no cover - ships with pydantic[email]/fastapi-users
+        # Minimal structural fallback: local-part@domain with a dotted domain.
+        parts = email.split("@")
+        return len(parts) == 2 and bool(parts[0]) and "." in parts[1]
+    try:
+        validate_email(email, check_deliverability=False)
+        return True
+    except EmailNotValidError:
+        return False
 
 
 async def seed_operator_user(email: str, hashed_password: str) -> None:

--- a/apps/mygamingassistant/backend/tests/test_seed_user_service.py
+++ b/apps/mygamingassistant/backend/tests/test_seed_user_service.py
@@ -1,0 +1,70 @@
+"""Unit tests for seed_user_service.is_valid_seed_email.
+
+Guards the operator-seed boot path: fastapi-users serializes the operator
+through an EmailStr field (UserRead), so seeding an operator whose
+SEED_USER_EMAIL is not a valid email makes GET /users/me return 500 on every
+authenticated request. is_valid_seed_email() must accept/reject exactly what
+Pydantic's EmailStr would (email-validator, no deliverability/DNS check).
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.user.seed_user_service import (
+    SeedUserInvalidEmailError,
+    SeedUserNotConfiguredError,
+    is_valid_seed_email,
+)
+
+
+class TestIsValidSeedEmail:
+    @pytest.mark.parametrize(
+        "email",
+        [
+            "user@example.com",
+            "dev@example.com",          # the recommended local-dev value
+            "operator@sub.domain.co",
+            "a.b+tag@mail.example.org",
+            "first.last@example.io",
+        ],
+    )
+    def test_valid_emails(self, email: str):
+        assert is_valid_seed_email(email) is True
+
+    @pytest.mark.parametrize(
+        "email",
+        [
+            "dev@localhost",   # THE bug: no dot in domain → EmailStr rejects → /users/me 500
+            "operator@localhost",
+            "",
+            "notanemail",
+            "@example.com",
+            "user@",
+            "user @example.com",
+            "user@exam ple.com",
+            "user@.com",
+            "user@com",
+        ],
+    )
+    def test_invalid_emails(self, email: str):
+        assert is_valid_seed_email(email) is False
+
+    def test_dev_at_localhost_is_rejected_explicitly(self):
+        """Regression: this exact value was seeded locally and 500'd
+        GET /users/me on every authenticated request."""
+        assert is_valid_seed_email("dev@localhost") is False
+        # The documented remediation value must pass.
+        assert is_valid_seed_email("dev@example.com") is True
+
+    def test_none_is_falsey_safe(self):
+        # _on_startup only calls this after the empty-string presence guard,
+        # but be defensive anyway.
+        assert is_valid_seed_email("") is False
+
+
+class TestSeedErrorContracts:
+    def test_invalid_email_error_is_runtime_error(self):
+        assert issubclass(SeedUserInvalidEmailError, RuntimeError)
+
+    def test_not_configured_error_is_runtime_error(self):
+        assert issubclass(SeedUserNotConfiguredError, RuntimeError)


### PR DESCRIPTION
## What

Independent follow-up surfaced during MGA ingestion diagnosis. `GET /api/users/me`
was returning **500 on every authenticated request** because the local operator
was seeded with `SEED_USER_EMAIL=dev@localhost`. fastapi-users serializes the
operator through `UserRead.email` (Pydantic `EmailStr`); `dev@localhost` has no
dot in the domain, so `email-validator` rejects it → `ResponseValidationError`
→ 500. Silent: the app boots, the healthcheck passes, only the authenticated
"who am I" call breaks.

## Fix

Loud, actionable boot guard matching the existing
`SeedUserNotConfigured` / `ClassifierNotConfigured` pattern:

- `is_valid_seed_email()` — mirrors Pydantic `EmailStr` exactly
  (`email-validator`, `check_deliverability=False`: no DNS, deterministic in
  CI), structural fallback if the lib is absent.
- `_on_startup` — after the presence guard, before seeding: **prod** raises
  `SeedUserInvalidEmailError` (deploy healthcheck catches it); **dev** logs an
  ERROR with the exact cause + remediation and skips the seed (no broken
  operator created).

**Deliberately not** loosening `UserRead.email` to `str`: production emails are
always valid (registration validates them); the only way to hit this is a
misconfigured `SEED_USER_EMAIL`, so the fix belongs at the seed boundary, not
by weakening the response schema for a local misconfig (that would be a
bandaid).

## Operator remediation (local dev only — prod unaffected)

Anyone whose local `.env` has an invalid `SEED_USER_EMAIL` (e.g.
`dev@localhost`) and already has a seeded user must, **in addition to merging
this**:

1. Set a valid `SEED_USER_EMAIL` in `apps/mygamingassistant/backend/.env`
   (e.g. `dev@example.com`).
2. Fix the existing row (the guard prevents *new* bad seeds; it can't rewrite
   an existing user): update that user's `email`, or delete it and let the
   next boot re-seed.
3. Restart the backend (env is read at process start).

## Tests

`tests/test_seed_user_service.py` — valid/invalid params including the exact
`dev@localhost` regression and the documented `dev@example.com` remediation
value, plus the error-class contracts. Isolated unit (no DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
