### PR TITLE
feat(mga): landing-clip pipeline (PR5) — LandingPane lights up

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0012_lineup_landing_clip.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0012_lineup_landing_clip.py
@@ -1,0 +1,43 @@
+"""Add landing_clip_url to lineup
+
+Revision ID: 0012
+Revises: 0011
+Create Date: 2026-05-21 00:00:00.000000
+
+Adds a nullable ``landing_clip_url`` column to the ``lineup`` table so the
+PR5 landing-clip pipeline and frontend LandingPane have a stable contract.
+
+The column stores a bare MinIO object key exactly like ``clip_url``
+(presigned to a 24-hour GET URL at read time in
+``lineup_service._build_read``). Landing-clip upload is handled by
+``app.services.ingestion.landing_clip_generator`` — this migration only
+extends the schema.
+
+Additive: all existing rows default to NULL. The app is fully functional
+without the backfill — new ingests auto-populate, old rows simply show the
+existing "Lands in: <zone>" text fallback in the LANDING pane. The
+operator runs ``python -m app.cli backfill-landing-clips`` once
+post-deploy to populate accepted ingested lineups (idempotent).
+
+Downgrade: drops the column unconditionally. Data loss is expected and
+acceptable on rollback — the LandingPane gracefully degrades to text.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0012"
+down_revision = "0011"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lineup",
+        sa.Column("landing_clip_url", sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("lineup", "landing_clip_url")

--- a/apps/mygamingassistant/backend/app/cli/__init__.py
+++ b/apps/mygamingassistant/backend/app/cli/__init__.py
@@ -4,6 +4,7 @@ Usage:
     python -m app.cli load-fixtures
     python -m app.cli backfill-clips
     python -m app.cli backfill-technique
+    python -m app.cli backfill-landing-clips
 """
 import asyncio
 import sys
@@ -54,6 +55,32 @@ async def _run_backfill_technique() -> int:
     return 1 if stats.failed else 0
 
 
+async def _run_backfill_landing_clips() -> int:
+    """Generate landing clips for accepted lineups missing one. Exit code.
+
+    Idempotent — safe to re-run; only lineups with ``landing_clip_url IS
+    NULL`` are touched. Independent of ``backfill-clips`` and
+    ``backfill-technique`` (separate NULL column). A non-zero exit signals
+    at least one hard failure so the operator notices (re-running retries
+    them — they are not fatal).
+    """
+    from app.db.session import AsyncSessionLocal
+    from app.services.ingestion.landing_clip_backfill import (
+        backfill_landing_clips,
+    )
+
+    async with AsyncSessionLocal() as db:
+        stats = await backfill_landing_clips(db)
+
+    print(stats.summary())
+    if stats.errors:
+        print(f"  {len(stats.errors)} issue(s):")
+        for err in stats.errors:
+            print(f"   - {err}")
+    # Re-runnable: failures retry next run, so a non-zero exit is advisory.
+    return 1 if stats.failed else 0
+
+
 def main() -> None:
     command = sys.argv[1] if len(sys.argv) > 1 else ""
 
@@ -65,12 +92,15 @@ def main() -> None:
         sys.exit(asyncio.run(_run_backfill_clips()))
     elif command == "backfill-technique":
         sys.exit(asyncio.run(_run_backfill_technique()))
+    elif command == "backfill-landing-clips":
+        sys.exit(asyncio.run(_run_backfill_landing_clips()))
     else:
         print(f"Unknown command: {command!r}")
         print("Available commands:")
-        print("  load-fixtures      — load game taxonomy fixtures into the database")
-        print("  backfill-clips     — generate clips for accepted lineups missing one")
-        print("  backfill-technique — name throw-technique for accepted lineups missing one")
+        print("  load-fixtures          — load game taxonomy fixtures into the database")
+        print("  backfill-clips         — generate clips for accepted lineups missing one")
+        print("  backfill-technique     — name throw-technique for accepted lineups missing one")
+        print("  backfill-landing-clips — generate landing clips for accepted lineups missing one")
         sys.exit(1)
 
 

--- a/apps/mygamingassistant/backend/app/models/game/lineup.py
+++ b/apps/mygamingassistant/backend/app/models/game/lineup.py
@@ -110,6 +110,12 @@ class Lineup(Base):
     stand_screenshot_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     aim_screenshot_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
     clip_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # PR5 short looping clip showing where the utility lands (smoke deploying,
+    # molly burning, etc.). Bare MinIO key like clip_url; presigned at read
+    # time. Best-effort and orthogonal to lineup validity — a NULL value
+    # renders the existing "Lands in: <zone>" text fallback in the LANDING
+    # pane. See app/services/ingestion/landing_clip_generator.py.
+    landing_clip_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     # Normalized 0-1 crosshair position on the aim screenshot
     aim_anchor_x: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -351,6 +351,71 @@ async def set_clip_url(
     return lineup
 
 
+async def list_accepted_lineups_needing_landing_clips(
+    db: AsyncSession,
+) -> list[Lineup]:
+    """Accepted, ingested lineups that don't have a landing clip yet.
+
+    The PR5 backfill set: ``status='accepted'`` AND a source video to
+    re-fetch (``youtube_video_id`` not null — manual uploads have no source
+    frames so a landing clip is never extractable for them) AND no landing
+    clip yet (``landing_clip_url`` null). Filtering on null
+    ``landing_clip_url`` is exactly what makes the backfill idempotent — a
+    generated landing clip drops out of this set, so re-running only touches
+    the remainder. Ordered oldest-first so a long backfill makes visible
+    monotonic progress.
+
+    Mirrors :func:`list_accepted_lineups_needing_clips` (PR2) — the two
+    backfills are independent (separate operator commands, separate NULL
+    columns) and intentionally not coupled. A lineup can have a throw clip
+    but no landing clip, or vice versa.
+    """
+    stmt = (
+        select(Lineup)
+        .where(
+            Lineup.status == "accepted",
+            Lineup.youtube_video_id.is_not(None),
+            Lineup.landing_clip_url.is_(None),
+        )
+        .order_by(Lineup.created_at.asc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def set_landing_clip_url(
+    db: AsyncSession,
+    lineup: Lineup,
+    landing_clip_key: str,
+) -> Lineup:
+    """Persist the generated landing-clip's bare MinIO key onto a lineup row.
+
+    Its own one-column commit (not folded into the throw-clip commit, the
+    classifier writeback, or the technique commit) on purpose — identical
+    rationale to :func:`set_clip_url` and :func:`set_technique`: the landing
+    clip is best-effort and orthogonal to the row's validity (a lineup is
+    fully usable from its stills + throw clip + technique with no landing
+    clip; the LandingPane gracefully falls back to "Lands in: <zone>"
+    text). A landing-clip failure must NEVER roll back the already-committed
+    lineup, classifier suggestions, throw clip, or technique; a successful
+    landing clip must NOT wait on anything else.
+
+    Transaction ownership lives here in the repo per PR #687/#695 — the
+    ingestion orchestrator and the backfill CLI never call db.commit().
+    ``landing_clip_url`` stores a BARE object key (like stand/aim screenshot
+    URLs and ``clip_url``); presigning happens at read time in
+    ``lineup_service._build_read``.
+    """
+    lineup.landing_clip_url = landing_clip_key
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
 async def list_accepted_lineups_needing_technique(
     db: AsyncSession,
 ) -> list[Lineup]:

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -70,6 +70,9 @@ class LineupRead(BaseModel):
     stand_screenshot_url: Optional[str] = None
     aim_screenshot_url: Optional[str] = None
     clip_url: Optional[str] = None
+    # PR5 landing-clip key; presigned to a 24h GET URL at read time in
+    # lineup_service._build_read alongside the other MinIO keys.
+    landing_clip_url: Optional[str] = None
     aim_anchor_x: Optional[float] = None
     aim_anchor_y: Optional[float] = None
     # Minimap anchor positions — raw values from the DB. May be NULL; use the

--- a/apps/mygamingassistant/backend/app/services/game/lineup_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_service.py
@@ -181,6 +181,7 @@ def _build_read(lineup: Lineup) -> LineupRead:
             "stand_screenshot_url": _sign_screenshot_url(read.stand_screenshot_url),
             "aim_screenshot_url": _sign_screenshot_url(read.aim_screenshot_url),
             "clip_url": _sign_screenshot_url(read.clip_url),
+            "landing_clip_url": _sign_screenshot_url(read.landing_clip_url),
         }
     )
 

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -50,6 +50,9 @@ from app.services.classification.classifier_service import (
     classify_frames_for_lineup_decision,
 )
 from app.services.ingestion.clip_generator import generate_clip_for_lineup
+from app.services.ingestion.landing_clip_generator import (
+    generate_landing_clip_for_lineup,
+)
 from app.services.ingestion.technique_extractor import (
     extract_technique_for_lineup,
 )
@@ -391,6 +394,7 @@ async def _process_chapter(
         # returns structured outcomes and doesn't raise for expected
         # failures; the broad catch is purely defensive against an unexpected
         # bug taking down ingestion.
+        clip_result = None
         try:
             utility_hint = await _resolve_utility_hint(db, result)
             clip_result = await generate_clip_for_lineup(
@@ -416,6 +420,48 @@ async def _process_chapter(
                 source.id, video_meta.video_id, start, lineup.id, str(exc),
                 exc_info=True,
             )
+
+        # PR5: best-effort landing clip. Shares PR2's classifier output —
+        # only fires when clip_result is "generated" (meaning PR2's gates
+        # cleared and result_ts is known). We pass precomputed_result_ts so
+        # landing_clip_generator does NOT make its own Claude call: the cost
+        # of adding the landing pane to ingest is one extra ffmpeg cut plus
+        # one extra MinIO upload per chapter — no extra classifier spend.
+        # Skipped landings stay NULL and render the existing zone-text
+        # fallback. Same non-fatal contract as the clip + technique blocks
+        # above (landing-clip failure must not roll back the lineup).
+        if (
+            clip_result is not None
+            and clip_result.status == "generated"
+            and clip_result.result_ts is not None
+        ):
+            try:
+                landing_result = await generate_landing_clip_for_lineup(
+                    db,
+                    lineup,
+                    chapter_start=float(chapter.start_seconds),
+                    chapter_end=float(chapter.end_seconds),
+                    video_path=video_path,
+                    precomputed_result_ts=clip_result.result_ts,
+                    precomputed_confidence=clip_result.confidence,
+                )
+                logger.info(
+                    "Landing-clip generation (ingest): source_id=%s "
+                    "video_id=%s chapter_start=%d lineup_id=%s status=%s "
+                    "reason=%s",
+                    source.id, video_meta.video_id, start, lineup.id,
+                    landing_result.status,
+                    landing_result.skip_reason
+                    or (",".join(landing_result.error_codes) or "-"),
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Landing-clip generation unexpected error "
+                    "(non-fatal): source_id=%s video_id=%s chapter_start=%d "
+                    "lineup_id=%s error=%s",
+                    source.id, video_meta.video_id, start, lineup.id,
+                    str(exc), exc_info=True,
+                )
 
         # PR3: best-effort throw-technique footer text. Symmetric to the clip
         # block above and equally non-fatal — independent Claude call, own

--- a/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_backfill.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_backfill.py
@@ -1,0 +1,240 @@
+"""Backfill landing clips for accepted lineups that predate the PR5 pipeline.
+
+Lineups created before PR5 (and any whose landing-clip generation failed at
+ingest time) have ``landing_clip_url IS NULL``. This walks that set,
+re-fetches each source video ONCE per video (not once per lineup — a
+tutorial video usually backs many lineups), localises the landing via
+``classify_throw_timing_from_frames``, and generates the landing clip.
+
+Independent of :mod:`clip_backfill` by design: a lineup can have a PR2
+throw clip but no landing clip (or vice versa). The two NULL columns are
+separate work sets and the operator runs the two commands independently.
+
+Idempotent by construction: the work set is exactly
+``status='accepted' AND youtube_video_id IS NOT NULL AND landing_clip_url IS NULL``
+(``lineup_repo.list_accepted_lineups_needing_landing_clips``). A generated
+landing clip sets ``landing_clip_url`` and drops out of the set, so
+re-running only processes the remainder. A ``failed`` lineup keeps
+``landing_clip_url`` NULL and is retried on the next run (transient
+yt-dlp / ffmpeg / Claude failures self-heal). A ``skipped`` lineup
+(genuinely not a throw / chapter too short) also stays NULL and will be
+re-evaluated on a future run.
+
+Per rules/no-bandaid-solutions.md + rules/check-third-party-error-codes.md:
+every yt-dlp / ffmpeg / Claude failure is captured with its structured
+reason and tallied — nothing silently disappears.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.lineup import Lineup
+from app.models.game.utility_type import UtilityType
+from app.repositories.game import lineup_repo
+from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.landing_clip_generator import (
+    generate_landing_clip_for_lineup,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+    download_video,
+    fetch_video_detail,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LandingClipBackfillStats:
+    """Aggregate outcome of a landing-clip backfill run (printed by the CLI)."""
+
+    total: int = 0
+    generated: int = 0
+    skipped: int = 0
+    failed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        return (
+            f"backfill-landing-clips: {self.total} candidate lineup(s) — "
+            f"{self.generated} generated, {self.skipped} skipped, "
+            f"{self.failed} failed"
+        )
+
+
+async def _utility_hint(db: AsyncSession, lineup: Lineup) -> str | None:
+    """The lineup's confirmed utility slug, for the throw-timing RESULT cue.
+
+    Same shape as :func:`clip_backfill._utility_hint` (PR2). A backfilled
+    lineup is ``accepted`` — the operator already confirmed
+    ``utility_type_id`` — so this hint is strictly stronger than the >0.6
+    grid suggestion the ingest path uses.
+    """
+    if lineup.utility_type_id is None:
+        return None
+    return (
+        await db.execute(
+            select(UtilityType.slug).where(
+                UtilityType.id == lineup.utility_type_id
+            )
+        )
+    ).scalar_one_or_none()
+
+
+def _find_chapter(
+    chapters: list[Chapter], start_seconds: int | None
+) -> Chapter | None:
+    """The chapter whose start matches the lineup's stored chapter start.
+
+    Identical to :func:`clip_backfill._find_chapter` — the ingest path
+    persisted ``chapter_start_seconds`` from the same ``parse_chapters``
+    output, so an exact start match re-identifies it. A miss means the
+    video's chapters changed since ingest.
+    """
+    if start_seconds is None:
+        return None
+    for ch in chapters:
+        if ch.start_seconds == start_seconds:
+            return ch
+    return None
+
+
+async def backfill_landing_clips(db: AsyncSession) -> LandingClipBackfillStats:
+    """Generate landing clips for every accepted ingested lineup missing one.
+
+    Returns a :class:`LandingClipBackfillStats`. Designed to be invoked once
+    by the operator post-deploy (``python -m app.cli backfill-landing-clips``);
+    safe to re-run at any time.
+    """
+    stats = LandingClipBackfillStats()
+
+    lineups = await lineup_repo.list_accepted_lineups_needing_landing_clips(db)
+    stats.total = len(lineups)
+    if not lineups:
+        logger.info(
+            "backfill-landing-clips: nothing to do (no candidate lineups)"
+        )
+        return stats
+
+    # Group by source video so each video is fetched + downloaded ONCE.
+    by_video: dict[str, list[Lineup]] = defaultdict(list)
+    for lineup in lineups:
+        by_video[lineup.youtube_video_id].append(lineup)
+
+    download_dir = Path(settings.ingestion_download_dir)
+    logger.info(
+        "backfill-landing-clips: %d lineup(s) across %d video(s)",
+        stats.total, len(by_video),
+    )
+
+    for video_id, video_lineups in by_video.items():
+        # ---- One metadata fetch per video ------------------------------
+        try:
+            meta = await fetch_video_detail(video_id)
+        except YouTubeFetchError as exc:
+            logger.warning(
+                "backfill-landing-clips: metadata fetch failed: video_id=%s "
+                "error_type=%s message=%s — %d lineup(s) failed",
+                video_id, exc.error_type, str(exc), len(video_lineups),
+            )
+            stats.failed += len(video_lineups)
+            stats.errors.append(
+                f"{video_id}: metadata fetch failed ({exc.error_type})"
+            )
+            continue
+
+        chapters = parse_chapters(
+            description=meta.description,
+            video_duration=meta.duration,
+            native_chapters=meta.chapters or None,
+        )
+
+        # ---- One download per video ------------------------------------
+        try:
+            video_path = await download_video(video_id, download_dir)
+        except VideoDownloadError as exc:
+            logger.warning(
+                "backfill-landing-clips: download failed: video_id=%s "
+                "error_type=%s message=%s — %d lineup(s) failed",
+                video_id, exc.error_type, str(exc), len(video_lineups),
+            )
+            stats.failed += len(video_lineups)
+            stats.errors.append(
+                f"{video_id}: download failed ({exc.error_type})"
+            )
+            continue
+
+        try:
+            for lineup in video_lineups:
+                chapter = _find_chapter(chapters, lineup.chapter_start_seconds)
+                if chapter is None:
+                    logger.warning(
+                        "backfill-landing-clips: chapter not found: "
+                        "lineup=%s video_id=%s chapter_start=%s — skipping",
+                        lineup.id, video_id, lineup.chapter_start_seconds,
+                    )
+                    stats.skipped += 1
+                    stats.errors.append(
+                        f"{video_id}[{lineup.chapter_start_seconds}]: "
+                        f"chapter not found (video changed since ingest)"
+                    )
+                    continue
+
+                try:
+                    result = await generate_landing_clip_for_lineup(
+                        db,
+                        lineup,
+                        chapter_start=float(chapter.start_seconds),
+                        chapter_end=float(chapter.end_seconds),
+                        # Reuse the once-downloaded file — do NOT let the
+                        # generator re-download per lineup.
+                        video_path=video_path,
+                        utility_hint=await _utility_hint(db, lineup),
+                        # Backfill runs its own classifier call — no PR2
+                        # context to share here.
+                        precomputed_result_ts=None,
+                    )
+                except Exception as exc:  # defensive: never abort the batch
+                    logger.warning(
+                        "backfill-landing-clips: unexpected error: lineup=%s "
+                        "video_id=%s error=%s",
+                        lineup.id, video_id, str(exc), exc_info=True,
+                    )
+                    stats.failed += 1
+                    stats.errors.append(
+                        f"{lineup.id}: unexpected:{type(exc).__name__} {exc}"
+                    )
+                    continue
+
+                if result.status == "generated":
+                    stats.generated += 1
+                elif result.status == "skipped":
+                    stats.skipped += 1
+                else:
+                    stats.failed += 1
+                    stats.errors.append(
+                        f"{lineup.id}: "
+                        f"{','.join(result.error_codes) or 'failed'}"
+                    )
+        finally:
+            # The backfill owns this download (one per video) — clean it up
+            # once, after all of the video's lineups are processed.
+            try:
+                video_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "backfill-landing-clips: failed to delete video: "
+                    "path=%s error=%s",
+                    video_path, str(exc),
+                )
+
+    logger.info("backfill-landing-clips: complete — %s", stats.summary())
+    return stats

--- a/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
@@ -1,0 +1,493 @@
+"""Landing-clip generator — short looping clip of where the utility LANDS.
+
+PR4 introduced the 2×2 storyboard tile (STAND still + AIM still + THROW clip +
+LANDING text). PR5 replaces the LANDING text placeholder with a short looping
+clip of the moment the utility actually lands/explodes — smoke deploying, molly
+burning, flash detonation, ability resolving. The text fallback ("Lands in:
+<zone>") remains the always-valid graceful degradation when no landing clip
+exists, exactly like the stills remain the fallback for the THROW clip.
+
+End-to-end:
+
+  1. Two entry paths share a single gate-passing contract:
+
+     a. **Ingest** — the orchestrator already ran PR2's throw-timing
+        classifier inside ``clip_generator``. It passes the resolved
+        ``precomputed_result_ts`` (PR2's ``result_ts``) directly. We skip the
+        classifier call entirely (cost saving: one Claude call per chapter
+        instead of two) and skip the gates because PR2 already cleared them.
+
+     b. **Backfill** — standalone CLI run. ``precomputed_result_ts`` is None,
+        so we run ``classify_throw_timing_from_frames`` ourselves and apply
+        the same gates PR2 uses (not-a-throw / low-confidence / no-result
+        frame → skip).
+
+  2. Anchor the clip on the LANDING moment (``result_ts``). PR2's throw clip
+     covers ``[release - 2.0, result + 0.5]`` — the throw motion — and crops
+     the post-landing tail tight. PR5's landing clip inverts the framing:
+     start just before the landing and dwell on the AFTER (``[result - 0.5,
+     result + 3.0]`` ≈ 3.5s). The two clips are deliberately offset so a
+     viewer sees motion in BOTH panes for the same lineup.
+
+  3. Cut + encode the muted MP4 via :func:`cut_clip` (re-uses PR2's ffmpeg
+     wrapper — same encode contract, same ``+faststart``), upload to MinIO
+     under a deterministic key, persist the bare key.
+
+Idempotent: the MinIO key is ``pending/{video_id}/{int(chapter_start)}-landing.mp4``;
+re-running overwrites the same object instead of orphaning a new one. The
+DB write is a single-column commit through :func:`lineup_repo.set_landing_clip_url`
+— a landing-clip failure NEVER rolls back the already-committed lineup, PR2
+throw clip, or PR3 technique. Mirrors :mod:`clip_generator` exactly.
+
+Failure handling (rules/no-bandaid-solutions.md +
+rules/check-third-party-error-codes.md): yt-dlp / ffmpeg / Claude failures
+are captured with structured codes, logged at WARNING, and returned as
+``status="failed"`` with ``error_codes``. ``landing_clip_url`` is left NULL
+and the LandingPane renders its text fallback. Nothing silent-fails.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.storage import get_storage
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+from app.services.classification.classifier_service import (
+    classify_throw_timing_from_frames,
+)
+from app.services.ingestion.frame_extractor import (
+    ClipCutError,
+    FrameExtractionError,
+    clip_window_timestamps,
+    cut_clip,
+    extract_frames_downscaled,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    download_video,
+)
+
+logger = logging.getLogger(__name__)
+
+# Frozen design-contract constants. The 0.55 gate matches PR2's throw clip —
+# if PR2 cleared its gate, the landing pass shares that judgment (so a clip
+# is generated or both are skipped together, never one without the other).
+_CLIP_CONFIDENCE_GATE = 0.55
+# Lead-in kept before landing / dwell time on the post-landing scene. The
+# 3.0s tail is the visible distinction from PR2's clip — PR2 cuts at result
+# + 0.5s, so landing gets a separate 3.5s pane focused on the after-effect
+# (smoke at full coverage, molly burn pattern, flash radius).
+_PRE_LANDING_SECONDS = 0.5
+_POST_LANDING_SECONDS = 3.0
+# Tight bounds — the landing pane is the smallest of the 2×2 storyboard.
+_MIN_CLIP_SECONDS = 1.0
+_TARGET_CLIP_SECONDS = _PRE_LANDING_SECONDS + _POST_LANDING_SECONDS  # 3.5s
+
+
+@dataclass
+class LandingClipGenerationResult:
+    """Structured outcome of a landing-clip-generation attempt.
+
+    Mirrors :class:`clip_generator.ClipGenerationResult` so the orchestrator's
+    summary logging and the backfill stats can route on ``status`` uniformly.
+
+    ``status`` is one of:
+      - ``"generated"`` — clip cut, uploaded, ``landing_clip_url`` committed.
+        ``clip_key`` is set.
+      - ``"skipped"``   — deliberately no clip (not a throw / low confidence /
+        no result frame / chapter too short / classifier disabled / no
+        precomputed result_ts when called from ingest). NOT an error; the
+        LandingPane gracefully falls back to "Lands in: <zone>" text.
+      - ``"failed"``    — an operational failure (download / extract / cut /
+        upload / Claude API). ``error_codes`` carries the structured reason;
+        ``landing_clip_url`` is left NULL; the lineup still works from its
+        stills + (possibly) throw clip + zone text. A later backfill run can
+        retry.
+    """
+
+    status: str
+    clip_key: Optional[str] = None
+    skip_reason: Optional[str] = None
+    error_codes: list[str] = field(default_factory=list)
+    reasoning: str = ""
+    confidence: Optional[float] = None
+    is_lineup_throw: Optional[bool] = None
+    result_ts: Optional[float] = None
+    clip_start: Optional[float] = None
+    clip_duration: Optional[float] = None
+
+
+def pending_landing_clip_key(video_id: str, chapter_start_seconds: float) -> str:
+    """Deterministic MinIO key for a lineup's landing clip.
+
+    Parallel to PR2's :func:`clip_generator.pending_clip_key` — same shape,
+    different suffix. One key per (video, chapter start) makes the backfill
+    idempotent: re-running overwrites the same object instead of orphaning a
+    new one.
+    """
+    return f"pending/{video_id}/{int(chapter_start_seconds)}-landing.mp4"
+
+
+def _compute_landing_bounds(
+    result_ts: float,
+    chapter_start: float,
+    chapter_end: float,
+) -> Optional[tuple[float, float]]:
+    """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
+
+    Centered on the landing: ``[result - 0.5, result + 3.0]`` clamped to the
+    chapter. Returns None when the clamped window is shorter than 1s (the
+    chapter has no headroom around the landing to carry a meaningful clip),
+    so the caller skips. We deliberately do NOT rebuild a target-length
+    window — for landing-clip the WHERE is more important than the
+    HOW-LONG, and a clamped sliver is more informative than a fabricated
+    one displaced to a different chapter region.
+    """
+    start = max(result_ts - _PRE_LANDING_SECONDS, chapter_start)
+    end = min(result_ts + _POST_LANDING_SECONDS, chapter_end)
+    duration = end - start
+    if duration < _MIN_CLIP_SECONDS:
+        return None
+    return start, duration
+
+
+async def generate_landing_clip_for_lineup(
+    db: AsyncSession,
+    lineup: Lineup,
+    *,
+    chapter_start: float,
+    chapter_end: float,
+    video_path: Optional[Path] = None,
+    download_dir: Optional[Path] = None,
+    utility_hint: Optional[str] = None,
+    precomputed_result_ts: Optional[float] = None,
+    precomputed_confidence: Optional[float] = None,
+) -> LandingClipGenerationResult:
+    """Cut a landing clip for *lineup*; persist ``landing_clip_url``.
+
+    Two entry paths:
+
+    **Ingest path** — caller (orchestrator) passes ``precomputed_result_ts``
+    from PR2's :class:`clip_generator.ClipGenerationResult`. We skip the
+    Claude classifier call entirely and skip the gates (PR2 already cleared
+    them). Cost: zero extra Claude spend; just an extra ffmpeg cut + MinIO
+    upload per chapter.
+
+    **Backfill path** — caller is the CLI; ``precomputed_result_ts`` is
+    None. We run ``classify_throw_timing_from_frames`` ourselves (cost: one
+    Claude call per lineup) and apply the same gates as PR2.
+
+    Args:
+        db: Active async session. On success the bare landing-clip key is
+            committed via ``lineup_repo.set_landing_clip_url`` (its own
+            one-column commit per PR #687/#695).
+        lineup: The row to clip. ``youtube_video_id`` must be set.
+        chapter_start / chapter_end: Source chapter bounds in seconds.
+        video_path: Already-downloaded source video to reuse (ingest /
+            backfill that batches per video). When None the video is
+            re-fetched into *download_dir* and deleted afterwards.
+        download_dir: Required when *video_path* is None.
+        utility_hint: Utility slug for the throw-timing RESULT cue.
+            Ignored when ``precomputed_result_ts`` is set.
+        precomputed_result_ts: PR2's ``result_ts`` if PR2's gate passed in
+            this same ingest call. Set this to skip the classifier call.
+        precomputed_confidence: PR2's confidence (purely informational —
+            propagated to the result for logging).
+
+    Returns:
+        LandingClipGenerationResult — see its docstring for ``status``
+        semantics. Never raises for an expected failure.
+    """
+    video_id = lineup.youtube_video_id
+    if not video_id:
+        logger.warning(
+            "landing_clip_generator: lineup %s has no youtube_video_id — "
+            "cannot clip",
+            lineup.id,
+        )
+        return LandingClipGenerationResult(
+            status="skipped", skip_reason="no_source_video"
+        )
+
+    # Resolve result_ts. Two paths: precomputed (ingest) or classify-ourselves
+    # (backfill). The precomputed path encodes PR2's gate decision — if the
+    # caller did not pass result_ts, that is itself a "gate decided no" signal
+    # and we skip silently with a matching reason.
+    if precomputed_result_ts is None:
+        # ---- Backfill path: run our own classifier ---------------------
+        if not settings.enable_classifier:
+            return LandingClipGenerationResult(
+                status="skipped", skip_reason="classifier_disabled"
+            )
+        if not settings.anthropic_api_key:
+            return LandingClipGenerationResult(
+                status="skipped",
+                skip_reason="classifier_unavailable:missing_api_key",
+            )
+
+        timestamps = clip_window_timestamps(chapter_start, chapter_end)
+        if not timestamps:
+            return LandingClipGenerationResult(
+                status="skipped", skip_reason="empty_clip_window"
+            )
+
+        owns_video = video_path is None
+        local_video: Optional[Path] = video_path
+        try:
+            if local_video is None:
+                if download_dir is None:
+                    logger.warning(
+                        "landing_clip_generator: lineup %s — no video_path "
+                        "and no download_dir; cannot re-fetch source",
+                        lineup.id,
+                    )
+                    return LandingClipGenerationResult(
+                        status="failed",
+                        error_codes=["no_download_dir"],
+                        reasoning="Re-fetch requested but no download_dir provided",
+                    )
+                try:
+                    local_video = await download_video(video_id, download_dir)
+                except VideoDownloadError as exc:
+                    logger.warning(
+                        "landing_clip_generator: source re-fetch failed: "
+                        "lineup=%s video_id=%s error_type=%s message=%s",
+                        lineup.id, video_id, exc.error_type, str(exc),
+                    )
+                    return LandingClipGenerationResult(
+                        status="failed",
+                        error_codes=[f"download:{exc.error_type}"],
+                        reasoning=f"Video re-fetch failed: {exc}",
+                    )
+
+            try:
+                frames = await extract_frames_downscaled(local_video, timestamps)
+            except FrameExtractionError as exc:
+                logger.warning(
+                    "landing_clip_generator: downscaled frame extraction "
+                    "failed: lineup=%s video_id=%s returncode=%s stderr=%s",
+                    lineup.id, video_id, exc.returncode, exc.stderr[:300],
+                )
+                return LandingClipGenerationResult(
+                    status="failed",
+                    error_codes=[f"frame_extract:rc={exc.returncode}"],
+                    reasoning=f"Downscaled frame extraction failed: {exc}",
+                )
+
+            chapter_duration = float(chapter_end) - float(chapter_start)
+            timing = await classify_throw_timing_from_frames(
+                frames=frames,
+                frame_timestamps=timestamps,
+                chapter_title=lineup.chapter_title,
+                chapter_duration=chapter_duration,
+                utility_hint=utility_hint,
+            )
+            if not timing.success:
+                logger.warning(
+                    "landing_clip_generator: throw-timing call failed: "
+                    "lineup=%s video_id=%s error_codes=%s reasoning=%s",
+                    lineup.id, video_id, timing.error_codes, timing.reasoning,
+                )
+                return LandingClipGenerationResult(
+                    status="failed",
+                    error_codes=list(timing.error_codes),
+                    reasoning=timing.reasoning,
+                )
+
+            # Apply PR2's gates (same order, same constants — the two pipelines
+            # share judgment).
+            if not timing.is_lineup_throw:
+                return LandingClipGenerationResult(
+                    status="skipped",
+                    skip_reason="not_a_throw",
+                    is_lineup_throw=False,
+                    confidence=timing.confidence,
+                    reasoning=timing.reasoning,
+                )
+            if (
+                timing.confidence is None
+                or timing.confidence < _CLIP_CONFIDENCE_GATE
+            ):
+                return LandingClipGenerationResult(
+                    status="skipped",
+                    skip_reason=f"low_confidence:{timing.confidence}",
+                    is_lineup_throw=True,
+                    confidence=timing.confidence,
+                    reasoning=timing.reasoning,
+                )
+            if timing.result_index is None:
+                return LandingClipGenerationResult(
+                    status="skipped",
+                    skip_reason="no_result_frame",
+                    is_lineup_throw=True,
+                    confidence=timing.confidence,
+                    reasoning=timing.reasoning,
+                )
+
+            result_ts = timestamps[timing.result_index - 1]
+            confidence_for_logging = timing.confidence
+            reasoning_for_logging = timing.reasoning
+
+            return await _cut_upload_persist(
+                db, lineup, video_id, local_video,
+                result_ts, chapter_start, chapter_end,
+                confidence_for_logging, reasoning_for_logging,
+                is_lineup_throw=True,
+            )
+        finally:
+            if owns_video and local_video is not None:
+                try:
+                    local_video.unlink(missing_ok=True)
+                except OSError as exc:
+                    logger.warning(
+                        "landing_clip_generator: failed to delete re-fetched "
+                        "video: path=%s error=%s",
+                        local_video, str(exc),
+                    )
+    else:
+        # ---- Ingest path: precomputed result_ts -----------------------
+        # The caller (orchestrator) only passes precomputed_result_ts after
+        # PR2's clip_generator returned status="generated", so the gates
+        # already cleared. We still validate video_path is set (ingest must
+        # reuse the on-disk video — re-downloading during ingest is a bug).
+        if video_path is None:
+            logger.warning(
+                "landing_clip_generator: lineup %s — precomputed_result_ts "
+                "set but no video_path provided. Ingest should reuse the "
+                "on-disk video; this is a wiring bug.",
+                lineup.id,
+            )
+            return LandingClipGenerationResult(
+                status="failed",
+                error_codes=["no_video_path_with_precomputed"],
+                reasoning="precomputed_result_ts requires video_path",
+            )
+
+        return await _cut_upload_persist(
+            db, lineup, video_id, video_path,
+            precomputed_result_ts, chapter_start, chapter_end,
+            precomputed_confidence, "",
+            is_lineup_throw=True,
+        )
+
+
+async def _cut_upload_persist(
+    db: AsyncSession,
+    lineup: Lineup,
+    video_id: str,
+    local_video: Path,
+    result_ts: float,
+    chapter_start: float,
+    chapter_end: float,
+    confidence: Optional[float],
+    reasoning: str,
+    *,
+    is_lineup_throw: bool,
+) -> LandingClipGenerationResult:
+    """Shared tail of the pipeline: bounds → ffmpeg cut → MinIO upload → DB commit.
+
+    Both the precomputed (ingest) and classify-ourselves (backfill) paths
+    converge here. Factored out so the gating/timing logic above stays
+    linear and the failure-handling shape is identical in both paths.
+    """
+    bounds = _compute_landing_bounds(
+        result_ts, float(chapter_start), float(chapter_end)
+    )
+    if bounds is None:
+        return LandingClipGenerationResult(
+            status="skipped",
+            skip_reason="chapter_too_short_for_landing_clip",
+            is_lineup_throw=is_lineup_throw,
+            confidence=confidence,
+            reasoning=reasoning,
+            result_ts=result_ts,
+        )
+    clip_start, clip_duration = bounds
+
+    # ---- Cut + encode the muted clip --------------------------------
+    try:
+        clip_bytes = await cut_clip(local_video, clip_start, clip_duration)
+    except ClipCutError as exc:
+        logger.warning(
+            "landing_clip_generator: clip cut failed: lineup=%s video_id=%s "
+            "start=%.2f dur=%.2f returncode=%s stderr=%s",
+            lineup.id, video_id, clip_start, clip_duration,
+            exc.returncode, exc.stderr[:300],
+        )
+        return LandingClipGenerationResult(
+            status="failed",
+            error_codes=[f"clip_cut:rc={exc.returncode}"],
+            reasoning=f"ffmpeg landing-clip cut failed: {exc}",
+            result_ts=result_ts,
+            clip_start=clip_start,
+            clip_duration=clip_duration,
+        )
+
+    # ---- Upload + persist the bare key ------------------------------
+    clip_key = pending_landing_clip_key(video_id, chapter_start)
+    try:
+        storage = get_storage()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, storage.upload_file, clip_key, clip_bytes, "video/mp4"
+        )
+    except Exception as exc:
+        logger.warning(
+            "landing_clip_generator: clip upload failed: lineup=%s key=%s "
+            "error=%s",
+            lineup.id, clip_key, str(exc),
+        )
+        return LandingClipGenerationResult(
+            status="failed",
+            error_codes=["clip_upload_failed"],
+            reasoning=f"MinIO landing-clip upload failed: {exc}",
+            result_ts=result_ts,
+            clip_start=clip_start,
+            clip_duration=clip_duration,
+        )
+
+    try:
+        await lineup_repo.set_landing_clip_url(db, lineup, clip_key)
+    except Exception as exc:
+        # The object is uploaded but the column did not commit. The key is
+        # deterministic, so a later backfill recomputes the same key and
+        # overwrites the same object — no orphan, safe to retry.
+        logger.warning(
+            "landing_clip_generator: landing_clip_url persist failed "
+            "(object uploaded, column not committed; backfill is "
+            "idempotent): lineup=%s key=%s error=%s",
+            lineup.id, clip_key, str(exc),
+        )
+        return LandingClipGenerationResult(
+            status="failed",
+            error_codes=["landing_clip_url_persist_failed"],
+            reasoning=f"landing_clip_url commit failed: {exc}",
+            result_ts=result_ts,
+            clip_start=clip_start,
+            clip_duration=clip_duration,
+        )
+
+    logger.info(
+        "landing_clip_generator: clip generated: lineup=%s video_id=%s "
+        "key=%s result_ts=%.2f clip=[%.2f,+%.2fs] confidence=%s",
+        lineup.id, video_id, clip_key, result_ts,
+        clip_start, clip_duration,
+        f"{confidence:.2f}" if confidence is not None else "n/a",
+    )
+    return LandingClipGenerationResult(
+        status="generated",
+        clip_key=clip_key,
+        is_lineup_throw=is_lineup_throw,
+        confidence=confidence,
+        reasoning=reasoning,
+        result_ts=result_ts,
+        clip_start=clip_start,
+        clip_duration=clip_duration,
+    )

--- a/apps/mygamingassistant/backend/tests/test_alembic_chain.py
+++ b/apps/mygamingassistant/backend/tests/test_alembic_chain.py
@@ -2,7 +2,7 @@
 
 These run against the raw migration scripts (no live DB) so they fit the
 default pytest suite. They lock in that the chain resolves to a single head
-(currently ``0010``) and that every revision is reachable base → head — the
+(currently ``0012``) and that every revision is reachable base → head — the
 class of bug where a new migration's ``down_revision`` is stale after a
 merge and silently orphans the chain.
 """
@@ -24,8 +24,8 @@ def script_directory() -> ScriptDirectory:
     return ScriptDirectory.from_config(cfg)
 
 
-def test_single_head_is_0011(script_directory: ScriptDirectory) -> None:
-    """The DAG must resolve to exactly one head and it must be 0011.
+def test_single_head_is_0012(script_directory: ScriptDirectory) -> None:
+    """The DAG must resolve to exactly one head and it must be 0012.
 
     Bump this pin (and add a down_revision assertion below) in the same PR
     that adds a new migration — same per-PR contract as the fixture
@@ -37,8 +37,8 @@ def test_single_head_is_0011(script_directory: ScriptDirectory) -> None:
         "Orphan heads usually mean a migration's down_revision is stale "
         "after a merge — rebase and re-point the down_revision."
     )
-    assert heads[0] == "0011", (
-        f"Expected head 0011 (the lineup technique column), got {heads[0]}."
+    assert heads[0] == "0012", (
+        f"Expected head 0012 (the lineup landing_clip_url column), got {heads[0]}."
     )
 
 
@@ -88,3 +88,11 @@ def test_0011_down_revision_points_at_0010(
     """0011 must chain directly off 0010 (the lineup technique column)."""
     rev = script_directory.get_revision("0011")
     assert rev.down_revision == "0010"
+
+
+def test_0012_down_revision_points_at_0011(
+    script_directory: ScriptDirectory,
+) -> None:
+    """0012 must chain directly off 0011 (the lineup landing_clip_url column)."""
+    rev = script_directory.get_revision("0012")
+    assert rev.down_revision == "0011"

--- a/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
@@ -113,6 +113,9 @@ def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock, clip_mock
     from unittest.mock import AsyncMock as _AsyncMock
 
     from app.services.ingestion.clip_generator import ClipGenerationResult
+    from app.services.ingestion.landing_clip_generator import (
+        LandingClipGenerationResult,
+    )
 
     if clip_mock is None:
         clip_mock = _AsyncMock(
@@ -120,6 +123,19 @@ def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock, clip_mock
                 status="skipped", skip_reason="test_default"
             )
         )
+
+    # PR5 landing-clip wire-up is also patched to a neutral no-op by default
+    # so the existing classifier tests don't fire the real generator. The
+    # orchestrator only invokes this when clip_result.status == "generated",
+    # so the default clip_mock="skipped" already prevents the call — this
+    # extra patch is a belt-and-suspenders guard for tests that pass a
+    # custom clip_mock with status="generated" and care about clip
+    # assertions, not landing.
+    landing_mock = _AsyncMock(
+        return_value=LandingClipGenerationResult(
+            status="skipped", skip_reason="test_default"
+        )
+    )
 
     with contextlib.ExitStack() as stack:
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]))
@@ -129,6 +145,7 @@ def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock, clip_mock
         mock_storage_factory = stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.get_storage"))
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.classify_frames_for_lineup_decision", new=classify_mock))
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.generate_clip_for_lineup", new=clip_mock))
+        stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.generate_landing_clip_for_lineup", new=landing_mock))
         mock_settings = stack.enter_context(patch.object(ingestion_orchestrator_module(), "settings"))
 
         mock_settings.ingestion_download_dir = str(tmp_path)

--- a/apps/mygamingassistant/backend/tests/test_landing_clip_backfill.py
+++ b/apps/mygamingassistant/backend/tests/test_landing_clip_backfill.py
@@ -1,0 +1,259 @@
+"""Unit tests for the PR5 landing-clip backfill orchestrator.
+
+Asserts the per-video grouping (one fetch + one download per video), the
+chapter-start match logic, and the structured generated / skipped / failed
+tallying. Mirrors :mod:`test_clip_backfill` (PR2) — the two backfills
+share the same orchestration shape and the two test modules are kept in
+sync.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.ingestion.landing_clip_backfill import (
+    LandingClipBackfillStats,
+    backfill_landing_clips,
+)
+from app.services.ingestion.landing_clip_generator import (
+    LandingClipGenerationResult,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+)
+
+_MOD = "app.services.ingestion.landing_clip_backfill"
+
+
+def _lineup(video_id="vidA", chapter_start=10, **kw):
+    base = dict(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_start_seconds=chapter_start,
+        utility_type_id=None,
+        title="t",
+    )
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def _meta(video_id="vidA", description="0:00 intro\n0:10 lineup",
+          duration=300, chapters=None):
+    return types.SimpleNamespace(
+        video_id=video_id, title="t", description=description,
+        duration=duration, chapters=chapters, url=f"https://yt/{video_id}",
+        channel_name="ch",
+    )
+
+
+def _chapter(start=10, end=30, title="lineup"):
+    return types.SimpleNamespace(
+        start_seconds=start, end_seconds=end, title=title,
+    )
+
+
+def _settings(download_dir="/tmp/x"):
+    s = MagicMock()
+    s.ingestion_download_dir = download_dir
+    return s
+
+
+@pytest.mark.asyncio
+async def test_no_lineups_returns_empty_stats():
+    db = AsyncMock()
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_landing_clips",
+            AsyncMock(return_value=[]),
+        ),
+        patch(f"{_MOD}.settings", _settings()),
+    ):
+        stats = await backfill_landing_clips(db)
+    assert stats.total == 0
+    assert stats.generated == 0
+    assert stats.skipped == 0
+    assert stats.failed == 0
+
+
+@pytest.mark.asyncio
+async def test_groups_lineups_per_video_one_download(tmp_path):
+    """Two lineups on the same video → one metadata fetch + one download."""
+    db = AsyncMock()
+    l1 = _lineup(video_id="vidA", chapter_start=10)
+    l2 = _lineup(video_id="vidA", chapter_start=40)
+    l3 = _lineup(video_id="vidB", chapter_start=12)
+
+    download = AsyncMock(side_effect=lambda vid, _dir: tmp_path / f"{vid}.mp4")
+    fetch_detail = AsyncMock(side_effect=lambda vid: _meta(video_id=vid))
+    parse = MagicMock(return_value=[_chapter(10, 30), _chapter(40, 60),
+                                    _chapter(12, 40)])
+    gen = AsyncMock(return_value=LandingClipGenerationResult(
+        status="generated", clip_key="k",
+    ))
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_landing_clips",
+            AsyncMock(return_value=[l1, l2, l3]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(f"{_MOD}.fetch_video_detail", fetch_detail),
+        patch(f"{_MOD}.parse_chapters", parse),
+        patch(f"{_MOD}.download_video", download),
+        patch(f"{_MOD}.generate_landing_clip_for_lineup", gen),
+    ):
+        # Materialize the videos so the unlink in the finally doesn't fail
+        for v in ("vidA", "vidB"):
+            (tmp_path / f"{v}.mp4").write_bytes(b"x")
+        stats = await backfill_landing_clips(db)
+
+    assert stats.total == 3
+    assert stats.generated == 3
+    # Exactly 2 downloads (one per video) — proves the per-video grouping.
+    assert download.await_count == 2
+    assert fetch_detail.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_metadata_fetch_failure_marks_all_lineups_failed(tmp_path):
+    db = AsyncMock()
+    l1 = _lineup(video_id="vidX", chapter_start=10)
+    l2 = _lineup(video_id="vidX", chapter_start=20)
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_landing_clips",
+            AsyncMock(return_value=[l1, l2]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(side_effect=YouTubeFetchError(
+                "boom", error_type="network", original=Exception(),
+            )),
+        ),
+    ):
+        stats = await backfill_landing_clips(db)
+
+    assert stats.total == 2
+    assert stats.failed == 2
+    assert stats.generated == 0
+
+
+@pytest.mark.asyncio
+async def test_download_failure_marks_all_video_lineups_failed(tmp_path):
+    db = AsyncMock()
+    l1 = _lineup(video_id="vidY", chapter_start=10)
+    l2 = _lineup(video_id="vidY", chapter_start=20)
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_landing_clips",
+            AsyncMock(return_value=[l1, l2]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(return_value=_meta(video_id="vidY")),
+        ),
+        patch(f"{_MOD}.parse_chapters", MagicMock(return_value=[_chapter()])),
+        patch(
+            f"{_MOD}.download_video",
+            AsyncMock(side_effect=VideoDownloadError(
+                "boom", video_id="vidY",
+                error_type="404", original=Exception(),
+            )),
+        ),
+    ):
+        stats = await backfill_landing_clips(db)
+
+    assert stats.total == 2
+    assert stats.failed == 2
+
+
+@pytest.mark.asyncio
+async def test_chapter_not_found_skips_that_lineup_only(tmp_path):
+    """Video changed since ingest → one lineup skipped, the rest still run."""
+    db = AsyncMock()
+    l_match = _lineup(video_id="vidZ", chapter_start=10)
+    l_miss = _lineup(video_id="vidZ", chapter_start=99)
+
+    download = AsyncMock(side_effect=lambda vid, _dir: tmp_path / f"{vid}.mp4")
+    gen = AsyncMock(return_value=LandingClipGenerationResult(
+        status="generated", clip_key="k",
+    ))
+    (tmp_path / "vidZ.mp4").write_bytes(b"x")
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_landing_clips",
+            AsyncMock(return_value=[l_match, l_miss]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(return_value=_meta(video_id="vidZ")),
+        ),
+        patch(
+            f"{_MOD}.parse_chapters",
+            MagicMock(return_value=[_chapter(start=10, end=20)]),
+        ),
+        patch(f"{_MOD}.download_video", download),
+        patch(f"{_MOD}.generate_landing_clip_for_lineup", gen),
+    ):
+        stats = await backfill_landing_clips(db)
+
+    assert stats.total == 2
+    assert stats.generated == 1
+    assert stats.skipped == 1
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_per_lineup_does_not_abort_batch(tmp_path):
+    """A surprise exception on one lineup must NOT break the rest of the batch."""
+    db = AsyncMock()
+    l_ok = _lineup(video_id="vidQ", chapter_start=10)
+    l_bad = _lineup(video_id="vidQ", chapter_start=40)
+
+    download = AsyncMock(side_effect=lambda vid, _dir: tmp_path / f"{vid}.mp4")
+    (tmp_path / "vidQ.mp4").write_bytes(b"x")
+
+    # First call succeeds, second raises a surprise.
+    call_count = {"n": 0}
+
+    async def gen_side(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return LandingClipGenerationResult(status="generated", clip_key="k")
+        raise RuntimeError("surprise")
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_landing_clips",
+            AsyncMock(return_value=[l_ok, l_bad]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(return_value=_meta(video_id="vidQ")),
+        ),
+        patch(
+            f"{_MOD}.parse_chapters",
+            MagicMock(return_value=[_chapter(10, 30), _chapter(40, 60)]),
+        ),
+        patch(f"{_MOD}.download_video", download),
+        patch(
+            f"{_MOD}.generate_landing_clip_for_lineup",
+            AsyncMock(side_effect=gen_side),
+        ),
+    ):
+        stats = await backfill_landing_clips(db)
+
+    assert stats.total == 2
+    assert stats.generated == 1
+    assert stats.failed == 1
+    assert any("surprise" in e for e in stats.errors)

--- a/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
@@ -1,0 +1,486 @@
+"""Unit tests for the PR5 landing-clip generator.
+
+Pure landing-bounds math + the full generate_landing_clip_for_lineup
+orchestration with every external (download / frame extract / Claude /
+ffmpeg cut / MinIO / repo commit) mocked. Asserts the frozen-contract gate
+sharing with PR2 (precomputed_result_ts skips both the classifier call AND
+the gates) and the structured generated / skipped / failed outcomes.
+
+Mirrors :mod:`test_clip_generator` exactly so the two pipelines stay
+synchronised. Re-read PR2's tests when porting any behaviour change.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.classification.classification_result import ThrowTimingResult
+from app.services.ingestion.frame_extractor import ClipCutError, FrameExtractionError
+from app.services.ingestion.landing_clip_generator import (
+    LandingClipGenerationResult,
+    _compute_landing_bounds,
+    generate_landing_clip_for_lineup,
+    pending_landing_clip_key,
+)
+from app.services.ingestion.youtube_fetcher import VideoDownloadError
+
+_MOD = "app.services.ingestion.landing_clip_generator"
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n"
+_FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
+
+
+def _lineup(video_id="vid123", chapter_title="B smoke"):
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_title=chapter_title,
+        landing_clip_url=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _compute_landing_bounds — pure math
+# ---------------------------------------------------------------------------
+
+class TestComputeLandingBounds:
+    def test_normal_window(self):
+        # result 24, chapter [10,40]: [23.5, 27] = 3.5s.
+        start, dur = _compute_landing_bounds(24.0, 10.0, 40.0)
+        assert start == pytest.approx(23.5)
+        assert dur == pytest.approx(3.5)
+
+    def test_clamped_to_chapter_start(self):
+        # result 10.2 → 10.2-0.5=9.7 but chapter starts at 10 → clamp to 10.
+        start, _dur = _compute_landing_bounds(10.2, 10.0, 40.0)
+        assert start == pytest.approx(10.0)
+
+    def test_clamped_to_chapter_end(self):
+        # result 39, chapter [10,40]: 39+3=42 → clamp to 40.
+        start, dur = _compute_landing_bounds(39.0, 10.0, 40.0)
+        assert start == pytest.approx(38.5)
+        # 40 - 38.5 = 1.5s — clamped tail but still >= 1s.
+        assert dur == pytest.approx(1.5)
+
+    def test_chapter_too_short_returns_none(self):
+        # 0.4s chapter — clamped window < 1s → skip signal.
+        assert _compute_landing_bounds(20.0, 19.9, 20.3) is None
+
+    def test_clip_never_exceeds_chapter_end(self):
+        start, dur = _compute_landing_bounds(20.0, 10.0, 22.0)
+        assert start + dur <= 22.0 + 1e-9
+
+
+def test_pending_landing_clip_key_is_deterministic():
+    """Stable key per (video, chapter start) → backfill idempotency."""
+    assert pending_landing_clip_key("abc", 42.0) == "pending/abc/42-landing.mp4"
+    assert pending_landing_clip_key("abc", 42.9) == "pending/abc/42-landing.mp4"
+
+
+def test_pending_landing_key_distinct_from_throw_clip_key():
+    """Landing and throw keys MUST differ so they don't overwrite each other.
+
+    Regression guard: a copy-paste typo that aliased both keys to
+    ``pending/{vid}/{start}-clip.mp4`` would silently destroy one clip
+    every time the other was generated.
+    """
+    from app.services.ingestion.clip_generator import pending_clip_key
+
+    assert pending_landing_clip_key("abc", 42) != pending_clip_key("abc", 42)
+
+
+# ---------------------------------------------------------------------------
+# generate_landing_clip_for_lineup — ingest path (precomputed result_ts)
+# ---------------------------------------------------------------------------
+
+def _ffmpeg_cut_mock():
+    return AsyncMock(return_value=_FAKE_MP4)
+
+
+def _storage_mock():
+    storage = MagicMock()
+    storage.upload_file = MagicMock()
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_ingest_path_generates_clip_without_classifier_call():
+    """Precomputed result_ts → skip classifier; cut + upload + persist."""
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_url_mock = AsyncMock(return_value=lineup)
+
+    classifier_mock = AsyncMock()  # MUST NOT be called
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()) as cut,
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_landing_clip_url", set_url_mock),
+        patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_result_ts=24.0,
+            precomputed_confidence=0.82,
+        )
+
+    assert result.status == "generated"
+    assert result.clip_key == "pending/vid123/10-landing.mp4"
+    assert result.result_ts == pytest.approx(24.0)
+    assert result.confidence == pytest.approx(0.82)
+    cut.assert_awaited_once()
+    storage.upload_file.assert_called_once()
+    set_url_mock.assert_awaited_once()
+    classifier_mock.assert_not_awaited(), (
+        "Ingest path must NOT call the classifier — cost regression"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingest_path_failed_without_video_path_is_wiring_bug():
+    """precomputed_result_ts without video_path is a caller error.
+
+    The ingest orchestrator MUST pass the on-disk video — if it didn't, the
+    landing-clip generator does not silently work around it by downloading
+    (that would double the ingest video-fetch cost on every chapter).
+    """
+    db = AsyncMock()
+    lineup = _lineup()
+    result = await generate_landing_clip_for_lineup(
+        db, lineup,
+        chapter_start=0.0, chapter_end=30.0,
+        video_path=None,  # missing!
+        precomputed_result_ts=20.0,
+    )
+    assert result.status == "failed"
+    assert "no_video_path_with_precomputed" in result.error_codes
+
+
+@pytest.mark.asyncio
+async def test_ingest_path_chapter_too_short_skips():
+    """Even with a valid result_ts, a sliver chapter clamps below 1s → skip."""
+    db = AsyncMock()
+    lineup = _lineup()
+    result = await generate_landing_clip_for_lineup(
+        db, lineup,
+        chapter_start=19.9, chapter_end=20.3,
+        video_path=Path("/tmp/x.mp4"),
+        precomputed_result_ts=20.0,
+    )
+    assert result.status == "skipped"
+    assert result.skip_reason == "chapter_too_short_for_landing_clip"
+
+
+# ---------------------------------------------------------------------------
+# generate_landing_clip_for_lineup — backfill path (own classifier call)
+# ---------------------------------------------------------------------------
+
+def _settings(enable=True, key="sk-test"):
+    s = MagicMock()
+    s.enable_classifier = enable
+    s.anthropic_api_key = key
+    return s
+
+
+def _timing(**kw):
+    base = dict(
+        success=True, is_lineup_throw=True, release_index=2,
+        result_index=4, confidence=0.8, reasoning="ok",
+        error_codes=[],
+    )
+    base.update(kw)
+    return ThrowTimingResult(**base)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_runs_classifier_and_generates():
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_url_mock = AsyncMock(return_value=lineup)
+    timing = _timing(result_index=5)
+    timestamps = [12.0, 18.0, 24.0, 30.0, 36.0]
+
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames_downscaled",
+              AsyncMock(return_value=[_FAKE_PNG] * 5)),
+        patch(f"{_MOD}.classify_throw_timing_from_frames",
+              AsyncMock(return_value=timing)),
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_landing_clip_url", set_url_mock),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            # No precomputed → backfill branch.
+        )
+
+    assert result.status == "generated"
+    # result_index 5 (1-based) → timestamps[4] = 36.0, then clamped end at 40.
+    assert result.result_ts == pytest.approx(36.0)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_skips_not_a_throw():
+    db = AsyncMock()
+    lineup = _lineup()
+    timing = _timing(is_lineup_throw=False)
+    timestamps = [12.0, 18.0, 24.0]
+
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames_downscaled",
+              AsyncMock(return_value=[_FAKE_PNG] * 3)),
+        patch(f"{_MOD}.classify_throw_timing_from_frames",
+              AsyncMock(return_value=timing)),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.status == "skipped"
+    assert result.skip_reason == "not_a_throw"
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_skips_low_confidence():
+    db = AsyncMock()
+    lineup = _lineup()
+    timing = _timing(confidence=0.4)
+    timestamps = [12.0, 18.0, 24.0]
+
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames_downscaled",
+              AsyncMock(return_value=[_FAKE_PNG] * 3)),
+        patch(f"{_MOD}.classify_throw_timing_from_frames",
+              AsyncMock(return_value=timing)),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.status == "skipped"
+    assert result.skip_reason.startswith("low_confidence")
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_skips_no_result_frame():
+    db = AsyncMock()
+    lineup = _lineup()
+    timing = _timing(result_index=None)
+    timestamps = [12.0, 18.0, 24.0]
+
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames_downscaled",
+              AsyncMock(return_value=[_FAKE_PNG] * 3)),
+        patch(f"{_MOD}.classify_throw_timing_from_frames",
+              AsyncMock(return_value=timing)),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.status == "skipped"
+    assert result.skip_reason == "no_result_frame"
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_classifier_disabled_skips():
+    db = AsyncMock()
+    lineup = _lineup()
+    with patch(f"{_MOD}.settings", _settings(enable=False)):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.status == "skipped"
+    assert result.skip_reason == "classifier_disabled"
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_classifier_missing_key_skips():
+    db = AsyncMock()
+    lineup = _lineup()
+    with patch(f"{_MOD}.settings", _settings(key="")):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.status == "skipped"
+    assert "missing_api_key" in result.skip_reason
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_classifier_api_failure_returns_failed():
+    db = AsyncMock()
+    lineup = _lineup()
+    timing = ThrowTimingResult(
+        success=False, error_codes=["overloaded_error"],
+        reasoning="rate limited",
+    )
+    timestamps = [12.0, 18.0, 24.0]
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames_downscaled",
+              AsyncMock(return_value=[_FAKE_PNG] * 3)),
+        patch(f"{_MOD}.classify_throw_timing_from_frames",
+              AsyncMock(return_value=timing)),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.status == "failed"
+    assert "overloaded_error" in result.error_codes
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_frame_extract_failure_returns_failed():
+    db = AsyncMock()
+    lineup = _lineup()
+    timestamps = [12.0, 18.0, 24.0]
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
+        patch(
+            f"{_MOD}.extract_frames_downscaled",
+            AsyncMock(side_effect=FrameExtractionError(
+                "boom", timestamp=18.0, returncode=1, stderr="x",
+            )),
+        ),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.status == "failed"
+    assert any("frame_extract" in c for c in result.error_codes)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_download_failure_returns_failed(tmp_path):
+    """When the generator owns the download (video_path=None), a yt-dlp
+    failure surfaces as status=failed with structured codes (not a raise)."""
+    db = AsyncMock()
+    lineup = _lineup()
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(
+            f"{_MOD}.download_video",
+            AsyncMock(side_effect=VideoDownloadError(
+                "boom", video_id="vid123",
+                error_type="network", original=Exception(),
+            )),
+        ),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=None,
+            download_dir=tmp_path,
+        )
+    assert result.status == "failed"
+    assert any("download:network" in c for c in result.error_codes)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_no_source_video_skips():
+    db = AsyncMock()
+    lineup = _lineup(video_id=None)
+    result = await generate_landing_clip_for_lineup(
+        db, lineup,
+        chapter_start=0.0, chapter_end=30.0,
+        video_path=Path("/tmp/x.mp4"),
+    )
+    assert result.status == "skipped"
+    assert result.skip_reason == "no_source_video"
+
+
+@pytest.mark.asyncio
+async def test_ffmpeg_cut_failure_returns_failed():
+    """Same failure shape on both ingest and backfill paths — assert via ingest."""
+    db = AsyncMock()
+    lineup = _lineup()
+
+    with patch(
+        f"{_MOD}.cut_clip",
+        AsyncMock(side_effect=ClipCutError(
+            "boom", start=20.0, duration=3.5, returncode=1, stderr="x",
+        )),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_result_ts=24.0,
+        )
+    assert result.status == "failed"
+    assert any("clip_cut" in c for c in result.error_codes)
+
+
+@pytest.mark.asyncio
+async def test_upload_failure_returns_failed():
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    storage.upload_file = MagicMock(side_effect=RuntimeError("minio down"))
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_result_ts=24.0,
+        )
+    assert result.status == "failed"
+    assert "clip_upload_failed" in result.error_codes
+
+
+@pytest.mark.asyncio
+async def test_persist_failure_returns_failed():
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(
+            f"{_MOD}.lineup_repo.set_landing_clip_url",
+            AsyncMock(side_effect=RuntimeError("db down")),
+        ),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_result_ts=24.0,
+        )
+    assert result.status == "failed"
+    assert "landing_clip_url_persist_failed" in result.error_codes

--- a/apps/mygamingassistant/backend/tests/test_lineup_landing_clip_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_landing_clip_repo.py
@@ -1,0 +1,165 @@
+"""DB-backed tests for lineup_repo.set_landing_clip_url (PR5).
+
+The landing-clip key must actually COMMIT (not just flush) — same silent
+data-loss class as PATCH #687: ``get_db`` doesn't auto-commit, so a
+flush-only write is rolled back on session close and the operator's
+landing clip silently never appears. Asserts the write survives a fresh
+read. Mirrors :mod:`test_lineup_clip_url_repo` exactly — the two columns
+are independent and the landing-clip pipeline must preserve the same
+commit-vs-flush discipline.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.game import Game
+from app.models.game.lineup import Lineup
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.models.game.utility_type import UtilityType
+from app.repositories.game import lineup_repo
+
+
+@pytest.mark.asyncio
+async def test_set_landing_clip_url_commits(db: AsyncSession):
+    created = await lineup_repo.create_lineup(
+        db, {"title": "landing repo test", "status": "pending_review"}
+    )
+
+    returned = await lineup_repo.set_landing_clip_url(
+        db, created, "pending/vidX/12-landing.mp4"
+    )
+    assert returned.landing_clip_url == "pending/vidX/12-landing.mp4"
+
+    # Capture the PK *before* expire_all(): referencing an expired attribute
+    # (created.id) inside the query expression triggers a synchronous lazy
+    # reload — sync session.execute outside the async greenlet, i.e.
+    # MissingGreenlet. Pattern lifted verbatim from PR2's
+    # test_lineup_clip_url_repo (kept synchronised on purpose).
+    lineup_id = created.id
+
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.landing_clip_url == "pending/vidX/12-landing.mp4"
+
+
+@pytest.mark.asyncio
+async def test_set_landing_clip_url_overwrite_is_idempotent(db: AsyncSession):
+    """Backfill recomputes the same deterministic key — overwrite must work."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "landing overwrite test", "status": "pending_review"}
+    )
+    await lineup_repo.set_landing_clip_url(db, created, "pending/v/1-landing.mp4")
+    await lineup_repo.set_landing_clip_url(db, created, "pending/v/1-landing.mp4")
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.landing_clip_url == "pending/v/1-landing.mp4"
+
+
+@pytest.mark.asyncio
+async def test_landing_clip_does_not_overwrite_throw_clip(db: AsyncSession):
+    """The two columns are independent — setting one must not touch the other.
+
+    Regression guard for the design intent: a lineup with a PR2 throw clip
+    should keep it intact after a PR5 landing-clip backfill, and vice
+    versa. If one setter ever drove a global UPDATE that nulled the sibling
+    column, the backfills would silently destroy each other's work.
+    """
+    created = await lineup_repo.create_lineup(
+        db, {"title": "both columns test", "status": "pending_review"}
+    )
+    await lineup_repo.set_clip_url(db, created, "pending/v/1-clip.mp4")
+    await lineup_repo.set_landing_clip_url(db, created, "pending/v/1-landing.mp4")
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.clip_url == "pending/v/1-clip.mp4"
+    assert refetched.landing_clip_url == "pending/v/1-landing.mp4"
+
+
+@pytest.mark.asyncio
+async def test_list_accepted_lineups_needing_landing_clips_filters(
+    db: AsyncSession,
+):
+    """Only accepted + has-source-video + no-landing-clip rows are in the set.
+
+    Mirrors :func:`test_list_accepted_lineups_needing_clips_filters` but for
+    the ``landing_clip_url`` column. Critically asserts that having a PR2
+    throw clip does NOT exclude a row from this set — the backfills are
+    independent.
+    """
+    game = Game(
+        slug=f"g-{uuid.uuid4().hex[:8]}", name="G",
+        side_a_label="A", side_b_label="B",
+    )
+    db.add(game)
+    await db.flush()
+    mp = Map(game_id=game.id, slug=f"m-{uuid.uuid4().hex[:8]}", name="M")
+    db.add(mp)
+    await db.flush()
+    zone = MapZone(
+        map_id=mp.id, slug=f"z-{uuid.uuid4().hex[:8]}",
+        name="Z", polygon_points=[],
+    )
+    db.add(zone)
+    util = UtilityType(
+        game_id=game.id, slug=f"u-{uuid.uuid4().hex[:8]}", name="U",
+    )
+    db.add(util)
+    await db.flush()
+
+    def _accepted(**over):
+        data = dict(
+            game_id=game.id, map_id=mp.id, target_zone_id=zone.id,
+            stand_zone_id=zone.id, side="side_a", utility_type_id=util.id,
+            title="t", status="accepted",
+            youtube_video_id="vidQ",
+            clip_url=None,
+            landing_clip_url=None,
+        )
+        data.update(over)
+        return data
+
+    # Wanted #1: no clips at all.
+    wanted_a = await lineup_repo.create_lineup(db, _accepted())
+    # Wanted #2: has PR2 throw clip but no landing — backfill must still pick this up.
+    wanted_b = await lineup_repo.create_lineup(
+        db, _accepted(clip_url="pending/vidQ/3-clip.mp4")
+    )
+    # Excluded: already has a landing clip.
+    await lineup_repo.create_lineup(
+        db, _accepted(landing_clip_url="pending/vidQ/5-landing.mp4")
+    )
+    # Excluded: no source video to re-fetch.
+    await lineup_repo.create_lineup(db, _accepted(youtube_video_id=None))
+    # Excluded: still pending_review (not accepted).
+    await lineup_repo.create_lineup(
+        db, {"title": "p", "status": "pending_review", "youtube_video_id": "vidQ"}
+    )
+
+    rows = await lineup_repo.list_accepted_lineups_needing_landing_clips(db)
+    ids = {r.id for r in rows}
+    assert wanted_a.id in ids
+    assert wanted_b.id in ids, (
+        "Having a PR2 throw clip must NOT exclude a row from the PR5 backfill — "
+        "the two NULL columns are independent."
+    )
+    assert all(
+        r.status == "accepted"
+        and r.youtube_video_id
+        and r.landing_clip_url is None
+        for r in rows
+    )

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -33,6 +33,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     stand_screenshot_url: "https://ex.com/stand.png",
     aim_screenshot_url: "https://ex.com/aim.png",
     clip_url: null,
+    landing_clip_url: null,
     technique: null,
     aim_anchor_x: 0.5,
     aim_anchor_y: 0.4,
@@ -165,6 +166,34 @@ describe("GlanceBoardTile LANDING pane", () => {
     render(<GlanceBoardTile lineup={makeLineup({ target_zone: null as unknown as Lineup["target_zone"] })} />);
     expect(screen.getByText("LANDING")).toBeInTheDocument();
     expect(screen.getByText("—")).toBeInTheDocument();
+  });
+
+  // PR5 — landing clip lights up the LANDING pane via the shared ClipView
+  // primitive when landing_clip_url is set.
+
+  it("PR5: renders looping landing-clip video when landing_clip_url is set", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({
+          landing_clip_url: "https://ex.com/landing.mp4",
+        })}
+      />,
+    );
+    const landingVideo = document.querySelector(
+      'video[aria-label*="looping landing clip"]',
+    );
+    expect(landingVideo).not.toBeNull();
+    // The text fallback ("Lands in") must NOT render once the clip is
+    // mounted — showing both would be confusing UX.
+    expect(screen.queryByText("Lands in")).not.toBeInTheDocument();
+  });
+
+  it("PR5: keeps text fallback when landing_clip_url is null", () => {
+    render(<GlanceBoardTile lineup={makeLineup({ landing_clip_url: null })} />);
+    expect(screen.getByText("Lands in")).toBeInTheDocument();
+    expect(
+      document.querySelector('video[aria-label*="looping landing clip"]'),
+    ).toBeNull();
   });
 });
 

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -43,6 +43,7 @@ const BASE_LINEUP: Lineup = {
   stand_screenshot_url: "https://example.com/stand.png",
   aim_screenshot_url: "https://example.com/aim.png",
   clip_url: null,
+  landing_clip_url: null,
   technique: null,
   aim_anchor_x: 0.5,
   aim_anchor_y: 0.4,
@@ -237,6 +238,41 @@ describe("LineupCard", () => {
     expect(document.querySelector("video")).not.toBeNull();
     // The ThrowPlaceholder copy must not appear when a clip is mounted.
     expect(screen.queryByText("No clip yet")).not.toBeInTheDocument();
+  });
+
+  // PR5 — landing clip lights up the LANDING pane via the shared ClipView
+  // primitive when landing_clip_url is set; otherwise the pane falls back to
+  // the original "Lands in: <zone>" text rendering.
+
+  it("expanded variant LANDING pane renders ClipView when landing_clip_url is set", () => {
+    const lineup: Lineup = {
+      ...BASE_LINEUP,
+      landing_clip_url: "https://ex.com/landing.mp4",
+    };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    // A second <video> element exists once both clips render. Just assert
+    // the landing-specific aria-label is present (independent of the throw
+    // pane's video, which would only mount with clip_url set).
+    const landingVideo = document.querySelector(
+      'video[aria-label*="looping landing clip"]',
+    );
+    expect(landingVideo).not.toBeNull();
+    // The "Lands in" text must NOT appear when the clip is mounted —
+    // showing both is the misleading "video unavailable" UX we explicitly
+    // avoid.
+    expect(screen.queryByText("Lands in")).not.toBeInTheDocument();
+  });
+
+  it("expanded variant LANDING pane keeps the text fallback when landing_clip_url is null", () => {
+    // Already covered by the existing "shows target_zone.name" test; this
+    // adds an explicit no-video assertion so a regression that mounts the
+    // ClipView with an empty src would still surface.
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    expect(screen.getByText("Lands in")).toBeInTheDocument();
+    const landingVideo = document.querySelector(
+      'video[aria-label*="looping landing clip"]',
+    );
+    expect(landingVideo).toBeNull();
   });
 
   it("expanded variant header surfaces technique when set", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
@@ -27,6 +27,7 @@ function makeLineup(id: string): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    landing_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
@@ -26,6 +26,7 @@ function makeLineup(overrides: Partial<Lineup>): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    landing_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/MinimapPinEditor.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MinimapPinEditor.test.tsx
@@ -38,6 +38,7 @@ function makeLineup(overrides: Partial<Lineup> = {}): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    landing_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
@@ -79,6 +79,7 @@ function makeUnclassifiedLineup(overrides: Partial<Lineup> = {}): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    landing_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
@@ -27,6 +27,7 @@ function makeLineup(overrides: Partial<Lineup>): Lineup {
     stand_screenshot_url: null,
     aim_screenshot_url: null,
     clip_url: null,
+    landing_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -137,7 +137,12 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
           ) : (
             <ThrowPlaceholder />
           )}
-          <LandingPane targetZoneName={lineup.target_zone?.name ?? null} />
+          <LandingPane
+            targetZoneName={lineup.target_zone?.name ?? null}
+            landingClipUrl={lineup.landing_clip_url}
+            posterUrl={lineup.aim_screenshot_url}
+            title={lineup.title}
+          />
         </div>
       </div>
 

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
@@ -154,7 +154,12 @@ export default function LineupCard({
           ) : (
             <ThrowPlaceholder />
           )}
-          <LandingPane targetZoneName={lineup.target_zone?.name ?? null} />
+          <LandingPane
+            targetZoneName={lineup.target_zone?.name ?? null}
+            landingClipUrl={lineup.landing_clip_url}
+            posterUrl={lineup.aim_screenshot_url}
+            title={lineup.title}
+          />
         </div>
       </div>
 

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
@@ -76,20 +76,31 @@ export function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProp
 }
 
 // ---------------------------------------------------------------------------
-// ClipView (PR2) — gif-style looping throw clip, in-view autoplay.
+// ClipView (PR2) — gif-style looping clip, in-view autoplay.
 //
 // The src is lazily attached on first view so off-screen clips never fetch;
 // only clips scrolled into view play (a glance board can hold dozens — letting
 // them all decode at once tanks the second-monitor frame rate). After PR4
-// this lives in the bottom-left THROW pane alongside the still panes.
+// this lives in the bottom-left THROW pane alongside the still panes, and
+// after PR5 the same primitive renders the bottom-right LANDING pane (with
+// a different label + URL).
+//
+// PR5 generalised the corner label to a prop so both THROW and LANDING use
+// the same byte-for-byte primitive. The aria-label and loading behaviour are
+// shared — only the label + URL differ between the two surfaces.
 // ---------------------------------------------------------------------------
 interface ClipViewProps {
   clipUrl: string;
   posterUrl: string | null;
   title: string;
+  // Corner label (uppercase, ~10px). PR2 callers pass "THROW"; PR5's
+  // LandingPane passes "LANDING". Default kept as "THROW" so any new caller
+  // that forgets to pass it gets the historical behaviour, not a blank
+  // label.
+  label?: string;
 }
 
-export function ClipView({ clipUrl, posterUrl, title }: ClipViewProps) {
+export function ClipView({ clipUrl, posterUrl, title, label = "THROW" }: ClipViewProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   // Sticky once the tile has been seen: keep the src attached (re-fetching on
   // every scroll-by is worse than keeping a paused decoded clip).
@@ -170,14 +181,14 @@ export function ClipView({ clipUrl, posterUrl, title }: ClipViewProps) {
         // Pre-view: metadata only. In view: allow buffering so the loop
         // doesn't stall on first frame.
         preload={armed ? "auto" : "metadata"}
-        aria-label={`${title} — looping throw clip (muted)`}
+        aria-label={`${title} — looping ${label.toLowerCase()} clip (muted)`}
         onError={() => setLoadFailed(true)}
         className="absolute inset-0 w-full h-full object-cover"
       />
-      {/* Hide the "THROW" affordance when the clip fails to load (e.g. an
-          expired presigned URL mid-session) — the poster (stand still)
-          stays as the graceful fallback rather than a misleading badge. */}
-      {!loadFailed && <CornerLabel>THROW</CornerLabel>}
+      {/* Hide the corner affordance when the clip fails to load (e.g. an
+          expired presigned URL mid-session) — the poster stays as the
+          graceful fallback rather than a misleading badge. */}
+      {!loadFailed && <CornerLabel>{label}</CornerLabel>}
     </div>
   );
 }
@@ -202,16 +213,50 @@ export function ThrowPlaceholder() {
 // ---------------------------------------------------------------------------
 // LandingPane — bottom-right pane. Shows where the utility lands.
 //
-// PR4 ships a text-only placeholder ("Lands in: <target_zone.name>") because
-// no landing-clip extraction exists yet. PR5 will replace the placeholder
-// with a real ~1-2s looping landing clip. The pane is the same dimensions
-// either way — only the inner content changes.
+// PR5: when ``landingClipUrl`` is set we render a looping muted clip via the
+// shared ``ClipView`` primitive (same lazy-load + in-view autoplay + load-
+// failure tolerance as the THROW pane — the two surfaces are byte-equivalent
+// except for the corner label and the source URL). When the clip key is
+// null — pre-PR5 lineups, ingest's landing pass skipped (PR2 confidence
+// gate didn't clear), or the chapter was too short for a clean cut — we
+// gracefully degrade to the original "Lands in: <zone>" text. This is the
+// same silent-fallback shape PR2 uses for the THROW pane (stills when clip
+// is null) — never a misleading "video unavailable" placeholder.
 // ---------------------------------------------------------------------------
 interface LandingPaneProps {
   targetZoneName: string | null;
+  // PR5 — presigned MinIO key for the landing clip. Null/undefined falls
+  // back to text rendering. Optional for backwards-compat with existing
+  // call sites that haven't been updated yet (they get the pre-PR5 text
+  // behaviour, never a runtime error).
+  landingClipUrl?: string | null;
+  // Poster shown before the clip loads / on a load failure. The aim still
+  // is the closest existing artifact to the landing view (the player's
+  // line-of-sight when throwing) — better than a blank black pane when the
+  // clip is slow or unreachable. Optional; defaults to no poster.
+  posterUrl?: string | null;
+  // Title used by ClipView's aria-label. Defaults to a derived label so
+  // existing call sites don't have to pass it; pass an explicit title (e.g.
+  // the lineup title) when one is meaningful.
+  title?: string;
 }
 
-export function LandingPane({ targetZoneName }: LandingPaneProps) {
+export function LandingPane({
+  targetZoneName,
+  landingClipUrl,
+  posterUrl = null,
+  title,
+}: LandingPaneProps) {
+  if (landingClipUrl) {
+    return (
+      <ClipView
+        clipUrl={landingClipUrl}
+        posterUrl={posterUrl}
+        title={title ?? `Lands in ${targetZoneName ?? "unknown"}`}
+        label="LANDING"
+      />
+    );
+  }
   return (
     <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
       <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 px-2 text-center">

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -107,6 +107,13 @@ export interface Lineup {
   // the throw could not be localised or the lineup predates the clip
   // pipeline — the tile then falls back to the stand/aim stills.
   clip_url: string | null;
+  // PR5: presigned URL of the short looping landing clip — shows the moment
+  // the utility lands/explodes (smoke deploying, molly burning, flash
+  // detonating). Null when ingest's landing pass was gated off (skipped via
+  // PR2's confidence gate), generation failed, or the lineup predates PR5 —
+  // the LandingPane then falls back to the "Lands in: <zone>" text rendering
+  // (graceful degradation, mirroring PR2's clip silent-fallback to stills).
+  landing_clip_url: string | null;
   aim_anchor_x: number | null;
   aim_anchor_y: number | null;
   // Explicit minimap coords; fall back to zone-polygon centroid via effective_*.


### PR DESCRIPTION
## Summary

PR4 reserved the bottom-right LANDING pane in the 2×2 storyboard for a real clip; this PR fills it. Mirrors PR2's throw-clip pattern end-to-end (separate column, separate generator, idempotent backfill, shared frontend ClipView).

## What lands

- Migration **0012** adds nullable `landing_clip_url` to `lineup` (presigned at read time alongside `clip_url`)
- `landing_clip_generator.generate_landing_clip_for_lineup` — gates, bounds math, ffmpeg cut, MinIO upload, one-column commit via `lineup_repo.set_landing_clip_url`
- `landing_clip_backfill.backfill_landing_clips` — per-video grouping (one fetch + one download per video)
- CLI: `python -m app.cli backfill-landing-clips`
- Ingestion wire-up: after PR2's throw clip generates, call landing generator with `precomputed_result_ts=clip_result.result_ts` — shares the classifier output so ingest still makes ONE Claude call per chapter (not two)
- Frontend: `LandingPane` renders looping clip via shared `ClipView` (label=\"LANDING\") when set; falls back to \"Lands in: <zone>\" text otherwise

## Design decisions (operator-confirmed before coding)

| Decision | Choice |
|---|---|
| Clip bounds | `[result_ts - 0.5, result_ts + 3.0]` ≈ 3.5s — tight on landing, dwell on smoke/molly |
| Gate sharing | Skip landing when PR2 skipped (not-a-throw / low-confidence / no result frame) — keeps clips in sync |
| Classifier reuse | Ingest passes PR2's `result_ts` (zero extra Claude cost); backfill runs its own call |

## Operational migration

```bash
cd apps/mygamingassistant/backend
alembic upgrade head                              # adds the new column
python -m app.cli backfill-landing-clips          # optional; populates pre-PR5 lineups
```

Local-only: MGA still isn't deployed to the VPS per \`project_mga_dev_only_no_prod_deploy.md\`.

## Followup deferred

- **PR5b** — drop the confidence gate for already-accepted lineups + ±1s nudge UI in review queue. Applies uniformly to BOTH throw and landing clips. Out of scope here to keep this PR's surface area reviewable.

## Test plan

- [x] Backend tests added:
  - \`test_lineup_landing_clip_repo.py\` — set commits, idempotent overwrite, independence from \`clip_url\`, backfill query filter
  - \`test_landing_clip_generator.py\` — bounds math, ingest-path classifier-skip, backfill-path gates, ffmpeg/upload/persist failure modes
  - \`test_landing_clip_backfill.py\` — per-video grouping, fetch/download failures, chapter-not-found, surprise tolerance
- [x] \`test_alembic_chain.py\` head pin bumped 0011→0012
- [x] \`test_ingestion_with_classifier.py\` patches the landing generator (neutral skipped default)
- [x] Frontend vitest: LineupCard / GlanceBoardTile assert \`<video aria-label=\"...looping landing clip\">\` renders when set; text fallback when null
- [x] 7 fixture files updated with \`landing_clip_url: null\`
- [ ] CI green
- [ ] Visual check on local dev once merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)