### PR TITLE
feat(mjh): interview_details UI on application events

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/InterviewDetailsFields.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/InterviewDetailsFields.tsx
@@ -1,0 +1,124 @@
+/**
+ * Sub-form rendered inside `LogEventDialog` when the operator selects an
+ * `interview_scheduled` / `interview_completed` event_type.
+ *
+ * Only `type` is required; everything else is best-effort metadata that
+ * gets serialised into the `interview_details` JSONB column at submit time.
+ */
+import type { UseFormRegister, FieldErrors } from "react-hook-form";
+import type { InterviewType } from "@/types/interview-details";
+import type { LogEventFormValues } from "./LogEventDialog";
+
+const INTERVIEW_TYPE_OPTIONS: { value: InterviewType; label: string }[] = [
+  { value: "phone", label: "Phone" },
+  { value: "video", label: "Video" },
+  { value: "onsite", label: "On-site" },
+  { value: "panel", label: "Panel" },
+];
+
+interface Props {
+  register: UseFormRegister<LogEventFormValues>;
+  errors: FieldErrors<LogEventFormValues>;
+}
+
+export default function InterviewDetailsFields({ register, errors }: Props) {
+  return (
+    <fieldset className="border rounded-md p-3 space-y-3">
+      <legend className="px-1 text-xs font-medium text-muted-foreground">
+        Interview details
+      </legend>
+
+      <div>
+        <label htmlFor="interview-type" className="block text-sm font-medium mb-1">
+          Type <span className="text-destructive">*</span>
+        </label>
+        <select
+          id="interview-type"
+          {...register("interview_type", {
+            required: "Pick the interview type",
+          })}
+          className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+        >
+          <option value="">Select…</option>
+          {INTERVIEW_TYPE_OPTIONS.map((o) => (
+            <option key={o.value} value={o.value}>{o.label}</option>
+          ))}
+        </select>
+        {errors.interview_type ? (
+          <p className="text-xs text-destructive mt-1">
+            {errors.interview_type.message}
+          </p>
+        ) : null}
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        <div>
+          <label htmlFor="interview-scheduled-at" className="block text-sm font-medium mb-1">
+            Scheduled at
+          </label>
+          <input
+            id="interview-scheduled-at"
+            type="datetime-local"
+            {...register("interview_scheduled_at")}
+            className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+          />
+        </div>
+        <div>
+          <label htmlFor="interview-duration" className="block text-sm font-medium mb-1">
+            Duration (min)
+          </label>
+          <input
+            id="interview-duration"
+            type="number"
+            min={1}
+            max={1440}
+            {...register("interview_duration_minutes", {
+              valueAsNumber: false,
+              validate: (v) => {
+                if (v === "" || v == null) return true;
+                const n = Number(v);
+                if (!Number.isFinite(n) || n < 1 || n > 1440) {
+                  return "Between 1 and 1440";
+                }
+                return true;
+              },
+            })}
+            placeholder="e.g. 60"
+            className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+          />
+          {errors.interview_duration_minutes ? (
+            <p className="text-xs text-destructive mt-1">
+              {errors.interview_duration_minutes.message}
+            </p>
+          ) : null}
+        </div>
+      </div>
+
+      <div>
+        <label htmlFor="interview-location" className="block text-sm font-medium mb-1">
+          Location or link
+        </label>
+        <input
+          id="interview-location"
+          type="text"
+          {...register("interview_location_or_link", { maxLength: 1024 })}
+          placeholder="https://meet.google.com/… or 123 Main St"
+          className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+        />
+      </div>
+
+      <div>
+        <label htmlFor="interview-interviewers" className="block text-sm font-medium mb-1">
+          Interviewer names
+        </label>
+        <textarea
+          id="interview-interviewers"
+          {...register("interview_interviewer_names")}
+          rows={2}
+          placeholder="One per line"
+          className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+        />
+      </div>
+    </fieldset>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/InterviewDetailsSummary.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/InterviewDetailsSummary.tsx
@@ -1,0 +1,89 @@
+/**
+ * Inline read-only summary of `interview_details` on an ApplicationEvent.
+ *
+ * Renders nothing when the field is null; otherwise a compact dt/dd grid
+ * (type / scheduled at / duration / location / interviewers) under the
+ * event card in `EventsSection`.
+ */
+import type { ReactNode } from "react";
+import type { InterviewDetails, InterviewType } from "@/types/interview-details";
+
+const TYPE_LABEL: Record<InterviewType, string> = {
+  phone: "Phone",
+  video: "Video",
+  onsite: "On-site",
+  panel: "Panel",
+};
+
+function formatScheduledAt(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+function isUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function Row({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <>
+      <dt className="font-medium text-foreground/80">{label}</dt>
+      <dd>{children}</dd>
+    </>
+  );
+}
+
+function ScheduledRow({ iso }: { iso: string | null | undefined }) {
+  if (!iso) return null;
+  return <Row label="Scheduled">{formatScheduledAt(iso)}</Row>;
+}
+
+function DurationRow({ minutes }: { minutes: number | null | undefined }) {
+  if (typeof minutes !== "number" || minutes <= 0) return null;
+  return <Row label="Duration">{minutes} min</Row>;
+}
+
+function LocationLink({ value }: { value: string }) {
+  if (!isUrl(value)) return <>{value}</>;
+  return (
+    <a
+      href={value}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="underline hover:text-foreground"
+    >
+      {value}
+    </a>
+  );
+}
+
+function LocationRow({ value }: { value: string | null | undefined }) {
+  if (!value) return null;
+  return (
+    <Row label="Where">
+      <span className="break-all">
+        <LocationLink value={value} />
+      </span>
+    </Row>
+  );
+}
+
+function InterviewersRow({ names }: { names: string[] | null | undefined }) {
+  if (!Array.isArray(names) || names.length === 0) return null;
+  return <Row label="With">{names.join(", ")}</Row>;
+}
+
+interface Props {
+  details: InterviewDetails;
+}
+
+export default function InterviewDetailsSummary({ details }: Props) {
+  return (
+    <dl className="text-xs grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 mt-2 text-muted-foreground">
+      <Row label="Type">{TYPE_LABEL[details.type]}</Row>
+      <ScheduledRow iso={details.scheduled_at} />
+      <DurationRow minutes={details.duration_minutes} />
+      <LocationRow value={details.location_or_link} />
+      <InterviewersRow names={details.interviewer_names} />
+    </dl>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
@@ -5,6 +5,11 @@ import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@pla
 import { X } from "lucide-react";
 import { useLogApplicationEventMutation } from "@/lib/applicationsApi";
 import type { ApplicationEventType } from "@/types/application-event";
+import type {
+  InterviewType,
+  InterviewDetails,
+} from "@/types/interview-details";
+import InterviewDetailsFields from "./InterviewDetailsFields";
 
 const EVENT_TYPE_OPTIONS: { value: ApplicationEventType; label: string }[] = [
   { value: "applied", label: "Applied" },
@@ -20,10 +25,22 @@ const EVENT_TYPE_OPTIONS: { value: ApplicationEventType; label: string }[] = [
   // the Gmail sync worker's lane.
 ];
 
-interface FormValues {
+const INTERVIEW_EVENT_TYPES = new Set<ApplicationEventType>([
+  "interview_scheduled",
+  "interview_completed",
+]);
+
+export interface LogEventFormValues {
   event_type: ApplicationEventType;
   occurred_at: string;
   note: string;
+  // Interview sub-form. Empty strings = "not set"; only sent to the API
+  // when event_type is an interview type AND interview_type is non-empty.
+  interview_type: InterviewType | "";
+  interview_scheduled_at: string;
+  interview_duration_minutes: string;
+  interview_location_or_link: string;
+  interview_interviewer_names: string;
 }
 
 function defaultOccurredAt(): string {
@@ -32,6 +49,45 @@ function defaultOccurredAt(): string {
   const tzOffsetMs = now.getTimezoneOffset() * 60_000;
   const local = new Date(now.getTime() - tzOffsetMs);
   return local.toISOString().slice(0, 16);
+}
+
+function emptyFormValues(): LogEventFormValues {
+  return {
+    event_type: "applied",
+    occurred_at: defaultOccurredAt(),
+    note: "",
+    interview_type: "",
+    interview_scheduled_at: "",
+    interview_duration_minutes: "",
+    interview_location_or_link: "",
+    interview_interviewer_names: "",
+  };
+}
+
+function buildInterviewDetails(values: LogEventFormValues): InterviewDetails | null {
+  if (!INTERVIEW_EVENT_TYPES.has(values.event_type)) return null;
+  if (!values.interview_type) return null;
+
+  const names = values.interview_interviewer_names
+    .split("\n")
+    .map((n) => n.trim())
+    .filter((n) => n.length > 0);
+
+  const details: InterviewDetails = { type: values.interview_type };
+  if (values.interview_scheduled_at) {
+    details.scheduled_at = new Date(values.interview_scheduled_at).toISOString();
+  }
+  if (values.interview_duration_minutes) {
+    const n = Number(values.interview_duration_minutes);
+    if (Number.isFinite(n) && n > 0) details.duration_minutes = n;
+  }
+  if (values.interview_location_or_link.trim()) {
+    details.location_or_link = values.interview_location_or_link.trim();
+  }
+  if (names.length > 0) {
+    details.interviewer_names = names;
+  }
+  return details;
 }
 
 export interface LogEventDialogProps {
@@ -48,19 +104,19 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
     handleSubmit,
     formState: { errors },
     reset,
-  } = useForm<FormValues>({
-    defaultValues: {
-      event_type: "applied",
-      occurred_at: defaultOccurredAt(),
-      note: "",
-    },
+    watch,
+  } = useForm<LogEventFormValues>({
+    defaultValues: emptyFormValues(),
   });
 
+  const eventType = watch("event_type");
+  const showInterviewFields = INTERVIEW_EVENT_TYPES.has(eventType);
+
   useEffect(() => {
-    if (!open) reset({ event_type: "applied", occurred_at: defaultOccurredAt(), note: "" });
+    if (!open) reset(emptyFormValues());
   }, [open, reset]);
 
-  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+  const onSubmit: SubmitHandler<LogEventFormValues> = async (values) => {
     try {
       // datetime-local is naive; promote to UTC ISO so the backend stores
       // a tz-aware datetime.
@@ -72,6 +128,7 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
           occurred_at: occurredIso,
           source: "manual",
           note: values.note.trim() || null,
+          interview_details: buildInterviewDetails(values),
         },
       }).unwrap();
       showSuccess("Event logged");
@@ -100,10 +157,11 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
 
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
             <div>
-              <label className="block text-sm font-medium mb-1">
+              <label htmlFor="log-event-type" className="block text-sm font-medium mb-1">
                 Event <span className="text-destructive">*</span>
               </label>
               <select
+                id="log-event-type"
                 {...register("event_type", { required: true })}
                 className="w-full border rounded-md px-3 py-2 text-sm bg-background"
               >
@@ -114,10 +172,11 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
             </div>
 
             <div>
-              <label className="block text-sm font-medium mb-1">
+              <label htmlFor="log-event-when" className="block text-sm font-medium mb-1">
                 When <span className="text-destructive">*</span>
               </label>
               <input
+                id="log-event-when"
                 type="datetime-local"
                 {...register("occurred_at", { required: "Date is required" })}
                 className="w-full border rounded-md px-3 py-2 text-sm bg-background"
@@ -127,9 +186,14 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
               ) : null}
             </div>
 
+            {showInterviewFields ? (
+              <InterviewDetailsFields register={register} errors={errors} />
+            ) : null}
+
             <div>
-              <label className="block text-sm font-medium mb-1">Note</label>
+              <label htmlFor="log-event-note" className="block text-sm font-medium mb-1">Note</label>
               <textarea
+                id="log-event-note"
                 {...register("note")}
                 rows={3}
                 className="w-full border rounded-md px-3 py-2 text-sm bg-background"

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/InterviewDetailsSummary.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/InterviewDetailsSummary.test.tsx
@@ -1,0 +1,89 @@
+/**
+ * Tests for the inline InterviewDetailsSummary read-view.
+ *
+ * Covers:
+ * - Type row always renders.
+ * - Optional rows (scheduled / duration / location / interviewers) are
+ *   omitted when null/empty.
+ * - URL-shaped locations render as a clickable link; plain strings render
+ *   as text.
+ */
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import InterviewDetailsSummary from "../InterviewDetailsSummary";
+
+describe("InterviewDetailsSummary", () => {
+  it("renders only the Type row when no optional fields are set", () => {
+    render(<InterviewDetailsSummary details={{ type: "phone" }} />);
+    expect(screen.getByText(/^Type$/)).toBeInTheDocument();
+    expect(screen.getByText(/Phone/)).toBeInTheDocument();
+    expect(screen.queryByText(/Scheduled/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Duration/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Where/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/With/)).not.toBeInTheDocument();
+  });
+
+  it("renders duration when a positive number is provided", () => {
+    render(
+      <InterviewDetailsSummary
+        details={{ type: "video", duration_minutes: 60 }}
+      />,
+    );
+    expect(screen.getByText(/60 min/)).toBeInTheDocument();
+  });
+
+  it("hides duration when zero or negative", () => {
+    render(
+      <InterviewDetailsSummary
+        details={{ type: "onsite", duration_minutes: 0 }}
+      />,
+    );
+    expect(screen.queryByText(/Duration/)).not.toBeInTheDocument();
+  });
+
+  it("renders the location as a clickable link when it looks like a URL", () => {
+    render(
+      <InterviewDetailsSummary
+        details={{
+          type: "video",
+          location_or_link: "https://meet.google.com/xyz",
+        }}
+      />,
+    );
+    const link = screen.getByRole("link", { name: /meet\.google\.com/i });
+    expect(link).toHaveAttribute("href", "https://meet.google.com/xyz");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+  });
+
+  it("renders a non-URL location as plain text", () => {
+    render(
+      <InterviewDetailsSummary
+        details={{ type: "onsite", location_or_link: "123 Main St" }}
+      />,
+    );
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.getByText(/123 Main St/)).toBeInTheDocument();
+  });
+
+  it("joins interviewer names with a comma", () => {
+    render(
+      <InterviewDetailsSummary
+        details={{
+          type: "panel",
+          interviewer_names: ["Sam Smith", "Alex Kim", "Jordan Lee"],
+        }}
+      />,
+    );
+    expect(screen.getByText(/Sam Smith, Alex Kim, Jordan Lee/)).toBeInTheDocument();
+  });
+
+  it("omits the interviewers row when the array is empty", () => {
+    render(
+      <InterviewDetailsSummary
+        details={{ type: "phone", interviewer_names: [] }}
+      />,
+    );
+    expect(screen.queryByText(/^With$/)).not.toBeInTheDocument();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/LogEventDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/LogEventDialog.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for the interview_details path in LogEventDialog.
+ *
+ * Covers:
+ * - Interview sub-form only appears when event_type is interview_*.
+ * - Submitting an interview event without picking a type shows an error.
+ * - Submitting a non-interview event sends `interview_details: null`.
+ * - Submitting a full interview event serialises the JSONB-safe payload.
+ * - Optional sub-fields are omitted when empty (no empty strings reach the API).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+const logEventMock = vi.fn();
+
+vi.mock("@/lib/applicationsApi", () => ({
+  useLogApplicationEventMutation: () => [logEventMock, { isLoading: false }],
+}));
+
+vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@radix-ui/react-dialog")>();
+  return {
+    ...actual,
+    Portal: ({ children }: { children: React.ReactNode }) => children,
+    Close: ({ asChild, children }: { asChild?: boolean; children: React.ReactNode }) => {
+      void asChild;
+      return <>{children}</>;
+    },
+  };
+});
+
+vi.mock("@platform/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@platform/ui")>();
+  return {
+    ...actual,
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    extractErrorMessage: (err: unknown) => (err as { message?: string }).message ?? "error",
+  };
+});
+
+import LogEventDialog from "../LogEventDialog";
+
+function renderDialog() {
+  return render(
+    <LogEventDialog applicationId="app-1" open={true} onOpenChange={() => {}} />,
+  );
+}
+
+describe("LogEventDialog — interview_details", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+  });
+
+  it("does not show interview fields for non-interview event types", () => {
+    renderDialog();
+    expect(screen.queryByText(/Interview details/i)).not.toBeInTheDocument();
+  });
+
+  it("reveals interview fields when the operator picks interview_scheduled", async () => {
+    renderDialog();
+    await userEvent.selectOptions(
+      screen.getByLabelText(/^Event/i),
+      "interview_scheduled",
+    );
+    expect(screen.getByText(/Interview details/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Type/i)).toBeInTheDocument();
+  });
+
+  it("hides interview fields again when switching back to a non-interview type", async () => {
+    renderDialog();
+    const eventSelect = screen.getByLabelText(/^Event/i);
+    await userEvent.selectOptions(eventSelect, "interview_scheduled");
+    expect(screen.getByText(/Interview details/i)).toBeInTheDocument();
+    await userEvent.selectOptions(eventSelect, "applied");
+    expect(screen.queryByText(/Interview details/i)).not.toBeInTheDocument();
+  });
+
+  it("sends interview_details: null on non-interview events", async () => {
+    renderDialog();
+    // Default event_type is "applied"; just submit.
+    await userEvent.click(screen.getByRole("button", { name: /Log event/i }));
+    expect(logEventMock).toHaveBeenCalledTimes(1);
+    const arg = logEventMock.mock.calls[0][0];
+    expect(arg.body.event_type).toBe("applied");
+    expect(arg.body.interview_details).toBeNull();
+  });
+
+  it("blocks submit on an interview event when type is unset", async () => {
+    renderDialog();
+    await userEvent.selectOptions(
+      screen.getByLabelText(/^Event/i),
+      "interview_scheduled",
+    );
+    await userEvent.click(screen.getByRole("button", { name: /Log event/i }));
+    expect(logEventMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/Pick the interview type/i)).toBeInTheDocument();
+  });
+
+  it("submits a full interview payload with only the non-empty optional fields", async () => {
+    renderDialog();
+
+    await userEvent.selectOptions(
+      screen.getByLabelText(/^Event/i),
+      "interview_scheduled",
+    );
+    await userEvent.selectOptions(screen.getByLabelText(/Type/i), "video");
+    await userEvent.type(
+      screen.getByLabelText(/Duration/i),
+      "45",
+    );
+    await userEvent.type(
+      screen.getByLabelText(/Location or link/i),
+      "https://meet.google.com/abc-def-ghi",
+    );
+    await userEvent.type(
+      screen.getByLabelText(/Interviewer names/i),
+      "Alex Kim\nJordan Lee\n  \n",
+    );
+
+    await userEvent.click(screen.getByRole("button", { name: /Log event/i }));
+
+    expect(logEventMock).toHaveBeenCalledTimes(1);
+    const body = logEventMock.mock.calls[0][0].body;
+    expect(body.event_type).toBe("interview_scheduled");
+    expect(body.interview_details).toEqual({
+      type: "video",
+      duration_minutes: 45,
+      location_or_link: "https://meet.google.com/abc-def-ghi",
+      interviewer_names: ["Alex Kim", "Jordan Lee"],
+    });
+    // Untouched sub-field (scheduled_at) must be omitted, not sent as "".
+    expect(body.interview_details).not.toHaveProperty("scheduled_at");
+  });
+
+  it("rejects a duration outside the 1..1440 range", async () => {
+    renderDialog();
+    await userEvent.selectOptions(
+      screen.getByLabelText(/^Event/i),
+      "interview_completed",
+    );
+    await userEvent.selectOptions(screen.getByLabelText(/Type/i), "onsite");
+    await userEvent.type(screen.getByLabelText(/Duration/i), "9999");
+    await userEvent.click(screen.getByRole("button", { name: /Log event/i }));
+    expect(logEventMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/Between 1 and 1440/i)).toBeInTheDocument();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/applications/sections/EventListItem.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/EventListItem.tsx
@@ -1,0 +1,89 @@
+import { Badge } from "@platform/ui";
+import InterviewDetailsSummary from "@/features/applications/InterviewDetailsSummary";
+import type {
+  ApplicationEvent,
+  ApplicationEventType,
+} from "@/types/application-event";
+
+const EVENT_LABELS: Record<ApplicationEventType, string> = {
+  applied: "Applied",
+  email_received: "Email received",
+  interview_scheduled: "Interview scheduled",
+  interview_completed: "Interview completed",
+  rejected: "Rejected",
+  offer_received: "Offer received",
+  withdrawn: "Withdrawn",
+  ghosted: "Ghosted",
+  note_added: "Note",
+  follow_up_sent: "Follow-up sent",
+};
+
+const EVENT_BADGE_COLOR: Record<
+  ApplicationEventType,
+  "gray" | "blue" | "yellow" | "green" | "red" | "purple"
+> = {
+  applied: "blue",
+  email_received: "gray",
+  interview_scheduled: "yellow",
+  interview_completed: "yellow",
+  rejected: "red",
+  offer_received: "green",
+  withdrawn: "gray",
+  ghosted: "gray",
+  note_added: "purple",
+  follow_up_sent: "blue",
+};
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString();
+}
+
+interface InterviewBlockProps {
+  event: ApplicationEvent;
+}
+
+function InterviewBlock({ event }: InterviewBlockProps) {
+  if (!event.interview_details) return null;
+  return <InterviewDetailsSummary details={event.interview_details} />;
+}
+
+interface NoteBlockProps {
+  note: string | null;
+}
+
+function NoteBlock({ note }: NoteBlockProps) {
+  if (!note) return null;
+  return <p className="text-sm mt-2 whitespace-pre-wrap">{note}</p>;
+}
+
+interface SourceBlockProps {
+  source: ApplicationEvent["source"];
+}
+
+function SourceBlock({ source }: SourceBlockProps) {
+  if (source === "manual") return null;
+  return <p className="text-xs text-muted-foreground mt-1">via {source}</p>;
+}
+
+interface Props {
+  event: ApplicationEvent;
+}
+
+export default function EventListItem({ event }: Props) {
+  return (
+    <li className="border rounded-lg p-3 bg-muted/20">
+      <div className="flex items-center justify-between gap-2">
+        <Badge
+          label={EVENT_LABELS[event.event_type]}
+          color={EVENT_BADGE_COLOR[event.event_type]}
+        />
+        <span className="text-xs text-muted-foreground">
+          {formatDate(event.occurred_at)}
+        </span>
+      </div>
+      <InterviewBlock event={event} />
+      <NoteBlock note={event.note} />
+      <SourceBlock source={event.source} />
+    </li>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/applications/sections/EventsSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/EventsSection.tsx
@@ -7,46 +7,12 @@
  */
 import { useState } from "react";
 import { Plus } from "lucide-react";
-import { Badge } from "@platform/ui";
 import LogEventDialog from "@/features/applications/LogEventDialog";
+import EventListItem from "./EventListItem";
 import { useListApplicationEventsQuery } from "@/lib/applicationsApi";
-import type { ApplicationEventType } from "@/types/application-event";
-
-const EVENT_LABELS: Record<ApplicationEventType, string> = {
-  applied: "Applied",
-  email_received: "Email received",
-  interview_scheduled: "Interview scheduled",
-  interview_completed: "Interview completed",
-  rejected: "Rejected",
-  offer_received: "Offer received",
-  withdrawn: "Withdrawn",
-  ghosted: "Ghosted",
-  note_added: "Note",
-  follow_up_sent: "Follow-up sent",
-};
-
-const EVENT_BADGE_COLOR: Record<
-  ApplicationEventType,
-  "gray" | "blue" | "yellow" | "green" | "red" | "purple"
-> = {
-  applied: "blue",
-  email_received: "gray",
-  interview_scheduled: "yellow",
-  interview_completed: "yellow",
-  rejected: "red",
-  offer_received: "green",
-  withdrawn: "gray",
-  ghosted: "gray",
-  note_added: "purple",
-  follow_up_sent: "blue",
-};
 
 interface EventsSectionProps {
   applicationId: string;
-}
-
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleString();
 }
 
 export default function EventsSection({ applicationId }: EventsSectionProps) {
@@ -77,23 +43,7 @@ export default function EventsSection({ applicationId }: EventsSectionProps) {
       ) : (
         <ol className="space-y-2">
           {events.map((event) => (
-            <li key={event.id} className="border rounded-lg p-3 bg-muted/20">
-              <div className="flex items-center justify-between gap-2">
-                <Badge
-                  label={EVENT_LABELS[event.event_type]}
-                  color={EVENT_BADGE_COLOR[event.event_type]}
-                />
-                <span className="text-xs text-muted-foreground">
-                  {formatDate(event.occurred_at)}
-                </span>
-              </div>
-              {event.note ? (
-                <p className="text-sm mt-2 whitespace-pre-wrap">{event.note}</p>
-              ) : null}
-              {event.source !== "manual" ? (
-                <p className="text-xs text-muted-foreground mt-1">via {event.source}</p>
-              ) : null}
-            </li>
+            <EventListItem key={event.id} event={event} />
           ))}
         </ol>
       )}

--- a/apps/myjobhunter/frontend/src/types/application-event-create-request.ts
+++ b/apps/myjobhunter/frontend/src/types/application-event-create-request.ts
@@ -1,12 +1,17 @@
 import type { ApplicationEventType, ApplicationEventSource } from "./application-event";
+import type { InterviewDetails } from "./interview-details";
 
 /**
  * Body for POST /applications/{id}/events. Mirrors `ApplicationEventCreateRequest`
  * in apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py.
+ *
+ * `interview_details` is only valid when `event_type` is `interview_scheduled`
+ * or `interview_completed`; the backend rejects other combinations with 422.
  */
 export interface ApplicationEventCreateRequest {
   event_type: ApplicationEventType;
   occurred_at: string;
   source?: ApplicationEventSource;
   note?: string | null;
+  interview_details?: InterviewDetails | null;
 }

--- a/apps/myjobhunter/frontend/src/types/application-event.ts
+++ b/apps/myjobhunter/frontend/src/types/application-event.ts
@@ -3,6 +3,8 @@
  * Mirrors `ApplicationEventResponse` in
  * apps/myjobhunter/backend/app/schemas/application/application_event_response.py.
  */
+import type { InterviewDetails } from "./interview-details";
+
 export type ApplicationEventType =
   | "applied"
   | "email_received"
@@ -31,6 +33,7 @@ export interface ApplicationEvent {
   source: ApplicationEventSource;
   email_message_id: string | null;
   raw_payload: Record<string, unknown> | null;
+  interview_details: InterviewDetails | null;
   note: string | null;
   created_at: string;
 }

--- a/apps/myjobhunter/frontend/src/types/interview-details.ts
+++ b/apps/myjobhunter/frontend/src/types/interview-details.ts
@@ -1,0 +1,19 @@
+/**
+ * Structured interview metadata stored on application_events.
+ *
+ * Mirrors `InterviewDetailsRequest` and the JSONB `interview_details` column
+ * in apps/myjobhunter/backend/app/schemas/application/application_event_create_request.py
+ * and apps/myjobhunter/backend/app/models/application/application_event.py.
+ *
+ * `type` is the only required field; the rest are best-effort metadata the
+ * operator may not yet know at logging time.
+ */
+export type InterviewType = "phone" | "video" | "onsite" | "panel";
+
+export interface InterviewDetails {
+  type: InterviewType;
+  scheduled_at?: string | null;
+  duration_minutes?: number | null;
+  location_or_link?: string | null;
+  interviewer_names?: string[] | null;
+}


### PR DESCRIPTION
## Summary

Frontend half of the interview-details feature shipped backend-side in #721. The operator can now log structured interview metadata from the Application drawer, and the events list renders it inline.

- **Types** — new `InterviewType` union (phone/video/onsite/panel) + `InterviewDetails` shape in `types/interview-details.ts`. `ApplicationEvent` and `ApplicationEventCreateRequest` carry the new field, matching the backend response/request shapes byte-for-byte.
- **LogEventDialog** — reveals an `InterviewDetailsFields` sub-form when the operator picks `interview_scheduled` / `interview_completed`. `type` is required; `scheduled_at`, `duration` (1..1440 min), `location_or_link`, and `interviewer_names` (newline-separated) are best-effort. Empty optional fields are dropped before submit so the stored JSONB stays compact and the backend validator is happy.
- **EventsSection** — renders `InterviewDetailsSummary` inline under the event card. URL-shaped locations become clickable (`target="_blank"` + `rel="noopener noreferrer"`); non-URL values render as plain text. Extracted `EventListItem` so each component stays within the ≤2 ternaries-per-JSX-expression budget.
- **Tests** — 14 new unit tests, all green; full applications-suite (42 tests) still green.
- **a11y** — added `htmlFor` / `id` associations on the LogEventDialog form labels (incidental but required for screen-reader users to navigate the form).

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run src/features/applications` — 42/42 green
- [x] `npm run build` — clean (bundle warning is pre-existing)
- [ ] CI runs the full frontend pipeline

## Operational migration

None — purely frontend changes. Bundle ships with no new env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)