### PR TITLE
feat(mga): on-demand widen-source endpoint per pane (PR2 — widen source)

### DIFF
--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -65,7 +65,12 @@ from app.schemas.game.pane_upload_schemas import (
     PaneUploadUrlRequest,
     PaneUploadUrlResponse,
 )
-from app.services.game import lineup_service, pane_trim_service, pane_upload_service
+from app.services.game import (
+    lineup_service,
+    pane_trim_service,
+    pane_upload_service,
+    pane_widen_source_service,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -571,3 +576,39 @@ async def trim_pane_clip(
     if lineup is None:
         raise HTTPException(status_code=404, detail="Lineup not found")
     return await pane_trim_service.trim_pane_clip(db, lineup, pane, body)
+
+
+# ---------------------------------------------------------------------------
+# Per-pane on-demand widen-source — one-row sibling of the bulk
+# ``python -m app.cli widen-source`` backfill. The operator clicks "Widen
+# source" in the trim editor and we re-fetch the YouTube video for THIS
+# pane, cut a wider clip, and update ``*_url_original`` so the next trim
+# can drag past the previous bounds. See pane_widen_source_service.
+# ---------------------------------------------------------------------------
+
+
+@auth_router.post(
+    "/lineups/{lineup_id}/panes/{pane}/widen-source",
+    response_model=LineupRead,
+)
+async def widen_pane_source(
+    lineup_id: uuid.UUID,
+    pane: Pane,
+    db: AsyncSession = Depends(get_db),
+) -> LineupRead:
+    """Re-cut a wider trim-editor source from the lineup's YouTube video.
+
+    Pane must be ``throw`` or ``landing`` (same allow-list as ``trim``).
+    Returns the admin-shape LineupRead so the frontend can rebind the
+    slider to the (possibly wider) bounds without a separate fetch.
+
+    Failure shapes:
+      * 400 — pane outside the trimmable allow-list
+      * 404 — lineup missing / no YouTube source / chapter shifted since ingest
+      * 502 — yt-dlp metadata fetch or video download failed
+      * 500 — ffmpeg cut, MinIO upload, or DB commit failed
+    """
+    lineup = await get_lineup_orm(db, lineup_id)
+    if lineup is None:
+        raise HTTPException(status_code=404, detail="Lineup not found")
+    return await pane_widen_source_service.widen_pane_source(db, lineup, pane)

--- a/apps/mygamingassistant/backend/app/services/game/pane_widen_source_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/pane_widen_source_service.py
@@ -1,0 +1,275 @@
+"""Per-pane on-demand widen-source service.
+
+The widen-source backfill (:mod:`widen_source_backfill`) is the bulk
+operation: walk every legacy-posture row and widen them all. This service
+is its one-row sibling — the operator clicks "Widen source" in the trim
+editor and we re-fetch the YouTube video for THIS pane, cut a wider clip
+via the shared :func:`cut_and_upload_wide_source` helper, and update
+``*_url_original`` so the next trim can drag past the previous bounds.
+
+End-to-end:
+
+  1. Validate pane (only throw / landing are trimmable — same allow-list
+     :mod:`pane_trim_service` uses).
+  2. Validate lineup has a YouTube source — manual uploads can't be widened
+     because there's no video to re-fetch.
+  3. One yt-dlp metadata fetch + one yt-dlp download for this single video
+     (we never share with sibling calls — by definition this is a one-row
+     op).
+  4. Find the chapter via exact ``chapter_start_seconds`` match; 404 if the
+     video's chapters changed since ingest (same posture as the backfill).
+  5. Cut + upload the wider clip via the shared helper. Storage key is the
+     same deterministic ``-clip-source`` / ``-landing-source`` shape the
+     backfill uses, so a sequence of on-demand widens + a subsequent backfill
+     run cleanly converge on the same bytes — no orphans.
+  6. Persist ONLY ``*_url_original`` via the corresponding setter. The served
+     tight ``*_url`` and the operator's existing trim offsets stay intact.
+  7. Return the admin-shape LineupRead so the frontend can rebind the slider
+     to the (possibly wider) bounds without a separate fetch.
+
+Failures (per rules/check-third-party-error-codes.md): yt-dlp errors
+surface as 502 with the structured error_type; ffmpeg/MinIO failures from
+the helper surface as 500 with the captured error_codes. Never a silent
+fail-through.
+
+Note on idempotence: re-running widen-source on the same pane overwrites
+the same deterministic MinIO key (no orphan) and rewrites
+``*_url_original`` to the same value (no DB change in steady state). If
+the operator wants MORE padding than the current env defaults, they bump
+``CLIP_SOURCE_PRE_SECONDS`` / ``CLIP_SOURCE_POST_SECONDS`` and call this
+endpoint again — the new wider bytes overwrite the old key in place.
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.config import settings
+from app.models.game.lineup import Lineup
+from app.repositories.game.lineup_repo import (
+    set_clip_url_original,
+    set_landing_clip_url_original,
+)
+from app.schemas.game.lineup_schemas import LineupRead
+from app.schemas.game.pane_trim_schemas import TRIMMABLE_PANES, TrimmablePane
+from app.services.game.lineup_service import _build_admin_read
+from app.services.ingestion.chapter_parser import Chapter, parse_chapters
+from app.services.ingestion.clip_generator import pending_clip_source_key
+from app.services.ingestion.landing_clip_generator import (
+    pending_landing_clip_source_key,
+)
+from app.services.ingestion.wide_source import cut_and_upload_wide_source
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+    download_video,
+    fetch_video_detail,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_pane(pane: str) -> TrimmablePane:
+    """Reject panes outside the trim/widen allow-list with a 400.
+
+    Same shape + same allow-list as :func:`pane_trim_service._validate_pane`
+    — widen-source and trim are sibling operations on the same panes, so the
+    allow-list is shared.
+    """
+    if pane not in TRIMMABLE_PANES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"pane '{pane}' cannot be widened (only "
+                f"{sorted(TRIMMABLE_PANES)} have a wider trim source today)"
+            ),
+        )
+    return pane  # type: ignore[return-value]
+
+
+def _find_chapter(
+    chapters: list[Chapter], start_seconds: int | None,
+) -> Chapter | None:
+    """The chapter whose start matches the lineup's stored chapter start.
+
+    Identical helper to the backfills' (`clip_backfill._find_chapter`) —
+    exact-start match re-identifies the chapter from the same
+    ``parse_chapters`` output the ingest path persisted. A miss means the
+    video's chapters changed since ingest.
+    """
+    if start_seconds is None:
+        return None
+    for ch in chapters:
+        if ch.start_seconds == start_seconds:
+            return ch
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def widen_pane_source(
+    db: AsyncSession,
+    lineup: Lineup,
+    pane: str,
+) -> LineupRead:
+    """Re-cut a wider trim-editor source for *pane* on *lineup* and persist.
+
+    Caller (route handler) is responsible for resolving ``lineup`` from the
+    path parameter first so a 404 surfaces cleanly without us duplicating
+    the lookup.
+
+    Each step has its own structured failure mode (400/404 for
+    operator-correctable issues, 502 for yt-dlp, 500 for ffmpeg/MinIO/DB) —
+    never a silent fail-through.
+    """
+    trimmable_pane = _validate_pane(pane)
+
+    video_id = lineup.youtube_video_id
+    if not video_id:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "pane has no YouTube source to widen — manual uploads cannot "
+                "be widened. Use the Replace flow to upload a wider clip "
+                "instead."
+            ),
+        )
+    if lineup.chapter_start_seconds is None:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "pane has a YouTube id but no chapter start recorded — "
+                "ingest metadata is incomplete; cannot widen"
+            ),
+        )
+
+    # ---- One metadata fetch + one download for this row ------------------
+    try:
+        meta = await fetch_video_detail(video_id)
+    except YouTubeFetchError as exc:
+        logger.warning(
+            "widen-source: metadata fetch failed: lineup=%s video_id=%s "
+            "error_type=%s message=%s",
+            lineup.id, video_id, exc.error_type, str(exc),
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"could not fetch YouTube metadata for source video "
+                f"({exc.error_type}); try again later"
+            ),
+        ) from exc
+
+    chapters = parse_chapters(
+        description=meta.description,
+        video_duration=meta.duration,
+        native_chapters=meta.chapters or None,
+    )
+    chapter = _find_chapter(chapters, lineup.chapter_start_seconds)
+    if chapter is None:
+        # The video's chapters have shifted since this lineup was ingested.
+        # Same skip-reason the bulk backfill records — the operator's
+        # recourse is to re-ingest or accept that the source has drifted.
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                f"chapter starting at {lineup.chapter_start_seconds}s no "
+                "longer exists in the source video (chapters changed since "
+                "ingest); cannot re-cut a wider source"
+            ),
+        )
+
+    download_dir = Path(settings.ingestion_download_dir)
+    try:
+        video_path = await download_video(video_id, download_dir)
+    except VideoDownloadError as exc:
+        logger.warning(
+            "widen-source: download failed: lineup=%s video_id=%s "
+            "error_type=%s message=%s",
+            lineup.id, video_id, exc.error_type, str(exc),
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                f"could not download source video ({exc.error_type}); "
+                "try again later"
+            ),
+        ) from exc
+
+    try:
+        # ---- Pane dispatch (source key + repo setter) ------------------
+        if trimmable_pane == "throw":
+            source_key = pending_clip_source_key(
+                video_id, chapter.start_seconds,
+            )
+            persist = set_clip_url_original
+        else:  # "landing" — exhaustive per _validate_pane
+            source_key = pending_landing_clip_source_key(
+                video_id, chapter.start_seconds,
+            )
+            persist = set_landing_clip_url_original
+
+        # ---- Cut + upload via the shared helper ------------------------
+        wide = await cut_and_upload_wide_source(
+            local_video=video_path,
+            video_id=video_id,
+            chapter_start=float(chapter.start_seconds),
+            chapter_end=float(chapter.end_seconds),
+            source_key=source_key,
+            log_prefix="widen-source-endpoint",
+            lineup_id=lineup.id,
+        )
+        if not wide.succeeded:
+            # Helper already logged the structured failure; surface as 500
+            # with the captured codes so the operator sees the actionable
+            # reason instead of a bare "internal error".
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "wide source cut/upload failed: "
+                    f"{','.join(wide.error_codes) or 'unknown'}"
+                ),
+            )
+
+        try:
+            updated = await persist(
+                db, lineup, wide.source_key,  # type: ignore[arg-type]
+            )
+        except Exception as exc:  # noqa: BLE001 — surface any DB failure
+            logger.warning(
+                "widen-source: %s_url_original persist failed (object "
+                "uploaded, column not committed): lineup=%s key=%s error=%s",
+                trimmable_pane, lineup.id, wide.source_key, str(exc),
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "wide source uploaded but database commit failed; "
+                    "re-trying should succeed once the underlying issue is "
+                    "resolved"
+                ),
+            ) from exc
+
+        return _build_admin_read(updated)
+    finally:
+        # The endpoint owns this download — clean it up regardless of
+        # success/failure so a 502/500 doesn't leak temp files.
+        try:
+            video_path.unlink(missing_ok=True)
+        except OSError as exc:
+            logger.warning(
+                "widen-source: failed to delete downloaded video: "
+                "path=%s error=%s",
+                video_path, str(exc),
+            )

--- a/apps/mygamingassistant/backend/tests/test_pane_widen_source_service.py
+++ b/apps/mygamingassistant/backend/tests/test_pane_widen_source_service.py
@@ -169,6 +169,16 @@ def _common_patches(
             f"{_MOD}.set_landing_clip_url_original",
             new=persist or AsyncMock(),
         ),
+        # ``_build_admin_read`` (re-exported via this service) calls
+        # ``_sign_screenshot_url`` which hits MinIO. CI doesn't configure
+        # MinIO env vars, so we short-circuit signing to return the bare
+        # key unchanged. The signing logic has its own dedicated tests in
+        # the lineup_service module — covering it here would couple two
+        # concerns.
+        patch(
+            "app.services.game.lineup_service._sign_screenshot_url",
+            side_effect=lambda key: key,
+        ),
     ]
 
 
@@ -272,6 +282,9 @@ class TestHappyPath:
             patch(f"{_MOD}.set_clip_url_original", new=persist_throw),
             patch(f"{_MOD}.set_landing_clip_url_original",
                   new=persist_landing),
+            # CI has no MinIO env — short-circuit signing.
+            patch("app.services.game.lineup_service._sign_screenshot_url",
+                  side_effect=lambda key: key),
         ]):
             result = await widen_pane_source(MagicMock(), _lineup(), "throw")
 
@@ -313,6 +326,8 @@ class TestHappyPath:
             patch(f"{_MOD}.cut_and_upload_wide_source", new=wide),
             patch(f"{_MOD}.set_clip_url_original", new=persist_throw),
             patch(f"{_MOD}.set_landing_clip_url_original", new=persist_landing),
+            patch("app.services.game.lineup_service._sign_screenshot_url",
+                  side_effect=lambda key: key),
         ]):
             result = await widen_pane_source(MagicMock(), _lineup(), "landing")
 

--- a/apps/mygamingassistant/backend/tests/test_pane_widen_source_service.py
+++ b/apps/mygamingassistant/backend/tests/test_pane_widen_source_service.py
@@ -1,0 +1,355 @@
+"""Unit tests for the on-demand widen-source service (PR2 of widen-source).
+
+Per-row sibling of :mod:`test_widen_source_backfill` — same shared helper
+under the hood (:func:`cut_and_upload_wide_source`), different orchestration
+(one row, HTTP-shaped failures). Asserts the validation guards, the
+yt-dlp/ffmpeg failure-to-status mapping, and the download-cleanup invariant.
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.services.game.pane_widen_source_service import widen_pane_source
+from app.services.ingestion.chapter_parser import Chapter
+from app.services.ingestion.wide_source import WideSourceResult
+from app.services.ingestion.youtube_fetcher import (
+    VideoDownloadError,
+    YouTubeFetchError,
+)
+
+_MOD = "app.services.game.pane_widen_source_service"
+
+
+def _lineup(
+    *,
+    video_id: str | None = "vid123",
+    chapter_start: int | None = 0,
+    clip_url: str | None = "tight.mp4",
+    landing_clip_url: str | None = "tight-landing.mp4",
+):
+    """Lineup stub. Defaults to a row that can be widened on either pane.
+
+    Carries every column LineupRead.model_validate needs (title + status
+    are required at the schema level) plus the trim-editor surface
+    (``*_url`` / ``*_url_original`` / ``*_trim_*``). All other LineupRead
+    fields default to ``None`` and Pydantic accepts that on Optional[..].
+    """
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        title="t",
+        status="accepted",
+        youtube_video_id=video_id,
+        chapter_start_seconds=chapter_start,
+        chapter_title="B smoke",
+        clip_url=clip_url,
+        clip_url_original=clip_url,
+        clip_trim_start_s=None,
+        clip_trim_end_s=None,
+        landing_clip_url=landing_clip_url,
+        landing_clip_url_original=landing_clip_url,
+        landing_clip_trim_start_s=None,
+        landing_clip_trim_end_s=None,
+        # Other Optional LineupRead fields — Pydantic .model_validate is
+        # happy with these being explicit None or missing entirely on a
+        # SimpleNamespace, but listing them makes the stub self-documenting.
+        stand_screenshot_url=None,
+        aim_screenshot_url=None,
+        stand_clip_url=None,
+        aim_clip_url=None,
+        game_id=None, map_id=None,
+        target_zone_id=None, stand_zone_id=None,
+        side=None, utility_type_id=None,
+        notes=None,
+        aim_anchor_x=None, aim_anchor_y=None,
+        stand_anchor_x=None, stand_anchor_y=None,
+        target_anchor_x=None, target_anchor_y=None,
+        setup_seconds=None, technique=None,
+        attribution_url=None, attribution_author=None,
+        suggested_game_id=None, suggested_map_id=None,
+        suggested_target_zone_id=None, suggested_stand_zone_id=None,
+        suggested_side=None, suggested_utility_type_id=None,
+        classification_confidence=None, classification_reasoning=None,
+        target_zone=None, stand_zone=None, utility_type=None,
+    )
+
+
+def _meta():
+    m = MagicMock()
+    m.description = ""
+    m.duration = 120
+    m.chapters = [{"start_time": 0, "end_time": 60, "title": "B smoke"}]
+    return m
+
+
+def _wide_ok(source_key="pending/vid123/0-clip-source.mp4"):
+    return WideSourceResult(
+        source_key=source_key, source_start_s=0.0, source_duration_s=60.0,
+    )
+
+
+def _wide_fail():
+    return WideSourceResult(error_codes=["wide_source_cut:rc=1"])
+
+
+# ---------------------------------------------------------------------------
+# Validation guards
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_pane_outside_trimmable_allow_list(self):
+        """Stand + aim panes have 1s micro-clips — widen is not meaningful."""
+        with pytest.raises(HTTPException) as exc_info:
+            await widen_pane_source(MagicMock(), _lineup(), "stand")
+        assert exc_info.value.status_code == 400
+        assert "cannot be widened" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_404_when_no_youtube_video_id(self):
+        """Manual uploads have no YouTube source — can't widen, must Replace."""
+        lineup = _lineup(video_id=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await widen_pane_source(MagicMock(), lineup, "throw")
+        assert exc_info.value.status_code == 404
+        assert "manual uploads cannot be widened" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_404_when_no_chapter_start_seconds(self):
+        """Ingest metadata incomplete — can't locate the chapter to widen."""
+        lineup = _lineup(chapter_start=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await widen_pane_source(MagicMock(), lineup, "throw")
+        assert exc_info.value.status_code == 404
+        assert "no chapter start" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Failure mapping — yt-dlp / ffmpeg / persist
+# ---------------------------------------------------------------------------
+
+
+def _common_patches(
+    *,
+    fetch=None,
+    download=None,
+    wide=None,
+    persist=None,
+    chapters=None,
+):
+    """Compose the typical patch stack for widen-source service tests."""
+    chapters = chapters or [
+        Chapter(start_seconds=0, end_seconds=60, title="B smoke"),
+    ]
+    return [
+        patch(
+            f"{_MOD}.fetch_video_detail",
+            new=fetch or AsyncMock(return_value=_meta()),
+        ),
+        patch(f"{_MOD}.parse_chapters", return_value=chapters),
+        patch(
+            f"{_MOD}.download_video",
+            new=download or AsyncMock(return_value=Path("/tmp/x.mp4")),
+        ),
+        patch(
+            f"{_MOD}.cut_and_upload_wide_source",
+            new=wide or AsyncMock(return_value=_wide_ok()),
+        ),
+        patch(
+            f"{_MOD}.set_clip_url_original",
+            new=persist or AsyncMock(),
+        ),
+        patch(
+            f"{_MOD}.set_landing_clip_url_original",
+            new=persist or AsyncMock(),
+        ),
+    ]
+
+
+def _enter(stack):
+    import contextlib
+    es = contextlib.ExitStack()
+    for p in stack:
+        es.enter_context(p)
+    return es
+
+
+class TestFailureMapping:
+    @pytest.mark.asyncio
+    async def test_yt_dlp_metadata_fetch_failure_is_502(self):
+        """yt-dlp metadata fetch failure → 502 with the structured error_type."""
+        fetch = AsyncMock(side_effect=YouTubeFetchError(
+            "gone", error_type="ExtractorError", original=Exception(),
+        ))
+        with _enter(_common_patches(fetch=fetch)):
+            with pytest.raises(HTTPException) as exc_info:
+                await widen_pane_source(MagicMock(), _lineup(), "throw")
+        assert exc_info.value.status_code == 502
+        assert "ExtractorError" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_chapter_not_found_is_404(self):
+        """Video chapters shifted since ingest → 404 — recoverable on re-ingest."""
+        chapters = [Chapter(start_seconds=999, end_seconds=1050, title="x")]
+        with _enter(_common_patches(chapters=chapters)):
+            with pytest.raises(HTTPException) as exc_info:
+                await widen_pane_source(MagicMock(), _lineup(), "throw")
+        assert exc_info.value.status_code == 404
+        assert "chapters changed since ingest" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_yt_dlp_download_failure_is_502(self):
+        dl = AsyncMock(side_effect=VideoDownloadError(
+            "boom", video_id="vid123",
+            error_type="UnavailableVideoError", original=Exception(),
+        ))
+        with _enter(_common_patches(download=dl)):
+            with pytest.raises(HTTPException) as exc_info:
+                await widen_pane_source(MagicMock(), _lineup(), "throw")
+        assert exc_info.value.status_code == 502
+        assert "UnavailableVideoError" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_wide_cut_failure_is_500_with_structured_codes(
+        self, tmp_path: Path,
+    ):
+        video_path = tmp_path / "v.mp4"; video_path.write_bytes(b"x")
+        wide = AsyncMock(return_value=_wide_fail())
+        download = AsyncMock(return_value=video_path)
+        with _enter(_common_patches(wide=wide, download=download)):
+            with pytest.raises(HTTPException) as exc_info:
+                await widen_pane_source(MagicMock(), _lineup(), "throw")
+        assert exc_info.value.status_code == 500
+        # Structured ffmpeg context propagated.
+        assert "wide_source_cut" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_is_500(self, tmp_path: Path):
+        video_path = tmp_path / "v.mp4"; video_path.write_bytes(b"x")
+        persist = AsyncMock(side_effect=RuntimeError("db down"))
+        download = AsyncMock(return_value=video_path)
+        with _enter(_common_patches(persist=persist, download=download)):
+            with pytest.raises(HTTPException) as exc_info:
+                await widen_pane_source(MagicMock(), _lineup(), "throw")
+        assert exc_info.value.status_code == 500
+        assert "database commit failed" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Happy paths + admin-shape contract
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_throw_widens_and_returns_admin_shape(self, tmp_path: Path):
+        """Widening throw: cut+upload via helper, persist clip_url_original,
+        return admin-shape LineupRead with the (signed) original key."""
+        video_path = tmp_path / "v.mp4"; video_path.write_bytes(b"x")
+        download = AsyncMock(return_value=video_path)
+        wide = AsyncMock(return_value=_wide_ok(
+            source_key="pending/vid123/0-clip-source.mp4",
+        ))
+        updated_lineup = _lineup()
+        updated_lineup.clip_url_original = "pending/vid123/0-clip-source.mp4"
+        persist_throw = AsyncMock(return_value=updated_lineup)
+        persist_landing = AsyncMock()
+
+        with _enter([
+            patch(f"{_MOD}.fetch_video_detail",
+                  new=AsyncMock(return_value=_meta())),
+            patch(f"{_MOD}.parse_chapters", return_value=[
+                Chapter(start_seconds=0, end_seconds=60, title="x"),
+            ]),
+            patch(f"{_MOD}.download_video", new=download),
+            patch(f"{_MOD}.cut_and_upload_wide_source", new=wide),
+            patch(f"{_MOD}.set_clip_url_original", new=persist_throw),
+            patch(f"{_MOD}.set_landing_clip_url_original",
+                  new=persist_landing),
+        ]):
+            result = await widen_pane_source(MagicMock(), _lineup(), "throw")
+
+        wide.assert_awaited_once()
+        wide_kwargs = wide.await_args.kwargs
+        assert wide_kwargs["source_key"] == "pending/vid123/0-clip-source.mp4"
+        # Throw persist called; landing persist NOT (independent panes).
+        persist_throw.assert_awaited_once()
+        persist_landing.assert_not_awaited()
+        # Returned shape is the LineupRead with clip_url_original present
+        # (admin shape). Signing in _build_admin_read may transform the URL,
+        # but the field must be populated (not None).
+        assert result.clip_url_original is not None
+        # Download was cleaned up.
+        assert not video_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_landing_widens_via_landing_persist(self, tmp_path: Path):
+        """Widening landing routes to the landing repo setter — NOT throw."""
+        video_path = tmp_path / "v.mp4"; video_path.write_bytes(b"x")
+        download = AsyncMock(return_value=video_path)
+        wide = AsyncMock(return_value=_wide_ok(
+            source_key="pending/vid123/0-landing-source.mp4",
+        ))
+        updated_lineup = _lineup()
+        updated_lineup.landing_clip_url_original = (
+            "pending/vid123/0-landing-source.mp4"
+        )
+        persist_landing = AsyncMock(return_value=updated_lineup)
+        persist_throw = AsyncMock()
+
+        with _enter([
+            patch(f"{_MOD}.fetch_video_detail",
+                  new=AsyncMock(return_value=_meta())),
+            patch(f"{_MOD}.parse_chapters", return_value=[
+                Chapter(start_seconds=0, end_seconds=60, title="x"),
+            ]),
+            patch(f"{_MOD}.download_video", new=download),
+            patch(f"{_MOD}.cut_and_upload_wide_source", new=wide),
+            patch(f"{_MOD}.set_clip_url_original", new=persist_throw),
+            patch(f"{_MOD}.set_landing_clip_url_original", new=persist_landing),
+        ]):
+            result = await widen_pane_source(MagicMock(), _lineup(), "landing")
+
+        # Landing persist called; throw persist NOT.
+        persist_landing.assert_awaited_once()
+        persist_throw.assert_not_awaited()
+        assert result.landing_clip_url_original is not None
+        assert not video_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_download_cleaned_up_even_on_persist_failure(
+        self, tmp_path: Path,
+    ):
+        """The downloaded video is unlinked in a finally block — a 500 from
+        persist must not leak temp files into ``INGESTION_DOWNLOAD_DIR``."""
+        video_path = tmp_path / "v.mp4"; video_path.write_bytes(b"x")
+        download = AsyncMock(return_value=video_path)
+        persist = AsyncMock(side_effect=RuntimeError("db down"))
+
+        with _enter(_common_patches(download=download, persist=persist)):
+            with pytest.raises(HTTPException):
+                await widen_pane_source(MagicMock(), _lineup(), "throw")
+
+        # The 500 propagated but the temp file was still cleaned up.
+        assert not video_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_download_cleaned_up_even_on_wide_failure(
+        self, tmp_path: Path,
+    ):
+        """Same cleanup invariant when the wide cut itself fails."""
+        video_path = tmp_path / "v.mp4"; video_path.write_bytes(b"x")
+        download = AsyncMock(return_value=video_path)
+        wide = AsyncMock(return_value=_wide_fail())
+
+        with _enter(_common_patches(download=download, wide=wide)):
+            with pytest.raises(HTTPException):
+                await widen_pane_source(MagicMock(), _lineup(), "throw")
+
+        assert not video_path.exists()


### PR DESCRIPTION
## Summary

- `POST /api/lineups/{id}/panes/{pane}/widen-source` — one-row sibling of the `python -m app.cli widen-source` backfill from PR #728
- Operator clicks "Widen source" in the trim editor → we re-fetch the YouTube video for THIS pane, cut a wider clip via the shared `cut_and_upload_wide_source` helper, and update `*_url_original` so the next trim can drag past the previous bounds
- Re-runnable: deterministic MinIO key (same `-clip-source` / `-landing-source` shape PR #728 uses) so repeated calls overwrite the same bytes — no orphans

## Failure mapping

| Status | Cause |
|---|---|
| 400 | Pane outside trim/widen allow-list (throw/landing only) |
| 404 | Lineup missing / no YouTube source / chapter shifted since ingest |
| 502 | yt-dlp metadata fetch or video download failed |
| 500 | ffmpeg cut, MinIO upload, or DB commit failed |

## PR3 follows

Frontend absolute timestamps in slider readout + Widen-source button → wires this endpoint into the trim editor UX.

## Test plan

- [x] 12 new tests in `test_pane_widen_source_service.py` (validation guards, failure mapping, happy paths, download cleanup invariant)
- [x] Full backend test suite passes (579 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)