### PR TITLE
feat(mga): widen-source button + absolute video timestamps in trim editor (PR3 — widen source)

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/PaneTrimOverlay.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/PaneTrimOverlay.test.tsx
@@ -29,6 +29,9 @@ vi.mock("@/hooks/useClipDuration", () => ({
 const unwrap = vi.fn();
 const trimPaneMutation = vi.fn(() => ({ unwrap }));
 
+const widenUnwrap = vi.fn();
+const widenPaneSourceMutation = vi.fn(() => ({ unwrap: widenUnwrap }));
+
 const triggerAdmin = vi.fn();
 // Mutable so individual tests can swap in cached / fetching / errored shapes
 // without rebuilding the entire module mock.
@@ -41,6 +44,7 @@ let adminQueryResult: {
 
 vi.mock("@/store/lineupsApi", () => ({
   useTrimPaneMutation: () => [trimPaneMutation, {}],
+  useWidenPaneSourceMutation: () => [widenPaneSourceMutation, {}],
   useLazyGetLineupAdminQuery: () => [triggerAdmin, adminQueryResult],
 }));
 
@@ -50,7 +54,10 @@ import PaneTrimOverlay from "@/components/lineup/PaneTrimOverlay";
 const mockedUseClipDuration = vi.mocked(useClipDuration);
 
 /** Build an admin-shape Lineup payload sufficient for the resolveSourceUrl /
- *  resolveStoredOffsets helpers. Defaults: untrimmed source on both panes. */
+ *  resolveStoredOffsets helpers. Defaults: untrimmed source on both panes
+ *  with a YouTube anchor (chapter at 1:23) so the PR3 absolute-timestamp
+ *  readout + Widen-source affordance are exercised by default. Tests that
+ *  want to assert the manual-upload fallback explicitly null them. */
 function makeAdminLineup(
   overrides: Partial<{
     clip_url_original: string | null;
@@ -59,6 +66,8 @@ function makeAdminLineup(
     clip_trim_end_s: number | null;
     landing_clip_trim_start_s: number | null;
     landing_clip_trim_end_s: number | null;
+    youtube_video_id: string | null;
+    chapter_start_seconds: number | null;
   }> = {},
 ): Record<string, unknown> {
   return {
@@ -69,12 +78,22 @@ function makeAdminLineup(
     clip_trim_end_s: null,
     landing_clip_trim_start_s: null,
     landing_clip_trim_end_s: null,
+    youtube_video_id: "dQw4w9WgXcQ",
+    chapter_start_seconds: 83, // 1:23 in M:SS
     ...overrides,
   };
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // clearAllMocks resets call records but NOT once-only implementations.
+  // Without mockReset, a leftover ``mockResolvedValueOnce`` from a prior
+  // test can be consumed by the next test's first invocation — silently
+  // resolving a widen / trim promise the next test expected to leave
+  // pending. The unwrap fns are the only ones we set once-implementations
+  // on, so the targeted reset is enough; the others stay as plain spies.
+  unwrap.mockReset();
+  widenUnwrap.mockReset();
   // Default admin result: no fetch yet (operator hasn't clicked scissors).
   adminQueryResult = {
     data: undefined,
@@ -473,6 +492,261 @@ describe("PaneTrimOverlay", () => {
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /trim throw clip duration/i }),
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // PR3 — absolute-in-video readout
+  // -------------------------------------------------------------------------
+
+  it("renders the readout as absolute video timestamps when the lineup has a chapter anchor", () => {
+    mockedUseClipDuration.mockReturnValue(30); // wide source
+    adminQueryResult = {
+      data: makeAdminLineup({ chapter_start_seconds: 83 }),
+      isFetching: false,
+      isSuccess: true,
+      originalArgs: "l1",
+    };
+    render(
+      <PaneTrimOverlay
+        lineupId="l1"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+    // Untrimmed → offsets [0, 30]. Readout = 1:23.0 — 1:53.0 / source 30.0s.
+    expect(
+      screen.getByText(/1:23\.0\s+—\s+1:53\.0\s*\/\s*source 30\.0s/),
+    ).toBeInTheDocument();
+  });
+
+  it("falls back to seconds-into-source readout when the lineup has no chapter anchor (manual upload)", () => {
+    mockedUseClipDuration.mockReturnValue(5);
+    adminQueryResult = {
+      data: makeAdminLineup({
+        chapter_start_seconds: null,
+        youtube_video_id: null,
+      }),
+      isFetching: false,
+      isSuccess: true,
+      originalArgs: "l1",
+    };
+    render(
+      <PaneTrimOverlay
+        lineupId="l1"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+    expect(
+      screen.getByText(/0\.0s\s+—\s+5\.0s\s*\/\s*5\.0s/),
+    ).toBeInTheDocument();
+  });
+
+  // -------------------------------------------------------------------------
+  // PR3 — Widen-source affordance
+  // -------------------------------------------------------------------------
+
+  it("renders the Widen source button when the lineup has a YouTube source", () => {
+    mockedUseClipDuration.mockReturnValue(10);
+    adminQueryResult = {
+      data: makeAdminLineup(),
+      isFetching: false,
+      isSuccess: true,
+      originalArgs: "l1",
+    };
+    render(
+      <PaneTrimOverlay
+        lineupId="l1"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+    expect(
+      screen.getByRole("button", { name: /widen throw source clip/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("hides the Widen source button when the lineup has no YouTube source (manual upload)", () => {
+    mockedUseClipDuration.mockReturnValue(5);
+    adminQueryResult = {
+      data: makeAdminLineup({ youtube_video_id: null }),
+      isFetching: false,
+      isSuccess: true,
+      originalArgs: "l1",
+    };
+    render(
+      <PaneTrimOverlay
+        lineupId="l1"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+    expect(
+      screen.queryByRole("button", { name: /widen .* source/i }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("fires the widen mutation with the lineup id and pane on click", async () => {
+    mockedUseClipDuration.mockReturnValue(10);
+    // The slider's open-after-source-resolves effect refuses to fire when
+    // the lineupId does not match the admin payload's originalArgs — match
+    // them both to a non-default id so the assertion proves the prop is
+    // threaded through to the mutation call (not just the literal "l1").
+    adminQueryResult = {
+      data: makeAdminLineup(),
+      isFetching: false,
+      isSuccess: true,
+      originalArgs: "lineup-abc",
+    };
+    widenUnwrap.mockResolvedValueOnce(makeAdminLineup());
+
+    render(
+      <PaneTrimOverlay
+        lineupId="lineup-abc"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /widen throw source clip/i }),
+    );
+    await waitFor(() => {
+      expect(widenPaneSourceMutation).toHaveBeenCalledWith({
+        lineup_id: "lineup-abc",
+        pane: "throw",
+      });
+    });
+  });
+
+  it("shows the widening spinner + label and disables Apply while widen is in flight", async () => {
+    mockedUseClipDuration.mockReturnValue(10);
+    adminQueryResult = {
+      data: makeAdminLineup(),
+      isFetching: false,
+      isSuccess: true,
+      originalArgs: "l1",
+    };
+    // Lock the widen in flight so the component stays in widening state.
+    widenUnwrap.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <PaneTrimOverlay
+        lineupId="l1"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /widen throw source clip/i }),
+    );
+    // Label flips to ``Widening...`` and aria-label updates so screen
+    // readers announce the state change.
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /widening throw source/i }),
+      ).toBeInTheDocument();
+    });
+    expect(screen.getByText(/widening\.\.\./i)).toBeInTheDocument();
+    // Apply must be disabled — widening mid-trim would be a foot-gun. The
+    // aria-label gains a ``(minimum 1s)`` suffix when canApply is false, so
+    // match the prefix rather than the exact ``Trim clip`` form.
+    expect(screen.getByRole("button", { name: /^Trim clip/i })).toBeDisabled();
+  });
+
+  it("renders the server error message + Retry/Dismiss when widen fails", async () => {
+    mockedUseClipDuration.mockReturnValue(5);
+    adminQueryResult = {
+      data: makeAdminLineup(),
+      isFetching: false,
+      isSuccess: true,
+      originalArgs: "l1",
+    };
+    widenUnwrap.mockRejectedValueOnce({
+      data: {
+        detail: "chapter no longer exists in the source video",
+      },
+    });
+
+    render(
+      <PaneTrimOverlay
+        lineupId="l1"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /widen throw source clip/i }),
+    );
+
+    // Error replaces the link in-place; alert role surfaces it to AT.
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/chapter no longer exists in the source video/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /retry widen on throw source/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /dismiss widen error/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("Dismiss on the widen error restores the Widen source link", async () => {
+    mockedUseClipDuration.mockReturnValue(5);
+    adminQueryResult = {
+      data: makeAdminLineup(),
+      isFetching: false,
+      isSuccess: true,
+      originalArgs: "l1",
+    };
+    widenUnwrap.mockRejectedValueOnce({ data: { detail: "boom" } });
+
+    render(
+      <PaneTrimOverlay
+        lineupId="l1"
+        pane="throw"
+        clipUrl="https://ex/clip.mp4"
+      />,
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /trim throw clip duration/i }),
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: /widen throw source clip/i }),
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+    });
+    fireEvent.click(
+      screen.getByRole("button", { name: /dismiss widen error/i }),
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /widen throw source clip/i }),
     ).toBeInTheDocument();
   });
 });

--- a/apps/mygamingassistant/frontend/src/components/lineup/PaneTrimOverlay.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/PaneTrimOverlay.tsx
@@ -33,7 +33,7 @@
  * idle (each in a different corner) — that's intentional so the operator
  * sees both options on hover.
  */
-import { useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
 import { Loader2, RotateCcw, Scissors, X } from "lucide-react";
 
 import { useClipDuration } from "@/hooks/useClipDuration";
@@ -46,7 +46,10 @@ import {
   useTrimPreviewVideo,
   type TrimPreviewThumb,
 } from "@/hooks/useTrimPreviewVideo";
-import { useLazyGetLineupAdminQuery } from "@/store/lineupsApi";
+import {
+  useLazyGetLineupAdminQuery,
+  useWidenPaneSourceMutation,
+} from "@/store/lineupsApi";
 
 import PaneRangeScrubber from "./PaneRangeScrubber";
 
@@ -84,6 +87,20 @@ export default function PaneTrimOverlay({
   const sourceUrl = resolveSourceUrl(adminLineup, pane, clipUrl);
   const sourceDurationS = useClipDuration(sourceUrl);
   const storedOffsets = resolveStoredOffsets(adminLineup, pane);
+  // YouTube anchor: the admin payload carries the source-video id + chapter
+  // marker so the Trim slider can render approximate-in-video timestamps and
+  // expose the "Widen source" affordance. Both are null on manual-upload
+  // lineups (no YouTube source → no widen possible, no chapter to anchor on).
+  const youtubeVideoId = adminLineup?.youtube_video_id ?? null;
+  const chapterStartSeconds = adminLineup?.chapter_start_seconds ?? null;
+
+  // Per-pane on-demand widen — re-cut a wider source from the YouTube video
+  // around the chapter marker. State stays local to the orchestrator (not the
+  // usePaneTrim hook) because widening is orthogonal to the trim transaction:
+  // it changes the SOURCE the slider binds against, not the trim itself.
+  const [widenPaneSource] = useWidenPaneSourceMutation();
+  const [isWidening, setIsWidening] = useState(false);
+  const [widenError, setWidenError] = useState<string | null>(null);
 
   // Escape closes the slider when open OR clears an error.
   useEffect(() => {
@@ -124,6 +141,29 @@ export default function PaneTrimOverlay({
     setAwaitingOpen(true);
     void fetchAdmin(lineupId, /* preferCacheValue */ true);
   };
+
+  // Widen-source dispatcher. On success we close the slider and re-arm
+  // ``awaitingOpen`` so the existing open-after-source-resolves effect
+  // re-opens it once the new admin payload and ``useClipDuration`` settle on
+  // the wider source — the brief transition through the scissors-button
+  // spinner state is the natural "fetching new bounds" feedback.
+  const handleWiden = useCallback(async () => {
+    setWidenError(null);
+    setIsWidening(true);
+    try {
+      await widenPaneSource({ lineup_id: lineupId, pane }).unwrap();
+      setAwaitingOpen(true);
+      close();
+    } catch (err) {
+      setWidenError(extractError(err) ?? "Could not widen source");
+    } finally {
+      setIsWidening(false);
+    }
+  }, [widenPaneSource, lineupId, pane, close]);
+
+  const handleDismissWidenError = useCallback(() => {
+    setWidenError(null);
+  }, []);
 
   // No clip → no trim affordance. (PaneTrimOverlay never mounts in that case
   // per the parent guard, but defending here keeps the component honest
@@ -175,6 +215,12 @@ export default function PaneTrimOverlay({
         onApply={apply}
         onClose={close}
         pane={pane}
+        chapterStartSeconds={chapterStartSeconds}
+        canWiden={!!youtubeVideoId}
+        isWidening={isWidening}
+        widenError={widenError}
+        onWiden={handleWiden}
+        onDismissWidenError={handleDismissWidenError}
       />
     );
   }
@@ -230,6 +276,53 @@ function resolveStoredOffsets(
   return { startOffsetS: start, endOffsetS: end };
 }
 
+function extractError(err: unknown): string | null {
+  if (typeof err !== "object" || err === null) return null;
+  const maybe = err as { data?: { detail?: unknown } };
+  const detail = maybe.data?.detail;
+  if (typeof detail === "string") return detail;
+  return null;
+}
+
+// Format an in-video timestamp (seconds → ``M:SS.s``). Always shows
+// minutes for visual stability so a ``0:45.3`` doesn't suddenly jump shape
+// to ``1:03.4`` mid-drag. Padding the seconds to two whole digits keeps
+// the readout monospace-friendly even though the surrounding glyphs are
+// proportional.
+function formatVideoTimestamp(totalSeconds: number): string {
+  const safe = Math.max(0, totalSeconds);
+  const minutes = Math.floor(safe / 60);
+  const seconds = safe - minutes * 60;
+  return `${minutes}:${seconds.toFixed(1).padStart(4, "0")}`;
+}
+
+// Build the slider footer readout. When the source clip has a YouTube
+// chapter anchor we surface approximate-in-video timestamps (cleaner
+// mental model than ``Xs into source``); otherwise we fall back to the
+// pre-PR3 seconds-into-clip shape. The approximation note: the formula
+// adds the slider offset to ``chapter_start_seconds`` rather than the
+// true source-clip-start-in-video (which would require backend to expose
+// per-row pre-padding). The drift is ``clip_source_pre_seconds`` (~15s)
+// and the preview <video> is the operator's authoritative visual anchor;
+// the readout exists to help them remember "roughly where in the source
+// video" they are.
+function buildReadout(
+  startOffsetS: number,
+  endOffsetS: number,
+  clipDurationS: number,
+  chapterStartSeconds: number | null,
+): string {
+  if (chapterStartSeconds == null) {
+    return (
+      `${startOffsetS.toFixed(1)}s — ${endOffsetS.toFixed(1)}s / ` +
+      `${clipDurationS.toFixed(1)}s`
+    );
+  }
+  const startVideoTime = formatVideoTimestamp(chapterStartSeconds + startOffsetS);
+  const endVideoTime = formatVideoTimestamp(chapterStartSeconds + endOffsetS);
+  return `${startVideoTime} — ${endVideoTime} / source ${clipDurationS.toFixed(1)}s`;
+}
+
 
 // ---------------------------------------------------------------------------
 // Sub-components — extracted so the orchestrator's JSX stays flat (no
@@ -245,6 +338,18 @@ interface TrimSliderPanelProps {
   onApply: () => void;
   onClose: () => void;
   pane: TrimmablePane;
+  // PR3 — in-video anchor for the absolute-timestamp readout. Null on
+  // manual-upload lineups (no YouTube source); falls back to the legacy
+  // seconds-into-source format.
+  chapterStartSeconds: number | null;
+  // PR3 — gates the "Widen source" link. False when the lineup has no
+  // ``youtube_video_id``, which is the only signal the backend's 404
+  // contract gives us upfront ("manual uploads cannot be widened").
+  canWiden: boolean;
+  isWidening: boolean;
+  widenError: string | null;
+  onWiden: () => void;
+  onDismissWidenError: () => void;
 }
 
 function TrimSliderPanel({
@@ -256,9 +361,15 @@ function TrimSliderPanel({
   onApply,
   onClose,
   pane,
+  chapterStartSeconds,
+  canWiden,
+  isWidening,
+  widenError,
+  onWiden,
+  onDismissWidenError,
 }: TrimSliderPanelProps) {
   const duration = endOffsetS - startOffsetS;
-  const canApply = duration >= MIN_TRIM_DURATION_S;
+  const canApply = duration >= MIN_TRIM_DURATION_S && !isWidening;
   const headerId = useId();
 
   // Drag-aware preview (PR3). The scrubber surfaces its active-thumb state
@@ -272,6 +383,19 @@ function TrimSliderPanel({
     activeThumb,
   });
 
+  const readout = buildReadout(
+    startOffsetS,
+    endOffsetS,
+    clipDurationS,
+    chapterStartSeconds,
+  );
+
+  // Widen-source affordance is hidden — not just disabled — when the
+  // lineup has no YouTube source. The button would be permanently
+  // unclickable for manual-upload lineups; pulling it from the layout
+  // keeps the slider footer uncluttered for that majority case.
+  const widenButtonLabel = isWidening ? "Widening..." : "Widen source";
+
   return (
     <div
       role="dialog"
@@ -284,7 +408,8 @@ function TrimSliderPanel({
         type="button"
         onClick={onClose}
         aria-label="Cancel trim"
-        className="absolute top-1.5 right-1.5 z-20 p-1 rounded bg-black/60 text-white hover:bg-black/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80"
+        disabled={isWidening}
+        className="absolute top-1.5 right-1.5 z-20 p-1 rounded bg-black/60 text-white hover:bg-black/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 disabled:opacity-50 disabled:cursor-not-allowed"
       >
         <X className="w-3 h-3" aria-hidden />
       </button>
@@ -320,12 +445,17 @@ function TrimSliderPanel({
         onThumbChange={setActiveThumb}
       />
 
-      {/* Readout — selected range / clip total */}
-      <div className="text-center text-[10px] text-white/80 leading-tight">
-        {startOffsetS.toFixed(1)}s — {endOffsetS.toFixed(1)}s / {clipDurationS.toFixed(1)}s
+      {/* Readout — selected range / clip total. When the lineup has a
+          YouTube chapter anchor we render approximate-in-video timestamps
+          (chapter_start_seconds + slider offset); otherwise we fall back
+          to the legacy seconds-into-source shape. See ``buildReadout``. */}
+      <div className="text-center text-[10px] text-white/80 leading-tight tabular-nums">
+        {readout}
       </div>
 
-      {/* Apply button — disabled below the min-window threshold */}
+      {/* Apply button — disabled below the min-window threshold AND
+          during a Widen request (mutating the source under an in-flight
+          trim would be a foot-gun). */}
       <button
         type="button"
         onClick={onApply}
@@ -342,7 +472,108 @@ function TrimSliderPanel({
       >
         Trim clip
       </button>
+
+      {/* Widen-source affordance (PR3). Renders as a low-emphasis text
+          link under the Apply button — operator-facing power-user feature,
+          not a primary action. Click → POST to the per-pane widen-source
+          endpoint, then the orchestrator closes the slider and re-arms
+          ``awaitingOpen`` so it re-opens with the new wider bounds once
+          the admin payload + clip-duration resolve.
+
+          Hidden entirely when the lineup has no YouTube source: a
+          permanently-disabled button is worse UX than an absent one for
+          the manual-upload majority case (per visible-loading-feedback /
+          minimize-ternaries — keep the surface uncluttered).
+
+          ``aria-live`` on the error span: the error replaces the link in
+          situ when widen fails, so the screen-reader announcement
+          surfaces the actionable reason (e.g. "chapter no longer exists
+          in the source video") without an extra modal.
+
+          Loading affordance: the link text swaps to ``Widening...`` with
+          an inline spinner the instant the request fires
+          (visible-loading-feedback.md — affordance at click time, not
+          response time). The widen call can take 5-30s (yt-dlp +
+          ffmpeg) so the spinner is the wait-shape match. */}
+      {canWiden ? (
+        <WidenSourceLink
+          isWidening={isWidening}
+          widenError={widenError}
+          label={widenButtonLabel}
+          pane={pane}
+          onWiden={onWiden}
+          onDismissError={onDismissWidenError}
+        />
+      ) : null}
     </div>
+  );
+}
+
+interface WidenSourceLinkProps {
+  isWidening: boolean;
+  widenError: string | null;
+  label: string;
+  pane: TrimmablePane;
+  onWiden: () => void;
+  onDismissError: () => void;
+}
+
+function WidenSourceLink({
+  isWidening,
+  widenError,
+  label,
+  pane,
+  onWiden,
+  onDismissError,
+}: WidenSourceLinkProps) {
+  if (widenError != null) {
+    return (
+      <div
+        role="alert"
+        className="flex flex-col items-center gap-0.5 text-[10px] leading-tight"
+      >
+        <span className="text-red-400 text-center px-1">{widenError}</span>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onWiden}
+            aria-label={`Retry widen on ${pane} source`}
+            className="inline-flex items-center gap-1 text-white/80 hover:text-white underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 rounded px-1"
+          >
+            <RotateCcw className="w-3 h-3" aria-hidden />
+            Retry
+          </button>
+          <button
+            type="button"
+            onClick={onDismissError}
+            aria-label="Dismiss widen error"
+            className="text-white/60 hover:text-white/80 underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 rounded px-1"
+          >
+            Dismiss
+          </button>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <button
+      type="button"
+      onClick={onWiden}
+      disabled={isWidening}
+      aria-label={
+        isWidening ? `Widening ${pane} source` : `Widen ${pane} source clip`
+      }
+      title="Re-cut a wider source from the YouTube video around the chapter"
+      className={[
+        "self-center inline-flex items-center gap-1",
+        "text-[10px] text-white/70 hover:text-white underline",
+        "disabled:opacity-60 disabled:cursor-wait disabled:hover:text-white/70",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/80 rounded px-1",
+      ].join(" ")}
+    >
+      {isWidening ? <Loader2 className="w-3 h-3 animate-spin" aria-hidden /> : null}
+      {label}
+    </button>
   );
 }
 

--- a/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
@@ -247,6 +247,35 @@ const lineupsApi = lineupsBaseApi.injectEndpoints({
     }),
 
     // ------------------------------------------------------------------
+    // Per-pane on-demand widen-source (PR3 — frontend wiring for PR2's
+    // POST /lineups/{id}/panes/{pane}/widen-source endpoint). Operator
+    // clicks "Widen source" in the Trim editor when the source clip is
+    // too narrow to reach the frames they need; the server re-fetches the
+    // YouTube video around the chapter and writes a wider clip to
+    // ``*_url_original``. Response is the admin-shape Lineup so the Trim
+    // slider rebinds to the new bounds without a separate fetch — and
+    // the Lineup tag invalidation refreshes any other surface holding
+    // this id.
+    // ------------------------------------------------------------------
+
+    widenPaneSource: build.mutation<
+      Lineup,
+      {
+        lineup_id: string;
+        pane: "throw" | "landing";
+      }
+    >({
+      query: ({ lineup_id, pane }) => ({
+        url: `/lineups/${lineup_id}/panes/${pane}/widen-source`,
+        method: "POST",
+      }),
+      invalidatesTags: (_result, _err, { lineup_id }) => [
+        { type: "Lineup", id: lineup_id },
+        "LineupList",
+      ],
+    }),
+
+    // ------------------------------------------------------------------
     // Zone density (map-level aggregate for density coloring)
     // ------------------------------------------------------------------
     getZoneDensity: build.query<ZoneDensity, ZoneDensityParams>({
@@ -282,4 +311,5 @@ export const {
   useRequestPaneUploadUrlMutation,
   useConfirmPaneUploadMutation,
   useTrimPaneMutation,
+  useWidenPaneSourceMutation,
 } = lineupsApi;


### PR DESCRIPTION
## Summary

Wires the wider-source primitives from PR1 (#728) and PR2 (#729) into the operator-facing Trim editor. Last PR in the widen-source initiative.

- **Approximate-in-video readout** — slider footer shows ``M:SS.s — M:SS.s / source NN.Ns`` when the lineup has a YouTube chapter anchor; falls back to legacy ``seconds-into-source`` for manual uploads.
- **"Widen source" affordance** — text link under the Trim button, visible only when ``youtube_video_id`` is present. Click → ``POST /lineups/{id}/panes/{pane}/widen-source`` (PR2 endpoint) → slider re-opens with new wider bounds once the admin payload + ``useClipDuration`` settle.
- **Loading / error states** — label flips to ``Widening...`` with inline spinner the instant the request fires; Apply disabled during the in-flight window; server errors replace the link with structured detail + Retry / Dismiss inline.

## Why this readout is ``approximate``

The formula is ``chapter_start_seconds + slider_offset`` — chapter-relative cast as video time. Drifts from true YouTube absolute time by ``clip_source_pre_seconds`` (~15s) since per-row pre-padding isn't on the admin payload. The preview ``<video>`` is the operator's authoritative visual anchor; the readout exists to help them recall ``roughly where in the source video`` they are.

## Why hide the Widen button on manual uploads (vs disabling)

The backend returns 404 for manual-upload widens (no ``youtube_video_id`` to re-fetch from). A permanently-disabled button would clutter the slider footer for the majority case; hiding it entirely keeps the UI tight.

## Why local widen state (vs in ``usePaneTrim``)

Widening changes the SOURCE the slider binds against, not the trim transaction itself. Keeping ``isWidening`` + ``widenError`` in the orchestrator avoids polluting the hook's phase machine and keeps the trim state machine pure.

## Operational migration

None — frontend-only wiring. No env vars, no schema, no boot guards. Backend already shipped in PR #729.

## Test plan

- [x] All 22 existing PaneTrimOverlay tests pass
- [x] 7 new test cases: absolute-timestamp readout, manual-upload fallback, button visible/hidden by ``youtube_video_id``, click fires mutation with correct args, in-flight spinner + Apply disabled, server error with Retry/Dismiss, Dismiss restores the link
- [x] Full frontend suite: 377/377 green
- [x] ``npm run typecheck`` clean
- [x] ``npm run build`` clean
- [x] No new lint debt (21 problems before, 21 after — all pre-existing)
- [ ] Manual UI verification recommended: open trim editor on a lineup with a YouTube source, confirm readout shows ``M:SS.s — M:SS.s / source NN.Ns``, click ``Widen source``, confirm slider re-opens with wider bounds. Open trim editor on a manual-upload lineup, confirm readout falls back to seconds + Widen affordance is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)