### PR TITLE
fix(mga): persist PATCH /lineups edits + relocate commits to service

### DIFF
--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -56,7 +56,6 @@ from app.schemas.game.lineup_schemas import (
     PendingLineupsResponse,
     UploadUrlResponse,
 )
-from app.services.classification.classifier_service import classify_lineup
 from app.services.game import lineup_service
 
 logger = logging.getLogger(__name__)
@@ -370,11 +369,10 @@ async def reclassify_lineup(
     """Re-run the Claude classifier on a lineup.
 
     Updates the suggested_* fields on the lineup row without accepting.
-    Returns the new suggestions directly.
+    Returns the new suggestions directly. Persistence (commit) is owned by
+    the service/repo layer — this route performs no DB transaction calls.
     """
-    result = await classify_lineup(db, lineup_id)
-    if result.success:
-        await db.commit()
+    result = await lineup_service.reclassify(db, lineup_id)
     return ClassifyResponse(
         lineup_id=lineup_id,
         success=result.success,
@@ -410,7 +408,6 @@ async def accept_lineup(
         raise HTTPException(status_code=422, detail=str(exc))
     if lineup is None:
         raise HTTPException(status_code=404, detail="Lineup not found")
-    await db.commit()
     return lineup
 
 
@@ -423,7 +420,6 @@ async def hide_pending_lineup(
     hidden = await lineup_service.hide(db, lineup_id)
     if hidden is None:
         raise HTTPException(status_code=404, detail="Lineup not found")
-    await db.commit()
     return hidden
 
 
@@ -435,8 +431,14 @@ async def bulk_accept_lineups(
     """Accept multiple pending lineups in a single request.
 
     Processes each lineup individually; failures on individual lineups are
-    returned as 207 partial success (accepted ones are in the response list).
-    Currently returns only successfully accepted lineups.
+    skipped (logged) and do NOT abort the batch. Returns only the
+    successfully accepted lineups.
+
+    Partial-success durability: ``lineup_service.accept`` → the repo's
+    ``accept_lineup`` owns a per-lineup commit/rollback. A failing lineup's
+    rollback discards only its own uncommitted unit — lineups committed by
+    earlier loop iterations are already durable in PostgreSQL and survive.
+    The route performs no DB transaction calls of its own.
     """
     accepted: list[LineupRead] = []
     for lid in body.lineup_ids:
@@ -444,11 +446,9 @@ async def bulk_accept_lineups(
         try:
             lineup = await lineup_service.accept(db, lid, patch)
             if lineup is not None:
-                await db.commit()
                 accepted.append(lineup)
         except Exception as exc:
             logger.warning(
                 "bulk_accept: skipping lineup_id=%s error=%s", lid, str(exc)
             )
-            await db.rollback()
     return accepted

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -53,16 +53,16 @@ def _apply_filters(stmt: "Select[tuple[Lineup]]", f: LineupFilters) -> "Select[t
     return stmt
 
 
-async def create_lineup(db: AsyncSession, data: dict) -> Lineup:
-    """Insert a new lineup row and return the refreshed ORM instance.
+async def _refresh_set_relations(db: AsyncSession, lineup: Lineup) -> None:
+    """Refresh the FK relationship attrs that have a non-null value.
 
-    Relationship attributes are only refreshed when the corresponding FK is
-    set — ingestion-path rows have null FKs until the classifier runs (PR 5).
+    Ingestion-path rows have null classification FKs until the classifier
+    runs (PR 5), so refreshing an unset relationship would be wasted work
+    (and ``selectinload`` already populated the loaded ones). Called while
+    the row is still attached and before commit; with
+    ``expire_on_commit=False`` the refreshed attributes stay populated for
+    the post-commit serialization in the service layer.
     """
-    lineup = Lineup(**data)
-    db.add(lineup)
-    await db.flush()
-    # Only refresh relationships that have a non-null FK value.
     attrs_to_refresh = [
         attr
         for attr, fk_field in [
@@ -74,6 +74,30 @@ async def create_lineup(db: AsyncSession, data: dict) -> Lineup:
     ]
     if attrs_to_refresh:
         await db.refresh(lineup, attribute_names=attrs_to_refresh)
+
+
+async def create_lineup(db: AsyncSession, data: dict) -> Lineup:
+    """Insert a new lineup row, commit, and return the refreshed instance.
+
+    Transaction ownership lives here in the repository layer (not the route
+    or service): ``platform_shared.db.session.get_db`` does NOT auto-commit,
+    so a flush-only write is rolled back when the request session closes.
+    Routes/services delegating here must NOT also commit. On failure the
+    transaction is rolled back and the error re-raised so the caller can
+    surface it (constraint violations become a 4xx/5xx, never a silent loss).
+
+    Relationship attributes are only refreshed when the corresponding FK is
+    set — ingestion-path rows have null FKs until the classifier runs (PR 5).
+    """
+    lineup = Lineup(**data)
+    db.add(lineup)
+    try:
+        await db.flush()
+        await _refresh_set_relations(db, lineup)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
     return lineup
 
 
@@ -119,29 +143,34 @@ async def update_lineup(
     lineup: Lineup,
     patch: dict,
 ) -> Lineup:
-    """Apply *patch* fields to *lineup* and flush."""
+    """Apply *patch* fields to *lineup*, commit, and return it.
+
+    This is the fix for the silent data-loss bug: ``PATCH /api/lineups/{id}``
+    previously returned 200 (the in-session ORM object reflected the change)
+    but the UPDATE was rolled back when ``get_db`` closed the session because
+    nothing committed. Transaction ownership now lives here in the repo.
+    """
     for key, value in patch.items():
         setattr(lineup, key, value)
-    await db.flush()
-    # Only refresh relationships when the FK is set (nullable after migration).
-    attrs_to_refresh = [
-        attr
-        for attr, fk_field in [
-            ("target_zone", "target_zone_id"),
-            ("stand_zone", "stand_zone_id"),
-            ("utility_type", "utility_type_id"),
-        ]
-        if getattr(lineup, fk_field) is not None
-    ]
-    if attrs_to_refresh:
-        await db.refresh(lineup, attribute_names=attrs_to_refresh)
+    try:
+        await db.flush()
+        await _refresh_set_relations(db, lineup)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
     return lineup
 
 
 async def hide_lineup(db: AsyncSession, lineup: Lineup) -> Lineup:
-    """Soft-delete: set status='hidden'."""
+    """Soft-delete: set status='hidden' and commit."""
     lineup.status = "hidden"
-    await db.flush()
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
     return lineup
 
 
@@ -223,19 +252,13 @@ async def accept_lineup(
         if value is not None:
             setattr(lineup, key, value)
     lineup.status = "accepted"
-    await db.flush()
-    # Refresh relations that changed
-    attrs_to_refresh = [
-        attr
-        for attr, fk_field in [
-            ("target_zone", "target_zone_id"),
-            ("stand_zone", "stand_zone_id"),
-            ("utility_type", "utility_type_id"),
-        ]
-        if getattr(lineup, fk_field) is not None
-    ]
-    if attrs_to_refresh:
-        await db.refresh(lineup, attribute_names=attrs_to_refresh)
+    try:
+        await db.flush()
+        await _refresh_set_relations(db, lineup)
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
     return lineup
 
 
@@ -253,6 +276,25 @@ async def write_classifier_suggestions(
         if hasattr(lineup, field_name):
             setattr(lineup, field_name, value)
     await db.flush()
+
+
+async def commit_classifier_run(db: AsyncSession) -> None:
+    """Commit the classifier's flushed suggestion writes for the single-lineup
+    reclassify path.
+
+    ``classifier_service.classify_lineup`` writes suggested_* fields and
+    flushes but, per its documented contract, leaves the commit to the
+    caller (the ingestion orchestrator batches many classify runs into one
+    commit; the interactive ``POST /api/lineups/{id}/classify`` route needs
+    exactly one). Transaction ownership for that interactive path lives here
+    in the repo layer — the route must NOT commit. On failure the
+    transaction is rolled back and the error re-raised.
+    """
+    try:
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
 
 
 async def zone_density(

--- a/apps/mygamingassistant/backend/app/services/game/lineup_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_service.py
@@ -6,8 +6,13 @@ Responsibilities:
 - Orchestrate lineup create/update by delegating to lineup_repo
 - Status transition validation (accept/hide)
 
-ORM operations live exclusively in lineup_repo. This service never
-imports AsyncSession directly — it receives it from the route handler.
+ORM operations — including the commit/rollback transaction boundary — live
+exclusively in lineup_repo. This service never imports AsyncSession for
+mutation; it receives the session from the route handler and passes it
+through. Routes must NOT commit: ``get_db`` does not auto-commit, so the
+repo owns the commit so a single missing call can't silently lose writes
+(the bug this module's history records: PATCH returning 200 then rolling
+back on session close).
 """
 from __future__ import annotations
 
@@ -24,6 +29,7 @@ from app.models.game.lineup import Lineup
 from app.repositories.game.lineup_repo import (
     LineupFilters,
     accept_lineup,
+    commit_classifier_run,
     create_lineup,
     get_lineup,
     hide_lineup,
@@ -32,6 +38,8 @@ from app.repositories.game.lineup_repo import (
     update_lineup,
     zone_density,
 )
+from app.services.classification.classification_result import ClassificationResult
+from app.services.classification.classifier_service import classify_lineup
 from app.schemas.game.lineup_schemas import (
     LineupAcceptBody,
     LineupCreate,
@@ -389,6 +397,25 @@ async def accept(
 
     updated = await accept_lineup(db, lineup, overrides)
     return _build_read(updated)
+
+
+async def reclassify(
+    db: AsyncSession,
+    lineup_id: uuid.UUID,
+) -> ClassificationResult:
+    """Re-run the Claude classifier on a single lineup and persist suggestions.
+
+    ``classify_lineup`` writes suggested_* fields and flushes but, per its
+    documented contract, leaves the commit to the caller (the ingestion
+    orchestrator batches; the interactive route commits one). Commit
+    ownership for the interactive path lives in the repo
+    (``commit_classifier_run``) so the route stays free of any ORM/DB call.
+    On classifier failure nothing was flushed worth keeping, so no commit.
+    """
+    result = await classify_lineup(db, lineup_id)
+    if result.success:
+        await commit_classifier_run(db)
+    return result
 
 
 async def get_zone_density(

--- a/apps/mygamingassistant/backend/tests/test_lineups.py
+++ b/apps/mygamingassistant/backend/tests/test_lineups.py
@@ -717,3 +717,219 @@ async def test_accept_range_guard_rejects_out_of_range_anchor(
         json={"stand_anchor_x": 1.5},
     )
     assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# Cross-session persistence (commit ownership relocated to lineup_repo)
+#
+# Regression guard for the silent data-loss bug: PATCH /api/lineups/{id}
+# (and create/accept/hide) returned 200 but the write was rolled back when
+# get_db closed the session, because nothing committed.
+#
+# How these tests genuinely catch the bug despite reusing one `db` session:
+# the conftest `db` fixture wraps each test in an outer transaction with a
+# re-opening SAVEPOINT (see its docstring). A mutating endpoint that only
+# *flushes* leaves its write in the CURRENT savepoint; a `await db.rollback()`
+# afterwards (which is exactly what production's get_db does on session close
+# for an uncommitted unit) discards it. A mutating endpoint that *commits*
+# releases the savepoint into the outer transaction, and the listener opens a
+# fresh savepoint — so a later rollback CANNOT discard it. Each test below
+# performs the endpoint mutation, then `await db.rollback()` to model the
+# session closing without an extra commit, then re-fetches and asserts the
+# change survived. With the pre-fix code (flush-only) the re-fetch sees the
+# old value and the assertion fails; with commit owned by the repo it passes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_lineup_persists_across_session_close(
+    auth_client: AsyncClient,
+    seeded_game_map: dict,
+    db: AsyncSession,
+):
+    """PATCH must survive the request session closing without an extra commit.
+
+    This is the core regression test for the data-loss bug. A test that
+    re-fetched on the same session WITHOUT the intervening rollback would
+    pass even with the bug (the flushed value is visible in-session) — the
+    `await db.rollback()` is what makes this test fail on the buggy code.
+    """
+    create_resp = await _create_lineup(auth_client, seeded_game_map)
+    assert create_resp.status_code == 201, create_resp.text
+    lineup_id = create_resp.json()["id"]
+    # Drop the create's identity-map state so the re-fetch is a real DB read.
+    await db.rollback()
+
+    patch_resp = await auth_client.patch(
+        f"/api/lineups/{lineup_id}",
+        json={"title": "Persisted title", "notes": "Persisted notes"},
+    )
+    assert patch_resp.status_code == 200, patch_resp.text
+
+    # Model production: get_db closes the session; any uncommitted unit is
+    # rolled back. A committed PATCH survives this; a flush-only one does not.
+    await db.rollback()
+
+    refetch = await auth_client.get(f"/api/lineups/{lineup_id}")
+    assert refetch.status_code == 200, refetch.text
+    body = refetch.json()
+    assert body["title"] == "Persisted title", (
+        "PATCH did not persist across session close — the UPDATE was rolled "
+        "back (commit ownership regression)."
+    )
+    assert body["notes"] == "Persisted notes"
+    assert body["side"] == "side_a"  # untouched field preserved
+
+
+@pytest.mark.asyncio
+async def test_create_lineup_persists_across_session_close(
+    auth_client: AsyncClient,
+    seeded_game_map: dict,
+    db: AsyncSession,
+):
+    """POST /api/lineups (manual upload path) must persist across session close."""
+    create_resp = await _create_lineup(auth_client, seeded_game_map)
+    assert create_resp.status_code == 201, create_resp.text
+    lineup_id = create_resp.json()["id"]
+
+    await db.rollback()  # model session close without an extra commit
+
+    refetch = await auth_client.get(f"/api/lineups/{lineup_id}")
+    assert refetch.status_code == 200, (
+        "Created lineup did not persist across session close — INSERT was "
+        "rolled back (commit ownership regression)."
+    )
+    assert refetch.json()["id"] == lineup_id
+
+
+@pytest.mark.asyncio
+async def test_accept_persists_across_session_close(
+    auth_client: AsyncClient,
+    pending_lineup_for_accept: "Lineup",
+    db: AsyncSession,
+):
+    """POST /api/lineups/{id}/accept must persist the status transition."""
+    lineup_id = str(pending_lineup_for_accept.id)
+
+    accept_resp = await auth_client.post(
+        f"/api/lineups/{lineup_id}/accept",
+        json={"stand_anchor_x": 0.21, "stand_anchor_y": 0.22},
+    )
+    assert accept_resp.status_code == 200, accept_resp.text
+
+    await db.rollback()  # model session close without an extra commit
+
+    admin = await auth_client.get(f"/api/lineups/{lineup_id}/admin")
+    assert admin.status_code == 200, admin.text
+    body = admin.json()
+    assert body["status"] == "accepted", (
+        "accept did not persist — status transition rolled back."
+    )
+    assert body["stand_anchor_x"] == pytest.approx(0.21)
+
+
+@pytest.mark.asyncio
+async def test_hide_persists_across_session_close(
+    auth_client: AsyncClient,
+    seeded_game_map: dict,
+    db: AsyncSession,
+):
+    """DELETE /api/lineups/{id} (soft-delete → hidden) must persist."""
+    create_resp = await _create_lineup(auth_client, seeded_game_map)
+    assert create_resp.status_code == 201
+    lineup_id = create_resp.json()["id"]
+    await db.rollback()
+
+    del_resp = await auth_client.delete(f"/api/lineups/{lineup_id}")
+    assert del_resp.status_code == 204
+
+    await db.rollback()  # model session close without an extra commit
+
+    admin = await auth_client.get(f"/api/lineups/{lineup_id}/admin")
+    assert admin.status_code == 200
+    assert admin.json()["status"] == "hidden", (
+        "hide did not persist — status='hidden' rolled back."
+    )
+
+
+@pytest.mark.asyncio
+async def test_bulk_accept_partial_success_persists_only_good(
+    auth_client: AsyncClient,
+    seeded_with_polygons: dict,
+    db: AsyncSession,
+):
+    """One acceptable + one un-acceptable lineup: the good one persists, the
+    bad one does not, and the response contains only the good one.
+
+    The "bad" lineup has no suggested_* fields and no override body, so
+    ``lineup_service.accept`` raises ValueError (missing required fields)
+    BEFORE the repo commits — it must be skipped without aborting the batch
+    or discarding the already-committed good lineup.
+
+    The cross-session durability of a committed write is already proven by
+    the four single-commit ``*_persists_across_session_close`` tests above
+    (which model the get_db session close via ``db.rollback()``). This test
+    deliberately does NOT add that post-request rollback: bulk-accept issues
+    one commit per accepted lineup in a single request, and the conftest
+    savepoint-restart listener does not cleanly survive a
+    commit→further-work→external-rollback sequence within one request
+    (a harness limitation, not a product defect). Re-fetching via the API
+    immediately after the request still proves the partial-success contract:
+    the good lineup's per-item repo commit released its SAVEPOINT into the
+    outer transaction, so it reads back as ``accepted``; the bad lineup never
+    committed and reads back as ``pending_review``.
+    """
+    seeded = seeded_with_polygons
+
+    good = Lineup(
+        game_id=seeded["game"].id,
+        map_id=seeded["map"].id,
+        title="good pending",
+        status="pending_review",
+        suggested_target_zone_id=seeded["zone_target"].id,
+        suggested_stand_zone_id=seeded["zone_stand"].id,
+        suggested_side="side_a",
+        suggested_utility_type_id=seeded["util"].id,
+    )
+    bad = Lineup(
+        game_id=seeded["game"].id,
+        map_id=seeded["map"].id,
+        title="bad pending (no suggestions → accept() raises)",
+        status="pending_review",
+    )
+    db.add(good)
+    db.add(bad)
+    await db.flush()
+    good_id = str(good.id)
+    bad_id = str(bad.id)
+    # NOTE: do NOT manually commit the seed rows here. Under the conftest
+    # savepoint harness, the good lineup's per-item repo commit (inside
+    # bulk-accept) releases the current SAVEPOINT into the outer transaction,
+    # carrying these flushed seed rows AND the auth user with it. A manual
+    # commit here would instead release a savepoint that the post-request
+    # rollback then discards, taking the auth user with it (→ 401).
+
+    resp = await auth_client.post(
+        "/api/lineups/bulk-accept",
+        json={"lineup_ids": [good_id, bad_id], "patches": {}},
+    )
+    assert resp.status_code == 200, resp.text
+    returned_ids = {item["id"] for item in resp.json()}
+    assert good_id in returned_ids, "good lineup missing from bulk-accept response"
+    assert bad_id not in returned_ids, "failed lineup leaked into the response"
+
+    # Expire the session so the re-fetch is a real DB read, not the identity
+    # map. The good lineup's per-item commit is in the outer transaction.
+    db.expire_all()
+
+    good_admin = await auth_client.get(f"/api/lineups/{good_id}/admin")
+    assert good_admin.status_code == 200, good_admin.text
+    assert good_admin.json()["status"] == "accepted", (
+        "good lineup's accept was lost — partial-success durability regression."
+    )
+
+    bad_admin = await auth_client.get(f"/api/lineups/{bad_id}/admin")
+    assert bad_admin.status_code == 200, bad_admin.text
+    assert bad_admin.json()["status"] == "pending_review", (
+        "bad lineup must remain pending_review (it was never accepted)."
+    )


### PR DESCRIPTION
## The bug — silent data loss

`PATCH /api/lineups/{id}` (the #685 ReviewCard editor) returned **HTTP 200**
with the updated values in the response body, but the edit was **silently
lost** — never present on subsequent reads. Operators edited a lineup, saw
success, and the change vanished.

## Root cause

`platform_shared.db.session.get_db` does **not** auto-commit (`async with
session_maker() as s: yield s`). When the request ends, the session closes
and any uncommitted unit is rolled back. The `patch_lineup` route called
`lineup_service.patch` and returned with **no `await db.commit()`**;
`lineup_service.patch` → `lineup_repo.update_lineup` only `flush()`ed. The
200 reflected the in-session ORM object (correct in memory) but the UPDATE
was rolled back on session close. The manual-upload `create` path had the
same missing-commit defect. Sibling mutating routes (accept / hide /
bulk-accept / reclassify) papered over this by calling `db.commit()`
**directly in the route handler** — an ORM-in-route layering violation.

## The fix

Transaction ownership relocated into the **repository layer**
(`lineup_repo.py`) — the only layer the project layering rule and the
pipeline quality gate sanction for `db.*` ("Routes → Services →
Repositories; only repository files may use db.add/flush/commit/execute").

- `create_lineup`, `update_lineup`, `hide_lineup`, `accept_lineup`, and a
  new `commit_classifier_run` each commit on success and **roll back +
  re-raise** on failure (constraint violations surface as 4xx/5xx, never a
  silent loss).
- All `db.commit()` / `db.rollback()` removed from the routes in
  `lineups.py`. `lineup_service.py` is now pure delegation (zero `db.*`).
- The triplicated relationship-refresh block was de-duplicated into a
  `_refresh_set_relations` helper (Boy Scout).
- The interactive reclassify path got a thin `lineup_service.reclassify`
  so the route no longer touches the session. `classify_lineup` and the
  shared `write_classifier_suggestions` (used by the **batched** ingestion
  orchestrator) are intentionally left flush-only — their
  caller-commits contract is out of scope.

## bulk_accept partial-success — preserved exactly

Each lineup is accepted independently with its own per-item repo commit.
A failing lineup is logged + skipped and does **not** abort the batch; a
rollback after a prior commit on the same `AsyncSession` only discards the
current uncommitted unit, so lineups committed by earlier iterations stay
durable. The route loop just collects successes.

## Regression test

Five new tests in `test_lineups.py`. The four
`*_persists_across_session_close` tests mutate via the endpoint, then
`await db.rollback()` to model **exactly** what production's `get_db` does
on session close (discard the uncommitted unit), then re-fetch and assert
the change survived — they **FAIL on the pre-fix flush-only code** and
**PASS with repo-owned commit**.
`test_bulk_accept_partial_success_persists_only_good` proves the good
lineup persists + is returned and the bad one neither persists nor leaks
into the response.

Full MGA backend suite: **286 passed, 0 failed** (281 prior + 5 new).
The documented `ix_game_slug` classifier test-isolation issue did not
manifest in this run (classifier tests green standalone and in the full
run); this change introduces no classifier regression.

## Out-of-scope follow-up

The same ORM-commit-in-route anti-pattern still exists in `games.py` /
`lineup_packages.py` / `totp.py` — left for a focused follow-up PR per
one-feature-per-PR.

## Operational migration

**None** — no schema, env, or config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)