### PR TITLE
feat(mga): glanceable second-monitor lineup board (PR1 — layout)

### DIFF
--- a/apps/mygamingassistant/TECH_DEBT.md
+++ b/apps/mygamingassistant/TECH_DEBT.md
@@ -180,3 +180,37 @@ Scope note: MGA is intentionally a casual single-user, public-read / auth-write 
   layering debt, also out of finding-#3 scope).
 
 ---
+
+## Glance-board polish (deferred from PR1 code review — 2026-05-17)
+
+Stylistic items flagged in the glance-board PR1 review and intentionally deferred per log-only policy.
+
+### [Frontend] GlanceBoardMinimapSidebar — IIFE tooltip pattern in JSX
+
+- **Severity:** Low
+- **Location:** `frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx` (hover tooltip rendered via `{hoveredZoneSlug && (() => { ... })()}`)
+- **Problem:** IIFE inside JSX is non-idiomatic and lint-unfriendly. The hover state belongs in a small sub-component (`ZoneTooltip`) or early-return variable so the return is clean.
+- **Recommendation:** Extract tooltip into a `ZoneTooltip` sub-component in the same file.
+
+### [Frontend] GlanceBoardOperatorMenu — two mergeable useEffects
+
+- **Severity:** Low
+- **Location:** `frontend/src/components/lineup/GlanceBoardOperatorMenu.tsx` (two separate `useEffect` blocks both gated on `open`)
+- **Problem:** Both effects depend solely on `open` and could share one `useEffect` with two event-listener registrations and a single cleanup. Minor readability/lint friction.
+- **Recommendation:** Merge into one `useEffect` with both `addEventListener` / `removeEventListener` calls in the same block.
+
+### [Frontend] MapPage — MessageChannel deferral for `setActiveCardIndex`
+
+- **Severity:** Low
+- **Location:** `frontend/src/pages/MapPage.tsx` (MessageChannel pattern inside `useEffect` for `setActiveCardIndex(0)`)
+- **Problem:** The `MessageChannel` deferral is a non-obvious pattern. A plain `useEffect` with `setActiveCardIndex(0)` inside satisfies the react-hooks/exhaustive-deps rule; the deferral adds complexity without observable benefit at this call site.
+- **Recommendation:** Replace `MessageChannel` deferral with a direct `setActiveCardIndex(0)` call in the `useEffect` body.
+
+### [Frontend] MapPage — fragmented empty-state logic
+
+- **Severity:** Low
+- **Location:** `frontend/src/pages/MapPage.tsx` (two separate empty-state conditions in the main scroll area — filtered-empty ternary and the below-board CTA)
+- **Problem:** The two empty-state render paths (filtered empty + no-filters CTA) are evaluated in separate JSX branches using duplicated conditions. Hard to follow when both filter conditions change.
+- **Recommendation:** Extract an `EmptyStatePanel` sub-component that accepts `{ isFiltered, mapName, gameSlug, mapSlug }` props and consolidates both branches.
+
+---

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
@@ -1,0 +1,189 @@
+/**
+ * GlanceBoard — main scrollable board for the redesigned MapPage.
+ *
+ * Renders all lineups for the current map grouped by target zone.
+ * Exactly 2 tiles per row, no navigation depth — every lineup is always
+ * visible in full-size. Zone section headers act as scroll anchors.
+ *
+ * Zone section order: A Site → B Site → Mid → others alphabetically.
+ * Within each zone: Smoke → Flash → Molotov → HE → Decoy → side (T/CT/Both).
+ *
+ * Usage:
+ *   <GlanceBoard lineups={allLineups} isFetching={...} mapName={...} />
+ */
+import { useMemo } from "react";
+import type { Lineup } from "@/types/game";
+import { utilDisplay } from "@/constants/utilityDisplay";
+import { zoneAnchorId } from "./glanceBoardUtils";
+import GlanceBoardTile from "./GlanceBoardTile";
+
+interface GlanceBoardProps {
+  lineups: Lineup[];
+  isFetching: boolean;
+  mapName: string;
+  /** Applied utility type slugs from top-bar chips ([] = all). */
+  filteredUtils: string[];
+  /** Applied side value ("any" / "side_a" / "side_b"). */
+  side: string;
+}
+
+// ---------------------------------------------------------------------------
+// Zone ordering
+// ---------------------------------------------------------------------------
+const ZONE_ORDER_PREFIXES = [
+  "a site", "a-site", "a_site",
+  "b site", "b-site", "b_site",
+  "mid",
+];
+
+function zoneOrder(zoneName: string): number {
+  const lower = zoneName.toLowerCase();
+  const idx = ZONE_ORDER_PREFIXES.findIndex((prefix) => lower.startsWith(prefix));
+  return idx === -1 ? ZONE_ORDER_PREFIXES.length : idx;
+}
+
+function compareZones(a: string, b: string): number {
+  const orderDiff = zoneOrder(a) - zoneOrder(b);
+  if (orderDiff !== 0) return orderDiff;
+  return a.localeCompare(b);
+}
+
+// ---------------------------------------------------------------------------
+// Lineup ordering within a zone — keyed by utility slug via utilDisplay
+// ---------------------------------------------------------------------------
+const SIDE_ORDER: Record<string, number> = {
+  side_a: 0,
+  side_b: 1,
+  any:    2,
+};
+
+function compareLineups(a: Lineup, b: Lineup): number {
+  const utilA = utilDisplay(a.utility_type?.slug).sortOrder;
+  const utilB = utilDisplay(b.utility_type?.slug).sortOrder;
+  if (utilA !== utilB) return utilA - utilB;
+  const sideA = SIDE_ORDER[a.side ?? "any"] ?? 99;
+  const sideB = SIDE_ORDER[b.side ?? "any"] ?? 99;
+  return sideA - sideB;
+}
+
+// ---------------------------------------------------------------------------
+// Grouping
+// ---------------------------------------------------------------------------
+interface ZoneGroup {
+  zoneName: string;
+  zoneSlug: string;
+  lineups: Lineup[];
+}
+
+function groupByZone(lineups: Lineup[]): ZoneGroup[] {
+  const map = new Map<string, ZoneGroup>();
+  for (const l of lineups) {
+    const name = l.target_zone?.name ?? "Unknown Zone";
+    const slug = l.target_zone?.slug ?? "unknown";
+    if (!map.has(name)) {
+      map.set(name, { zoneName: name, zoneSlug: slug, lineups: [] });
+    }
+    map.get(name)!.lineups.push(l);
+  }
+  const groups = [...map.values()];
+  for (const g of groups) {
+    g.lineups.sort(compareLineups);
+  }
+  return groups.sort((a, b) => compareZones(a.zoneName, b.zoneName));
+}
+
+// ---------------------------------------------------------------------------
+// Skeleton loader (2 tiles per row)
+// ---------------------------------------------------------------------------
+function GlanceBoardSkeleton() {
+  return (
+    <div className="space-y-8">
+      {[1, 2].map((s) => (
+        <div key={s} className="space-y-3">
+          <div className="h-5 w-48 bg-muted/40 rounded animate-pulse" />
+          <div className="grid grid-cols-2 gap-4">
+            {[1, 2].map((t) => (
+              <div key={t} className="rounded-lg bg-muted/40 animate-pulse" style={{ aspectRatio: "2 / 1" }} />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Empty state helpers
+// ---------------------------------------------------------------------------
+function buildEmptyMessage(mapName: string, side: string, filteredUtils: string[]): string {
+  const sideLabel = side === "side_a" ? "T" : side === "side_b" ? "CT" : null;
+  const utilLabel = filteredUtils.length > 0 ? filteredUtils.join(", ") : null;
+  if (!sideLabel && !utilLabel) return `No lineups on ${mapName} yet.`;
+  const parts: string[] = [];
+  if (utilLabel) parts.push(utilLabel);
+  if (sideLabel) parts.push(sideLabel);
+  return `No ${parts.join(" ")} lineups on this map.`;
+}
+
+// ---------------------------------------------------------------------------
+// GlanceBoard
+// ---------------------------------------------------------------------------
+export default function GlanceBoard({
+  lineups,
+  isFetching,
+  mapName,
+  filteredUtils,
+  side,
+}: GlanceBoardProps) {
+  const groups = useMemo(() => groupByZone(lineups), [lineups]);
+
+  if (isFetching) {
+    return <GlanceBoardSkeleton />;
+  }
+
+  if (lineups.length === 0) {
+    const isFiltered = filteredUtils.length > 0 || side !== "any";
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-3">
+        <p className="text-sm text-muted-foreground text-center">
+          {buildEmptyMessage(mapName, side, filteredUtils)}
+        </p>
+        {isFiltered && (
+          // Placeholder anchor — parent passes an onClearFilters via the
+          // empty-state link rendered directly in MapPage, not here.
+          // GlanceBoard itself is filter-agnostic; it just renders.
+          <span className="text-xs text-muted-foreground/60">
+            Try clearing filters in the top bar.
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      {groups.map((group) => (
+        <section key={group.zoneSlug} id={zoneAnchorId(group.zoneSlug)}>
+          {/* Zone section header — used as scroll anchor */}
+          <h2 className="text-[13px] font-semibold text-muted-foreground mb-3 flex items-center gap-2">
+            <span className="flex-1 border-t border-border" />
+            <span>
+              {group.zoneName}
+              <span className="ml-1.5 font-normal text-muted-foreground/60">
+                ({group.lineups.length})
+              </span>
+            </span>
+            <span className="flex-1 border-t border-border" />
+          </h2>
+
+          {/* 2-column tile grid */}
+          <div className="grid grid-cols-2 gap-4">
+            {group.lineups.map((lineup) => (
+              <GlanceBoardTile key={lineup.id} lineup={lineup} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx
@@ -1,0 +1,150 @@
+/**
+ * GlanceBoardMinimapSidebar — passive spatial index for the glance board.
+ *
+ * Renders the minimap image with zone SVG polygons (density coloring,
+ * same as MapZoneOverlay). Clicking or hovering a zone smooth-scrolls
+ * the main board area to that zone's section header.
+ *
+ * No filter-gate behavior — this is read-only spatial navigation only.
+ *
+ * Fallback: if the minimap image fails to load, renders a scrollable text
+ * list of zone names that still trigger scroll-to-section on click.
+ */
+import { useState } from "react";
+import type { MapZone, ZoneDensity } from "@/types/game";
+import { zoneAnchorId } from "./glanceBoardUtils";
+
+interface Props {
+  minimapUrl: string | null;
+  zones: MapZone[];
+  density: ZoneDensity;
+  viewBoxSize?: number;
+}
+
+// Density fill/stroke — same tokens as MapZoneOverlay
+const FILL_HAS_LINEUPS   = "rgba(34,197,94,0.18)";
+const FILL_EMPTY         = "rgba(156,163,175,0.10)";
+const STROKE_HAS_LINEUPS = "rgba(34,197,94,0.7)";
+const STROKE_EMPTY       = "rgba(255,255,255,0.25)";
+const STROKE_HOVER       = "rgba(251,191,36,0.9)";
+const FILL_HOVER         = "rgba(251,191,36,0.18)";
+
+function pointsToSvg(
+  polygon_points: Array<{ x: number; y: number }>,
+  viewBoxSize: number,
+): string {
+  return polygon_points
+    .map((p) => `${p.x * viewBoxSize},${p.y * viewBoxSize}`)
+    .join(" ");
+}
+
+function scrollToZone(zoneSlug: string) {
+  const el = document.getElementById(zoneAnchorId(zoneSlug));
+  if (el) {
+    el.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+}
+
+export default function GlanceBoardMinimapSidebar({
+  minimapUrl,
+  zones,
+  density,
+  viewBoxSize = 1000,
+}: Props) {
+  const [minimapFailed, setMinimapFailed] = useState(false);
+  const [hoveredZoneSlug, setHoveredZoneSlug] = useState<string | null>(null);
+
+  // Fallback: text zone list when minimap unavailable
+  if (!minimapUrl || minimapFailed) {
+    return (
+      <nav
+        className="flex flex-col gap-1 overflow-y-auto"
+        aria-label="Zone navigation"
+      >
+        <p className="text-[11px] text-muted-foreground px-1 pb-1 font-medium uppercase tracking-wide">
+          Zones
+        </p>
+        {zones.map((zone) => {
+          const count = density[zone.id]?.count ?? 0;
+          return (
+            <button
+              key={zone.id}
+              type="button"
+              onClick={() => scrollToZone(zone.slug)}
+              className="text-left px-2 py-1 rounded text-[12px] hover:bg-muted/40 transition-colors flex items-center justify-between gap-2"
+            >
+              <span className="truncate">{zone.name}</span>
+              {count > 0 && (
+                <span className="text-[10px] text-muted-foreground flex-shrink-0">
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </nav>
+    );
+  }
+
+  return (
+    <nav
+      className="relative rounded-lg border overflow-hidden bg-card"
+      style={{ aspectRatio: "1 / 1" }}
+      aria-label="Zone minimap — click a zone to scroll to it"
+    >
+      <img
+        src={minimapUrl}
+        alt="Map minimap"
+        className="absolute inset-0 w-full h-full object-cover"
+        draggable={false}
+        onError={() => setMinimapFailed(true)}
+      />
+      <svg
+        viewBox={`0 0 ${viewBoxSize} ${viewBoxSize}`}
+        className="absolute inset-0 w-full h-full"
+        style={{ overflow: "visible" }}
+      >
+        {zones.map((zone) => {
+          const count = density[zone.id]?.count ?? 0;
+          const isHovered = zone.slug === hoveredZoneSlug;
+          const hasPolygon = zone.polygon_points.length > 0;
+          if (!hasPolygon) return null;
+
+          const points = pointsToSvg(zone.polygon_points, viewBoxSize);
+          const fill   = isHovered ? FILL_HOVER   : count > 0 ? FILL_HAS_LINEUPS   : FILL_EMPTY;
+          const stroke = isHovered ? STROKE_HOVER : count > 0 ? STROKE_HAS_LINEUPS : STROKE_EMPTY;
+
+          return (
+            <polygon
+              key={zone.id}
+              points={points}
+              fill={fill}
+              stroke={stroke}
+              strokeWidth={isHovered ? 2 : 1}
+              className="cursor-pointer transition-all duration-150"
+              onClick={() => scrollToZone(zone.slug)}
+              onMouseEnter={() => setHoveredZoneSlug(zone.slug)}
+              onMouseLeave={() => setHoveredZoneSlug(null)}
+              aria-label={`${zone.name} — ${count} lineup${count !== 1 ? "s" : ""} — click to scroll`}
+            />
+          );
+        })}
+      </svg>
+
+      {/* Hover tooltip */}
+      {hoveredZoneSlug && (() => {
+        const zone = zones.find((z) => z.slug === hoveredZoneSlug);
+        if (!zone) return null;
+        const count = density[zone.id]?.count ?? 0;
+        return (
+          <div className="absolute bottom-2 left-1/2 -translate-x-1/2 pointer-events-none z-10 px-2 py-1 rounded-md bg-popover border text-xs shadow-md whitespace-nowrap">
+            <span className="font-semibold">{zone.name}</span>
+            <span className="ml-1.5 text-muted-foreground">
+              {count} lineup{count !== 1 ? "s" : ""}
+            </span>
+          </div>
+        );
+      })()}
+    </nav>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardOperatorMenu.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardOperatorMenu.tsx
@@ -1,0 +1,131 @@
+/**
+ * GlanceBoardOperatorMenu — ⚙ dropdown for operator-only map actions.
+ *
+ * Houses actions that were previously scattered in the MapPage header:
+ *   - Add lineup
+ *   - Edit zones (superuser)
+ *   - Replace minimap (superuser)
+ *   - Unplaceable lineups notice (if applicable)
+ *
+ * Opened via the ⚙ chip in the top bar. Closes on outside-click or Escape.
+ */
+import { useEffect, useRef, useState } from "react";
+import { Link } from "react-router-dom";
+import { ImagePlus, Pencil, Plus, Settings2 } from "lucide-react";
+
+interface GlanceBoardOperatorMenuProps {
+  gameSlug: string;
+  mapSlug: string;
+  isSuperuser: boolean;
+  unplaceableCount: number;
+  onReplaceMinimapClick: () => void;
+}
+
+export default function GlanceBoardOperatorMenu({
+  gameSlug,
+  mapSlug,
+  isSuperuser,
+  unplaceableCount,
+  onReplaceMinimapClick,
+}: GlanceBoardOperatorMenuProps) {
+  const [open, setOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  // Close on outside-click
+  useEffect(() => {
+    if (!open) return;
+    function onPointerDown(e: PointerEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener("pointerdown", onPointerDown);
+    return () => document.removeEventListener("pointerdown", onPointerDown);
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [open]);
+
+  const addLineupHref = `/lineups/new?game=${gameSlug}&map=${mapSlug}`;
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={[
+          "inline-flex items-center gap-1 px-2.5 py-1 rounded-md text-xs border transition-colors min-h-[30px]",
+          open ? "bg-muted" : "bg-card hover:bg-muted/40",
+        ].join(" ")}
+        aria-expanded={open}
+        aria-haspopup="menu"
+        title="Map actions"
+        aria-label="Map actions"
+      >
+        <Settings2 className="w-3.5 h-3.5" aria-hidden />
+      </button>
+
+      {open && (
+        <div
+          className="absolute right-0 top-full mt-1 z-30 bg-card border rounded-lg shadow-lg py-1 min-w-[180px]"
+          role="menu"
+          aria-label="Map actions menu"
+        >
+          <Link
+            to={addLineupHref}
+            className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/40 transition-colors"
+            role="menuitem"
+            onClick={() => setOpen(false)}
+          >
+            <Plus className="w-4 h-4 flex-shrink-0" aria-hidden />
+            Add lineup
+          </Link>
+
+          {isSuperuser && (
+            <>
+              <Link
+                to={`/${gameSlug}/${mapSlug}/zones/edit`}
+                className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/40 transition-colors"
+                role="menuitem"
+                onClick={() => setOpen(false)}
+                title="Author the clickable zone polygons for this map"
+              >
+                <Pencil className="w-4 h-4 flex-shrink-0" aria-hidden />
+                Edit zones
+              </Link>
+              <button
+                type="button"
+                className="w-full flex items-center gap-2 px-3 py-2 text-sm hover:bg-muted/40 transition-colors text-left"
+                role="menuitem"
+                onClick={() => {
+                  setOpen(false);
+                  onReplaceMinimapClick();
+                }}
+                title="Replace this map's minimap image"
+              >
+                <ImagePlus className="w-4 h-4 flex-shrink-0" aria-hidden />
+                Replace minimap
+              </button>
+            </>
+          )}
+
+          {unplaceableCount > 0 && (
+            <>
+              <div className="mx-2 my-1 border-t border-border" role="separator" />
+              <div className="px-3 py-2 text-xs text-muted-foreground">
+                {unplaceableCount} lineup{unplaceableCount !== 1 ? "s" : ""} can't be placed on the minimap
+              </div>
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -1,0 +1,174 @@
+/**
+ * GlanceBoardTile — full-size tile for the glance board viewer.
+ *
+ * Designed for second-monitor use: both STAND and AIM screenshots rendered
+ * at full size (~380px each, 16:9) with no click-to-expand. The detail IS
+ * the default state.
+ *
+ * Layout:
+ *   ┌───────────────────────────────────────────────┐
+ *   │ [UTIL BADGE]  <title>            <side>·<from> │  header
+ *   ├──────────────────────┬────────────────────────┤
+ *   │   STAND screenshot   │   AIM screenshot        │  two 16:9 halves
+ *   │   (label STAND)      │   (label AIM + dot)     │
+ *   ├──────────────────────┴────────────────────────┤
+ *   │  ⏱ <setup_seconds>s   [ — technique — ]        │  reserved footer
+ *   └───────────────────────────────────────────────┘
+ *
+ * The footer is a PR2 placeholder — structure reserved, content muted.
+ * notes are NOT displayed inline; they live in a title= tooltip.
+ */
+import { Clock } from "lucide-react";
+import type { Lineup } from "@/types/game";
+import { utilDisplay } from "@/constants/utilityDisplay";
+
+interface GlanceBoardTileProps {
+  lineup: Lineup;
+}
+
+// ---------------------------------------------------------------------------
+// Side chip — CS2-style T=gold / CT=blue / Both=neutral
+// ---------------------------------------------------------------------------
+const SIDE_CHIP: Record<string, { bg: string; text: string; label: string }> = {
+  side_a: { bg: "bg-yellow-500/20 border border-yellow-500/50", text: "text-yellow-600 dark:text-yellow-400", label: "T" },
+  side_b: { bg: "bg-blue-500/20 border border-blue-500/50",     text: "text-blue-600 dark:text-blue-400",     label: "CT" },
+  any:    { bg: "bg-muted border border-border",                text: "text-muted-foreground",                label: "⊕" },
+};
+
+function SideChip({ side }: { side: string | null }) {
+  const cfg = side ? (SIDE_CHIP[side] ?? SIDE_CHIP.any) : SIDE_CHIP.any;
+  return (
+    <span
+      className={`inline-flex items-center justify-center h-5 min-w-[22px] px-1 rounded text-[11px] font-bold ${cfg.bg} ${cfg.text}`}
+    >
+      {cfg.label}
+    </span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Aim anchor dot — 12px red circle, white outline, drop shadow
+// (Identical spec to LineupCard's AimAnchorDot)
+// ---------------------------------------------------------------------------
+function AimAnchorDot({ x, y }: { x: number; y: number }) {
+  return (
+    <div
+      aria-label={`Aim anchor at ${Math.round(x * 100)}%, ${Math.round(y * 100)}%`}
+      style={{
+        position: "absolute",
+        left: `calc(${x * 100}% - 6px)`,
+        top:  `calc(${y * 100}% - 6px)`,
+        width: 12,
+        height: 12,
+        borderRadius: "50%",
+        background: "rgba(239, 68, 68, 0.85)",
+        border: "2px solid white",
+        boxShadow: "0 1px 4px rgba(0,0,0,0.7)",
+        pointerEvents: "none",
+      }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Screenshot half
+// ---------------------------------------------------------------------------
+interface ScreenshotHalfProps {
+  url: string | null;
+  alt: string;
+  label: string;
+  children?: React.ReactNode;
+}
+
+function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProps) {
+  return (
+    <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
+      {url ? (
+        <img
+          src={url}
+          alt={alt}
+          className="absolute inset-0 w-full h-full object-cover"
+          draggable={false}
+        />
+      ) : (
+        <div className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
+          No screenshot
+        </div>
+      )}
+      {/* Corner label */}
+      <span className="absolute top-1.5 left-2 text-[10px] font-semibold tracking-wider text-white/80 bg-black/40 px-1.5 py-0.5 rounded uppercase select-none pointer-events-none">
+        {label}
+      </span>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// GlanceBoardTile
+// ---------------------------------------------------------------------------
+export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
+  const ud = utilDisplay(lineup.utility_type?.slug);
+
+  return (
+    <article
+      className="rounded-lg border bg-card overflow-hidden flex flex-col"
+      aria-label={`${ud.label}: ${lineup.title} — ${lineup.side ?? "any"} side — target ${lineup.target_zone?.name ?? "unknown"}`}
+      title={lineup.notes ?? undefined}
+    >
+      {/* ── Header ────────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-2 px-3 py-2 border-b min-h-[36px]">
+        <span
+          className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-semibold uppercase tracking-wide flex-shrink-0 ${ud.badgeBg} ${ud.badgeText}`}
+        >
+          {ud.label.toUpperCase()}
+        </span>
+        <span className="flex-1 min-w-0 text-[13px] font-semibold leading-tight truncate">
+          {lineup.title}
+        </span>
+        <div className="flex items-center gap-1.5 flex-shrink-0">
+          <SideChip side={lineup.side} />
+          {lineup.stand_zone && (
+            <span className="text-[11px] text-muted-foreground truncate max-w-[140px]">
+              From: {lineup.stand_zone.name}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* ── Images (side-by-side, 16:9 each) ──────────────────────────── */}
+      <div className="flex divide-x divide-border">
+        <ScreenshotHalf
+          url={lineup.stand_screenshot_url}
+          alt={`${lineup.title} — stand position`}
+          label="STAND"
+        />
+        <ScreenshotHalf
+          url={lineup.aim_screenshot_url}
+          alt={`${lineup.title} — aim reference`}
+          label="AIM"
+        >
+          {lineup.aim_screenshot_url &&
+            lineup.aim_anchor_x != null &&
+            lineup.aim_anchor_y != null && (
+              <AimAnchorDot x={lineup.aim_anchor_x} y={lineup.aim_anchor_y} />
+            )}
+        </ScreenshotHalf>
+      </div>
+
+      {/* ── Footer — PR2 throw-technique placeholder ───────────────────── */}
+      {/* PR2: throw-technique fields (throw type / mouse button / movement) land here */}
+      <div className="flex items-center gap-3 px-3 py-1.5 bg-muted/30 border-t min-h-[28px]">
+        {lineup.setup_seconds != null && (
+          <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
+            <Clock className="w-3 h-3 flex-shrink-0" aria-hidden />
+            {lineup.setup_seconds}s
+          </span>
+        )}
+        <span className="text-[11px] text-muted-foreground/50 italic select-none">
+          — technique —
+        </span>
+      </div>
+    </article>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/glanceBoardUtils.ts
+++ b/apps/mygamingassistant/frontend/src/components/lineup/glanceBoardUtils.ts
@@ -1,0 +1,11 @@
+/**
+ * glanceBoardUtils — pure helpers shared between GlanceBoard and its siblings.
+ *
+ * Extracted into its own module so that GlanceBoard.tsx does not export a
+ * non-component value from a component file (fixes react-refresh/only-export-components).
+ */
+
+/** Returns the DOM id used as a scroll anchor for a given zone slug. */
+export function zoneAnchorId(zoneSlug: string): string {
+  return `glance-zone-${zoneSlug}`;
+}

--- a/apps/mygamingassistant/frontend/src/constants/utilityDisplay.ts
+++ b/apps/mygamingassistant/frontend/src/constants/utilityDisplay.ts
@@ -1,0 +1,41 @@
+/**
+ * utilityDisplay — single source of truth for utility type display metadata.
+ *
+ * Keyed by slug (the backend fixture slug), not by display name.
+ * CS2 slugs: smoke, flash, molotov, grenade, decoy
+ * Valorant slugs: smoke, flash, molotov, recon (subset; unknown slugs use fallback)
+ *
+ * sortOrder defines the LOCKED within-zone ordering:
+ *   Smoke → Flash → Molotov → HE → Decoy
+ * Unknown/unrecognized slugs sort last (sortOrder 99).
+ */
+
+export interface UtilDisplay {
+  label: string;      // short display label
+  chipLabel: string;  // filter-chip label (compact)
+  badgeBg: string;    // Tailwind bg class
+  badgeText: string;  // Tailwind text class
+  sortOrder: number;
+}
+
+export const UTIL_DISPLAY: Record<string, UtilDisplay> = {
+  smoke:   { label: "Smoke",   chipLabel: "Smoke",   badgeBg: "bg-blue-600",   badgeText: "text-white",     sortOrder: 0 },
+  flash:   { label: "Flash",   chipLabel: "Flash",   badgeBg: "bg-yellow-400", badgeText: "text-slate-900", sortOrder: 1 },
+  molotov: { label: "Molotov", chipLabel: "Molotov", badgeBg: "bg-orange-700", badgeText: "text-white",     sortOrder: 2 },
+  grenade: { label: "HE",      chipLabel: "HE",      badgeBg: "bg-red-600",    badgeText: "text-white",     sortOrder: 3 },
+  decoy:   { label: "Decoy",   chipLabel: "Decoy",   badgeBg: "bg-purple-600", badgeText: "text-white",     sortOrder: 4 },
+  // Valorant-only slugs that share names with CS2 entries above (smoke/flash/molotov)
+  // are handled by the entries already keyed above.
+  recon:   { label: "Recon",   chipLabel: "Recon",   badgeBg: "bg-teal-600",   badgeText: "text-white",     sortOrder: 5 },
+};
+
+/** Safe accessor — returns a sensible fallback for any unknown slug. Never throws. */
+export function utilDisplay(slug: string | undefined | null): UtilDisplay {
+  return (slug != null && UTIL_DISPLAY[slug]) || {
+    label: "Util",
+    chipLabel: "Util",
+    badgeBg: "bg-muted",
+    badgeText: "text-foreground",
+    sortOrder: 99,
+  };
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -1,80 +1,73 @@
 /**
- * MapPage — plan-mode lineup viewer.
+ * MapPage — CS2 lineup glance board.
  * Route: /:gameSlug/:mapSlug
  *
+ * Second-monitor design: every lineup for the open map is a full-size tile,
+ * all visible at once, grouped by target zone, vertical scroll. No click to
+ * expand anything — the detail IS the default state.
+ *
  * URL is the single source of truth for all filter state:
- *   ?side=side_a&util=smoke,molly&zone=mid&round=1&compact=1
+ *   ?side=side_a&util=smoke,molly&loadout=smoke,flash&round=1&compact=1
+ *
+ * Layout:
+ *   ┌─────────────────────────────────────────────────────┐
+ *   │ Slim sticky top bar (~40px)                         │
+ *   │ ← Game · MapName | T/CT/Both | util chips | loadout │
+ *   │                                    chips | ⚙        │
+ *   ├──────────────┬──────────────────────────────────────┤
+ *   │ Sidebar      │ Main scroll area                     │
+ *   │ (~200px)     │                                      │
+ *   │ Minimap +    │ ━━ A SITE (n) ━━                     │
+ *   │ zone SVG     │ [tile] [tile]                        │
+ *   │              │ ━━ B SITE (n) ━━                     │
+ *   │              │ ...                                  │
+ *   └──────────────┴──────────────────────────────────────┘
  *
  * Modes:
- *  - Plan mode (default): SVG zone map, side toggle, utility chips, results panel
+ *  - Glance board (default): full-size tiles, all lineups visible
  *  - Round mode (?round=1): only pinned lineups, no map, no chrome
- *  - Compact mode (?compact=1): borderless — app shell hides itself (see RootLayout)
- *
- * Features:
- *  - Pin system via usePins (localStorage, cross-tab sync)
- *  - Keyboard shortcuts via useMapKeyboardShortcuts
- *  - Keyboard shortcuts help overlay via "?" key
- *  - Storage-unavailable toast (one-time, in-memory fallback)
+ *  - Compact mode (?compact=1): borderless — app shell hides itself
  */
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { AlertTriangle, Backpack, ImagePlus, Pencil, Plus } from "lucide-react";
-import { ToggleChipGroup, showSuccess } from "@platform/ui";
+import { ArrowLeft, HelpCircle } from "lucide-react";
 import { useGetGamesQuery, useGetMapDetailQuery } from "@/store/gamesApi";
 import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
-import { useGetLineupPackagesQuery, usePinAllLineupPackageMutation } from "@/store/lineupPackagesApi";
-import MapZoneOverlay from "@/components/lineup/MapZoneOverlay";
-import MapLineupPins, {
-  type PinMode,
-  countUnplaceableLineups,
-} from "@/components/lineup/MapLineupPins";
-import PinModeToggle from "@/components/lineup/PinModeToggle";
-import LineupDetailPanel from "@/components/lineup/LineupDetailPanel";
-import UnplaceableLineupsNotice from "@/components/lineup/UnplaceableLineupsNotice";
+import { countUnplaceableLineups } from "@/components/lineup/MapLineupPins";
+import type { PinMode } from "@/components/lineup/MapLineupPins";
 import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
+import GlanceBoard from "@/components/lineup/GlanceBoard";
+import GlanceBoardMinimapSidebar from "@/components/lineup/GlanceBoardMinimapSidebar";
+import GlanceBoardOperatorMenu from "@/components/lineup/GlanceBoardOperatorMenu";
 import MinimapUploadDialog from "@/components/game/MinimapUploadDialog";
 import RoundMode from "@/pages/RoundMode";
-import BackButton from "@/components/map/BackButton";
-import LoadoutPopover from "@/components/map/LoadoutPopover";
-import PackagesDropdown from "@/components/map/PackagesDropdown";
 import StorageUnavailableBanner from "@/components/map/StorageUnavailableBanner";
-import LineupResultsPanel from "@/components/map/LineupResultsPanel";
 import { usePins } from "@/hooks/usePins";
 import { useLoadout, computeEffectiveUtilFilter } from "@/hooks/useLoadout";
 import { useMapKeyboardShortcuts } from "@/hooks/useMapKeyboardShortcuts";
 import { useIsSuperuser } from "@/hooks/useIsSuperuser";
+import { utilDisplay } from "@/constants/utilityDisplay";
 import type { ZoneDensity } from "@/types/game";
-
-const SIDE_BG: Record<string, string> = {
-  side_a: "rgba(239,68,68,0.05)",
-  side_b: "rgba(59,130,246,0.05)",
-  any: "transparent",
-};
 
 export default function MapPage() {
   const { gameSlug, mapSlug } = useParams<{ gameSlug: string; mapSlug: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
   const navigate = useNavigate();
 
-  const side = searchParams.get("side") ?? "any";
-  const util = searchParams.get("util") ?? "";
-  const zone = searchParams.get("zone") ?? "";
-  const isRoundMode = searchParams.get("round") === "1";
-  const pinModeParam = searchParams.get("pins");
+  const side               = searchParams.get("side")   ?? "any";
+  const util               = searchParams.get("util")   ?? "";
+  const isRoundMode        = searchParams.get("round")  === "1";
+  const pinModeParam       = searchParams.get("pins");
   const pinMode: PinMode | null =
     pinModeParam === "stand" || pinModeParam === "target" || pinModeParam === "both"
       ? pinModeParam
       : null;
-  const selectedLineupId = searchParams.get("lineup");
 
-  // Card cycling (Arrow left/right in round mode or panel)
-  const [activeCardIndex, setActiveCardIndex] = useState(0);
-  // Keyboard shortcuts help overlay
-  const [showShortcutsHelp, setShowShortcutsHelp] = useState(false);
-  // One-time storage-unavailable toast
+  const [showShortcutsHelp,   setShowShortcutsHelp]   = useState(false);
   const [storageUnavailableToast, setStorageUnavailableToast] = useState(false);
-  // Minimap <img> 404/network failure — falls back to text rather than broken-image icon
-  const [minimapLoadFailed, setMinimapLoadFailed] = useState(false);
+  const [showMinimapUpload,   setShowMinimapUpload]    = useState(false);
+  // Card cycling — used by round mode + keyboard shortcuts
+  const [activeCardIndex,     setActiveCardIndex]      = useState(0);
 
   const { data: games } = useGetGamesQuery();
   const {
@@ -88,104 +81,67 @@ export default function MapPage() {
   );
 
   const { isSuperuser } = useIsSuperuser();
-  const [showMinimapUpload, setShowMinimapUpload] = useState(false);
-
   const game = games?.find((g) => g.slug === gameSlug);
 
+  // ---------------------------------------------------------------------------
+  // Filter state derived from URL
+  // ---------------------------------------------------------------------------
   const utilOptions =
     mapDetail?.utility_types.map((u) => ({
       value: u.slug,
-      label: u.name,
+      label: utilDisplay(u.slug).chipLabel,
     })) ?? [];
+
   const selectedUtils = util ? util.split(",").filter(Boolean) : [];
 
-  // Loadout filter — per-(game, side) localStorage-backed set of utility slugs.
+  // Loadout filter — persistent inline chips in the top bar.
+  // Default loadout = empty = "no loadout filter applied" (show all).
+  // State lives in useLoadout (localStorage-backed). Filter chips always
+  // visible; compose with the utility chips.
   const { loadout, toggleLoadout, clearLoadout } = useLoadout(gameSlug ?? "", side);
-  const [showLoadoutPopover, setShowLoadoutPopover] = useState(false);
 
-  // Keyboard shortcut 'l' opens the loadout popover
-  useEffect(() => {
-    function onKeyDown(e: KeyboardEvent) {
-      if (e.key !== "l" || e.ctrlKey || e.metaKey || e.altKey) return;
-      if (document.activeElement?.tagName === "INPUT" || document.activeElement?.tagName === "TEXTAREA") return;
-      setShowLoadoutPopover((v) => !v);
-    }
-    document.addEventListener("keydown", onKeyDown);
-    return () => document.removeEventListener("keydown", onKeyDown);
-  }, []);
-
-  // Effective utility filter: intersection of loadout + selected util chips
   const effectiveUtils = computeEffectiveUtilFilter(loadout, selectedUtils);
 
+  // ---------------------------------------------------------------------------
+  // Data fetching
+  // ---------------------------------------------------------------------------
   const { data: density = {} as ZoneDensity } = useGetZoneDensityQuery(
     {
       game_slug: gameSlug ?? "",
-      map_slug: mapSlug ?? "",
-      side: side !== "any" ? side : undefined,
-      util: effectiveUtils.length > 0 ? effectiveUtils.join(",") : undefined,
+      map_slug:  mapSlug  ?? "",
+      side:      side !== "any" ? side : undefined,
+      util:      effectiveUtils.length > 0 ? effectiveUtils.join(",") : undefined,
     },
     { skip: !gameSlug || !mapSlug },
   );
 
-  const targetZone = mapDetail?.zones.find((z) => z.slug === zone);
-  const { data: lineups = [], isFetching: lineupsFetching } = useGetLineupsQuery(
+  // Glance board always fetches all map lineups (no zone filter).
+  const {
+    data: allMapLineups = [],
+    isFetching: allMapFetching,
+  } = useGetLineupsQuery(
     {
-      game_slug: gameSlug ?? "",
-      map_slug: mapSlug ?? "",
-      target_zone_slug: zone || undefined,
-      side: side !== "any" ? side : undefined,
-      utility_type_slugs: effectiveUtils.length > 0 ? effectiveUtils.join(",") : util || undefined,
+      game_slug:            gameSlug ?? "",
+      map_slug:             mapSlug  ?? "",
+      side:                 side !== "any" ? side : undefined,
+      utility_type_slugs:   effectiveUtils.length > 0 ? effectiveUtils.join(",") : undefined,
     },
-    { skip: !gameSlug || !mapSlug || !zone },
+    { skip: !gameSlug || !mapSlug },
   );
 
-  // Packages — for the current map (no side filter here to show all packages)
-  const { data: packages = [] } = useGetLineupPackagesQuery(
-    {
-      map_id: mapDetail?.id,
-    },
-    { skip: !mapDetail?.id },
-  );
-  const [pinAllPackage] = usePinAllLineupPackageMutation();
-
-  // --------------------------------------------------------------------------
-  // Pin system
-  // --------------------------------------------------------------------------
-  const pins = usePins(gameSlug ?? "", mapSlug ?? "", side);
-
-  // Fetch all map lineups for round mode AND for the pin layer (no zone filter).
-  // Pin mode shows pins across the whole map; round mode shows pinned lineups.
-  const needsAllMapLineups = isRoundMode || pinMode !== null;
-  const { data: allMapLineups = [], isFetching: allMapFetching } = useGetLineupsQuery(
-    {
-      game_slug: gameSlug ?? "",
-      map_slug: mapSlug ?? "",
-      side: side !== "any" ? side : undefined,
-      utility_type_slugs: effectiveUtils.length > 0 ? effectiveUtils.join(",") : undefined,
-    },
-    { skip: !gameSlug || !mapSlug || !needsAllMapLineups },
-  );
-
+  // ---------------------------------------------------------------------------
+  // Pin system (used by round mode)
+  // ---------------------------------------------------------------------------
+  const pins          = usePins(gameSlug ?? "", mapSlug ?? "", side);
   const pinnedLineups = allMapLineups.filter((l) => pins.isPinned(l.id));
 
-  // Unplaceable hint: lineups exist for the current filter but every one
-  // lacks a resolvable map position (no explicit anchor AND the referenced
-  // zone has no polygon). The hint is non-blocking — the results panel still
-  // lists the lineups; only the map pin is unavailable. Use the lineup set
-  // that drives the current view: the map-wide set when pins are on, the
-  // zone-filtered set otherwise.
-  const unplaceableSource = pinMode !== null ? allMapLineups : lineups;
-  const unplaceablePinMode: PinMode = pinMode ?? "both";
+  // Unplaceable count — for operator ⚙ menu notice
   const unplaceableCount =
-    unplaceableSource.length > 0
-      ? countUnplaceableLineups(unplaceableSource, unplaceablePinMode)
+    allMapLineups.length > 0
+      ? countUnplaceableLineups(allMapLineups, pinMode ?? "both")
       : 0;
-  const allUnplaceable =
-    unplaceableSource.length > 0 && unplaceableCount === unplaceableSource.length;
 
   // Reset active card index when round mode is entered or pin count changes.
-  // Using MessageChannel to schedule asynchronously, avoiding the
-  // "set-state-in-effect" lint rule against synchronous setState in effects.
   useEffect(() => {
     const channel = new MessageChannel();
     channel.port1.onmessage = () => setActiveCardIndex(0);
@@ -202,14 +158,9 @@ export default function MapPage() {
     return () => window.removeEventListener("mga:storage-unavailable", onStorageUnavailable);
   }, []);
 
-  // Reset minimap-load failure when navigating to a different map.
-  useEffect(() => {
-    setMinimapLoadFailed(false);
-  }, [mapDetail?.minimap_url]);
-
-  // --------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
   // URL helpers
-  // --------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
   function updateParam(key: string, value: string | null) {
     setSearchParams(
       (prev) => {
@@ -233,51 +184,51 @@ export default function MapPage() {
     updateParam("util", slugs.length > 0 ? slugs.join(",") : null);
   }
 
-  function handleZoneClick(zoneSlug: string) {
-    updateParam("zone", zone === zoneSlug ? null : zoneSlug);
+  // Individual util chip toggle (for top-bar chips that toggle one at a time)
+  function handleUtilChipToggle(slug: string) {
+    const next = selectedUtils.includes(slug)
+      ? selectedUtils.filter((s) => s !== slug)
+      : [...selectedUtils, slug];
+    handleUtilToggle(next);
   }
 
-  function handleClosePanel() {
-    updateParam("zone", null);
-  }
-
-  function handlePinModeChange(next: PinMode | null) {
-    updateParam("pins", next);
-  }
-
-  function handlePinSelect(lineupId: string) {
-    updateParam("lineup", lineupId);
-  }
-
-  function handleCloseLineupPanel() {
-    updateParam("lineup", null);
-  }
-
-  // --------------------------------------------------------------------------
-  // Keyboard shortcuts
-  // --------------------------------------------------------------------------
-  const cardCount = isRoundMode ? pinnedLineups.length : lineups.length;
+  // ---------------------------------------------------------------------------
+  // Keyboard shortcuts (kept for power users — ? for help)
+  // ---------------------------------------------------------------------------
+  const cardCount = isRoundMode ? pinnedLineups.length : allMapLineups.length;
 
   useMapKeyboardShortcuts({
     utilOptions,
     selectedUtils,
     side,
-    zone,
+    zone: "",
     cardCount,
     activeCardIndex,
-    onSideChange: handleSideChange,
-    onUtilToggle: handleUtilToggle,
-    onCloseZonePanel: handleClosePanel,
-    onActiveCardIndexChange: setActiveCardIndex,
-    onToggleShortcutsHelp: () => setShowShortcutsHelp((v) => !v),
+    onSideChange:             handleSideChange,
+    onUtilToggle:             handleUtilToggle,
+    onCloseZonePanel:         () => {},
+    onActiveCardIndexChange:  setActiveCardIndex,
+    onToggleShortcutsHelp:    () => setShowShortcutsHelp((v) => !v),
   });
 
-  // --------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Round mode exit href
+  // ---------------------------------------------------------------------------
+  const exitRoundHref = (() => {
+    const p = new URLSearchParams(searchParams);
+    p.delete("round");
+    const qs = p.toString();
+    return `/${gameSlug}/${mapSlug}${qs ? `?${qs}` : ""}`;
+  })();
+
+  const planModeHref = exitRoundHref;
+
+  // ---------------------------------------------------------------------------
   // Loading / error states
-  // --------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
   if (mapLoading) {
     return (
-      <main className="p-4 sm:p-8 space-y-4 max-w-5xl">
+      <main className="p-4 sm:p-8 space-y-4">
         <div className="flex items-center gap-3">
           <div className="w-9 h-9 rounded-md bg-muted/40 animate-pulse" />
           <div className="h-7 w-40 bg-muted/40 rounded animate-pulse" />
@@ -290,42 +241,23 @@ export default function MapPage() {
 
   if (mapError || !mapDetail) {
     return (
-      <main className="p-4 sm:p-8 max-w-5xl">
-        <BackButton gameSlug={gameSlug!} navigate={navigate} />
+      <main className="p-4 sm:p-8">
+        <button
+          type="button"
+          onClick={() => navigate(`/${gameSlug}`)}
+          className="p-2 rounded-md hover:bg-muted/40 transition-colors min-h-[44px]"
+          aria-label="Back to maps"
+        >
+          <ArrowLeft className="h-5 w-5" />
+        </button>
         <p className="text-sm text-destructive mt-4">Failed to load map. Please refresh.</p>
       </main>
     );
   }
 
-  const sideBg = SIDE_BG[side] ?? "transparent";
-
-  const sideOptions = [
-    { value: "any", label: "Any" },
-    { value: "side_a", label: game?.side_a_label ?? "Side A" },
-    { value: "side_b", label: game?.side_b_label ?? "Side B" },
-  ];
-
-  const addLineupHref = `/lineups/new?game=${gameSlug}&map=${mapSlug}${zone ? `&target_zone=${zone}` : ""}`;
-
-  // Round mode exit: removes ?round=1, keeps other params
-  const exitRoundHref = (() => {
-    const p = new URLSearchParams(searchParams);
-    p.delete("round");
-    const qs = p.toString();
-    return `/${gameSlug}/${mapSlug}${qs ? `?${qs}` : ""}`;
-  })();
-
-  // Plan mode href (for "open plan mode" link in round mode empty state)
-  const planModeHref = (() => {
-    const p = new URLSearchParams(searchParams);
-    p.delete("round");
-    const qs = p.toString();
-    return `/${gameSlug}/${mapSlug}${qs ? `?${qs}` : ""}`;
-  })();
-
-  // --------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
   // Round mode
-  // --------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
   if (isRoundMode) {
     return (
       <>
@@ -347,9 +279,21 @@ export default function MapPage() {
     );
   }
 
-  // --------------------------------------------------------------------------
-  // Plan mode
-  // --------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Side chip helpers
+  // ---------------------------------------------------------------------------
+  const sideA  = game?.side_a_label ?? "T";
+  const sideB  = game?.side_b_label ?? "CT";
+
+  const sideChips = [
+    { value: "side_a", label: sideA },
+    { value: "side_b", label: sideB },
+    { value: "any",    label: "Both" },
+  ];
+
+  // ---------------------------------------------------------------------------
+  // Glance board
+  // ---------------------------------------------------------------------------
   return (
     <>
       {showShortcutsHelp && (
@@ -360,301 +304,206 @@ export default function MapPage() {
         <StorageUnavailableBanner onClose={() => setStorageUnavailableToast(false)} />
       )}
 
-      <div
-        className="relative min-h-screen transition-colors duration-300"
-        style={{ background: sideBg }}
-      >
-        <main className="p-4 sm:p-8 space-y-4 max-w-5xl">
-          {/* Header row */}
-          <div className="flex items-center gap-3 flex-wrap">
-            <BackButton gameSlug={gameSlug!} navigate={navigate} />
-            <div className="flex-1 min-w-0">
-              <p className="text-xs text-muted-foreground">{game?.name ?? gameSlug}</p>
-              <h1 className="text-xl font-semibold capitalize">{mapDetail.name}</h1>
-            </div>
-            {isSuperuser && (
-              <Link
-                to={`/${gameSlug}/${mapSlug}/zones/edit`}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
-                title="Author the clickable zone polygons for this map"
-              >
-                <Pencil className="w-4 h-4" />
-                Edit zones
-              </Link>
-            )}
-            {isSuperuser && (
+      {showMinimapUpload && (
+        <MinimapUploadDialog
+          mapId={mapDetail.id}
+          mapName={mapDetail.name}
+          onClose={() => setShowMinimapUpload(false)}
+          onUploaded={() => {
+            refetchMapDetail();
+          }}
+        />
+      )}
+
+      {/* ── Full-height flex container ──────────────────────────────────── */}
+      <div className="flex flex-col min-h-screen">
+
+        {/* ── Slim sticky top bar (~40px) ─────────────────────────────── */}
+        <header className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm border-b h-10 flex items-center gap-2 px-3 shrink-0 overflow-x-auto">
+
+          {/* Back + map name */}
+          <button
+            type="button"
+            onClick={() => navigate(`/${gameSlug}`)}
+            className="flex items-center gap-1.5 text-sm font-medium hover:text-foreground text-muted-foreground transition-colors shrink-0"
+            aria-label="Back to maps"
+          >
+            <ArrowLeft className="w-3.5 h-3.5" aria-hidden />
+            <span className="hidden sm:inline text-xs text-muted-foreground">{game?.name ?? gameSlug} ·</span>
+            <span className="text-sm font-semibold text-foreground capitalize">{mapDetail.name}</span>
+          </button>
+
+          <span className="text-border shrink-0">|</span>
+
+          {/* Side chips */}
+          <div className="flex items-center gap-0.5 shrink-0" role="group" aria-label="Side filter">
+            {sideChips.map((opt) => (
               <button
+                key={opt.value}
                 type="button"
-                onClick={() => setShowMinimapUpload(true)}
-                className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
-                title="Replace this map's minimap image"
+                onClick={() => handleSideChange(opt.value)}
+                className={[
+                  "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors",
+                  side === opt.value
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+                ].join(" ")}
+                aria-pressed={side === opt.value}
               >
-                <ImagePlus className="w-4 h-4" />
-                Replace minimap
+                {opt.label}
               </button>
-            )}
-            <Link
-              to={addLineupHref}
-              className="flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
-            >
-              <Plus className="w-4 h-4" />
-              Add lineup
-            </Link>
+            ))}
           </div>
 
-          {isSuperuser &&
-            mapDetail.zones.length > 0 &&
-            mapDetail.zones.every((z) => z.polygon_points.length === 0) && (
-              <div
-                className="flex items-start gap-2.5 px-3 py-2.5 rounded-md border bg-amber-500/10 border-amber-500/30 text-sm"
-                role="status"
-              >
-                <AlertTriangle
-                  className="w-4 h-4 text-amber-600 dark:text-amber-400 flex-shrink-0 mt-0.5"
-                  aria-hidden
-                />
-                <div className="flex-1">
-                  <p className="font-medium">
-                    This map's zones aren't drawn yet.
-                  </p>
-                  <p className="text-xs text-muted-foreground">
-                    Visitors will see a static minimap until you author the
-                    clickable zone polygons.
-                  </p>
-                </div>
-                <Link
-                  to={`/${gameSlug}/${mapSlug}/zones/edit`}
-                  className="px-3 py-1 text-sm rounded-md bg-primary text-primary-foreground hover:opacity-90 min-h-[32px] inline-flex items-center"
-                >
-                  Set up zones
-                </Link>
-              </div>
-            )}
+          <span className="text-border shrink-0">|</span>
 
-          {showMinimapUpload && (
-            <MinimapUploadDialog
-              mapId={mapDetail.id}
-              mapName={mapDetail.name}
-              onClose={() => setShowMinimapUpload(false)}
-              onUploaded={() => {
-                refetchMapDetail();
-                setMinimapLoadFailed(false);
-              }}
-            />
-          )}
-
-          {/* Sticky filter bar */}
-          <div className="sticky top-0 z-10 bg-background/90 backdrop-blur-sm border-b pb-3 -mx-4 px-4 sm:-mx-8 sm:px-8">
-            <div className="flex flex-wrap gap-3 items-center pt-2">
-              {/* Side toggle */}
-              <div className="flex gap-1">
-                {sideOptions.map((opt) => (
+          {/* Utility type chips */}
+          {utilOptions.length > 0 && (
+            <div className="flex items-center gap-0.5 shrink-0" role="group" aria-label="Utility type filter">
+              {utilOptions.map((opt) => {
+                const active = selectedUtils.includes(opt.value);
+                return (
                   <button
                     key={opt.value}
                     type="button"
-                    onClick={() => handleSideChange(opt.value)}
+                    onClick={() => handleUtilChipToggle(opt.value)}
                     className={[
-                      "px-3 py-1.5 rounded-md text-sm font-medium transition-colors min-h-[36px]",
-                      side === opt.value
+                      "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors",
+                      active
                         ? "bg-primary text-primary-foreground"
-                        : "bg-card border hover:bg-muted/40",
+                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
                     ].join(" ")}
-                    aria-pressed={side === opt.value}
+                    aria-pressed={active}
                   >
                     {opt.label}
                   </button>
-                ))}
-              </div>
-
-              {/* Loadout filter — "My loadout" chip group above utility chips */}
-              {utilOptions.length > 0 && (
-                <div className="relative">
-                  <button
-                    type="button"
-                    onClick={() => setShowLoadoutPopover((v) => !v)}
-                    className={[
-                      "inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md text-sm border transition-colors min-h-[36px]",
-                      loadout.length > 0
-                        ? "bg-amber-500/10 border-amber-500/40 text-amber-700 dark:text-amber-400"
-                        : "bg-card hover:bg-muted/40",
-                    ].join(" ")}
-                    title="Set your current loadout utilities (keyboard: l)"
-                    aria-expanded={showLoadoutPopover}
-                  >
-                    <Backpack className="w-3.5 h-3.5" aria-hidden />
-                    {loadout.length > 0 ? `Loadout (${loadout.length})` : "My loadout"}
-                  </button>
-
-                  {showLoadoutPopover && (
-                    <LoadoutPopover
-                      utilOptions={utilOptions}
-                      loadout={loadout}
-                      onToggle={toggleLoadout}
-                      onClear={clearLoadout}
-                      onClose={() => setShowLoadoutPopover(false)}
-                    />
-                  )}
-                </div>
-              )}
-
-              {/* Utility chips */}
-              {utilOptions.length > 0 && (
-                <ToggleChipGroup
-                  options={utilOptions}
-                  value={selectedUtils}
-                  onChange={handleUtilToggle}
-                />
-              )}
-
-              {/* Packages dropdown */}
-              {packages.length > 0 && (
-                <PackagesDropdown
-                  packages={packages}
-                  pins={pins}
-                  pinAllPackage={pinAllPackage}
-                  onPinAllComplete={(count) => {
-                    showSuccess(`Pinned ${count} lineup${count !== 1 ? "s" : ""} — entering round mode.`);
-                    updateParam("round", "1");
-                  }}
-                />
-              )}
-
-              {/* Pin mode toggle — show per-lineup pins on the minimap */}
-              <PinModeToggle mode={pinMode} onChange={handlePinModeChange} />
-
-              {/* Round mode button */}
-              <button
-                type="button"
-                onClick={() => updateParam("round", "1")}
-                className="px-3 py-1.5 rounded-md text-sm border bg-card hover:bg-muted/40 transition-colors min-h-[36px]"
-                title="Enter round mode (show pinned lineups only)"
-                aria-label="Enter round mode"
-              >
-                Round mode
-              </button>
+                );
+              })}
             </div>
-          </div>
-
-          {allUnplaceable && (
-            <UnplaceableLineupsNotice count={unplaceableCount} />
           )}
 
-          {/* Map + results layout */}
-          <div className="flex flex-col lg:flex-row gap-4">
-            {/* Map minimap with zone overlay */}
-            <div className="flex-1 min-w-0">
+          {/* Loadout chips — persistent inline toggle strip.
+              Composable with utility chips; default empty = no filter.
+              Keyboard shortcut 'l' from old popover removed; inline chips
+              are always accessible without shortcut. */}
+          {utilOptions.length > 0 && (
+            <>
+              <span className="text-border shrink-0">|</span>
               <div
-                className="relative rounded-xl border overflow-hidden bg-card"
-                style={{ aspectRatio: "1 / 1" }}
+                className="flex items-center gap-0.5 shrink-0"
+                role="group"
+                aria-label="Loadout filter — utilities you are carrying this round"
               >
-                {mapDetail.minimap_url && !minimapLoadFailed ? (
-                  <img
-                    src={mapDetail.minimap_url}
-                    alt={`${mapDetail.name} minimap`}
-                    className="absolute inset-0 w-full h-full object-cover"
-                    draggable={false}
-                    onError={() => setMinimapLoadFailed(true)}
-                  />
-                ) : (
-                  <div className="absolute inset-0 flex items-center justify-center text-muted-foreground text-sm">
-                    Minimap not available
-                  </div>
-                )}
-                <MapZoneOverlay
-                  zones={mapDetail.zones}
-                  density={density}
-                  selectedZoneSlug={zone || null}
-                  onZoneClick={handleZoneClick}
-                />
-                {pinMode && (
-                  <MapLineupPins
-                    lineups={allMapLineups}
-                    mode={pinMode}
-                    selectedLineupId={selectedLineupId}
-                    onPinSelect={handlePinSelect}
-                  />
-                )}
-                {pinMode && !allMapFetching && allMapLineups.length === 0 && (
-                  <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-                    <div className="bg-popover/95 border rounded-md px-4 py-3 text-sm text-center shadow-md pointer-events-auto">
-                      <p className="text-muted-foreground mb-2">
-                        No lineups match the current filter
-                      </p>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          handleSideChange("any");
-                          handleUtilToggle([]);
-                        }}
-                        className="text-primary hover:underline"
-                      >
-                        Clear filters
-                      </button>
-                    </div>
-                  </div>
-                )}
+                {utilOptions.map((opt) => {
+                  const inLoadout = loadout.includes(opt.value);
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => toggleLoadout(opt.value)}
+                      className={[
+                        "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors border",
+                        inLoadout
+                          ? "bg-amber-500/20 border-amber-500/50 text-amber-700 dark:text-amber-400"
+                          : "border-transparent text-muted-foreground hover:text-foreground hover:bg-muted/60",
+                      ].join(" ")}
+                      aria-pressed={inLoadout}
+                      title={`${inLoadout ? "Remove" : "Add"} ${opt.label} from loadout`}
+                    >
+                      {opt.label}
+                    </button>
+                  );
+                })}
               </div>
+            </>
+          )}
 
-              {/* Zone legend */}
-              <div className="mt-2 flex items-center gap-3 text-xs text-muted-foreground">
-                <span className="flex items-center gap-1">
-                  <span className="w-3 h-3 rounded-sm" style={{ background: "rgba(34,197,94,0.4)" }} />
-                  Has lineups
-                </span>
-                <span className="flex items-center gap-1">
-                  <span className="w-3 h-3 rounded-sm" style={{ background: "rgba(156,163,175,0.2)" }} />
-                  Empty
-                </span>
-                <span className="flex items-center gap-1">
-                  <span className="w-3 h-3 rounded-sm" style={{ background: "rgba(251,191,36,0.4)" }} />
-                  Selected
-                </span>
+          {/* Spacer */}
+          <div className="flex-1" />
+
+          {/* Help shortcut */}
+          <button
+            type="button"
+            onClick={() => setShowShortcutsHelp(true)}
+            className="p-1 rounded hover:bg-muted/40 text-muted-foreground transition-colors shrink-0"
+            aria-label="Keyboard shortcuts (?)"
+            title="Keyboard shortcuts"
+          >
+            <HelpCircle className="w-3.5 h-3.5" aria-hidden />
+          </button>
+
+          {/* Operator ⚙ menu */}
+          <GlanceBoardOperatorMenu
+            gameSlug={gameSlug!}
+            mapSlug={mapSlug!}
+            isSuperuser={isSuperuser}
+            unplaceableCount={unplaceableCount}
+            onReplaceMinimapClick={() => setShowMinimapUpload(true)}
+          />
+        </header>
+
+        {/* ── Body: sidebar + main ─────────────────────────────────────── */}
+        <div className="flex flex-1 min-h-0">
+
+          {/* Passive minimap sidebar */}
+          <aside
+            className="hidden lg:block w-[200px] shrink-0 p-3 border-r overflow-y-auto sticky top-10 h-[calc(100vh-40px)]"
+            aria-label="Map zone navigation"
+          >
+            <GlanceBoardMinimapSidebar
+              minimapUrl={mapDetail.minimap_url}
+              zones={mapDetail.zones}
+              density={density}
+            />
+          </aside>
+
+          {/* Main scrollable area */}
+          <main className="flex-1 min-w-0 p-4 lg:p-6 overflow-y-auto">
+            {allMapLineups.length === 0 && !allMapFetching && (
+              effectiveUtils.length > 0 || side !== "any"
+            ) ? (
+              /* Filtered empty state */
+              <div className="flex flex-col items-center justify-center py-20 gap-3">
+                <p className="text-sm text-muted-foreground text-center">
+                  No{effectiveUtils.length > 0 ? ` ${effectiveUtils.join("/")}` : ""} lineups
+                  {side !== "any" ? ` for ${side === "side_a" ? sideA : sideB}` : ""} on this map.
+                </p>
+                <button
+                  type="button"
+                  onClick={() => {
+                    handleSideChange("any");
+                    handleUtilToggle([]);
+                    clearLoadout();
+                  }}
+                  className="text-sm text-primary hover:underline"
+                >
+                  Clear filters
+                </button>
               </div>
-            </div>
-
-            {/* Results panel */}
-            {zone && targetZone && (
-              <aside className="lg:w-80 xl:w-96 flex-shrink-0" aria-label="Lineup results">
-                <div className="flex items-center justify-between mb-3">
-                  <h2 className="text-sm font-semibold">
-                    {targetZone.name}
-                    {lineups.length > 0 && (
-                      <span className="ml-1.5 text-xs text-muted-foreground font-normal">
-                        {lineups.length} lineup{lineups.length !== 1 ? "s" : ""}
-                      </span>
-                    )}
-                  </h2>
-                  <button
-                    type="button"
-                    onClick={handleClosePanel}
-                    className="p-1 rounded hover:bg-muted/40 text-muted-foreground text-xs"
-                    aria-label="Close results panel"
-                  >
-                    ✕
-                  </button>
-                </div>
-
-                <LineupResultsPanel
-                  fetching={lineupsFetching}
-                  lineups={lineups}
-                  activeCardIndex={activeCardIndex}
-                  pins={pins}
-                  addLineupHref={addLineupHref}
-                  targetZoneName={targetZone.name}
-                />
-              </aside>
+            ) : (
+              <GlanceBoard
+                lineups={allMapLineups}
+                isFetching={allMapFetching}
+                mapName={mapDetail.name}
+                filteredUtils={effectiveUtils}
+                side={side}
+              />
             )}
-          </div>
-        </main>
-      </div>
 
-      {selectedLineupId && (
-        <LineupDetailPanel
-          lineupId={selectedLineupId}
-          onClose={handleCloseLineupPanel}
-          pins={pins}
-        />
-      )}
+            {/* Add lineup CTA at bottom if empty and no filters */}
+            {allMapLineups.length === 0 && !allMapFetching && effectiveUtils.length === 0 && side === "any" && (
+              <div className="mt-6 text-center">
+                <Link
+                  to={`/lineups/new?game=${gameSlug}&map=${mapSlug}`}
+                  className="text-sm text-primary hover:underline"
+                >
+                  Add the first lineup for {mapDetail.name}
+                </Link>
+              </div>
+            )}
+          </main>
+        </div>
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## What

Rebuilds the CS2 lineup viewer as a **zero-click, always-on board for a second monitor**. Every lineup for the map is a full-size tile (2/row, ~380px stand+aim images), grouped by target zone, all visible at once — no click-to-enlarge, no detail panel.

- Minimap demoted to a passive sticky spatial index (clicking a zone scrolls to its section; no filter gate / mode change).
- **Loadout filter** added as persistent top-bar chips — tap what you''re holding, board shows only executable lineups.
- One-tap side + utility chips; default state shows everything.
- Cut from the board: zone-click-to-filter gate, separate results list, detail-panel overlay, Pins/Round-mode/Packages/zone-legend; operator actions moved to a ⚙ menu.
- A **reserved technique footer row** renders a `— technique —` placeholder, wired for PR3 to drop in `jump-throw · L-click · stationary` with zero layout change.

## Scope note (important)

This PR is **layout only**. The stored screenshots are arbitrary YouTube frames (verified: intro title cards / knife-out walking frames) — that is the real useless problem and is **out of scope here**. It is fixed in **PR2 (looping source-video clips)**, for which this layout already reserves the tile media area. The bad imagery was equally bad in the old UI; this PR just makes the data quality legible.

## Quality

g-design-ux design pass + g-review-frontend review (all CRITICAL/HIGH findings fixed; deferred stylistic polish logged to `apps/mygamingassistant/TECH_DEBT.md`). `npm run typecheck` + `npm run build` green; `npm run lint` at pre-existing baseline. Frontend-only — **no operational migration** (no env/schema/boot-guard changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)