### PR TITLE
refactor(mga): split MapPage into one-component-per-file + extract LineupResultsPanel

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * LineupResultsPanel — encapsulates the results-panel branch logic
+ * (fetching / empty / ≤3 → expanded / else → thumbnail) via early returns.
+ *
+ * This component was extracted from MapPage.tsx as part of the one-component-
+ * per-file refactor (PR #688). These tests prove the early-return branching is
+ * equivalent to the original 3-level nested ternary it replaced.
+ */
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import LineupResultsPanel from "@/components/map/LineupResultsPanel";
+import type { Lineup } from "@/types/game";
+
+// Minimal Lineup shape needed by the panel's child components
+function makeLineup(id: string): Lineup {
+  return {
+    id,
+    game_id: "g1",
+    map_id: "m1",
+    target_zone_id: "z1",
+    stand_zone_id: "z2",
+    side: "side_a",
+    utility_type_id: "u1",
+    title: `Lineup ${id}`,
+    notes: null,
+    stand_screenshot_url: null,
+    aim_screenshot_url: null,
+    aim_anchor_x: null,
+    aim_anchor_y: null,
+    stand_anchor_x: null,
+    stand_anchor_y: null,
+    target_anchor_x: null,
+    target_anchor_y: null,
+    effective_stand_x: null,
+    effective_stand_y: null,
+    effective_target_x: null,
+    effective_target_y: null,
+    setup_seconds: null,
+    attribution_url: null,
+    attribution_author: null,
+    status: "accepted",
+    youtube_video_id: null,
+    chapter_start_seconds: null,
+    chapter_title: null,
+    suggested_game_id: null,
+    suggested_map_id: null,
+    suggested_target_zone_id: null,
+    suggested_stand_zone_id: null,
+    suggested_side: null,
+    suggested_utility_type_id: null,
+    classification_confidence: null,
+    classification_reasoning: null,
+    target_zone: null,
+    stand_zone: null,
+    utility_type: null,
+  };
+}
+
+// Minimal mock for the usePins return value (matches UsePinsReturn interface)
+const mockPins = {
+  isPinned: vi.fn().mockReturnValue(false),
+  pin: vi.fn(),
+  unpin: vi.fn(),
+  reorder: vi.fn(),
+  pinnedIds: [] as string[],
+};
+
+function renderPanel(props: Parameters<typeof LineupResultsPanel>[0]) {
+  return render(
+    <MemoryRouter>
+      <LineupResultsPanel {...props} />
+    </MemoryRouter>,
+  );
+}
+
+const BASE_PROPS = {
+  fetching: false,
+  lineups: [] as Lineup[],
+  activeCardIndex: 0,
+  pins: mockPins,
+  addLineupHref: "/lineups/new?game=cs2&map=mirage",
+  targetZoneName: "A site",
+};
+
+describe("LineupResultsPanel — branch routing (early returns)", () => {
+  it("shows skeleton placeholders while fetching (regardless of lineup count)", () => {
+    renderPanel({ ...BASE_PROPS, fetching: true, lineups: [makeLineup("l1")] });
+    // Skeleton: two pulse divs — no lineup titles visible
+    expect(screen.queryByText(/Lineup l1/i)).toBeNull();
+    // The pulse divs should be in the DOM (they have animate-pulse class)
+    const { container } = render(
+      <MemoryRouter>
+        <LineupResultsPanel {...BASE_PROPS} fetching={true} lineups={[makeLineup("l1")]} />
+      </MemoryRouter>,
+    );
+    const pulses = container.querySelectorAll(".animate-pulse");
+    expect(pulses.length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state with add-lineup link when not fetching and lineups is empty", () => {
+    renderPanel({ ...BASE_PROPS, fetching: false, lineups: [] });
+    expect(screen.getByText(/no lineups match this filter/i)).toBeDefined();
+    const link = screen.getByRole("link", { name: /add lineup for a site/i });
+    expect(link).toBeDefined();
+    // The href should contain the addLineupHref value
+    expect((link as HTMLAnchorElement).getAttribute("href")).toContain(
+      "/lineups/new",
+    );
+  });
+
+  it("renders expanded view (PlanModeExpandedResults) when 1-3 lineups", () => {
+    const lineups = [makeLineup("l1"), makeLineup("l2"), makeLineup("l3")];
+    renderPanel({ ...BASE_PROPS, lineups });
+    // Expanded renders LineupCards in a vertical space-y-4 list — each card
+    // renders the lineup title somewhere accessible
+    expect(screen.getAllByText(/Lineup l/i).length).toBeGreaterThan(0);
+  });
+
+  it("still uses expanded view at exactly 3 lineups (boundary)", () => {
+    const lineups = [makeLineup("a"), makeLineup("b"), makeLineup("c")];
+    renderPanel({ ...BASE_PROPS, lineups });
+    // Three lineup cards rendered
+    expect(screen.getAllByText(/Lineup/i).length).toBe(3);
+  });
+
+  it("renders thumbnail view (PlanModeThumbnailResults) when 4+ lineups", () => {
+    const lineups = [
+      makeLineup("1"),
+      makeLineup("2"),
+      makeLineup("3"),
+      makeLineup("4"),
+    ];
+    renderPanel({ ...BASE_PROPS, lineups });
+    // Thumbnail renders LineupCard in thumbnail variant — titles still rendered
+    expect(screen.getAllByText(/Lineup/i).length).toBe(4);
+  });
+
+  it("activeCardIndex prop is forwarded and selects the right card ring in expanded view", () => {
+    const lineups = [makeLineup("x1"), makeLineup("x2")];
+    const { container } = render(
+      <MemoryRouter>
+        <LineupResultsPanel
+          {...BASE_PROPS}
+          lineups={lineups}
+          activeCardIndex={1}
+        />
+      </MemoryRouter>,
+    );
+    // The second card wrapper should have the ring-2 class
+    const wrappers = container.querySelectorAll(".rounded-xl");
+    expect(wrappers[1]?.className).toContain("ring-2");
+    // The first card wrapper should NOT have it
+    expect(wrappers[0]?.className).not.toContain("ring-2");
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/map/BackButton.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/BackButton.tsx
@@ -1,0 +1,20 @@
+import { ArrowLeft } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+
+export interface BackButtonProps {
+  gameSlug: string;
+  navigate: ReturnType<typeof useNavigate>;
+}
+
+export default function BackButton({ gameSlug, navigate }: BackButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={() => navigate(`/${gameSlug}`)}
+      className="p-2 rounded-md hover:bg-muted/40 transition-colors min-h-[44px]"
+      aria-label="Back to maps"
+    >
+      <ArrowLeft className="h-5 w-5" />
+    </button>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/map/LineupResultsPanel.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/LineupResultsPanel.tsx
@@ -1,0 +1,56 @@
+import { Link } from "react-router-dom";
+import { usePins } from "@/hooks/usePins";
+import type { Lineup } from "@/types/game";
+import PlanModeExpandedResults from "./PlanModeExpandedResults";
+import PlanModeThumbnailResults from "./PlanModeThumbnailResults";
+
+export interface LineupResultsPanelProps {
+  fetching: boolean;
+  lineups: Lineup[];
+  activeCardIndex: number;
+  pins: ReturnType<typeof usePins>;
+  addLineupHref: string;
+  targetZoneName: string;
+}
+
+export default function LineupResultsPanel({
+  fetching,
+  lineups,
+  activeCardIndex,
+  pins,
+  addLineupHref,
+  targetZoneName,
+}: LineupResultsPanelProps) {
+  if (fetching) {
+    return (
+      <div className="space-y-3">
+        {[1, 2].map((i) => (
+          <div key={i} className="h-48 rounded-lg bg-muted/40 animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (lineups.length === 0) {
+    return (
+      <div className="text-center py-8 space-y-3">
+        <p className="text-sm text-muted-foreground">No lineups match this filter.</p>
+        <Link to={addLineupHref} className="text-sm text-primary hover:underline">
+          Add lineup for {targetZoneName}
+        </Link>
+      </div>
+    );
+  }
+
+  if (lineups.length <= 3) {
+    return (
+      <PlanModeExpandedResults
+        lineups={lineups}
+        activeCardIndex={activeCardIndex}
+        pins={pins}
+      />
+    );
+  }
+
+  return <PlanModeThumbnailResults lineups={lineups} pins={pins} />;
+}

--- a/apps/mygamingassistant/frontend/src/components/map/LoadoutPopover.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/LoadoutPopover.tsx
@@ -1,0 +1,66 @@
+export interface LoadoutPopoverProps {
+  utilOptions: Array<{ value: string; label: string }>;
+  loadout: string[];
+  onToggle: (slug: string) => void;
+  onClear: () => void;
+  onClose: () => void;
+}
+
+export default function LoadoutPopover({
+  utilOptions,
+  loadout,
+  onToggle,
+  onClear,
+  onClose,
+}: LoadoutPopoverProps) {
+  return (
+    <div
+      className="absolute top-full left-0 mt-1 z-20 bg-card border rounded-lg shadow-lg p-3 min-w-[200px]"
+      role="dialog"
+      aria-label="Set your loadout utilities"
+    >
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs font-medium text-muted-foreground">My loadout</p>
+        <button
+          type="button"
+          onClick={onClose}
+          className="p-0.5 rounded hover:bg-muted/40 text-muted-foreground text-xs"
+          aria-label="Close loadout"
+        >
+          ✕
+        </button>
+      </div>
+      <p className="text-xs text-muted-foreground mb-2">
+        Select utilities you have this round to narrow the filter.
+      </p>
+      <div className="space-y-1">
+        {utilOptions.map((opt) => (
+          <label
+            key={opt.value}
+            className="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer hover:bg-muted/40 text-sm"
+          >
+            <input
+              type="checkbox"
+              checked={loadout.includes(opt.value)}
+              onChange={() => onToggle(opt.value)}
+              className="h-4 w-4 rounded"
+            />
+            <span>{opt.label}</span>
+          </label>
+        ))}
+      </div>
+      {loadout.length > 0 && (
+        <button
+          type="button"
+          onClick={() => {
+            onClear();
+            onClose();
+          }}
+          className="mt-2 w-full text-xs text-muted-foreground hover:text-foreground py-1"
+        >
+          Clear loadout
+        </button>
+      )}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/map/PackagesDropdown.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/PackagesDropdown.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import { Package } from "lucide-react";
+import { usePins } from "@/hooks/usePins";
+import { usePinAllLineupPackageMutation } from "@/store/lineupPackagesApi";
+import type { LineupPackage } from "@/types/game";
+
+export interface PackagesDropdownProps {
+  packages: LineupPackage[];
+  pins: ReturnType<typeof usePins>;
+  pinAllPackage: ReturnType<typeof usePinAllLineupPackageMutation>[0];
+  onPinAllComplete: (count: number) => void;
+}
+
+export default function PackagesDropdown({
+  packages,
+  pins,
+  pinAllPackage,
+  onPinAllComplete,
+}: PackagesDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const [loading, setLoading] = useState<string | null>(null);
+
+  async function handlePinAll(pkg: LineupPackage) {
+    setLoading(pkg.id);
+    try {
+      const result = await pinAllPackage(pkg.id).unwrap();
+      for (const id of result.lineup_ids) {
+        pins.pin(id);
+      }
+      onPinAllComplete(result.lineup_ids.length);
+    } catch {
+      // Error silently falls through — user sees no pin
+    } finally {
+      setLoading(null);
+      setOpen(false);
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
+        title="Apply a lineup package"
+        aria-expanded={open}
+      >
+        <Package className="w-3.5 h-3.5" aria-hidden />
+        Packages
+      </button>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-10"
+            aria-hidden
+            onClick={() => setOpen(false)}
+          />
+          <div className="absolute top-full left-0 mt-1 z-20 bg-card border rounded-lg shadow-lg p-2 min-w-[220px]">
+            <p className="text-xs font-medium text-muted-foreground px-2 pb-1">
+              Pin all and enter round mode
+            </p>
+            {packages.map((pkg) => (
+              <button
+                key={pkg.id}
+                type="button"
+                onClick={() => handlePinAll(pkg)}
+                disabled={loading === pkg.id}
+                className="w-full text-left px-3 py-2 rounded-md text-sm hover:bg-muted/40 flex items-center justify-between gap-2 disabled:opacity-60"
+              >
+                <span className="truncate">{pkg.name}</span>
+                <span className="text-xs text-muted-foreground shrink-0">
+                  {loading === pkg.id ? "Pinning…" : `${pkg.lineup_ids.length} lineups`}
+                </span>
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/map/PlanModeExpandedResults.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/PlanModeExpandedResults.tsx
@@ -1,0 +1,42 @@
+import LineupCard from "@/components/lineup/LineupCard";
+import { usePins } from "@/hooks/usePins";
+import type { Lineup } from "@/types/game";
+
+export interface PlanModeExpandedResultsProps {
+  lineups: Lineup[];
+  activeCardIndex: number;
+  pins: ReturnType<typeof usePins>;
+}
+
+export default function PlanModeExpandedResults({
+  lineups,
+  activeCardIndex,
+  pins,
+}: PlanModeExpandedResultsProps) {
+  return (
+    <div className="space-y-4">
+      {lineups.map((lineup, i) => (
+        <div
+          key={lineup.id}
+          className={[
+            "rounded-xl transition-all duration-150",
+            i === activeCardIndex ? "ring-2 ring-primary" : "",
+          ].join(" ")}
+        >
+          <LineupCard
+            lineup={lineup}
+            variant="expanded"
+            isPinned={pins.isPinned(lineup.id)}
+            onPinToggle={() => {
+              if (pins.isPinned(lineup.id)) {
+                pins.unpin(lineup.id);
+              } else {
+                pins.pin(lineup.id);
+              }
+            }}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/map/PlanModeThumbnailResults.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/PlanModeThumbnailResults.tsx
@@ -1,0 +1,33 @@
+import LineupCard from "@/components/lineup/LineupCard";
+import { usePins } from "@/hooks/usePins";
+import type { Lineup } from "@/types/game";
+
+export interface PlanModeThumbnailResultsProps {
+  lineups: Lineup[];
+  pins: ReturnType<typeof usePins>;
+}
+
+export default function PlanModeThumbnailResults({
+  lineups,
+  pins,
+}: PlanModeThumbnailResultsProps) {
+  return (
+    <div className="grid grid-cols-2 gap-2">
+      {lineups.map((lineup) => (
+        <LineupCard
+          key={lineup.id}
+          lineup={lineup}
+          variant="thumbnail"
+          isPinned={pins.isPinned(lineup.id)}
+          onPinToggle={() => {
+            if (pins.isPinned(lineup.id)) {
+              pins.unpin(lineup.id);
+            } else {
+              pins.pin(lineup.id);
+            }
+          }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/map/StorageUnavailableBanner.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/StorageUnavailableBanner.tsx
@@ -1,0 +1,24 @@
+export interface StorageUnavailableBannerProps {
+  onClose: () => void;
+}
+
+export default function StorageUnavailableBanner({
+  onClose,
+}: StorageUnavailableBannerProps) {
+  return (
+    <div
+      role="alert"
+      className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-card border rounded-lg shadow-lg px-4 py-3 text-sm max-w-sm"
+    >
+      <span className="flex-1">Pins won't persist (storage unavailable)</span>
+      <button
+        type="button"
+        onClick={onClose}
+        className="p-1 rounded hover:bg-muted/40 text-muted-foreground"
+        aria-label="Dismiss"
+      >
+        ✕
+      </button>
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -18,12 +18,11 @@
  */
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { AlertTriangle, ArrowLeft, Backpack, ImagePlus, Package, Pencil, Plus } from "lucide-react";
+import { AlertTriangle, Backpack, ImagePlus, Pencil, Plus } from "lucide-react";
 import { ToggleChipGroup, showSuccess } from "@platform/ui";
 import { useGetGamesQuery, useGetMapDetailQuery } from "@/store/gamesApi";
 import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
 import { useGetLineupPackagesQuery, usePinAllLineupPackageMutation } from "@/store/lineupPackagesApi";
-import LineupCard from "@/components/lineup/LineupCard";
 import MapZoneOverlay from "@/components/lineup/MapZoneOverlay";
 import MapLineupPins, {
   type PinMode,
@@ -35,11 +34,16 @@ import UnplaceableLineupsNotice from "@/components/lineup/UnplaceableLineupsNoti
 import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
 import MinimapUploadDialog from "@/components/game/MinimapUploadDialog";
 import RoundMode from "@/pages/RoundMode";
+import BackButton from "@/components/map/BackButton";
+import LoadoutPopover from "@/components/map/LoadoutPopover";
+import PackagesDropdown from "@/components/map/PackagesDropdown";
+import StorageUnavailableBanner from "@/components/map/StorageUnavailableBanner";
+import LineupResultsPanel from "@/components/map/LineupResultsPanel";
 import { usePins } from "@/hooks/usePins";
 import { useLoadout, computeEffectiveUtilFilter } from "@/hooks/useLoadout";
 import { useMapKeyboardShortcuts } from "@/hooks/useMapKeyboardShortcuts";
 import { useIsSuperuser } from "@/hooks/useIsSuperuser";
-import type { Lineup, ZoneDensity } from "@/types/game";
+import type { ZoneDensity } from "@/types/game";
 
 const SIDE_BG: Record<string, string> = {
   side_a: "rgba(239,68,68,0.05)",
@@ -630,34 +634,14 @@ export default function MapPage() {
                   </button>
                 </div>
 
-                {lineupsFetching ? (
-                  <div className="space-y-3">
-                    {[1, 2].map((i) => (
-                      <div key={i} className="h-48 rounded-lg bg-muted/40 animate-pulse" />
-                    ))}
-                  </div>
-                ) : lineups.length === 0 ? (
-                  <div className="text-center py-8 space-y-3">
-                    <p className="text-sm text-muted-foreground">No lineups match this filter.</p>
-                    <Link
-                      to={addLineupHref}
-                      className="text-sm text-primary hover:underline"
-                    >
-                      Add lineup for {targetZone.name}
-                    </Link>
-                  </div>
-                ) : lineups.length <= 3 ? (
-                  <PlanModeExpandedResults
-                    lineups={lineups}
-                    activeCardIndex={activeCardIndex}
-                    pins={pins}
-                  />
-                ) : (
-                  <PlanModeThumbnailResults
-                    lineups={lineups}
-                    pins={pins}
-                  />
-                )}
+                <LineupResultsPanel
+                  fetching={lineupsFetching}
+                  lineups={lineups}
+                  activeCardIndex={activeCardIndex}
+                  pins={pins}
+                  addLineupHref={addLineupHref}
+                  targetZoneName={targetZone.name}
+                />
               </aside>
             )}
           </div>
@@ -672,249 +656,5 @@ export default function MapPage() {
         />
       )}
     </>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Sub-components
-// ---------------------------------------------------------------------------
-
-interface PlanModeExpandedResultsProps {
-  lineups: Lineup[];
-  activeCardIndex: number;
-  pins: ReturnType<typeof usePins>;
-}
-
-function PlanModeExpandedResults({ lineups, activeCardIndex, pins }: PlanModeExpandedResultsProps) {
-  return (
-    <div className="space-y-4">
-      {lineups.map((lineup, i) => (
-        <div
-          key={lineup.id}
-          className={[
-            "rounded-xl transition-all duration-150",
-            i === activeCardIndex ? "ring-2 ring-primary" : "",
-          ].join(" ")}
-        >
-          <LineupCard
-            lineup={lineup}
-            variant="expanded"
-            isPinned={pins.isPinned(lineup.id)}
-            onPinToggle={() => {
-              if (pins.isPinned(lineup.id)) {
-                pins.unpin(lineup.id);
-              } else {
-                pins.pin(lineup.id);
-              }
-            }}
-          />
-        </div>
-      ))}
-    </div>
-  );
-}
-
-interface PlanModeThumbnailResultsProps {
-  lineups: Lineup[];
-  pins: ReturnType<typeof usePins>;
-}
-
-function PlanModeThumbnailResults({ lineups, pins }: PlanModeThumbnailResultsProps) {
-  return (
-    <div className="grid grid-cols-2 gap-2">
-      {lineups.map((lineup) => (
-        <LineupCard
-          key={lineup.id}
-          lineup={lineup}
-          variant="thumbnail"
-          isPinned={pins.isPinned(lineup.id)}
-          onPinToggle={() => {
-            if (pins.isPinned(lineup.id)) {
-              pins.unpin(lineup.id);
-            } else {
-              pins.pin(lineup.id);
-            }
-          }}
-        />
-      ))}
-    </div>
-  );
-}
-
-function StorageUnavailableBanner({ onClose }: { onClose: () => void }) {
-  return (
-    <div
-      role="alert"
-      className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 bg-card border rounded-lg shadow-lg px-4 py-3 text-sm max-w-sm"
-    >
-      <span className="flex-1">Pins won't persist (storage unavailable)</span>
-      <button
-        type="button"
-        onClick={onClose}
-        className="p-1 rounded hover:bg-muted/40 text-muted-foreground"
-        aria-label="Dismiss"
-      >
-        ✕
-      </button>
-    </div>
-  );
-}
-
-function BackButton({
-  gameSlug,
-  navigate,
-}: {
-  gameSlug: string;
-  navigate: ReturnType<typeof useNavigate>;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={() => navigate(`/${gameSlug}`)}
-      className="p-2 rounded-md hover:bg-muted/40 transition-colors min-h-[44px]"
-      aria-label="Back to maps"
-    >
-      <ArrowLeft className="h-5 w-5" />
-    </button>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// LoadoutPopover
-// ---------------------------------------------------------------------------
-
-interface LoadoutPopoverProps {
-  utilOptions: Array<{ value: string; label: string }>;
-  loadout: string[];
-  onToggle: (slug: string) => void;
-  onClear: () => void;
-  onClose: () => void;
-}
-
-function LoadoutPopover({ utilOptions, loadout, onToggle, onClear, onClose }: LoadoutPopoverProps) {
-  return (
-    <div
-      className="absolute top-full left-0 mt-1 z-20 bg-card border rounded-lg shadow-lg p-3 min-w-[200px]"
-      role="dialog"
-      aria-label="Set your loadout utilities"
-    >
-      <div className="flex items-center justify-between mb-2">
-        <p className="text-xs font-medium text-muted-foreground">My loadout</p>
-        <button
-          type="button"
-          onClick={onClose}
-          className="p-0.5 rounded hover:bg-muted/40 text-muted-foreground text-xs"
-          aria-label="Close loadout"
-        >
-          ✕
-        </button>
-      </div>
-      <p className="text-xs text-muted-foreground mb-2">
-        Select utilities you have this round to narrow the filter.
-      </p>
-      <div className="space-y-1">
-        {utilOptions.map((opt) => (
-          <label
-            key={opt.value}
-            className="flex items-center gap-2 px-2 py-1.5 rounded cursor-pointer hover:bg-muted/40 text-sm"
-          >
-            <input
-              type="checkbox"
-              checked={loadout.includes(opt.value)}
-              onChange={() => onToggle(opt.value)}
-              className="h-4 w-4 rounded"
-            />
-            <span>{opt.label}</span>
-          </label>
-        ))}
-      </div>
-      {loadout.length > 0 && (
-        <button
-          type="button"
-          onClick={() => { onClear(); onClose(); }}
-          className="mt-2 w-full text-xs text-muted-foreground hover:text-foreground py-1"
-        >
-          Clear loadout
-        </button>
-      )}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// PackagesDropdown
-// ---------------------------------------------------------------------------
-
-import type { LineupPackage } from "@/types/game";
-
-interface PackagesDropdownProps {
-  packages: LineupPackage[];
-  pins: ReturnType<typeof usePins>;
-  pinAllPackage: ReturnType<typeof usePinAllLineupPackageMutation>[0];
-  onPinAllComplete: (count: number) => void;
-}
-
-function PackagesDropdown({ packages, pins, pinAllPackage, onPinAllComplete }: PackagesDropdownProps) {
-  const [open, setOpen] = useState(false);
-  const [loading, setLoading] = useState<string | null>(null);
-
-  async function handlePinAll(pkg: LineupPackage) {
-    setLoading(pkg.id);
-    try {
-      const result = await pinAllPackage(pkg.id).unwrap();
-      for (const id of result.lineup_ids) {
-        pins.pin(id);
-      }
-      onPinAllComplete(result.lineup_ids.length);
-    } catch {
-      // Error silently falls through — user sees no pin
-    } finally {
-      setLoading(null);
-      setOpen(false);
-    }
-  }
-
-  return (
-    <div className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
-        title="Apply a lineup package"
-        aria-expanded={open}
-      >
-        <Package className="w-3.5 h-3.5" aria-hidden />
-        Packages
-      </button>
-
-      {open && (
-        <>
-          <div
-            className="fixed inset-0 z-10"
-            aria-hidden
-            onClick={() => setOpen(false)}
-          />
-          <div className="absolute top-full left-0 mt-1 z-20 bg-card border rounded-lg shadow-lg p-2 min-w-[220px]">
-            <p className="text-xs font-medium text-muted-foreground px-2 pb-1">
-              Pin all and enter round mode
-            </p>
-            {packages.map((pkg) => (
-              <button
-                key={pkg.id}
-                type="button"
-                onClick={() => handlePinAll(pkg)}
-                disabled={loading === pkg.id}
-                className="w-full text-left px-3 py-2 rounded-md text-sm hover:bg-muted/40 flex items-center justify-between gap-2 disabled:opacity-60"
-              >
-                <span className="truncate">{pkg.name}</span>
-                <span className="text-xs text-muted-foreground shrink-0">
-                  {loading === pkg.id ? "Pinning…" : `${pkg.lineup_ids.length} lineups`}
-                </span>
-              </button>
-            ))}
-          </div>
-        </>
-      )}
-    </div>
   );
 }


### PR DESCRIPTION
## Summary

Pure structural refactor of `apps/mygamingassistant/frontend/src/pages/MapPage.tsx` — zero behavior change, zero new features, zero API/route changes.

**Resolves two quality-gate violations:**

- **Check #4 — one component per file:** MapPage.tsx previously declared 7 components in one file (MapPage + 6 sub-components). Each sub-component is now in its own file under `src/components/map/` (new directory, matching the existing `src/components/lineup/`, `src/components/live/`, etc. convention).

- **Check #7 — no nested ternaries in JSX:** The 3-level nested ternary at ~lines 633-657 (`lineupsFetching ? ... : lineups.length === 0 ? ... : lineups.length <= 3 ? <PlanModeExpandedResults/> : <PlanModeThumbnailResults/>`) is replaced by `<LineupResultsPanel>` which uses early `return` statements.

## Files changed

**Extracted to `src/components/map/` (6 existing sub-components, each verbatim):**
- `PlanModeExpandedResults.tsx` — expanded cards (≤3 lineups), props interface extracted
- `PlanModeThumbnailResults.tsx` — 2-col thumbnail grid (>3 lineups), props interface extracted
- `StorageUnavailableBanner.tsx` — bottom toast for localStorage unavailability, props interface extracted
- `BackButton.tsx` — left-arrow nav button, props interface extracted
- `LoadoutPopover.tsx` — utility loadout picker dropdown, props interface extracted
- `PackagesDropdown.tsx` — package pin-all dropdown (has its own `useState`), props interface extracted

**New component (resolves Check #7):**
- `LineupResultsPanel.tsx` — encapsulates the results-panel branching using early returns: fetching → skeleton, empty → add-lineup link, ≤3 lineups → PlanModeExpandedResults, >3 → PlanModeThumbnailResults

**Modified:**
- `src/pages/MapPage.tsx` — now contains only `MapPage`; imports from `src/components/map/`; uses `<LineupResultsPanel>` in place of the nested ternary

**New test:**
- `src/__tests__/LineupResultsPanel.test.tsx` — 6 unit tests covering all 4 branches + activeCardIndex ring forwarding

## Proof of no behavior change

- `npm run build` passes (TypeScript clean)
- 278 pre-existing tests pass unchanged
- 6 new tests for `LineupResultsPanel` verify each branch matches original ternary logic

## Operational migration

None. Pure frontend restructure — no new routes, no new API endpoints, no schema changes, no env vars.