### PR TITLE
feat(mga): PR6 — STAND + AIM 1-second micro-clips (4-pane storyboard, complete)

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0014_lineup_stand_aim_clips.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0014_lineup_stand_aim_clips.py
@@ -1,0 +1,58 @@
+"""Add stand_clip_url + aim_clip_url to lineup
+
+Revision ID: 0014
+Revises: 0013
+Create Date: 2026-05-21 04:00:00.000000
+
+Adds two nullable columns to ``lineup`` so the PR6 stand/aim micro-clip
+pipeline and the frontend StandPane / AimPane have a stable contract:
+
+  * ``stand_clip_url`` — 1s looped clip anchored on the same chapter timestamp
+    the classifier chose for ``stand_screenshot_url``. The STAND pane upgrades
+    from the still to this clip when set; the still remains the poster /
+    pre-load fallback so a slow MinIO presign doesn't blank the pane.
+  * ``aim_clip_url`` — 1s looped clip anchored on the same chapter timestamp
+    the classifier chose for ``aim_screenshot_url``. The AIM pane upgrades
+    similarly; the aim anchor dot continues to overlay because the clip's
+    first frame IS the aim still (same timestamp), so the existing normalized
+    anchor coords stay accurate.
+
+Both columns store a BARE MinIO object key (like the existing
+``stand_screenshot_url`` / ``aim_screenshot_url`` / ``clip_url`` /
+``landing_clip_url``). Presigning happens at read time in
+``lineup_service._build_read``. Upload is handled by
+``app.services.ingestion.micro_clip_generator`` — this migration only extends
+the schema.
+
+Additive: existing rows default to NULL. The app is fully functional without
+the backfill — new ingests auto-populate, old rows keep showing the existing
+stand/aim stills. The operator runs ``python -m app.cli backfill-micro-clips``
+once post-deploy to populate accepted ingested lineups (idempotent).
+
+Downgrade: drops both columns unconditionally. Data loss is expected and
+acceptable on rollback — the STAND/AIM panes gracefully degrade to stills.
+"""
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0014"
+down_revision = "0013"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "lineup",
+        sa.Column("stand_clip_url", sa.String(length=500), nullable=True),
+    )
+    op.add_column(
+        "lineup",
+        sa.Column("aim_clip_url", sa.String(length=500), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("lineup", "aim_clip_url")
+    op.drop_column("lineup", "stand_clip_url")

--- a/apps/mygamingassistant/backend/app/cli/__init__.py
+++ b/apps/mygamingassistant/backend/app/cli/__init__.py
@@ -5,6 +5,7 @@ Usage:
     python -m app.cli backfill-clips
     python -m app.cli backfill-technique
     python -m app.cli backfill-landing-clips
+    python -m app.cli backfill-micro-clips
 """
 import asyncio
 import sys
@@ -81,6 +82,33 @@ async def _run_backfill_landing_clips() -> int:
     return 1 if stats.failed else 0
 
 
+async def _run_backfill_micro_clips() -> int:
+    """Generate stand + aim micro-clips for accepted lineups missing one.
+    Returns an exit code.
+
+    Idempotent — safe to re-run; only lineups with at least one of
+    ``stand_clip_url`` / ``aim_clip_url`` NULL are touched. Independent of
+    ``backfill-clips`` / ``backfill-landing-clips`` (separate NULL columns).
+    A non-zero exit signals at least one hard failure on either side so the
+    operator notices (re-running retries them — they are not fatal).
+    """
+    from app.db.session import AsyncSessionLocal
+    from app.services.ingestion.micro_clip_backfill import (
+        backfill_micro_clips,
+    )
+
+    async with AsyncSessionLocal() as db:
+        stats = await backfill_micro_clips(db)
+
+    print(stats.summary())
+    if stats.errors:
+        print(f"  {len(stats.errors)} issue(s):")
+        for err in stats.errors:
+            print(f"   - {err}")
+    # Re-runnable: failures retry next run, so a non-zero exit is advisory.
+    return 1 if stats.failed else 0
+
+
 def main() -> None:
     command = sys.argv[1] if len(sys.argv) > 1 else ""
 
@@ -94,6 +122,8 @@ def main() -> None:
         sys.exit(asyncio.run(_run_backfill_technique()))
     elif command == "backfill-landing-clips":
         sys.exit(asyncio.run(_run_backfill_landing_clips()))
+    elif command == "backfill-micro-clips":
+        sys.exit(asyncio.run(_run_backfill_micro_clips()))
     else:
         print(f"Unknown command: {command!r}")
         print("Available commands:")
@@ -101,6 +131,7 @@ def main() -> None:
         print("  backfill-clips         — generate clips for accepted lineups missing one")
         print("  backfill-technique     — name throw-technique for accepted lineups missing one")
         print("  backfill-landing-clips — generate landing clips for accepted lineups missing one")
+        print("  backfill-micro-clips   — generate stand + aim micro-clips for accepted lineups missing one")
         sys.exit(1)
 
 

--- a/apps/mygamingassistant/backend/app/models/game/lineup.py
+++ b/apps/mygamingassistant/backend/app/models/game/lineup.py
@@ -116,6 +116,17 @@ class Lineup(Base):
     # renders the existing "Lands in: <zone>" text fallback in the LANDING
     # pane. See app/services/ingestion/landing_clip_generator.py.
     landing_clip_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    # PR6 short looped micro-clips for STAND + AIM panes. Anchored on the
+    # classifier-chosen stand/aim timestamps (same instant the existing
+    # stand/aim stills represent) so the AIM clip's first frame IS the aim
+    # still and the normalized aim_anchor_x/y overlay stays pixel-accurate.
+    # Bare MinIO keys like clip_url / landing_clip_url; presigned at read time
+    # in lineup_service._build_read. Best-effort and orthogonal to lineup
+    # validity — NULL gracefully degrades to the existing stand/aim stills in
+    # LineupPanes.StandPane / AimPane. See
+    # app/services/ingestion/micro_clip_generator.py.
+    stand_clip_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    aim_clip_url: Mapped[str | None] = mapped_column(String(500), nullable=True)
 
     # Normalized 0-1 crosshair position on the aim screenshot
     aim_anchor_x: Mapped[float | None] = mapped_column(Float, nullable=True)

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -416,6 +416,95 @@ async def set_landing_clip_url(
     return lineup
 
 
+async def list_accepted_lineups_needing_micro_clips(
+    db: AsyncSession,
+) -> list[Lineup]:
+    """Accepted, ingested lineups missing EITHER stand or aim micro-clip.
+
+    The PR6 backfill set: ``status='accepted'`` AND a source video to re-fetch
+    (``youtube_video_id`` not null) AND at least ONE of the two micro-clip
+    columns is still null. A single composite list (rather than two separate
+    lists) means a video is fetched + downloaded ONCE per backfill run even
+    when it backs many lineups — the generator handles partial state
+    internally, skipping the side that's already populated.
+
+    Idempotent: once both columns are set, the lineup drops out of the set.
+    Re-running only touches the remainder. Ordered oldest-first so a long
+    backfill makes monotonic progress.
+
+    Mirrors :func:`list_accepted_lineups_needing_clips` (PR2) /
+    :func:`list_accepted_lineups_needing_landing_clips` (PR5) — the three
+    backfills are independent (separate operator commands, separate NULL
+    columns) and intentionally not coupled.
+    """
+    stmt = (
+        select(Lineup)
+        .where(
+            Lineup.status == "accepted",
+            Lineup.youtube_video_id.is_not(None),
+            (
+                Lineup.stand_clip_url.is_(None)
+                | Lineup.aim_clip_url.is_(None)
+            ),
+        )
+        .order_by(Lineup.created_at.asc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
+
+
+async def set_stand_clip_url(
+    db: AsyncSession,
+    lineup: Lineup,
+    stand_clip_key: str,
+) -> Lineup:
+    """Persist the generated stand micro-clip's bare MinIO key onto a lineup.
+
+    One-column commit on purpose — same rationale as :func:`set_clip_url` /
+    :func:`set_landing_clip_url`: the stand clip is best-effort and orthogonal
+    to lineup validity (the stand still already covers this pane; the clip is
+    a motion upgrade). A stand-clip failure must NEVER roll back the lineup
+    or the sibling aim clip; a stand-clip success must NOT wait on the aim
+    clip or any other parallel writer.
+
+    Transaction ownership lives here in the repo per PR #687/#695 — callers
+    (ingestion orchestrator + backfill CLI) never call db.commit().
+    ``stand_clip_url`` stores a BARE object key; presigning happens at read
+    time in ``lineup_service._build_read``.
+    """
+    lineup.stand_clip_url = stand_clip_key
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
+async def set_aim_clip_url(
+    db: AsyncSession,
+    lineup: Lineup,
+    aim_clip_key: str,
+) -> Lineup:
+    """Persist the generated aim micro-clip's bare MinIO key onto a lineup.
+
+    Sibling to :func:`set_stand_clip_url` — identical contract, independent
+    column. Anchoring on the same chapter timestamp the classifier chose for
+    ``aim_screenshot_url`` is what keeps the existing ``aim_anchor_x/y``
+    overlay pixel-accurate on the clip's first frame (the first frame IS the
+    aim still).
+    """
+    lineup.aim_clip_url = aim_clip_key
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
 async def list_accepted_lineups_needing_technique(
     db: AsyncSession,
 ) -> list[Lineup]:

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -73,6 +73,12 @@ class LineupRead(BaseModel):
     # PR5 landing-clip key; presigned to a 24h GET URL at read time in
     # lineup_service._build_read alongside the other MinIO keys.
     landing_clip_url: Optional[str] = None
+    # PR6 stand/aim micro-clip keys; presigned alongside clip_url +
+    # landing_clip_url in _build_read. NULL until the generator (ingest path)
+    # or backfill CLI populates them — UI gracefully degrades to the existing
+    # stand_screenshot_url / aim_screenshot_url stills.
+    stand_clip_url: Optional[str] = None
+    aim_clip_url: Optional[str] = None
     aim_anchor_x: Optional[float] = None
     aim_anchor_y: Optional[float] = None
     # Minimap anchor positions — raw values from the DB. May be NULL; use the

--- a/apps/mygamingassistant/backend/app/services/game/lineup_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_service.py
@@ -182,6 +182,8 @@ def _build_read(lineup: Lineup) -> LineupRead:
             "aim_screenshot_url": _sign_screenshot_url(read.aim_screenshot_url),
             "clip_url": _sign_screenshot_url(read.clip_url),
             "landing_clip_url": _sign_screenshot_url(read.landing_clip_url),
+            "stand_clip_url": _sign_screenshot_url(read.stand_clip_url),
+            "aim_clip_url": _sign_screenshot_url(read.aim_clip_url),
         }
     )
 

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -53,6 +53,9 @@ from app.services.ingestion.clip_generator import generate_clip_for_lineup
 from app.services.ingestion.landing_clip_generator import (
     generate_landing_clip_for_lineup,
 )
+from app.services.ingestion.micro_clip_generator import (
+    generate_micro_clips_for_lineup,
+)
 from app.services.ingestion.technique_extractor import (
     extract_technique_for_lineup,
 )
@@ -462,6 +465,38 @@ async def _process_chapter(
                     source.id, video_meta.video_id, start, lineup.id,
                     str(exc), exc_info=True,
                 )
+
+        # PR6: best-effort STAND + AIM 1s micro-clips. Anchored on the SAME
+        # grid timestamps the classifier already chose for the stand/aim
+        # stills, so the AIM clip's first frame IS today's aim still and the
+        # persisted aim_anchor_x/y overlay stays pixel-accurate. Zero extra
+        # Claude spend — just two ffmpeg cuts + two MinIO uploads per chapter.
+        # Same non-fatal contract as the surrounding clip / landing / technique
+        # blocks (a micro-clip failure must not roll back the lineup).
+        try:
+            micro_result = await generate_micro_clips_for_lineup(
+                db,
+                lineup,
+                chapter_start=float(chapter.start_seconds),
+                chapter_end=float(chapter.end_seconds),
+                video_path=video_path,
+                precomputed_stand_ts=timestamps[stand_idx],
+                precomputed_aim_ts=timestamps[aim_idx],
+            )
+            logger.info(
+                "Micro-clip generation (ingest): source_id=%s video_id=%s "
+                "chapter_start=%d lineup_id=%s stand=%s aim=%s",
+                source.id, video_meta.video_id, start, lineup.id,
+                micro_result.stand_status, micro_result.aim_status,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Micro-clip generation unexpected error (non-fatal): "
+                "source_id=%s video_id=%s chapter_start=%d lineup_id=%s "
+                "error=%s",
+                source.id, video_meta.video_id, start, lineup.id, str(exc),
+                exc_info=True,
+            )
 
         # PR3: best-effort throw-technique footer text. Symmetric to the clip
         # block above and equally non-fatal — independent Claude call, own

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_backfill.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_backfill.py
@@ -1,0 +1,273 @@
+"""Backfill stand + aim micro-clips for accepted lineups that predate PR6.
+
+Lineups created before PR6 (and any whose micro-clip generation failed at
+ingest time) have ``stand_clip_url IS NULL`` and/or ``aim_clip_url IS NULL``.
+This walks that set, re-fetches each source video ONCE per video (not once
+per lineup — a tutorial video usually backs many lineups), runs the grid
+classifier to recover the stand/aim anchor timestamps, and generates the
+micro-clips. Mirrors :mod:`landing_clip_backfill` (PR5) shape exactly.
+
+Independent of :mod:`clip_backfill` (PR2) and :mod:`landing_clip_backfill`
+(PR5) by design: a lineup can have any combination of NULL micro-clip
+columns. The three backfills are separate work sets and the operator runs
+the commands independently.
+
+Idempotent by construction: the work set is
+``status='accepted' AND youtube_video_id IS NOT NULL AND (stand_clip_url IS
+NULL OR aim_clip_url IS NULL)`` (``lineup_repo.list_accepted_lineups_needing_micro_clips``).
+A generated clip sets the matching column and may drop the lineup out of
+the set. The generator handles partial state internally — uploading both
+sides per call is cheap (the heavy cost is the grid classifier + download,
+done once per video). A ``failed`` side leaves its column NULL and is
+retried on the next run (transient yt-dlp / ffmpeg / Claude failures
+self-heal). A ``skipped`` side (no source video / chapter too short /
+classifier disabled) also stays NULL and will be re-evaluated on a future
+run.
+
+Per rules/no-bandaid-solutions.md + rules/check-third-party-error-codes.md:
+every yt-dlp / ffmpeg / Claude failure is captured with its structured
+reason and tallied — nothing silently disappears.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.micro_clip_generator import (
+    generate_micro_clips_for_lineup,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+    download_video,
+    fetch_video_detail,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class MicroClipBackfillStats:
+    """Aggregate outcome of a micro-clip backfill run (printed by the CLI).
+
+    Stand and aim are tallied independently — each lineup contributes one
+    side-outcome to each counter pair. ``total`` is the number of
+    *candidate lineups*; a candidate may have one or two NULL columns.
+    """
+
+    total: int = 0
+    stand_generated: int = 0
+    stand_skipped: int = 0
+    stand_failed: int = 0
+    aim_generated: int = 0
+    aim_skipped: int = 0
+    aim_failed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    @property
+    def generated(self) -> int:
+        """Sides successfully generated this run (stand + aim)."""
+        return self.stand_generated + self.aim_generated
+
+    @property
+    def failed(self) -> int:
+        """Sides that hard-failed this run (stand + aim) — drives exit code."""
+        return self.stand_failed + self.aim_failed
+
+    def summary(self) -> str:
+        return (
+            f"backfill-micro-clips: {self.total} candidate lineup(s) — "
+            f"stand: {self.stand_generated}g/{self.stand_skipped}s/{self.stand_failed}f, "
+            f"aim: {self.aim_generated}g/{self.aim_skipped}s/{self.aim_failed}f"
+        )
+
+
+def _find_chapter(
+    chapters: list[Chapter], start_seconds: int | None
+) -> Chapter | None:
+    """The chapter whose start matches the lineup's stored chapter start.
+
+    Identical to :func:`landing_clip_backfill._find_chapter` — the ingest
+    path persisted ``chapter_start_seconds`` from the same ``parse_chapters``
+    output, so an exact start match re-identifies it. A miss means the
+    video's chapters changed since ingest.
+    """
+    if start_seconds is None:
+        return None
+    for ch in chapters:
+        if ch.start_seconds == start_seconds:
+            return ch
+    return None
+
+
+async def backfill_micro_clips(db: AsyncSession) -> MicroClipBackfillStats:
+    """Generate stand + aim micro-clips for every accepted ingested lineup
+    missing at least one.
+
+    Returns a :class:`MicroClipBackfillStats`. Designed to be invoked once
+    by the operator post-deploy (``python -m app.cli backfill-micro-clips``);
+    safe to re-run at any time.
+    """
+    stats = MicroClipBackfillStats()
+
+    lineups = await lineup_repo.list_accepted_lineups_needing_micro_clips(db)
+    stats.total = len(lineups)
+    if not lineups:
+        logger.info(
+            "backfill-micro-clips: nothing to do (no candidate lineups)"
+        )
+        return stats
+
+    # Group by source video so each video is fetched + downloaded ONCE.
+    by_video: dict[str, list[Lineup]] = defaultdict(list)
+    for lineup in lineups:
+        by_video[lineup.youtube_video_id].append(lineup)
+
+    download_dir = Path(settings.ingestion_download_dir)
+    logger.info(
+        "backfill-micro-clips: %d lineup(s) across %d video(s)",
+        stats.total, len(by_video),
+    )
+
+    for video_id, video_lineups in by_video.items():
+        # ---- One metadata fetch per video ------------------------------
+        try:
+            meta = await fetch_video_detail(video_id)
+        except YouTubeFetchError as exc:
+            logger.warning(
+                "backfill-micro-clips: metadata fetch failed: video_id=%s "
+                "error_type=%s message=%s — %d lineup(s) failed (both sides)",
+                video_id, exc.error_type, str(exc), len(video_lineups),
+            )
+            # Both sides hard-fail per lineup (one operational fault).
+            stats.stand_failed += len(video_lineups)
+            stats.aim_failed += len(video_lineups)
+            stats.errors.append(
+                f"{video_id}: metadata fetch failed ({exc.error_type})"
+            )
+            continue
+
+        chapters = parse_chapters(
+            description=meta.description,
+            video_duration=meta.duration,
+            native_chapters=meta.chapters or None,
+        )
+
+        # ---- One download per video ------------------------------------
+        try:
+            video_path = await download_video(video_id, download_dir)
+        except VideoDownloadError as exc:
+            logger.warning(
+                "backfill-micro-clips: download failed: video_id=%s "
+                "error_type=%s message=%s — %d lineup(s) failed (both sides)",
+                video_id, exc.error_type, str(exc), len(video_lineups),
+            )
+            stats.stand_failed += len(video_lineups)
+            stats.aim_failed += len(video_lineups)
+            stats.errors.append(
+                f"{video_id}: download failed ({exc.error_type})"
+            )
+            continue
+
+        try:
+            for lineup in video_lineups:
+                chapter = _find_chapter(chapters, lineup.chapter_start_seconds)
+                if chapter is None:
+                    logger.warning(
+                        "backfill-micro-clips: chapter not found: "
+                        "lineup=%s video_id=%s chapter_start=%s — skipping",
+                        lineup.id, video_id, lineup.chapter_start_seconds,
+                    )
+                    stats.stand_skipped += 1
+                    stats.aim_skipped += 1
+                    stats.errors.append(
+                        f"{video_id}[{lineup.chapter_start_seconds}]: "
+                        f"chapter not found (video changed since ingest)"
+                    )
+                    continue
+
+                try:
+                    result = await generate_micro_clips_for_lineup(
+                        db,
+                        lineup,
+                        chapter_start=float(chapter.start_seconds),
+                        chapter_end=float(chapter.end_seconds),
+                        # Reuse the once-downloaded file — do NOT let the
+                        # generator re-download per lineup.
+                        video_path=video_path,
+                        # Backfill: no precomputed timestamps; the generator
+                        # re-runs the grid classifier itself.
+                        precomputed_stand_ts=None,
+                        precomputed_aim_ts=None,
+                    )
+                except Exception as exc:  # defensive: never abort the batch
+                    logger.warning(
+                        "backfill-micro-clips: unexpected error: lineup=%s "
+                        "video_id=%s error=%s",
+                        lineup.id, video_id, str(exc), exc_info=True,
+                    )
+                    stats.stand_failed += 1
+                    stats.aim_failed += 1
+                    stats.errors.append(
+                        f"{lineup.id}: unexpected:{type(exc).__name__} {exc}"
+                    )
+                    continue
+
+                # Tally per side independently — the generator returns the
+                # paired result but the two columns are committed separately.
+                _tally_side(stats, lineup, "stand", result.stand_status,
+                            result.stand_error_codes)
+                _tally_side(stats, lineup, "aim", result.aim_status,
+                            result.aim_error_codes)
+        finally:
+            # The backfill owns this download (one per video) — clean it up
+            # once, after all of the video's lineups are processed.
+            try:
+                video_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "backfill-micro-clips: failed to delete video: "
+                    "path=%s error=%s",
+                    video_path, str(exc),
+                )
+
+    logger.info("backfill-micro-clips: complete — %s", stats.summary())
+    return stats
+
+
+def _tally_side(
+    stats: MicroClipBackfillStats,
+    lineup: Lineup,
+    side: str,
+    status: str,
+    error_codes: list[str],
+) -> None:
+    """Increment the matching counter for one side; record errors flat."""
+    if side == "stand":
+        if status == "generated":
+            stats.stand_generated += 1
+        elif status == "skipped":
+            stats.stand_skipped += 1
+        else:
+            stats.stand_failed += 1
+            stats.errors.append(
+                f"{lineup.id}[stand]: {','.join(error_codes) or 'failed'}"
+            )
+    else:  # aim
+        if status == "generated":
+            stats.aim_generated += 1
+        elif status == "skipped":
+            stats.aim_skipped += 1
+        else:
+            stats.aim_failed += 1
+            stats.errors.append(
+                f"{lineup.id}[aim]: {','.join(error_codes) or 'failed'}"
+            )

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
@@ -1,0 +1,545 @@
+"""Stand + Aim micro-clip generator — 1s looped clips for the STAND and AIM
+panes of the 2×2 storyboard tile (PR6).
+
+PR4 introduced the four-pane storyboard (STAND still | AIM still+anchor | THROW
+clip | LANDING text). PR5 replaced the LANDING text with a real landing clip.
+PR6 replaces the STAND and AIM stills with **1-second looping micro-clips**
+anchored on the **same chapter timestamps** the Strategy-A classifier already
+chose for ``stand_screenshot_url`` and ``aim_screenshot_url``. The still
+remains the always-valid graceful degradation when no micro-clip exists.
+
+Two entry paths share a single contract:
+
+  1. **Ingest path** — orchestrator already ran the grid classifier and knows
+     ``timestamps[stand_idx]`` / ``timestamps[aim_idx]``. It passes them via
+     ``precomputed_stand_ts`` / ``precomputed_aim_ts``. The generator skips
+     the classifier call entirely (cost saving: zero extra Claude spend) and
+     just ffmpeg-cuts + uploads + commits.
+
+  2. **Backfill path** — standalone CLI. ``precomputed_*_ts`` are None, so we
+     re-run ``classify_frames_for_lineup_decision`` over the same grid the
+     ingest path uses, recover the indices, and turn them back into
+     timestamps via the deterministic ``grid_timestamps``. Cost: one grid-
+     classifier call per lineup.
+
+Why anchor on the **classifier-chosen** timestamps rather than fixed offsets
+(chapter_start + 0 / chapter_start + 4): the first frame of the AIM clip IS
+the existing aim still (same timestamp), so the persisted ``aim_anchor_x/y``
+normalized overlay stays pixel-accurate when StandPane / AimPane swap from
+``ScreenshotHalf`` to ``ClipView``. Fixed offsets would invalidate the anchor.
+
+Cut + encode the muted MP4 via :func:`cut_clip` (re-uses the PR2 ffmpeg
+wrapper — same encode contract, same ``+faststart``), upload to MinIO under
+a deterministic key, persist the bare key via the matching repo setter.
+
+Idempotent: keys are ``pending/{video_id}/{int(chapter_start)}-stand-micro.mp4``
+and ``pending/{video_id}/{int(chapter_start)}-aim-micro.mp4``. Re-running
+overwrites the same objects instead of orphaning new ones. The DB writes are
+**two separate one-column commits** (``set_stand_clip_url`` +
+``set_aim_clip_url``) so a stand-side failure NEVER rolls back the already-
+committed aim clip, and vice versa. Mirrors PR2 / PR5 exactly.
+
+Failure handling (rules/no-bandaid-solutions.md +
+rules/check-third-party-error-codes.md): yt-dlp / ffmpeg / Claude failures
+are captured with structured codes, logged at WARNING, and returned in
+``stand_error_codes`` / ``aim_error_codes``. ``*_clip_url`` is left NULL and
+the matching pane renders its still fallback. Nothing silent-fails.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.core.storage import get_storage
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+from app.services.classification.classifier_service import (
+    classify_frames_for_lineup_decision,
+)
+from app.services.ingestion.frame_extractor import (
+    ClipCutError,
+    FrameExtractionError,
+    cut_clip,
+    extract_frames,
+    grid_timestamps,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    download_video,
+)
+
+logger = logging.getLogger(__name__)
+
+# Frozen design-contract constants.
+# 1-second micro-clip per pane — matches the operator's stated ideal of
+# "at most each lineup should be 4 seconds total" with four 1s panes.
+_MICRO_CLIP_SECONDS = 1.0
+# Minimum acceptable clamped duration. A near-end timestamp may clip short;
+# under this threshold we skip rather than ship a useless ~200ms sliver.
+_MIN_CLIP_SECONDS = 0.5
+# Grid sample count + edge padding — must match the ingest orchestrator's
+# ingestion_orchestrator._GRID_FRAME_COUNT / _GRID_EDGE_PADDING_SECONDS so
+# the backfill recovers the SAME timestamps the ingest pass extracted.
+_GRID_FRAME_COUNT = 9
+_GRID_EDGE_PADDING_SECONDS = 1.0
+
+
+@dataclass
+class MicroClipGenerationResult:
+    """Structured outcome of a stand+aim micro-clip-generation attempt.
+
+    Two independent halves (stand / aim) — each can be ``"generated"``,
+    ``"skipped"`` (deliberate non-error), or ``"failed"`` (operational fault
+    with structured ``error_codes``). The orchestrator / backfill route on
+    these to count outcomes without re-parsing log lines.
+
+    ``status`` values per side:
+      - ``"generated"`` — clip cut, uploaded, ``*_clip_url`` committed.
+      - ``"skipped"``   — deliberately no clip (no source video / chapter too
+        short / classifier disabled or unavailable on the backfill path).
+        NOT an error; the matching pane gracefully falls back to its still.
+      - ``"failed"``    — operational failure (download / extract / cut /
+        upload / persist / Claude API). ``*_error_codes`` carries the
+        structured reason; ``*_clip_url`` left NULL; a later backfill retries.
+    """
+
+    stand_status: str
+    aim_status: str
+    stand_clip_key: Optional[str] = None
+    aim_clip_key: Optional[str] = None
+    stand_skip_reason: Optional[str] = None
+    aim_skip_reason: Optional[str] = None
+    stand_error_codes: list[str] = field(default_factory=list)
+    aim_error_codes: list[str] = field(default_factory=list)
+    stand_ts: Optional[float] = None
+    aim_ts: Optional[float] = None
+    reasoning: str = ""
+
+    @property
+    def any_generated(self) -> bool:
+        return self.stand_status == "generated" or self.aim_status == "generated"
+
+    @property
+    def any_failed(self) -> bool:
+        return self.stand_status == "failed" or self.aim_status == "failed"
+
+
+def pending_stand_clip_key(video_id: str, chapter_start_seconds: float) -> str:
+    """Deterministic MinIO key for a lineup's STAND micro-clip.
+
+    Parallel to PR2's :func:`clip_generator.pending_clip_key` and PR5's
+    :func:`landing_clip_generator.pending_landing_clip_key` — same shape,
+    different suffix. One key per (video, chapter start) makes the backfill
+    idempotent: re-running overwrites the same object instead of orphaning
+    a new one.
+    """
+    return f"pending/{video_id}/{int(chapter_start_seconds)}-stand-micro.mp4"
+
+
+def pending_aim_clip_key(video_id: str, chapter_start_seconds: float) -> str:
+    """Deterministic MinIO key for a lineup's AIM micro-clip."""
+    return f"pending/{video_id}/{int(chapter_start_seconds)}-aim-micro.mp4"
+
+
+def _compute_micro_bounds(
+    anchor_ts: float,
+    chapter_start: float,
+    chapter_end: float,
+) -> Optional[tuple[float, float]]:
+    """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
+
+    Starts AT the anchor timestamp (the classifier-chosen frame), runs
+    forward for ``_MICRO_CLIP_SECONDS``, clamped to the chapter end. The
+    important property is that ``clip_start == anchor_ts`` exactly — that
+    is what keeps the AIM clip's first frame identical to the existing aim
+    still, so the persisted ``aim_anchor_x/y`` overlay stays pixel-accurate.
+
+    Returns None when the clamped duration is shorter than
+    ``_MIN_CLIP_SECONDS`` (the anchor is too close to the chapter end to
+    carry a meaningful clip). Caller skips with reason
+    ``chapter_too_short_for_microclip``.
+    """
+    start = max(float(anchor_ts), float(chapter_start))
+    end = min(start + _MICRO_CLIP_SECONDS, float(chapter_end))
+    duration = end - start
+    if duration < _MIN_CLIP_SECONDS:
+        return None
+    return start, duration
+
+
+async def _resolve_anchor_timestamps_via_classifier(
+    db: AsyncSession,
+    lineup: Lineup,
+    video_path: Path,
+    chapter_start: float,
+    chapter_end: float,
+) -> tuple[Optional[float], Optional[float], list[str], str]:
+    """Backfill helper: re-run the grid classifier to recover stand/aim ts.
+
+    Returns ``(stand_ts, aim_ts, error_codes, reasoning)``. On any failure
+    the timestamps are None and ``error_codes`` carries the structured
+    reason. The caller then converts both sides to ``status="failed"`` /
+    ``status="skipped"`` per the failure shape.
+    """
+    timestamps = grid_timestamps(
+        float(chapter_start),
+        float(chapter_end),
+        _GRID_FRAME_COUNT,
+        edge_padding_seconds=_GRID_EDGE_PADDING_SECONDS,
+    )
+    if not timestamps:
+        return None, None, ["empty_grid_window"], "chapter window produced no grid frames"
+
+    try:
+        frames = await extract_frames(video_path, timestamps)
+    except FrameExtractionError as exc:
+        logger.warning(
+            "micro_clip_generator: grid frame extraction failed: "
+            "lineup=%s returncode=%s stderr=%s",
+            lineup.id, exc.returncode, exc.stderr[:300],
+        )
+        return None, None, [f"frame_extract:rc={exc.returncode}"], str(exc)
+
+    if not frames:
+        return None, None, ["grid_frames_empty"], "ffmpeg returned no frames"
+
+    try:
+        result = await classify_frames_for_lineup_decision(
+            db,
+            frames=frames,
+            chapter_title=lineup.chapter_title or "",
+            attribution_author=lineup.attribution_author,
+            game_hint=None,
+        )
+    except Exception as exc:
+        logger.warning(
+            "micro_clip_generator: grid classifier raised: lineup=%s error=%s",
+            lineup.id, str(exc),
+        )
+        return None, None, [f"classifier_raised:{type(exc).__name__}"], str(exc)
+
+    if not result.success:
+        logger.warning(
+            "micro_clip_generator: grid classifier call failed: lineup=%s "
+            "error_codes=%s",
+            lineup.id, result.error_codes,
+        )
+        return None, None, list(result.error_codes), "grid classifier reported failure"
+
+    if not result.is_lineup:
+        # The backfill candidate is an accepted lineup, so the classifier
+        # judging it "not a lineup" here would be a regression — keep the
+        # signal but skip cleanly rather than fabricate timestamps.
+        return None, None, [], "backfill grid says not_a_lineup (skip)"
+
+    # 1-based → 0-based, clamped to the grid range. Falls back to
+    # first/last index when the model omitted one — same shape as
+    # ingestion_orchestrator's classifier-disabled fallback.
+    stand_idx = (result.best_stand_index or 1) - 1
+    aim_idx = (result.best_aim_index or len(frames)) - 1
+    stand_idx = max(0, min(stand_idx, len(timestamps) - 1))
+    aim_idx = max(0, min(aim_idx, len(timestamps) - 1))
+    return timestamps[stand_idx], timestamps[aim_idx], [], result.reasoning or ""
+
+
+async def generate_micro_clips_for_lineup(
+    db: AsyncSession,
+    lineup: Lineup,
+    *,
+    chapter_start: float,
+    chapter_end: float,
+    video_path: Optional[Path] = None,
+    download_dir: Optional[Path] = None,
+    precomputed_stand_ts: Optional[float] = None,
+    precomputed_aim_ts: Optional[float] = None,
+) -> MicroClipGenerationResult:
+    """Cut + persist STAND and AIM 1s micro-clips for *lineup*.
+
+    Two entry paths:
+
+    **Ingest path** — caller (orchestrator) passes ``precomputed_stand_ts``
+    AND ``precomputed_aim_ts`` from the grid classifier output it already
+    has. The generator skips its own classifier call entirely. Cost: zero
+    extra Claude spend; two extra ffmpeg cuts + two MinIO uploads per
+    chapter.
+
+    **Backfill path** — caller is the CLI; ``precomputed_*_ts`` are None.
+    We re-run ``classify_frames_for_lineup_decision`` ourselves over the
+    same grid the ingest path uses (cost: one Claude call per lineup),
+    then cut both clips.
+
+    Per-side independence: a stand-side failure NEVER rolls back the
+    already-committed aim side, and vice versa. Each side has its own
+    status / error_codes in the returned result.
+
+    Args:
+        db: Active async session. On success each clip's bare key is
+            committed via ``lineup_repo.set_stand_clip_url`` /
+            ``set_aim_clip_url`` (each its own one-column commit per
+            PR #687/#695).
+        lineup: The row to clip. ``youtube_video_id`` must be set.
+        chapter_start / chapter_end: Source chapter bounds in seconds.
+        video_path: Already-downloaded source video to reuse (ingest /
+            backfill that batches per video). When None the video is
+            re-fetched into *download_dir* and deleted afterwards.
+        download_dir: Required when *video_path* is None.
+        precomputed_stand_ts / precomputed_aim_ts: Ingest path — pass the
+            ``timestamps[stand_idx]`` / ``timestamps[aim_idx]`` the
+            orchestrator already computed. Either both set or both None;
+            mixed is a wiring bug.
+
+    Returns:
+        MicroClipGenerationResult — never raises for expected failures.
+    """
+    video_id = lineup.youtube_video_id
+    if not video_id:
+        logger.warning(
+            "micro_clip_generator: lineup %s has no youtube_video_id — "
+            "cannot clip",
+            lineup.id,
+        )
+        return MicroClipGenerationResult(
+            stand_status="skipped",
+            aim_status="skipped",
+            stand_skip_reason="no_source_video",
+            aim_skip_reason="no_source_video",
+        )
+
+    # Validate the precomputed pair — either both supplied or both None.
+    if (precomputed_stand_ts is None) != (precomputed_aim_ts is None):
+        logger.warning(
+            "micro_clip_generator: lineup %s — precomputed_stand_ts / "
+            "precomputed_aim_ts must both be set or both None; got "
+            "stand=%s aim=%s",
+            lineup.id, precomputed_stand_ts, precomputed_aim_ts,
+        )
+        return MicroClipGenerationResult(
+            stand_status="failed",
+            aim_status="failed",
+            stand_error_codes=["precomputed_pair_mismatch"],
+            aim_error_codes=["precomputed_pair_mismatch"],
+            reasoning="precomputed stand/aim timestamps must be paired",
+        )
+
+    owns_video = video_path is None
+    local_video: Optional[Path] = video_path
+
+    try:
+        # ---- Resolve video path (download if needed) ----------------------
+        if local_video is None:
+            if download_dir is None:
+                logger.warning(
+                    "micro_clip_generator: lineup %s — no video_path and no "
+                    "download_dir; cannot re-fetch source",
+                    lineup.id,
+                )
+                return MicroClipGenerationResult(
+                    stand_status="failed",
+                    aim_status="failed",
+                    stand_error_codes=["no_download_dir"],
+                    aim_error_codes=["no_download_dir"],
+                    reasoning="re-fetch requested but no download_dir provided",
+                )
+            try:
+                local_video = await download_video(video_id, download_dir)
+            except VideoDownloadError as exc:
+                logger.warning(
+                    "micro_clip_generator: source re-fetch failed: lineup=%s "
+                    "video_id=%s error_type=%s message=%s",
+                    lineup.id, video_id, exc.error_type, str(exc),
+                )
+                return MicroClipGenerationResult(
+                    stand_status="failed",
+                    aim_status="failed",
+                    stand_error_codes=[f"download:{exc.error_type}"],
+                    aim_error_codes=[f"download:{exc.error_type}"],
+                    reasoning=f"video re-fetch failed: {exc}",
+                )
+
+        # ---- Resolve anchor timestamps ------------------------------------
+        if precomputed_stand_ts is not None:
+            stand_ts = float(precomputed_stand_ts)
+            aim_ts = float(precomputed_aim_ts)  # type: ignore[arg-type]
+            reasoning = ""
+        else:
+            # Backfill path — re-run the grid classifier.
+            if not settings.enable_classifier:
+                return MicroClipGenerationResult(
+                    stand_status="skipped",
+                    aim_status="skipped",
+                    stand_skip_reason="classifier_disabled",
+                    aim_skip_reason="classifier_disabled",
+                    reasoning="ENABLE_CLASSIFIER=false; backfill cannot localise frames",
+                )
+            if not settings.anthropic_api_key:
+                return MicroClipGenerationResult(
+                    stand_status="skipped",
+                    aim_status="skipped",
+                    stand_skip_reason="classifier_unavailable:missing_api_key",
+                    aim_skip_reason="classifier_unavailable:missing_api_key",
+                    reasoning="anthropic_api_key not configured",
+                )
+
+            (
+                stand_ts,
+                aim_ts,
+                err_codes,
+                reasoning,
+            ) = await _resolve_anchor_timestamps_via_classifier(
+                db, lineup, local_video, chapter_start, chapter_end,
+            )
+            if stand_ts is None or aim_ts is None:
+                # Either real failure (err_codes set) or "not a lineup"
+                # backfill regression (err_codes empty, skip cleanly).
+                if err_codes:
+                    return MicroClipGenerationResult(
+                        stand_status="failed",
+                        aim_status="failed",
+                        stand_error_codes=list(err_codes),
+                        aim_error_codes=list(err_codes),
+                        reasoning=reasoning,
+                    )
+                return MicroClipGenerationResult(
+                    stand_status="skipped",
+                    aim_status="skipped",
+                    stand_skip_reason="backfill_not_a_lineup",
+                    aim_skip_reason="backfill_not_a_lineup",
+                    reasoning=reasoning,
+                )
+
+        # ---- Cut + upload + persist each side independently ---------------
+        stand_outcome = await _cut_upload_persist_one_side(
+            db, lineup, video_id, local_video,
+            anchor_ts=stand_ts,
+            chapter_start=chapter_start,
+            chapter_end=chapter_end,
+            side="stand",
+            key_fn=pending_stand_clip_key,
+            persist_fn=lineup_repo.set_stand_clip_url,
+        )
+        aim_outcome = await _cut_upload_persist_one_side(
+            db, lineup, video_id, local_video,
+            anchor_ts=aim_ts,
+            chapter_start=chapter_start,
+            chapter_end=chapter_end,
+            side="aim",
+            key_fn=pending_aim_clip_key,
+            persist_fn=lineup_repo.set_aim_clip_url,
+        )
+
+        return MicroClipGenerationResult(
+            stand_status=stand_outcome["status"],
+            aim_status=aim_outcome["status"],
+            stand_clip_key=stand_outcome.get("clip_key"),
+            aim_clip_key=aim_outcome.get("clip_key"),
+            stand_skip_reason=stand_outcome.get("skip_reason"),
+            aim_skip_reason=aim_outcome.get("skip_reason"),
+            stand_error_codes=stand_outcome.get("error_codes", []),
+            aim_error_codes=aim_outcome.get("error_codes", []),
+            stand_ts=stand_ts,
+            aim_ts=aim_ts,
+            reasoning=reasoning,
+        )
+    finally:
+        if owns_video and local_video is not None:
+            try:
+                local_video.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "micro_clip_generator: failed to delete re-fetched "
+                    "video: path=%s error=%s",
+                    local_video, str(exc),
+                )
+
+
+async def _cut_upload_persist_one_side(
+    db: AsyncSession,
+    lineup: Lineup,
+    video_id: str,
+    local_video: Path,
+    *,
+    anchor_ts: float,
+    chapter_start: float,
+    chapter_end: float,
+    side: str,
+    key_fn,
+    persist_fn,
+) -> dict:
+    """Cut + upload + persist exactly ONE side (stand or aim).
+
+    Returns a flat dict consumed by ``generate_micro_clips_for_lineup`` —
+    not a dataclass because the caller flattens the two sides into the
+    composite ``MicroClipGenerationResult``. The same shape is used for
+    both sides so a future third pane (unlikely but possible) can be added
+    without touching this function.
+    """
+    bounds = _compute_micro_bounds(anchor_ts, chapter_start, chapter_end)
+    if bounds is None:
+        return {
+            "status": "skipped",
+            "skip_reason": "chapter_too_short_for_microclip",
+        }
+    clip_start, clip_duration = bounds
+
+    try:
+        clip_bytes = await cut_clip(local_video, clip_start, clip_duration)
+    except ClipCutError as exc:
+        logger.warning(
+            "micro_clip_generator: %s clip cut failed: lineup=%s video_id=%s "
+            "start=%.2f dur=%.2f returncode=%s stderr=%s",
+            side, lineup.id, video_id, clip_start, clip_duration,
+            exc.returncode, exc.stderr[:300],
+        )
+        return {
+            "status": "failed",
+            "error_codes": [f"clip_cut:rc={exc.returncode}"],
+        }
+
+    clip_key = key_fn(video_id, chapter_start)
+    try:
+        storage = get_storage()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, storage.upload_file, clip_key, clip_bytes, "video/mp4"
+        )
+    except Exception as exc:
+        logger.warning(
+            "micro_clip_generator: %s clip upload failed: lineup=%s key=%s "
+            "error=%s",
+            side, lineup.id, clip_key, str(exc),
+        )
+        return {
+            "status": "failed",
+            "error_codes": ["clip_upload_failed"],
+        }
+
+    try:
+        await persist_fn(db, lineup, clip_key)
+    except Exception as exc:
+        # Object uploaded but column did not commit. The key is deterministic
+        # so a later backfill recomputes the same key and overwrites the same
+        # object — no orphan, safe to retry.
+        logger.warning(
+            "micro_clip_generator: %s_clip_url persist failed (object "
+            "uploaded, column not committed; backfill is idempotent): "
+            "lineup=%s key=%s error=%s",
+            side, lineup.id, clip_key, str(exc),
+        )
+        return {
+            "status": "failed",
+            "error_codes": [f"{side}_clip_url_persist_failed"],
+        }
+
+    logger.info(
+        "micro_clip_generator: %s clip generated: lineup=%s video_id=%s "
+        "key=%s anchor_ts=%.2f clip=[%.2f,+%.2fs]",
+        side, lineup.id, video_id, clip_key, anchor_ts,
+        clip_start, clip_duration,
+    )
+    return {"status": "generated", "clip_key": clip_key}

--- a/apps/mygamingassistant/backend/tests/test_alembic_chain.py
+++ b/apps/mygamingassistant/backend/tests/test_alembic_chain.py
@@ -24,8 +24,8 @@ def script_directory() -> ScriptDirectory:
     return ScriptDirectory.from_config(cfg)
 
 
-def test_single_head_is_0013(script_directory: ScriptDirectory) -> None:
-    """The DAG must resolve to exactly one head and it must be 0013.
+def test_single_head_is_0014(script_directory: ScriptDirectory) -> None:
+    """The DAG must resolve to exactly one head and it must be 0014.
 
     Bump this pin (and add a down_revision assertion below) in the same PR
     that adds a new migration — same per-PR contract as the fixture
@@ -37,8 +37,8 @@ def test_single_head_is_0013(script_directory: ScriptDirectory) -> None:
         "Orphan heads usually mean a migration's down_revision is stale "
         "after a merge — rebase and re-point the down_revision."
     )
-    assert heads[0] == "0013", (
-        f"Expected head 0013 (removes cs2 decoy utility type), got {heads[0]}."
+    assert heads[0] == "0014", (
+        f"Expected head 0014 (lineup stand_clip_url + aim_clip_url), got {heads[0]}."
     )
 
 
@@ -104,3 +104,11 @@ def test_0013_down_revision_points_at_0012(
     """0013 must chain directly off 0012 (removes cs2 decoy utility type)."""
     rev = script_directory.get_revision("0013")
     assert rev.down_revision == "0012"
+
+
+def test_0014_down_revision_points_at_0013(
+    script_directory: ScriptDirectory,
+) -> None:
+    """0014 must chain directly off 0013 (lineup stand/aim micro-clip columns)."""
+    rev = script_directory.get_revision("0014")
+    assert rev.down_revision == "0013"

--- a/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_ingestion_with_classifier.py
@@ -116,6 +116,9 @@ def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock, clip_mock
     from app.services.ingestion.landing_clip_generator import (
         LandingClipGenerationResult,
     )
+    from app.services.ingestion.micro_clip_generator import (
+        MicroClipGenerationResult,
+    )
 
     if clip_mock is None:
         clip_mock = _AsyncMock(
@@ -137,6 +140,17 @@ def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock, clip_mock
         )
     )
 
+    # PR6 micro-clip wire-up is also patched to a neutral no-op by default —
+    # same belt-and-suspenders rationale as ``landing_mock`` above. Both
+    # sides default to skipped so the existing classifier tests don't fire
+    # the real generator (which would try to download videos + call Claude).
+    micro_mock = _AsyncMock(
+        return_value=MicroClipGenerationResult(
+            stand_status="skipped", aim_status="skipped",
+            stand_skip_reason="test_default", aim_skip_reason="test_default",
+        )
+    )
+
     with contextlib.ExitStack() as stack:
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.list_videos", new_callable=AsyncMock, return_value=[FAKE_VIDEO]))
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.fetch_video_detail", new_callable=AsyncMock, return_value=FAKE_VIDEO))
@@ -146,6 +160,7 @@ def _grid_env(tmp_path: Path, fake_video_path: Path, *, classify_mock, clip_mock
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.classify_frames_for_lineup_decision", new=classify_mock))
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.generate_clip_for_lineup", new=clip_mock))
         stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.generate_landing_clip_for_lineup", new=landing_mock))
+        stack.enter_context(patch("app.services.ingestion.ingestion_orchestrator.generate_micro_clips_for_lineup", new=micro_mock))
         mock_settings = stack.enter_context(patch.object(ingestion_orchestrator_module(), "settings"))
 
         mock_settings.ingestion_download_dir = str(tmp_path)

--- a/apps/mygamingassistant/backend/tests/test_lineup_micro_clip_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_micro_clip_repo.py
@@ -1,0 +1,211 @@
+"""DB-backed tests for lineup_repo.set_stand_clip_url / set_aim_clip_url (PR6).
+
+The two micro-clip keys must actually COMMIT (not just flush) — same silent
+data-loss class as PATCH #687 and the PR5 landing-clip discipline: ``get_db``
+doesn't auto-commit, so a flush-only write is rolled back on session close
+and the operator's micro-clip silently never appears. Asserts each write
+survives a fresh read AND that the two columns are independent (a stand-
+clip failure must NEVER null the aim clip and vice versa).
+
+Mirrors :mod:`test_lineup_landing_clip_repo` exactly — the three NULL
+columns (``clip_url``, ``landing_clip_url``, ``stand_clip_url`` /
+``aim_clip_url``) are independent and each pipeline must preserve the same
+commit-vs-flush discipline.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.game import Game
+from app.models.game.lineup import Lineup
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.models.game.utility_type import UtilityType
+from app.repositories.game import lineup_repo
+
+
+@pytest.mark.asyncio
+async def test_set_stand_clip_url_commits(db: AsyncSession):
+    created = await lineup_repo.create_lineup(
+        db, {"title": "stand repo test", "status": "pending_review"}
+    )
+
+    returned = await lineup_repo.set_stand_clip_url(
+        db, created, "pending/vidX/12-stand-micro.mp4"
+    )
+    assert returned.stand_clip_url == "pending/vidX/12-stand-micro.mp4"
+
+    # Capture the PK *before* expire_all(): referencing an expired attribute
+    # (created.id) inside the query expression triggers a synchronous lazy
+    # reload — sync session.execute outside the async greenlet, i.e.
+    # MissingGreenlet. Pattern lifted verbatim from PR2's
+    # test_lineup_clip_url_repo (kept synchronised on purpose).
+    lineup_id = created.id
+
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.stand_clip_url == "pending/vidX/12-stand-micro.mp4"
+
+
+@pytest.mark.asyncio
+async def test_set_aim_clip_url_commits(db: AsyncSession):
+    created = await lineup_repo.create_lineup(
+        db, {"title": "aim repo test", "status": "pending_review"}
+    )
+
+    returned = await lineup_repo.set_aim_clip_url(
+        db, created, "pending/vidX/12-aim-micro.mp4"
+    )
+    assert returned.aim_clip_url == "pending/vidX/12-aim-micro.mp4"
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.aim_clip_url == "pending/vidX/12-aim-micro.mp4"
+
+
+@pytest.mark.asyncio
+async def test_set_micro_clip_urls_are_independent(db: AsyncSession):
+    """Setting stand must not touch aim and vice versa — the two columns are
+    independent and a one-side failure must never roll back the other side."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "both micro test", "status": "pending_review"}
+    )
+    await lineup_repo.set_stand_clip_url(
+        db, created, "pending/v/1-stand-micro.mp4"
+    )
+    await lineup_repo.set_aim_clip_url(
+        db, created, "pending/v/1-aim-micro.mp4"
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.stand_clip_url == "pending/v/1-stand-micro.mp4"
+    assert refetched.aim_clip_url == "pending/v/1-aim-micro.mp4"
+
+
+@pytest.mark.asyncio
+async def test_micro_clips_do_not_overwrite_other_clip_columns(
+    db: AsyncSession,
+):
+    """The three pipelines (PR2 throw, PR5 landing, PR6 micro) write to
+    disjoint columns. If any setter ever drove a global UPDATE that nulled
+    a sibling column, the backfills would silently destroy each other's
+    work. Regression guard for that whole class of bug."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "four-column test", "status": "pending_review"}
+    )
+    await lineup_repo.set_clip_url(db, created, "pending/v/1-clip.mp4")
+    await lineup_repo.set_landing_clip_url(
+        db, created, "pending/v/1-landing.mp4"
+    )
+    await lineup_repo.set_stand_clip_url(
+        db, created, "pending/v/1-stand-micro.mp4"
+    )
+    await lineup_repo.set_aim_clip_url(
+        db, created, "pending/v/1-aim-micro.mp4"
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.clip_url == "pending/v/1-clip.mp4"
+    assert refetched.landing_clip_url == "pending/v/1-landing.mp4"
+    assert refetched.stand_clip_url == "pending/v/1-stand-micro.mp4"
+    assert refetched.aim_clip_url == "pending/v/1-aim-micro.mp4"
+
+
+@pytest.mark.asyncio
+async def test_list_accepted_lineups_needing_micro_clips_filters(
+    db: AsyncSession,
+):
+    """The set is rows that are missing EITHER stand or aim. Confirms a
+    half-populated row (one side filled, the other NULL) is included so the
+    backfill picks it up — the generator handles partial state internally,
+    so the repo set is correctly the union, not the intersection."""
+    game = Game(
+        slug=f"g-{uuid.uuid4().hex[:8]}", name="G",
+        side_a_label="A", side_b_label="B",
+    )
+    db.add(game)
+    await db.flush()
+    mp = Map(game_id=game.id, slug=f"m-{uuid.uuid4().hex[:8]}", name="M")
+    db.add(mp)
+    await db.flush()
+    zone = MapZone(
+        map_id=mp.id, slug=f"z-{uuid.uuid4().hex[:8]}",
+        name="Z", polygon_points=[],
+    )
+    db.add(zone)
+    util = UtilityType(
+        game_id=game.id, slug=f"u-{uuid.uuid4().hex[:8]}", name="U",
+    )
+    db.add(util)
+    await db.flush()
+
+    def _accepted(**over):
+        data = dict(
+            game_id=game.id, map_id=mp.id, target_zone_id=zone.id,
+            stand_zone_id=zone.id, side="side_a", utility_type_id=util.id,
+            title="t", status="accepted",
+            youtube_video_id="vidQ",
+            stand_clip_url=None,
+            aim_clip_url=None,
+        )
+        data.update(over)
+        return data
+
+    # Wanted #1: neither side filled.
+    wanted_a = await lineup_repo.create_lineup(db, _accepted())
+    # Wanted #2: stand filled, aim missing — backfill must still pick this up.
+    wanted_b = await lineup_repo.create_lineup(
+        db, _accepted(stand_clip_url="pending/vidQ/3-stand-micro.mp4")
+    )
+    # Wanted #3: aim filled, stand missing — symmetric to wanted_b.
+    wanted_c = await lineup_repo.create_lineup(
+        db, _accepted(aim_clip_url="pending/vidQ/4-aim-micro.mp4")
+    )
+    # Excluded: both sides already filled.
+    await lineup_repo.create_lineup(
+        db,
+        _accepted(
+            stand_clip_url="pending/vidQ/5-stand-micro.mp4",
+            aim_clip_url="pending/vidQ/5-aim-micro.mp4",
+        ),
+    )
+    # Excluded: no source video to re-fetch.
+    await lineup_repo.create_lineup(db, _accepted(youtube_video_id=None))
+    # Excluded: still pending_review (not accepted).
+    await lineup_repo.create_lineup(
+        db, {"title": "p", "status": "pending_review", "youtube_video_id": "vidQ"}
+    )
+
+    rows = await lineup_repo.list_accepted_lineups_needing_micro_clips(db)
+    ids = {r.id for r in rows}
+    assert wanted_a.id in ids
+    assert wanted_b.id in ids, (
+        "A row with stand filled but aim missing must still be in the set — "
+        "the two micro-clip columns are independent and the backfill is a "
+        "union, not an intersection."
+    )
+    assert wanted_c.id in ids, (
+        "A row with aim filled but stand missing must still be in the set."
+    )
+    for r in rows:
+        assert r.status == "accepted"
+        assert r.youtube_video_id
+        # Each row must have AT LEAST ONE side still NULL.
+        assert r.stand_clip_url is None or r.aim_clip_url is None

--- a/apps/mygamingassistant/backend/tests/test_micro_clip_backfill.py
+++ b/apps/mygamingassistant/backend/tests/test_micro_clip_backfill.py
@@ -1,0 +1,330 @@
+"""Unit tests for the PR6 micro-clip backfill orchestrator.
+
+Asserts the per-video grouping (one fetch + one download per video), the
+chapter-start match logic, and the per-side structured tallying (stand /
+aim counted independently). Mirrors :mod:`test_landing_clip_backfill`
+(PR5) — the two backfills share the same orchestration shape and the two
+test modules are kept in sync. The key difference here is that each
+lineup contributes outcomes to TWO counters (stand + aim), not one.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.ingestion.micro_clip_backfill import (
+    MicroClipBackfillStats,
+    backfill_micro_clips,
+)
+from app.services.ingestion.micro_clip_generator import (
+    MicroClipGenerationResult,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+)
+
+_MOD = "app.services.ingestion.micro_clip_backfill"
+
+
+def _lineup(video_id="vidA", chapter_start=10, **kw):
+    base = dict(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_start_seconds=chapter_start,
+        title="t",
+    )
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def _meta(video_id="vidA", description="0:00 intro\n0:10 lineup",
+          duration=300, chapters=None):
+    return types.SimpleNamespace(
+        video_id=video_id, title="t", description=description,
+        duration=duration, chapters=chapters, url=f"https://yt/{video_id}",
+        channel_name="ch",
+    )
+
+
+def _chapter(start=10, end=30, title="lineup"):
+    return types.SimpleNamespace(
+        start_seconds=start, end_seconds=end, title=title,
+    )
+
+
+def _settings(download_dir="/tmp/x"):
+    s = MagicMock()
+    s.ingestion_download_dir = download_dir
+    return s
+
+
+def _both_generated() -> MicroClipGenerationResult:
+    return MicroClipGenerationResult(
+        stand_status="generated", aim_status="generated",
+        stand_clip_key="ks", aim_clip_key="ka",
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_lineups_returns_empty_stats():
+    db = AsyncMock()
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_micro_clips",
+            AsyncMock(return_value=[]),
+        ),
+        patch(f"{_MOD}.settings", _settings()),
+    ):
+        stats = await backfill_micro_clips(db)
+    assert stats.total == 0
+    assert stats.generated == 0
+    assert stats.failed == 0
+    assert stats.stand_generated == 0
+    assert stats.aim_generated == 0
+
+
+@pytest.mark.asyncio
+async def test_groups_lineups_per_video_one_download(tmp_path):
+    """Two lineups on the same video → one metadata fetch + one download.
+
+    Three candidate lineups → both-sides-generated → 6 side-outcomes total
+    (3 stand + 3 aim). ``generated`` aggregates the two sides.
+    """
+    db = AsyncMock()
+    l1 = _lineup(video_id="vidA", chapter_start=10)
+    l2 = _lineup(video_id="vidA", chapter_start=40)
+    l3 = _lineup(video_id="vidB", chapter_start=12)
+
+    download = AsyncMock(side_effect=lambda vid, _dir: tmp_path / f"{vid}.mp4")
+    fetch_detail = AsyncMock(side_effect=lambda vid: _meta(video_id=vid))
+    parse = MagicMock(return_value=[_chapter(10, 30), _chapter(40, 60),
+                                    _chapter(12, 40)])
+    gen = AsyncMock(return_value=_both_generated())
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_micro_clips",
+            AsyncMock(return_value=[l1, l2, l3]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(f"{_MOD}.fetch_video_detail", fetch_detail),
+        patch(f"{_MOD}.parse_chapters", parse),
+        patch(f"{_MOD}.download_video", download),
+        patch(f"{_MOD}.generate_micro_clips_for_lineup", gen),
+    ):
+        # Materialize the videos so the unlink in the finally doesn't fail
+        for v in ("vidA", "vidB"):
+            (tmp_path / f"{v}.mp4").write_bytes(b"x")
+        stats = await backfill_micro_clips(db)
+
+    assert stats.total == 3
+    assert stats.stand_generated == 3
+    assert stats.aim_generated == 3
+    assert stats.generated == 6  # 3 stand + 3 aim
+    assert stats.failed == 0
+    # Exactly 2 downloads (one per video) — proves the per-video grouping.
+    assert download.await_count == 2
+    assert fetch_detail.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_metadata_fetch_failure_marks_all_lineups_failed_both_sides(
+    tmp_path,
+):
+    """A single yt-dlp fault on the metadata fetch fails BOTH sides for each
+    lineup that backs onto that video — the failure is operational, not
+    side-specific."""
+    db = AsyncMock()
+    l1 = _lineup(video_id="vidX", chapter_start=10)
+    l2 = _lineup(video_id="vidX", chapter_start=20)
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_micro_clips",
+            AsyncMock(return_value=[l1, l2]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(side_effect=YouTubeFetchError(
+                "boom", error_type="network", original=Exception(),
+            )),
+        ),
+    ):
+        stats = await backfill_micro_clips(db)
+
+    assert stats.total == 2
+    assert stats.stand_failed == 2
+    assert stats.aim_failed == 2
+    assert stats.failed == 4
+    assert stats.generated == 0
+
+
+@pytest.mark.asyncio
+async def test_download_failure_marks_all_video_lineups_failed_both_sides(
+    tmp_path,
+):
+    db = AsyncMock()
+    l1 = _lineup(video_id="vidY", chapter_start=10)
+    l2 = _lineup(video_id="vidY", chapter_start=20)
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_micro_clips",
+            AsyncMock(return_value=[l1, l2]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(return_value=_meta(video_id="vidY")),
+        ),
+        patch(f"{_MOD}.parse_chapters", MagicMock(return_value=[_chapter()])),
+        patch(
+            f"{_MOD}.download_video",
+            AsyncMock(side_effect=VideoDownloadError(
+                "boom", video_id="vidY",
+                error_type="404", original=Exception(),
+            )),
+        ),
+    ):
+        stats = await backfill_micro_clips(db)
+
+    assert stats.total == 2
+    assert stats.stand_failed == 2
+    assert stats.aim_failed == 2
+    assert stats.failed == 4
+
+
+@pytest.mark.asyncio
+async def test_chapter_not_found_skips_that_lineup_only(tmp_path):
+    """Video changed since ingest → one lineup skipped on BOTH sides; the
+    rest of the batch still runs."""
+    db = AsyncMock()
+    l_match = _lineup(video_id="vidZ", chapter_start=10)
+    l_miss = _lineup(video_id="vidZ", chapter_start=99)
+
+    download = AsyncMock(side_effect=lambda vid, _dir: tmp_path / f"{vid}.mp4")
+    gen = AsyncMock(return_value=_both_generated())
+    (tmp_path / "vidZ.mp4").write_bytes(b"x")
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_micro_clips",
+            AsyncMock(return_value=[l_match, l_miss]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(return_value=_meta(video_id="vidZ")),
+        ),
+        patch(
+            f"{_MOD}.parse_chapters",
+            MagicMock(return_value=[_chapter(start=10, end=20)]),
+        ),
+        patch(f"{_MOD}.download_video", download),
+        patch(f"{_MOD}.generate_micro_clips_for_lineup", gen),
+    ):
+        stats = await backfill_micro_clips(db)
+
+    assert stats.total == 2
+    assert stats.stand_generated == 1
+    assert stats.aim_generated == 1
+    assert stats.stand_skipped == 1
+    assert stats.aim_skipped == 1
+    assert stats.failed == 0
+
+
+@pytest.mark.asyncio
+async def test_unexpected_error_per_lineup_does_not_abort_batch(tmp_path):
+    """A surprise exception on one lineup must NOT break the rest of the batch;
+    the affected lineup fails on BOTH sides (a hard fault is operational)."""
+    db = AsyncMock()
+    l_ok = _lineup(video_id="vidQ", chapter_start=10)
+    l_bad = _lineup(video_id="vidQ", chapter_start=40)
+
+    download = AsyncMock(side_effect=lambda vid, _dir: tmp_path / f"{vid}.mp4")
+    (tmp_path / "vidQ.mp4").write_bytes(b"x")
+
+    call_count = {"n": 0}
+
+    async def gen_side(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return _both_generated()
+        raise RuntimeError("surprise")
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_micro_clips",
+            AsyncMock(return_value=[l_ok, l_bad]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(return_value=_meta(video_id="vidQ")),
+        ),
+        patch(
+            f"{_MOD}.parse_chapters",
+            MagicMock(return_value=[_chapter(10, 30), _chapter(40, 60)]),
+        ),
+        patch(f"{_MOD}.download_video", download),
+        patch(
+            f"{_MOD}.generate_micro_clips_for_lineup",
+            AsyncMock(side_effect=gen_side),
+        ),
+    ):
+        stats = await backfill_micro_clips(db)
+
+    assert stats.total == 2
+    assert stats.stand_generated == 1
+    assert stats.aim_generated == 1
+    assert stats.stand_failed == 1
+    assert stats.aim_failed == 1
+    assert any("surprise" in e for e in stats.errors)
+
+
+@pytest.mark.asyncio
+async def test_mixed_per_side_outcomes_tally_independently(tmp_path):
+    """A lineup with stand=generated + aim=failed counts as one of each.
+
+    Validates the per-side tally is not collapsed into a coarse 'lineup
+    succeeded / failed' bool — that would hide real signal from the operator.
+    """
+    db = AsyncMock()
+    l_mixed = _lineup(video_id="vidM", chapter_start=10)
+
+    download = AsyncMock(side_effect=lambda vid, _dir: tmp_path / f"{vid}.mp4")
+    (tmp_path / "vidM.mp4").write_bytes(b"x")
+    gen = AsyncMock(return_value=MicroClipGenerationResult(
+        stand_status="generated", aim_status="failed",
+        stand_clip_key="ks",
+        aim_error_codes=["clip_upload_failed"],
+    ))
+
+    with (
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_micro_clips",
+            AsyncMock(return_value=[l_mixed]),
+        ),
+        patch(f"{_MOD}.settings", _settings(str(tmp_path))),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            AsyncMock(return_value=_meta(video_id="vidM")),
+        ),
+        patch(f"{_MOD}.parse_chapters",
+              MagicMock(return_value=[_chapter(10, 30)])),
+        patch(f"{_MOD}.download_video", download),
+        patch(f"{_MOD}.generate_micro_clips_for_lineup", gen),
+    ):
+        stats = await backfill_micro_clips(db)
+
+    assert stats.total == 1
+    assert stats.stand_generated == 1
+    assert stats.aim_generated == 0
+    assert stats.stand_failed == 0
+    assert stats.aim_failed == 1
+    assert any("aim" in e and "clip_upload_failed" in e for e in stats.errors)

--- a/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
@@ -1,0 +1,523 @@
+"""Unit tests for the PR6 stand + aim micro-clip generator.
+
+Pure micro-bounds math + the full generate_micro_clips_for_lineup
+orchestration with every external (download / frame extract / Claude /
+ffmpeg cut / MinIO / repo commit) mocked. Asserts the frozen-contract
+gate sharing with PR5 (precomputed pair skips the classifier entirely)
+and the structured per-side generated / skipped / failed outcomes.
+
+Mirrors :mod:`test_landing_clip_generator` so the two pipelines stay
+synchronised. Re-read PR5's tests when porting any behaviour change.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.classification.classification_result import (
+    ClassificationResult,
+)
+from app.services.ingestion.frame_extractor import (
+    ClipCutError,
+    FrameExtractionError,
+)
+from app.services.ingestion.micro_clip_generator import (
+    _compute_micro_bounds,
+    generate_micro_clips_for_lineup,
+    pending_aim_clip_key,
+    pending_stand_clip_key,
+)
+from app.services.ingestion.youtube_fetcher import VideoDownloadError
+
+_MOD = "app.services.ingestion.micro_clip_generator"
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n"
+_FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
+
+
+def _lineup(video_id="vid123", chapter_title="B smoke"):
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_title=chapter_title,
+        attribution_author=None,
+        stand_clip_url=None,
+        aim_clip_url=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _compute_micro_bounds — pure math
+# ---------------------------------------------------------------------------
+
+class TestComputeMicroBounds:
+    def test_normal_window(self):
+        # anchor 24, chapter [10,40]: [24, 25] = 1.0s.
+        start, dur = _compute_micro_bounds(24.0, 10.0, 40.0)
+        assert start == pytest.approx(24.0)
+        assert dur == pytest.approx(1.0)
+
+    def test_clamped_to_chapter_start(self):
+        # anchor 9.5 (before start 10): start clamps to 10, duration 1.0.
+        start, dur = _compute_micro_bounds(9.5, 10.0, 40.0)
+        assert start == pytest.approx(10.0)
+        assert dur == pytest.approx(1.0)
+
+    def test_clamped_to_chapter_end_tail(self):
+        # anchor 39.7, chapter ends 40 → clip [39.7, 40] = 0.3s — too short.
+        assert _compute_micro_bounds(39.7, 10.0, 40.0) is None
+
+    def test_clamped_tail_above_threshold_is_kept(self):
+        # anchor 39.4, chapter ends 40 → [39.4, 40] = 0.6s, above 0.5s threshold.
+        start, dur = _compute_micro_bounds(39.4, 10.0, 40.0)
+        assert start == pytest.approx(39.4)
+        assert dur == pytest.approx(0.6)
+
+    def test_chapter_too_short_returns_none(self):
+        # 0.4s chapter — clamped window < 0.5s → skip signal.
+        assert _compute_micro_bounds(20.0, 19.9, 20.3) is None
+
+    def test_clip_never_exceeds_chapter_end(self):
+        start, dur = _compute_micro_bounds(21.5, 10.0, 22.0)
+        assert start + dur <= 22.0 + 1e-9
+
+    def test_start_equals_anchor_for_overlay_accuracy(self):
+        """The first frame of the AIM clip MUST equal the anchor still —
+        otherwise the persisted aim_anchor_x/y pixel coords don't apply."""
+        start, _dur = _compute_micro_bounds(24.0, 10.0, 40.0)
+        assert start == pytest.approx(24.0)
+
+
+def test_pending_micro_clip_keys_are_deterministic():
+    """Stable key per (video, chapter start) → backfill idempotency."""
+    assert pending_stand_clip_key("abc", 42.0) == "pending/abc/42-stand-micro.mp4"
+    assert pending_aim_clip_key("abc", 42.0) == "pending/abc/42-aim-micro.mp4"
+    assert pending_stand_clip_key("abc", 42.9) == "pending/abc/42-stand-micro.mp4"
+
+
+def test_micro_clip_keys_distinct_from_other_clip_keys():
+    """All four key shapes (throw / landing / stand / aim) MUST differ so a
+    backfill never overwrites a sibling pipeline's object."""
+    from app.services.ingestion.clip_generator import pending_clip_key
+    from app.services.ingestion.landing_clip_generator import (
+        pending_landing_clip_key,
+    )
+
+    keys = {
+        pending_clip_key("abc", 42),
+        pending_landing_clip_key("abc", 42),
+        pending_stand_clip_key("abc", 42),
+        pending_aim_clip_key("abc", 42),
+    }
+    assert len(keys) == 4, f"Key collision: {keys}"
+
+
+# ---------------------------------------------------------------------------
+# generate_micro_clips_for_lineup — ingest path (precomputed pair)
+# ---------------------------------------------------------------------------
+
+def _ffmpeg_cut_mock():
+    return AsyncMock(return_value=_FAKE_MP4)
+
+
+def _storage_mock():
+    storage = MagicMock()
+    storage.upload_file = MagicMock()
+    return storage
+
+
+@pytest.mark.asyncio
+async def test_ingest_path_generates_both_clips_without_classifier_call():
+    """Precomputed stand+aim ts → skip classifier; cut + upload + persist twice."""
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_stand_mock = AsyncMock(return_value=lineup)
+    set_aim_mock = AsyncMock(return_value=lineup)
+
+    classifier_mock = AsyncMock()  # MUST NOT be called
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()) as cut,
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
+        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
+        patch(f"{_MOD}.classify_frames_for_lineup_decision", classifier_mock),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_stand_ts=12.0,
+            precomputed_aim_ts=24.0,
+        )
+
+    assert result.stand_status == "generated"
+    assert result.aim_status == "generated"
+    assert result.stand_clip_key == "pending/vid123/10-stand-micro.mp4"
+    assert result.aim_clip_key == "pending/vid123/10-aim-micro.mp4"
+    assert result.stand_ts == pytest.approx(12.0)
+    assert result.aim_ts == pytest.approx(24.0)
+    assert cut.await_count == 2
+    assert storage.upload_file.call_count == 2
+    set_stand_mock.assert_awaited_once()
+    set_aim_mock.assert_awaited_once()
+    classifier_mock.assert_not_awaited(), (
+        "Ingest path must NOT call the classifier — cost regression"
+    )
+
+
+@pytest.mark.asyncio
+async def test_ingest_path_mixed_precomputed_is_wiring_bug():
+    """One side precomputed, the other None → caller error (both fail)."""
+    db = AsyncMock()
+    lineup = _lineup()
+    result = await generate_micro_clips_for_lineup(
+        db, lineup,
+        chapter_start=10.0, chapter_end=40.0,
+        video_path=Path("/tmp/x.mp4"),
+        precomputed_stand_ts=12.0,
+        precomputed_aim_ts=None,  # missing!
+    )
+    assert result.stand_status == "failed"
+    assert result.aim_status == "failed"
+    assert "precomputed_pair_mismatch" in result.stand_error_codes
+    assert "precomputed_pair_mismatch" in result.aim_error_codes
+
+
+@pytest.mark.asyncio
+async def test_ingest_path_chapter_too_short_skips_both():
+    """A sliver chapter clamps below 0.5s → both sides skip."""
+    db = AsyncMock()
+    lineup = _lineup()
+    result = await generate_micro_clips_for_lineup(
+        db, lineup,
+        chapter_start=19.9, chapter_end=20.3,
+        video_path=Path("/tmp/x.mp4"),
+        precomputed_stand_ts=20.0,
+        precomputed_aim_ts=20.1,
+    )
+    assert result.stand_status == "skipped"
+    assert result.aim_status == "skipped"
+    assert result.stand_skip_reason == "chapter_too_short_for_microclip"
+    assert result.aim_skip_reason == "chapter_too_short_for_microclip"
+
+
+# ---------------------------------------------------------------------------
+# generate_micro_clips_for_lineup — backfill path (own classifier call)
+# ---------------------------------------------------------------------------
+
+def _settings(enable=True, key="sk-test"):
+    s = MagicMock()
+    s.enable_classifier = enable
+    s.anthropic_api_key = key
+    return s
+
+
+def _grid(**kw):
+    base = dict(
+        success=True, is_lineup=True,
+        best_stand_index=2, best_aim_index=5,
+        reasoning="ok", error_codes=[],
+    )
+    base.update(kw)
+    return ClassificationResult(**base)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_runs_classifier_and_generates():
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_stand_mock = AsyncMock(return_value=lineup)
+    set_aim_mock = AsyncMock(return_value=lineup)
+    grid = _grid(best_stand_index=2, best_aim_index=5)
+    timestamps = [12.0, 18.0, 24.0, 30.0, 36.0]
+
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames",
+              AsyncMock(return_value=[_FAKE_PNG] * 5)),
+        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+              AsyncMock(return_value=grid)),
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
+        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            # No precomputed → backfill branch.
+        )
+
+    assert result.stand_status == "generated"
+    assert result.aim_status == "generated"
+    # best_stand_index 2 (1-based) → timestamps[1] = 18.0.
+    # best_aim_index 5 (1-based) → timestamps[4] = 36.0.
+    assert result.stand_ts == pytest.approx(18.0)
+    assert result.aim_ts == pytest.approx(36.0)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_skips_not_a_lineup():
+    db = AsyncMock()
+    lineup = _lineup()
+    grid = _grid(is_lineup=False, best_stand_index=None, best_aim_index=None)
+    timestamps = [12.0, 18.0, 24.0]
+
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames",
+              AsyncMock(return_value=[_FAKE_PNG] * 3)),
+        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+              AsyncMock(return_value=grid)),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.stand_status == "skipped"
+    assert result.aim_status == "skipped"
+    assert result.stand_skip_reason == "backfill_not_a_lineup"
+    assert result.aim_skip_reason == "backfill_not_a_lineup"
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_classifier_disabled_skips_both():
+    db = AsyncMock()
+    lineup = _lineup()
+    with patch(f"{_MOD}.settings", _settings(enable=False)):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.stand_status == "skipped"
+    assert result.aim_status == "skipped"
+    assert result.stand_skip_reason == "classifier_disabled"
+    assert result.aim_skip_reason == "classifier_disabled"
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_classifier_missing_key_skips_both():
+    db = AsyncMock()
+    lineup = _lineup()
+    with patch(f"{_MOD}.settings", _settings(key="")):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.stand_status == "skipped"
+    assert result.aim_status == "skipped"
+    assert "missing_api_key" in result.stand_skip_reason
+    assert "missing_api_key" in result.aim_skip_reason
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_classifier_api_failure_returns_failed():
+    db = AsyncMock()
+    lineup = _lineup()
+    grid = ClassificationResult(
+        success=False, error_codes=["overloaded_error"],
+        reasoning="rate limited",
+    )
+    timestamps = [12.0, 18.0, 24.0]
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames",
+              AsyncMock(return_value=[_FAKE_PNG] * 3)),
+        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+              AsyncMock(return_value=grid)),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.stand_status == "failed"
+    assert result.aim_status == "failed"
+    assert "overloaded_error" in result.stand_error_codes
+    assert "overloaded_error" in result.aim_error_codes
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_frame_extract_failure_returns_failed():
+    db = AsyncMock()
+    lineup = _lineup()
+    timestamps = [12.0, 18.0, 24.0]
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
+        patch(
+            f"{_MOD}.extract_frames",
+            AsyncMock(side_effect=FrameExtractionError(
+                "boom", timestamp=18.0, returncode=1, stderr="x",
+            )),
+        ),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.stand_status == "failed"
+    assert result.aim_status == "failed"
+    assert any("frame_extract" in c for c in result.stand_error_codes)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_download_failure_returns_failed(tmp_path):
+    """When the generator owns the download (video_path=None), a yt-dlp
+    failure surfaces as status=failed (both sides) with structured codes."""
+    db = AsyncMock()
+    lineup = _lineup()
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(
+            f"{_MOD}.download_video",
+            AsyncMock(side_effect=VideoDownloadError(
+                "boom", video_id="vid123",
+                error_type="network", original=Exception(),
+            )),
+        ),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=None,
+            download_dir=tmp_path,
+        )
+    assert result.stand_status == "failed"
+    assert result.aim_status == "failed"
+    assert any("download:network" in c for c in result.stand_error_codes)
+    assert any("download:network" in c for c in result.aim_error_codes)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_no_source_video_skips_both():
+    db = AsyncMock()
+    lineup = _lineup(video_id=None)
+    result = await generate_micro_clips_for_lineup(
+        db, lineup,
+        chapter_start=0.0, chapter_end=30.0,
+        video_path=Path("/tmp/x.mp4"),
+    )
+    assert result.stand_status == "skipped"
+    assert result.aim_status == "skipped"
+    assert result.stand_skip_reason == "no_source_video"
+    assert result.aim_skip_reason == "no_source_video"
+
+
+# ---------------------------------------------------------------------------
+# Per-side independence — a stand failure must NOT leak into aim and v/v
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_stand_cut_failure_does_not_affect_aim():
+    """The two sides are committed by separate setters; a stand ffmpeg fault
+    must leave aim_status='generated', not 'failed'."""
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_stand_mock = AsyncMock(return_value=lineup)
+    set_aim_mock = AsyncMock(return_value=lineup)
+
+    # cut_clip raises on the first call (stand), succeeds on the second (aim).
+    cut_side_effects = [
+        ClipCutError("boom", start=12.0, duration=1.0, returncode=1, stderr="x"),
+        _FAKE_MP4,
+    ]
+
+    async def cut_clip_impl(*args, **kwargs):
+        outcome = cut_side_effects.pop(0)
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    with (
+        patch(f"{_MOD}.cut_clip", AsyncMock(side_effect=cut_clip_impl)),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
+        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_stand_ts=12.0,
+            precomputed_aim_ts=24.0,
+        )
+
+    assert result.stand_status == "failed"
+    assert result.aim_status == "generated", (
+        "Aim side must not regress when stand cut fails — the two columns "
+        "are independent."
+    )
+    set_stand_mock.assert_not_awaited()
+    set_aim_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stand_persist_failure_does_not_affect_aim():
+    """stand-column commit fails but aim succeeds → aim still 'generated'."""
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(
+            f"{_MOD}.lineup_repo.set_stand_clip_url",
+            AsyncMock(side_effect=RuntimeError("db down")),
+        ),
+        patch(
+            f"{_MOD}.lineup_repo.set_aim_clip_url",
+            AsyncMock(return_value=lineup),
+        ),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_stand_ts=12.0,
+            precomputed_aim_ts=24.0,
+        )
+    assert result.stand_status == "failed"
+    assert "stand_clip_url_persist_failed" in result.stand_error_codes
+    assert result.aim_status == "generated"
+
+
+@pytest.mark.asyncio
+async def test_upload_failure_per_side_returns_failed():
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    storage.upload_file = MagicMock(side_effect=RuntimeError("minio down"))
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_stand_ts=12.0,
+            precomputed_aim_ts=24.0,
+        )
+    # Storage down → both sides fail (same underlying fault per side).
+    assert result.stand_status == "failed"
+    assert result.aim_status == "failed"
+    assert "clip_upload_failed" in result.stand_error_codes
+    assert "clip_upload_failed" in result.aim_error_codes

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -34,6 +34,8 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     aim_screenshot_url: "https://ex.com/aim.png",
     clip_url: null,
     landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
     technique: null,
     aim_anchor_x: 0.5,
     aim_anchor_y: 0.4,

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -261,6 +261,92 @@ describe("GlanceBoardTile THROW pane (clip)", () => {
 });
 
 // ---------------------------------------------------------------------------
+// PR6 — STAND + AIM panes swap stills for 1s micro-clips
+// ---------------------------------------------------------------------------
+describe("GlanceBoardTile PR6 micro-clips (STAND + AIM)", () => {
+  it("renders the STAND looping clip when stand_clip_url is set", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ stand_clip_url: "https://ex.com/stand.mp4" })}
+      />,
+    );
+    const standVideo = document.querySelector(
+      'video[aria-label*="looping stand clip"]',
+    );
+    expect(standVideo).not.toBeNull();
+    // The STAND label still shows on the clip pane.
+    expect(screen.getByText("STAND")).toBeInTheDocument();
+  });
+
+  it("keeps the STAND still when stand_clip_url is null", () => {
+    render(<GlanceBoardTile lineup={makeLineup({ stand_clip_url: null })} />);
+    // The stand still is the graceful fallback — no stand-clip <video>.
+    expect(
+      document.querySelector('video[aria-label*="looping stand clip"]'),
+    ).toBeNull();
+    expect(
+      screen.getByAltText(/stand position/i),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the AIM looping clip when aim_clip_url is set", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ aim_clip_url: "https://ex.com/aim.mp4" })}
+      />,
+    );
+    const aimVideo = document.querySelector(
+      'video[aria-label*="looping aim clip"]',
+    );
+    expect(aimVideo).not.toBeNull();
+  });
+
+  it("AIM anchor dot still renders when aim_clip_url is set (overlay invariant)", () => {
+    // The whole point of anchoring the AIM clip on the same classifier-chosen
+    // timestamp as the still is that the persisted aim_anchor_x/y dot stays
+    // pixel-accurate over the clip. If the dot dropped when AimPane swapped
+    // to ClipView, the overlay would silently disappear — exactly the PR6
+    // contract this test protects.
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ aim_clip_url: "https://ex.com/aim.mp4" })}
+      />,
+    );
+    expect(screen.getByLabelText(/aim anchor/i)).toBeInTheDocument();
+  });
+
+  it("all four panes show motion when every clip URL is set", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({
+          stand_clip_url: "https://ex.com/stand.mp4",
+          aim_clip_url: "https://ex.com/aim.mp4",
+          clip_url: "https://ex.com/throw.mp4",
+          landing_clip_url: "https://ex.com/landing.mp4",
+        })}
+      />,
+    );
+    // Four <video> elements — one per pane — all simultaneously rendered.
+    expect(document.querySelectorAll("video").length).toBe(4);
+    // The four corner labels still render on the clip panes.
+    expect(screen.getByText("STAND")).toBeInTheDocument();
+    expect(screen.getByText("AIM")).toBeInTheDocument();
+    expect(screen.getByText("THROW")).toBeInTheDocument();
+    expect(screen.getByText("LANDING")).toBeInTheDocument();
+  });
+
+  it("gracefully falls back to all stills when every clip URL is null (pre-PR6 lineups)", () => {
+    render(<GlanceBoardTile lineup={makeLineup()} />);
+    // No video elements anywhere — both stills + ThrowPlaceholder + landing text.
+    expect(document.querySelectorAll("video").length).toBe(0);
+    expect(screen.getByAltText(/stand position/i)).toBeInTheDocument();
+    expect(screen.getByAltText(/aim reference/i)).toBeInTheDocument();
+    expect(screen.getByText("No clip yet")).toBeInTheDocument();
+    expect(screen.getByText("Lands in")).toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
 // PR3 — throw-technique footer (preserved)
 // ---------------------------------------------------------------------------
 describe("GlanceBoardTile technique footer", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -44,6 +44,8 @@ const BASE_LINEUP: Lineup = {
   aim_screenshot_url: "https://example.com/aim.png",
   clip_url: null,
   landing_clip_url: null,
+  stand_clip_url: null,
+  aim_clip_url: null,
   technique: null,
   aim_anchor_x: 0.5,
   aim_anchor_y: 0.4,

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -282,4 +282,65 @@ describe("LineupCard", () => {
     render(<LineupCard lineup={lineup} variant="expanded" />);
     expect(screen.getByText(/Jumpthrow \+ LMB/)).toBeInTheDocument();
   });
+
+  // -------------------------------------------------------------------------
+  // PR6 — STAND + AIM panes swap stills for 1s micro-clips (expanded only)
+  // -------------------------------------------------------------------------
+
+  it("expanded variant STAND pane renders ClipView when stand_clip_url is set", () => {
+    const lineup: Lineup = {
+      ...BASE_LINEUP,
+      stand_clip_url: "https://ex.com/stand.mp4",
+    };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    const standVideo = document.querySelector(
+      'video[aria-label*="looping stand clip"]',
+    );
+    expect(standVideo).not.toBeNull();
+  });
+
+  it("expanded variant STAND pane keeps the still when stand_clip_url is null", () => {
+    render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
+    expect(
+      document.querySelector('video[aria-label*="looping stand clip"]'),
+    ).toBeNull();
+    expect(
+      screen.getByAltText(/stand position/i),
+    ).toBeInTheDocument();
+  });
+
+  it("expanded variant AIM pane renders ClipView when aim_clip_url is set", () => {
+    const lineup: Lineup = {
+      ...BASE_LINEUP,
+      aim_clip_url: "https://ex.com/aim.mp4",
+    };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    const aimVideo = document.querySelector(
+      'video[aria-label*="looping aim clip"]',
+    );
+    expect(aimVideo).not.toBeNull();
+  });
+
+  it("expanded variant AIM anchor dot still renders when aim_clip_url is set", () => {
+    // Critical PR6 invariant: the anchor dot must overlay the AIM clip just
+    // as it overlays the AIM still. See LineupPanes.AimPane.
+    const lineup: Lineup = {
+      ...BASE_LINEUP,
+      aim_clip_url: "https://ex.com/aim.mp4",
+    };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    expect(screen.getByLabelText(/aim anchor/i)).toBeInTheDocument();
+  });
+
+  it("expanded variant renders four <video> elements when all four clip URLs are set", () => {
+    const lineup: Lineup = {
+      ...BASE_LINEUP,
+      stand_clip_url: "https://ex.com/stand.mp4",
+      aim_clip_url: "https://ex.com/aim.mp4",
+      clip_url: "https://ex.com/throw.mp4",
+      landing_clip_url: "https://ex.com/landing.mp4",
+    };
+    render(<LineupCard lineup={lineup} variant="expanded" />);
+    expect(document.querySelectorAll("video").length).toBe(4);
+  });
 });

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupResultsPanel.test.tsx
@@ -28,6 +28,8 @@ function makeLineup(id: string): Lineup {
     aim_screenshot_url: null,
     clip_url: null,
     landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MapLineupPins.test.tsx
@@ -27,6 +27,8 @@ function makeLineup(overrides: Partial<Lineup>): Lineup {
     aim_screenshot_url: null,
     clip_url: null,
     landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/MinimapPinEditor.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/MinimapPinEditor.test.tsx
@@ -39,6 +39,8 @@ function makeLineup(overrides: Partial<Lineup> = {}): Lineup {
     aim_screenshot_url: null,
     clip_url: null,
     landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
@@ -80,6 +80,8 @@ function makeUnclassifiedLineup(overrides: Partial<Lineup> = {}): Lineup {
     aim_screenshot_url: null,
     clip_url: null,
     landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
+++ b/apps/mygamingassistant/frontend/src/__tests__/countUnplaceableLineups.test.ts
@@ -28,6 +28,8 @@ function makeLineup(overrides: Partial<Lineup>): Lineup {
     aim_screenshot_url: null,
     clip_url: null,
     landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
     technique: null,
     aim_anchor_x: null,
     aim_anchor_y: null,

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -38,10 +38,10 @@ import { Clock } from "lucide-react";
 import type { Lineup } from "@/types/game";
 import { utilDisplay } from "@/constants/utilityDisplay";
 import {
-  AimAnchorDot,
+  AimPane,
   ClipView,
   LandingPane,
-  ScreenshotHalf,
+  StandPane,
   ThrowPlaceholder,
 } from "./LineupPanes";
 
@@ -109,22 +109,18 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
       <div className="flex flex-col divide-y divide-border">
         {/* Top row: STAND | AIM */}
         <div className="flex divide-x divide-border">
-          <ScreenshotHalf
-            url={lineup.stand_screenshot_url}
-            alt={`${lineup.title} — stand position`}
-            label="STAND"
+          <StandPane
+            standScreenshotUrl={lineup.stand_screenshot_url}
+            standClipUrl={lineup.stand_clip_url}
+            title={lineup.title}
           />
-          <ScreenshotHalf
-            url={lineup.aim_screenshot_url}
-            alt={`${lineup.title} — aim reference`}
-            label="AIM"
-          >
-            {lineup.aim_screenshot_url &&
-              lineup.aim_anchor_x != null &&
-              lineup.aim_anchor_y != null && (
-                <AimAnchorDot x={lineup.aim_anchor_x} y={lineup.aim_anchor_y} />
-              )}
-          </ScreenshotHalf>
+          <AimPane
+            aimScreenshotUrl={lineup.aim_screenshot_url}
+            aimClipUrl={lineup.aim_clip_url}
+            aimAnchorX={lineup.aim_anchor_x}
+            aimAnchorY={lineup.aim_anchor_y}
+            title={lineup.title}
+          />
         </div>
         {/* Bottom row: THROW | LANDING */}
         <div className="flex divide-x divide-border">

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
@@ -17,10 +17,10 @@ import { Clock } from "lucide-react";
 import type { Lineup } from "@/types/game";
 import PinButton from "./PinButton";
 import {
-  AimAnchorDot,
+  AimPane,
   ClipView,
   LandingPane,
-  ScreenshotHalf,
+  StandPane,
   ThrowPlaceholder,
 } from "./LineupPanes";
 
@@ -127,22 +127,18 @@ export default function LineupCard({
           sees the same layout. */}
       <div className="flex flex-col divide-y divide-border">
         <div className="flex divide-x divide-border">
-          <ScreenshotHalf
-            url={lineup.stand_screenshot_url}
-            alt={`${lineup.title} — stand position`}
-            label="STAND"
+          <StandPane
+            standScreenshotUrl={lineup.stand_screenshot_url}
+            standClipUrl={lineup.stand_clip_url}
+            title={lineup.title}
           />
-          <ScreenshotHalf
-            url={lineup.aim_screenshot_url}
-            alt={`${lineup.title} — aim reference`}
-            label="AIM"
-          >
-            {lineup.aim_screenshot_url &&
-              lineup.aim_anchor_x != null &&
-              lineup.aim_anchor_y != null && (
-                <AimAnchorDot x={lineup.aim_anchor_x} y={lineup.aim_anchor_y} />
-              )}
-          </ScreenshotHalf>
+          <AimPane
+            aimScreenshotUrl={lineup.aim_screenshot_url}
+            aimClipUrl={lineup.aim_clip_url}
+            aimAnchorX={lineup.aim_anchor_x}
+            aimAnchorY={lineup.aim_anchor_y}
+            title={lineup.title}
+          />
         </div>
         <div className="flex divide-x divide-border">
           {lineup.clip_url ? (

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
@@ -98,9 +98,15 @@ interface ClipViewProps {
   // that forgets to pass it gets the historical behaviour, not a blank
   // label.
   label?: string;
+  // PR6 — overlay slot. AimPane mounts ``AimAnchorDot`` here so the dot sits
+  // ON the clip pane (same aspect-video container, so the dot's normalized
+  // coords still resolve to the same pixel position as the still-pane
+  // counterpart). Optional; ClipView callers that don't need an overlay
+  // (THROW, LANDING) pass nothing.
+  children?: React.ReactNode;
 }
 
-export function ClipView({ clipUrl, posterUrl, title, label = "THROW" }: ClipViewProps) {
+export function ClipView({ clipUrl, posterUrl, title, label = "THROW", children }: ClipViewProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   // Sticky once the tile has been seen: keep the src attached (re-fetching on
   // every scroll-by is worse than keeping a paused decoded clip).
@@ -189,7 +195,113 @@ export function ClipView({ clipUrl, posterUrl, title, label = "THROW" }: ClipVie
           expired presigned URL mid-session) — the poster stays as the
           graceful fallback rather than a misleading badge. */}
       {!loadFailed && <CornerLabel>{label}</CornerLabel>}
+      {/* PR6 — overlay slot for absolutely-positioned children (AimPane's
+          anchor dot). Renders last so it sits on top of the video. */}
+      {children}
     </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StandPane (PR6) — top-left pane. Shows the player's stand position.
+//
+// Renders the looping 1s micro-clip via ``ClipView`` when ``standClipUrl`` is
+// set, otherwise falls back to the original ``ScreenshotHalf`` still. The
+// micro-clip is anchored on the same classifier-chosen frame as the still, so
+// the swap is a visual upgrade — the framing matches frame-for-frame.
+//
+// Silent-fallback shape mirrors PR2's THROW pane: a missing clip URL must
+// never read as a broken/error state, just as the still rendering.
+// ---------------------------------------------------------------------------
+interface StandPaneProps {
+  // Pre-PR6 stand still — the always-valid graceful degradation.
+  standScreenshotUrl: string | null;
+  // PR6 — presigned MinIO key for the stand 1s loop. Null/undefined falls
+  // back to the still.
+  standClipUrl?: string | null;
+  // Title carried into the ClipView aria-label when the clip is rendered.
+  title: string;
+}
+
+export function StandPane({ standScreenshotUrl, standClipUrl, title }: StandPaneProps) {
+  if (standClipUrl) {
+    return (
+      <ClipView
+        clipUrl={standClipUrl}
+        posterUrl={standScreenshotUrl}
+        title={title}
+        label="STAND"
+      />
+    );
+  }
+  return (
+    <ScreenshotHalf
+      url={standScreenshotUrl}
+      alt={`${title} — stand position`}
+      label="STAND"
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// AimPane (PR6) — top-right pane. Shows the player's crosshair-aim view.
+//
+// Same upgrade-with-still-fallback shape as ``StandPane`` plus the persisted
+// aim anchor overlay dot, which renders ON TOP of whichever surface is active
+// (still or clip). Both surfaces are the same ``aspect-video`` container, so
+// the dot's normalized coords resolve to the same pixel position regardless
+// of which one is showing. The clip's first frame IS the still — anchoring on
+// the same classifier-chosen timestamp keeps this invariant.
+// ---------------------------------------------------------------------------
+interface AimPaneProps {
+  aimScreenshotUrl: string | null;
+  aimClipUrl?: string | null;
+  // Persisted normalized anchor coords. Null when the classifier didn't
+  // produce them (manual upload / pre-classifier ingest) — the dot then
+  // omits cleanly.
+  aimAnchorX: number | null;
+  aimAnchorY: number | null;
+  title: string;
+}
+
+export function AimPane({
+  aimScreenshotUrl,
+  aimClipUrl,
+  aimAnchorX,
+  aimAnchorY,
+  title,
+}: AimPaneProps) {
+  // Only render the anchor when both axes are set AND there's a base surface
+  // to anchor over — a dot floating on the "No screenshot" empty state has no
+  // meaning.
+  const renderAnchor =
+    aimAnchorX != null &&
+    aimAnchorY != null &&
+    (aimClipUrl != null || aimScreenshotUrl != null);
+  const anchor = renderAnchor ? (
+    <AimAnchorDot x={aimAnchorX!} y={aimAnchorY!} />
+  ) : null;
+
+  if (aimClipUrl) {
+    return (
+      <ClipView
+        clipUrl={aimClipUrl}
+        posterUrl={aimScreenshotUrl}
+        title={title}
+        label="AIM"
+      >
+        {anchor}
+      </ClipView>
+    );
+  }
+  return (
+    <ScreenshotHalf
+      url={aimScreenshotUrl}
+      alt={`${title} — aim reference`}
+      label="AIM"
+    >
+      {anchor}
+    </ScreenshotHalf>
   );
 }
 

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -114,6 +114,19 @@ export interface Lineup {
   // the LandingPane then falls back to the "Lands in: <zone>" text rendering
   // (graceful degradation, mirroring PR2's clip silent-fallback to stills).
   landing_clip_url: string | null;
+  // PR6: presigned URL of the 1-second looping STAND micro-clip — animates
+  // the stand pane (player arriving at the throw position). Null when ingest
+  // skipped it (manual upload / chapter too short / classifier disabled) or
+  // the lineup predates PR6 — the StandPane then falls back to the stand
+  // still (silent fallback, same shape as PR2/PR5).
+  stand_clip_url: string | null;
+  // PR6: presigned URL of the 1-second looping AIM micro-clip — animates the
+  // aim pane (player crosshair-aim during the lineup). Null with the same
+  // semantics as ``stand_clip_url``. The clip's first frame is the classifier-
+  // chosen anchor frame (same timestamp as ``aim_screenshot_url``), so the
+  // persisted ``aim_anchor_x/y`` overlay dot stays pixel-accurate when the
+  // AimPane swaps from still to clip.
+  aim_clip_url: string | null;
   aim_anchor_x: number | null;
   aim_anchor_y: number | null;
   // Explicit minimap coords; fall back to zone-polygon centroid via effective_*.


### PR DESCRIPTION
## Summary

Final step of the 4-pane storyboard vision. PR4 introduced the 2×2 layout (STAND still | AIM still+anchor | THROW clip | LANDING text). PR5 replaced the LANDING text with a real landing clip (#714). **PR6 replaces the STAND and AIM stills with 1-second looping micro-clips anchored on the same classifier-chosen timestamps** the orchestrator already uses for the stills.

Anchoring on the existing classifier timestamps is the key design choice: the first frame of the AIM clip **is** the existing aim still, so the persisted `aim_anchor_x/y` normalized overlay dot stays pixel-accurate when the AimPane swaps from `ScreenshotHalf` to `ClipView`.

All four panes can now be live-motion when all four clips exist; gracefully degrades per-pane when any clip URL is null.

## Backend

- **Migration 0014** — `stand_clip_url` + `aim_clip_url` columns on `lineup`.
- **`micro_clip_generator`** — paired stand+aim generator with two entry paths:
  - **Ingest path** (orchestrator): pass `precomputed_stand_ts` + `precomputed_aim_ts` from the grid classifier output it already has → skip the classifier entirely (zero extra Claude spend; cost = 2 ffmpeg cuts + 2 uploads per chapter).
  - **Backfill path** (CLI): no precomputed timestamps → re-run the grid classifier itself (one Claude call per lineup) to recover the same anchors the ingest pass chose.
  - Per-side independence: a stand-side failure NEVER rolls back the already-committed aim clip, and vice versa. Two separate one-column repo commits (PR #687/#695 pattern).
  - Structured error codes per side (`clip_cut:rc=*`, `clip_upload_failed`, `*_clip_url_persist_failed`, `download:*`, `frame_extract:*`, classifier codes) — never silent-fail.
- **`micro_clip_backfill`** — group lineups by video, fetch metadata + download once, run the generator per lineup with `video_path` reuse, tally per-side. `stats.failed = stand_failed + aim_failed` so a mixed-success run with even one hard failure still exits non-zero.
- **CLI** — `python -m app.cli backfill-micro-clips` (independent from `backfill-clips` / `backfill-landing-clips`).
- **`lineup_service._build_read`** presigns both new keys at read time.

## Frontend

- **`StandPane`** + **`AimPane`** in `LineupPanes.tsx` — swap from `ScreenshotHalf` (still) to `ClipView` (looping muted 1s clip) when the matching clip URL is set; else fall back to the still. Same silent-fallback shape as PR2's THROW pane.
- **`ClipView`** gains a `children` slot so `AimPane` can mount `AimAnchorDot` *inside the active pane* — both `ScreenshotHalf` and `ClipView` are the same `aspect-video` container, so the dot's normalized coords resolve to the same pixel position regardless of which surface is showing.
- **`Lineup` type** — adds `stand_clip_url: string \| null` + `aim_clip_url: string \| null`.
- **`GlanceBoardTile` + `LineupCard`** — replace `ScreenshotHalf`+`AimAnchorDot` calls with the new pane primitives. The two surfaces stay byte-equivalent (PR4 invariant).
- **7 fixture files** updated with `stand_clip_url: null, aim_clip_url: null`.

## Tests

- **Backend**: 491/491 pass.
  - `test_micro_clip_generator.py` — 21 tests: pure micro-bounds math (incl. `start==anchor` for AIM overlay accuracy + key distinctness from throw/landing/landing keys), ingest path (precomputed pair skips classifier — cost regression guard), backfill path (own grid-classifier call), per-side independence (stand fault never affects aim), every error shape.
  - `test_micro_clip_backfill.py` — 7 tests: per-video grouping (1 fetch + 1 download per multi-lineup video), per-side tallying, metadata/download faults marking both sides failed, chapter-not-found skipping both sides only for that lineup, mixed per-side outcomes.
  - `test_lineup_micro_clip_repo.py` — 5 DB-backed tests: each setter actually COMMITS, the two setters are independent, all four clip columns can be set without cross-contamination, the candidate set is the union (half-populated rows still picked up) not intersection.
  - `test_ingestion_with_classifier.py` — patches `generate_micro_clips_for_lineup` to a neutral skipped default so existing classifier tests don't fire the real generator.
- **Frontend**: 26 files / 320 tests pass; `tsc --noEmit` clean.
  - `GlanceBoardTile.test.tsx` — 6 new PR6 tests covering the still→clip swap for each side, the AIM anchor dot rendering invariant when AimPane shows a clip, all-four-clips simultaneous rendering, and all-nulls graceful degradation.
  - `LineupCard.test.tsx` — 5 new PR6 tests covering the same invariants for the expanded variant.

## Operational migration

None. Additive only:
- Migration 0014 is a pure column add (two new `String(N)` columns, both nullable, no default). Existing rows are NULL → panes fall back to stills, identical pre-PR6 behavior.
- No new env vars; no boot guard changes.
- After deploy, the operator runs `python -m app.cli backfill-micro-clips` to populate existing accepted lineups. The new ingest path picks up future lineups automatically.

## Test plan

- [x] `pytest` (backend) — 491/491 pass
- [x] `npm test` (frontend) — 320/320 pass
- [x] `npm run typecheck` — clean
- [x] `alembic upgrade head` applies cleanly on the local dev DB (0013 → 0014)
- [ ] Browser smoke at the staging deploy — verify the panes light up on at least one ingested lineup after a `backfill-micro-clips` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)