### PR TITLE
feat(mjh): show Company column on Applications list

### DIFF
--- a/apps/myjobhunter/backend/app/repositories/application/application_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/application/application_repository.py
@@ -10,11 +10,13 @@ Soft-delete convention: ``applications`` carries ``deleted_at``. Reads filter
 list / detail endpoints. ``soft_delete`` is idempotent — calling it on a row
 that is already soft-deleted is a no-op (returns the existing row unchanged).
 
-Status query: ``list_with_status`` returns ``(Application, str | None)``
-tuples where the second element is the latest ``event_type`` from
-``application_events`` via a correlated scalar sub-select on the covering
-index ``ix_appevent_app_occurred(application_id, occurred_at) INCLUDE
-(event_type)``.  The INCLUDE column lets PostgreSQL satisfy the sub-select
+Status query: ``list_with_status`` returns
+``(Application, str | None, str)`` tuples where the second element is the
+latest ``event_type`` from ``application_events`` via a correlated scalar
+sub-select on the covering index ``ix_appevent_app_occurred(application_id,
+occurred_at) INCLUDE (event_type)``, and the third element is the
+``companies.name`` of the application's owning company (INNER joined since
+``applications.company_id`` is non-null).  The INCLUDE column lets PostgreSQL satisfy the sub-select
 entirely from the index leaf pages (Index Only Scan) with no heap fetch.
 No denormalized column is written to the ``applications`` table — status
 is always computed at query time per CLAUDE.md architecture rules.
@@ -151,8 +153,8 @@ async def list_with_status(
     since: _dt.datetime | None = None,
     limit: int = 100,
     offset: int = 0,
-) -> list[tuple[Application, str | None]]:
-    """List a user's non-deleted applications with their latest event type.
+) -> list[tuple[Application, str | None, str]]:
+    """List a user's non-deleted applications with their latest event type and company name.
 
     Uses a correlated scalar sub-select (equivalent to a lateral join) so
     PostgreSQL can use the covering index ``ix_appevent_app_occurred`` on
@@ -160,11 +162,13 @@ async def list_with_status(
     Only Scan per row with no heap fetch and no sequential scan of
     ``application_events``.
 
-    Returns a list of ``(Application, latest_event_type_or_None)`` tuples.
-    The ``latest_status`` is ``None`` for applications that have zero events.
-    Tenant isolation is enforced on both sides of the correlated sub-query
-    (``user_id`` on ``application_events`` as well) so user A's events can
-    never bleed into user B's application rows.
+    Returns a list of ``(Application, latest_event_type_or_None, company_name)``
+    tuples. The ``latest_status`` is ``None`` for applications that have
+    zero events. Tenant isolation is enforced on both sides of the
+    correlated sub-query (``user_id`` on ``application_events`` as well)
+    so user A's events can never bleed into user B's application rows.
+    The ``companies`` join is INNER because ``applications.company_id``
+    is non-null at the schema level.
 
     Optional filters:
     - ``company_id``: narrow to a specific company (tenant-safe — returns
@@ -193,7 +197,12 @@ async def list_with_status(
     )
 
     stmt = (
-        select(Application, latest_event_sq.label("latest_status"))
+        select(
+            Application,
+            latest_event_sq.label("latest_status"),
+            Company.name.label("company_name"),
+        )
+        .join(Company, Application.company_id == Company.id)
         .where(
             Application.user_id == user_id,
             Application.deleted_at.is_(None),
@@ -209,12 +218,12 @@ async def list_with_status(
 
     stmt = stmt.offset(offset).limit(limit)
     result = await db.execute(stmt)
-    rows = [(row[0], row[1]) for row in result.all()]
+    rows = [(row[0], row[1], row[2]) for row in result.all()]
 
     # status_filter is applied post-query because it filters on the sub-select
     # label value, which is not a real column and cannot be used in WHERE.
     if status_filter is not None:
-        rows = [(app, status) for app, status in rows if status == status_filter]
+        rows = [(app, status, company_name) for app, status, company_name in rows if status == status_filter]
 
     return rows
 

--- a/apps/myjobhunter/backend/app/schemas/application/application_list_item.py
+++ b/apps/myjobhunter/backend/app/schemas/application/application_list_item.py
@@ -1,13 +1,17 @@
 """Pydantic schema for a single row in ``GET /applications`` response.
 
-Extends the full ``ApplicationResponse`` with ``latest_status`` — the
-``event_type`` of the most-recent ``application_events`` row, computed by
-the repository via a correlated sub-select (lateral join idiom).  ``None``
-when the application has no events yet.
+Extends the full ``ApplicationResponse`` with two list-only fields:
+
+- ``latest_status`` — the ``event_type`` of the most-recent
+  ``application_events`` row, computed via a correlated sub-select
+  (lateral join idiom). ``None`` when the application has no events yet.
+- ``company_name`` — the display name from the joined ``companies`` row,
+  so the frontend table can render a Company column without a second
+  round-trip per row.
 
 Kept as a separate schema from ``ApplicationResponse`` so the detail
 endpoint (``GET /applications/{id}``) is not affected — it has no need to
-join against the event log.
+join against the event log or denormalize the company name.
 """
 from __future__ import annotations
 
@@ -15,6 +19,7 @@ from app.schemas.application.application_response import ApplicationResponse
 
 
 class ApplicationListItem(ApplicationResponse):
-    """ApplicationResponse extended with the computed status field."""
+    """ApplicationResponse extended with computed list-only fields."""
 
     latest_status: str | None = None
+    company_name: str | None = None

--- a/apps/myjobhunter/backend/app/services/application/application_service.py
+++ b/apps/myjobhunter/backend/app/services/application/application_service.py
@@ -105,8 +105,10 @@ async def list_applications(
         offset=offset,
     )
     return [
-        ApplicationListItem.model_validate(app).model_copy(update={"latest_status": status})
-        for app, status in rows
+        ApplicationListItem.model_validate(app).model_copy(
+            update={"latest_status": status, "company_name": company_name},
+        )
+        for app, status, company_name in rows
     ]
 
 

--- a/apps/myjobhunter/frontend/src/features/applications/ApplicationsSkeleton.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/ApplicationsSkeleton.tsx
@@ -1,9 +1,9 @@
 import { Skeleton } from "@platform/ui";
 
 // Column widths mirror the loaded DataTable column widths exactly.
-// Order: Role | Status | Location | Remote | Applied | Fit
-const COLUMN_WIDTHS = ["w-1/3", "w-20", "w-1/4", "w-20", "w-24", "w-16"] as const;
-const COLUMN_HEADERS = ["Role", "Status", "Location", "Remote", "Applied", "Fit"] as const;
+// Order: Company | Role | Status | Location | Remote | Applied | Fit
+const COLUMN_WIDTHS = ["w-1/5", "w-1/4", "w-20", "w-1/4", "w-20", "w-24", "w-16"] as const;
+const COLUMN_HEADERS = ["Company", "Role", "Status", "Location", "Remote", "Applied", "Fit"] as const;
 
 export default function ApplicationsSkeleton() {
   return (

--- a/apps/myjobhunter/frontend/src/pages/Applications.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Applications.tsx
@@ -11,10 +11,16 @@ import type { Application } from "@/types/application";
 
 const COLUMNS: ColumnDef<Application>[] = [
   {
+    id: "company_name",
+    header: "Company",
+    accessorFn: (row) => row.company_name ?? "—",
+    cell: ({ getValue }) => <span className="font-medium">{getValue<string>()}</span>,
+  },
+  {
     id: "role_title",
     header: "Role",
     accessorKey: "role_title",
-    cell: ({ getValue }) => <span className="font-medium">{getValue<string>()}</span>,
+    cell: ({ getValue }) => <span>{getValue<string>()}</span>,
   },
   {
     id: "latest_status",

--- a/apps/myjobhunter/frontend/src/pages/__tests__/Applications.test.tsx
+++ b/apps/myjobhunter/frontend/src/pages/__tests__/Applications.test.tsx
@@ -10,11 +10,14 @@ import Applications from "@/pages/Applications";
 vi.mock("@/lib/applicationsApi", () => ({
   useListApplicationsQuery: vi.fn(),
   useCreateApplicationMutation: vi.fn(),
+  useParseJobDescriptionMutation: vi.fn(),
+  useExtractJdFromUrlMutation: vi.fn(),
 }));
 
 vi.mock("@/lib/companiesApi", () => ({
   useListCompaniesQuery: vi.fn(),
   useCreateCompanyMutation: vi.fn(),
+  useTriggerCompanyResearchMutation: vi.fn(),
 }));
 
 // Suppress radix-dialog portal errors in jsdom.
@@ -46,16 +49,22 @@ vi.mock("@platform/ui", async (importOriginal) => {
 import {
   useListApplicationsQuery,
   useCreateApplicationMutation,
+  useParseJobDescriptionMutation,
+  useExtractJdFromUrlMutation,
 } from "@/lib/applicationsApi";
 import {
   useListCompaniesQuery,
   useCreateCompanyMutation,
+  useTriggerCompanyResearchMutation,
 } from "@/lib/companiesApi";
 
 const mockUseListApplicationsQuery = vi.mocked(useListApplicationsQuery);
 const mockUseCreateApplicationMutation = vi.mocked(useCreateApplicationMutation);
 const mockUseListCompaniesQuery = vi.mocked(useListCompaniesQuery);
 const mockUseCreateCompanyMutation = vi.mocked(useCreateCompanyMutation);
+const mockUseTriggerCompanyResearchMutation = vi.mocked(useTriggerCompanyResearchMutation);
+const mockUseParseJobDescriptionMutation = vi.mocked(useParseJobDescriptionMutation);
+const mockUseExtractJdFromUrlMutation = vi.mocked(useExtractJdFromUrlMutation);
 
 const stubMutation = [vi.fn(), { isLoading: false }] as unknown as ReturnType<
   typeof useCreateApplicationMutation
@@ -63,6 +72,18 @@ const stubMutation = [vi.fn(), { isLoading: false }] as unknown as ReturnType<
 
 const stubCompanyMutation = [vi.fn(), { isLoading: false }] as unknown as ReturnType<
   typeof useCreateCompanyMutation
+>;
+
+const stubResearchMutation = [vi.fn(), { isLoading: false }] as unknown as ReturnType<
+  typeof useTriggerCompanyResearchMutation
+>;
+
+const stubParseJdMutation = [vi.fn(), { isLoading: false }] as unknown as ReturnType<
+  typeof useParseJobDescriptionMutation
+>;
+
+const stubExtractJdMutation = [vi.fn(), { isLoading: false }] as unknown as ReturnType<
+  typeof useExtractJdFromUrlMutation
 >;
 
 function renderApplications() {
@@ -81,6 +102,7 @@ function makeApp(overrides: Partial<{
   id: string;
   role_title: string;
   latest_status: string | null;
+  company_name: string | null;
 }> = {}) {
   return {
     id: overrides.id ?? "app-1",
@@ -104,6 +126,7 @@ function makeApp(overrides: Partial<{
     external_ref: null,
     external_source: null,
     latest_status: overrides.latest_status ?? null,
+    company_name: overrides.company_name ?? "Acme Corp",
     deleted_at: null,
     created_at: "2026-01-01T00:00:00Z",
     updated_at: "2026-01-01T00:00:00Z",
@@ -115,6 +138,9 @@ describe("Applications page", () => {
     vi.clearAllMocks();
     mockUseCreateApplicationMutation.mockReturnValue(stubMutation);
     mockUseCreateCompanyMutation.mockReturnValue(stubCompanyMutation);
+    mockUseTriggerCompanyResearchMutation.mockReturnValue(stubResearchMutation);
+    mockUseParseJobDescriptionMutation.mockReturnValue(stubParseJdMutation);
+    mockUseExtractJdFromUrlMutation.mockReturnValue(stubExtractJdMutation);
     mockUseListCompaniesQuery.mockReturnValue({
       data: { items: [], total: 0 },
       isLoading: false,
@@ -292,6 +318,40 @@ describe("Applications page", () => {
       renderApplications();
 
       expect(screen.getByRole("columnheader", { name: /status/i })).toBeInTheDocument();
+    });
+
+    it("renders the Company column with the company_name value", () => {
+      mockUseListApplicationsQuery.mockReturnValue({
+        data: {
+          items: [makeApp({ latest_status: "applied", company_name: "Stripe" })],
+          total: 1,
+        },
+        isLoading: false,
+        isError: false,
+        error: undefined,
+      } as unknown as ReturnType<typeof useListApplicationsQuery>);
+
+      renderApplications();
+
+      expect(screen.getByRole("columnheader", { name: /company/i })).toBeInTheDocument();
+      expect(screen.getByRole("cell", { name: "Stripe" })).toBeInTheDocument();
+    });
+
+    it("renders an em-dash in the Company cell when company_name is null", () => {
+      mockUseListApplicationsQuery.mockReturnValue({
+        data: {
+          items: [makeApp({ latest_status: "applied", company_name: null })],
+          total: 1,
+        },
+        isLoading: false,
+        isError: false,
+        error: undefined,
+      } as unknown as ReturnType<typeof useListApplicationsQuery>);
+
+      renderApplications();
+
+      const dashes = screen.getAllByText("—");
+      expect(dashes.length).toBeGreaterThan(0);
     });
 
     it("renders unknown event type with neutral badge text (no crash)", () => {

--- a/apps/myjobhunter/frontend/src/types/application.ts
+++ b/apps/myjobhunter/frontend/src/types/application.ts
@@ -44,6 +44,13 @@ export interface Application {
    */
   latest_status: string | null;
 
+  /**
+   * Display name of the joined company. Returned by the list endpoint
+   * so the Applications table can render a Company column without an
+   * extra round-trip per row. Only present in list responses.
+   */
+  company_name: string | null;
+
   deleted_at: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Summary

The Applications table previously surfaced only **Role / Status / Location / Remote / Applied / Fit** — the company a row belongs to was invisible (visible in the screenshot the user flagged). Adds a leftmost **Company** column, sourced from a new `company_name` field on the list endpoint.

### Backend
- `list_with_status` INNER JOINs `companies` (`applications.company_id` is non-null) and returns `(Application, latest_status, company_name)` triples
- `ApplicationListItem` adds `company_name: str | None = None`
- Mirrors the existing Kanban endpoint's pattern (`list_for_kanban` already joins `Company.name` + `logo_url`); logo deferred — list cell is text-only for now

### Frontend
- `Application` type carries `company_name: string | null`
- `Applications.tsx` adds a "Company" column left of "Role" (em-dash on null)
- `ApplicationsSkeleton` mirrors the new column order + widths
- Adds 2 `Applications.test.tsx` tests for the new column

### Drive-by cleanup
Fixes pre-existing mock-incomplete failures in `Applications.test.tsx` — the dialog component consumes `useTriggerCompanyResearchMutation` / `useParseJobDescriptionMutation` / `useExtractJdFromUrlMutation`, but the test mock had not kept up. 9 tests that were failing on `main` now pass.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npx vitest run src/pages/__tests__/Applications.test.tsx` — 13/13 pass
- [ ] CI green
- [ ] Manual: visit `/applications`, confirm Company column renders with company name on each row

🤖 Generated with [Claude Code](https://claude.com/claude-code)