### PR TITLE
fix(mga): bulk-accept surfaces per-lineup skip reasons

### DIFF
--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -48,6 +48,8 @@ from app.models.user.user import User
 from app.repositories.game.lineup_repo import LineupFilters
 from app.schemas.game.lineup_schemas import (
     BulkAcceptBody,
+    BulkAcceptResult,
+    BulkAcceptSkip,
     ClassifyResponse,
     LineupAcceptBody,
     LineupCreate,
@@ -423,16 +425,19 @@ async def hide_pending_lineup(
     return hidden
 
 
-@auth_router.post("/lineups/bulk-accept", response_model=list[LineupRead])
+@auth_router.post("/lineups/bulk-accept", response_model=BulkAcceptResult)
 async def bulk_accept_lineups(
     body: BulkAcceptBody,
     db: AsyncSession = Depends(get_db),
-) -> list[LineupRead]:
+) -> BulkAcceptResult:
     """Accept multiple pending lineups in a single request.
 
-    Processes each lineup individually; failures on individual lineups are
-    skipped (logged) and do NOT abort the batch. Returns only the
-    successfully accepted lineups.
+    Processes each lineup individually. A lineup that cannot be accepted
+    (missing a required classification field, not found, etc.) is recorded
+    in ``skipped`` with an operator-facing reason instead of being silently
+    dropped — so "Accepted 0" is never a dead end: the operator sees *which*
+    lineups failed and *why*, and can fix them. Failures on individual
+    lineups never abort the batch.
 
     Partial-success durability: ``lineup_service.accept`` → the repo's
     ``accept_lineup`` owns a per-lineup commit/rollback. A failing lineup's
@@ -441,14 +446,29 @@ async def bulk_accept_lineups(
     The route performs no DB transaction calls of its own.
     """
     accepted: list[LineupRead] = []
+    skipped: list[BulkAcceptSkip] = []
     for lid in body.lineup_ids:
         patch = body.patches.get(str(lid), LineupAcceptBody())
         try:
             lineup = await lineup_service.accept(db, lid, patch)
-            if lineup is not None:
-                accepted.append(lineup)
-        except Exception as exc:
+            if lineup is None:
+                skipped.append(
+                    BulkAcceptSkip(lineup_id=lid, reason="Lineup not found")
+                )
+                continue
+            accepted.append(lineup)
+        except ValueError as exc:
+            # Expected validation failure (e.g. missing required fields) —
+            # surface the exact reason the single-accept 422 would give.
+            skipped.append(BulkAcceptSkip(lineup_id=lid, reason=str(exc)))
+        except Exception as exc:  # noqa: BLE001 - record + log, never abort batch
             logger.warning(
                 "bulk_accept: skipping lineup_id=%s error=%s", lid, str(exc)
             )
-    return accepted
+            skipped.append(
+                BulkAcceptSkip(
+                    lineup_id=lid,
+                    reason="Unexpected error accepting this lineup — see server logs.",
+                )
+            )
+    return BulkAcceptResult(accepted=accepted, skipped=skipped)

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -296,6 +296,30 @@ class BulkAcceptBody(BaseModel):
     patches: dict[str, LineupAcceptBody] = Field(default_factory=dict)
 
 
+class BulkAcceptSkip(BaseModel):
+    """One lineup bulk-accept could not accept, with the reason why.
+
+    ``reason`` is operator-facing: it carries the same message the single
+    ``POST /lineups/{id}/accept`` endpoint returns as its 422 detail (e.g.
+    "Cannot accept lineup: missing required fields: utility_type_id ..."), so
+    the operator can fix the lineup instead of staring at a bare "Accepted 0".
+    """
+    lineup_id: uuid.UUID
+    reason: str
+
+
+class BulkAcceptResult(BaseModel):
+    """Outcome of POST /lineups/bulk-accept.
+
+    ``accepted`` carries the lineups that transitioned to 'accepted'.
+    ``skipped`` carries the ones that could not be accepted, each with a
+    human-readable reason. Skips never abort the batch — a missing-field
+    lineup in the selection does not block the valid ones from accepting.
+    """
+    accepted: list[LineupRead]
+    skipped: list[BulkAcceptSkip]
+
+
 class ClassifyResponse(BaseModel):
     """Returned by POST /lineups/{id}/classify — the new suggested values."""
     lineup_id: uuid.UUID

--- a/apps/mygamingassistant/backend/tests/test_lineups.py
+++ b/apps/mygamingassistant/backend/tests/test_lineups.py
@@ -914,9 +914,19 @@ async def test_bulk_accept_partial_success_persists_only_good(
         json={"lineup_ids": [good_id, bad_id], "patches": {}},
     )
     assert resp.status_code == 200, resp.text
-    returned_ids = {item["id"] for item in resp.json()}
-    assert good_id in returned_ids, "good lineup missing from bulk-accept response"
-    assert bad_id not in returned_ids, "failed lineup leaked into the response"
+    payload = resp.json()
+    accepted_ids = {item["id"] for item in payload["accepted"]}
+    assert good_id in accepted_ids, "good lineup missing from bulk-accept response"
+    assert bad_id not in accepted_ids, "failed lineup leaked into accepted"
+
+    # The bad lineup must be reported as skipped WITH an operator-facing reason
+    # (not silently dropped) — this is the "Accepted 0" black-hole fix.
+    skipped = {item["lineup_id"]: item["reason"] for item in payload["skipped"]}
+    assert bad_id in skipped, "failed lineup must be reported in skipped[]"
+    assert good_id not in skipped, "accepted lineup must not appear in skipped[]"
+    assert "required fields" in skipped[bad_id], (
+        f"skip reason must name the missing fields, got: {skipped[bad_id]!r}"
+    )
 
     # Expire the session so the re-fetch is a real DB read, not the identity
     # map. The good lineup's per-item commit is in the outer transaction.

--- a/apps/mygamingassistant/frontend/src/__tests__/summarizeSkips.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/summarizeSkips.test.ts
@@ -1,0 +1,48 @@
+/**
+ * summarizeSkips — turns bulk-accept's skipped[] into the concise toast the
+ * operator sees instead of a bare "Accepted 0 lineups". Identical reasons
+ * dedupe (one phrase for every missing-utility lineup) and the list is capped
+ * so a 10-lineup batch can't produce an unreadable wall of text.
+ */
+import { describe, expect, it } from "vitest";
+import { summarizeSkips } from "@/pages/Review";
+import type { BulkAcceptSkip } from "@/types/game";
+
+const skip = (lineup_id: string, reason: string): BulkAcceptSkip => ({
+  lineup_id,
+  reason,
+});
+
+describe("summarizeSkips", () => {
+  it("uses singular for one skipped lineup and includes the reason", () => {
+    const out = summarizeSkips([skip("a", "missing required fields: utility_type_id")]);
+    expect(out).toContain("1 lineup skipped");
+    expect(out).not.toContain("1 lineups");
+    expect(out).toContain("utility_type_id");
+  });
+
+  it("pluralizes and dedupes identical reasons into one phrase", () => {
+    const out = summarizeSkips([
+      skip("a", "missing required fields: utility_type_id"),
+      skip("b", "missing required fields: utility_type_id"),
+      skip("c", "missing required fields: utility_type_id"),
+    ]);
+    expect(out).toContain("3 lineups skipped");
+    // Reason appears once despite three lineups.
+    expect(out.match(/utility_type_id/g)).toHaveLength(1);
+  });
+
+  it("caps the reason list and reports the overflow count", () => {
+    const out = summarizeSkips([
+      skip("a", "reason one"),
+      skip("b", "reason two"),
+      skip("c", "reason three"),
+      skip("d", "reason four"),
+    ]);
+    expect(out).toContain("4 lineups skipped");
+    expect(out).toContain("reason one");
+    expect(out).toContain("reason two");
+    expect(out).not.toContain("reason three");
+    expect(out).toContain("(+2 more)");
+  });
+});

--- a/apps/mygamingassistant/frontend/src/pages/Review.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/Review.tsx
@@ -26,6 +26,7 @@ import {
   useBulkAcceptLineupsMutation,
 } from "@/store/lineupsApi";
 import { useGetGamesQuery } from "@/store/gamesApi";
+import type { BulkAcceptSkip } from "@/types/game";
 import ReviewCard from "@/components/review/ReviewCard";
 import ReviewSkeletonCard from "@/components/review/ReviewSkeletonCard";
 
@@ -40,6 +41,20 @@ const CONFIDENCE_LEVELS = [
   { label: "Low (<0.5)", value: 0.49 },
   { label: "Medium (<0.75)", value: 0.74 },
 ] as const;
+
+/**
+ * Build a concise operator-facing summary of why bulk-accept skipped some
+ * lineups. Dedupes identical reasons (every "missing utility_type_id" lineup
+ * collapses to one phrase) and caps the toast length so a 10-lineup batch
+ * doesn't produce an unreadable wall of text.
+ */
+export function summarizeSkips(skipped: BulkAcceptSkip[]): string {
+  const reasons = Array.from(new Set(skipped.map((s) => s.reason)));
+  const head = reasons.slice(0, 2).join(" · ");
+  const more = reasons.length > 2 ? ` (+${reasons.length - 2} more)` : "";
+  const n = skipped.length;
+  return `${n} lineup${n === 1 ? "" : "s"} skipped — ${head}${more}`;
+}
 
 // ---------------------------------------------------------------------------
 // Review page
@@ -97,14 +112,22 @@ export default function Review() {
     if (selectedIds.size === 0) return;
     const ids = Array.from(selectedIds);
     try {
-      const accepted = await bulkAccept({
+      const { accepted, skipped } = await bulkAccept({
         lineup_ids: ids,
         patches: {},
       }).unwrap();
-      showSuccess(
-        `Accepted ${accepted.length} lineup${accepted.length === 1 ? "" : "s"}.`,
-      );
-      setSelectedIds(new Set());
+
+      if (accepted.length > 0) {
+        showSuccess(
+          `Accepted ${accepted.length} lineup${accepted.length === 1 ? "" : "s"}.`,
+        );
+      }
+      if (skipped.length > 0) {
+        showError(summarizeSkips(skipped));
+      }
+      // Keep the skipped lineups selected so the operator can fix the
+      // flagged field(s) and retry; drop the ones that went through.
+      setSelectedIds(new Set(skipped.map((s) => s.lineup_id)));
     } catch {
       showError("Bulk accept failed. Some lineups may still be pending.");
     }

--- a/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
@@ -9,6 +9,7 @@
 import { baseApi } from "@platform/ui";
 import type {
   BulkAcceptBody,
+  BulkAcceptResult,
   ClassifyResponse,
   Lineup,
   LineupAcceptBody,
@@ -154,7 +155,7 @@ const lineupsApi = lineupsBaseApi.injectEndpoints({
       ],
     }),
 
-    bulkAcceptLineups: build.mutation<Lineup[], BulkAcceptBody>({
+    bulkAcceptLineups: build.mutation<BulkAcceptResult, BulkAcceptBody>({
       query: (body) => ({ url: "/lineups/bulk-accept", method: "POST", data: body }),
       invalidatesTags: ["LineupList", "PendingLineups", "ZoneDensity"],
     }),

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -168,6 +168,18 @@ export interface BulkAcceptBody {
   patches: Record<string, LineupAcceptBody>;
 }
 
+/** One lineup bulk-accept could not accept, with the operator-facing reason. */
+export interface BulkAcceptSkip {
+  lineup_id: string;
+  reason: string;
+}
+
+/** Outcome of POST /lineups/bulk-accept — accepted lineups + skipped + why. */
+export interface BulkAcceptResult {
+  accepted: Lineup[];
+  skipped: BulkAcceptSkip[];
+}
+
 export interface ClassifyResponse {
   lineup_id: string;
   success: boolean;


### PR DESCRIPTION
## Problem (operator-reported)

Testing the review queue, the operator hit *"Accepted 0 lineups."* after **Select all → Accept** with pending lineups still in review. Root cause: the two lineups were missing `utility_type_id` (the classifier's most common gap — Game/Map/zones/side filled, Utility blank). `lineup_service.accept` correctly raises `ValueError`, the **single**-accept endpoint returns a clear 422 — but **bulk-accept silently swallowed every per-lineup failure** (logged server-side only) and returned a bare list. The operator got a count with zero indication of *which* lineups failed or *why*. A dead end.

## Fix

**Backend** — `/lineups/bulk-accept` now returns `BulkAcceptResult { accepted, skipped[] }`. Each `skipped` entry carries the same operator-facing `reason` the single-accept endpoint returns as its 422 detail (`"Cannot accept lineup: missing required fields: utility_type_id ..."`). Expected `ValueError` captured verbatim; unexpected errors logged + reported generically. Batch never aborts; partial-success durability contract unchanged.

**Frontend** — `Review.handleBulkAccept` reports the accepted count **and** a concise, deduped skip summary (`summarizeSkips`), and keeps the skipped lineups selected so the operator can set the missing field and retry without re-selecting.

## Tests

- Backend partial-success test updated to assert `skipped[]` names the missing fields (was asserting the old list shape).
- New `summarizeSkips` unit tests: dedupe, pluralization, overflow cap.
- Full suites green: backend `60 passed`, frontend `287 passed`, frontend build clean.

## Not in scope

*Why* the classifier leaves `utility_type_id` null is a separate classifier-quality concern (related to the #689 prompt work) — this PR makes the failure **visible and actionable**, it doesn't change classification. Operator can set the Utility dropdown and accept; this PR makes that the obvious next step instead of a guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)