### PR TITLE
perf(mga): detach <video> src on scroll-out in ClipView (was sticky-armed)

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -228,16 +228,47 @@ describe("GlanceBoardTile THROW pane (clip)", () => {
     expect(playSpy).toHaveBeenCalled();
   });
 
-  it("pauses when the tile leaves the viewport", () => {
+  it("stops playback when the tile leaves the viewport (via src detach)", () => {
+    // Post-perf-fix: scroll-out disarms the tile (armed=false), which causes
+    // <video> to re-render without a src attribute. The browser stops
+    // playback as a side effect of src removal — we no longer call pause()
+    // explicitly because the play/pause effect early-returns when !armed.
+    // The detached src is the assertion that matters; explicit pause was an
+    // implementation detail of the previous sticky-arm design.
     render(
       <GlanceBoardTile
         lineup={makeLineup({ clip_url: "https://ex.com/clip.mp4" })}
       />,
     );
+    const video = document.querySelector("video") as HTMLVideoElement;
     expect(lastIO).not.toBeNull();
     act(() => lastIO!.cb([{ isIntersecting: true }]));
+    expect(video.getAttribute("src")).toBe("https://ex.com/clip.mp4");
     act(() => lastIO!.cb([{ isIntersecting: false }]));
-    expect(pauseSpy).toHaveBeenCalled();
+    expect(video.hasAttribute("src")).toBe(false);
+  });
+
+  it("detaches src on scroll-out so the browser can release decoded frames", () => {
+    // Perf fix: sticky-arm was costing us — a glance board with 60+ lineups
+    // (4 video tags each) accumulates decoded frames in GPU memory and
+    // exhausts browser per-origin connection slots. After this fix the src
+    // attribute is removed when the tile leaves the viewport, dropping the
+    // <video> back to its lazy state for the next scroll-in.
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ clip_url: "https://ex.com/clip.mp4" })}
+      />,
+    );
+    const video = document.querySelector("video") as HTMLVideoElement;
+    act(() => lastIO!.cb([{ isIntersecting: true }]));
+    expect(video.getAttribute("src")).toBe("https://ex.com/clip.mp4");
+    expect(video.getAttribute("preload")).toBe("auto");
+
+    act(() => lastIO!.cb([{ isIntersecting: false }]));
+    // src attribute removed (not src="") AND preload reverted to "metadata"
+    // — same posture as before the tile was ever armed.
+    expect(video.hasAttribute("src")).toBe(false);
+    expect(video.getAttribute("preload")).toBe("metadata");
   });
 
   it("hides the THROW badge when the clip fails to load", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -94,7 +94,6 @@ class FakeIO {
 }
 
 let playSpy: ReturnType<typeof vi.spyOn>;
-let pauseSpy: ReturnType<typeof vi.spyOn>;
 
 beforeEach(() => {
   lastIO = null;
@@ -104,9 +103,7 @@ beforeEach(() => {
   playSpy = vi
     .spyOn(window.HTMLMediaElement.prototype, "play")
     .mockResolvedValue(undefined);
-  pauseSpy = vi
-    .spyOn(window.HTMLMediaElement.prototype, "pause")
-    .mockImplementation(() => {});
+  vi.spyOn(window.HTMLMediaElement.prototype, "pause").mockImplementation(() => {});
 });
 
 afterEach(() => {

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
@@ -88,6 +88,17 @@ export function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProp
 // PR5 generalised the corner label to a prop so both THROW and LANDING use
 // the same byte-for-byte primitive. The aria-label and loading behaviour are
 // shared — only the label + URL differ between the two surfaces.
+//
+// **Arm lifecycle (post-perf-fix):** ``armed`` flips ON when the tile enters
+// the viewport and OFF when it leaves — i.e. the src attribute is detached on
+// scroll-out, not just paused. The pre-fix sticky-arm behaviour decoded every
+// clip the operator had ever scrolled past, accumulating GPU-held frames as
+// the operator browsed a large map (each ``map`` page mounts 4 video tags
+// per lineup × N lineups, and a CS2 map can carry 60-80 lineups). The
+// trade-off: scroll-back-in re-fetches the MP4 from MinIO instead of
+// re-using a decoded clip, costing ~100-300ms before the loop starts
+// playing again. That's worth bounding worst-case memory; the alternative
+// is unbounded growth.
 // ---------------------------------------------------------------------------
 interface ClipViewProps {
   clipUrl: string;
@@ -108,8 +119,11 @@ interface ClipViewProps {
 
 export function ClipView({ clipUrl, posterUrl, title, label = "THROW", children }: ClipViewProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  // Sticky once the tile has been seen: keep the src attached (re-fetching on
-  // every scroll-by is worse than keeping a paused decoded clip).
+  // ``armed`` controls whether the <video> has a src attached. The tile arms
+  // on viewport entry and DISARMS on viewport exit (post-perf-fix; was
+  // sticky-armed previously). Disarming detaches the src so the browser can
+  // release decoded frames + the underlying HTTP connection — critical for
+  // grids that mount dozens of looping H.264 streams.
   const [armed, setArmed] = useState(false);
   // True while the tile is on screen — drives play/pause in a separate effect
   // so play() never runs before React has committed the src to the DOM.
@@ -143,7 +157,12 @@ export function ClipView({ clipUrl, posterUrl, title, label = "THROW", children 
           setArmed(true);
           setInView(true);
         } else {
+          // Scroll-out: pause (via inView=false → play/pause effect) AND
+          // detach src (via armed=false → src={undefined}). The previous
+          // sticky-arm kept decoded frames around forever; on a 60-lineup
+          // map that exhausts GPU memory and browser connection slots.
           setInView(false);
+          setArmed(false);
         }
       },
       { threshold: 0.25 },


### PR DESCRIPTION
## Summary

Detach `<video>` src on scroll-out in `ClipView` so the browser releases decoded frames + the underlying TCP connection. Pre-fix, sticky-arm meant a CS2 map with 60-80 lineups (4 clips each) accumulated 240-320 paused-but-buffered video tags by the time the operator finished scrolling — eating GPU memory and exhausting the browser's per-origin connection cap.

## Root cause

`IntersectionObserver` armed on viewport entry but only paused (never disarmed) on exit. Comment in the prior implementation justified the sticky behavior with ``re-fetching on every scroll-by is worse than keeping a paused decoded clip`` — true for small grids; false the moment lineup count crosses a couple dozen.

## Trade-off

Scroll-back-in re-fetches the MP4 from MinIO instead of resuming a decoded clip — adds ~100-300ms before the loop replays. Bounded worst-case memory in exchange for a small re-arm delay; I think that's clearly the right cut for a 60-lineup map.

## Test plan

- [x] Updated "pauses when tile leaves viewport" to assert src detach (the contract) rather than the explicit `pause()` spy (implementation detail under the old sticky design — pause is now implicit in src removal)
- [x] New test "detaches src on scroll-out so the browser can release decoded frames" — covers lazy → armed → disarmed full transition with preload assertions
- [x] All 378 frontend tests pass (1 new)
- [x] Typecheck clean
- [ ] Manual verification: scroll through cs2/mirage and confirm responsiveness; scroll back to a previously-seen tile and confirm clip reloads within a fraction of a second

## Follow-ups deferred

If the symptom persists after this lands, the natural next steps are an **explicit concurrent-arm cap** (FIFO or distance-from-viewport-center eviction) and **pre-rendered thumbnail-quality posters at ingest** so the grid uses `<img>` and only swaps to `<video>` on hover/focus. Not in this PR — viewport-based natural cap should be sufficient for typical map sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)