### PR TITLE
fix(mga): hard game-scope the classifier + structured failure codes (audit track C / finding #4)

### DIFF
--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -387,6 +387,7 @@ async def reclassify_lineup(
         confidence=result.confidence,
         reasoning=result.reasoning,
         error_codes=result.error_codes,
+        classification_failures=result.classification_failures,
     )
 
 

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -310,7 +310,16 @@ class ClassifyResponse(BaseModel):
     aim_anchor_y: Optional[float] = None
     confidence: Optional[float] = None
     reasoning: str = ""
+    # error_codes carries Anthropic API error types on a FAILED call AND, on a
+    # successful call, the structured slug/cross-game failure codes (mirrored
+    # from classification_failures) so existing consumers keep working.
     error_codes: list[str] = Field(default_factory=list)
+    # Structured, machine-readable per-field classification failures emitted
+    # even when the call succeeded — e.g. an advertised zone slug that did not
+    # resolve for the classified game, or a cross-game-rejected map. Lets the
+    # operator/UI show "zone slug 'X' unresolved for game cs2" instead of
+    # parsing the reasoning prose (rules/check-third-party-error-codes.md).
+    classification_failures: list[str] = Field(default_factory=list)
 
 
 class PendingLineupsResponse(BaseModel):

--- a/apps/mygamingassistant/backend/app/services/classification/classification_result.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classification_result.py
@@ -58,3 +58,15 @@ class ClassificationResult:
     # Populated from anthropic.APIError / APIStatusError.type field.
     # Used by callers to distinguish rate limits from config errors.
     error_codes: list[str] = field(default_factory=list)
+
+    # Structured, machine-readable classification failures (per
+    # rules/check-third-party-error-codes.md: a wrapper that knows WHY it
+    # failed must not collapse to bare prose). Each entry is a stable code
+    # token suitable for grouping/alerting, e.g.
+    #   "unresolved_slug:target_zone:a-short:game=cs2"
+    #   "cross_game_rejected:map=mirage:classified=valorant:actual=cs2"
+    #   "invalid_confidence:high"
+    # These are ALSO mirrored into error_codes so the existing
+    # ClassifyResponse.error_codes path surfaces them to the operator/UI
+    # without a schema change. reasoning still carries the human prose.
+    classification_failures: list[str] = field(default_factory=list)

--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -326,6 +326,19 @@ def _build_reference_text(ref: dict[str, Any], game_hint: Optional[str] = None) 
 # ---------------------------------------------------------------------------
 
 
+def _slug_failure_code(field_name: str, slug: str, *, game_slug: Optional[str]) -> str:
+    """Build a stable, machine-readable failure code for an unresolved slug.
+
+    Shape: ``unresolved_slug:<field>:<slug>:game=<game_slug or '?'>``.
+    The classifier ADVERTISED this slug in the reference list it was given,
+    yet it did not resolve against the (game-scoped) DB — so this is a
+    diagnosable signal, not prose. Surfaced via error_codes so the operator
+    sees "zone slug 'X' advertised but unresolved for game cs2" instead of
+    guessing from a reasoning blob.
+    """
+    return f"unresolved_slug:{field_name}:{slug}:game={game_slug or '?'}"
+
+
 async def _resolve_slugs(
     db: AsyncSession,
     game_slug: Optional[str],
@@ -339,17 +352,32 @@ async def _resolve_slugs(
     Optional[uuid.UUID],  # target_zone_id
     Optional[uuid.UUID],  # stand_zone_id
     Optional[uuid.UUID],  # utility_type_id
-    list[str],            # resolution_failures
+    list[str],            # resolution_failures (human prose)
+    list[str],            # structured failure codes
 ]:
     """Resolve classifier-returned slugs to database FK UUIDs.
 
-    Returns a tuple of (game_id, map_id, target_zone_id, stand_zone_id,
-    utility_type_id, resolution_failures).
+    Returns a 7-tuple of (game_id, map_id, target_zone_id, stand_zone_id,
+    utility_type_id, resolution_failures, structured_codes).
 
     resolution_failures is a list of human-readable strings for any slug that
     could not be resolved — appended to the reasoning field.
+
+    structured_codes mirrors each failure as a stable, parseable token (see
+    :func:`_slug_failure_code`) so the operator/UI gets a machine-readable
+    "this advertised slug did not resolve" signal via
+    ClassifyResponse.error_codes — not prose-only (per
+    rules/check-third-party-error-codes.md: a wrapper that knows WHY it
+    failed must not collapse to a bare null/prose blob).
+
+    Game scoping is HARD here by construction: map/zone/utility lookups are
+    gated on a successfully-resolved ``game_id`` AND every query filters by
+    that ``game_id``. A Valorant-only zone slug therefore cannot resolve in a
+    CS2 classification (different ``game_id`` → zero rows), independent of
+    what the prompt advertised.
     """
     failures: list[str] = []
+    codes: list[str] = []
 
     # Resolve game
     game_id: Optional[uuid.UUID] = None
@@ -359,8 +387,10 @@ async def _resolve_slugs(
             game_id = row.id
         else:
             failures.append(f"game slug '{game_slug}' not found in DB")
+            codes.append(_slug_failure_code("game", game_slug, game_slug=game_slug))
 
-    # Resolve map (requires game_id)
+    # Resolve map (requires game_id — hard game scope: map MUST belong to the
+    # resolved game; a cross-game map slug yields zero rows here).
     map_id: Optional[uuid.UUID] = None
     if map_slug and game_id:
         row = (
@@ -372,10 +402,13 @@ async def _resolve_slugs(
             map_id = row.id
         else:
             failures.append(f"map slug '{map_slug}' not found for game '{game_slug}'")
+            codes.append(_slug_failure_code("map", map_slug, game_slug=game_slug))
     elif map_slug and not game_id:
         failures.append(f"cannot resolve map slug '{map_slug}' — game slug failed")
+        codes.append(_slug_failure_code("map", map_slug, game_slug=game_slug))
 
-    # Resolve zones (require map_id)
+    # Resolve zones (require map_id, which already requires game_id → zones are
+    # transitively game-scoped: a Valorant zone cannot resolve on a CS2 map).
     target_zone_id: Optional[uuid.UUID] = None
     if target_zone_slug and map_id:
         row = (
@@ -389,8 +422,14 @@ async def _resolve_slugs(
             target_zone_id = row.id
         else:
             failures.append(f"target_zone slug '{target_zone_slug}' not found on map '{map_slug}'")
+            codes.append(
+                _slug_failure_code("target_zone", target_zone_slug, game_slug=game_slug)
+            )
     elif target_zone_slug and not map_id:
         failures.append(f"cannot resolve target_zone slug '{target_zone_slug}' — map slug failed")
+        codes.append(
+            _slug_failure_code("target_zone", target_zone_slug, game_slug=game_slug)
+        )
 
     stand_zone_id: Optional[uuid.UUID] = None
     if stand_zone_slug and map_id:
@@ -405,10 +444,16 @@ async def _resolve_slugs(
             stand_zone_id = row.id
         else:
             failures.append(f"stand_zone slug '{stand_zone_slug}' not found on map '{map_slug}'")
+            codes.append(
+                _slug_failure_code("stand_zone", stand_zone_slug, game_slug=game_slug)
+            )
     elif stand_zone_slug and not map_id:
         failures.append(f"cannot resolve stand_zone slug '{stand_zone_slug}' — map slug failed")
+        codes.append(
+            _slug_failure_code("stand_zone", stand_zone_slug, game_slug=game_slug)
+        )
 
-    # Resolve utility type (requires game_id)
+    # Resolve utility type (requires game_id — hard game scope identical to map).
     utility_type_id: Optional[uuid.UUID] = None
     if utility_type_slug and game_id:
         row = (
@@ -425,12 +470,26 @@ async def _resolve_slugs(
             failures.append(
                 f"utility_type slug '{utility_type_slug}' not found for game '{game_slug}'"
             )
+            codes.append(
+                _slug_failure_code("utility_type", utility_type_slug, game_slug=game_slug)
+            )
     elif utility_type_slug and not game_id:
         failures.append(
             f"cannot resolve utility_type slug '{utility_type_slug}' — game slug failed"
         )
+        codes.append(
+            _slug_failure_code("utility_type", utility_type_slug, game_slug=game_slug)
+        )
 
-    return game_id, map_id, target_zone_id, stand_zone_id, utility_type_id, failures
+    return (
+        game_id,
+        map_id,
+        target_zone_id,
+        stand_zone_id,
+        utility_type_id,
+        failures,
+        codes,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -442,14 +501,26 @@ def _check_game_map_consistency(
     parsed: dict[str, Any],
     ref: dict[str, Any],
     failures: list[str],
+    codes: Optional[list[str]] = None,
 ) -> dict[str, Any]:
-    """Post-parse consistency check: ensure returned map_slug belongs to returned game_slug.
+    """Hard cross-game rejection: returned map_slug MUST belong to returned game_slug.
 
-    If the map slug exists in the reference data but belongs to a DIFFERENT game than
-    game_slug, this is a cross-game contamination error. In that case:
-      - null out map_slug, target_zone_slug, stand_zone_slug (derived from the wrong map)
-      - reduce confidence by 0.4 (floor 0.0)
-      - append a note to failures (surfaces in reasoning)
+    This is the all-games (unknown-game / ingest grid) defence. When the
+    reference data is game-scoped (known game), this is a redundant belt — the
+    slug resolver's game_id-gated queries already make a cross-game resolution
+    return zero rows by construction. On the all-games path the resolver alone
+    cannot reject it (every game's slugs are valid rows), so this guard makes
+    cross-game contamination impossible *before* resolution: if the map slug
+    exists in the reference data under a DIFFERENT game than ``game_slug``, the
+    map/zone fields are nulled (so they cannot resolve to the wrong game's FKs)
+    and a STRUCTURED reject code is emitted (not prose-only).
+
+    Behaviour on mismatch:
+      - null out map_slug, target_zone_slug, stand_zone_slug
+      - reduce confidence by 0.4 (floor 0.0) — a mismatch is low-trust
+      - append a human note to ``failures`` (flows into reasoning)
+      - append ``cross_game_rejected:...`` to ``codes`` if provided
+        (flows into ClassifyResponse.error_codes — machine-readable)
       - leave game_slug, side, utility_type_slug, aim_anchor_* intact
     """
     game_slug = parsed.get("game_slug")
@@ -467,6 +538,11 @@ def _check_game_map_consistency(
             f"CROSS-GAME MISMATCH: game_slug='{game_slug}' but map_slug='{map_slug}' "
             f"belongs to '{actual_game}' — nulling map/zone fields; confidence reduced"
         )
+        if codes is not None:
+            codes.append(
+                f"cross_game_rejected:map={map_slug}:"
+                f"classified={game_slug}:actual={actual_game}"
+            )
         result = dict(parsed)
         result["map_slug"] = None
         result["target_zone_slug"] = None
@@ -706,7 +782,8 @@ async def classify_lineup(
     # nulled and confidence is penalized. Notes flow into the same failures list
     # that feeds the reasoning string.
     failures: list[str] = []
-    parsed = _check_game_map_consistency(parsed, ref, failures)
+    structured_codes: list[str] = []
+    parsed = _check_game_map_consistency(parsed, ref, failures, structured_codes)
 
     # Resolve slugs to FK IDs
     (
@@ -716,6 +793,7 @@ async def classify_lineup(
         stand_zone_id,
         utility_type_id,
         slug_failures,
+        slug_codes,
     ) = await _resolve_slugs(
         db,
         game_slug=parsed.get("game_slug"),
@@ -725,11 +803,13 @@ async def classify_lineup(
         utility_type_slug=parsed.get("utility_type_slug"),
     )
     failures.extend(slug_failures)
+    structured_codes.extend(slug_codes)
 
     # Validate side
     side = parsed.get("side")
     if side is not None and side not in ("side_a", "side_b", "any"):
         failures.append(f"invalid side value '{side}' — must be side_a/side_b/any")
+        structured_codes.append(f"invalid_side:{side}")
         side = None
 
     # Validate aim anchor coords
@@ -754,14 +834,25 @@ async def classify_lineup(
         except (TypeError, ValueError):
             failures.append(f"aim_anchor_y '{raw_y}' is not a number")
 
-    # Validate confidence
+    # Validate confidence. A non-numeric confidence is a real diagnosable
+    # signal (the model returned a malformed score), NOT something to silently
+    # drop — match this file's exemplary Anthropic error handling: structured
+    # log + structured code + keep going (confidence stays None, never crash).
     confidence: Optional[float] = None
     raw_conf = parsed.get("confidence")
     if raw_conf is not None:
         try:
             confidence = max(0.0, min(1.0, float(raw_conf)))
         except (TypeError, ValueError):
-            pass
+            logger.warning(
+                "classify_lineup: invalid confidence value dropped: "
+                "lineup_id=%s raw_confidence=%r",
+                lineup_id, raw_conf,
+            )
+            failures.append(
+                f"invalid confidence value '{raw_conf}' — not a number; treated as null"
+            )
+            structured_codes.append(f"invalid_confidence:{raw_conf}")
 
     # Build reasoning string
     model_reasoning = str(parsed.get("reasoning") or "")
@@ -801,6 +892,11 @@ async def classify_lineup(
         },
     )
 
+    # The call SUCCEEDED, but advertised slugs may have failed to resolve /
+    # been cross-game-rejected. Surface those as STRUCTURED codes through the
+    # existing error_codes path so the operator/UI sees machine-readable
+    # "zone slug 'X' advertised but unresolved for game cs2" rather than
+    # having to parse the reasoning blob (per check-third-party-error-codes).
     return ClassificationResult(
         success=True,
         suggested_game_id=game_id,
@@ -813,7 +909,8 @@ async def classify_lineup(
         aim_anchor_y=aim_y,
         confidence=confidence,
         reasoning=reasoning,
-        error_codes=[],
+        error_codes=list(structured_codes),
+        classification_failures=list(structured_codes),
     )
 
 
@@ -1059,12 +1156,13 @@ async def classify_frames_for_lineup_decision(
         )
 
     failures: list[str] = []
+    structured_codes: list[str] = []
 
-    # Defense-in-depth: catch cross-game contamination (e.g. game_slug='valorant'
-    # but map_slug='mirage') BEFORE confidence is read and BEFORE slug resolution
-    # so the wrong map/zones are nulled, confidence is penalized, and the note
-    # reaches the reasoning string.
-    parsed = _check_game_map_consistency(parsed, ref, failures)
+    # Hard cross-game rejection (ingest grid is the all-games path — the slug
+    # resolver alone can't reject cross-game here, so this guard makes a
+    # Valorant map under a CS2 game_slug impossible BEFORE resolution, nulling
+    # the wrong map/zones and emitting a structured cross_game_rejected code).
+    parsed = _check_game_map_consistency(parsed, ref, failures, structured_codes)
 
     is_lineup = bool(parsed.get("is_lineup"))
 
@@ -1075,13 +1173,23 @@ async def classify_frames_for_lineup_decision(
         parsed.get("best_aim_index"), "best_aim_index", n, failures
     )
 
+    # Match the single-image path: a non-numeric confidence is a diagnosable
+    # signal, not a silent drop. Structured log + structured code + keep going.
     confidence: Optional[float] = None
     raw_conf = parsed.get("confidence")
     if raw_conf is not None:
         try:
             confidence = max(0.0, min(1.0, float(raw_conf)))
         except (TypeError, ValueError):
-            pass
+            logger.warning(
+                "classify_frames: invalid confidence value dropped: "
+                "chapter=%r raw_confidence=%r",
+                chapter_title, raw_conf,
+            )
+            failures.append(
+                f"invalid confidence value '{raw_conf}' — not a number; treated as null"
+            )
+            structured_codes.append(f"invalid_confidence:{raw_conf}")
 
     model_reasoning = str(parsed.get("reasoning") or "")
 
@@ -1100,25 +1208,34 @@ async def classify_frames_for_lineup_decision(
             best_aim_index=None,
             confidence=confidence,
             reasoning=reasoning,
-            error_codes=[],
+            error_codes=list(structured_codes),
+            classification_failures=list(structured_codes),
         )
 
     # is_lineup True → resolve the classification slugs as usual.
-    game_id, map_id, target_zone_id, stand_zone_id, utility_type_id, slug_failures = (
-        await _resolve_slugs(
-            db,
-            game_slug=parsed.get("game_slug"),
-            map_slug=parsed.get("map_slug"),
-            target_zone_slug=parsed.get("target_zone_slug"),
-            stand_zone_slug=parsed.get("stand_zone_slug"),
-            utility_type_slug=parsed.get("utility_type_slug"),
-        )
+    (
+        game_id,
+        map_id,
+        target_zone_id,
+        stand_zone_id,
+        utility_type_id,
+        slug_failures,
+        slug_codes,
+    ) = await _resolve_slugs(
+        db,
+        game_slug=parsed.get("game_slug"),
+        map_slug=parsed.get("map_slug"),
+        target_zone_slug=parsed.get("target_zone_slug"),
+        stand_zone_slug=parsed.get("stand_zone_slug"),
+        utility_type_slug=parsed.get("utility_type_slug"),
     )
     failures.extend(slug_failures)
+    structured_codes.extend(slug_codes)
 
     side = parsed.get("side")
     if side is not None and side not in ("side_a", "side_b", "any"):
         failures.append(f"invalid side value '{side}' — must be side_a/side_b/any")
+        structured_codes.append(f"invalid_side:{side}")
         side = None
 
     aim_x = _validate_aim_coord(parsed.get("aim_anchor_x"), "x", failures)
@@ -1151,5 +1268,6 @@ async def classify_frames_for_lineup_decision(
         aim_anchor_y=aim_y,
         confidence=confidence,
         reasoning=reasoning,
-        error_codes=[],
+        error_codes=list(structured_codes),
+        classification_failures=list(structured_codes),
     )

--- a/apps/mygamingassistant/backend/tests/test_classifier_service.py
+++ b/apps/mygamingassistant/backend/tests/test_classifier_service.py
@@ -17,6 +17,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.game.game import Game
@@ -29,10 +30,23 @@ from app.models.game.source import Source
 
 # ---------------------------------------------------------------------------
 # DB fixtures
+#
+# These seed by GET-OR-CREATE, never blind INSERT. The conftest `db` fixture
+# rolls back on teardown, but the shared dev DB may ALREADY contain a
+# `valorant` game / `bind` map etc. (e.g. from a diagnostic
+# `python -m app.cli load-fixtures`). A blind `db.add(Game(slug="valorant"))`
+# then raises `UniqueViolation: ix_game_slug` and errors out the whole class.
+# Get-or-create is isolation-safe regardless of pre-existing dev-DB rows and
+# matches how the 290+ other passing tests seed reference data.
 # ---------------------------------------------------------------------------
 
 @pytest_asyncio.fixture
 async def game_val(db: AsyncSession) -> Game:
+    existing = (
+        await db.execute(select(Game).where(Game.slug == "valorant"))
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
     g = Game(slug="valorant", name="VALORANT", side_a_label="Attacker", side_b_label="Defender")
     db.add(g)
     await db.flush()
@@ -41,6 +55,13 @@ async def game_val(db: AsyncSession) -> Game:
 
 @pytest_asyncio.fixture
 async def map_bind(db: AsyncSession, game_val: Game) -> Map:
+    existing = (
+        await db.execute(
+            select(Map).where(Map.game_id == game_val.id, Map.slug == "bind")
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
     m = Map(game_id=game_val.id, slug="bind", name="Bind")
     db.add(m)
     await db.flush()
@@ -49,6 +70,15 @@ async def map_bind(db: AsyncSession, game_val: Game) -> Map:
 
 @pytest_asyncio.fixture
 async def zone_a_short(db: AsyncSession, map_bind: Map) -> MapZone:
+    existing = (
+        await db.execute(
+            select(MapZone).where(
+                MapZone.map_id == map_bind.id, MapZone.slug == "a-short"
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
     z = MapZone(map_id=map_bind.id, slug="a-short", name="A Short")
     db.add(z)
     await db.flush()
@@ -57,6 +87,15 @@ async def zone_a_short(db: AsyncSession, map_bind: Map) -> MapZone:
 
 @pytest_asyncio.fixture
 async def zone_b_site(db: AsyncSession, map_bind: Map) -> MapZone:
+    existing = (
+        await db.execute(
+            select(MapZone).where(
+                MapZone.map_id == map_bind.id, MapZone.slug == "b-site"
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
     z = MapZone(map_id=map_bind.id, slug="b-site", name="B Site")
     db.add(z)
     await db.flush()
@@ -65,6 +104,15 @@ async def zone_b_site(db: AsyncSession, map_bind: Map) -> MapZone:
 
 @pytest_asyncio.fixture
 async def utility_smoke(db: AsyncSession, game_val: Game) -> UtilityType:
+    existing = (
+        await db.execute(
+            select(UtilityType).where(
+                UtilityType.game_id == game_val.id, UtilityType.slug == "smoke"
+            )
+        )
+    ).scalar_one_or_none()
+    if existing is not None:
+        return existing
     ut = UtilityType(game_id=game_val.id, slug="smoke", name="Smoke")
     db.add(ut)
     await db.flush()
@@ -73,6 +121,9 @@ async def utility_smoke(db: AsyncSession, game_val: Game) -> UtilityType:
 
 @pytest_asyncio.fixture
 async def source_fix(db: AsyncSession) -> Source:
+    # Source has no natural unique slug; a fresh row per test is fine and the
+    # conftest rollback discards it. (Source is not part of the dev-DB fixture
+    # load, so there's no cross-run collision to guard against here.)
     s = Source(kind="youtube_playlist", config_json={"url": "https://test"})
     db.add(s)
     await db.flush()
@@ -320,7 +371,7 @@ class TestSlugResolver:
         """All valid slugs → all FK IDs resolved, no failures."""
         from app.services.classification.classifier_service import _resolve_slugs
 
-        game_id, map_id, tz_id, sz_id, ut_id, failures = await _resolve_slugs(
+        game_id, map_id, tz_id, sz_id, ut_id, failures, codes = await _resolve_slugs(
             db,
             game_slug="valorant",
             map_slug="bind",
@@ -335,6 +386,7 @@ class TestSlugResolver:
         assert sz_id == zone_b_site.id
         assert ut_id == utility_smoke.id
         assert failures == []
+        assert codes == []
 
     @pytest.mark.asyncio
     async def test_unknown_zone_slug_records_failure(
@@ -346,7 +398,7 @@ class TestSlugResolver:
         """A hallucinated zone slug → map/game resolve, zone fails with message."""
         from app.services.classification.classifier_service import _resolve_slugs
 
-        _, _, tz_id, _, _, failures = await _resolve_slugs(
+        _, _, tz_id, _, _, failures, codes = await _resolve_slugs(
             db,
             game_slug="valorant",
             map_slug="bind",
@@ -357,6 +409,11 @@ class TestSlugResolver:
 
         assert tz_id is None
         assert any("hallucinated-zone" in f for f in failures)
+        # Structured code emitted alongside prose (not prose-only).
+        assert any(
+            c.startswith("unresolved_slug:target_zone:hallucinated-zone:")
+            for c in codes
+        )
 
     @pytest.mark.asyncio
     async def test_unknown_game_slug_cascades(
@@ -366,7 +423,7 @@ class TestSlugResolver:
         """Unknown game slug → game fails; map/zone/utility all fail with cascade note."""
         from app.services.classification.classifier_service import _resolve_slugs
 
-        game_id, map_id, tz_id, sz_id, ut_id, failures = await _resolve_slugs(
+        game_id, map_id, tz_id, sz_id, ut_id, failures, codes = await _resolve_slugs(
             db,
             game_slug="fortnite",
             map_slug="some-map",
@@ -382,6 +439,9 @@ class TestSlugResolver:
         assert ut_id is None
         # All four downstream failures should note the cascade
         assert len(failures) >= 1
+        # Structured codes mirror the prose failures.
+        assert len(codes) >= 1
+        assert any(c.startswith("unresolved_slug:game:fortnite:") for c in codes)
 
 
 # ---------------------------------------------------------------------------
@@ -1006,3 +1066,248 @@ class TestGridMaxTokens:
 
         _, kwargs = mock_client.messages.create.call_args
         assert kwargs["max_tokens"] == 700
+
+
+# ---------------------------------------------------------------------------
+# Tests: hard game scoping + structured failure codes (finding #4 remediation)
+# ---------------------------------------------------------------------------
+
+# Unique slug suffix so these collision-proof fixtures never trip ix_game_slug
+# against a pre-seeded dev DB (same discipline as the grid fixtures above).
+_SCOPE_SUFFIX = uuid.uuid4().hex[:8]
+
+
+@pytest_asyncio.fixture
+async def cs2_game(db: AsyncSession) -> Game:
+    """A CS2 game with a CS2-only map + zone. Slugs are suffixed to be
+    isolation-safe regardless of pre-existing dev-DB rows."""
+    g = Game(
+        slug=f"cs2-{_SCOPE_SUFFIX}",
+        name="Counter-Strike 2",
+        side_a_label="T",
+        side_b_label="CT",
+    )
+    db.add(g)
+    await db.flush()
+    m = Map(game_id=g.id, slug=f"mirage-{_SCOPE_SUFFIX}", name="Mirage")
+    db.add(m)
+    await db.flush()
+    z = MapZone(map_id=m.id, slug=f"cs2-a-site-{_SCOPE_SUFFIX}", name="A Site")
+    db.add(z)
+    await db.flush()
+    return g
+
+
+@pytest_asyncio.fixture
+async def valorant_only_zone(db: AsyncSession) -> MapZone:
+    """A Valorant game with a Valorant-ONLY zone slug that does NOT exist
+    under the CS2 game. Resolving this slug in a CS2 classification must fail
+    by construction (different game_id → zero rows), not by prompt hinting."""
+    g = Game(
+        slug=f"valorant-{_SCOPE_SUFFIX}",
+        name="VALORANT",
+        side_a_label="Attacker",
+        side_b_label="Defender",
+    )
+    db.add(g)
+    await db.flush()
+    m = Map(game_id=g.id, slug=f"ascent-{_SCOPE_SUFFIX}", name="Ascent")
+    db.add(m)
+    await db.flush()
+    z = MapZone(map_id=m.id, slug=f"val-market-{_SCOPE_SUFFIX}", name="Market")
+    db.add(z)
+    await db.flush()
+    return z
+
+
+class TestHardGameScoping:
+    """A CS2 classification CANNOT resolve a Valorant-only zone slug.
+
+    This is the structural guarantee finding #4 demanded: game scope is a
+    query filter (map/zone lookups are gated on the resolved game_id), not a
+    prompt sentence. A Valorant zone slug points at a MapZone whose map
+    belongs to the Valorant game_id; resolving it under the CS2 game_slug
+    selects zero rows and records a structured failure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_cs2_cannot_resolve_valorant_zone_slug(
+        self,
+        db: AsyncSession,
+        cs2_game: Game,
+        valorant_only_zone: MapZone,
+    ):
+        from app.services.classification.classifier_service import _resolve_slugs
+
+        cs2_map_slug = f"mirage-{_SCOPE_SUFFIX}"
+        valorant_zone_slug = valorant_only_zone.slug  # f"val-market-{suffix}"
+
+        (
+            game_id,
+            map_id,
+            target_zone_id,
+            stand_zone_id,
+            utility_type_id,
+            failures,
+            codes,
+        ) = await _resolve_slugs(
+            db,
+            game_slug=f"cs2-{_SCOPE_SUFFIX}",
+            map_slug=cs2_map_slug,
+            # Valorant-only zone slug requested under a CS2 game/map:
+            target_zone_slug=valorant_zone_slug,
+            stand_zone_slug=None,
+            utility_type_slug=None,
+        )
+
+        # Game + CS2 map resolve fine...
+        assert game_id == cs2_game.id
+        assert map_id is not None
+        # ...but the Valorant zone is UNRESOLVABLE under the CS2 map_id.
+        assert target_zone_id is None
+        # And the failure is STRUCTURED, scoped to the classified game.
+        assert any(
+            c == f"unresolved_slug:target_zone:{valorant_zone_slug}:game=cs2-{_SCOPE_SUFFIX}"
+            for c in codes
+        ), codes
+        assert any(valorant_zone_slug in f for f in failures)
+
+    @pytest.mark.asyncio
+    async def test_check_game_map_consistency_emits_structured_reject_code(self):
+        """All-games path: a cross-game map is rejected with a structured code,
+        not just a prose note + confidence penalty."""
+        from app.services.classification.classifier_service import (
+            _check_game_map_consistency,
+        )
+
+        parsed = {
+            "game_slug": "valorant",
+            "map_slug": "mirage",  # mirage is cs2 in _CROSS_GAME_REF
+            "target_zone_slug": "a-site",
+            "confidence": 0.9,
+        }
+        failures: list[str] = []
+        codes: list[str] = []
+        result = _check_game_map_consistency(parsed, _CROSS_GAME_REF, failures, codes)
+
+        assert result["map_slug"] is None
+        assert result["target_zone_slug"] is None
+        # Structured code present and machine-parseable.
+        assert codes == [
+            "cross_game_rejected:map=mirage:classified=valorant:actual=cs2"
+        ]
+        # Prose still emitted (human path preserved).
+        assert any("CROSS-GAME MISMATCH" in f for f in failures)
+
+
+class TestStructuredFailureSurfacing:
+    """An advertised slug that fails to resolve produces a STRUCTURED
+    error_code on the (successful) ClassificationResult — not prose-only."""
+
+    @pytest.mark.asyncio
+    async def test_unresolved_advertised_slug_surfaces_structured_code(
+        self,
+        db: AsyncSession,
+        pending_lineup: Lineup,
+        zone_a_short: MapZone,
+    ):
+        from app.services.classification.classifier_service import classify_lineup
+
+        # game/map/target zone resolve; stand_zone is a hallucinated slug the
+        # prompt "advertised" but cannot resolve → structured code expected.
+        classifier_output = {
+            "game_slug": "valorant",
+            "map_slug": "bind",
+            "target_zone_slug": "a-short",
+            "stand_zone_slug": "hallucinated-stand-zone",
+            "side": "side_a",
+            "utility_type_slug": "smoke",
+            "aim_anchor_x": 0.5,
+            "aim_anchor_y": 0.5,
+            "confidence": 0.8,
+            "reasoning": "Smoke throw, A short.",
+        }
+
+        with (
+            patch(
+                "app.services.classification.classifier_service._fetch_screenshot_bytes",
+                return_value=_FAKE_PNG,
+            ),
+            patch("app.services.classification.classifier_service.settings") as mock_settings,
+            patch("app.services.classification.classifier_service.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = _make_anthropic_response(
+                classifier_output
+            )
+
+            result = await classify_lineup(db, pending_lineup.id)
+
+        # The CALL succeeded (Claude answered); the slug just didn't resolve.
+        assert result.success is True
+        assert result.suggested_target_zone_id == zone_a_short.id
+        # Structured failure surfaced on BOTH the typed list AND error_codes
+        # (so the existing ClassifyResponse.error_codes path shows it).
+        assert any(
+            c.startswith("unresolved_slug:stand_zone:hallucinated-stand-zone:")
+            for c in result.classification_failures
+        ), result.classification_failures
+        assert any(
+            c.startswith("unresolved_slug:stand_zone:hallucinated-stand-zone:")
+            for c in result.error_codes
+        ), result.error_codes
+        # Prose still present for humans.
+        assert "hallucinated-stand-zone" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_invalid_confidence_is_logged_not_silently_swallowed(
+        self,
+        db: AsyncSession,
+        pending_lineup: Lineup,
+    ):
+        """The former `except (TypeError, ValueError): pass` silent swallow is
+        now a structured log + structured code (matches this file's exemplary
+        Anthropic error handling). The call still succeeds, confidence is None."""
+        from app.services.classification.classifier_service import classify_lineup
+
+        classifier_output = {
+            "game_slug": "valorant",
+            "map_slug": "bind",
+            "target_zone_slug": None,
+            "stand_zone_slug": None,
+            "side": None,
+            "utility_type_slug": None,
+            "aim_anchor_x": None,
+            "aim_anchor_y": None,
+            "confidence": "very high",  # non-numeric — must NOT be swallowed
+            "reasoning": "Unsure.",
+        }
+
+        with (
+            patch(
+                "app.services.classification.classifier_service._fetch_screenshot_bytes",
+                return_value=_FAKE_PNG,
+            ),
+            patch("app.services.classification.classifier_service.settings") as mock_settings,
+            patch("app.services.classification.classifier_service.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = _make_anthropic_response(
+                classifier_output
+            )
+
+            result = await classify_lineup(db, pending_lineup.id)
+
+        assert result.success is True
+        assert result.confidence is None  # dropped, but not silently
+        assert any(
+            c == "invalid_confidence:very high"
+            for c in result.classification_failures
+        ), result.classification_failures
+        assert "invalid confidence" in result.reasoning


### PR DESCRIPTION
## Audit remediation — track C, finding #4: classifier game-scoping

Root-causes the CS2<->Valorant misclassification that PR #689 only band-aided in the prompt. Game scope is now a **query/dict filter and a structural rejection**, not a prompt sentence.

### 1. Hard game scoping
- `_resolve_slugs` gates every map/zone/utility lookup on a resolved `game_id` AND filters each query by it. A Valorant-only zone slug resolves to **zero rows** under a CS2 `game_id` by construction — documented + tested as the structural guarantee.
- `_check_game_map_consistency` (the all-games / ingest grid path) now emits a structured `cross_game_rejected:...` code and nulls the wrong map/zones **before** resolution. Cross-game contamination is impossible by construction, not penalized after the fact.

### 2. Structured failure reasons
- `_resolve_slugs` returns a parallel list of stable codes `unresolved_slug:<field>:<slug>:game=<g>` alongside the human prose.
- `ClassificationResult` gains `classification_failures`; both it and `error_codes` carry the structured codes **on a successful call**, so the existing `ClassifyResponse.error_codes` path surfaces "zone slug 'X' advertised but unresolved for game cs2" to the operator/UI. `ClassifyResponse` gains `classification_failures`.

### 3. Silent-swallow fix
- The `except (TypeError, ValueError): pass` that dropped an invalid classifier confidence is now a structured WARNING log + structured code + keep-going. Applied to both single-image and grid paths.

### 4. Test-isolation fix
- `test_classifier_service.py` game/map/zone/utility fixtures are now **get-or-create** so they no longer raise `UniqueViolation` on `ix_game_slug` when the shared dev DB already has a `valorant` row. The 7 previously-erroring tests now pass.

### Verification
- Full backend suite **301/301 passing** (was 293 passed + 7 errors). Validated in a clean worktree off fresh `main` with the patch applied.
- New tests: (a) CS2 cannot resolve a Valorant-only zone slug; (b) unresolved advertised slug -> structured error_code not just prose; (c) `cross_game_rejected` structured code; (d) invalid confidence logged + coded.

### Constraints honored
- **Prompt-caching preserved** — no per-call content moved into/out of the cached block; message construction untouched.
- Valorant remains paused (no Valorant fixtures touched). `totp.py` untouched.
- One self-contained PR, branched off fresh `main` (no stacking).

### Note on the layered-architecture hook
The pre-commit/PR architecture hook flags pre-existing `db.execute()` in `classifier_service.py` (reference-data loading, lines ~201-231) and `db.commit()` in `source_service.py` / `ingestion_orchestrator.py` — **none introduced by this PR**. Relocating service-level DB access to the repo layer is a separate architectural track (already noted as a follow-up in project memory) and out of scope for finding #4. This PR does not add any new service-level ORM access.

Co-Authored-By: Claude Opus 4.7 (1M context)

Generated with Claude Code