### PR TITLE
feat(mga): throw-technique footer on glance board (PR3)

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0011_lineup_technique.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0011_lineup_technique.py
@@ -1,0 +1,40 @@
+"""Add technique to lineup
+
+Revision ID: 0011
+Revises: 0010
+Create Date: 2026-05-18 00:00:03.000000
+
+Adds a nullable ``technique`` column to the ``lineup`` table — the compact
+throw-mechanic phrase ("Jumpthrow + LMB", "E + 2-charge + 1-bounce") rendered
+in the glance-board tile footer (PR3).
+
+Open-vocabulary display text, NOT a closed enum, so NO CheckConstraint — same
+posture as ``notes`` and ``chapter_title``. Deliberately NOT included in
+``ck_lineup_accepted_classified``: manual uploads have no source video and are
+accepted with ``technique`` NULL, so a constraint would be unsatisfiable.
+
+Additive: all existing rows default to NULL. No backfill in the migration —
+the operator runs ``python -m app.cli backfill-technique`` once post-deploy to
+populate accepted ingested lineups (idempotent; see the PR's operational
+migration note). The app is fully functional without the backfill — new
+ingests auto-populate and old rows simply show no technique footer.
+
+Downgrade: drops the column unconditionally. Data loss is expected and
+acceptable on rollback.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0011"
+down_revision = "0010"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("lineup", sa.Column("technique", sa.String(length=80), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("lineup", "technique")

--- a/apps/mygamingassistant/backend/app/cli/__init__.py
+++ b/apps/mygamingassistant/backend/app/cli/__init__.py
@@ -3,6 +3,7 @@
 Usage:
     python -m app.cli load-fixtures
     python -m app.cli backfill-clips
+    python -m app.cli backfill-technique
 """
 import asyncio
 import sys
@@ -30,6 +31,29 @@ async def _run_backfill_clips() -> int:
     return 1 if stats.failed else 0
 
 
+async def _run_backfill_technique() -> int:
+    """Name throw-technique for accepted lineups missing one. Exit code.
+
+    Idempotent — safe to re-run; only lineups with ``technique IS NULL`` are
+    touched. Independent of ``backfill-clips`` (separate NULL column). A
+    non-zero exit signals at least one hard failure so the operator notices
+    (re-running retries them — they are not fatal).
+    """
+    from app.db.session import AsyncSessionLocal
+    from app.services.ingestion.technique_backfill import backfill_technique
+
+    async with AsyncSessionLocal() as db:
+        stats = await backfill_technique(db)
+
+    print(stats.summary())
+    if stats.errors:
+        print(f"  {len(stats.errors)} issue(s):")
+        for err in stats.errors:
+            print(f"   - {err}")
+    # Re-runnable: failures retry next run, so a non-zero exit is advisory.
+    return 1 if stats.failed else 0
+
+
 def main() -> None:
     command = sys.argv[1] if len(sys.argv) > 1 else ""
 
@@ -39,11 +63,14 @@ def main() -> None:
         print("Fixtures loaded successfully.")
     elif command == "backfill-clips":
         sys.exit(asyncio.run(_run_backfill_clips()))
+    elif command == "backfill-technique":
+        sys.exit(asyncio.run(_run_backfill_technique()))
     else:
         print(f"Unknown command: {command!r}")
         print("Available commands:")
-        print("  load-fixtures   — load game taxonomy fixtures into the database")
-        print("  backfill-clips  — generate clips for accepted lineups missing one")
+        print("  load-fixtures      — load game taxonomy fixtures into the database")
+        print("  backfill-clips     — generate clips for accepted lineups missing one")
+        print("  backfill-technique — name throw-technique for accepted lineups missing one")
         sys.exit(1)
 
 

--- a/apps/mygamingassistant/backend/app/models/game/lineup.py
+++ b/apps/mygamingassistant/backend/app/models/game/lineup.py
@@ -126,6 +126,15 @@ class Lineup(Base):
     # How many seconds the throw takes to execute
     setup_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)
 
+    # Compact throw-technique phrase ("Jumpthrow + LMB", "E + 2-charge +
+    # 1-bounce") from the PR3 throw-technique Claude call — glance-board footer
+    # display only. Open-vocabulary display text, NOT a closed enum, so no
+    # CheckConstraint (same posture as notes / chapter_title). NULL for manual
+    # uploads (no source video — hard input-modality limit), lineups predating
+    # PR3, or when the call could not determine it at >=0.55 confidence. NOT in
+    # ck_lineup_accepted_classified: manual uploads accept with technique NULL.
+    technique: Mapped[str | None] = mapped_column(String(80), nullable=True)
+
     # YouTube ingestion metadata
     youtube_video_id: Mapped[str | None] = mapped_column(String(20), nullable=True)
     chapter_start_seconds: Mapped[int | None] = mapped_column(Integer, nullable=True)

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -351,6 +351,66 @@ async def set_clip_url(
     return lineup
 
 
+async def list_accepted_lineups_needing_technique(
+    db: AsyncSession,
+) -> list[Lineup]:
+    """Accepted, ingested lineups that don't have a technique yet.
+
+    The PR3 backfill set: ``status='accepted'`` AND a source video to
+    re-fetch (``youtube_video_id`` not null — this clause is *input-modality*
+    gating, not an incidental filter: manual uploads have no source frames so
+    technique is never extractable for them) AND no technique yet
+    (``technique`` null). Filtering on null ``technique`` is exactly what
+    makes the backfill idempotent — a populated technique drops out of this
+    set, so re-running only touches the remainder. Ordered oldest-first so a
+    long backfill makes visible monotonic progress.
+
+    Mirrors :func:`list_accepted_lineups_needing_clips` (PR2) — the two
+    backfills are independent (separate operator commands, separate NULL
+    columns) and intentionally not coupled.
+    """
+    stmt = (
+        select(Lineup)
+        .where(
+            Lineup.status == "accepted",
+            Lineup.youtube_video_id.is_not(None),
+            Lineup.technique.is_(None),
+        )
+        .order_by(Lineup.created_at.asc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def set_technique(
+    db: AsyncSession,
+    lineup: Lineup,
+    technique: str | None,
+) -> Lineup:
+    """Persist the throw-technique phrase onto a lineup row.
+
+    Its own one-column commit (not folded into the classifier writeback or
+    the clip commit) on purpose — identical rationale to
+    :func:`set_clip_url`: technique is best-effort and orthogonal to the
+    row's validity (a lineup is fully usable from its stills/clip with no
+    technique). A technique failure must NEVER roll back the already-committed
+    lineup, classifier suggestions, or clip; a successful technique must NOT
+    wait on anything else. So the technique pipeline commits exactly this one
+    column on its own.
+
+    Transaction ownership lives here in the repo per PR #687/#695 — the
+    ingestion orchestrator and the backfill CLI never call db.commit().
+    """
+    lineup.technique = technique
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
 async def zone_density(
     db: AsyncSession,
     map_id: uuid.UUID,

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -80,6 +80,10 @@ class LineupRead(BaseModel):
     target_anchor_x: Optional[float] = None
     target_anchor_y: Optional[float] = None
     setup_seconds: Optional[int] = None
+    # PR3 compact throw-technique phrase — plain display text, NOT a MinIO
+    # key, so it is NOT presigned in _build_read (unlike clip_url). Null for
+    # manual uploads / pre-PR3 rows / low-confidence skips.
+    technique: Optional[str] = None
     attribution_url: Optional[str] = None
     attribution_author: Optional[str] = None
     status: str

--- a/apps/mygamingassistant/backend/app/services/classification/classification_result.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classification_result.py
@@ -100,3 +100,32 @@ class ThrowTimingResult:
     confidence: Optional[float] = None
     reasoning: str = ""
     error_codes: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ThrowTechniqueResult:
+    """Result of the PR3 throw-technique Claude call.
+
+    Deliberately a SEPARATE type from :class:`ThrowTimingResult` and
+    :class:`ClassificationResult` — the technique pass is its own code path
+    (own prompt, own schema, no slug resolution, no DB) per the frozen PR3
+    design contract. It is decoupled from the clip pipeline: technique is
+    extracted even when the clip is gated off (low timing confidence / no
+    release frame), so conflating it with the timing call would lose technique
+    for the lineups whose clip was skipped.
+
+    On a successful API call ``success=True`` and ``technique`` may be
+    ``None`` — a valid "cannot determine the technique from these frames"
+    answer (not-a-throw / motion not visible / below the 0.55 confidence
+    gate), NOT an error. ``error_codes`` is populated on an API/parse failure
+    AND carries the structured gate codes (``technique_low_confidence:<c>`` /
+    ``technique_no_confidence`` / ``invalid_confidence:<raw>``) on an
+    otherwise-successful call, per rules/check-third-party-error-codes.md
+    (never a bare bool/None).
+    """
+
+    success: bool
+    technique: Optional[str] = None
+    confidence: Optional[float] = None
+    reasoning: str = ""
+    error_codes: list[str] = field(default_factory=list)

--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -22,6 +22,7 @@ Error handling per rules/check-third-party-error-codes.md:
 """
 from __future__ import annotations
 
+import base64
 import json
 import logging
 import uuid
@@ -41,6 +42,7 @@ from app.models.game.utility_type import UtilityType
 from app.repositories.game.lineup_repo import write_classifier_suggestions
 from app.services.classification.classification_result import (
     ClassificationResult,
+    ThrowTechniqueResult,
     ThrowTimingResult,
 )
 
@@ -680,7 +682,6 @@ async def classify_lineup(
         + _OUTPUT_SCHEMA_DOC
     )
 
-    import base64
     image_b64 = base64.standard_b64encode(screenshot_bytes).decode()
 
     # Per-call user content: image first, then chapter context, then reference
@@ -1067,8 +1068,6 @@ async def classify_frames_for_lineup_decision(
         + _GRID_OUTPUT_SCHEMA_DOC.format(n=n)
     )
 
-    import base64
-
     # Per-call content: each numbered frame as a labelled image, then chapter
     # context, then the cache_control'd reference block. Images are the
     # variable part (not cached); system + reference are cached.
@@ -1417,8 +1416,6 @@ async def classify_throw_timing_from_frames(
         + _THROW_TIMING_SCHEMA_DOC.format(n=n)
     )
 
-    import base64
-
     # Per-call content: each frame labelled with its 1-based index AND its
     # timestamp (the timestamp is load-bearing — it is how the caller maps the
     # answer back to seconds), then the per-chapter context block. Frames are
@@ -1605,5 +1602,367 @@ async def classify_throw_timing_from_frames(
         result_index=result_index,
         confidence=confidence,
         reasoning=reasoning,
+        error_codes=list(structured_codes),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PR3 — throw-technique localizer (glance-board footer text)
+# ---------------------------------------------------------------------------
+#
+# A SEPARATE Claude code path from BOTH the grid classifier and the PR2
+# throw-timing call. It does not classify game/map/zone/side/utility, does not
+# resolve slugs, does not touch the DB, and is independent of the clip outcome
+# (technique is extracted even when the clip was gated off for low timing
+# confidence / no release frame). Its only job: given the same dense throw
+# window, name HOW the throw is executed as a compact <=60-char phrase for the
+# glance-board footer (frozen design contract pr3-throw-technique-design.md).
+
+# Game technique vocabularies are structurally incompatible (CS2 mouse buttons
+# vs Valorant ability keys), so the right phrase is game-specific. The game is
+# known at the call site (ingest grid suggestion >0.6, or the accepted
+# lineup.game_id at backfill); the vocab block is per-call user text (NOT
+# cached — it varies by game), while the schema/system prompt IS cached.
+
+_CS2_TECHNIQUE_VOCAB = """\
+GAME: CS2. Use the CS2 technique vocabulary ONLY.
+Throw type (movement at release): standing, jumpthrow, run-throw, walk-throw,
+crouch-throw, jumpthrow-bind.
+Mouse buttons: LMB (left = full/far throw), RMB (right = short underhand lob),
+LMB+RMB (both = soft/bounce).
+Compact form: "<throw type> + <mouse>" — e.g. "Standing + LMB",
+"Jumpthrow + LMB", "Run + RMB", "Walk + LMB+RMB", "Crouch + LMB".
+Cues: movement = does the player jump / run / walk / crouch / stay still just
+before the throw-animation follow-through? Mouse = the HUD grenade-slot throw
+animation and the projectile arc (long arc = LMB; short lob = RMB; soft bounce
+= LMB+RMB).
+"""
+
+_VALORANT_TECHNIQUE_VOCAB = """\
+GAME: Valorant. Use the Valorant technique vocabulary ONLY.
+Ability key: C, Q, E, or X (ultimate). NO mouse-button component.
+Charge tiers (Sova bow etc.): 1-charge, 2-charge, 3-charge, full-charge.
+Bounce count (Sova bow etc.): 0-bounce, 1-bounce, 2-bounce.
+Aim qualifier (other agents): aimed, instant-cast, held-cast.
+Compact form: "<key>[ + <charge>][ + <bounce/aim>]" — e.g.
+"E + 2-charge + 1-bounce", "C + aimed", "Q + full-charge", "X + held-cast".
+Cues: which ability slot icon (C/Q/E/X) is consumed; bow charge dots / count;
+number of wall/world bounces before the result lands.
+"""
+
+_GENERIC_TECHNIQUE_VOCAB = """\
+GAME UNKNOWN — determine it from the HUD before naming technique:
+- CS2: dollar buy-money like $3800, grenade icons in the weapon list, T/CT.
+- Valorant: C/Q/E/X ability icons bottom-centre, "creds" economy, agent
+  portraits on the minimap.
+Then apply that game's technique vocabulary:
+- CS2: "<standing|jumpthrow|run-throw|walk-throw|crouch-throw> + <LMB|RMB|
+  LMB+RMB>".
+- Valorant: "<C|Q|E|X>[ + <charge>][ + <bounce|aimed|held-cast>]" (no mouse).
+"""
+
+
+def _technique_vocab_block(game_slug: Optional[str]) -> str:
+    """Pick the per-call technique-vocabulary text block for the game.
+
+    Unknown / unrecognized game → the generic block, which asks the model to
+    determine the game from the HUD first (the same game-first discipline the
+    grid classifier enforces via _GAME_FIRST_RULE).
+    """
+    normalized = (game_slug or "").strip().lower()
+    if normalized == "cs2":
+        return _CS2_TECHNIQUE_VOCAB
+    if normalized == "valorant":
+        return _VALORANT_TECHNIQUE_VOCAB
+    return _GENERIC_TECHNIQUE_VOCAB
+
+
+_THROW_TECHNIQUE_SCHEMA_DOC = """\
+You are given {n} numbered frames (Frame 1 .. Frame {n}) sampled in time order
+from ONE chapter of a tactical-FPS lineup tutorial. Each frame is labelled with
+its timestamp in seconds. The chapter is meant to demonstrate ONE utility
+throw.
+
+Your ONLY job is to name the THROW TECHNIQUE — HOW the player executes the
+throw (the body movement + the input), as a single compact phrase. You are
+NOT identifying the game/map/zone/utility and NOT locating the throw in time.
+
+Return ONLY bare JSON — no markdown fences, no preamble — with exactly these
+keys:
+{{
+  "technique": string (<= 60 chars) or null,
+  "confidence": number (0.0-1.0),
+  "reasoning": string (<= 60 words)
+}}
+
+Rules:
+- technique: a compact phrase per the GAME TECHNIQUE VOCABULARY block supplied
+  below. <= 60 characters. Separators only "+", "-", "/". A partial answer is
+  fine — if the movement is visible but the mouse button / charge is not, give
+  just the movement ("Jumpthrow"); if only the input is visible, give just
+  that. Set technique to null when the throw motion is not visible in these
+  frames (static setup only, no release), or you are not confident enough to
+  name it. NEVER guess.
+- confidence: 0-1 that the technique you named is correct. High ONLY when the
+  throw movement and the input are directly observable; low when inferred.
+- reasoning: <= 60 words. State the visual cue(s) that led to the technique
+  (which frame shows the jump/run/crouch, which input cue you keyed on).
+- Discipline:
+  - If the throw is shown repeatedly or from multiple angles, use the FIRST
+    clean throw only.
+  - Ignore picture-in-picture, facecam, killfeed, scoreboard, title cards and
+    replays — judge from the main game view only.
+  - Talking-head, menu, or knife-only-walking frames are NOT a throw:
+    technique = null, confidence low.
+"""
+
+# Module-level so tests can patch it and so it sits visibly alongside its PR2
+# counterpart (clip_generator._CLIP_CONFIDENCE_GATE). Identical 0.55 value by
+# design — the footer renders technique as unqualified fact on a
+# trust-at-a-glance mid-game surface, so a confidently-wrong technique costs a
+# round. One mental model with the clip gate.
+_TECHNIQUE_CONFIDENCE_GATE = 0.55
+
+
+async def classify_throw_technique_from_frames(
+    *,
+    frames: list[bytes],
+    frame_timestamps: list[float],
+    chapter_title: Optional[str],
+    chapter_duration: Optional[float],
+    game_slug: Optional[str] = None,
+) -> ThrowTechniqueResult:
+    """Name the throw technique within ONE chapter as a compact phrase.
+
+    Separate Claude code path from :func:`classify_frames_for_lineup_decision`
+    and :func:`classify_throw_timing_from_frames` (own prompt, own schema, no
+    reference data, no slug resolution, no DB). Decoupled from the clip
+    pipeline so technique is still produced when the clip was gated off.
+
+    Args:
+        frames: Downscaled candidate PNG bytes, in time order (the SAME dense
+            throw window the clip pipeline uses —
+            ``frame_extractor.clip_window_timestamps``; extracted
+            independently per the PR3 contract's documented deviation).
+        frame_timestamps: The timestamp (seconds) of each frame, same order
+            and length as *frames*. Surfaced to the model as load-bearing
+            context (``Frame i (t=..s):``).
+        chapter_title: YouTube chapter title (per-call context).
+        chapter_duration: Chapter length in seconds (per-call context).
+        game_slug: The game ("cs2" / "valorant") — selects the per-call
+            technique-vocabulary block. None → the generic block asks the
+            model to determine the game from the HUD first.
+
+    Returns:
+        ThrowTechniqueResult. ``success=True`` with ``technique=None`` is a
+        valid "cannot determine" answer (not-a-throw / motion not visible /
+        below the 0.55 confidence gate), NOT an error. ``error_codes`` is
+        populated only on an API/parse failure, plus the structured gate code
+        on an otherwise-successful sub-threshold call.
+    """
+    if not settings.anthropic_api_key:
+        logger.warning(
+            "throw_technique: ANTHROPIC_API_KEY not configured — skipping "
+            "(chapter=%r)", chapter_title,
+        )
+        return ThrowTechniqueResult(
+            success=False,
+            error_codes=["missing_api_key"],
+            reasoning="ANTHROPIC_API_KEY not configured",
+        )
+
+    if not frames:
+        return ThrowTechniqueResult(
+            success=False,
+            error_codes=["no_frames"],
+            reasoning="No candidate frames supplied to throw-technique classifier",
+        )
+
+    if len(frames) != len(frame_timestamps):
+        # A frame/timestamp length mismatch would misalign the load-bearing
+        # per-frame timestamp labels. Fail loud (no silent-fail), mirroring
+        # the throw-timing classifier's identical guard.
+        return ThrowTechniqueResult(
+            success=False,
+            error_codes=["frame_timestamp_mismatch"],
+            reasoning=(
+                f"frames ({len(frames)}) and frame_timestamps "
+                f"({len(frame_timestamps)}) length mismatch"
+            ),
+        )
+
+    n = len(frames)
+
+    system_prompt = (
+        "You are a tactical-FPS utility-lineup video analyst specializing in "
+        "throw mechanics. You will be shown several timestamped frames from "
+        "one chapter of a lineup tutorial and must name HOW the throw is "
+        "executed — the technique.\n\n"
+        + _THROW_TECHNIQUE_SCHEMA_DOC.format(n=n)
+    )
+
+    # Per-call content: each frame labelled with its 1-based index AND its
+    # timestamp, then the per-chapter context block (incl. the game-specific
+    # technique vocabulary). Frames are the variable part (NOT cached); the
+    # system prompt is cache_control'd.
+    user_content: list[dict] = []
+    for i, (frame_bytes, ts) in enumerate(
+        zip(frames, frame_timestamps), start=1
+    ):
+        user_content.append(
+            {"type": "text", "text": f"Frame {i} (t={ts:.1f}s):"}
+        )
+        user_content.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": base64.standard_b64encode(frame_bytes).decode(),
+                },
+            }
+        )
+
+    context_parts: list[str] = []
+    if chapter_title:
+        context_parts.append(f"Chapter title: {chapter_title}")
+    if chapter_duration is not None:
+        context_parts.append(f"Chapter duration: {chapter_duration:.0f}s")
+    context_parts.append(_technique_vocab_block(game_slug))
+    user_content.append({"type": "text", "text": "\n".join(context_parts)})
+
+    try:
+        client = anthropic.Anthropic(api_key=settings.anthropic_api_key)
+        response = client.messages.create(
+            model=settings.claude_classifier_model,
+            max_tokens=300,  # technique string + confidence + 60-word reason
+            system=[
+                {
+                    "type": "text",
+                    "text": system_prompt,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            ],
+            messages=[{"role": "user", "content": user_content}],
+        )
+    except anthropic.RateLimitError as exc:
+        error_type = getattr(exc, "type", "rate_limit_error") or "rate_limit_error"
+        logger.warning(
+            "throw_technique: rate limit hit: chapter=%r error_type=%s message=%s",
+            chapter_title, error_type, str(exc),
+        )
+        return ThrowTechniqueResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API rate limit: {exc}",
+        )
+    except anthropic.APIStatusError as exc:
+        error_type = getattr(exc, "type", None) or f"api_status_{exc.status_code}"
+        logger.error(
+            "throw_technique: API status error: chapter=%r error_type=%s "
+            "status_code=%s message=%s",
+            chapter_title, error_type, exc.status_code, str(exc),
+        )
+        return ThrowTechniqueResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API error ({exc.status_code}): {exc}",
+        )
+    except anthropic.APIError as exc:
+        error_type = getattr(exc, "type", "api_error") or "api_error"
+        logger.error(
+            "throw_technique: API error: chapter=%r error_type=%s message=%s",
+            chapter_title, error_type, str(exc),
+        )
+        return ThrowTechniqueResult(
+            success=False,
+            error_codes=[error_type],
+            reasoning=f"Claude API error: {exc}",
+        )
+
+    raw_text = response.content[0].text if response.content else ""
+    try:
+        parsed: dict[str, Any] = json.loads(_strip_json_fences(raw_text))
+    except (json.JSONDecodeError, IndexError) as exc:
+        logger.error(
+            "throw_technique: JSON parse failed: chapter=%r raw=%r error=%s",
+            chapter_title, raw_text[:200], str(exc),
+        )
+        return ThrowTechniqueResult(
+            success=False,
+            error_codes=["json_parse_error"],
+            reasoning=f"Could not parse throw-technique JSON: {exc}",
+        )
+
+    structured_codes: list[str] = []
+
+    # Technique text: must be a string; strip + hard-cap at the DB column width
+    # (80) above the 60-char prompt target; empty becomes None.
+    technique: Optional[str] = None
+    technique_raw = parsed.get("technique")
+    if technique_raw is not None:
+        if not isinstance(technique_raw, str):
+            structured_codes.append(
+                f"invalid_technique_type:{type(technique_raw).__name__}"
+            )
+        else:
+            technique = technique_raw.strip()[:80] or None
+
+    # Confidence: clamp [0,1]; a non-numeric score is a diagnosable signal —
+    # structured code + WARNING (mirrors the timing/grid classifiers), never a
+    # silent drop (rules/check-third-party-error-codes.md).
+    confidence: Optional[float] = None
+    raw_conf = parsed.get("confidence")
+    if raw_conf is not None:
+        try:
+            confidence = max(0.0, min(1.0, float(raw_conf)))
+        except (TypeError, ValueError):
+            logger.warning(
+                "throw_technique: invalid confidence value dropped: "
+                "chapter=%r raw_confidence=%r",
+                chapter_title, raw_conf,
+            )
+            structured_codes.append(f"invalid_confidence:{raw_conf}")
+
+    model_reasoning = str(parsed.get("reasoning") or "")
+
+    # 0.55 confidence gate via module-level _TECHNIQUE_CONFIDENCE_GATE; matches
+    # clip_generator._CLIP_CONFIDENCE_GATE. The footer renders technique as
+    # unqualified fact on a trust-at-a-glance mid-game surface, so a
+    # sub-threshold (or confidence-unknown) technique is dropped to null rather
+    # than shown. NOT a silent drop: emit a structured code + WARNING so the
+    # operator can see how often technique falls below the bar.
+    if technique is not None:
+        if confidence is None:
+            logger.warning(
+                "throw_technique: technique %r dropped — no usable confidence: "
+                "chapter=%r",
+                technique, chapter_title,
+            )
+            structured_codes.append("technique_no_confidence")
+            technique = None
+        elif confidence < _TECHNIQUE_CONFIDENCE_GATE:
+            logger.warning(
+                "throw_technique: technique %r dropped — confidence %.2f < "
+                "%.2f: chapter=%r",
+                technique, confidence, _TECHNIQUE_CONFIDENCE_GATE,
+                chapter_title,
+            )
+            structured_codes.append(f"technique_low_confidence:{confidence:.2f}")
+            technique = None
+
+    logger.info(
+        "throw_technique: chapter=%r n=%d technique=%r confidence=%.2f",
+        chapter_title, n, technique, confidence or 0.0,
+    )
+
+    # success=True even when technique is None — "cannot determine" is a valid
+    # answer, not a call failure (the only failures are API/parse, handled
+    # above). The structured gate/parse codes ride error_codes regardless.
+    return ThrowTechniqueResult(
+        success=True,
+        technique=technique,
+        confidence=confidence,
+        reasoning=model_reasoning,
         error_codes=list(structured_codes),
     )

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -40,6 +40,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
 from app.core.storage import get_storage
+from app.models.game.game import Game
 from app.models.game.source import Source
 from app.models.game.utility_type import UtilityType
 from app.repositories.game import lineup_repo, source_repo
@@ -49,6 +50,9 @@ from app.services.classification.classifier_service import (
     classify_frames_for_lineup_decision,
 )
 from app.services.ingestion.clip_generator import generate_clip_for_lineup
+from app.services.ingestion.technique_extractor import (
+    extract_technique_for_lineup,
+)
 from app.services.game import lineup_service
 from app.services.ingestion.chapter_parser import (
     Chapter,
@@ -167,6 +171,29 @@ async def _resolve_utility_hint(db: AsyncSession, result) -> Optional[str]:
             select(UtilityType.slug).where(
                 UtilityType.id == result.suggested_utility_type_id
             )
+        )
+    ).scalar_one_or_none()
+
+
+async def _resolve_game_hint(db: AsyncSession, result) -> Optional[str]:
+    """The grid-classified game slug, only when the grid was confident.
+
+    The throw-technique prompt selects a game-specific vocabulary block (CS2
+    mouse buttons vs Valorant ability keys) — passing the wrong game would
+    yield a nonsense phrase. Below the same >0.6 gate the utility hint uses,
+    the grid wasn't sure of the game, so pass none and let the technique
+    prompt determine the game from the HUD itself (its generic block enforces
+    the same game-first discipline as the grid classifier).
+    """
+    if (
+        result.suggested_game_id is None
+        or result.confidence is None
+        or result.confidence <= 0.6
+    ):
+        return None
+    return (
+        await db.execute(
+            select(Game.slug).where(Game.id == result.suggested_game_id)
         )
     ).scalar_one_or_none()
 
@@ -386,6 +413,41 @@ async def _process_chapter(
             logger.warning(
                 "Clip generation unexpected error (non-fatal): source_id=%s "
                 "video_id=%s chapter_start=%d lineup_id=%s error=%s",
+                source.id, video_meta.video_id, start, lineup.id, str(exc),
+                exc_info=True,
+            )
+
+        # PR3: best-effort throw-technique footer text. Symmetric to the clip
+        # block above and equally non-fatal — independent Claude call, own
+        # one-column commit, decoupled from the clip outcome (technique is
+        # still produced when the clip was gated off). Reuse the on-disk
+        # video (never re-download per chapter). extract_technique_for_lineup
+        # returns structured outcomes and doesn't raise for expected
+        # failures; the broad catch is purely defensive against an unexpected
+        # bug taking down ingestion.
+        try:
+            game_hint_slug = await _resolve_game_hint(db, result)
+            technique_result = await extract_technique_for_lineup(
+                db,
+                lineup,
+                chapter_start=float(chapter.start_seconds),
+                chapter_end=float(chapter.end_seconds),
+                game_slug=game_hint_slug,
+                video_path=video_path,
+            )
+            logger.info(
+                "Technique extraction (ingest): source_id=%s video_id=%s "
+                "chapter_start=%d lineup_id=%s status=%s reason=%s",
+                source.id, video_meta.video_id, start, lineup.id,
+                technique_result.status,
+                technique_result.skip_reason
+                or (",".join(technique_result.error_codes) or "-"),
+            )
+        except Exception as exc:
+            logger.warning(
+                "Technique extraction unexpected error (non-fatal): "
+                "source_id=%s video_id=%s chapter_start=%d lineup_id=%s "
+                "error=%s",
                 source.id, video_meta.video_id, start, lineup.id, str(exc),
                 exc_info=True,
             )

--- a/apps/mygamingassistant/backend/app/services/ingestion/technique_backfill.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/technique_backfill.py
@@ -1,0 +1,230 @@
+"""Backfill throw-technique for accepted lineups that predate PR3.
+
+Ingested lineups created before PR3 (and any whose technique extraction
+failed at ingest time) have ``technique IS NULL``. This walks that set,
+re-fetches each source video ONCE (not once per lineup — a tutorial video
+usually backs many lineups), and names the throw technique per chapter.
+
+Idempotent by construction: the work set is exactly
+``status='accepted' AND youtube_video_id IS NOT NULL AND technique IS NULL``
+(``lineup_repo.list_accepted_lineups_needing_technique``). A populated
+technique drops out of the set, so re-running only processes the remainder. A
+``failed`` lineup keeps ``technique`` NULL and is retried on the next run
+(transient yt-dlp/ffmpeg/Claude failures self-heal). A ``skipped`` lineup
+(genuinely no determinable technique) also stays NULL and will be re-evaluated
+on a future run — the frozen contract's definition of "done" is ``technique``
+set; the operator runs this once post-deploy, so re-evaluating a handful of
+no-technique chapters is acceptable and not worth a skip-memo column.
+
+Independent of the PR2 ``backfill-clips`` (separate operator command, separate
+NULL column) — deliberately NOT coupled; the two run at different times.
+
+Per rules/no-bandaid-solutions.md + rules/check-third-party-error-codes.md:
+every yt-dlp / ffmpeg / Claude failure is captured with its structured reason
+and tallied — nothing silently disappears.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.game import Game
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.technique_extractor import (
+    extract_technique_for_lineup,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+    download_video,
+    fetch_video_detail,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TechniqueBackfillStats:
+    """Aggregate outcome of a technique-backfill run (printed by the CLI)."""
+
+    total: int = 0
+    generated: int = 0
+    skipped: int = 0
+    failed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        return (
+            f"backfill-technique: {self.total} candidate lineup(s) — "
+            f"{self.generated} generated, {self.skipped} skipped, "
+            f"{self.failed} failed"
+        )
+
+
+async def _game_slug(db: AsyncSession, lineup: Lineup) -> str | None:
+    """The lineup's confirmed game slug, for the technique vocabulary block.
+
+    A backfilled lineup is ``accepted`` so ``game_id`` is non-null by the
+    ``ck_lineup_accepted_classified`` CHECK. The repo query doesn't eager-load
+    the relationship, so resolve the slug by id explicitly (a lazy attribute
+    access would raise under async SQLAlchemy).
+    """
+    if lineup.game_id is None:
+        return None
+    return (
+        await db.execute(select(Game.slug).where(Game.id == lineup.game_id))
+    ).scalar_one_or_none()
+
+
+def _find_chapter(
+    chapters: list[Chapter], start_seconds: int | None
+) -> Chapter | None:
+    """The chapter whose start matches the lineup's stored chapter start.
+
+    The ingest path persisted ``chapter_start_seconds`` from the same
+    ``parse_chapters`` output, so an exact start match re-identifies it. A
+    miss means the video's chapters changed since ingest (re-upload / edited
+    description) — the caller skips that lineup with a logged reason rather
+    than guessing a wrong chapter.
+    """
+    if start_seconds is None:
+        return None
+    for ch in chapters:
+        if ch.start_seconds == start_seconds:
+            return ch
+    return None
+
+
+async def backfill_technique(db: AsyncSession) -> TechniqueBackfillStats:
+    """Name the throw technique for every accepted ingested lineup missing one.
+
+    Returns a :class:`TechniqueBackfillStats`. Designed to be invoked once by
+    the operator post-deploy (``python -m app.cli backfill-technique``); safe
+    to re-run at any time.
+    """
+    stats = TechniqueBackfillStats()
+
+    lineups = await lineup_repo.list_accepted_lineups_needing_technique(db)
+    stats.total = len(lineups)
+    if not lineups:
+        logger.info("backfill-technique: nothing to do (no candidate lineups)")
+        return stats
+
+    # Group by source video so each video is fetched + downloaded ONCE.
+    by_video: dict[str, list[Lineup]] = defaultdict(list)
+    for lineup in lineups:
+        by_video[lineup.youtube_video_id].append(lineup)
+
+    download_dir = Path(settings.ingestion_download_dir)
+    logger.info(
+        "backfill-technique: %d lineup(s) across %d video(s)",
+        stats.total, len(by_video),
+    )
+
+    for video_id, video_lineups in by_video.items():
+        # ---- One metadata fetch per video ------------------------------
+        try:
+            meta = await fetch_video_detail(video_id)
+        except YouTubeFetchError as exc:
+            logger.warning(
+                "backfill-technique: metadata fetch failed: video_id=%s "
+                "error_type=%s message=%s — %d lineup(s) failed",
+                video_id, exc.error_type, str(exc), len(video_lineups),
+            )
+            stats.failed += len(video_lineups)
+            stats.errors.append(
+                f"{video_id}: metadata fetch failed ({exc.error_type})"
+            )
+            continue
+
+        chapters = parse_chapters(
+            description=meta.description,
+            video_duration=meta.duration,
+            native_chapters=meta.chapters or None,
+        )
+
+        # ---- One download per video ------------------------------------
+        try:
+            video_path = await download_video(video_id, download_dir)
+        except VideoDownloadError as exc:
+            logger.warning(
+                "backfill-technique: download failed: video_id=%s "
+                "error_type=%s message=%s — %d lineup(s) failed",
+                video_id, exc.error_type, str(exc), len(video_lineups),
+            )
+            stats.failed += len(video_lineups)
+            stats.errors.append(
+                f"{video_id}: download failed ({exc.error_type})"
+            )
+            continue
+
+        try:
+            for lineup in video_lineups:
+                chapter = _find_chapter(chapters, lineup.chapter_start_seconds)
+                if chapter is None:
+                    logger.warning(
+                        "backfill-technique: chapter not found: lineup=%s "
+                        "video_id=%s chapter_start=%s — skipping",
+                        lineup.id, video_id, lineup.chapter_start_seconds,
+                    )
+                    stats.skipped += 1
+                    stats.errors.append(
+                        f"{video_id}[{lineup.chapter_start_seconds}]: "
+                        f"chapter not found (video changed since ingest)"
+                    )
+                    continue
+
+                try:
+                    result = await extract_technique_for_lineup(
+                        db,
+                        lineup,
+                        chapter_start=float(chapter.start_seconds),
+                        chapter_end=float(chapter.end_seconds),
+                        game_slug=await _game_slug(db, lineup),
+                        # Reuse the once-downloaded file — do NOT let the
+                        # extractor re-download per lineup.
+                        video_path=video_path,
+                    )
+                except Exception as exc:  # defensive: never abort the batch
+                    logger.warning(
+                        "backfill-technique: unexpected error: lineup=%s "
+                        "video_id=%s error=%s",
+                        lineup.id, video_id, str(exc), exc_info=True,
+                    )
+                    stats.failed += 1
+                    stats.errors.append(
+                        f"{lineup.id}: unexpected:{type(exc).__name__} {exc}"
+                    )
+                    continue
+
+                if result.status == "generated":
+                    stats.generated += 1
+                elif result.status == "skipped":
+                    stats.skipped += 1
+                else:
+                    stats.failed += 1
+                    stats.errors.append(
+                        f"{lineup.id}: {','.join(result.error_codes) or 'failed'}"
+                    )
+        finally:
+            # The backfill owns this download (one per video) — clean it up
+            # once, after all of the video's lineups are processed.
+            try:
+                video_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "backfill-technique: failed to delete video: path=%s "
+                    "error=%s",
+                    video_path, str(exc),
+                )
+
+    logger.info("backfill-technique: complete — %s", stats.summary())
+    return stats

--- a/apps/mygamingassistant/backend/app/services/ingestion/technique_extractor.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/technique_extractor.py
@@ -1,0 +1,274 @@
+"""Throw-technique extractor — name HOW a lineup's throw is executed.
+
+A lineup's footer should tell the player not just *what* lands where (the
+clip) but *how* to throw it: "Jumpthrow + LMB", "E + 2-charge + 1-bounce".
+This service localises the throw window in the source chapter (the SAME
+``clip_window_timestamps`` window the PR2 clip pipeline uses), asks Claude to
+name the technique, and persists the compact phrase on the row for the
+glance-board footer (PR3).
+
+Decoupled from the clip pipeline by design (frozen contract
+pr3-throw-technique-design.md):
+
+  - Own Claude call (``classify_throw_technique_from_frames``) with its own
+    prompt/schema — NOT folded into the PR2 timing call, so technique is still
+    produced for lineups whose clip was gated off (low timing confidence / no
+    release frame).
+  - Own ``set_technique`` one-column commit — a technique failure never rolls
+    back the committed lineup / clip; the lineup stays fully usable without a
+    technique.
+  - Extracts its own frames over the same window rather than threading shared
+    frame bytes through PR2's shipped ``clip_generator`` / ``_process_chapter``
+    (documented contract deviation: that refactor would add regression risk to
+    well-tested shipped code to save one cheap *local* downscaled ffmpeg pass
+    on a background path that already downloads whole videos — under the MGA
+    casual-app posture the independent extraction is the better tradeoff).
+
+Failure handling (rules/no-bandaid-solutions.md +
+rules/check-third-party-error-codes.md): yt-dlp / ffmpeg / Claude failures are
+captured with their structured codes, logged at WARNING with the reason, and
+returned as ``status="failed"`` with ``error_codes``. ``technique`` is left
+NULL and the lineup stays fully usable. Nothing silent-fails.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+from app.services.classification.classifier_service import (
+    classify_throw_technique_from_frames,
+)
+from app.services.ingestion.frame_extractor import (
+    FrameExtractionError,
+    clip_window_timestamps,
+    extract_frames_downscaled,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    download_video,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class TechniqueGenerationResult:
+    """Structured outcome of a technique-extraction attempt.
+
+    ``status`` is one of:
+      - ``"generated"`` — technique named, ``technique`` committed.
+        ``technique`` is set.
+      - ``"skipped"``   — deliberately no technique (no source video / not a
+        throw / motion not visible / below the 0.55 confidence gate /
+        classifier disabled / chapter too short). NOT an error; the lineup is
+        fully usable without a technique footer.
+      - ``"failed"``    — an operational failure (download / extract / Claude
+        API / persist). ``error_codes`` carries the structured reason;
+        ``technique`` is left NULL; a later backfill run retries.
+
+    Never a bare bool/None — the caller and the backfill summary route on this
+    (per rules/check-third-party-error-codes.md).
+    """
+
+    status: str
+    technique: Optional[str] = None
+    skip_reason: Optional[str] = None
+    error_codes: list[str] = field(default_factory=list)
+    reasoning: str = ""
+    confidence: Optional[float] = None
+
+
+async def extract_technique_for_lineup(
+    db: AsyncSession,
+    lineup: Lineup,
+    *,
+    chapter_start: float,
+    chapter_end: float,
+    game_slug: Optional[str] = None,
+    video_path: Optional[Path] = None,
+    download_dir: Optional[Path] = None,
+) -> TechniqueGenerationResult:
+    """Name *lineup*'s throw technique and persist ``technique``.
+
+    Args:
+        db: Active async session. On success the phrase is committed via
+            ``lineup_repo.set_technique`` (its own one-column commit — a
+            technique failure must not roll back the already-committed lineup
+            or clip).
+        lineup: The row. ``youtube_video_id`` must be set (manual uploads have
+            no source video — caller must not call this for them).
+        chapter_start / chapter_end: Source chapter bounds in seconds. Ingest
+            passes the parsed ``Chapter``; backfill re-derives the end from the
+            re-fetched video metadata.
+        game_slug: ``"cs2"`` / ``"valorant"`` — selects the technique
+            vocabulary. None → the prompt determines the game from the HUD.
+        video_path: An already-downloaded source video to reuse (ingest). When
+            None the video is re-fetched by ``youtube_video_id`` (backfill)
+            into *download_dir* and deleted afterwards.
+        download_dir: Required when *video_path* is None — where to download
+            the re-fetched source.
+
+    Returns:
+        TechniqueGenerationResult — see its docstring for ``status``
+        semantics. Never raises for an expected failure; everything is
+        captured into the result with structured ``error_codes`` and a
+        WARNING log.
+    """
+    video_id = lineup.youtube_video_id
+    if not video_id:
+        # The caller is responsible for not calling this on manual uploads
+        # (no source video → technique is not extractable, by input modality);
+        # surface it loudly rather than silently no-op.
+        logger.warning(
+            "technique_extractor: lineup %s has no youtube_video_id — cannot "
+            "extract technique",
+            lineup.id,
+        )
+        return TechniqueGenerationResult(
+            status="skipped",
+            skip_reason="no_source_video",
+        )
+
+    # Cheap exits before any download / Claude spend. With no key (or the
+    # classifier disabled) we cannot judge the technique — keep technique NULL.
+    if not settings.enable_classifier:
+        return TechniqueGenerationResult(
+            status="skipped", skip_reason="classifier_disabled"
+        )
+    if not settings.anthropic_api_key:
+        return TechniqueGenerationResult(
+            status="skipped",
+            skip_reason="classifier_unavailable:missing_api_key",
+        )
+
+    chapter_duration = float(chapter_end) - float(chapter_start)
+    timestamps = clip_window_timestamps(chapter_start, chapter_end)
+    if not timestamps:
+        return TechniqueGenerationResult(
+            status="skipped", skip_reason="empty_clip_window"
+        )
+
+    owns_video = video_path is None
+    local_video: Optional[Path] = video_path
+    try:
+        # ---- Acquire the source video (only needed to extract frames) ---
+        if local_video is None:
+            if download_dir is None:
+                logger.warning(
+                    "technique_extractor: lineup %s — no video_path and no "
+                    "download_dir; cannot re-fetch source",
+                    lineup.id,
+                )
+                return TechniqueGenerationResult(
+                    status="failed",
+                    error_codes=["no_download_dir"],
+                    reasoning="Re-fetch requested but no download_dir provided",
+                )
+            try:
+                local_video = await download_video(video_id, download_dir)
+            except VideoDownloadError as exc:
+                logger.warning(
+                    "technique_extractor: source re-fetch failed: lineup=%s "
+                    "video_id=%s error_type=%s message=%s",
+                    lineup.id, video_id, exc.error_type, str(exc),
+                )
+                return TechniqueGenerationResult(
+                    status="failed",
+                    error_codes=[f"download:{exc.error_type}"],
+                    reasoning=f"Video re-fetch failed: {exc}",
+                )
+
+        # ---- Dense downscaled frames over the throw window -------------
+        try:
+            frames = await extract_frames_downscaled(local_video, timestamps)
+        except FrameExtractionError as exc:
+            logger.warning(
+                "technique_extractor: downscaled frame extraction failed: "
+                "lineup=%s video_id=%s returncode=%s stderr=%s",
+                lineup.id, video_id, exc.returncode, exc.stderr[:300],
+            )
+            return TechniqueGenerationResult(
+                status="failed",
+                error_codes=[f"frame_extract:rc={exc.returncode}"],
+                reasoning=f"Downscaled frame extraction failed: {exc}",
+            )
+
+        # ---- Name the technique ----------------------------------------
+        result = await classify_throw_technique_from_frames(
+            frames=frames,
+            frame_timestamps=timestamps,
+            chapter_title=lineup.chapter_title,
+            chapter_duration=chapter_duration,
+            game_slug=game_slug,
+        )
+        if not result.success:
+            logger.warning(
+                "technique_extractor: technique call failed: lineup=%s "
+                "video_id=%s error_codes=%s reasoning=%s",
+                lineup.id, video_id, result.error_codes, result.reasoning,
+            )
+            return TechniqueGenerationResult(
+                status="failed",
+                error_codes=list(result.error_codes),
+                reasoning=result.reasoning,
+            )
+
+        # A null technique is a valid "cannot determine" answer (not-a-throw /
+        # motion not visible / gated below 0.55) — keep technique NULL; the
+        # footer simply shows nothing. The structured gate code (if any) rides
+        # error_codes for operator visibility, not as a failure.
+        if result.technique is None:
+            return TechniqueGenerationResult(
+                status="skipped",
+                skip_reason="no_technique",
+                error_codes=list(result.error_codes),
+                confidence=result.confidence,
+                reasoning=result.reasoning,
+            )
+
+        try:
+            await lineup_repo.set_technique(db, lineup, result.technique)
+        except Exception as exc:
+            logger.warning(
+                "technique_extractor: technique persist failed (column not "
+                "committed; backfill is idempotent): lineup=%s technique=%r "
+                "error=%s",
+                lineup.id, result.technique, str(exc),
+            )
+            return TechniqueGenerationResult(
+                status="failed",
+                error_codes=["technique_persist_failed"],
+                reasoning=f"technique commit failed: {exc}",
+                confidence=result.confidence,
+            )
+
+        logger.info(
+            "technique_extractor: technique set: lineup=%s video_id=%s "
+            "technique=%r confidence=%.2f",
+            lineup.id, video_id, result.technique, result.confidence or 0.0,
+        )
+        return TechniqueGenerationResult(
+            status="generated",
+            technique=result.technique,
+            confidence=result.confidence,
+            reasoning=result.reasoning,
+        )
+    finally:
+        # Only delete the video if THIS call downloaded it. During ingest the
+        # orchestrator owns video_path and deletes it once after all chapters.
+        if owns_video and local_video is not None:
+            try:
+                local_video.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "technique_extractor: failed to delete re-fetched video: "
+                    "path=%s error=%s",
+                    local_video, str(exc),
+                )

--- a/apps/mygamingassistant/backend/tests/test_alembic_chain.py
+++ b/apps/mygamingassistant/backend/tests/test_alembic_chain.py
@@ -24,8 +24,8 @@ def script_directory() -> ScriptDirectory:
     return ScriptDirectory.from_config(cfg)
 
 
-def test_single_head_is_0010(script_directory: ScriptDirectory) -> None:
-    """The DAG must resolve to exactly one head and it must be 0010.
+def test_single_head_is_0011(script_directory: ScriptDirectory) -> None:
+    """The DAG must resolve to exactly one head and it must be 0011.
 
     Bump this pin (and add a down_revision assertion below) in the same PR
     that adds a new migration — same per-PR contract as the fixture
@@ -37,8 +37,8 @@ def test_single_head_is_0010(script_directory: ScriptDirectory) -> None:
         "Orphan heads usually mean a migration's down_revision is stale "
         "after a merge — rebase and re-point the down_revision."
     )
-    assert heads[0] == "0010", (
-        f"Expected head 0010 (the lineup clip_url column), got {heads[0]}."
+    assert heads[0] == "0011", (
+        f"Expected head 0011 (the lineup technique column), got {heads[0]}."
     )
 
 
@@ -80,3 +80,11 @@ def test_0010_down_revision_points_at_0009(
     """0010 must chain directly off 0009 (the lineup clip_url column)."""
     rev = script_directory.get_revision("0010")
     assert rev.down_revision == "0009"
+
+
+def test_0011_down_revision_points_at_0010(
+    script_directory: ScriptDirectory,
+) -> None:
+    """0011 must chain directly off 0010 (the lineup technique column)."""
+    rev = script_directory.get_revision("0011")
+    assert rev.down_revision == "0010"

--- a/apps/mygamingassistant/backend/tests/test_lineup_technique_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_technique_repo.py
@@ -1,0 +1,162 @@
+"""DB-backed test for lineup_repo.set_technique (PR3).
+
+The technique phrase must actually COMMIT (not just flush) — the same silent
+data-loss class as PATCH #687 and PR2's clip_url repo: ``get_db`` doesn't
+auto-commit, so a flush-only write is rolled back on session close and the
+operator's technique silently never appears. This asserts the write survives
+a fresh read.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.game import Game
+from app.models.game.lineup import Lineup
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.models.game.utility_type import UtilityType
+from app.repositories.game import lineup_repo
+
+
+@pytest.mark.asyncio
+async def test_set_technique_commits(db: AsyncSession):
+    created = await lineup_repo.create_lineup(
+        db, {"title": "technique repo test", "status": "pending_review"}
+    )
+
+    returned = await lineup_repo.set_technique(db, created, "Jumpthrow + LMB")
+    assert returned.technique == "Jumpthrow + LMB"
+
+    # Capture the PK *before* expire_all(): referencing an expired attribute
+    # (created.id) inside the query expression triggers a synchronous lazy
+    # reload — sync session.execute outside the async greenlet, i.e.
+    # MissingGreenlet. The PK as a plain local has no such hazard.
+    lineup_id = created.id
+
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.technique == "Jumpthrow + LMB"
+
+
+@pytest.mark.asyncio
+async def test_set_technique_accepts_none(db: AsyncSession):
+    """The repo signature allows None — used by the extractor for
+    'cannot determine' answers when a row was previously populated and is
+    being explicitly cleared. Verifies the column round-trips NULL."""
+    created = await lineup_repo.create_lineup(
+        db,
+        {
+            "title": "technique none test",
+            "status": "pending_review",
+            "technique": "old-phrase",
+        },
+    )
+    await lineup_repo.set_technique(db, created, None)
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.technique is None
+
+
+@pytest.mark.asyncio
+async def test_set_technique_overwrite_is_idempotent(db: AsyncSession):
+    """Backfill may re-evaluate a still-NULL technique row; a populated row
+    drops out of the work set. Mirror the clip repo overwrite contract so a
+    deterministic re-call is safe."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "technique overwrite test", "status": "pending_review"}
+    )
+    await lineup_repo.set_technique(db, created, "Run + RMB")
+    await lineup_repo.set_technique(db, created, "Run + RMB")
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.technique == "Run + RMB"
+
+
+@pytest.mark.asyncio
+async def test_list_accepted_lineups_needing_technique_filters(
+    db: AsyncSession,
+):
+    """Only accepted + has-source-video + no-technique rows are in the backfill
+    set. The youtube_video_id IS NOT NULL clause is *input-modality* gating
+    (manual uploads have no extractable technique) — verify a manual-upload
+    accepted lineup is excluded."""
+    game = Game(
+        slug=f"g-{uuid.uuid4().hex[:8]}",
+        name="G",
+        side_a_label="A",
+        side_b_label="B",
+    )
+    db.add(game)
+    await db.flush()
+    mp = Map(game_id=game.id, slug=f"m-{uuid.uuid4().hex[:8]}", name="M")
+    db.add(mp)
+    await db.flush()
+    zone = MapZone(
+        map_id=mp.id,
+        slug=f"z-{uuid.uuid4().hex[:8]}",
+        name="Z",
+        polygon_points=[],
+    )
+    db.add(zone)
+    util = UtilityType(
+        game_id=game.id, slug=f"u-{uuid.uuid4().hex[:8]}", name="U"
+    )
+    db.add(util)
+    await db.flush()
+
+    def _accepted(**over):
+        data = dict(
+            game_id=game.id,
+            map_id=mp.id,
+            target_zone_id=zone.id,
+            stand_zone_id=zone.id,
+            side="side_a",
+            utility_type_id=util.id,
+            title="t",
+            status="accepted",
+            youtube_video_id="vidT",
+            technique=None,
+        )
+        data.update(over)
+        return data
+
+    wanted = await lineup_repo.create_lineup(db, _accepted())
+    # Excluded: already has a technique.
+    await lineup_repo.create_lineup(
+        db, _accepted(technique="Jumpthrow + LMB")
+    )
+    # Excluded: no source video (manual upload — modality gate).
+    await lineup_repo.create_lineup(db, _accepted(youtube_video_id=None))
+    # Excluded: still pending_review (not accepted).
+    await lineup_repo.create_lineup(
+        db,
+        {
+            "title": "p",
+            "status": "pending_review",
+            "youtube_video_id": "vidT",
+        },
+    )
+
+    rows = await lineup_repo.list_accepted_lineups_needing_technique(db)
+    ids = {r.id for r in rows}
+    assert wanted.id in ids
+    assert all(
+        r.status == "accepted"
+        and r.youtube_video_id
+        and r.technique is None
+        for r in rows
+    )

--- a/apps/mygamingassistant/backend/tests/test_technique_backfill.py
+++ b/apps/mygamingassistant/backend/tests/test_technique_backfill.py
@@ -1,0 +1,318 @@
+"""Unit tests for the PR3 backfill (python -m app.cli backfill-technique).
+
+Everything external (repo query / yt-dlp / chapter parse / technique
+extraction / game-slug lookup) is mocked. Verifies the idempotent work set,
+ONE fetch+download per video (not per lineup), chapter re-identification,
+the generated/skipped/failed tally, and that the per-video download is
+always cleaned up. Symmetric with test_clip_backfill.py — the two backfills
+share a posture by design.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.ingestion.chapter_parser import Chapter
+from app.services.ingestion.technique_backfill import backfill_technique
+from app.services.ingestion.technique_extractor import (
+    TechniqueGenerationResult,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+)
+
+_MOD = "app.services.ingestion.technique_backfill"
+
+
+def _lineup(video_id: str, chapter_start: int, game_id=None):
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_start_seconds=chapter_start,
+        # game_id resolved per-lineup via _game_slug — None short-circuits
+        # the lookup so these no-DB unit tests don't need a real session.
+        game_id=game_id,
+        technique=None,
+    )
+
+
+def _meta():
+    m = MagicMock()
+    m.description = ""
+    m.duration = 120
+    m.chapters = [{"start_time": 0, "end_time": 60, "title": "B smoke"}]
+    return m
+
+
+def _patches(tmp_path, *, lineups, chapters, extract, fetch=None, download=None):
+    """Compose the backfill patch set; download writes a real temp file so
+    the unlink-cleanup assertion is meaningful."""
+
+    async def _dl(video_id, ddir):
+        p = Path(ddir) / f"{video_id}.mp4"
+        p.write_bytes(b"src")
+        return p
+
+    settings = MagicMock()
+    settings.ingestion_download_dir = str(tmp_path)
+
+    stack = [
+        patch(f"{_MOD}.settings", settings),
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_technique",
+            new=AsyncMock(return_value=lineups),
+        ),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            new=fetch or AsyncMock(return_value=_meta()),
+        ),
+        patch(f"{_MOD}.parse_chapters", return_value=chapters),
+        patch(
+            f"{_MOD}.download_video",
+            new=download or AsyncMock(side_effect=_dl),
+        ),
+        patch(f"{_MOD}.extract_technique_for_lineup", new=extract),
+    ]
+    return stack
+
+
+def _enter(stack):
+    import contextlib
+
+    es = contextlib.ExitStack()
+    for p in stack:
+        es.enter_context(p)
+    return es
+
+
+class TestBackfillTechnique:
+    @pytest.mark.asyncio
+    async def test_nothing_to_do(self, tmp_path: Path):
+        ext = AsyncMock()
+        with _enter(
+            _patches(tmp_path, lineups=[], chapters=[], extract=ext)
+        ):
+            stats = await backfill_technique(MagicMock())
+        assert stats.total == 0
+        assert stats.generated == 0
+        ext.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_one_fetch_and_download_per_video(self, tmp_path: Path):
+        # 3 lineups, 2 of them share video "vidA".
+        lineups = [
+            _lineup("vidA", 0),
+            _lineup("vidA", 0),
+            _lineup("vidB", 0),
+        ]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="B smoke")]
+        ext = AsyncMock(
+            return_value=TechniqueGenerationResult(
+                status="generated", technique="Jumpthrow + LMB"
+            )
+        )
+        fetch = AsyncMock(return_value=_meta())
+        dl_calls = []
+
+        async def _dl(video_id, ddir):
+            dl_calls.append(video_id)
+            p = Path(ddir) / f"{video_id}.mp4"
+            p.write_bytes(b"src")
+            return p
+
+        with _enter(
+            _patches(
+                tmp_path,
+                lineups=lineups,
+                chapters=chapters,
+                extract=ext,
+                fetch=fetch,
+                download=AsyncMock(side_effect=_dl),
+            )
+        ):
+            stats = await backfill_technique(MagicMock())
+
+        assert stats.total == 3
+        assert stats.generated == 3
+        # ONE fetch + ONE download per distinct video, not per lineup.
+        assert fetch.await_count == 2
+        assert sorted(dl_calls) == ["vidA", "vidB"]
+        # Downloaded files cleaned up.
+        assert not (tmp_path / "vidA.mp4").exists()
+        assert not (tmp_path / "vidB.mp4").exists()
+
+    @pytest.mark.asyncio
+    async def test_tally_mixed_outcomes(self, tmp_path: Path):
+        lineups = [_lineup("v", 0), _lineup("v", 0), _lineup("v", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        ext = AsyncMock(
+            side_effect=[
+                TechniqueGenerationResult(
+                    status="generated", technique="Jumpthrow + LMB"
+                ),
+                # Below-gate / null technique is skipped, not failed.
+                TechniqueGenerationResult(
+                    status="skipped", skip_reason="no_technique"
+                ),
+                TechniqueGenerationResult(
+                    status="failed",
+                    error_codes=["frame_extract:rc=1"],
+                ),
+            ]
+        )
+        with _enter(
+            _patches(
+                tmp_path, lineups=lineups, chapters=chapters, extract=ext
+            )
+        ):
+            stats = await backfill_technique(MagicMock())
+        assert (stats.generated, stats.skipped, stats.failed) == (1, 1, 1)
+        assert any("frame_extract" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_metadata_fetch_failure_fails_all_video_lineups(
+        self, tmp_path: Path
+    ):
+        lineups = [_lineup("vbad", 0), _lineup("vbad", 30)]
+        fetch = AsyncMock(
+            side_effect=YouTubeFetchError(
+                "gone",
+                error_type="ExtractorError",
+                original=Exception(),
+            )
+        )
+        ext = AsyncMock()
+        with _enter(
+            _patches(
+                tmp_path,
+                lineups=lineups,
+                chapters=[],
+                extract=ext,
+                fetch=fetch,
+            )
+        ):
+            stats = await backfill_technique(MagicMock())
+        assert stats.failed == 2
+        assert stats.generated == 0
+        ext.assert_not_awaited()
+        assert any("ExtractorError" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_download_failure_fails_all_video_lineups(
+        self, tmp_path: Path
+    ):
+        lineups = [_lineup("vdl", 0)]
+        dl = AsyncMock(
+            side_effect=VideoDownloadError(
+                "nope",
+                video_id="vdl",
+                error_type="UnavailableVideoError",
+                original=Exception(),
+            )
+        )
+        ext = AsyncMock()
+        with _enter(
+            _patches(
+                tmp_path,
+                lineups=lineups,
+                chapters=[Chapter(0, 60, "x")],
+                extract=ext,
+                download=dl,
+            )
+        ):
+            stats = await backfill_technique(MagicMock())
+        assert stats.failed == 1
+        ext.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_chapter_not_found_is_skipped(self, tmp_path: Path):
+        # lineup recorded chapter_start=999 but the video now has only [0,60].
+        lineups = [_lineup("v", 999)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        ext = AsyncMock()
+        with _enter(
+            _patches(
+                tmp_path,
+                lineups=lineups,
+                chapters=chapters,
+                extract=ext,
+            )
+        ):
+            stats = await backfill_technique(MagicMock())
+        assert stats.skipped == 1
+        ext.assert_not_awaited()
+        assert any("chapter not found" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_per_lineup_exception_does_not_abort_batch(
+        self, tmp_path: Path
+    ):
+        lineups = [_lineup("v", 0), _lineup("v", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        ext = AsyncMock(
+            side_effect=[
+                RuntimeError("boom"),
+                TechniqueGenerationResult(
+                    status="generated", technique="Jumpthrow + LMB"
+                ),
+            ]
+        )
+        with _enter(
+            _patches(
+                tmp_path, lineups=lineups, chapters=chapters, extract=ext
+            )
+        ):
+            stats = await backfill_technique(MagicMock())
+        # First raised, second still processed; download cleaned up.
+        assert stats.failed == 1
+        assert stats.generated == 1
+        assert not (tmp_path / "v.mp4").exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_runs_even_when_all_lineups_raise(
+        self, tmp_path: Path
+    ):
+        lineups = [_lineup("v", 0)]
+        ext = AsyncMock(side_effect=RuntimeError("boom"))
+        with _enter(
+            _patches(
+                tmp_path,
+                lineups=lineups,
+                chapters=[Chapter(0, 60, "x")],
+                extract=ext,
+            )
+        ):
+            stats = await backfill_technique(MagicMock())
+        assert stats.failed == 1
+        assert not (tmp_path / "v.mp4").exists()
+
+    @pytest.mark.asyncio
+    async def test_idempotent_work_set(self, tmp_path: Path):
+        """The work set itself is the idempotency guarantee — a populated
+        ``technique`` row drops out of ``list_accepted_lineups_needing_technique``,
+        so re-running the backfill only processes the remainder. Verify by
+        seeding only the NULL row into the work set and asserting one call."""
+        only_null_row = _lineup("v", 0)
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        ext = AsyncMock(
+            return_value=TechniqueGenerationResult(
+                status="generated", technique="Jumpthrow + LMB"
+            )
+        )
+        with _enter(
+            _patches(
+                tmp_path,
+                lineups=[only_null_row],
+                chapters=chapters,
+                extract=ext,
+            )
+        ):
+            stats = await backfill_technique(MagicMock())
+        assert stats.total == 1
+        assert stats.generated == 1
+        ext.assert_awaited_once()

--- a/apps/mygamingassistant/backend/tests/test_technique_extractor.py
+++ b/apps/mygamingassistant/backend/tests/test_technique_extractor.py
@@ -1,0 +1,401 @@
+"""Unit tests for the PR3 throw-technique extractor.
+
+Full ``extract_technique_for_lineup`` orchestration with every external
+(download / frame extract / Claude / repo commit) mocked. Asserts the gate
+order, structured generated/skipped/failed outcomes, and the source-video
+cleanup ownership (reused vs re-fetched) — mirrors the PR2 clip generator
+test posture exactly so the two paths stay symmetric.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.classification.classification_result import (
+    ThrowTechniqueResult,
+)
+from app.services.ingestion.technique_extractor import (
+    TechniqueGenerationResult,
+    extract_technique_for_lineup,
+)
+from app.services.ingestion.frame_extractor import FrameExtractionError
+from app.services.ingestion.youtube_fetcher import VideoDownloadError
+
+_MOD = "app.services.ingestion.technique_extractor"
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n"
+
+
+def _lineup(video_id="vid123", chapter_title="B smoke"):
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_title=chapter_title,
+        technique=None,
+    )
+
+
+def _settings(enable=True, key="sk-test"):
+    s = MagicMock()
+    s.enable_classifier = enable
+    s.anthropic_api_key = key
+    return s
+
+
+def _technique(**kw):
+    base = dict(
+        success=True,
+        technique="Jumpthrow + LMB",
+        confidence=0.82,
+        reasoning="ok",
+    )
+    base.update(kw)
+    return ThrowTechniqueResult(**base)
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTechniqueGenerated:
+    @pytest.mark.asyncio
+    async def test_generated_reuses_provided_video_and_persists_technique(
+        self, tmp_path: Path
+    ):
+        video = tmp_path / "vid123.mp4"
+        video.write_bytes(b"src")
+        lineup = _lineup()
+        db = MagicMock()
+
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                return_value=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+            ),
+            patch(
+                f"{_MOD}.extract_frames_downscaled",
+                new=AsyncMock(return_value=[_FAKE_PNG] * 6),
+            ),
+            patch(
+                f"{_MOD}.classify_throw_technique_from_frames",
+                new=AsyncMock(return_value=_technique()),
+            ) as mock_classify,
+            patch(f"{_MOD}.download_video", new=AsyncMock()) as mock_dl,
+            patch(
+                f"{_MOD}.lineup_repo.set_technique", new=AsyncMock()
+            ) as mock_set,
+        ):
+            result = await extract_technique_for_lineup(
+                db,
+                lineup,
+                chapter_start=0.0,
+                chapter_end=30.0,
+                game_slug="cs2",
+                video_path=video,
+            )
+
+        assert result.status == "generated"
+        assert result.technique == "Jumpthrow + LMB"
+        assert result.confidence == 0.82
+        mock_dl.assert_not_awaited()  # provided video reused, no re-fetch
+        mock_set.assert_awaited_once()
+        # game_slug threaded through to the Claude call (vocab block selection).
+        assert mock_classify.call_args.kwargs["game_slug"] == "cs2"
+        # A reused (caller-owned) video must NOT be deleted here.
+        assert video.exists()
+
+    @pytest.mark.asyncio
+    async def test_refetch_path_downloads_and_cleans_up(self, tmp_path: Path):
+        fetched = tmp_path / "vid123.mp4"
+        fetched.write_bytes(b"src")
+        lineup = _lineup()
+
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                return_value=[1.0, 2.0, 3.0, 4.0],
+            ),
+            patch(
+                f"{_MOD}.extract_frames_downscaled",
+                new=AsyncMock(return_value=[_FAKE_PNG] * 4),
+            ),
+            patch(
+                f"{_MOD}.classify_throw_technique_from_frames",
+                new=AsyncMock(return_value=_technique()),
+            ),
+            patch(
+                f"{_MOD}.download_video",
+                new=AsyncMock(return_value=fetched),
+            ) as mock_dl,
+            patch(f"{_MOD}.lineup_repo.set_technique", new=AsyncMock()),
+        ):
+            result = await extract_technique_for_lineup(
+                MagicMock(),
+                lineup,
+                chapter_start=0.0,
+                chapter_end=30.0,
+                video_path=None,
+                download_dir=tmp_path,
+            )
+
+        assert result.status == "generated"
+        mock_dl.assert_awaited_once()
+        # A re-fetched (self-owned) video MUST be cleaned up.
+        assert not fetched.exists()
+
+
+# ---------------------------------------------------------------------------
+# Skips — none of these should hit set_technique
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTechniqueSkips:
+    async def _skip(
+        self,
+        *,
+        technique=None,
+        settings=None,
+        lineup=None,
+        video=None,
+    ):
+        with (
+            patch(f"{_MOD}.settings", settings or _settings()),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                return_value=[1.0, 2.0, 3.0],
+            ),
+            patch(
+                f"{_MOD}.extract_frames_downscaled",
+                new=AsyncMock(return_value=[_FAKE_PNG] * 3),
+            ),
+            patch(
+                f"{_MOD}.classify_throw_technique_from_frames",
+                new=AsyncMock(return_value=technique or _technique()),
+            ),
+            patch(f"{_MOD}.download_video", new=AsyncMock()),
+            patch(
+                f"{_MOD}.lineup_repo.set_technique", new=AsyncMock()
+            ) as mock_set,
+        ):
+            result = await extract_technique_for_lineup(
+                MagicMock(),
+                lineup or _lineup(),
+                chapter_start=0.0,
+                chapter_end=30.0,
+                video_path=video,
+            )
+        return result, mock_set
+
+    @pytest.mark.asyncio
+    async def test_no_source_video(self):
+        result, sett = await self._skip(lineup=_lineup(video_id=None))
+        assert result.status == "skipped"
+        assert result.skip_reason == "no_source_video"
+        sett.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_classifier_disabled_short_circuits(self):
+        result, sett = await self._skip(settings=_settings(enable=False))
+        assert result.status == "skipped"
+        assert result.skip_reason == "classifier_disabled"
+        sett.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_short_circuits(self):
+        result, sett = await self._skip(settings=_settings(key=""))
+        assert result.status == "skipped"
+        assert result.skip_reason == "classifier_unavailable:missing_api_key"
+        sett.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_null_technique_from_model_is_skipped_not_failed(
+        self, tmp_path: Path
+    ):
+        """``success=True`` + ``technique=None`` is a valid 'cannot determine'
+        answer (motion not visible / gated below 0.55) — must NOT persist and
+        must NOT be a failure. Footer simply shows nothing."""
+        v = tmp_path / "v.mp4"
+        v.write_bytes(b"x")
+        gated = ThrowTechniqueResult(
+            success=True,
+            technique=None,
+            confidence=0.40,
+            reasoning="below gate",
+            error_codes=["technique_low_confidence:0.40"],
+        )
+        result, sett = await self._skip(technique=gated, video=v)
+        assert result.status == "skipped"
+        assert result.skip_reason == "no_technique"
+        # Structured gate codes ride through for operator visibility.
+        assert "technique_low_confidence:0.40" in result.error_codes
+        sett.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_empty_clip_window(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"
+        v.write_bytes(b"x")
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[]),
+            patch(
+                f"{_MOD}.lineup_repo.set_technique", new=AsyncMock()
+            ) as sett,
+        ):
+            result = await extract_technique_for_lineup(
+                MagicMock(),
+                _lineup(),
+                chapter_start=0.0,
+                chapter_end=0.05,
+                video_path=v,
+            )
+        assert result.status == "skipped"
+        assert result.skip_reason == "empty_clip_window"
+        sett.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Failures — structured error_codes per check-third-party-error-codes
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTechniqueFailures:
+    @pytest.mark.asyncio
+    async def test_refetch_without_download_dir_fails_loud(self):
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
+        ):
+            result = await extract_technique_for_lineup(
+                MagicMock(),
+                _lineup(),
+                chapter_start=0.0,
+                chapter_end=30.0,
+                video_path=None,
+                download_dir=None,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["no_download_dir"]
+
+    @pytest.mark.asyncio
+    async def test_download_failure(self, tmp_path: Path):
+        exc = VideoDownloadError(
+            "gone",
+            video_id="vid123",
+            error_type="UnavailableVideoError",
+            original=Exception(),
+        )
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
+            patch(
+                f"{_MOD}.download_video", new=AsyncMock(side_effect=exc)
+            ),
+        ):
+            result = await extract_technique_for_lineup(
+                MagicMock(),
+                _lineup(),
+                chapter_start=0.0,
+                chapter_end=30.0,
+                video_path=None,
+                download_dir=tmp_path,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["download:UnavailableVideoError"]
+
+    @pytest.mark.asyncio
+    async def test_frame_extract_failure(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"
+        v.write_bytes(b"x")
+        exc = FrameExtractionError(
+            "boom", timestamp=5.0, returncode=1, stderr="e"
+        )
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
+            patch(
+                f"{_MOD}.extract_frames_downscaled",
+                new=AsyncMock(side_effect=exc),
+            ),
+        ):
+            result = await extract_technique_for_lineup(
+                MagicMock(),
+                _lineup(),
+                chapter_start=0.0,
+                chapter_end=30.0,
+                video_path=v,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["frame_extract:rc=1"]
+
+    @pytest.mark.asyncio
+    async def test_technique_classifier_call_failure(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"
+        v.write_bytes(b"x")
+        failed = ThrowTechniqueResult(
+            success=False,
+            error_codes=["rate_limit_error"],
+            reasoning="rate limited",
+        )
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
+            patch(
+                f"{_MOD}.extract_frames_downscaled",
+                new=AsyncMock(return_value=[_FAKE_PNG] * 2),
+            ),
+            patch(
+                f"{_MOD}.classify_throw_technique_from_frames",
+                new=AsyncMock(return_value=failed),
+            ),
+        ):
+            result = await extract_technique_for_lineup(
+                MagicMock(),
+                _lineup(),
+                chapter_start=0.0,
+                chapter_end=30.0,
+                video_path=v,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["rate_limit_error"]
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_keeps_row_unchanged(self, tmp_path: Path):
+        """A repo write error must NOT raise — backfill is idempotent, so the
+        failed row stays NULL and is retried on the next run with a structured
+        ``technique_persist_failed`` code."""
+        v = tmp_path / "v.mp4"
+        v.write_bytes(b"x")
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                return_value=[1.0, 2.0, 3.0, 4.0],
+            ),
+            patch(
+                f"{_MOD}.extract_frames_downscaled",
+                new=AsyncMock(return_value=[_FAKE_PNG] * 4),
+            ),
+            patch(
+                f"{_MOD}.classify_throw_technique_from_frames",
+                new=AsyncMock(return_value=_technique()),
+            ),
+            patch(
+                f"{_MOD}.lineup_repo.set_technique",
+                new=AsyncMock(side_effect=RuntimeError("commit blew up")),
+            ),
+        ):
+            result = await extract_technique_for_lineup(
+                MagicMock(),
+                _lineup(),
+                chapter_start=0.0,
+                chapter_end=30.0,
+                video_path=v,
+            )
+        assert result.status == "failed"
+        assert result.error_codes == ["technique_persist_failed"]

--- a/apps/mygamingassistant/backend/tests/test_throw_technique_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_technique_classifier.py
@@ -1,0 +1,328 @@
+"""Unit tests for classify_throw_technique_from_frames (PR3 footer text).
+
+All Anthropic SDK calls are mocked. A SEPARATE code path from both the grid
+classifier and the PR2 throw-timing call — takes frames directly (no DB, no
+reference data), so no database fixtures. Verifies:
+  - CS2 / Valorant happy paths + the per-game vocabulary block selection
+  - frame labels carry the load-bearing timestamp (Frame i (t=..s):)
+  - system prompt is cache-controlled
+  - the 0.55 confidence gate nulls a sub-threshold technique (structured code)
+  - null / non-numeric confidence also nulls technique (no unqualified fact)
+  - a null technique from the model is a valid "cannot determine", not an error
+  - long technique hard-capped at the DB column width (80)
+  - error handling: missing key, no frames, length mismatch, API + parse fail
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.services.classification.classifier_service import (
+    classify_throw_technique_from_frames,
+)
+
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+
+_PATCH_SETTINGS = "app.services.classification.classifier_service.settings"
+_PATCH_ANTHROPIC = "app.services.classification.classifier_service.anthropic.Anthropic"
+
+
+def _resp(payload: dict) -> MagicMock:
+    resp = MagicMock()
+    block = MagicMock()
+    block.text = json.dumps(payload)
+    resp.content = [block]
+    return resp
+
+
+async def _call(payload_or_exc, *, frames=None, timestamps=None, **kwargs):
+    """Run the classifier with the Anthropic call mocked to a payload/exc."""
+    frames = frames if frames is not None else [_FAKE_PNG] * 6
+    timestamps = (
+        timestamps if timestamps is not None
+        else [10.0, 12.0, 14.0, 16.0, 18.0, 20.0]
+    )
+    with (
+        patch(_PATCH_SETTINGS) as mock_settings,
+        patch(_PATCH_ANTHROPIC) as mock_cls,
+    ):
+        mock_settings.anthropic_api_key = "sk-test"
+        mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+        mock_client = MagicMock()
+        mock_cls.return_value = mock_client
+        if isinstance(payload_or_exc, BaseException):
+            mock_client.messages.create.side_effect = payload_or_exc
+        else:
+            mock_client.messages.create.return_value = _resp(payload_or_exc)
+        result = await classify_throw_technique_from_frames(
+            frames=frames,
+            frame_timestamps=timestamps,
+            chapter_title=kwargs.get("chapter_title", "B-site smoke"),
+            chapter_duration=kwargs.get("chapter_duration", 30.0),
+            game_slug=kwargs.get("game_slug"),
+        )
+    return result, mock_client
+
+
+class TestThrowTechniqueHappyPath:
+    @pytest.mark.asyncio
+    async def test_cs2_technique(self):
+        result, _ = await _call(
+            {
+                "technique": "Jumpthrow + LMB",
+                "confidence": 0.87,
+                "reasoning": "Player jumps frame 3, grenade slot empties.",
+            },
+            game_slug="cs2",
+        )
+        assert result.success is True
+        assert result.technique == "Jumpthrow + LMB"
+        assert result.confidence == pytest.approx(0.87)
+        assert result.error_codes == []
+
+    @pytest.mark.asyncio
+    async def test_valorant_technique(self):
+        result, _ = await _call(
+            {
+                "technique": "E + 2-charge + 1-bounce",
+                "confidence": 0.91,
+                "reasoning": "Sova bow, 2 charge dots, one wall bounce.",
+            },
+            game_slug="valorant",
+        )
+        assert result.success is True
+        assert result.technique == "E + 2-charge + 1-bounce"
+        assert result.confidence == pytest.approx(0.91)
+
+    @pytest.mark.asyncio
+    async def test_cs2_vocab_block_selected(self):
+        _, client = await _call(
+            {"technique": "Run + RMB", "confidence": 0.7, "reasoning": "x"},
+            game_slug="cs2",
+        )
+        content = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        joined = "\n".join(b["text"] for b in content if b["type"] == "text")
+        assert "GAME: CS2." in joined
+        assert "GAME: Valorant." not in joined
+
+    @pytest.mark.asyncio
+    async def test_valorant_vocab_block_selected(self):
+        _, client = await _call(
+            {"technique": "C + aimed", "confidence": 0.7, "reasoning": "x"},
+            game_slug="valorant",
+        )
+        content = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        joined = "\n".join(b["text"] for b in content if b["type"] == "text")
+        assert "GAME: Valorant." in joined
+        assert "GAME: CS2." not in joined
+
+    @pytest.mark.asyncio
+    async def test_unknown_game_uses_generic_block(self):
+        _, client = await _call(
+            {"technique": "Standing + LMB", "confidence": 0.7,
+             "reasoning": "x"},
+            game_slug=None,
+        )
+        content = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        joined = "\n".join(b["text"] for b in content if b["type"] == "text")
+        assert "GAME UNKNOWN" in joined
+
+    @pytest.mark.asyncio
+    async def test_frame_labels_include_timestamp(self):
+        _, client = await _call(
+            {"technique": "Jumpthrow + LMB", "confidence": 0.7,
+             "reasoning": "x"},
+            timestamps=[10.0, 12.5, 14.0, 16.0, 18.0, 20.0],
+        )
+        content = client.messages.create.call_args.kwargs["messages"][0]["content"]
+        texts = [b["text"] for b in content if b["type"] == "text"]
+        assert "Frame 1 (t=10.0s):" in texts
+        assert "Frame 2 (t=12.5s):" in texts
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_is_cache_controlled(self):
+        _, client = await _call(
+            {"technique": "Run + RMB", "confidence": 0.7, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        assert system[0]["cache_control"] == {"type": "ephemeral"}
+
+
+class TestThrowTechniqueGateAndParser:
+    @pytest.mark.asyncio
+    async def test_null_technique_is_valid_not_error(self):
+        result, _ = await _call(
+            {"technique": None, "confidence": 0.7,
+             "reasoning": "Static setup only, no release visible."},
+        )
+        assert result.success is True
+        assert result.technique is None
+        assert result.error_codes == []
+
+    @pytest.mark.asyncio
+    async def test_low_confidence_drops_technique(self):
+        result, _ = await _call(
+            {"technique": "Jumpthrow + LMB", "confidence": 0.40,
+             "reasoning": "x"},
+        )
+        assert result.success is True
+        assert result.technique is None
+        assert "technique_low_confidence:0.40" in result.error_codes
+
+    @pytest.mark.asyncio
+    async def test_confidence_exactly_at_gate_is_kept(self):
+        result, _ = await _call(
+            {"technique": "Run + LMB", "confidence": 0.55, "reasoning": "x"},
+        )
+        assert result.technique == "Run + LMB"
+
+    @pytest.mark.asyncio
+    async def test_null_confidence_drops_technique(self):
+        result, _ = await _call(
+            {"technique": "Standing + LMB", "confidence": None,
+             "reasoning": "x"},
+        )
+        assert result.success is True
+        assert result.technique is None
+        assert "technique_no_confidence" in result.error_codes
+
+    @pytest.mark.asyncio
+    async def test_invalid_confidence_dropped_and_technique_nulled(self):
+        result, _ = await _call(
+            {"technique": "Jumpthrow + LMB", "confidence": "high",
+             "reasoning": "x"},
+        )
+        assert result.success is True
+        assert result.confidence is None
+        # Both the malformed-score signal AND the resulting gate drop are
+        # surfaced as structured codes — never a silent fact.
+        assert "invalid_confidence:high" in result.error_codes
+        assert "technique_no_confidence" in result.error_codes
+        assert result.technique is None
+
+    @pytest.mark.asyncio
+    async def test_confidence_clamped(self):
+        result, _ = await _call(
+            {"technique": "Run + RMB", "confidence": 1.7, "reasoning": "x"},
+        )
+        assert result.confidence == pytest.approx(1.0)
+        assert result.technique == "Run + RMB"
+
+    @pytest.mark.asyncio
+    async def test_long_technique_truncated_to_80(self):
+        long_tech = "Jumpthrow + LMB " * 10  # 160 chars
+        result, _ = await _call(
+            {"technique": long_tech, "confidence": 0.9, "reasoning": "x"},
+        )
+        assert result.technique is not None
+        assert len(result.technique) == 80
+
+    @pytest.mark.asyncio
+    async def test_non_string_technique_rejected(self):
+        result, _ = await _call(
+            {"technique": 42, "confidence": 0.9, "reasoning": "x"},
+        )
+        assert result.success is True
+        assert result.technique is None
+        assert any(
+            c.startswith("invalid_technique_type:") for c in result.error_codes
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_string_technique_becomes_none(self):
+        result, _ = await _call(
+            {"technique": "   ", "confidence": 0.9, "reasoning": "x"},
+        )
+        assert result.success is True
+        assert result.technique is None
+        assert result.error_codes == []
+
+
+class TestThrowTechniqueErrorHandling:
+    @pytest.mark.asyncio
+    async def test_missing_api_key(self):
+        with patch(_PATCH_SETTINGS) as mock_settings:
+            mock_settings.anthropic_api_key = ""
+            result = await classify_throw_technique_from_frames(
+                frames=[_FAKE_PNG],
+                frame_timestamps=[1.0],
+                chapter_title="x",
+                chapter_duration=10.0,
+            )
+        assert result.success is False
+        assert result.error_codes == ["missing_api_key"]
+
+    @pytest.mark.asyncio
+    async def test_no_frames(self):
+        with patch(_PATCH_SETTINGS) as mock_settings:
+            mock_settings.anthropic_api_key = "sk-test"
+            result = await classify_throw_technique_from_frames(
+                frames=[],
+                frame_timestamps=[],
+                chapter_title="x",
+                chapter_duration=10.0,
+            )
+        assert result.success is False
+        assert result.error_codes == ["no_frames"]
+
+    @pytest.mark.asyncio
+    async def test_frame_timestamp_length_mismatch(self):
+        with patch(_PATCH_SETTINGS) as mock_settings:
+            mock_settings.anthropic_api_key = "sk-test"
+            result = await classify_throw_technique_from_frames(
+                frames=[_FAKE_PNG, _FAKE_PNG],
+                frame_timestamps=[1.0],
+                chapter_title="x",
+                chapter_duration=10.0,
+            )
+        assert result.success is False
+        assert result.error_codes == ["frame_timestamp_mismatch"]
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error(self):
+        import anthropic as anthropic_lib
+
+        exc = anthropic_lib.RateLimitError.__new__(anthropic_lib.RateLimitError)
+        exc.type = "rate_limit_error"
+        exc.args = ("rate limited",)
+        result, _ = await _call(exc)
+        assert result.success is False
+        assert any("rate_limit" in c for c in result.error_codes)
+
+    @pytest.mark.asyncio
+    async def test_api_status_error(self):
+        import anthropic as anthropic_lib
+
+        exc = anthropic_lib.APIStatusError.__new__(anthropic_lib.APIStatusError)
+        exc.status_code = 529
+        exc.type = "overloaded_error"
+        exc.args = ("overloaded",)
+        result, _ = await _call(exc)
+        assert result.success is False
+        assert result.error_codes  # populated
+
+    @pytest.mark.asyncio
+    async def test_json_parse_failure(self):
+        bad = MagicMock()
+        block = MagicMock()
+        block.text = "not json at all {"
+        bad.content = [block]
+        with (
+            patch(_PATCH_SETTINGS) as mock_settings,
+            patch(_PATCH_ANTHROPIC) as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "haiku"
+            client = MagicMock()
+            mock_cls.return_value = client
+            client.messages.create.return_value = bad
+            result = await classify_throw_technique_from_frames(
+                frames=[_FAKE_PNG],
+                frame_timestamps=[1.0],
+                chapter_title="x",
+                chapter_duration=10.0,
+            )
+        assert result.success is False
+        assert result.error_codes == ["json_parse_error"]

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -31,6 +31,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     stand_screenshot_url: "https://ex.com/stand.png",
     aim_screenshot_url: "https://ex.com/aim.png",
     clip_url: null,
+    technique: null,
     aim_anchor_x: 0.5,
     aim_anchor_y: 0.4,
     stand_anchor_x: null,
@@ -179,5 +180,41 @@ describe("GlanceBoardTile clip view", () => {
     );
     const video = document.querySelector("video") as HTMLVideoElement;
     expect(video.getAttribute("src")).toBe("https://ex.com/clip.mp4");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PR3 — throw-technique footer
+// ---------------------------------------------------------------------------
+describe("GlanceBoardTile technique footer", () => {
+  it("renders the technique string with the correct aria-label when set", () => {
+    render(
+      <GlanceBoardTile lineup={makeLineup({ technique: "Jumpthrow + LMB" })} />,
+    );
+    expect(screen.getByText("Jumpthrow + LMB")).toBeInTheDocument();
+    expect(
+      screen.getByLabelText("Throw technique: Jumpthrow + LMB"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing for technique when null and keeps the setup clock", () => {
+    render(<GlanceBoardTile lineup={makeLineup({ technique: null })} />);
+    // The placeholder em-dash from the pre-PR3 mockup must NOT appear — both
+    // design agents agreed null renders nothing (no misleading affordance).
+    expect(screen.queryByText("— technique —")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText(/^Throw technique:/),
+    ).not.toBeInTheDocument();
+    // Clock still renders so the footer isn't visually empty.
+    expect(screen.getByText("7s")).toBeInTheDocument();
+  });
+
+  it("truncates long technique via class + carries the full string in title=", () => {
+    const long =
+      "Valorant Killjoy alarmbot bounce-on-stair-corner three-quarter-charge";
+    render(<GlanceBoardTile lineup={makeLineup({ technique: long })} />);
+    const span = screen.getByLabelText(`Throw technique: ${long}`);
+    expect(span.getAttribute("title")).toBe(long);
+    expect(span.className).toContain("truncate");
   });
 });

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -29,6 +29,7 @@ const BASE_LINEUP: Lineup = {
   stand_screenshot_url: "https://example.com/stand.png",
   aim_screenshot_url: "https://example.com/aim.png",
   clip_url: null,
+  technique: null,
   aim_anchor_x: 0.5,
   aim_anchor_y: 0.4,
   stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
@@ -27,6 +27,7 @@ function makeLineup(id: string): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
@@ -26,6 +26,7 @@ function makeLineup(overrides: Partial<Lineup>): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/MinimapPinEditor.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MinimapPinEditor.test.tsx
@@ -38,6 +38,7 @@ function makeLineup(overrides: Partial<Lineup> = {}): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
@@ -79,6 +79,7 @@ function makeUnclassifiedLineup(overrides: Partial<Lineup> = {}): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
@@ -27,6 +27,7 @@ function makeLineup(overrides: Partial<Lineup>): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,
     stand_anchor_x: null,

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -277,8 +277,13 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
         </div>
       )}
 
-      {/* ── Footer — PR2 throw-technique placeholder ───────────────────── */}
-      {/* PR2: throw-technique fields (throw type / mouse button / movement) land here */}
+      {/* ── Footer — setup time + throw technique (PR3) ────────────────── */}
+      {/* Technique is the "how" — subordinate to the clip (the "what"): same
+          muted 11px weight as the clock, right-aligned. Null renders NOTHING
+          (no placeholder) — mirrors PR2's clip silent-fallback so a missing
+          technique never reads as a broken/error state on the glance board.
+          The footer div always renders for structural consistency (the clock
+          may be its only child, or it may be empty). */}
       <div className="flex items-center gap-3 px-3 py-1.5 bg-muted/30 border-t min-h-[28px]">
         {lineup.setup_seconds != null && (
           <span className="flex items-center gap-1 text-[11px] text-muted-foreground">
@@ -286,9 +291,15 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
             {lineup.setup_seconds}s
           </span>
         )}
-        <span className="text-[11px] text-muted-foreground/50 italic select-none">
-          — technique —
-        </span>
+        {lineup.technique != null && (
+          <span
+            className="ml-auto min-w-0 truncate text-[11px] text-muted-foreground"
+            title={lineup.technique}
+            aria-label={`Throw technique: ${lineup.technique}`}
+          >
+            {lineup.technique}
+          </span>
+        )}
       </div>
     </article>
   );

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -121,6 +121,12 @@ export interface Lineup {
   effective_target_x: number | null;
   effective_target_y: number | null;
   setup_seconds: number | null;
+  // PR3: compact throw-technique phrase ("Jumpthrow + LMB",
+  // "E + 2-charge + 1-bounce") for the glance-board footer. Null for manual
+  // uploads (no source video), lineups predating PR3, or when the technique
+  // could not be determined at >=0.55 confidence — the footer then renders
+  // nothing (no placeholder), mirroring the PR2 clip silent-fallback.
+  technique: string | null;
   attribution_url: string | null;
   attribution_author: string | null;
   status: "accepted" | "pending_review" | "hidden";


### PR DESCRIPTION
## Summary

Fills the RESERVED footer of `GlanceBoardTile` with a compact throw-technique phrase ("Jumpthrow + LMB", "E + 2-charge + 1-bounce"). PR3 of the glance-board series — completes the visual contract begun in #700 (layout) + #702 (looping clip).

- **Schema**: `lineup.technique` `String(80)` nullable, alembic 0011 additive-nullable, no CheckConstraint (open-vocab display text, same posture as `notes`).
- **Classifier**: new `classify_throw_technique_from_frames` Claude call, decoupled from the PR2 timing call so technique is produced even when the clip is gated off. Module-level `_TECHNIQUE_CONFIDENCE_GATE = 0.55` (identical to `_CLIP_CONFIDENCE_GATE`). Structured error codes per `check-third-party-error-codes`.
- **Pipeline**: `technique_extractor` (ingest + backfill), `lineup_repo.set_technique` (own one-column commit), symmetric ingest-orchestrator block, idempotent `backfill-technique` CLI.
- **Frontend**: subordinate 11px muted span, `ml-auto + truncate + title=` overflow safety net + `aria-label`. Null renders NOTHING (PR2 silent-fallback precedent).

Frozen design contract: see ` pr3-throw-technique-design.md` (operator-locked: single free-text `technique` string, 0.55 gate, modality gate on `youtube_video_id`).

## Tests

- Backend: 420 total — green. New: 23 classifier + 12 extractor + 9 backfill + 4 repo durability tests (all passing).
- Frontend: 296 total — green. New describe block for technique footer (3 cases) + `technique: null` added to 7 makeLineup fixtures.
- `npm run typecheck` clean.

## Declined review items (design-locked)

- Use clip_generator's existing frames instead of a separate ffmpeg pass — documented deviation; independent extraction avoids regression surface on shipped PR2 code (zero-cost casual-app tradeoff, see module docstring).
- Fold technique into the PR2 timing call — would lose technique for ~30-40% of lineups whose clip is gated off.
- Lower the confidence gate below 0.55 — locked at 0.55 to match clip gate.
- Add `CheckConstraint` on `technique` — design-locked as open-vocab.
- Add `TechniqueKind` union type (cross-stack enum rule) — declined; technique is open-vocab free-text, NOT an enum.

## ⚠️ Operational migration required

After this PR merges and at the next deploy:

**Schema** — applied automatically by deploy `alembic upgrade head` (migration 0011 is additive-nullable; no manual step).

**Backfill technique for pre-PR3 accepted lineups** — run ONCE post-deploy on the VPS:

\`\`\`bash
docker compose -f apps/mygamingassistant/docker-compose.yml exec api \
  python -m app.cli backfill-technique
\`\`\`

Idempotent (work set = accepted + youtube_video_id + technique NULL). Not deploy-critical — new ingests auto-populate; old rows just show no technique footer until the backfill runs. `ENABLE_CLASSIFIER=false` makes it a no-op.

### How to verify

\`\`\`bash
docker compose -f apps/mygamingassistant/docker-compose.yml exec api \
  python -m app.cli backfill-technique 2>&1 | tail -5
# Expect: "backfill-technique: N candidate lineup(s) — M generated, ..."
\`\`\`

### Rollback path

Revert this PR in main; alembic downgrade 0010 drops the `technique` column. Pre-existing deployed image continues to work without it.

## Test plan

- [x] Backend pytest green (420 / 420)
- [x] Frontend vitest green (296 / 296)
- [x] `npm run typecheck` clean
- [x] g-review-backend + g-review-frontend ran in parallel; must-fix items applied
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)