### PR TITLE
feat(mjh): render JD inline on application detail page

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/sections/OverviewSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/OverviewSection.tsx
@@ -73,6 +73,17 @@ export default function OverviewSection({ application }: OverviewSectionProps) {
         <Field label="Remote" value={remoteLabel} />
         <Field label="Source" value={application.source ?? "—"} />
       </dl>
+
+      {application.jd_text ? (
+        <details className="rounded-md border bg-card" open>
+          <summary className="cursor-pointer select-none px-4 py-2 text-xs uppercase tracking-wide text-muted-foreground hover:bg-muted/50">
+            Job description
+          </summary>
+          <div className="px-4 pb-4 pt-2 text-sm whitespace-pre-wrap break-words">
+            {application.jd_text}
+          </div>
+        </details>
+      ) : null}
     </section>
   );
 }


### PR DESCRIPTION
## Summary

- The `OverviewSection` claimed in its docstring to show the JD summary but never rendered `application.jd_text`.
- Add a collapsible "Job description" section after the field grid that renders the JD with `whitespace-pre-wrap` so line breaks survive.
- Renders in both `ApplicationDrawer` and `ApplicationDetail` since `OverviewSection` is shared.

Reported by the operator: "I can't see the job description" on the application detail page.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Visit `/applications/<id>` for an application with `jd_text` set — section renders, open by default
- [ ] Visit one without `jd_text` — section is hidden (no empty placeholder)
- [ ] Open kanban drawer (`?app=<id>`) — same section appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)