### PR TITLE
fix(mga): repair broken lineup screenshots + dead-center pins (two-bug fix)

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0007_repair_corrupted_screenshot_keys.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0007_repair_corrupted_screenshot_keys.py
@@ -1,0 +1,104 @@
+"""Repair lineup screenshot columns corrupted with presigned URLs
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-05-16 00:00:00.000000
+
+Data-repair migration for the double-signing bug.
+
+``lineup_service._sign_lineup`` used to assign the presigned GET URL back
+onto the ORM instance's ``stand_screenshot_url`` / ``aim_screenshot_url``
+attributes. Because the accept / bulk-accept / hide flows commit the request
+session, that mutation was flushed into the **object-key** column, replacing
+the bare key (``pending/<vid>/<n>-stand.png`` or
+``<user_id>/<lineup_id>/stand.png``) with a full presigned URL. Every later
+read then signed that URL *again* — producing a URL whose S3 object key was
+a URL-encoded URL → 404 → broken ``<img>`` in the lineup detail panel.
+
+The code fix (``lineup_service._build_read``) stops the corruption going
+forward, but rows accepted before the fix still hold a presigned URL in the
+key column. This migration peels every URL layer back to the bare object key
+and writes it back, so signing on read resolves to the real object again.
+
+Idempotent: bare keys never start with ``http``; re-running this migration
+selects nothing.
+
+Downgrade is intentionally a no-op — the original (already buggy) presigned
+URL carried an embedded expiry and signature that there is no value in
+reconstructing. Rolling back the code is the supported revert path; the
+repaired bare keys are correct input for the *old* code too (it signed
+whatever the column held; a bare key is exactly what it expected before the
+bug), so leaving them repaired is strictly safer than re-corrupting them.
+"""
+from urllib.parse import unquote, urlsplit
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0007"
+down_revision = "0006"
+branch_labels = None
+depends_on = None
+
+
+def _object_key_from_value(value: str) -> str:
+    """Peel presigned-URL layers down to the bare object key.
+
+    Mirrors ``app.services.game.lineup_service._object_key_from_value`` but is
+    inlined so the migration stays valid even if that helper later changes.
+    """
+    seen = 0
+    while value[:4].lower() == "http" and seen < 5:
+        parts = urlsplit(value)
+        if not parts.scheme or not parts.netloc:
+            break
+        # URL path is "/<bucket>/<key...>" — drop the leading bucket segment.
+        path = parts.path.lstrip("/")
+        _, _, key = path.partition("/")
+        value = unquote(key or path)
+        seen += 1
+    return value
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    lineup = sa.table(
+        "lineup",
+        sa.column("id", sa.String),
+        sa.column("stand_screenshot_url", sa.String),
+        sa.column("aim_screenshot_url", sa.String),
+    )
+
+    rows = bind.execute(
+        sa.select(
+            lineup.c.id,
+            lineup.c.stand_screenshot_url,
+            lineup.c.aim_screenshot_url,
+        ).where(
+            sa.or_(
+                lineup.c.stand_screenshot_url.like("http%"),
+                lineup.c.aim_screenshot_url.like("http%"),
+            )
+        )
+    ).fetchall()
+
+    for row in rows:
+        updates = {}
+        if row.stand_screenshot_url and row.stand_screenshot_url[:4].lower() == "http":
+            updates["stand_screenshot_url"] = _object_key_from_value(
+                row.stand_screenshot_url
+            )
+        if row.aim_screenshot_url and row.aim_screenshot_url[:4].lower() == "http":
+            updates["aim_screenshot_url"] = _object_key_from_value(
+                row.aim_screenshot_url
+            )
+        if updates:
+            bind.execute(
+                sa.update(lineup).where(lineup.c.id == row.id).values(**updates)
+            )
+
+
+def downgrade() -> None:
+    # Intentionally a no-op — see module docstring.
+    pass

--- a/apps/mygamingassistant/backend/alembic/versions/0008_backfill_cs2_zone_polygons.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0008_backfill_cs2_zone_polygons.py
@@ -1,0 +1,143 @@
+"""Backfill CS2 map-zone polygons from the fixture for existing DBs
+
+Revision ID: 0008
+Revises: 0007
+Create Date: 2026-05-16 00:00:01.000000
+
+Data migration for the dead-center-pin bug.
+
+CS2 ``map_zone`` rows seeded before this series shipped have an empty
+``polygon_points`` (``[]``). Without a polygon and without an explicit
+anchor, ``LineupRead.effective_*`` resolves to ``None`` and the lineup has
+no place on the map (the correctness fix in ``lineup_schemas`` stopped the
+old ``(0.5, 0.5)`` dead-center sentinel from masking this).
+
+``app/fixtures/cs2_maps.json`` now carries approximate seed polygons for all
+62 CS2 zones, but ``load_fixtures`` is CLI-only — it does NOT run in the
+app lifespan, so an already-deployed database would never receive the
+polygons. This migration walks the fixture and writes its polygon onto
+every CS2 zone whose stored ``polygon_points`` is empty.
+
+Conservative + idempotent:
+- Only zones joined to a ``game`` with ``slug = 'cs2'`` are touched.
+- Only rows whose ``polygon_points`` is NULL or a zero-length JSON array
+  are updated — a zone that already has a non-empty polygon (operator-drawn
+  via the #656 editor, or already backfilled) is NEVER overwritten.
+- Re-running selects nothing once polygons are populated.
+
+Downgrade is intentionally a no-op: the pre-migration state was an empty
+polygon, which is indistinguishable from a deliberately-cleared zone, and
+restoring "empty" would re-break pin placement. Reverting the code is the
+supported rollback path; a populated approximate polygon is valid input
+for the old code too (it simply rendered the centroid), so leaving the
+backfilled polygons in place is strictly safer than clearing them.
+"""
+import json
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0008"
+down_revision = "0007"
+branch_labels = None
+depends_on = None
+
+
+def _load_cs2_fixture() -> list[dict]:
+    """Resolve and parse ``app/fixtures/cs2_maps.json`` independent of CWD.
+
+    This file lives at ``alembic/versions/0008_*.py``; ``parents[2]`` is the
+    backend root, mirroring how ``fixture_loader`` resolves its fixtures dir.
+    """
+    fixture_path = (
+        Path(__file__).resolve().parents[2]
+        / "app"
+        / "fixtures"
+        / "cs2_maps.json"
+    )
+    with fixture_path.open(encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _fixture_polygons() -> dict[tuple[str, str], list]:
+    """Flatten the fixture into ``{(map_slug, zone_slug): polygon_points}``.
+
+    Only non-empty polygons are included — there is nothing to backfill from
+    an empty fixture entry.
+    """
+    out: dict[tuple[str, str], list] = {}
+    for entry in _load_cs2_fixture():
+        if entry.get("game_slug") != "cs2":
+            continue
+        for m in entry.get("maps", []):
+            for z in m.get("zones", []):
+                points = z.get("polygon_points") or []
+                if points:
+                    out[(m["slug"], z["slug"])] = points
+    return out
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+
+    game = sa.table("game", sa.column("id", sa.String), sa.column("slug", sa.String))
+    mp = sa.table(
+        "map",
+        sa.column("id", sa.String),
+        sa.column("game_id", sa.String),
+        sa.column("slug", sa.String),
+    )
+    map_zone = sa.table(
+        "map_zone",
+        sa.column("id", sa.String),
+        sa.column("map_id", sa.String),
+        sa.column("slug", sa.String),
+        sa.column("polygon_points", sa.JSON),
+    )
+
+    # Empty == NULL OR a zero-length JSON array. polygon_points is a JSON
+    # column (not JSONB), so use json_array_length under a type guard so the
+    # length check never raises on a non-array value.
+    is_empty = sa.or_(
+        map_zone.c.polygon_points.is_(None),
+        sa.text(
+            "(json_typeof(map_zone.polygon_points) = 'array' "
+            "AND json_array_length(map_zone.polygon_points) = 0)"
+        ),
+    )
+
+    rows = bind.execute(
+        sa.select(
+            map_zone.c.id,
+            mp.c.slug.label("map_slug"),
+            map_zone.c.slug.label("zone_slug"),
+        )
+        .select_from(
+            map_zone.join(mp, map_zone.c.map_id == mp.c.id).join(
+                game, mp.c.game_id == game.c.id
+            )
+        )
+        .where(sa.and_(game.c.slug == "cs2", is_empty))
+    ).fetchall()
+
+    if not rows:
+        return
+
+    polygons = _fixture_polygons()
+
+    for row in rows:
+        points = polygons.get((row.map_slug, row.zone_slug))
+        if not points:
+            continue
+        bind.execute(
+            sa.update(map_zone)
+            .where(map_zone.c.id == row.id)
+            .values(polygon_points=points)
+        )
+
+
+def downgrade() -> None:
+    # Intentionally a no-op — see module docstring.
+    pass

--- a/apps/mygamingassistant/backend/alembic/versions/0008_backfill_cs2_zone_polygons.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0008_backfill_cs2_zone_polygons.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 import sqlalchemy as sa
 from alembic import op
+from sqlalchemy.dialects import postgresql
 
 
 revision = "0008"
@@ -94,17 +95,19 @@ def upgrade() -> None:
         sa.column("id", sa.String),
         sa.column("map_id", sa.String),
         sa.column("slug", sa.String),
-        sa.column("polygon_points", sa.JSON),
+        sa.column("polygon_points", postgresql.JSONB),
     )
 
-    # Empty == NULL OR a zero-length JSON array. polygon_points is a JSON
-    # column (not JSONB), so use json_array_length under a type guard so the
-    # length check never raises on a non-array value.
+    # Empty == NULL OR a zero-length array. The real column is JSONB
+    # (created by migration 0001 as postgresql.JSONB with server_default
+    # '[]' — the model's loose `JSON` annotation is Python-side only), so
+    # use the jsonb_* functions. The type guard keeps the length check from
+    # raising on a non-array value.
     is_empty = sa.or_(
         map_zone.c.polygon_points.is_(None),
         sa.text(
-            "(json_typeof(map_zone.polygon_points) = 'array' "
-            "AND json_array_length(map_zone.polygon_points) = 0)"
+            "(jsonb_typeof(map_zone.polygon_points) = 'array' "
+            "AND jsonb_array_length(map_zone.polygon_points) = 0)"
         ),
     )
 

--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -21,8 +21,9 @@ Two routers in this module per MGA's public-read / auth-write model:
 
 The public ``GET /api/lineups/{id}`` only returns accepted lineups — pending /
 hidden lineups 404 to unauthenticated callers, since their presigned screenshot
-URLs are baked into the response by ``lineup_service._sign_lineup``. Operators
-who need to view a pending/hidden lineup directly use the auth-gated list-pending
+URLs are baked into the response by ``lineup_service._build_read`` (which signs
+onto the Pydantic model only — never back onto the ORM column). Operators who
+need to view a pending/hidden lineup directly use the auth-gated list-pending
 endpoint or pass through the existing PATCH/accept flow.
 
 See ``apps/mygamingassistant/CLAUDE.md`` → Authentication Model.
@@ -180,8 +181,7 @@ async def list_lineups(
         # Public route forces accepted — pending/hidden are operator-only.
         status="accepted",
     )
-    lineups = await lineup_service.list_by_filters(db, filters)
-    return [LineupRead.model_validate(l) for l in lineups]
+    return await lineup_service.list_by_filters(db, filters)
 
 
 @public_router.get("/lineups/{lineup_id}", response_model=LineupRead)
@@ -202,7 +202,7 @@ async def get_lineup(
         # Treat non-accepted lineups as not-found from a public POV — they
         # have signed screenshot URLs that shouldn't leak before review.
         raise HTTPException(status_code=404, detail="Lineup not found")
-    return LineupRead.model_validate(lineup)
+    return lineup
 
 
 @public_router.get(
@@ -319,8 +319,7 @@ async def create_lineup(
     db: AsyncSession = Depends(get_db),
 ) -> LineupRead:
     """Create a lineup. Pass lineup_id from upload-url to link screenshots."""
-    lineup = await lineup_service.create(db, user.id, payload, lineup_id=lineup_id)
-    return LineupRead.model_validate(lineup)
+    return await lineup_service.create(db, user.id, payload, lineup_id=lineup_id)
 
 
 @auth_router.get("/lineups/{lineup_id}/admin", response_model=LineupRead)
@@ -338,7 +337,7 @@ async def get_lineup_admin(
     lineup = await lineup_service.get(db, lineup_id)
     if lineup is None:
         raise HTTPException(status_code=404, detail="Lineup not found")
-    return LineupRead.model_validate(lineup)
+    return lineup
 
 
 @auth_router.patch("/lineups/{lineup_id}", response_model=LineupRead)
@@ -350,7 +349,7 @@ async def patch_lineup(
     lineup = await lineup_service.patch(db, lineup_id, payload)
     if lineup is None:
         raise HTTPException(status_code=404, detail="Lineup not found")
-    return LineupRead.model_validate(lineup)
+    return lineup
 
 
 @auth_router.delete("/lineups/{lineup_id}", status_code=204)
@@ -412,7 +411,7 @@ async def accept_lineup(
     if lineup is None:
         raise HTTPException(status_code=404, detail="Lineup not found")
     await db.commit()
-    return LineupRead.model_validate(lineup)
+    return lineup
 
 
 @auth_router.post("/lineups/{lineup_id}/hide", response_model=LineupRead)
@@ -421,14 +420,11 @@ async def hide_pending_lineup(
     db: AsyncSession = Depends(get_db),
 ) -> LineupRead:
     """Soft-delete a lineup by setting status to 'hidden'."""
-    from app.repositories.game.lineup_repo import get_lineup, hide_lineup
-
-    lineup = await get_lineup(db, lineup_id)
-    if lineup is None:
+    hidden = await lineup_service.hide(db, lineup_id)
+    if hidden is None:
         raise HTTPException(status_code=404, detail="Lineup not found")
-    hidden = await hide_lineup(db, lineup)
     await db.commit()
-    return LineupRead.model_validate(hidden)
+    return hidden
 
 
 @auth_router.post("/lineups/bulk-accept", response_model=list[LineupRead])
@@ -449,7 +445,7 @@ async def bulk_accept_lineups(
             lineup = await lineup_service.accept(db, lid, patch)
             if lineup is not None:
                 await db.commit()
-                accepted.append(LineupRead.model_validate(lineup))
+                accepted.append(lineup)
         except Exception as exc:
             logger.warning(
                 "bulk_accept: skipping lineup_id=%s error=%s", lid, str(exc)

--- a/apps/mygamingassistant/backend/app/fixtures/_apply_cs2_polygons.py
+++ b/apps/mygamingassistant/backend/app/fixtures/_apply_cs2_polygons.py
@@ -1,0 +1,141 @@
+"""Inject approximate seed zone polygons into cs2_maps.json.
+
+Coordinates are normalized 0-1 over the FULL radar PNG (incl. transparent
+margin) — the minimap fills the square SVG viewBox, origin top-left. These are
+SEED polygons: centroids land in the correct callout region so lineup pins
+appear in the right area. Edges are approximate and meant to be refined via the
+operator polygon editor (#656). Anchored to the in-game bombsite (orange) /
+spawn (green) markers visible on each radar + standard CS2 north-up layouts.
+
+Re-runnable: overwrites polygon_points for every (map, zone) listed below.
+Run:  python -m app.fixtures._apply_cs2_polygons
+"""
+import json
+from pathlib import Path
+
+_F = Path(__file__).with_name("cs2_maps.json")
+
+
+def _rect(x0, y0, x1, y1):
+    return [
+        {"x": x0, "y": y0},
+        {"x": x1, "y": y0},
+        {"x": x1, "y": y1},
+        {"x": x0, "y": y1},
+    ]
+
+
+def _poly(*pts):
+    return [{"x": x, "y": y} for x, y in pts]
+
+
+POLYGONS: dict[str, dict[str, list]] = {
+    "mirage": {
+        "a-site": _poly((0.17, 0.22), (0.31, 0.22), (0.32, 0.34), (0.16, 0.35)),
+        "a-palace": _rect(0.29, 0.34, 0.41, 0.47),
+        "a-ramp": _rect(0.14, 0.43, 0.28, 0.58),
+        "catwalk": _rect(0.40, 0.36, 0.53, 0.49),
+        "mid": _rect(0.46, 0.49, 0.59, 0.69),
+        "b-site": _rect(0.27, 0.55, 0.42, 0.70),
+        "b-van": _rect(0.27, 0.54, 0.35, 0.62),
+        "b-apts": _rect(0.26, 0.68, 0.41, 0.80),
+        "t-spawn": _rect(0.42, 0.76, 0.60, 0.87),
+        "ct-spawn": _rect(0.78, 0.30, 0.92, 0.45),
+    },
+    "inferno": {
+        "a-site": _rect(0.43, 0.17, 0.57, 0.30),
+        "b-site": _rect(0.74, 0.61, 0.88, 0.75),
+        "a-long": _rect(0.59, 0.24, 0.72, 0.38),
+        "banana": _poly((0.22, 0.42), (0.36, 0.45), (0.34, 0.58), (0.21, 0.55)),
+        "mid": _rect(0.43, 0.43, 0.57, 0.57),
+        "second-mid": _rect(0.44, 0.33, 0.56, 0.43),
+        "t-spawn": _rect(0.27, 0.74, 0.45, 0.87),
+        "ct-spawn": _rect(0.82, 0.29, 0.94, 0.44),
+    },
+    "dust2": {
+        "b-site": _rect(0.09, 0.06, 0.25, 0.21),
+        "a-site": _rect(0.70, 0.08, 0.87, 0.25),
+        "a-long": _rect(0.71, 0.27, 0.86, 0.55),
+        "a-short": _rect(0.55, 0.22, 0.69, 0.40),
+        "b-tunnels": _rect(0.10, 0.45, 0.28, 0.66),
+        "mid": _rect(0.40, 0.30, 0.56, 0.62),
+        "catwalk": _rect(0.52, 0.43, 0.66, 0.58),
+        "t-spawn": _rect(0.30, 0.83, 0.52, 0.95),
+        "ct-spawn": _rect(0.55, 0.62, 0.71, 0.76),
+    },
+    "overpass": {
+        "b-site": _rect(0.38, 0.13, 0.54, 0.28),
+        "a-site": _rect(0.54, 0.54, 0.71, 0.71),
+        "a-long": _rect(0.66, 0.45, 0.80, 0.66),
+        "b-monster": _rect(0.22, 0.32, 0.38, 0.50),
+        "mid": _rect(0.40, 0.36, 0.55, 0.55),
+        "canal": _rect(0.14, 0.54, 0.31, 0.72),
+        "t-spawn": _rect(0.58, 0.80, 0.74, 0.93),
+        "ct-spawn": _rect(0.42, 0.05, 0.58, 0.16),
+    },
+    "nuke": {
+        "upper-a": _rect(0.50, 0.42, 0.67, 0.57),
+        "lower-b": _rect(0.49, 0.57, 0.64, 0.70),
+        "a-ramp": _rect(0.62, 0.48, 0.72, 0.63),
+        "outside": _rect(0.72, 0.40, 0.93, 0.60),
+        "lobby": _rect(0.33, 0.49, 0.48, 0.62),
+        "t-spawn": _rect(0.07, 0.48, 0.24, 0.62),
+        "ct-spawn": _rect(0.49, 0.26, 0.64, 0.40),
+    },
+    "anubis": {
+        "a-site": _rect(0.65, 0.20, 0.80, 0.35),
+        "b-site": _rect(0.23, 0.43, 0.38, 0.57),
+        "a-main": _rect(0.58, 0.46, 0.73, 0.64),
+        "b-main": _rect(0.27, 0.58, 0.42, 0.74),
+        "mid": _rect(0.43, 0.42, 0.57, 0.58),
+        "t-spawn": _rect(0.40, 0.76, 0.57, 0.88),
+        "ct-spawn": _rect(0.37, 0.13, 0.54, 0.27),
+    },
+    "ancient": {
+        "a-site": _rect(0.71, 0.34, 0.86, 0.50),
+        "b-site": _rect(0.16, 0.18, 0.31, 0.33),
+        "a-main": _rect(0.58, 0.50, 0.74, 0.66),
+        "b-main": _rect(0.16, 0.37, 0.32, 0.55),
+        "mid": _rect(0.40, 0.42, 0.56, 0.60),
+        "t-spawn": _rect(0.38, 0.74, 0.55, 0.87),
+        "ct-spawn": _rect(0.34, 0.20, 0.51, 0.34),
+    },
+    "vertigo": {
+        "a-site": _rect(0.13, 0.17, 0.28, 0.32),
+        "b-site": _rect(0.64, 0.51, 0.80, 0.66),
+        "a-ramp": _rect(0.14, 0.46, 0.30, 0.64),
+        "mid": _rect(0.37, 0.37, 0.53, 0.55),
+        "t-spawn": _rect(0.30, 0.72, 0.47, 0.85),
+        "ct-spawn": _rect(0.47, 0.15, 0.63, 0.30),
+    },
+}
+
+
+def main() -> None:
+    data = json.loads(_F.read_text(encoding="utf-8"))
+    applied = 0
+    missing = []
+    for entry in data:
+        if entry.get("game_slug") != "cs2":
+            continue
+        for m in entry["maps"]:
+            table = POLYGONS.get(m["slug"], {})
+            seen = set()
+            for z in m["zones"]:
+                if z["slug"] in table:
+                    z["polygon_points"] = table[z["slug"]]
+                    seen.add(z["slug"])
+                    applied += 1
+                else:
+                    missing.append(f'{m["slug"]}/{z["slug"]}')
+            extra = set(table) - seen
+            if extra:
+                missing.append(f'{m["slug"]} UNUSED {sorted(extra)}')
+    _F.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    print(f"applied polygons: {applied}")
+    if missing:
+        print("UNMATCHED:", *missing, sep="\n  ")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/mygamingassistant/backend/app/fixtures/cs2_maps.json
+++ b/apps/mygamingassistant/backend/app/fixtures/cs2_maps.json
@@ -7,20 +7,236 @@
         "name": "Mirage",
         "minimap_url": "/minimaps/cs2/mirage.png",
         "zones": [
-          { "slug": "a-site",     "name": "A Site",     "polygon_points": [] },
-          { "slug": "b-site",     "name": "B Site",     "polygon_points": [] },
-          { "slug": "a-ramp",     "name": "A Ramp",     "polygon_points": [] },
-          { "slug": "a-palace",   "name": "Palace",     "polygon_points": [] },
-          { "slug": "b-apts",     "name": "B Apartments","polygon_points": [] },
-          { "slug": "b-van",      "name": "Van",        "polygon_points": [] },
-          { "slug": "mid",        "name": "Mid",        "polygon_points": [] },
-          { "slug": "catwalk",    "name": "Catwalk",    "polygon_points": [] },
-          { "slug": "t-spawn",    "name": "T Spawn",    "polygon_points": [] },
-          { "slug": "ct-spawn",   "name": "CT Spawn",   "polygon_points": [] }
+          {
+            "slug": "a-site",
+            "name": "A Site",
+            "polygon_points": [
+              {
+                "x": 0.17,
+                "y": 0.22
+              },
+              {
+                "x": 0.31,
+                "y": 0.22
+              },
+              {
+                "x": 0.32,
+                "y": 0.34
+              },
+              {
+                "x": 0.16,
+                "y": 0.35
+              }
+            ]
+          },
+          {
+            "slug": "b-site",
+            "name": "B Site",
+            "polygon_points": [
+              {
+                "x": 0.27,
+                "y": 0.55
+              },
+              {
+                "x": 0.42,
+                "y": 0.55
+              },
+              {
+                "x": 0.42,
+                "y": 0.7
+              },
+              {
+                "x": 0.27,
+                "y": 0.7
+              }
+            ]
+          },
+          {
+            "slug": "a-ramp",
+            "name": "A Ramp",
+            "polygon_points": [
+              {
+                "x": 0.14,
+                "y": 0.43
+              },
+              {
+                "x": 0.28,
+                "y": 0.43
+              },
+              {
+                "x": 0.28,
+                "y": 0.58
+              },
+              {
+                "x": 0.14,
+                "y": 0.58
+              }
+            ]
+          },
+          {
+            "slug": "a-palace",
+            "name": "Palace",
+            "polygon_points": [
+              {
+                "x": 0.29,
+                "y": 0.34
+              },
+              {
+                "x": 0.41,
+                "y": 0.34
+              },
+              {
+                "x": 0.41,
+                "y": 0.47
+              },
+              {
+                "x": 0.29,
+                "y": 0.47
+              }
+            ]
+          },
+          {
+            "slug": "b-apts",
+            "name": "B Apartments",
+            "polygon_points": [
+              {
+                "x": 0.26,
+                "y": 0.68
+              },
+              {
+                "x": 0.41,
+                "y": 0.68
+              },
+              {
+                "x": 0.41,
+                "y": 0.8
+              },
+              {
+                "x": 0.26,
+                "y": 0.8
+              }
+            ]
+          },
+          {
+            "slug": "b-van",
+            "name": "Van",
+            "polygon_points": [
+              {
+                "x": 0.27,
+                "y": 0.54
+              },
+              {
+                "x": 0.35,
+                "y": 0.54
+              },
+              {
+                "x": 0.35,
+                "y": 0.62
+              },
+              {
+                "x": 0.27,
+                "y": 0.62
+              }
+            ]
+          },
+          {
+            "slug": "mid",
+            "name": "Mid",
+            "polygon_points": [
+              {
+                "x": 0.46,
+                "y": 0.49
+              },
+              {
+                "x": 0.59,
+                "y": 0.49
+              },
+              {
+                "x": 0.59,
+                "y": 0.69
+              },
+              {
+                "x": 0.46,
+                "y": 0.69
+              }
+            ]
+          },
+          {
+            "slug": "catwalk",
+            "name": "Catwalk",
+            "polygon_points": [
+              {
+                "x": 0.4,
+                "y": 0.36
+              },
+              {
+                "x": 0.53,
+                "y": 0.36
+              },
+              {
+                "x": 0.53,
+                "y": 0.49
+              },
+              {
+                "x": 0.4,
+                "y": 0.49
+              }
+            ]
+          },
+          {
+            "slug": "t-spawn",
+            "name": "T Spawn",
+            "polygon_points": [
+              {
+                "x": 0.42,
+                "y": 0.76
+              },
+              {
+                "x": 0.6,
+                "y": 0.76
+              },
+              {
+                "x": 0.6,
+                "y": 0.87
+              },
+              {
+                "x": 0.42,
+                "y": 0.87
+              }
+            ]
+          },
+          {
+            "slug": "ct-spawn",
+            "name": "CT Spawn",
+            "polygon_points": [
+              {
+                "x": 0.78,
+                "y": 0.3
+              },
+              {
+                "x": 0.92,
+                "y": 0.3
+              },
+              {
+                "x": 0.92,
+                "y": 0.45
+              },
+              {
+                "x": 0.78,
+                "y": 0.45
+              }
+            ]
+          }
         ],
         "sites": [
-          { "slug": "a", "name": "A" },
-          { "slug": "b", "name": "B" }
+          {
+            "slug": "a",
+            "name": "A"
+          },
+          {
+            "slug": "b",
+            "name": "B"
+          }
         ]
       },
       {
@@ -28,18 +244,192 @@
         "name": "Inferno",
         "minimap_url": "/minimaps/cs2/inferno.png",
         "zones": [
-          { "slug": "a-site",     "name": "A Site",     "polygon_points": [] },
-          { "slug": "b-site",     "name": "B Site",     "polygon_points": [] },
-          { "slug": "a-long",     "name": "A Long",     "polygon_points": [] },
-          { "slug": "banana",     "name": "Banana",     "polygon_points": [] },
-          { "slug": "mid",        "name": "Mid",        "polygon_points": [] },
-          { "slug": "second-mid", "name": "Second Mid", "polygon_points": [] },
-          { "slug": "t-spawn",    "name": "T Spawn",    "polygon_points": [] },
-          { "slug": "ct-spawn",   "name": "CT Spawn",   "polygon_points": [] }
+          {
+            "slug": "a-site",
+            "name": "A Site",
+            "polygon_points": [
+              {
+                "x": 0.43,
+                "y": 0.17
+              },
+              {
+                "x": 0.57,
+                "y": 0.17
+              },
+              {
+                "x": 0.57,
+                "y": 0.3
+              },
+              {
+                "x": 0.43,
+                "y": 0.3
+              }
+            ]
+          },
+          {
+            "slug": "b-site",
+            "name": "B Site",
+            "polygon_points": [
+              {
+                "x": 0.74,
+                "y": 0.61
+              },
+              {
+                "x": 0.88,
+                "y": 0.61
+              },
+              {
+                "x": 0.88,
+                "y": 0.75
+              },
+              {
+                "x": 0.74,
+                "y": 0.75
+              }
+            ]
+          },
+          {
+            "slug": "a-long",
+            "name": "A Long",
+            "polygon_points": [
+              {
+                "x": 0.59,
+                "y": 0.24
+              },
+              {
+                "x": 0.72,
+                "y": 0.24
+              },
+              {
+                "x": 0.72,
+                "y": 0.38
+              },
+              {
+                "x": 0.59,
+                "y": 0.38
+              }
+            ]
+          },
+          {
+            "slug": "banana",
+            "name": "Banana",
+            "polygon_points": [
+              {
+                "x": 0.22,
+                "y": 0.42
+              },
+              {
+                "x": 0.36,
+                "y": 0.45
+              },
+              {
+                "x": 0.34,
+                "y": 0.58
+              },
+              {
+                "x": 0.21,
+                "y": 0.55
+              }
+            ]
+          },
+          {
+            "slug": "mid",
+            "name": "Mid",
+            "polygon_points": [
+              {
+                "x": 0.43,
+                "y": 0.43
+              },
+              {
+                "x": 0.57,
+                "y": 0.43
+              },
+              {
+                "x": 0.57,
+                "y": 0.57
+              },
+              {
+                "x": 0.43,
+                "y": 0.57
+              }
+            ]
+          },
+          {
+            "slug": "second-mid",
+            "name": "Second Mid",
+            "polygon_points": [
+              {
+                "x": 0.44,
+                "y": 0.33
+              },
+              {
+                "x": 0.56,
+                "y": 0.33
+              },
+              {
+                "x": 0.56,
+                "y": 0.43
+              },
+              {
+                "x": 0.44,
+                "y": 0.43
+              }
+            ]
+          },
+          {
+            "slug": "t-spawn",
+            "name": "T Spawn",
+            "polygon_points": [
+              {
+                "x": 0.27,
+                "y": 0.74
+              },
+              {
+                "x": 0.45,
+                "y": 0.74
+              },
+              {
+                "x": 0.45,
+                "y": 0.87
+              },
+              {
+                "x": 0.27,
+                "y": 0.87
+              }
+            ]
+          },
+          {
+            "slug": "ct-spawn",
+            "name": "CT Spawn",
+            "polygon_points": [
+              {
+                "x": 0.82,
+                "y": 0.29
+              },
+              {
+                "x": 0.94,
+                "y": 0.29
+              },
+              {
+                "x": 0.94,
+                "y": 0.44
+              },
+              {
+                "x": 0.82,
+                "y": 0.44
+              }
+            ]
+          }
         ],
         "sites": [
-          { "slug": "a", "name": "A" },
-          { "slug": "b", "name": "B" }
+          {
+            "slug": "a",
+            "name": "A"
+          },
+          {
+            "slug": "b",
+            "name": "B"
+          }
         ]
       },
       {
@@ -47,19 +437,214 @@
         "name": "Dust II",
         "minimap_url": "/minimaps/cs2/dust2.png",
         "zones": [
-          { "slug": "a-site",     "name": "A Site",     "polygon_points": [] },
-          { "slug": "b-site",     "name": "B Site",     "polygon_points": [] },
-          { "slug": "a-long",     "name": "A Long",     "polygon_points": [] },
-          { "slug": "a-short",    "name": "A Short",    "polygon_points": [] },
-          { "slug": "b-tunnels",  "name": "B Tunnels",  "polygon_points": [] },
-          { "slug": "mid",        "name": "Mid",        "polygon_points": [] },
-          { "slug": "catwalk",    "name": "Catwalk",    "polygon_points": [] },
-          { "slug": "t-spawn",    "name": "T Spawn",    "polygon_points": [] },
-          { "slug": "ct-spawn",   "name": "CT Spawn",   "polygon_points": [] }
+          {
+            "slug": "a-site",
+            "name": "A Site",
+            "polygon_points": [
+              {
+                "x": 0.7,
+                "y": 0.08
+              },
+              {
+                "x": 0.87,
+                "y": 0.08
+              },
+              {
+                "x": 0.87,
+                "y": 0.25
+              },
+              {
+                "x": 0.7,
+                "y": 0.25
+              }
+            ]
+          },
+          {
+            "slug": "b-site",
+            "name": "B Site",
+            "polygon_points": [
+              {
+                "x": 0.09,
+                "y": 0.06
+              },
+              {
+                "x": 0.25,
+                "y": 0.06
+              },
+              {
+                "x": 0.25,
+                "y": 0.21
+              },
+              {
+                "x": 0.09,
+                "y": 0.21
+              }
+            ]
+          },
+          {
+            "slug": "a-long",
+            "name": "A Long",
+            "polygon_points": [
+              {
+                "x": 0.71,
+                "y": 0.27
+              },
+              {
+                "x": 0.86,
+                "y": 0.27
+              },
+              {
+                "x": 0.86,
+                "y": 0.55
+              },
+              {
+                "x": 0.71,
+                "y": 0.55
+              }
+            ]
+          },
+          {
+            "slug": "a-short",
+            "name": "A Short",
+            "polygon_points": [
+              {
+                "x": 0.55,
+                "y": 0.22
+              },
+              {
+                "x": 0.69,
+                "y": 0.22
+              },
+              {
+                "x": 0.69,
+                "y": 0.4
+              },
+              {
+                "x": 0.55,
+                "y": 0.4
+              }
+            ]
+          },
+          {
+            "slug": "b-tunnels",
+            "name": "B Tunnels",
+            "polygon_points": [
+              {
+                "x": 0.1,
+                "y": 0.45
+              },
+              {
+                "x": 0.28,
+                "y": 0.45
+              },
+              {
+                "x": 0.28,
+                "y": 0.66
+              },
+              {
+                "x": 0.1,
+                "y": 0.66
+              }
+            ]
+          },
+          {
+            "slug": "mid",
+            "name": "Mid",
+            "polygon_points": [
+              {
+                "x": 0.4,
+                "y": 0.3
+              },
+              {
+                "x": 0.56,
+                "y": 0.3
+              },
+              {
+                "x": 0.56,
+                "y": 0.62
+              },
+              {
+                "x": 0.4,
+                "y": 0.62
+              }
+            ]
+          },
+          {
+            "slug": "catwalk",
+            "name": "Catwalk",
+            "polygon_points": [
+              {
+                "x": 0.52,
+                "y": 0.43
+              },
+              {
+                "x": 0.66,
+                "y": 0.43
+              },
+              {
+                "x": 0.66,
+                "y": 0.58
+              },
+              {
+                "x": 0.52,
+                "y": 0.58
+              }
+            ]
+          },
+          {
+            "slug": "t-spawn",
+            "name": "T Spawn",
+            "polygon_points": [
+              {
+                "x": 0.3,
+                "y": 0.83
+              },
+              {
+                "x": 0.52,
+                "y": 0.83
+              },
+              {
+                "x": 0.52,
+                "y": 0.95
+              },
+              {
+                "x": 0.3,
+                "y": 0.95
+              }
+            ]
+          },
+          {
+            "slug": "ct-spawn",
+            "name": "CT Spawn",
+            "polygon_points": [
+              {
+                "x": 0.55,
+                "y": 0.62
+              },
+              {
+                "x": 0.71,
+                "y": 0.62
+              },
+              {
+                "x": 0.71,
+                "y": 0.76
+              },
+              {
+                "x": 0.55,
+                "y": 0.76
+              }
+            ]
+          }
         ],
         "sites": [
-          { "slug": "a", "name": "A" },
-          { "slug": "b", "name": "B" }
+          {
+            "slug": "a",
+            "name": "A"
+          },
+          {
+            "slug": "b",
+            "name": "B"
+          }
         ]
       },
       {
@@ -67,18 +652,192 @@
         "name": "Overpass",
         "minimap_url": "/minimaps/cs2/overpass.png",
         "zones": [
-          { "slug": "a-site",     "name": "A Site",     "polygon_points": [] },
-          { "slug": "b-site",     "name": "B Site",     "polygon_points": [] },
-          { "slug": "a-long",     "name": "A Long",     "polygon_points": [] },
-          { "slug": "b-monster",  "name": "Monster",    "polygon_points": [] },
-          { "slug": "mid",        "name": "Mid",        "polygon_points": [] },
-          { "slug": "canal",      "name": "Canal",      "polygon_points": [] },
-          { "slug": "t-spawn",    "name": "T Spawn",    "polygon_points": [] },
-          { "slug": "ct-spawn",   "name": "CT Spawn",   "polygon_points": [] }
+          {
+            "slug": "a-site",
+            "name": "A Site",
+            "polygon_points": [
+              {
+                "x": 0.54,
+                "y": 0.54
+              },
+              {
+                "x": 0.71,
+                "y": 0.54
+              },
+              {
+                "x": 0.71,
+                "y": 0.71
+              },
+              {
+                "x": 0.54,
+                "y": 0.71
+              }
+            ]
+          },
+          {
+            "slug": "b-site",
+            "name": "B Site",
+            "polygon_points": [
+              {
+                "x": 0.38,
+                "y": 0.13
+              },
+              {
+                "x": 0.54,
+                "y": 0.13
+              },
+              {
+                "x": 0.54,
+                "y": 0.28
+              },
+              {
+                "x": 0.38,
+                "y": 0.28
+              }
+            ]
+          },
+          {
+            "slug": "a-long",
+            "name": "A Long",
+            "polygon_points": [
+              {
+                "x": 0.66,
+                "y": 0.45
+              },
+              {
+                "x": 0.8,
+                "y": 0.45
+              },
+              {
+                "x": 0.8,
+                "y": 0.66
+              },
+              {
+                "x": 0.66,
+                "y": 0.66
+              }
+            ]
+          },
+          {
+            "slug": "b-monster",
+            "name": "Monster",
+            "polygon_points": [
+              {
+                "x": 0.22,
+                "y": 0.32
+              },
+              {
+                "x": 0.38,
+                "y": 0.32
+              },
+              {
+                "x": 0.38,
+                "y": 0.5
+              },
+              {
+                "x": 0.22,
+                "y": 0.5
+              }
+            ]
+          },
+          {
+            "slug": "mid",
+            "name": "Mid",
+            "polygon_points": [
+              {
+                "x": 0.4,
+                "y": 0.36
+              },
+              {
+                "x": 0.55,
+                "y": 0.36
+              },
+              {
+                "x": 0.55,
+                "y": 0.55
+              },
+              {
+                "x": 0.4,
+                "y": 0.55
+              }
+            ]
+          },
+          {
+            "slug": "canal",
+            "name": "Canal",
+            "polygon_points": [
+              {
+                "x": 0.14,
+                "y": 0.54
+              },
+              {
+                "x": 0.31,
+                "y": 0.54
+              },
+              {
+                "x": 0.31,
+                "y": 0.72
+              },
+              {
+                "x": 0.14,
+                "y": 0.72
+              }
+            ]
+          },
+          {
+            "slug": "t-spawn",
+            "name": "T Spawn",
+            "polygon_points": [
+              {
+                "x": 0.58,
+                "y": 0.8
+              },
+              {
+                "x": 0.74,
+                "y": 0.8
+              },
+              {
+                "x": 0.74,
+                "y": 0.93
+              },
+              {
+                "x": 0.58,
+                "y": 0.93
+              }
+            ]
+          },
+          {
+            "slug": "ct-spawn",
+            "name": "CT Spawn",
+            "polygon_points": [
+              {
+                "x": 0.42,
+                "y": 0.05
+              },
+              {
+                "x": 0.58,
+                "y": 0.05
+              },
+              {
+                "x": 0.58,
+                "y": 0.16
+              },
+              {
+                "x": 0.42,
+                "y": 0.16
+              }
+            ]
+          }
         ],
         "sites": [
-          { "slug": "a", "name": "A" },
-          { "slug": "b", "name": "B" }
+          {
+            "slug": "a",
+            "name": "A"
+          },
+          {
+            "slug": "b",
+            "name": "B"
+          }
         ]
       },
       {
@@ -86,17 +845,170 @@
         "name": "Nuke",
         "minimap_url": "/minimaps/cs2/nuke.png",
         "zones": [
-          { "slug": "upper-a",    "name": "Upper A",    "polygon_points": [] },
-          { "slug": "lower-b",    "name": "Lower B",    "polygon_points": [] },
-          { "slug": "a-ramp",     "name": "Ramp",       "polygon_points": [] },
-          { "slug": "outside",    "name": "Outside",    "polygon_points": [] },
-          { "slug": "lobby",      "name": "Lobby",      "polygon_points": [] },
-          { "slug": "t-spawn",    "name": "T Spawn",    "polygon_points": [] },
-          { "slug": "ct-spawn",   "name": "CT Spawn",   "polygon_points": [] }
+          {
+            "slug": "upper-a",
+            "name": "Upper A",
+            "polygon_points": [
+              {
+                "x": 0.5,
+                "y": 0.42
+              },
+              {
+                "x": 0.67,
+                "y": 0.42
+              },
+              {
+                "x": 0.67,
+                "y": 0.57
+              },
+              {
+                "x": 0.5,
+                "y": 0.57
+              }
+            ]
+          },
+          {
+            "slug": "lower-b",
+            "name": "Lower B",
+            "polygon_points": [
+              {
+                "x": 0.49,
+                "y": 0.57
+              },
+              {
+                "x": 0.64,
+                "y": 0.57
+              },
+              {
+                "x": 0.64,
+                "y": 0.7
+              },
+              {
+                "x": 0.49,
+                "y": 0.7
+              }
+            ]
+          },
+          {
+            "slug": "a-ramp",
+            "name": "Ramp",
+            "polygon_points": [
+              {
+                "x": 0.62,
+                "y": 0.48
+              },
+              {
+                "x": 0.72,
+                "y": 0.48
+              },
+              {
+                "x": 0.72,
+                "y": 0.63
+              },
+              {
+                "x": 0.62,
+                "y": 0.63
+              }
+            ]
+          },
+          {
+            "slug": "outside",
+            "name": "Outside",
+            "polygon_points": [
+              {
+                "x": 0.72,
+                "y": 0.4
+              },
+              {
+                "x": 0.93,
+                "y": 0.4
+              },
+              {
+                "x": 0.93,
+                "y": 0.6
+              },
+              {
+                "x": 0.72,
+                "y": 0.6
+              }
+            ]
+          },
+          {
+            "slug": "lobby",
+            "name": "Lobby",
+            "polygon_points": [
+              {
+                "x": 0.33,
+                "y": 0.49
+              },
+              {
+                "x": 0.48,
+                "y": 0.49
+              },
+              {
+                "x": 0.48,
+                "y": 0.62
+              },
+              {
+                "x": 0.33,
+                "y": 0.62
+              }
+            ]
+          },
+          {
+            "slug": "t-spawn",
+            "name": "T Spawn",
+            "polygon_points": [
+              {
+                "x": 0.07,
+                "y": 0.48
+              },
+              {
+                "x": 0.24,
+                "y": 0.48
+              },
+              {
+                "x": 0.24,
+                "y": 0.62
+              },
+              {
+                "x": 0.07,
+                "y": 0.62
+              }
+            ]
+          },
+          {
+            "slug": "ct-spawn",
+            "name": "CT Spawn",
+            "polygon_points": [
+              {
+                "x": 0.49,
+                "y": 0.26
+              },
+              {
+                "x": 0.64,
+                "y": 0.26
+              },
+              {
+                "x": 0.64,
+                "y": 0.4
+              },
+              {
+                "x": 0.49,
+                "y": 0.4
+              }
+            ]
+          }
         ],
         "sites": [
-          { "slug": "a", "name": "A (Upper)" },
-          { "slug": "b", "name": "B (Lower)" }
+          {
+            "slug": "a",
+            "name": "A (Upper)"
+          },
+          {
+            "slug": "b",
+            "name": "B (Lower)"
+          }
         ]
       },
       {
@@ -104,17 +1016,170 @@
         "name": "Anubis",
         "minimap_url": "/minimaps/cs2/anubis.png",
         "zones": [
-          { "slug": "a-site",     "name": "A Site",     "polygon_points": [] },
-          { "slug": "b-site",     "name": "B Site",     "polygon_points": [] },
-          { "slug": "a-main",     "name": "A Main",     "polygon_points": [] },
-          { "slug": "b-main",     "name": "B Main",     "polygon_points": [] },
-          { "slug": "mid",        "name": "Mid",        "polygon_points": [] },
-          { "slug": "t-spawn",    "name": "T Spawn",    "polygon_points": [] },
-          { "slug": "ct-spawn",   "name": "CT Spawn",   "polygon_points": [] }
+          {
+            "slug": "a-site",
+            "name": "A Site",
+            "polygon_points": [
+              {
+                "x": 0.65,
+                "y": 0.2
+              },
+              {
+                "x": 0.8,
+                "y": 0.2
+              },
+              {
+                "x": 0.8,
+                "y": 0.35
+              },
+              {
+                "x": 0.65,
+                "y": 0.35
+              }
+            ]
+          },
+          {
+            "slug": "b-site",
+            "name": "B Site",
+            "polygon_points": [
+              {
+                "x": 0.23,
+                "y": 0.43
+              },
+              {
+                "x": 0.38,
+                "y": 0.43
+              },
+              {
+                "x": 0.38,
+                "y": 0.57
+              },
+              {
+                "x": 0.23,
+                "y": 0.57
+              }
+            ]
+          },
+          {
+            "slug": "a-main",
+            "name": "A Main",
+            "polygon_points": [
+              {
+                "x": 0.58,
+                "y": 0.46
+              },
+              {
+                "x": 0.73,
+                "y": 0.46
+              },
+              {
+                "x": 0.73,
+                "y": 0.64
+              },
+              {
+                "x": 0.58,
+                "y": 0.64
+              }
+            ]
+          },
+          {
+            "slug": "b-main",
+            "name": "B Main",
+            "polygon_points": [
+              {
+                "x": 0.27,
+                "y": 0.58
+              },
+              {
+                "x": 0.42,
+                "y": 0.58
+              },
+              {
+                "x": 0.42,
+                "y": 0.74
+              },
+              {
+                "x": 0.27,
+                "y": 0.74
+              }
+            ]
+          },
+          {
+            "slug": "mid",
+            "name": "Mid",
+            "polygon_points": [
+              {
+                "x": 0.43,
+                "y": 0.42
+              },
+              {
+                "x": 0.57,
+                "y": 0.42
+              },
+              {
+                "x": 0.57,
+                "y": 0.58
+              },
+              {
+                "x": 0.43,
+                "y": 0.58
+              }
+            ]
+          },
+          {
+            "slug": "t-spawn",
+            "name": "T Spawn",
+            "polygon_points": [
+              {
+                "x": 0.4,
+                "y": 0.76
+              },
+              {
+                "x": 0.57,
+                "y": 0.76
+              },
+              {
+                "x": 0.57,
+                "y": 0.88
+              },
+              {
+                "x": 0.4,
+                "y": 0.88
+              }
+            ]
+          },
+          {
+            "slug": "ct-spawn",
+            "name": "CT Spawn",
+            "polygon_points": [
+              {
+                "x": 0.37,
+                "y": 0.13
+              },
+              {
+                "x": 0.54,
+                "y": 0.13
+              },
+              {
+                "x": 0.54,
+                "y": 0.27
+              },
+              {
+                "x": 0.37,
+                "y": 0.27
+              }
+            ]
+          }
         ],
         "sites": [
-          { "slug": "a", "name": "A" },
-          { "slug": "b", "name": "B" }
+          {
+            "slug": "a",
+            "name": "A"
+          },
+          {
+            "slug": "b",
+            "name": "B"
+          }
         ]
       },
       {
@@ -122,17 +1187,170 @@
         "name": "Ancient",
         "minimap_url": "/minimaps/cs2/ancient.png",
         "zones": [
-          { "slug": "a-site",     "name": "A Site",     "polygon_points": [] },
-          { "slug": "b-site",     "name": "B Site",     "polygon_points": [] },
-          { "slug": "a-main",     "name": "A Main",     "polygon_points": [] },
-          { "slug": "b-main",     "name": "B Main",     "polygon_points": [] },
-          { "slug": "mid",        "name": "Mid",        "polygon_points": [] },
-          { "slug": "t-spawn",    "name": "T Spawn",    "polygon_points": [] },
-          { "slug": "ct-spawn",   "name": "CT Spawn",   "polygon_points": [] }
+          {
+            "slug": "a-site",
+            "name": "A Site",
+            "polygon_points": [
+              {
+                "x": 0.71,
+                "y": 0.34
+              },
+              {
+                "x": 0.86,
+                "y": 0.34
+              },
+              {
+                "x": 0.86,
+                "y": 0.5
+              },
+              {
+                "x": 0.71,
+                "y": 0.5
+              }
+            ]
+          },
+          {
+            "slug": "b-site",
+            "name": "B Site",
+            "polygon_points": [
+              {
+                "x": 0.16,
+                "y": 0.18
+              },
+              {
+                "x": 0.31,
+                "y": 0.18
+              },
+              {
+                "x": 0.31,
+                "y": 0.33
+              },
+              {
+                "x": 0.16,
+                "y": 0.33
+              }
+            ]
+          },
+          {
+            "slug": "a-main",
+            "name": "A Main",
+            "polygon_points": [
+              {
+                "x": 0.58,
+                "y": 0.5
+              },
+              {
+                "x": 0.74,
+                "y": 0.5
+              },
+              {
+                "x": 0.74,
+                "y": 0.66
+              },
+              {
+                "x": 0.58,
+                "y": 0.66
+              }
+            ]
+          },
+          {
+            "slug": "b-main",
+            "name": "B Main",
+            "polygon_points": [
+              {
+                "x": 0.16,
+                "y": 0.37
+              },
+              {
+                "x": 0.32,
+                "y": 0.37
+              },
+              {
+                "x": 0.32,
+                "y": 0.55
+              },
+              {
+                "x": 0.16,
+                "y": 0.55
+              }
+            ]
+          },
+          {
+            "slug": "mid",
+            "name": "Mid",
+            "polygon_points": [
+              {
+                "x": 0.4,
+                "y": 0.42
+              },
+              {
+                "x": 0.56,
+                "y": 0.42
+              },
+              {
+                "x": 0.56,
+                "y": 0.6
+              },
+              {
+                "x": 0.4,
+                "y": 0.6
+              }
+            ]
+          },
+          {
+            "slug": "t-spawn",
+            "name": "T Spawn",
+            "polygon_points": [
+              {
+                "x": 0.38,
+                "y": 0.74
+              },
+              {
+                "x": 0.55,
+                "y": 0.74
+              },
+              {
+                "x": 0.55,
+                "y": 0.87
+              },
+              {
+                "x": 0.38,
+                "y": 0.87
+              }
+            ]
+          },
+          {
+            "slug": "ct-spawn",
+            "name": "CT Spawn",
+            "polygon_points": [
+              {
+                "x": 0.34,
+                "y": 0.2
+              },
+              {
+                "x": 0.51,
+                "y": 0.2
+              },
+              {
+                "x": 0.51,
+                "y": 0.34
+              },
+              {
+                "x": 0.34,
+                "y": 0.34
+              }
+            ]
+          }
         ],
         "sites": [
-          { "slug": "a", "name": "A" },
-          { "slug": "b", "name": "B" }
+          {
+            "slug": "a",
+            "name": "A"
+          },
+          {
+            "slug": "b",
+            "name": "B"
+          }
         ]
       },
       {
@@ -140,16 +1358,148 @@
         "name": "Vertigo",
         "minimap_url": "/minimaps/cs2/vertigo.png",
         "zones": [
-          { "slug": "a-site",     "name": "A Site",     "polygon_points": [] },
-          { "slug": "b-site",     "name": "B Site",     "polygon_points": [] },
-          { "slug": "a-ramp",     "name": "A Ramp",     "polygon_points": [] },
-          { "slug": "mid",        "name": "Mid",        "polygon_points": [] },
-          { "slug": "t-spawn",    "name": "T Spawn",    "polygon_points": [] },
-          { "slug": "ct-spawn",   "name": "CT Spawn",   "polygon_points": [] }
+          {
+            "slug": "a-site",
+            "name": "A Site",
+            "polygon_points": [
+              {
+                "x": 0.13,
+                "y": 0.17
+              },
+              {
+                "x": 0.28,
+                "y": 0.17
+              },
+              {
+                "x": 0.28,
+                "y": 0.32
+              },
+              {
+                "x": 0.13,
+                "y": 0.32
+              }
+            ]
+          },
+          {
+            "slug": "b-site",
+            "name": "B Site",
+            "polygon_points": [
+              {
+                "x": 0.64,
+                "y": 0.51
+              },
+              {
+                "x": 0.8,
+                "y": 0.51
+              },
+              {
+                "x": 0.8,
+                "y": 0.66
+              },
+              {
+                "x": 0.64,
+                "y": 0.66
+              }
+            ]
+          },
+          {
+            "slug": "a-ramp",
+            "name": "A Ramp",
+            "polygon_points": [
+              {
+                "x": 0.14,
+                "y": 0.46
+              },
+              {
+                "x": 0.3,
+                "y": 0.46
+              },
+              {
+                "x": 0.3,
+                "y": 0.64
+              },
+              {
+                "x": 0.14,
+                "y": 0.64
+              }
+            ]
+          },
+          {
+            "slug": "mid",
+            "name": "Mid",
+            "polygon_points": [
+              {
+                "x": 0.37,
+                "y": 0.37
+              },
+              {
+                "x": 0.53,
+                "y": 0.37
+              },
+              {
+                "x": 0.53,
+                "y": 0.55
+              },
+              {
+                "x": 0.37,
+                "y": 0.55
+              }
+            ]
+          },
+          {
+            "slug": "t-spawn",
+            "name": "T Spawn",
+            "polygon_points": [
+              {
+                "x": 0.3,
+                "y": 0.72
+              },
+              {
+                "x": 0.47,
+                "y": 0.72
+              },
+              {
+                "x": 0.47,
+                "y": 0.85
+              },
+              {
+                "x": 0.3,
+                "y": 0.85
+              }
+            ]
+          },
+          {
+            "slug": "ct-spawn",
+            "name": "CT Spawn",
+            "polygon_points": [
+              {
+                "x": 0.47,
+                "y": 0.15
+              },
+              {
+                "x": 0.63,
+                "y": 0.15
+              },
+              {
+                "x": 0.63,
+                "y": 0.3
+              },
+              {
+                "x": 0.47,
+                "y": 0.3
+              }
+            ]
+          }
         ],
         "sites": [
-          { "slug": "a", "name": "A" },
-          { "slug": "b", "name": "B" }
+          {
+            "slug": "a",
+            "name": "A"
+          },
+          {
+            "slug": "b",
+            "name": "B"
+          }
         ]
       }
     ]

--- a/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
@@ -158,11 +158,27 @@ async def upsert_map_zone(
     name: str,
     polygon_points: list[list[float]] | None = None,
 ) -> MapZone:
+    """Insert a zone if missing; backfill an empty polygon if the fixture has one.
+
+    Backfill rule (idempotent, conservative):
+    - The (map_id, slug) zone already exists, AND
+    - its stored ``polygon_points`` is empty/falsy, AND
+    - the incoming ``polygon_points`` is non-empty
+      → write the incoming polygon onto the existing row and flush.
+
+    A zone that already has a non-empty polygon is NEVER overwritten — this
+    protects operator-drawn polygons (the #656 zone editor) from being
+    clobbered by a re-run of ``load-fixtures``. Re-running with the same
+    fixture is a no-op once the polygon is populated.
+    """
     result = await db.execute(
         select(MapZone).where(MapZone.map_id == map_id, MapZone.slug == slug)
     )
     existing = result.scalar_one_or_none()
     if existing is not None:
+        if not existing.polygon_points and polygon_points:
+            existing.polygon_points = polygon_points
+            await db.flush()
         return existing
     zone = MapZone(
         map_id=map_id,

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -38,6 +38,17 @@ class UtilityTypeRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+def _has_polygon(zone: Optional["ZoneRead"]) -> bool:
+    """True when *zone* exists and carries a non-empty polygon.
+
+    An empty ``polygon_points`` ([]) means the zone was seeded from a fixture
+    but never calibrated (no operator-drawn polygon, no shipped geometry).
+    In that state there is no real centroid — callers must treat the pin
+    position as unknown rather than invent the map centre.
+    """
+    return zone is not None and bool(zone.polygon_points)
+
+
 # ---------------------------------------------------------------------------
 # Lineup read
 # ---------------------------------------------------------------------------
@@ -97,10 +108,19 @@ class LineupRead(BaseModel):
     @computed_field  # type: ignore[misc]
     @property
     def effective_stand_x(self) -> Optional[float]:
-        """Minimap x for the stand pin: explicit anchor or stand_zone centroid."""
+        """Minimap x for the stand pin: explicit anchor or stand_zone centroid.
+
+        Returns None when there is neither an explicit anchor nor a zone with
+        a non-empty polygon. We deliberately do NOT fall back to the
+        polygon_centroid([]) → (0.5, 0.5) map-centre sentinel: a fabricated
+        dead-centre coordinate is indistinguishable from a real one on the
+        map, so it renders a misleading pin instead of signalling "position
+        unknown — calibrate this zone / pin this lineup". The frontend skips
+        null pins (see MapLineupPins).
+        """
         if self.stand_anchor_x is not None:
             return self.stand_anchor_x
-        if self.stand_zone is not None:
+        if _has_polygon(self.stand_zone):
             return polygon_centroid(self.stand_zone.polygon_points)[0]
         return None
 
@@ -109,17 +129,21 @@ class LineupRead(BaseModel):
     def effective_stand_y(self) -> Optional[float]:
         if self.stand_anchor_y is not None:
             return self.stand_anchor_y
-        if self.stand_zone is not None:
+        if _has_polygon(self.stand_zone):
             return polygon_centroid(self.stand_zone.polygon_points)[1]
         return None
 
     @computed_field  # type: ignore[misc]
     @property
     def effective_target_x(self) -> Optional[float]:
-        """Minimap x for the target pin: explicit anchor or target_zone centroid."""
+        """Minimap x for the target pin: explicit anchor or target_zone centroid.
+
+        Returns None when neither an explicit anchor nor a non-empty polygon
+        is available — see ``effective_stand_x`` for the rationale.
+        """
         if self.target_anchor_x is not None:
             return self.target_anchor_x
-        if self.target_zone is not None:
+        if _has_polygon(self.target_zone):
             return polygon_centroid(self.target_zone.polygon_points)[0]
         return None
 
@@ -128,7 +152,7 @@ class LineupRead(BaseModel):
     def effective_target_y(self) -> Optional[float]:
         if self.target_anchor_y is not None:
             return self.target_anchor_y
-        if self.target_zone is not None:
+        if _has_polygon(self.target_zone):
             return polygon_centroid(self.target_zone.polygon_points)[1]
         return None
 

--- a/apps/mygamingassistant/backend/app/services/game/lineup_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_service.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import uuid
 from datetime import timedelta
 from typing import Optional
+from urllib.parse import unquote, urlsplit
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -36,6 +37,7 @@ from app.schemas.game.lineup_schemas import (
     LineupCreate,
     LineupIngestCreate,
     LineupPatch,
+    LineupRead,
     PendingLineupsResponse,
     UploadUrlResponse,
 )
@@ -110,23 +112,68 @@ def _presigned_put(storage, key: str) -> str:
     )
 
 
-def _sign_screenshot_url(key: Optional[str]) -> Optional[str]:
-    """Return a presigned GET URL for *key*, or None if key is falsy."""
+def _object_key_from_value(value: str) -> str:
+    """Return the bare MinIO object key from a stored screenshot column value.
+
+    Normally *value* is already a bare key (``pending/<vid>/<n>-stand.png`` or
+    ``<user_id>/<lineup_id>/stand.png``) — the column's intended content.
+
+    A historical bug (fixed alongside migration 0007) persisted a *presigned
+    URL* into the key column: ``_sign_lineup`` assigned the signed URL back
+    onto the ORM instance, and mutating flows (accept/patch/create) committed
+    the request session, flushing that URL into the object-key column. Reads
+    then signed the URL *again*, producing a URL whose "key" was a URL-encoded
+    URL → 404 → broken image.
+
+    This peels every URL layer so signing always receives the real key. It is
+    idempotent for already-clean keys (returns them unchanged), so it doubles
+    as defense-in-depth even after the data-repair migration runs.
+    """
+    seen = 0
+    while value[:4].lower() == "http" and seen < 5:
+        parts = urlsplit(value)
+        if not parts.scheme or not parts.netloc:
+            break
+        # URL path is "/<bucket>/<key...>" — drop the leading bucket segment.
+        path = parts.path.lstrip("/")
+        _, _, key = path.partition("/")
+        value = unquote(key or path)
+        seen += 1
+    return value
+
+
+def _sign_screenshot_url(stored: Optional[str]) -> Optional[str]:
+    """Return a presigned GET URL for the screenshot, or None if unset.
+
+    Defensive: extracts the real object key first so a row whose column was
+    corrupted with a presigned URL still resolves (and never double-signs).
+    """
+    if not stored:
+        return None
+    key = _object_key_from_value(stored)
     if not key:
         return None
     storage = get_storage()
     return storage.generate_presigned_url(key, expires_in_seconds=_READ_URL_TTL)
 
 
-def _sign_lineup(lineup: Lineup) -> Lineup:
-    """Mutate lineup's screenshot URL fields to presigned GET URLs in-place.
+def _build_read(lineup: Lineup) -> LineupRead:
+    """Serialize an ORM ``Lineup`` to ``LineupRead`` with signed screenshot URLs.
 
-    The DB stores object keys (e.g. ``<user_id>/<lineup_id>/stand.png``).
-    Callers receive presigned URLs valid for 24 h.
+    CRITICAL: this never mutates the ORM instance. The previous implementation
+    assigned the signed URL back onto ``lineup.stand_screenshot_url`` /
+    ``.aim_screenshot_url``; because accept/patch/create commit the request
+    session, that persisted the presigned URL into the object-key column,
+    destroying the key and double-signing on every later read. Signing happens
+    on the Pydantic model only — the ORM column keeps the bare key.
     """
-    lineup.stand_screenshot_url = _sign_screenshot_url(lineup.stand_screenshot_url)
-    lineup.aim_screenshot_url = _sign_screenshot_url(lineup.aim_screenshot_url)
-    return lineup
+    read = LineupRead.model_validate(lineup)
+    return read.model_copy(
+        update={
+            "stand_screenshot_url": _sign_screenshot_url(read.stand_screenshot_url),
+            "aim_screenshot_url": _sign_screenshot_url(read.aim_screenshot_url),
+        }
+    )
 
 
 async def create(
@@ -134,7 +181,7 @@ async def create(
     user_id: uuid.UUID,
     payload: LineupCreate,
     lineup_id: Optional[uuid.UUID] = None,
-) -> Lineup:
+) -> LineupRead:
     """Create a lineup via the manual upload path.
 
     All classification fields are required. Status is always set to 'accepted'
@@ -169,7 +216,7 @@ async def create(
         data["id"] = lineup_id
 
     lineup = await create_lineup(db, data)
-    return _sign_lineup(lineup)
+    return _build_read(lineup)
 
 
 async def create_from_ingestion(
@@ -207,43 +254,43 @@ async def create_from_ingestion(
 async def get(
     db: AsyncSession,
     lineup_id: uuid.UUID,
-) -> Lineup | None:
+) -> LineupRead | None:
     lineup = await get_lineup(db, lineup_id)
     if lineup is None:
         return None
-    return _sign_lineup(lineup)
+    return _build_read(lineup)
 
 
 async def list_by_filters(
     db: AsyncSession,
     filters: LineupFilters,
-) -> list[Lineup]:
+) -> list[LineupRead]:
     lineups = await list_lineups(db, filters)
-    return [_sign_lineup(l) for l in lineups]
+    return [_build_read(l) for l in lineups]
 
 
 async def patch(
     db: AsyncSession,
     lineup_id: uuid.UUID,
     payload: LineupPatch,
-) -> Lineup | None:
+) -> LineupRead | None:
     lineup = await get_lineup(db, lineup_id)
     if lineup is None:
         return None
     patch_data = payload.model_dump(exclude_unset=True)
     updated = await update_lineup(db, lineup, patch_data)
-    return _sign_lineup(updated)
+    return _build_read(updated)
 
 
 async def hide(
     db: AsyncSession,
     lineup_id: uuid.UUID,
-) -> Lineup | None:
+) -> LineupRead | None:
     lineup = await get_lineup(db, lineup_id)
     if lineup is None:
         return None
     hidden = await hide_lineup(db, lineup)
-    return hidden
+    return _build_read(hidden)
 
 
 async def get_pending(
@@ -256,8 +303,6 @@ async def get_pending(
     game_id: Optional[uuid.UUID] = None,
 ) -> PendingLineupsResponse:
     """Return paginated pending_review lineups with presigned screenshot URLs."""
-    from app.schemas.game.lineup_schemas import LineupRead
-
     items, total = await list_pending_lineups(
         db,
         limit=limit,
@@ -266,9 +311,8 @@ async def get_pending(
         confidence_max=confidence_max,
         game_id=game_id,
     )
-    signed_items = [_sign_lineup(l) for l in items]
     return PendingLineupsResponse(
-        items=[LineupRead.model_validate(l) for l in signed_items],
+        items=[_build_read(l) for l in items],
         total=total,
         limit=limit,
         offset=offset,
@@ -279,7 +323,7 @@ async def accept(
     db: AsyncSession,
     lineup_id: uuid.UUID,
     body: LineupAcceptBody,
-) -> Lineup | None:
+) -> LineupRead | None:
     """Accept a pending lineup, applying optional overrides.
 
     Resolves suggested values as defaults, then applies overrides on top.
@@ -344,7 +388,7 @@ async def accept(
         overrides["setup_seconds"] = body.setup_seconds
 
     updated = await accept_lineup(db, lineup, overrides)
-    return _sign_lineup(updated)
+    return _build_read(updated)
 
 
 async def get_zone_density(

--- a/apps/mygamingassistant/backend/tests/test_alembic_chain.py
+++ b/apps/mygamingassistant/backend/tests/test_alembic_chain.py
@@ -1,0 +1,61 @@
+"""Regression tests for the alembic migration DAG.
+
+These run against the raw migration scripts (no live DB) so they fit the
+default pytest suite. They lock in that the chain resolves to a single head
+(currently ``0008``) and that every revision is reachable base → head — the
+class of bug where a new migration's ``down_revision`` is stale after a
+merge and silently orphans the chain.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+BACKEND_DIR = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def script_directory() -> ScriptDirectory:
+    cfg = Config(str(BACKEND_DIR / "alembic.ini"))
+    cfg.set_main_option("script_location", str(BACKEND_DIR / "alembic"))
+    return ScriptDirectory.from_config(cfg)
+
+
+def test_single_head_is_0008(script_directory: ScriptDirectory) -> None:
+    """The DAG must resolve to exactly one head and it must be 0008."""
+    heads = script_directory.get_heads()
+    assert len(heads) == 1, (
+        f"Expected a single alembic head, got {len(heads)}: {heads}. "
+        "Orphan heads usually mean a migration's down_revision is stale "
+        "after a merge — rebase and re-point the down_revision."
+    )
+    assert heads[0] == "0008", (
+        f"Expected head 0008 (the CS2 polygon backfill), got {heads[0]}."
+    )
+
+
+def test_full_walk_from_base_reaches_head(
+    script_directory: ScriptDirectory,
+) -> None:
+    """Every revision must be reachable by walking from base → head."""
+    heads = script_directory.get_heads()
+    assert heads, "No alembic heads found"
+    head = heads[0]
+    walked = {rev.revision for rev in script_directory.walk_revisions("base", head)}
+    all_revs = {rev.revision for rev in script_directory.walk_revisions()}
+    missing = all_revs - walked
+    assert not missing, (
+        f"Revisions not reachable from base→head: {sorted(missing)}. "
+        "Likely caused by a stale down_revision pointer."
+    )
+
+
+def test_0008_down_revision_points_at_0007(
+    script_directory: ScriptDirectory,
+) -> None:
+    """0008 must chain directly off 0007 (the screenshot-key repair)."""
+    rev = script_directory.get_revision("0008")
+    assert rev.down_revision == "0007"

--- a/apps/mygamingassistant/backend/tests/test_effective_anchor_resolution.py
+++ b/apps/mygamingassistant/backend/tests/test_effective_anchor_resolution.py
@@ -1,0 +1,101 @@
+"""Tests for LineupRead.effective_* resolution (Issue #2 correctness fix).
+
+The pin-position contract:
+  - explicit anchor set        → effective_* == anchor
+  - no anchor, non-empty zone  → effective_* == polygon centroid
+  - no anchor, empty/no zone   → effective_* is None (NOT the (0.5, 0.5)
+    dead-centre sentinel — a fabricated centre pin is indistinguishable
+    from a real one; None lets the frontend skip it and surface the
+    "needs calibration" hint instead).
+
+These are pure-schema tests — they build ``LineupRead`` directly so the
+``@computed_field`` properties are exercised without a DB round-trip.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.schemas.game.lineup_schemas import LineupRead, ZoneRead
+
+SQUARE = [
+    {"x": 0.1, "y": 0.2},
+    {"x": 0.3, "y": 0.2},
+    {"x": 0.3, "y": 0.4},
+    {"x": 0.1, "y": 0.4},
+]  # centroid == (0.2, 0.3)
+
+
+def _zone(polygon: list[dict]) -> ZoneRead:
+    return ZoneRead(
+        id=uuid.uuid4(), slug="z", name="Z", polygon_points=polygon
+    )
+
+
+def _lineup(**kw) -> LineupRead:
+    base = dict(
+        id=uuid.uuid4(),
+        title="t",
+        status="accepted",
+    )
+    base.update(kw)
+    return LineupRead(**base)
+
+
+def test_effective_none_when_polygon_empty_and_no_anchor():
+    """Empty polygon + no anchor → None for every effective_* field."""
+    lr = _lineup(
+        stand_zone=_zone([]),
+        target_zone=_zone([]),
+    )
+    assert lr.effective_stand_x is None
+    assert lr.effective_stand_y is None
+    assert lr.effective_target_x is None
+    assert lr.effective_target_y is None
+
+
+def test_effective_none_when_zone_absent_and_no_anchor():
+    """No zone at all + no anchor → None (not the centre sentinel)."""
+    lr = _lineup(stand_zone=None, target_zone=None)
+    assert lr.effective_stand_x is None
+    assert lr.effective_target_y is None
+
+
+def test_effective_is_centroid_when_polygon_non_empty():
+    """Non-empty polygon, no anchor → the geometric centroid."""
+    lr = _lineup(
+        stand_zone=_zone(SQUARE),
+        target_zone=_zone(SQUARE),
+    )
+    assert lr.effective_stand_x == pytest.approx(0.2)
+    assert lr.effective_stand_y == pytest.approx(0.3)
+    assert lr.effective_target_x == pytest.approx(0.2)
+    assert lr.effective_target_y == pytest.approx(0.3)
+
+
+def test_effective_is_explicit_anchor_when_set():
+    """An explicit anchor wins over the polygon centroid."""
+    lr = _lineup(
+        stand_anchor_x=0.66,
+        stand_anchor_y=0.77,
+        target_anchor_x=0.11,
+        target_anchor_y=0.22,
+        stand_zone=_zone(SQUARE),
+        target_zone=_zone(SQUARE),
+    )
+    assert lr.effective_stand_x == pytest.approx(0.66)
+    assert lr.effective_stand_y == pytest.approx(0.77)
+    assert lr.effective_target_x == pytest.approx(0.11)
+    assert lr.effective_target_y == pytest.approx(0.22)
+
+
+def test_explicit_anchor_resolves_even_when_polygon_empty():
+    """Anchor set but polygon empty → anchor still wins (not None)."""
+    lr = _lineup(
+        stand_anchor_x=0.4,
+        stand_anchor_y=0.5,
+        stand_zone=_zone([]),
+    )
+    assert lr.effective_stand_x == pytest.approx(0.4)
+    assert lr.effective_stand_y == pytest.approx(0.5)

--- a/apps/mygamingassistant/backend/tests/test_screenshot_signing.py
+++ b/apps/mygamingassistant/backend/tests/test_screenshot_signing.py
@@ -1,0 +1,189 @@
+"""Tests for the screenshot double-signing fix (Issue #1).
+
+Two concerns:
+
+1. ``_object_key_from_value`` — pure idempotency guard. A clean bare key is
+   returned unchanged; a single-signed presigned URL peels back to the bare
+   key; a double-encoded URL (URL whose object key is itself a URL-encoded
+   URL — the exact corruption the bug produced) also peels to the bare key.
+
+2. Signing must NEVER mutate the ORM column. ``_build_read`` signs on the
+   ``LineupRead`` Pydantic model only. After ``lineup_service.get`` /
+   ``accept`` (the latter commits the request session), re-querying the row
+   must show ``stand_screenshot_url`` still holding the bare object key, not
+   a presigned URL — the regression that corrupted the column.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from urllib.parse import quote
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.game import Game
+from app.models.game.lineup import Lineup
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.models.game.utility_type import UtilityType
+from app.schemas.game.lineup_schemas import LineupAcceptBody
+from app.services.game import lineup_service
+from app.services.game.lineup_service import _object_key_from_value
+
+BUCKET = settings.minio_bucket
+
+
+# ---------------------------------------------------------------------------
+# _object_key_from_value — idempotency / peel
+# ---------------------------------------------------------------------------
+
+def test_clean_bare_key_unchanged():
+    """A bare object key must pass through untouched (idempotent)."""
+    key = "user-123/lineup-456/stand.png"
+    assert _object_key_from_value(key) == key
+
+
+def test_clean_pending_key_unchanged():
+    """The ingestion-path key shape is also bare and must be untouched."""
+    key = "pending/dQw4w9WgXcQ/3-stand.png"
+    assert _object_key_from_value(key) == key
+
+
+def test_single_signed_url_peels_to_bare_key():
+    """A presigned GET URL must reduce to its bare object key."""
+    key = "user-123/lineup-456/stand.png"
+    signed = (
+        f"https://minio.example.com/{BUCKET}/{key}"
+        "?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Expires=86400&X-Amz-Signature=abc"
+    )
+    assert _object_key_from_value(signed) == key
+
+
+def test_double_encoded_url_peels_to_bare_key():
+    """The exact corruption shape: a URL whose object key is a URL-encoded URL.
+
+    The bug signed the column, persisted the URL into the key column, then
+    signed *that* — producing a URL whose path segment is the percent-encoded
+    earlier presigned URL. Peeling must recover the original bare key.
+    """
+    key = "user-123/lineup-456/stand.png"
+    inner = f"https://minio.example.com/{BUCKET}/{key}?X-Amz-Signature=inner"
+    outer = (
+        f"https://minio.example.com/{BUCKET}/{quote(inner, safe='')}"
+        "?X-Amz-Signature=outer"
+    )
+    assert _object_key_from_value(outer) == key
+
+
+# ---------------------------------------------------------------------------
+# Signing must not mutate the ORM column
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _mock_storage():
+    mock = MagicMock()
+    mock.bucket = BUCKET
+    mock.generate_presigned_url.return_value = (
+        "https://minio.example.com/bucket/signed-read-url?X-Amz-Signature=z"
+    )
+    with patch(
+        "app.services.game.lineup_service.get_storage", return_value=mock
+    ):
+        yield mock
+
+
+@pytest_asyncio.fixture
+async def seeded(db: AsyncSession) -> dict:
+    game = Game(slug="sign-game", name="Sign Game", side_a_label="T", side_b_label="CT")
+    db.add(game)
+    await db.flush()
+    map_obj = Map(game_id=game.id, slug="sign-map", name="Sign Map")
+    db.add(map_obj)
+    await db.flush()
+    zone_t = MapZone(map_id=map_obj.id, slug="t", name="T", polygon_points=[])
+    zone_s = MapZone(map_id=map_obj.id, slug="s", name="S", polygon_points=[])
+    db.add_all([zone_t, zone_s])
+    await db.flush()
+    util = UtilityType(game_id=game.id, slug="smoke", name="Smoke")
+    db.add(util)
+    await db.flush()
+    return {"game": game, "map": map_obj, "zt": zone_t, "zs": zone_s, "util": util}
+
+
+BARE_STAND = "u-1/l-1/stand.png"
+BARE_AIM = "u-1/l-1/aim.png"
+
+
+@pytest.mark.asyncio
+async def test_get_does_not_mutate_orm_key_column(db: AsyncSession, seeded: dict):
+    """lineup_service.get returns a signed URL but leaves the column bare."""
+    lineup = Lineup(
+        game_id=seeded["game"].id,
+        map_id=seeded["map"].id,
+        target_zone_id=seeded["zt"].id,
+        stand_zone_id=seeded["zs"].id,
+        side="side_a",
+        utility_type_id=seeded["util"].id,
+        title="signing test",
+        status="accepted",
+        stand_screenshot_url=BARE_STAND,
+        aim_screenshot_url=BARE_AIM,
+    )
+    db.add(lineup)
+    await db.flush()
+    lineup_id = lineup.id
+
+    read = await lineup_service.get(db, lineup_id)
+    assert read is not None
+    # The Pydantic model carries the SIGNED url for the browser...
+    assert read.stand_screenshot_url.startswith("http")
+
+    # ...but the ORM column must still hold the BARE key.
+    db.expire_all()
+    row = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert row.stand_screenshot_url == BARE_STAND
+    assert row.aim_screenshot_url == BARE_AIM
+
+
+@pytest.mark.asyncio
+async def test_accept_does_not_corrupt_orm_key_column(db: AsyncSession, seeded: dict):
+    """accept() commits the session — the column must remain a bare key.
+
+    This is the exact flow the original bug corrupted: accept persists the
+    session, so any signing-time mutation of the ORM instance would be
+    flushed into the object-key column.
+    """
+    lineup = Lineup(
+        game_id=seeded["game"].id,
+        map_id=seeded["map"].id,
+        title="accept signing test",
+        status="pending_review",
+        stand_screenshot_url=BARE_STAND,
+        aim_screenshot_url=BARE_AIM,
+        suggested_target_zone_id=seeded["zt"].id,
+        suggested_stand_zone_id=seeded["zs"].id,
+        suggested_side="side_a",
+        suggested_utility_type_id=seeded["util"].id,
+    )
+    db.add(lineup)
+    await db.flush()
+    lineup_id = lineup.id
+
+    read = await lineup_service.accept(db, lineup_id, LineupAcceptBody())
+    assert read is not None
+    assert read.status == "accepted"
+    assert read.stand_screenshot_url.startswith("http")
+
+    db.expire_all()
+    row = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    # Column unchanged — the bare key, not a presigned URL.
+    assert row.stand_screenshot_url == BARE_STAND
+    assert row.aim_screenshot_url == BARE_AIM
+    assert not row.stand_screenshot_url.startswith("http")

--- a/apps/mygamingassistant/backend/tests/test_upsert_map_zone_backfill.py
+++ b/apps/mygamingassistant/backend/tests/test_upsert_map_zone_backfill.py
@@ -1,0 +1,125 @@
+"""Tests for game_repo.upsert_map_zone backfill behavior (Task 6).
+
+upsert_map_zone is the idempotent zone loader. The backfill rule:
+
+  - zone missing                         → insert with the fixture polygon
+  - zone exists, polygon EMPTY, fixture
+    provides a non-empty polygon         → backfill the existing row
+  - zone exists, polygon NON-EMPTY       → NEVER overwrite (protects
+    operator-drawn polygons / the #656 editor) — even if the fixture has
+    a different polygon
+  - re-running once populated            → no-op (idempotent)
+"""
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.game import Game
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.repositories.game import game_repo
+
+POLY_A = [{"x": 0.1, "y": 0.1}, {"x": 0.2, "y": 0.1}, {"x": 0.2, "y": 0.2}]
+POLY_B = [{"x": 0.8, "y": 0.8}, {"x": 0.9, "y": 0.8}, {"x": 0.9, "y": 0.9}]
+
+
+@pytest_asyncio.fixture
+async def map_obj(db: AsyncSession) -> Map:
+    game = Game(slug="bf-game", name="BF", side_a_label="T", side_b_label="CT")
+    db.add(game)
+    await db.flush()
+    m = Map(game_id=game.id, slug="bf-map", name="BF Map")
+    db.add(m)
+    await db.flush()
+    return m
+
+
+async def _reload(db: AsyncSession, zone_id) -> MapZone:
+    db.expire_all()
+    return (
+        await db.execute(select(MapZone).where(MapZone.id == zone_id))
+    ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_inserts_when_zone_missing(db: AsyncSession, map_obj: Map):
+    zone = await game_repo.upsert_map_zone(
+        db, map_id=map_obj.id, slug="a", name="A", polygon_points=POLY_A
+    )
+    fresh = await _reload(db, zone.id)
+    assert fresh.polygon_points == POLY_A
+
+
+@pytest.mark.asyncio
+async def test_backfills_empty_existing_polygon(db: AsyncSession, map_obj: Map):
+    """Existing zone with [] polygon gets the fixture polygon written in."""
+    existing = MapZone(map_id=map_obj.id, slug="a", name="A", polygon_points=[])
+    db.add(existing)
+    await db.flush()
+    zone_id = existing.id
+
+    result = await game_repo.upsert_map_zone(
+        db, map_id=map_obj.id, slug="a", name="A", polygon_points=POLY_A
+    )
+    assert result.id == zone_id  # same row, not a new insert
+    fresh = await _reload(db, zone_id)
+    assert fresh.polygon_points == POLY_A
+
+
+@pytest.mark.asyncio
+async def test_never_overwrites_non_empty_polygon(db: AsyncSession, map_obj: Map):
+    """An operator-drawn (non-empty) polygon must survive a fixture re-load."""
+    existing = MapZone(
+        map_id=map_obj.id, slug="a", name="A", polygon_points=POLY_A
+    )
+    db.add(existing)
+    await db.flush()
+    zone_id = existing.id
+
+    # Fixture provides a DIFFERENT polygon — must be ignored.
+    result = await game_repo.upsert_map_zone(
+        db, map_id=map_obj.id, slug="a", name="A", polygon_points=POLY_B
+    )
+    assert result.id == zone_id
+    fresh = await _reload(db, zone_id)
+    assert fresh.polygon_points == POLY_A  # unchanged
+
+
+@pytest.mark.asyncio
+async def test_backfill_is_idempotent(db: AsyncSession, map_obj: Map):
+    """Running the backfill twice produces the same result and no clobber."""
+    existing = MapZone(map_id=map_obj.id, slug="a", name="A", polygon_points=[])
+    db.add(existing)
+    await db.flush()
+    zone_id = existing.id
+
+    await game_repo.upsert_map_zone(
+        db, map_id=map_obj.id, slug="a", name="A", polygon_points=POLY_A
+    )
+    # Second run with the SAME fixture — polygon already populated, no-op.
+    await game_repo.upsert_map_zone(
+        db, map_id=map_obj.id, slug="a", name="A", polygon_points=POLY_A
+    )
+    fresh = await _reload(db, zone_id)
+    assert fresh.polygon_points == POLY_A
+
+
+@pytest.mark.asyncio
+async def test_empty_fixture_does_not_touch_empty_zone(
+    db: AsyncSession, map_obj: Map
+):
+    """An empty incoming polygon must not 'backfill' anything."""
+    existing = MapZone(map_id=map_obj.id, slug="a", name="A", polygon_points=[])
+    db.add(existing)
+    await db.flush()
+    zone_id = existing.id
+
+    result = await game_repo.upsert_map_zone(
+        db, map_id=map_obj.id, slug="a", name="A", polygon_points=[]
+    )
+    assert result.id == zone_id
+    fresh = await _reload(db, zone_id)
+    assert fresh.polygon_points == []

--- a/apps/mygamingassistant/frontend/src/__tests__/UnplaceableLineupsNotice.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/UnplaceableLineupsNotice.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * UnplaceableLineupsNotice — the non-blocking MapPage hint shown when every
+ * lineup for the current filter lacks a resolvable map position (Task 7).
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import UnplaceableLineupsNotice from "@/components/lineup/UnplaceableLineupsNotice";
+
+describe("UnplaceableLineupsNotice", () => {
+  it("renders a status role so it is announced but non-blocking", () => {
+    render(<UnplaceableLineupsNotice count={3} />);
+    expect(screen.getByRole("status")).toBeDefined();
+  });
+
+  it("pluralizes the count for multiple lineups", () => {
+    render(<UnplaceableLineupsNotice count={3} />);
+    expect(
+      screen.getByText(/3 lineups can't be shown on the map yet/i),
+    ).toBeDefined();
+  });
+
+  it("uses the singular form for a single lineup", () => {
+    render(<UnplaceableLineupsNotice count={1} />);
+    expect(
+      screen.getByText(/1 lineup can't be shown on the map yet/i),
+    ).toBeDefined();
+    expect(screen.queryByText(/1 lineups/i)).toBeNull();
+  });
+
+  it("points the operator at calibration (Review / zone editor)", () => {
+    render(<UnplaceableLineupsNotice count={2} />);
+    expect(screen.getByText(/need calibration/i)).toBeDefined();
+    expect(screen.getByText(/Review or the\s+zone editor/i)).toBeDefined();
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
@@ -1,0 +1,112 @@
+/**
+ * countUnplaceableLineups — drives the MapPage "can't be shown on the map
+ * yet" hint (Task 7). A lineup is unplaceable when neither its stand nor its
+ * target endpoint resolved (no explicit anchor AND the referenced zone has
+ * no polygon to take a centroid from).
+ *
+ * Mode semantics mirror MapLineupPins:
+ *   - "stand"  → unplaceable when the stand endpoint is missing
+ *   - "target" → unplaceable when the target endpoint is missing
+ *   - "both"   → unplaceable only when BOTH endpoints are missing
+ */
+import { describe, expect, it } from "vitest";
+import { countUnplaceableLineups } from "@/components/lineup/MapLineupPins";
+import type { Lineup } from "@/types/game";
+
+function makeLineup(overrides: Partial<Lineup>): Lineup {
+  return {
+    id: "default-id",
+    game_id: "g",
+    map_id: "m",
+    target_zone_id: "z",
+    stand_zone_id: "z",
+    side: "side_a",
+    utility_type_id: "u",
+    title: "lineup",
+    notes: null,
+    stand_screenshot_url: null,
+    aim_screenshot_url: null,
+    aim_anchor_x: null,
+    aim_anchor_y: null,
+    stand_anchor_x: null,
+    stand_anchor_y: null,
+    target_anchor_x: null,
+    target_anchor_y: null,
+    effective_stand_x: null,
+    effective_stand_y: null,
+    effective_target_x: null,
+    effective_target_y: null,
+    setup_seconds: null,
+    attribution_url: null,
+    attribution_author: null,
+    status: "accepted",
+    youtube_video_id: null,
+    chapter_start_seconds: null,
+    chapter_title: null,
+    suggested_game_id: null,
+    suggested_map_id: null,
+    suggested_target_zone_id: null,
+    suggested_stand_zone_id: null,
+    suggested_side: null,
+    suggested_utility_type_id: null,
+    classification_confidence: null,
+    classification_reasoning: null,
+    target_zone: null,
+    stand_zone: null,
+    utility_type: null,
+    ...overrides,
+  };
+}
+
+describe("countUnplaceableLineups", () => {
+  it("counts a lineup with no coords at all as unplaceable in every mode", () => {
+    const lineups = [makeLineup({ id: "a" })];
+    expect(countUnplaceableLineups(lineups, "stand")).toBe(1);
+    expect(countUnplaceableLineups(lineups, "target")).toBe(1);
+    expect(countUnplaceableLineups(lineups, "both")).toBe(1);
+  });
+
+  it("counts zero when every lineup resolves", () => {
+    const lineups = [
+      makeLineup({
+        id: "a",
+        effective_stand_x: 0.2,
+        effective_stand_y: 0.3,
+        effective_target_x: 0.7,
+        effective_target_y: 0.8,
+      }),
+    ];
+    expect(countUnplaceableLineups(lineups, "both")).toBe(0);
+    expect(countUnplaceableLineups(lineups, "stand")).toBe(0);
+    expect(countUnplaceableLineups(lineups, "target")).toBe(0);
+  });
+
+  it("in 'both' mode a lineup with only a stand endpoint is placeable", () => {
+    const lineups = [
+      makeLineup({ id: "a", effective_stand_x: 0.5, effective_stand_y: 0.5 }),
+    ];
+    expect(countUnplaceableLineups(lineups, "both")).toBe(0);
+    // ...but in target mode that same lineup is unplaceable.
+    expect(countUnplaceableLineups(lineups, "target")).toBe(1);
+  });
+
+  it("treats a half-set endpoint (x but no y) as missing", () => {
+    const lineups = [
+      makeLineup({ id: "a", effective_stand_x: 0.5, effective_stand_y: null }),
+    ];
+    expect(countUnplaceableLineups(lineups, "stand")).toBe(1);
+  });
+
+  it("counts only the unplaceable subset across a mixed list", () => {
+    const lineups = [
+      makeLineup({ id: "ok", effective_stand_x: 0.1, effective_stand_y: 0.1 }),
+      makeLineup({ id: "bad-1" }),
+      makeLineup({ id: "bad-2" }),
+    ];
+    expect(countUnplaceableLineups(lineups, "stand")).toBe(2);
+  });
+
+  it("returns 0 for an empty list", () => {
+    expect(countUnplaceableLineups([], "both")).toBe(0);
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/lineup/MapLineupPins.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/MapLineupPins.tsx
@@ -55,6 +55,26 @@ interface Cluster {
   pins: Pin[];
 }
 
+/** True when this lineup has no place on the map for the given mode. */
+function isUnplaceable(l: Lineup, mode: PinMode): boolean {
+  const standMissing = l.effective_stand_x == null || l.effective_stand_y == null;
+  const targetMissing = l.effective_target_x == null || l.effective_target_y == null;
+  if (mode === "stand") return standMissing;
+  if (mode === "target") return targetMissing;
+  // "both" — placeable if EITHER endpoint resolves.
+  return standMissing && targetMissing;
+}
+
+/**
+ * Count lineups that exist but can't be shown on the map because neither
+ * their stand nor target endpoint resolved (no explicit anchor AND the
+ * referenced zone has no polygon to take a centroid from). Used by MapPage
+ * to surface a non-blocking calibration hint.
+ */
+export function countUnplaceableLineups(lineups: Lineup[], mode: PinMode): number {
+  return lineups.reduce((acc, l) => acc + (isUnplaceable(l, mode) ? 1 : 0), 0);
+}
+
 function buildPins(
   lineups: Lineup[],
   mode: PinMode,

--- a/apps/mygamingassistant/frontend/src/components/lineup/UnplaceableLineupsNotice.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/UnplaceableLineupsNotice.tsx
@@ -1,0 +1,40 @@
+/**
+ * UnplaceableLineupsNotice — non-blocking hint shown on MapPage when every
+ * lineup for the current filter lacks a resolvable map position (no explicit
+ * anchor AND the referenced zone has no polygon to take a centroid from).
+ *
+ * The notice never blocks interaction — the results panel still lists the
+ * lineups; only the map pin is unavailable. It points the operator at the
+ * Review queue / zone editor to calibrate the affected zones.
+ */
+import { AlertTriangle } from "lucide-react";
+
+interface UnplaceableLineupsNoticeProps {
+  count: number;
+}
+
+export default function UnplaceableLineupsNotice({
+  count,
+}: UnplaceableLineupsNoticeProps) {
+  const plural = count !== 1 ? "s" : "";
+  return (
+    <div
+      className="flex items-start gap-2.5 px-3 py-2.5 rounded-md border bg-amber-500/10 border-amber-500/30 text-sm"
+      role="status"
+    >
+      <AlertTriangle
+        className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
+        aria-hidden
+      />
+      <div className="flex-1">
+        <p className="font-medium">
+          {count} lineup{plural} can't be shown on the map yet
+        </p>
+        <p className="text-xs text-muted-foreground">
+          These zones need calibration — open the lineups in Review or the
+          zone editor to set their map position.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -25,7 +25,10 @@ import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
 import { useGetLineupPackagesQuery, usePinAllLineupPackageMutation } from "@/store/lineupPackagesApi";
 import LineupCard from "@/components/lineup/LineupCard";
 import MapZoneOverlay from "@/components/lineup/MapZoneOverlay";
-import MapLineupPins, { type PinMode } from "@/components/lineup/MapLineupPins";
+import MapLineupPins, {
+  type PinMode,
+  countUnplaceableLineups,
+} from "@/components/lineup/MapLineupPins";
 import PinModeToggle from "@/components/lineup/PinModeToggle";
 import LineupDetailPanel from "@/components/lineup/LineupDetailPanel";
 import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
@@ -159,6 +162,21 @@ export default function MapPage() {
   );
 
   const pinnedLineups = allMapLineups.filter((l) => pins.isPinned(l.id));
+
+  // Unplaceable hint: lineups exist for the current filter but every one
+  // lacks a resolvable map position (no explicit anchor AND the referenced
+  // zone has no polygon). The hint is non-blocking — the results panel still
+  // lists the lineups; only the map pin is unavailable. Use the lineup set
+  // that drives the current view: the map-wide set when pins are on, the
+  // zone-filtered set otherwise.
+  const unplaceableSource = pinMode !== null ? allMapLineups : lineups;
+  const unplaceablePinMode: PinMode = pinMode ?? "both";
+  const unplaceableCount =
+    unplaceableSource.length > 0
+      ? countUnplaceableLineups(unplaceableSource, unplaceablePinMode)
+      : 0;
+  const allUnplaceable =
+    unplaceableSource.length > 0 && unplaceableCount === unplaceableSource.length;
 
   // Reset active card index when round mode is entered or pin count changes.
   // Using MessageChannel to schedule asynchronously, avoiding the
@@ -512,6 +530,10 @@ export default function MapPage() {
             </div>
           </div>
 
+          {allUnplaceable && (
+            <UnplaceableLineupsNotice count={unplaceableCount} />
+          )}
+
           {/* Map + results layout */}
           <div className="flex flex-col lg:flex-row gap-4">
             {/* Map minimap with zone overlay */}
@@ -733,6 +755,34 @@ function StorageUnavailableBanner({ onClose }: { onClose: () => void }) {
       >
         ✕
       </button>
+    </div>
+  );
+}
+
+interface UnplaceableLineupsNoticeProps {
+  count: number;
+}
+
+function UnplaceableLineupsNotice({ count }: UnplaceableLineupsNoticeProps) {
+  const plural = count !== 1 ? "s" : "";
+  return (
+    <div
+      className="flex items-start gap-2.5 px-3 py-2.5 rounded-md border bg-amber-500/10 border-amber-500/30 text-sm"
+      role="status"
+    >
+      <AlertTriangle
+        className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
+        aria-hidden
+      />
+      <div className="flex-1">
+        <p className="font-medium">
+          {count} lineup{plural} can't be shown on the map yet
+        </p>
+        <p className="text-xs text-muted-foreground">
+          These zones need calibration — open the lineups in Review or the
+          zone editor to set their map position.
+        </p>
+      </div>
     </div>
   );
 }

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -31,6 +31,7 @@ import MapLineupPins, {
 } from "@/components/lineup/MapLineupPins";
 import PinModeToggle from "@/components/lineup/PinModeToggle";
 import LineupDetailPanel from "@/components/lineup/LineupDetailPanel";
+import UnplaceableLineupsNotice from "@/components/lineup/UnplaceableLineupsNotice";
 import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
 import MinimapUploadDialog from "@/components/game/MinimapUploadDialog";
 import RoundMode from "@/pages/RoundMode";
@@ -755,34 +756,6 @@ function StorageUnavailableBanner({ onClose }: { onClose: () => void }) {
       >
         ✕
       </button>
-    </div>
-  );
-}
-
-interface UnplaceableLineupsNoticeProps {
-  count: number;
-}
-
-function UnplaceableLineupsNotice({ count }: UnplaceableLineupsNoticeProps) {
-  const plural = count !== 1 ? "s" : "";
-  return (
-    <div
-      className="flex items-start gap-2.5 px-3 py-2.5 rounded-md border bg-amber-500/10 border-amber-500/30 text-sm"
-      role="status"
-    >
-      <AlertTriangle
-        className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
-        aria-hidden
-      />
-      <div className="flex-1">
-        <p className="font-medium">
-          {count} lineup{plural} can't be shown on the map yet
-        </p>
-        <p className="text-xs text-muted-foreground">
-          These zones need calibration — open the lineups in Review or the
-          zone editor to set their map position.
-        </p>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
Fixes two MGA bugs reported together: lineup screenshots returning 404 in the detail panel, and every lineup pin landing dead-center on the minimap.

## Issue #1 — Lineup screenshots broken (404 in detail panel)

**Root cause:** The old `_sign_lineup` assigned the presigned GET URL back onto the ORM instance's `stand_screenshot_url` / `aim_screenshot_url` attributes. The accept / bulk-accept / hide flows commit the request session, so that mutation flushed into the **object-key column**, replacing the bare key with a full presigned URL. Every later read then signed that URL *again*, producing a URL whose S3 object key was a URL-encoded URL — 404 — broken `<img>`.

**Fix (already in 5bee5c9):**
- `_build_read` signs on the `LineupRead` Pydantic model only — it never mutates the ORM instance. Routes in `app/api/lineups.py` return the service `LineupRead` directly.
- `_object_key_from_value` idempotency guard peels any presigned-URL layers back to the bare key (defense-in-depth even after the data repair).
- **Migration `0007`** is a data-repair: it peels every URL layer in already-corrupted rows back to the bare object key so signing on read resolves the real object again. Idempotent (bare keys never start with `http`); downgrade is a documented no-op.

**Tests (this PR):** `_object_key_from_value` clean-key / single-signed / double-encoded; signing does NOT mutate the ORM column (re-query after `get` and `accept` — `accept` commits the session, the exact flow that corrupted the column — and assert the key column is still bare).

## Issue #2 — Pins dead-center on the minimap

**Root cause:** `polygon_centroid([])` returned the `(0.5, 0.5)` map-centre sentinel, and `LineupRead.effective_*` fell back to it whenever a zone had no polygon and no explicit anchor. A fabricated dead-centre coordinate is indistinguishable from a real one, so every uncalibrated lineup rendered a misleading pin in the map centre.

**Correctness fix (already in 5bee5c9):** `LineupRead.effective_*` now returns `None` (via `_has_polygon` in `lineup_schemas.py`) when there is neither an explicit anchor nor a non-empty polygon. The frontend already skips null pins.

**Seed polygons (677655c):** All **62 CS2 zones** across 8 maps now carry approximate polygons in `cs2_maps.json` (re-runnable generator `_apply_cs2_polygons.py` kept for provenance). **These coords are eyeballed from radar thumbnails** — bombsites/spawns are well-anchored to the in-game orange/green markers; connectors/mid centroids land in the correct callout region but edges are approximate and meant to be refined via the #656 operator zone editor.

**Backfill (`0008`, this PR):** `load_fixtures` is CLI-only and never runs in the app lifespan, so a deployed DB would keep null pins forever. `upsert_map_zone` now backfills `polygon_points` when the existing zone is empty AND the fixture provides a non-empty polygon (a non-empty existing polygon is **never** overwritten — protects operator-drawn polygons / the #656 editor). Migration `0008` does the same for existing DBs: walks `cs2_maps.json` and writes the polygon onto every CS2 zone whose stored polygon is NULL/`[]`. Conservative + idempotent; downgrade is a documented no-op. Single alembic head `0008`.

**Frontend hint (this PR):** When every lineup for the current filter is unplaceable (no anchor, no zone polygon), MapPage shows a non-blocking amber notice — "N lineups can't be shown on the map yet — these zones need calibration; open them in Review or the zone editor." The results panel still lists the lineups; only the map pin is unavailable.

## Test results

- Backend: **274 passed** (+19 new), 7 pre-existing unrelated errors in `test_classifier_service.py` (documented `ix_game_slug` test-isolation issue, not introduced here, out of scope).
- Frontend: **274 passed** (22 files), `npm run build` green (TypeScript clean).

## Operational migration

Migrations `0007` (repairs corrupted screenshot keys) and `0008` (backfills CS2 zone polygons) apply automatically via `alembic upgrade head` on the normal deploy. **No manual VPS or env step is required** — both are idempotent data migrations with documented no-op downgrades.

Recovery if a deploy migration step fails: check `alembic current` against `alembic heads` (expected single head `0008`); both migrations are safe to re-run (idempotent).

## Follow-ups (not blocking)

- CS2 connector/mid polygon edges are approximate seed data — refine via the #656 operator zone editor as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
