### PR TITLE
fix(mbk): extend_lease clears tenant_ended_at + writes applicant_event

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/extevt260520_add_tenancy_extension_event_types.py
+++ b/apps/mybookkeeper/backend/alembic/versions/extevt260520_add_tenancy_extension_event_types.py
@@ -1,0 +1,49 @@
+"""Add tenancy_extended and extension_undone to applicant_events CHECK constraint.
+
+The lease-extension flow (extend_lease / undo_extension in
+``services/leases/lease_extension_service.py``) now writes a timeline event
+on every extension and undo so the applicant history reflects the lifecycle.
+
+Revision ID: extevt260520
+Revises: rarqprop260517
+Create Date: 2026-05-20 00:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "extevt260520"
+down_revision: Union[str, None] = "rarqprop260517"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "chk_applicant_event_type", "applicant_events", type_="check",
+    )
+    op.create_check_constraint(
+        "chk_applicant_event_type",
+        "applicant_events",
+        "event_type IN ('lead', 'screening_pending', 'screening_passed', "
+        "'screening_failed', 'video_call_done', 'approved', 'lease_sent', "
+        "'lease_signed', 'declined', 'note_added', 'screening_initiated', "
+        "'screening_completed', 'reference_contacted', 'stage_changed', "
+        "'contract_dates_changed', 'tenancy_ended', 'tenancy_restarted', "
+        "'tenancy_extended', 'extension_undone')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "chk_applicant_event_type", "applicant_events", type_="check",
+    )
+    op.create_check_constraint(
+        "chk_applicant_event_type",
+        "applicant_events",
+        "event_type IN ('lead', 'screening_pending', 'screening_passed', "
+        "'screening_failed', 'video_call_done', 'approved', 'lease_sent', "
+        "'lease_signed', 'declined', 'note_added', 'screening_initiated', "
+        "'screening_completed', 'reference_contacted', 'stage_changed', "
+        "'contract_dates_changed', 'tenancy_ended', 'tenancy_restarted')",
+    )

--- a/apps/mybookkeeper/backend/app/core/applicant_enums.py
+++ b/apps/mybookkeeper/backend/app/core/applicant_enums.py
@@ -33,6 +33,8 @@ APPLICANT_EVENT_TYPES: tuple[str, ...] = APPLICANT_STAGES + (
     "contract_dates_changed",
     "tenancy_ended",
     "tenancy_restarted",
+    "tenancy_extended",
+    "extension_undone",
 )
 
 APPLICANT_EVENT_ACTORS: tuple[str, ...] = ("host", "system", "applicant")

--- a/apps/mybookkeeper/backend/app/services/leases/lease_extension_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/lease_extension_service.py
@@ -28,6 +28,7 @@ import uuid
 
 from app.core.storage import get_storage
 from app.db.session import unit_of_work
+from app.repositories.applicants import applicant_event_repo, applicant_repo
 from app.repositories.leases import (
     lease_term_version_repo,
     signed_lease_attachment_repo,
@@ -228,6 +229,26 @@ async def extend_lease(
                 organization_id=organization_id,
                 fields={"ends_on": new_ends_on, "updated_at": now},
             )
+
+            if applicant is not None:
+                tenancy_restarted = applicant.tenant_ended_at is not None
+                if tenancy_restarted:
+                    await applicant_repo.clear_tenancy_ended(
+                        db, applicant=applicant, now=now,
+                    )
+                await applicant_event_repo.append(
+                    db,
+                    applicant_id=applicant.id,
+                    event_type="tenancy_extended",
+                    actor="host",
+                    occurred_at=now,
+                    payload={
+                        "lease_id": str(lease_id),
+                        "previous_ends_on": original_ends_on.isoformat(),
+                        "new_ends_on": new_ends_on.isoformat(),
+                        "tenancy_restarted": tenancy_restarted,
+                    },
+                )
         except Exception:
             # DB write failed after we uploaded the PDF — best-effort cleanup
             # of the orphan object so the bucket doesn't accumulate dead files
@@ -343,6 +364,19 @@ async def undo_extension(
             user_id=user_id,
             organization_id=organization_id,
             fields={"ends_on": new_ends_on, "updated_at": now},
+        )
+
+        await applicant_event_repo.append(
+            db,
+            applicant_id=lease.applicant_id,
+            event_type="extension_undone",
+            actor="host",
+            occurred_at=now,
+            payload={
+                "lease_id": str(lease_id),
+                "undone_version_id": str(version_id),
+                "new_ends_on": new_ends_on.isoformat(),
+            },
         )
 
     return await get_lease(

--- a/apps/mybookkeeper/backend/tests/test_lease_extension_service.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_extension_service.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.applicants.applicant import Applicant
+from app.models.applicants.applicant_event import ApplicantEvent
 from app.models.leases.lease_term_version import LeaseTermVersion
 from app.models.leases.signed_lease import SignedLease
 from app.models.leases.signed_lease_attachment import SignedLeaseAttachment
@@ -299,3 +300,114 @@ async def test_storage_failure_cleans_up_no_partial_version(
     # The lease's ends_on is unchanged.
     await db.refresh(lease)
     assert lease.ends_on == _dt.date(2026, 12, 31)
+
+
+@pytest.mark.asyncio
+async def test_extend_clears_tenant_ended_and_writes_event(
+    db: AsyncSession,
+) -> None:
+    """Extending a lease for a manually-ended tenant restarts the tenancy.
+
+    Without this, host's mental model ("extension means they're staying")
+    silently diverges from system state (UI keeps showing the tenancy as
+    ended because tenant_ended_at is non-null).
+    """
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_signed_lease(db, user_id=user_id, org_id=org_id)
+    applicant = (
+        await db.execute(
+            select(Applicant).where(Applicant.id == lease.applicant_id),
+        )
+    ).scalar_one()
+    applicant.tenant_ended_at = _dt.datetime(2026, 6, 1, tzinfo=_dt.timezone.utc)
+    applicant.tenant_ended_reason = "moved out"
+    await db.flush()
+
+    storage = AsyncMock()
+    storage.upload_file = lambda *a, **kw: None
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), patch(
+        "app.services.leases.lease_extension_service.get_storage", lambda: storage,
+    ), patch(
+        "app.services.leases.lease_extension_service.get_lease",
+        AsyncMock(return_value=object()),
+    ):
+        await extend_lease(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            new_ends_on=_dt.date(2027, 6, 30),
+            notes=None,
+        )
+
+    await db.refresh(applicant)
+    assert applicant.tenant_ended_at is None
+    assert applicant.tenant_ended_reason is None
+
+    events = (
+        await db.execute(
+            select(ApplicantEvent).where(
+                ApplicantEvent.applicant_id == applicant.id,
+            )
+        )
+    ).scalars().all()
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.event_type == "tenancy_extended"
+    assert evt.actor == "host"
+    assert evt.payload["tenancy_restarted"] is True
+    assert evt.payload["new_ends_on"] == "2027-06-30"
+    assert evt.payload["previous_ends_on"] == "2026-12-31"
+    assert evt.payload["lease_id"] == str(lease.id)
+
+
+@pytest.mark.asyncio
+async def test_extend_with_active_tenancy_writes_event_without_clearing(
+    db: AsyncSession,
+) -> None:
+    """The normal-path extension still writes a timeline event, no clear needed."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_signed_lease(db, user_id=user_id, org_id=org_id)
+    applicant = (
+        await db.execute(
+            select(Applicant).where(Applicant.id == lease.applicant_id),
+        )
+    ).scalar_one()
+    assert applicant.tenant_ended_at is None  # baseline
+
+    storage = AsyncMock()
+    storage.upload_file = lambda *a, **kw: None
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), patch(
+        "app.services.leases.lease_extension_service.get_storage", lambda: storage,
+    ), patch(
+        "app.services.leases.lease_extension_service.get_lease",
+        AsyncMock(return_value=object()),
+    ):
+        await extend_lease(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            new_ends_on=_dt.date(2027, 6, 30),
+            notes=None,
+        )
+
+    await db.refresh(applicant)
+    assert applicant.tenant_ended_at is None
+
+    events = (
+        await db.execute(
+            select(ApplicantEvent).where(
+                ApplicantEvent.applicant_id == applicant.id,
+            )
+        )
+    ).scalars().all()
+    assert len(events) == 1
+    assert events[0].event_type == "tenancy_extended"
+    assert events[0].payload["tenancy_restarted"] is False
+
+

--- a/apps/mybookkeeper/backend/tests/test_lease_extension_undo_service.py
+++ b/apps/mybookkeeper/backend/tests/test_lease_extension_undo_service.py
@@ -23,6 +23,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.applicants.applicant import Applicant
+from app.models.applicants.applicant_event import ApplicantEvent
 from app.models.leases.lease_term_version import LeaseTermVersion
 from app.models.leases.signed_lease import SignedLease
 from app.services.leases.lease_extension_service import (
@@ -304,3 +305,45 @@ async def test_cross_tenant_lease_returns_not_found(db: AsyncSession) -> None:
             lease_id=lease.id,
             version_id=uuid.uuid4(),
         )
+
+
+@pytest.mark.asyncio
+async def test_undo_writes_extension_undone_event(db: AsyncSession) -> None:
+    """Undoing an extension records a timeline event so the host can see why
+    the lease's ends_on rolled back."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    lease = await _seed_lease_with_seed_version(
+        db, user_id=user_id, org_id=org_id,
+    )
+    version = await _seed_extension(
+        db, lease=lease, user_id=user_id, ends_on=_dt.date(2027, 6, 30),
+    )
+
+    with patch(
+        "app.services.leases.lease_extension_service.unit_of_work",
+        _fake_uow_for(db),
+    ), patch(
+        "app.services.leases.lease_extension_service.get_lease",
+        AsyncMock(return_value=object()),
+    ):
+        await undo_extension(
+            user_id=user_id,
+            organization_id=org_id,
+            lease_id=lease.id,
+            version_id=version.id,
+        )
+
+    events = (
+        await db.execute(
+            select(ApplicantEvent).where(
+                ApplicantEvent.applicant_id == lease.applicant_id,
+            )
+        )
+    ).scalars().all()
+    assert len(events) == 1
+    evt = events[0]
+    assert evt.event_type == "extension_undone"
+    assert evt.actor == "host"
+    assert evt.payload["lease_id"] == str(lease.id)
+    assert evt.payload["undone_version_id"] == str(version.id)
+    assert evt.payload["new_ends_on"] == "2026-12-31"

--- a/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantTimelineList.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/applicants/ApplicantTimelineList.tsx
@@ -26,6 +26,12 @@ const NON_STAGE_EVENT_LABELS: Record<string, string> = {
   screening_initiated: "Screening initiated",
   screening_completed: "Screening completed",
   reference_contacted: "Reference contacted",
+  stage_changed: "Stage changed",
+  contract_dates_changed: "Contract dates changed",
+  tenancy_ended: "Tenancy ended",
+  tenancy_restarted: "Tenancy restarted",
+  tenancy_extended: "Lease extended",
+  extension_undone: "Extension undone",
 };
 
 export interface ApplicantTimelineListProps {


### PR DESCRIPTION
## Summary

Fixes STATE.md gap #2 (Sonu King investigation, 2026-05-21): a manually-ended tenancy that later gets extended via the proper `extend_lease` flow left `applicant.tenant_ended_at` set, so the tenant UI continued to show "tenancy ended" despite a future `signed_leases.ends_on`. The state was self-contradictory.

## Changes

- **`extend_lease`** — when `applicant.tenant_ended_at` is set, clear it + `tenant_ended_reason` via the existing `applicant_repo.clear_tenancy_ended` helper (same path `restart_tenancy` uses). Append a `tenancy_extended` applicant_event whose payload records `tenancy_restarted: true|false`, `lease_id`, `previous_ends_on`, `new_ends_on`.
- **`undo_extension`** — append an `extension_undone` applicant_event so the timeline reflects the rollback (lease ends_on moves backward — host needs to see why).
- **Enum + migration** — add `tenancy_extended` and `extension_undone` to `APPLICANT_EVENT_TYPES`; migration `extevt260520` drops/recreates `chk_applicant_event_type` with the expanded value list.
- **Frontend timeline labels** — add the two new types, plus the pre-existing-but-missing labels for `stage_changed`, `contract_dates_changed`, `tenancy_ended`, `tenancy_restarted` (same component, same one-liners — cleaner than leaving "Tenancy_ended" rendered with default-capitalize fallback).

## Out of scope

STATE.md **gap #1** — the reconciliation banner for the "host generated an extension PDF + uploaded a signed addendum but never actually called extend_lease" path. That requires a `g-design-ux` pass per the design-pass-before-UX preference and ships as a separate PR.

## Test plan

- [x] `pytest tests/test_lease_extension_service.py tests/test_lease_extension_undo_service.py` — 20 passed
- [x] Related: `test_lease_extend_api.py test_lease_extension_undo_api.py test_tenancy_api.py test_applicant_event_repo.py test_lease_term_version_model.py` — 50 passed
- [x] `test_alembic_chain.py` — 3 passed
- [x] Migration applied to local dev DB (`extevt260520` is now head)
- [ ] CI green before admin-merge

## Operational migration

After merge + deploy, the next backend boot will apply `extevt260520`, which extends the existing `chk_applicant_event_type` CHECK constraint with two new event-type strings. Pure additive — no existing rows or app code break. No env vars to set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)