### PR TITLE
feat(mbk/demo): seed Airbnb-payout shapes that exercise #697–#703 UX

### DIFF
--- a/apps/mybookkeeper/backend/app/repositories/demo/demo_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/demo/demo_repo.py
@@ -14,9 +14,14 @@ from app.models.properties.property_classification import PropertyClassification
 from app.models.tax.tax_form_field import TaxFormField
 from app.models.tax.tax_form_instance import TaxFormInstance
 from app.models.tax.tax_return import TaxReturn
+from app.models.transactions.rent_attribution_review_queue import (
+    RentAttributionReviewQueue,
+)
 from app.models.transactions.transaction import Transaction
 from app.models.transactions.transaction_document import TransactionDocument
 from app.models.user.user import Role, User
+
+_AIRBNB_CHANNELS = {"airbnb", "vrbo", "booking.com"}
 
 
 async def get_user_by_email(db: AsyncSession, email: str) -> User | None:
@@ -201,15 +206,31 @@ async def create_transactions(
     property_ids: list[uuid.UUID],
     transactions_data: list[tuple],
 ) -> list[Transaction]:
-    """Create transactions and return them for document linking."""
+    """Create transactions and return them for document linking.
+
+    ``prop_idx=None`` seeds an unattributed transaction (NULL property_id).
+    Airbnb-tagged income rows get ``channel="airbnb"`` + ``payment_method=
+    "platform_payout"`` so they match the real shape the extraction prompt
+    emits for platform payouts (per ``_is_airbnb_payout`` in PR #698) — this
+    is the cue the dashboard and review-queue UX use to render the new
+    Airbnb-payout row shapes.
+    """
     created: list[Transaction] = []
     for row in transactions_data:
         prop_idx, date_str, vendor, desc, amount, txn_type, category, sched_line, tags, sub_cat = row
         txn_date = date.fromisoformat(date_str)
+        channel: str | None = next(
+            (t for t in tags if t in _AIRBNB_CHANNELS), None,
+        )
+        payment_method: str | None = (
+            "platform_payout"
+            if channel == "airbnb" and txn_type == "income" and category == "rental_revenue"
+            else None
+        )
         txn = Transaction(
             organization_id=organization_id,
             user_id=user_id,
-            property_id=property_ids[prop_idx],
+            property_id=property_ids[prop_idx] if prop_idx is not None else None,
             transaction_date=txn_date,
             tax_year=txn_date.year,
             vendor=vendor,
@@ -220,12 +241,55 @@ async def create_transactions(
             sub_category=sub_cat,
             schedule_e_line=sched_line,
             tags=tags,
+            channel=channel,
+            payment_method=payment_method,
             tax_relevant=True,
             status="approved",
             is_manual=True,
         )
         db.add(txn)
         created.append(txn)
+    await db.flush()
+    return created
+
+
+async def create_attribution_review(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    organization_id: uuid.UUID,
+    property_ids: list[uuid.UUID],
+    transactions: list[Transaction],
+    review_data: list[tuple[str, int | None, str]],
+) -> int:
+    """Seed rent_attribution_review_queue rows for unattributed payouts.
+
+    Each ``review_data`` tuple is matched to a transaction by description
+    substring. ``proposed_property_index`` is resolved against ``property_ids``;
+    ``None`` leaves the row in the airbnb-unmatched shape.
+
+    Returns the number of review rows created (for logging / tests).
+    """
+    created = 0
+    for description_match, proposed_prop_idx, confidence in review_data:
+        txn = next(
+            (t for t in transactions if description_match in (t.description or "")),
+            None,
+        )
+        if txn is None:
+            continue
+        proposed_property_id = (
+            property_ids[proposed_prop_idx] if proposed_prop_idx is not None else None
+        )
+        row = RentAttributionReviewQueue(
+            user_id=user_id,
+            organization_id=organization_id,
+            transaction_id=txn.id,
+            proposed_property_id=proposed_property_id,
+            confidence=confidence,
+            status="pending",
+        )
+        db.add(row)
+        created += 1
     await db.flush()
     return created
 

--- a/apps/mybookkeeper/backend/app/services/demo/demo_constants.py
+++ b/apps/mybookkeeper/backend/app/services/demo/demo_constants.py
@@ -51,8 +51,10 @@ DEMO_PROPERTIES = [
 
 # Each tuple: (property_index, date, vendor, description, amount, type, category, schedule_e_line, tags, sub_category)
 # sub_category is optional (None for non-utility transactions)
+# property_index=None means an UNATTRIBUTED transaction (shows up in the dashboard's
+# Unassigned bucket per PR #697; review-queue rows in DEMO_ATTRIBUTION_REVIEW below).
 # Property indexes: 0=Sunset Villa (LA), 1=Oak Street Duplex (Austin), 2=Downtown Loft (Nashville)
-DEMO_TRANSACTIONS: list[tuple[int, str, str, str, str, str, str, str | None, list[str], str | None]] = [
+DEMO_TRANSACTIONS: list[tuple[int | None, str, str, str, str, str, str, str | None, list[str], str | None]] = [
     # ==========================================================================
     # REVENUE — Sunset Villa (Airbnb short-term, seasonal LA market)
     # ==========================================================================
@@ -471,6 +473,38 @@ DEMO_TRANSACTIONS: list[tuple[int, str, str, str, str, str, str, str | None, lis
     (0, "2025-04-02", "Home Depot", "Guest amenities and bathroom supplies", "85.00", "expense", "other_expense", "line_19_other", [], None),
     (0, "2025-10-15", "Home Depot", "Smoke detectors and fire extinguisher replacement", "120.00", "expense", "other_expense", "line_19_other", [], None),
     (2, "2025-07-05", "Lowes", "Replacement door locks and hardware", "95.00", "expense", "other_expense", "line_19_other", [], None),
+
+    # ==========================================================================
+    # REVENUE — UNATTRIBUTED Airbnb payouts (property_index=None)
+    # Showcases PR #697 (Unassigned dashboard bucket reconciles with totals) and
+    # the four review-queue row shapes from PR #703 (airbnb-fuzzy / airbnb-unmatched).
+    # Matching review-queue rows are seeded by demo_repo.create_attribution_review
+    # from DEMO_ATTRIBUTION_REVIEW below. Rent-fuzzy / rent-unmatched shapes are
+    # not seeded — demo doesn't include applicants.
+    # ==========================================================================
+    (None, "2025-11-22", "Airbnb", "Airbnb payout — guest stay at Sunset Villa", "1450.00", "income", "rental_revenue", "line_3_rents_received", ["airbnb"], None),
+    (None, "2025-12-18", "Airbnb", "Airbnb payout — Sunset Villa December guests", "1820.00", "income", "rental_revenue", "line_3_rents_received", ["airbnb"], None),
+    (None, "2025-11-28", "Airbnb", "Airbnb payout — Downtown Loft Nashville stay", "1290.00", "income", "rental_revenue", "line_3_rents_received", ["airbnb"], None),
+    (None, "2025-12-05", "Airbnb", "Airbnb payout — multi-night booking", "980.00", "income", "rental_revenue", "line_3_rents_received", ["airbnb"], None),
+    (None, "2025-12-22", "Airbnb", "Airbnb payout — reservation HMABC123456", "1640.00", "income", "rental_revenue", "line_3_rents_received", ["airbnb"], None),
+]
+
+# ==========================================================================
+# DEMO_ATTRIBUTION_REVIEW — rent_attribution_review_queue rows for the
+# unattributed Airbnb payouts above. The first two tiers of the matcher
+# (PR #701) auto-attribute on their own; this seed populates rows that
+# would have landed in review (tier 3 fuzzy / tier 4 unmatched).
+#
+# Each tuple: (description_substring_to_match, proposed_property_index_or_None, confidence)
+# confidence ∈ {"fuzzy", "unmatched"} (CHECK constraint on the table).
+# A "fuzzy" row should set proposed_property_index; "unmatched" leaves it None.
+# ==========================================================================
+DEMO_ATTRIBUTION_REVIEW: list[tuple[str, int | None, str]] = [
+    ("guest stay at Sunset Villa", 0, "fuzzy"),
+    ("Sunset Villa December guests", 0, "fuzzy"),
+    ("Downtown Loft Nashville stay", 2, "fuzzy"),
+    ("multi-night booking", None, "unmatched"),
+    ("reservation HMABC123456", None, "unmatched"),
 ]
 
 # ==========================================================================

--- a/apps/mybookkeeper/backend/app/services/demo/demo_service.py
+++ b/apps/mybookkeeper/backend/app/services/demo/demo_service.py
@@ -17,6 +17,7 @@ from app.schemas.demo.demo import (
     DemoUserSummary,
 )
 from app.services.demo.demo_constants import (
+    DEMO_ATTRIBUTION_REVIEW,
     DEMO_DOCUMENTS,
     DEMO_PROPERTIES,
     DEMO_TAX_DOCUMENTS,
@@ -61,6 +62,9 @@ async def create_demo_user(
         property_ids = await demo_repo.create_properties(db, user.id, org.id, DEMO_PROPERTIES)
         transactions = await demo_repo.create_transactions(
             db, user.id, org.id, property_ids, DEMO_TRANSACTIONS,
+        )
+        await demo_repo.create_attribution_review(
+            db, user.id, org.id, property_ids, transactions, DEMO_ATTRIBUTION_REVIEW,
         )
         await demo_repo.create_documents_with_links(
             db, user.id, org.id, property_ids, DEMO_PROPERTIES,

--- a/apps/mybookkeeper/backend/tests/test_demo_service.py
+++ b/apps/mybookkeeper/backend/tests/test_demo_service.py
@@ -16,12 +16,16 @@ from app.models.organization.organization import Organization
 from app.models.tax.tax_form_field import TaxFormField
 from app.models.tax.tax_form_instance import TaxFormInstance
 from app.models.tax.tax_return import TaxReturn
+from app.models.transactions.rent_attribution_review_queue import (
+    RentAttributionReviewQueue,
+)
 from app.models.transactions.transaction import Transaction
 from app.models.transactions.transaction_document import TransactionDocument
 from app.models.user.user import User
 from app.repositories.demo import demo_repo
 from app.services.demo import demo_service
 from app.services.demo.demo_constants import (
+    DEMO_ATTRIBUTION_REVIEW,
     DEMO_DOCUMENTS,
     DEMO_TAX_DOCUMENTS,
     DEMO_TRANSACTIONS,
@@ -129,6 +133,105 @@ class TestDemoServiceCreateDemoUser:
         await demo_service.create_demo_user("dup-test")
         with pytest.raises(ValueError, match="already exists"):
             await demo_service.create_demo_user("dup-test")
+
+
+class TestDemoServiceAirbnbAttributionShowcase:
+    """Demo data must exercise PR #697/#699/#701/#703 — Unassigned dashboard
+    bucket and the airbnb-fuzzy / airbnb-unmatched review-queue row shapes.
+    Demo users created without these become stale once the feature ships."""
+
+    @pytest.mark.asyncio
+    async def test_seeds_unattributed_airbnb_payouts(self, db: AsyncSession) -> None:
+        await demo_service.create_demo_user("unassigned-test")
+        user = await demo_repo.get_user_by_email(
+            db, "demo+unassigned-test@mybookkeeper.com",
+        )
+        assert user is not None
+        org = await demo_repo.get_org_by_user(db, user.id)
+        assert org is not None
+
+        # At least one NULL-property Airbnb payout — this is what drives the
+        # dashboard's Unassigned bucket (PR #697).
+        unattributed = (await db.execute(
+            select(Transaction).where(
+                Transaction.organization_id == org.id,
+                Transaction.property_id.is_(None),
+                Transaction.transaction_type == "income",
+            )
+        )).scalars().all()
+        assert len(unattributed) >= 1, "demo must seed unattributed Airbnb payouts"
+        for txn in unattributed:
+            assert txn.channel == "airbnb", "Airbnb payouts must carry channel='airbnb'"
+            assert txn.payment_method == "platform_payout"
+
+    @pytest.mark.asyncio
+    async def test_attributed_airbnb_revenue_has_channel_and_payment_method(
+        self, db: AsyncSession,
+    ) -> None:
+        """Existing Airbnb payouts must also look like real platform payouts —
+        otherwise channel-aware dashboards (and the matcher's detection per
+        PR #698) treat them as P2P revenue."""
+        await demo_service.create_demo_user("channel-test")
+        user = await demo_repo.get_user_by_email(
+            db, "demo+channel-test@mybookkeeper.com",
+        )
+        assert user is not None
+        org = await demo_repo.get_org_by_user(db, user.id)
+        assert org is not None
+
+        airbnb_txns = (await db.execute(
+            select(Transaction).where(
+                Transaction.organization_id == org.id,
+                Transaction.tags.contains(["airbnb"]),
+                Transaction.transaction_type == "income",
+            )
+        )).scalars().all()
+        assert len(airbnb_txns) > 0
+        for txn in airbnb_txns:
+            assert txn.channel == "airbnb"
+            assert txn.payment_method == "platform_payout"
+
+    @pytest.mark.asyncio
+    async def test_seeds_review_queue_rows_for_all_four_shapes(
+        self, db: AsyncSession,
+    ) -> None:
+        """Seeds both airbnb-fuzzy (proposed_property_id set, confidence='fuzzy')
+        and airbnb-unmatched (proposed_property_id=NULL, confidence='unmatched')
+        so the review UI from PR #703 renders against real data."""
+        await demo_service.create_demo_user("queue-test")
+        user = await demo_repo.get_user_by_email(
+            db, "demo+queue-test@mybookkeeper.com",
+        )
+        assert user is not None
+        org = await demo_repo.get_org_by_user(db, user.id)
+        assert org is not None
+
+        rows = (await db.execute(
+            select(RentAttributionReviewQueue).where(
+                RentAttributionReviewQueue.organization_id == org.id,
+            )
+        )).scalars().all()
+        assert len(rows) == len(DEMO_ATTRIBUTION_REVIEW)
+
+        fuzzy_with_property = [
+            r for r in rows
+            if r.confidence == "fuzzy" and r.proposed_property_id is not None
+        ]
+        unmatched_without_property = [
+            r for r in rows
+            if r.confidence == "unmatched" and r.proposed_property_id is None
+        ]
+        assert len(fuzzy_with_property) >= 1, "airbnb-fuzzy shape missing"
+        assert len(unmatched_without_property) >= 1, "airbnb-unmatched shape missing"
+
+        # Every review row must link to a transaction that's actually unattributed
+        # — confirming pending; otherwise the host-side confirm flow would no-op.
+        for row in rows:
+            assert row.status == "pending"
+            txn = (await db.execute(
+                select(Transaction).where(Transaction.id == row.transaction_id)
+            )).scalar_one()
+            assert txn.property_id is None
 
 
 class TestDemoServiceListDemoUsers:


### PR DESCRIPTION
## Summary

The Airbnb-payout attribution series (PRs #697–#703) added the dashboard Unassigned bucket and the airbnb-fuzzy / airbnb-unmatched review-queue row shapes. The demo seed predates them — every demo Airbnb transaction was already attributed to a property, and the review queue was always empty — so demo testers never saw the new UX.

## Changes

- **5 unattributed Airbnb payouts** (`property_id IS NULL`) in `DEMO_TRANSACTIONS` → drives the dashboard's Unassigned bucket (PR #697).
- **Tag-derived `channel` / `payment_method`** in `demo_repo.create_transactions`: every Airbnb income row gets `channel="airbnb"` + `payment_method="platform_payout"` to match the real shape the extraction prompt emits and the matcher's `_is_airbnb_payout` detection (PR #698).
- **New `DEMO_ATTRIBUTION_REVIEW` constant** + `demo_repo.create_attribution_review` seed `rent_attribution_review_queue` rows:
  - 3 **airbnb-fuzzy** (proposed_property_id set, confidence=`fuzzy`)
  - 2 **airbnb-unmatched** (proposed_property_id=NULL, confidence=`unmatched`)
  So the review UI from PR #703 renders both shapes against real demo data (PRs #699, #701).

## Out of scope

- **Rent-fuzzy / rent-unmatched** shapes — demo doesn't seed applicants, and adding applicants is a larger refresh. The two new Airbnb shapes are the ones that recent PRs added; rent shapes were already reachable via the older review-queue flow.

## Test plan

- [x] `pytest tests/test_demo_service.py` — 45 passed (42 existing + 3 new)
- [x] `pytest tests/test_attribution_routes.py tests/test_attribution_service_confirm_property.py tests/test_attribution_repo.py tests/test_demo_security.py` — 43 passed
- [ ] CI green
- [ ] After merge + deploy, operator creates a fresh demo user and confirms in the demo's dashboard: an "Unassigned" line appears with ~$7,180 across 5 Airbnb payouts; the review queue shows 5 rows (3 with a property suggestion, 2 without)

🤖 Generated with [Claude Code](https://claude.com/claude-code)