### PR TITLE
feat(mjh): structured interview_details on application_events

### DIFF
--- a/apps/myjobhunter/backend/alembic/versions/intrvdt260521_interview_details_column.py
+++ b/apps/myjobhunter/backend/alembic/versions/intrvdt260521_interview_details_column.py
@@ -1,0 +1,45 @@
+"""Add interview_details JSONB column to application_events.
+
+When the operator logs an ``interview_scheduled`` or ``interview_completed``
+event, they can now supply structured interview metadata — interview type
+(phone/video/onsite/panel), scheduled datetime, duration, location/link,
+and a list of interviewer names.
+
+This is stored in a dedicated ``interview_details`` JSONB column rather than
+reusing ``raw_payload``.  The ``raw_payload`` field is reserved for Gmail-sync
+worker payloads and is excluded from all response schemas by CWE-200 audit
+(2026-05-02).  Using a purpose-built column keeps the security boundary clean.
+
+The column is nullable so existing rows and non-interview events are unaffected.
+No data migration or backfill required.
+
+Revision ID: intrvdt260521
+Revises: discmrg260511
+Create Date: 2026-05-21
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+
+revision: str = "intrvdt260521"
+down_revision: Union[str, None] = "discmrg260511"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "application_events",
+        sa.Column(
+            "interview_details",
+            JSONB,
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("application_events", "interview_details")

--- a/apps/myjobhunter/backend/app/core/enums.py
+++ b/apps/myjobhunter/backend/app/core/enums.py
@@ -123,6 +123,15 @@ class RemoteType:
     ALL = ("remote", "hybrid", "onsite", "unknown")
 
 
+class InterviewType:
+    PHONE = "phone"
+    VIDEO = "video"
+    ONSITE = "onsite"
+    PANEL = "panel"
+
+    ALL = ("phone", "video", "onsite", "panel")
+
+
 class EventType:
     APPLIED = "applied"
     EMAIL_RECEIVED = "email_received"

--- a/apps/myjobhunter/backend/app/models/application/application_event.py
+++ b/apps/myjobhunter/backend/app/models/application/application_event.py
@@ -39,6 +39,7 @@ class ApplicationEvent(Base):
     source: Mapped[str] = mapped_column(String(20), nullable=False)
     email_message_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     raw_payload: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
+    interview_details: Mapped[dict | None] = mapped_column(JSONB, nullable=True)
     note: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     created_at: Mapped[datetime] = mapped_column(

--- a/apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py
@@ -9,6 +9,12 @@ them.
 
 ``event_type`` and ``source`` are validated against the enum allowlists
 in ``app.core.enums`` to match the DB CHECK constraints.
+
+``interview_details`` is optional and accepted only when ``event_type``
+is ``interview_scheduled`` or ``interview_completed``.  When present, the
+``type`` sub-field is required and must be one of the ``InterviewType``
+values.  All other sub-fields are optional so the operator can supply
+only the information they know at the time of logging.
 """
 from __future__ import annotations
 
@@ -16,11 +22,52 @@ import datetime as _dt
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from app.core.enums import EventType, EventSource
+from app.core.enums import EventType, EventSource, InterviewType
 
 _EVENT_TYPE_MAX_LEN = 30
 _SOURCE_MAX_LEN = 20
 _NOTE_MAX_LEN = 5000
+_LOCATION_MAX_LEN = 1024
+_NAME_MAX_LEN = 200
+_MAX_INTERVIEWERS = 20
+
+# Event types for which interview_details is meaningful.
+_INTERVIEW_EVENT_TYPES = frozenset({
+    EventType.INTERVIEW_SCHEDULED,
+    EventType.INTERVIEW_COMPLETED,
+})
+
+
+class InterviewDetailsRequest(BaseModel):
+    """Structured interview metadata accepted in the manual-log request.
+
+    ``type`` is the only required sub-field when this object is present.
+    Everything else is best-effort: the operator might know only the date,
+    or only the meeting link.
+    """
+
+    type: str = Field(min_length=1, max_length=20)
+    scheduled_at: _dt.datetime | None = None
+    duration_minutes: int | None = Field(default=None, ge=1, le=1440)
+    location_or_link: str | None = Field(default=None, max_length=_LOCATION_MAX_LEN)
+    interviewer_names: list[str] | None = Field(default=None, max_length=_MAX_INTERVIEWERS)
+
+    model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _validate_type(self) -> "InterviewDetailsRequest":
+        if self.type not in InterviewType.ALL:
+            raise ValueError(
+                f"interview_details.type must be one of {InterviewType.ALL}, "
+                f"got {self.type!r}",
+            )
+        if self.interviewer_names is not None:
+            for name in self.interviewer_names:
+                if len(name) > _NAME_MAX_LEN:
+                    raise ValueError(
+                        f"Interviewer name exceeds {_NAME_MAX_LEN} characters: {name!r}",
+                    )
+        return self
 
 
 class ApplicationEventCreateRequest(BaseModel):
@@ -30,6 +77,7 @@ class ApplicationEventCreateRequest(BaseModel):
     occurred_at: _dt.datetime
     source: str = Field(default=EventSource.MANUAL, max_length=_SOURCE_MAX_LEN)
     note: str | None = Field(default=None, max_length=_NOTE_MAX_LEN)
+    interview_details: InterviewDetailsRequest | None = None
 
     model_config = ConfigDict(extra="forbid")
 
@@ -42,5 +90,10 @@ class ApplicationEventCreateRequest(BaseModel):
         if self.source not in EventSource.ALL:
             raise ValueError(
                 f"source must be one of {EventSource.ALL}, got {self.source!r}",
+            )
+        if self.interview_details is not None and self.event_type not in _INTERVIEW_EVENT_TYPES:
+            raise ValueError(
+                f"interview_details is only valid for event_type in "
+                f"{sorted(_INTERVIEW_EVENT_TYPES)}, got {self.event_type!r}",
             )
         return self

--- a/apps/myjobhunter/backend/app/schemas/application/application_event_response.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_event_response.py
@@ -9,11 +9,17 @@ CWE-200). The field is always null in Phase 1-2 and exposing it in the public
 API response is a forward-looking data-exposure risk. If Phase 3 Gmail
 sync workers need to surface parsed email artifacts, introduce a separate
 admin-only response schema at that time.
+
+``interview_details`` is a purpose-built JSONB field for structured interview
+metadata (type, scheduled_at, duration_minutes, location_or_link,
+interviewer_names). Distinct from raw_payload — no CWE-200 concern because
+the operator explicitly supplies these values via the manual-log form.
 """
 from __future__ import annotations
 
 import datetime as _dt
 import uuid
+from typing import Any
 
 from pydantic import BaseModel, ConfigDict
 
@@ -28,6 +34,7 @@ class ApplicationEventResponse(BaseModel):
     source: str
     email_message_id: str | None = None
     note: str | None = None
+    interview_details: dict[str, Any] | None = None
 
     created_at: _dt.datetime
 

--- a/apps/myjobhunter/backend/app/services/application/application_service.py
+++ b/apps/myjobhunter/backend/app/services/application/application_service.py
@@ -313,6 +313,18 @@ async def log_application_event(
     application = await application_repository.get_by_id(db, application_id, user_id)
     if application is None:
         return None
+
+    # Serialise the nested InterviewDetailsRequest to a plain dict for JSONB
+    # storage.  ``model_dump(mode="json")`` converts datetime fields to ISO
+    # strings (JSONB-safe) and drops None sub-fields so the stored blob stays
+    # compact.  When ``interview_details`` is None the column stores NULL.
+    interview_details_dict: dict | None = None
+    if request.interview_details is not None:
+        interview_details_dict = request.interview_details.model_dump(
+            mode="json",
+            exclude_none=True,
+        )
+
     event = ApplicationEvent(
         user_id=user_id,
         application_id=application_id,
@@ -320,6 +332,7 @@ async def log_application_event(
         occurred_at=request.occurred_at,
         source=request.source,
         note=request.note,
+        interview_details=interview_details_dict,
     )
     event = await application_event_repository.create(db, event)
     await db.commit()

--- a/apps/myjobhunter/backend/tests/test_interview_details.py
+++ b/apps/myjobhunter/backend/tests/test_interview_details.py
@@ -1,0 +1,254 @@
+"""Tests for interview_details on application events.
+
+Covers:
+- POST /applications/{id}/events with interview_details persists correctly
+  and round-trips through the response.
+- interview_details rejected on non-interview event types (422).
+- interview_details with missing ``type`` sub-field rejected (422).
+- interview_details with invalid ``type`` value rejected (422).
+- interview_details is null on events that don't supply it.
+- interview_details partial data (only type provided) accepted.
+- GET /applications/{id}/events returns interview_details in response.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.company.company import Company
+
+
+async def _create_company(db: AsyncSession, user_id: uuid.UUID, name: str) -> Company:
+    company = Company(
+        user_id=user_id,
+        name=name,
+        primary_domain=f"{name.lower().replace(' ', '-')}.example.com",
+    )
+    db.add(company)
+    await db.commit()
+    await db.refresh(company)
+    return company
+
+
+def _now_iso() -> str:
+    return _dt.datetime.now(_dt.timezone.utc).isoformat()
+
+
+def _app_payload(company_id: uuid.UUID) -> dict:
+    return {
+        "company_id": str(company_id),
+        "role_title": "Software Engineer",
+        "source": "linkedin",
+        "remote_type": "remote",
+    }
+
+
+def _event_payload(event_type: str = "interview_scheduled", **overrides) -> dict:
+    payload: dict = {
+        "event_type": event_type,
+        "occurred_at": _now_iso(),
+        "source": "manual",
+    }
+    payload.update(overrides)
+    return payload
+
+
+_FULL_INTERVIEW_DETAILS = {
+    "type": "video",
+    "scheduled_at": "2026-06-01T14:00:00+00:00",
+    "duration_minutes": 60,
+    "location_or_link": "https://meet.google.com/xyz-abc-def",
+    "interviewer_names": ["Alex Kim", "Jordan Lee"],
+}
+
+
+class TestInterviewDetailsCreate:
+    @pytest.mark.asyncio
+    async def test_full_interview_details_persisted_and_returned(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """POST with full interview_details returns 201 and the details round-trip."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "TechCorp")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            assert create_app.status_code == 201
+            app_id = create_app.json()["id"]
+
+            resp = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload(
+                    "interview_scheduled",
+                    interview_details=_FULL_INTERVIEW_DETAILS,
+                ),
+            )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["event_type"] == "interview_scheduled"
+        details = body["interview_details"]
+        assert details is not None
+        assert details["type"] == "video"
+        assert details["duration_minutes"] == 60
+        assert details["location_or_link"] == "https://meet.google.com/xyz-abc-def"
+        assert details["interviewer_names"] == ["Alex Kim", "Jordan Lee"]
+        # scheduled_at is stored as ISO string in JSONB
+        assert "2026-06-01" in details["scheduled_at"]
+
+    @pytest.mark.asyncio
+    async def test_partial_interview_details_only_type(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """Only the 'type' sub-field is required; partial data is accepted."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "MiniCorp")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+            resp = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload(
+                    "interview_completed",
+                    interview_details={"type": "onsite"},
+                ),
+            )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        details = body["interview_details"]
+        assert details is not None
+        assert details["type"] == "onsite"
+        # Optional fields omitted — should not appear in response
+        assert "duration_minutes" not in details or details.get("duration_minutes") is None
+        assert "interviewer_names" not in details or details.get("interviewer_names") is None
+
+    @pytest.mark.asyncio
+    async def test_no_interview_details_returns_null(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """When interview_details is not supplied, the response field is null."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "NullCorp")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+            resp = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload("interview_scheduled"),
+            )
+
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["interview_details"] is None
+
+    @pytest.mark.asyncio
+    async def test_interview_details_on_non_interview_event_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """interview_details is rejected when event_type is not interview_scheduled/completed."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "BadCorp")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+            resp = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload(
+                    "rejected",
+                    interview_details={"type": "video"},
+                ),
+            )
+
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_invalid_interview_type_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """An unknown interview type value is rejected."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "InvalidTypeCorp")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+            resp = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload(
+                    "interview_scheduled",
+                    interview_details={"type": "smoke_signal"},
+                ),
+            )
+
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_missing_type_in_interview_details_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """interview_details without 'type' is rejected (type is required)."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "MissingTypeCorp")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+            resp = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload(
+                    "interview_scheduled",
+                    interview_details={"duration_minutes": 45},
+                ),
+            )
+
+        assert resp.status_code == 422, resp.text
+
+
+class TestInterviewDetailsGetList:
+    @pytest.mark.asyncio
+    async def test_list_events_includes_interview_details(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """GET /events returns interview_details in the items list."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "ListCorp")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+
+            await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload(
+                    "interview_scheduled",
+                    interview_details={
+                        "type": "phone",
+                        "interviewer_names": ["Sam Smith"],
+                    },
+                ),
+            )
+
+            list_resp = await authed.get(f"/applications/{app_id}/events")
+
+        assert list_resp.status_code == 200, list_resp.text
+        items = list_resp.json()["items"]
+        # auto-created "applied" event (no details) + our interview event
+        interview_event = next(
+            (e for e in items if e["event_type"] == "interview_scheduled"), None
+        )
+        assert interview_event is not None
+        assert interview_event["interview_details"] is not None
+        assert interview_event["interview_details"]["type"] == "phone"
+        assert interview_event["interview_details"]["interviewer_names"] == ["Sam Smith"]


### PR DESCRIPTION
## Summary

- Adds a JSONB `interview_details` column to `application_events` plus an `InterviewDetailsRequest` schema, so the operator can log structured interview metadata (type, scheduled_at, duration_minutes, location_or_link, interviewer_names) when creating `interview_scheduled` / `interview_completed` events.
- New `InterviewType` enum (`phone` / `video` / `onsite` / `panel`); only `type` is required when `interview_details` is present.
- Validation rejects `interview_details` on non-interview event types (422), invalid type values, and missing `type` sub-field. Purpose-built column rather than reusing `raw_payload` — keeps the existing CWE-200 boundary clean (`raw_payload` is excluded from response schemas).
- 7 backend tests cover full / partial / null payloads, all rejection paths, and round-trip through `GET /applications/{id}/events`.

## ⚠️ Operational migration required

After merge, the next deploy applies migration `intrvdt260521_interview_details_column` which adds a nullable `interview_details JSONB` column to `application_events`. No operator action required — the column is nullable and additive; existing rows and non-interview events are unaffected.

## Follow-up — frontend (next PR)

Per the in-repo "enum additions must update frontend type unions in same/next PR" rule, a follow-up PR will:
- Add `InterviewType` TS union + `InterviewDetailsRequest` shape to `frontend/src/types/`
- Surface the interview-details sub-form in `LogEventDialog.tsx` when the operator selects `interview_scheduled` / `interview_completed`
- Render `interview_details` in `EventsSection.tsx` on `ApplicationDetail`

## Test plan

- [x] Pydantic validation paths verified offline (full / partial / null / non-interview rejection / invalid type / missing type)
- [x] JSONB serialisation produces compact dict (datetime → ISO, `exclude_none=True`)
- [x] Migration `intrvdt260521 -> discmrg260511` produces a single alembic head (no fork)
- [ ] CI runs the full 7-test suite against real Postgres

🤖 Generated with [Claude Code](https://claude.com/claude-code)