### PR TITLE
fix(mga): game-first classification + CS2/Valorant disambiguation + cross-game guard

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -71,6 +71,60 @@ Rules:
 - side_a = attacking/T side; side_b = defending/CT side; any = side-agnostic.
 """
 
+# ---------------------------------------------------------------------------
+# Visual game-identification cues (cached in system prompt — never changes)
+#
+# MAINTENANCE COUPLING: when a new game is added to the fixture data
+# (app/fixtures/), this cue list MUST be extended with that game's
+# distinguishing HUD/art-style signals and the NAME-COLLISION WARNING updated.
+# A reference list that grows a third game without a matching visual-cue block
+# reintroduces exactly the cross-game contamination this constant prevents.
+# ---------------------------------------------------------------------------
+
+_GAME_VISUAL_CUES = """\
+HOW TO IDENTIFY THE GAME FROM THE SCREEN:
+
+Look for these signals BEFORE reading any map or zone names:
+
+CS2 (Counter-Strike 2):
+- Realistic Source 2 military/urban art style — concrete, grime, realistic lighting
+- Bottom-left HUD: dollar amount like $3800 (buy money), health + armor number with
+  a small helmet/vest icon when kevlar equipped
+- Left-side weapon list (primary + secondary + grenades as small icons stacked vertically)
+- Minimap in a corner showing teammates as colored dots, bomb carrier marker
+- Round timer at top center; "Bomb" (C4) as a throwable; no agent ability icons
+- Grenades are the utility: smoke, flashbang, HE grenade, Molotov/incendiary, decoy
+- Scoreboard uses T / CT team labels with a knife/bomb icon
+
+Valorant:
+- Stylized/cel-shaded art — sharp outlines, saturated colors, sci-fi or fantasy architecture
+- Bottom-center HUD: four ability icons labeled C / Q / E / X (ultimate), often with charge
+  dots or a numeric charge counter beneath each
+- Economy shows "creds" (credits) not dollar signs; buy menu shows numbered cred costs
+- Minimap corner shows agent icons (character portraits) not generic colored dots
+- "Spike" is the bomb equivalent (not "Bomb"); spike plant animation is distinct
+- Ultimate orbs visible on minimap/map as glowing collectibles
+- Agent-specific ability effects on screen (e.g. Sage wall, Jett dash trail, Killjoy turret)
+
+NAME-COLLISION WARNING:
+Many zone names appear in BOTH games: "A Site", "B Site", "Mid", "T Spawn", "CT Spawn",
+"Market", "A Main", "B Main". Recognizing a zone name is NOT evidence of the game.
+The game must be determined from visual HUD and art-style cues ONLY.
+"""
+
+_GAME_FIRST_RULE = """\
+CLASSIFICATION ORDER — YOU MUST FOLLOW THIS SEQUENCE:
+1. DETERMINE game_slug FIRST from visual HUD and art cues (see above).
+   Do not read map or zone names yet. If you cannot confidently identify the
+   game from the visuals, set game_slug=null and all slug fields to null.
+2. Once game_slug is set, filter the reference lists to entries where
+   [game_slug] matches your determined game. IGNORE all other entries.
+3. Select map_slug, zone slugs, and utility_type_slug ONLY from the filtered set.
+   Never select a slug whose [game_slug] differs from your game_slug.
+4. In the "reasoning" field, state: (a) which visual cue(s) confirmed the game,
+   (b) which map you identified, and (c) why you chose the zones you chose.
+"""
+
 # Strategy A grid schema. The model is given N numbered candidate frames
 # sampled across the chapter and must (a) decide whether the chapter is a real
 # utility-lineup demo at all, and (b) pick which frame best shows the throwing
@@ -108,6 +162,9 @@ Rules:
   equipped or its effect mid-air/landing, a recognizable map location). If the
   frames are webcam, desktop, montage, menus, title cards, or unrelated
   gameplay, set is_lineup=false and set the index/slug fields to null.
+- game_slug: follow CLASSIFICATION ORDER above — determine from visual cues first, then
+  constrain all map/zone/utility slugs to entries tagged [<your game_slug>] in the
+  reference list.
 - best_stand_index: the 1-based frame number that best shows the player STANDING
   at the throw position lining up the utility (crosshair on the alignment
   marker, throwable equipped, before release). null if is_lineup is false.
@@ -377,6 +434,54 @@ async def _resolve_slugs(
 
 
 # ---------------------------------------------------------------------------
+# Post-parse cross-game consistency guard (defense-in-depth)
+# ---------------------------------------------------------------------------
+
+
+def _check_game_map_consistency(
+    parsed: dict[str, Any],
+    ref: dict[str, Any],
+    failures: list[str],
+) -> dict[str, Any]:
+    """Post-parse consistency check: ensure returned map_slug belongs to returned game_slug.
+
+    If the map slug exists in the reference data but belongs to a DIFFERENT game than
+    game_slug, this is a cross-game contamination error. In that case:
+      - null out map_slug, target_zone_slug, stand_zone_slug (derived from the wrong map)
+      - reduce confidence by 0.4 (floor 0.0)
+      - append a note to failures (surfaces in reasoning)
+      - leave game_slug, side, utility_type_slug, aim_anchor_* intact
+    """
+    game_slug = parsed.get("game_slug")
+    map_slug = parsed.get("map_slug")
+    if not game_slug or not map_slug:
+        return parsed
+    map_game_lookup: dict[str, str] = {
+        m["slug"]: m["game_slug"] for m in ref.get("maps", [])
+    }
+    actual_game = map_game_lookup.get(map_slug)
+    if actual_game is None:
+        return parsed  # slug resolver will catch a truly-absent slug
+    if actual_game != game_slug:
+        failures.append(
+            f"CROSS-GAME MISMATCH: game_slug='{game_slug}' but map_slug='{map_slug}' "
+            f"belongs to '{actual_game}' — nulling map/zone fields; confidence reduced"
+        )
+        result = dict(parsed)
+        result["map_slug"] = None
+        result["target_zone_slug"] = None
+        result["stand_zone_slug"] = None
+        raw_conf = result.get("confidence")
+        if raw_conf is not None:
+            try:
+                result["confidence"] = max(0.0, float(raw_conf) - 0.4)
+            except (TypeError, ValueError):
+                result["confidence"] = 0.0
+        return result
+    return parsed
+
+
+# ---------------------------------------------------------------------------
 # Screenshot loader
 # ---------------------------------------------------------------------------
 
@@ -489,6 +594,10 @@ async def classify_lineup(
         "You are classifying tactical-FPS utility lineup screenshots.\n"
         "Your task: identify the game, map, zones, side, and utility type from the screenshot "
         "and chapter metadata. Return the crosshair/aim anchor position on the aim screenshot.\n\n"
+        + _GAME_VISUAL_CUES
+        + "\n"
+        + _GAME_FIRST_RULE
+        + "\n"
         + _OUTPUT_SCHEMA_DOC
     )
 
@@ -592,17 +701,30 @@ async def classify_lineup(
             reasoning=f"Could not parse classifier JSON: {exc}",
         )
 
+    # Defense-in-depth: catch cross-game contamination (e.g. game_slug='valorant'
+    # but map_slug='mirage') BEFORE slug resolution so the wrong map/zones are
+    # nulled and confidence is penalized. Notes flow into the same failures list
+    # that feeds the reasoning string.
+    failures: list[str] = []
+    parsed = _check_game_map_consistency(parsed, ref, failures)
+
     # Resolve slugs to FK IDs
-    game_id, map_id, target_zone_id, stand_zone_id, utility_type_id, failures = (
-        await _resolve_slugs(
-            db,
-            game_slug=parsed.get("game_slug"),
-            map_slug=parsed.get("map_slug"),
-            target_zone_slug=parsed.get("target_zone_slug"),
-            stand_zone_slug=parsed.get("stand_zone_slug"),
-            utility_type_slug=parsed.get("utility_type_slug"),
-        )
+    (
+        game_id,
+        map_id,
+        target_zone_id,
+        stand_zone_id,
+        utility_type_id,
+        slug_failures,
+    ) = await _resolve_slugs(
+        db,
+        game_slug=parsed.get("game_slug"),
+        map_slug=parsed.get("map_slug"),
+        target_zone_slug=parsed.get("target_zone_slug"),
+        stand_zone_slug=parsed.get("stand_zone_slug"),
+        utility_type_slug=parsed.get("utility_type_slug"),
     )
+    failures.extend(slug_failures)
 
     # Validate side
     side = parsed.get("side")
@@ -838,6 +960,10 @@ async def classify_frames_for_lineup_decision(
         "You will receive several numbered candidate frames from ONE video "
         "chapter and must judge whether the chapter is a real utility-lineup "
         "demo, pick the best frames, and classify it.\n\n"
+        + _GAME_VISUAL_CUES
+        + "\n"
+        + _GAME_FIRST_RULE
+        + "\n"
         + _GRID_OUTPUT_SCHEMA_DOC.format(n=n)
     )
 
@@ -873,7 +999,7 @@ async def classify_frames_for_lineup_decision(
         client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
         response = client.messages.create(
             model=settings.claude_classifier_model,
-            max_tokens=600,  # grid adds is_lineup + 2 indices vs the single-image schema
+            max_tokens=700,  # grid: is_lineup + 2 indices + richer game-evidence reasoning
             system=[
                 {
                     "type": "text",
@@ -933,6 +1059,12 @@ async def classify_frames_for_lineup_decision(
         )
 
     failures: list[str] = []
+
+    # Defense-in-depth: catch cross-game contamination (e.g. game_slug='valorant'
+    # but map_slug='mirage') BEFORE confidence is read and BEFORE slug resolution
+    # so the wrong map/zones are nulled, confidence is penalized, and the note
+    # reaches the reasoning string.
+    parsed = _check_game_map_consistency(parsed, ref, failures)
 
     is_lineup = bool(parsed.get("is_lineup"))
 

--- a/apps/mygamingassistant/backend/tests/test_classifier_service.py
+++ b/apps/mygamingassistant/backend/tests/test_classifier_service.py
@@ -737,3 +737,272 @@ class TestClassifyFramesForLineupDecision:
         # Reference block is still cache_control'd (caching preserved).
         assert any(b.get("cache_control") for b in content)
         assert kwargs["system"][0]["cache_control"] == {"type": "ephemeral"}
+
+
+# ---------------------------------------------------------------------------
+# Tests: game-first disambiguation prompt + cross-game consistency guard
+# (regression for CS2 Mirage misclassified as Valorant Ascent)
+# ---------------------------------------------------------------------------
+
+# A reference dict where 'mirage' is a CS2 map and 'ascent' is a Valorant map —
+# mirrors the real fixture asymmetry that produced the misclassification.
+_CROSS_GAME_REF: dict = {
+    "games": [
+        {"slug": "cs2", "name": "Counter-Strike 2", "side_a_label": "T", "side_b_label": "CT"},
+        {"slug": "valorant", "name": "VALORANT", "side_a_label": "Attacker", "side_b_label": "Defender"},
+    ],
+    "maps": [
+        {"slug": "mirage", "name": "Mirage", "game_slug": "cs2", "zones": [{"slug": "a-site", "name": "A Site"}]},
+        {"slug": "ascent", "name": "Ascent", "game_slug": "valorant", "zones": [{"slug": "market", "name": "Market"}]},
+    ],
+    "utility_types": [
+        {"slug": "smoke", "name": "Smoke", "game_slug": "cs2"},
+    ],
+}
+
+
+class TestGameFirstPromptWiring:
+    """Both system-prompt paths must carry the visual-cue block + game-first rule."""
+
+    def _single_image_system_prompt(self) -> str:
+        """Reconstruct the single-image (classify_lineup) system prompt."""
+        from app.services.classification import classifier_service as cs
+
+        return (
+            "You are classifying tactical-FPS utility lineup screenshots.\n"
+            "Your task: identify the game, map, zones, side, and utility type from the screenshot "
+            "and chapter metadata. Return the crosshair/aim anchor position on the aim screenshot.\n\n"
+            + cs._GAME_VISUAL_CUES
+            + "\n"
+            + cs._GAME_FIRST_RULE
+            + "\n"
+            + cs._OUTPUT_SCHEMA_DOC
+        )
+
+    def _grid_system_prompt(self, n: int = 5) -> str:
+        """Reconstruct the grid (classify_frames_for_lineup_decision) system prompt."""
+        from app.services.classification import classifier_service as cs
+
+        return (
+            "You are classifying tactical-FPS utility lineup screenshots.\n"
+            "You will receive several numbered candidate frames from ONE video "
+            "chapter and must judge whether the chapter is a real utility-lineup "
+            "demo, pick the best frames, and classify it.\n\n"
+            + cs._GAME_VISUAL_CUES
+            + "\n"
+            + cs._GAME_FIRST_RULE
+            + "\n"
+            + cs._GRID_OUTPUT_SCHEMA_DOC.format(n=n)
+        )
+
+    def test_single_image_prompt_has_game_first_and_cues(self):
+        prompt = self._single_image_system_prompt()
+        assert "DETERMINE game_slug FIRST" in prompt
+        assert "NAME-COLLISION WARNING" in prompt
+        assert "C / Q / E / X" in prompt  # Valorant ability HUD cue
+        assert "$3800" in prompt  # CS2 buy-money HUD cue
+        assert "CLASSIFICATION ORDER" in prompt
+        # Schema doc still present after the new blocks (order preserved).
+        assert "Return ONLY valid JSON" in prompt
+
+    def test_grid_prompt_has_game_first_and_cues(self):
+        prompt = self._grid_system_prompt()
+        assert "DETERMINE game_slug FIRST" in prompt
+        assert "NAME-COLLISION WARNING" in prompt
+        assert "C / Q / E / X" in prompt
+        assert "$3800" in prompt
+        assert "CLASSIFICATION ORDER" in prompt
+        # Grid schema's new game_slug bullet present and references the order rule.
+        assert "constrain all map/zone/utility slugs to entries tagged" in prompt
+        # Grid schema body still present.
+        assert "is_lineup" in prompt
+
+    def test_grid_schema_format_does_not_break(self):
+        """_GRID_OUTPUT_SCHEMA_DOC.format(n=...) must still substitute n cleanly.
+
+        The literal JSON-example braces are escaped as ``{{``/``}}`` so the only
+        substitution is ``{n}``. A stray single brace would raise KeyError/
+        ValueError here — proving the new game_slug bullet did not break the
+        .format template.
+        """
+        from app.services.classification import classifier_service as cs
+
+        rendered = cs._GRID_OUTPUT_SCHEMA_DOC.format(n=7)  # must not raise
+        assert "Frame 1 .. Frame 7" in rendered
+        assert "(1-7)" in rendered  # {n} substituted inside the JSON example
+        # The new game_slug rule bullet survived the format round-trip intact.
+        assert "constrain all map/zone/utility slugs to entries tagged" in rendered
+
+
+class TestCheckGameMapConsistency:
+    """Defense-in-depth: map_slug belonging to a different game than game_slug."""
+
+    def test_cross_game_mismatch_nulls_map_and_zones(self):
+        from app.services.classification.classifier_service import (
+            _check_game_map_consistency,
+        )
+
+        # game_slug says valorant, but 'mirage' is a cs2 map → contamination.
+        parsed = {
+            "game_slug": "valorant",
+            "map_slug": "mirage",
+            "target_zone_slug": "a-site",
+            "stand_zone_slug": "a-site",
+            "side": "side_a",
+            "utility_type_slug": "smoke",
+            "aim_anchor_x": 0.5,
+            "aim_anchor_y": 0.5,
+            "confidence": 0.9,
+        }
+        failures: list[str] = []
+        result = _check_game_map_consistency(parsed, _CROSS_GAME_REF, failures)
+
+        assert result["map_slug"] is None
+        assert result["target_zone_slug"] is None
+        assert result["stand_zone_slug"] is None
+        # confidence reduced by 0.4 (0.9 - 0.4 = 0.5), floored at 0.0
+        assert result["confidence"] == pytest.approx(0.5)
+        # game/side/utility/aim untouched
+        assert result["game_slug"] == "valorant"
+        assert result["side"] == "side_a"
+        assert result["utility_type_slug"] == "smoke"
+        assert result["aim_anchor_x"] == pytest.approx(0.5)
+        assert len(failures) == 1
+        assert "CROSS-GAME MISMATCH" in failures[0]
+        assert "mirage" in failures[0]
+        assert "valorant" in failures[0]
+        assert "cs2" in failures[0]
+        # original dict not mutated (guard returns a copy on mismatch)
+        assert parsed["map_slug"] == "mirage"
+
+    def test_consistent_game_map_unchanged(self):
+        from app.services.classification.classifier_service import (
+            _check_game_map_consistency,
+        )
+
+        parsed = {
+            "game_slug": "cs2",
+            "map_slug": "mirage",
+            "target_zone_slug": "a-site",
+            "stand_zone_slug": "a-site",
+            "confidence": 0.85,
+        }
+        failures: list[str] = []
+        result = _check_game_map_consistency(parsed, _CROSS_GAME_REF, failures)
+
+        assert result["map_slug"] == "mirage"
+        assert result["target_zone_slug"] == "a-site"
+        assert result["confidence"] == pytest.approx(0.85)
+        assert failures == []
+
+    def test_map_slug_absent_from_ref_unchanged(self):
+        """A truly-absent map slug is left for the slug resolver to catch."""
+        from app.services.classification.classifier_service import (
+            _check_game_map_consistency,
+        )
+
+        parsed = {
+            "game_slug": "cs2",
+            "map_slug": "nonexistent-map",
+            "confidence": 0.7,
+        }
+        failures: list[str] = []
+        result = _check_game_map_consistency(parsed, _CROSS_GAME_REF, failures)
+
+        assert result["map_slug"] == "nonexistent-map"
+        assert result["confidence"] == pytest.approx(0.7)
+        assert failures == []
+
+    def test_null_game_slug_unchanged(self):
+        from app.services.classification.classifier_service import (
+            _check_game_map_consistency,
+        )
+
+        parsed = {"game_slug": None, "map_slug": "mirage", "confidence": 0.5}
+        failures: list[str] = []
+        result = _check_game_map_consistency(parsed, _CROSS_GAME_REF, failures)
+
+        assert result == parsed
+        assert failures == []
+
+    def test_null_map_slug_unchanged(self):
+        from app.services.classification.classifier_service import (
+            _check_game_map_consistency,
+        )
+
+        parsed = {"game_slug": "cs2", "map_slug": None, "confidence": 0.5}
+        failures: list[str] = []
+        result = _check_game_map_consistency(parsed, _CROSS_GAME_REF, failures)
+
+        assert result == parsed
+        assert failures == []
+
+    def test_confidence_none_on_mismatch_no_crash(self):
+        """A mismatch with confidence=None must not crash; map/zones still nulled."""
+        from app.services.classification.classifier_service import (
+            _check_game_map_consistency,
+        )
+
+        parsed = {
+            "game_slug": "valorant",
+            "map_slug": "mirage",
+            "target_zone_slug": "a-site",
+            "confidence": None,
+        }
+        failures: list[str] = []
+        result = _check_game_map_consistency(parsed, _CROSS_GAME_REF, failures)
+
+        assert result["map_slug"] is None
+        assert result["target_zone_slug"] is None
+        assert result["confidence"] is None  # untouched when None
+        assert len(failures) == 1
+
+    def test_confidence_non_numeric_on_mismatch_floored(self):
+        """A mismatch with a non-numeric confidence must floor to 0.0, not crash."""
+        from app.services.classification.classifier_service import (
+            _check_game_map_consistency,
+        )
+
+        parsed = {
+            "game_slug": "valorant",
+            "map_slug": "mirage",
+            "confidence": "high",
+        }
+        failures: list[str] = []
+        result = _check_game_map_consistency(parsed, _CROSS_GAME_REF, failures)
+
+        assert result["map_slug"] is None
+        assert result["confidence"] == pytest.approx(0.0)
+        assert len(failures) == 1
+
+
+class TestGridMaxTokens:
+    """Regression: grid path bumped to 700 max_tokens for richer game evidence."""
+
+    @pytest.mark.asyncio
+    async def test_grid_max_tokens_is_700(self, db: AsyncSession, grid_game: Game):
+        from app.services.classification.classifier_service import (
+            classify_frames_for_lineup_decision,
+        )
+
+        payload = {"is_lineup": False, "confidence": 0.0, "reasoning": "x"}
+
+        with (
+            patch("app.services.classification.classifier_service.settings") as mock_settings,
+            patch("app.services.classification.classifier_service.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = _make_anthropic_response(payload)
+
+            await classify_frames_for_lineup_decision(
+                db,
+                frames=_THREE_FRAMES,
+                chapter_title="x",
+                attribution_author="y",
+            )
+
+        _, kwargs = mock_client.messages.create.call_args
+        assert kwargs["max_tokens"] == 700


### PR DESCRIPTION
## The bug

Claude Haiku 4.5 vision classifier misclassifies CS2 lineups as Valorant.
Confirmed case: a CS2 Mirage **"Market Door -> B Site"** smoke was classified
as **VALORANT / Ascent**.

## Root causes (confirmed, not re-derived)

1. **No game-first ordering** - the system prompt asked for game/map/zones at
   once with no instruction to identify the game *before* reading map/zone
   names, so the model anchored on collision-prone names.
2. **No visual cues** - the prompt gave no guidance on how CS2 vs Valorant
   actually *look* (HUD, economy, abilities, art style).
3. **Name collisions** - the combined reference list contains zone names that
   exist in both games ("A Site", "B Site", "Mid", "Market", "A Main", ...).
   Recognizing a name was being treated as evidence of the game.
4. **Fixture asymmetry** - CS2 Mirage has **no `market` zone slug**, but
   `market [valorant]` exists on Ascent, so "Market" in the chapter title had
   *only* a Valorant match, pulling the whole classification cross-game.

## Changes (`classifier_service.py`)

- **`_GAME_VISUAL_CUES`** - module constant: CS2 vs Valorant HUD/art-style
  identification signals + an explicit NAME-COLLISION WARNING. Carries a
  maintenance-coupling comment: adding a new game to fixtures *must* extend
  this list.
- **`_GAME_FIRST_RULE`** - module constant: a strict CLASSIFICATION ORDER
  (determine `game_slug` from visuals first -> filter reference lists to that
  game -> only then pick map/zone/utility slugs -> justify in reasoning).
- Both constants are integrated into **both** system prompts (single-image
  `classify_lineup` and grid `classify_frames_for_lineup_decision`), inserted
  before the existing schema doc, leading instruction sentences kept.
- Added a `game_slug` rule bullet to the grid schema's `Rules:` block
  (the `.format(n=...)` template still substitutes cleanly - covered by a test).
- **Grid `max_tokens` 600 -> 700** - the game-first rule asks for richer
  game-evidence reasoning; only the grid path changed.
- **`_check_game_map_consistency`** - parse-time defense-in-depth guard. If
  the returned `map_slug` exists in the reference data but belongs to a
  *different* game than the returned `game_slug`, it nulls
  `map_slug`/`target_zone_slug`/`stand_zone_slug`, reduces `confidence` by
  0.4 (floor 0.0), and appends a note that flows into `reasoning`.
  `game_slug`/`side`/`utility_type_slug`/`aim_anchor_*` are left intact
  (`utility_type_slug` is already game-gated by the slug resolver; `side` and
  aim are game-agnostic). Wired into **both** parse paths immediately after
  `json.loads(...)` and **before** slug resolution, merging into the same
  failures list that feeds `reasoning`.

## Prompt-cache preservation

`_build_reference_text` and every `cache_control: ephemeral` marker are
**untouched**. The two new constants are static module-level strings appended
to the cached system prompt, so the system-prompt cache breakpoint stays
cache-efficient (no per-call variability introduced).

## Tests

11 new tests in `tests/test_classifier_service.py`:
- `TestGameFirstPromptWiring` - both system prompts contain the visual-cue
  block + game-first rule (asserts "DETERMINE game_slug FIRST",
  "NAME-COLLISION WARNING", the Valorant "C / Q / E / X" cue, the CS2 "\$3800"
  cue); grid schema `.format()` still substitutes cleanly with the new bullet.
- `TestCheckGameMapConsistency` - cross-game mismatch nulls map/zones +
  reduces confidence + adds note; consistent pair unchanged; absent map slug
  left for the resolver; null game/map slug unchanged; confidence None /
  non-numeric handled without crash.
- `TestGridMaxTokens` - grid call uses `max_tokens=700`.

**Suite result (full MGA backend suite):** `290 passed, 7 errors`.
The 7 errors are the **pre-existing, documented `ix_game_slug` test-isolation
issue** in `TestClassifyLineup`/`TestSlugResolver` (shared fixture hardcodes
`slug='valorant'`). Verified before/after:
- Without this change: `11 passed, 7 errors` (classifier file)
- With this change: `22 passed, 7 errors` (classifier file)

Same 7 errors, unchanged in count - not a regression from this PR. The new
tests use a collision-proof in-memory reference dict / the existing
unique-slug grid fixtures and pass deterministically in isolation.

## Operational migration

None. No schema, env-var, migration, or config change.

## Out-of-scope follow-ups (noted, not acted on)

1. **Data gap:** CS2 Mirage has no `market` / `window` fixture zone - this
   asymmetry contributed to the misclassification and should be filled in a
   separate fixture PR.
2. The prompt-design pass surfaced a reusable agent-pattern about
   shared-name reference lists across games - flagged for a possible
   `/session-retro`; deliberately **not** acted on here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)