### PR TITLE
feat(mbk): Airbnb payout → property matcher (PR C/4)

### DIFF
--- a/apps/mybookkeeper/backend/app/services/transactions/airbnb_payout_matcher.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/airbnb_payout_matcher.py
@@ -1,0 +1,136 @@
+"""Pure decision logic for attributing an Airbnb payout to a property.
+
+No DB / ORM here — the orchestrator (`attribution_service._attribute_airbnb_payout`)
+loads the data and applies the decision. Kept pure so the cascade is exhaustively
+table-testable (mirrors the `attribution_service.find_best_match` precedent).
+
+Cascade, first hit wins, each tier requires exactly ONE distinct property or it
+falls through:
+
+1. **res_code → BookingStatement.property_id** → ``auto``. Strongest signal: an
+   exact match on the ``UNIQUE(organization_id, res_code)`` key of a statement
+   the user's own PM import created.
+2. **exactly one Airbnb listing (with a property)** → ``auto``. Preserves the
+   prior single-listing behavior, but now ranked *below* res_code so a payout
+   whose code resolves elsewhere wins over "the user happens to have one
+   listing".
+3. **a listing title appears in the payout text** resolving to exactly one
+   property → ``propose`` (review queue, not auto — free-text title substring
+   is too weak to silently move money).
+4. otherwise → ``unmatched``.
+
+There is deliberately no guest/date tier: an Airbnb payout transaction carries
+no guest field and ``payer_name`` is null, and direct payouts create no
+``BookingStatement`` row — so no sound guest/date signal exists from the data
+available here. A no-match payout goes to the review queue, where the operator
+resolves it via the property-confirm path.
+"""
+import re
+import uuid
+from collections.abc import Sequence
+from typing import Literal, NamedTuple, Protocol
+
+# Airbnb confirmation codes are uppercase alphanumeric, almost always
+# ``HM``-prefixed in payout emails. The HM literal + word boundaries + the
+# uppercase-only class keep this precise (false auto-attribution of money is
+# the cardinal sin — prefer a miss over a wrong auto). A context-anchored
+# fallback catches non-HM codes only when an explicit "reservation/
+# confirmation/booking" word precedes them.
+#
+# Every quantifier is bounded by a small constant (no unbounded ``\s+``/``\s*``
+# that an attacker-controlled whitespace run could partition O(n) ways) →
+# linear time, not ReDoS-exploitable. Do NOT reintroduce ``\s+``/``\s*`` here.
+_HM_CODE_RE = re.compile(r"\bHM[A-Z0-9]{4,12}\b")
+_ANCHORED_CODE_RE = re.compile(
+    r"(?:reservation|confirmation|booking)(?: code)?[ \t\r\n#:]{1,3}([A-Z0-9]{6,12})\b",
+    re.IGNORECASE,
+)
+# Deliberately lossy: a code past this offset is silently missed (→ review
+# queue), never mis-attributed. Do NOT raise this unbounded — it caps the
+# regex-scan attack surface (see the ReDoS note above).
+_MAX_DESCRIPTION_SCAN = 4096
+_MIN_TITLE_MATCH_LEN = 4
+
+Confidence = Literal["auto", "propose", "unmatched"]
+
+
+class ListingLike(Protocol):
+    """Structural view of a Listing the decider needs (keeps this module
+    ORM-free; the ORM ``Listing`` satisfies it at the call site)."""
+
+    title: str
+    property_id: uuid.UUID | None
+
+
+class AirbnbMatch(NamedTuple):
+    property_id: uuid.UUID | None
+    confidence: Confidence
+
+
+def parse_res_code(text: str | None) -> str | None:
+    """Extract a single unambiguous Airbnb reservation code from free text.
+
+    Returns the code only when exactly one distinct candidate is found —
+    zero or multiple (e.g. adversarial / multi-reservation text) returns
+    ``None`` so the caller falls through rather than auto-attributing wrong.
+    """
+    if not text:
+        return None
+
+    scanned = text[:_MAX_DESCRIPTION_SCAN]
+    candidates: set[str] = set(_HM_CODE_RE.findall(scanned))
+
+    for match in _ANCHORED_CODE_RE.finditer(scanned):
+        code = match.group(1)
+        # IGNORECASE on the anchor also relaxes the code class; keep only
+        # genuine codes — uppercase, mixed letters+digits (rejects prose
+        # words like "SUMMARY" and pure-numeric runs like an amount).
+        if (
+            code == code.upper()
+            and any(c.isdigit() for c in code)
+            and any(c.isalpha() for c in code)
+        ):
+            candidates.add(code)
+
+    if len(candidates) == 1:
+        return next(iter(candidates))
+    return None
+
+
+def decide_airbnb_attribution(
+    *,
+    res_code_property_id: uuid.UUID | None,
+    airbnb_listings: Sequence[ListingLike],
+    txn_description: str | None,
+    txn_address: str | None,
+) -> AirbnbMatch:
+    """Decide how an Airbnb payout attributes to a property. Pure."""
+    # Tier 1 — res_code resolved to a property (exact, UNIQUE key). Outranks
+    # the single-listing shortcut: a definitive code beats circumstance.
+    if res_code_property_id is not None:
+        return AirbnbMatch(res_code_property_id, "auto")
+
+    # Tier 2 — exactly one Airbnb listing with a property (prior behavior,
+    # preserved). A lone listing with no property falls through (previously
+    # this silently stamped auto_exact with no property + no review).
+    if len(airbnb_listings) == 1 and airbnb_listings[0].property_id is not None:
+        return AirbnbMatch(airbnb_listings[0].property_id, "auto")
+
+    # Tier 3 — a listing title occurs in the payout text, resolving to exactly
+    # one property → propose only (free-text substring is review-grade, not
+    # auto-grade).
+    haystack = " ".join(p for p in (txn_description, txn_address) if p).lower()
+    if haystack:
+        matched: set[uuid.UUID] = set()
+        for listing in airbnb_listings:
+            title = (listing.title or "").strip()
+            if (
+                len(title) >= _MIN_TITLE_MATCH_LEN
+                and listing.property_id is not None
+                and title.lower() in haystack
+            ):
+                matched.add(listing.property_id)
+        if len(matched) == 1:
+            return AirbnbMatch(next(iter(matched)), "propose")
+
+    return AirbnbMatch(None, "unmatched")

--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -6,9 +6,10 @@ applicant and either:
   - queues for host review (Levenshtein ≤ 2 fuzzy match), or
   - queues as unmatched (no candidate found).
 
-Airbnb payouts with the ``Properties/airbnb reservation`` Gmail label are
-auto-attributed to the matching listing / property when exactly one Airbnb
-listing is linked to the account; otherwise queued for review.
+Airbnb payouts are attributed via the cascade in ``airbnb_payout_matcher``
+(res_code → property auto; single linked listing auto; listing-title-in-text
+→ propose; else unmatched); non-auto outcomes go to the review queue, where
+the operator resolves them via the property-confirm path.
 """
 import logging
 import uuid
@@ -20,12 +21,17 @@ from app.db.session import AsyncSessionLocal, unit_of_work
 from app.models.applicants.applicant import Applicant
 from app.models.transactions.transaction import Transaction
 from app.repositories import attribution_repo
+from app.repositories import booking_statement_repo
 from app.repositories.applicants import applicant_repo
 from app.repositories.leases import signed_lease_repo
 from app.repositories.listings import listing_repo
 from app.repositories.properties import property_repo
 from app.repositories import transaction_repo as txn_repo
 from app.services.leases import receipt_service
+from app.services.transactions.airbnb_payout_matcher import (
+    decide_airbnb_attribution,
+    parse_res_code,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -222,10 +228,11 @@ async def _attribute_airbnb_payout(
     organization_id: uuid.UUID,
     user_id: uuid.UUID,
 ) -> None:
-    """Auto-attribute an Airbnb-labelled payout to the linked listing's property.
+    """Attribute an Airbnb payout to a property via the matcher cascade.
 
-    If the user has exactly one Airbnb listing, auto-attribute to it.
-    Otherwise, queue for review as "unmatched".
+    res_code→property and single-linked-listing auto-attribute; a listing
+    title found in the payout text is proposed for review; anything else is
+    queued unmatched. See ``airbnb_payout_matcher``.
     """
     airbnb_listings = await listing_repo.list_by_channel(
         db,
@@ -234,19 +241,50 @@ async def _attribute_airbnb_payout(
         channel="airbnb",
     )
 
-    if len(airbnb_listings) == 1:
-        listing = airbnb_listings[0]
-        if listing.property_id and txn.property_id is None:
-            txn.property_id = listing.property_id
+    res_code = parse_res_code(txn.description)
+    stmt = (
+        await booking_statement_repo.find_by_res_code(db, organization_id, res_code)
+        if res_code
+        else None
+    )
+    match = decide_airbnb_attribution(
+        res_code_property_id=stmt.property_id if stmt else None,
+        airbnb_listings=airbnb_listings,
+        txn_description=txn.description,
+        txn_address=txn.address,
+    )
+
+    if match.confidence == "auto":
+        # decide_airbnb_attribution only returns "auto" with a non-None
+        # property_id (both auto branches gate on `... is not None`).
+        # Preserve the idempotency guard — never overwrite a set property_id.
+        if txn.property_id is None:
+            txn.property_id = match.property_id
         txn.attribution_source = "auto_exact"
         txn.category = "rental_revenue"
         logger.info(
-            "Auto-attributed Airbnb payout %s to listing %s / property %s",
-            txn.id, listing.id, listing.property_id,
+            "Auto-attributed Airbnb payout %s to property %s (res_code=%s)",
+            txn.id, match.property_id, res_code,
         )
         return
 
-    # Multiple or zero listings — queue for review
+    if match.confidence == "propose":
+        await attribution_repo.create(
+            db,
+            user_id=user_id,
+            organization_id=organization_id,
+            transaction_id=txn.id,
+            proposed_applicant_id=None,
+            proposed_property_id=match.property_id,
+            confidence="fuzzy",
+        )
+        logger.info(
+            "Queued Airbnb payout %s for review with proposed property %s",
+            txn.id, match.property_id,
+        )
+        return
+
+    # Unmatched — queue for review with no proposal
     await attribution_repo.create(
         db,
         user_id=user_id,
@@ -256,7 +294,7 @@ async def _attribute_airbnb_payout(
         confidence="unmatched",
     )
     logger.info(
-        "Queued Airbnb payout %s for review (%d listings found)",
+        "Queued Airbnb payout %s for review (unmatched; %d airbnb listings)",
         txn.id, len(airbnb_listings),
     )
 

--- a/apps/mybookkeeper/backend/tests/test_airbnb_payout_matcher.py
+++ b/apps/mybookkeeper/backend/tests/test_airbnb_payout_matcher.py
@@ -1,0 +1,265 @@
+"""Unit tests for the pure Airbnb-payout→property matcher.
+
+All tests operate on pure functions — no DB or async fixtures. The
+composite-key matrix (res_code present/absent/no-property; one/zero/many
+listings; title collisions) is enumerated exhaustively per the
+entity-matching test rule.
+"""
+import time
+import uuid
+from unittest.mock import MagicMock
+
+from app.services.transactions.airbnb_payout_matcher import (
+    decide_airbnb_attribution,
+    parse_res_code,
+)
+
+
+def _make_listing(title: str | None, property_id: uuid.UUID | None) -> MagicMock:
+    listing = MagicMock()
+    listing.title = title
+    listing.property_id = property_id
+    return listing
+
+
+# ---------------------------------------------------------------------------
+# parse_res_code
+# ---------------------------------------------------------------------------
+
+class TestParseResCode:
+    def test_none_input(self):
+        assert parse_res_code(None) is None
+
+    def test_empty_input(self):
+        assert parse_res_code("") is None
+
+    def test_hm_code_in_sentence(self):
+        assert parse_res_code("Payout for reservation HM12345 is ready") == "HM12345"
+
+    def test_hm_code_modern_10_char(self):
+        assert parse_res_code("Your payout HMABCD1234 has arrived") == "HMABCD1234"
+
+    def test_two_distinct_hm_codes_returns_none(self):
+        # Adversarial / multi-reservation text → ambiguous → no auto.
+        assert parse_res_code("codes HM11111AA and HM22222BB") is None
+
+    def test_same_code_twice_is_one_distinct(self):
+        assert parse_res_code("HM12345 ... reference HM12345 again") == "HM12345"
+
+    def test_lowercase_hm_not_matched(self):
+        # Real codes are uppercase; lowercase prose must not match.
+        assert parse_res_code("the hm12345 thing") is None
+
+    def test_anchored_non_hm_code(self):
+        assert parse_res_code("confirmation code AB12CD34 enclosed") == "AB12CD34"
+
+    def test_anchored_pure_digits_rejected(self):
+        # A numeric run after "reservation" is an amount/id, not a code.
+        assert parse_res_code("reservation 12345678 total") is None
+
+    def test_anchored_prose_word_rejected(self):
+        # Uppercase word with no digit after the anchor is not a code.
+        assert parse_res_code("reservation SUMMARY follows") is None
+
+    def test_hm_and_anchored_same_code_one_distinct(self):
+        assert parse_res_code("reservation HM99887766") == "HM99887766"
+
+    def test_code_beyond_scan_cap_not_found(self):
+        assert parse_res_code("x" * 5000 + " HM12345") is None
+
+    def test_no_code_present(self):
+        assert parse_res_code("Airbnb payout deposited to your bank account") is None
+
+    def test_anchored_regex_is_linear_no_redos(self):
+        """Regression: a long whitespace run after an anchor word must not
+        blow up (the bounded quantifiers make this O(n), not O(n^2))."""
+        adversarial = "reservation " + " " * 4000
+        start = time.perf_counter()
+        result = parse_res_code(adversarial)
+        elapsed = time.perf_counter() - start
+        assert result is None
+        assert elapsed < 0.05, f"parse_res_code took {elapsed:.3f}s — ReDoS regression"
+
+
+# ---------------------------------------------------------------------------
+# decide_airbnb_attribution
+# ---------------------------------------------------------------------------
+
+class TestDecideAirbnbAttribution:
+    def test_res_code_property_auto(self):
+        pid = uuid.uuid4()
+        match = decide_airbnb_attribution(
+            res_code_property_id=pid,
+            airbnb_listings=[],
+            txn_description=None,
+            txn_address=None,
+        )
+        assert match == (pid, "auto")
+
+    def test_res_code_outranks_lone_listing(self):
+        """Regression guard (architecture Finding 2): a res_code-resolved
+        property beats 'user happens to have one listing'."""
+        res_pid = uuid.uuid4()
+        other_pid = uuid.uuid4()
+        match = decide_airbnb_attribution(
+            res_code_property_id=res_pid,
+            airbnb_listings=[_make_listing("Beach House", other_pid)],
+            txn_description="Beach House payout",
+            txn_address=None,
+        )
+        assert match == (res_pid, "auto")
+
+    def test_single_listing_with_property_auto(self):
+        pid = uuid.uuid4()
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=[_make_listing("Anything", pid)],
+            txn_description=None,
+            txn_address=None,
+        )
+        assert match == (pid, "auto")
+
+    def test_single_listing_without_property_falls_through(self):
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=[_make_listing("Anything", None)],
+            txn_description=None,
+            txn_address=None,
+        )
+        assert match == (None, "unmatched")
+
+    def test_zero_listings_unmatched(self):
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=[],
+            txn_description="Some payout text",
+            txn_address=None,
+        )
+        assert match == (None, "unmatched")
+
+    def test_unique_title_in_description_proposes(self):
+        pid_a, pid_b = uuid.uuid4(), uuid.uuid4()
+        listings = [
+            _make_listing("Lakeside Cabin", pid_a),
+            _make_listing("Downtown Loft", pid_b),
+        ]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description="Airbnb payout for Lakeside Cabin",
+            txn_address=None,
+        )
+        assert match == (pid_a, "propose")
+
+    def test_title_match_via_address(self):
+        pid_a, pid_b = uuid.uuid4(), uuid.uuid4()
+        listings = [
+            _make_listing("Peerless Retreat", pid_a),
+            _make_listing("Other Place", pid_b),
+        ]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description=None,
+            txn_address="Peerless Retreat, 6738 Peerless St",
+        )
+        assert match == (pid_a, "propose")
+
+    def test_two_titles_match_distinct_properties_unmatched(self):
+        pid_a, pid_b = uuid.uuid4(), uuid.uuid4()
+        listings = [
+            _make_listing("Lakeside Cabin", pid_a),
+            _make_listing("Downtown Loft", pid_b),
+        ]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description="payout Lakeside Cabin and Downtown Loft",
+            txn_address=None,
+        )
+        assert match == (None, "unmatched")
+
+    def test_two_titles_same_property_proposes(self):
+        pid = uuid.uuid4()
+        listings = [
+            _make_listing("Lakeside Cabin", pid),
+            _make_listing("Lakeside Cabin Suite", pid),
+        ]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description="payout for Lakeside Cabin Suite",
+            txn_address=None,
+        )
+        assert match == (pid, "propose")
+
+    def test_title_substring_collision_distinct_properties_unmatched(self):
+        """'Loft' ⊂ 'Sky Loft' → both match → ambiguous → unmatched (never a
+        wrong auto/propose)."""
+        pid_a, pid_b = uuid.uuid4(), uuid.uuid4()
+        listings = [
+            _make_listing("Loft", pid_a),
+            _make_listing("Sky Loft", pid_b),
+        ]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description="payout for Sky Loft",
+            txn_address=None,
+        )
+        assert match == (None, "unmatched")
+
+    def test_short_title_not_matched(self):
+        pid_a, pid_b = uuid.uuid4(), uuid.uuid4()
+        listings = [
+            _make_listing("A1", pid_a),  # < min length, ignored
+            _make_listing("Downtown Loft", pid_b),
+        ]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description="payout A1 area",
+            txn_address=None,
+        )
+        assert match == (None, "unmatched")
+
+    def test_none_title_skipped(self):
+        pid_a, pid_b = uuid.uuid4(), uuid.uuid4()
+        listings = [
+            _make_listing(None, pid_a),
+            _make_listing("Downtown Loft", pid_b),
+        ]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description="a payout with no listing title in it",
+            txn_address=None,
+        )
+        assert match == (None, "unmatched")
+
+    def test_matching_listing_without_property_skipped(self):
+        pid_b = uuid.uuid4()
+        listings = [
+            _make_listing("Lakeside Cabin", None),  # title matches but no property
+            _make_listing("Downtown Loft", pid_b),
+        ]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description="payout for Lakeside Cabin",
+            txn_address=None,
+        )
+        assert match == (None, "unmatched")
+
+    def test_single_listing_no_property_title_in_text_unmatched(self):
+        """Lone listing, no property, its title in the payout text: tier 2
+        falls through (no property) and tier 3 skips it (property guard) →
+        unmatched, never a null-property propose."""
+        listings = [_make_listing("Lakeside Cabin", None)]
+        match = decide_airbnb_attribution(
+            res_code_property_id=None,
+            airbnb_listings=listings,
+            txn_description="Airbnb payout for Lakeside Cabin",
+            txn_address=None,
+        )
+        assert match == (None, "unmatched")

--- a/apps/mybookkeeper/backend/tests/test_attribution_service_airbnb_payout.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_service_airbnb_payout.py
@@ -1,0 +1,274 @@
+"""Integration tests for the Airbnb-payout wiring in
+``attribution_service._attribute_airbnb_payout``.
+
+The exhaustive cascade matrix lives in ``test_airbnb_payout_matcher.py``
+(pure). These tests verify the orchestration: parse_res_code(txn.description)
+→ booking_statement lookup → decide → act (mutate txn for auto, create a
+review row with proposed_property_id for propose, unmatched otherwise).
+
+The Airbnb path does not open its own unit_of_work (writes flush into the
+caller's session), so no uow patching is needed. ``list_by_channel`` (a
+Channel/ChannelListing join — infra, not under test) is patched at the repo
+boundary; ``find_by_res_code`` runs for real against seeded rows.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.properties.property import Property
+from app.models.transactions.booking_statement import BookingStatement
+from app.models.transactions.rent_attribution_review_queue import (
+    RentAttributionReviewQueue,
+)
+from app.models.transactions.transaction import Transaction
+from app.services.transactions.attribution_service import maybe_attribute_payment
+
+
+def _property(org_id: uuid.UUID, user_id: uuid.UUID, name: str = "Beach House") -> Property:
+    return Property(id=uuid.uuid4(), organization_id=org_id, user_id=user_id, name=name)
+
+
+def _txn(
+    org_id: uuid.UUID,
+    user_id: uuid.UUID,
+    *,
+    description: str | None = None,
+    address: str | None = None,
+) -> Transaction:
+    return Transaction(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        transaction_date=_dt.date(2026, 5, 1),
+        tax_year=2026,
+        amount="850.00",
+        transaction_type="income",
+        category="uncategorized",
+        status="approved",
+        is_manual=False,
+        description=description,
+        address=address,
+    )
+
+
+def _booking_statement(
+    org_id: uuid.UUID, res_code: str, property_id: uuid.UUID | None
+) -> BookingStatement:
+    return BookingStatement(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        property_id=property_id,
+        res_code=res_code,
+        check_in=_dt.date(2026, 4, 20),
+        check_out=_dt.date(2026, 4, 25),
+    )
+
+
+def _fake_listing(title: str, property_id: uuid.UUID | None) -> MagicMock:
+    listing = MagicMock()
+    listing.title = title
+    listing.property_id = property_id
+    return listing
+
+
+def _patch_listings(listings: list) -> object:
+    return patch(
+        "app.services.transactions.attribution_service.listing_repo.list_by_channel",
+        new_callable=AsyncMock,
+        return_value=listings,
+    )
+
+
+async def _review_for(db: AsyncSession, txn_id: uuid.UUID) -> RentAttributionReviewQueue | None:
+    return (
+        await db.execute(
+            select(RentAttributionReviewQueue).where(
+                RentAttributionReviewQueue.transaction_id == txn_id
+            )
+        )
+    ).scalar_one_or_none()
+
+
+@pytest.mark.asyncio
+async def test_res_code_resolves_property_auto(db: AsyncSession):
+    """res_code in description → BookingStatement → property: auto-attributed,
+    no review row."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = _property(org_id, user_id)
+    stmt = _booking_statement(org_id, "HM12345", prop.id)
+    txn = _txn(org_id, user_id, description="Payout for reservation HM12345")
+    db.add_all([prop, stmt, txn])
+    await db.flush()
+
+    with _patch_listings([]):
+        await maybe_attribute_payment(
+            db,
+            txn=txn,
+            payer_name=None,
+            organization_id=org_id,
+            user_id=user_id,
+            is_airbnb_payout=True,
+        )
+
+    refreshed = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed.property_id == prop.id
+    assert refreshed.attribution_source == "auto_exact"
+    assert refreshed.category == "rental_revenue"
+    assert await _review_for(db, txn.id) is None
+
+
+@pytest.mark.asyncio
+async def test_title_in_description_proposes_property(db: AsyncSession):
+    """No res_code, ≥2 listings, one title in the payout text → review row
+    with proposed_property_id + confidence 'fuzzy'; txn left untouched."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop_a, prop_b = uuid.uuid4(), uuid.uuid4()
+    txn = _txn(org_id, user_id, description="Airbnb payout for Lakeside Cabin")
+    db.add(txn)
+    await db.flush()
+
+    listings = [_fake_listing("Lakeside Cabin", prop_a), _fake_listing("City Loft", prop_b)]
+    with _patch_listings(listings):
+        await maybe_attribute_payment(
+            db,
+            txn=txn,
+            payer_name=None,
+            organization_id=org_id,
+            user_id=user_id,
+            is_airbnb_payout=True,
+        )
+
+    refreshed = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed.property_id is None
+    assert refreshed.attribution_source is None
+
+    review = await _review_for(db, txn.id)
+    assert review is not None
+    assert review.proposed_property_id == prop_a
+    assert review.proposed_applicant_id is None
+    assert review.confidence == "fuzzy"
+    assert review.status == "pending"
+
+
+@pytest.mark.asyncio
+async def test_no_signal_queues_unmatched(db: AsyncSession):
+    """No res_code, no listings → unmatched review row, no proposal."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    txn = _txn(org_id, user_id, description="Airbnb payout deposited")
+    db.add(txn)
+    await db.flush()
+
+    with _patch_listings([]):
+        await maybe_attribute_payment(
+            db,
+            txn=txn,
+            payer_name=None,
+            organization_id=org_id,
+            user_id=user_id,
+            is_airbnb_payout=True,
+        )
+
+    review = await _review_for(db, txn.id)
+    assert review is not None
+    assert review.confidence == "unmatched"
+    assert review.proposed_property_id is None
+    refreshed = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed.property_id is None
+
+
+@pytest.mark.asyncio
+async def test_res_code_without_statement_falls_through_to_unmatched(db: AsyncSession):
+    """A parseable code with no matching BookingStatement and no listings →
+    unmatched (does not crash, does not auto-attribute)."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    txn = _txn(org_id, user_id, description="Payout for reservation HM99999")
+    db.add(txn)
+    await db.flush()
+
+    with _patch_listings([]):
+        await maybe_attribute_payment(
+            db,
+            txn=txn,
+            payer_name=None,
+            organization_id=org_id,
+            user_id=user_id,
+            is_airbnb_payout=True,
+        )
+
+    review = await _review_for(db, txn.id)
+    assert review is not None
+    assert review.confidence == "unmatched"
+
+
+@pytest.mark.asyncio
+async def test_res_code_statement_without_property_falls_through(db: AsyncSession):
+    """A BookingStatement exists for the res_code but its property_id is NULL
+    (FK SET NULL after property delete) → fall through, never auto with no
+    property; with no listings → unmatched."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    stmt = _booking_statement(org_id, "HM55555", property_id=None)
+    txn = _txn(org_id, user_id, description="Payout for reservation HM55555")
+    db.add_all([stmt, txn])
+    await db.flush()
+
+    with _patch_listings([]):
+        await maybe_attribute_payment(
+            db,
+            txn=txn,
+            payer_name=None,
+            organization_id=org_id,
+            user_id=user_id,
+            is_airbnb_payout=True,
+        )
+
+    refreshed = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed.property_id is None
+    assert refreshed.attribution_source is None
+    review = await _review_for(db, txn.id)
+    assert review is not None
+    assert review.confidence == "unmatched"
+    assert review.proposed_property_id is None
+
+
+@pytest.mark.asyncio
+async def test_res_code_outranks_single_listing(db: AsyncSession):
+    """Regression: res_code-resolved property wins over a lone Airbnb
+    listing pointing elsewhere (architecture Finding 2)."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    res_prop = _property(org_id, user_id, "Res Code Property")
+    other_prop_id = uuid.uuid4()
+    stmt = _booking_statement(org_id, "HMRESCODE1", res_prop.id)
+    txn = _txn(org_id, user_id, description="payout reservation HMRESCODE1")
+    db.add_all([res_prop, stmt, txn])
+    await db.flush()
+
+    with _patch_listings([_fake_listing("Some Other Place", other_prop_id)]):
+        await maybe_attribute_payment(
+            db,
+            txn=txn,
+            payer_name=None,
+            organization_id=org_id,
+            user_id=user_id,
+            is_airbnb_payout=True,
+        )
+
+    refreshed = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed.property_id == res_prop.id
+    assert refreshed.attribution_source == "auto_exact"
+    assert await _review_for(db, txn.id) is None

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -872,6 +872,7 @@
         "backend/app/models/transactions/rent_attribution_review_queue.py",
         "backend/app/repositories/transactions/attribution_repo.py",
         "backend/app/services/transactions/attribution_service.py",
+        "backend/app/services/transactions/airbnb_payout_matcher.py",
         "backend/app/services/transactions/property_pnl_service.py",
         "backend/app/schemas/transactions/attribution.py",
         "backend/app/api/attribution.py",
@@ -889,7 +890,9 @@
         "test_attribution_repo.py",
         "test_attribution_routes.py",
         "test_attribution_service_attribute_manually.py",
-        "test_attribution_service_confirm_property.py"
+        "test_attribution_service_confirm_property.py",
+        "test_airbnb_payout_matcher.py",
+        "test_attribution_service_airbnb_payout.py"
       ],
       "frontend_tests": [
         "AttributionReviewPanel.test.tsx",


### PR DESCRIPTION
## What

PR **C of 4** in the Airbnb-payout auto-attribution build (PR A #698, PR B #699 merged). Auto-attributes Airbnb payouts to the right property instead of dumping every multi-listing payout into the unmatched review queue.

New pure module `app/services/transactions/airbnb_payout_matcher.py` (no DB/ORM — exhaustively table-tested). Cascade, first hit wins, each tier requires **exactly one** distinct property or falls through:

1. **res_code** parsed from `txn.description` → `BookingStatement` → property → **auto** (exact `UNIQUE(org,res_code)` key; ranked **above** the single-listing shortcut so a definitive code beats circumstance)
2. **exactly one linked Airbnb listing with a property** → **auto** (prior behavior preserved; a lone listing with *no* property now falls through instead of silently stamping `auto_exact` with no property + no review — a latent silent-fail fixed)
3. **a listing title found in the payout text** → **propose-only** via PR-B `proposed_property_id`, `confidence="fuzzy"` (free-text substring is review-grade, never auto-moves money)
4. else **unmatched**

No guest/date tier — an Airbnb payout carries no guest field and direct payouts create no `BookingStatement`, so no sound signal exists from the available data. Unmatched payouts go to the review queue where the operator resolves them via **PR B's** property-confirm path. Reuses `auto_exact`/`fuzzy`/`unmatched` — **no migration, no CHECK widening**.

`_attribute_airbnb_payout` rewritten to orchestrate (parse → repo lookup → pure decide → act); the `txn.property_id is None` idempotency guard is preserved.

## Design + review

- **g-design-architecture** (pre-implementation): corrections applied — only res_code is `auto`; title is propose-only; res_code outranks the single-listing fast path; dropped the unsound guest/date tier; reuse existing enums (no migration); ReDoS-safe regex; preserve idempotency guard.
- **g-pre-commit**: found an **O(n²) ReDoS** in the anchored res_code regex (attacker-influenceable `txn.description` on the email-sync worker, ~110 ms/payload). **Fixed** — rewrote with bounded quantifiers (no unbounded `\s+`/`\s*`), linear by construction (0.3 ms uncapped at N=20000 vs ~110 ms before), with a regression test. Re-reviewed: **RESOLVED**, no semantic regression, nothing new introduced.

## Scope / parity notes

- Consumes PR B's `proposed_property_id` + property-only `confirm_review` exactly as designed. No schema/API/UX change here.
- `AirbnbMatch`/`ListingLike`/`Confidence` kept module-local: deliberate. A self-contained pure module whose types are its own contract — extracting 3 single-use types into 3 files would be over-engineering and mirrors the existing `find_best_match` precedent. Flagged by review as borderline-acceptable; recorded as a conscious decision (extract if a 2nd consumer appears).
- PR D wires the review UX that surfaces the proposed property.

## Operational note

No manual steps. No migration (reuses PR B's `rarqprop260517`), no env/boot-guard change. Safe rollback = revert (matcher only changes how Airbnb payouts are bucketed; the review-queue terminal state is unchanged).

## Tests

`87 passed` — full attribution backend suite. New: 27 table-driven pure-matcher tests (full composite-key matrix: res_code present/absent/no-statement/null-property; 0/1/many listings; title collisions/substring/short/None; via-address) + ReDoS regression + 6 integration tests through `maybe_attribute_payment` (incl. res_code-outranks-single-listing regression guard). `test-map.json` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)