### PR TITLE
feat(mga): per-pane local-upload Replace flow (PR1 — pane editor foundation)

### DIFF
--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -45,7 +45,7 @@ from app.models.game.map import Map
 from app.models.game.map_zone import MapZone
 from app.models.game.utility_type import UtilityType
 from app.models.user.user import User
-from app.repositories.game.lineup_repo import LineupFilters
+from app.repositories.game.lineup_repo import LineupFilters, get_lineup as get_lineup_orm
 from app.schemas.game.lineup_schemas import (
     BulkAcceptBody,
     BulkAcceptResult,
@@ -58,7 +58,13 @@ from app.schemas.game.lineup_schemas import (
     PendingLineupsResponse,
     UploadUrlResponse,
 )
-from app.services.game import lineup_service
+from app.schemas.game.pane_upload_schemas import (
+    Pane,
+    PaneConfirmRequest,
+    PaneUploadUrlRequest,
+    PaneUploadUrlResponse,
+)
+from app.services.game import lineup_service, pane_upload_service
 
 logger = logging.getLogger(__name__)
 
@@ -473,3 +479,59 @@ async def bulk_accept_lineups(
                 )
             )
     return BulkAcceptResult(accepted=accepted, skipped=skipped)
+
+
+# ---------------------------------------------------------------------------
+# Per-pane local-upload Replace flow (PR1)
+#
+# Two endpoints per (lineup, pane) — request-url then confirm — mirroring the
+# existing /api/lineups/upload-url + POST /api/lineups manual-upload split.
+# The operator renders the artifact locally (ffmpeg/DaVinci/etc) and uploads
+# the bytes directly to MinIO via the presigned PUT; the confirm endpoint
+# then writes the resulting key onto the matching lineup column.
+#
+# Auth is inherited from auth_router (operator only). See
+# pane_upload_service for the validation + key-naming logic.
+# ---------------------------------------------------------------------------
+
+
+@auth_router.post(
+    "/lineups/{lineup_id}/panes/{pane}/upload-url",
+    response_model=PaneUploadUrlResponse,
+)
+async def request_pane_upload_url(
+    lineup_id: uuid.UUID,
+    pane: Pane,
+    body: PaneUploadUrlRequest,
+) -> PaneUploadUrlResponse:
+    """Return a presigned PUT URL the browser uploads directly to MinIO.
+
+    No DB read or write — we deliberately don't pre-check the lineup exists
+    here. The check is at confirm time, where it matters. A signed URL
+    pointing at a non-existent lineup is harmless — the object just lands
+    under an unused ``edits/<lineup_id>/`` prefix and is never referenced.
+    """
+    return pane_upload_service.request_upload_url(lineup_id, pane, body)
+
+
+@auth_router.post(
+    "/lineups/{lineup_id}/panes/{pane}/confirm",
+    response_model=LineupRead,
+)
+async def confirm_pane_upload(
+    lineup_id: uuid.UUID,
+    pane: Pane,
+    body: PaneConfirmRequest,
+    db: AsyncSession = Depends(get_db),
+) -> LineupRead:
+    """Record a completed upload as the new canonical asset for the pane.
+
+    Fetches the lineup (404 if missing), then delegates to the pane-upload
+    service which validates the object actually exists at the declared key
+    and routes through the matching repo setter (one-column commit owned by
+    the repo per PR #687/#695).
+    """
+    lineup = await get_lineup_orm(db, lineup_id)
+    if lineup is None:
+        raise HTTPException(status_code=404, detail="Lineup not found")
+    return await pane_upload_service.confirm_upload(db, lineup, pane, body)

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -505,6 +505,58 @@ async def set_aim_clip_url(
     return lineup
 
 
+async def set_stand_screenshot_url(
+    db: AsyncSession,
+    lineup: Lineup,
+    stand_screenshot_key: str,
+) -> Lineup:
+    """Persist a new stand-still bare MinIO key onto a lineup row.
+
+    Operator-facing setter for the per-pane Replace flow (PR1). One-column
+    commit on purpose — identical contract to :func:`set_stand_clip_url` and
+    siblings: a screenshot replace is best-effort and orthogonal to the
+    classifier suggestions / sibling clip column, and must NEVER roll back
+    them.
+
+    Transaction ownership lives here in the repo per PR #687/#695 — the
+    pane-upload service never calls db.commit(). ``stand_screenshot_url``
+    stores a BARE object key (same convention as every other URL column);
+    presigning happens at read time in ``lineup_service._build_read``.
+    """
+    lineup.stand_screenshot_url = stand_screenshot_key
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
+async def set_aim_screenshot_url(
+    db: AsyncSession,
+    lineup: Lineup,
+    aim_screenshot_key: str,
+) -> Lineup:
+    """Persist a new aim-still bare MinIO key onto a lineup row.
+
+    Sibling to :func:`set_stand_screenshot_url` — identical contract,
+    independent column. Replacing the aim still does NOT affect the persisted
+    ``aim_anchor_x/y`` overlay coords (those are normalized 0..1) — the dot
+    will continue to render at the same proportional position over whatever
+    image now occupies the slot. The operator can re-classify or hand-edit
+    the anchor coords separately via the existing PATCH route.
+    """
+    lineup.aim_screenshot_url = aim_screenshot_key
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
 async def list_accepted_lineups_needing_technique(
     db: AsyncSession,
 ) -> list[Lineup]:

--- a/apps/mygamingassistant/backend/app/schemas/game/pane_upload_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/pane_upload_schemas.py
@@ -1,0 +1,123 @@
+"""Schemas for the per-pane local-upload Replace flow (PR1).
+
+The operator runs whatever editor they prefer locally (ffmpeg, DaVinci, Premiere)
+and uploads the rendered small artifact directly to MinIO via a presigned PUT,
+then confirms it server-side. The server never re-encodes — it just records the
+new key on the right column.
+
+Two endpoints per (lineup, pane) — request-url then confirm — mirroring the
+existing /api/lineups/upload-url + POST /api/lineups manual-upload pattern:
+
+  POST /api/lineups/{lineup_id}/panes/{pane}/upload-url
+       -> PaneUploadUrlResponse {upload_url, object_key}
+  POST /api/lineups/{lineup_id}/panes/{pane}/confirm
+       -> LineupRead (the refreshed lineup, with the new presigned GET URL
+          on the matching column)
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+# ---------------------------------------------------------------------------
+# Pane + kind enums
+# ---------------------------------------------------------------------------
+
+Pane = Literal["stand", "aim", "throw", "landing"]
+Kind = Literal["still", "clip"]
+
+# Which (pane, kind) tuples are actually editable. STAND + AIM have both a
+# still and a clip column; THROW + LANDING have only a clip column (no still
+# column exists in the schema today, and adding one is out of PR1 scope).
+VALID_PANE_KIND: frozenset[tuple[Pane, Kind]] = frozenset({
+    ("stand", "still"), ("stand", "clip"),
+    ("aim",   "still"), ("aim",   "clip"),
+    ("throw", "clip"),
+    ("landing", "clip"),
+})
+
+# ---------------------------------------------------------------------------
+# Allowed MIME types per kind
+# ---------------------------------------------------------------------------
+
+ALLOWED_STILL_MIMES: frozenset[str] = frozenset({
+    "image/png",
+    "image/jpeg",
+    "image/webp",
+})
+
+ALLOWED_CLIP_MIMES: frozenset[str] = frozenset({
+    "video/mp4",
+    "video/webm",
+})
+
+# ---------------------------------------------------------------------------
+# Size limits per kind. Stills are tiny; clips can be a few seconds of muted
+# H.264 — generous enough to accept slightly-oversized files but tight enough
+# to refuse a full source video by mistake.
+# ---------------------------------------------------------------------------
+
+MAX_STILL_BYTES = 5 * 1024 * 1024     # 5 MB
+MAX_CLIP_BYTES = 50 * 1024 * 1024     # 50 MB
+
+
+def _ext_for_content_type(content_type: str) -> str:
+    """Return a sensible file extension for the stored MinIO key.
+
+    The extension is part of the key only for human inspectability; clients
+    infer the type at GET time from the Content-Type response header MinIO
+    records at PUT time.
+    """
+    mapping = {
+        "image/png":  "png",
+        "image/jpeg": "jpg",
+        "image/webp": "webp",
+        "video/mp4":  "mp4",
+        "video/webm": "webm",
+    }
+    return mapping.get(content_type, "bin")
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class PaneUploadUrlRequest(BaseModel):
+    """Operator declares what they're about to upload."""
+
+    kind: Kind
+    content_type: str = Field(
+        ...,
+        description="MIME type of the file being uploaded (e.g. image/png, video/mp4)",
+    )
+    content_length: int = Field(
+        ...,
+        ge=1,
+        description="Byte size of the file being uploaded",
+    )
+
+    @field_validator("content_type")
+    @classmethod
+    def _content_type_lower(cls, v: str) -> str:
+        return v.lower()
+
+
+class PaneUploadUrlResponse(BaseModel):
+    """Presigned PUT plus the deterministic MinIO key the client will upload to.
+
+    The client must echo ``object_key`` back to the confirm endpoint so the
+    server can validate the upload landed where it expected, before writing the
+    key onto the lineup column.
+    """
+
+    upload_url: str
+    object_key: str
+
+
+class PaneConfirmRequest(BaseModel):
+    """Operator confirms a completed upload at ``object_key`` for the given kind."""
+
+    kind: Kind
+    object_key: str

--- a/apps/mygamingassistant/backend/app/services/game/pane_upload_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/pane_upload_service.py
@@ -1,0 +1,208 @@
+"""Per-pane local-upload Replace service (PR1).
+
+Implements the two-endpoint flow:
+
+  1. ``request_upload_url(lineup, pane, request)`` validates the operator's
+     intent, allocates a deterministic MinIO key, and returns a presigned PUT
+     URL the browser uploads to directly. No DB write yet.
+
+  2. ``confirm_upload(db, lineup, pane, request)`` verifies the object exists
+     at the declared key and writes it onto the matching column via the
+     appropriate repo setter (which owns its own one-column commit per PR
+     #687/#695). Returns the refreshed ``LineupRead`` with the new presigned
+     GET URL already attached.
+
+The server never re-encodes — the operator renders the artifact locally with
+whatever editor they prefer (ffmpeg, DaVinci, Premiere, ScreenStudio) and the
+backend just records the new key. Source videos never need to live on the
+server for editing purposes.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Callable, Awaitable
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.storage import get_storage
+from app.models.game.lineup import Lineup
+from app.repositories.game.lineup_repo import (
+    set_aim_clip_url,
+    set_aim_screenshot_url,
+    set_clip_url,
+    set_landing_clip_url,
+    set_stand_clip_url,
+    set_stand_screenshot_url,
+)
+from app.schemas.game.lineup_schemas import LineupRead
+from app.schemas.game.pane_upload_schemas import (
+    ALLOWED_CLIP_MIMES,
+    ALLOWED_STILL_MIMES,
+    Kind,
+    MAX_CLIP_BYTES,
+    MAX_STILL_BYTES,
+    Pane,
+    PaneConfirmRequest,
+    PaneUploadUrlRequest,
+    PaneUploadUrlResponse,
+    VALID_PANE_KIND,
+    _ext_for_content_type,
+)
+from app.services.game.lineup_service import _build_read, _presigned_put
+
+
+# Operator setters indexed by (pane, kind). Each value is a coroutine taking
+# (db, lineup, key) and committing one column — see lineup_repo for the
+# transaction-ownership pattern. Keeping the dispatch table in service rather
+# than the repo keeps the repo's existing per-column setters typed and
+# discoverable (no untyped string columns leak through).
+_PaneSetter = Callable[[AsyncSession, Lineup, str], Awaitable[Lineup]]
+
+_SETTERS: dict[tuple[Pane, Kind], _PaneSetter] = {
+    ("stand", "still"): set_stand_screenshot_url,
+    ("stand", "clip"):  set_stand_clip_url,
+    ("aim",   "still"): set_aim_screenshot_url,
+    ("aim",   "clip"):  set_aim_clip_url,
+    ("throw", "clip"):  set_clip_url,
+    ("landing", "clip"): set_landing_clip_url,
+}
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def _validate_pane_kind(pane: Pane, kind: Kind) -> None:
+    """Reject invalid (pane, kind) combinations with a 400.
+
+    THROW + LANDING are clip-only today (no still column exists). The matching
+    pane primitive's text fallback covers the still slot for LANDING; THROW
+    has no still slot at all (the THROW pane is the actual throw motion).
+    """
+    if (pane, kind) not in VALID_PANE_KIND:
+        raise HTTPException(
+            status_code=400,
+            detail=f"pane '{pane}' does not accept kind '{kind}'",
+        )
+
+
+def _validate_content_type(kind: Kind, content_type: str) -> None:
+    """Reject MIMEs outside the allow-list for the declared kind."""
+    allowed = ALLOWED_STILL_MIMES if kind == "still" else ALLOWED_CLIP_MIMES
+    if content_type not in allowed:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"content_type '{content_type}' not allowed for kind '{kind}' "
+                f"(accepted: {sorted(allowed)})"
+            ),
+        )
+
+
+def _validate_content_length(kind: Kind, content_length: int) -> None:
+    """Reject files larger than the per-kind cap."""
+    limit = MAX_STILL_BYTES if kind == "still" else MAX_CLIP_BYTES
+    if content_length > limit:
+        raise HTTPException(
+            status_code=413,
+            detail=(
+                f"file size {content_length} exceeds {limit}-byte limit "
+                f"for kind '{kind}'"
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Key naming — operator-uploaded edits live under ``edits/`` so they never
+# collide with auto-generated ingestion keys (``pending/<vid>/...``) or the
+# manual-upload-create keys (``<user_id>/<lineup_id>/...``).
+#
+# A uuid suffix per upload makes each edit a distinct object (no overwrite),
+# so the column always points at the latest while older keys remain available
+# for forensic comparison. Disk cost is negligible at MGA scale; a cleanup job
+# can prune unreferenced ``edits/`` keys later if it becomes meaningful.
+# ---------------------------------------------------------------------------
+
+
+def _build_edit_key(lineup_id: uuid.UUID, pane: Pane, kind: Kind, content_type: str) -> str:
+    ext = _ext_for_content_type(content_type)
+    return f"edits/{lineup_id}/{pane}-{kind}-{uuid.uuid4()}.{ext}"
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def request_upload_url(
+    lineup_id: uuid.UUID,
+    pane: Pane,
+    request: PaneUploadUrlRequest,
+) -> PaneUploadUrlResponse:
+    """Validate the intended upload and return a presigned PUT URL.
+
+    Synchronous — no DB read, no DB write. The lineup_id is taken from the
+    path, never from the body, so an operator can't sign a URL for a different
+    lineup than the one their browser tile is showing. We deliberately do NOT
+    check that the lineup exists here: that check happens at ``confirm`` time
+    where it matters, and skipping it now keeps the signing path fast and
+    independent of database availability. A signed URL pointing at a non-
+    existent lineup is harmless — the object just lands under an unused
+    ``edits/<lineup_id>/`` prefix.
+    """
+    _validate_pane_kind(pane, request.kind)
+    _validate_content_type(request.kind, request.content_type)
+    _validate_content_length(request.kind, request.content_length)
+
+    object_key = _build_edit_key(lineup_id, pane, request.kind, request.content_type)
+    storage = get_storage()
+    upload_url = _presigned_put(storage, object_key)
+
+    return PaneUploadUrlResponse(upload_url=upload_url, object_key=object_key)
+
+
+async def confirm_upload(
+    db: AsyncSession,
+    lineup: Lineup,
+    pane: Pane,
+    request: PaneConfirmRequest,
+) -> LineupRead:
+    """Validate the upload landed, then point the column at the new key.
+
+    The route handler is responsible for resolving ``lineup`` from the path
+    parameter before calling here (so a 404 surfaces cleanly without us
+    duplicating the lookup). We re-validate (pane, kind) defensively in case
+    a client mixed up the request body — surfaces a 400 with a useful message
+    rather than silently writing to the wrong column.
+
+    Object-key tampering: we reject any ``object_key`` that doesn't live under
+    this lineup's ``edits/<lineup_id>/`` prefix. Without this guard a client
+    could confirm someone else's just-uploaded blob into their own lineup.
+    """
+    _validate_pane_kind(pane, request.kind)
+
+    expected_prefix = f"edits/{lineup.id}/"
+    if not request.object_key.startswith(expected_prefix):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"object_key must live under '{expected_prefix}' "
+                "(refusing to write a key from a different lineup's prefix)"
+            ),
+        )
+
+    storage = get_storage()
+    if not storage.object_exists(request.object_key):
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"no uploaded object found at '{request.object_key}' — "
+                "confirm the PUT completed before calling confirm"
+            ),
+        )
+
+    setter = _SETTERS[(pane, request.kind)]
+    updated = await setter(db, lineup, request.object_key)
+    return _build_read(updated)

--- a/apps/mygamingassistant/backend/tests/test_lineup_screenshot_url_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_screenshot_url_repo.py
@@ -1,0 +1,123 @@
+"""DB-backed tests for lineup_repo.set_stand_screenshot_url + set_aim_screenshot_url (PR1).
+
+The two operator-facing screenshot setters MUST commit (not just flush) —
+same silent data-loss class as PATCH #687 and the PR5/PR6 clip-setter
+discipline: ``get_db`` doesn't auto-commit, so a flush-only write is rolled
+back on session close and the operator's just-uploaded still silently never
+appears. Asserts each write survives a fresh read AND that the two columns
+are independent (a stand-still replace must never affect aim, and vice
+versa).
+
+Mirrors :mod:`test_lineup_micro_clip_repo` exactly — the new operator-side
+setters preserve the same one-column-commit contract as the
+ingestion-side clip setters.
+"""
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+
+
+@pytest.mark.asyncio
+async def test_set_stand_screenshot_url_commits(db: AsyncSession):
+    created = await lineup_repo.create_lineup(
+        db, {"title": "stand still repo test", "status": "pending_review"}
+    )
+
+    returned = await lineup_repo.set_stand_screenshot_url(
+        db, created, "edits/00000000-0000-0000-0000-000000000abc/stand-still-xx.png"
+    )
+    assert returned.stand_screenshot_url == \
+        "edits/00000000-0000-0000-0000-000000000abc/stand-still-xx.png"
+
+    # Capture the PK BEFORE expire_all() to avoid the MissingGreenlet trap
+    # documented in PR2/PR6 sibling tests.
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.stand_screenshot_url == \
+        "edits/00000000-0000-0000-0000-000000000abc/stand-still-xx.png"
+
+
+@pytest.mark.asyncio
+async def test_set_aim_screenshot_url_commits(db: AsyncSession):
+    created = await lineup_repo.create_lineup(
+        db, {"title": "aim still repo test", "status": "pending_review"}
+    )
+
+    returned = await lineup_repo.set_aim_screenshot_url(
+        db, created, "edits/00000000-0000-0000-0000-000000000def/aim-still-yy.png"
+    )
+    assert returned.aim_screenshot_url == \
+        "edits/00000000-0000-0000-0000-000000000def/aim-still-yy.png"
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.aim_screenshot_url == \
+        "edits/00000000-0000-0000-0000-000000000def/aim-still-yy.png"
+
+
+@pytest.mark.asyncio
+async def test_setters_are_independent(db: AsyncSession):
+    """Stand replace must never affect aim, and vice versa.
+
+    The two setters are siblings — operator may replace one slot without
+    touching the other — so a stand write must persist as a stand-only
+    change. Asserts both columns can hold distinct values simultaneously
+    after independent writes.
+    """
+    created = await lineup_repo.create_lineup(
+        db, {"title": "independence test", "status": "pending_review"}
+    )
+
+    await lineup_repo.set_stand_screenshot_url(
+        db, created, "edits/lineupA/stand-still-A.png"
+    )
+    await lineup_repo.set_aim_screenshot_url(
+        db, created, "edits/lineupA/aim-still-A.png"
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.stand_screenshot_url == "edits/lineupA/stand-still-A.png"
+    assert refetched.aim_screenshot_url   == "edits/lineupA/aim-still-A.png"
+
+
+@pytest.mark.asyncio
+async def test_setters_do_not_clobber_sibling_clip_columns(db: AsyncSession):
+    """Replacing a still must NOT null the matching clip column.
+
+    The operator may have both a clip and a still set on a pane (per LineupPanes
+    fallback behavior — when both are present the clip wins). Replacing the
+    still slot must leave the clip slot untouched so the prior clip continues
+    to take precedence.
+    """
+    created = await lineup_repo.create_lineup(
+        db, {"title": "clip preservation test", "status": "pending_review"}
+    )
+    await lineup_repo.set_stand_clip_url(
+        db, created, "pending/vidX/12-stand-micro.mp4"
+    )
+    await lineup_repo.set_stand_screenshot_url(
+        db, created, "edits/lineupB/stand-still-B.png"
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.stand_clip_url        == "pending/vidX/12-stand-micro.mp4"
+    assert refetched.stand_screenshot_url  == "edits/lineupB/stand-still-B.png"

--- a/apps/mygamingassistant/backend/tests/test_pane_upload_service.py
+++ b/apps/mygamingassistant/backend/tests/test_pane_upload_service.py
@@ -1,0 +1,257 @@
+"""Unit tests for the per-pane Replace upload service (PR1).
+
+Covers the validation surface (pane/kind combination, MIME allow-list, size
+caps), the deterministic key-naming under ``edits/<lineup_id>/``, the
+``object_key`` tamper guard at confirm time, and the
+(pane, kind) → repo-setter dispatch table.
+
+No database — repo setters and the MinIO storage client are both patched
+with simple stubs so the test asserts the service logic, not the IO layer.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.schemas.game.pane_upload_schemas import (
+    MAX_CLIP_BYTES,
+    MAX_STILL_BYTES,
+    PaneConfirmRequest,
+    PaneUploadUrlRequest,
+)
+from app.services.game import pane_upload_service
+
+
+# ---------------------------------------------------------------------------
+# request_upload_url — validation + key naming
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def patched_storage():
+    """Patch get_storage + _presigned_put so request_upload_url is IO-free."""
+    with patch.object(pane_upload_service, "get_storage") as get_storage, \
+         patch.object(pane_upload_service, "_presigned_put") as presign:
+        storage = MagicMock()
+        get_storage.return_value = storage
+        presign.return_value = "https://minio.test/presigned-put"
+        yield {"storage": storage, "presign": presign}
+
+
+def test_request_upload_url_happy_path_stand_still(patched_storage):
+    lineup_id = uuid.uuid4()
+    body = PaneUploadUrlRequest(
+        kind="still", content_type="image/png", content_length=1024
+    )
+    resp = pane_upload_service.request_upload_url(lineup_id, "stand", body)
+
+    assert resp.upload_url == "https://minio.test/presigned-put"
+    assert resp.object_key.startswith(f"edits/{lineup_id}/stand-still-")
+    assert resp.object_key.endswith(".png")
+    patched_storage["presign"].assert_called_once()
+
+
+def test_request_upload_url_happy_path_throw_clip(patched_storage):
+    lineup_id = uuid.uuid4()
+    body = PaneUploadUrlRequest(
+        kind="clip", content_type="video/mp4", content_length=2_000_000
+    )
+    resp = pane_upload_service.request_upload_url(lineup_id, "throw", body)
+    assert resp.object_key.startswith(f"edits/{lineup_id}/throw-clip-")
+    assert resp.object_key.endswith(".mp4")
+
+
+def test_request_upload_url_rejects_still_on_throw_pane(patched_storage):
+    """THROW pane has no still column; uploading a still must 400."""
+    body = PaneUploadUrlRequest(
+        kind="still", content_type="image/png", content_length=1024
+    )
+    with pytest.raises(HTTPException) as exc:
+        pane_upload_service.request_upload_url(uuid.uuid4(), "throw", body)
+    assert exc.value.status_code == 400
+    assert "throw" in exc.value.detail.lower()
+
+
+def test_request_upload_url_rejects_still_on_landing_pane(patched_storage):
+    body = PaneUploadUrlRequest(
+        kind="still", content_type="image/png", content_length=1024
+    )
+    with pytest.raises(HTTPException) as exc:
+        pane_upload_service.request_upload_url(uuid.uuid4(), "landing", body)
+    assert exc.value.status_code == 400
+
+
+def test_request_upload_url_rejects_bad_content_type_for_still(patched_storage):
+    body = PaneUploadUrlRequest(
+        kind="still", content_type="application/octet-stream", content_length=1024
+    )
+    with pytest.raises(HTTPException) as exc:
+        pane_upload_service.request_upload_url(uuid.uuid4(), "stand", body)
+    assert exc.value.status_code == 400
+
+
+def test_request_upload_url_rejects_bad_content_type_for_clip(patched_storage):
+    body = PaneUploadUrlRequest(
+        kind="clip", content_type="image/png", content_length=1024
+    )
+    with pytest.raises(HTTPException) as exc:
+        pane_upload_service.request_upload_url(uuid.uuid4(), "stand", body)
+    assert exc.value.status_code == 400
+
+
+def test_request_upload_url_rejects_oversize_still(patched_storage):
+    body = PaneUploadUrlRequest(
+        kind="still", content_type="image/png", content_length=MAX_STILL_BYTES + 1
+    )
+    with pytest.raises(HTTPException) as exc:
+        pane_upload_service.request_upload_url(uuid.uuid4(), "stand", body)
+    assert exc.value.status_code == 413
+
+
+def test_request_upload_url_rejects_oversize_clip(patched_storage):
+    body = PaneUploadUrlRequest(
+        kind="clip", content_type="video/mp4", content_length=MAX_CLIP_BYTES + 1
+    )
+    with pytest.raises(HTTPException) as exc:
+        pane_upload_service.request_upload_url(uuid.uuid4(), "throw", body)
+    assert exc.value.status_code == 413
+
+
+def test_request_upload_url_key_uniqueness(patched_storage):
+    """Same inputs yield distinct keys (uuid suffix) so retries don't overwrite."""
+    lineup_id = uuid.uuid4()
+    body = PaneUploadUrlRequest(
+        kind="still", content_type="image/png", content_length=1024
+    )
+    r1 = pane_upload_service.request_upload_url(lineup_id, "stand", body)
+    r2 = pane_upload_service.request_upload_url(lineup_id, "stand", body)
+    assert r1.object_key != r2.object_key
+
+
+# ---------------------------------------------------------------------------
+# confirm_upload — tamper guard + dispatch
+# ---------------------------------------------------------------------------
+
+
+def _make_lineup(lineup_id: uuid.UUID) -> MagicMock:
+    """Build an ORM-like Lineup stub good enough for confirm_upload to dispatch."""
+    lineup = MagicMock()
+    lineup.id = lineup_id
+    lineup.stand_screenshot_url = None
+    lineup.aim_screenshot_url = None
+    lineup.stand_clip_url = None
+    lineup.aim_clip_url = None
+    lineup.clip_url = None
+    lineup.landing_clip_url = None
+    return lineup
+
+
+@pytest.fixture
+def patched_confirm_io():
+    """Patch storage + _build_read for the confirm-path tests."""
+    with patch.object(pane_upload_service, "get_storage") as get_storage, \
+         patch.object(pane_upload_service, "_build_read") as build_read:
+        storage = MagicMock()
+        storage.object_exists.return_value = True
+        get_storage.return_value = storage
+        build_read.side_effect = lambda lineup: {"id": str(lineup.id)}
+        yield {"storage": storage, "build_read": build_read}
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_rejects_foreign_object_key(patched_confirm_io):
+    lineup_id = uuid.uuid4()
+    other_id = uuid.uuid4()
+    lineup = _make_lineup(lineup_id)
+    body = PaneConfirmRequest(
+        kind="still",
+        object_key=f"edits/{other_id}/stand-still-xx.png",
+    )
+    with pytest.raises(HTTPException) as exc:
+        await pane_upload_service.confirm_upload(AsyncMock(), lineup, "stand", body)
+    assert exc.value.status_code == 400
+    assert "prefix" in exc.value.detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_404_when_object_missing(patched_confirm_io):
+    patched_confirm_io["storage"].object_exists.return_value = False
+
+    lineup_id = uuid.uuid4()
+    lineup = _make_lineup(lineup_id)
+    body = PaneConfirmRequest(
+        kind="still",
+        object_key=f"edits/{lineup_id}/stand-still-xx.png",
+    )
+    with pytest.raises(HTTPException) as exc:
+        await pane_upload_service.confirm_upload(AsyncMock(), lineup, "stand", body)
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_dispatches_to_correct_setter_per_pane_kind(
+    patched_confirm_io,
+):
+    """The (pane, kind) → repo-setter dispatch must hit the right column.
+
+    Walk every valid combination, patch the matching setter to record the call,
+    confirm that one setter ran with the lineup + key and no other ran.
+    """
+    cases: list[tuple[str, str, str]] = [
+        ("stand", "still", "set_stand_screenshot_url"),
+        ("stand", "clip",  "set_stand_clip_url"),
+        ("aim",   "still", "set_aim_screenshot_url"),
+        ("aim",   "clip",  "set_aim_clip_url"),
+        ("throw", "clip",  "set_clip_url"),
+        ("landing", "clip", "set_landing_clip_url"),
+    ]
+    db_stub: Any = AsyncMock()
+
+    for pane, kind, expected_setter in cases:
+        lineup_id = uuid.uuid4()
+        lineup = _make_lineup(lineup_id)
+        object_key = f"edits/{lineup_id}/{pane}-{kind}-aa.bin"
+        body = PaneConfirmRequest(kind=kind, object_key=object_key)
+
+        # Replace the dispatch table entry with an async mock for this iteration
+        recorded: dict[str, Any] = {}
+
+        async def mock_setter(db, lin, key, _r=recorded):
+            _r["db"] = db
+            _r["lineup"] = lin
+            _r["key"] = key
+            return lin
+
+        original = pane_upload_service._SETTERS[(pane, kind)]
+        pane_upload_service._SETTERS[(pane, kind)] = mock_setter
+        try:
+            await pane_upload_service.confirm_upload(db_stub, lineup, pane, body)
+        finally:
+            pane_upload_service._SETTERS[(pane, kind)] = original
+
+        assert recorded["lineup"] is lineup, f"({pane},{kind}) wrong lineup"
+        assert recorded["key"] == object_key, f"({pane},{kind}) wrong key"
+        assert original.__name__ == expected_setter, (
+            f"({pane},{kind}) dispatch table points at "
+            f"{original.__name__}, expected {expected_setter}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_confirm_upload_rejects_invalid_pane_kind(patched_confirm_io):
+    """A confirm with kind='still' on the throw pane must 400 the same way
+    request_upload_url does — defense in depth even if the client somehow
+    obtained a presigned URL for it."""
+    lineup_id = uuid.uuid4()
+    lineup = _make_lineup(lineup_id)
+    body = PaneConfirmRequest(
+        kind="still",
+        object_key=f"edits/{lineup_id}/throw-still-xx.png",
+    )
+    with pytest.raises(HTTPException) as exc:
+        await pane_upload_service.confirm_upload(AsyncMock(), lineup, "throw", body)
+    assert exc.value.status_code == 400

--- a/apps/mygamingassistant/frontend/src/__tests__/PaneReplaceOverlay.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/PaneReplaceOverlay.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * PaneReplaceOverlay unit tests — PR1 per-pane local-upload Replace.
+ *
+ * Focused on the rendered affordance + the file-picker MIME guard. The upload
+ * state machine itself (idle → uploading → error) lives in usePaneUpload;
+ * end-to-end XHR + RTK-mutation orchestration would need heavy mocking and is
+ * better covered by a follow-up hook test or a vitest fixture.
+ */
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { baseApi } from "@platform/ui";
+
+import PaneReplaceOverlay from "@/components/lineup/PaneReplaceOverlay";
+
+function makeStore() {
+  return configureStore({
+    reducer: { [baseApi.reducerPath]: baseApi.reducer },
+    middleware: (gdm) => gdm().concat(baseApi.middleware),
+  });
+}
+
+function renderWithStore(ui: React.ReactElement) {
+  return render(<Provider store={makeStore()}>{ui}</Provider>);
+}
+
+describe("PaneReplaceOverlay", () => {
+  it("renders the Replace button with pane-specific aria-label", () => {
+    renderWithStore(
+      <PaneReplaceOverlay lineupId="abc-123" pane="stand" />,
+    );
+    expect(
+      screen.getByRole("button", { name: /replace stand pane content/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("file input accepts both image and video MIME for STAND pane", () => {
+    const { container } = renderWithStore(
+      <PaneReplaceOverlay lineupId="abc-123" pane="stand" />,
+    );
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input).toBeTruthy();
+    // STAND accepts both still and clip → image/* and video/* MIMEs
+    expect(input.accept).toMatch(/image\/png/);
+    expect(input.accept).toMatch(/video\/mp4/);
+  });
+
+  it("file input accepts video MIME ONLY for THROW pane (no still column)", () => {
+    const { container } = renderWithStore(
+      <PaneReplaceOverlay lineupId="abc-123" pane="throw" />,
+    );
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input.accept).toMatch(/video\/mp4/);
+    expect(input.accept).not.toMatch(/image\//);
+  });
+
+  it("file input accepts video MIME ONLY for LANDING pane", () => {
+    const { container } = renderWithStore(
+      <PaneReplaceOverlay lineupId="abc-123" pane="landing" />,
+    );
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input.accept).toMatch(/video\/mp4/);
+    expect(input.accept).not.toMatch(/image\//);
+  });
+
+  it("file input accepts both image and video MIME for AIM pane", () => {
+    const { container } = renderWithStore(
+      <PaneReplaceOverlay lineupId="abc-123" pane="aim" />,
+    );
+    const input = container.querySelector(
+      'input[type="file"]',
+    ) as HTMLInputElement;
+    expect(input.accept).toMatch(/image\/png/);
+    expect(input.accept).toMatch(/video\/mp4/);
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
@@ -29,6 +29,10 @@ interface GlanceBoardProps {
   side: string;
   /** Direct-manipulation tile knobs (optional — falls back to DEFAULT_KNOBS). */
   knobs?: DesignKnobs;
+  /** Operator-only per-pane Replace affordance. Threaded through to each tile;
+   *  auth gating lives at the page (MapPage) level so this component stays
+   *  pure-presentation and its existing tests don't need a Redux Provider. */
+  showReplaceOverlay?: boolean;
 }
 
 const GRID_COLS_CLASS: Record<1 | 2 | 3, string> = {
@@ -145,6 +149,7 @@ export default function GlanceBoard({
   filteredUtils,
   side,
   knobs = DEFAULT_KNOBS,
+  showReplaceOverlay = false,
 }: GlanceBoardProps) {
   const colsClass = GRID_COLS_CLASS[knobs.tilesPerRow];
   const groups = useMemo(() => groupByZone(lineups), [lineups]);
@@ -191,7 +196,12 @@ export default function GlanceBoard({
           {/* Tile grid — column count comes from the design knobs panel */}
           <div className={`grid ${colsClass} gap-4`}>
             {group.lineups.map((lineup) => (
-              <GlanceBoardTile key={lineup.id} lineup={lineup} knobs={knobs} />
+              <GlanceBoardTile
+                key={lineup.id}
+                lineup={lineup}
+                knobs={knobs}
+                showReplaceOverlay={showReplaceOverlay}
+              />
             ))}
           </div>
         </section>

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -35,6 +35,7 @@
  * notes are NOT displayed inline; they live in a title= tooltip.
  */
 import { Clock } from "lucide-react";
+import type { ReactNode } from "react";
 import type { Lineup } from "@/types/game";
 import { utilDisplay } from "@/constants/utilityDisplay";
 import {
@@ -46,10 +47,48 @@ import {
 } from "./LineupPanes";
 import { DEFAULT_KNOBS } from "@/hooks/useDesignKnobs";
 import type { DesignKnobs } from "@/hooks/useDesignKnobs";
+import PaneReplaceOverlay from "./PaneReplaceOverlay";
+import type { PanePosition } from "@/hooks/usePaneUpload";
 
 interface GlanceBoardTileProps {
   lineup: Lineup;
   knobs?: DesignKnobs;
+  /** Operator-only per-pane Replace affordance. Auth gating lives at MapPage
+   *  level so this component stays a pure presentation tile (no Redux deps,
+   *  no Provider required in unit tests). Default false keeps guest viewers
+   *  + existing test fixtures unchanged. */
+  showReplaceOverlay?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// PaneSlot — wraps each pane in a group/pane div so hover-scoped affordances
+// (PaneReplaceOverlay) resolve to THIS pane only, not the whole tile. The
+// pane primitives in LineupPanes.tsx own their own ``flex-1 min-w-0`` so the
+// wrapper just adds positioning context — no flex sizing is moved here.
+// ---------------------------------------------------------------------------
+
+function PaneSlot({
+  lineupId,
+  pane,
+  showOverlay,
+  children,
+}: {
+  lineupId: string;
+  pane: PanePosition;
+  showOverlay: boolean;
+  children: ReactNode;
+}) {
+  // ``flex`` so the inner pane primitive's own ``flex-1 min-w-0`` resolves to
+  // the full wrapper width. ``relative`` is the positioning context for the
+  // absolutely-positioned overlay. ``group/pane`` scopes hover/focus reveal
+  // to THIS pane only — the sibling pane keeps its overlay hidden until
+  // hovered independently.
+  return (
+    <div className="relative group/pane flex flex-1 min-w-0">
+      {children}
+      {showOverlay && <PaneReplaceOverlay lineupId={lineupId} pane={pane} />}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -75,7 +114,11 @@ function SideChip({ side }: { side: string | null }) {
 // ---------------------------------------------------------------------------
 // GlanceBoardTile
 // ---------------------------------------------------------------------------
-export default function GlanceBoardTile({ lineup, knobs = DEFAULT_KNOBS }: GlanceBoardTileProps) {
+export default function GlanceBoardTile({
+  lineup,
+  knobs = DEFAULT_KNOBS,
+  showReplaceOverlay = false,
+}: GlanceBoardTileProps) {
   const ud = utilDisplay(lineup.utility_type?.slug);
 
   // Knob-forced overrides: a "still" mode discards any clip URL even when
@@ -122,36 +165,44 @@ export default function GlanceBoardTile({ lineup, knobs = DEFAULT_KNOBS }: Glanc
       <div className="flex flex-col divide-y divide-border">
         {/* Top row: STAND | AIM */}
         <div className="flex divide-x divide-border">
-          <StandPane
-            standScreenshotUrl={lineup.stand_screenshot_url}
-            standClipUrl={standClipForRender}
-            title={lineup.title}
-          />
-          <AimPane
-            aimScreenshotUrl={lineup.aim_screenshot_url}
-            aimClipUrl={aimClipForRender}
-            aimAnchorX={aimDotX}
-            aimAnchorY={aimDotY}
-            title={lineup.title}
-          />
+          <PaneSlot lineupId={lineup.id} pane="stand" showOverlay={showReplaceOverlay}>
+            <StandPane
+              standScreenshotUrl={lineup.stand_screenshot_url}
+              standClipUrl={standClipForRender}
+              title={lineup.title}
+            />
+          </PaneSlot>
+          <PaneSlot lineupId={lineup.id} pane="aim" showOverlay={showReplaceOverlay}>
+            <AimPane
+              aimScreenshotUrl={lineup.aim_screenshot_url}
+              aimClipUrl={aimClipForRender}
+              aimAnchorX={aimDotX}
+              aimAnchorY={aimDotY}
+              title={lineup.title}
+            />
+          </PaneSlot>
         </div>
         {/* Bottom row: THROW | LANDING */}
         <div className="flex divide-x divide-border">
-          {lineup.clip_url ? (
-            <ClipView
-              clipUrl={lineup.clip_url}
-              posterUrl={lineup.stand_screenshot_url}
+          <PaneSlot lineupId={lineup.id} pane="throw" showOverlay={showReplaceOverlay}>
+            {lineup.clip_url ? (
+              <ClipView
+                clipUrl={lineup.clip_url}
+                posterUrl={lineup.stand_screenshot_url}
+                title={lineup.title}
+              />
+            ) : (
+              <ThrowPlaceholder />
+            )}
+          </PaneSlot>
+          <PaneSlot lineupId={lineup.id} pane="landing" showOverlay={showReplaceOverlay}>
+            <LandingPane
+              targetZoneName={lineup.target_zone?.name ?? null}
+              landingClipUrl={landingClipForRender}
+              posterUrl={lineup.aim_screenshot_url}
               title={lineup.title}
             />
-          ) : (
-            <ThrowPlaceholder />
-          )}
-          <LandingPane
-            targetZoneName={lineup.target_zone?.name ?? null}
-            landingClipUrl={landingClipForRender}
-            posterUrl={lineup.aim_screenshot_url}
-            title={lineup.title}
-          />
+          </PaneSlot>
         </div>
       </div>
 

--- a/apps/mygamingassistant/frontend/src/components/lineup/PaneReplaceOverlay.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/PaneReplaceOverlay.tsx
@@ -1,0 +1,149 @@
+/**
+ * PaneReplaceOverlay — per-pane upload affordance (PR1).
+ *
+ * Two visual states layered over a single pane:
+ *
+ *   1. **Idle** — the Replace icon button sits in the bottom-right corner.
+ *      Invisible by default; opacity fades to 100 on parent ``group/pane``
+ *      hover OR on the button's own keyboard focus (so tab-key users can
+ *      reach it without a mouse). Per the UX review: icon-only at this
+ *      density (~250×140px panes), not a text label.
+ *
+ *   2. **Uploading / error** — a full-pane scrim overlays the pane content
+ *      with a horizontal progress bar at the bottom edge (or a red inline
+ *      error with a Retry link if the upload failed). RTK Query
+ *      invalidation transitions back to idle when the confirm completes,
+ *      so this component doesn't render a separate success state.
+ *
+ * Only renders when the operator is authenticated — the parent gates the
+ * mount via ``useIsSuperuser`` so guest viewers never see the affordance.
+ */
+import { useId, useRef } from "react";
+import { Upload, RotateCcw } from "lucide-react";
+import { usePaneUpload } from "@/hooks/usePaneUpload";
+import type { PanePosition } from "@/hooks/usePaneUpload";
+
+interface PaneReplaceOverlayProps {
+  lineupId: string;
+  pane: PanePosition;
+  /** Last file the operator picked — kept on the parent so Retry can resend
+   *  without re-opening the OS file picker. */
+  // Set inside the component via a ref so re-renders don't rebuild the input.
+}
+
+// File picker accept lists. Mirror the server's ALLOWED_*_MIMES — keeping
+// them in lockstep is part of "MIME mismatch rejection" guard #1 (pre-filter
+// at the OS picker, before any selection).
+const ACCEPT_STAND_AIM = "image/png,image/jpeg,image/webp,video/mp4,video/webm";
+const ACCEPT_CLIP_ONLY = "video/mp4,video/webm";
+
+function acceptFor(pane: PanePosition): string {
+  return pane === "stand" || pane === "aim" ? ACCEPT_STAND_AIM : ACCEPT_CLIP_ONLY;
+}
+
+export default function PaneReplaceOverlay({ lineupId, pane }: PaneReplaceOverlayProps) {
+  const inputId = useId();
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const lastFileRef = useRef<File | null>(null);
+
+  const { phase, upload, reset } = usePaneUpload();
+
+  function pickFile() {
+    inputRef.current?.click();
+  }
+
+  function onFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    // Reset the input value so picking the SAME file twice still fires
+    // change. Without this, a retry that re-picks the same file silently
+    // does nothing.
+    e.target.value = "";
+    if (!file) return;
+    lastFileRef.current = file;
+    void upload({ lineupId, pane, file });
+  }
+
+  function retry() {
+    if (lastFileRef.current) {
+      void upload({ lineupId, pane, file: lastFileRef.current });
+    } else {
+      // No prior file (e.g. operator cleared the picker) — reopen it.
+      reset();
+      pickFile();
+    }
+  }
+
+  return (
+    <>
+      {/* Hidden file input — sr-only style instead of display:none because
+          Safari blocks programmatic .click() on display:none inputs. */}
+      <input
+        ref={inputRef}
+        id={inputId}
+        type="file"
+        accept={acceptFor(pane)}
+        onChange={onFileChange}
+        className="sr-only"
+        aria-hidden
+      />
+
+      {/* Idle: hover/focus-revealed Upload button. Hidden during upload so
+          the operator can't accidentally start a second upload mid-flight. */}
+      {phase.phase === "idle" && (
+        <button
+          type="button"
+          onClick={pickFile}
+          aria-label={`Replace ${pane} pane content`}
+          title={`Replace ${pane}`}
+          className={[
+            "absolute bottom-1.5 right-1.5 z-10",
+            "opacity-0 group-hover/pane:opacity-100 focus-visible:opacity-100",
+            "transition-opacity duration-150",
+            "p-1.5 rounded bg-black/60 text-white hover:bg-black/80",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 focus-visible:ring-inset",
+          ].join(" ")}
+        >
+          <Upload className="w-3.5 h-3.5" aria-hidden />
+        </button>
+      )}
+
+      {/* Uploading: full-pane semi-transparent scrim + bottom progress bar. */}
+      {phase.phase === "uploading" && (
+        <div
+          role="status"
+          aria-label={`Uploading replacement for ${pane}: ${Math.round(phase.progress * 100)}%`}
+          className="absolute inset-0 z-10 bg-black/50 flex flex-col justify-end"
+        >
+          <div className="h-0.5 bg-white/20 w-full">
+            <div
+              className="h-full bg-white transition-[width] duration-100 ease-linear"
+              style={{ width: `${Math.round(phase.progress * 100)}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* Error: full-pane scrim + inline message + Retry. Stays in-pane (not
+          a toast) per the UX review — the operator's eye is on the pane they
+          just dropped on. */}
+      {phase.phase === "error" && (
+        <div
+          role="alert"
+          className="absolute inset-0 z-10 bg-black/70 flex flex-col items-center justify-center gap-1.5 px-2 text-center"
+        >
+          <span className="text-xs font-semibold text-red-400 leading-tight">
+            {phase.message}
+          </span>
+          <button
+            type="button"
+            onClick={retry}
+            className="inline-flex items-center gap-1 text-[11px] text-white/80 hover:text-white underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 rounded px-1"
+          >
+            <RotateCcw className="w-3 h-3" aria-hidden />
+            Retry
+          </button>
+        </div>
+      )}
+    </>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/hooks/usePaneUpload.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/usePaneUpload.ts
@@ -1,0 +1,181 @@
+/**
+ * usePaneUpload — three-step per-pane Replace flow (PR1).
+ *
+ *   1. Operator picks a file → request a presigned PUT URL from the backend
+ *   2. PUT the bytes to MinIO directly via XHR (with upload progress)
+ *   3. Confirm to the backend — it writes the new key onto the right column
+ *      and RTK Query invalidation re-fetches the lineup so the tile re-renders
+ *
+ * State machine:
+ *   { phase: "idle" }
+ *   { phase: "uploading", progress: 0..1 }
+ *   { phase: "error", message }
+ *
+ * No explicit "success" phase — RTK Query cache invalidation re-renders the
+ * pane with the new asset, which IS the success confirmation. After the
+ * confirm mutation settles we transition the local state back to idle.
+ */
+import { useCallback, useRef, useState } from "react";
+import {
+  useConfirmPaneUploadMutation,
+  useRequestPaneUploadUrlMutation,
+} from "@/store/lineupsApi";
+
+export type PanePosition = "stand" | "aim" | "throw" | "landing";
+export type PaneKind = "still" | "clip";
+
+export type PaneUploadPhase =
+  | { phase: "idle" }
+  | { phase: "uploading"; progress: number }
+  | { phase: "error"; message: string };
+
+interface UploadArgs {
+  lineupId: string;
+  pane: PanePosition;
+  file: File;
+}
+
+// 30 seconds is generous for a few-MB clip on a typical connection; an
+// upload still progressing past that is almost always a stall worth
+// surfacing as a clear error rather than a silent hang.
+const UPLOAD_TIMEOUT_MS = 30_000;
+
+function inferKindFromMime(mime: string): PaneKind | null {
+  if (mime.startsWith("image/")) return "still";
+  if (mime.startsWith("video/")) return "clip";
+  return null;
+}
+
+export function usePaneUpload() {
+  const [phase, setPhase] = useState<PaneUploadPhase>({ phase: "idle" });
+  // Live XHR reference so the overlay's retry path can abort an in-flight
+  // upload before re-trying — without this the second attempt races the
+  // first and the slower one's confirm clobbers the faster one's.
+  const xhrRef = useRef<XMLHttpRequest | null>(null);
+
+  const [requestUrl] = useRequestPaneUploadUrlMutation();
+  const [confirmUpload] = useConfirmPaneUploadMutation();
+
+  const upload = useCallback(
+    async ({ lineupId, pane, file }: UploadArgs) => {
+      const kind = inferKindFromMime(file.type);
+      if (kind === null) {
+        setPhase({
+          phase: "error",
+          message: `Unsupported file type '${file.type}'`,
+        });
+        return;
+      }
+
+      // Validate pane / kind combination on the client so we fail fast and
+      // can show a useful inline message before hitting the network. The
+      // server re-checks the same constraint (defense in depth).
+      if ((pane === "throw" || pane === "landing") && kind === "still") {
+        setPhase({
+          phase: "error",
+          message: `${pane.toUpperCase()} pane only accepts video files`,
+        });
+        return;
+      }
+
+      setPhase({ phase: "uploading", progress: 0 });
+
+      let urlResp: { upload_url: string; object_key: string };
+      try {
+        urlResp = await requestUrl({
+          lineup_id: lineupId,
+          pane,
+          kind,
+          content_type: file.type,
+          content_length: file.size,
+        }).unwrap();
+      } catch (err) {
+        setPhase({
+          phase: "error",
+          message: extractError(err) ?? "Could not request upload URL",
+        });
+        return;
+      }
+
+      // Abort any prior in-flight upload before starting this one (retry
+      // path). Tracked via xhrRef so the cleanup is reachable from the
+      // outer callback.
+      xhrRef.current?.abort();
+
+      const xhr = new XMLHttpRequest();
+      xhrRef.current = xhr;
+      xhr.timeout = UPLOAD_TIMEOUT_MS;
+
+      const putPromise = new Promise<void>((resolve, reject) => {
+        xhr.upload.addEventListener("progress", (e) => {
+          if (!e.lengthComputable) return;
+          setPhase({ phase: "uploading", progress: e.loaded / e.total });
+        });
+        xhr.addEventListener("load", () => {
+          if (xhr.status >= 200 && xhr.status < 300) {
+            resolve();
+          } else {
+            reject(new Error(`MinIO PUT failed: ${xhr.status}`));
+          }
+        });
+        xhr.addEventListener("error", () => reject(new Error("Upload network error")));
+        xhr.addEventListener("timeout", () => reject(new Error("Upload timed out")));
+        xhr.addEventListener("abort", () => reject(new Error("Upload aborted")));
+        xhr.open("PUT", urlResp.upload_url);
+        xhr.setRequestHeader("Content-Type", file.type);
+        xhr.send(file);
+      });
+
+      try {
+        await putPromise;
+      } catch (err) {
+        // An aborted upload was superseded by a retry — surface nothing
+        // (the retry's own state will drive the UI).
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg !== "Upload aborted") {
+          setPhase({ phase: "error", message: msg });
+        }
+        return;
+      } finally {
+        if (xhrRef.current === xhr) {
+          xhrRef.current = null;
+        }
+      }
+
+      try {
+        await confirmUpload({
+          lineup_id: lineupId,
+          pane,
+          kind,
+          object_key: urlResp.object_key,
+        }).unwrap();
+      } catch (err) {
+        setPhase({
+          phase: "error",
+          message: extractError(err) ?? "Could not confirm upload",
+        });
+        return;
+      }
+
+      // Confirm succeeded → RTK Query invalidation re-fetches the lineup,
+      // pane re-renders with the new asset, no separate success state.
+      setPhase({ phase: "idle" });
+    },
+    [requestUrl, confirmUpload],
+  );
+
+  const reset = useCallback(() => {
+    xhrRef.current?.abort();
+    setPhase({ phase: "idle" });
+  }, []);
+
+  return { phase, upload, reset };
+}
+
+function extractError(err: unknown): string | null {
+  if (typeof err !== "object" || err === null) return null;
+  const maybe = err as { data?: { detail?: unknown }; status?: number };
+  const detail = maybe.data?.detail;
+  if (typeof detail === "string") return detail;
+  return null;
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -493,6 +493,7 @@ export default function MapPage() {
                 filteredUtils={effectiveUtils}
                 side={side}
                 knobs={knobs}
+                showReplaceOverlay={isSuperuser}
               />
             )}
 

--- a/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
@@ -161,6 +161,51 @@ const lineupsApi = lineupsBaseApi.injectEndpoints({
     }),
 
     // ------------------------------------------------------------------
+    // Per-pane local-upload Replace flow (PR1)
+    // The browser PUTs the file directly to MinIO via the presigned URL —
+    // RTK Query is only used for the two metadata calls (request URL +
+    // confirm). The PUT itself is a plain XHR so we get upload progress.
+    // ------------------------------------------------------------------
+
+    requestPaneUploadUrl: build.mutation<
+      { upload_url: string; object_key: string },
+      {
+        lineup_id: string;
+        pane: "stand" | "aim" | "throw" | "landing";
+        kind: "still" | "clip";
+        content_type: string;
+        content_length: number;
+      }
+    >({
+      query: ({ lineup_id, pane, kind, content_type, content_length }) => ({
+        url: `/lineups/${lineup_id}/panes/${pane}/upload-url`,
+        method: "POST",
+        data: { kind, content_type, content_length },
+      }),
+    }),
+
+    confirmPaneUpload: build.mutation<
+      Lineup,
+      {
+        lineup_id: string;
+        pane: "stand" | "aim" | "throw" | "landing";
+        kind: "still" | "clip";
+        object_key: string;
+      }
+    >({
+      query: ({ lineup_id, pane, kind, object_key }) => ({
+        url: `/lineups/${lineup_id}/panes/${pane}/confirm`,
+        method: "POST",
+        data: { kind, object_key },
+      }),
+      invalidatesTags: (_result, _err, { lineup_id }) => [
+        { type: "Lineup", id: lineup_id },
+        "LineupList",
+        "PendingLineups",
+      ],
+    }),
+
+    // ------------------------------------------------------------------
     // Zone density (map-level aggregate for density coloring)
     // ------------------------------------------------------------------
     getZoneDensity: build.query<ZoneDensity, ZoneDensityParams>({
@@ -192,4 +237,6 @@ export const {
   useAcceptLineupMutation,
   useHideLineupMutation,
   useBulkAcceptLineupsMutation,
+  useRequestPaneUploadUrlMutation,
+  useConfirmPaneUploadMutation,
 } = lineupsApi;


### PR DESCRIPTION
## Summary

Each pane on the 4-pane storyboard tile gets a hover-revealed **Replace** button. Operators render the artifact locally with whatever tool they prefer (ffmpeg, DaVinci, Premiere, ScreenStudio) — the bytes upload directly to MinIO via a presigned PUT, then a confirm endpoint writes the new MinIO key onto the matching column. The server never re-encodes; source videos never need to live on the server for editing.

This is the **foundation PR** for the per-pane editor. Future iterations (clip-duration sliders, anchor-drag, technique-text inline edit) reuse this two-endpoint + presigned-PUT shape.

## Why local-first

Source videos are ~250MB each. Server-side editing required either re-downloading on every edit session (slow) or caching every source forever (~2.5TB at 10K lineups). Local-editor-plus-small-upload sidesteps both — the operator's machine already has whatever editor they prefer, and only the rendered ~5MB clip / ~100KB still leaves the device.

## Backend (~150 LOC + 17 tests)

**Endpoints (auth_router, operator-only):**
- `POST /api/lineups/{lineup_id}/panes/{pane}/upload-url` → `{upload_url, object_key}`
- `POST /api/lineups/{lineup_id}/panes/{pane}/confirm` → refreshed `LineupRead`

**Validation:**
- (pane, kind): STAND/AIM accept still or clip; THROW/LANDING clip-only (no still column in schema today, unchanged)
- MIME allow-list: `image/png|jpeg|webp` for still, `video/mp4|webm` for clip
- Size cap: 5 MB still / 50 MB clip
- `object_key` tamper guard at confirm — refuses any key not under `edits/<lineup_id>/`

**Repo setters** (mirror `set_stand_clip_url` et al., one-column commit per PR #687/#695):
- `set_stand_screenshot_url`
- `set_aim_screenshot_url`

**Key naming:** `edits/<lineup_id>/<pane>-<kind>-<uuid>.<ext>` — uuid suffix makes each upload distinct; latest URL is in the column, older keys remain as forensic copies (cleanup job future PR).

## Frontend (~350 LOC + 5 tests)

- RTK Query mutations on existing `lineupsApi` (`useRequestPaneUploadUrlMutation` / `useConfirmPaneUploadMutation`). Confirm invalidates `Lineup` + `LineupList` + `PendingLineups` so the tile re-renders with the new asset — no separate success state needed.
- `usePaneUpload` hook owns the 3-step flow + state machine (`idle | uploading{progress} | error{message}`). XHR PUT with progress events + 30s timeout. Aborts in-flight XHR on retry so a slow original doesn't clobber a fast retry's confirm.
- `PaneReplaceOverlay` component: hidden Upload icon button that fades in on parent `group/pane` hover OR keyboard focus (`focus-visible:opacity-100`). Full-pane scrim + horizontal progress bar during upload; inline error with Retry on failure. Stays in-pane (no toasts) per the UX review — operator's eye is on the pane they just dropped on.
- `GlanceBoardTile` wraps each pane in `PaneSlot` (`relative group/pane flex flex-1 min-w-0`) so hover scopes to **this** pane only, not the whole tile. Pane primitives in `LineupPanes.tsx` are **unchanged** — they stay knob/overlay-agnostic so `LineupCard`'s detail-panel surface doesn't need to know.
- Operator auth gating lives at `MapPage` level (`useIsSuperuser`) and threads through `GlanceBoard` → `GlanceBoardTile` as a plain prop. This keeps the tile pure-presentation — its existing unit tests still render without a Redux Provider. Server enforces the same gate independently via `auth_router`, so a hand-rolled request without auth fails 401.

## Tests

- `test_pane_upload_service.py` — 13 tests: validation matrix (every reject path), key naming, uniqueness, foreign-prefix tamper guard, 404-when-object-missing, dispatch-table walk verifying each `(pane, kind) → repo setter` mapping.
- `test_lineup_screenshot_url_repo.py` — 4 DB-backed tests: each setter commits (survives `expire_all` + fresh read), the two setters are independent, replacing a still does **not** clobber the sibling clip column.
- `PaneReplaceOverlay.test.tsx` — 5 tests: pane-specific `accept` attribute (STAND/AIM accept image+video; THROW/LANDING video-only), pane-specific aria-label.

**508/508 backend tests pass** (up from 491). **325/325 frontend tests pass** (up from 320). Typecheck clean.

## Test plan

- [x] Backend pytest green
- [x] Frontend vitest green
- [x] Typecheck clean
- [ ] Visual: log in as operator on `/cs2/mirage`, hover any pane → Replace icon appears bottom-right; click → file picker; upload completes; pane re-renders with new asset
- [ ] Visual: as guest viewer (logged out), Replace icon never appears
- [ ] MIME guard: drop an image on the THROW pane → file picker pre-filter rejects it; if somehow uploaded, inline error shown

## Follow-ups

- **PR2** — clip-duration slider per pane (reuses the same endpoints + state machine)
- **PR3** — anchor-dot drag editor on AIM pane
- **PR4** — technique-text inline edit
- Cleanup job for unreferenced `edits/<lineup_id>/` keys (only matters at scale)

🤖 Generated with [Claude Code](https://claude.com/claude-code)