### PR TITLE
feat(mga): wider trim-editor source via ingest + widen-source backfill (PR1 — widen source)

### DIFF
--- a/apps/mygamingassistant/backend/app/cli/__init__.py
+++ b/apps/mygamingassistant/backend/app/cli/__init__.py
@@ -6,6 +6,7 @@ Usage:
     python -m app.cli backfill-technique
     python -m app.cli backfill-landing-clips
     python -m app.cli backfill-micro-clips
+    python -m app.cli widen-source
 """
 import asyncio
 import sys
@@ -82,6 +83,32 @@ async def _run_backfill_landing_clips() -> int:
     return 1 if stats.failed else 0
 
 
+async def _run_widen_source() -> int:
+    """Widen the trim-editor source for lineups still on the legacy posture
+    (``*_url_original`` equals the tight ``*_url``). Exit code.
+
+    Idempotent — safe to re-run; only panes whose tight still equals their
+    wide are touched. Independent of the other backfills (separate columns,
+    separate work set). A non-zero exit signals at least one hard failure
+    so the operator notices (re-running retries them — they are not fatal).
+    """
+    from app.db.session import AsyncSessionLocal
+    from app.services.ingestion.widen_source_backfill import (
+        backfill_widen_source,
+    )
+
+    async with AsyncSessionLocal() as db:
+        stats = await backfill_widen_source(db)
+
+    print(stats.summary())
+    if stats.errors:
+        print(f"  {len(stats.errors)} issue(s):")
+        for err in stats.errors:
+            print(f"   - {err}")
+    # Re-runnable: failures retry next run, so a non-zero exit is advisory.
+    return 1 if stats.failed else 0
+
+
 async def _run_backfill_micro_clips() -> int:
     """Generate stand + aim micro-clips for accepted lineups missing one.
     Returns an exit code.
@@ -124,6 +151,8 @@ def main() -> None:
         sys.exit(asyncio.run(_run_backfill_landing_clips()))
     elif command == "backfill-micro-clips":
         sys.exit(asyncio.run(_run_backfill_micro_clips()))
+    elif command == "widen-source":
+        sys.exit(asyncio.run(_run_widen_source()))
     else:
         print(f"Unknown command: {command!r}")
         print("Available commands:")
@@ -132,6 +161,7 @@ def main() -> None:
         print("  backfill-technique     — name throw-technique for accepted lineups missing one")
         print("  backfill-landing-clips — generate landing clips for accepted lineups missing one")
         print("  backfill-micro-clips   — generate stand + aim micro-clips for accepted lineups missing one")
+        print("  widen-source           — replace tight=wide pairs with a wider trim-editor source")
         sys.exit(1)
 
 

--- a/apps/mygamingassistant/backend/app/core/config.py
+++ b/apps/mygamingassistant/backend/app/core/config.py
@@ -89,6 +89,21 @@ class Settings(BaseAppSettings):
     ingestion_download_dir_max_gb: int = 10
 
     # ------------------------------------------------------------------
+    # Pane-editor wide-source window (for the trim editor)
+    # ------------------------------------------------------------------
+    # Seconds of padding kept BEFORE the chapter when extracting the
+    # ``*_url_original`` source clip the trim editor reads from. The operator
+    # can drag the trim slider into this pre-chapter padding to grab frames
+    # the original ingest cut left behind (typical use: 1-2s of approach /
+    # setup that the chapter title misses).
+    clip_source_pre_seconds: float = 15.0
+    # Seconds of padding kept AFTER the chapter, symmetric to the pre-padding
+    # above. Same purpose: lets the trim editor extend past the original
+    # ingest cut. 15s mirrors the pre-padding so the editor's slider feels
+    # symmetric around the chapter.
+    clip_source_post_seconds: float = 15.0
+
+    # ------------------------------------------------------------------
     # Scheduler (PR 6+)
     # ------------------------------------------------------------------
     # Set SCHEDULER_ENABLED=false to disable the background cron entirely

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -326,15 +326,31 @@ async def set_clip_url(
     db: AsyncSession,
     lineup: Lineup,
     clip_key: str,
+    *,
+    source_key: str | None = None,
+    trim_start_s: float | None = None,
+    trim_end_s: float | None = None,
 ) -> Lineup:
     """Persist a fresh full clip onto the THROW pane (ingest + Replace path).
 
-    Writes BOTH ``clip_url`` AND ``clip_url_original`` to ``clip_key`` and
-    NULLs out the trim offset pair. A fresh upload IS the source: it starts
-    untrimmed, and the editor's slider opens with bounds = full duration.
-    The next ``set_clip_url_trim`` will overwrite only ``clip_url`` + the
-    offsets and leave ``clip_url_original`` alone so the editor can widen
-    past whatever the trim left behind (PR4 pane-editor model).
+    Two shapes, selected by the optional widening kwargs:
+
+    **Replace shape** (default — no kwargs): writes BOTH ``clip_url`` AND
+    ``clip_url_original`` to ``clip_key`` and NULLs out the trim offsets. A
+    fresh operator upload IS the source; it starts untrimmed and the editor's
+    slider opens with bounds = full duration. This is the byte-identical
+    posture from before the widen-source change.
+
+    **Widened-source shape** (``source_key`` + offsets provided): writes
+    ``clip_url=clip_key`` (the tight served clip) but ``clip_url_original=
+    source_key`` (the wider clip the trim editor reads from) and persists
+    the offsets the tight clip occupies inside the wider source. The slider
+    opens at the tight bounds already trimmed, and the operator can widen
+    the trim past those bounds without re-fetching the YouTube video.
+
+    Either shape's next ``set_clip_url_trim`` overwrites only ``clip_url`` +
+    the offsets and leaves ``clip_url_original`` alone, so the operator can
+    keep widening past previous trims (PR4 pane-editor model).
 
     Its own commit (not folded into the classifier writeback) on purpose:
     clip generation is best-effort and orthogonal to the row's validity — a
@@ -349,9 +365,39 @@ async def set_clip_url(
     presigning happens at read time in ``lineup_service._build_read``.
     """
     lineup.clip_url = clip_key
-    lineup.clip_url_original = clip_key
-    lineup.clip_trim_start_s = None
-    lineup.clip_trim_end_s = None
+    lineup.clip_url_original = source_key if source_key is not None else clip_key
+    lineup.clip_trim_start_s = trim_start_s
+    lineup.clip_trim_end_s = trim_end_s
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
+async def set_clip_url_original(
+    db: AsyncSession,
+    lineup: Lineup,
+    source_key: str,
+) -> Lineup:
+    """Persist a freshly-widened source clip onto the THROW pane (backfill).
+
+    The widen-source backfill cuts a wider clip from the chapter + padding
+    and uploads it under a distinct key from the tight ``clip_url``. Only
+    ``clip_url_original`` moves; the served tight ``clip_url`` and the trim
+    offsets stay as they were. Offsets are left NULL deliberately: the
+    backfill doesn't know where the tight clip sits inside the wider source
+    (we don't re-run Claude — see ``widen_source_backfill`` for the
+    rationale), so the slider opens at the full wide bounds and the operator
+    drags to refine. The previously-served tight bytes remain in MinIO and
+    autoplay is unchanged.
+
+    Same one-column commit posture as :func:`set_clip_url_trim` — backfill
+    is best-effort and must never roll back unrelated state.
+    """
+    lineup.clip_url_original = source_key
     try:
         await db.flush()
         await db.commit()
@@ -429,15 +475,25 @@ async def set_landing_clip_url(
     db: AsyncSession,
     lineup: Lineup,
     landing_clip_key: str,
+    *,
+    source_key: str | None = None,
+    trim_start_s: float | None = None,
+    trim_end_s: float | None = None,
 ) -> Lineup:
     """Persist a fresh full clip onto the LANDING pane (ingest + Replace path).
 
-    Writes BOTH ``landing_clip_url`` AND ``landing_clip_url_original`` to
-    ``landing_clip_key`` and NULLs out the trim offset pair — same model
-    as :func:`set_clip_url` for the throw pane. Lets the editor's trim
-    slider open with bounds = full duration on every fresh upload, while
-    preserving the source for future widen-the-trim ops via
-    :func:`set_landing_clip_url_trim` (PR4 pane-editor model).
+    Sibling to :func:`set_clip_url` — same two shapes:
+
+    **Replace shape** (default — no kwargs): writes BOTH ``landing_clip_url``
+    AND ``landing_clip_url_original`` to ``landing_clip_key`` and NULLs out
+    the trim offsets. Slider opens with bounds = full duration.
+
+    **Widened-source shape** (``source_key`` + offsets provided): writes
+    ``landing_clip_url=landing_clip_key`` (the tight served landing clip)
+    but ``landing_clip_url_original=source_key`` (wider) and persists the
+    offsets the tight clip occupies inside the wider source. Slider opens
+    at the tight bounds and the operator can widen the trim past those
+    bounds without re-fetching the YouTube video.
 
     Its own one-column commit (not folded into the throw-clip commit, the
     classifier writeback, or the technique commit) on purpose — identical
@@ -456,9 +512,34 @@ async def set_landing_clip_url(
     ``lineup_service._build_read``.
     """
     lineup.landing_clip_url = landing_clip_key
-    lineup.landing_clip_url_original = landing_clip_key
-    lineup.landing_clip_trim_start_s = None
-    lineup.landing_clip_trim_end_s = None
+    lineup.landing_clip_url_original = (
+        source_key if source_key is not None else landing_clip_key
+    )
+    lineup.landing_clip_trim_start_s = trim_start_s
+    lineup.landing_clip_trim_end_s = trim_end_s
+    try:
+        await db.flush()
+        await db.commit()
+    except Exception:
+        await db.rollback()
+        raise
+    return lineup
+
+
+async def set_landing_clip_url_original(
+    db: AsyncSession,
+    lineup: Lineup,
+    source_key: str,
+) -> Lineup:
+    """Persist a freshly-widened source clip onto the LANDING pane (backfill).
+
+    Sibling to :func:`set_clip_url_original` — identical contract,
+    independent column. Only ``landing_clip_url_original`` moves; the served
+    tight ``landing_clip_url`` and the trim offsets stay as they were.
+    Offsets stay NULL so the slider opens at the full wide bounds and the
+    operator drags to refine the landing trim.
+    """
+    lineup.landing_clip_url_original = source_key
     try:
         await db.flush()
         await db.commit()
@@ -492,6 +573,54 @@ async def set_landing_clip_url_trim(
         await db.rollback()
         raise
     return lineup
+
+
+async def list_accepted_lineups_needing_widen_source(
+    db: AsyncSession,
+) -> list[Lineup]:
+    """Accepted, ingested lineups whose trim-editor source still equals the
+    tight served clip — the widen-source backfill candidate set.
+
+    The 0015 migration backfilled ``*_url_original = *_url`` on pre-existing
+    rows so the trim editor had something to read; widen-source's job is to
+    replace those equal pairs with a wider source clip the operator can
+    drag past the tight bounds. A row qualifies if EITHER pane's tight ==
+    wide (independent panes; one or both may need widening). The operator
+    runs this once post-deploy; safe to re-run.
+
+    Filtering on equality is exactly what makes the backfill idempotent —
+    a widened pane stops matching (``clip_url_original != clip_url``) and
+    drops out of the work for that pane. Ordered oldest-first so a long
+    backfill makes monotonic progress; mirrors the other ``list_*_needing_*``
+    queries.
+
+    The ``youtube_video_id IS NOT NULL`` clause is input-modality gating
+    (per ``list_accepted_lineups_needing_clips``): manual uploads have no
+    source video to re-fetch, so a wider clip is unreachable for them.
+    """
+    stmt = (
+        select(Lineup)
+        .where(
+            Lineup.status == "accepted",
+            Lineup.youtube_video_id.is_not(None),
+            (
+                (
+                    Lineup.clip_url.is_not(None)
+                    & (Lineup.clip_url_original == Lineup.clip_url)
+                )
+                | (
+                    Lineup.landing_clip_url.is_not(None)
+                    & (
+                        Lineup.landing_clip_url_original
+                        == Lineup.landing_clip_url
+                    )
+                )
+            ),
+        )
+        .order_by(Lineup.created_at.asc())
+    )
+    result = await db.execute(stmt)
+    return list(result.scalars().all())
 
 
 async def list_accepted_lineups_needing_micro_clips(

--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
@@ -54,6 +54,10 @@ from app.services.ingestion.frame_extractor import (
     cut_clip,
     extract_frames_downscaled,
 )
+from app.services.ingestion.wide_source import (
+    cut_and_upload_wide_source,
+    tight_offsets_within_source,
+)
 from app.services.ingestion.youtube_fetcher import (
     VideoDownloadError,
     download_video,
@@ -120,6 +124,21 @@ def pending_clip_key(video_id: str, chapter_start_seconds: float) -> str:
     orphaning a new one.
     """
     return f"pending/{video_id}/{int(chapter_start_seconds)}-clip.mp4"
+
+
+def pending_clip_source_key(video_id: str, chapter_start_seconds: float) -> str:
+    """Deterministic MinIO key for a lineup's wider source clip.
+
+    Companion to :func:`pending_clip_key` — the trim editor reads from this
+    wider clip via ``clip_url_original``. Distinct key suffix (``-source``)
+    so the tight served clip and the wider trim source coexist in MinIO and
+    a backfill run overwrites only the wide one without touching the tight
+    bytes the glance board autoplays. One key per (video, chapter start)
+    matches :func:`pending_clip_key`'s idempotence — re-running the
+    widen-source backfill overwrites the same object instead of orphaning
+    a new one.
+    """
+    return f"pending/{video_id}/{int(chapter_start_seconds)}-clip-source.mp4"
 
 
 def _compute_clip_bounds(
@@ -386,12 +405,49 @@ async def generate_clip_for_lineup(
                 clip_duration=clip_duration,
             )
 
+        # ---- Cut + upload the wider trim-editor source (best-effort) ---
+        # Failure here keeps the row in the legacy posture (clip_url_original
+        # = clip_url, NULL offsets) so the tight clip is still persisted; the
+        # widen-source backfill (``python -m app.cli widen-source``) retries
+        # later. Done AFTER the tight upload so an aborted ingest (network
+        # blip during the tight upload) doesn't leave an orphan wide source
+        # for a row that has no served clip.
+        wide = await cut_and_upload_wide_source(
+            local_video=local_video,
+            video_id=video_id,
+            chapter_start=float(chapter_start),
+            chapter_end=float(chapter_end),
+            source_key=pending_clip_source_key(video_id, chapter_start),
+            log_prefix="clip_generator",
+            lineup_id=lineup.id,
+        )
+        if wide.succeeded:
+            assert wide.source_start_s is not None  # narrow for type checker
+            trim_start_s, trim_end_s = tight_offsets_within_source(
+                tight_start=clip_start,
+                tight_duration=clip_duration,
+                source_start=wide.source_start_s,
+            )
+            source_key: str | None = wide.source_key
+        else:
+            trim_start_s = trim_end_s = None
+            source_key = None
+
         try:
-            await lineup_repo.set_clip_url(db, lineup, clip_key)
+            await lineup_repo.set_clip_url(
+                db,
+                lineup,
+                clip_key,
+                source_key=source_key,
+                trim_start_s=trim_start_s,
+                trim_end_s=trim_end_s,
+            )
         except Exception as exc:
-            # The object is uploaded but the column did not commit. The key is
-            # deterministic, so a later backfill recomputes the same key and
-            # overwrites the same object — no orphan, safe to retry.
+            # The objects are uploaded but the column did not commit. The
+            # tight key is deterministic and the wide key is too (matches
+            # ``pending_clip_source_key``), so a later backfill recomputes the
+            # same keys and overwrites the same objects — no orphan, safe to
+            # retry.
             logger.warning(
                 "clip_generator: clip_url persist failed (object uploaded, "
                 "column not committed; backfill is idempotent): lineup=%s "

--- a/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
@@ -332,6 +332,37 @@ def clip_window_timestamps(
     )
 
 
+def wide_source_bounds(
+    chapter_start_seconds: float,
+    chapter_end_seconds: float,
+    *,
+    pre_seconds: float,
+    post_seconds: float,
+) -> tuple[float, float]:
+    """Bounds of the wider source clip the trim editor reads from.
+
+    The trim editor (``pane_trim_service``) cuts from ``*_url_original``, so
+    that key MUST point at a clip wide enough for the operator to drag past
+    whatever the tight ingest cut left behind. This helper computes that
+    wider window: extend the chapter symmetrically by *pre_seconds* and
+    *post_seconds*. The start is clamped at 0 (ffmpeg refuses negative
+    ``-ss``); the end is NOT clamped — ffmpeg silently truncates at the
+    real video end, so passing a slightly-long duration is safe and avoids
+    needing the video duration up front.
+
+    Used by both the ingest path (``clip_generator`` /
+    ``landing_clip_generator``) AND the backfill path
+    (``widen_source_backfill``) so the bounds are identical regardless of
+    which path generated the wide source — a backfill widen and a fresh
+    ingest widen for the same chapter produce the same clip.
+
+    Returns ``(source_start, source_duration)`` seconds.
+    """
+    source_start = max(0.0, float(chapter_start_seconds) - pre_seconds)
+    source_end = float(chapter_end_seconds) + post_seconds
+    return source_start, source_end - source_start
+
+
 def _cut_clip_sync(
     video_path: Path,
     start_seconds: float,

--- a/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
@@ -69,6 +69,10 @@ from app.services.ingestion.frame_extractor import (
     cut_clip,
     extract_frames_downscaled,
 )
+from app.services.ingestion.wide_source import (
+    cut_and_upload_wide_source,
+    tight_offsets_within_source,
+)
 from app.services.ingestion.youtube_fetcher import (
     VideoDownloadError,
     download_video,
@@ -133,6 +137,20 @@ def pending_landing_clip_key(video_id: str, chapter_start_seconds: float) -> str
     new one.
     """
     return f"pending/{video_id}/{int(chapter_start_seconds)}-landing.mp4"
+
+
+def pending_landing_clip_source_key(
+    video_id: str, chapter_start_seconds: float,
+) -> str:
+    """Deterministic MinIO key for a lineup's wider landing source clip.
+
+    Companion to :func:`pending_landing_clip_key` — the trim editor reads
+    from this wider clip via ``landing_clip_url_original``. Distinct suffix
+    (``-landing-source``) so the tight served landing clip and the wider
+    trim source coexist in MinIO and a backfill run overwrites only the
+    wide one without touching the tight bytes the glance board autoplays.
+    """
+    return f"pending/{video_id}/{int(chapter_start_seconds)}-landing-source.mp4"
 
 
 def _compute_landing_bounds(
@@ -453,12 +471,45 @@ async def _cut_upload_persist(
             clip_duration=clip_duration,
         )
 
+    # ---- Cut + upload the wider trim-editor source (best-effort) -------
+    # Mirrors clip_generator's posture: failure here keeps the row in the
+    # legacy posture (landing_clip_url_original = landing_clip_url, NULL
+    # offsets); the widen-source backfill retries later.
+    wide = await cut_and_upload_wide_source(
+        local_video=local_video,
+        video_id=video_id,
+        chapter_start=float(chapter_start),
+        chapter_end=float(chapter_end),
+        source_key=pending_landing_clip_source_key(video_id, chapter_start),
+        log_prefix="landing_clip_generator",
+        lineup_id=lineup.id,
+    )
+    if wide.succeeded:
+        assert wide.source_start_s is not None  # narrow for type checker
+        trim_start_s, trim_end_s = tight_offsets_within_source(
+            tight_start=clip_start,
+            tight_duration=clip_duration,
+            source_start=wide.source_start_s,
+        )
+        source_key: str | None = wide.source_key
+    else:
+        trim_start_s = trim_end_s = None
+        source_key = None
+
     try:
-        await lineup_repo.set_landing_clip_url(db, lineup, clip_key)
+        await lineup_repo.set_landing_clip_url(
+            db,
+            lineup,
+            clip_key,
+            source_key=source_key,
+            trim_start_s=trim_start_s,
+            trim_end_s=trim_end_s,
+        )
     except Exception as exc:
-        # The object is uploaded but the column did not commit. The key is
-        # deterministic, so a later backfill recomputes the same key and
-        # overwrites the same object — no orphan, safe to retry.
+        # The objects are uploaded but the column did not commit. Both the
+        # tight key and the wide key (``pending_landing_clip_source_key``)
+        # are deterministic, so a later backfill recomputes the same keys
+        # and overwrites the same objects — no orphan, safe to retry.
         logger.warning(
             "landing_clip_generator: landing_clip_url persist failed "
             "(object uploaded, column not committed; backfill is "

--- a/apps/mygamingassistant/backend/app/services/ingestion/wide_source.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/wide_source.py
@@ -1,0 +1,158 @@
+"""Shared cut+upload of the wider trim-editor source clip.
+
+Three callers need the same shape: (1) the throw-clip ingest path
+(:mod:`clip_generator`), (2) the landing-clip ingest path
+(:mod:`landing_clip_generator`), and (3) the standalone widen-source
+backfill (:mod:`widen_source_backfill`). All of them download or reuse the
+source video, then cut a wider clip covering ``[chapter_start - PRE_S,
+chapter_end + POST_S]`` (clamped at 0 — ffmpeg silently truncates past the
+real video end so we don't need the duration up front) and upload it under
+a deterministic key the trim editor reads via ``*_url_original``.
+
+Best-effort by contract: failure here NEVER blocks the surrounding pipeline.
+The ingest paths persist the legacy posture (``*_url_original = *_url``,
+NULL offsets) on wide failure; the widen-source backfill records the
+failure in its stats and continues to the next row. Mirrors the same
+"orthogonal to lineup validity" failure shape :func:`set_clip_url` and
+:func:`set_landing_clip_url` document at the repo layer.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from app.core.config import settings
+from app.core.storage import get_storage
+from app.services.ingestion.frame_extractor import (
+    ClipCutError,
+    cut_clip,
+    wide_source_bounds,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WideSourceResult:
+    """Outcome of a wide-source cut+upload.
+
+    On success ``source_key`` is the uploaded bare MinIO key (set into
+    ``*_url_original`` by the caller) and ``source_start_s`` /
+    ``source_duration_s`` are the bounds the wider clip was cut from in the
+    SOURCE VIDEO timeline (the caller needs ``source_start_s`` to compute
+    the tight clip's offset inside the wider source for the trim editor).
+
+    On failure all fields are ``None`` and ``error_codes`` carries the
+    structured ffmpeg/MinIO failure reason. The widen-source backfill
+    tallies these; the ingest paths log and fall back to the legacy posture
+    so the tight clip is still persisted.
+    """
+
+    source_key: Optional[str] = None
+    source_start_s: Optional[float] = None
+    source_duration_s: Optional[float] = None
+    error_codes: list[str] = None  # type: ignore[assignment]
+
+    def __post_init__(self) -> None:
+        if self.error_codes is None:
+            self.error_codes = []
+
+    @property
+    def succeeded(self) -> bool:
+        return self.source_key is not None
+
+
+async def cut_and_upload_wide_source(
+    *,
+    local_video: Path,
+    video_id: str,
+    chapter_start: float,
+    chapter_end: float,
+    source_key: str,
+    log_prefix: str,
+    lineup_id: uuid.UUID,
+) -> WideSourceResult:
+    """Cut a wider clip from *local_video* and upload it under *source_key*.
+
+    Args:
+        local_video: Already-downloaded source video on disk. The caller
+            owns its lifecycle (ingest reuses the orchestrator's download;
+            backfill manages its own one-per-video download).
+        video_id: YouTube id, for logging context only.
+        chapter_start / chapter_end: Chapter bounds (seconds). The wider
+            clip spans ``[chapter_start - settings.clip_source_pre_seconds,
+            chapter_end + settings.clip_source_post_seconds]`` clamped at 0.
+        source_key: Where to upload the wider clip (caller supplies via
+            ``pending_clip_source_key`` or ``pending_landing_clip_source_key``
+            so the key naming is owned by each pane's generator module).
+        log_prefix: Subsystem name to prefix WARNING logs (e.g.
+            ``"clip_generator"``, ``"widen-source-backfill"``).
+        lineup_id: The row this clip belongs to, for log correlation.
+
+    Returns:
+        :class:`WideSourceResult`. Never raises for an expected failure;
+        ffmpeg / MinIO errors are captured into ``error_codes``.
+    """
+    source_start, source_duration = wide_source_bounds(
+        chapter_start, chapter_end,
+        pre_seconds=settings.clip_source_pre_seconds,
+        post_seconds=settings.clip_source_post_seconds,
+    )
+
+    try:
+        source_bytes = await cut_clip(local_video, source_start, source_duration)
+    except ClipCutError as exc:
+        logger.warning(
+            "%s: wide source cut failed (best-effort; tight clip / "
+            "existing source unchanged): lineup=%s video_id=%s start=%.2f "
+            "duration=%.2f returncode=%s stderr=%s",
+            log_prefix, lineup_id, video_id, source_start, source_duration,
+            exc.returncode, exc.stderr[:300],
+        )
+        return WideSourceResult(
+            error_codes=[f"wide_source_cut:rc={exc.returncode}"],
+        )
+
+    try:
+        storage = get_storage()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, storage.upload_file, source_key, source_bytes, "video/mp4",
+        )
+    except Exception as exc:  # noqa: BLE001 — MinIO/network errors are diverse
+        logger.warning(
+            "%s: wide source upload failed (best-effort; tight clip / "
+            "existing source unchanged): lineup=%s key=%s error=%s",
+            log_prefix, lineup_id, source_key, str(exc),
+        )
+        return WideSourceResult(error_codes=["wide_source_upload_failed"])
+
+    return WideSourceResult(
+        source_key=source_key,
+        source_start_s=source_start,
+        source_duration_s=source_duration,
+    )
+
+
+def tight_offsets_within_source(
+    *,
+    tight_start: float,
+    tight_duration: float,
+    source_start: float,
+) -> tuple[float, float]:
+    """Offsets the tight clip occupies inside the wider source, in source-
+    timeline seconds.
+
+    The trim editor's slider opens at ``[trim_start_s, trim_end_s]`` inside
+    the wider ``*_url_original``. After ingest those bounds match the tight
+    served clip so the slider opens already-trimmed to what the operator
+    sees on the glance board; the operator can drag wider (into the padding)
+    or narrower from there. Returns ``(trim_start_s, trim_end_s)``.
+    """
+    trim_start_s = tight_start - source_start
+    trim_end_s = tight_start + tight_duration - source_start
+    return trim_start_s, trim_end_s

--- a/apps/mygamingassistant/backend/app/services/ingestion/widen_source_backfill.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/widen_source_backfill.py
@@ -1,0 +1,336 @@
+"""Backfill the wider trim-editor source for lineups still on the legacy
+pane-editor posture (``*_url_original`` equals the tight ``*_url``).
+
+The 0015 migration backfilled ``*_url_original = *_url`` so the trim editor
+had something to read on rows that predated the pane-editor work. That's
+correct as a floor — every trim cuts from a clip — but it gives the
+operator nothing wider than the original ingest cut. This backfill replaces
+each equal pair with a wider clip spanning the chapter + padding, so the
+operator can drag the trim past those tight bounds without re-fetching the
+YouTube video each time.
+
+End-to-end (mirrors :mod:`clip_backfill` / :mod:`landing_clip_backfill`):
+
+  1. Walk ``lineup_repo.list_accepted_lineups_needing_widen_source`` —
+     accepted, has a YouTube source, at least one pane where tight == wide.
+  2. Group by ``youtube_video_id`` so each source video is fetched +
+     downloaded ONCE (a tutorial video usually backs many lineups).
+  3. For each lineup in the video's group, look up the chapter via
+     ``parse_chapters`` (same exact-start match the other backfills use),
+     then for each pane whose tight == wide, cut the wider clip via
+     :func:`cut_and_upload_wide_source` and persist via the matching
+     ``set_*_url_original`` setter.
+  4. Offsets stay NULL deliberately — the backfill does NOT re-run Claude
+     (saves $0.016/row and an ffmpeg + upload), so it cannot place the
+     existing tight clip's window inside the wider source. The slider opens
+     at the full wide bounds and the operator drags to refine. The
+     previously-served tight bytes remain unchanged at their original key
+     and autoplay is unaffected.
+
+Idempotent by construction: a successful widen on a pane sets
+``*_url_original`` to the new key, breaking the equality the candidate
+query checks, so the pane drops out on the next run. A failed pane keeps
+the equality and is retried.
+
+Per rules/no-bandaid-solutions.md + rules/check-third-party-error-codes.md:
+every yt-dlp / ffmpeg / MinIO failure is captured with its structured
+reason and tallied — nothing silently disappears.
+"""
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.lineup import Lineup
+from app.repositories.game import lineup_repo
+from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.clip_generator import pending_clip_source_key
+from app.services.ingestion.landing_clip_generator import (
+    pending_landing_clip_source_key,
+)
+from app.services.ingestion.wide_source import cut_and_upload_wide_source
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+    download_video,
+    fetch_video_detail,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class WidenSourceBackfillStats:
+    """Aggregate outcome of a widen-source backfill run (printed by the CLI).
+
+    Counts are per-pane (not per-row), so a row with both throw and landing
+    widened contributes 2 to ``widened``. A row where only the throw needed
+    widening (landing already widened or absent) contributes 1.
+    """
+
+    total_rows: int = 0
+    widened: int = 0
+    skipped: int = 0
+    failed: int = 0
+    errors: list[str] = field(default_factory=list)
+
+    def summary(self) -> str:
+        return (
+            f"widen-source: {self.total_rows} candidate row(s) — "
+            f"{self.widened} pane(s) widened, {self.skipped} skipped, "
+            f"{self.failed} failed"
+        )
+
+
+def _find_chapter(
+    chapters: list[Chapter], start_seconds: int | None,
+) -> Chapter | None:
+    """The chapter whose start matches the lineup's stored chapter start.
+
+    Identical to :func:`clip_backfill._find_chapter` — the ingest path
+    persisted ``chapter_start_seconds`` from the same ``parse_chapters``
+    output, so an exact start match re-identifies it. A miss means the
+    video's chapters changed since ingest.
+    """
+    if start_seconds is None:
+        return None
+    for ch in chapters:
+        if ch.start_seconds == start_seconds:
+            return ch
+    return None
+
+
+def _throw_needs_widen(lineup: Lineup) -> bool:
+    """True when the throw pane's source still equals its tight clip."""
+    return (
+        lineup.clip_url is not None
+        and lineup.clip_url_original == lineup.clip_url
+    )
+
+
+def _landing_needs_widen(lineup: Lineup) -> bool:
+    """True when the landing pane's source still equals its tight clip."""
+    return (
+        lineup.landing_clip_url is not None
+        and lineup.landing_clip_url_original == lineup.landing_clip_url
+    )
+
+
+async def _widen_pane(
+    *,
+    db: AsyncSession,
+    lineup: Lineup,
+    video_path: Path,
+    chapter: Chapter,
+    pane: str,
+    stats: WidenSourceBackfillStats,
+) -> None:
+    """Widen one pane on one lineup; mutate *stats* with the outcome.
+
+    Encapsulates the per-pane cut + upload + persist tuple so the outer
+    loop reads as "for each pane that needs widening, widen it". The two
+    panes are independent: a throw failure does NOT prevent the landing
+    widen on the same row from being attempted.
+    """
+    video_id = lineup.youtube_video_id
+    assert video_id is not None  # guaranteed by the repo query
+
+    if pane == "throw":
+        source_key = pending_clip_source_key(video_id, chapter.start_seconds)
+        persist = lineup_repo.set_clip_url_original
+    elif pane == "landing":
+        source_key = pending_landing_clip_source_key(
+            video_id, chapter.start_seconds,
+        )
+        persist = lineup_repo.set_landing_clip_url_original
+    else:
+        raise ValueError(f"unknown pane {pane!r}")
+
+    wide = await cut_and_upload_wide_source(
+        local_video=video_path,
+        video_id=video_id,
+        chapter_start=float(chapter.start_seconds),
+        chapter_end=float(chapter.end_seconds),
+        source_key=source_key,
+        log_prefix="widen-source-backfill",
+        lineup_id=lineup.id,
+    )
+    if not wide.succeeded:
+        stats.failed += 1
+        stats.errors.append(
+            f"{lineup.id}[{pane}]: "
+            f"{','.join(wide.error_codes) or 'wide_source_failed'}"
+        )
+        return
+
+    try:
+        await persist(db, lineup, wide.source_key)  # type: ignore[arg-type]
+    except Exception as exc:  # noqa: BLE001 — surface any persistence error
+        logger.warning(
+            "widen-source-backfill: %s_url_original persist failed "
+            "(object uploaded, column not committed; backfill is "
+            "idempotent): lineup=%s key=%s error=%s",
+            pane, lineup.id, wide.source_key, str(exc),
+        )
+        stats.failed += 1
+        stats.errors.append(
+            f"{lineup.id}[{pane}]: persist_failed:{type(exc).__name__}"
+        )
+        return
+
+    stats.widened += 1
+
+
+async def backfill_widen_source(
+    db: AsyncSession,
+) -> WidenSourceBackfillStats:
+    """Widen the trim-editor source for every accepted ingested lineup that
+    still has ``*_url_original = *_url``.
+
+    Returns a :class:`WidenSourceBackfillStats`. Designed to be invoked once
+    by the operator post-deploy (``python -m app.cli widen-source``); safe
+    to re-run at any time — only rows whose tight still equals their wide
+    are touched.
+    """
+    stats = WidenSourceBackfillStats()
+
+    lineups = await lineup_repo.list_accepted_lineups_needing_widen_source(db)
+    stats.total_rows = len(lineups)
+    if not lineups:
+        logger.info("widen-source: nothing to do (no candidate lineups)")
+        return stats
+
+    # Group by source video so each video is fetched + downloaded ONCE.
+    by_video: dict[str, list[Lineup]] = defaultdict(list)
+    for lineup in lineups:
+        by_video[lineup.youtube_video_id].append(lineup)  # type: ignore[index]
+
+    download_dir = Path(settings.ingestion_download_dir)
+    logger.info(
+        "widen-source: %d candidate row(s) across %d video(s)",
+        stats.total_rows, len(by_video),
+    )
+
+    for video_id, video_lineups in by_video.items():
+        # ---- One metadata fetch per video ------------------------------
+        try:
+            meta = await fetch_video_detail(video_id)
+        except YouTubeFetchError as exc:
+            # Count one failure per pane that needed widening across the
+            # video's lineups — so the stats reflect actual blocked work.
+            blocked_panes = sum(
+                int(_throw_needs_widen(li)) + int(_landing_needs_widen(li))
+                for li in video_lineups
+            )
+            logger.warning(
+                "widen-source: metadata fetch failed: video_id=%s "
+                "error_type=%s message=%s — %d pane(s) blocked",
+                video_id, exc.error_type, str(exc), blocked_panes,
+            )
+            stats.failed += blocked_panes
+            stats.errors.append(
+                f"{video_id}: metadata fetch failed ({exc.error_type})"
+            )
+            continue
+
+        chapters = parse_chapters(
+            description=meta.description,
+            video_duration=meta.duration,
+            native_chapters=meta.chapters or None,
+        )
+
+        # ---- One download per video ------------------------------------
+        try:
+            video_path = await download_video(video_id, download_dir)
+        except VideoDownloadError as exc:
+            blocked_panes = sum(
+                int(_throw_needs_widen(li)) + int(_landing_needs_widen(li))
+                for li in video_lineups
+            )
+            logger.warning(
+                "widen-source: download failed: video_id=%s error_type=%s "
+                "message=%s — %d pane(s) blocked",
+                video_id, exc.error_type, str(exc), blocked_panes,
+            )
+            stats.failed += blocked_panes
+            stats.errors.append(
+                f"{video_id}: download failed ({exc.error_type})"
+            )
+            continue
+
+        try:
+            for lineup in video_lineups:
+                chapter = _find_chapter(chapters, lineup.chapter_start_seconds)
+                if chapter is None:
+                    blocked_panes = (
+                        int(_throw_needs_widen(lineup))
+                        + int(_landing_needs_widen(lineup))
+                    )
+                    logger.warning(
+                        "widen-source: chapter not found: lineup=%s "
+                        "video_id=%s chapter_start=%s — %d pane(s) skipped",
+                        lineup.id, video_id, lineup.chapter_start_seconds,
+                        blocked_panes,
+                    )
+                    stats.skipped += blocked_panes
+                    stats.errors.append(
+                        f"{video_id}[{lineup.chapter_start_seconds}]: "
+                        f"chapter not found (video changed since ingest)"
+                    )
+                    continue
+
+                # Two panes per row, independent — both attempted even if
+                # one fails. ``_widen_pane`` mutates ``stats`` directly.
+                if _throw_needs_widen(lineup):
+                    try:
+                        await _widen_pane(
+                            db=db, lineup=lineup, video_path=video_path,
+                            chapter=chapter, pane="throw", stats=stats,
+                        )
+                    except Exception as exc:  # defensive: never abort the batch
+                        logger.warning(
+                            "widen-source: unexpected error widening throw: "
+                            "lineup=%s video_id=%s error=%s",
+                            lineup.id, video_id, str(exc), exc_info=True,
+                        )
+                        stats.failed += 1
+                        stats.errors.append(
+                            f"{lineup.id}[throw]: "
+                            f"unexpected:{type(exc).__name__} {exc}"
+                        )
+
+                if _landing_needs_widen(lineup):
+                    try:
+                        await _widen_pane(
+                            db=db, lineup=lineup, video_path=video_path,
+                            chapter=chapter, pane="landing", stats=stats,
+                        )
+                    except Exception as exc:  # defensive: never abort the batch
+                        logger.warning(
+                            "widen-source: unexpected error widening landing: "
+                            "lineup=%s video_id=%s error=%s",
+                            lineup.id, video_id, str(exc), exc_info=True,
+                        )
+                        stats.failed += 1
+                        stats.errors.append(
+                            f"{lineup.id}[landing]: "
+                            f"unexpected:{type(exc).__name__} {exc}"
+                        )
+        finally:
+            # The backfill owns this download (one per video) — clean it up
+            # once, after all of the video's lineups are processed.
+            try:
+                video_path.unlink(missing_ok=True)
+            except OSError as exc:
+                logger.warning(
+                    "widen-source: failed to delete video: path=%s error=%s",
+                    video_path, str(exc),
+                )
+
+    logger.info("widen-source: complete — %s", stats.summary())
+    return stats

--- a/apps/mygamingassistant/backend/tests/test_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_generator.py
@@ -21,13 +21,30 @@ from app.services.ingestion.clip_generator import (
     _compute_clip_bounds,
     generate_clip_for_lineup,
     pending_clip_key,
+    pending_clip_source_key,
 )
 from app.services.ingestion.frame_extractor import ClipCutError, FrameExtractionError
+from app.services.ingestion.wide_source import WideSourceResult
 from app.services.ingestion.youtube_fetcher import VideoDownloadError
 
 _MOD = "app.services.ingestion.clip_generator"
 _FAKE_PNG = b"\x89PNG\r\n\x1a\n"
 _FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
+
+
+def _wide_ok(source_start=0.0, source_duration=60.0, source_key="pending/vid/0-clip-source.mp4"):
+    """A successful WideSourceResult for the cut_and_upload_wide_source mock."""
+    return WideSourceResult(
+        source_key=source_key,
+        source_start_s=source_start,
+        source_duration_s=source_duration,
+    )
+
+
+def _wide_fail():
+    """A failed WideSourceResult — best-effort failure leaves the row in the
+    legacy posture (clip_url_original = clip_url, NULL offsets)."""
+    return WideSourceResult(error_codes=["wide_source_cut:rc=1"])
 
 
 def _lineup(video_id="vid123", chapter_title="B smoke"):
@@ -83,6 +100,16 @@ def test_pending_clip_key_is_deterministic():
     assert pending_clip_key("abc", 42.9) == "pending/abc/42-clip.mp4"
 
 
+def test_pending_clip_source_key_is_deterministic_and_distinct():
+    # Same idempotency contract as the tight key, distinct suffix so the
+    # wide source and the tight clip coexist in MinIO.
+    assert pending_clip_source_key("abc", 42.0) == "pending/abc/42-clip-source.mp4"
+    assert pending_clip_source_key("abc", 42.9) == "pending/abc/42-clip-source.mp4"
+    # Tight and wide must NEVER share a key — overwriting one would destroy
+    # the other's bytes.
+    assert pending_clip_key("abc", 42.0) != pending_clip_source_key("abc", 42.0)
+
+
 # ---------------------------------------------------------------------------
 # generate_clip_for_lineup — orchestration
 # ---------------------------------------------------------------------------
@@ -122,6 +149,8 @@ class TestGenerateClipGeneratedPath:
             patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)) as mock_cut,
             patch(f"{_MOD}.get_storage", return_value=storage),
             patch(f"{_MOD}.download_video", new=AsyncMock()) as mock_dl,
+            patch(f"{_MOD}.cut_and_upload_wide_source",
+                  new=AsyncMock(return_value=_wide_fail())),
             patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()) as mock_set,
         ):
             result = await generate_clip_for_lineup(
@@ -132,6 +161,7 @@ class TestGenerateClipGeneratedPath:
         assert result.status == "generated"
         assert result.clip_key == "pending/vid123/0-clip.mp4"
         mock_dl.assert_not_awaited()  # provided video reused, no re-fetch
+        # ONE tight upload (wide is mocked out of the storage layer).
         storage.upload_file.assert_called_once()
         assert storage.upload_file.call_args[0][2] == "video/mp4"
         mock_set.assert_awaited_once()
@@ -154,6 +184,8 @@ class TestGenerateClipGeneratedPath:
             patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
             patch(f"{_MOD}.get_storage", return_value=MagicMock()),
             patch(f"{_MOD}.download_video", new=AsyncMock(return_value=fetched)) as mock_dl,
+            patch(f"{_MOD}.cut_and_upload_wide_source",
+                  new=AsyncMock(return_value=_wide_fail())),
             patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()),
         ):
             result = await generate_clip_for_lineup(
@@ -165,6 +197,103 @@ class TestGenerateClipGeneratedPath:
         mock_dl.assert_awaited_once()
         # A re-fetched (self-owned) video MUST be cleaned up.
         assert not fetched.exists()
+
+
+class TestGenerateClipWideSourceWiring:
+    """The widen-source upgrade: when the wide cut+upload succeeds, the
+    persisted ``clip_url_original`` differs from ``clip_url`` and the trim
+    offsets describe where the tight clip lives inside the wide source.
+    When it fails, the row stays in the legacy posture so the operator's
+    tight clip is unchanged. Both shapes route through ``set_clip_url``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_widened_source_persists_offsets(self, tmp_path: Path):
+        """Happy path: tight is at [release-2, result+0.5]; wide spans the
+        whole chapter + padding. set_clip_url is called with source_key +
+        the offset pair so the slider opens at the tight bounds."""
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"src")
+        wide = _wide_ok(
+            source_start=0.0,
+            source_duration=60.0,
+            source_key="pending/vid123/0-clip-source.mp4",
+        )
+
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            # 6 frames spread across [9..24]; release_index=2 → release_ts=12,
+            # result_index=4 → result_ts=18. _compute_clip_bounds gives
+            # [12-2, 18+0.5] = [10, 18.5] = 8.5s within band.
+            patch(f"{_MOD}.clip_window_timestamps",
+                  return_value=[9.0, 12.0, 15.0, 18.0, 21.0, 24.0]),
+            patch(f"{_MOD}.extract_frames_downscaled",
+                  new=AsyncMock(return_value=[_FAKE_PNG] * 6)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames",
+                  new=AsyncMock(return_value=_timing(
+                      release_index=2, result_index=4))),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
+            patch(f"{_MOD}.get_storage", return_value=MagicMock()),
+            patch(f"{_MOD}.cut_and_upload_wide_source",
+                  new=AsyncMock(return_value=wide)) as mock_wide,
+            patch(f"{_MOD}.lineup_repo.set_clip_url",
+                  new=AsyncMock()) as mock_set,
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
+                video_path=video,
+            )
+
+        assert result.status == "generated"
+        mock_wide.assert_awaited_once()
+        wide_kwargs = mock_wide.await_args.kwargs
+        assert wide_kwargs["chapter_start"] == 0.0
+        assert wide_kwargs["chapter_end"] == 30.0
+        assert wide_kwargs["source_key"] == "pending/vid123/0-clip-source.mp4"
+
+        mock_set.assert_awaited_once()
+        set_kwargs = mock_set.await_args.kwargs
+        assert set_kwargs["source_key"] == "pending/vid123/0-clip-source.mp4"
+        # tight bounds: clip_start=10, clip_duration=8.5; source_start=0
+        # → trim_start_s = 10 - 0 = 10; trim_end_s = 10 + 8.5 - 0 = 18.5
+        assert set_kwargs["trim_start_s"] == pytest.approx(10.0)
+        assert set_kwargs["trim_end_s"] == pytest.approx(18.5)
+
+    @pytest.mark.asyncio
+    async def test_wide_failure_falls_back_to_legacy_posture(self, tmp_path: Path):
+        """When the wide cut fails the tight clip MUST still be persisted —
+        with source_key=None so the repo writes the legacy posture
+        (clip_url_original = clip_url, NULL offsets) and the widen-source
+        backfill can retry later. The whole call still returns 'generated'."""
+        video = tmp_path / "v.mp4"
+        video.write_bytes(b"src")
+
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.clip_window_timestamps",
+                  return_value=[1.0, 2.0, 3.0, 4.0]),
+            patch(f"{_MOD}.extract_frames_downscaled",
+                  new=AsyncMock(return_value=[_FAKE_PNG] * 4)),
+            patch(f"{_MOD}.classify_throw_timing_from_frames",
+                  new=AsyncMock(return_value=_timing(release_index=1, result_index=2))),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
+            patch(f"{_MOD}.get_storage", return_value=MagicMock()),
+            patch(f"{_MOD}.cut_and_upload_wide_source",
+                  new=AsyncMock(return_value=_wide_fail())),
+            patch(f"{_MOD}.lineup_repo.set_clip_url",
+                  new=AsyncMock()) as mock_set,
+        ):
+            result = await generate_clip_for_lineup(
+                MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
+                video_path=video,
+            )
+
+        assert result.status == "generated"
+        mock_set.assert_awaited_once()
+        set_kwargs = mock_set.await_args.kwargs
+        assert set_kwargs["source_key"] is None
+        assert set_kwargs["trim_start_s"] is None
+        assert set_kwargs["trim_end_s"] is None
 
 
 class TestGenerateClipSkips:

--- a/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
@@ -25,12 +25,29 @@ from app.services.ingestion.landing_clip_generator import (
     _compute_landing_bounds,
     generate_landing_clip_for_lineup,
     pending_landing_clip_key,
+    pending_landing_clip_source_key,
 )
+from app.services.ingestion.wide_source import WideSourceResult
 from app.services.ingestion.youtube_fetcher import VideoDownloadError
 
 _MOD = "app.services.ingestion.landing_clip_generator"
 _FAKE_PNG = b"\x89PNG\r\n\x1a\n"
 _FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
+
+
+def _wide_ok(source_start=10.0, source_duration=45.0,
+             source_key="pending/vid123/10-landing-source.mp4"):
+    """Successful WideSourceResult for the landing-pane wide cut+upload mock."""
+    return WideSourceResult(
+        source_key=source_key,
+        source_start_s=source_start,
+        source_duration_s=source_duration,
+    )
+
+
+def _wide_fail():
+    """Failed WideSourceResult — best-effort fall-back to legacy posture."""
+    return WideSourceResult(error_codes=["wide_source_cut:rc=1"])
 
 
 def _lineup(video_id="vid123", chapter_title="B smoke"):
@@ -92,6 +109,32 @@ def test_pending_landing_key_distinct_from_throw_clip_key():
     assert pending_landing_clip_key("abc", 42) != pending_clip_key("abc", 42)
 
 
+def test_pending_landing_source_key_is_deterministic_and_distinct():
+    """Wide landing source key is stable + distinct from the tight key AND
+    the throw wide-source key. Sharing any of those would silently destroy
+    bytes on the next backfill overwrite."""
+    from app.services.ingestion.clip_generator import pending_clip_source_key
+
+    assert (
+        pending_landing_clip_source_key("abc", 42.0)
+        == "pending/abc/42-landing-source.mp4"
+    )
+    assert (
+        pending_landing_clip_source_key("abc", 42.9)
+        == "pending/abc/42-landing-source.mp4"
+    )
+    # Wide landing != tight landing.
+    assert (
+        pending_landing_clip_source_key("abc", 42)
+        != pending_landing_clip_key("abc", 42)
+    )
+    # Wide landing != wide throw — separate columns, separate bytes.
+    assert (
+        pending_landing_clip_source_key("abc", 42)
+        != pending_clip_source_key("abc", 42)
+    )
+
+
 # ---------------------------------------------------------------------------
 # generate_landing_clip_for_lineup — ingest path (precomputed result_ts)
 # ---------------------------------------------------------------------------
@@ -121,6 +164,9 @@ async def test_ingest_path_generates_clip_without_classifier_call():
         patch(f"{_MOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_landing_clip_url", set_url_mock),
         patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+        # Wide source mocked out — it has its own explicit tests below.
+        patch(f"{_MOD}.cut_and_upload_wide_source",
+              new=AsyncMock(return_value=_wide_fail())),
     ):
         result = await generate_landing_clip_for_lineup(
             db, lineup,
@@ -217,6 +263,8 @@ async def test_backfill_path_runs_classifier_and_generates():
         patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
         patch(f"{_MOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_landing_clip_url", set_url_mock),
+        patch(f"{_MOD}.cut_and_upload_wide_source",
+              new=AsyncMock(return_value=_wide_fail())),
     ):
         result = await generate_landing_clip_for_lineup(
             db, lineup,
@@ -471,6 +519,8 @@ async def test_persist_failure_returns_failed():
     with (
         patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
         patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.cut_and_upload_wide_source",
+              new=AsyncMock(return_value=_wide_fail())),
         patch(
             f"{_MOD}.lineup_repo.set_landing_clip_url",
             AsyncMock(side_effect=RuntimeError("db down")),
@@ -484,3 +534,90 @@ async def test_persist_failure_returns_failed():
         )
     assert result.status == "failed"
     assert "landing_clip_url_persist_failed" in result.error_codes
+
+
+# ---------------------------------------------------------------------------
+# Wide-source wiring — mirrors test_clip_generator's TestGenerateClipWideSourceWiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_widen_source_persists_offsets_for_landing():
+    """Happy wide path: landing tight is [24-0.5, 24+3.0] = [23.5, 3.5]; wide
+    spans chapter + padding starting at source_start=10. set_landing_clip_url
+    is called with source_key + the offset pair so the slider opens at the
+    tight landing bounds within the wider source."""
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_url_mock = AsyncMock(return_value=lineup)
+
+    wide = _wide_ok(
+        source_start=10.0,
+        source_duration=45.0,
+        source_key="pending/vid123/10-landing-source.mp4",
+    )
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_landing_clip_url", set_url_mock),
+        patch(f"{_MOD}.cut_and_upload_wide_source",
+              new=AsyncMock(return_value=wide)) as mock_wide,
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_result_ts=24.0,
+            precomputed_confidence=0.82,
+        )
+
+    assert result.status == "generated"
+    mock_wide.assert_awaited_once()
+    wide_kwargs = mock_wide.await_args.kwargs
+    assert wide_kwargs["chapter_start"] == 10.0
+    assert wide_kwargs["chapter_end"] == 40.0
+    assert (
+        wide_kwargs["source_key"] == "pending/vid123/10-landing-source.mp4"
+    )
+
+    set_url_mock.assert_awaited_once()
+    set_kwargs = set_url_mock.await_args.kwargs
+    assert set_kwargs["source_key"] == "pending/vid123/10-landing-source.mp4"
+    # Landing tight: clip_start=23.5, clip_duration=3.5; source_start=10
+    # → trim_start_s = 23.5 - 10 = 13.5; trim_end_s = 23.5 + 3.5 - 10 = 17.0
+    assert set_kwargs["trim_start_s"] == pytest.approx(13.5)
+    assert set_kwargs["trim_end_s"] == pytest.approx(17.0)
+
+
+@pytest.mark.asyncio
+async def test_wide_failure_falls_back_to_legacy_landing_posture():
+    """Wide failure leaves the row in the legacy posture — set_landing_clip_url
+    is called with source_key=None so landing_clip_url_original equals
+    landing_clip_url; the widen-source backfill can retry later."""
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_url_mock = AsyncMock(return_value=lineup)
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_landing_clip_url", set_url_mock),
+        patch(f"{_MOD}.cut_and_upload_wide_source",
+              new=AsyncMock(return_value=_wide_fail())),
+    ):
+        result = await generate_landing_clip_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_result_ts=24.0,
+        )
+
+    assert result.status == "generated"
+    set_url_mock.assert_awaited_once()
+    set_kwargs = set_url_mock.await_args.kwargs
+    assert set_kwargs["source_key"] is None
+    assert set_kwargs["trim_start_s"] is None
+    assert set_kwargs["trim_end_s"] is None

--- a/apps/mygamingassistant/backend/tests/test_lineup_clip_url_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_clip_url_repo.py
@@ -151,6 +151,178 @@ async def test_set_clip_url_overwrite_is_idempotent(db: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_set_clip_url_with_widened_source_persists_all_four_columns(
+    db: AsyncSession,
+):
+    """Widened-source ingest writes clip_url (tight) + clip_url_original
+    (wider) + the offset pair that locates the tight clip inside the wider
+    source. Slider opens already-trimmed to the tight bounds."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "widen", "status": "pending_review"}
+    )
+
+    await lineup_repo.set_clip_url(
+        db, created, "pending/v/0-clip.mp4",
+        source_key="pending/v/0-clip-source.mp4",
+        trim_start_s=10.0,
+        trim_end_s=18.5,
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.clip_url == "pending/v/0-clip.mp4"
+    assert refetched.clip_url_original == "pending/v/0-clip-source.mp4"
+    assert refetched.clip_trim_start_s == 10.0
+    assert refetched.clip_trim_end_s == 18.5
+
+
+@pytest.mark.asyncio
+async def test_set_clip_url_original_only_moves_source_column(
+    db: AsyncSession,
+):
+    """widen-source backfill writes ONLY clip_url_original — the served
+    tight clip_url and the trim offsets stay as they were. Operator's
+    glance-board autoplay is unchanged after backfill."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "widen-bf", "status": "pending_review"}
+    )
+    # Start in the legacy posture (tight == wide, NULL offsets).
+    await lineup_repo.set_clip_url(db, created, "pending/v/0-clip.mp4")
+
+    await lineup_repo.set_clip_url_original(
+        db, created, "pending/v/0-clip-source.mp4",
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    # Served clip unchanged; only the source moved.
+    assert refetched.clip_url == "pending/v/0-clip.mp4"
+    assert refetched.clip_url_original == "pending/v/0-clip-source.mp4"
+    # Offsets stay NULL — backfill doesn't know where tight sits inside wide.
+    assert refetched.clip_trim_start_s is None
+    assert refetched.clip_trim_end_s is None
+
+
+@pytest.mark.asyncio
+async def test_set_clip_url_original_preserves_existing_trim_offsets(
+    db: AsyncSession,
+):
+    """If the operator already trimmed (offsets non-NULL), the backfill
+    widening of clip_url_original MUST NOT clobber those offsets — the
+    operator's prior trim still applies to the new wider source's bytes
+    (subject to operator re-review)."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "widen-after-trim", "status": "pending_review"}
+    )
+    await lineup_repo.set_clip_url(db, created, "pending/v/orig.mp4")
+    await lineup_repo.set_clip_url_trim(
+        db, created, "edits/v/trimmed.mp4", 1.0, 4.0,
+    )
+
+    await lineup_repo.set_clip_url_original(
+        db, created, "pending/v/orig-source.mp4",
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.clip_url == "edits/v/trimmed.mp4"
+    assert refetched.clip_url_original == "pending/v/orig-source.mp4"  # new wide
+    assert refetched.clip_trim_start_s == 1.0  # offsets preserved
+    assert refetched.clip_trim_end_s == 4.0
+
+
+@pytest.mark.asyncio
+async def test_list_accepted_lineups_needing_widen_source(db: AsyncSession):
+    """Backfill candidate set: accepted + has source video + at least one
+    pane where tight == wide. Already-widened rows AND no-source rows drop
+    out."""
+    game = Game(slug=f"g-{uuid.uuid4().hex[:8]}", name="G",
+                side_a_label="A", side_b_label="B")
+    db.add(game)
+    await db.flush()
+    mp = Map(game_id=game.id, slug=f"m-{uuid.uuid4().hex[:8]}", name="M")
+    db.add(mp)
+    await db.flush()
+    zone = MapZone(map_id=mp.id, slug=f"z-{uuid.uuid4().hex[:8]}",
+                   name="Z", polygon_points=[])
+    db.add(zone)
+    util = UtilityType(game_id=game.id, slug=f"u-{uuid.uuid4().hex[:8]}",
+                       name="U")
+    db.add(util)
+    await db.flush()
+
+    def _accepted(**over):
+        data = dict(
+            game_id=game.id, map_id=mp.id, target_zone_id=zone.id,
+            stand_zone_id=zone.id, side="side_a", utility_type_id=util.id,
+            title="t", status="accepted", youtube_video_id="vidW",
+        )
+        data.update(over)
+        return data
+
+    # Wanted: throw tight == wide.
+    wanted_throw = await lineup_repo.create_lineup(
+        db, _accepted(
+            clip_url="tight.mp4", clip_url_original="tight.mp4",
+        ),
+    )
+    # Wanted: landing tight == wide (throw absent).
+    wanted_landing = await lineup_repo.create_lineup(
+        db, _accepted(
+            landing_clip_url="tight-land.mp4",
+            landing_clip_url_original="tight-land.mp4",
+        ),
+    )
+    # Excluded: throw already widened AND no landing.
+    await lineup_repo.create_lineup(
+        db, _accepted(
+            clip_url="tight.mp4", clip_url_original="wide.mp4",
+        ),
+    )
+    # Excluded: no source video to re-fetch.
+    await lineup_repo.create_lineup(
+        db, _accepted(
+            youtube_video_id=None,
+            clip_url="tight.mp4", clip_url_original="tight.mp4",
+        ),
+    )
+    # Excluded: still pending_review.
+    await lineup_repo.create_lineup(
+        db, {
+            "title": "p", "status": "pending_review",
+            "youtube_video_id": "vidW",
+            "clip_url": "tight.mp4", "clip_url_original": "tight.mp4",
+        },
+    )
+
+    rows = await lineup_repo.list_accepted_lineups_needing_widen_source(db)
+    ids = {r.id for r in rows}
+    assert wanted_throw.id in ids
+    assert wanted_landing.id in ids
+    # All returned rows satisfy the candidate predicate.
+    for r in rows:
+        assert r.status == "accepted"
+        assert r.youtube_video_id is not None
+        throw_legacy = (
+            r.clip_url is not None and r.clip_url_original == r.clip_url
+        )
+        landing_legacy = (
+            r.landing_clip_url is not None
+            and r.landing_clip_url_original == r.landing_clip_url
+        )
+        assert throw_legacy or landing_legacy
+
+
+@pytest.mark.asyncio
 async def test_list_accepted_lineups_needing_clips_filters(db: AsyncSession):
     """Only accepted + has-source-video + no-clip rows are in the backfill set."""
     game = Game(slug=f"g-{uuid.uuid4().hex[:8]}", name="G",

--- a/apps/mygamingassistant/backend/tests/test_lineup_landing_clip_repo.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_landing_clip_repo.py
@@ -126,6 +126,95 @@ async def test_landing_clip_does_not_overwrite_throw_clip(db: AsyncSession):
 
 
 @pytest.mark.asyncio
+async def test_set_landing_clip_url_with_widened_source(db: AsyncSession):
+    """Widened-source ingest writes landing_clip_url (tight) +
+    landing_clip_url_original (wider) + the offset pair that locates the
+    tight landing clip inside the wider source. Mirrors the throw-clip
+    sibling test."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "widen-landing", "status": "pending_review"}
+    )
+
+    await lineup_repo.set_landing_clip_url(
+        db, created, "pending/v/0-landing.mp4",
+        source_key="pending/v/0-landing-source.mp4",
+        trim_start_s=13.5,
+        trim_end_s=17.0,
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.landing_clip_url == "pending/v/0-landing.mp4"
+    assert refetched.landing_clip_url_original == "pending/v/0-landing-source.mp4"
+    assert refetched.landing_clip_trim_start_s == 13.5
+    assert refetched.landing_clip_trim_end_s == 17.0
+
+
+@pytest.mark.asyncio
+async def test_set_landing_clip_url_original_only_moves_source_column(
+    db: AsyncSession,
+):
+    """widen-source backfill writes ONLY landing_clip_url_original — the
+    served tight landing_clip_url and trim offsets stay as they were."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "widen-bf-landing", "status": "pending_review"}
+    )
+    await lineup_repo.set_landing_clip_url(
+        db, created, "pending/v/0-landing.mp4",
+    )
+
+    await lineup_repo.set_landing_clip_url_original(
+        db, created, "pending/v/0-landing-source.mp4",
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.landing_clip_url == "pending/v/0-landing.mp4"
+    assert refetched.landing_clip_url_original == "pending/v/0-landing-source.mp4"
+    assert refetched.landing_clip_trim_start_s is None
+    assert refetched.landing_clip_trim_end_s is None
+
+
+@pytest.mark.asyncio
+async def test_set_landing_clip_url_original_preserves_existing_trim_offsets(
+    db: AsyncSession,
+):
+    """Backfill widening of landing_clip_url_original MUST NOT clobber the
+    operator's existing landing trim offsets — mirrors the throw-clip sibling
+    test."""
+    created = await lineup_repo.create_lineup(
+        db, {"title": "widen-after-landing-trim", "status": "pending_review"}
+    )
+    await lineup_repo.set_landing_clip_url(db, created, "pending/v/orig-l.mp4")
+    await lineup_repo.set_landing_clip_url_trim(
+        db, created, "edits/v/landing-trimmed.mp4", 0.5, 3.0,
+    )
+
+    await lineup_repo.set_landing_clip_url_original(
+        db, created, "pending/v/orig-landing-source.mp4",
+    )
+
+    lineup_id = created.id
+    db.expire_all()
+    refetched = (
+        await db.execute(select(Lineup).where(Lineup.id == lineup_id))
+    ).scalar_one()
+    assert refetched.landing_clip_url == "edits/v/landing-trimmed.mp4"
+    assert (
+        refetched.landing_clip_url_original
+        == "pending/v/orig-landing-source.mp4"
+    )
+    assert refetched.landing_clip_trim_start_s == 0.5
+    assert refetched.landing_clip_trim_end_s == 3.0
+
+
+@pytest.mark.asyncio
 async def test_list_accepted_lineups_needing_landing_clips_filters(
     db: AsyncSession,
 ):

--- a/apps/mygamingassistant/backend/tests/test_wide_source.py
+++ b/apps/mygamingassistant/backend/tests/test_wide_source.py
@@ -1,0 +1,229 @@
+"""Unit tests for the shared wide-source cut+upload helper.
+
+Three callers consume :func:`cut_and_upload_wide_source` — clip_generator,
+landing_clip_generator, and widen_source_backfill. The helper itself MUST
+be best-effort (ffmpeg/MinIO failures captured into structured codes,
+never raised) and the bounds + offsets math MUST be exact (the trim
+editor's slider math depends on it).
+"""
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.ingestion.frame_extractor import ClipCutError, wide_source_bounds
+from app.services.ingestion.wide_source import (
+    WideSourceResult,
+    cut_and_upload_wide_source,
+    tight_offsets_within_source,
+)
+
+_MOD = "app.services.ingestion.wide_source"
+_FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
+
+
+# ---------------------------------------------------------------------------
+# wide_source_bounds — pure math
+# ---------------------------------------------------------------------------
+
+
+class TestWideSourceBounds:
+    def test_normal_window_extends_chapter(self):
+        # chapter [10, 40], pre=15, post=15 → [max(0, -5), 55] = [0, 55]
+        start, dur = wide_source_bounds(
+            10.0, 40.0, pre_seconds=15.0, post_seconds=15.0,
+        )
+        # 10 - 15 = -5 → clamped at 0
+        assert start == pytest.approx(0.0)
+        assert dur == pytest.approx(55.0)
+
+    def test_pre_clamps_at_zero(self):
+        # Chapter starts at 5; 15s pre would underflow → start clamped at 0,
+        # duration = (5 + 30 + 15) - 0 = 50.
+        start, dur = wide_source_bounds(
+            5.0, 30.0, pre_seconds=15.0, post_seconds=15.0,
+        )
+        assert start == pytest.approx(0.0)
+        assert dur == pytest.approx(45.0)
+
+    def test_late_chapter_keeps_full_pre(self):
+        # Chapter [200, 230], pre=15, post=15 → [185, 245] = 60s.
+        start, dur = wide_source_bounds(
+            200.0, 230.0, pre_seconds=15.0, post_seconds=15.0,
+        )
+        assert start == pytest.approx(185.0)
+        assert dur == pytest.approx(60.0)
+
+    def test_zero_padding_returns_exact_chapter(self):
+        # Sanity: with pre=0/post=0 we get exactly the chapter bounds.
+        start, dur = wide_source_bounds(
+            50.0, 80.0, pre_seconds=0.0, post_seconds=0.0,
+        )
+        assert start == pytest.approx(50.0)
+        assert dur == pytest.approx(30.0)
+
+    def test_asymmetric_padding(self):
+        # 5s pre, 20s post — operator might want more lead-in OR tail.
+        start, dur = wide_source_bounds(
+            100.0, 110.0, pre_seconds=5.0, post_seconds=20.0,
+        )
+        assert start == pytest.approx(95.0)
+        assert dur == pytest.approx(35.0)
+
+
+# ---------------------------------------------------------------------------
+# tight_offsets_within_source — pure math
+# ---------------------------------------------------------------------------
+
+
+class TestTightOffsetsWithinSource:
+    def test_tight_inside_wide(self):
+        # Tight [50, 56] (duration 6) inside wide that starts at 35.
+        # Offsets: start_in_wide=50-35=15; end_in_wide=15+6=21.
+        start, end = tight_offsets_within_source(
+            tight_start=50.0, tight_duration=6.0, source_start=35.0,
+        )
+        assert start == pytest.approx(15.0)
+        assert end == pytest.approx(21.0)
+
+    def test_tight_at_source_start(self):
+        # Edge: tight begins right at the wide's start → offset 0.
+        start, end = tight_offsets_within_source(
+            tight_start=10.0, tight_duration=4.0, source_start=10.0,
+        )
+        assert start == pytest.approx(0.0)
+        assert end == pytest.approx(4.0)
+
+    def test_tight_offset_when_wide_pre_clamped(self):
+        # Wide is clamped to start at 0; tight at 5, duration 2 → [5, 7] in
+        # source coordinates (matches the source-timeline contract).
+        start, end = tight_offsets_within_source(
+            tight_start=5.0, tight_duration=2.0, source_start=0.0,
+        )
+        assert start == pytest.approx(5.0)
+        assert end == pytest.approx(7.0)
+
+
+# ---------------------------------------------------------------------------
+# cut_and_upload_wide_source — orchestration with ffmpeg + MinIO mocked
+# ---------------------------------------------------------------------------
+
+
+def _lineup_id():
+    return uuid.uuid4()
+
+
+class TestCutAndUploadWideSource:
+    @pytest.mark.asyncio
+    async def test_success_returns_key_and_bounds(self, tmp_path: Path):
+        video = tmp_path / "v.mp4"; video.write_bytes(b"src")
+        storage = MagicMock()
+        settings = MagicMock()
+        settings.clip_source_pre_seconds = 15.0
+        settings.clip_source_post_seconds = 15.0
+
+        with (
+            patch(f"{_MOD}.settings", settings),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)) as cut,
+            patch(f"{_MOD}.get_storage", return_value=storage),
+        ):
+            result = await cut_and_upload_wide_source(
+                local_video=video,
+                video_id="vid123",
+                chapter_start=20.0,
+                chapter_end=50.0,
+                source_key="pending/vid123/20-clip-source.mp4",
+                log_prefix="test",
+                lineup_id=_lineup_id(),
+            )
+
+        assert result.succeeded is True
+        assert result.source_key == "pending/vid123/20-clip-source.mp4"
+        # 20 - 15 = 5 (no clamp); 50 + 15 = 65; duration = 60
+        assert result.source_start_s == pytest.approx(5.0)
+        assert result.source_duration_s == pytest.approx(60.0)
+        cut.assert_awaited_once_with(video, 5.0, 60.0)
+        storage.upload_file.assert_called_once()
+        # MIME type matches the rest of the clip pipeline.
+        assert storage.upload_file.call_args[0][2] == "video/mp4"
+
+    @pytest.mark.asyncio
+    async def test_cut_failure_returns_structured_error(self, tmp_path: Path):
+        """ffmpeg failure NEVER raises — captured into error_codes so the
+        caller (ingest path or backfill) can route on it. Per
+        rules/check-third-party-error-codes.md."""
+        video = tmp_path / "v.mp4"; video.write_bytes(b"src")
+        settings = MagicMock()
+        settings.clip_source_pre_seconds = 15.0
+        settings.clip_source_post_seconds = 15.0
+        exc = ClipCutError("boom", start=5.0, duration=60.0, returncode=42, stderr="x")
+
+        with (
+            patch(f"{_MOD}.settings", settings),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(side_effect=exc)),
+            patch(f"{_MOD}.get_storage") as get_storage_mock,
+        ):
+            result = await cut_and_upload_wide_source(
+                local_video=video,
+                video_id="vid123",
+                chapter_start=20.0,
+                chapter_end=50.0,
+                source_key="pending/vid123/20-clip-source.mp4",
+                log_prefix="test",
+                lineup_id=_lineup_id(),
+            )
+
+        assert result.succeeded is False
+        assert result.source_key is None
+        assert "wide_source_cut:rc=42" in result.error_codes
+        # MinIO must NOT be touched when the cut failed — no orphan bytes.
+        get_storage_mock.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_upload_failure_returns_structured_error(
+        self, tmp_path: Path,
+    ):
+        """MinIO failure NEVER raises — same shape as the cut-failure path."""
+        video = tmp_path / "v.mp4"; video.write_bytes(b"src")
+        storage = MagicMock()
+        storage.upload_file.side_effect = RuntimeError("minio down")
+        settings = MagicMock()
+        settings.clip_source_pre_seconds = 15.0
+        settings.clip_source_post_seconds = 15.0
+
+        with (
+            patch(f"{_MOD}.settings", settings),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
+            patch(f"{_MOD}.get_storage", return_value=storage),
+        ):
+            result = await cut_and_upload_wide_source(
+                local_video=video,
+                video_id="vid123",
+                chapter_start=20.0,
+                chapter_end=50.0,
+                source_key="pending/vid123/20-clip-source.mp4",
+                log_prefix="test",
+                lineup_id=_lineup_id(),
+            )
+
+        assert result.succeeded is False
+        assert result.source_key is None
+        assert "wide_source_upload_failed" in result.error_codes
+
+
+class TestWideSourceResult:
+    def test_empty_init_defaults_to_failure(self):
+        """A bare WideSourceResult() represents failure (no key, empty
+        error_codes). Useful as a sentinel for the legacy posture."""
+        r = WideSourceResult()
+        assert r.succeeded is False
+        assert r.error_codes == []
+
+    def test_succeeded_requires_source_key(self):
+        r = WideSourceResult(
+            source_key="k", source_start_s=1.0, source_duration_s=2.0,
+        )
+        assert r.succeeded is True

--- a/apps/mygamingassistant/backend/tests/test_widen_source_backfill.py
+++ b/apps/mygamingassistant/backend/tests/test_widen_source_backfill.py
@@ -1,0 +1,400 @@
+"""Unit tests for the widen-source backfill (python -m app.cli widen-source).
+
+Mirrors :mod:`test_clip_backfill` / :mod:`test_landing_clip_backfill` —
+everything external (repo query / yt-dlp / chapter parse / cut+upload /
+persistence) is mocked. Asserts the idempotent work set per pane, ONE
+fetch+download per video, chapter re-identification, the
+widened/skipped/failed tally, and that the per-video download is always
+cleaned up.
+"""
+from __future__ import annotations
+
+import contextlib
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.ingestion.chapter_parser import Chapter
+from app.services.ingestion.wide_source import WideSourceResult
+from app.services.ingestion.widen_source_backfill import (
+    backfill_widen_source,
+)
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+)
+
+_MOD = "app.services.ingestion.widen_source_backfill"
+
+
+def _lineup(
+    video_id: str,
+    chapter_start: int,
+    *,
+    clip_url: str | None = "tight.mp4",
+    landing_clip_url: str | None = "tight-land.mp4",
+    clip_url_original: str | None = None,
+    landing_clip_url_original: str | None = None,
+):
+    """Build a lineup with the legacy posture (tight == wide) by default.
+
+    Tests can override individual columns to model already-widened panes or
+    panes without a tight clip (e.g. ``clip_url=None`` for landing-only).
+    """
+    if clip_url_original is None:
+        clip_url_original = clip_url  # legacy posture
+    if landing_clip_url_original is None:
+        landing_clip_url_original = landing_clip_url  # legacy posture
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        youtube_video_id=video_id,
+        chapter_start_seconds=chapter_start,
+        clip_url=clip_url,
+        clip_url_original=clip_url_original,
+        landing_clip_url=landing_clip_url,
+        landing_clip_url_original=landing_clip_url_original,
+    )
+
+
+def _meta():
+    m = MagicMock()
+    m.description = ""
+    m.duration = 120
+    m.chapters = [{"start_time": 0, "end_time": 60, "title": "B smoke"}]
+    return m
+
+
+def _patches(
+    tmp_path,
+    *,
+    lineups,
+    chapters,
+    wide,
+    fetch=None,
+    download=None,
+    throw_persist=None,
+    landing_persist=None,
+):
+    """Compose the backfill patch set; download writes a real temp file so
+    the unlink-cleanup assertion is meaningful."""
+
+    async def _dl(video_id, ddir):
+        p = Path(ddir) / f"{video_id}.mp4"
+        p.write_bytes(b"src")
+        return p
+
+    settings = MagicMock()
+    settings.ingestion_download_dir = str(tmp_path)
+
+    return [
+        patch(f"{_MOD}.settings", settings),
+        patch(
+            f"{_MOD}.lineup_repo.list_accepted_lineups_needing_widen_source",
+            new=AsyncMock(return_value=lineups),
+        ),
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            new=fetch or AsyncMock(return_value=_meta()),
+        ),
+        patch(f"{_MOD}.parse_chapters", return_value=chapters),
+        patch(
+            f"{_MOD}.download_video",
+            new=download or AsyncMock(side_effect=_dl),
+        ),
+        patch(f"{_MOD}.cut_and_upload_wide_source", new=wide),
+        patch(
+            f"{_MOD}.lineup_repo.set_clip_url_original",
+            new=throw_persist or AsyncMock(),
+        ),
+        patch(
+            f"{_MOD}.lineup_repo.set_landing_clip_url_original",
+            new=landing_persist or AsyncMock(),
+        ),
+    ]
+
+
+def _enter(stack):
+    es = contextlib.ExitStack()
+    for p in stack:
+        es.enter_context(p)
+    return es
+
+
+def _wide_ok(source_key="pending/v/0-clip-source.mp4"):
+    return WideSourceResult(
+        source_key=source_key, source_start_s=0.0, source_duration_s=60.0,
+    )
+
+
+def _wide_fail():
+    return WideSourceResult(error_codes=["wide_source_cut:rc=1"])
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestWidenSourceBackfill:
+    @pytest.mark.asyncio
+    async def test_nothing_to_do(self, tmp_path: Path):
+        """Empty candidate list → no fetch, no download, no widen."""
+        wide = AsyncMock()
+        with _enter(_patches(tmp_path, lineups=[], chapters=[], wide=wide)):
+            stats = await backfill_widen_source(MagicMock())
+        assert stats.total_rows == 0
+        assert stats.widened == 0
+        wide.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_both_panes_widened_per_row(self, tmp_path: Path):
+        """A row with both throw and landing legacy → 2 panes widened, 1 row."""
+        lineups = [_lineup("vidA", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        wide = AsyncMock(return_value=_wide_ok())
+        throw_persist = AsyncMock()
+        landing_persist = AsyncMock()
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+            throw_persist=throw_persist, landing_persist=landing_persist,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        assert stats.total_rows == 1
+        assert stats.widened == 2  # throw + landing
+        assert stats.failed == 0
+        # Two wide cuts (one per pane); two persist calls.
+        assert wide.await_count == 2
+        throw_persist.assert_awaited_once()
+        landing_persist.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_only_throw_legacy_widens_only_throw(self, tmp_path: Path):
+        """Landing already widened (clip_url_original != landing_clip_url)
+        → only throw is in the work set; landing is left alone."""
+        lineups = [_lineup(
+            "vidA", 0,
+            landing_clip_url="tight-land.mp4",
+            landing_clip_url_original="wide-land.mp4",  # already widened
+        )]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        wide = AsyncMock(return_value=_wide_ok())
+        throw_persist = AsyncMock()
+        landing_persist = AsyncMock()
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+            throw_persist=throw_persist, landing_persist=landing_persist,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        assert stats.widened == 1
+        wide.assert_awaited_once()
+        throw_persist.assert_awaited_once()
+        landing_persist.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_row_with_no_tight_clip_widens_neither(self, tmp_path: Path):
+        """A row with both clip_url=None and landing_clip_url=None contributes
+        nothing — _throw_needs_widen and _landing_needs_widen both False.
+        (Such rows shouldn't appear in the candidate set, but be defensive.)"""
+        lineups = [_lineup(
+            "vidA", 0, clip_url=None, landing_clip_url=None,
+        )]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        wide = AsyncMock()
+        throw_persist = AsyncMock()
+        landing_persist = AsyncMock()
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+            throw_persist=throw_persist, landing_persist=landing_persist,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        assert stats.widened == 0
+        wide.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_one_fetch_and_download_per_video(self, tmp_path: Path):
+        """3 rows, 2 share video 'vidA' → ONE fetch + ONE download per
+        distinct video, not per row. Same shape as clip_backfill."""
+        lineups = [
+            _lineup("vidA", 0), _lineup("vidA", 0), _lineup("vidB", 0),
+        ]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        wide = AsyncMock(return_value=_wide_ok())
+        fetch = AsyncMock(return_value=_meta())
+        dl_calls = []
+
+        async def _dl(video_id, ddir):
+            dl_calls.append(video_id)
+            p = Path(ddir) / f"{video_id}.mp4"
+            p.write_bytes(b"src")
+            return p
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+            fetch=fetch, download=AsyncMock(side_effect=_dl),
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        assert stats.total_rows == 3
+        # 3 rows × 2 panes each = 6 wide cuts.
+        assert stats.widened == 6
+        # ONE fetch + ONE download per distinct video.
+        assert fetch.await_count == 2
+        assert sorted(dl_calls) == ["vidA", "vidB"]
+        # Downloaded files cleaned up.
+        assert not (tmp_path / "vidA.mp4").exists()
+        assert not (tmp_path / "vidB.mp4").exists()
+
+    @pytest.mark.asyncio
+    async def test_throw_failure_does_not_block_landing(self, tmp_path: Path):
+        """The two panes are independent. A throw widen failure on a row
+        must NOT prevent the landing widen on the SAME row from being
+        attempted."""
+        lineups = [_lineup("v", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        # First wide call (throw) fails; second (landing) succeeds.
+        wide = AsyncMock(side_effect=[_wide_fail(), _wide_ok()])
+        throw_persist = AsyncMock()
+        landing_persist = AsyncMock()
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+            throw_persist=throw_persist, landing_persist=landing_persist,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        assert stats.widened == 1   # landing succeeded
+        assert stats.failed == 1    # throw failed
+        # Throw persist not awaited (cut failed); landing persist was.
+        throw_persist.assert_not_awaited()
+        landing_persist.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_recorded_as_per_pane_failure(
+        self, tmp_path: Path,
+    ):
+        """When the wide cut succeeds but the DB persist fails, the pane is
+        counted as failed and the error includes the lineup id + pane."""
+        lineups = [_lineup("v", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        wide = AsyncMock(return_value=_wide_ok())
+        throw_persist = AsyncMock(side_effect=RuntimeError("db down"))
+        landing_persist = AsyncMock()
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+            throw_persist=throw_persist, landing_persist=landing_persist,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        assert stats.failed == 1   # throw persist failed
+        assert stats.widened == 1  # landing succeeded
+        assert any("[throw]" in e and "persist_failed" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_metadata_fetch_failure_fails_all_panes_for_video(
+        self, tmp_path: Path,
+    ):
+        lineups = [_lineup("vbad", 0), _lineup("vbad", 30)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        fetch = AsyncMock(side_effect=YouTubeFetchError(
+            "gone", error_type="ExtractorError", original=Exception(),
+        ))
+        wide = AsyncMock()
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+            fetch=fetch,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        # 2 rows × 2 panes each = 4 panes blocked.
+        assert stats.failed == 4
+        wide.assert_not_awaited()
+        assert any("ExtractorError" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_download_failure_fails_all_panes_for_video(
+        self, tmp_path: Path,
+    ):
+        lineups = [_lineup("vdl", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        dl = AsyncMock(side_effect=VideoDownloadError(
+            "nope", video_id="vdl",
+            error_type="UnavailableVideoError", original=Exception(),
+        ))
+        wide = AsyncMock()
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+            download=dl,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        assert stats.failed == 2  # throw + landing for the one row
+        wide.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_chapter_not_found_skips_both_panes(self, tmp_path: Path):
+        """Video chapters changed since ingest — both panes skipped (not
+        failed; this is a recoverable state if the video gets fixed)."""
+        # lineup recorded chapter_start=999 but the video now has only [0,60].
+        lineups = [_lineup("v", 999)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        wide = AsyncMock()
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        assert stats.skipped == 2  # throw + landing both skipped
+        wide.assert_not_awaited()
+        assert any("chapter not found" in e for e in stats.errors)
+
+    @pytest.mark.asyncio
+    async def test_per_pane_exception_does_not_abort_batch(
+        self, tmp_path: Path,
+    ):
+        """A raised exception on one row's pane must not abort the next row.
+        Mirrors :func:`test_clip_backfill.test_per_lineup_exception_does_not_abort_batch`."""
+        lineups = [_lineup("v", 0), _lineup("v", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        # First throw raises, then subsequent calls succeed.
+        wide = AsyncMock(side_effect=[
+            RuntimeError("boom"),  # row 1 throw — raises
+            _wide_ok(),            # row 1 landing — succeeds
+            _wide_ok(),            # row 2 throw — succeeds
+            _wide_ok(),            # row 2 landing — succeeds
+        ])
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        # 3 panes widened, 1 failed (the raised throw on row 1).
+        assert stats.widened == 3
+        assert stats.failed == 1
+
+    @pytest.mark.asyncio
+    async def test_summary_text_is_useful(self, tmp_path: Path):
+        """Summary string surfaces both per-row total AND per-pane outcomes."""
+        lineups = [_lineup("v", 0)]
+        chapters = [Chapter(start_seconds=0, end_seconds=60, title="x")]
+        wide = AsyncMock(return_value=_wide_ok())
+
+        with _enter(_patches(
+            tmp_path, lineups=lineups, chapters=chapters, wide=wide,
+        )):
+            stats = await backfill_widen_source(MagicMock())
+
+        summary = stats.summary()
+        assert "1 candidate row" in summary
+        assert "2 pane(s) widened" in summary


### PR DESCRIPTION
## Summary

- Ingest now cuts a wider source clip alongside the existing tight clip and points `clip_url_original` / `landing_clip_url_original` at it, with offsets so the trim slider opens already-trimmed to the tight bounds
- New `python -m app.cli widen-source` backfill widens existing rows whose `*_url_original == *_url` (the legacy posture) — only `*_url_original` moves, served tight bytes are untouched
- Wide cut + upload is best-effort: failure keeps the row in the legacy posture so the tight served clip is never blocked

## Design notes

- Wide source = `[chapter_start - 15s, chapter_end + 15s]` clamped at 0; ffmpeg silently truncates past video end (no need to know video duration up front)
- Shared `cut_and_upload_wide_source` helper in `app/services/ingestion/wide_source.py` consumed by three callers: clip_generator, landing_clip_generator, widen_source_backfill
- New repo functions `set_clip_url_original` / `set_landing_clip_url_original` move ONLY the source column so a backfill widen never clobbers existing trim offsets or the served tight clip
- `set_clip_url` / `set_landing_clip_url` gain optional `source_key` + `trim_start_s` + `trim_end_s` kwargs — Replace callers unchanged (no kwargs → legacy posture); ingest passes kwargs for the widened-source shape
- Backfill skips Claude (saves $0.016/row × 19 = ~$0.30) — leaves offsets NULL on backfilled rows; operator drags slider to refine

## Config

- `CLIP_SOURCE_PRE_SECONDS` (default 15.0) — seconds of padding kept BEFORE the chapter in the wider source
- `CLIP_SOURCE_POST_SECONDS` (default 15.0) — seconds of padding kept AFTER the chapter
- No operational migration required (defaults work as-is)

## Storage impact

- Future ingests: ~3MB extra per lineup (wide source ~3.6MB vs ~600KB tight)
- One-time backfill on 19 existing lineups: ~133MB (2 wide cuts per row × ~3.5MB)

## Test plan

- [x] 567 backend tests pass
- [x] New test files: `test_wide_source.py` (13 tests), `test_widen_source_backfill.py` (12 tests)
- [x] Updated `test_clip_generator.py` / `test_landing_clip_generator.py` with explicit wide-source wiring tests (both happy + best-effort-failure paths)
- [x] Updated `test_lineup_clip_url_repo.py` / `test_lineup_landing_clip_repo.py` with new kwargs + `set_*_url_original` tests + `list_accepted_lineups_needing_widen_source` test
- [ ] Operator runs `python -m app.cli widen-source` post-deploy to widen existing 19 rows
- [ ] PR2 follows: on-demand `/widen-source` endpoint for re-widening individual panes
- [ ] PR3 follows: frontend absolute timestamps in slider readout + Widen-source button

🤖 Generated with [Claude Code](https://claude.com/claude-code)