### PR TITLE
feat(mga): 4-pane storyboard lineup tile (PR4 — frontend-only)

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -1,16 +1,18 @@
 /**
- * GlanceBoardTile unit tests (PR2 clip view).
+ * GlanceBoardTile unit tests — PR4 4-pane storyboard.
  *
  * jsdom implements neither IntersectionObserver nor HTMLMediaElement
  * play/pause, so both are stubbed here (not globally — keeps blast radius
  * to this file).
  *
  * Tests:
- * - clip_url present → <video> rendered (poster=stand), stills NOT rendered
- * - clip_url null → falls back to the STAND/AIM stills, no <video>
- * - src is lazy: absent until the tile scrolls into view
- * - in view → play() called + src attached; out of view → pause() called
- * - IntersectionObserver missing → arms immediately (graceful degrade)
+ * - All four panes (STAND, AIM, THROW, LANDING) render simultaneously
+ *   regardless of clip_url presence (PR4 invariant)
+ * - THROW pane: ClipView lazy-loads on scroll; pauses out of view; degrades
+ *   without IntersectionObserver (existing PR2 behavior preserved)
+ * - THROW pane: ThrowPlaceholder when clip_url is null
+ * - LANDING pane: renders target_zone.name; falls back to "—" when null
+ * - Throw technique footer (PR3 behavior preserved)
  */
 import { render, screen, act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -103,31 +105,73 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("GlanceBoardTile clip view", () => {
-  it("renders the stills fallback when clip_url is null", () => {
+// ---------------------------------------------------------------------------
+// 4-pane storyboard — the PR4 invariant
+// ---------------------------------------------------------------------------
+describe("GlanceBoardTile storyboard (4 panes)", () => {
+  it("renders all four panes simultaneously when clip_url is null (stills + placeholders)", () => {
     render(<GlanceBoardTile lineup={makeLineup({ clip_url: null })} />);
     expect(screen.getByText("STAND")).toBeInTheDocument();
     expect(screen.getByText("AIM")).toBeInTheDocument();
+    // THROW pane shows the placeholder badge + "No clip yet" message.
+    expect(screen.getByText("THROW")).toBeInTheDocument();
+    expect(screen.getByText("No clip yet")).toBeInTheDocument();
+    expect(screen.getByText("LANDING")).toBeInTheDocument();
+    expect(screen.getByText("B Site")).toBeInTheDocument();
     expect(document.querySelector("video")).toBeNull();
   });
 
-  it("renders a <video> (poster=stand) and hides the stills when clip_url is set", () => {
+  it("renders all four panes simultaneously when clip_url is set (stills + clip + landing)", () => {
     render(
       <GlanceBoardTile
         lineup={makeLineup({ clip_url: "https://ex.com/clip.mp4" })}
       />,
     );
+    // The stills must still render — PR4 reverses PR2's clip-replaces-stills.
+    expect(screen.getByText("STAND")).toBeInTheDocument();
+    expect(screen.getByText("AIM")).toBeInTheDocument();
+    expect(screen.getByText("LANDING")).toBeInTheDocument();
+    expect(screen.getByText("B Site")).toBeInTheDocument();
+    // THROW pane now hosts the clip.
+    expect(screen.getByText("THROW")).toBeInTheDocument();
     const video = document.querySelector("video") as HTMLVideoElement;
     expect(video).not.toBeNull();
     expect(video.getAttribute("poster")).toBe("https://ex.com/stand.png");
-    expect(video.muted).toBe(true);
-    expect(video.hasAttribute("loop")).toBe(true);
-    expect(video.hasAttribute("playsinline")).toBe(true);
-    // The split stills are not used when a clip exists.
-    expect(screen.queryByText("STAND")).not.toBeInTheDocument();
-    expect(screen.queryByText("AIM")).not.toBeInTheDocument();
   });
 
+  it("renders the aim anchor dot when coords are set on the AIM pane", () => {
+    render(<GlanceBoardTile lineup={makeLineup()} />);
+    expect(screen.getByLabelText(/aim anchor/i)).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// LANDING pane behavior
+// ---------------------------------------------------------------------------
+describe("GlanceBoardTile LANDING pane", () => {
+  it("renders the target zone name", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({
+          target_zone: { id: "z9", slug: "mid", name: "Mid", polygon_points: [] },
+        })}
+      />,
+    );
+    expect(screen.getByText("Mid")).toBeInTheDocument();
+    expect(screen.getByText("Lands in")).toBeInTheDocument();
+  });
+
+  it("falls back to '—' when target_zone is null (malformed lineup)", () => {
+    render(<GlanceBoardTile lineup={makeLineup({ target_zone: null as unknown as Lineup["target_zone"] })} />);
+    expect(screen.getByText("LANDING")).toBeInTheDocument();
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// THROW pane clip behavior (PR2 — preserved in the new bottom-left pane)
+// ---------------------------------------------------------------------------
+describe("GlanceBoardTile THROW pane (clip)", () => {
   it("lazily attaches src only after the tile scrolls into view", () => {
     render(
       <GlanceBoardTile
@@ -159,16 +203,18 @@ describe("GlanceBoardTile clip view", () => {
     expect(pauseSpy).toHaveBeenCalled();
   });
 
-  it("hides the Clip badge when the clip fails to load", () => {
+  it("hides the THROW badge when the clip fails to load", () => {
     render(
       <GlanceBoardTile
         lineup={makeLineup({ clip_url: "https://ex.com/gone.mp4" })}
       />,
     );
-    expect(screen.getByText("Clip")).toBeInTheDocument();
+    expect(screen.getByText("THROW")).toBeInTheDocument();
     const video = document.querySelector("video") as HTMLVideoElement;
     act(() => video.dispatchEvent(new Event("error")));
-    expect(screen.queryByText("Clip")).not.toBeInTheDocument();
+    // The clip pane's overlay label is hidden so the poster (stand still)
+    // stays as the graceful fallback rather than reading as broken.
+    expect(screen.queryByText("THROW")).not.toBeInTheDocument();
   });
 
   it("arms immediately when IntersectionObserver is unavailable", () => {
@@ -184,7 +230,7 @@ describe("GlanceBoardTile clip view", () => {
 });
 
 // ---------------------------------------------------------------------------
-// PR3 — throw-technique footer
+// PR3 — throw-technique footer (preserved)
 // ---------------------------------------------------------------------------
 describe("GlanceBoardTile technique footer", () => {
   it("renders the technique string with the correct aria-label when set", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -12,9 +12,23 @@
  */
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import LineupCard from "@/components/lineup/LineupCard";
 import type { Lineup } from "@/types/game";
+
+// jsdom doesn't implement HTMLMediaElement.play/pause — when the expanded
+// variant mounts ClipView (for the THROW pane on a lineup with clip_url),
+// its useEffect calls el.play().catch(...) which would throw on the
+// undefined return. Stub locally rather than globally to keep blast radius
+// to this file (same posture as GlanceBoardTile.test.tsx).
+beforeEach(() => {
+  vi.spyOn(window.HTMLMediaElement.prototype, "play").mockResolvedValue(undefined);
+  vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 const BASE_LINEUP: Lineup = {
   id: "lineup-1",
@@ -180,5 +194,54 @@ describe("LineupCard", () => {
       />,
     );
     expect(screen.getByRole("button", { name: "Pin lineup" })).toBeDefined();
+  });
+
+  // ---------------------------------------------------------------------------
+  // PR4 — 2×2 storyboard (expanded variant only; thumbnail unchanged)
+  // ---------------------------------------------------------------------------
+
+  it("expanded variant renders all four pane labels (STAND, AIM, THROW, LANDING)", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    expect(screen.getByText("STAND")).toBeInTheDocument();
+    expect(screen.getByText("AIM")).toBeInTheDocument();
+    expect(screen.getByText("THROW")).toBeInTheDocument();
+    expect(screen.getByText("LANDING")).toBeInTheDocument();
+  });
+
+  it("expanded variant LANDING pane shows target_zone.name", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    expect(screen.getByText("Lands in")).toBeInTheDocument();
+    // BASE_LINEUP.target_zone.name = "A Site". Both the LANDING pane and the
+    // zone-context footer render that string; getAllByText covers either.
+    expect(screen.getAllByText("A Site").length).toBeGreaterThan(0);
+  });
+
+  it("expanded variant LANDING pane falls back to '—' when target_zone is null", () => {
+    const lineup: Lineup = {
+      ...BASE_LINEUP,
+      target_zone: null as unknown as Lineup["target_zone"],
+    };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  it("expanded variant THROW pane shows ThrowPlaceholder when clip_url is null", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    expect(screen.getByText("No clip yet")).toBeInTheDocument();
+    expect(document.querySelector("video")).toBeNull();
+  });
+
+  it("expanded variant THROW pane renders ClipView when clip_url is set", () => {
+    const lineup: Lineup = { ...BASE_LINEUP, clip_url: "https://ex.com/clip.mp4" };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    expect(document.querySelector("video")).not.toBeNull();
+    // The ThrowPlaceholder copy must not appear when a clip is mounted.
+    expect(screen.queryByText("No clip yet")).not.toBeInTheDocument();
+  });
+
+  it("expanded variant header surfaces technique when set", () => {
+    const lineup: Lineup = { ...BASE_LINEUP, technique: "Jumpthrow + LMB" };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    expect(screen.getByText(/Jumpthrow \+ LMB/)).toBeInTheDocument();
   });
 });

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -1,27 +1,49 @@
 /**
  * GlanceBoardTile — full-size tile for the glance board viewer.
  *
- * Designed for second-monitor use: both STAND and AIM screenshots rendered
- * at full size (~380px each, 16:9) with no click-to-expand. The detail IS
- * the default state.
+ * Designed for second-monitor use: a 2×2 storyboard with no click-to-expand.
+ * The detail IS the default state.
  *
- * Layout:
- *   ┌───────────────────────────────────────────────┐
- *   │ [UTIL BADGE]  <title>            <side>·<from> │  header
- *   ├──────────────────────┬────────────────────────┤
- *   │   STAND screenshot   │   AIM screenshot        │  two 16:9 halves
- *   │   (label STAND)      │   (label AIM + dot)     │
- *   ├──────────────────────┴────────────────────────┤
- *   │  ⏱ <setup_seconds>s   [ — technique — ]        │  reserved footer
- *   └───────────────────────────────────────────────┘
+ * Layout (PR4 — four panes for four jobs):
+ *   ┌────────────────────────────────────────────────┐
+ *   │ [UTIL]  <title>                 <side>·<from>  │  header
+ *   ├──────────────────────┬─────────────────────────┤
+ *   │   STAND screenshot   │   AIM screenshot         │  top row
+ *   │                      │       ● anchor dot      │
+ *   ├──────────────────────┼─────────────────────────┤
+ *   │   THROW (clip loop)  │   LANDING (text card)   │  bottom row
+ *   │                      │   Lands in: <zone>      │
+ *   ├──────────────────────┴─────────────────────────┤
+ *   │  ⏱ <setup_seconds>s     <technique>            │  footer
+ *   └────────────────────────────────────────────────┘
  *
- * The footer is a PR2 placeholder — structure reserved, content muted.
+ * Each pane does a distinct executional job: arrive (stand), look (aim),
+ * throw (clip motion), land (target zone). All four render unconditionally
+ * — gracefully degrades per-pane when its data is null. Same height as
+ * today's single-clip tile (~346px at 500px wide); same per-pane size as
+ * today's stand|aim fallback so the aim anchor dot keeps its accuracy.
+ *
+ * Today: STAND/AIM are stills; THROW is the PR2 looping clip; LANDING is a
+ * placeholder text card. PR5 will replace LANDING with a real landing clip;
+ * PR6 will replace stand/aim stills with 1s micro-clips. The 2×2 framework
+ * is the same; panes just upgrade their content.
+ *
+ * Pane primitives (ScreenshotHalf, AimAnchorDot, ClipView, ThrowPlaceholder,
+ * LandingPane) live in LineupPanes.tsx so LineupCard's expanded variant
+ * renders the identical shape inside the detail-panel.
+ *
  * notes are NOT displayed inline; they live in a title= tooltip.
  */
-import { useEffect, useRef, useState } from "react";
 import { Clock } from "lucide-react";
 import type { Lineup } from "@/types/game";
 import { utilDisplay } from "@/constants/utilityDisplay";
+import {
+  AimAnchorDot,
+  ClipView,
+  LandingPane,
+  ScreenshotHalf,
+  ThrowPlaceholder,
+} from "./LineupPanes";
 
 interface GlanceBoardTileProps {
   lineup: Lineup;
@@ -44,176 +66,6 @@ function SideChip({ side }: { side: string | null }) {
     >
       {cfg.label}
     </span>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Aim anchor dot — 12px red circle, white outline, drop shadow
-// (Identical spec to LineupCard's AimAnchorDot)
-// ---------------------------------------------------------------------------
-function AimAnchorDot({ x, y }: { x: number; y: number }) {
-  return (
-    <div
-      aria-label={`Aim anchor at ${Math.round(x * 100)}%, ${Math.round(y * 100)}%`}
-      style={{
-        position: "absolute",
-        left: `calc(${x * 100}% - 6px)`,
-        top:  `calc(${y * 100}% - 6px)`,
-        width: 12,
-        height: 12,
-        borderRadius: "50%",
-        background: "rgba(239, 68, 68, 0.85)",
-        border: "2px solid white",
-        boxShadow: "0 1px 4px rgba(0,0,0,0.7)",
-        pointerEvents: "none",
-      }}
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Screenshot half
-// ---------------------------------------------------------------------------
-interface ScreenshotHalfProps {
-  url: string | null;
-  alt: string;
-  label: string;
-  children?: React.ReactNode;
-}
-
-function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProps) {
-  return (
-    <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
-      {url ? (
-        <img
-          src={url}
-          alt={alt}
-          className="absolute inset-0 w-full h-full object-cover"
-          draggable={false}
-        />
-      ) : (
-        <div className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
-          No screenshot
-        </div>
-      )}
-      {/* Corner label */}
-      <span className="absolute top-1.5 left-2 text-[10px] font-semibold tracking-wider text-white/80 bg-black/40 px-1.5 py-0.5 rounded uppercase select-none pointer-events-none">
-        {label}
-      </span>
-      {children}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Clip view (PR2) — gif-style looping throw clip, in-view autoplay
-//
-// A lineup is a *motion*; two stills structurally cannot show it. When a clip
-// exists it replaces the stand/aim split with a single muted looping video.
-// Only clips scrolled into view play (a glance board can hold dozens — letting
-// them all decode at once tanks the second-monitor frame rate). The src is
-// lazily attached on first view so off-screen clips never fetch.
-// ---------------------------------------------------------------------------
-interface ClipViewProps {
-  clipUrl: string;
-  posterUrl: string | null;
-  title: string;
-}
-
-function ClipView({ clipUrl, posterUrl, title }: ClipViewProps) {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  // Sticky once the tile has been seen: keep the src attached (re-fetching on
-  // every scroll-by is worse than keeping a paused decoded clip).
-  const [armed, setArmed] = useState(false);
-  // True while the tile is on screen — drives play/pause in a separate effect
-  // so play() never runs before React has committed the src to the DOM.
-  const [inView, setInView] = useState(false);
-  const [loadFailed, setLoadFailed] = useState(false);
-
-  // A new clipUrl (re-processed clip / rotated presigned URL) is a different
-  // clip — restart the lazy-load + error cycle.
-  useEffect(() => {
-    setArmed(false);
-    setLoadFailed(false);
-  }, [clipUrl]);
-
-  // Observer lifecycle ONLY. disconnect() (not unobserve) is the correct
-  // teardown — it covers React Strict Mode's mount→unmount→remount.
-  useEffect(() => {
-    const el = videoRef.current;
-    if (!el) return;
-    // Degrade where IntersectionObserver is absent (old webviews / jsdom):
-    // arm + treat as in view, let muted autoplay carry it.
-    if (typeof IntersectionObserver === "undefined") {
-      setArmed(true);
-      setInView(true);
-      return;
-    }
-    const obs = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0];
-        if (!entry) return;
-        if (entry.isIntersecting) {
-          setArmed(true);
-          setInView(true);
-        } else {
-          setInView(false);
-        }
-      },
-      { threshold: 0.25 },
-    );
-    obs.observe(el);
-    return () => obs.disconnect();
-  }, []);
-
-  // Play/pause AFTER src is committed (depends on armed+inView). autoPlay
-  // only fires on initial load, not on src reassignment, so re-entry needs
-  // an explicit play().
-  useEffect(() => {
-    const el = videoRef.current;
-    if (!el || !armed) return;
-    if (inView) {
-      // Rejects under autoplay policy / before the src is ready — muted
-      // autoplay will start it once loaded, so swallow the rejection.
-      void el.play().catch(() => {});
-    } else {
-      el.pause();
-      // Rewind so re-entry replays from the throw start (gif behaviour).
-      // seekable is empty for not-yet-loaded / non-seekable streams — an
-      // explicit check, not a silent try/catch (rules/no-bandaid).
-      if (el.seekable.length > 0) {
-        el.currentTime = 0;
-      }
-    }
-  }, [armed, inView]);
-
-  return (
-    <div className="relative bg-muted/20 aspect-video overflow-hidden">
-      <video
-        ref={videoRef}
-        // Lazy: no src until the tile has been in view at least once.
-        src={armed ? clipUrl : undefined}
-        poster={posterUrl ?? undefined}
-        muted
-        loop
-        autoPlay
-        playsInline
-        // Pre-view: metadata only. In view: allow buffering so the loop
-        // doesn't stall on first frame.
-        preload={armed ? "auto" : "metadata"}
-        aria-label={`${title} — looping throw clip (muted)`}
-        onError={() => setLoadFailed(true)}
-        className="absolute inset-0 w-full h-full object-cover"
-      />
-      {/* Hide the "Clip" affordance when the clip fails to load (e.g. an
-          expired presigned URL mid-session) — the poster (stand still)
-          stays as the graceful fallback rather than a misleading badge. */}
-      {!loadFailed && (
-        <span className="absolute top-1.5 left-2 text-[10px] font-semibold tracking-wider text-white/80 bg-black/40 px-1.5 py-0.5 rounded uppercase select-none pointer-events-none">
-          Clip
-        </span>
-      )}
-    </div>
   );
 }
 
@@ -249,14 +101,13 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
         </div>
       </div>
 
-      {/* ── Clip (PR2) if localised, else the stand/aim stills ────────── */}
-      {lineup.clip_url ? (
-        <ClipView
-          clipUrl={lineup.clip_url}
-          posterUrl={lineup.stand_screenshot_url}
-          title={lineup.title}
-        />
-      ) : (
+      {/* ── Body: 2×2 storyboard grid ───────────────────────────────────
+          Four panes, one per executional job. All render unconditionally;
+          each gracefully degrades when its source data is null. Same
+          per-pane dimensions as today's stand|aim fallback so the aim
+          anchor dot retains current pixel accuracy. */}
+      <div className="flex flex-col divide-y divide-border">
+        {/* Top row: STAND | AIM */}
         <div className="flex divide-x divide-border">
           <ScreenshotHalf
             url={lineup.stand_screenshot_url}
@@ -275,7 +126,20 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
               )}
           </ScreenshotHalf>
         </div>
-      )}
+        {/* Bottom row: THROW | LANDING */}
+        <div className="flex divide-x divide-border">
+          {lineup.clip_url ? (
+            <ClipView
+              clipUrl={lineup.clip_url}
+              posterUrl={lineup.stand_screenshot_url}
+              title={lineup.title}
+            />
+          ) : (
+            <ThrowPlaceholder />
+          )}
+          <LandingPane targetZoneName={lineup.target_zone?.name ?? null} />
+        </div>
+      </div>
 
       {/* ── Footer — setup time + throw technique (PR3) ────────────────── */}
       {/* Technique is the "how" — subordinate to the clip (the "what"): same

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
@@ -1,10 +1,13 @@
 /**
  * LineupCard — displays a single lineup in one of two variants:
- *   expanded   — side-by-side stand + aim images, full metadata, aim anchor overlay
- *   thumbnail  — stand image only (small), title underneath
+ *   expanded   — 2×2 storyboard (STAND | AIM / THROW | LANDING) + metadata
+ *                + notes + zone context, used by LineupDetailPanel
+ *   thumbnail  — stand image only (small), title underneath, used in lists
  *
- * The aim anchor circle renders at (aim_anchor_x * width, aim_anchor_y * height)
- * relative to the aim screenshot, using a CSS-absolute circle overlay.
+ * The expanded variant shares its pane primitives (ScreenshotHalf, AimAnchorDot,
+ * ClipView, ThrowPlaceholder, LandingPane) with GlanceBoardTile via
+ * LineupPanes.tsx — both surfaces converge on the same 4-pane shape so a
+ * change in pane behavior lands on both at once.
  *
  * Pin toggle:
  *   Pass isPinned + onPinToggle to show the pin button in either variant.
@@ -13,6 +16,13 @@
 import { Clock } from "lucide-react";
 import type { Lineup } from "@/types/game";
 import PinButton from "./PinButton";
+import {
+  AimAnchorDot,
+  ClipView,
+  LandingPane,
+  ScreenshotHalf,
+  ThrowPlaceholder,
+} from "./LineupPanes";
 
 interface LineupCardProps {
   lineup: Lineup;
@@ -75,7 +85,7 @@ export default function LineupCard({
     );
   }
 
-  // Expanded variant
+  // Expanded variant — 2×2 storyboard shared with GlanceBoardTile.
   return (
     <div className="rounded-lg border bg-card overflow-hidden">
       {/* Header */}
@@ -99,6 +109,11 @@ export default function LineupCard({
                 {lineup.setup_seconds}s
               </span>
             )}
+            {lineup.technique && (
+              <span className="text-xs text-muted-foreground truncate" title={lineup.technique}>
+                · {lineup.technique}
+              </span>
+            )}
           </div>
         </div>
 
@@ -107,62 +122,51 @@ export default function LineupCard({
         )}
       </div>
 
-      {/* Screenshots */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 p-3">
-        {/* Stand screenshot */}
-        <div>
-          <p className="text-xs text-muted-foreground mb-1.5 font-medium">Stand position</p>
-          <div className="rounded-md overflow-hidden bg-muted/20 aspect-video">
-            {lineup.stand_screenshot_url ? (
-              <img
-                src={lineup.stand_screenshot_url}
-                alt={`${lineup.title} — stand position`}
-                className="w-full h-full object-cover"
-              />
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-xs text-muted-foreground">
-                No screenshot
-              </div>
-            )}
-          </div>
+      {/* Body: 2×2 storyboard — same primitives as GlanceBoardTile, identical
+          per-pane shape so a player viewing the same lineup in either surface
+          sees the same layout. */}
+      <div className="flex flex-col divide-y divide-border">
+        <div className="flex divide-x divide-border">
+          <ScreenshotHalf
+            url={lineup.stand_screenshot_url}
+            alt={`${lineup.title} — stand position`}
+            label="STAND"
+          />
+          <ScreenshotHalf
+            url={lineup.aim_screenshot_url}
+            alt={`${lineup.title} — aim reference`}
+            label="AIM"
+          >
+            {lineup.aim_screenshot_url &&
+              lineup.aim_anchor_x != null &&
+              lineup.aim_anchor_y != null && (
+                <AimAnchorDot x={lineup.aim_anchor_x} y={lineup.aim_anchor_y} />
+              )}
+          </ScreenshotHalf>
         </div>
-
-        {/* Aim screenshot with anchor overlay */}
-        <div>
-          <p className="text-xs text-muted-foreground mb-1.5 font-medium">Aim reference</p>
-          <div className="rounded-md overflow-hidden bg-muted/20 aspect-video relative">
-            {lineup.aim_screenshot_url ? (
-              <>
-                <img
-                  src={lineup.aim_screenshot_url}
-                  alt={`${lineup.title} — aim reference`}
-                  className="w-full h-full object-cover"
-                />
-                {lineup.aim_anchor_x != null && lineup.aim_anchor_y != null && (
-                  <AimAnchorDot
-                    x={lineup.aim_anchor_x}
-                    y={lineup.aim_anchor_y}
-                  />
-                )}
-              </>
-            ) : (
-              <div className="w-full h-full flex items-center justify-center text-xs text-muted-foreground">
-                No screenshot
-              </div>
-            )}
-          </div>
+        <div className="flex divide-x divide-border">
+          {lineup.clip_url ? (
+            <ClipView
+              clipUrl={lineup.clip_url}
+              posterUrl={lineup.stand_screenshot_url}
+              title={lineup.title}
+            />
+          ) : (
+            <ThrowPlaceholder />
+          )}
+          <LandingPane targetZoneName={lineup.target_zone?.name ?? null} />
         </div>
       </div>
 
       {/* Notes */}
       {lineup.notes && (
-        <div className="px-4 pb-4">
+        <div className="px-4 py-3 border-t">
           <p className="text-xs text-muted-foreground whitespace-pre-wrap">{lineup.notes}</p>
         </div>
       )}
 
       {/* Zone context */}
-      <div className="px-4 pb-3 flex flex-wrap gap-2 text-xs text-muted-foreground">
+      <div className="px-4 py-3 flex flex-wrap gap-2 text-xs text-muted-foreground border-t">
         {lineup.target_zone && (
           <span>Target: <span className="text-foreground">{lineup.target_zone.name}</span></span>
         )}
@@ -171,26 +175,5 @@ export default function LineupCard({
         )}
       </div>
     </div>
-  );
-}
-
-/** Red crosshair dot positioned via CSS at the normalized anchor coords. */
-function AimAnchorDot({ x, y }: { x: number; y: number }) {
-  return (
-    <div
-      aria-label={`Aim anchor at ${Math.round(x * 100)}%, ${Math.round(y * 100)}%`}
-      style={{
-        position: "absolute",
-        left: `calc(${x * 100}% - 6px)`,
-        top: `calc(${y * 100}% - 6px)`,
-        width: 12,
-        height: 12,
-        borderRadius: "50%",
-        border: "2px solid rgba(239, 68, 68, 0.9)",
-        background: "rgba(239, 68, 68, 0.3)",
-        boxShadow: "0 0 0 1px rgba(0,0,0,0.5)",
-        pointerEvents: "none",
-      }}
-    />
   );
 }

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
@@ -1,0 +1,239 @@
+/**
+ * LineupPanes — shared pane primitives for the 4-pane lineup storyboard.
+ *
+ * Both GlanceBoardTile (glance-board surface) and LineupCard (detail-panel
+ * surface) render the same 2×2 grid: STAND (still), AIM (still + anchor),
+ * THROW (clip loop or empty state), LANDING (text card until PR5).
+ *
+ * Extracted here so the two surfaces stay byte-equivalent — if the throw-
+ * pane behavior or the landing pane content evolves in PR5/PR6 we change
+ * it once and both surfaces follow. None of these primitives manage their
+ * own grid; the caller arranges them inside a flex row container.
+ */
+import { useEffect, useRef, useState } from "react";
+
+// ---------------------------------------------------------------------------
+// Aim anchor dot — 12px red filled circle, white outline, drop shadow.
+//
+// Positioned via CSS-absolute at (x*width, y*height) within an aspect-video
+// pane. Receives normalized coords (0..1). Use as a child of ScreenshotHalf
+// inside the AIM pane only.
+// ---------------------------------------------------------------------------
+export function AimAnchorDot({ x, y }: { x: number; y: number }) {
+  return (
+    <div
+      aria-label={`Aim anchor at ${Math.round(x * 100)}%, ${Math.round(y * 100)}%`}
+      style={{
+        position: "absolute",
+        left: `calc(${x * 100}% - 6px)`,
+        top:  `calc(${y * 100}% - 6px)`,
+        width: 12,
+        height: 12,
+        borderRadius: "50%",
+        background: "rgba(239, 68, 68, 0.85)",
+        border: "2px solid white",
+        boxShadow: "0 1px 4px rgba(0,0,0,0.7)",
+        pointerEvents: "none",
+      }}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ScreenshotHalf — one still-image pane.
+//
+// Used for STAND and AIM panes (the two stand-in jobs). Renders the image
+// when url is non-null, otherwise a "No screenshot" empty state. Corner
+// label overlays in top-left. Children render on top (used by AIM to host
+// the anchor dot).
+// ---------------------------------------------------------------------------
+interface ScreenshotHalfProps {
+  url: string | null;
+  alt: string;
+  label: string;
+  children?: React.ReactNode;
+}
+
+export function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProps) {
+  return (
+    <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
+      {url ? (
+        <img
+          src={url}
+          alt={alt}
+          className="absolute inset-0 w-full h-full object-cover"
+          draggable={false}
+        />
+      ) : (
+        <div className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
+          No screenshot
+        </div>
+      )}
+      <CornerLabel>{label}</CornerLabel>
+      {children}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ClipView (PR2) — gif-style looping throw clip, in-view autoplay.
+//
+// The src is lazily attached on first view so off-screen clips never fetch;
+// only clips scrolled into view play (a glance board can hold dozens — letting
+// them all decode at once tanks the second-monitor frame rate). After PR4
+// this lives in the bottom-left THROW pane alongside the still panes.
+// ---------------------------------------------------------------------------
+interface ClipViewProps {
+  clipUrl: string;
+  posterUrl: string | null;
+  title: string;
+}
+
+export function ClipView({ clipUrl, posterUrl, title }: ClipViewProps) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  // Sticky once the tile has been seen: keep the src attached (re-fetching on
+  // every scroll-by is worse than keeping a paused decoded clip).
+  const [armed, setArmed] = useState(false);
+  // True while the tile is on screen — drives play/pause in a separate effect
+  // so play() never runs before React has committed the src to the DOM.
+  const [inView, setInView] = useState(false);
+  const [loadFailed, setLoadFailed] = useState(false);
+
+  // A new clipUrl (re-processed clip / rotated presigned URL) is a different
+  // clip — restart the lazy-load + error cycle.
+  useEffect(() => {
+    setArmed(false);
+    setLoadFailed(false);
+  }, [clipUrl]);
+
+  // Observer lifecycle ONLY. disconnect() (not unobserve) is the correct
+  // teardown — it covers React Strict Mode's mount→unmount→remount.
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el) return;
+    // Degrade where IntersectionObserver is absent (old webviews / jsdom):
+    // arm + treat as in view, let muted autoplay carry it.
+    if (typeof IntersectionObserver === "undefined") {
+      setArmed(true);
+      setInView(true);
+      return;
+    }
+    const obs = new IntersectionObserver(
+      (entries) => {
+        const entry = entries[0];
+        if (!entry) return;
+        if (entry.isIntersecting) {
+          setArmed(true);
+          setInView(true);
+        } else {
+          setInView(false);
+        }
+      },
+      { threshold: 0.25 },
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, []);
+
+  // Play/pause AFTER src is committed (depends on armed+inView). autoPlay
+  // only fires on initial load, not on src reassignment, so re-entry needs
+  // an explicit play().
+  useEffect(() => {
+    const el = videoRef.current;
+    if (!el || !armed) return;
+    if (inView) {
+      // Rejects under autoplay policy / before the src is ready — muted
+      // autoplay will start it once loaded, so swallow the rejection.
+      void el.play().catch(() => {});
+    } else {
+      el.pause();
+      // Rewind so re-entry replays from the throw start (gif behaviour).
+      // seekable is empty for not-yet-loaded / non-seekable streams — an
+      // explicit check, not a silent try/catch (rules/no-bandaid).
+      if (el.seekable.length > 0) {
+        el.currentTime = 0;
+      }
+    }
+  }, [armed, inView]);
+
+  return (
+    <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
+      <video
+        ref={videoRef}
+        // Lazy: no src until the tile has been in view at least once.
+        src={armed ? clipUrl : undefined}
+        poster={posterUrl ?? undefined}
+        muted
+        loop
+        autoPlay
+        playsInline
+        // Pre-view: metadata only. In view: allow buffering so the loop
+        // doesn't stall on first frame.
+        preload={armed ? "auto" : "metadata"}
+        aria-label={`${title} — looping throw clip (muted)`}
+        onError={() => setLoadFailed(true)}
+        className="absolute inset-0 w-full h-full object-cover"
+      />
+      {/* Hide the "THROW" affordance when the clip fails to load (e.g. an
+          expired presigned URL mid-session) — the poster (stand still)
+          stays as the graceful fallback rather than a misleading badge. */}
+      {!loadFailed && <CornerLabel>THROW</CornerLabel>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ThrowPlaceholder — empty state for the bottom-left pane when clip_url is
+// null (no clip generated yet). Same dimensions + corner-label posture as
+// ScreenshotHalf — reads as "this pane belongs to throw motion; nothing
+// captured yet" rather than as a load failure.
+// ---------------------------------------------------------------------------
+export function ThrowPlaceholder() {
+  return (
+    <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
+      <div className="absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
+        No clip yet
+      </div>
+      <CornerLabel>THROW</CornerLabel>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// LandingPane — bottom-right pane. Shows where the utility lands.
+//
+// PR4 ships a text-only placeholder ("Lands in: <target_zone.name>") because
+// no landing-clip extraction exists yet. PR5 will replace the placeholder
+// with a real ~1-2s looping landing clip. The pane is the same dimensions
+// either way — only the inner content changes.
+// ---------------------------------------------------------------------------
+interface LandingPaneProps {
+  targetZoneName: string | null;
+}
+
+export function LandingPane({ targetZoneName }: LandingPaneProps) {
+  return (
+    <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
+      <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-2 text-center">
+        <span className="text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+          Lands in
+        </span>
+        <span className="text-sm font-semibold leading-tight max-w-full truncate">
+          {targetZoneName ?? "—"}
+        </span>
+      </div>
+      <CornerLabel>LANDING</CornerLabel>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// CornerLabel — small TL-corner uppercase label. Shared across all panes.
+// ---------------------------------------------------------------------------
+function CornerLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="absolute top-1.5 left-2 text-[10px] font-semibold tracking-wider text-white/80 bg-black/40 px-1.5 py-0.5 rounded uppercase select-none pointer-events-none">
+      {children}
+    </span>
+  );
+}


### PR DESCRIPTION
## Summary

Reverses PR2's "clip replaces stand+aim stills" decision. The clip teaches the throw motion; the stills tell you *where to stand* and *where to look* — different jobs. Hiding either kills lineup usefulness during execution.

PR4 makes both `GlanceBoardTile` and `LineupCard`'s expanded variant share a permanent **2×2 storyboard**:

| | |
|---|---|
| STAND (still) | AIM (still + anchor dot) |
| THROW (clip) | LANDING (text "Lands in: <zone>") |

All four panes render unconditionally; each gracefully degrades when its data is null (stills → "No screenshot"; THROW → "No clip yet"; LANDING → "—" when zone missing).

## Constraints honored

- Same per-pane dimensions as today's stand|aim fallback → aim anchor dot keeps current pixel accuracy
- Same total tile height as today's clip-only tile (~346px at 500px wide) → no glance-board density loss
- Backend-free PR by design (the framework lands now; PR5/PR6 fill in the loops)
- Ternary budget: 2 ternaries per JSX expression respected; uses `&&` short-circuits + early returns
- One-feature-per-PR: minimap-bigger, sidebar-collapse, search improvements are separate

## Architecture

Shared pane primitives (`ScreenshotHalf`, `AimAnchorDot`, `ClipView`, `ThrowPlaceholder`, `LandingPane`) extracted to `LineupPanes.tsx` so both surfaces stay byte-equivalent. PR2's clip behavior (lazy `src`, in-view autoplay, fail-quietly-on-load-error) preserved unchanged.

## Followup PRs (referenced for context, NOT in scope here)

- **PR5** — Backend extracts a `landing_clip_url` (Claude window-identify + ffmpeg cut + idempotent backfill, mirroring PR2/PR3 pattern). LANDING pane lights up.
- **PR6** — Backend converts stand/aim stills to 1s micro-clips. The 2×2 framework stays; STAND/AIM panes get motion.
- **Search PRs** — minimap-click-to-filter, text search, keyboard zone filter (separate small PRs).

## Stacking note ⚠️

This PR's base is `feature/jykwon91/mga-throw-technique` (PR #710). **Once PR #710 merges into main, retarget this PR's base to `main`** — see `claude-code-push-u-cleanup-hazard.md` and `stacked-pr-merge-base-trap.md`. Without retargeting, squash-merging the parent orphans this PR.

## Test plan

- [x] Frontend vitest green — 305/305
- [x] `npm run typecheck` clean
- [x] All 4 panes render simultaneously regardless of `clip_url` (asserted)
- [x] LANDING pane fallback to "—" when `target_zone` is null (asserted)
- [x] PR2 clip behavior preserved (lazy src, in-view autoplay, badge hide on load error)
- [x] PR3 technique footer untouched (existing tests still green)
- [ ] CI green
- [ ] Visual check on dev server after PR710 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)