### PR TITLE
fix(mbk): make Airbnb payout attribution actually fire (dead since #213)

### DIFF
--- a/apps/mybookkeeper/backend/app/models/extraction/extraction_types.py
+++ b/apps/mybookkeeper/backend/app/models/extraction/extraction_types.py
@@ -14,6 +14,12 @@ class ExtractionData(TypedDict, total=False):
     channel: str
     address: str
     line_items: list[dict[str, str]]
+    document_type: str
+    category: str
+    payment_method: str
+    payer_name: str
+    sender: str
+    file_name: str
 
 
 class ExtractionResult(TypedDict):

--- a/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
@@ -214,15 +214,15 @@ async def save_email_extraction(
             if surviving:
                 # Attribution — attempt to link this payment to a tenant
                 payer_name = data.get("payer_name")
-                is_airbnb_label = _has_airbnb_label(data)
-                if payer_name or is_airbnb_label:
+                is_airbnb_payout = _is_airbnb_payout(data)
+                if payer_name or is_airbnb_payout:
                     await maybe_attribute_payment(
                         db,
                         txn=surviving,
                         payer_name=payer_name if isinstance(payer_name, str) else None,
                         organization_id=organization_id,
                         user_id=user_id,
-                        is_airbnb_label=is_airbnb_label,
+                        is_airbnb_payout=is_airbnb_payout,
                     )
 
                 for li in (data.get("line_items") or []):
@@ -317,18 +317,25 @@ def _resolve_attachment_content(
     return att["data"], att.get("filename"), att.get("content_type")
 
 
-def _has_airbnb_label(data: ExtractionData) -> bool:
-    """Return True if the extraction data signals an Airbnb payout label.
+def _is_airbnb_payout(data: ExtractionData) -> bool:
+    """Return True if the extraction is an Airbnb booking payout.
 
-    The email worker attaches Gmail label names to extraction data under
-    ``gmail_labels``. If 'Properties/airbnb reservation' is present and
-    the channel is 'airbnb', treat this as an Airbnb payout.
+    Airbnb payout emails have the platform itself as the sender, so the
+    extraction prompt deliberately leaves ``payer_name`` null (see
+    ``prompts/base_prompt.py``). The original design keyed off a
+    ``gmail_labels`` signal, but the email worker never attached labels to the
+    extraction data — so this path was dead and Airbnb payouts were never
+    attributed. Detect from the structured extraction itself instead of the
+    user's Gmail label hygiene: the booking channel is Airbnb and the row is
+    platform-payout / rental-revenue shaped (which excludes P2P transfers like
+    Cash App / Venmo, whose ``channel`` is null).
     """
-    labels = data.get("gmail_labels") or []
-    if not isinstance(labels, list):
+    def _norm(key: str) -> str:
+        # Claude output is untrusted — a non-string here must degrade to
+        # "not an Airbnb payout", never crash the email's persistence.
+        value = data.get(key)
+        return value.strip().lower() if isinstance(value, str) else ""
+
+    if _norm("channel") != "airbnb":
         return False
-    has_label = any(
-        isinstance(label, str) and "airbnb" in label.lower()
-        for label in labels
-    )
-    return has_label and data.get("channel") == "airbnb"
+    return _norm("category") == "rental_revenue" or _norm("payment_method") == "platform_payout"

--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -149,7 +149,7 @@ async def maybe_attribute_payment(
     payer_name: str | None,
     organization_id: uuid.UUID,
     user_id: uuid.UUID,
-    is_airbnb_label: bool = False,
+    is_airbnb_payout: bool = False,
 ) -> None:
     """Attempt to attribute a newly-created transaction to a tenant.
 
@@ -164,7 +164,7 @@ async def maybe_attribute_payment(
         return  # already attributed
 
     # --- Airbnb payout path ---------------------------------------------------
-    if is_airbnb_label:
+    if is_airbnb_payout:
         await _attribute_airbnb_payout(db, txn=txn, organization_id=organization_id, user_id=user_id)
         return
 

--- a/apps/mybookkeeper/backend/tests/test_airbnb_payout_detection.py
+++ b/apps/mybookkeeper/backend/tests/test_airbnb_payout_detection.py
@@ -1,0 +1,71 @@
+"""Regression tests for Airbnb payout detection.
+
+Before this fix the trigger keyed off ``gmail_labels``, which the email
+worker never populated, AND the extraction prompt deliberately nulls
+``payer_name`` for platform payouts — so ``_is_airbnb_payout`` was always
+False and ``_attribute_airbnb_payout`` was unreachable. Airbnb payouts were
+never attributed to a property. These tests pin the structured-extraction
+detector that replaced the dead label signal.
+"""
+import pytest
+
+from app.services.extraction.extraction_persistence import _is_airbnb_payout
+
+
+@pytest.mark.parametrize(
+    ("data", "expected"),
+    [
+        # The exact shape the prompt emits for an Airbnb payout
+        # (prompts/base_prompt.py:308) — this used to evaluate False.
+        (
+            {
+                "vendor": "Airbnb",
+                "amount": "850.00",
+                "channel": "airbnb",
+                "category": "rental_revenue",
+                "payment_method": "platform_payout",
+                "payer_name": None,
+            },
+            True,
+        ),
+        # Channel airbnb + rental_revenue is enough.
+        ({"channel": "airbnb", "category": "rental_revenue"}, True),
+        # Channel airbnb + platform_payout is enough.
+        ({"channel": "airbnb", "payment_method": "platform_payout"}, True),
+        # Case / whitespace tolerant.
+        ({"channel": " Airbnb ", "category": " RENTAL_REVENUE "}, True),
+        # Airbnb channel but neither payout- nor revenue-shaped → not a payout.
+        ({"channel": "airbnb", "category": "cleaning_fee_revenue"}, False),
+        ({"channel": "airbnb"}, False),
+        # Other channels never match.
+        ({"channel": "vrbo", "category": "rental_revenue"}, False),
+        ({"channel": "booking.com", "payment_method": "platform_payout"}, False),
+        # No channel → not an Airbnb payout.
+        ({"category": "rental_revenue", "payment_method": "platform_payout"}, False),
+        ({"channel": None, "category": "rental_revenue"}, False),
+        ({}, False),
+        # Malformed Claude output must degrade to False, never raise.
+        ({"channel": ["airbnb"], "category": "rental_revenue"}, False),
+        ({"channel": 123}, False),
+        # A bad non-string field is neutralized, not fatal: a valid airbnb
+        # channel + valid payment_method still detects despite a junk category.
+        (
+            {"channel": "airbnb", "category": ["junk"], "payment_method": "platform_payout"},
+            True,
+        ),
+        # A Cash App / Venmo P2P transfer carries payment_method
+        # "platform_payout" but no channel — must NOT be routed as Airbnb.
+        (
+            {
+                "vendor": "Cash App",
+                "channel": None,
+                "payment_method": "platform_payout",
+                "category": "rental_revenue",
+                "payer_name": "Jane Smith",
+            },
+            False,
+        ),
+    ],
+)
+def test_is_airbnb_payout(data: dict, expected: bool) -> None:
+    assert _is_airbnb_payout(data) is expected  # type: ignore[arg-type]

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -204,6 +204,7 @@
         "test_extraction_mapper.py",
         "test_extraction_repo.py",
         "test_extraction_to_transactions.py",
+        "test_airbnb_payout_detection.py",
         "test_prompt_service.py",
         "test_property_matcher.py",
         "test_self_healing.py",


### PR DESCRIPTION
## Root cause (found while scoping the auto-match feature)

The Airbnb-payout attribution path has been **inert since PR #213**:

1. `_has_airbnb_label(data)` keyed off `data["gmail_labels"]` — but **no code anywhere ever writes `gmail_labels`** (one introducing commit, zero writers across workers/services/tests).
2. The extraction prompt **deliberately** sets `payer_name=null` for platform payouts (`base_prompt.py:278` — "the platform is the sender, not a specific tenant").

So in `extraction_persistence.py` the gate `if payer_name or is_airbnb_label:` was **always False** for Airbnb payouts → `maybe_attribute_payment` / `_attribute_airbnb_payout` never ran → payouts were **never** attributed to a property. This is the underlying cause of the dashboard "Unassigned" revenue (the earlier PR #697 made that revenue *visible*; this makes attribution actually *fire*).

No test referenced any of this code — it was dead and unguarded.

## Fix

Detect Airbnb payouts from the **structured extraction itself**, not the never-wired Gmail label (no-bandaid: don't depend on the user's Gmail label hygiene):

- `_is_airbnb_payout(data)`: `channel == "airbnb"` **AND** (`category == "rental_revenue"` **OR** `payment_method == "platform_payout"`) — the exact shape the prompt emits (`base_prompt.py:308`). P2P transfers (Cash App/Venmo) have `channel=null` and are correctly excluded. Untrusted Claude fields are string-coerced so malformed output degrades to `False` instead of crashing the email's persistence (matches the file's existing defensive idiom).
- Renamed `maybe_attribute_payment` kwarg `is_airbnb_label` → `is_airbnb_payout` (only caller updated; nothing else referenced it).
- `ExtractionData` TypedDict gained the keys this path actually reads (`document_type`, `category`, `payment_method`, `payer_name`, `sender`, `file_name`) — it was lying about the contract.
- New table-driven `tests/test_airbnb_payout_detection.py` (15 cases: the always-False regression shape, the P2P false-positive guard, malformed-output hardening, vrbo/booking.com negatives); registered in `test-map.json`.

## Safety

- **PM statements unaffected:** the prompt leaves their `channel` null, so `_is_airbnb_payout` short-circuits — they do not route into `_attribute_airbnb_payout`. The booking-statement creation loop is independent.
- With 1 Airbnb listing → auto-attributes (existing behavior, now reachable). With 0/multiple → review queue (`unmatched`) — PRs B/C/D turn that into smart auto-match + one-click resolve.
- 100+ backend tests green (new + full extraction + full attribution suites). Pre-commit review run; the one warning it raised (lost non-string defensiveness) is fixed in this PR with tests.

First of 4 Phase-1 PRs for Airbnb payout auto-attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)