### PR TITLE
fix(mga): review-queue minimap — resolve from selected map + add Game/Map/Zone pickers

### DIFF
--- a/apps/mygamingassistant/frontend/src/components/review/ReviewCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/review/ReviewCard.tsx
@@ -13,6 +13,11 @@ import {
   useHideLineupMutation,
   useReclassifyLineupMutation,
 } from "@/store/lineupsApi";
+import {
+  useGetGamesQuery,
+  useGetMapsQuery,
+  useGetMapDetailQuery,
+} from "@/store/gamesApi";
 import type { Lineup, LineupAcceptBody } from "@/types/game";
 import ConfidenceBadge from "./ConfidenceBadge";
 import { confidenceBorderClass } from "./confidenceUtils";
@@ -90,6 +95,21 @@ function fieldsToAcceptBody(fields: ClassificationFields): LineupAcceptBody {
   return body;
 }
 
+/**
+ * First-<option> label for a dependent <select>: a "pick the parent first"
+ * hint when blocked, a loading note while its data is in flight, otherwise
+ * the normal choose-prompt.
+ */
+function placeholderLabel(
+  blockedMsg: string | null,
+  loading: boolean,
+  chooseLabel: string,
+): string {
+  if (blockedMsg) return blockedMsg;
+  if (loading) return "Loading…";
+  return chooseLabel;
+}
+
 // ---------------------------------------------------------------------------
 // ReviewCard component
 // ---------------------------------------------------------------------------
@@ -98,15 +118,12 @@ export interface ReviewCardProps {
   lineup: Lineup;
   checked: boolean;
   onCheckToggle: () => void;
-  /** Resolved minimap URL for this lineup's map (MinIO URL or bundled fallback). */
-  minimapUrl: string | null;
 }
 
 export default function ReviewCard({
   lineup,
   checked,
   onCheckToggle,
-  minimapUrl,
 }: ReviewCardProps) {
   const [fields, setFields] = useState<ClassificationFields>(() =>
     initFieldsFromLineup(lineup),
@@ -119,6 +136,55 @@ export default function ReviewCard({
 
   const setField = (key: keyof ClassificationFields, value: string) => {
     setFields((prev) => ({ ...prev, [key]: value }));
+  };
+
+  // --- Classification data (cascading: game → map → zones/utility) --------
+  const { data: games = [] } = useGetGamesQuery();
+  const gameSlug = games.find((g) => g.id === fields.game_id)?.slug ?? "";
+
+  const { data: maps = [], isFetching: isMapsFetching } = useGetMapsQuery(
+    gameSlug,
+    { skip: !gameSlug },
+  );
+  const selectedMap = maps.find((m) => m.id === fields.map_id) ?? null;
+  const mapSlug = selectedMap?.slug ?? "";
+
+  const { data: mapDetail, isFetching: isMapDetailFetching } =
+    useGetMapDetailQuery(
+      { gameSlug, mapSlug },
+      { skip: !gameSlug || !mapSlug },
+    );
+
+  // Minimap is resolved reactively from the operator-selected map. A pending
+  // lineup's own map_id is null until accept, so it cannot drive this — see
+  // the PR description for the full P1/P2 analysis.
+  const minimapUrl = selectedMap?.minimap_url ?? null;
+  const zones = mapDetail?.zones ?? [];
+  const utilityTypes = mapDetail?.utility_types ?? [];
+
+  // First-<option> hints for the dependent selects.
+  const mapBlockedMsg = gameSlug ? null : "— pick a game first —";
+  const detailBlockedMsg = mapSlug ? null : "— pick a map first —";
+
+  // A game change invalidates the chosen map (and its zones/utility); a map
+  // change invalidates the chosen zones (zones are map-scoped).
+  const handleGameChange = (gameId: string) => {
+    setFields((prev) => ({
+      ...prev,
+      game_id: gameId,
+      map_id: "",
+      stand_zone_id: "",
+      target_zone_id: "",
+      utility_type_id: "",
+    }));
+  };
+  const handleMapChange = (mapId: string) => {
+    setFields((prev) => ({
+      ...prev,
+      map_id: mapId,
+      stand_zone_id: "",
+      target_zone_id: "",
+    }));
   };
 
   const handleAccept = async () => {
@@ -267,8 +333,12 @@ export default function ReviewCard({
       <div className="px-3 pb-3">
         <p className="text-xs text-muted-foreground mb-1.5 font-medium">
           Minimap positions{" "}
-          {minimapUrl && (
+          {minimapUrl ? (
             <span className="opacity-60">(drag pins to refine)</span>
+          ) : (
+            <span className="opacity-60">
+              (pick a game and map below to load the minimap)
+            </span>
           )}
         </p>
         <MinimapPinEditor
@@ -300,6 +370,110 @@ export default function ReviewCard({
 
       {/* Classification fields */}
       <div className="px-3 pb-3 grid grid-cols-2 sm:grid-cols-3 gap-2">
+        <label className="flex flex-col gap-0.5">
+          <span className="text-xs text-muted-foreground">Game</span>
+          <select
+            value={fields.game_id}
+            onChange={(e) => handleGameChange(e.target.value)}
+            className="h-8 rounded border border-input bg-background px-2 text-xs"
+          >
+            <option value="">— choose a game —</option>
+            {games.map((g) => (
+              <option key={g.id} value={g.id}>
+                {g.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-0.5">
+          <span className="text-xs text-muted-foreground">Map</span>
+          <select
+            value={fields.map_id}
+            onChange={(e) => handleMapChange(e.target.value)}
+            disabled={!gameSlug || isMapsFetching}
+            className="h-8 rounded border border-input bg-background px-2 text-xs disabled:opacity-50"
+          >
+            <option value="">
+              {placeholderLabel(mapBlockedMsg, isMapsFetching, "— choose a map —")}
+            </option>
+            {maps.map((m) => (
+              <option key={m.id} value={m.id}>
+                {m.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-0.5">
+          <span className="text-xs text-muted-foreground">Utility type</span>
+          <select
+            value={fields.utility_type_id}
+            onChange={(e) => setField("utility_type_id", e.target.value)}
+            disabled={!mapSlug || isMapDetailFetching}
+            className="h-8 rounded border border-input bg-background px-2 text-xs disabled:opacity-50"
+          >
+            <option value="">
+              {placeholderLabel(
+                detailBlockedMsg,
+                isMapDetailFetching,
+                "— choose a utility —",
+              )}
+            </option>
+            {utilityTypes.map((u) => (
+              <option key={u.id} value={u.id}>
+                {u.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-0.5">
+          <span className="text-xs text-muted-foreground">Stand zone</span>
+          <select
+            value={fields.stand_zone_id}
+            onChange={(e) => setField("stand_zone_id", e.target.value)}
+            disabled={!mapSlug || isMapDetailFetching}
+            className="h-8 rounded border border-input bg-background px-2 text-xs disabled:opacity-50"
+          >
+            <option value="">
+              {placeholderLabel(
+                detailBlockedMsg,
+                isMapDetailFetching,
+                "— choose a zone —",
+              )}
+            </option>
+            {zones.map((z) => (
+              <option key={z.id} value={z.id}>
+                {z.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="flex flex-col gap-0.5">
+          <span className="text-xs text-muted-foreground">Target zone</span>
+          <select
+            value={fields.target_zone_id}
+            onChange={(e) => setField("target_zone_id", e.target.value)}
+            disabled={!mapSlug || isMapDetailFetching}
+            className="h-8 rounded border border-input bg-background px-2 text-xs disabled:opacity-50"
+          >
+            <option value="">
+              {placeholderLabel(
+                detailBlockedMsg,
+                isMapDetailFetching,
+                "— choose a zone —",
+              )}
+            </option>
+            {zones.map((z) => (
+              <option key={z.id} value={z.id}>
+                {z.name}
+              </option>
+            ))}
+          </select>
+        </label>
+
         <label className="flex flex-col gap-0.5">
           <span className="text-xs text-muted-foreground">Side</span>
           <select

--- a/apps/mygamingassistant/frontend/src/pages/Review.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/Review.tsx
@@ -25,7 +25,7 @@ import {
   useGetPendingLineupsQuery,
   useBulkAcceptLineupsMutation,
 } from "@/store/lineupsApi";
-import { useGetGamesQuery, useGetMapsQuery } from "@/store/gamesApi";
+import { useGetGamesQuery } from "@/store/gamesApi";
 import ReviewCard from "@/components/review/ReviewCard";
 import ReviewSkeletonCard from "@/components/review/ReviewSkeletonCard";
 
@@ -66,28 +66,13 @@ export default function Review() {
 
   const lineups = useMemo(() => data?.items ?? [], [data?.items]);
 
-  // Resolve the game slug to fetch maps for. When a game filter is active use
-  // that slug directly; otherwise fall back to the first game in the lineup
-  // page (typically "cs2"). RTK Query deduplicates the fetch automatically.
-  const mapsGameSlug = useMemo(() => {
-    if (gameSlugFilter) return gameSlugFilter;
-    if (!games || !lineups.length) return "";
-    const firstGameId = lineups[0]?.game_id;
-    return games.find((g) => g.id === firstGameId)?.slug ?? "";
-  }, [gameSlugFilter, games, lineups]);
-
-  const { data: maps = [] } = useGetMapsQuery(mapsGameSlug, {
-    skip: !mapsGameSlug,
-  });
-
-  // map_id → minimap_url lookup (MinIO URL; MinimapPinEditor applies bundled fallback on onError).
-  const minimapByMapId = useMemo<Record<string, string | null>>(() => {
-    const out: Record<string, string | null> = {};
-    for (const m of maps) {
-      out[m.id] = m.minimap_url;
-    }
-    return out;
-  }, [maps]);
+  // Minimap resolution lives in ReviewCard, not here. Pending lineups carry
+  // their classification in the suggested_* columns and map_id stays null
+  // until accept, so a page-level lineup.map_id → minimap lookup resolved to
+  // null for every card — and the maps fetch was skipped entirely whenever
+  // the first card was unclassified (its game_id null). ReviewCard now
+  // fetches maps for the operator-selected game and resolves the minimap
+  // from the selected map reactively.
   const total = data?.total ?? 0;
   const totalPages = Math.ceil(total / PAGE_SIZE);
 
@@ -262,7 +247,6 @@ export default function Review() {
               lineup={lineup}
               checked={selectedIds.has(lineup.id)}
               onCheckToggle={() => toggleSelect(lineup.id)}
-              minimapUrl={minimapByMapId[lineup.map_id] ?? null}
             />
           ))}
         </div>


### PR DESCRIPTION
﻿## Symptom
Review Queue showed "No minimap image" on every card.

## Diagnosis (confirmed against the dev DB)
All 11 pending lineups have `game_id`, `map_id`, `suggested_game_id`, `suggested_map_id`, `classification_confidence` **all null** ? the legacy `@TigerrGG` rows ingested before Phase-2 classify-on-ingest. A minimap is per-map; with no map on the row there is nothing to resolve.

On top of that, two real bugs in `Review.tsx` blanked the minimap even for correctly-classified pending lineups:

- **P1** ? `mapsGameSlug` derived from `lineups[0].game_id`, always null for pending lineups (classification lives in `suggested_*` until accept), so `useGetMapsQuery` was `skip`-ped and **no** card could resolve a minimap.
- **P2** ? each card resolved `minimapByMapId[lineup.map_id]`, but `map_id` is only set on accept, so a correctly-classified pending lineup resolved to `null`.

The review flow also had no Game/Map/Zone/Utility selectors, so when the classifier abstained there was no way to assign a map ? the minimap could never appear, by construction.

## Fix
- Delete the P1/P2 resolution block + `minimapUrl` prop from `Review.tsx`. Minimap resolution moves into `ReviewCard`, driven reactively by the operator-selected map.
- Add cascading **Game ? Map ? (Stand zone / Target zone / Utility)** selects to `ReviewCard` with correct invalidation. Minimap loads from the selected map. `fieldsToAcceptBody` already serialized these fields ? only the UI inputs were missing, so Accept now works end-to-end.

## What you'll see
Each card now has **Game** + **Map** dropdowns. Pick `Counter-Strike 2` ? `Dust II` and the Dust2 minimap loads; drag pins; Accept. The current 11 rows are still junk content (prior session) but are now actionable instead of dead ? Hide the non-real ones. A real classified source resolves its minimap automatically.

## Validation
- `tsc` typecheck: clean
- `eslint` on both changed files: clean. (14 pre-existing repo-wide `react-hooks/*` errors in `calibrate/*` + `ZoneEditPage.tsx` are unrelated, present on `main`, and **not run by CI** ? MGA CI runs only `npm run build` for the frontend.)
- vitest: 246/246 pass (MinimapPinEditor untouched)
- production build: succeeds

## Scope
Separate from the not-yet-PR'd `fix/jykwon91/mga-sources-error-render` (422 error-render) branch and the still-pending sync-feedback / confirm-modal items ? those follow next.

?? Generated with [Claude Code](https://claude.com/claude-code)
