### PR TITLE
fix(mga): window.confirm → shared ConfirmDialog (source-delete + lineup-hide)

### DIFF
--- a/apps/mygamingassistant/frontend/src/components/review/ReviewCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/review/ReviewCard.tsx
@@ -7,7 +7,12 @@
  */
 import { useState } from "react";
 import { Check, EyeOff, RefreshCw } from "lucide-react";
-import { showError, showSuccess, extractErrorMessage } from "@platform/ui";
+import {
+  showError,
+  showSuccess,
+  extractErrorMessage,
+  ConfirmDialog,
+} from "@platform/ui";
 import {
   useAcceptLineupMutation,
   useHideLineupMutation,
@@ -133,6 +138,7 @@ export default function ReviewCard({
   const [hideLineup, { isLoading: isHiding }] = useHideLineupMutation();
   const [reclassify, { isLoading: isReclassifying }] =
     useReclassifyLineupMutation();
+  const [hideConfirmOpen, setHideConfirmOpen] = useState(false);
 
   const setField = (key: keyof ClassificationFields, value: string) => {
     setFields((prev) => ({ ...prev, [key]: value }));
@@ -198,11 +204,10 @@ export default function ReviewCard({
   };
 
   const handleHide = async () => {
-    if (!window.confirm("Hide this lineup? It can be recovered from the database."))
-      return;
     try {
       await hideLineup(lineup.id).unwrap();
       showSuccess("Lineup hidden.");
+      setHideConfirmOpen(false);
     } catch {
       showError("Failed to hide lineup.");
     }
@@ -563,7 +568,7 @@ export default function ReviewCard({
 
         <button
           type="button"
-          onClick={handleHide}
+          onClick={() => setHideConfirmOpen(true)}
           disabled={isHiding}
           className="inline-flex items-center gap-1.5 rounded-md border border-destructive/30 px-3 h-8 text-xs font-medium text-destructive disabled:opacity-50 hover:bg-destructive/10 ml-auto"
         >
@@ -571,6 +576,17 @@ export default function ReviewCard({
           {isHiding ? "Hiding…" : "Hide"}
         </button>
       </div>
+
+      <ConfirmDialog
+        open={hideConfirmOpen}
+        title="Hide this lineup?"
+        description="It can be recovered from the database."
+        confirmLabel="Hide"
+        variant="destructive"
+        isLoading={isHiding}
+        onConfirm={handleHide}
+        onCancel={() => setHideConfirmOpen(false)}
+      />
     </div>
   );
 }

--- a/apps/mygamingassistant/frontend/src/pages/Sources.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/Sources.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { PlaySquare, Trash2, RefreshCw } from "lucide-react";
-import { showError, showSuccess, extractErrorMessage } from "@platform/ui";
+import {
+  showError,
+  showSuccess,
+  extractErrorMessage,
+  ConfirmDialog,
+} from "@platform/ui";
 import {
   useGetSourcesQuery,
   useCreateSourceMutation,
@@ -128,6 +133,7 @@ interface SourceRowProps {
 function SourceRow({ source }: SourceRowProps) {
   const [syncSource, { isLoading: isSyncing }] = useSyncSourceMutation();
   const [deleteSource, { isLoading: isDeleting }] = useDeleteSourceMutation();
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
 
   const url = extractUrl(source.config_json);
   const syncStats = source.config_json["last_sync_stats"] as
@@ -144,10 +150,10 @@ function SourceRow({ source }: SourceRowProps) {
   };
 
   const handleDelete = async () => {
-    if (!window.confirm("Remove this source? Existing lineups from it will be kept.")) return;
     try {
       await deleteSource(source.id).unwrap();
       showSuccess("Source removed.");
+      setDeleteConfirmOpen(false);
     } catch {
       showError("Failed to remove source.");
     }
@@ -194,7 +200,7 @@ function SourceRow({ source }: SourceRowProps) {
           {isSyncing ? "Syncing…" : "Sync now"}
         </button>
         <button
-          onClick={handleDelete}
+          onClick={() => setDeleteConfirmOpen(true)}
           disabled={isDeleting}
           aria-label="Delete source"
           className="inline-flex items-center rounded-md border border-destructive/30 px-3 h-8 text-xs font-medium text-destructive disabled:opacity-50 hover:bg-destructive/10"
@@ -203,6 +209,17 @@ function SourceRow({ source }: SourceRowProps) {
           <span className="sr-only">Delete</span>
         </button>
       </div>
+
+      <ConfirmDialog
+        open={deleteConfirmOpen}
+        title="Remove this source?"
+        description="Existing lineups from it will be kept."
+        confirmLabel="Remove"
+        variant="destructive"
+        isLoading={isDeleting}
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteConfirmOpen(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
﻿## Problem
The Sources "delete source" and Review "hide lineup" actions used native `window.confirm()` ? unstyled, thread-blocking, and inconsistent with the rest of the app, which standardizes on the shared `@platform/ui` `ConfirmDialog` (used in `ZoneEditPage`, `ZonePropertiesPanel`, `LiveCs2Calibrate`).

## Change
- `Sources.tsx` (SourceRow delete) and `ReviewCard.tsx` (hide) now render the themed `ConfirmDialog`: `destructive` variant, controlled open state, `isLoading` wired to the RTK mutation so the confirm button shows in-flight state. Dialog stays open on error (retry) and closes on success.
- No behavior change to the underlying delete/hide mutations themselves.

## Validation
- `tsc` typecheck: clean
- `eslint` on both changed files: clean (pre-existing repo-wide react-hooks debt in `calibrate/*` + `ZoneEditPage` is unrelated and not run by CI)
- vitest: 246/246 pass
- production build: succeeds

Part of the MGA review/sources UX sweep (follows #682). Next: sync-feedback UX.

?? Generated with [Claude Code](https://claude.com/claude-code)
