### PR TITLE
feat(mga): POST /panes/{stand|aim}/shift-window endpoint (PR2 — STAND/AIM editor)

### DIFF
--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -58,6 +58,7 @@ from app.schemas.game.lineup_schemas import (
     PendingLineupsResponse,
     UploadUrlResponse,
 )
+from app.schemas.game.pane_shift_window_schemas import PaneShiftWindowRequest
 from app.schemas.game.pane_trim_schemas import PaneTrimRequest
 from app.schemas.game.pane_upload_schemas import (
     Pane,
@@ -67,6 +68,7 @@ from app.schemas.game.pane_upload_schemas import (
 )
 from app.services.game import (
     lineup_service,
+    pane_shift_window_service,
     pane_trim_service,
     pane_upload_service,
     pane_widen_source_service,
@@ -612,3 +614,47 @@ async def widen_pane_source(
     if lineup is None:
         raise HTTPException(status_code=404, detail="Lineup not found")
     return await pane_widen_source_service.widen_pane_source(db, lineup, pane)
+
+
+# ---------------------------------------------------------------------------
+# Per-pane STAND/AIM shift-window — fixed-width sibling of /trim.
+#
+# Re-cuts the served 1s micro-clip at the operator's chosen offset inside
+# the shared wider source ``clip_url_original``. The slider in the frontend
+# is single-thumb (window width is fixed at 1s) so the operator just chooses
+# where the window starts; the throw / landing trim endpoints handle the
+# two-thumb range case for those panes. See pane_shift_window_service.
+# ---------------------------------------------------------------------------
+
+
+@auth_router.post(
+    "/lineups/{lineup_id}/panes/{pane}/shift-window",
+    response_model=LineupRead,
+)
+async def shift_pane_window(
+    lineup_id: uuid.UUID,
+    pane: Pane,
+    body: PaneShiftWindowRequest,
+    db: AsyncSession = Depends(get_db),
+) -> LineupRead:
+    """Re-cut the STAND or AIM 1-second micro-clip at ``body.offset_s``.
+
+    Pane must be ``stand`` or ``aim`` (THROW + LANDING use the variable-
+    width ``/trim`` endpoint instead — see the comment on that handler).
+
+    Failure shapes:
+      * 400 — pane outside the shiftable allow-list, or offset_s pushes
+              past the wider source's actual duration
+      * 404 — lineup missing
+      * 409 — no wider source for this chapter (``clip_url_original`` is
+              null or equals ``clip_url``; widen-source the throw pane
+              first to unlock shifting for all four panes)
+      * 502 — MinIO download or upload failed
+      * 500 — ffprobe, ffmpeg cut, or DB commit failed
+    """
+    lineup = await get_lineup_orm(db, lineup_id)
+    if lineup is None:
+        raise HTTPException(status_code=404, detail="Lineup not found")
+    return await pane_shift_window_service.shift_pane_window(
+        db, lineup, pane, body,
+    )

--- a/apps/mygamingassistant/backend/app/schemas/game/pane_shift_window_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/pane_shift_window_schemas.py
@@ -1,0 +1,77 @@
+"""Schemas for the per-pane STAND/AIM shift-window flow.
+
+The STAND and AIM panes carry 1-second looping micro-clips anchored on the
+classifier-chosen frame the existing stand/aim still represents. When the
+classifier picks a bad anchor — common on busy frames where the player is
+moving — the served clip shows the wrong moment and the whole storyboard
+tile looks wrong even when the lineup itself is classified correctly.
+
+This is the operator's way out: drag a single-thumb slider that picks where
+in the SHARED wider source ``clip_url_original`` the 1-second window starts,
+then save. The micro-clip width is fixed (1.0s); only the start offset is
+operator-controlled — that's why this is a "shift", not a "trim".
+
+Endpoint:
+
+  POST /api/lineups/{lineup_id}/panes/{pane}/shift-window
+       body: PaneShiftWindowRequest {offset_s}
+       -> LineupRead (admin shape — re-binds slider thumb)
+
+Only ``stand`` and ``aim`` panes are shiftable. THROW + LANDING use a
+two-thumb range trim instead (``PaneTrimRequest``); their wider source
+column is the same ``clip_url_original`` but the user-controlled width
+is variable, not fixed.
+
+Validation is split: pydantic enforces non-negative numeric bounds here;
+the service layer enforces the upper bound against the actual wider
+source's duration (which we don't know until we've probed it).
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Pane allow-list — STAND + AIM only. THROW + LANDING are trimmable via
+# ``PaneTrimRequest`` (variable-width range, separate endpoint).
+# ---------------------------------------------------------------------------
+
+ShiftablePane = Literal["stand", "aim"]
+
+SHIFTABLE_PANES: frozenset[ShiftablePane] = frozenset({"stand", "aim"})
+
+
+# ---------------------------------------------------------------------------
+# Window-width constant — must match
+# ``app.services.ingestion.micro_clip_generator._MICRO_CLIP_SECONDS``. The
+# shift endpoint re-cuts the served micro-clip at this exact width starting
+# from the operator's chosen offset; ingest cuts at the same width starting
+# from the classifier's chosen anchor. Both paths produce 1s clips so the
+# StandPane / AimPane swap between them seamlessly.
+# ---------------------------------------------------------------------------
+
+MICRO_CLIP_DURATION_S = 1.0
+
+
+class PaneShiftWindowRequest(BaseModel):
+    """Operator-supplied start offset for the 1-second STAND/AIM window.
+
+    The offset is in seconds from the start of ``clip_url_original`` — the
+    SHARED wider source the throw / stand / aim panes all index into (reuse
+    over per-pane originals saves ~4 GB MinIO across the library). 0.0 means
+    "start the 1-second window at the very beginning of the wider source";
+    the upper bound (`source_duration - 1.0`) is enforced at the service
+    layer once the wider source has been downloaded + probed (we don't know
+    the duration here at validation time).
+    """
+
+    offset_s: float = Field(
+        ...,
+        ge=0.0,
+        description=(
+            "Seconds from the start of clip_url_original where the served "
+            "1-second micro-clip should begin. Upper bound enforced "
+            "server-side against the wider source's actual duration."
+        ),
+    )

--- a/apps/mygamingassistant/backend/app/services/game/pane_shift_window_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/pane_shift_window_service.py
@@ -1,0 +1,314 @@
+"""Per-pane STAND/AIM shift-window service.
+
+The STAND and AIM panes show 1-second looping micro-clips anchored on the
+classifier's chosen stand/aim frame. When the classifier picks badly, the
+operator needs a way to nudge the 1-second window without leaving the
+glance board. This service is the backend half of that flow: it re-cuts
+the served micro-clip at the operator's chosen offset inside the SHARED
+wider source ``clip_url_original`` (the same column the throw trim editor
+reads from — micro panes reuse the chapter's wider source rather than
+keeping per-pane originals; saves ~4 GB MinIO across the library).
+
+End-to-end:
+
+  1. Validate pane (only ``stand`` / ``aim`` — THROW/LANDING use the
+     two-thumb trim path instead).
+  2. Validate the wider source exists. ``clip_url_original`` MUST be set
+     AND must be distinct from ``clip_url``; equality means the ingest
+     widen-source step fell back to the legacy "original = served" posture
+     (no wider footage available) and shifting is a no-op. Returns 409 with
+     a "widen source first" message in that case.
+  3. Download ``clip_url_original`` bytes from MinIO and ffprobe the
+     duration. We need the actual on-disk duration (not the math from
+     chapter bounds) to enforce a precise upper bound on ``offset_s``.
+  4. Validate ``offset_s + 1.0 <= source_duration``. Pydantic already
+     enforces ``offset_s >= 0``; the upper bound depends on the source
+     bytes, so it lives here.
+  5. Cut a 1.0s clip from the wider source at ``offset_s`` via the shared
+     :func:`cut_clip` helper (same encode contract as ingest's micro-clip
+     cut so glance-board playback stays consistent).
+  6. Upload the new clip under the same deterministic
+     ``pending_stand_clip_key`` / ``pending_aim_clip_key`` the ingest path
+     used — overwriting in place. Re-shifts overwrite the same object, no
+     orphans.
+  7. Persist ``stand_clip_url`` (or ``aim_clip_url``) + ``stand_clip_offset_s``
+     (or ``aim_clip_offset_s``) via the PR1 setter's two-shape contract
+     (offset_s kwarg). The shift overlay opens the slider at the saved
+     offset on the next visit.
+  8. Return the admin-shape LineupRead so the frontend rebinds the slider
+     without a separate fetch.
+
+Failures (per rules/check-third-party-error-codes.md): structured codes are
+captured + surfaced. MinIO download failure → 502; ffprobe / ffmpeg failure
+→ 500 with the structured stderr context; DB commit failure → 500. Never
+a silent fail-through.
+
+Note on offset semantics: ``offset_s`` is in seconds from the start of the
+WIDER source, NOT from the chapter start. The frontend converts between
+the two (chapter offset + clip_source_pre_seconds) when surfacing
+human-readable timestamps to the operator.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.storage import get_storage
+from app.models.game.lineup import Lineup
+from app.repositories.game.lineup_repo import (
+    set_aim_clip_url,
+    set_stand_clip_url,
+)
+from app.schemas.game.lineup_schemas import LineupRead
+from app.schemas.game.pane_shift_window_schemas import (
+    MICRO_CLIP_DURATION_S,
+    SHIFTABLE_PANES,
+    PaneShiftWindowRequest,
+    ShiftablePane,
+)
+from app.services.game.lineup_service import _build_admin_read
+from app.services.ingestion.frame_extractor import (
+    ClipCutError,
+    ProbeError,
+    cut_clip,
+    probe_duration,
+)
+from app.services.ingestion.micro_clip_generator import (
+    pending_aim_clip_key,
+    pending_stand_clip_key,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def _validate_pane(pane: str) -> ShiftablePane:
+    """Reject panes outside the shift allow-list with a 400.
+
+    THROW + LANDING use the two-thumb trim path (``pane_trim_service``); only
+    STAND + AIM have a single-offset shift UX because their served clip
+    width is fixed at 1.0s.
+    """
+    if pane not in SHIFTABLE_PANES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"pane '{pane}' cannot be shifted (only "
+                f"{sorted(SHIFTABLE_PANES)} have a fixed-width micro-clip "
+                "today; throw/landing use the two-thumb trim endpoint instead)"
+            ),
+        )
+    return pane  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Pane → (source key fn, persistence setter) dispatch.
+# Resolved inline in shift_pane_window rather than via a module-level table
+# so tests that patch ``pane_shift_window_service.set_stand_clip_url``
+# actually see the patched binding (same rationale as pane_trim_service).
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+async def shift_pane_window(
+    db: AsyncSession,
+    lineup: Lineup,
+    pane: str,
+    request: PaneShiftWindowRequest,
+) -> LineupRead:
+    """Re-cut the STAND or AIM 1-second micro-clip at *request.offset_s*.
+
+    Caller (route handler) resolves *lineup* from the path so a 404 surfaces
+    cleanly without us duplicating the lookup.
+
+    Each step has its own structured failure mode (400 for invalid pane /
+    offset out of range, 409 for "widen source first", 502 for MinIO,
+    500 for ffprobe/ffmpeg/DB) — never a silent fail-through.
+    """
+    shiftable_pane = _validate_pane(pane)
+
+    # The shared wider source must exist AND be distinct from the served
+    # clip. Equality means the throw widen-source step never ran (or fell
+    # back to the legacy "original = served" posture), so there's no wider
+    # footage to shift inside. 409 communicates "do the prerequisite first"
+    # rather than 404 which would imply "the lineup doesn't exist".
+    if (
+        lineup.clip_url_original is None
+        or lineup.clip_url_original == lineup.clip_url
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "no wider source for this chapter — click 'Widen source' on "
+                "the throw pane first; that unlocks shifting for stand/aim "
+                "too (the wider source is shared across all four panes)"
+            ),
+        )
+
+    source_key = lineup.clip_url_original
+
+    # ---- Download the wider source from MinIO --------------------------
+    storage = get_storage()
+    loop = asyncio.get_running_loop()
+    try:
+        source_bytes = await loop.run_in_executor(
+            None, storage.download_file, source_key
+        )
+    except Exception as exc:  # noqa: BLE001 — surface as a 502 with context
+        logger.warning(
+            "pane_shift_window: source download failed: lineup=%s pane=%s "
+            "key=%s error=%s",
+            lineup.id, pane, source_key, str(exc),
+        )
+        raise HTTPException(
+            status_code=502,
+            detail=f"could not download wider source clip from storage: {exc}",
+        ) from exc
+
+    # Write to a temp file so ffprobe / ffmpeg can input-seek through it.
+    # NamedTemporaryFile + delete=False lets us close the handle before
+    # ffprobe + ffmpeg read (Windows-safe) and unlink in a finally block.
+    with tempfile.NamedTemporaryFile(suffix=".mp4", delete=False) as tmp:
+        tmp.write(source_bytes)
+        source_path = Path(tmp.name)
+
+    try:
+        # ---- Probe the actual duration ---------------------------------
+        # We need the on-disk duration (not the chapter-math estimate) to
+        # enforce a precise upper bound on offset_s. ffprobe is cheap
+        # (~50ms) and ensures the validation matches reality even if
+        # clip_source_pre/post_seconds changed since the wider source was
+        # cut.
+        try:
+            source_duration = await probe_duration(source_path)
+        except ProbeError as exc:
+            logger.warning(
+                "pane_shift_window: ffprobe failed: lineup=%s pane=%s "
+                "returncode=%d stderr=%s",
+                lineup.id, pane, exc.returncode, exc.stderr,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "could not probe wider source duration "
+                    f"(ffprobe rc={exc.returncode}); the source file may "
+                    "be corrupt"
+                ),
+            ) from exc
+
+        # ---- Enforce the operator's offset is in range ------------------
+        max_offset = source_duration - MICRO_CLIP_DURATION_S
+        if max_offset < 0:
+            # The wider source is shorter than the micro-clip width.
+            # Shouldn't happen for any real wider source (chapter + pre/post
+            # is always at least a few seconds) but guard against corrupt
+            # state rather than feeding ffmpeg a negative duration.
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"wider source is too short ({source_duration:.3f}s) "
+                    "to host a 1-second micro-clip — re-run widen-source"
+                ),
+            )
+        if request.offset_s > max_offset:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"offset_s {request.offset_s:.3f}s would push the "
+                    f"1-second window past the wider source "
+                    f"({source_duration:.3f}s); valid range is "
+                    f"[0, {max_offset:.3f}]"
+                ),
+            )
+
+        # ---- Cut the new 1s micro-clip ----------------------------------
+        try:
+            clip_bytes = await cut_clip(
+                source_path,
+                start_seconds=request.offset_s,
+                duration_seconds=MICRO_CLIP_DURATION_S,
+            )
+        except ClipCutError as exc:
+            logger.warning(
+                "pane_shift_window: ffmpeg cut failed: lineup=%s pane=%s "
+                "offset=%.3f returncode=%d stderr=%s",
+                lineup.id, pane, request.offset_s, exc.returncode, exc.stderr,
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"ffmpeg shift cut failed (rc={exc.returncode}); the "
+                    "wider source may be corrupt"
+                ),
+            ) from exc
+
+        # ---- Pane dispatch (key fn + repo setter) -----------------------
+        if shiftable_pane == "stand":
+            new_key = pending_stand_clip_key(
+                lineup.youtube_video_id or "",
+                float(lineup.chapter_start_seconds or 0),
+            )
+            persist = set_stand_clip_url
+        else:  # "aim" — exhaustive per _validate_pane
+            new_key = pending_aim_clip_key(
+                lineup.youtube_video_id or "",
+                float(lineup.chapter_start_seconds or 0),
+            )
+            persist = set_aim_clip_url
+
+        # ---- Upload (overwrites the deterministic key) ------------------
+        # The micro-clip key is one per (video, chapter start), so re-shifting
+        # overwrites the same MinIO object — no orphan accumulation.
+        try:
+            await loop.run_in_executor(
+                None, storage.upload_file, new_key, clip_bytes, "video/mp4"
+            )
+        except Exception as exc:  # noqa: BLE001 — surface as 502 with context
+            logger.warning(
+                "pane_shift_window: upload failed: lineup=%s pane=%s "
+                "key=%s error=%s",
+                lineup.id, pane, new_key, str(exc),
+            )
+            raise HTTPException(
+                status_code=502,
+                detail=f"could not upload shifted clip to storage: {exc}",
+            ) from exc
+
+        # ---- Persist clip_url + offset_s in one commit ------------------
+        try:
+            updated = await persist(
+                db, lineup, new_key, offset_s=request.offset_s,
+            )
+        except Exception as exc:  # noqa: BLE001 — surface any DB failure
+            logger.warning(
+                "pane_shift_window: %s_clip_url persist failed (object "
+                "uploaded, column not committed): lineup=%s key=%s error=%s",
+                shiftable_pane, lineup.id, new_key, str(exc),
+            )
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    "shifted clip uploaded but database commit failed; "
+                    "re-trying should succeed once the underlying issue "
+                    "is resolved"
+                ),
+            ) from exc
+
+        return _build_admin_read(updated)
+    finally:
+        # Always clean up the temp source file — even on success the bytes
+        # are no longer needed (MinIO owns the canonical copy).
+        source_path.unlink(missing_ok=True)

--- a/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/frame_extractor.py
@@ -467,3 +467,73 @@ async def cut_clip(
     return await loop.run_in_executor(
         None, _cut_clip_sync, video_path, start_seconds, duration_seconds
     )
+
+
+class ProbeError(Exception):
+    """Raised when ffprobe cannot read a duration from a video file.
+
+    Captures the returncode + stderr the same way :class:`ClipCutError`
+    does so callers can surface a structured 5xx with the actionable
+    ffprobe message rather than a bare 500.
+    """
+
+    def __init__(self, message: str, *, returncode: int, stderr: str) -> None:
+        super().__init__(message)
+        self.returncode = returncode
+        self.stderr = stderr
+
+
+def _probe_duration_sync(video_path: Path) -> float:
+    """Synchronously read the duration in seconds from *video_path* via ffprobe.
+
+    Uses ``-show_entries format=duration`` + ``-of csv=p=0`` to get a single
+    bare-number stdout line — cheaper than the full JSON output and trivial
+    to parse. Raises :class:`ProbeError` on any non-zero exit or unparseable
+    output so callers never confuse "duration is 0.0" with "ffprobe failed".
+    """
+    cmd = [
+        "ffprobe",
+        "-v", "error",
+        "-show_entries", "format=duration",
+        "-of", "csv=p=0",
+        str(video_path),
+    ]
+    result = subprocess.run(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        stderr_text = result.stderr.decode("utf-8", errors="replace")
+        logger.error(
+            "ffprobe duration failed: video=%s returncode=%d stderr=%s",
+            video_path, result.returncode, stderr_text,
+        )
+        raise ProbeError(
+            f"ffprobe exited {result.returncode} probing {video_path.name}",
+            returncode=result.returncode,
+            stderr=stderr_text,
+        )
+    raw = result.stdout.decode("utf-8", errors="replace").strip()
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise ProbeError(
+            f"ffprobe produced unparseable duration for {video_path.name}: "
+            f"{raw!r}",
+            returncode=result.returncode,
+            stderr=result.stderr.decode("utf-8", errors="replace"),
+        ) from exc
+
+
+async def probe_duration(video_path: Path) -> float:
+    """Return the duration (seconds) of *video_path* via ffprobe.
+
+    Runs the blocking ffprobe subprocess in the default thread-pool executor
+    so it doesn't block the event loop (same shape as :func:`cut_clip`).
+    Raises :class:`ProbeError` on any ffprobe failure (non-zero exit or
+    unparseable output) — never a silent 0.0.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _probe_duration_sync, video_path)

--- a/apps/mygamingassistant/backend/tests/test_frame_extractor.py
+++ b/apps/mygamingassistant/backend/tests/test_frame_extractor.py
@@ -15,11 +15,13 @@ import pytest
 from app.services.ingestion.frame_extractor import (
     ClipCutError,
     FrameExtractionError,
+    ProbeError,
     clip_window_timestamps,
     cut_clip,
     extract_frames,
     extract_frames_downscaled,
     grid_timestamps,
+    probe_duration,
 )
 
 _FAKE_PNG = b"\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00"  # PNG magic bytes header
@@ -329,3 +331,60 @@ class TestCutClip:
 
         after = set(glob.glob(str(Path(tempfile.gettempdir()) / "*.mp4")))
         assert after == before
+
+
+class TestProbeDuration:
+    @pytest.mark.asyncio
+    async def test_returns_float_from_ffprobe_stdout(self, tmp_path: Path):
+        """ffprobe with -of csv=p=0 emits a bare-number stdout line — we
+        parse it as a float and return."""
+        video = tmp_path / "src.mp4"
+        video.write_bytes(b"fake")
+
+        ok = MagicMock()
+        ok.returncode = 0
+        ok.stdout = b"12.345\n"
+        ok.stderr = b""
+        with patch("subprocess.run", return_value=ok) as mr:
+            duration = await probe_duration(video)
+
+        assert duration == pytest.approx(12.345)
+        cmd = mr.call_args[0][0]
+        assert cmd[0] == "ffprobe"
+        assert "-show_entries" in cmd
+
+    @pytest.mark.asyncio
+    async def test_raises_probe_error_on_nonzero_exit(self, tmp_path: Path):
+        video = tmp_path / "src.mp4"
+        video.write_bytes(b"fake")
+
+        bad = MagicMock()
+        bad.returncode = 1
+        bad.stdout = b""
+        bad.stderr = b"Invalid data"
+        with patch("subprocess.run", return_value=bad):
+            with pytest.raises(ProbeError) as exc_info:
+                await probe_duration(video)
+
+        assert exc_info.value.returncode == 1
+        assert "Invalid data" in exc_info.value.stderr
+
+    @pytest.mark.asyncio
+    async def test_raises_probe_error_on_unparseable_stdout(
+        self, tmp_path: Path,
+    ):
+        """A non-numeric stdout (e.g. ``N/A`` from ffprobe on a corrupt file)
+        must be a structured ProbeError, NOT a silent 0.0 — the caller can
+        then surface a 5xx with the actionable reason."""
+        video = tmp_path / "src.mp4"
+        video.write_bytes(b"fake")
+
+        weird = MagicMock()
+        weird.returncode = 0
+        weird.stdout = b"N/A\n"
+        weird.stderr = b""
+        with patch("subprocess.run", return_value=weird):
+            with pytest.raises(ProbeError) as exc_info:
+                await probe_duration(video)
+
+        assert "unparseable duration" in str(exc_info.value)

--- a/apps/mygamingassistant/backend/tests/test_pane_shift_window_service.py
+++ b/apps/mygamingassistant/backend/tests/test_pane_shift_window_service.py
@@ -1,0 +1,340 @@
+"""Unit tests for the STAND/AIM per-pane shift-window service.
+
+Mirrors :mod:`test_pane_trim_service` (download → cut → upload pipeline) and
+:mod:`test_pane_widen_source_service` (pane validation + admin-shape return)
+since this service is the fixed-width sibling of both.
+
+The shift flow re-cuts the served 1-second STAND/AIM micro-clip at the
+operator's chosen ``offset_s`` inside the shared wider source
+``clip_url_original`` (the same column the throw trim editor reads from —
+micro panes reuse the chapter's wider source rather than keeping per-pane
+originals).
+"""
+from __future__ import annotations
+
+import types
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+from app.schemas.game.pane_shift_window_schemas import PaneShiftWindowRequest
+from app.services.game import pane_shift_window_service
+from app.services.game.pane_shift_window_service import shift_pane_window
+from app.services.ingestion.frame_extractor import ClipCutError, ProbeError
+
+_MOD = "app.services.game.pane_shift_window_service"
+_FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
+
+
+def _lineup(
+    *,
+    clip_url="pending/vid123/10-clip.mp4",
+    clip_url_original="pending/vid123/10-clip-source.mp4",
+    chapter_start_seconds=10,
+    youtube_video_id="vid123",
+):
+    """ORM-like Lineup stub with the columns shift_pane_window reads.
+
+    Defaults reflect a "shiftable" row — wider source present and distinct
+    from the served clip. Each test overrides only what it needs.
+    """
+    return types.SimpleNamespace(
+        id=uuid.uuid4(),
+        title="t",
+        status="accepted",
+        youtube_video_id=youtube_video_id,
+        chapter_start_seconds=chapter_start_seconds,
+        chapter_title="B smoke",
+        clip_url=clip_url,
+        clip_url_original=clip_url_original,
+        # Fields _build_admin_read reads (we patch _build_admin_read in
+        # most tests, but listing them keeps the stub self-documenting).
+        clip_trim_start_s=None,
+        clip_trim_end_s=None,
+        landing_clip_url=None,
+        landing_clip_url_original=None,
+        landing_clip_trim_start_s=None,
+        landing_clip_trim_end_s=None,
+        stand_screenshot_url=None,
+        aim_screenshot_url=None,
+        stand_clip_url=None,
+        aim_clip_url=None,
+        stand_clip_offset_s=None,
+        aim_clip_offset_s=None,
+    )
+
+
+def _storage_mock(download_bytes: bytes = _FAKE_MP4):
+    storage = MagicMock()
+    storage.download_file = MagicMock(return_value=download_bytes)
+    storage.upload_file = MagicMock()
+    return storage
+
+
+@pytest.fixture
+def patched_pipeline():
+    """Patch the heavy externals — storage + ffprobe + cut + persist + build_read.
+
+    Yields a dict of the relevant mocks so individual tests can configure
+    return values / side effects + assert call shape.
+    """
+    storage = _storage_mock()
+    set_stand = AsyncMock(side_effect=lambda db, lineup, key, **kw: lineup)
+    set_aim = AsyncMock(side_effect=lambda db, lineup, key, **kw: lineup)
+    build_read = MagicMock(side_effect=lambda lineup: f"admin_read({lineup.id})")
+
+    with (
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.probe_duration", AsyncMock(return_value=10.0)) as probe,
+        patch(f"{_MOD}.cut_clip", AsyncMock(return_value=_FAKE_MP4)) as cut,
+        patch(f"{_MOD}.set_stand_clip_url", set_stand),
+        patch(f"{_MOD}.set_aim_clip_url", set_aim),
+        patch(f"{_MOD}._build_admin_read", build_read),
+    ):
+        yield {
+            "storage": storage,
+            "probe": probe,
+            "cut": cut,
+            "set_stand": set_stand,
+            "set_aim": set_aim,
+            "build_read": build_read,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Validation guards
+# ---------------------------------------------------------------------------
+
+
+class TestValidation:
+    @pytest.mark.asyncio
+    async def test_rejects_pane_outside_shiftable_allow_list(self):
+        """THROW + LANDING use the variable-width trim path; the shift
+        endpoint must reject them with a 400 explaining the routing."""
+        body = PaneShiftWindowRequest(offset_s=2.0)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "throw", body)
+        assert exc_info.value.status_code == 400
+        assert "cannot be shifted" in exc_info.value.detail
+
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "landing", body)
+        assert exc_info.value.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_no_wider_source(self):
+        """clip_url_original is None → 409 telling the operator to widen first."""
+        body = PaneShiftWindowRequest(offset_s=2.0)
+        lineup = _lineup(clip_url_original=None)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), lineup, "stand", body)
+        assert exc_info.value.status_code == 409
+        assert "widen source" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_rejects_when_original_equals_served(self):
+        """clip_url_original == clip_url → ingest fell back to the legacy
+        posture (no wider source available). Same 409 as 'never widened'."""
+        body = PaneShiftWindowRequest(offset_s=2.0)
+        lineup = _lineup(
+            clip_url="pending/vid/0-clip.mp4",
+            clip_url_original="pending/vid/0-clip.mp4",  # same!
+        )
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), lineup, "aim", body)
+        assert exc_info.value.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_pydantic_rejects_negative_offset(self):
+        """Schema-level guard — never reach the service for offset < 0."""
+        with pytest.raises(Exception):  # pydantic.ValidationError
+            PaneShiftWindowRequest(offset_s=-0.5)
+
+    @pytest.mark.asyncio
+    async def test_rejects_offset_past_source_duration(self, patched_pipeline):
+        """Service-layer upper bound: offset + 1.0 must fit inside the
+        actual wider source's probed duration. ffprobe returns 10.0s; a
+        9.5s offset would leave only 0.5s of window — reject as 400."""
+        patched_pipeline["probe"].return_value = 10.0
+        body = PaneShiftWindowRequest(offset_s=9.5)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "stand", body)
+        assert exc_info.value.status_code == 400
+        assert "1-second window" in exc_info.value.detail
+        # cut_clip must NOT have been invoked — validation failed first.
+        patched_pipeline["cut"].assert_not_awaited()
+        patched_pipeline["set_stand"].assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_rejects_source_shorter_than_micro_clip(
+        self, patched_pipeline,
+    ):
+        """A wider source shorter than 1.0s can't host the micro-clip.
+        Shouldn't happen for any real chapter, but we guard rather than
+        feeding ffmpeg a negative duration."""
+        patched_pipeline["probe"].return_value = 0.5
+        body = PaneShiftWindowRequest(offset_s=0.0)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "stand", body)
+        assert exc_info.value.status_code == 500
+        assert "too short" in exc_info.value.detail
+
+
+# ---------------------------------------------------------------------------
+# Happy path — stand and aim each end-to-end
+# ---------------------------------------------------------------------------
+
+
+class TestHappyPath:
+    @pytest.mark.asyncio
+    async def test_stand_shift_cuts_uploads_and_persists(self, patched_pipeline):
+        """End-to-end on the STAND pane.
+
+        Pipeline contract:
+          1. storage.download_file called with clip_url_original
+          2. cut_clip called with start=offset, duration=1.0
+          3. storage.upload_file called with the deterministic stand key
+          4. set_stand_clip_url called with offset_s kwarg
+          5. _build_admin_read called with the persisted lineup
+        """
+        body = PaneShiftWindowRequest(offset_s=3.0)
+        lineup = _lineup()
+
+        result = await shift_pane_window(MagicMock(), lineup, "stand", body)
+
+        # Pipeline calls in order
+        patched_pipeline["storage"].download_file.assert_called_once_with(
+            lineup.clip_url_original,
+        )
+        patched_pipeline["probe"].assert_awaited_once()
+        cut_call = patched_pipeline["cut"].await_args
+        assert cut_call.kwargs["start_seconds"] == pytest.approx(3.0)
+        assert cut_call.kwargs["duration_seconds"] == pytest.approx(1.0)
+
+        # Upload key matches the deterministic stand pattern
+        upload_call = patched_pipeline["storage"].upload_file.call_args
+        new_key = upload_call.args[0]
+        assert new_key == "pending/vid123/10-stand-micro.mp4", new_key
+
+        # Persistence: stand setter only, with offset kwarg
+        patched_pipeline["set_stand"].assert_awaited_once()
+        set_call = patched_pipeline["set_stand"].await_args
+        assert set_call.args[2] == new_key
+        assert set_call.kwargs["offset_s"] == pytest.approx(3.0)
+        patched_pipeline["set_aim"].assert_not_awaited()
+
+        # Admin-shape returned
+        patched_pipeline["build_read"].assert_called_once_with(lineup)
+        assert result == f"admin_read({lineup.id})"
+
+    @pytest.mark.asyncio
+    async def test_aim_shift_uses_aim_setter_and_aim_key(self, patched_pipeline):
+        """The AIM dispatch must go through set_aim_clip_url + the AIM key."""
+        body = PaneShiftWindowRequest(offset_s=5.5)
+        lineup = _lineup()
+
+        await shift_pane_window(MagicMock(), lineup, "aim", body)
+
+        patched_pipeline["set_aim"].assert_awaited_once()
+        patched_pipeline["set_stand"].assert_not_awaited()
+        new_key = patched_pipeline["storage"].upload_file.call_args.args[0]
+        assert new_key == "pending/vid123/10-aim-micro.mp4", new_key
+        assert (
+            patched_pipeline["set_aim"].await_args.kwargs["offset_s"]
+            == pytest.approx(5.5)
+        )
+
+    @pytest.mark.asyncio
+    async def test_offset_zero_is_valid_and_persists(self, patched_pipeline):
+        """Offset 0 means "start the window at the start of the wider source"
+        — a legitimate operator choice (not a sentinel for NULL)."""
+        body = PaneShiftWindowRequest(offset_s=0.0)
+        lineup = _lineup()
+
+        await shift_pane_window(MagicMock(), lineup, "stand", body)
+
+        assert (
+            patched_pipeline["set_stand"].await_args.kwargs["offset_s"]
+            == pytest.approx(0.0)
+        )
+
+    @pytest.mark.asyncio
+    async def test_max_offset_at_source_boundary_is_valid(
+        self, patched_pipeline,
+    ):
+        """offset_s = source_duration - 1.0 exactly is at the boundary —
+        the served clip's last frame is the wider source's last frame."""
+        patched_pipeline["probe"].return_value = 9.0
+        body = PaneShiftWindowRequest(offset_s=8.0)
+        await shift_pane_window(MagicMock(), _lineup(), "stand", body)
+        patched_pipeline["cut"].assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Failure modes through the pipeline
+# ---------------------------------------------------------------------------
+
+
+class TestFailureModes:
+    @pytest.mark.asyncio
+    async def test_download_failure_surfaces_502(self, patched_pipeline):
+        patched_pipeline["storage"].download_file.side_effect = (
+            RuntimeError("connection refused")
+        )
+        body = PaneShiftWindowRequest(offset_s=2.0)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "stand", body)
+        assert exc_info.value.status_code == 502
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_surfaces_500_with_context(
+        self, patched_pipeline,
+    ):
+        patched_pipeline["probe"].side_effect = ProbeError(
+            "ffprobe boom", returncode=1, stderr="bad mp4 header",
+        )
+        body = PaneShiftWindowRequest(offset_s=2.0)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "stand", body)
+        assert exc_info.value.status_code == 500
+        assert "ffprobe" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_cut_failure_surfaces_500_with_context(
+        self, patched_pipeline,
+    ):
+        patched_pipeline["cut"].side_effect = ClipCutError(
+            "boom", start=2.0, duration=1.0, returncode=2, stderr="bad codec",
+        )
+        body = PaneShiftWindowRequest(offset_s=2.0)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "stand", body)
+        assert exc_info.value.status_code == 500
+        assert "rc=2" in exc_info.value.detail
+
+    @pytest.mark.asyncio
+    async def test_upload_failure_surfaces_502(self, patched_pipeline):
+        patched_pipeline["storage"].upload_file.side_effect = (
+            RuntimeError("storage down")
+        )
+        body = PaneShiftWindowRequest(offset_s=2.0)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "stand", body)
+        assert exc_info.value.status_code == 502
+        # Persist must NOT have been called — upload failed first.
+        patched_pipeline["set_stand"].assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_surfaces_500_after_upload(
+        self, patched_pipeline,
+    ):
+        patched_pipeline["set_stand"].side_effect = RuntimeError("db down")
+        body = PaneShiftWindowRequest(offset_s=2.0)
+        with pytest.raises(HTTPException) as exc_info:
+            await shift_pane_window(MagicMock(), _lineup(), "stand", body)
+        assert exc_info.value.status_code == 500
+        # Upload DID happen before the DB failure — that's the documented
+        # ordering (object first, column second).
+        patched_pipeline["storage"].upload_file.assert_called_once()


### PR DESCRIPTION
## Summary

Backend half of the STAND/AIM shift-window editor. Re-cuts the served 1-second micro-clip at the operator's chosen offset inside the **shared** wider source ``clip_url_original`` — PR1 added the `stand_clip_offset_s` / `aim_clip_offset_s` columns and the setter kwarg; this PR wires the route and service that uses them. PR3 (frontend overlay) lands next.

## Endpoint

```
POST /api/lineups/{lineup_id}/panes/{pane}/shift-window
     body: {offset_s: float}
     -> LineupRead (admin shape — rebinds the slider thumb)
```

## Service pipeline

1. Validate ``pane ∈ {stand, aim}`` (400 otherwise — throw/landing use the variable-width ``/trim`` endpoint).
2. Validate ``clip_url_original`` exists AND differs from ``clip_url``. Equality means ingest's widen-source step never produced a wider source; return **409** telling the operator to widen first (the throw widen-source endpoint widens for all four panes since they share the column).
3. Download ``clip_url_original`` from MinIO and ffprobe its actual duration — enforces the offset upper bound against on-disk reality, not a chapter-math estimate (which would miss any settings drift between widen + shift).
4. Reject ``offset_s`` past the wider source's actual duration (400).
5. Cut a 1.0s clip via the shared ``cut_clip`` helper.
6. Upload under the deterministic ``pending_stand/aim_clip_key`` — overwriting in place, no orphan accumulation on re-shifts.
7. Persist ``stand_clip_url`` + ``stand_clip_offset_s`` (or aim equivalents) via PR1's two-shape setter contract.
8. Return ``_build_admin_read`` so the frontend rebinds without a separate fetch.

## New helper

``frame_extractor.probe_duration()`` + ``ProbeError`` — async ffprobe wrapper for any caller that needs an on-disk media duration. Used here to enforce the offset upper bound; reusable for future trim/widen surfaces.

## Test plan

- [x] 6 validation tests — pane allow-list, missing wider source, source==served posture, negative offset, offset past source, source < 1s
- [x] 4 happy-path tests — stand pipeline end-to-end, aim dispatch, offset 0, offset at source boundary
- [x] 5 failure-mode tests — download, probe, cut, upload, DB persist (each with the documented status code + context)
- [x] 3 ``probe_duration`` tests — success, non-zero exit → ``ProbeError``, unparseable stdout → ``ProbeError`` (not silent 0.0)

## Follow-ups

- **PR3**: ``MicroClipShiftOverlay`` mirroring ``PaneTrimOverlay`` with a single-thumb scrubber; mounts on ``StandPane`` + ``AimPane`` and calls this endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)