### PR TITLE
fix(platform): include iat claim in JWT tokens (unblocks strict-superuser gate)

### DIFF
--- a/apps/mybookkeeper/backend/uv.lock
+++ b/apps/mybookkeeper/backend/uv.lock
@@ -911,6 +911,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastapi-users", extras = ["sqlalchemy"], marker = "extra == 'dev'", specifier = ">=15.0,<16.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.1.0" },
     { name = "mammoth", marker = "extra == 'dev'", specifier = ">=1.12.0" },

--- a/apps/mygamingassistant/backend/uv.lock
+++ b/apps/mygamingassistant/backend/uv.lock
@@ -655,6 +655,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastapi-users", extras = ["sqlalchemy"], marker = "extra == 'dev'", specifier = ">=15.0,<16.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.1.0" },
     { name = "mammoth", marker = "extra == 'dev'", specifier = ">=1.12.0" },

--- a/apps/mypizzatracker/backend/uv.lock
+++ b/apps/mypizzatracker/backend/uv.lock
@@ -732,6 +732,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "cryptography", specifier = ">=43.0.0" },
     { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastapi-users", extras = ["sqlalchemy"], marker = "extra == 'dev'", specifier = ">=15.0,<16.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "jinja2", marker = "extra == 'dev'", specifier = ">=3.1.0" },
     { name = "mammoth", marker = "extra == 'dev'", specifier = ">=1.12.0" },

--- a/packages/shared-backend/platform_shared/auth/jwt_backend.py
+++ b/packages/shared-backend/platform_shared/auth/jwt_backend.py
@@ -16,13 +16,39 @@ from each app's ``app.core.auth`` continue to resolve unchanged.
 """
 from __future__ import annotations
 
-from typing import NamedTuple
+import time
+from typing import Generic, NamedTuple
 
+from fastapi_users import models
 from fastapi_users.authentication import (
     AuthenticationBackend,
     BearerTransport,
     JWTStrategy,
 )
+from fastapi_users.jwt import generate_jwt
+
+
+class IatJWTStrategy(JWTStrategy[models.UP, models.ID], Generic[models.UP, models.ID]):
+    """JWTStrategy that always emits an ``iat`` (issued-at) claim.
+
+    fastapi-users 15.x ``JWTStrategy.write_token`` emits only ``sub``,
+    ``aud``, and ``exp``. The platform's strict-superuser gate
+    (``platform_shared.core.permissions.make_strict_superuser_gate``)
+    enforces a recent-auth window by reading ``iat`` — without it,
+    every gated endpoint fails with 401 "Token missing or unreadable
+    iat claim". This subclass closes that gap so the gate works against
+    real platform-issued tokens, not just hand-crafted test tokens.
+    """
+
+    async def write_token(self, user: models.UP) -> str:
+        data = {
+            "sub": str(user.id),
+            "aud": self.token_audience,
+            "iat": int(time.time()),
+        }
+        return generate_jwt(
+            data, self.encode_key, self.lifetime_seconds, algorithm=self.algorithm,
+        )
 
 
 class JwtAuthBackend(NamedTuple):
@@ -63,7 +89,7 @@ def build_jwt_auth_backend(
     bearer_transport = BearerTransport(tokenUrl=token_url)
 
     def get_jwt_strategy() -> JWTStrategy:
-        return JWTStrategy(secret=secret_key, lifetime_seconds=lifetime_seconds)
+        return IatJWTStrategy(secret=secret_key, lifetime_seconds=lifetime_seconds)
 
     auth_backend = AuthenticationBackend(
         name=backend_name,
@@ -78,4 +104,4 @@ def build_jwt_auth_backend(
     )
 
 
-__all__ = ["JwtAuthBackend", "build_jwt_auth_backend"]
+__all__ = ["IatJWTStrategy", "JwtAuthBackend", "build_jwt_auth_backend"]

--- a/packages/shared-backend/pyproject.toml
+++ b/packages/shared-backend/pyproject.toml
@@ -42,6 +42,10 @@ dev = [
     "pypdf>=5.6",
     "mammoth>=1.12.0",
     "openpyxl>=3.1.5",
+    # Required for tests of platform_shared.auth.jwt_backend that exercise
+    # the real JWTStrategy write/read paths. Runtime apps that authenticate
+    # pull fastapi-users in via their own pyproject.toml.
+    "fastapi-users[sqlalchemy]>=15.0,<16.0",
 ]
 
 [tool.pytest.ini_options]

--- a/packages/shared-backend/tests/test_jwt_backend.py
+++ b/packages/shared-backend/tests/test_jwt_backend.py
@@ -1,0 +1,108 @@
+"""Tests for ``platform_shared.auth.jwt_backend``.
+
+Pinned to the real bug: PR #555 added the strict-superuser gate which
+demands an ``iat`` claim, but fastapi-users' default ``JWTStrategy``
+emits only ``sub``/``aud``/``exp``. The result was every gated endpoint
+(Demo create, toggle_superuser, etc.) returning 401 "Token missing or
+unreadable iat claim" against real platform-issued tokens. These tests
+lock in that platform-issued tokens are loadable by the gate's
+``decode_token_iat`` callable.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from typing import Any
+
+import jwt
+import pytest
+
+from platform_shared.auth.jwt_backend import (
+    IatJWTStrategy,
+    build_jwt_auth_backend,
+)
+from platform_shared.core.permissions import make_decode_token_iat
+
+SECRET = "test-secret-key-for-jwt-backend-tests-32bytes"
+
+
+class _FakeUser:
+    def __init__(self) -> None:
+        self.id = uuid.uuid4()
+
+
+def _decode_unchecked(token: str) -> dict[str, Any]:
+    return jwt.decode(
+        token,
+        SECRET,
+        algorithms=["HS256"],
+        audience="fastapi-users:auth",
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_token_includes_iat_claim() -> None:
+    """Tokens MUST carry ``iat`` — the strict-superuser gate requires it."""
+    backend = build_jwt_auth_backend(secret_key=SECRET, lifetime_seconds=3600)
+    strategy = backend.get_jwt_strategy()
+    before = int(time.time())
+
+    token = await strategy.write_token(_FakeUser())
+
+    payload = _decode_unchecked(token)
+    assert "iat" in payload, "iat claim missing — strict-superuser gate will 401"
+    assert isinstance(payload["iat"], int)
+    assert before <= payload["iat"] <= int(time.time())
+
+
+@pytest.mark.asyncio
+async def test_write_token_preserves_standard_claims() -> None:
+    """The fix MUST NOT drop sub/aud/exp."""
+    backend = build_jwt_auth_backend(secret_key=SECRET, lifetime_seconds=3600)
+    strategy = backend.get_jwt_strategy()
+    user = _FakeUser()
+
+    token = await strategy.write_token(user)
+
+    payload = _decode_unchecked(token)
+    assert payload["sub"] == str(user.id)
+    assert payload["aud"] == ["fastapi-users:auth"]
+    assert "exp" in payload
+    assert payload["exp"] > payload["iat"]
+
+
+@pytest.mark.asyncio
+async def test_factory_returns_iat_strategy() -> None:
+    """The factory MUST instantiate the iat-emitting subclass.
+
+    A future refactor that swaps ``IatJWTStrategy`` back to the upstream
+    ``JWTStrategy`` would silently re-introduce the bug; pin the type.
+    """
+    backend = build_jwt_auth_backend(secret_key=SECRET, lifetime_seconds=3600)
+    assert isinstance(backend.get_jwt_strategy(), IatJWTStrategy)
+
+
+@pytest.mark.asyncio
+async def test_iat_roundtrips_through_decode_token_iat() -> None:
+    """The gate's iat reader MUST see the value the strategy writes.
+
+    Catches mismatches in audience, algorithm, or secret-key plumbing
+    between issue-side and verify-side.
+    """
+    from fastapi import Request
+
+    backend = build_jwt_auth_backend(secret_key=SECRET, lifetime_seconds=3600)
+    strategy = backend.get_jwt_strategy()
+    token = await strategy.write_token(_FakeUser())
+
+    decode = make_decode_token_iat(secret_key=SECRET)
+    request = Request(
+        {
+            "type": "http",
+            "headers": [(b"authorization", f"Bearer {token}".encode())],
+        }
+    )
+
+    iat = decode(request)
+    assert iat is not None, "decode_token_iat returned None on a freshly-issued token"
+    assert abs(iat - time.time()) < 5


### PR DESCRIPTION
## Summary

- fastapi-users 15.0.5's default `JWTStrategy.write_token` emits only `{sub, aud, exp}` — no `iat`. PR #555's `make_strict_superuser_gate` enforces a recent-auth window by reading `iat`, so every strict-superuser endpoint returned **401 "Token missing or unreadable iat claim"** against real platform-issued tokens. Surfaced by the diagnostic toast added in #709 (admin Demo create).
- Adds `IatJWTStrategy` subclass that always emits `iat` in `write_token`; `build_jwt_auth_backend` instantiates it so all 5 consuming apps (MBK, MJH, MGA, MPT, scaffold) inherit the fix from one factory call.
- New test file `packages/shared-backend/tests/test_jwt_backend.py` (4 tests) exercises the full issue-side → verify-side round trip, including the gate's `make_decode_token_iat` callable. Closes the test gap that let this ship (existing gate tests mocked `decode_token_iat`, never hit `write_token`).

## Why this slipped through

Strict-superuser gate tests in `test_permissions.py` and `test_admin_router_stepup.py` mock `decode_token_iat` to return a fresh timestamp. They verify the gate logic but never run a real token through `JWTStrategy.write_token`. The new test pins both halves.

## Test plan

- [x] `pytest tests/test_jwt_backend.py tests/test_permissions.py tests/test_admin_router_stepup.py` — 29 passed locally
- [x] Full `packages/shared-backend` suite — 538 passed; 6 failures are pre-existing and unrelated (twilio module not installed in MBK venv; MGA infra-template drift)
- [ ] CI green
- [ ] After merge: deploy → operator retries Create Demo User → confirm 200 OK (or `X-TOTP-Code header required` if step-up is the next gate, which is the documented happy path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)