### PR TITLE
fix(mga): Strategy A — Claude grid classifier is the lineup detector + frame picker

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/classification_result.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classification_result.py
@@ -28,6 +28,17 @@ class ClassificationResult:
 
     success: bool
 
+    # Strategy A grid fields (ingest-time multi-frame path only).
+    # is_lineup: did the classifier judge the chapter to be a real tactical-FPS
+    #   utility-lineup demo at all? None for the legacy single-image
+    #   re-classify path (it cannot make this judgement — see classify_lineup).
+    # best_stand_index / best_aim_index: 1-based index into the candidate frame
+    #   grid the classifier was shown. None on the single-image path or when
+    #   is_lineup is False. The orchestrator uploads these chosen frames.
+    is_lineup: Optional[bool] = None
+    best_stand_index: Optional[int] = None
+    best_aim_index: Optional[int] = None
+
     # Suggested classification — may be None if classifier could not determine
     # the field confidently (slug failed to resolve → FK stays null).
     suggested_game_id: Optional[uuid.UUID] = None

--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -71,6 +71,59 @@ Rules:
 - side_a = attacking/T side; side_b = defending/CT side; any = side-agnostic.
 """
 
+# Strategy A grid schema. The model is given N numbered candidate frames
+# sampled across the chapter and must (a) decide whether the chapter is a real
+# utility-lineup demo at all, and (b) pick which frame best shows the throwing
+# stance and which best shows the aim/result. The aim_anchor_* coordinates are
+# relative to the chosen best_aim_index frame.
+_GRID_OUTPUT_SCHEMA_DOC = """\
+You are given {n} numbered candidate frames (Frame 1 .. Frame {n}) sampled at
+even intervals across ONE YouTube chapter from a tactical-FPS video. The
+chapter MIGHT be a real utility-lineup demonstration (player walks to a spot,
+lines up a smoke/molly/flash/grenade throw against a wall/skybox marker, throws
+it, and the result lands on a bombsite/choke) OR it might be junk (intro/outro,
+webcam talking-head, gameplay montage, kill highlights, menu, loading screen,
+title card). Most chapters in a mixed video are NOT lineups.
+
+Return ONLY valid JSON with exactly these fields (no extra keys):
+{{
+  "is_lineup": boolean,
+  "best_stand_index": integer (1-{n}) or null,
+  "best_aim_index": integer (1-{n}) or null,
+  "game_slug": string or null,
+  "map_slug": string or null,
+  "target_zone_slug": string or null,
+  "stand_zone_slug": string or null,
+  "side": "side_a" | "side_b" | "any" | null,
+  "utility_type_slug": string or null,
+  "aim_anchor_x": number (0.0-1.0) or null,
+  "aim_anchor_y": number (0.0-1.0) or null,
+  "confidence": number (0.0-1.0),
+  "reasoning": string
+}}
+
+Rules:
+- is_lineup: true ONLY if at least one frame clearly shows in-game tactical-FPS
+  gameplay consistent with a utility lineup (HUD/minimap visible, a throwable
+  equipped or its effect mid-air/landing, a recognizable map location). If the
+  frames are webcam, desktop, montage, menus, title cards, or unrelated
+  gameplay, set is_lineup=false and set the index/slug fields to null.
+- best_stand_index: the 1-based frame number that best shows the player STANDING
+  at the throw position lining up the utility (crosshair on the alignment
+  marker, throwable equipped, before release). null if is_lineup is false.
+- best_aim_index: the 1-based frame number that best shows the AIM/RESULT — the
+  crosshair placement for the throw or the utility landing on target. May equal
+  best_stand_index if one frame shows both. null if is_lineup is false.
+- aim_anchor_x / aim_anchor_y: normalized (0-1) crosshair position IN THE
+  best_aim_index FRAME. x=0 left, x=1 right; y=0 top, y=1 bottom. null if
+  is_lineup is false or you cannot locate the crosshair.
+- confidence: your overall confidence (0-1) that this is a usable lineup AND the
+  classification is correct. Low confidence on junk; high only when sure.
+- Set any field to null and explain in reasoning if you cannot determine it.
+- Only use slugs from the Valid reference lists provided; do not invent slugs.
+- side_a = attacking/T side; side_b = defending/CT side; any = side-agnostic.
+"""
+
 # ---------------------------------------------------------------------------
 # Reference data loader
 # ---------------------------------------------------------------------------
@@ -628,6 +681,334 @@ async def classify_lineup(
 
     return ClassificationResult(
         success=True,
+        suggested_game_id=game_id,
+        suggested_map_id=map_id,
+        suggested_target_zone_id=target_zone_id,
+        suggested_stand_zone_id=stand_zone_id,
+        suggested_side=side,
+        suggested_utility_type_id=utility_type_id,
+        aim_anchor_x=aim_x,
+        aim_anchor_y=aim_y,
+        confidence=confidence,
+        reasoning=reasoning,
+        error_codes=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Strategy A — multi-frame grid classifier (ingest-time only)
+# ---------------------------------------------------------------------------
+#
+# The legacy classify_lineup() above runs at *re-classify* time: the source
+# video is already deleted, only the two stored screenshots survive, so it can
+# only re-judge a single stand image. It deliberately CANNOT decide is_lineup
+# (one arbitrary frame is exactly the input that made the original ingestion
+# unable to reject junk chapters — see the g-debug-bug diagnosis).
+#
+# classify_lineup_from_frames() runs at *ingest* time, while the video is still
+# on disk: it is handed N evenly-spaced candidate frames and is the actual
+# lineup detector + frame picker (Strategy A). This asymmetry is expected and
+# documented, not a bug.
+
+
+def _strip_json_fences(raw_text: str) -> str:
+    """Strip a leading ```json / ``` markdown fence if Claude added one."""
+    clean = raw_text.strip()
+    if clean.startswith("```"):
+        clean = clean.split("```", 2)[1]
+        if clean.startswith("json"):
+            clean = clean[4:]
+        clean = clean.strip()
+    return clean
+
+
+def _validate_aim_coord(
+    value: Any, axis: str, failures: list[str]
+) -> Optional[float]:
+    """Validate one normalized aim-anchor coordinate (shared with single-image path)."""
+    if value is None:
+        return None
+    try:
+        coord = float(value)
+    except (TypeError, ValueError):
+        failures.append(f"aim_anchor_{axis} '{value}' is not a number")
+        return None
+    if not (0.0 <= coord <= 1.0):
+        failures.append(f"aim_anchor_{axis}={coord} out of range [0,1]")
+        return None
+    return coord
+
+
+def _validate_grid_index(
+    value: Any, field_name: str, n: int, failures: list[str]
+) -> Optional[int]:
+    """Validate a 1-based frame index returned by the grid classifier.
+
+    Returns the 1-based int if it is an integer within [1, n], else None and
+    appends a human-readable note to *failures*.
+    """
+    if value is None:
+        return None
+    try:
+        idx = int(value)
+    except (TypeError, ValueError):
+        failures.append(f"{field_name} '{value}' is not an integer")
+        return None
+    if not (1 <= idx <= n):
+        failures.append(f"{field_name}={idx} out of range [1,{n}]")
+        return None
+    return idx
+
+
+async def classify_frames_for_lineup_decision(
+    db: AsyncSession,
+    *,
+    frames: list[bytes],
+    chapter_title: Optional[str],
+    attribution_author: Optional[str],
+    game_hint: Optional[str] = None,
+) -> ClassificationResult:
+    """Strategy A: classify a chapter from N candidate frames at ingest time.
+
+    Unlike :func:`classify_lineup`, this takes the raw frame bytes in memory
+    (the video is still on disk during ingestion) and asks Claude to:
+
+      1. decide ``is_lineup`` — is this chapter a real tactical-FPS utility
+         lineup demo at all (the real "stop junk" mechanism); and
+      2. pick ``best_stand_index`` / ``best_aim_index`` — which of the N frames
+         best shows the throw stance and the aim/result; and
+      3. classify the usual game/map/zone/side/utility/aim-anchor fields.
+
+    It does NOT touch the database (no lineup row exists yet — the orchestrator
+    creates the row only if ``is_lineup`` is True, using the chosen frames).
+    Reference data is still loaded for slug resolution.
+
+    Cost: one cheap-model (haiku) call with N images. Reference data + system
+    prompt are cache_control-marked so they're billed once per game, not per
+    chapter. N is capped by the caller (orchestrator uses N=5) to bound tokens.
+
+    Args:
+        db: Active async session (read-only here — reference data + slug resolve).
+        frames: Candidate PNG byte strings, in chapter start→end order. The
+            1-based ``best_*_index`` values index into this list.
+        chapter_title: YouTube chapter title (per-call context).
+        attribution_author: Source channel name (per-call context).
+        game_hint: Optional game slug hint from source metadata.
+
+    Returns:
+        ClassificationResult. On a successful call ``success=True`` and
+        ``is_lineup`` reflects Claude's judgement (it may be False — that is a
+        successful *call* with a "this is junk" answer, not an error).
+        ``error_codes`` is populated only on an API/parse failure.
+    """
+    if not settings.anthropic_api_key:
+        logger.warning(
+            "classify_frames: ANTHROPIC_API_KEY not configured — skipping "
+            "(chapter=%r)", chapter_title,
+        )
+        return ClassificationResult(
+            success=False,
+            error_codes=["missing_api_key"],
+            reasoning="ANTHROPIC_API_KEY not configured",
+        )
+
+    if not frames:
+        return ClassificationResult(
+            success=False,
+            error_codes=["no_frames"],
+            reasoning="No candidate frames supplied to grid classifier",
+        )
+
+    n = len(frames)
+
+    # Reference data spans all games when there's no row yet (ingest time has
+    # no lineup.game_id). The game_hint narrows the prompt textually.
+    ref = await _load_reference_data(db, game_id=None)
+    reference_text = _build_reference_text(ref, game_hint=game_hint)
+
+    chapter_context_parts: list[str] = []
+    if chapter_title:
+        chapter_context_parts.append(f"Chapter title: {chapter_title}")
+    if attribution_author:
+        chapter_context_parts.append(f"Source channel: {attribution_author}")
+    chapter_context = "\n".join(chapter_context_parts)
+
+    system_prompt = (
+        "You are classifying tactical-FPS utility lineup screenshots.\n"
+        "You will receive several numbered candidate frames from ONE video "
+        "chapter and must judge whether the chapter is a real utility-lineup "
+        "demo, pick the best frames, and classify it.\n\n"
+        + _GRID_OUTPUT_SCHEMA_DOC.format(n=n)
+    )
+
+    import base64
+
+    # Per-call content: each numbered frame as a labelled image, then chapter
+    # context, then the cache_control'd reference block. Images are the
+    # variable part (not cached); system + reference are cached.
+    user_content: list[dict] = []
+    for i, frame_bytes in enumerate(frames, start=1):
+        user_content.append({"type": "text", "text": f"Frame {i}:"})
+        user_content.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": base64.standard_b64encode(frame_bytes).decode(),
+                },
+            }
+        )
+    if chapter_context:
+        user_content.append({"type": "text", "text": chapter_context})
+    user_content.append(
+        {
+            "type": "text",
+            "text": reference_text,
+            "cache_control": {"type": "ephemeral"},
+        }
+    )
+
+    try:
+        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+        response = client.messages.create(
+            model=settings.claude_classifier_model,
+            max_tokens=600,  # grid adds is_lineup + 2 indices vs the single-image schema
+            system=[
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": user_content}],
+        )
+    except anthropic.RateLimitError as exc:
+        error_type = getattr(exc, "type", "rate_limit_error") or "rate_limit_error"
+        logger.warning(
+            "classify_frames: rate limit hit: chapter=%r error_type=%s message=%s",
+            chapter_title, error_type, str(exc),
+        )
+        return ClassificationResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API rate limit: {exc}",
+        )
+    except anthropic.APIStatusError as exc:
+        error_type = getattr(exc, "type", None) or f"api_status_{exc.status_code}"
+        logger.error(
+            "classify_frames: API status error: chapter=%r error_type=%s "
+            "status_code=%s message=%s",
+            chapter_title, error_type, exc.status_code, str(exc),
+        )
+        return ClassificationResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API error ({exc.status_code}): {exc}",
+        )
+    except anthropic.APIError as exc:
+        error_type = getattr(exc, "type", "api_error") or "api_error"
+        logger.error(
+            "classify_frames: API error: chapter=%r error_type=%s message=%s",
+            chapter_title, error_type, str(exc),
+        )
+        return ClassificationResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API error: {exc}",
+        )
+
+    raw_text = response.content[0].text if response.content else ""
+    try:
+        parsed: dict[str, Any] = json.loads(_strip_json_fences(raw_text))
+    except (json.JSONDecodeError, IndexError) as exc:
+        logger.error(
+            "classify_frames: JSON parse failed: chapter=%r raw=%r error=%s",
+            chapter_title, raw_text[:200], str(exc),
+        )
+        return ClassificationResult(
+            success=False,
+            error_codes=["json_parse_error"],
+            reasoning=f"Could not parse classifier JSON: {exc}",
+        )
+
+    failures: list[str] = []
+
+    is_lineup = bool(parsed.get("is_lineup"))
+
+    best_stand_index = _validate_grid_index(
+        parsed.get("best_stand_index"), "best_stand_index", n, failures
+    )
+    best_aim_index = _validate_grid_index(
+        parsed.get("best_aim_index"), "best_aim_index", n, failures
+    )
+
+    confidence: Optional[float] = None
+    raw_conf = parsed.get("confidence")
+    if raw_conf is not None:
+        try:
+            confidence = max(0.0, min(1.0, float(raw_conf)))
+        except (TypeError, ValueError):
+            pass
+
+    model_reasoning = str(parsed.get("reasoning") or "")
+
+    # If Claude says it's not a lineup, don't bother resolving slugs — the
+    # orchestrator will skip the row entirely. Return early with the verdict.
+    if not is_lineup:
+        reasoning = model_reasoning or "Classifier judged chapter is not a lineup."
+        logger.info(
+            "classify_frames: is_lineup=False chapter=%r n=%d confidence=%.2f",
+            chapter_title, n, confidence or 0.0,
+        )
+        return ClassificationResult(
+            success=True,
+            is_lineup=False,
+            best_stand_index=None,
+            best_aim_index=None,
+            confidence=confidence,
+            reasoning=reasoning,
+            error_codes=[],
+        )
+
+    # is_lineup True → resolve the classification slugs as usual.
+    game_id, map_id, target_zone_id, stand_zone_id, utility_type_id, slug_failures = (
+        await _resolve_slugs(
+            db,
+            game_slug=parsed.get("game_slug"),
+            map_slug=parsed.get("map_slug"),
+            target_zone_slug=parsed.get("target_zone_slug"),
+            stand_zone_slug=parsed.get("stand_zone_slug"),
+            utility_type_slug=parsed.get("utility_type_slug"),
+        )
+    )
+    failures.extend(slug_failures)
+
+    side = parsed.get("side")
+    if side is not None and side not in ("side_a", "side_b", "any"):
+        failures.append(f"invalid side value '{side}' — must be side_a/side_b/any")
+        side = None
+
+    aim_x = _validate_aim_coord(parsed.get("aim_anchor_x"), "x", failures)
+    aim_y = _validate_aim_coord(parsed.get("aim_anchor_y"), "y", failures)
+
+    if failures:
+        reasoning = f"{model_reasoning}\nNotes: {'; '.join(failures)}".strip()
+    else:
+        reasoning = model_reasoning
+
+    logger.info(
+        "classify_frames: is_lineup=True chapter=%r n=%d stand_idx=%s aim_idx=%s "
+        "game=%s map=%s confidence=%.2f",
+        chapter_title, n, best_stand_index, best_aim_index,
+        parsed.get("game_slug"), parsed.get("map_slug"), confidence or 0.0,
+    )
+
+    return ClassificationResult(
+        success=True,
+        is_lineup=True,
+        best_stand_index=best_stand_index,
+        best_aim_index=best_aim_index,
         suggested_game_id=game_id,
         suggested_map_id=map_id,
         suggested_target_zone_id=target_zone_id,

--- a/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
@@ -99,3 +99,62 @@ async def extract_frames(
         )
         results.append(png_bytes)
     return results
+
+
+def grid_timestamps(
+    start_seconds: float,
+    end_seconds: float,
+    n: int,
+    *,
+    edge_padding_seconds: float = 0.5,
+) -> list[float]:
+    """Compute *n* evenly-spaced timestamps strictly inside (start, end).
+
+    Strategy A's frame grid. The exact chapter boundaries are the worst
+    possible sample points (deterministic fade-in / title-card / transition /
+    black frame), so the grid is placed strictly *inside* the chapter with a
+    small padding pulled off each edge, then *n* points spaced evenly across
+    the padded interior. The boundaries themselves are never sampled.
+
+    For ``n=5`` over a chapter ``(20, 200)`` with default padding the result is
+    five points evenly spread across ``[20.5, 199.5]`` — i.e. ``20.5``,
+    ``70.25``, ``120.0``, ``169.75``, ``199.5``.
+
+    Args:
+        start_seconds: Chapter start (exclusive — never sampled).
+        end_seconds: Chapter end (exclusive — never sampled).
+        n: Number of frames to sample (>= 1). Clamped to >= 1.
+        edge_padding_seconds: Seconds pulled off each edge before spacing.
+            On very short chapters the padded interior can collapse; the
+            timestamps then degenerate toward the chapter midpoint, which is
+            still strictly inside (start, end).
+
+    Returns:
+        A list of *n* monotonically non-decreasing float timestamps, each
+        strictly within the open interval ``(start_seconds, end_seconds)``.
+        Order matches the natural start→end progression so callers can treat
+        earlier indices as "earlier in the chapter".
+    """
+    count = max(1, int(n))
+    span_lo = float(start_seconds)
+    span_hi = float(end_seconds)
+
+    # Degenerate / inverted chapter — collapse everything to a safe interior
+    # point. Strictly-inside is impossible if hi <= lo, so just nudge off lo.
+    if span_hi <= span_lo:
+        return [span_lo + 0.001] * count
+
+    midpoint = (span_lo + span_hi) / 2.0
+    lo = span_lo + edge_padding_seconds
+    hi = span_hi - edge_padding_seconds
+
+    # Padding ate the whole interval (chapter shorter than 2*padding) — fall
+    # back to the midpoint, which is guaranteed strictly inside (lo, hi).
+    if hi <= lo:
+        return [midpoint] * count
+
+    if count == 1:
+        return [midpoint]
+
+    step = (hi - lo) / (count - 1)
+    return [lo + step * i for i in range(count)]

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -6,9 +6,13 @@ Pipeline per source sync:
   3. For each new video:
      a. Download video to INGESTION_DOWNLOAD_DIR.
      b. Parse chapter timestamps (native yt-dlp or description regex).
-     c. For each chapter: extract stand frame (t=start) + aim frame (t=start+4s).
-     d. Upload both frames to MinIO under pending/{video_id}/{start}-{stand|aim}.png.
-     e. Insert Lineup row with status='pending_review'.
+     c. For each chapter (Strategy A): extract an evenly-spaced grid of
+        candidate frames; the Claude classifier decides is_lineup and picks the
+        best stand/aim frames. Chapters judged "not a lineup" are skipped with
+        no row created.
+     d. Upload the two Claude-chosen frames to MinIO under
+        pending/{video_id}/{start}-{stand|aim}.png.
+     e. Insert Lineup row with status='pending_review' + classifier suggestions.
      f. Delete downloaded video.
   4. Update source.last_synced_at + last_sync_stats.
 
@@ -37,15 +41,22 @@ from app.core.config import settings
 from app.core.storage import get_storage
 from app.models.game.source import Source
 from app.repositories.game import lineup_repo, source_repo
+from app.repositories.game.lineup_repo import write_classifier_suggestions
 from app.schemas.game.lineup_schemas import LineupIngestCreate
-from app.services.classification.classifier_service import classify_lineup
+from app.services.classification.classifier_service import (
+    classify_frames_for_lineup_decision,
+)
 from app.services.game import lineup_service
 from app.services.ingestion.chapter_parser import (
     Chapter,
     filter_lineup_chapters,
     parse_chapters,
 )
-from app.services.ingestion.frame_extractor import FrameExtractionError, extract_frames
+from app.services.ingestion.frame_extractor import (
+    FrameExtractionError,
+    extract_frames,
+    grid_timestamps,
+)
 from app.services.ingestion.youtube_fetcher import (
     VideoDownloadError,
     VideoMeta,
@@ -57,14 +68,25 @@ from app.services.ingestion.youtube_fetcher import (
 
 logger = logging.getLogger(__name__)
 
-# Phase-1 frame-timing heuristic. The exact chapter boundary is the worst
-# possible sample point — it's a deterministic fade-in / transition / black
-# frame (a t=0 "Intro" chapter is *always* a black frame). Offsetting a few
-# seconds into the chapter avoids that deterministic failure. This is still a
-# blind heuristic; Phase 2 (Strategy A: extract a grid of candidate frames and
-# let Claude pick the best stand/aim + decide is_lineup) replaces it wholesale.
-_STAND_FRAME_OFFSET_SECONDS = 3.0
-_AIM_FRAME_GAP_SECONDS = 4.0
+# Strategy A. The Phase-1 blind +3s/+7s frame-offset heuristic is GONE: a
+# single arbitrary frame is exactly the input that left ingestion unable to
+# reject junk chapters (see the g-debug-bug diagnosis). Instead we extract a
+# grid of evenly-spaced candidate frames across the chapter and let the cheap
+# Claude model both (a) decide is_lineup and (b) pick the best stand/aim frame.
+#
+# N is capped low so token cost stays bounded — a haiku call with 5 PNG frames
+# is ≈7-9K image tokens (reference data + system prompt are cache_control'd, so
+# billed once per game, not per chapter). _GRID_FRAME_COUNT is the only knob;
+# do NOT raise it without re-checking the per-chapter cost note in the PR.
+_GRID_FRAME_COUNT = 5
+
+# Pulled off each chapter edge before the grid is spaced, so no candidate ever
+# lands on the exact boundary (deterministic fade-in / title-card / black).
+_GRID_EDGE_PADDING_SECONDS = 0.5
+
+# Chapters the classifier judged a lineup but with confidence at/below this are
+# treated as junk and skipped — a weak "maybe" is not worth a review-queue row.
+_MIN_LINEUP_CONFIDENCE = 0.15
 
 
 @dataclass
@@ -103,6 +125,26 @@ def _upload_frame(storage, key: str, png_bytes: bytes) -> None:
     )
 
 
+def _classifier_suggestion_fields(result) -> dict:
+    """Map a ClassificationResult onto the lineup writeback dict.
+
+    Same field set the legacy single-image path wrote via the repo, so the
+    review UI sees identical columns regardless of which path classified it.
+    """
+    return {
+        "aim_anchor_x": result.aim_anchor_x,
+        "aim_anchor_y": result.aim_anchor_y,
+        "suggested_game_id": result.suggested_game_id,
+        "suggested_map_id": result.suggested_map_id,
+        "suggested_target_zone_id": result.suggested_target_zone_id,
+        "suggested_stand_zone_id": result.suggested_stand_zone_id,
+        "suggested_side": result.suggested_side,
+        "suggested_utility_type_id": result.suggested_utility_type_id,
+        "classification_confidence": result.confidence,
+        "classification_reasoning": result.reasoning,
+    }
+
+
 async def _process_chapter(
     video_meta: VideoMeta,
     chapter: Chapter,
@@ -111,22 +153,36 @@ async def _process_chapter(
     db: AsyncSession,
     source: Source,
 ) -> bool:
-    """Extract frames, upload to MinIO, and create a Lineup row.
+    """Strategy A: grid-extract, let Claude detect+pick, then create the row.
 
-    Returns True on success, False on any handled error.
+    Flow:
+      1. Extract ``_GRID_FRAME_COUNT`` evenly-spaced candidate frames strictly
+         inside the chapter.
+      2. Ask the classifier whether the chapter is a real lineup and which
+         frames best show the stand/aim (ONE cheap-model call, before any DB
+         write or MinIO upload).
+      3. If ``is_lineup`` is False (or confidence too low), skip the chapter
+         entirely — no pending row is created. This is the real "stop junk"
+         mechanism. Dedup is keyed by ``youtube_video_id`` (whole video), not
+         per-chapter, so skipping a chapter does not break re-sync dedup.
+      4. Upload only the two Claude-chosen frames, create the lineup row, and
+         write the classifier suggestions through the repo.
+
+    Returns True when the chapter was handled successfully (including a
+    deliberate "not a lineup" skip — that is a success, not an error). Returns
+    False only on an unexpected handled failure (ffmpeg / MinIO / DB / API).
     """
     start = chapter.start_seconds
-    # Clamp all sampling strictly inside [start, end) — never the exact
-    # boundary (fade-in/transition/black). filter_lineup_chapters already
-    # drops <15s chapters, but keep the math safe on short ones anyway.
-    chapter_end = float(chapter.end_seconds)
-    last_safe_ts = max(float(start), chapter_end - 0.5)
-    stand_ts = min(float(start) + _STAND_FRAME_OFFSET_SECONDS, last_safe_ts)
-    aim_ts = min(stand_ts + _AIM_FRAME_GAP_SECONDS, last_safe_ts)
-    aim_ts = max(aim_ts, stand_ts)
+
+    timestamps = grid_timestamps(
+        float(start),
+        float(chapter.end_seconds),
+        _GRID_FRAME_COUNT,
+        edge_padding_seconds=_GRID_EDGE_PADDING_SECONDS,
+    )
 
     try:
-        stand_bytes, aim_bytes = await extract_frames(video_path, [stand_ts, aim_ts])
+        frames = await extract_frames(video_path, timestamps)
     except FrameExtractionError as exc:
         logger.error(
             "Frame extraction failed: source_id=%s video_id=%s chapter_start=%d error=%s",
@@ -134,6 +190,84 @@ async def _process_chapter(
             exc_info=True,
         )
         return False
+
+    if not frames:
+        logger.error(
+            "Frame grid empty: source_id=%s video_id=%s chapter_start=%d",
+            source.id, video_meta.video_id, start,
+        )
+        return False
+
+    game_hint = (
+        source.config_json.get("game_hint") if source.config_json else None
+    )
+
+    # Strategy A core: the classifier IS the lineup detector + frame picker.
+    # When the classifier is disabled we cannot make the is_lineup judgement,
+    # so fall back to a defined behaviour: keep the chapter and use the first
+    # and last grid frames as stand/aim (still strictly inside the chapter,
+    # never the boundary). This keeps the classifier-disabled test/dev path
+    # working without resurrecting the discredited +3s/+7s heuristic.
+    classifier_ran = False
+    result = None
+    if settings.enable_classifier:
+        try:
+            result = await classify_frames_for_lineup_decision(
+                db,
+                frames=frames,
+                chapter_title=chapter.title,
+                attribution_author=video_meta.channel_name,
+                game_hint=game_hint,
+            )
+            classifier_ran = True
+        except Exception as exc:
+            logger.error(
+                "Grid classifier unexpected error (non-fatal): source_id=%s "
+                "video_id=%s chapter_start=%d error=%s",
+                source.id, video_meta.video_id, start, str(exc),
+                exc_info=True,
+            )
+
+    if classifier_ran and result is not None:
+        if not result.success:
+            logger.warning(
+                "Grid classifier call failed (non-fatal, skipping chapter): "
+                "source_id=%s video_id=%s chapter_start=%d error_codes=%s",
+                source.id, video_meta.video_id, start, result.error_codes,
+            )
+            # A failed classifier *call* (API/parse) — we cannot judge the
+            # chapter. Skip it rather than create an unjudged junk row; the
+            # whole point of Strategy A is to not ingest unverifiable frames.
+            return True
+
+        if not result.is_lineup or (
+            result.confidence is not None
+            and result.confidence <= _MIN_LINEUP_CONFIDENCE
+        ):
+            logger.info(
+                "Chapter judged NOT a lineup — skipping (no row created): "
+                "source_id=%s video_id=%s chapter_start=%d is_lineup=%s "
+                "confidence=%.2f title=%r",
+                source.id, video_meta.video_id, start, result.is_lineup,
+                result.confidence or 0.0, chapter.title,
+            )
+            return True
+
+        # Claude-selected best frames (1-based → 0-based). Fall back to
+        # first/last if the model omitted an index (validation already nulled
+        # out-of-range values).
+        stand_idx = (result.best_stand_index or 1) - 1
+        aim_idx = (result.best_aim_index or len(frames)) - 1
+        stand_idx = max(0, min(stand_idx, len(frames) - 1))
+        aim_idx = max(0, min(aim_idx, len(frames) - 1))
+    else:
+        # Classifier disabled or threw before returning — keep chapter, use
+        # first/last grid frame. No suggestions written.
+        stand_idx = 0
+        aim_idx = len(frames) - 1
+
+    stand_bytes = frames[stand_idx]
+    aim_bytes = frames[aim_idx]
 
     stand_key = _pending_screenshot_key(video_meta.video_id, start, "stand")
     aim_key = _pending_screenshot_key(video_meta.video_id, start, "aim")
@@ -164,6 +298,12 @@ async def _process_chapter(
 
     try:
         lineup = await lineup_service.create_from_ingestion(db, payload)
+        # If the classifier produced suggestions, write them through the repo
+        # before the single commit (status stays pending_review).
+        if classifier_ran and result is not None and result.is_lineup:
+            await write_classifier_suggestions(
+                db, lineup, _classifier_suggestion_fields(result)
+            )
         await db.commit()
     except Exception as exc:
         await db.rollback()
@@ -174,43 +314,14 @@ async def _process_chapter(
         )
         return False
 
-    # Classifier — runs immediately after the lineup is created.
-    # Failures are logged but non-fatal: the lineup stays in pending_review
-    # with no suggestions, and the user can re-classify from the review queue.
-    if settings.enable_classifier:
-        try:
-            result = await classify_lineup(
-                db,
-                lineup.id,
-                game_hint=source.config_json.get("game_hint") if source.config_json else None,
-            )
-            if result.success:
-                await db.commit()
-                logger.info(
-                    "Classifier success: source_id=%s video_id=%s chapter_start=%d "
-                    "lineup_id=%s confidence=%.2f",
-                    source.id, video_meta.video_id, start, lineup.id,
-                    result.confidence or 0.0,
-                )
-            else:
-                logger.warning(
-                    "Classifier failed (non-fatal): source_id=%s video_id=%s "
-                    "chapter_start=%d lineup_id=%s error_codes=%s",
-                    source.id, video_meta.video_id, start, lineup.id,
-                    result.error_codes,
-                )
-        except Exception as exc:
-            logger.error(
-                "Classifier unexpected error (non-fatal): source_id=%s video_id=%s "
-                "chapter_start=%d lineup_id=%s error=%s",
-                source.id, video_meta.video_id, start, lineup.id, str(exc),
-                exc_info=True,
-            )
-            # Rollback any partial classifier flush; lineup row is already committed above.
-            try:
-                await db.rollback()
-            except Exception:
-                pass
+    if classifier_ran and result is not None and result.is_lineup:
+        logger.info(
+            "Classifier success (grid): source_id=%s video_id=%s "
+            "chapter_start=%d lineup_id=%s stand_idx=%d aim_idx=%d "
+            "confidence=%.2f",
+            source.id, video_meta.video_id, start, lineup.id,
+            stand_idx, aim_idx, result.confidence or 0.0,
+        )
 
     return True
 

--- a/apps/mygamingassistant/backend/tests/test_classifier_service.py
+++ b/apps/mygamingassistant/backend/tests/test_classifier_service.py
@@ -423,3 +423,317 @@ class TestReferenceTextBuilder:
         ref = {"games": [], "maps": [], "utility_types": []}
         text = _build_reference_text(ref, game_hint=None)
         assert "Expected game" not in text
+
+
+# ---------------------------------------------------------------------------
+# Tests: Strategy A grid classifier (classify_frames_for_lineup_decision)
+# ---------------------------------------------------------------------------
+
+_THREE_FRAMES = [_FAKE_PNG, _FAKE_PNG, _FAKE_PNG]
+
+
+# Collision-proof reference fixtures for the grid tests. The shared
+# game_val/map_bind/zone/utility fixtures hardcode slug='valorant'/'bind'
+# which collides on ix_game_slug under the SAVEPOINT-restart conftest (the
+# documented pre-existing 7 errors in TestClassifyLineup/TestSlugResolver —
+# NOT this class's bug). These grid tests deliberately use unique slugs so
+# they pass independently of that pre-existing breakage and never add to it.
+_GRID_SLUG_SUFFIX = uuid.uuid4().hex[:8]
+
+
+@pytest_asyncio.fixture
+async def grid_game(db: AsyncSession) -> Game:
+    g = Game(
+        slug=f"grid-game-{_GRID_SLUG_SUFFIX}",
+        name="Grid Test Game",
+        side_a_label="Attacker",
+        side_b_label="Defender",
+    )
+    db.add(g)
+    await db.flush()
+    return g
+
+
+@pytest_asyncio.fixture
+async def grid_map(db: AsyncSession, grid_game: Game) -> Map:
+    m = Map(
+        game_id=grid_game.id,
+        slug=f"grid-map-{_GRID_SLUG_SUFFIX}",
+        name="Grid Test Map",
+    )
+    db.add(m)
+    await db.flush()
+    return m
+
+
+@pytest_asyncio.fixture
+async def grid_zone(db: AsyncSession, grid_map: Map) -> MapZone:
+    z = MapZone(
+        map_id=grid_map.id,
+        slug=f"grid-zone-{_GRID_SLUG_SUFFIX}",
+        name="Grid Zone",
+    )
+    db.add(z)
+    await db.flush()
+    return z
+
+
+@pytest_asyncio.fixture
+async def grid_utility(db: AsyncSession, grid_game: Game) -> UtilityType:
+    ut = UtilityType(
+        game_id=grid_game.id,
+        slug=f"grid-smoke-{_GRID_SLUG_SUFFIX}",
+        name="Grid Smoke",
+    )
+    db.add(ut)
+    await db.flush()
+    return ut
+
+
+class TestClassifyFramesForLineupDecision:
+    @pytest.mark.asyncio
+    async def test_is_lineup_true_resolves_slugs_and_picks_frames(
+        self,
+        db: AsyncSession,
+        grid_game: Game,
+        grid_map: Map,
+        grid_zone: MapZone,
+        grid_utility: UtilityType,
+    ):
+        """is_lineup=True → slugs resolved to FK IDs, chosen indices returned."""
+        from app.services.classification.classifier_service import (
+            classify_frames_for_lineup_decision,
+        )
+
+        payload = {
+            "is_lineup": True,
+            "best_stand_index": 2,
+            "best_aim_index": 3,
+            "game_slug": grid_game.slug,
+            "map_slug": grid_map.slug,
+            "target_zone_slug": grid_zone.slug,
+            "stand_zone_slug": None,
+            "side": "side_a",
+            "utility_type_slug": grid_utility.slug,
+            "aim_anchor_x": 0.4,
+            "aim_anchor_y": 0.6,
+            "confidence": 0.9,
+            "reasoning": "Smoke lineup for A short.",
+        }
+
+        with (
+            patch("app.services.classification.classifier_service.settings") as mock_settings,
+            patch("app.services.classification.classifier_service.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = _make_anthropic_response(payload)
+
+            result = await classify_frames_for_lineup_decision(
+                db,
+                frames=_THREE_FRAMES,
+                chapter_title="A short smoke",
+                attribution_author="TestCreator",
+            )
+
+        assert result.success is True
+        assert result.is_lineup is True
+        assert result.best_stand_index == 2
+        assert result.best_aim_index == 3
+        assert result.suggested_target_zone_id == grid_zone.id
+        assert result.suggested_utility_type_id == grid_utility.id
+        assert result.suggested_side == "side_a"
+        assert result.aim_anchor_x == pytest.approx(0.4)
+        assert result.confidence == pytest.approx(0.9)
+        assert result.error_codes == []
+
+    @pytest.mark.asyncio
+    async def test_is_lineup_false_returns_early_no_slug_resolution(
+        self,
+        db: AsyncSession,
+        grid_game: Game,
+    ):
+        """is_lineup=False → success=True, is_lineup=False, no suggested FKs."""
+        from app.services.classification.classifier_service import (
+            classify_frames_for_lineup_decision,
+        )
+
+        payload = {
+            "is_lineup": False,
+            "best_stand_index": None,
+            "best_aim_index": None,
+            "game_slug": None,
+            "confidence": 0.03,
+            "reasoning": "Intro card / webcam — not a lineup.",
+        }
+
+        with (
+            patch("app.services.classification.classifier_service.settings") as mock_settings,
+            patch("app.services.classification.classifier_service.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = _make_anthropic_response(payload)
+
+            result = await classify_frames_for_lineup_decision(
+                db,
+                frames=_THREE_FRAMES,
+                chapter_title="Intro",
+                attribution_author="TestCreator",
+            )
+
+        assert result.success is True
+        assert result.is_lineup is False
+        assert result.best_stand_index is None
+        assert result.best_aim_index is None
+        assert result.suggested_game_id is None
+        assert result.confidence == pytest.approx(0.03)
+        assert result.error_codes == []
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_indices_nulled(
+        self,
+        db: AsyncSession,
+        grid_game: Game,
+        grid_map: Map,
+    ):
+        """best_*_index outside [1,n] is rejected → None, note in reasoning."""
+        from app.services.classification.classifier_service import (
+            classify_frames_for_lineup_decision,
+        )
+
+        payload = {
+            "is_lineup": True,
+            "best_stand_index": 0,   # invalid (1-based)
+            "best_aim_index": 99,    # invalid (> n)
+            "game_slug": grid_game.slug,
+            "map_slug": grid_map.slug,
+            "side": "any",
+            "confidence": 0.7,
+            "reasoning": "Lineup but bad indices.",
+        }
+
+        with (
+            patch("app.services.classification.classifier_service.settings") as mock_settings,
+            patch("app.services.classification.classifier_service.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = _make_anthropic_response(payload)
+
+            result = await classify_frames_for_lineup_decision(
+                db,
+                frames=_THREE_FRAMES,
+                chapter_title="A site",
+                attribution_author="TestCreator",
+            )
+
+        assert result.success is True
+        assert result.is_lineup is True
+        assert result.best_stand_index is None
+        assert result.best_aim_index is None
+        assert "best_stand_index" in result.reasoning
+        assert "best_aim_index" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_empty_frames_returns_error(self, db: AsyncSession):
+        from app.services.classification.classifier_service import (
+            classify_frames_for_lineup_decision,
+        )
+
+        with patch("app.services.classification.classifier_service.settings") as mock_settings:
+            mock_settings.anthropic_api_key = "sk-test"
+            result = await classify_frames_for_lineup_decision(
+                db, frames=[], chapter_title="x", attribution_author="y"
+            )
+
+        assert result.success is False
+        assert "no_frames" in result.error_codes
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_returns_error(self, db: AsyncSession):
+        from app.services.classification.classifier_service import (
+            classify_frames_for_lineup_decision,
+        )
+
+        with patch("app.services.classification.classifier_service.settings") as mock_settings:
+            mock_settings.anthropic_api_key = ""
+            result = await classify_frames_for_lineup_decision(
+                db, frames=_THREE_FRAMES, chapter_title="x", attribution_author="y"
+            )
+
+        assert result.success is False
+        assert "missing_api_key" in result.error_codes
+
+    @pytest.mark.asyncio
+    async def test_json_parse_failure(self, db: AsyncSession, grid_game: Game):
+        from app.services.classification.classifier_service import (
+            classify_frames_for_lineup_decision,
+        )
+
+        bad_response = MagicMock()
+        bad_text = MagicMock()
+        bad_text.text = "I cannot classify these frames."
+        bad_response.content = [bad_text]
+
+        with (
+            patch("app.services.classification.classifier_service.settings") as mock_settings,
+            patch("app.services.classification.classifier_service.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = bad_response
+
+            result = await classify_frames_for_lineup_decision(
+                db,
+                frames=_THREE_FRAMES,
+                chapter_title="x",
+                attribution_author="y",
+            )
+
+        assert result.success is False
+        assert "json_parse_error" in result.error_codes
+
+    @pytest.mark.asyncio
+    async def test_n_images_sent_to_claude(
+        self, db: AsyncSession, grid_game: Game
+    ):
+        """All N frames must be in the user content as image blocks."""
+        from app.services.classification.classifier_service import (
+            classify_frames_for_lineup_decision,
+        )
+
+        payload = {"is_lineup": False, "confidence": 0.0, "reasoning": "x"}
+
+        with (
+            patch("app.services.classification.classifier_service.settings") as mock_settings,
+            patch("app.services.classification.classifier_service.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = _make_anthropic_response(payload)
+
+            await classify_frames_for_lineup_decision(
+                db,
+                frames=_THREE_FRAMES,
+                chapter_title="x",
+                attribution_author="y",
+            )
+
+        _, kwargs = mock_client.messages.create.call_args
+        content = kwargs["messages"][0]["content"]
+        image_blocks = [b for b in content if b.get("type") == "image"]
+        assert len(image_blocks) == 3
+        # Reference block is still cache_control'd (caching preserved).
+        assert any(b.get("cache_control") for b in content)
+        assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}

--- a/apps/mygamingassistant/backend/tests/test_frame_extractor.py
+++ b/apps/mygamingassistant/backend/tests/test_frame_extractor.py
@@ -12,7 +12,11 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.services.ingestion.frame_extractor import FrameExtractionError, extract_frames
+from app.services.ingestion.frame_extractor import (
+    FrameExtractionError,
+    extract_frames,
+    grid_timestamps,
+)
 
 _FAKE_PNG = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00"  # PNG magic bytes header
 
@@ -97,3 +101,47 @@ class TestExtractFrames:
 
         cmd = mock_run.call_args[0][0]
         assert "pipe:1" in cmd
+
+
+class TestGridTimestamps:
+    def test_n_evenly_spaced_strictly_inside(self):
+        ts = grid_timestamps(20.0, 200.0, 5, edge_padding_seconds=0.5)
+        assert len(ts) == 5
+        # Strictly inside the open interval (20, 200).
+        assert all(20.0 < t < 200.0 for t in ts)
+        # First/last pulled in by the edge padding; never the boundary.
+        assert ts[0] == pytest.approx(20.5)
+        assert ts[-1] == pytest.approx(199.5)
+        # Evenly spaced + monotonic.
+        diffs = [ts[i + 1] - ts[i] for i in range(len(ts) - 1)]
+        assert all(d == pytest.approx(diffs[0]) for d in diffs)
+        assert ts == sorted(ts)
+
+    def test_boundaries_never_sampled(self):
+        ts = grid_timestamps(0.0, 90.0, 5)
+        assert 0.0 not in ts
+        assert 90.0 not in ts
+        assert all(0.0 < t < 90.0 for t in ts)
+
+    def test_single_frame_returns_midpoint(self):
+        ts = grid_timestamps(10.0, 50.0, 1)
+        assert ts == [pytest.approx(30.0)]
+
+    def test_short_chapter_collapses_to_midpoint(self):
+        # Padding (0.5*2=1.0) exceeds the 0.4s chapter — degenerate to the
+        # midpoint, still strictly inside (10.0, 10.4).
+        ts = grid_timestamps(10.0, 10.4, 5, edge_padding_seconds=0.5)
+        assert len(ts) == 5
+        assert all(t == pytest.approx(10.2) for t in ts)
+        assert all(10.0 < t < 10.4 for t in ts)
+
+    def test_inverted_chapter_is_safe(self):
+        # end <= start must not crash and must stay near start.
+        ts = grid_timestamps(50.0, 50.0, 3)
+        assert len(ts) == 3
+        assert all(t >= 50.0 for t in ts)
+
+    def test_n_clamped_to_at_least_one(self):
+        ts = grid_timestamps(0.0, 100.0, 0)
+        assert len(ts) == 1
+        assert 0.0 < ts[0] < 100.0

--- a/apps/mygamingassistant/backend/tests/test_ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/tests/test_ingestion_orchestrator.py
@@ -109,7 +109,7 @@ class TestSyncSource:
             patch(
                 "app.services.ingestion.ingestion_orchestrator.extract_frames",
                 new_callable=AsyncMock,
-                return_value=[_FAKE_PNG, _FAKE_PNG],
+                return_value=[_FAKE_PNG] * 5,
             ),
             patch(
                 "app.services.ingestion.ingestion_orchestrator.get_storage",
@@ -120,6 +120,10 @@ class TestSyncSource:
             ) as mock_settings,
         ):
             mock_settings.ingestion_download_dir = str(tmp_path)
+            # Classifier disabled → Strategy A keeps the chapter and uses the
+            # first/last grid frame as stand/aim (no is_lineup gate, no
+            # suggestions). Isolates the fetch→parse→create plumbing.
+            mock_settings.enable_classifier = False
             mock_storage = MagicMock()
             mock_storage.bucket = "mygamingassistant-screenshots"
             mock_storage._client = MagicMock()
@@ -150,17 +154,21 @@ class TestSyncSource:
             assert lineup.side is None
 
     @pytest.mark.asyncio
-    async def test_structural_chapters_filtered_and_frames_offset(
+    async def test_structural_chapters_filtered_and_grid_sampled(
         self,
         db: AsyncSession,
         source: Source,
         tmp_path: Path,
     ):
         """Intro/Outro/short chapters are dropped before extraction; the
-        surviving lineup's frames are sampled a few seconds INTO the chapter,
-        never at the exact boundary (the deterministic black/transition frame).
+        surviving lineup is grid-sampled (Strategy A) — N evenly-spaced
+        frames strictly inside the chapter, never at the boundary (the
+        deterministic black/transition frame).
         """
         from app.services.ingestion import ingestion_orchestrator
+        from app.services.ingestion.ingestion_orchestrator import (
+            _GRID_FRAME_COUNT,
+        )
         from sqlalchemy import select
 
         fake_video_path = tmp_path / "vid002.mp4"
@@ -185,7 +193,7 @@ class TestSyncSource:
             patch(
                 "app.services.ingestion.ingestion_orchestrator.extract_frames",
                 new_callable=AsyncMock,
-                return_value=[_FAKE_PNG, _FAKE_PNG],
+                return_value=[_FAKE_PNG] * _GRID_FRAME_COUNT,
             ) as mock_extract,
             patch(
                 "app.services.ingestion.ingestion_orchestrator.get_storage",
@@ -217,13 +225,16 @@ class TestSyncSource:
         assert lineups[0].title == "A ramp smoke"
         assert lineups[0].chapter_start_seconds == 20  # keyed by chapter start
 
-        # extract_frames called exactly once (one surviving chapter), and the
-        # timestamps are offset INTO the chapter: stand = start+3, aim =
-        # stand+4 — never the exact boundary (start=20).
+        # extract_frames called exactly once (one surviving chapter), with a
+        # grid of _GRID_FRAME_COUNT evenly-spaced timestamps strictly inside
+        # the chapter (20, 200) — never the exact boundary.
         assert mock_extract.await_count == 1
         _video_arg, timestamps = mock_extract.await_args.args
-        assert timestamps == [23.0, 27.0]
-        assert 20.0 not in timestamps  # never the chapter boundary
+        assert len(timestamps) == _GRID_FRAME_COUNT
+        assert all(20.0 < t < 200.0 for t in timestamps)
+        assert 20.0 not in timestamps  # never the chapter start boundary
+        assert 200.0 not in timestamps  # never the chapter end boundary
+        assert timestamps == sorted(timestamps)  # chapter start→end order
 
     @pytest.mark.asyncio
     async def test_dedup_skips_existing_video(
@@ -289,12 +300,12 @@ class TestSyncSource:
         fake_video_path = tmp_path / "vid001.mp4"
         fake_video_path.write_bytes(b"fake")
 
-        # First chapter fails, second succeeds.
+        # First chapter fails, second succeeds (grid of N frames).
         frame_results = iter([
             FrameExtractionError(
                 "ffmpeg failed", timestamp=0.0, returncode=1, stderr="error"
             ),
-            (_FAKE_PNG, _FAKE_PNG),  # won't reach here due to raise
+            [_FAKE_PNG] * 5,
         ])
 
         async def _mock_extract(video_path, timestamps):
@@ -332,6 +343,9 @@ class TestSyncSource:
             ) as mock_settings,
         ):
             mock_settings.ingestion_download_dir = str(tmp_path)
+            # Classifier disabled so the surviving chapter is kept via the
+            # first/last grid frame — isolates the frame-error skip behaviour.
+            mock_settings.enable_classifier = False
             mock_storage = MagicMock()
             mock_storage.bucket = "mygamingassistant-screenshots"
             mock_storage._client = MagicMock()

--- a/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
@@ -1,11 +1,15 @@
-"""Integration test — ingestion_orchestrator calls classifier after creating lineups.
+"""Integration test — ingestion_orchestrator runs the Strategy A grid classifier.
 
-Classifier is mocked. Verifies:
-  - On classifier success, suggested FK fields are written to the Lineup row.
-  - On classifier failure, the lineup row is still committed with status=pending_review.
+The grid classifier (classify_frames_for_lineup_decision) is mocked. Verifies:
+  - is_lineup=True → row created + suggested FK fields written via the repo.
+  - Classifier call failure → chapter skipped, no row (Strategy A refuses to
+    ingest frames it could not verify).
+  - is_lineup=False → chapter skipped, no row created (the "stop junk" lever).
+  - enable_classifier=False → classifier never called, chapter still kept.
 """
 from __future__ import annotations
 
+import contextlib
 import uuid
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -89,22 +93,63 @@ async def _seed_classifier_targets(db: AsyncSession) -> None:
     await db.flush()
 
 
+@contextlib.contextmanager
+def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock):
+    """Enter the common ingestion patches for a grid-classifier test.
+
+    `classify_mock` is the mock to install for
+    classify_frames_for_lineup_decision (an AsyncMock). Yields
+    (mock_settings, mock_storage) for the test to configure further.
+
+    A parenthesized `with (...)` cannot mix ``*tuple`` unpacking with ``as``
+    bindings, so the shared patch set is entered via an ExitStack here.
+    """
+    with contextlib.ExitStack() as stack:
+        stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]))
+        stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO))
+        stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.download_video", new_callable=AsyncMock, return_value=fake_video_path))
+        stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.extract_frames", new_callable=AsyncMock, return_value=[_FAKE_PNG] * 5))
+        mock_storage_factory = stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.get_storage"))
+        stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.classify_frames_for_lineup_decision", new=classify_mock))
+        mock_settings = stack.enter_context(patch.object(ingestion_orchestrator_module(), "settings"))
+
+        mock_settings.ingestion_download_dir = str(tmp_path)
+        mock_storage = MagicMock()
+        mock_storage.bucket = "test-bucket"
+        mock_storage._client = MagicMock()
+        mock_storage_factory.return_value = mock_storage
+        yield mock_settings, mock_storage
+
+
+def ingestion_orchestrator_module():
+    from app.services.ingestion import ingestion_orchestrator
+    return ingestion_orchestrator
+
+
 class TestIngestionWithClassifier:
     @pytest.mark.asyncio
-    async def test_classifier_suggestions_written_on_success(
+    async def test_lineup_created_and_suggestions_written_when_is_lineup(
         self,
         db: AsyncSession,
         source: Source,
         tmp_path: Path,
     ):
-        """After successful classification, suggested_* fields populated on the Lineup."""
-        from app.services.ingestion import ingestion_orchestrator
+        """is_lineup=True → row created and suggested_* written via the repo."""
+        ingestion_orchestrator = ingestion_orchestrator_module()
 
         fake_video_path = tmp_path / "vid_cls_001.mp4"
         fake_video_path.write_bytes(b"fake")
 
-        successful_result = ClassificationResult(
+        # Strategy A: classify_frames_for_lineup_decision does NOT touch the
+        # DB (no row exists yet). It just returns the verdict + suggestions;
+        # the orchestrator creates the row and writes the suggestions via the
+        # repo. So a plain return_value mock is correct here (unlike the old
+        # single-image path which needed a writeback side effect).
+        grid_result = ClassificationResult(
             success=True,
+            is_lineup=True,
+            best_stand_index=2,
+            best_aim_index=4,
             suggested_game_id=_FAKE_GAME_ID,
             suggested_map_id=_FAKE_MAP_ID,
             suggested_target_zone_id=_FAKE_ZONE_ID,
@@ -117,44 +162,13 @@ class TestIngestionWithClassifier:
             reasoning="Clear smoke throw",
             error_codes=[],
         )
+        classify_mock = AsyncMock(return_value=grid_result)
 
-        # The real classify_lineup (see classifier_service.classify_lineup
-        # docstring) writes suggested_* fields to the Lineup row as a side
-        # effect and returns the result. AsyncMock with just return_value
-        # would skip the write, so the mock here mirrors the side effect.
-        async def _classify_with_writeback(db_arg, lineup_id, *, game_hint=None):
-            target = (
-                await db_arg.execute(select(Lineup).where(Lineup.id == lineup_id))
-            ).scalar_one()
-            target.suggested_game_id = successful_result.suggested_game_id
-            target.suggested_map_id = successful_result.suggested_map_id
-            target.suggested_target_zone_id = successful_result.suggested_target_zone_id
-            target.suggested_stand_zone_id = successful_result.suggested_stand_zone_id
-            target.suggested_side = successful_result.suggested_side
-            target.suggested_utility_type_id = successful_result.suggested_utility_type_id
-            target.aim_anchor_x = successful_result.aim_anchor_x
-            target.aim_anchor_y = successful_result.aim_anchor_y
-            target.classification_confidence = successful_result.confidence
-            target.classification_reasoning = successful_result.reasoning
-            await db_arg.flush()
-            return successful_result
-
-        with (
-            patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]),
-            patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO),
-            patch("app.services.ingestion.ingestion_orchestrator.download_video", new_callable=AsyncMock, return_value=fake_video_path),
-            patch("app.services.ingestion.ingestion_orchestrator.extract_frames", new_callable=AsyncMock, return_value=[_FAKE_PNG, _FAKE_PNG]),
-            patch("app.services.ingestion.ingestion_orchestrator.get_storage") as mock_storage_factory,
-            patch("app.services.ingestion.ingestion_orchestrator.classify_lineup", new=_classify_with_writeback),
-            patch.object(ingestion_orchestrator, "settings") as mock_settings,
+        with _grid_env(tmp_path, fake_video_path, classify_mock=classify_mock) as (
+            mock_settings,
+            _mock_storage,
         ):
-            mock_settings.ingestion_download_dir = str(tmp_path)
             mock_settings.enable_classifier = True
-            mock_storage = MagicMock()
-            mock_storage.bucket = "test-bucket"
-            mock_storage._client = MagicMock()
-            mock_storage_factory.return_value = mock_storage
-
             await ingestion_orchestrator.sync_source(source.id, db)
 
         result = await db.execute(
@@ -164,20 +178,22 @@ class TestIngestionWithClassifier:
         assert len(lineups) == 1
         lineup = lineups[0]
         assert lineup.status == "pending_review"
-        # Classifier should have written suggested values
+        # Orchestrator wrote the classifier suggestions through the repo.
         assert lineup.suggested_game_id == _FAKE_GAME_ID
         assert lineup.suggested_side == "side_a"
         assert lineup.suggested_utility_type_id == _FAKE_UT_ID
+        assert lineup.classification_confidence == pytest.approx(0.85)
 
     @pytest.mark.asyncio
-    async def test_classifier_failure_does_not_abort(
+    async def test_classifier_call_failure_skips_chapter(
         self,
         db: AsyncSession,
         source: Source,
         tmp_path: Path,
     ):
-        """Classifier failure leaves lineup in pending_review without suggestions."""
-        from app.services.ingestion import ingestion_orchestrator
+        """A failed classifier *call* skips the chapter — Strategy A refuses
+        to ingest a chapter it could not verify (no unjudged junk rows)."""
+        ingestion_orchestrator = ingestion_orchestrator_module()
 
         fake_video_path = tmp_path / "vid_cls_001.mp4"
         fake_video_path.write_bytes(b"fake")
@@ -187,38 +203,63 @@ class TestIngestionWithClassifier:
             error_codes=["rate_limit_error"],
             reasoning="Rate limit hit",
         )
+        classify_mock = AsyncMock(return_value=failed_result)
 
-        with (
-            patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]),
-            patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO),
-            patch("app.services.ingestion.ingestion_orchestrator.download_video", new_callable=AsyncMock, return_value=fake_video_path),
-            patch("app.services.ingestion.ingestion_orchestrator.extract_frames", new_callable=AsyncMock, return_value=[_FAKE_PNG, _FAKE_PNG]),
-            patch("app.services.ingestion.ingestion_orchestrator.get_storage") as mock_storage_factory,
-            patch("app.services.ingestion.ingestion_orchestrator.classify_lineup", new_callable=AsyncMock, return_value=failed_result),
-            patch.object(ingestion_orchestrator, "settings") as mock_settings,
+        with _grid_env(tmp_path, fake_video_path, classify_mock=classify_mock) as (
+            mock_settings,
+            _mock_storage,
         ):
-            mock_settings.ingestion_download_dir = str(tmp_path)
             mock_settings.enable_classifier = True
-            mock_storage = MagicMock()
-            mock_storage.bucket = "test-bucket"
-            mock_storage._client = MagicMock()
-            mock_storage_factory.return_value = mock_storage
-
             stats = await ingestion_orchestrator.sync_source(source.id, db)
 
-        # Sync should still succeed despite classifier failure
+        # Chapter skipped (handled, not an error) and NO row created.
         assert stats.chapter_count == 1
         assert stats.error_count == 0
 
         result = await db.execute(
             select(Lineup).where(Lineup.youtube_video_id == "vid_cls_001")
         )
-        lineups = result.scalars().all()
-        assert len(lineups) == 1
-        lineup = lineups[0]
-        assert lineup.status == "pending_review"
-        # No suggestions written on failure
-        assert lineup.suggested_game_id is None
+        assert result.scalars().all() == []
+
+    @pytest.mark.asyncio
+    async def test_not_a_lineup_skips_chapter_no_row(
+        self,
+        db: AsyncSession,
+        source: Source,
+        tmp_path: Path,
+    ):
+        """is_lineup=False → chapter skipped, no pending row (the junk lever)."""
+        ingestion_orchestrator = ingestion_orchestrator_module()
+
+        fake_video_path = tmp_path / "vid_cls_001.mp4"
+        fake_video_path.write_bytes(b"fake")
+
+        not_lineup = ClassificationResult(
+            success=True,
+            is_lineup=False,
+            confidence=0.02,
+            reasoning="Webcam talking-head, not a lineup.",
+            error_codes=[],
+        )
+        classify_mock = AsyncMock(return_value=not_lineup)
+
+        with _grid_env(tmp_path, fake_video_path, classify_mock=classify_mock) as (
+            mock_settings,
+            mock_storage,
+        ):
+            mock_settings.enable_classifier = True
+            stats = await ingestion_orchestrator.sync_source(source.id, db)
+
+        # Handled (not an error) but NO row — this is the "stop junk" behaviour.
+        assert stats.chapter_count == 1
+        assert stats.error_count == 0
+
+        result = await db.execute(
+            select(Lineup).where(Lineup.youtube_video_id == "vid_cls_001")
+        )
+        assert result.scalars().all() == []
+        # MinIO must NOT have been written for a skipped chapter.
+        mock_storage._client.put_object.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_classifier_skipped_when_disabled(
@@ -227,28 +268,28 @@ class TestIngestionWithClassifier:
         source: Source,
         tmp_path: Path,
     ):
-        """When enable_classifier=False, classify_lineup is never called."""
-        from app.services.ingestion import ingestion_orchestrator
+        """enable_classifier=False → grid classifier never called, row kept."""
+        ingestion_orchestrator = ingestion_orchestrator_module()
 
         fake_video_path = tmp_path / "vid_cls_001.mp4"
         fake_video_path.write_bytes(b"fake")
 
-        with (
-            patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]),
-            patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO),
-            patch("app.services.ingestion.ingestion_orchestrator.download_video", new_callable=AsyncMock, return_value=fake_video_path),
-            patch("app.services.ingestion.ingestion_orchestrator.extract_frames", new_callable=AsyncMock, return_value=[_FAKE_PNG, _FAKE_PNG]),
-            patch("app.services.ingestion.ingestion_orchestrator.get_storage") as mock_storage_factory,
-            patch("app.services.ingestion.ingestion_orchestrator.classify_lineup", new_callable=AsyncMock) as mock_classify,
-            patch.object(ingestion_orchestrator, "settings") as mock_settings,
+        classify_mock = AsyncMock()
+
+        with _grid_env(tmp_path, fake_video_path, classify_mock=classify_mock) as (
+            mock_settings,
+            _mock_storage,
         ):
-            mock_settings.ingestion_download_dir = str(tmp_path)
             mock_settings.enable_classifier = False
-            mock_storage = MagicMock()
-            mock_storage.bucket = "test-bucket"
-            mock_storage._client = MagicMock()
-            mock_storage_factory.return_value = mock_storage
+            stats = await ingestion_orchestrator.sync_source(source.id, db)
 
-            await ingestion_orchestrator.sync_source(source.id, db)
-
-        mock_classify.assert_not_called()
+        classify_mock.assert_not_called()
+        # Classifier disabled → Strategy A still keeps the chapter (first/last
+        # grid frame), so the row is created with no suggestions.
+        assert stats.chapter_count == 1
+        result = await db.execute(
+            select(Lineup).where(Lineup.youtube_video_id == "vid_cls_001")
+        )
+        lineups = result.scalars().all()
+        assert len(lineups) == 1
+        assert lineups[0].suggested_game_id is None


### PR DESCRIPTION
## Strategy A — make the Claude classifier the lineup detector + frame picker

### Problem (diagnosis already done, not re-litigated)

`g-debug-bug` found ingestion frame-selection was structurally wrong: stand
frame = chapter start, aim = start+4s, **every** chapter became a lineup, and
the classifier was fed one arbitrary frame so it could not reject a chapter.
On a real source 0/5 chapters were lineups and 0/10 frames usably depicted
one (chapter starts land on fade-ins/title-cards/webcam). The classifier + API
key work correctly — Claude correctly returned conf 0.05 on junk. The defect
was purely the single-arbitrary-frame input.

Phase 1 (#679) added the chapter title denylist + 15s min-duration and a blind
+3s/+7s offset. **This PR keeps the denylist and supersedes the blind offset.**

### What changed

- **`frame_extractor.grid_timestamps()`** — N evenly-spaced timestamps strictly
  inside `(start, end)`; boundaries never sampled; short/inverted chapters
  collapse safely to the interior midpoint. Reuses the existing single-frame
  ffmpeg path (one ffmpeg call per timestamp).
- **`classifier_service.classify_frames_for_lineup_decision()`** — ONE cheap
  (haiku) call given N numbered candidate frames. Returns, in addition to the
  existing fields, `is_lineup` (bool), `best_stand_index`, `best_aim_index`.
  Prompt caching preserved: system prompt + reference data are
  `cache_control`'d (billed once per game); the N images are the per-call
  variable part. Parse/slug-resolve/validate helpers are shared with the
  legacy single-image path.
- **`ingestion_orchestrator._process_chapter()`** — extracts the N-frame grid
  and classifies **before** any DB write or MinIO upload. `is_lineup=False`
  (or confidence ≤ threshold) → **chapter skipped, no row created**. Only the
  two Claude-chosen frames are uploaded. A failed classifier *call* also skips
  the chapter (refuse to ingest unverifiable frames). Classifier-disabled path
  keeps the chapter using first/last grid frame (no resurrected blind
  heuristic).
- **`ClassificationResult`** — gains `is_lineup` / `best_stand_index` /
  `best_aim_index`.

### Design-fork decisions (surfaced per the task)

1. **N = 5, no image downscaling.** Downscaling would blunt exactly the
   minimap/spot/crosshair detail the judgement depends on. Token cost per
   chapter on haiku ≈ **$0.01–0.015** (5 PNG frames ≈ 7–9K image tokens +
   ~500–600 output; reference data + system prompt are cache_control'd so
   billed once per game, not per chapter). N is the only knob and is
   commented "do not raise without re-checking this cost note".
2. **`is_lineup=False` → skip the row (do NOT create hidden).** Dedup is keyed
   by `youtube_video_id` (the **whole video**, via
   `lineup_repo.get_ingested_video_ids`), not per-chapter, so skipping a
   chapter does not break re-sync dedup — the video is still reconciled on
   `video_id`. A hidden junk row would only add review-queue/storage noise
   with no audit value (the chapter title is already in the structured logs).
   This skip is the real "stop junk" mechanism.
3. **Re-classify from the review queue stays single-image** (existing
   `POST /lineups/{id}/classify` → legacy `classify_lineup`). The source
   video is deleted post-ingest; only the two stored screenshots survive, so
   the grid **cannot** apply there. The grid is ingest-time only. This
   asymmetry is **expected and documented**, not a bug. `ClassificationResult`
   is never serialized to the API, so no frontend type/union change is
   required (`feedback_enum_changes_cross_stack` satisfied —
   verified `app/api/lineups.py` does not surface the new fields).

### Tests

Extended `test_frame_extractor` (grid math: spacing, boundary exclusion,
short/inverted/clamp), `test_ingestion_orchestrator` (grid sampling replaces
the old `[23.0, 27.0]` offset assertion), `test_ingestion_with_classifier`
(is_lineup True→row+suggestions, call-failure→skip, is_lineup False→no row +
no MinIO write, disabled→kept), `test_classifier_service`
(`TestClassifyFramesForLineupDecision`: slug resolution, early-return on
is_lineup=False, out-of-range index nulling, empty frames, missing key, JSON
parse failure, N images sent + caching preserved).

New grid tests use **collision-proof unique-slug fixtures** so they do NOT
inherit the **documented pre-existing 7-error `ix_game_slug` fixture
collision** in `TestClassifyLineup` / `TestSlugResolver`. That collision
predates this change, is unrelated to it, and is explicitly out of scope —
not fixed here.

**Full backend suite: `255 passed, 7 errors`.** The 7 errors are exactly the
pre-existing `TestClassifyLineup`(×5)/`TestSlugResolver`(×2) collision
(confirmed identical on clean `main` with this PR's code stashed). **0 new
failures introduced.**

### Needs a human

The current MGA DB only has the junk `@TigerrGG` source, so the **happy path
(is_lineup=True on a genuine CS2 lineup tutorial) has not been validated
end-to-end against real video** — only via mocked classifier responses. A real
CS2 lineup-tutorial YouTube source (chaptered, e.g. a Mirage/Ancient utility
guide) should be added and a sync run observed to confirm Claude picks usable
stand/aim frames and correctly rejects the interspersed structural chapters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
