### PR TITLE
fix(mbk): surface backend error detail in admin Demo toast

### DIFF
--- a/apps/mybookkeeper/frontend/src/__tests__/Demo.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/Demo.test.tsx
@@ -1,10 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { Provider } from "react-redux";
 import { BrowserRouter } from "react-router-dom";
 import { store } from "@/shared/store";
 import Demo from "@/admin/pages/Demo";
 import type { DemoUser } from "@/shared/types/demo/demo-user";
+
+const mockShowError = vi.fn();
+const mockShowSuccess = vi.fn();
 
 const mockUsers: DemoUser[] = [
   {
@@ -70,9 +73,24 @@ vi.mock("@/shared/store/demoApi", () => ({
 
 vi.mock("@/shared/hooks/useToast", () => ({
   useToast: () => ({
-    showSuccess: vi.fn(),
-    showError: vi.fn(),
+    showSuccess: mockShowSuccess,
+    showError: mockShowError,
   }),
+}));
+
+vi.mock("@/admin/features/demo/CreateDemoDialog", () => ({
+  default: ({
+    open,
+    onSubmit,
+  }: {
+    open: boolean;
+    onSubmit: (tag: string, email?: string) => void;
+  }) =>
+    open ? (
+      <button data-testid="mock-create-submit" onClick={() => onSubmit("regression")}>
+        submit
+      </button>
+    ) : null,
 }));
 
 import { useListDemoUsersQuery } from "@/shared/store/demoApi";
@@ -155,5 +173,28 @@ describe("Demo Admin Page", () => {
 
     renderWithProviders(<Demo />);
     expect(screen.getByText("1 demo user")).toBeInTheDocument();
+  });
+
+  it("surfaces the backend error detail when create fails", async () => {
+    mockCreateTagged.mockImplementationOnce(
+      () =>
+        ({
+          unwrap: () =>
+            Promise.reject({
+              status: 500,
+              data: { detail: "channel column is missing in demo fixtures" },
+            }),
+        }) as unknown as ReturnType<typeof mockCreateTagged>,
+    );
+
+    renderWithProviders(<Demo />);
+    fireEvent.click(screen.getByText("Create Demo User"));
+    fireEvent.click(screen.getByTestId("mock-create-submit"));
+
+    await waitFor(() => {
+      expect(mockShowError).toHaveBeenCalledWith(
+        expect.stringContaining("channel column is missing in demo fixtures"),
+      );
+    });
   });
 });

--- a/apps/mybookkeeper/frontend/src/admin/pages/Demo.tsx
+++ b/apps/mybookkeeper/frontend/src/admin/pages/Demo.tsx
@@ -14,6 +14,7 @@ import DemoUserTable from "@/admin/features/demo/DemoUserTable";
 import CreateDemoDialog from "@/admin/features/demo/CreateDemoDialog";
 import CredentialsModal from "@/admin/features/demo/CredentialsModal";
 import DemoPageSkeleton from "@/admin/features/demo/DemoPageSkeleton";
+import { extractErrorMessage } from "@/shared/utils/errorMessage";
 
 interface Credentials {
   email: string;
@@ -57,8 +58,8 @@ export default function Demo() {
       } else {
         showSuccess("Demo user created! Credentials shown below");
       }
-    } catch {
-      showError("Failed to create demo user");
+    } catch (err) {
+      showError(`Failed to create demo user: ${extractErrorMessage(err)}`);
     }
   }
 
@@ -69,8 +70,8 @@ export default function Demo() {
       try {
         const result = await deleteUser(confirmAction.userId).unwrap();
         showSuccess(result.message);
-      } catch {
-        showError("Failed to delete demo user");
+      } catch (err) {
+        showError(`Failed to delete demo user: ${extractErrorMessage(err)}`);
       }
     } else {
       try {
@@ -78,8 +79,8 @@ export default function Demo() {
         setCredentials({ email: result.email, password: result.password });
         resetResetCache();
         showSuccess(result.message);
-      } catch {
-        showError("Failed to reset demo user");
+      } catch (err) {
+        showError(`Failed to reset demo user: ${extractErrorMessage(err)}`);
       }
     }
 


### PR DESCRIPTION
## Why

Operator reported: clicking **Create Demo User** on the admin Demo page produces only a generic `Failed to create demo user` toast — no clue whether it's the strict-superuser step-up gate (#555), schema drift in the demo seed fixtures after the recent attribution PRs (#697–#703), a duplicate tag, or something else.

Sentry shows zero exceptions on `POST /admin/demo/create` in the last 14 days (`mybookkeeper-api`), which is consistent with the failure being a 4xx (e.g. step-up rejection) that doesn't reach Sentry — or the noise filter dropping it. Either way, the operator currently has no diagnostic.

## What this PR does

Replace three bare `catch { showError("Failed to ...") }` blocks in `Demo.tsx` with handlers that pipe the FastAPI `detail` through the shared `extractErrorMessage` helper (`shared/utils/errorMessage.ts`). All three demo actions (create, delete, reset) now surface the real reason.

This is intentionally PR 1 of 2. PR 2 (demo seed fixture drift fix) is gated on the next reproduction reading the actual error string this PR exposes.

## Test plan

- [x] Vitest: 8/8 in `Demo.test.tsx` including new `surfaces the backend error detail when create fails`
- [ ] After merge: operator re-clicks Create Demo User on prod, screenshots the new toast — that string identifies the root cause for PR 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)