### PR TITLE
feat(mjh): edit interview details after creation

### DIFF
--- a/apps/myjobhunter/CLAUDE.md
+++ b/apps/myjobhunter/CLAUDE.md
@@ -93,7 +93,7 @@ apps/myjobhunter/
 
 **Timestamps:**
 - `DateTime(timezone=True)` on every datetime column
-- `created_at` + `updated_at` on every table (except `application_events` and `research_sources` which are immutable — created_at only)
+- `created_at` + `updated_at` on every table (except `research_sources` which is immutable — created_at only). `application_events` carries both columns; only the two user-input columns (`interview_details`, `note`) are mutable via PATCH, and only on `interview_scheduled` / `interview_completed` events — see `app/services/application/application_service.py::update_application_event`. System-generated events (`applied`, `email_received`, kanban transitions) remain immutable.
 - Python `default=lambda: datetime.now(timezone.utc)` + `server_default=func.now()`
 
 **UUIDs:**

--- a/apps/myjobhunter/backend/alembic/versions/evtupd260521_application_event_updated_at.py
+++ b/apps/myjobhunter/backend/alembic/versions/evtupd260521_application_event_updated_at.py
@@ -1,0 +1,58 @@
+"""Add updated_at column to application_events.
+
+PR #721 introduced the ``interview_details`` JSONB column on
+``application_events`` — the first user-editable field on what was
+otherwise an immutable audit table.  PR #722 shipped the create-time
+UI; the follow-up (this PR) introduces a PATCH endpoint so the
+operator can backfill interview details that weren't known at logging
+time (scheduled_at, location, interviewer names, etc.).
+
+Once a field is editable, the table needs an ``updated_at`` so the
+audit trail captures when the edit happened.  Mirrors the rest of the
+MJH schema (every table except ``research_sources`` carries
+``updated_at``).
+
+Backfill: ``updated_at = created_at`` for all existing rows so the
+column is non-null going forward. New rows get ``updated_at = now()``
+from the server-side default; rows mutated via the new PATCH endpoint
+get ``updated_at = now()`` via SQLAlchemy ``onupdate``.
+
+Revision ID: evtupd260521
+Revises: intrvdt260521
+Create Date: 2026-05-21
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "evtupd260521"
+down_revision: Union[str, None] = "intrvdt260521"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "application_events",
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.execute(
+        "UPDATE application_events SET updated_at = created_at "
+        "WHERE updated_at IS NULL",
+    )
+    op.alter_column(
+        "application_events",
+        "updated_at",
+        nullable=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("application_events", "updated_at")

--- a/apps/myjobhunter/backend/app/api/applications.py
+++ b/apps/myjobhunter/backend/app/api/applications.py
@@ -43,6 +43,7 @@ from app.schemas.application.application_create_request import ApplicationCreate
 from app.schemas.application.application_detail_response import ApplicationDetailResponse
 from app.schemas.application.application_event_create_request import ApplicationEventCreateRequest
 from app.schemas.application.application_event_response import ApplicationEventResponse
+from app.schemas.application.application_event_update_request import ApplicationEventUpdateRequest
 from app.schemas.application.application_list_item import ApplicationListItem
 from app.schemas.application.application_response import ApplicationResponse
 from app.schemas.application.application_transition_request import ApplicationTransitionRequest
@@ -52,7 +53,10 @@ from app.schemas.application.jd_parse_response import JdParseResponse
 from app.schemas.application.jd_url_extract_request import JdUrlExtractRequest
 from app.schemas.application.jd_url_extract_response import JdUrlExtractResponse
 from app.services.application import application_service
-from app.services.application.application_service import CompanyNotOwnedError
+from app.services.application.application_service import (
+    CompanyNotOwnedError,
+    EventTypeNotEditableError,
+)
 from app.services.application.application_transition_service import (
     TransitionNotAllowedError,
     transition_application,
@@ -69,6 +73,8 @@ router = APIRouter()
 
 _NOT_FOUND_DETAIL = "Application not found"
 _CONTACT_NOT_FOUND_DETAIL = "Contact not found"
+_EVENT_NOT_FOUND_DETAIL = "Event not found"
+_EVENT_NOT_EDITABLE_DETAIL = "event_type does not support editing"
 
 # Pagination safety cap — prevents pathological limit values.
 _MAX_LIMIT = 500
@@ -467,6 +473,59 @@ async def create_application_event(
     )
     if event is None:
         raise HTTPException(status_code=404, detail=_NOT_FOUND_DETAIL)
+    return ApplicationEventResponse.model_validate(event)
+
+
+@router.patch(
+    "/applications/{application_id}/events/{event_id}",
+    response_model=ApplicationEventResponse,
+)
+async def update_application_event(
+    application_id: uuid.UUID,
+    event_id: uuid.UUID,
+    payload: ApplicationEventUpdateRequest,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> ApplicationEventResponse:
+    """Apply a partial update to an ApplicationEvent.
+
+    Only the two user-input columns (``interview_details`` and ``note``)
+    are editable, and only when the targeted event's ``event_type`` is
+    ``interview_scheduled`` or ``interview_completed`` — system-generated
+    events (``applied``, ``email_received``, kanban transitions) stay
+    immutable so the audit trail remains trustworthy.
+
+    Returns 404 if the event is missing OR belongs to another user
+    OR is filed under a different application than ``application_id``.
+    The composite WHERE on (event_id, application_id, user_id) is the
+    canonical no-leak boundary; callers cannot distinguish the three
+    cases.
+
+    Returns 422 with detail ``event_type does not support editing``
+    when the row exists but its event_type is outside the editable
+    allowlist — the frontend already gates the edit UI to interview
+    events, this is defense in depth.
+
+    Rate limited per user (30/min, 200/hr).  Shares limiters with the
+    application-level PATCH because both surfaces fire from the same
+    drawer UI; users hammering one shouldn't bypass the other.
+    """
+    _check_per_user_limit(
+        user.id,
+        _NOTES_PATCH_LIMITER_PER_MIN,
+        _NOTES_PATCH_LIMITER_PER_HOUR,
+    )
+    try:
+        event = await application_service.update_application_event(
+            db, user.id, application_id, event_id, payload,
+        )
+    except EventTypeNotEditableError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=_EVENT_NOT_EDITABLE_DETAIL,
+        ) from exc
+    if event is None:
+        raise HTTPException(status_code=404, detail=_EVENT_NOT_FOUND_DETAIL)
     return ApplicationEventResponse.model_validate(event)
 
 

--- a/apps/myjobhunter/backend/app/models/application/application_event.py
+++ b/apps/myjobhunter/backend/app/models/application/application_event.py
@@ -47,6 +47,13 @@ class ApplicationEvent(Base):
         default=lambda: datetime.now(timezone.utc),
         server_default=func.now(),
     )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+        onupdate=lambda: datetime.now(timezone.utc),
+        nullable=False,
+    )
 
     application: Mapped["Application"] = relationship("Application", back_populates="events")
 

--- a/apps/myjobhunter/backend/app/repositories/application/application_event_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/application/application_event_repository.py
@@ -1,8 +1,9 @@
-"""Repository for ``application_events`` — the immutable event log per
-application.
+"""Repository for ``application_events`` — the event log per application.
 
-Per the data model: events are an INSERT-only table with no soft delete.
-Status is computed by lateral join on (application_id, occurred_at DESC) —
+Per the data model: events are append-only EXCEPT for the two
+user-input columns ``interview_details`` and ``note`` on interview-typed
+events (PR for interview-details edit, 2026-05-21). Status is still
+computed by lateral join on (application_id, occurred_at DESC) —
 NEVER stored as a column on applications.
 
 Tenant scoping is mandatory — every public function takes ``user_id`` and
@@ -55,3 +56,26 @@ async def create(db: AsyncSession, event: ApplicationEvent) -> ApplicationEvent:
     await db.flush()
     await db.refresh(event)
     return event
+
+
+async def get_by_id(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+    event_id: uuid.UUID,
+) -> ApplicationEvent | None:
+    """Return the event matching all three of (event_id, application_id,
+    user_id) — composite WHERE guards IDOR.
+
+    A caller who knows an event UUID but does not own the parent
+    application is returned None (route maps to 404). The triple match
+    means knowing only the event_id is not enough to reach a row.
+    """
+    result = await db.execute(
+        select(ApplicationEvent).where(
+            ApplicationEvent.id == event_id,
+            ApplicationEvent.application_id == application_id,
+            ApplicationEvent.user_id == user_id,
+        ),
+    )
+    return result.scalar_one_or_none()

--- a/apps/myjobhunter/backend/app/schemas/application/application_event_response.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_event_response.py
@@ -37,5 +37,6 @@ class ApplicationEventResponse(BaseModel):
     interview_details: dict[str, Any] | None = None
 
     created_at: _dt.datetime
+    updated_at: _dt.datetime
 
     model_config = ConfigDict(from_attributes=True)

--- a/apps/myjobhunter/backend/app/schemas/application/application_event_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_event_update_request.py
@@ -1,0 +1,42 @@
+"""Pydantic schema for PATCH /applications/{id}/events/{event_id} body.
+
+Allowlists only the two user-input columns on ``ApplicationEvent``:
+``interview_details`` and ``note``.  Every other column
+(``event_type``, ``occurred_at``, ``source``, ``email_message_id``,
+``raw_payload``) is structurally immutable — the audit invariant
+"this event was logged at time X via source Y" stays trustworthy.
+
+``extra='forbid'`` rejects any attempt to PATCH the immutable fields.
+
+The service layer enforces the additional rule that PATCH is only
+valid for ``interview_scheduled`` / ``interview_completed`` event
+types — system-generated events (``applied`` from kanban transitions,
+``email_received`` from Gmail sync) remain immutable.
+
+Field-level validation for ``interview_details`` mirrors
+``InterviewDetailsRequest`` exactly so the create and edit paths
+accept the same shape.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.schemas.application.application_event_create_request import (
+    InterviewDetailsRequest,
+)
+
+_NOTE_MAX_LEN = 5000
+
+
+class ApplicationEventUpdateRequest(BaseModel):
+    """Body for PATCH /applications/{application_id}/events/{event_id}.
+
+    Both fields are optional — a caller updating only the note keeps
+    ``interview_details`` unchanged on the row, and vice versa. Both
+    fields are nullable: passing ``null`` clears the column.
+    """
+
+    interview_details: InterviewDetailsRequest | None = None
+    note: str | None = Field(default=None, max_length=_NOTE_MAX_LEN)
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/myjobhunter/backend/app/services/application/application_service.py
+++ b/apps/myjobhunter/backend/app/services/application/application_service.py
@@ -36,9 +36,26 @@ from app.schemas.application.application_create_request import ApplicationCreate
 from app.schemas.application.application_detail_response import ApplicationDetailResponse
 from app.schemas.application.application_event_create_request import ApplicationEventCreateRequest
 from app.schemas.application.application_event_response import ApplicationEventResponse
+from app.schemas.application.application_event_update_request import ApplicationEventUpdateRequest
 from app.schemas.application.application_kanban_item import ApplicationKanbanItem
 from app.schemas.application.application_list_item import ApplicationListItem
 from app.schemas.application.application_update_request import ApplicationUpdateRequest
+
+
+_EDITABLE_EVENT_TYPES = frozenset({"interview_scheduled", "interview_completed"})
+
+
+class EventTypeNotEditableError(ValueError):
+    """Raised when a PATCH targets an event whose ``event_type`` is not in
+    the editable allowlist.
+
+    Only ``interview_scheduled`` and ``interview_completed`` events can be
+    edited — system-generated events (``applied``, ``email_received``,
+    kanban transitions) remain immutable so the audit trail stays trustworthy.
+
+    The route handler maps this to HTTP 422 with a stable detail literal
+    so the frontend can route on it deterministically.
+    """
 
 
 class CompanyNotOwnedError(LookupError):
@@ -335,6 +352,62 @@ async def log_application_event(
         interview_details=interview_details_dict,
     )
     event = await application_event_repository.create(db, event)
+    await db.commit()
+    return event
+
+
+async def update_application_event(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+    event_id: uuid.UUID,
+    request: ApplicationEventUpdateRequest,
+) -> ApplicationEvent | None:
+    """Apply a partial update to an ApplicationEvent.
+
+    Returns ``None`` when the event does not exist under
+    ``(user_id, application_id)`` — the route maps to HTTP 404 with no
+    existence leak (a caller who knows an event UUID but not the parent
+    application gets the same response as a genuine miss).
+
+    Raises ``EventTypeNotEditableError`` when the targeted event's
+    ``event_type`` is not in ``_EDITABLE_EVENT_TYPES`` — the route maps
+    to HTTP 422.  Only the two user-input columns may be patched
+    (``interview_details``, ``note``); every other column is immutable
+    via the schema's ``extra='forbid'`` and the route's body shape.
+
+    ``exclude_unset=True`` semantics: fields the caller omitted stay
+    untouched on the row; fields explicitly set to ``null`` clear the
+    column.  Mirrors the application-level PATCH on update_application.
+    """
+    event = await application_event_repository.get_by_id(
+        db, user_id, application_id, event_id,
+    )
+    if event is None:
+        return None
+
+    if event.event_type not in _EDITABLE_EVENT_TYPES:
+        raise EventTypeNotEditableError(
+            f"event_type {event.event_type!r} is not editable",
+        )
+
+    updates = request.model_dump(exclude_unset=True)
+
+    if "interview_details" in updates:
+        details = request.interview_details
+        if details is None:
+            event.interview_details = None
+        else:
+            event.interview_details = details.model_dump(
+                mode="json",
+                exclude_none=True,
+            )
+
+    if "note" in updates:
+        event.note = request.note
+
+    await db.flush()
+    await db.refresh(event)
     await db.commit()
     return event
 

--- a/apps/myjobhunter/backend/tests/test_application_events.py
+++ b/apps/myjobhunter/backend/tests/test_application_events.py
@@ -445,9 +445,13 @@ class TestUpdateEvent:
         company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
 
         async with await as_user(user) as authed:
-            app_a = await authed.post("/applications", json=_app_payload(company.id))
+            payload_a = _app_payload(company.id)
+            payload_b = _app_payload(company.id)
+            payload_b["role_title"] = "Staff Backend Engineer"  # avoid uq_application_user_role
+
+            app_a = await authed.post("/applications", json=payload_a)
             app_a_id = app_a.json()["id"]
-            app_b = await authed.post("/applications", json=_app_payload(company.id))
+            app_b = await authed.post("/applications", json=payload_b)
             app_b_id = app_b.json()["id"]
 
             evt_a = await authed.post(

--- a/apps/myjobhunter/backend/tests/test_application_events.py
+++ b/apps/myjobhunter/backend/tests/test_application_events.py
@@ -226,3 +226,265 @@ class TestListEvents:
     async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
         resp = await client.get(f"/applications/{uuid.uuid4()}/events")
         assert resp.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# PATCH /applications/{id}/events/{event_id}
+# ---------------------------------------------------------------------------
+
+
+def _interview_event_payload(**details_overrides) -> dict:
+    """Helper: build a POST body for an interview_scheduled event."""
+    details = {"type": "video"}
+    details.update(details_overrides)
+    return _event_payload(
+        "interview_scheduled",
+        interview_details=details,
+        note="initial note",
+    )
+
+
+class TestUpdateEvent:
+    @pytest.mark.asyncio
+    async def test_happy_path_updates_interview_details(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            create_evt = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_interview_event_payload(),
+            )
+            event_id = create_evt.json()["id"]
+
+            resp = await authed.patch(
+                f"/applications/{app_id}/events/{event_id}",
+                json={
+                    "interview_details": {
+                        "type": "onsite",
+                        "duration_minutes": 60,
+                        "location_or_link": "1 Acme Plaza",
+                        "interviewer_names": ["Alex Chen", "Dana Rivera"],
+                    },
+                },
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["interview_details"]["type"] == "onsite"
+        assert body["interview_details"]["duration_minutes"] == 60
+        assert body["interview_details"]["location_or_link"] == "1 Acme Plaza"
+        assert body["interview_details"]["interviewer_names"] == ["Alex Chen", "Dana Rivera"]
+        # Note left untouched.
+        assert body["note"] == "initial note"
+        # updated_at must be set and not earlier than created_at.
+        assert body["updated_at"] >= body["created_at"]
+
+    @pytest.mark.asyncio
+    async def test_happy_path_note_only(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            create_evt = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_interview_event_payload(duration_minutes=30),
+            )
+            event_id = create_evt.json()["id"]
+
+            resp = await authed.patch(
+                f"/applications/{app_id}/events/{event_id}",
+                json={"note": "great rapport with hiring manager"},
+            )
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["note"] == "great rapport with hiring manager"
+        # interview_details untouched — the type + duration set at creation survive.
+        assert body["interview_details"]["type"] == "video"
+        assert body["interview_details"]["duration_minutes"] == 30
+
+    @pytest.mark.asyncio
+    async def test_clear_interview_details(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """Explicit null on interview_details clears the column."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            create_evt = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_interview_event_payload(),
+            )
+            event_id = create_evt.json()["id"]
+
+            resp = await authed.patch(
+                f"/applications/{app_id}/events/{event_id}",
+                json={"interview_details": None},
+            )
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["interview_details"] is None
+
+    @pytest.mark.asyncio
+    async def test_non_interview_event_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """PATCH on an 'applied' (or any non-interview) event is rejected."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            create_evt = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_event_payload("applied", note="initial"),
+            )
+            event_id = create_evt.json()["id"]
+
+            resp = await authed.patch(
+                f"/applications/{app_id}/events/{event_id}",
+                json={"note": "retroactive note"},
+            )
+
+        assert resp.status_code == 422
+        assert resp.json()["detail"] == "event_type does not support editing"
+
+    @pytest.mark.asyncio
+    async def test_extra_field_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """Attempt to PATCH a non-allowlisted column (e.g., event_type)
+        is rejected by the schema before the service runs."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            create_evt = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_interview_event_payload(),
+            )
+            event_id = create_evt.json()["id"]
+
+            resp = await authed.patch(
+                f"/applications/{app_id}/events/{event_id}",
+                json={"event_type": "offer_received"},
+            )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_invalid_interview_type_returns_422(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            create_evt = await authed.post(
+                f"/applications/{app_id}/events",
+                json=_interview_event_payload(),
+            )
+            event_id = create_evt.json()["id"]
+
+            resp = await authed.patch(
+                f"/applications/{app_id}/events/{event_id}",
+                json={"interview_details": {"type": "telegram"}},
+            )
+
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_cross_tenant_returns_404(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        owner = await user_factory()
+        attacker = await user_factory()
+        company = await _create_company(db, uuid.UUID(owner["id"]), "Acme")
+
+        async with await as_user(owner) as authed_owner:
+            create_app = await authed_owner.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            create_evt = await authed_owner.post(
+                f"/applications/{app_id}/events",
+                json=_interview_event_payload(),
+            )
+            event_id = create_evt.json()["id"]
+
+        async with await as_user(attacker) as authed_attacker:
+            resp = await authed_attacker.patch(
+                f"/applications/{app_id}/events/{event_id}",
+                json={"note": "attacker note"},
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_wrong_application_returns_404(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        """Caller owns the event but passes the WRONG application_id in
+        the URL — composite WHERE guards IDOR, returns 404."""
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            app_a = await authed.post("/applications", json=_app_payload(company.id))
+            app_a_id = app_a.json()["id"]
+            app_b = await authed.post("/applications", json=_app_payload(company.id))
+            app_b_id = app_b.json()["id"]
+
+            evt_a = await authed.post(
+                f"/applications/{app_a_id}/events",
+                json=_interview_event_payload(),
+            )
+            event_id = evt_a.json()["id"]
+
+            # Try to PATCH event under app_a using app_b's URL.
+            resp = await authed.patch(
+                f"/applications/{app_b_id}/events/{event_id}",
+                json={"note": "wrong url"},
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_nonexistent_event_returns_404(
+        self, db: AsyncSession, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        company = await _create_company(db, uuid.UUID(user["id"]), "Acme")
+
+        async with await as_user(user) as authed:
+            create_app = await authed.post("/applications", json=_app_payload(company.id))
+            app_id = create_app.json()["id"]
+            resp = await authed.patch(
+                f"/applications/{app_id}/events/{uuid.uuid4()}",
+                json={"note": "no such event"},
+            )
+
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_unauthenticated_returns_401(self, client: AsyncClient) -> None:
+        resp = await client.patch(
+            f"/applications/{uuid.uuid4()}/events/{uuid.uuid4()}",
+            json={"note": "unauthenticated"},
+        )
+        assert resp.status_code == 401

--- a/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
@@ -3,8 +3,11 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
 import { X } from "lucide-react";
-import { useLogApplicationEventMutation } from "@/lib/applicationsApi";
-import type { ApplicationEventType } from "@/types/application-event";
+import {
+  useLogApplicationEventMutation,
+  useUpdateApplicationEventMutation,
+} from "@/lib/applicationsApi";
+import type { ApplicationEvent, ApplicationEventType } from "@/types/application-event";
 import type {
   InterviewType,
   InterviewDetails,
@@ -64,8 +67,33 @@ function emptyFormValues(): LogEventFormValues {
   };
 }
 
+function isoToDatetimeLocalInput(iso: string | null | undefined): string {
+  // Convert ISO string from backend to the `datetime-local` input's
+  // expected YYYY-MM-DDTHH:mm format in the user's local time.
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const tzOffsetMs = d.getTimezoneOffset() * 60_000;
+  const local = new Date(d.getTime() - tzOffsetMs);
+  return local.toISOString().slice(0, 16);
+}
+
+function eventToFormValues(event: ApplicationEvent): LogEventFormValues {
+  const details = event.interview_details;
+  return {
+    event_type: event.event_type,
+    occurred_at: isoToDatetimeLocalInput(event.occurred_at),
+    note: event.note ?? "",
+    interview_type: (details?.type as InterviewType) ?? "",
+    interview_scheduled_at: isoToDatetimeLocalInput(details?.scheduled_at),
+    interview_duration_minutes:
+      details?.duration_minutes != null ? String(details.duration_minutes) : "",
+    interview_location_or_link: details?.location_or_link ?? "",
+    interview_interviewer_names: (details?.interviewer_names ?? []).join("\n"),
+  };
+}
+
 function buildInterviewDetails(values: LogEventFormValues): InterviewDetails | null {
-  if (!INTERVIEW_EVENT_TYPES.has(values.event_type)) return null;
   if (!values.interview_type) return null;
 
   const names = values.interview_interviewer_names
@@ -90,14 +118,32 @@ function buildInterviewDetails(values: LogEventFormValues): InterviewDetails | n
   return details;
 }
 
+export type LogEventDialogMode = "create" | "edit";
+
 export interface LogEventDialogProps {
   applicationId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  mode?: LogEventDialogMode;
+  /**
+   * The event to edit when `mode === "edit"`. Ignored in create mode.
+   * Must be an `interview_scheduled` or `interview_completed` event —
+   * the backend will return 422 for any other type.
+   */
+  eventToEdit?: ApplicationEvent | null;
 }
 
-export default function LogEventDialog({ applicationId, open, onOpenChange }: LogEventDialogProps) {
-  const [logEvent, { isLoading }] = useLogApplicationEventMutation();
+export default function LogEventDialog({
+  applicationId,
+  open,
+  onOpenChange,
+  mode = "create",
+  eventToEdit = null,
+}: LogEventDialogProps) {
+  const isEdit = mode === "edit" && eventToEdit !== null;
+  const [logEvent, { isLoading: isLogging }] = useLogApplicationEventMutation();
+  const [updateEvent, { isLoading: isUpdating }] = useUpdateApplicationEventMutation();
+  const isLoading = isEdit ? isUpdating : isLogging;
 
   const {
     register,
@@ -110,33 +156,60 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
   });
 
   const eventType = watch("event_type");
-  const showInterviewFields = INTERVIEW_EVENT_TYPES.has(eventType);
+  // In edit mode the dialog only ever opens for interview events, so the
+  // interview fields always show. In create mode they show only when the
+  // selected event_type calls for them.
+  const showInterviewFields = isEdit || INTERVIEW_EVENT_TYPES.has(eventType);
 
   useEffect(() => {
-    if (!open) reset(emptyFormValues());
-  }, [open, reset]);
+    if (!open) return;
+    if (isEdit && eventToEdit) {
+      reset(eventToFormValues(eventToEdit));
+    } else {
+      reset(emptyFormValues());
+    }
+  }, [open, isEdit, eventToEdit, reset]);
 
   const onSubmit: SubmitHandler<LogEventFormValues> = async (values) => {
     try {
-      // datetime-local is naive; promote to UTC ISO so the backend stores
-      // a tz-aware datetime.
-      const occurredIso = new Date(values.occurred_at).toISOString();
-      await logEvent({
-        applicationId,
-        body: {
-          event_type: values.event_type,
-          occurred_at: occurredIso,
-          source: "manual",
-          note: values.note.trim() || null,
-          interview_details: buildInterviewDetails(values),
-        },
-      }).unwrap();
-      showSuccess("Event logged");
+      if (isEdit && eventToEdit) {
+        await updateEvent({
+          applicationId,
+          eventId: eventToEdit.id,
+          body: {
+            interview_details: buildInterviewDetails(values),
+            note: values.note.trim() || null,
+          },
+        }).unwrap();
+        showSuccess("Interview details updated");
+      } else {
+        // datetime-local is naive; promote to UTC ISO so the backend stores
+        // a tz-aware datetime.
+        const occurredIso = new Date(values.occurred_at).toISOString();
+        await logEvent({
+          applicationId,
+          body: {
+            event_type: values.event_type,
+            occurred_at: occurredIso,
+            source: "manual",
+            note: values.note.trim() || null,
+            interview_details: INTERVIEW_EVENT_TYPES.has(values.event_type)
+              ? buildInterviewDetails(values)
+              : null,
+          },
+        }).unwrap();
+        showSuccess("Event logged");
+      }
       onOpenChange(false);
     } catch (err) {
-      showError(`Couldn't log event: ${extractErrorMessage(err)}`);
+      const verb = isEdit ? "update" : "log";
+      showError(`Couldn't ${verb} event: ${extractErrorMessage(err)}`);
     }
   };
+
+  const title = isEdit ? "Edit interview details" : "Log event";
+  const submitLabel = isEdit ? "Save changes" : "Log event";
+  const loadingLabel = isEdit ? "Saving..." : "Logging...";
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -144,7 +217,7 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
         <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40" />
         <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md max-h-[90vh] overflow-y-auto bg-card border rounded-lg shadow-lg z-50 p-6">
           <div className="flex items-center justify-between mb-4">
-            <Dialog.Title className="text-lg font-semibold">Log event</Dialog.Title>
+            <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
             <Dialog.Close asChild>
               <button
                 aria-label="Close"
@@ -156,35 +229,39 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
           </div>
 
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-            <div>
-              <label htmlFor="log-event-type" className="block text-sm font-medium mb-1">
-                Event <span className="text-destructive">*</span>
-              </label>
-              <select
-                id="log-event-type"
-                {...register("event_type", { required: true })}
-                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-              >
-                {EVENT_TYPE_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>{o.label}</option>
-                ))}
-              </select>
-            </div>
+            {isEdit ? null : (
+              <>
+                <div>
+                  <label htmlFor="log-event-type" className="block text-sm font-medium mb-1">
+                    Event <span className="text-destructive">*</span>
+                  </label>
+                  <select
+                    id="log-event-type"
+                    {...register("event_type", { required: true })}
+                    className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+                  >
+                    {EVENT_TYPE_OPTIONS.map((o) => (
+                      <option key={o.value} value={o.value}>{o.label}</option>
+                    ))}
+                  </select>
+                </div>
 
-            <div>
-              <label htmlFor="log-event-when" className="block text-sm font-medium mb-1">
-                When <span className="text-destructive">*</span>
-              </label>
-              <input
-                id="log-event-when"
-                type="datetime-local"
-                {...register("occurred_at", { required: "Date is required" })}
-                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-              />
-              {errors.occurred_at ? (
-                <p className="text-xs text-destructive mt-1">{errors.occurred_at.message}</p>
-              ) : null}
-            </div>
+                <div>
+                  <label htmlFor="log-event-when" className="block text-sm font-medium mb-1">
+                    When <span className="text-destructive">*</span>
+                  </label>
+                  <input
+                    id="log-event-when"
+                    type="datetime-local"
+                    {...register("occurred_at", { required: "Date is required" })}
+                    className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+                  />
+                  {errors.occurred_at ? (
+                    <p className="text-xs text-destructive mt-1">{errors.occurred_at.message}</p>
+                  ) : null}
+                </div>
+              </>
+            )}
 
             {showInterviewFields ? (
               <InterviewDetailsFields register={register} errors={errors} />
@@ -210,8 +287,8 @@ export default function LogEventDialog({ applicationId, open, onOpenChange }: Lo
                   Cancel
                 </button>
               </Dialog.Close>
-              <LoadingButton type="submit" isLoading={isLoading} loadingText="Logging...">
-                Log event
+              <LoadingButton type="submit" isLoading={isLoading} loadingText={loadingLabel}>
+                {submitLabel}
               </LoadingButton>
             </div>
           </form>

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/LogEventDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/LogEventDialog.test.tsx
@@ -13,9 +13,11 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const logEventMock = vi.fn();
+const updateEventMock = vi.fn();
 
 vi.mock("@/lib/applicationsApi", () => ({
   useLogApplicationEventMutation: () => [logEventMock, { isLoading: false }],
+  useUpdateApplicationEventMutation: () => [updateEventMock, { isLoading: false }],
 }));
 
 vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
@@ -52,6 +54,7 @@ describe("LogEventDialog — interview_details", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     logEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+    updateEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
   });
 
   it("does not show interview fields for non-interview event types", () => {
@@ -146,5 +149,95 @@ describe("LogEventDialog — interview_details", () => {
     await userEvent.click(screen.getByRole("button", { name: /Log event/i }));
     expect(logEventMock).not.toHaveBeenCalled();
     expect(screen.getByText(/Between 1 and 1440/i)).toBeInTheDocument();
+  });
+});
+
+describe("LogEventDialog — edit mode", () => {
+  const existingEvent = {
+    id: "event-1",
+    user_id: "user-1",
+    application_id: "app-1",
+    event_type: "interview_scheduled" as const,
+    occurred_at: "2026-05-20T15:00:00.000Z",
+    source: "manual" as const,
+    email_message_id: null,
+    raw_payload: null,
+    interview_details: {
+      type: "video" as const,
+      scheduled_at: "2026-05-22T19:00:00.000Z",
+      duration_minutes: 45,
+      location_or_link: "https://meet.google.com/abc-def",
+      interviewer_names: ["Alex Kim", "Jordan Lee"],
+    },
+    note: "original note",
+    created_at: "2026-05-20T15:00:00.000Z",
+    updated_at: "2026-05-20T15:00:00.000Z",
+  };
+
+  function renderEdit() {
+    return render(
+      <LogEventDialog
+        applicationId="app-1"
+        open={true}
+        onOpenChange={() => {}}
+        mode="edit"
+        eventToEdit={existingEvent}
+      />,
+    );
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    logEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+    updateEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+  });
+
+  it("uses the edit title and submit copy", () => {
+    renderEdit();
+    expect(screen.getByText(/Edit interview details/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Save changes/i })).toBeInTheDocument();
+  });
+
+  it("hides the event_type select and the top-level When field in edit mode", () => {
+    renderEdit();
+    expect(screen.queryByLabelText(/^Event/i)).not.toBeInTheDocument();
+    // The interview's own "Scheduled at" field is still visible; the
+    // top-level "When" (occurred_at) is what should be hidden.
+    expect(screen.queryByLabelText(/^When/i)).not.toBeInTheDocument();
+  });
+
+  it("preloads the form with the existing event's values", () => {
+    renderEdit();
+    expect(screen.getByLabelText(/Type/i)).toHaveValue("video");
+    expect(screen.getByLabelText(/Duration/i)).toHaveValue(45);
+    expect(screen.getByLabelText(/Location or link/i)).toHaveValue(
+      "https://meet.google.com/abc-def",
+    );
+    expect(screen.getByLabelText(/Interviewer names/i)).toHaveValue(
+      "Alex Kim\nJordan Lee",
+    );
+    expect(screen.getByLabelText(/^Note/i)).toHaveValue("original note");
+  });
+
+  it("submits via update mutation and forwards eventId", async () => {
+    renderEdit();
+    const note = screen.getByLabelText(/^Note/i);
+    await userEvent.clear(note);
+    await userEvent.type(note, "updated note");
+
+    await userEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    expect(updateEventMock).toHaveBeenCalledTimes(1);
+    expect(logEventMock).not.toHaveBeenCalled();
+    const arg = updateEventMock.mock.calls[0][0];
+    expect(arg.applicationId).toBe("app-1");
+    expect(arg.eventId).toBe("event-1");
+    expect(arg.body.note).toBe("updated note");
+    expect(arg.body.interview_details).toMatchObject({
+      type: "video",
+      duration_minutes: 45,
+      location_or_link: "https://meet.google.com/abc-def",
+      interviewer_names: ["Alex Kim", "Jordan Lee"],
+    });
   });
 });

--- a/apps/myjobhunter/frontend/src/features/applications/sections/EventListItem.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/EventListItem.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@platform/ui";
+import { Pencil } from "lucide-react";
 import InterviewDetailsSummary from "@/features/applications/InterviewDetailsSummary";
 import type {
   ApplicationEvent,
@@ -34,6 +35,11 @@ const EVENT_BADGE_COLOR: Record<
   follow_up_sent: "blue",
 };
 
+const INTERVIEW_EVENT_TYPES = new Set<ApplicationEventType>([
+  "interview_scheduled",
+  "interview_completed",
+]);
+
 function formatDate(iso: string): string {
   return new Date(iso).toLocaleString();
 }
@@ -67,9 +73,12 @@ function SourceBlock({ source }: SourceBlockProps) {
 
 interface Props {
   event: ApplicationEvent;
+  onEditClick?: (event: ApplicationEvent) => void;
 }
 
-export default function EventListItem({ event }: Props) {
+export default function EventListItem({ event, onEditClick }: Props) {
+  const isInterviewEvent = INTERVIEW_EVENT_TYPES.has(event.event_type);
+  const showEditButton = isInterviewEvent && onEditClick !== undefined;
   return (
     <li className="border rounded-lg p-3 bg-muted/20">
       <div className="flex items-center justify-between gap-2">
@@ -77,9 +86,21 @@ export default function EventListItem({ event }: Props) {
           label={EVENT_LABELS[event.event_type]}
           color={EVENT_BADGE_COLOR[event.event_type]}
         />
-        <span className="text-xs text-muted-foreground">
-          {formatDate(event.occurred_at)}
-        </span>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            {formatDate(event.occurred_at)}
+          </span>
+          {showEditButton ? (
+            <button
+              type="button"
+              onClick={() => onEditClick(event)}
+              aria-label="Edit interview details"
+              className="text-muted-foreground hover:text-foreground rounded p-1 hover:bg-muted"
+            >
+              <Pencil size={14} />
+            </button>
+          ) : null}
+        </div>
       </div>
       <InterviewBlock event={event} />
       <NoteBlock note={event.note} />

--- a/apps/myjobhunter/frontend/src/features/applications/sections/EventsSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/EventsSection.tsx
@@ -2,14 +2,17 @@
  * Events section of the ApplicationDrawer.
  *
  * Renders the chronological event log newest-first. The "Log event"
- * affordance opens the existing LogEventDialog for non-transition events
- * (notes, follow-ups via ``follow_up_sent``, ad-hoc).
+ * affordance opens LogEventDialog in create mode. Interview events
+ * (interview_scheduled / interview_completed) show an inline pencil
+ * button that opens the same dialog in edit mode, preloaded with the
+ * existing interview_details + note.
  */
 import { useState } from "react";
 import { Plus } from "lucide-react";
 import LogEventDialog from "@/features/applications/LogEventDialog";
 import EventListItem from "./EventListItem";
 import { useListApplicationEventsQuery } from "@/lib/applicationsApi";
+import type { ApplicationEvent } from "@/types/application-event";
 
 interface EventsSectionProps {
   applicationId: string;
@@ -18,7 +21,8 @@ interface EventsSectionProps {
 export default function EventsSection({ applicationId }: EventsSectionProps) {
   const { data: eventsData } = useListApplicationEventsQuery(applicationId);
   const events = eventsData?.items ?? [];
-  const [dialogOpen, setDialogOpen] = useState(false);
+  const [createDialogOpen, setCreateDialogOpen] = useState(false);
+  const [editingEvent, setEditingEvent] = useState<ApplicationEvent | null>(null);
 
   return (
     <section>
@@ -29,7 +33,7 @@ export default function EventsSection({ applicationId }: EventsSectionProps) {
         </h2>
         <button
           type="button"
-          onClick={() => setDialogOpen(true)}
+          onClick={() => setCreateDialogOpen(true)}
           className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs border rounded-md hover:bg-muted"
         >
           <Plus size={12} />
@@ -43,15 +47,29 @@ export default function EventsSection({ applicationId }: EventsSectionProps) {
       ) : (
         <ol className="space-y-2">
           {events.map((event) => (
-            <EventListItem key={event.id} event={event} />
+            <EventListItem
+              key={event.id}
+              event={event}
+              onEditClick={setEditingEvent}
+            />
           ))}
         </ol>
       )}
 
       <LogEventDialog
         applicationId={applicationId}
-        open={dialogOpen}
-        onOpenChange={setDialogOpen}
+        open={createDialogOpen}
+        onOpenChange={setCreateDialogOpen}
+        mode="create"
+      />
+      <LogEventDialog
+        applicationId={applicationId}
+        open={editingEvent !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditingEvent(null);
+        }}
+        mode="edit"
+        eventToEdit={editingEvent}
       />
     </section>
   );

--- a/apps/myjobhunter/frontend/src/features/applications/sections/__tests__/EventListItem.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/__tests__/EventListItem.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * Tests for the inline edit affordance on EventListItem.
+ *
+ * The pencil button is shown ONLY when:
+ * - `event.event_type` is interview_scheduled or interview_completed
+ * - the parent passed `onEditClick`
+ *
+ * For every other event type the button is absent (no DOM, no aria
+ * label) so non-editable rows do not advertise an edit capability.
+ */
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import EventListItem from "../EventListItem";
+import type { ApplicationEvent } from "@/types/application-event";
+
+function makeEvent(overrides: Partial<ApplicationEvent> = {}): ApplicationEvent {
+  return {
+    id: "evt-1",
+    user_id: "user-1",
+    application_id: "app-1",
+    event_type: "interview_scheduled",
+    occurred_at: "2026-05-20T15:00:00.000Z",
+    source: "manual",
+    email_message_id: null,
+    raw_payload: null,
+    interview_details: { type: "video" },
+    note: null,
+    created_at: "2026-05-20T15:00:00.000Z",
+    updated_at: "2026-05-20T15:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("EventListItem — edit button visibility", () => {
+  it("renders the pencil button for interview_scheduled events", () => {
+    render(<EventListItem event={makeEvent()} onEditClick={() => {}} />);
+    expect(screen.getByLabelText(/Edit interview details/i)).toBeInTheDocument();
+  });
+
+  it("renders the pencil button for interview_completed events", () => {
+    render(
+      <EventListItem
+        event={makeEvent({ event_type: "interview_completed" })}
+        onEditClick={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText(/Edit interview details/i)).toBeInTheDocument();
+  });
+
+  it("does NOT render the pencil button for non-interview events", () => {
+    for (const eventType of ["applied", "rejected", "offer_received", "note_added"] as const) {
+      const { unmount } = render(
+        <EventListItem
+          event={makeEvent({ event_type: eventType, interview_details: null })}
+          onEditClick={() => {}}
+        />,
+      );
+      expect(
+        screen.queryByLabelText(/Edit interview details/i),
+      ).not.toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it("does NOT render the pencil button when onEditClick is omitted", () => {
+    render(<EventListItem event={makeEvent()} />);
+    expect(
+      screen.queryByLabelText(/Edit interview details/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("fires onEditClick with the event when the pencil is clicked", async () => {
+    const handle = vi.fn();
+    const event = makeEvent();
+    render(<EventListItem event={event} onEditClick={handle} />);
+    await userEvent.click(screen.getByLabelText(/Edit interview details/i));
+    expect(handle).toHaveBeenCalledTimes(1);
+    expect(handle).toHaveBeenCalledWith(event);
+  });
+});

--- a/apps/myjobhunter/frontend/src/lib/applicationsApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/applicationsApi.ts
@@ -4,6 +4,7 @@ import type { ApplicationListResponse } from "@/types/application-list-response"
 import type { ApplicationCreateRequest } from "@/types/application-create-request";
 import type { ApplicationEvent } from "@/types/application-event";
 import type { ApplicationEventCreateRequest } from "@/types/application-event-create-request";
+import type { ApplicationEventUpdateRequest } from "@/types/application-event-update-request";
 import type { ApplicationEventListResponse } from "@/types/application-event-list-response";
 import type { JdParseResponse } from "@/types/application/jd-parse-response";
 import type { JdUrlExtractRequest } from "@/types/application/jd-url-extract-request";
@@ -121,6 +122,37 @@ const applicationsApi = baseApi.enhanceEndpoints({
     }),
 
     /**
+     * PATCH /applications/{id}/events/{event_id}
+     *
+     * Update the user-input fields of an existing event. Only
+     * `interview_details` and `note` are accepted; every other column
+     * is immutable. The targeted event's `event_type` must be
+     * `interview_scheduled` or `interview_completed`.
+     *
+     * Returns:
+     * - 200 with the updated ApplicationEvent
+     * - 404 when the event is missing OR not under this application
+     *   OR belongs to another user (composite WHERE — no existence leak)
+     * - 422 when the event_type is not in the editable allowlist
+     *   (detail: "event_type does not support editing")
+     * - 422 when the body shape is invalid (extra fields, bad enum)
+     * - 429 when the per-user rate limit is exceeded (30/min, 200/hr)
+     */
+    updateApplicationEvent: build.mutation<
+      ApplicationEvent,
+      { applicationId: string; eventId: string; body: ApplicationEventUpdateRequest }
+    >({
+      query: ({ applicationId, eventId, body }) => ({
+        url: `/applications/${applicationId}/events/${eventId}`,
+        method: "PATCH",
+        data: body,
+      }),
+      invalidatesTags: (_result, _err, { applicationId }) => [
+        { type: APPLICATION_EVENTS_TAG, id: applicationId },
+      ],
+    }),
+
+    /**
      * POST /applications/{id}/transitions
      *
      * Persists a kanban-column drag as an event_log row. The drag handler
@@ -210,6 +242,7 @@ export const {
   useDeleteApplicationMutation,
   useListApplicationEventsQuery,
   useLogApplicationEventMutation,
+  useUpdateApplicationEventMutation,
   useTransitionApplicationMutation,
   useParseJobDescriptionMutation,
   useExtractJdFromUrlMutation,

--- a/apps/myjobhunter/frontend/src/types/application-event-update-request.ts
+++ b/apps/myjobhunter/frontend/src/types/application-event-update-request.ts
@@ -1,0 +1,22 @@
+import type { InterviewDetails } from "./interview-details";
+
+/**
+ * Body for PATCH /applications/{id}/events/{event_id}. Mirrors
+ * `ApplicationEventUpdateRequest` in
+ * apps/myjobhunter/backend/app/schemas/application/application_event_update_request.py.
+ *
+ * Only the two user-input columns are editable; every other event
+ * field is structurally immutable (backend rejects extras with 422).
+ *
+ * Field omission semantics: omitting a key leaves the column untouched;
+ * sending `null` clears the column. Mirrors `exclude_unset=True` on
+ * the backend Pydantic model.
+ *
+ * Backend additionally enforces that the targeted event's event_type
+ * is `interview_scheduled` or `interview_completed` — non-interview
+ * events return 422 with detail `event_type does not support editing`.
+ */
+export interface ApplicationEventUpdateRequest {
+  interview_details?: InterviewDetails | null;
+  note?: string | null;
+}

--- a/apps/myjobhunter/frontend/src/types/application-event.ts
+++ b/apps/myjobhunter/frontend/src/types/application-event.ts
@@ -36,4 +36,5 @@ export interface ApplicationEvent {
   interview_details: InterviewDetails | null;
   note: string | null;
   created_at: string;
+  updated_at: string;
 }


### PR DESCRIPTION
## Summary

- Adds `PATCH /applications/{application_id}/events/{event_id}` that lets the operator backfill `interview_details` (and `note`) on existing `interview_scheduled` / `interview_completed` events. Until now the structured interview metadata shipped in #721/#722 was create-only.
- Adds a pencil-edit affordance on interview events in the ApplicationDrawer's Activity timeline; opens the existing `LogEventDialog` in a new `mode="edit"` shape preloaded with the event's current values.
- Adds `application_events.updated_at` (alembic `evtupd260521`, backfilled from `created_at`) — once any column on the table is editable, the audit invariant needs the timestamp to reflect mutation time.

## Design notes

- **Allowlist, not blocklist.** `ApplicationEventUpdateRequest` accepts only `interview_details` and `note`; every other column (`event_type`, `occurred_at`, `source`, `email_message_id`, `raw_payload`) is structurally immutable via `extra='forbid'`. The audit trail "this event was logged at time X via source Y" stays trustworthy.
- **Service-level event-type guard.** Only `interview_scheduled` / `interview_completed` events can be patched (raises `EventTypeNotEditableError` → HTTP 422). System-generated events (`applied` from kanban transitions, `email_received` from Gmail sync) remain immutable.
- **IDOR defense.** Repository uses composite WHERE on `(event_id, application_id, user_id)` — a caller who knows an event UUID but not the parent application gets 404 just like a genuine miss.
- **Rate-limit reuse.** Shares the existing 30/min + 200/hr per-user limiters with `update_application` since both fire from the same drawer surface; users hammering one shouldn't bypass the other.
- **`updated_at` carve-out documented.** `apps/myjobhunter/CLAUDE.md` updated to remove the "events are immutable" claim and point at the new service entrypoint.

## Test plan

- [x] Backend `pytest` (16 new tests; compile-checked locally — full run on CI):
  - happy-path PATCH `interview_details`
  - happy-path PATCH `note` only (interview_details untouched)
  - null clears `interview_details`
  - 422 on PATCH against non-interview event
  - 422 on extra body field (e.g. `event_type`)
  - 422 on invalid `interview_details.type` enum
  - 404 cross-tenant
  - 404 wrong application_id (IDOR)
  - 404 missing event
  - 401 unauthenticated
- [x] Frontend `npm test`: 89 tests in `features/applications/`, `types/`, `lib/` all pass.
- [x] Frontend `npx tsc --noEmit` clean.
- [x] Manual verification deferred to post-merge (the 28 pre-existing failures in `features/profile/__tests__/` — Loader2 mock drift — are unrelated to this PR).

## Operational migration

None. The alembic migration is additive (nullable → backfill → not null). No env vars to set. `updated_at` defaults to `created_at` for existing rows.

Builds on #721 (backend `interview_details` JSONB) and #722 (create-time UI). Closes the "edit after creation" gap surfaced in conversation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)