### PR TITLE
feat(mbk): review queue can propose+confirm a property (Airbnb payout attribution, PR B/4)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/rarqprop260517_add_proposed_property.py
+++ b/apps/mybookkeeper/backend/alembic/versions/rarqprop260517_add_proposed_property.py
@@ -1,0 +1,38 @@
+"""add proposed_property_id to rent_attribution_review_queue
+
+Airbnb payouts have no tenant/applicant — they attribute to a property.
+This adds an optional proposed-property suggestion to the review queue so a
+host can one-click confirm an Airbnb payout to the right property.
+
+- rent_attribution_review_queue.proposed_property_id — FK properties, SET NULL
+
+Revision ID: rarqprop260517
+Revises: trustsndr260514
+Create Date: 2026-05-17 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "rarqprop260517"
+down_revision: Union[str, None] = "trustsndr260514"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "rent_attribution_review_queue",
+        sa.Column(
+            "proposed_property_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("properties.id", ondelete="SET NULL", name="fk_rarq_property"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("rent_attribution_review_queue", "proposed_property_id")

--- a/apps/mybookkeeper/backend/app/api/attribution.py
+++ b/apps/mybookkeeper/backend/app/api/attribution.py
@@ -58,6 +58,7 @@ async def confirm_attribution_review(
             organization_id=ctx.organization_id,
             user_id=ctx.user_id,
             applicant_id=body.applicant_id,
+            property_id=body.property_id,
         )
     except ValueError as e:
         detail = str(e)

--- a/apps/mybookkeeper/backend/app/models/transactions/rent_attribution_review_queue.py
+++ b/apps/mybookkeeper/backend/app/models/transactions/rent_attribution_review_queue.py
@@ -33,6 +33,10 @@ class RentAttributionReviewQueue(Base):
     organization_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False)
     transaction_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("transactions.id", ondelete="CASCADE"), nullable=False)
     proposed_applicant_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("applicants.id", ondelete="SET NULL"), nullable=True)
+    # Airbnb payouts have no tenant/applicant — they attribute to a property.
+    # Mutually exclusive with proposed_applicant_id in practice (not constrained;
+    # precedence is resolved in attribution_service.confirm_review).
+    proposed_property_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("properties.id", ondelete="SET NULL"), nullable=True)
 
     # "fuzzy" = Levenshtein ≤ 2 candidate found; "unmatched" = no candidate
     confidence: Mapped[str] = mapped_column(String(10), nullable=False)
@@ -64,3 +68,4 @@ class RentAttributionReviewQueue(Base):
 
     transaction = relationship("Transaction", lazy="noload")
     proposed_applicant = relationship("Applicant", lazy="noload")
+    proposed_property = relationship("Property", lazy="noload")

--- a/apps/mybookkeeper/backend/app/repositories/transactions/attribution_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/transactions/attribution_repo.py
@@ -23,12 +23,14 @@ async def create(
     transaction_id: uuid.UUID,
     proposed_applicant_id: uuid.UUID | None,
     confidence: str,
+    proposed_property_id: uuid.UUID | None = None,
 ) -> RentAttributionReviewQueue:
     row = RentAttributionReviewQueue(
         user_id=user_id,
         organization_id=organization_id,
         transaction_id=transaction_id,
         proposed_applicant_id=proposed_applicant_id,
+        proposed_property_id=proposed_property_id,
         confidence=confidence,
         status="pending",
     )
@@ -47,6 +49,7 @@ async def get_by_id(
         .options(
             selectinload(RentAttributionReviewQueue.transaction),
             selectinload(RentAttributionReviewQueue.proposed_applicant),
+            selectinload(RentAttributionReviewQueue.proposed_property),
         )
         .where(
             RentAttributionReviewQueue.id == review_id,
@@ -85,6 +88,7 @@ async def list_pending(
         .options(
             selectinload(RentAttributionReviewQueue.transaction),
             selectinload(RentAttributionReviewQueue.proposed_applicant),
+            selectinload(RentAttributionReviewQueue.proposed_property),
         )
         .where(
             RentAttributionReviewQueue.organization_id == organization_id,

--- a/apps/mybookkeeper/backend/app/schemas/transactions/attribution.py
+++ b/apps/mybookkeeper/backend/app/schemas/transactions/attribution.py
@@ -31,16 +31,26 @@ class AttributionApplicantSummary(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class AttributionPropertySummary(BaseModel):
+    """Slim property view for the review queue (Airbnb-payout proposals)."""
+    id: uuid.UUID
+    name: str
+
+    model_config = {"from_attributes": True}
+
+
 class AttributionReviewItemRead(BaseModel):
     id: uuid.UUID
     transaction_id: uuid.UUID
     proposed_applicant_id: uuid.UUID | None = None
+    proposed_property_id: uuid.UUID | None = None
     confidence: str
     status: str
     created_at: datetime
     resolved_at: datetime | None = None
     transaction: AttributionTransactionSummary | None = None
     proposed_applicant: AttributionApplicantSummary | None = None
+    proposed_property: AttributionPropertySummary | None = None
 
     model_config = {"from_attributes": True}
 
@@ -55,6 +65,9 @@ class ConfirmReviewRequest(BaseModel):
     model_config = {"extra": "forbid"}
     # Optionally override the suggested applicant (for "pick a different tenant")
     applicant_id: uuid.UUID | None = None
+    # Optionally override the suggested property (for "pick a different room"
+    # on an Airbnb-payout review item)
+    property_id: uuid.UUID | None = None
 
 
 class AttributeManuallyRequest(BaseModel):

--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -23,6 +23,7 @@ from app.repositories import attribution_repo
 from app.repositories.applicants import applicant_repo
 from app.repositories.leases import signed_lease_repo
 from app.repositories.listings import listing_repo
+from app.repositories.properties import property_repo
 from app.repositories import transaction_repo as txn_repo
 from app.services.leases import receipt_service
 
@@ -287,15 +288,23 @@ async def confirm_review(
     organization_id: uuid.UUID,
     user_id: uuid.UUID,
     applicant_id: uuid.UUID | None = None,
+    property_id: uuid.UUID | None = None,
 ) -> dict:
-    """Confirm a review queue item.
+    """Confirm a review queue item against an applicant OR a property.
 
-    If ``applicant_id`` is provided it overrides ``proposed_applicant_id``
-    (supports "Pick a different tenant" flow). Uses the proposed candidate
-    otherwise.
+    Two attribution targets are supported:
+      - **applicant** (tenant rent) — sets ``txn.applicant_id`` and creates a
+        pending receipt. ``applicant_id`` overrides ``proposed_applicant_id``
+        ("pick a different tenant").
+      - **property** (Airbnb payout — no tenant) — sets ``txn.property_id``
+        only; no receipt (an Airbnb payout has no tenant to receipt).
+        ``property_id`` overrides ``proposed_property_id``.
 
-    Mutates the linked transaction: sets applicant_id, category=rental_revenue,
-    attribution_source=auto_fuzzy_confirmed, and property_id if resolvable.
+    The applicant target takes precedence: the property path is only taken
+    when there is no chosen applicant (a row never has both in practice; this
+    branch order makes the resolution deterministic if it ever does).
+
+    Mutates the linked transaction and sets category=rental_revenue.
     """
     async with unit_of_work() as db:
         row = await attribution_repo.get_by_id(db, review_id, organization_id)
@@ -304,44 +313,62 @@ async def confirm_review(
         if row.status != "pending":
             raise ValueError("Review item is already resolved")
 
-        chosen_applicant_id = applicant_id or row.proposed_applicant_id
-        if not chosen_applicant_id:
-            raise ValueError("No applicant specified and no proposed candidate")
-
-        # Fetch the applicant to verify it belongs to this org
-        applicant = await applicant_repo.get(
-            db,
-            applicant_id=chosen_applicant_id,
-            organization_id=organization_id,
-            user_id=user_id,
-        )
-        if not applicant:
-            raise ValueError("Applicant not found")
-
-        # Update the transaction
         txn = await txn_repo.get_by_id(db, row.transaction_id, organization_id)
         if not txn:
             raise ValueError("Transaction not found")
 
-        txn.applicant_id = applicant.id
-        txn.attribution_source = "auto_fuzzy_confirmed"
-        txn.category = "rental_revenue"
+        chosen_applicant_id = applicant_id or row.proposed_applicant_id
+        if chosen_applicant_id:
+            # Fetch the applicant to verify it belongs to this org
+            applicant = await applicant_repo.get(
+                db,
+                applicant_id=chosen_applicant_id,
+                organization_id=organization_id,
+                user_id=user_id,
+            )
+            if not applicant:
+                raise ValueError("Applicant not found")
 
-        # Resolve property from applicant's active lease if not already set
-        if txn.property_id is None:
-            property_id = await _get_property_id_for_applicant(db, applicant, organization_id)
-            if property_id:
-                txn.property_id = property_id
+            txn.applicant_id = applicant.id
+            txn.attribution_source = "auto_fuzzy_confirmed"
+            txn.category = "rental_revenue"
 
-        await attribution_repo.resolve(db, row, "confirmed")
-        await receipt_service.create_pending_receipt_in_session(
-            db,
-            transaction_id=txn.id,
-            applicant_id=applicant.id,
-            user_id=user_id,
-            organization_id=organization_id,
-        )
-        return {"ok": True, "transaction_id": str(txn.id)}
+            # Resolve property from applicant's active lease if not already set
+            if txn.property_id is None:
+                resolved_property_id = await _get_property_id_for_applicant(
+                    db, applicant, organization_id
+                )
+                if resolved_property_id:
+                    txn.property_id = resolved_property_id
+
+            await attribution_repo.resolve(db, row, "confirmed")
+            await receipt_service.create_pending_receipt_in_session(
+                db,
+                transaction_id=txn.id,
+                applicant_id=applicant.id,
+                user_id=user_id,
+                organization_id=organization_id,
+            )
+            return {"ok": True, "transaction_id": str(txn.id)}
+
+        # Property path — Airbnb payout, no tenant. Fail closed: a bad or
+        # cross-org property_id raises and leaves the row pending + txn untouched.
+        chosen_property_id = property_id or row.proposed_property_id
+        if chosen_property_id:
+            prop = await property_repo.get_by_id(db, chosen_property_id, organization_id)
+            if not prop:
+                raise ValueError("Property not found")
+
+            txn.property_id = prop.id
+            # An Airbnb payout has no tenant — re-attributing to a property
+            # must not leave a stale applicant link on the transaction.
+            txn.applicant_id = None
+            txn.attribution_source = "manual"
+            txn.category = "rental_revenue"
+            await attribution_repo.resolve(db, row, "confirmed")
+            return {"ok": True, "transaction_id": str(txn.id)}
+
+        raise ValueError("No applicant or property specified and no proposed candidate")
 
 
 async def reject_review(

--- a/apps/mybookkeeper/backend/tests/test_attribution_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_repo.py
@@ -50,6 +50,15 @@ def _applicant(user: User, org: Organization, legal_name: str) -> Applicant:
     )
 
 
+def _property(user: User, org: Organization, name: str = "Beach House") -> Property:
+    return Property(
+        id=uuid.uuid4(),
+        user_id=user.id,
+        organization_id=org.id,
+        name=name,
+    )
+
+
 def _txn(user: User, org: Organization) -> Transaction:
     return Transaction(
         id=uuid.uuid4(),
@@ -113,6 +122,37 @@ async def test_create_and_get_pending(db: AsyncSession, seed):
     assert fetched.confidence == "fuzzy"
     assert fetched.status == "pending"
     assert fetched.proposed_applicant_id == applicant.id
+
+
+@pytest.mark.asyncio
+async def test_create_with_proposed_property(db: AsyncSession, seed):
+    """Airbnb-payout review row carries a proposed property; it round-trips
+    and the proposed_property relationship is eagerly loaded by get_by_id."""
+    user = seed["user"]
+    org = seed["org"]
+    txn = seed["txn"]
+
+    prop = _property(user, org, "Lakeside Cabin")
+    db.add(prop)
+    await db.flush()
+
+    row = await attribution_repo.create(
+        db,
+        user_id=user.id,
+        organization_id=org.id,
+        transaction_id=txn.id,
+        proposed_applicant_id=None,
+        confidence="unmatched",
+        proposed_property_id=prop.id,
+    )
+    await db.commit()
+
+    fetched = await attribution_repo.get_by_id(db, row.id, org.id)
+    assert fetched is not None
+    assert fetched.proposed_applicant_id is None
+    assert fetched.proposed_property_id == prop.id
+    assert fetched.proposed_property is not None
+    assert fetched.proposed_property.name == "Lakeside Cabin"
 
 
 @pytest.mark.asyncio

--- a/apps/mybookkeeper/backend/tests/test_attribution_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_routes.py
@@ -140,6 +140,35 @@ class TestConfirmAttributionReview:
         assert resp.status_code == 200
         assert resp.json()["ok"] is True
 
+    def test_confirm_with_property_id(self, client, override_ctx):
+        """An Airbnb-payout review item is confirmed by passing property_id;
+        the route forwards it to the service."""
+        review_id = uuid.uuid4()
+        property_id = uuid.uuid4()
+        with patch(
+            "app.services.transactions.attribution_service.confirm_review",
+            new_callable=AsyncMock,
+            return_value={"ok": True, "transaction_id": str(uuid.uuid4())},
+        ) as confirm_mock:
+            resp = client.post(
+                f"/transactions/attribution-review-queue/{review_id}/confirm",
+                json={"property_id": str(property_id)},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["ok"] is True
+        confirm_mock.assert_awaited_once()
+        assert confirm_mock.await_args.kwargs["property_id"] == property_id
+        assert confirm_mock.await_args.kwargs["applicant_id"] is None
+
+    def test_confirm_rejects_unknown_field(self, client, override_ctx):
+        """ConfirmReviewRequest is extra=forbid — unknown keys are rejected."""
+        review_id = uuid.uuid4()
+        resp = client.post(
+            f"/transactions/attribution-review-queue/{review_id}/confirm",
+            json={"property_id": str(uuid.uuid4()), "evil": "x"},
+        )
+        assert resp.status_code == 422
+
     def test_confirm_not_found(self, client, override_ctx):
         review_id = uuid.uuid4()
         with patch(

--- a/apps/mybookkeeper/backend/tests/test_attribution_service_confirm_property.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_service_confirm_property.py
@@ -1,0 +1,249 @@
+"""Service-level tests for the property-only confirm path of
+``attribution_service.confirm_review`` (PR B — Airbnb-payout attribution).
+
+An Airbnb payout has no tenant/applicant — it attributes to a property.
+Confirming such a review row must set ``txn.property_id`` (not applicant_id),
+mark the source ``manual``, resolve the row, and create NO pending receipt
+(receipts are tenant-scoped). The applicant target keeps precedence when both
+are present.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch, AsyncMock
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.properties.property import Property
+from app.models.transactions.rent_attribution_review_queue import (
+    RentAttributionReviewQueue,
+)
+from app.models.transactions.transaction import Transaction
+from app.services.transactions.attribution_service import confirm_review
+
+
+def _make_fake_uow(session: AsyncSession):
+    @asynccontextmanager
+    async def _fake_uow():
+        yield session
+
+    return _fake_uow
+
+
+def _property(org_id: uuid.UUID, user_id: uuid.UUID, name: str = "Beach House") -> Property:
+    return Property(id=uuid.uuid4(), organization_id=org_id, user_id=user_id, name=name)
+
+
+def _txn(org_id: uuid.UUID, user_id: uuid.UUID) -> Transaction:
+    return Transaction(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        transaction_date=_dt.date(2026, 5, 1),
+        tax_year=2026,
+        amount="2500.00",
+        transaction_type="income",
+        category="uncategorized",
+        status="approved",
+        is_manual=False,
+    )
+
+
+def _review(
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    txn_id: uuid.UUID,
+    *,
+    proposed_property_id: uuid.UUID | None = None,
+    proposed_applicant_id: uuid.UUID | None = None,
+) -> RentAttributionReviewQueue:
+    return RentAttributionReviewQueue(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        organization_id=org_id,
+        transaction_id=txn_id,
+        proposed_applicant_id=proposed_applicant_id,
+        proposed_property_id=proposed_property_id,
+        confidence="unmatched",
+        status="pending",
+    )
+
+
+@pytest.mark.asyncio
+async def test_confirm_uses_proposed_property(db: AsyncSession):
+    """No applicant — confirming sets txn.property_id from proposed_property_id,
+    source=manual, row confirmed, and NO receipt is created."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = _property(org_id, user_id)
+    txn = _txn(org_id, user_id)
+    # Seed a stale prior applicant attribution: the property path must clear it
+    # (an Airbnb payout has no tenant), so this assertion is non-trivial.
+    txn.applicant_id = uuid.uuid4()
+    review = _review(org_id, user_id, txn.id, proposed_property_id=prop.id)
+    db.add_all([prop, txn, review])
+    await db.flush()
+
+    receipt_mock = AsyncMock()
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        _make_fake_uow(db),
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        receipt_mock,
+    ):
+        result = await confirm_review(
+            review_id=review.id, organization_id=org_id, user_id=user_id,
+        )
+
+    assert result["ok"] is True
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.property_id == prop.id
+    assert refreshed_txn.applicant_id is None
+    assert refreshed_txn.attribution_source == "manual"
+    assert refreshed_txn.category == "rental_revenue"
+
+    refreshed_review = (
+        await db.execute(
+            select(RentAttributionReviewQueue).where(RentAttributionReviewQueue.id == review.id)
+        )
+    ).scalar_one()
+    assert refreshed_review.status == "confirmed"
+    assert refreshed_review.resolved_at is not None
+    receipt_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_confirm_property_id_override_wins(db: AsyncSession):
+    """An explicit property_id arg overrides the proposed property ("pick a
+    different room")."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    proposed = _property(org_id, user_id, "Proposed Room")
+    chosen = _property(org_id, user_id, "Chosen Room")
+    txn = _txn(org_id, user_id)
+    review = _review(org_id, user_id, txn.id, proposed_property_id=proposed.id)
+    db.add_all([proposed, chosen, txn, review])
+    await db.flush()
+
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        _make_fake_uow(db),
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        new_callable=AsyncMock,
+    ):
+        await confirm_review(
+            review_id=review.id,
+            organization_id=org_id,
+            user_id=user_id,
+            property_id=chosen.id,
+        )
+
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.property_id == chosen.id
+
+
+@pytest.mark.asyncio
+async def test_confirm_property_not_found_fails_closed(db: AsyncSession):
+    """A property_id that doesn't exist (or belongs to another org) raises and
+    leaves the row pending + transaction untouched."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    txn = _txn(org_id, user_id)
+    review = _review(org_id, user_id, txn.id, proposed_property_id=uuid.uuid4())
+    db.add_all([txn, review])
+    await db.flush()
+
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        _make_fake_uow(db),
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(ValueError, match="Property not found"):
+            await confirm_review(
+                review_id=review.id, organization_id=org_id, user_id=user_id,
+            )
+
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.property_id is None
+    refreshed_review = (
+        await db.execute(
+            select(RentAttributionReviewQueue).where(RentAttributionReviewQueue.id == review.id)
+        )
+    ).scalar_one()
+    assert refreshed_review.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_confirm_applicant_takes_precedence_over_property(db: AsyncSession):
+    """A row with BOTH a proposed applicant and a proposed property resolves
+    via the applicant path (receipt created); the property path is not taken."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    applicant = Applicant(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        stage="lease_signed",
+        legal_name="Jane Doe",
+    )
+    prop = _property(org_id, user_id)
+    txn = _txn(org_id, user_id)
+    review = _review(
+        org_id, user_id, txn.id,
+        proposed_applicant_id=applicant.id,
+        proposed_property_id=prop.id,
+    )
+    db.add_all([applicant, prop, txn, review])
+    await db.flush()
+
+    receipt_mock = AsyncMock()
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        _make_fake_uow(db),
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        receipt_mock,
+    ):
+        await confirm_review(
+            review_id=review.id, organization_id=org_id, user_id=user_id,
+        )
+
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.applicant_id == applicant.id
+    assert refreshed_txn.attribution_source == "auto_fuzzy_confirmed"
+    receipt_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_confirm_no_applicant_or_property_raises(db: AsyncSession):
+    """A row with neither proposed target and no override args raises."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    txn = _txn(org_id, user_id)
+    review = _review(org_id, user_id, txn.id)
+    db.add_all([txn, review])
+    await db.flush()
+
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        _make_fake_uow(db),
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        new_callable=AsyncMock,
+    ):
+        with pytest.raises(ValueError, match="No applicant or property specified"):
+            await confirm_review(
+                review_id=review.id, organization_id=org_id, user_id=user_id,
+            )

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -876,6 +876,7 @@
         "backend/app/schemas/transactions/attribution.py",
         "backend/app/api/attribution.py",
         "backend/alembic/versions/txnattr260504_rent_attribution.py",
+        "backend/alembic/versions/rarqprop260517_add_proposed_property.py",
         "frontend/src/shared/store/attributionApi.ts",
         "frontend/src/shared/types/attribution/",
         "frontend/src/app/features/attribution/",
@@ -886,7 +887,9 @@
       "backend_tests": [
         "test_attribution_matcher.py",
         "test_attribution_repo.py",
-        "test_attribution_routes.py"
+        "test_attribution_routes.py",
+        "test_attribution_service_attribute_manually.py",
+        "test_attribution_service_confirm_property.py"
       ],
       "frontend_tests": [
         "AttributionReviewPanel.test.tsx",


### PR DESCRIPTION
## What

PR **B of 4** in the Airbnb-payout auto-attribution build (PR A `#698` merged). Airbnb payouts have no tenant/applicant — they attribute to a **property**. This adds the plumbing for an Airbnb-payout review-queue row to carry a *proposed property* and for the host to one-click confirm it onto the transaction.

- `RentAttributionReviewQueue.proposed_property_id` — FK `properties.id` `ON DELETE SET NULL` (mirrors `proposed_applicant_id`) + `proposed_property` relationship
- Migration `rarqprop260517` — additive, nullable, reversible; `down_revision=trustsndr260514`
- `attribution_repo.create` accepts `proposed_property_id`; `get_by_id`/`list_pending` eager-load `proposed_property`
- `confirm_review`: applicant path **unchanged and keeps precedence**; new **property-only** path sets `txn.property_id` via org-scoped `property_repo` (fail-closed — bad/cross-org id raises, leaves row pending + txn untouched), clears any stale `applicant_id`, `attribution_source="manual"`, **no receipt** (Airbnb payouts have no tenant)
- `ConfirmReviewRequest.property_id`; `AttributionReviewItemRead` gains `proposed_property_id` + `proposed_property`; new `AttributionPropertySummary`
- Tests: repo round-trip, 5 confirm-path service tests (incl. fail-closed, applicant-precedence, stale-applicant-cleared), 2 route tests; `test-map.json` registers the new tests + the previously-unmapped `test_attribution_service_attribute_manually.py` + the new migration

## Scope notes

- The matcher that *populates* `proposed_property_id` lands in **PR C**. PR B's tests exercise the column end-to-end (repo create + confirm path), so this is a complete, independently-reviewable vertical slice, not dead code.
- Frontend type + review UX is **PR D** (runs `g-design-ux` first) per the agreed build plan. The new response fields are optional/additive — no frontend breakage, no enum-sync trigger (`confidence`/`attribution_source` unchanged).

## Operational note

No manual migration required. `rarqprop260517` is additive + nullable with no boot guard / env / required-arg change — the deploy pipeline (`scripts/migrate.sh`) applies it automatically. Safe rollback = revert this PR (prior image works without the column).

## Design + review

- `g-design-data`: SET NULL correct, no index needed, no CHECK widening, encode precedence in service (done).
- `g-pre-commit`: no critical issues; flagged stale-`applicant_id` invariant on the property path — **fixed in this PR** (`txn.applicant_id = None` + strengthened test).

## Tests

`53 passed` — full attribution backend suite (`test_attribution_{matcher,repo,routes,service_attribute_manually,service_confirm_property}.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)