### PR TITLE
feat(mga): live preview while trimming pane clip (PR3 — pane editor)

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/PaneTrimOverlay.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/PaneTrimOverlay.test.tsx
@@ -13,7 +13,7 @@
  *     applying-state assertion can lock the component in that phase, and the
  *     error path can exercise extractError without an HTTP round-trip.
  */
-import { describe, expect, it, vi, beforeEach } from "vitest";
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 vi.mock("@/hooks/useClipDuration", () => ({
@@ -33,6 +33,19 @@ const mockedUseClipDuration = vi.mocked(useClipDuration);
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // jsdom doesn't implement HTMLMediaElement play/pause — stub so the PR3
+  // preview <video> inside TrimSliderPanel doesn't warn or throw. Same
+  // pattern as GlanceBoardTile.test.tsx.
+  vi.spyOn(window.HTMLMediaElement.prototype, "play").mockResolvedValue(
+    undefined,
+  );
+  vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(
+    () => {},
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });
 
 describe("PaneTrimOverlay", () => {
@@ -102,6 +115,29 @@ describe("PaneTrimOverlay", () => {
     expect(sliders[1]).toHaveAttribute("aria-valuenow", "5");
     expect(sliders[0]).toHaveAttribute("aria-valuemax", "5");
     expect(sliders[1]).toHaveAttribute("aria-valuemax", "5");
+  });
+
+  it("mounts a muted aria-hidden preview <video> with the clip URL when the panel opens (PR3)", () => {
+    mockedUseClipDuration.mockReturnValue(5);
+    const { container } = render(
+      <PaneTrimOverlay
+        lineupId="l1"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    // Closed → no preview video.
+    expect(container.querySelector("video")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+
+    const video = container.querySelector("video") as HTMLVideoElement;
+    expect(video).not.toBeNull();
+    expect(video.getAttribute("src")).toBe("https://ex/clip.mp4");
+    expect(video.muted).toBe(true);
+    expect(video.getAttribute("aria-hidden")).toBe("true");
   });
 
   it("Apply button is disabled when initial range is shorter than MIN_TRIM_DURATION_S", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/useTrimPreviewVideo.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/useTrimPreviewVideo.test.tsx
@@ -1,0 +1,250 @@
+/**
+ * useTrimPreviewVideo unit tests — PR3 trim-panel live preview.
+ *
+ * The hook owns a `<video>` element's lifecycle (seek + play + loop +
+ * error). We render a minimal TestHarness rather than ``renderHook`` so
+ * the returned ``videoRef`` actually attaches to a real element — the
+ * hook's effects only fire once ``videoRef.current`` is non-null.
+ *
+ * jsdom doesn't implement HTMLMediaElement.play / pause natively (they
+ * warn and return undefined), so we spy + mock both. ``currentTime`` IS
+ * implemented as a getter/setter on the prototype, so we can read it
+ * back directly to verify seek positions.
+ */
+import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render } from "@testing-library/react";
+
+import {
+  useTrimPreviewVideo,
+  type TrimPreviewThumb,
+} from "@/hooks/useTrimPreviewVideo";
+
+interface TestHarnessProps {
+  clipUrl: string;
+  startOffsetS: number;
+  endOffsetS: number;
+  activeThumb: TrimPreviewThumb;
+}
+
+/** Render the hook with a real `<video>` element so the ref attaches. */
+function TestHarness({ clipUrl, startOffsetS, endOffsetS, activeThumb }: TestHarnessProps) {
+  const { videoRef, isSeeking, hasError } = useTrimPreviewVideo({
+    clipUrl,
+    startOffsetS,
+    endOffsetS,
+    activeThumb,
+  });
+  return (
+    <>
+      <video ref={videoRef} src={clipUrl} data-testid="preview-video" />
+      <div data-testid="seeking">{String(isSeeking)}</div>
+      <div data-testid="error">{String(hasError)}</div>
+    </>
+  );
+}
+
+let playSpy: ReturnType<typeof vi.spyOn>;
+let pauseSpy: ReturnType<typeof vi.spyOn>;
+
+beforeEach(() => {
+  playSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, "play")
+    .mockResolvedValue(undefined);
+  pauseSpy = vi
+    .spyOn(window.HTMLMediaElement.prototype, "pause")
+    .mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useTrimPreviewVideo", () => {
+  // -------------------------------------------------------------------------
+  // Idle (no drag)
+  // -------------------------------------------------------------------------
+
+  it("on mount with no active thumb, seeks to startOffsetS and plays (loop)", () => {
+    const { getByTestId } = render(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={1.5}
+        endOffsetS={4}
+        activeThumb={null}
+      />,
+    );
+    const video = getByTestId("preview-video") as HTMLVideoElement;
+    expect(video.currentTime).toBe(1.5);
+    expect(playSpy).toHaveBeenCalled();
+  });
+
+  it("when timeupdate crosses endOffsetS, currentTime wraps back to startOffsetS", () => {
+    const { getByTestId } = render(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={2}
+        endOffsetS={4}
+        activeThumb={null}
+      />,
+    );
+    const video = getByTestId("preview-video") as HTMLVideoElement;
+    // Move past the end manually + fire timeupdate; the hook's listener
+    // should reset to startOffsetS.
+    video.currentTime = 4.2;
+    act(() => {
+      fireEvent(video, new Event("timeupdate"));
+    });
+    expect(video.currentTime).toBe(2);
+  });
+
+  // -------------------------------------------------------------------------
+  // Drag
+  // -------------------------------------------------------------------------
+
+  it("dragging the start thumb pauses and seeks to startOffsetS", () => {
+    const { getByTestId, rerender } = render(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={0}
+        endOffsetS={5}
+        activeThumb={null}
+      />,
+    );
+    pauseSpy.mockClear();
+
+    rerender(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={1.2}
+        endOffsetS={5}
+        activeThumb="start"
+      />,
+    );
+    const video = getByTestId("preview-video") as HTMLVideoElement;
+    expect(pauseSpy).toHaveBeenCalled();
+    expect(video.currentTime).toBe(1.2);
+  });
+
+  it("dragging the end thumb pauses and seeks to endOffsetS", () => {
+    const { getByTestId, rerender } = render(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={0}
+        endOffsetS={5}
+        activeThumb={null}
+      />,
+    );
+    pauseSpy.mockClear();
+
+    rerender(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={0}
+        endOffsetS={3.7}
+        activeThumb="end"
+      />,
+    );
+    const video = getByTestId("preview-video") as HTMLVideoElement;
+    expect(pauseSpy).toHaveBeenCalled();
+    expect(video.currentTime).toBe(3.7);
+  });
+
+  it("releasing the drag (activeThumb back to null) restarts the loop from startOffsetS", () => {
+    const { getByTestId, rerender } = render(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={0}
+        endOffsetS={5}
+        activeThumb="start"
+      />,
+    );
+    playSpy.mockClear();
+
+    rerender(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={1}
+        endOffsetS={5}
+        activeThumb={null}
+      />,
+    );
+    const video = getByTestId("preview-video") as HTMLVideoElement;
+    expect(video.currentTime).toBe(1);
+    expect(playSpy).toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Seek state surfacing
+  // -------------------------------------------------------------------------
+
+  it("isSeeking is true between `seeking` and `seeked` events", () => {
+    const { getByTestId } = render(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={0}
+        endOffsetS={5}
+        activeThumb={null}
+      />,
+    );
+    const video = getByTestId("preview-video") as HTMLVideoElement;
+    expect(getByTestId("seeking").textContent).toBe("false");
+
+    act(() => {
+      fireEvent(video, new Event("seeking"));
+    });
+    expect(getByTestId("seeking").textContent).toBe("true");
+
+    act(() => {
+      fireEvent(video, new Event("seeked"));
+    });
+    expect(getByTestId("seeking").textContent).toBe("false");
+  });
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  it("hasError flips to true when the video element fires `error`", () => {
+    const { getByTestId } = render(
+      <TestHarness
+        clipUrl="https://ex/clip.mp4"
+        startOffsetS={0}
+        endOffsetS={5}
+        activeThumb={null}
+      />,
+    );
+    const video = getByTestId("preview-video") as HTMLVideoElement;
+    expect(getByTestId("error").textContent).toBe("false");
+
+    act(() => {
+      fireEvent(video, new Event("error"));
+    });
+    expect(getByTestId("error").textContent).toBe("true");
+  });
+
+  it("hasError resets when the clipUrl prop changes (presigned URL rotation)", () => {
+    const { getByTestId, rerender } = render(
+      <TestHarness
+        clipUrl="https://ex/clip-v1.mp4"
+        startOffsetS={0}
+        endOffsetS={5}
+        activeThumb={null}
+      />,
+    );
+    const video = getByTestId("preview-video") as HTMLVideoElement;
+    act(() => {
+      fireEvent(video, new Event("error"));
+    });
+    expect(getByTestId("error").textContent).toBe("true");
+
+    rerender(
+      <TestHarness
+        clipUrl="https://ex/clip-v2.mp4"
+        startOffsetS={0}
+        endOffsetS={5}
+        activeThumb={null}
+      />,
+    );
+    expect(getByTestId("error").textContent).toBe("false");
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/lineup/PaneRangeScrubber.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/PaneRangeScrubber.tsx
@@ -33,6 +33,10 @@ interface PaneRangeScrubberProps {
   onChange: (start: number, end: number) => void;
   /** Disable interaction (e.g., during apply/error state). */
   disabled?: boolean;
+  /** Notified when the operator starts / ends a drag gesture. Used by the
+   *  preview-video hook (PR3) to switch between snap-to-thumb (drag) and
+   *  loop-between-thumbs (idle). ``null`` = idle, no thumb actively held. */
+  onThumbChange?: (thumb: "start" | "end" | null) => void;
 }
 
 type ActiveThumb = "start" | "end" | null;
@@ -45,10 +49,19 @@ export default function PaneRangeScrubber({
   step = 0.1,
   onChange,
   disabled = false,
+  onThumbChange,
 }: PaneRangeScrubberProps) {
   const trackRef = useRef<HTMLDivElement | null>(null);
   const [active, setActive] = useState<ActiveThumb>(null);
   const labelId = useId();
+
+  // Surface drag state to the parent so the preview-video hook (PR3) can
+  // distinguish "operator is scrubbing" from "operator paused, play the
+  // loop". One-line event-driven bridge keeps the existing setActive call
+  // sites unchanged.
+  useEffect(() => {
+    onThumbChange?.(active);
+  }, [active, onThumbChange]);
 
   // Drag handler — pointer events because they cover mouse + touch + stylus
   // uniformly. We listen on window during a drag so the operator can drag

--- a/apps/mygamingassistant/frontend/src/components/lineup/PaneTrimOverlay.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/PaneTrimOverlay.tsx
@@ -25,7 +25,7 @@
  * idle (each in a different corner) — that's intentional so the operator
  * sees both options on hover.
  */
-import { useEffect, useId } from "react";
+import { useEffect, useId, useState } from "react";
 import { RotateCcw, Scissors, X } from "lucide-react";
 
 import { useClipDuration } from "@/hooks/useClipDuration";
@@ -34,6 +34,10 @@ import {
   usePaneTrim,
   type TrimmablePane,
 } from "@/hooks/usePaneTrim";
+import {
+  useTrimPreviewVideo,
+  type TrimPreviewThumb,
+} from "@/hooks/useTrimPreviewVideo";
 
 import PaneRangeScrubber from "./PaneRangeScrubber";
 
@@ -101,6 +105,7 @@ export default function PaneTrimOverlay({
         startOffsetS={phase.startOffsetS}
         endOffsetS={phase.endOffsetS}
         clipDurationS={phase.clipDurationS}
+        clipUrl={clipUrl}
         onChange={updateRange}
         onApply={apply}
         onClose={close}
@@ -133,6 +138,7 @@ interface TrimSliderPanelProps {
   startOffsetS: number;
   endOffsetS: number;
   clipDurationS: number;
+  clipUrl: string;
   onChange: (start: number, end: number) => void;
   onApply: () => void;
   onClose: () => void;
@@ -143,6 +149,7 @@ function TrimSliderPanel({
   startOffsetS,
   endOffsetS,
   clipDurationS,
+  clipUrl,
   onChange,
   onApply,
   onClose,
@@ -151,6 +158,18 @@ function TrimSliderPanel({
   const duration = endOffsetS - startOffsetS;
   const canApply = duration >= MIN_TRIM_DURATION_S;
   const headerId = useId();
+
+  // Drag-aware preview (PR3). The scrubber surfaces its active-thumb state
+  // up via onThumbChange; the preview hook seeks to the active offset and
+  // pauses on drag, then loops between [start, end] when idle.
+  const [activeThumb, setActiveThumb] = useState<TrimPreviewThumb>(null);
+  const { videoRef, isSeeking, hasError } = useTrimPreviewVideo({
+    clipUrl,
+    startOffsetS,
+    endOffsetS,
+    activeThumb,
+  });
+
   return (
     <div
       role="dialog"
@@ -163,10 +182,32 @@ function TrimSliderPanel({
         type="button"
         onClick={onClose}
         aria-label="Cancel trim"
-        className="absolute top-1.5 right-1.5 p-1 rounded bg-black/60 text-white hover:bg-black/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+        className="absolute top-1.5 right-1.5 z-20 p-1 rounded bg-black/60 text-white hover:bg-black/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
       >
         <X className="w-3 h-3" aria-hidden />
       </button>
+
+      {/* Live preview (PR3). Fills the vertical space above the slider via
+          the parent's ``flex flex-col justify-end`` layout. Always rendered
+          so the ref stays attached; if the underlying clip URL fails to
+          load, the element decays to a black box and the slider remains
+          fully operable (Apply still works, just no preview).
+          ``aria-hidden`` because the slider thumbs are the semantic
+          control surface (role=slider + aria-valuenow). */}
+      <video
+        ref={videoRef}
+        src={clipUrl}
+        muted
+        playsInline
+        preload="auto"
+        aria-hidden
+        className={[
+          "w-full aspect-video object-cover rounded-sm",
+          "transition-opacity duration-100",
+          isSeeking ? "opacity-50" : "opacity-100",
+          hasError ? "invisible" : "visible",
+        ].join(" ")}
+      />
 
       <PaneRangeScrubber
         max={clipDurationS}
@@ -174,6 +215,7 @@ function TrimSliderPanel({
         endValue={endOffsetS}
         minWindow={MIN_TRIM_DURATION_S}
         onChange={onChange}
+        onThumbChange={setActiveThumb}
       />
 
       {/* Readout — selected range / clip total */}

--- a/apps/mygamingassistant/frontend/src/hooks/useTrimPreviewVideo.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/useTrimPreviewVideo.ts
@@ -115,13 +115,19 @@ export function useTrimPreviewVideo({
     if (!video || activeThumb !== null) return;
 
     video.currentTime = startOffsetS;
-    void video.play().catch(() => {
-      // Autoplay can be blocked in some browser contexts (e.g., the
-      // operator hasn't interacted with the page yet). Muted + playsInline
-      // satisfies modern autoplay policies but we still defensively
-      // swallow the rejection — the still-frame at startOffsetS remains
-      // visible, which is acceptable degradation.
-    });
+    // Modern browsers return a Promise from play() that rejects when
+    // autoplay is blocked. jsdom and some older runtimes return undefined.
+    // Defensively handle both — the still at startOffsetS remains visible
+    // either way, which is acceptable degradation when autoplay is
+    // unavailable.
+    try {
+      const playResult = video.play() as Promise<void> | undefined;
+      if (playResult && typeof playResult.catch === "function") {
+        playResult.catch(() => {});
+      }
+    } catch {
+      /* play() not implemented or threw synchronously */
+    }
 
     const onTimeUpdate = () => {
       // ``timeupdate`` fires ~4x/sec, so the loop point can overshoot the

--- a/apps/mygamingassistant/frontend/src/hooks/useTrimPreviewVideo.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/useTrimPreviewVideo.ts
@@ -1,0 +1,143 @@
+/**
+ * useTrimPreviewVideo — drive the in-panel preview video for the trim slider
+ * (PR3, follow-up to PR2 trim).
+ *
+ * The hook owns a `<video>` element that the caller renders inside the trim
+ * panel. It seeks the playhead deterministically based on the operator's drag
+ * gesture so the operator sees the new in/out point WITHOUT shipping bytes:
+ *
+ *   - **Dragging start thumb**: video pauses, seeks to ``startOffsetS``. The
+ *     operator sees a still of the proposed first frame.
+ *   - **Dragging end thumb**:   video pauses, seeks to ``endOffsetS``. Still
+ *     of the proposed last frame.
+ *   - **Idle (no drag)**:       video plays a tight loop between
+ *     ``startOffsetS`` and ``endOffsetS``. A ``timeupdate`` listener resets
+ *     ``currentTime`` whenever it crosses ``endOffsetS``.
+ *
+ * The hook is a sibling of ``useClipDuration``: both encapsulate a single
+ * `<video>` lifecycle for a single concern. ``useClipDuration`` probes
+ * detached for metadata; this one drives a DOM-mounted element for visible
+ * playback. They never share a video element — the trim panel mounts its own
+ * so the underlying ``ClipView`` video isn't perturbed.
+ *
+ * No throttle on ``currentTime`` writes — modern browsers handle short muted
+ * MP4s without stutter at typical pointermove rates. The ``isSeeking`` flag
+ * lets the panel dim the video while the browser is mid-seek, which doubles
+ * as a natural perceptual brake on fast drags.
+ */
+import type { RefObject } from "react";
+import { useEffect, useRef, useState } from "react";
+
+export type TrimPreviewThumb = "start" | "end" | null;
+
+interface UseTrimPreviewVideoArgs {
+  /** Presigned MinIO URL for the clip being trimmed. */
+  clipUrl: string;
+  /** Current start-offset in seconds (live from the trim state machine). */
+  startOffsetS: number;
+  /** Current end-offset in seconds. */
+  endOffsetS: number;
+  /** Which thumb (if any) the operator is currently dragging. ``null`` =
+   *  idle, play the loop. */
+  activeThumb: TrimPreviewThumb;
+}
+
+interface UseTrimPreviewVideoResult {
+  /** Attach to the `<video>` element rendered inside the trim panel. */
+  videoRef: RefObject<HTMLVideoElement | null>;
+  /** True while the browser is mid-seek; the caller dims the video to
+   *  signal "not ready" without obscuring the last-decoded frame. */
+  isSeeking: boolean;
+  /** True if the video failed to load (e.g., presigned URL rotated /
+   *  expired). The trim panel stays operable — the operator can still
+   *  Apply / Cancel without the preview. */
+  hasError: boolean;
+}
+
+export function useTrimPreviewVideo({
+  clipUrl,
+  startOffsetS,
+  endOffsetS,
+  activeThumb,
+}: UseTrimPreviewVideoArgs): UseTrimPreviewVideoResult {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [isSeeking, setIsSeeking] = useState(false);
+  const [hasError, setHasError] = useState(false);
+
+  // ---------------------------------------------------------------------
+  // Track seek state + error state for the lifetime of the video element.
+  // Empty deps because videoRef.current is stable across renders.
+  // ---------------------------------------------------------------------
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const onSeeking = () => setIsSeeking(true);
+    const onSeeked = () => setIsSeeking(false);
+    const onError = () => setHasError(true);
+
+    video.addEventListener("seeking", onSeeking);
+    video.addEventListener("seeked", onSeeked);
+    video.addEventListener("error", onError);
+    return () => {
+      video.removeEventListener("seeking", onSeeking);
+      video.removeEventListener("seeked", onSeeked);
+      video.removeEventListener("error", onError);
+    };
+  }, []);
+
+  // ---------------------------------------------------------------------
+  // Reset error state whenever the URL rotates (presigned-URL refresh).
+  // ---------------------------------------------------------------------
+  useEffect(() => {
+    setHasError(false);
+  }, [clipUrl]);
+
+  // ---------------------------------------------------------------------
+  // Drag: snap to the active thumb's offset, pause. Re-runs on every drag
+  // step (start/end offsets change as the operator drags).
+  // ---------------------------------------------------------------------
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || activeThumb === null) return;
+
+    video.pause();
+    video.currentTime = activeThumb === "start" ? startOffsetS : endOffsetS;
+  }, [activeThumb, startOffsetS, endOffsetS]);
+
+  // ---------------------------------------------------------------------
+  // Idle: loop between [startOffsetS, endOffsetS]. Only active when no
+  // thumb is being dragged. Restarts whenever the loop bounds change so
+  // the operator sees the new range take effect on drag release.
+  // ---------------------------------------------------------------------
+  useEffect(() => {
+    const video = videoRef.current;
+    if (!video || activeThumb !== null) return;
+
+    video.currentTime = startOffsetS;
+    void video.play().catch(() => {
+      // Autoplay can be blocked in some browser contexts (e.g., the
+      // operator hasn't interacted with the page yet). Muted + playsInline
+      // satisfies modern autoplay policies but we still defensively
+      // swallow the rejection — the still-frame at startOffsetS remains
+      // visible, which is acceptable degradation.
+    });
+
+    const onTimeUpdate = () => {
+      // ``timeupdate`` fires ~4x/sec, so the loop point can overshoot the
+      // end by up to ~250ms before we wrap. Acceptable for a preview at
+      // tile size. A finer loop would require requestAnimationFrame +
+      // currentTime polling; deferred unless we get a UX complaint.
+      if (video.currentTime >= endOffsetS) {
+        video.currentTime = startOffsetS;
+      }
+    };
+    video.addEventListener("timeupdate", onTimeUpdate);
+    return () => {
+      video.removeEventListener("timeupdate", onTimeUpdate);
+      video.pause();
+    };
+  }, [activeThumb, startOffsetS, endOffsetS]);
+
+  return { videoRef, isSeeking, hasError };
+}


### PR DESCRIPTION
## Summary

Drag-aware live preview inside the trim panel — operator sees the new in/out frames in real time as they drag the range thumbs. Closes the deferral PR2 (#724) explicitly called out: "no live preview in PR2 (deferred); the apply-then-see-result loop is sufficient for a first cut".

This is PR3 of the pane-editor track. Parents: PR1 #720 (Replace) + PR2 #724 (Trim).

## What ships

### New hook: `useTrimPreviewVideo`
- Owns a single `<video>` lifecycle inside the trim panel
- Drag start thumb → pause, seek to `startOffsetS` (still of proposed first frame)
- Drag end thumb → pause, seek to `endOffsetS` (still of proposed last frame)
- Idle (no drag) → loop between `[startOffsetS, endOffsetS]` via `timeupdate` listener
- Surfaces `isSeeking` (true between `seeking` and `seeked` events) for visual feedback
- Surfaces `hasError` so the panel stays operable when the presigned URL fails to load
- Hardened against runtimes that return `undefined` from `play()` (jsdom + older browsers)

### `PaneRangeScrubber` — new `onThumbChange` prop
- Optional callback notifies parent when drag gesture starts / ends
- One-line event-driven bridge from existing `active` state → existing setActive call sites untouched

### `TrimSliderPanel` — new preview video
- Accepts `clipUrl` from `PaneTrimOverlay`
- Tracks `activeThumb` via `useState`, passed to `PaneRangeScrubber.onThumbChange` and `useTrimPreviewVideo`
- Renders `<video>` above the slider (`flex flex-col justify-end` layout pushes controls to bottom)
- `aspect-video w-full object-cover rounded-sm` — scales naturally inside the 250×140 pane scrim
- Dims to `opacity-50` while seeking (perceptual brake, no spinner — wouldn't fit at this size)
- `aria-hidden` because the slider thumbs are the semantic control surface

### Design decisions (per g-design-ux pass)
- **New video element, not reuse `ClipView`** — `ClipView` has no forwarded ref and its IntersectionObserver lifecycle would have to be threaded through. A self-contained preview video is autonomously seekable, costs one extra decoder, and follows `useClipDuration`'s single-purpose pattern.
- **Snap+pause on drag, loop on idle** — frame-at-thumb-position is the cleanest answer to "what will my first/last frame be?". Playing a brief preview on every drag step would stutter; looping during drag adds complexity.
- **No throttle on `currentTime` writes** — modern browsers handle short muted MP4s without stutter. The `isSeeking` dimming doubles as a natural brake on fast drags.
- **Same UI for throw + landing** — landing's "interesting moment is in the middle" is operator knowledge, not UI knowledge. Looping the operator's chosen range covers both cases.
- **Mobile/responsive** — preview renders at all screen sizes (matches `ClipView` behavior). Hiding on mobile would leave the slider with a blank scrim, worse than a small preview.

### Tests
- `useTrimPreviewVideo.test.tsx` (8 tests) — idle play-from-start, loop wrap on timeupdate, drag-seek to start/end thumb, idle resume on drag release, seeking-event surface, error-event surface, hasError reset on clipUrl rotation. Uses `TestHarness` pattern so the hook's `videoRef` attaches to a real `<video>` (renderHook alone can't satisfy refs).
- `PaneTrimOverlay.test.tsx` extended with panel-mount assertion (preview `<video>` renders with clip URL, muted, aria-hidden) + adds `HTMLMediaElement.play/pause` spies in `beforeEach` (jsdom doesn't implement them; mirrors `GlanceBoardTile.test.tsx`).
- 364/364 frontend tests pass (+9 over PR2's 355 baseline); `tsc --noEmit` clean.

## Out of scope (potential follow-ups)
- **Pause underlying pane `ClipView` while panel is open** — currently the background video keeps playing under the scrim. Wasted decode but harmless. Would require threading a ref or pause callback through `PaneSlot`; skipped to keep PR3 self-contained.
- **Explicit error-state UI** — when `hasError === true` the video goes invisible but no message is shown. Slider + Apply remain operable. Add a "preview unavailable" hint if operators report confusion.

## Test plan

- [x] `npx vitest run` — 364/364 pass
- [x] `npx tsc --noEmit` — clean
- [ ] **Manual smoke (operator)**: log into the local app at http://localhost:5176/, navigate to a CS2 map with at least one accepted lineup that has a throw clip, hover the THROW pane, click the scissors icon at bottom-left.
  - [ ] Preview video appears above the slider, looping the full clip range
  - [ ] Drag the LEFT thumb right — video pauses and shows the new first frame
  - [ ] Drag the RIGHT thumb left — video pauses and shows the new last frame
  - [ ] Release a thumb — video resumes looping between the new in/out points
  - [ ] Click "Trim clip" — server-side ffmpeg cut happens, pane re-renders with the trimmed clip
  - [ ] Repeat on a LANDING pane with a landing clip
- [ ] **Manual smoke (edge)**: confirm scissors STILL hidden on STAND + AIM panes; STILL hidden on a THROW pane with `clip_url=null`; Escape still closes the open slider

Parent PRs: #720 + #724

🤖 Generated with [Claude Code](https://claude.com/claude-code)