### PR TITLE
feat(mga): remove decoy from cs2 utility types

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0013_remove_cs2_decoy_utility_type.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0013_remove_cs2_decoy_utility_type.py
@@ -1,0 +1,79 @@
+"""Remove cs2 decoy utility_type
+
+Revision ID: 0013
+Revises: 0012
+Create Date: 2026-05-21 00:00:00.000000
+
+Removes the ``decoy`` utility_type row for CS2 (slug='decoy', game='cs2').
+Decoys are intentionally excluded from the MGA lineup library — they're
+not useful enough to warrant browsable lineups.
+
+Data-only migration. Safe because:
+  - At time of authoring zero ``lineup`` rows reference this utility_type
+    (verified via SELECT COUNT(*) FROM lineup l JOIN utility_type ut ON
+    l.utility_type_id = ut.id WHERE ut.slug='decoy').
+  - The DELETE includes a defensive subquery on lineup so the migration
+    fails loudly rather than silently orphaning rows if any operator's DB
+    has decoy lineups in flight.
+
+The matching fixture entry was removed in the same PR, so re-running
+``load-fixtures`` will not re-create the row.
+
+Downgrade re-creates the row via INSERT (idempotent against the
+(game_id, slug) unique constraint).
+"""
+from alembic import op
+
+
+revision = "0013"
+down_revision = "0012"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Defensive: if any lineup references this utility_type, raise rather
+    # than silently breaking the FK. This catches the case where a
+    # downstream environment seeded decoy lineups between authoring + apply.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            ref_count INTEGER;
+        BEGIN
+            SELECT COUNT(*) INTO ref_count
+            FROM lineup l
+            JOIN utility_type ut ON l.utility_type_id = ut.id
+            JOIN game g ON ut.game_id = g.id
+            WHERE ut.slug = 'decoy' AND g.slug = 'cs2';
+
+            IF ref_count > 0 THEN
+                RAISE EXCEPTION
+                    'Cannot remove cs2 decoy utility_type: % lineup(s) still reference it. '
+                    'Reassign or delete those lineups first.', ref_count;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM utility_type
+        WHERE slug = 'decoy'
+          AND game_id IN (SELECT id FROM game WHERE slug = 'cs2')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        INSERT INTO utility_type (id, game_id, slug, name, created_at)
+        SELECT gen_random_uuid(), g.id, 'decoy', 'Decoy', NOW()
+        FROM game g
+        WHERE g.slug = 'cs2'
+          AND NOT EXISTS (
+            SELECT 1 FROM utility_type ut
+            WHERE ut.game_id = g.id AND ut.slug = 'decoy'
+          )
+        """
+    )

--- a/apps/mygamingassistant/backend/app/fixtures/utility_types.json
+++ b/apps/mygamingassistant/backend/app/fixtures/utility_types.json
@@ -14,8 +14,7 @@
       { "slug": "smoke",   "name": "Smoke" },
       { "slug": "flash",   "name": "Flashbang" },
       { "slug": "molotov", "name": "Molotov / Incendiary" },
-      { "slug": "grenade", "name": "HE Grenade" },
-      { "slug": "decoy",   "name": "Decoy" }
+      { "slug": "grenade", "name": "HE Grenade" }
     ]
   }
 ]

--- a/apps/mygamingassistant/backend/app/models/game/utility_type.py
+++ b/apps/mygamingassistant/backend/app/models/game/utility_type.py
@@ -1,6 +1,6 @@
 """UtilityType model — a throwable or ability type within a game.
 
-CS2:      smoke, flash, molly, he, decoy
+CS2:      smoke, flash, molly, he
 Valorant: smoke, flash, molly, wall (generic; agent-specific abilities in later phases)
 """
 import uuid

--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -98,7 +98,7 @@ CS2 (Counter-Strike 2):
 - Left-side weapon list (primary + secondary + grenades as small icons stacked vertically)
 - Minimap in a corner showing teammates as colored dots, bomb carrier marker
 - Round timer at top center; "Bomb" (C4) as a throwable; no agent ability icons
-- Grenades are the utility: smoke, flashbang, HE grenade, Molotov/incendiary, decoy
+- Grenades are the utility: smoke, flashbang, HE grenade, Molotov/incendiary
 - Scoreboard uses T / CT team labels with a knife/bomb icon
 
 Valorant:
@@ -1292,7 +1292,7 @@ _THROW_TIMING_SCHEMA_DOC = """\
 You are given {n} numbered frames (Frame 1 .. Frame {n}) sampled in time order
 from ONE chapter of a tactical-FPS lineup tutorial. Each frame is labelled with
 its timestamp in seconds. The chapter is meant to demonstrate ONE utility throw
-(smoke / molotov / flash / HE / decoy): the player lines up, RELEASES the
+(smoke / molotov / flash / HE): the player lines up, RELEASES the
 utility, and it produces a RESULT on the map.
 
 Your ONLY job is to locate the throw in time:
@@ -1327,7 +1327,6 @@ Rules:
     FLASH   - white wash / detonation. If it is too fast to land on its own
               frame, set result_index = release_index and confidence <= 0.45.
     HE      - explosion burst / debris.
-    DECOY   - landed canister with a small ground smoke puff.
 - confidence: 0-1 that you localised the throw correctly. Low when the throw is
   off-screen, cut away from, or only inferred from trajectory; high only when
   the release and the result are both directly visible.

--- a/apps/mygamingassistant/backend/tests/test_alembic_chain.py
+++ b/apps/mygamingassistant/backend/tests/test_alembic_chain.py
@@ -2,7 +2,7 @@
 
 These run against the raw migration scripts (no live DB) so they fit the
 default pytest suite. They lock in that the chain resolves to a single head
-(currently ``0012``) and that every revision is reachable base → head — the
+(currently ``0013``) and that every revision is reachable base → head — the
 class of bug where a new migration's ``down_revision`` is stale after a
 merge and silently orphans the chain.
 """
@@ -24,8 +24,8 @@ def script_directory() -> ScriptDirectory:
     return ScriptDirectory.from_config(cfg)
 
 
-def test_single_head_is_0012(script_directory: ScriptDirectory) -> None:
-    """The DAG must resolve to exactly one head and it must be 0012.
+def test_single_head_is_0013(script_directory: ScriptDirectory) -> None:
+    """The DAG must resolve to exactly one head and it must be 0013.
 
     Bump this pin (and add a down_revision assertion below) in the same PR
     that adds a new migration — same per-PR contract as the fixture
@@ -37,8 +37,8 @@ def test_single_head_is_0012(script_directory: ScriptDirectory) -> None:
         "Orphan heads usually mean a migration's down_revision is stale "
         "after a merge — rebase and re-point the down_revision."
     )
-    assert heads[0] == "0012", (
-        f"Expected head 0012 (the lineup landing_clip_url column), got {heads[0]}."
+    assert heads[0] == "0013", (
+        f"Expected head 0013 (removes cs2 decoy utility type), got {heads[0]}."
     )
 
 
@@ -96,3 +96,11 @@ def test_0012_down_revision_points_at_0011(
     """0012 must chain directly off 0011 (the lineup landing_clip_url column)."""
     rev = script_directory.get_revision("0012")
     assert rev.down_revision == "0011"
+
+
+def test_0013_down_revision_points_at_0012(
+    script_directory: ScriptDirectory,
+) -> None:
+    """0013 must chain directly off 0012 (removes cs2 decoy utility type)."""
+    rev = script_directory.get_revision("0013")
+    assert rev.down_revision == "0012"

--- a/apps/mygamingassistant/desktop/src-tauri/src/gsi/weapons.rs
+++ b/apps/mygamingassistant/desktop/src-tauri/src/gsi/weapons.rs
@@ -4,7 +4,7 @@
 //! number (`weapon_0`, `weapon_1`, ...). Each entry has a `name` field
 //! using Valve's internal slug ("weapon_smokegrenade", "weapon_flashbang",
 //! etc.). The MGA backend, in contrast, uses short utility slugs
-//! ("smoke", "flash", "molotov", "grenade", "decoy") drawn from
+//! ("smoke", "flash", "molotov", "grenade") drawn from
 //! `backend/app/fixtures/utility_types.json`.
 //!
 //! This module is the ONLY place CS2 weapon names get translated to MGA
@@ -20,10 +20,9 @@
 //!   - `weapon_hegrenade` is HE. The MGA fixture currently uses the slug
 //!     `grenade` for HE (see `utility_types.json`), NOT `he` — we honour
 //!     the fixture's choice.
-//!   - `weapon_decoy` is the decoy grenade. The MGA fixture has the slug
-//!     `decoy`. No lineups exist for decoys yet, but the mapping is in
-//!     place so PR 10 doesn't need a follow-up if creators start uploading
-//!     decoy lineups.
+//!   - `weapon_decoy` returns `None` — decoys are intentionally excluded
+//!     from the MGA lineup library (decoys are not useful enough to
+//!     warrant browsable lineups).
 //!
 //! Anything that isn't a grenade (knife, rifle, pistol, c4) returns
 //! `None`. The frontend only uses utility for narrowing lineup queries,
@@ -47,7 +46,7 @@ pub fn weapon_to_utility_slug(weapon_name: &str) -> Option<&'static str> {
         "weapon_incgrenade" => Some("molotov"),
         // CS2 fixture uses `grenade` (not `he`) for HE — see utility_types.json
         "weapon_hegrenade" => Some("grenade"),
-        "weapon_decoy" => Some("decoy"),
+        // `weapon_decoy` deliberately returns None — decoys excluded from lineup library.
         _ => None,
     }
 }
@@ -92,8 +91,9 @@ mod tests {
     }
 
     #[test]
-    fn decoy_maps_to_decoy() {
-        assert_eq!(weapon_to_utility_slug("weapon_decoy"), Some("decoy"));
+    fn decoy_returns_none() {
+        // Decoys are deliberately excluded from the lineup library.
+        assert_eq!(weapon_to_utility_slug("weapon_decoy"), None);
     }
 
     #[test]
@@ -124,7 +124,7 @@ mod tests {
         assert!(is_utility_weapon("weapon_molotov"));
         assert!(is_utility_weapon("weapon_incgrenade"));
         assert!(is_utility_weapon("weapon_hegrenade"));
-        assert!(is_utility_weapon("weapon_decoy"));
+        assert!(!is_utility_weapon("weapon_decoy"));
         assert!(!is_utility_weapon("weapon_ak47"));
         assert!(!is_utility_weapon("weapon_knife"));
         assert!(!is_utility_weapon("weapon_c4"));

--- a/apps/mygamingassistant/frontend/src/__tests__/LiveOverridePanel.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LiveOverridePanel.test.tsx
@@ -78,7 +78,6 @@ describe("LiveOverridePanel — utility dropdown (PR 10)", () => {
     expect(optionTexts).toContain("Flash");
     expect(optionTexts).toContain("Molotov");
     expect(optionTexts).toContain("HE");
-    expect(optionTexts).toContain("Decoy");
   });
 
   it("defaults to 'All utility' when override.utility is null", () => {

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
@@ -6,7 +6,7 @@
  * visible in full-size. Zone section headers act as scroll anchors.
  *
  * Zone section order: A Site → B Site → Mid → others alphabetically.
- * Within each zone: Smoke → Flash → Molotov → HE → Decoy → side (T/CT/Both).
+ * Within each zone: Smoke → Flash → Molotov → HE → side (T/CT/Both).
  *
  * Usage:
  *   <GlanceBoard lineups={allLineups} isFetching={...} mapName={...} />

--- a/apps/mygamingassistant/frontend/src/constants/utilityDisplay.ts
+++ b/apps/mygamingassistant/frontend/src/constants/utilityDisplay.ts
@@ -2,11 +2,11 @@
  * utilityDisplay — single source of truth for utility type display metadata.
  *
  * Keyed by slug (the backend fixture slug), not by display name.
- * CS2 slugs: smoke, flash, molotov, grenade, decoy
+ * CS2 slugs: smoke, flash, molotov, grenade
  * Valorant slugs: smoke, flash, molotov, recon (subset; unknown slugs use fallback)
  *
  * sortOrder defines the LOCKED within-zone ordering:
- *   Smoke → Flash → Molotov → HE → Decoy
+ *   Smoke → Flash → Molotov → HE
  * Unknown/unrecognized slugs sort last (sortOrder 99).
  */
 
@@ -23,7 +23,6 @@ export const UTIL_DISPLAY: Record<string, UtilDisplay> = {
   flash:   { label: "Flash",   chipLabel: "Flash",   badgeBg: "bg-yellow-400", badgeText: "text-slate-900", sortOrder: 1 },
   molotov: { label: "Molotov", chipLabel: "Molotov", badgeBg: "bg-orange-700", badgeText: "text-white",     sortOrder: 2 },
   grenade: { label: "HE",      chipLabel: "HE",      badgeBg: "bg-red-600",    badgeText: "text-white",     sortOrder: 3 },
-  decoy:   { label: "Decoy",   chipLabel: "Decoy",   badgeBg: "bg-purple-600", badgeText: "text-white",     sortOrder: 4 },
   // Valorant-only slugs that share names with CS2 entries above (smoke/flash/molotov)
   // are handled by the entries already keyed above.
   recon:   { label: "Recon",   chipLabel: "Recon",   badgeBg: "bg-teal-600",   badgeText: "text-white",     sortOrder: 5 },

--- a/apps/mygamingassistant/frontend/src/types/desktop.ts
+++ b/apps/mygamingassistant/frontend/src/types/desktop.ts
@@ -45,8 +45,7 @@ export type Cs2UtilitySlug =
   | "smoke"
   | "flash"
   | "molotov"
-  | "grenade"
-  | "decoy";
+  | "grenade";
 
 /** Display labels for the override panel + HUD. */
 export const CS2_UTILITY_LABELS: Record<Cs2UtilitySlug, string> = {
@@ -54,7 +53,6 @@ export const CS2_UTILITY_LABELS: Record<Cs2UtilitySlug, string> = {
   flash: "Flash",
   molotov: "Molotov",
   grenade: "HE",
-  decoy: "Decoy",
 };
 
 /** Ordered list of slugs for select dropdowns — keeps "ALL" group ordering
@@ -64,7 +62,6 @@ export const CS2_UTILITY_SLUGS: Cs2UtilitySlug[] = [
   "flash",
   "molotov",
   "grenade",
-  "decoy",
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Decoys are excluded from the lineup library — not useful enough to warrant browsable lineups.
- Removes the cs2 `decoy` utility_type across fixture, frontend display, desktop GSI mapping.
- Adds data migration `0013` to delete the existing DB row (defensive: raises if any lineup still references decoy; verified zero at authoring).

## Files changed (9)
- **Backend**: `utility_types.json` (fixture), `utility_type.py` docstring, `classifier_service.py` (3 prompt mentions), new alembic `0013_remove_cs2_decoy_utility_type.py`
- **Frontend**: `utilityDisplay.ts` (remove decoy entry), `types/desktop.ts` (union + label + array), `GlanceBoard.tsx` (comment), `LiveOverridePanel.test.tsx` (test expectation)
- **Desktop**: `weapons.rs` — `weapon_decoy` now returns `None`; test updated accordingly

## Test plan
- [ ] CI green
- [ ] After deploy, `/cs2/mirage` shows 4 utility chips (Smoke/Flash/HE/Molotov), no Decoy
- [ ] Existing lineups unaffected (zero decoy lineups existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)