### PR TITLE
feat(mga): looping throw-clip pipeline (PR2)

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0010_lineup_clip_url.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0010_lineup_clip_url.py
@@ -1,0 +1,36 @@
+"""Add clip_url to lineup
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-05-17 00:00:02.000000
+
+Adds a nullable ``clip_url`` column to the ``lineup`` table so the clip
+pipeline (separate task) and frontend can depend on a stable contract.
+
+The column stores a bare MinIO object key exactly like ``stand_screenshot_url``
+and ``aim_screenshot_url`` — presigning to a 24-hour GET URL happens at read
+time in ``lineup_service._build_read``. Clip upload is handled by a future
+pipeline task; this migration only extends the schema.
+
+Additive: all existing rows default to NULL. No backfill needed.
+
+Downgrade: drops the column unconditionally. Data loss is expected and
+acceptable on rollback — no clip keys will exist in the column before the
+clip pipeline ships.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0010"
+down_revision = "0009"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("lineup", sa.Column("clip_url", sa.String(length=500), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lineup", "clip_url")

--- a/apps/mygamingassistant/backend/app/cli/__init__.py
+++ b/apps/mygamingassistant/backend/app/cli/__init__.py
@@ -2,9 +2,32 @@
 
 Usage:
     python -m app.cli load-fixtures
+    python -m app.cli backfill-clips
 """
 import asyncio
 import sys
+
+
+async def _run_backfill_clips() -> int:
+    """Generate clips for accepted lineups missing one. Returns an exit code.
+
+    Idempotent — safe to re-run; only lineups with ``clip_url IS NULL`` are
+    touched. A non-zero exit signals at least one hard failure so the
+    operator notices (re-running retries them — they are not fatal).
+    """
+    from app.db.session import AsyncSessionLocal
+    from app.services.ingestion.clip_backfill import backfill_clips
+
+    async with AsyncSessionLocal() as db:
+        stats = await backfill_clips(db)
+
+    print(stats.summary())
+    if stats.errors:
+        print(f"  {len(stats.errors)} issue(s):")
+        for err in stats.errors:
+            print(f"   - {err}")
+    # Re-runnable: failures retry next run, so a non-zero exit is advisory.
+    return 1 if stats.failed else 0
 
 
 def main() -> None:
@@ -14,10 +37,13 @@ def main() -> None:
         from app.services.game.fixture_loader import load_fixtures_standalone
         asyncio.run(load_fixtures_standalone())
         print("Fixtures loaded successfully.")
+    elif command == "backfill-clips":
+        sys.exit(asyncio.run(_run_backfill_clips()))
     else:
         print(f"Unknown command: {command!r}")
         print("Available commands:")
         print("  load-fixtures   — load game taxonomy fixtures into the database")
+        print("  backfill-clips  — generate clips for accepted lineups missing one")
         sys.exit(1)
 
 

--- a/apps/mygamingassistant/backend/app/models/game/lineup.py
+++ b/apps/mygamingassistant/backend/app/models/game/lineup.py
@@ -109,6 +109,7 @@ class Lineup(Base):
     # Screenshot URLs in MinIO (presigned at read time)
     stand_screenshot_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     aim_screenshot_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    clip_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     # Normalized 0-1 crosshair position on the aim screenshot
     aim_anchor_x: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -297,6 +297,31 @@ async def commit_classifier_run(db: AsyncSession) -> None:
         raise
 
 
+async def list_accepted_lineups_needing_clips(
+    db: AsyncSession,
+) -> list[Lineup]:
+    """Accepted, ingested lineups that don't have a clip yet.
+
+    The backfill set: ``status='accepted'`` AND a source video to re-fetch
+    (``youtube_video_id`` not null) AND no clip yet (``clip_url`` null).
+    Filtering on null ``clip_url`` is exactly what makes the backfill
+    idempotent — a generated clip drops out of this set, so re-running only
+    touches the remainder. Ordered oldest-first so a long backfill makes
+    visible monotonic progress.
+    """
+    stmt = (
+        select(Lineup)
+        .where(
+            Lineup.status == "accepted",
+            Lineup.youtube_video_id.is_not(None),
+            Lineup.clip_url.is_(None),
+        )
+        .order_by(Lineup.created_at.asc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
 async def set_clip_url(
     db: AsyncSession,
     lineup: Lineup,

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -297,6 +297,35 @@ async def commit_classifier_run(db: AsyncSession) -> None:
         raise
 
 
+async def set_clip_url(
+    db: AsyncSession,
+    lineup: Lineup,
+    clip_key: str,
+) -> Lineup:
+    """Persist the generated clip's bare MinIO key onto a lineup row.
+
+    Its own commit (not folded into the classifier writeback) on purpose:
+    clip generation is best-effort and orthogonal to the row's validity — a
+    lineup is fully usable from its two stills with no clip. A clip failure
+    must NEVER roll back the already-committed lineup + classifier
+    suggestions, and a successful clip must NOT wait on anything else. So the
+    clip pipeline commits exactly this one column on its own.
+
+    Transaction ownership lives here in the repo per PR #687/#695 — the
+    ingestion orchestrator and the backfill CLI never call db.commit().
+    ``clip_url`` stores a BARE object key (like stand/aim screenshot URLs);
+    presigning happens at read time in ``lineup_service._build_read``.
+    """
+    lineup.clip_url = clip_key
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
 async def zone_density(
     db: AsyncSession,
     map_id: uuid.UUID,

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -69,6 +69,7 @@ class LineupRead(BaseModel):
     notes: Optional[str] = None
     stand_screenshot_url: Optional[str] = None
     aim_screenshot_url: Optional[str] = None
+    clip_url: Optional[str] = None
     aim_anchor_x: Optional[float] = None
     aim_anchor_y: Optional[float] = None
     # Minimap anchor positions — raw values from the DB. May be NULL; use the

--- a/apps/mygamingassistant/backend/app/services/classification/classification_result.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classification_result.py
@@ -70,3 +70,33 @@ class ClassificationResult:
     # ClassifyResponse.error_codes path surfaces them to the operator/UI
     # without a schema change. reasoning still carries the human prose.
     classification_failures: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ThrowTimingResult:
+    """Result of the PR2 throw-localization Claude call.
+
+    Deliberately a SEPARATE type from :class:`ClassificationResult` — the
+    throw-timing pass is its own code path (own prompt, own schema, no slug
+    resolution, no DB) per the frozen design contract. Conflating them would
+    couple two prompts that evolve independently.
+
+    On a successful API call ``success=True`` and ``is_lineup_throw`` reflects
+    Claude's judgement (it may be ``False`` — a real "this chapter isn't a
+    throw demo" answer, NOT an error). ``error_codes`` is populated only on an
+    API/parse failure (per rules/check-third-party-error-codes.md — never a
+    bare bool/None).
+
+    ``release_index`` / ``result_index`` are 1-based into the dense frame
+    window the call was shown. The parser guarantees
+    ``result_index >= release_index`` when both are set (a result cannot
+    precede its own release).
+    """
+
+    success: bool
+    is_lineup_throw: Optional[bool] = None
+    release_index: Optional[int] = None
+    result_index: Optional[int] = None
+    confidence: Optional[float] = None
+    reasoning: str = ""
+    error_codes: list[str] = field(default_factory=list)

--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -39,7 +39,10 @@ from app.models.game.map import Map
 from app.models.game.map_zone import MapZone
 from app.models.game.utility_type import UtilityType
 from app.repositories.game.lineup_repo import write_classifier_suggestions
-from app.services.classification.classification_result import ClassificationResult
+from app.services.classification.classification_result import (
+    ClassificationResult,
+    ThrowTimingResult,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1270,4 +1273,322 @@ async def classify_frames_for_lineup_decision(
         reasoning=reasoning,
         error_codes=list(structured_codes),
         classification_failures=list(structured_codes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR2 — throw-timing localizer (clip pipeline)
+# ---------------------------------------------------------------------------
+#
+# A SEPARATE Claude code path from classify_frames_for_lineup_decision. It does
+# NOT classify game/map/zone/side/utility and does NOT resolve slugs or touch
+# the DB — its only job is to find, within ONE chapter, the frame the utility
+# is RELEASED and the frame its RESULT first shows, so the caller can cut a
+# tight gif-style clip around the throw. Conflating it with the grid classifier
+# would couple two prompts that must evolve independently (frozen design
+# contract pr2-clip-localization-design.md).
+
+
+_THROW_TIMING_SCHEMA_DOC = """\
+You are given {n} numbered frames (Frame 1 .. Frame {n}) sampled in time order
+from ONE chapter of a tactical-FPS lineup tutorial. Each frame is labelled with
+its timestamp in seconds. The chapter is meant to demonstrate ONE utility throw
+(smoke / molotov / flash / HE / decoy): the player lines up, RELEASES the
+utility, and it produces a RESULT on the map.
+
+Your ONLY job is to locate the throw in time:
+  - which frame is the RELEASE (the utility leaves the player's hand), and
+  - which frame is the RESULT (the utility's effect is first clearly visible).
+
+Return ONLY bare JSON — no markdown fences, no preamble — with exactly these
+keys:
+{{
+  "is_lineup_throw": boolean,
+  "release_index": integer (1-{n}) or null,
+  "result_index": integer (1-{n}) or null,
+  "confidence": number (0.0-1.0),
+  "reasoning": string (<= 80 words)
+}}
+
+Rules:
+- is_lineup_throw: true ONLY if these frames show a real first-person utility
+  throw in the main game view. false for intro/outro/title cards, webcam or
+  talking-head, knife-only walking, menus, montages, or anything that is not an
+  actual throw — when false, release_index AND result_index MUST be null.
+- release_index: the 1-based frame where the utility is released. RELEASE cues:
+  the projectile is first airborne; the throw-animation follow-through; the HUD
+  grenade/ability slot empties. If no frame catches the exact release, choose
+  the frame immediately BEFORE the effect first appears.
+- result_index: the 1-based frame where the RESULT is first clearly visible. It
+  MUST be at or after release_index — a result cannot precede its own release.
+  RESULT cues by utility:
+    SMOKE   - grey/white cloud expanding (count the FIRST wisp; a canister
+              still in flight is NOT yet the result).
+    MOLOTOV - orange floor flame spreading.
+    FLASH   - white wash / detonation. If it is too fast to land on its own
+              frame, set result_index = release_index and confidence <= 0.45.
+    HE      - explosion burst / debris.
+    DECOY   - landed canister with a small ground smoke puff.
+- confidence: 0-1 that you localised the throw correctly. Low when the throw is
+  off-screen, cut away from, or only inferred from trajectory; high only when
+  the release and the result are both directly visible.
+- Discipline:
+  - If the throw is shown repeatedly or from multiple angles, use the FIRST
+    clean throw only.
+  - Ignore picture-in-picture, facecam, killfeed, scoreboard, title cards and
+    replays — judge from the main game view only.
+  - Talking-head or knife-only-walking frames are NOT a throw:
+    is_lineup_throw=false, both indices null.
+- reasoning: <= 80 words. State the release cue, the result cue, and which
+  utility you keyed on.
+"""
+
+
+async def classify_throw_timing_from_frames(
+    *,
+    frames: list[bytes],
+    frame_timestamps: list[float],
+    chapter_title: Optional[str],
+    chapter_duration: Optional[float],
+    utility_hint: Optional[str] = None,
+) -> ThrowTimingResult:
+    """Locate the release/result frames of a throw within ONE chapter.
+
+    Separate Claude code path from :func:`classify_frames_for_lineup_decision`
+    (own prompt, own schema, no reference data, no slug resolution, no DB).
+    The caller turns ``release_index`` / ``result_index`` back into timestamps
+    via the SAME ``frame_timestamps`` list the frames were extracted from.
+
+    Args:
+        frames: Downscaled candidate PNG bytes, in time order (the dense
+            throw window — see ``frame_extractor.clip_window_timestamps``).
+        frame_timestamps: The timestamp (seconds) of each frame, same order
+            and length as *frames*. Surfaced to the model as load-bearing
+            context (``Frame i (t=..s):``) AND used by the caller to map the
+            returned 1-based indices back to seconds.
+        chapter_title: YouTube chapter title (per-call context).
+        chapter_duration: Chapter length in seconds (per-call context).
+        utility_hint: Optional utility slug from the prior grid classification
+            (only passed when that ran at confidence > 0.6) — helps the model
+            pick the right RESULT cue.
+
+    Returns:
+        ThrowTimingResult. ``success=True`` with ``is_lineup_throw`` possibly
+        False is a successful "this is not a throw" answer, not an error.
+        ``error_codes`` is populated only on an API/parse failure.
+    """
+    if not settings.anthropic_api_key:
+        logger.warning(
+            "throw_timing: ANTHROPIC_API_KEY not configured — skipping "
+            "(chapter=%r)", chapter_title,
+        )
+        return ThrowTimingResult(
+            success=False,
+            error_codes=["missing_api_key"],
+            reasoning="ANTHROPIC_API_KEY not configured",
+        )
+
+    if not frames:
+        return ThrowTimingResult(
+            success=False,
+            error_codes=["no_frames"],
+            reasoning="No candidate frames supplied to throw-timing classifier",
+        )
+
+    if len(frames) != len(frame_timestamps):
+        # A frame/timestamp length mismatch would silently misalign every
+        # returned index → wrong clip bounds. Fail loud (no silent-fail).
+        return ThrowTimingResult(
+            success=False,
+            error_codes=["frame_timestamp_mismatch"],
+            reasoning=(
+                f"frames ({len(frames)}) and frame_timestamps "
+                f"({len(frame_timestamps)}) length mismatch"
+            ),
+        )
+
+    n = len(frames)
+
+    system_prompt = (
+        "You are a tactical-FPS utility-lineup video analyst. You will be "
+        "shown several timestamped frames from one chapter of a lineup "
+        "tutorial and must pinpoint exactly when the utility is released and "
+        "when its effect first lands.\n\n"
+        + _THROW_TIMING_SCHEMA_DOC.format(n=n)
+    )
+
+    import base64
+
+    # Per-call content: each frame labelled with its 1-based index AND its
+    # timestamp (the timestamp is load-bearing — it is how the caller maps the
+    # answer back to seconds), then the per-chapter context block. Frames are
+    # the variable part (NOT cached); the system prompt is cache_control'd.
+    user_content: list[dict] = []
+    for i, (frame_bytes, ts) in enumerate(
+        zip(frames, frame_timestamps), start=1
+    ):
+        user_content.append(
+            {"type": "text", "text": f"Frame {i} (t={ts:.1f}s):"}
+        )
+        user_content.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": base64.standard_b64encode(frame_bytes).decode(),
+                },
+            }
+        )
+
+    context_parts: list[str] = []
+    if chapter_title:
+        context_parts.append(f"Chapter title: {chapter_title}")
+    if chapter_duration is not None:
+        context_parts.append(f"Chapter duration: {chapter_duration:.0f}s")
+    if utility_hint:
+        context_parts.append(
+            f"Utility type (from prior classification): {utility_hint}"
+        )
+    if context_parts:
+        user_content.append({"type": "text", "text": "\n".join(context_parts)})
+
+    try:
+        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+        response = client.messages.create(
+            model=settings.claude_classifier_model,
+            max_tokens=600,
+            system=[
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": user_content}],
+        )
+    except anthropic.RateLimitError as exc:
+        error_type = getattr(exc, "type", "rate_limit_error") or "rate_limit_error"
+        logger.warning(
+            "throw_timing: rate limit hit: chapter=%r error_type=%s message=%s",
+            chapter_title, error_type, str(exc),
+        )
+        return ThrowTimingResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API rate limit: {exc}",
+        )
+    except anthropic.APIStatusError as exc:
+        error_type = getattr(exc, "type", None) or f"api_status_{exc.status_code}"
+        logger.error(
+            "throw_timing: API status error: chapter=%r error_type=%s "
+            "status_code=%s message=%s",
+            chapter_title, error_type, exc.status_code, str(exc),
+        )
+        return ThrowTimingResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API error ({exc.status_code}): {exc}",
+        )
+    except anthropic.APIError as exc:
+        error_type = getattr(exc, "type", "api_error") or "api_error"
+        logger.error(
+            "throw_timing: API error: chapter=%r error_type=%s message=%s",
+            chapter_title, error_type, str(exc),
+        )
+        return ThrowTimingResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API error: {exc}",
+        )
+
+    raw_text = response.content[0].text if response.content else ""
+    try:
+        parsed: dict[str, Any] = json.loads(_strip_json_fences(raw_text))
+    except (json.JSONDecodeError, IndexError) as exc:
+        logger.error(
+            "throw_timing: JSON parse failed: chapter=%r raw=%r error=%s",
+            chapter_title, raw_text[:200], str(exc),
+        )
+        return ThrowTimingResult(
+            success=False,
+            error_codes=["json_parse_error"],
+            reasoning=f"Could not parse throw-timing JSON: {exc}",
+        )
+
+    failures: list[str] = []
+
+    confidence: Optional[float] = None
+    raw_conf = parsed.get("confidence")
+    if raw_conf is not None:
+        try:
+            confidence = max(0.0, min(1.0, float(raw_conf)))
+        except (TypeError, ValueError):
+            logger.warning(
+                "throw_timing: invalid confidence value dropped: "
+                "chapter=%r raw_confidence=%r",
+                chapter_title, raw_conf,
+            )
+
+    model_reasoning = str(parsed.get("reasoning") or "")
+    is_lineup_throw = bool(parsed.get("is_lineup_throw"))
+
+    # Not a throw → indices are meaningless; return the verdict early so the
+    # caller skips clip generation and keeps the stills.
+    if not is_lineup_throw:
+        logger.info(
+            "throw_timing: is_lineup_throw=False chapter=%r n=%d confidence=%.2f",
+            chapter_title, n, confidence or 0.0,
+        )
+        return ThrowTimingResult(
+            success=True,
+            is_lineup_throw=False,
+            release_index=None,
+            result_index=None,
+            confidence=confidence,
+            reasoning=model_reasoning
+            or "Classifier judged these frames are not a utility throw.",
+        )
+
+    release_index = _validate_grid_index(
+        parsed.get("release_index"), "release_index", n, failures
+    )
+    result_index = _validate_grid_index(
+        parsed.get("result_index"), "result_index", n, failures
+    )
+
+    # Frozen-contract parser enforcement: a result cannot precede its own
+    # release. If the model returned both but inverted, force result to the
+    # release frame and log (do NOT silently swap — the operator/dash should
+    # be able to see this happened).
+    if (
+        release_index is not None
+        and result_index is not None
+        and result_index < release_index
+    ):
+        logger.info(
+            "throw_timing: result_index (%d) < release_index (%d) — forcing "
+            "result_index = release_index: chapter=%r",
+            result_index, release_index, chapter_title,
+        )
+        result_index = release_index
+
+    if failures:
+        reasoning = f"{model_reasoning}\nNotes: {'; '.join(failures)}".strip()
+    else:
+        reasoning = model_reasoning
+
+    logger.info(
+        "throw_timing: is_lineup_throw=True chapter=%r n=%d release_idx=%s "
+        "result_idx=%s confidence=%.2f",
+        chapter_title, n, release_index, result_index, confidence or 0.0,
+    )
+
+    return ThrowTimingResult(
+        success=True,
+        is_lineup_throw=True,
+        release_index=release_index,
+        result_index=result_index,
+        confidence=confidence,
+        reasoning=reasoning,
     )

--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -1517,6 +1517,7 @@ async def classify_throw_timing_from_frames(
         )
 
     failures: list[str] = []
+    structured_codes: list[str] = []
 
     confidence: Optional[float] = None
     raw_conf = parsed.get("confidence")
@@ -1524,11 +1525,20 @@ async def classify_throw_timing_from_frames(
         try:
             confidence = max(0.0, min(1.0, float(raw_conf)))
         except (TypeError, ValueError):
+            # A malformed score is a diagnosable signal — structured log +
+            # structured code (mirrors classify_lineup /
+            # classify_frames_for_lineup_decision), never a silent drop
+            # (rules/check-third-party-error-codes.md).
             logger.warning(
                 "throw_timing: invalid confidence value dropped: "
                 "chapter=%r raw_confidence=%r",
                 chapter_title, raw_conf,
             )
+            failures.append(
+                f"invalid confidence value '{raw_conf}' — not a number; "
+                f"treated as null"
+            )
+            structured_codes.append(f"invalid_confidence:{raw_conf}")
 
     model_reasoning = str(parsed.get("reasoning") or "")
     is_lineup_throw = bool(parsed.get("is_lineup_throw"))
@@ -1548,6 +1558,7 @@ async def classify_throw_timing_from_frames(
             confidence=confidence,
             reasoning=model_reasoning
             or "Classifier judged these frames are not a utility throw.",
+            error_codes=list(structured_codes),
         )
 
     release_index = _validate_grid_index(
@@ -1566,7 +1577,10 @@ async def classify_throw_timing_from_frames(
         and result_index is not None
         and result_index < release_index
     ):
-        logger.info(
+        # A result cannot precede its own release — a real model-quality
+        # signal. WARNING (not INFO) so it survives production log levels and
+        # the operator can track how often the model inverts the throw.
+        logger.warning(
             "throw_timing: result_index (%d) < release_index (%d) — forcing "
             "result_index = release_index: chapter=%r",
             result_index, release_index, chapter_title,
@@ -1591,4 +1605,5 @@ async def classify_throw_timing_from_frames(
         result_index=result_index,
         confidence=confidence,
         reasoning=reasoning,
+        error_codes=list(structured_codes),
     )

--- a/apps/mygamingassistant/backend/app/services/game/lineup_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_service.py
@@ -180,6 +180,7 @@ def _build_read(lineup: Lineup) -> LineupRead:
         update={
             "stand_screenshot_url": _sign_screenshot_url(read.stand_screenshot_url),
             "aim_screenshot_url": _sign_screenshot_url(read.aim_screenshot_url),
+            "clip_url": _sign_screenshot_url(read.clip_url),
         }
     )
 

--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_backfill.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_backfill.py
@@ -27,10 +27,12 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.models.game.lineup import Lineup
+from app.models.game.utility_type import UtilityType
 from app.repositories.game import lineup_repo
 from app.services.ingestion.chapter_parser import Chapter, parse_chapters
 from app.services.ingestion.clip_generator import generate_clip_for_lineup
@@ -60,6 +62,26 @@ class BackfillStats:
             f"{self.generated} generated, {self.skipped} skipped, "
             f"{self.failed} failed"
         )
+
+
+async def _utility_hint(db: AsyncSession, lineup: Lineup) -> str | None:
+    """The lineup's confirmed utility slug, for the throw-timing RESULT cue.
+
+    A backfilled lineup is ``accepted`` — the operator already confirmed
+    ``utility_type_id`` — so this hint is strictly stronger than the >0.6
+    grid suggestion the ingest path uses. The repo query doesn't eager-load
+    the relationship, so resolve the slug by id explicitly (a lazy attribute
+    access would raise under async SQLAlchemy).
+    """
+    if lineup.utility_type_id is None:
+        return None
+    return (
+        await db.execute(
+            select(UtilityType.slug).where(
+                UtilityType.id == lineup.utility_type_id
+            )
+        )
+    ).scalar_one_or_none()
 
 
 def _find_chapter(
@@ -169,6 +191,7 @@ async def backfill_clips(db: AsyncSession) -> BackfillStats:
                         # Reuse the once-downloaded file — do NOT let the
                         # generator re-download per lineup.
                         video_path=video_path,
+                        utility_hint=await _utility_hint(db, lineup),
                     )
                 except Exception as exc:  # defensive: never abort the batch
                     logger.warning(
@@ -177,7 +200,9 @@ async def backfill_clips(db: AsyncSession) -> BackfillStats:
                         lineup.id, video_id, str(exc), exc_info=True,
                     )
                     stats.failed += 1
-                    stats.errors.append(f"{lineup.id}: unexpected {exc}")
+                    stats.errors.append(
+                        f"{lineup.id}: unexpected:{type(exc).__name__} {exc}"
+                    )
                     continue
 
                 if result.status == "generated":

--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_backfill.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_backfill.py
@@ -1,0 +1,204 @@
+"""Backfill clips for accepted lineups that predate the clip pipeline.
+
+Ingested lineups created before PR2 (and any whose clip generation failed at
+ingest time) have ``clip_url IS NULL``. This walks that set, re-fetches each
+source video ONCE (not once per lineup — a tutorial video usually backs many
+lineups), localises the throw per chapter, and generates the clip.
+
+Idempotent by construction: the work set is exactly
+``status='accepted' AND youtube_video_id IS NOT NULL AND clip_url IS NULL``
+(``lineup_repo.list_accepted_lineups_needing_clips``). A generated clip sets
+``clip_url`` and drops out of the set, so re-running only processes the
+remainder. A ``failed`` lineup keeps ``clip_url`` NULL and is retried on the
+next run (transient yt-dlp/ffmpeg/Claude failures self-heal). A ``skipped``
+lineup (genuinely not a throw) also stays NULL and will be re-evaluated on a
+future run — that is the frozen design contract's definition of "done"
+(clip_url set); the operator runs this once post-deploy, so re-evaluating a
+handful of non-throws is acceptable and not worth a skip-memo column.
+
+Per rules/no-bandaid-solutions.md + rules/check-third-party-error-codes.md:
+every yt-dlp / ffmpeg / Claude failure is captured with its structured reason
+and tallied — nothing silently disappears.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.clip_generator import generate_clip_for_lineup
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+    download_video,
+    fetch_video_detail,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class BackfillStats:
+    """Aggregate outcome of a backfill run (printed by the CLI)."""
+
+    total: int = 0
+    generated: int = 0
+    skipped: int = 0
+    failed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        return (
+            f"backfill-clips: {self.total} candidate lineup(s) — "
+            f"{self.generated} generated, {self.skipped} skipped, "
+            f"{self.failed} failed"
+        )
+
+
+def _find_chapter(
+    chapters: list[Chapter], start_seconds: int | None
+) -> Chapter | None:
+    """The chapter whose start matches the lineup's stored chapter start.
+
+    The ingest path persisted ``chapter_start_seconds`` from the same
+    ``parse_chapters`` output, so an exact start match re-identifies it. A
+    miss means the video's chapters changed since ingest (re-upload / edited
+    description) — the caller skips that lineup with a logged reason rather
+    than guessing a wrong chapter.
+    """
+    if start_seconds is None:
+        return None
+    for ch in chapters:
+        if ch.start_seconds == start_seconds:
+            return ch
+    return None
+
+
+async def backfill_clips(db: AsyncSession) -> BackfillStats:
+    """Generate clips for every accepted ingested lineup missing one.
+
+    Returns a :class:`BackfillStats`. Designed to be invoked once by the
+    operator post-deploy (``python -m app.cli backfill-clips``); safe to
+    re-run at any time.
+    """
+    stats = BackfillStats()
+
+    lineups = await lineup_repo.list_accepted_lineups_needing_clips(db)
+    stats.total = len(lineups)
+    if not lineups:
+        logger.info("backfill-clips: nothing to do (no candidate lineups)")
+        return stats
+
+    # Group by source video so each video is fetched + downloaded ONCE.
+    by_video: dict[str, list[Lineup]] = defaultdict(list)
+    for lineup in lineups:
+        by_video[lineup.youtube_video_id].append(lineup)
+
+    download_dir = Path(settings.ingestion_download_dir)
+    logger.info(
+        "backfill-clips: %d lineup(s) across %d video(s)",
+        stats.total, len(by_video),
+    )
+
+    for video_id, video_lineups in by_video.items():
+        # ---- One metadata fetch per video ------------------------------
+        try:
+            meta = await fetch_video_detail(video_id)
+        except YouTubeFetchError as exc:
+            logger.warning(
+                "backfill-clips: metadata fetch failed: video_id=%s "
+                "error_type=%s message=%s — %d lineup(s) failed",
+                video_id, exc.error_type, str(exc), len(video_lineups),
+            )
+            stats.failed += len(video_lineups)
+            stats.errors.append(
+                f"{video_id}: metadata fetch failed ({exc.error_type})"
+            )
+            continue
+
+        chapters = parse_chapters(
+            description=meta.description,
+            video_duration=meta.duration,
+            native_chapters=meta.chapters or None,
+        )
+
+        # ---- One download per video ------------------------------------
+        try:
+            video_path = await download_video(video_id, download_dir)
+        except VideoDownloadError as exc:
+            logger.warning(
+                "backfill-clips: download failed: video_id=%s error_type=%s "
+                "message=%s — %d lineup(s) failed",
+                video_id, exc.error_type, str(exc), len(video_lineups),
+            )
+            stats.failed += len(video_lineups)
+            stats.errors.append(
+                f"{video_id}: download failed ({exc.error_type})"
+            )
+            continue
+
+        try:
+            for lineup in video_lineups:
+                chapter = _find_chapter(chapters, lineup.chapter_start_seconds)
+                if chapter is None:
+                    logger.warning(
+                        "backfill-clips: chapter not found: lineup=%s "
+                        "video_id=%s chapter_start=%s — skipping",
+                        lineup.id, video_id, lineup.chapter_start_seconds,
+                    )
+                    stats.skipped += 1
+                    stats.errors.append(
+                        f"{video_id}[{lineup.chapter_start_seconds}]: "
+                        f"chapter not found (video changed since ingest)"
+                    )
+                    continue
+
+                try:
+                    result = await generate_clip_for_lineup(
+                        db,
+                        lineup,
+                        chapter_start=float(chapter.start_seconds),
+                        chapter_end=float(chapter.end_seconds),
+                        # Reuse the once-downloaded file — do NOT let the
+                        # generator re-download per lineup.
+                        video_path=video_path,
+                    )
+                except Exception as exc:  # defensive: never abort the batch
+                    logger.warning(
+                        "backfill-clips: unexpected error: lineup=%s "
+                        "video_id=%s error=%s",
+                        lineup.id, video_id, str(exc), exc_info=True,
+                    )
+                    stats.failed += 1
+                    stats.errors.append(f"{lineup.id}: unexpected {exc}")
+                    continue
+
+                if result.status == "generated":
+                    stats.generated += 1
+                elif result.status == "skipped":
+                    stats.skipped += 1
+                else:
+                    stats.failed += 1
+                    stats.errors.append(
+                        f"{lineup.id}: {','.join(result.error_codes) or 'failed'}"
+                    )
+        finally:
+            # The backfill owns this download (one per video) — clean it up
+            # once, after all of the video's lineups are processed.
+            try:
+                video_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "backfill-clips: failed to delete video: path=%s error=%s",
+                    video_path, str(exc),
+                )
+
+    logger.info("backfill-clips: complete — %s", stats.summary())
+    return stats

--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
@@ -32,6 +32,7 @@ NULL and the lineup stays fully usable from its stills. Nothing silent-fails.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -285,6 +286,10 @@ async def generate_clip_for_lineup(
             )
 
         # ---- Gate (frozen contract) ------------------------------------
+        # Gate order mirrors the frozen contract: not-a-throw → low
+        # confidence → no release frame. Low confidence is the more common
+        # (and more actionable) root cause, so it is reported ahead of a
+        # literally-absent release index.
         if not timing.is_lineup_throw:
             return ClipGenerationResult(
                 status="skipped",
@@ -293,18 +298,18 @@ async def generate_clip_for_lineup(
                 confidence=timing.confidence,
                 reasoning=timing.reasoning,
             )
-        if timing.release_index is None:
-            return ClipGenerationResult(
-                status="skipped",
-                skip_reason="no_release_frame",
-                is_lineup_throw=True,
-                confidence=timing.confidence,
-                reasoning=timing.reasoning,
-            )
         if timing.confidence is None or timing.confidence < _CLIP_CONFIDENCE_GATE:
             return ClipGenerationResult(
                 status="skipped",
                 skip_reason=f"low_confidence:{timing.confidence}",
+                is_lineup_throw=True,
+                confidence=timing.confidence,
+                reasoning=timing.reasoning,
+            )
+        if timing.release_index is None:
+            return ClipGenerationResult(
+                status="skipped",
+                skip_reason="no_release_frame",
                 is_lineup_throw=True,
                 confidence=timing.confidence,
                 reasoning=timing.reasoning,
@@ -359,7 +364,12 @@ async def generate_clip_for_lineup(
         clip_key = pending_clip_key(video_id, chapter_start)
         try:
             storage = get_storage()
-            storage.upload_file(clip_key, clip_bytes, "video/mp4")
+            # upload_file is a blocking minio put_object — a clip MP4 is far
+            # larger than a PNG screenshot, so run it off the event loop.
+            loop = asyncio.get_running_loop()
+            await loop.run_in_executor(
+                None, storage.upload_file, clip_key, clip_bytes, "video/mp4"
+            )
         except Exception as exc:
             logger.warning(
                 "clip_generator: clip upload failed: lineup=%s key=%s "

--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
@@ -1,0 +1,429 @@
+"""Clip generator — produce a short gif-style throw clip for one lineup.
+
+The two ingested stills (stand + aim) structurally cannot represent a lineup:
+a lineup is a *motion*. This service localises the throw within its source
+chapter and cuts a tight, muted, looping MP4 around it so the glance board can
+autoplay it like a gif. The stills remain the always-valid fallback — a clip
+is best-effort and never required for a lineup to be usable.
+
+End-to-end (the frozen design contract, pr2-clip-localization-design.md):
+
+  1. Sample a dense frame window over the throw portion of the chapter
+     (``frame_extractor.clip_window_timestamps`` — trims the walk-in / talk
+     lead-in).
+  2. Downscale-extract those frames (cheap; throw *timing* doesn't need full
+     pixels).
+  3. Ask Claude to localise the RELEASE and RESULT frames
+     (``classify_throw_timing_from_frames`` — a separate code path from the
+     game/map grid classifier).
+  4. Gate: skip (keep stills) when it is not a throw, confidence < 0.55, or no
+     release frame was found.
+  5. Turn the returned indices back into timestamps, compute a throw-centric
+     ~6s clip window, clamp to the chapter.
+  6. Re-use the already-downloaded video (ingest) or re-fetch it by
+     ``youtube_video_id`` (backfill), cut + encode a small muted MP4, upload
+     to MinIO under a deterministic key, and persist the bare key on the row.
+
+Failure handling (rules/no-bandaid-solutions.md +
+rules/check-third-party-error-codes.md): yt-dlp / ffmpeg / Claude failures are
+captured with their structured codes, logged at WARNING with the reason, and
+returned as ``status="failed"`` with ``error_codes``. ``clip_url`` is left
+NULL and the lineup stays fully usable from its stills. Nothing silent-fails.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.storage import get_storage
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+from app.services.classification.classifier_service import (
+    classify_throw_timing_from_frames,
+)
+from app.services.ingestion.frame_extractor import (
+    ClipCutError,
+    FrameExtractionError,
+    clip_window_timestamps,
+    cut_clip,
+    extract_frames_downscaled,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    download_video,
+)
+
+logger = logging.getLogger(__name__)
+
+# Frozen design-contract constants. The 0.55 gate accepts both
+# "inferred-from-trajectory" (0.55-0.79) and direct observation (>=0.80);
+# below 0.55 the dense window missed the throw and the stills are the right
+# artifact.
+_CLIP_CONFIDENCE_GATE = 0.55
+# Lead-in kept before release / tail kept after the result first shows.
+_PRE_RELEASE_SECONDS = 2.0
+_POST_RESULT_SECONDS = 0.5
+# Accepted clip-length band; outside it we rebuild a throw-centric ~6s window.
+_MIN_CLIP_SECONDS = 2.0
+_MAX_CLIP_SECONDS = 12.0
+_TARGET_CLIP_SECONDS = 6.0
+# Below this even the rebuilt window is unusable (chapter too short) → skip.
+_ABSOLUTE_MIN_CLIP_SECONDS = 1.0
+
+
+@dataclass
+class ClipGenerationResult:
+    """Structured outcome of a clip-generation attempt.
+
+    ``status`` is one of:
+      - ``"generated"`` — clip cut, uploaded, ``clip_url`` committed.
+        ``clip_key`` is set.
+      - ``"skipped"``   — deliberately no clip (not a throw / low confidence /
+        no release frame / chapter too short / classifier disabled). NOT an
+        error; the lineup is fully usable from its stills.
+      - ``"failed"``    — an operational failure (download / extract / cut /
+        upload / Claude API). ``error_codes`` carries the structured reason;
+        ``clip_url`` is left NULL; the lineup still works from its stills. A
+        later backfill run can retry.
+
+    Never a bare bool/None — the caller and the backfill summary route on this
+    (per rules/check-third-party-error-codes.md).
+    """
+
+    status: str
+    clip_key: Optional[str] = None
+    skip_reason: Optional[str] = None
+    error_codes: list[str] = field(default_factory=list)
+    reasoning: str = ""
+    confidence: Optional[float] = None
+    is_lineup_throw: Optional[bool] = None
+    release_ts: Optional[float] = None
+    result_ts: Optional[float] = None
+    clip_start: Optional[float] = None
+    clip_duration: Optional[float] = None
+
+
+def pending_clip_key(video_id: str, chapter_start_seconds: float) -> str:
+    """Deterministic MinIO key for a lineup's clip.
+
+    Parallel to the ingestion screenshot keys
+    (``pending/{video_id}/{start}-{slot}.png``) — and, like them, ingested
+    rows keep this key after the operator accepts them (accept does not
+    re-key MinIO objects). One key per (video, chapter start) makes the
+    backfill idempotent: re-running overwrites the same object instead of
+    orphaning a new one.
+    """
+    return f"pending/{video_id}/{int(chapter_start_seconds)}-clip.mp4"
+
+
+def _compute_clip_bounds(
+    release_ts: float,
+    result_ts: float,
+    chapter_start: float,
+    chapter_end: float,
+) -> Optional[tuple[float, float]]:
+    """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
+
+    [release-2.0, result+0.5] clamped to the chapter. If that is outside the
+    [~2s, ~12s] band (e.g. a long gap between release and result, or a missing
+    result frame collapsing it), rebuild a throw-centric ~6s window anchored
+    at release. Returns None when even the rebuilt window is shorter than ~1s
+    (the chapter is too short to carry a meaningful clip) so the caller skips.
+    """
+    start = max(release_ts - _PRE_RELEASE_SECONDS, chapter_start)
+    end = min(result_ts + _POST_RESULT_SECONDS, chapter_end)
+    duration = end - start
+
+    if duration < _MIN_CLIP_SECONDS or duration > _MAX_CLIP_SECONDS:
+        # Throw-centric ~6s rebuild: keep the 2s pre-release lead-in, take the
+        # rest after release. Re-clamp to the chapter.
+        start = max(release_ts - _PRE_RELEASE_SECONDS, chapter_start)
+        end = min(start + _TARGET_CLIP_SECONDS, chapter_end)
+        duration = end - start
+
+    if duration < _ABSOLUTE_MIN_CLIP_SECONDS:
+        return None
+    return start, duration
+
+
+async def generate_clip_for_lineup(
+    db: AsyncSession,
+    lineup: Lineup,
+    *,
+    chapter_start: float,
+    chapter_end: float,
+    video_path: Optional[Path] = None,
+    download_dir: Optional[Path] = None,
+    utility_hint: Optional[str] = None,
+) -> ClipGenerationResult:
+    """Localise the throw and cut a clip for *lineup*; persist ``clip_url``.
+
+    Args:
+        db: Active async session. On success the bare clip key is committed
+            via ``lineup_repo.set_clip_url`` (its own one-column commit — a
+            clip failure must not roll back the already-committed lineup).
+        lineup: The row to clip. ``youtube_video_id`` must be set (manual
+            uploads have no source video — caller must not call this for
+            them).
+        chapter_start / chapter_end: The source chapter bounds in seconds.
+            Ingest passes the parsed ``Chapter``; backfill re-derives the end
+            from the re-fetched video metadata (this service does not store
+            it).
+        video_path: An already-downloaded source video to reuse (ingest). When
+            None the video is re-fetched by ``youtube_video_id`` (backfill)
+            into *download_dir* and deleted afterwards.
+        download_dir: Required when *video_path* is None — where to download
+            the re-fetched source.
+        utility_hint: Utility slug from a prior grid classification at
+            confidence > 0.6, if any — sharpens the RESULT cue.
+
+    Returns:
+        ClipGenerationResult — see its docstring for ``status`` semantics.
+        Never raises for an expected failure; everything is captured into the
+        result with structured ``error_codes`` and a WARNING log.
+    """
+    video_id = lineup.youtube_video_id
+    if not video_id:
+        # The caller is responsible for not calling this on manual uploads;
+        # surface it loudly rather than silently no-op.
+        logger.warning(
+            "clip_generator: lineup %s has no youtube_video_id — cannot clip",
+            lineup.id,
+        )
+        return ClipGenerationResult(
+            status="skipped",
+            skip_reason="no_source_video",
+        )
+
+    # Cheap exits before any download / Claude spend. The throw-timing call is
+    # the clip gate; with no key (or the classifier disabled) we cannot judge
+    # the throw, so there is nothing to clip — keep the stills.
+    if not settings.enable_classifier:
+        return ClipGenerationResult(
+            status="skipped", skip_reason="classifier_disabled"
+        )
+    if not settings.anthropic_api_key:
+        return ClipGenerationResult(
+            status="skipped", skip_reason="classifier_unavailable:missing_api_key"
+        )
+
+    chapter_duration = float(chapter_end) - float(chapter_start)
+    timestamps = clip_window_timestamps(chapter_start, chapter_end)
+    if not timestamps:
+        return ClipGenerationResult(
+            status="skipped", skip_reason="empty_clip_window"
+        )
+
+    owns_video = video_path is None
+    local_video: Optional[Path] = video_path
+    try:
+        # ---- Acquire the source video -----------------------------------
+        if local_video is None:
+            if download_dir is None:
+                logger.warning(
+                    "clip_generator: lineup %s — no video_path and no "
+                    "download_dir; cannot re-fetch source",
+                    lineup.id,
+                )
+                return ClipGenerationResult(
+                    status="failed",
+                    error_codes=["no_download_dir"],
+                    reasoning="Re-fetch requested but no download_dir provided",
+                )
+            try:
+                local_video = await download_video(video_id, download_dir)
+            except VideoDownloadError as exc:
+                logger.warning(
+                    "clip_generator: source re-fetch failed: lineup=%s "
+                    "video_id=%s error_type=%s message=%s",
+                    lineup.id, video_id, exc.error_type, str(exc),
+                )
+                return ClipGenerationResult(
+                    status="failed",
+                    error_codes=[f"download:{exc.error_type}"],
+                    reasoning=f"Video re-fetch failed: {exc}",
+                )
+
+        # ---- Dense downscaled frames over the throw window --------------
+        try:
+            frames = await extract_frames_downscaled(local_video, timestamps)
+        except FrameExtractionError as exc:
+            logger.warning(
+                "clip_generator: downscaled frame extraction failed: "
+                "lineup=%s video_id=%s returncode=%s stderr=%s",
+                lineup.id, video_id, exc.returncode, exc.stderr[:300],
+            )
+            return ClipGenerationResult(
+                status="failed",
+                error_codes=[f"frame_extract:rc={exc.returncode}"],
+                reasoning=f"Downscaled frame extraction failed: {exc}",
+            )
+
+        # ---- Localise the throw ----------------------------------------
+        timing = await classify_throw_timing_from_frames(
+            frames=frames,
+            frame_timestamps=timestamps,
+            chapter_title=lineup.chapter_title,
+            chapter_duration=chapter_duration,
+            utility_hint=utility_hint,
+        )
+        if not timing.success:
+            logger.warning(
+                "clip_generator: throw-timing call failed: lineup=%s "
+                "video_id=%s error_codes=%s reasoning=%s",
+                lineup.id, video_id, timing.error_codes, timing.reasoning,
+            )
+            return ClipGenerationResult(
+                status="failed",
+                error_codes=list(timing.error_codes),
+                reasoning=timing.reasoning,
+            )
+
+        # ---- Gate (frozen contract) ------------------------------------
+        if not timing.is_lineup_throw:
+            return ClipGenerationResult(
+                status="skipped",
+                skip_reason="not_a_throw",
+                is_lineup_throw=False,
+                confidence=timing.confidence,
+                reasoning=timing.reasoning,
+            )
+        if timing.release_index is None:
+            return ClipGenerationResult(
+                status="skipped",
+                skip_reason="no_release_frame",
+                is_lineup_throw=True,
+                confidence=timing.confidence,
+                reasoning=timing.reasoning,
+            )
+        if timing.confidence is None or timing.confidence < _CLIP_CONFIDENCE_GATE:
+            return ClipGenerationResult(
+                status="skipped",
+                skip_reason=f"low_confidence:{timing.confidence}",
+                is_lineup_throw=True,
+                confidence=timing.confidence,
+                reasoning=timing.reasoning,
+            )
+
+        # ---- Indices → timestamps → clip bounds ------------------------
+        release_ts = timestamps[timing.release_index - 1]
+        # result_index is guaranteed >= release_index by the parser when set;
+        # when the model omitted it we anchor the tail at release (the
+        # standard 2.5s window then still passes the >=2s contract band).
+        if timing.result_index is not None:
+            result_ts = timestamps[timing.result_index - 1]
+        else:
+            result_ts = release_ts
+
+        bounds = _compute_clip_bounds(
+            release_ts, result_ts, float(chapter_start), float(chapter_end)
+        )
+        if bounds is None:
+            return ClipGenerationResult(
+                status="skipped",
+                skip_reason="chapter_too_short_for_clip",
+                is_lineup_throw=True,
+                confidence=timing.confidence,
+                reasoning=timing.reasoning,
+                release_ts=release_ts,
+                result_ts=result_ts,
+            )
+        clip_start, clip_duration = bounds
+
+        # ---- Cut + encode the muted clip -------------------------------
+        try:
+            clip_bytes = await cut_clip(local_video, clip_start, clip_duration)
+        except ClipCutError as exc:
+            logger.warning(
+                "clip_generator: clip cut failed: lineup=%s video_id=%s "
+                "start=%.2f dur=%.2f returncode=%s stderr=%s",
+                lineup.id, video_id, clip_start, clip_duration,
+                exc.returncode, exc.stderr[:300],
+            )
+            return ClipGenerationResult(
+                status="failed",
+                error_codes=[f"clip_cut:rc={exc.returncode}"],
+                reasoning=f"ffmpeg clip cut failed: {exc}",
+                release_ts=release_ts,
+                result_ts=result_ts,
+                clip_start=clip_start,
+                clip_duration=clip_duration,
+            )
+
+        # ---- Upload + persist the bare key -----------------------------
+        clip_key = pending_clip_key(video_id, chapter_start)
+        try:
+            storage = get_storage()
+            storage.upload_file(clip_key, clip_bytes, "video/mp4")
+        except Exception as exc:
+            logger.warning(
+                "clip_generator: clip upload failed: lineup=%s key=%s "
+                "error=%s",
+                lineup.id, clip_key, str(exc),
+            )
+            return ClipGenerationResult(
+                status="failed",
+                error_codes=["clip_upload_failed"],
+                reasoning=f"MinIO clip upload failed: {exc}",
+                release_ts=release_ts,
+                result_ts=result_ts,
+                clip_start=clip_start,
+                clip_duration=clip_duration,
+            )
+
+        try:
+            await lineup_repo.set_clip_url(db, lineup, clip_key)
+        except Exception as exc:
+            # The object is uploaded but the column did not commit. The key is
+            # deterministic, so a later backfill recomputes the same key and
+            # overwrites the same object — no orphan, safe to retry.
+            logger.warning(
+                "clip_generator: clip_url persist failed (object uploaded, "
+                "column not committed; backfill is idempotent): lineup=%s "
+                "key=%s error=%s",
+                lineup.id, clip_key, str(exc),
+            )
+            return ClipGenerationResult(
+                status="failed",
+                error_codes=["clip_url_persist_failed"],
+                reasoning=f"clip_url commit failed: {exc}",
+                release_ts=release_ts,
+                result_ts=result_ts,
+                clip_start=clip_start,
+                clip_duration=clip_duration,
+            )
+
+        logger.info(
+            "clip_generator: clip generated: lineup=%s video_id=%s key=%s "
+            "release_ts=%.2f result_ts=%.2f clip=[%.2f,+%.2fs] confidence=%.2f",
+            lineup.id, video_id, clip_key, release_ts, result_ts,
+            clip_start, clip_duration, timing.confidence or 0.0,
+        )
+        return ClipGenerationResult(
+            status="generated",
+            clip_key=clip_key,
+            is_lineup_throw=True,
+            confidence=timing.confidence,
+            reasoning=timing.reasoning,
+            release_ts=release_ts,
+            result_ts=result_ts,
+            clip_start=clip_start,
+            clip_duration=clip_duration,
+        )
+    finally:
+        # Only delete the video if THIS call downloaded it. During ingest the
+        # orchestrator owns video_path and deletes it once after all chapters.
+        if owns_video and local_video is not None:
+            try:
+                local_video.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "clip_generator: failed to delete re-fetched video: "
+                    "path=%s error=%s",
+                    local_video, str(exc),
+                )

--- a/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
@@ -265,7 +265,9 @@ async def extract_frames_downscaled(
     Same sequential thread-pool shape as :func:`extract_frames`. Raises
     :class:`FrameExtractionError` on any individual ffmpeg failure.
     """
-    loop = asyncio.get_event_loop()
+    # get_running_loop (not get_event_loop, which is deprecated in 3.10+ /
+    # raises in 3.12 when called from inside a coroutine — MGA is 3.12).
+    loop = asyncio.get_running_loop()
     results: list[bytes] = []
     for ts in timestamps:
         png_bytes = await loop.run_in_executor(
@@ -430,7 +432,7 @@ async def cut_clip(
     it doesn't block the event loop (same shape as :func:`extract_frames`).
     Raises :class:`ClipCutError` on any ffmpeg failure.
     """
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         None, _cut_clip_sync, video_path, start_seconds, duration_seconds
     )

--- a/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import subprocess
+import tempfile
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -158,3 +159,278 @@ def grid_timestamps(
 
     step = (hi - lo) / (count - 1)
     return [lo + step * i for i in range(count)]
+
+
+# ---------------------------------------------------------------------------
+# Clip pipeline (PR2) — downscaled dense-window frames + ffmpeg clip cut.
+#
+# These exist alongside the Strategy-A grid path (extract_frames /
+# grid_timestamps) and deliberately DO NOT touch it: the classification grid
+# needs full-resolution frames for aim-anchor pixel work, whereas the
+# throw-timing pass only needs to *order* the throw in time, so its frames are
+# downscaled to keep the N=12 dense window at roughly the same image-token cost
+# as the old N=5 full-res grid.
+# ---------------------------------------------------------------------------
+
+# Downscale target for the throw-timing classifier frames. 640x360 keeps a
+# 12-frame dense window ≈ the token cost of the old 5-frame full-res grid
+# (~$0.016/haiku call). Do NOT raise without re-checking the per-call cost note
+# in the PR — token cost scales with pixel area.
+_DOWNSCALE_W = 640
+_DOWNSCALE_H = 360
+
+
+class ClipCutError(Exception):
+    """Raised when ffmpeg fails to cut/encode a clip segment.
+
+    Mirrors :class:`FrameExtractionError` (a clip cut is a distinct ffmpeg op,
+    so it carries its own structured failure context per
+    rules/check-third-party-error-codes.md — never a bare bool/None).
+
+    Attributes:
+        start: Clip start (seconds) that failed.
+        duration: Requested clip duration (seconds).
+        returncode: ffmpeg exit code (or -1 when output was empty).
+        stderr: ffmpeg stderr output (the structured error message).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        start: float,
+        duration: float,
+        returncode: int,
+        stderr: str,
+    ) -> None:
+        super().__init__(message)
+        self.start = start
+        self.duration = duration
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def _extract_frame_downscaled_sync(video_path: Path, timestamp: float) -> bytes:
+    """Synchronously extract one PNG frame at *timestamp*, downscaled.
+
+    Identical to :func:`_extract_frame_sync` but adds an ffmpeg ``scale``
+    filter so the throw-timing classifier gets cheap, small frames. The
+    full-res :func:`_extract_frame_sync` is intentionally left untouched —
+    the classification grid still needs full pixels for aim-anchor work.
+    """
+    cmd = [
+        "ffmpeg",
+        "-ss", str(timestamp),
+        "-i", str(video_path),
+        "-frames:v", "1",
+        "-vf", f"scale={_DOWNSCALE_W}:{_DOWNSCALE_H}",
+        "-f", "image2pipe",
+        "-vcodec", "png",
+        "pipe:1",
+    ]
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        stderr_text = result.stderr.decode("utf-8", errors="replace")
+        logger.error(
+            "ffmpeg downscaled frame extraction failed: video=%s timestamp=%.1f "
+            "returncode=%d stderr=%s",
+            video_path, timestamp, result.returncode, stderr_text,
+        )
+        raise FrameExtractionError(
+            f"ffmpeg exited {result.returncode} extracting downscaled "
+            f"t={timestamp:.1f}s from {video_path.name}",
+            timestamp=timestamp,
+            returncode=result.returncode,
+            stderr=stderr_text,
+        )
+    return result.stdout
+
+
+async def extract_frames_downscaled(
+    video_path: Path,
+    timestamps: list[float],
+) -> list[bytes]:
+    """Extract downscaled (640x360) PNG frames at each timestamp.
+
+    The throw-timing classifier only needs to *order* the throw within the
+    chapter, not read crosshair pixels, so its frames are downscaled. This
+    keeps the N=12 dense window at roughly the image-token cost of the old
+    N=5 full-res classification grid.
+
+    Same sequential thread-pool shape as :func:`extract_frames`. Raises
+    :class:`FrameExtractionError` on any individual ffmpeg failure.
+    """
+    loop = asyncio.get_event_loop()
+    results: list[bytes] = []
+    for ts in timestamps:
+        png_bytes = await loop.run_in_executor(
+            None, _extract_frame_downscaled_sync, video_path, ts
+        )
+        results.append(png_bytes)
+    return results
+
+
+def clip_window_timestamps(
+    chapter_start_seconds: float,
+    chapter_end_seconds: float,
+) -> list[float]:
+    """Dense single-pass sample window for throw-timing detection (PR2).
+
+    NOT the Strategy-A classification grid (:func:`grid_timestamps`). That one
+    samples the *whole* chapter sparsely to pick a stand/aim still. This one
+    trims the walk-in/explanation lead-in and densely samples the part of the
+    chapter where the throw actually happens, so the throw-timing classifier
+    can localise release/result frames.
+
+    Per the frozen design contract (pr2-clip-localization-design.md):
+
+      - ``duration = end - start``
+      - ``skip_fraction = 0.30 if duration >= 20 else 0.15`` — drop the
+        walk-in / "here's the spot" explanation lead-in.
+      - ``window = [start + duration*skip_fraction, end]``
+      - ``N = 12`` evenly across the window, edge_padding 0.5s, EXCEPT:
+        - remaining window < 12s after the skip → ``N = 8`` over that window
+        - chapter longer than 180s → cap the window to the final 120s before
+          the chapter end (a long chapter's throw is near the end), keep N=12.
+
+    Returns the list of frame timestamps. Index ``i`` (1-based in the
+    classifier's schema) maps to ``result[i-1]`` — the caller turns the
+    classifier's release/result indices back into timestamps via this list,
+    so it MUST be the exact list the frames were extracted from.
+    """
+    start = float(chapter_start_seconds)
+    end = float(chapter_end_seconds)
+    duration = end - start
+
+    skip_fraction = 0.30 if duration >= 20 else 0.15
+    window_start = start + duration * skip_fraction
+    window_end = end
+
+    if duration > 180:
+        # A long chapter's actual throw is near the end (the front is a long
+        # walk-through / explanation). Cap to the final 120s so the dense
+        # window isn't wasted on lead-in. max() guards the degenerate case
+        # where the skip already pushed past end-120.
+        window_start = max(window_start, end - 120.0)
+        n = 12
+    elif (window_end - window_start) < 12:
+        # Short remaining window — fewer frames is plenty and keeps token
+        # cost down; cover the whole remaining window.
+        n = 8
+    else:
+        n = 12
+
+    return grid_timestamps(
+        window_start, window_end, n, edge_padding_seconds=0.5
+    )
+
+
+def _cut_clip_sync(
+    video_path: Path,
+    start_seconds: float,
+    duration_seconds: float,
+) -> bytes:
+    """Synchronously cut a muted, web-playable MP4 segment via ffmpeg.
+
+    ``-ss`` is placed BEFORE ``-i`` for fast input seeking (same trade-off as
+    :func:`_extract_frame_sync`): keyframe-accurate rather than exact, which is
+    correct for a gif-style autoplay clip and avoids decoding the whole video.
+
+    Encode choices (frozen design contract):
+      - ``-an`` — muted (the tile autoplays; audio would be a UX bug).
+      - ``libx264 -crf 28 -preset veryfast`` — small, fast, "good enough".
+      - ``-vf scale=-2:'min(720,ih)'`` — cap at 720p, never upscale, keep even
+        width (libx264 requires even dimensions).
+      - ``-pix_fmt yuv420p`` — REQUIRED for ``<video>`` playback across
+        browsers; libx264 may otherwise pick yuv444p which Safari/Firefox
+        refuse to decode.
+      - ``-movflags +faststart`` — moves the moov atom to the front so the
+        clip starts playing before it's fully buffered. This needs a seekable
+        output, so we write to a temp file and read it back (you cannot
+        +faststart to a pipe).
+
+    Raises :class:`ClipCutError` (structured: returncode + stderr) on a
+    non-zero exit or an empty/missing output file — never a silent failure.
+    """
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+        out_path = Path(tmp.name)
+    try:
+        cmd = [
+            "ffmpeg",
+            "-ss", f"{start_seconds:.3f}",
+            "-i", str(video_path),
+            "-t", f"{duration_seconds:.3f}",
+            "-an",
+            "-c:v", "libx264",
+            "-crf", "28",
+            "-preset", "veryfast",
+            "-vf", "scale=-2:'min(720,ih)'",
+            "-pix_fmt", "yuv420p",
+            "-movflags", "+faststart",
+            "-f", "mp4",
+            "-y",
+            str(out_path),
+        ]
+        result = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=180,  # input-seek keeps this fast; generous for big sources
+        )
+        if result.returncode != 0:
+            stderr_text = result.stderr.decode("utf-8", errors="replace")
+            logger.error(
+                "ffmpeg clip cut failed: video=%s start=%.2f dur=%.2f "
+                "returncode=%d stderr=%s",
+                video_path, start_seconds, duration_seconds,
+                result.returncode, stderr_text,
+            )
+            raise ClipCutError(
+                f"ffmpeg exited {result.returncode} cutting clip "
+                f"[{start_seconds:.2f}, +{duration_seconds:.2f}s] from "
+                f"{video_path.name}",
+                start=start_seconds,
+                duration=duration_seconds,
+                returncode=result.returncode,
+                stderr=stderr_text,
+            )
+        data = out_path.read_bytes()
+        if not data:
+            stderr_text = result.stderr.decode("utf-8", errors="replace")
+            logger.error(
+                "ffmpeg clip cut produced empty output: video=%s start=%.2f "
+                "dur=%.2f stderr=%s",
+                video_path, start_seconds, duration_seconds, stderr_text,
+            )
+            raise ClipCutError(
+                f"ffmpeg produced an empty clip from {video_path.name}",
+                start=start_seconds,
+                duration=duration_seconds,
+                returncode=-1,
+                stderr=stderr_text,
+            )
+        return data
+    finally:
+        out_path.unlink(missing_ok=True)
+
+
+async def cut_clip(
+    video_path: Path,
+    start_seconds: float,
+    duration_seconds: float,
+) -> bytes:
+    """Cut a muted, web-playable MP4 segment and return its bytes.
+
+    Runs the blocking ffmpeg subprocess in the default thread-pool executor so
+    it doesn't block the event loop (same shape as :func:`extract_frames`).
+    Raises :class:`ClipCutError` on any ffmpeg failure.
+    """
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None, _cut_clip_sync, video_path, start_seconds, duration_seconds
+    )

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -35,17 +35,20 @@ from io import BytesIO
 from pathlib import Path
 from typing import Optional
 
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.storage import get_storage
 from app.models.game.source import Source
+from app.models.game.utility_type import UtilityType
 from app.repositories.game import lineup_repo, source_repo
 from app.repositories.game.lineup_repo import write_classifier_suggestions
 from app.schemas.game.lineup_schemas import LineupIngestCreate
 from app.services.classification.classifier_service import (
     classify_frames_for_lineup_decision,
 )
+from app.services.ingestion.clip_generator import generate_clip_for_lineup
 from app.services.game import lineup_service
 from app.services.ingestion.chapter_parser import (
     Chapter,
@@ -143,6 +146,29 @@ def _classifier_suggestion_fields(result) -> dict:
         "classification_confidence": result.confidence,
         "classification_reasoning": result.reasoning,
     }
+
+
+async def _resolve_utility_hint(db: AsyncSession, result) -> Optional[str]:
+    """The grid-classified utility slug, only when the grid was confident.
+
+    The throw-timing prompt keys its RESULT cue on the utility (an expanding
+    smoke cloud and a molotov flame look nothing alike). Below the >0.6 gate
+    the grid wasn't sure of the utility, so a hint would mislead more than it
+    helps — pass none and let the throw-timing call judge unaided.
+    """
+    if (
+        result.suggested_utility_type_id is None
+        or result.confidence is None
+        or result.confidence <= 0.6
+    ):
+        return None
+    return (
+        await db.execute(
+            select(UtilityType.slug).where(
+                UtilityType.id == result.suggested_utility_type_id
+            )
+        )
+    ).scalar_one_or_none()
 
 
 async def _process_chapter(
@@ -328,6 +354,41 @@ async def _process_chapter(
             source.id, video_meta.video_id, start, lineup.id,
             stand_idx, aim_idx, result.confidence or 0.0,
         )
+
+        # PR2: best-effort throw clip. The source video is still on disk
+        # (_process_video deletes it once after ALL chapters), so reuse it —
+        # never re-download per chapter. This runs AFTER the row + classifier
+        # suggestions are committed: a clip failure must NOT roll back or fail
+        # the chapter — the lineup is fully usable from its two stills, and a
+        # clip is a best-effort enhancement only. generate_clip_for_lineup
+        # returns structured outcomes and doesn't raise for expected
+        # failures; the broad catch is purely defensive against an unexpected
+        # bug taking down ingestion.
+        try:
+            utility_hint = await _resolve_utility_hint(db, result)
+            clip_result = await generate_clip_for_lineup(
+                db,
+                lineup,
+                chapter_start=float(chapter.start_seconds),
+                chapter_end=float(chapter.end_seconds),
+                video_path=video_path,
+                utility_hint=utility_hint,
+            )
+            logger.info(
+                "Clip generation (ingest): source_id=%s video_id=%s "
+                "chapter_start=%d lineup_id=%s status=%s reason=%s",
+                source.id, video_meta.video_id, start, lineup.id,
+                clip_result.status,
+                clip_result.skip_reason
+                or (",".join(clip_result.error_codes) or "-"),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Clip generation unexpected error (non-fatal): source_id=%s "
+                "video_id=%s chapter_start=%d lineup_id=%s error=%s",
+                source.id, video_meta.video_id, start, lineup.id, str(exc),
+                exc_info=True,
+            )
 
     return True
 

--- a/apps/mygamingassistant/backend/tests/test_alembic_chain.py
+++ b/apps/mygamingassistant/backend/tests/test_alembic_chain.py
@@ -2,7 +2,7 @@
 
 These run against the raw migration scripts (no live DB) so they fit the
 default pytest suite. They lock in that the chain resolves to a single head
-(currently ``0009``) and that every revision is reachable base → head — the
+(currently ``0010``) and that every revision is reachable base → head — the
 class of bug where a new migration's ``down_revision`` is stale after a
 merge and silently orphans the chain.
 """
@@ -24,8 +24,8 @@ def script_directory() -> ScriptDirectory:
     return ScriptDirectory.from_config(cfg)
 
 
-def test_single_head_is_0009(script_directory: ScriptDirectory) -> None:
-    """The DAG must resolve to exactly one head and it must be 0009.
+def test_single_head_is_0010(script_directory: ScriptDirectory) -> None:
+    """The DAG must resolve to exactly one head and it must be 0010.
 
     Bump this pin (and add a down_revision assertion below) in the same PR
     that adds a new migration — same per-PR contract as the fixture
@@ -37,8 +37,8 @@ def test_single_head_is_0009(script_directory: ScriptDirectory) -> None:
         "Orphan heads usually mean a migration's down_revision is stale "
         "after a merge — rebase and re-point the down_revision."
     )
-    assert heads[0] == "0009", (
-        f"Expected head 0009 (the Valorant polygon backfill), got {heads[0]}."
+    assert heads[0] == "0010", (
+        f"Expected head 0010 (the lineup clip_url column), got {heads[0]}."
     )
 
 
@@ -72,3 +72,11 @@ def test_0009_down_revision_points_at_0008(
     """0009 must chain directly off 0008 (the CS2 polygon backfill)."""
     rev = script_directory.get_revision("0009")
     assert rev.down_revision == "0008"
+
+
+def test_0010_down_revision_points_at_0009(
+    script_directory: ScriptDirectory,
+) -> None:
+    """0010 must chain directly off 0009 (the lineup clip_url column)."""
+    rev = script_directory.get_revision("0010")
+    assert rev.down_revision == "0009"

--- a/apps/mygamingassistant/backend/tests/test_clip_backfill.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_backfill.py
@@ -30,6 +30,9 @@ def _lineup(video_id: str, chapter_start: int):
         id=uuid.uuid4(),
         youtube_video_id=video_id,
         chapter_start_seconds=chapter_start,
+        # None → _utility_hint short-circuits before any DB call (these are
+        # no-DB unit tests; hint resolution is exercised elsewhere).
+        utility_type_id=None,
         clip_url=None,
     )
 

--- a/apps/mygamingassistant/backend/tests/test_clip_backfill.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_backfill.py
@@ -1,0 +1,212 @@
+"""Unit tests for the PR2 backfill (python -m app.cli backfill-clips).
+
+Everything external (repo query / yt-dlp / chapter parse / clip generation)
+is mocked. Verifies the idempotent work set, ONE fetch+download per video
+(not per lineup), chapter re-identification, the generated/skipped/failed
+tally, and that the per-video download is always cleaned up.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.ingestion.chapter_parser import Chapter
+from app.services.ingestion.clip_backfill import backfill_clips
+from app.services.ingestion.clip_generator import ClipGenerationResult
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+)
+
+_MOD = "app.services.ingestion.clip_backfill"
+
+
+def _lineup(video_id: str, chapter_start: int):
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_start_seconds=chapter_start,
+        clip_url=None,
+    )
+
+
+def _meta():
+    m = MagicMock()
+    m.description = ""
+    m.duration = 120
+    m.chapters = [{"start_time": 0, "end_time": 60, "title": "B smoke"}]
+    return m
+
+
+def _patches(tmp_path, *, lineups, chapters, generate, fetch=None, download=None):
+    """Compose the backfill patch set; download writes a real temp file so
+    the unlink-cleanup assertion is meaningful."""
+    dl_path = tmp_path / "video.mp4"
+
+    async def _dl(video_id, ddir):
+        p = Path(ddir) / f"{video_id}.mp4"
+        p.write_bytes(b"src")
+        return p
+
+    settings = MagicMock()
+    settings.ingestion_download_dir = str(tmp_path)
+
+    stack = [
+        patch(f"{_MOD}.settings", settings),
+        patch(f"{_MOD}.lineup_repo.list_accepted_lineups_needing_clips",
+              new=AsyncMock(return_value=lineups)),
+        patch(f"{_MOD}.fetch_video_detail",
+              new=fetch or AsyncMock(return_value=_meta())),
+        patch(f"{_MOD}.parse_chapters", return_value=chapters),
+        patch(f"{_MOD}.download_video",
+              new=download or AsyncMock(side_effect=_dl)),
+        patch(f"{_MOD}.generate_clip_for_lineup", new=generate),
+    ]
+    return stack
+
+
+def _enter(stack):
+    import contextlib
+    es = contextlib.ExitStack()
+    for p in stack:
+        es.enter_context(p)
+    return es
+
+
+class TestBackfill:
+    @pytest.mark.asyncio
+    async def test_nothing_to_do(self, tmp_path: Path):
+        gen = AsyncMock()
+        with _enter(_patches(tmp_path, lineups=[], chapters=[], generate=gen)):
+            stats = await backfill_clips(MagicMock())
+        assert stats.total == 0
+        assert stats.generated == 0
+        gen.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_one_fetch_and_download_per_video(self, tmp_path: Path):
+        # 3 lineups, 2 of them share video "vidA".
+        lineups = [
+            _lineup("vidA", 0), _lineup("vidA", 0), _lineup("vidB", 0),
+        ]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="B smoke")]
+        gen = AsyncMock(return_value=ClipGenerationResult(
+            status="generated", clip_key="k"))
+        fetch = AsyncMock(return_value=_meta())
+        dl_calls = []
+
+        async def _dl(video_id, ddir):
+            dl_calls.append(video_id)
+            p = Path(ddir) / f"{video_id}.mp4"
+            p.write_bytes(b"src")
+            return p
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, generate=gen,
+            fetch=fetch, download=AsyncMock(side_effect=_dl),
+        )):
+            stats = await backfill_clips(MagicMock())
+
+        assert stats.total == 3
+        assert stats.generated == 3
+        # ONE fetch + ONE download per distinct video, not per lineup.
+        assert fetch.await_count == 2
+        assert sorted(dl_calls) == ["vidA", "vidB"]
+        # Downloaded files cleaned up.
+        assert not (tmp_path / "vidA.mp4").exists()
+        assert not (tmp_path / "vidB.mp4").exists()
+
+    @pytest.mark.asyncio
+    async def test_tally_mixed_outcomes(self, tmp_path: Path):
+        lineups = [_lineup("v", 0), _lineup("v", 0), _lineup("v", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        gen = AsyncMock(side_effect=[
+            ClipGenerationResult(status="generated", clip_key="k"),
+            ClipGenerationResult(status="skipped", skip_reason="not_a_throw"),
+            ClipGenerationResult(status="failed", error_codes=["clip_cut:rc=1"]),
+        ])
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, generate=gen)):
+            stats = await backfill_clips(MagicMock())
+        assert (stats.generated, stats.skipped, stats.failed) == (1, 1, 1)
+        assert any("clip_cut" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_metadata_fetch_failure_fails_all_video_lineups(
+        self, tmp_path: Path
+    ):
+        lineups = [_lineup("vbad", 0), _lineup("vbad", 30)]
+        fetch = AsyncMock(side_effect=YouTubeFetchError(
+            "gone", error_type="ExtractorError", original=Exception()))
+        gen = AsyncMock()
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=[], generate=gen, fetch=fetch)):
+            stats = await backfill_clips(MagicMock())
+        assert stats.failed == 2
+        assert stats.generated == 0
+        gen.assert_not_awaited()
+        assert any("ExtractorError" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_download_failure_fails_all_video_lineups(
+        self, tmp_path: Path
+    ):
+        lineups = [_lineup("vdl", 0)]
+        dl = AsyncMock(side_effect=VideoDownloadError(
+            "nope", video_id="vdl", error_type="UnavailableVideoError",
+            original=Exception()))
+        gen = AsyncMock()
+        with _enter(_patches(
+            tmp_path, lineups=lineups,
+            chapters=[Chapter(0, 60, "x")], generate=gen, download=dl)):
+            stats = await backfill_clips(MagicMock())
+        assert stats.failed == 1
+        gen.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_chapter_not_found_is_skipped(self, tmp_path: Path):
+        # lineup recorded chapter_start=999 but the video now has only [0,60].
+        lineups = [_lineup("v", 999)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        gen = AsyncMock()
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, generate=gen)):
+            stats = await backfill_clips(MagicMock())
+        assert stats.skipped == 1
+        gen.assert_not_awaited()
+        assert any("chapter not found" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_per_lineup_exception_does_not_abort_batch(
+        self, tmp_path: Path
+    ):
+        lineups = [_lineup("v", 0), _lineup("v", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        gen = AsyncMock(side_effect=[
+            RuntimeError("boom"),
+            ClipGenerationResult(status="generated", clip_key="k"),
+        ])
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, generate=gen)):
+            stats = await backfill_clips(MagicMock())
+        # First raised, second still processed; download cleaned up.
+        assert stats.failed == 1
+        assert stats.generated == 1
+        assert not (tmp_path / "v.mp4").exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_runs_even_when_all_lineups_raise(
+        self, tmp_path: Path
+    ):
+        lineups = [_lineup("v", 0)]
+        gen = AsyncMock(side_effect=RuntimeError("boom"))
+        with _enter(_patches(
+            tmp_path, lineups=lineups,
+            chapters=[Chapter(0, 60, "x")], generate=gen)):
+            stats = await backfill_clips(MagicMock())
+        assert stats.failed == 1
+        assert not (tmp_path / "v.mp4").exists()

--- a/apps/mygamingassistant/backend/tests/test_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_generator.py
@@ -220,6 +220,17 @@ class TestGenerateClipSkips:
         assert result.skip_reason == "no_release_frame"
 
     @pytest.mark.asyncio
+    async def test_low_conf_reported_before_missing_release(self, tmp_path: Path):
+        """Frozen-contract gate order: when BOTH confidence<0.55 and
+        release is absent, the (more actionable) low-confidence reason wins."""
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        result, _, _ = await self._skip(
+            timing=_timing(release_index=None, confidence=0.4), video=v
+        )
+        assert result.status == "skipped"
+        assert result.skip_reason.startswith("low_confidence")
+
+    @pytest.mark.asyncio
     async def test_classifier_disabled_short_circuits(self):
         result, cut, _ = await self._skip(settings=_settings(enable=False))
         assert result.status == "skipped"

--- a/apps/mygamingassistant/backend/tests/test_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_generator.py
@@ -1,0 +1,374 @@
+"""Unit tests for the PR2 clip generator.
+
+Pure clip-bounds math + the full generate_clip_for_lineup orchestration with
+every external (download / frame extract / Claude / ffmpeg cut / MinIO / repo
+commit) mocked. Asserts the frozen-contract gate, the structured
+generated/skipped/failed outcomes, and the source-video cleanup ownership
+(reused vs re-fetched).
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.classification.classification_result import ThrowTimingResult
+from app.services.ingestion.clip_generator import (
+    ClipGenerationResult,
+    _compute_clip_bounds,
+    generate_clip_for_lineup,
+    pending_clip_key,
+)
+from app.services.ingestion.frame_extractor import ClipCutError, FrameExtractionError
+from app.services.ingestion.youtube_fetcher import VideoDownloadError
+
+_MOD = "app.services.ingestion.clip_generator"
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n"
+_FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
+
+
+def _lineup(video_id="vid123", chapter_title="B smoke"):
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_title=chapter_title,
+        clip_url=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _compute_clip_bounds — pure math
+# ---------------------------------------------------------------------------
+
+class TestComputeClipBounds:
+    def test_normal_window_within_band(self):
+        # release 20, result 24, chapter [10,40]: [18, 24.5] = 6.5s in [2,12].
+        start, dur = _compute_clip_bounds(20.0, 24.0, 10.0, 40.0)
+        assert start == pytest.approx(18.0)
+        assert dur == pytest.approx(6.5)
+
+    def test_clamped_to_chapter_start(self):
+        # release 11 → 11-2=9 but chapter starts at 10 → clamp to 10.
+        start, dur = _compute_clip_bounds(11.0, 13.0, 10.0, 40.0)
+        assert start == pytest.approx(10.0)
+
+    def test_too_long_rebuilds_throw_centric_6s(self):
+        # release 20, result 60, chapter [10,90]: raw 42.5s > 12 → rebuild to
+        # ~6s anchored at release: [18, 24].
+        start, dur = _compute_clip_bounds(20.0, 60.0, 10.0, 90.0)
+        assert start == pytest.approx(18.0)
+        assert dur == pytest.approx(6.0)
+
+    def test_missing_result_collapses_to_25s_clip(self):
+        # result_ts == release_ts (no result frame): [release-2, release+0.5]
+        # = 2.5s, which is within the [2,12] band by frozen-contract design.
+        start, dur = _compute_clip_bounds(20.0, 20.0, 0.0, 60.0)
+        assert dur == pytest.approx(2.5)
+
+    def test_chapter_too_short_returns_none(self):
+        # 0.5s chapter — even the rebuilt window is < 1s → skip signal.
+        assert _compute_clip_bounds(20.0, 20.0, 20.0, 20.5) is None
+
+    def test_clip_never_exceeds_chapter_end(self):
+        start, dur = _compute_clip_bounds(20.0, 24.0, 10.0, 23.0)
+        assert start + dur <= 23.0 + 1e-9
+
+
+def test_pending_clip_key_is_deterministic():
+    # Stable key per (video, chapter start) → backfill idempotency.
+    assert pending_clip_key("abc", 42.0) == "pending/abc/42-clip.mp4"
+    assert pending_clip_key("abc", 42.9) == "pending/abc/42-clip.mp4"
+
+
+# ---------------------------------------------------------------------------
+# generate_clip_for_lineup — orchestration
+# ---------------------------------------------------------------------------
+
+def _settings(enable=True, key="sk-test"):
+    s = MagicMock()
+    s.enable_classifier = enable
+    s.anthropic_api_key = key
+    return s
+
+
+def _timing(**kw):
+    base = dict(
+        success=True, is_lineup_throw=True, release_index=2,
+        result_index=4, confidence=0.8, reasoning="ok",
+    )
+    base.update(kw)
+    return ThrowTimingResult(**base)
+
+
+class TestGenerateClipGeneratedPath:
+    @pytest.mark.asyncio
+    async def test_generated_reuses_provided_video_and_persists_key(
+        self, tmp_path: Path
+    ):
+        video = tmp_path / "vid123.mp4"
+        video.write_bytes(b"src")
+        lineup = _lineup()
+        db = MagicMock()
+        storage = MagicMock()
+
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
+            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 6)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames", new=AsyncMock(return_value=_timing())),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)) as mock_cut,
+            patch(f"{_MOD}.get_storage", return_value=storage),
+            patch(f"{_MOD}.download_video", new=AsyncMock()) as mock_dl,
+            patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()) as mock_set,
+        ):
+            result = await generate_clip_for_lineup(
+                db, lineup, chapter_start=0.0, chapter_end=30.0,
+                video_path=video,
+            )
+
+        assert result.status == "generated"
+        assert result.clip_key == "pending/vid123/0-clip.mp4"
+        mock_dl.assert_not_awaited()  # provided video reused, no re-fetch
+        storage.upload_file.assert_called_once()
+        assert storage.upload_file.call_args[0][2] == "video/mp4"
+        mock_set.assert_awaited_once()
+        mock_cut.assert_awaited_once()
+        # A reused (caller-owned) video must NOT be deleted here.
+        assert video.exists()
+
+    @pytest.mark.asyncio
+    async def test_refetch_path_downloads_and_cleans_up(self, tmp_path: Path):
+        fetched = tmp_path / "vid123.mp4"
+        fetched.write_bytes(b"src")
+        lineup = _lineup()
+
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0, 4.0]),
+            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 4)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames",
+                  new=AsyncMock(return_value=_timing(release_index=1, result_index=2))),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
+            patch(f"{_MOD}.get_storage", return_value=MagicMock()),
+            patch(f"{_MOD}.download_video", new=AsyncMock(return_value=fetched)) as mock_dl,
+            patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()),
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), lineup, chapter_start=0.0, chapter_end=30.0,
+                video_path=None, download_dir=tmp_path,
+            )
+
+        assert result.status == "generated"
+        mock_dl.assert_awaited_once()
+        # A re-fetched (self-owned) video MUST be cleaned up.
+        assert not fetched.exists()
+
+
+class TestGenerateClipSkips:
+    async def _skip(self, *, timing=None, settings=None, lineup=None, video=None):
+        with (
+            patch(f"{_MOD}.settings", settings or _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0]),
+            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 3)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames",
+                  new=AsyncMock(return_value=timing or _timing())),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock()) as mock_cut,
+            patch(f"{_MOD}.get_storage", return_value=MagicMock()),
+            patch(f"{_MOD}.download_video", new=AsyncMock()),
+            patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()) as mock_set,
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), lineup or _lineup(),
+                chapter_start=0.0, chapter_end=30.0,
+                video_path=video,
+            )
+        return result, mock_cut, mock_set
+
+    @pytest.mark.asyncio
+    async def test_not_a_throw(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        result, cut, sett = await self._skip(
+            timing=_timing(is_lineup_throw=False, release_index=None,
+                           result_index=None, confidence=0.05),
+            video=v,
+        )
+        assert result.status == "skipped"
+        assert result.skip_reason == "not_a_throw"
+        cut.assert_not_awaited()
+        sett.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_below_055_gate(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        result, cut, _ = await self._skip(
+            timing=_timing(confidence=0.54), video=v
+        )
+        assert result.status == "skipped"
+        assert result.skip_reason.startswith("low_confidence")
+        cut.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_release_frame(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        result, _, _ = await self._skip(
+            timing=_timing(release_index=None), video=v
+        )
+        assert result.status == "skipped"
+        assert result.skip_reason == "no_release_frame"
+
+    @pytest.mark.asyncio
+    async def test_classifier_disabled_short_circuits(self):
+        result, cut, _ = await self._skip(settings=_settings(enable=False))
+        assert result.status == "skipped"
+        assert result.skip_reason == "classifier_disabled"
+        cut.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_short_circuits(self):
+        result, _, _ = await self._skip(settings=_settings(key=""))
+        assert result.status == "skipped"
+        assert result.skip_reason == "classifier_unavailable:missing_api_key"
+
+    @pytest.mark.asyncio
+    async def test_no_source_video_id(self):
+        result, _, _ = await self._skip(lineup=_lineup(video_id=None))
+        assert result.status == "skipped"
+        assert result.skip_reason == "no_source_video"
+
+    @pytest.mark.asyncio
+    async def test_chapter_too_short_for_clip(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        # release==result and a sub-second chapter → bounds None → skip.
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[20.0, 20.1, 20.2]),
+            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 3)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames",
+                  new=AsyncMock(return_value=_timing(release_index=1, result_index=1))),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock()) as mock_cut,
+            patch(f"{_MOD}.get_storage", return_value=MagicMock()),
+            patch(f"{_MOD}.download_video", new=AsyncMock()),
+            patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()),
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=20.0, chapter_end=20.5,
+                video_path=v,
+            )
+        assert result.status == "skipped"
+        assert result.skip_reason == "chapter_too_short_for_clip"
+        mock_cut.assert_not_awaited()
+
+
+class TestGenerateClipFailures:
+    @pytest.mark.asyncio
+    async def test_refetch_without_download_dir_fails_loud(self):
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
+                video_path=None, download_dir=None,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["no_download_dir"]
+
+    @pytest.mark.asyncio
+    async def test_download_failure(self, tmp_path: Path):
+        exc = VideoDownloadError(
+            "gone", video_id="vid123", error_type="UnavailableVideoError",
+            original=Exception(),
+        )
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
+            patch(f"{_MOD}.download_video", new=AsyncMock(side_effect=exc)),
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
+                video_path=None, download_dir=tmp_path,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["download:UnavailableVideoError"]
+
+    @pytest.mark.asyncio
+    async def test_frame_extract_failure(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        exc = FrameExtractionError("boom", timestamp=5.0, returncode=1, stderr="e")
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
+            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(side_effect=exc)),
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
+                video_path=v,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["frame_extract:rc=1"]
+
+    @pytest.mark.asyncio
+    async def test_throw_timing_call_failure(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        failed_timing = ThrowTimingResult(
+            success=False, error_codes=["rate_limit_error"],
+            reasoning="rate limited",
+        )
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
+            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 2)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames",
+                  new=AsyncMock(return_value=failed_timing)),
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
+                video_path=v,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["rate_limit_error"]
+
+    @pytest.mark.asyncio
+    async def test_clip_cut_failure(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        exc = ClipCutError("nope", start=1.0, duration=6.0, returncode=1, stderr="e")
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0, 4.0]),
+            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 4)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames",
+                  new=AsyncMock(return_value=_timing(release_index=1, result_index=2))),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(side_effect=exc)),
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
+                video_path=v,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["clip_cut:rc=1"]
+
+    @pytest.mark.asyncio
+    async def test_upload_failure(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        storage = MagicMock()
+        storage.upload_file.side_effect = RuntimeError("minio down")
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0, 4.0]),
+            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 4)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames",
+                  new=AsyncMock(return_value=_timing(release_index=1, result_index=2))),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
+            patch(f"{_MOD}.get_storage", return_value=storage),
+            patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()) as mock_set,
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
+                video_path=v,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["clip_upload_failed"]
+        mock_set.assert_not_awaited()  # nothing persisted on upload failure

--- a/apps/mygamingassistant/backend/tests/test_frame_extractor.py
+++ b/apps/mygamingassistant/backend/tests/test_frame_extractor.py
@@ -231,6 +231,15 @@ class TestClipWindowTimestamps:
         # Every sample is inside [280, 400] (the last 120s), never the lead-in.
         assert all(280.0 <= t <= 400.0 for t in ts)
 
+    def test_200s_boundary_max_guard(self):
+        # duration 200 > 180. skip 30% → window_start 60, but the 120s cap
+        # (end-120 = 80) is later, so max() pulls window_start to 80, NOT 60.
+        # Pins the exact >180 boundary the cap's max() guard handles.
+        ts = clip_window_timestamps(0.0, 200.0)
+        assert len(ts) == 12
+        assert all(80.0 <= t <= 200.0 for t in ts)
+        assert min(ts) >= 80.0  # the 60-80s lead-in is excluded by the cap
+
     def test_very_short_chapter_degrades_safely(self):
         # 5s chapter: skip 15% → window [0.75, 5]; <12 → N=8; grid_timestamps
         # keeps every sample strictly inside the chapter.

--- a/apps/mygamingassistant/backend/tests/test_frame_extractor.py
+++ b/apps/mygamingassistant/backend/tests/test_frame_extractor.py
@@ -13,12 +13,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services.ingestion.frame_extractor import (
+    ClipCutError,
     FrameExtractionError,
+    clip_window_timestamps,
+    cut_clip,
     extract_frames,
+    extract_frames_downscaled,
     grid_timestamps,
 )
 
 _FAKE_PNG = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00"  # PNG magic bytes header
+_FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42" + b"\x00" * 64  # MP4 ftyp box header
 
 
 class TestExtractFrames:
@@ -145,3 +150,173 @@ class TestGridTimestamps:
         ts = grid_timestamps(0.0, 100.0, 0)
         assert len(ts) == 1
         assert 0.0 < ts[0] < 100.0
+
+
+class TestExtractFramesDownscaled:
+    @pytest.mark.asyncio
+    async def test_returns_bytes_and_adds_scale_filter(self, tmp_path: Path):
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"fake")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = _FAKE_PNG
+
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            frames = await extract_frames_downscaled(video, [3.0, 7.0])
+
+        assert frames == [_FAKE_PNG, _FAKE_PNG]
+        # Every call must carry the 640x360 scale filter — that downscale is
+        # the whole point (token cost), regressing it silently inflates spend.
+        for call in mock_run.call_args_list:
+            cmd = call[0][0]
+            assert "-vf" in cmd
+            assert cmd[cmd.index("-vf") + 1] == "scale=640:360"
+
+    @pytest.mark.asyncio
+    async def test_raises_frame_extraction_error_on_failure(self, tmp_path: Path):
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"fake")
+
+        mock_result = MagicMock()
+        mock_result.returncode = 1
+        mock_result.stdout = b""
+        mock_result.stderr = b"ffmpeg: scale failed"
+
+        with patch("subprocess.run", return_value=mock_result):
+            with pytest.raises(FrameExtractionError) as exc_info:
+                await extract_frames_downscaled(video, [4.0])
+
+        assert exc_info.value.returncode == 1
+        assert exc_info.value.timestamp == 4.0
+
+    @pytest.mark.asyncio
+    async def test_does_not_change_full_res_extract_frames(self, tmp_path: Path):
+        """The full-res path must NOT gain a scale filter (aim-anchor needs px)."""
+        video = tmp_path / "test.mp4"
+        video.write_bytes(b"fake")
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        mock_result.stdout = _FAKE_PNG
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            await extract_frames(video, [1.0])
+        assert "-vf" not in mock_run.call_args[0][0]
+
+
+class TestClipWindowTimestamps:
+    def test_skip_fraction_30pct_for_long_chapter(self):
+        # duration 100s >= 20 → skip 30% → window [30, 100], N=12.
+        ts = clip_window_timestamps(0.0, 100.0)
+        assert len(ts) == 12
+        assert all(30.0 <= t <= 100.0 for t in ts)
+        assert ts == sorted(ts)
+
+    def test_skip_fraction_15pct_for_short_chapter(self):
+        # duration 16s < 20 → skip 15% → window [2.4, 16]; remaining 13.6 >= 12
+        # so N stays 12.
+        ts = clip_window_timestamps(0.0, 16.0)
+        assert len(ts) == 12
+        assert all(2.4 <= t <= 16.0 for t in ts)
+
+    def test_short_remaining_window_uses_8_frames(self):
+        # duration 14s < 20 → skip 15% → window_start 2.1, remaining 11.9 < 12
+        # → N = 8.
+        ts = clip_window_timestamps(0.0, 14.0)
+        assert len(ts) == 8
+
+    def test_long_chapter_caps_to_final_120s(self):
+        # duration 400s > 180 → window capped to the final 120s, N=12.
+        ts = clip_window_timestamps(0.0, 400.0)
+        assert len(ts) == 12
+        # Every sample is inside [280, 400] (the last 120s), never the lead-in.
+        assert all(280.0 <= t <= 400.0 for t in ts)
+
+    def test_very_short_chapter_degrades_safely(self):
+        # 5s chapter: skip 15% → window [0.75, 5]; <12 → N=8; grid_timestamps
+        # keeps every sample strictly inside the chapter.
+        ts = clip_window_timestamps(10.0, 15.0)
+        assert len(ts) == 8
+        assert all(10.0 < t < 15.0 for t in ts)
+
+
+class TestCutClip:
+    def _run_writes_output(self, payload: bytes = _FAKE_MP4):
+        """subprocess.run side effect: write the ffmpeg output file + succeed.
+
+        The real cut_clip reads the temp file back, so the mock must actually
+        produce it (last cmd arg is the output path).
+        """
+        def _side_effect(cmd, **kwargs):
+            Path(cmd[-1]).write_bytes(payload)
+            r = MagicMock()
+            r.returncode = 0
+            r.stderr = b""
+            return r
+        return _side_effect
+
+    @pytest.mark.asyncio
+    async def test_returns_clip_bytes_with_web_safe_encode(self, tmp_path: Path):
+        video = tmp_path / "src.mp4"
+        video.write_bytes(b"fake")
+
+        with patch("subprocess.run", side_effect=self._run_writes_output()) as mr:
+            data = await cut_clip(video, 12.0, 6.0)
+
+        assert data == _FAKE_MP4
+        cmd = mr.call_args[0][0]
+        # Muted + browser-playable + faststart are load-bearing for the
+        # autoplay <video> tile; assert they survive refactors.
+        assert "-an" in cmd
+        assert "yuv420p" in cmd
+        assert "+faststart" in cmd
+        # Input seek before -i (fast, keyframe-accurate — correct for a clip).
+        assert cmd.index("-ss") < cmd.index("-i")
+        assert cmd[cmd.index("-t") + 1] == "6.000"
+
+    @pytest.mark.asyncio
+    async def test_raises_clip_cut_error_on_nonzero_exit(self, tmp_path: Path):
+        video = tmp_path / "src.mp4"
+        video.write_bytes(b"fake")
+
+        bad = MagicMock()
+        bad.returncode = 1
+        bad.stderr = b"x264 not found"
+
+        with patch("subprocess.run", return_value=bad):
+            with pytest.raises(ClipCutError) as exc_info:
+                await cut_clip(video, 5.0, 6.0)
+
+        err = exc_info.value
+        assert err.returncode == 1
+        assert "x264 not found" in err.stderr
+        assert err.start == 5.0
+        assert err.duration == 6.0
+
+    @pytest.mark.asyncio
+    async def test_raises_clip_cut_error_on_empty_output(self, tmp_path: Path):
+        video = tmp_path / "src.mp4"
+        video.write_bytes(b"fake")
+
+        with patch(
+            "subprocess.run", side_effect=self._run_writes_output(payload=b"")
+        ):
+            with pytest.raises(ClipCutError) as exc_info:
+                await cut_clip(video, 1.0, 6.0)
+
+        assert exc_info.value.returncode == -1
+
+    @pytest.mark.asyncio
+    async def test_temp_file_cleaned_up(self, tmp_path: Path):
+        """No stray .mp4 temp files leak after a successful cut."""
+        import glob
+        import tempfile
+
+        video = tmp_path / "src.mp4"
+        video.write_bytes(b"fake")
+        before = set(glob.glob(str(Path(tempfile.gettempdir()) / "*.mp4")))
+
+        with patch("subprocess.run", side_effect=self._run_writes_output()):
+            await cut_clip(video, 2.0, 6.0)
+
+        after = set(glob.glob(str(Path(tempfile.gettempdir()) / "*.mp4")))
+        assert after == before

--- a/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
@@ -28,6 +28,7 @@ from app.models.game.utility_type import UtilityType
 from app.services.ingestion.chapter_parser import Chapter
 from app.services.ingestion.youtube_fetcher import VideoMeta
 from app.services.classification.classification_result import ClassificationResult
+from app.services.ingestion.clip_generator import ClipGenerationResult
 
 FAKE_VIDEO = VideoMeta(
     video_id="vid_cls_001",
@@ -94,16 +95,32 @@ async def _seed_classifier_targets(db: AsyncSession) -> None:
 
 
 @contextlib.contextmanager
-def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock):
+def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock, clip_mock=None):
     """Enter the common ingestion patches for a grid-classifier test.
 
     `classify_mock` is the mock to install for
     classify_frames_for_lineup_decision (an AsyncMock). Yields
     (mock_settings, mock_storage) for the test to configure further.
 
+    `clip_mock` (PR2) replaces generate_clip_for_lineup. It defaults to a
+    neutral AsyncMock returning a "skipped" result so clip generation is a
+    no-op for the existing classifier tests; clip-specific tests pass their
+    own to assert it was invoked with the reused on-disk video.
+
     A parenthesized `with (...)` cannot mix ``*tuple`` unpacking with ``as``
     bindings, so the shared patch set is entered via an ExitStack here.
     """
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    from app.services.ingestion.clip_generator import ClipGenerationResult
+
+    if clip_mock is None:
+        clip_mock = _AsyncMock(
+            return_value=ClipGenerationResult(
+                status="skipped", skip_reason="test_default"
+            )
+        )
+
     with contextlib.ExitStack() as stack:
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]))
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO))
@@ -111,6 +128,7 @@ def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock):
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.extract_frames", new_callable=AsyncMock, return_value=[_FAKE_PNG] * 5))
         mock_storage_factory = stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.get_storage"))
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.classify_frames_for_lineup_decision", new=classify_mock))
+        stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.generate_clip_for_lineup", new=clip_mock))
         mock_settings = stack.enter_context(patch.object(ingestion_orchestrator_module(), "settings"))
 
         mock_settings.ingestion_download_dir = str(tmp_path)
@@ -293,3 +311,112 @@ class TestIngestionWithClassifier:
         lineups = result.scalars().all()
         assert len(lineups) == 1
         assert lineups[0].suggested_game_id is None
+
+
+class TestIngestClipWiring:
+    """PR2: clip generation is wired into the ingest path, best-effort."""
+
+    def _grid_result(self) -> ClassificationResult:
+        return ClassificationResult(
+            success=True,
+            is_lineup=True,
+            best_stand_index=2,
+            best_aim_index=4,
+            suggested_game_id=_FAKE_GAME_ID,
+            suggested_map_id=_FAKE_MAP_ID,
+            suggested_target_zone_id=_FAKE_ZONE_ID,
+            suggested_side="side_a",
+            suggested_utility_type_id=_FAKE_UT_ID,
+            confidence=0.85,
+            reasoning="Clear smoke throw",
+            error_codes=[],
+        )
+
+    @pytest.mark.asyncio
+    async def test_clip_gen_reuses_on_disk_video_and_gets_chapter_bounds(
+        self, db: AsyncSession, source: Source, tmp_path: Path
+    ):
+        """is_lineup → generate_clip_for_lineup invoked with the already-
+        downloaded video (no per-chapter re-download) + the chapter bounds +
+        the resolved utility hint (grid confidence 0.85 > 0.6)."""
+        ingestion_orchestrator = ingestion_orchestrator_module()
+        fake_video_path = tmp_path / "vid_cls_001.mp4"
+        fake_video_path.write_bytes(b"fake")
+
+        classify_mock = AsyncMock(return_value=self._grid_result())
+        clip_mock = AsyncMock(
+            return_value=ClipGenerationResult(
+                status="generated", clip_key="pending/vid_cls_001/0-clip.mp4"
+            )
+        )
+
+        with _grid_env(
+            tmp_path, fake_video_path,
+            classify_mock=classify_mock, clip_mock=clip_mock,
+        ) as (mock_settings, _):
+            mock_settings.enable_classifier = True
+            await ingestion_orchestrator.sync_source(source.id, db)
+
+        clip_mock.assert_awaited_once()
+        kwargs = clip_mock.call_args.kwargs
+        assert kwargs["video_path"] == fake_video_path
+        assert kwargs["chapter_start"] == 0.0
+        assert kwargs["chapter_end"] == 60.0
+        # _FAKE_UT_ID is seeded as slug "cls-smoke"; confidence 0.85 > 0.6.
+        assert kwargs["utility_hint"] == "cls-smoke"
+
+    @pytest.mark.asyncio
+    async def test_clip_gen_not_called_when_not_a_lineup(
+        self, db: AsyncSession, source: Source, tmp_path: Path
+    ):
+        ingestion_orchestrator = ingestion_orchestrator_module()
+        fake_video_path = tmp_path / "vid_cls_001.mp4"
+        fake_video_path.write_bytes(b"fake")
+
+        classify_mock = AsyncMock(
+            return_value=ClassificationResult(
+                success=True, is_lineup=False, confidence=0.02,
+                reasoning="not a lineup", error_codes=[],
+            )
+        )
+        clip_mock = AsyncMock()
+
+        with _grid_env(
+            tmp_path, fake_video_path,
+            classify_mock=classify_mock, clip_mock=clip_mock,
+        ) as (mock_settings, _):
+            mock_settings.enable_classifier = True
+            await ingestion_orchestrator.sync_source(source.id, db)
+
+        clip_mock.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clip_failure_is_non_fatal_to_the_chapter(
+        self, db: AsyncSession, source: Source, tmp_path: Path
+    ):
+        """An unexpected clip-gen exception must NOT fail the chapter — the
+        lineup is fully usable from its stills and is already committed."""
+        ingestion_orchestrator = ingestion_orchestrator_module()
+        fake_video_path = tmp_path / "vid_cls_001.mp4"
+        fake_video_path.write_bytes(b"fake")
+
+        classify_mock = AsyncMock(return_value=self._grid_result())
+        clip_mock = AsyncMock(side_effect=RuntimeError("ffmpeg blew up"))
+
+        with _grid_env(
+            tmp_path, fake_video_path,
+            classify_mock=classify_mock, clip_mock=clip_mock,
+        ) as (mock_settings, _):
+            mock_settings.enable_classifier = True
+            stats = await ingestion_orchestrator.sync_source(source.id, db)
+
+        # Chapter still counted as handled, no error, row persisted.
+        assert stats.chapter_count == 1
+        assert stats.error_count == 0
+        rows = (
+            await db.execute(
+                select(Lineup).where(Lineup.youtube_video_id == "vid_cls_001")
+            )
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].status == "pending_review"

--- a/apps/mygamingassistant/backend/tests/test_lineup_clip_url_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_clip_url_repo.py
@@ -1,0 +1,53 @@
+"""DB-backed test for lineup_repo.set_clip_url (PR2).
+
+The clip key must actually COMMIT (not just flush) — the same silent
+data-loss class as PATCH #687: ``get_db`` doesn't auto-commit, so a
+flush-only write is rolled back on session close and the operator's clip
+silently never appears. This asserts the write survives a fresh read.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+
+
+@pytest.mark.asyncio
+async def test_set_clip_url_commits(db: AsyncSession):
+    created = await lineup_repo.create_lineup(
+        db, {"title": "clip repo test", "status": "pending_review"}
+    )
+
+    returned = await lineup_repo.set_clip_url(
+        db, created, "pending/vidX/12-clip.mp4"
+    )
+    assert returned.clip_url == "pending/vidX/12-clip.mp4"
+
+    # Fresh query (expire_on_commit=False keeps the instance, so re-select to
+    # prove it's the committed DB state, not just the in-session attribute).
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == created.id))
+    ).scalar_one()
+    assert refetched.clip_url == "pending/vidX/12-clip.mp4"
+
+
+@pytest.mark.asyncio
+async def test_set_clip_url_overwrite_is_idempotent(db: AsyncSession):
+    """Backfill recomputes the same deterministic key — overwrite must work."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "clip overwrite test", "status": "pending_review"}
+    )
+    await lineup_repo.set_clip_url(db, created, "pending/v/1-clip.mp4")
+    await lineup_repo.set_clip_url(db, created, "pending/v/1-clip.mp4")
+
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == created.id))
+    ).scalar_one()
+    assert refetched.clip_url == "pending/v/1-clip.mp4"

--- a/apps/mygamingassistant/backend/tests/test_lineup_clip_url_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_clip_url_repo.py
@@ -13,7 +13,11 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.game.game import Game
 from app.models.game.lineup import Lineup
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.models.game.utility_type import UtilityType
 from app.repositories.game import lineup_repo
 
 
@@ -51,3 +55,53 @@ async def test_set_clip_url_overwrite_is_idempotent(db: AsyncSession):
         await db.execute(select(Lineup).where(Lineup.id == created.id))
     ).scalar_one()
     assert refetched.clip_url == "pending/v/1-clip.mp4"
+
+
+@pytest.mark.asyncio
+async def test_list_accepted_lineups_needing_clips_filters(db: AsyncSession):
+    """Only accepted + has-source-video + no-clip rows are in the backfill set."""
+    game = Game(slug=f"g-{uuid.uuid4().hex[:8]}", name="G",
+                side_a_label="A", side_b_label="B")
+    db.add(game)
+    await db.flush()
+    mp = Map(game_id=game.id, slug=f"m-{uuid.uuid4().hex[:8]}", name="M")
+    db.add(mp)
+    await db.flush()
+    zone = MapZone(map_id=mp.id, slug=f"z-{uuid.uuid4().hex[:8]}",
+                   name="Z", polygon_points=[])
+    db.add(zone)
+    util = UtilityType(game_id=game.id, slug=f"u-{uuid.uuid4().hex[:8]}",
+                       name="U")
+    db.add(util)
+    await db.flush()
+
+    def _accepted(**over):
+        data = dict(
+            game_id=game.id, map_id=mp.id, target_zone_id=zone.id,
+            stand_zone_id=zone.id, side="side_a", utility_type_id=util.id,
+            title="t", status="accepted",
+            youtube_video_id="vidQ", clip_url=None,
+        )
+        data.update(over)
+        return data
+
+    wanted = await lineup_repo.create_lineup(db, _accepted())
+    # Excluded: already has a clip.
+    await lineup_repo.create_lineup(
+        db, _accepted(clip_url="pending/vidQ/3-clip.mp4")
+    )
+    # Excluded: no source video to re-fetch.
+    await lineup_repo.create_lineup(db, _accepted(youtube_video_id=None))
+    # Excluded: still pending_review (not accepted).
+    await lineup_repo.create_lineup(
+        db, {"title": "p", "status": "pending_review",
+             "youtube_video_id": "vidQ"}
+    )
+
+    rows = await lineup_repo.list_accepted_lineups_needing_clips(db)
+    ids = {r.id for r in rows}
+    assert wanted.id in ids
+    assert all(
+        r.status == "accepted" and r.youtube_video_id and r.clip_url is None
+        for r in rows
+    )

--- a/apps/mygamingassistant/backend/tests/test_lineup_clip_url_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_clip_url_repo.py
@@ -32,11 +32,17 @@ async def test_set_clip_url_commits(db: AsyncSession):
     )
     assert returned.clip_url == "pending/vidX/12-clip.mp4"
 
-    # Fresh query (expire_on_commit=False keeps the instance, so re-select to
-    # prove it's the committed DB state, not just the in-session attribute).
+    # Capture the PK *before* expire_all(): referencing an expired attribute
+    # (created.id) inside the query expression triggers a synchronous lazy
+    # reload — sync session.execute outside the async greenlet, i.e.
+    # MissingGreenlet. The PK as a plain local has no such hazard.
+    lineup_id = created.id
+
+    # Fresh query (expire_on_commit=False keeps the instance, so expire then
+    # re-select to prove it's the committed DB state, not the in-session attr).
     db.expire_all()
     refetched = (
-        await db.execute(select(Lineup).where(Lineup.id == created.id))
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
     ).scalar_one()
     assert refetched.clip_url == "pending/vidX/12-clip.mp4"
 
@@ -50,9 +56,11 @@ async def test_set_clip_url_overwrite_is_idempotent(db: AsyncSession):
     await lineup_repo.set_clip_url(db, created, "pending/v/1-clip.mp4")
     await lineup_repo.set_clip_url(db, created, "pending/v/1-clip.mp4")
 
+    # PK captured before expire_all() — see test_set_clip_url_commits.
+    lineup_id = created.id
     db.expire_all()
     refetched = (
-        await db.execute(select(Lineup).where(Lineup.id == created.id))
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
     ).scalar_one()
     assert refetched.clip_url == "pending/v/1-clip.mp4"
 

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -181,6 +181,8 @@ class TestThrowTimingVerdictAndParser:
         )
         assert result.success is True
         assert result.confidence is None
+        # Surfaced as a structured code, not silently dropped.
+        assert "invalid_confidence:high" in result.error_codes
 
 
 class TestThrowTimingErrorHandling:

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -1,0 +1,273 @@
+"""Unit tests for classify_throw_timing_from_frames (PR2 clip pipeline).
+
+All Anthropic SDK calls are mocked. This is a SEPARATE code path from the
+game/map grid classifier — it takes frames directly (no DB, no reference
+data), so these tests need no database fixtures. Verifies:
+  - happy path: is_lineup_throw True with valid release/result indices
+  - is_lineup_throw False → indices null, still success
+  - parser enforces result_index >= release_index
+  - out-of-range indices nulled (shared _validate_grid_index)
+  - confidence clamped; invalid confidence dropped to None
+  - frame labels carry the load-bearing timestamp (Frame i (t=..s):)
+  - error handling: missing key, no frames, length mismatch, API + parse fail
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.classification.classifier_service import (
+    classify_throw_timing_from_frames,
+)
+
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+
+_PATCH_SETTINGS = "app.services.classification.classifier_service.settings"
+_PATCH_ANTHROPIC = "app.services.classification.classifier_service.anthropic.Anthropic"
+
+
+def _resp(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    block = MagicMock()
+    block.text = json.dumps(payload)
+    resp.content = [block]
+    return resp
+
+
+async def _call(payload_or_exc, *, frames=None, timestamps=None, **kwargs):
+    """Run the classifier with the Anthropic call mocked to a payload/exception."""
+    frames = frames if frames is not None else [_FAKE_PNG] * 6
+    timestamps = (
+        timestamps if timestamps is not None
+        else [10.0, 12.0, 14.0, 16.0, 18.0, 20.0]
+    )
+    with (
+        patch(_PATCH_SETTINGS) as mock_settings,
+        patch(_PATCH_ANTHROPIC) as mock_cls,
+    ):
+        mock_settings.anthropic_api_key = "sk-test"
+        mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        if isinstance(payload_or_exc, BaseException):
+            mock_client.messages.create.side_effect = payload_or_exc
+        else:
+            mock_client.messages.create.return_value = _resp(payload_or_exc)
+        result = await classify_throw_timing_from_frames(
+            frames=frames,
+            frame_timestamps=timestamps,
+            chapter_title=kwargs.get("chapter_title", "B-site smoke"),
+            chapter_duration=kwargs.get("chapter_duration", 30.0),
+            utility_hint=kwargs.get("utility_hint"),
+        )
+    return result, mock_client
+
+
+class TestThrowTimingHappyPath:
+    @pytest.mark.asyncio
+    async def test_valid_release_and_result(self):
+        result, client = await _call(
+            {
+                "is_lineup_throw": True,
+                "release_index": 2,
+                "result_index": 4,
+                "confidence": 0.82,
+                "reasoning": "Smoke leaves hand frame 2, cloud blooms frame 4.",
+            }
+        )
+        assert result.success is True
+        assert result.is_lineup_throw is True
+        assert result.release_index == 2
+        assert result.result_index == 4
+        assert result.confidence == pytest.approx(0.82)
+        assert result.error_codes == []
+
+    @pytest.mark.asyncio
+    async def test_frame_labels_include_timestamp(self):
+        """The timestamp in the frame label is load-bearing (caller maps it)."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 1,
+             "confidence": 0.6, "reasoning": "x"},
+            timestamps=[10.0, 12.5, 14.0, 16.0, 18.0, 20.0],
+        )
+        content = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        texts = [b["text"] for b in content if b["type"] == "text"]
+        assert "Frame 1 (t=10.0s):" in texts
+        assert "Frame 2 (t=12.5s):" in texts
+
+    @pytest.mark.asyncio
+    async def test_utility_hint_passed_as_context(self):
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.7, "reasoning": "x"},
+            utility_hint="molotov",
+        )
+        content = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        joined = "\n".join(b["text"] for b in content if b["type"] == "text")
+        assert "molotov" in joined
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_is_cache_controlled(self):
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 1,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+class TestThrowTimingVerdictAndParser:
+    @pytest.mark.asyncio
+    async def test_not_a_throw_nulls_indices(self):
+        result, _ = await _call(
+            {
+                "is_lineup_throw": False,
+                "release_index": None,
+                "result_index": None,
+                "confidence": 0.02,
+                "reasoning": "Webcam talking-head intro.",
+            }
+        )
+        assert result.success is True
+        assert result.is_lineup_throw is False
+        assert result.release_index is None
+        assert result.result_index is None
+
+    @pytest.mark.asyncio
+    async def test_result_before_release_is_forced_equal(self):
+        """A result cannot precede its own release — parser forces equality."""
+        result, _ = await _call(
+            {
+                "is_lineup_throw": True,
+                "release_index": 5,
+                "result_index": 3,
+                "confidence": 0.7,
+                "reasoning": "x",
+            }
+        )
+        assert result.release_index == 5
+        assert result.result_index == 5
+
+    @pytest.mark.asyncio
+    async def test_out_of_range_indices_nulled(self):
+        result, _ = await _call(
+            {
+                "is_lineup_throw": True,
+                "release_index": 99,   # n=6 → out of range
+                "result_index": 0,     # < 1 → out of range
+                "confidence": 0.7,
+                "reasoning": "x",
+            }
+        )
+        assert result.success is True
+        assert result.release_index is None
+        assert result.result_index is None
+
+    @pytest.mark.asyncio
+    async def test_confidence_clamped(self):
+        result, _ = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 1.7, "reasoning": "x"},
+        )
+        assert result.confidence == pytest.approx(1.0)
+
+    @pytest.mark.asyncio
+    async def test_invalid_confidence_dropped_to_none(self):
+        result, _ = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": "high", "reasoning": "x"},
+        )
+        assert result.success is True
+        assert result.confidence is None
+
+
+class TestThrowTimingErrorHandling:
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self):
+        with patch(_PATCH_SETTINGS) as mock_settings:
+            mock_settings.anthropic_api_key = ""
+            result = await classify_throw_timing_from_frames(
+                frames=[_FAKE_PNG],
+                frame_timestamps=[1.0],
+                chapter_title="x",
+                chapter_duration=10.0,
+            )
+        assert result.success is False
+        assert result.error_codes == ["missing_api_key"]
+
+    @pytest.mark.asyncio
+    async def test_no_frames(self):
+        with patch(_PATCH_SETTINGS) as mock_settings:
+            mock_settings.anthropic_api_key = "sk-test"
+            result = await classify_throw_timing_from_frames(
+                frames=[],
+                frame_timestamps=[],
+                chapter_title="x",
+                chapter_duration=10.0,
+            )
+        assert result.success is False
+        assert result.error_codes == ["no_frames"]
+
+    @pytest.mark.asyncio
+    async def test_frame_timestamp_length_mismatch(self):
+        """A misaligned frame/timestamp pair would silently corrupt clip
+        bounds — must fail loud, not best-effort."""
+        with patch(_PATCH_SETTINGS) as mock_settings:
+            mock_settings.anthropic_api_key = "sk-test"
+            result = await classify_throw_timing_from_frames(
+                frames=[_FAKE_PNG, _FAKE_PNG],
+                frame_timestamps=[1.0],
+                chapter_title="x",
+                chapter_duration=10.0,
+            )
+        assert result.success is False
+        assert result.error_codes == ["frame_timestamp_mismatch"]
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error(self):
+        import anthropic as anthropic_lib
+
+        exc = anthropic_lib.RateLimitError.__new__(anthropic_lib.RateLimitError)
+        exc.type = "rate_limit_error"
+        exc.args = ("rate limited",)
+        result, _ = await _call(exc)
+        assert result.success is False
+        assert any("rate_limit" in c for c in result.error_codes)
+
+    @pytest.mark.asyncio
+    async def test_api_status_error(self):
+        import anthropic as anthropic_lib
+
+        exc = anthropic_lib.APIStatusError.__new__(anthropic_lib.APIStatusError)
+        exc.status_code = 529
+        exc.type = "overloaded_error"
+        exc.args = ("overloaded",)
+        result, _ = await _call(exc)
+        assert result.success is False
+        assert result.error_codes  # populated
+
+    @pytest.mark.asyncio
+    async def test_json_parse_failure(self):
+        bad = MagicMock()
+        block = MagicMock()
+        block.text = "not json at all {"
+        bad.content = [block]
+        with (
+            patch(_PATCH_SETTINGS) as mock_settings,
+            patch(_PATCH_ANTHROPIC) as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "haiku"
+            client = MagicMock()
+            mock_cls.return_value = client
+            client.messages.create.return_value = bad
+            result = await classify_throw_timing_from_frames(
+                frames=[_FAKE_PNG],
+                frame_timestamps=[1.0],
+                chapter_title="x",
+                chapter_duration=10.0,
+            )
+        assert result.success is False
+        assert result.error_codes == ["json_parse_error"]

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * GlanceBoardTile unit tests (PR2 clip view).
+ *
+ * jsdom implements neither IntersectionObserver nor HTMLMediaElement
+ * play/pause, so both are stubbed here (not globally — keeps blast radius
+ * to this file).
+ *
+ * Tests:
+ * - clip_url present → <video> rendered (poster=stand), stills NOT rendered
+ * - clip_url null → falls back to the STAND/AIM stills, no <video>
+ * - src is lazy: absent until the tile scrolls into view
+ * - in view → play() called + src attached; out of view → pause() called
+ * - IntersectionObserver missing → arms immediately (graceful degrade)
+ */
+import { render, screen, act } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import GlanceBoardTile from "@/components/lineup/GlanceBoardTile";
+import type { Lineup } from "@/types/game";
+
+function makeLineup(over: Partial<Lineup> = {}): Lineup {
+  return {
+    id: "l1",
+    game_id: "g1",
+    map_id: "m1",
+    target_zone_id: "z1",
+    stand_zone_id: "z2",
+    side: "side_a",
+    utility_type_id: "u1",
+    title: "B-site smoke from T spawn",
+    notes: null,
+    stand_screenshot_url: "https://ex.com/stand.png",
+    aim_screenshot_url: "https://ex.com/aim.png",
+    clip_url: null,
+    aim_anchor_x: 0.5,
+    aim_anchor_y: 0.4,
+    stand_anchor_x: null,
+    stand_anchor_y: null,
+    target_anchor_x: null,
+    target_anchor_y: null,
+    effective_stand_x: null,
+    effective_stand_y: null,
+    effective_target_x: null,
+    effective_target_y: null,
+    setup_seconds: 7,
+    attribution_url: null,
+    attribution_author: null,
+    status: "accepted",
+    youtube_video_id: "vid1",
+    chapter_start_seconds: 12,
+    chapter_title: "B smoke",
+    suggested_game_id: null,
+    suggested_map_id: null,
+    suggested_target_zone_id: null,
+    suggested_stand_zone_id: null,
+    suggested_side: null,
+    suggested_utility_type_id: null,
+    classification_confidence: null,
+    classification_reasoning: null,
+    target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
+    stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke" },
+    ...over,
+  };
+}
+
+// --- IntersectionObserver capture --------------------------------------
+type IOCb = (entries: { isIntersecting: boolean }[]) => void;
+let lastIO: { cb: IOCb; observe: ReturnType<typeof vi.fn>; disconnect: ReturnType<typeof vi.fn> } | null;
+
+class FakeIO {
+  cb: IOCb;
+  observe = vi.fn();
+  disconnect = vi.fn();
+  constructor(cb: IOCb) {
+    this.cb = cb;
+    lastIO = this;
+  }
+  takeRecords() {
+    return [];
+  }
+  unobserve = vi.fn();
+}
+
+let playSpy: ReturnType<typeof vi.spyOn>;
+let pauseSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  lastIO = null;
+  vi.stubGlobal("IntersectionObserver", FakeIO as unknown as typeof IntersectionObserver);
+  // jsdom doesn't implement play/pause — spy + no-op so the component's
+  // best-effort calls don't throw.
+  playSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, "play")
+    .mockResolvedValue(undefined);
+  pauseSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, "pause")
+    .mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("GlanceBoardTile clip view", () => {
+  it("renders the stills fallback when clip_url is null", () => {
+    render(<GlanceBoardTile lineup={makeLineup({ clip_url: null })} />);
+    expect(screen.getByText("STAND")).toBeInTheDocument();
+    expect(screen.getByText("AIM")).toBeInTheDocument();
+    expect(document.querySelector("video")).toBeNull();
+  });
+
+  it("renders a <video> (poster=stand) and hides the stills when clip_url is set", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ clip_url: "https://ex.com/clip.mp4" })}
+      />,
+    );
+    const video = document.querySelector("video") as HTMLVideoElement;
+    expect(video).not.toBeNull();
+    expect(video.getAttribute("poster")).toBe("https://ex.com/stand.png");
+    expect(video.muted).toBe(true);
+    expect(video.hasAttribute("loop")).toBe(true);
+    expect(video.hasAttribute("playsinline")).toBe(true);
+    // The split stills are not used when a clip exists.
+    expect(screen.queryByText("STAND")).not.toBeInTheDocument();
+    expect(screen.queryByText("AIM")).not.toBeInTheDocument();
+  });
+
+  it("lazily attaches src only after the tile scrolls into view", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ clip_url: "https://ex.com/clip.mp4" })}
+      />,
+    );
+    const video = document.querySelector("video") as HTMLVideoElement;
+    // Before any intersection: no src fetched.
+    expect(video.getAttribute("src")).toBeNull();
+
+    act(() => lastIO!.cb([{ isIntersecting: true }]));
+
+    expect(video.getAttribute("src")).toBe("https://ex.com/clip.mp4");
+    expect(playSpy).toHaveBeenCalled();
+  });
+
+  it("pauses when the tile leaves the viewport", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ clip_url: "https://ex.com/clip.mp4" })}
+      />,
+    );
+    act(() => lastIO!.cb([{ isIntersecting: true }]));
+    act(() => lastIO!.cb([{ isIntersecting: false }]));
+    expect(pauseSpy).toHaveBeenCalled();
+  });
+
+  it("arms immediately when IntersectionObserver is unavailable", () => {
+    vi.stubGlobal("IntersectionObserver", undefined);
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ clip_url: "https://ex.com/clip.mp4" })}
+      />,
+    );
+    const video = document.querySelector("video") as HTMLVideoElement;
+    expect(video.getAttribute("src")).toBe("https://ex.com/clip.mp4");
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -134,12 +134,15 @@ describe("GlanceBoardTile clip view", () => {
       />,
     );
     const video = document.querySelector("video") as HTMLVideoElement;
-    // Before any intersection: no src fetched.
-    expect(video.getAttribute("src")).toBeNull();
+    // Before any intersection: the attribute is absent (not src="").
+    expect(video.hasAttribute("src")).toBe(false);
+    expect(video.getAttribute("preload")).toBe("metadata");
 
+    expect(lastIO).not.toBeNull();
     act(() => lastIO!.cb([{ isIntersecting: true }]));
 
     expect(video.getAttribute("src")).toBe("https://ex.com/clip.mp4");
+    expect(video.getAttribute("preload")).toBe("auto");
     expect(playSpy).toHaveBeenCalled();
   });
 
@@ -149,9 +152,22 @@ describe("GlanceBoardTile clip view", () => {
         lineup={makeLineup({ clip_url: "https://ex.com/clip.mp4" })}
       />,
     );
+    expect(lastIO).not.toBeNull();
     act(() => lastIO!.cb([{ isIntersecting: true }]));
     act(() => lastIO!.cb([{ isIntersecting: false }]));
     expect(pauseSpy).toHaveBeenCalled();
+  });
+
+  it("hides the Clip badge when the clip fails to load", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ clip_url: "https://ex.com/gone.mp4" })}
+      />,
+    );
+    expect(screen.getByText("Clip")).toBeInTheDocument();
+    const video = document.querySelector("video") as HTMLVideoElement;
+    act(() => video.dispatchEvent(new Event("error")));
+    expect(screen.queryByText("Clip")).not.toBeInTheDocument();
   });
 
   it("arms immediately when IntersectionObserver is unavailable", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -28,6 +28,7 @@ const BASE_LINEUP: Lineup = {
   notes: "Stand on the crate",
   stand_screenshot_url: "https://example.com/stand.png",
   aim_screenshot_url: "https://example.com/aim.png",
+  clip_url: null,
   aim_anchor_x: 0.5,
   aim_anchor_y: 0.4,
   stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
@@ -26,6 +26,7 @@ function makeLineup(id: string): Lineup {
     notes: null,
     stand_screenshot_url: null,
     aim_screenshot_url: null,
+    clip_url: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
@@ -25,6 +25,7 @@ function makeLineup(overrides: Partial<Lineup>): Lineup {
     notes: null,
     stand_screenshot_url: null,
     aim_screenshot_url: null,
+    clip_url: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/MinimapPinEditor.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MinimapPinEditor.test.tsx
@@ -37,6 +37,7 @@ function makeLineup(overrides: Partial<Lineup> = {}): Lineup {
     notes: null,
     stand_screenshot_url: null,
     aim_screenshot_url: null,
+    clip_url: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
@@ -78,6 +78,7 @@ function makeUnclassifiedLineup(overrides: Partial<Lineup> = {}): Lineup {
     notes: null,
     stand_screenshot_url: null,
     aim_screenshot_url: null,
+    clip_url: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
@@ -26,6 +26,7 @@ function makeLineup(overrides: Partial<Lineup>): Lineup {
     notes: null,
     stand_screenshot_url: null,
     aim_screenshot_url: null,
+    clip_url: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -18,6 +18,7 @@
  * The footer is a PR2 placeholder — structure reserved, content muted.
  * notes are NOT displayed inline; they live in a title= tooltip.
  */
+import { useEffect, useRef, useState } from "react";
 import { Clock } from "lucide-react";
 import type { Lineup } from "@/types/game";
 import { utilDisplay } from "@/constants/utilityDisplay";
@@ -105,6 +106,87 @@ function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Clip view (PR2) — gif-style looping throw clip, in-view autoplay
+//
+// A lineup is a *motion*; two stills structurally cannot show it. When a clip
+// exists it replaces the stand/aim split with a single muted looping video.
+// Only clips scrolled into view play (a glance board can hold dozens — letting
+// them all decode at once tanks the second-monitor frame rate). The src is
+// lazily attached on first view so off-screen clips never fetch.
+// ---------------------------------------------------------------------------
+interface ClipViewProps {
+  clipUrl: string;
+  posterUrl: string | null;
+  title: string;
+}
+
+function ClipView({ clipUrl, posterUrl, title }: ClipViewProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  // Sticky: once the tile has been seen, keep the src attached (re-fetching
+  // on every scroll-by would be worse than keeping a paused decoded clip).
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) return;
+
+    // Degrade gracefully where IntersectionObserver is unavailable (old
+    // webviews / jsdom): arm immediately and let muted autoplay handle it.
+    if (typeof IntersectionObserver === "undefined") {
+      setArmed(true);
+      return;
+    }
+
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        if (entry.isIntersecting) {
+          setArmed(true);
+          // play() can reject (autoplay policy / src not yet ready) — the
+          // muted+autoPlay attributes will start it once loaded, so the
+          // rejection is safe to swallow.
+          void el.play().catch(() => {});
+        } else {
+          el.pause();
+          // Reset so re-entering the viewport replays from the throw start
+          // (gif behaviour). Seeking before metadata loads throws — guard it.
+          try {
+            el.currentTime = 0;
+          } catch {
+            /* not seekable yet — fine, it'll start at 0 anyway */
+          }
+        }
+      },
+      { threshold: 0.25 },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  return (
+    <div className="relative bg-muted/20 aspect-video overflow-hidden">
+      <video
+        ref={videoRef}
+        // Lazy: no src until the tile has been in view at least once.
+        src={armed ? clipUrl : undefined}
+        poster={posterUrl ?? undefined}
+        muted
+        loop
+        autoPlay
+        playsInline
+        preload="metadata"
+        aria-label={`${title} — looping throw clip (muted)`}
+        className="absolute inset-0 w-full h-full object-cover"
+      />
+      <span className="absolute top-1.5 left-2 text-[10px] font-semibold tracking-wider text-white/80 bg-black/40 px-1.5 py-0.5 rounded uppercase select-none pointer-events-none">
+        Clip
+      </span>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // GlanceBoardTile
 // ---------------------------------------------------------------------------
 export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
@@ -136,25 +218,33 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
         </div>
       </div>
 
-      {/* ── Images (side-by-side, 16:9 each) ──────────────────────────── */}
-      <div className="flex divide-x divide-border">
-        <ScreenshotHalf
-          url={lineup.stand_screenshot_url}
-          alt={`${lineup.title} — stand position`}
-          label="STAND"
+      {/* ── Clip (PR2) if localised, else the stand/aim stills ────────── */}
+      {lineup.clip_url ? (
+        <ClipView
+          clipUrl={lineup.clip_url}
+          posterUrl={lineup.stand_screenshot_url}
+          title={lineup.title}
         />
-        <ScreenshotHalf
-          url={lineup.aim_screenshot_url}
-          alt={`${lineup.title} — aim reference`}
-          label="AIM"
-        >
-          {lineup.aim_screenshot_url &&
-            lineup.aim_anchor_x != null &&
-            lineup.aim_anchor_y != null && (
-              <AimAnchorDot x={lineup.aim_anchor_x} y={lineup.aim_anchor_y} />
-            )}
-        </ScreenshotHalf>
-      </div>
+      ) : (
+        <div className="flex divide-x divide-border">
+          <ScreenshotHalf
+            url={lineup.stand_screenshot_url}
+            alt={`${lineup.title} — stand position`}
+            label="STAND"
+          />
+          <ScreenshotHalf
+            url={lineup.aim_screenshot_url}
+            alt={`${lineup.title} — aim reference`}
+            label="AIM"
+          >
+            {lineup.aim_screenshot_url &&
+              lineup.aim_anchor_x != null &&
+              lineup.aim_anchor_y != null && (
+                <AimAnchorDot x={lineup.aim_anchor_x} y={lineup.aim_anchor_y} />
+              )}
+          </ScreenshotHalf>
+        </div>
+      )}
 
       {/* ── Footer — PR2 throw-technique placeholder ───────────────────── */}
       {/* PR2: throw-technique fields (throw type / mouse button / movement) land here */}

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -122,40 +122,42 @@ interface ClipViewProps {
 
 function ClipView({ clipUrl, posterUrl, title }: ClipViewProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  // Sticky: once the tile has been seen, keep the src attached (re-fetching
-  // on every scroll-by would be worse than keeping a paused decoded clip).
+  // Sticky once the tile has been seen: keep the src attached (re-fetching on
+  // every scroll-by is worse than keeping a paused decoded clip).
   const [armed, setArmed] = useState(false);
+  // True while the tile is on screen — drives play/pause in a separate effect
+  // so play() never runs before React has committed the src to the DOM.
+  const [inView, setInView] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
 
+  // A new clipUrl (re-processed clip / rotated presigned URL) is a different
+  // clip — restart the lazy-load + error cycle.
+  useEffect(() => {
+    setArmed(false);
+    setLoadFailed(false);
+  }, [clipUrl]);
+
+  // Observer lifecycle ONLY. disconnect() (not unobserve) is the correct
+  // teardown — it covers React Strict Mode's mount→unmount→remount.
   useEffect(() => {
     const el = videoRef.current;
     if (!el) return;
-
-    // Degrade gracefully where IntersectionObserver is unavailable (old
-    // webviews / jsdom): arm immediately and let muted autoplay handle it.
+    // Degrade where IntersectionObserver is absent (old webviews / jsdom):
+    // arm + treat as in view, let muted autoplay carry it.
     if (typeof IntersectionObserver === "undefined") {
       setArmed(true);
+      setInView(true);
       return;
     }
-
     const obs = new IntersectionObserver(
       (entries) => {
         const entry = entries[0];
         if (!entry) return;
         if (entry.isIntersecting) {
           setArmed(true);
-          // play() can reject (autoplay policy / src not yet ready) — the
-          // muted+autoPlay attributes will start it once loaded, so the
-          // rejection is safe to swallow.
-          void el.play().catch(() => {});
+          setInView(true);
         } else {
-          el.pause();
-          // Reset so re-entering the viewport replays from the throw start
-          // (gif behaviour). Seeking before metadata loads throws — guard it.
-          try {
-            el.currentTime = 0;
-          } catch {
-            /* not seekable yet — fine, it'll start at 0 anyway */
-          }
+          setInView(false);
         }
       },
       { threshold: 0.25 },
@@ -163,6 +165,27 @@ function ClipView({ clipUrl, posterUrl, title }: ClipViewProps) {
     obs.observe(el);
     return () => obs.disconnect();
   }, []);
+
+  // Play/pause AFTER src is committed (depends on armed+inView). autoPlay
+  // only fires on initial load, not on src reassignment, so re-entry needs
+  // an explicit play().
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el || !armed) return;
+    if (inView) {
+      // Rejects under autoplay policy / before the src is ready — muted
+      // autoplay will start it once loaded, so swallow the rejection.
+      void el.play().catch(() => {});
+    } else {
+      el.pause();
+      // Rewind so re-entry replays from the throw start (gif behaviour).
+      // seekable is empty for not-yet-loaded / non-seekable streams — an
+      // explicit check, not a silent try/catch (rules/no-bandaid).
+      if (el.seekable.length > 0) {
+        el.currentTime = 0;
+      }
+    }
+  }, [armed, inView]);
 
   return (
     <div className="relative bg-muted/20 aspect-video overflow-hidden">
@@ -175,13 +198,21 @@ function ClipView({ clipUrl, posterUrl, title }: ClipViewProps) {
         loop
         autoPlay
         playsInline
-        preload="metadata"
+        // Pre-view: metadata only. In view: allow buffering so the loop
+        // doesn't stall on first frame.
+        preload={armed ? "auto" : "metadata"}
         aria-label={`${title} — looping throw clip (muted)`}
+        onError={() => setLoadFailed(true)}
         className="absolute inset-0 w-full h-full object-cover"
       />
-      <span className="absolute top-1.5 left-2 text-[10px] font-semibold tracking-wider text-white/80 bg-black/40 px-1.5 py-0.5 rounded uppercase select-none pointer-events-none">
-        Clip
-      </span>
+      {/* Hide the "Clip" affordance when the clip fails to load (e.g. an
+          expired presigned URL mid-session) — the poster (stand still)
+          stays as the graceful fallback rather than a misleading badge. */}
+      {!loadFailed && (
+        <span className="absolute top-1.5 left-2 text-[10px] font-semibold tracking-wider text-white/80 bg-black/40 px-1.5 py-0.5 rounded uppercase select-none pointer-events-none">
+          Clip
+        </span>
+      )}
     </div>
   );
 }

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -103,6 +103,10 @@ export interface Lineup {
   notes: string | null;
   stand_screenshot_url: string | null;
   aim_screenshot_url: string | null;
+  // PR2: presigned URL of the short looping throw clip (gif-style). Null when
+  // the throw could not be localised or the lineup predates the clip
+  // pipeline — the tile then falls back to the stand/aim stills.
+  clip_url: string | null;
   aim_anchor_x: number | null;
   aim_anchor_y: number | null;
   // Explicit minimap coords; fall back to zone-polygon centroid via effective_*.


### PR DESCRIPTION
## PR2 — Looping throw-clip pipeline (MGA)

Two stills (stand + aim) structurally cannot represent a lineup — a lineup is a *motion*. This adds a gif-style looping clip of the actual throw, generated by localising the release/result within the source chapter, and renders it on the glance board with in-view autoplay. Builds on PR1 (#700, the glance-board layout).

Operator-locked: gif-style autoplay, clips-first (throw-technique text is PR3), `/effort max`. Implemented to the frozen design contract.

### What ships

**T2 (schema, pre-existing on branch — 3040cb3):** `clip_url` column + `LineupRead` + `_build_read` presign + Alembic `0010_lineup_clip_url`.

**T3 — clip service**
- `frame_extractor`: `extract_frames_downscaled` (640x360 — keeps the N=12 dense window ≈ the old N=5 full-res token cost; full-res `extract_frames` untouched, aim-anchor still needs pixels), `clip_window_timestamps` (skip-trims the walk-in/talk lead-in: 30/15% skip, N=12/8, 120s cap for long chapters), `cut_clip` + `ClipCutError` (muted H.264 `yuv420p` `+faststart` — browser-playable; input-seek; temp-file read-back).
- `classify_throw_timing_from_frames`: a **separate** Claude code path (own prompt + schema, no slug/DB), cache-controlled system prompt; parser enforces `result_index >= release_index`.
- `clip_generator.generate_clip_for_lineup`: gate (`not-a-throw` / `confidence < 0.55` / no release frame), throw-centric ~6s clip math `[release-2, result+0.5]` clamped to the chapter with a ~6s rebuild, reuse the ingest video vs re-fetch+cleanup for backfill. Structured `generated`/`skipped`/`failed` outcome — yt-dlp/ffmpeg/Claude failures captured with codes + WARNING-logged; never silent-fails; a clip failure never rolls back the committed lineup (stills remain valid).
- `lineup_repo.set_clip_url`: its own one-column commit (txn ownership in the repo, per #687/#695).

**T4 — wiring + backfill**
- Ingest: best-effort clip after the row + suggestions commit, reusing the on-disk video (never re-download per chapter); non-fatal.
- `python -m app.cli backfill-clips`: idempotent (work set = accepted + `youtube_video_id` set + `clip_url` NULL), one fetch+download per video, structured tally.

**T5 — frontend**
- `Lineup.clip_url` TS type (+ 6 fixtures). `GlanceBoardTile` renders a muted looping `<video>` (poster = stand still) when a clip exists, else the existing stand/aim stills + aim dot. 3-effect `ClipView`: IntersectionObserver lifecycle, play/pause after src commit (only in-view tiles play — a board holds dozens), lazy src, rewind off-screen, graceful degrade where IO is absent, `onError` hides the badge on an expired URL. Reserved technique footer untouched (PR3).

**T6** — applied g-review-backend + g-review-frontend findings (commit `d5bcfdb`); see that commit for the full list and the declined items with rationale (WCAG pause-control vs. the locked gif-style/casual-app posture; ClipView file-split vs. MGA's log-only tech-debt policy; pre-existing patterns out of PR2 scope).

### Tests
70 backend mock tests + 293 frontend tests pass locally; typecheck + production build green. DB-backed tests (`test_lineup_clip_url_repo.py`, the 3 new `test_ingestion_with_classifier.py` cases) run in CI on the fresh migrated `test` Postgres — the local `mygamingassistant` role lacks CREATEDB and the shared dev DB belongs to a concurrent session.

## ⚠️ Operational migration required

This PR ships Alembic migration **`0010_lineup_clip_url`** (additive, nullable — existing rows default NULL; deploy runs `alembic upgrade head`, no manual step for the schema).

After deploy, to populate clips for lineups that predate the pipeline, the operator runs **once** on the VPS:

```bash
docker compose -f apps/mygamingassistant/docker-compose.yml exec api \
  python -m app.cli backfill-clips
```

- Idempotent and re-runnable — only `accepted` lineups with a `youtube_video_id` and no `clip_url` are touched; a generated clip drops out of the set, transient failures retry on the next run.
- Not required for the app to function — new ingests get clips automatically; without the backfill, pre-existing lineups simply keep showing their stand/aim stills (the always-valid fallback).
- Re-fetches source videos via yt-dlp + runs Claude (one cheap haiku call per chapter) + ffmpeg — run it when convenient, not in the deploy critical path.

No env-var changes. `ENABLE_CLASSIFIER=false` (CI/local default) makes clip generation a no-op skip (the stills path is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
