### PR TITLE
feat(mga): design-knobs panel for storyboard tile iteration

### DIFF
--- a/apps/mygamingassistant/frontend/src/components/lineup/DesignKnobsPanel.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/DesignKnobsPanel.tsx
@@ -1,0 +1,160 @@
+/**
+ * DesignKnobsPanel — floating bottom-right panel for direct-manipulation
+ * tuning of the storyboard tile. Collapsed to a small chip by default;
+ * click to expand a panel with the five knobs.
+ *
+ * The panel is wired to URL params via `useDesignKnobs` so refresh and
+ * link-sharing preserve the chosen combination. Once the operator settles
+ * on a preferred default, they tell the assistant which combo to lock in
+ * as the shipped default in `DEFAULT_KNOBS`.
+ */
+import { useState } from "react";
+import { Settings2, X, RotateCcw } from "lucide-react";
+import { useDesignKnobs } from "@/hooks/useDesignKnobs";
+import type { PaneMode, LandingMode, TilesPerRow } from "@/hooks/useDesignKnobs";
+
+interface SegmentedProps<T extends string | number> {
+  label: string;
+  value: T;
+  options: ReadonlyArray<{ label: string; value: T }>;
+  onChange: (next: T) => void;
+}
+
+function Segmented<T extends string | number>({ label, value, options, onChange }: SegmentedProps<T>) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">
+        {label}
+      </span>
+      <div className="flex rounded-md border border-border overflow-hidden">
+        {options.map((opt) => {
+          const active = opt.value === value;
+          return (
+            <button
+              key={String(opt.value)}
+              type="button"
+              onClick={() => onChange(opt.value)}
+              className={[
+                "px-2.5 py-1 text-[11px] font-medium transition-colors",
+                active
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+              ].join(" ")}
+              aria-pressed={active}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default function DesignKnobsPanel() {
+  const { knobs, setKnob, reset } = useDesignKnobs();
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="fixed bottom-4 right-4 z-30 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-background/90 border border-border shadow-md hover:bg-muted/60 transition-colors text-[11px] font-medium text-muted-foreground"
+        aria-label="Open design knobs"
+        title="Design knobs"
+      >
+        <Settings2 className="w-3.5 h-3.5" aria-hidden />
+        Design
+      </button>
+    );
+  }
+
+  return (
+    <aside
+      role="dialog"
+      aria-label="Design knobs"
+      className="fixed bottom-4 right-4 z-30 w-[260px] rounded-lg border border-border bg-background shadow-xl p-3 space-y-2.5"
+    >
+      <header className="flex items-center justify-between">
+        <span className="text-xs font-semibold uppercase tracking-wide text-foreground">
+          Design knobs
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={reset}
+            className="p-1 rounded hover:bg-muted/40 text-muted-foreground"
+            aria-label="Reset to defaults"
+            title="Reset to defaults"
+          >
+            <RotateCcw className="w-3.5 h-3.5" aria-hidden />
+          </button>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="p-1 rounded hover:bg-muted/40 text-muted-foreground"
+            aria-label="Close design knobs"
+          >
+            <X className="w-3.5 h-3.5" aria-hidden />
+          </button>
+        </div>
+      </header>
+
+      <Segmented<PaneMode>
+        label="Stand"
+        value={knobs.standMode}
+        options={[
+          { label: "Still", value: "still" },
+          { label: "Clip",  value: "clip"  },
+        ]}
+        onChange={(v) => setKnob("standMode", v)}
+      />
+
+      <Segmented<PaneMode>
+        label="Aim"
+        value={knobs.aimMode}
+        options={[
+          { label: "Still", value: "still" },
+          { label: "Clip",  value: "clip"  },
+        ]}
+        onChange={(v) => setKnob("aimMode", v)}
+      />
+
+      <Segmented<"on" | "off">
+        label="Aim dot"
+        value={knobs.showAimDot ? "on" : "off"}
+        options={[
+          { label: "On",  value: "on"  },
+          { label: "Off", value: "off" },
+        ]}
+        onChange={(v) => setKnob("showAimDot", v === "on")}
+      />
+
+      <Segmented<LandingMode>
+        label="Landing"
+        value={knobs.landingMode}
+        options={[
+          { label: "Clip", value: "clip" },
+          { label: "Text", value: "text" },
+        ]}
+        onChange={(v) => setKnob("landingMode", v)}
+      />
+
+      <Segmented<TilesPerRow>
+        label="Per row"
+        value={knobs.tilesPerRow}
+        options={[
+          { label: "1", value: 1 },
+          { label: "2", value: 2 },
+          { label: "3", value: 3 },
+        ]}
+        onChange={(v) => setKnob("tilesPerRow", v)}
+      />
+
+      <p className="text-[10px] text-muted-foreground/70 leading-snug pt-1">
+        URL-backed — refresh keeps choices. Tell me the combo you like and I'll lock it in as the default.
+      </p>
+    </aside>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
@@ -16,6 +16,8 @@ import type { Lineup } from "@/types/game";
 import { utilDisplay } from "@/constants/utilityDisplay";
 import { zoneAnchorId } from "./glanceBoardUtils";
 import GlanceBoardTile from "./GlanceBoardTile";
+import { DEFAULT_KNOBS } from "@/hooks/useDesignKnobs";
+import type { DesignKnobs } from "@/hooks/useDesignKnobs";
 
 interface GlanceBoardProps {
   lineups: Lineup[];
@@ -25,7 +27,15 @@ interface GlanceBoardProps {
   filteredUtils: string[];
   /** Applied side value ("any" / "side_a" / "side_b"). */
   side: string;
+  /** Direct-manipulation tile knobs (optional — falls back to DEFAULT_KNOBS). */
+  knobs?: DesignKnobs;
 }
+
+const GRID_COLS_CLASS: Record<1 | 2 | 3, string> = {
+  1: "grid-cols-1",
+  2: "grid-cols-2",
+  3: "grid-cols-3",
+};
 
 // ---------------------------------------------------------------------------
 // Zone ordering
@@ -134,7 +144,9 @@ export default function GlanceBoard({
   mapName,
   filteredUtils,
   side,
+  knobs = DEFAULT_KNOBS,
 }: GlanceBoardProps) {
+  const colsClass = GRID_COLS_CLASS[knobs.tilesPerRow];
   const groups = useMemo(() => groupByZone(lineups), [lineups]);
 
   if (isFetching) {
@@ -176,10 +188,10 @@ export default function GlanceBoard({
             <span className="flex-1 border-t border-border" />
           </h2>
 
-          {/* 2-column tile grid */}
-          <div className="grid grid-cols-2 gap-4">
+          {/* Tile grid — column count comes from the design knobs panel */}
+          <div className={`grid ${colsClass} gap-4`}>
             {group.lineups.map((lineup) => (
-              <GlanceBoardTile key={lineup.id} lineup={lineup} />
+              <GlanceBoardTile key={lineup.id} lineup={lineup} knobs={knobs} />
             ))}
           </div>
         </section>

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -44,9 +44,12 @@ import {
   StandPane,
   ThrowPlaceholder,
 } from "./LineupPanes";
+import { DEFAULT_KNOBS } from "@/hooks/useDesignKnobs";
+import type { DesignKnobs } from "@/hooks/useDesignKnobs";
 
 interface GlanceBoardTileProps {
   lineup: Lineup;
+  knobs?: DesignKnobs;
 }
 
 // ---------------------------------------------------------------------------
@@ -72,8 +75,18 @@ function SideChip({ side }: { side: string | null }) {
 // ---------------------------------------------------------------------------
 // GlanceBoardTile
 // ---------------------------------------------------------------------------
-export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
+export default function GlanceBoardTile({ lineup, knobs = DEFAULT_KNOBS }: GlanceBoardTileProps) {
   const ud = utilDisplay(lineup.utility_type?.slug);
+
+  // Knob-forced overrides: a "still" mode discards any clip URL even when
+  // present, an "off" anchor-dot blanks the persisted coords. Done here
+  // rather than inside the pane primitives so the panes stay knob-agnostic.
+  const standClipForRender = knobs.standMode === "clip" ? lineup.stand_clip_url : null;
+  const aimClipForRender   = knobs.aimMode   === "clip" ? lineup.aim_clip_url   : null;
+  const aimDotX = knobs.showAimDot ? lineup.aim_anchor_x : null;
+  const aimDotY = knobs.showAimDot ? lineup.aim_anchor_y : null;
+  const landingClipForRender =
+    knobs.landingMode === "clip" ? lineup.landing_clip_url : null;
 
   return (
     <article
@@ -111,14 +124,14 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
         <div className="flex divide-x divide-border">
           <StandPane
             standScreenshotUrl={lineup.stand_screenshot_url}
-            standClipUrl={lineup.stand_clip_url}
+            standClipUrl={standClipForRender}
             title={lineup.title}
           />
           <AimPane
             aimScreenshotUrl={lineup.aim_screenshot_url}
-            aimClipUrl={lineup.aim_clip_url}
-            aimAnchorX={lineup.aim_anchor_x}
-            aimAnchorY={lineup.aim_anchor_y}
+            aimClipUrl={aimClipForRender}
+            aimAnchorX={aimDotX}
+            aimAnchorY={aimDotY}
             title={lineup.title}
           />
         </div>
@@ -135,7 +148,7 @@ export default function GlanceBoardTile({ lineup }: GlanceBoardTileProps) {
           )}
           <LandingPane
             targetZoneName={lineup.target_zone?.name ?? null}
-            landingClipUrl={lineup.landing_clip_url}
+            landingClipUrl={landingClipForRender}
             posterUrl={lineup.aim_screenshot_url}
             title={lineup.title}
           />

--- a/apps/mygamingassistant/frontend/src/hooks/useDesignKnobs.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/useDesignKnobs.ts
@@ -1,0 +1,121 @@
+/**
+ * useDesignKnobs — URL-backed direct-manipulation knobs for the storyboard
+ * tile, so the operator can A/B layout decisions in the browser instead of
+ * describing them back via chat. Read by GlanceBoard / GlanceBoardTile when
+ * present; absent values fall back to the shipped defaults so the panel is
+ * additive (existing URLs unaffected).
+ *
+ * URL params (all optional):
+ *   stand=still|clip       — STAND pane content
+ *   aim=still|clip         — AIM pane content
+ *   dot=on|off             — AIM anchor dot
+ *   landing=clip|text      — LANDING pane content
+ *   cols=1|2|3             — tiles per row in the grid
+ */
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+
+export type PaneMode = "still" | "clip";
+export type LandingMode = "clip" | "text";
+export type TilesPerRow = 1 | 2 | 3;
+
+export interface DesignKnobs {
+  standMode: PaneMode;
+  aimMode: PaneMode;
+  showAimDot: boolean;
+  landingMode: LandingMode;
+  tilesPerRow: TilesPerRow;
+}
+
+export const DEFAULT_KNOBS: DesignKnobs = {
+  standMode: "clip",
+  aimMode: "clip",
+  showAimDot: true,
+  landingMode: "clip",
+  tilesPerRow: 2,
+};
+
+function parsePaneMode(raw: string | null, fallback: PaneMode): PaneMode {
+  return raw === "still" || raw === "clip" ? raw : fallback;
+}
+
+function parseLandingMode(raw: string | null, fallback: LandingMode): LandingMode {
+  return raw === "clip" || raw === "text" ? raw : fallback;
+}
+
+function parseTilesPerRow(raw: string | null, fallback: TilesPerRow): TilesPerRow {
+  const n = Number(raw);
+  return n === 1 || n === 2 || n === 3 ? (n as TilesPerRow) : fallback;
+}
+
+export interface UseDesignKnobsReturn {
+  knobs: DesignKnobs;
+  setKnob: <K extends keyof DesignKnobs>(key: K, value: DesignKnobs[K]) => void;
+  reset: () => void;
+}
+
+export function useDesignKnobs(): UseDesignKnobsReturn {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const knobs = useMemo<DesignKnobs>(
+    () => ({
+      standMode:   parsePaneMode(searchParams.get("stand"),   DEFAULT_KNOBS.standMode),
+      aimMode:     parsePaneMode(searchParams.get("aim"),     DEFAULT_KNOBS.aimMode),
+      showAimDot:  searchParams.get("dot") === "off" ? false : DEFAULT_KNOBS.showAimDot,
+      landingMode: parseLandingMode(searchParams.get("landing"), DEFAULT_KNOBS.landingMode),
+      tilesPerRow: parseTilesPerRow(searchParams.get("cols"),   DEFAULT_KNOBS.tilesPerRow),
+    }),
+    [searchParams],
+  );
+
+  const setKnob = useCallback(
+    <K extends keyof DesignKnobs>(key: K, value: DesignKnobs[K]) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          const paramKey =
+            key === "standMode"   ? "stand"   :
+            key === "aimMode"     ? "aim"     :
+            key === "showAimDot"  ? "dot"     :
+            key === "landingMode" ? "landing" :
+            "cols";
+          const paramValue =
+            key === "showAimDot"
+              ? (value ? "on" : "off")
+              : String(value);
+          const isDefault =
+            (key === "standMode"   && value === DEFAULT_KNOBS.standMode)   ||
+            (key === "aimMode"     && value === DEFAULT_KNOBS.aimMode)     ||
+            (key === "showAimDot"  && value === DEFAULT_KNOBS.showAimDot)  ||
+            (key === "landingMode" && value === DEFAULT_KNOBS.landingMode) ||
+            (key === "tilesPerRow" && value === DEFAULT_KNOBS.tilesPerRow);
+          if (isDefault) {
+            next.delete(paramKey);
+          } else {
+            next.set(paramKey, paramValue);
+          }
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const reset = useCallback(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.delete("stand");
+        next.delete("aim");
+        next.delete("dot");
+        next.delete("landing");
+        next.delete("cols");
+        return next;
+      },
+      { replace: true },
+    );
+  }, [setSearchParams]);
+
+  return { knobs, setKnob, reset };
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -39,6 +39,8 @@ import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
 import GlanceBoard from "@/components/lineup/GlanceBoard";
 import GlanceBoardMinimapSidebar from "@/components/lineup/GlanceBoardMinimapSidebar";
 import GlanceBoardOperatorMenu from "@/components/lineup/GlanceBoardOperatorMenu";
+import DesignKnobsPanel from "@/components/lineup/DesignKnobsPanel";
+import { useDesignKnobs } from "@/hooks/useDesignKnobs";
 import MinimapUploadDialog from "@/components/game/MinimapUploadDialog";
 import RoundMode from "@/pages/RoundMode";
 import StorageUnavailableBanner from "@/components/map/StorageUnavailableBanner";
@@ -82,6 +84,9 @@ export default function MapPage() {
 
   const { isSuperuser } = useIsSuperuser();
   const game = games?.find((g) => g.slug === gameSlug);
+
+  // Direct-manipulation knobs for the storyboard tile (URL-backed).
+  const { knobs } = useDesignKnobs();
 
   // ---------------------------------------------------------------------------
   // Filter state derived from URL
@@ -487,6 +492,7 @@ export default function MapPage() {
                 mapName={mapDetail.name}
                 filteredUtils={effectiveUtils}
                 side={side}
+                knobs={knobs}
               />
             )}
 
@@ -504,6 +510,9 @@ export default function MapPage() {
           </main>
         </div>
       </div>
+
+      {/* Floating direct-manipulation knobs panel (collapsed by default). */}
+      <DesignKnobsPanel />
     </>
   );
 }


### PR DESCRIPTION
## Summary

URL-backed knobs panel on `MapPage` so the operator can A/B storyboard render decisions directly in the browser instead of describing them back via chat.

Five knobs (collapsed bottom-right; click 🎨 Design to expand):

- **Stand pane**: still | clip
- **Aim pane**: still | clip
- **Aim anchor dot**: on | off
- **Landing pane**: clip | text
- **Tiles per row**: 1 | 2 | 3

State lives entirely in URL params (`?stand=still&aim=clip&dot=off&landing=text&cols=3`) so refresh + link-sharing preserve a chosen combination. Defaults match current behavior — when no params are set the page renders exactly as before (fully additive).

## Why

Operator feedback during iteration on the 4-pane storyboard: ``there needs to be a way I can make slight adjustments rather than have you figure out exactly through prompting.'' Direct manipulation > prompt-tuning. Once the preferred combo settles, those values get locked in as the shipped `DEFAULT_KNOBS` and the panel either stays as a power-user override or is removed.

## How it applies

- `GlanceboardTile` receives a `DesignKnobs` prop. A `still` mode discards any present clip URL before passing to `StandPane`/`AimPane` (so the existing fallback-to-still path triggers); `aim-dot=off` blanks the anchor coords; `landing=text` discards `landing_clip_url`; the column count maps to a `grid-cols-N` class on `GlanceBoard`.
- Pane primitives in `LineupPanes.tsx` are unchanged — they stay knob-agnostic so `LineupCard`'s detail-panel surface (which also consumes them) doesn't need to know about the panel.
- Knobs scoped to `MapPage`'s glance-board surface only.

## Test plan

- [x] Frontend typecheck passes (`tsc --noEmit`, no errors)
- [ ] Visual: open `/cs2/mirage`, click 🎨 Design, toggle each knob, verify tiles re-render correctly
- [ ] URL state survives refresh
- [ ] Reset button clears knobs back to defaults

Tests not added for this PR: dev/iteration tooling — minimum surface, defaults preserve existing behavior, and the panel may be removed once a good combo is locked in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)