### PR TITLE
fix(mga): audit track D — postgres:16-alpine + extract source_schemas.py

### DIFF
--- a/apps/mygamingassistant/backend/app/api/sources.py
+++ b/apps/mygamingassistant/backend/app/api/sources.py
@@ -23,7 +23,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_active_user
 from app.db.session import get_db
-from app.schemas.game.lineup_schemas import SourceCreate, SourceRead, SyncJobResponse
+from app.schemas.game.source_schemas import SourceCreate, SourceRead, SyncJobResponse
 from app.services.game import source_service
 from app.services.ingestion import ingestion_orchestrator
 

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -320,34 +320,3 @@ class PendingLineupsResponse(BaseModel):
     offset: int
 
 
-# ---------------------------------------------------------------------------
-# Source schemas
-# ---------------------------------------------------------------------------
-
-class SourceCreate(BaseModel):
-    kind: str
-    url: str
-
-    @field_validator("kind")
-    @classmethod
-    def validate_kind(cls, v: str) -> str:
-        if v not in ("youtube_playlist", "youtube_channel"):
-            raise ValueError("kind must be youtube_playlist or youtube_channel")
-        return v
-
-
-class SourceRead(BaseModel):
-    id: uuid.UUID
-    kind: str
-    config_json: dict
-    last_synced_at: Optional[str] = None
-    created_at: str
-
-    model_config = {"from_attributes": True}
-
-
-class SyncJobResponse(BaseModel):
-    job_id: str
-    source_id: uuid.UUID
-    status: str = "queued"
-    message: str = "Sync started — lineups will appear in pending_review when complete"

--- a/apps/mygamingassistant/backend/app/schemas/game/source_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/source_schemas.py
@@ -1,0 +1,36 @@
+"""Pydantic schemas for source-related API requests and responses."""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from pydantic import BaseModel, field_validator
+
+
+class SourceCreate(BaseModel):
+    kind: str
+    url: str
+
+    @field_validator("kind")
+    @classmethod
+    def validate_kind(cls, v: str) -> str:
+        if v not in ("youtube_playlist", "youtube_channel"):
+            raise ValueError("kind must be youtube_playlist or youtube_channel")
+        return v
+
+
+class SourceRead(BaseModel):
+    id: uuid.UUID
+    kind: str
+    config_json: dict
+    last_synced_at: Optional[str] = None
+    created_at: str
+
+    model_config = {"from_attributes": True}
+
+
+class SyncJobResponse(BaseModel):
+    job_id: str
+    source_id: uuid.UUID
+    status: str = "queued"
+    message: str = "Sync started — lineups will appear in pending_review when complete"

--- a/apps/mygamingassistant/backend/app/services/game/source_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/source_service.py
@@ -17,7 +17,7 @@ from app.repositories.game.source_repo import (
     list_sources,
     soft_delete_source,
 )
-from app.schemas.game.lineup_schemas import SourceCreate
+from app.schemas.game.source_schemas import SourceCreate
 
 
 # ---------------------------------------------------------------------------

--- a/apps/mygamingassistant/docker-compose.yml
+++ b/apps/mygamingassistant/docker-compose.yml
@@ -4,7 +4,7 @@
 
 services:
   postgres:
-    image: postgres:16
+    image: postgres:16-alpine
     restart: unless-stopped
     environment:
       POSTGRES_USER: mygamingassistant


### PR DESCRIPTION
## Summary

- **Tier-2 operational drift:** `docker-compose.yml` postgres image changed from `postgres:16` to `postgres:16-alpine` to match MBK canonical (same libc/locale/patch cadence between prod DBs)
- **Schema file hygiene:** Extracted `SourceCreate`, `SourceRead`, `SyncJobResponse` out of `lineup_schemas.py` into new `app/schemas/game/source_schemas.py` — Source-domain schemas were misfiled in the Lineup schema module; now each domain has its own file per MGA CLAUDE.md "one schema per file" convention
- Updated import sites: `api/sources.py` and `services/game/source_service.py`

## Test plan

- [x] 290 backend tests pass (`pytest tests/ -q`)
- [x] 7 `test_classifier_service.py` setup ERRORs are pre-existing environmental UniqueViolation (valorant duplicate-game-row) unrelated to these changes
- [x] No behavior changes — pure file move + import fixups + compose image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)