### PR TITLE
fix(mga): add app/cli/__main__.py so `python -m app.cli` works

### DIFF
--- a/apps/mygamingassistant/backend/app/cli/__main__.py
+++ b/apps/mygamingassistant/backend/app/cli/__main__.py
@@ -1,0 +1,11 @@
+"""Package entry point so ``python -m app.cli <command>`` works.
+
+``app.cli`` is a package, so ``python -m app.cli`` requires this module to
+exist — without it the documented command (CLAUDE.md, the deploy runbook's
+``docker compose ... exec api python -m app.cli load-fixtures``) fails with
+"'app.cli' is a package and cannot be directly executed".
+"""
+from app.cli import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

`app.cli` is a package with no `__main__.py`. The command documented in `CLAUDE.md` and the deploy runbook —

```
docker compose -f apps/mygamingassistant/docker-compose.yml exec api python -m app.cli load-fixtures
```

— fails with `'app.cli' is a package and cannot be directly executed`. This is the fixture-reload recovery path; it's needed exactly when map zones ship/seed without polygon geometry (the issue behind the operator's "lineups not showing on the map" report). The documented recovery was broken.

## Fix

Add `app/cli/__main__.py` delegating to the existing `main()`. `python -m app.cli load-fixtures` now resolves and runs.

Verified: `python -m app.cli` now executes the CLI dispatcher (prints the usage banner instead of the package-execution error).

🤖 Generated with [Claude Code](https://claude.com/claude-code)