### PR TITLE
fix(mjh): inline edit-in-place for interview details (replaces broken modal)

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/InterviewDetailsFields.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/InterviewDetailsFields.tsx
@@ -1,13 +1,13 @@
 /**
- * Sub-form rendered inside `LogEventDialog` when the operator selects an
- * `interview_scheduled` / `interview_completed` event_type.
+ * Sub-form rendered inside `LogEventDialog` (create) and `EventListItem`
+ * (inline edit) when the event_type is interview-shaped.
  *
  * Only `type` is required; everything else is best-effort metadata that
  * gets serialised into the `interview_details` JSONB column at submit time.
  */
 import type { UseFormRegister, FieldErrors } from "react-hook-form";
 import type { InterviewType } from "@/types/interview-details";
-import type { LogEventFormValues } from "./LogEventDialog";
+import type { LogEventFormValues } from "./interviewEventForm";
 
 const INTERVIEW_TYPE_OPTIONS: { value: InterviewType; label: string }[] = [
   { value: "phone", label: "Phone" },
@@ -19,9 +19,30 @@ const INTERVIEW_TYPE_OPTIONS: { value: InterviewType; label: string }[] = [
 interface Props {
   register: UseFormRegister<LogEventFormValues>;
   errors: FieldErrors<LogEventFormValues>;
+  /**
+   * When true, `scheduled_at` + `duration_minutes` stack vertically
+   * instead of the 2-column grid. The inline edit affordance inside
+   * EventListItem uses this — the panel is narrower than the create
+   * modal and the datetime-local picker clips at 2-col.
+   */
+  stackedLayout?: boolean;
+  /**
+   * Optional prefix used to scope DOM ids so multiple instances of this
+   * fieldset can coexist (e.g. one inline form per event card). Defaults
+   * to "interview" which preserves the historic id values.
+   */
+  idPrefix?: string;
 }
 
-export default function InterviewDetailsFields({ register, errors }: Props) {
+export default function InterviewDetailsFields({
+  register,
+  errors,
+  stackedLayout = false,
+  idPrefix = "interview",
+}: Props) {
+  const dateDurationLayout = stackedLayout
+    ? "space-y-3"
+    : "grid grid-cols-2 gap-3";
   return (
     <fieldset className="border rounded-md p-3 space-y-3">
       <legend className="px-1 text-xs font-medium text-muted-foreground">
@@ -29,11 +50,11 @@ export default function InterviewDetailsFields({ register, errors }: Props) {
       </legend>
 
       <div>
-        <label htmlFor="interview-type" className="block text-sm font-medium mb-1">
+        <label htmlFor={`${idPrefix}-type`} className="block text-sm font-medium mb-1">
           Type <span className="text-destructive">*</span>
         </label>
         <select
-          id="interview-type"
+          id={`${idPrefix}-type`}
           {...register("interview_type", {
             required: "Pick the interview type",
           })}
@@ -51,24 +72,24 @@ export default function InterviewDetailsFields({ register, errors }: Props) {
         ) : null}
       </div>
 
-      <div className="grid grid-cols-2 gap-3">
+      <div className={dateDurationLayout}>
         <div>
-          <label htmlFor="interview-scheduled-at" className="block text-sm font-medium mb-1">
+          <label htmlFor={`${idPrefix}-scheduled-at`} className="block text-sm font-medium mb-1">
             Scheduled at
           </label>
           <input
-            id="interview-scheduled-at"
+            id={`${idPrefix}-scheduled-at`}
             type="datetime-local"
             {...register("interview_scheduled_at")}
             className="w-full border rounded-md px-3 py-2 text-sm bg-background"
           />
         </div>
         <div>
-          <label htmlFor="interview-duration" className="block text-sm font-medium mb-1">
+          <label htmlFor={`${idPrefix}-duration`} className="block text-sm font-medium mb-1">
             Duration (min)
           </label>
           <input
-            id="interview-duration"
+            id={`${idPrefix}-duration`}
             type="number"
             min={1}
             max={1440}
@@ -95,11 +116,11 @@ export default function InterviewDetailsFields({ register, errors }: Props) {
       </div>
 
       <div>
-        <label htmlFor="interview-location" className="block text-sm font-medium mb-1">
+        <label htmlFor={`${idPrefix}-location`} className="block text-sm font-medium mb-1">
           Location or link
         </label>
         <input
-          id="interview-location"
+          id={`${idPrefix}-location`}
           type="text"
           {...register("interview_location_or_link", { maxLength: 1024 })}
           placeholder="https://meet.google.com/… or 123 Main St"
@@ -108,11 +129,11 @@ export default function InterviewDetailsFields({ register, errors }: Props) {
       </div>
 
       <div>
-        <label htmlFor="interview-interviewers" className="block text-sm font-medium mb-1">
+        <label htmlFor={`${idPrefix}-interviewers`} className="block text-sm font-medium mb-1">
           Interviewer names
         </label>
         <textarea
-          id="interview-interviewers"
+          id={`${idPrefix}-interviewers`}
           {...register("interview_interviewer_names")}
           rows={2}
           placeholder="One per line"

--- a/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/LogEventDialog.tsx
@@ -3,16 +3,14 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { useForm, type SubmitHandler } from "react-hook-form";
 import { LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
 import { X } from "lucide-react";
-import {
-  useLogApplicationEventMutation,
-  useUpdateApplicationEventMutation,
-} from "@/lib/applicationsApi";
-import type { ApplicationEvent, ApplicationEventType } from "@/types/application-event";
-import type {
-  InterviewType,
-  InterviewDetails,
-} from "@/types/interview-details";
+import { useLogApplicationEventMutation } from "@/lib/applicationsApi";
+import type { ApplicationEventType } from "@/types/application-event";
 import InterviewDetailsFields from "./InterviewDetailsFields";
+import {
+  buildInterviewDetails,
+  emptyFormValues,
+  type LogEventFormValues,
+} from "./interviewEventForm";
 
 const EVENT_TYPE_OPTIONS: { value: ApplicationEventType; label: string }[] = [
   { value: "applied", label: "Applied" },
@@ -33,117 +31,18 @@ const INTERVIEW_EVENT_TYPES = new Set<ApplicationEventType>([
   "interview_completed",
 ]);
 
-export interface LogEventFormValues {
-  event_type: ApplicationEventType;
-  occurred_at: string;
-  note: string;
-  // Interview sub-form. Empty strings = "not set"; only sent to the API
-  // when event_type is an interview type AND interview_type is non-empty.
-  interview_type: InterviewType | "";
-  interview_scheduled_at: string;
-  interview_duration_minutes: string;
-  interview_location_or_link: string;
-  interview_interviewer_names: string;
-}
-
-function defaultOccurredAt(): string {
-  // datetime-local input expects YYYY-MM-DDTHH:mm without timezone.
-  const now = new Date();
-  const tzOffsetMs = now.getTimezoneOffset() * 60_000;
-  const local = new Date(now.getTime() - tzOffsetMs);
-  return local.toISOString().slice(0, 16);
-}
-
-function emptyFormValues(): LogEventFormValues {
-  return {
-    event_type: "applied",
-    occurred_at: defaultOccurredAt(),
-    note: "",
-    interview_type: "",
-    interview_scheduled_at: "",
-    interview_duration_minutes: "",
-    interview_location_or_link: "",
-    interview_interviewer_names: "",
-  };
-}
-
-function isoToDatetimeLocalInput(iso: string | null | undefined): string {
-  // Convert ISO string from backend to the `datetime-local` input's
-  // expected YYYY-MM-DDTHH:mm format in the user's local time.
-  if (!iso) return "";
-  const d = new Date(iso);
-  if (Number.isNaN(d.getTime())) return "";
-  const tzOffsetMs = d.getTimezoneOffset() * 60_000;
-  const local = new Date(d.getTime() - tzOffsetMs);
-  return local.toISOString().slice(0, 16);
-}
-
-function eventToFormValues(event: ApplicationEvent): LogEventFormValues {
-  const details = event.interview_details;
-  return {
-    event_type: event.event_type,
-    occurred_at: isoToDatetimeLocalInput(event.occurred_at),
-    note: event.note ?? "",
-    interview_type: (details?.type as InterviewType) ?? "",
-    interview_scheduled_at: isoToDatetimeLocalInput(details?.scheduled_at),
-    interview_duration_minutes:
-      details?.duration_minutes != null ? String(details.duration_minutes) : "",
-    interview_location_or_link: details?.location_or_link ?? "",
-    interview_interviewer_names: (details?.interviewer_names ?? []).join("\n"),
-  };
-}
-
-function buildInterviewDetails(values: LogEventFormValues): InterviewDetails | null {
-  if (!values.interview_type) return null;
-
-  const names = values.interview_interviewer_names
-    .split("\n")
-    .map((n) => n.trim())
-    .filter((n) => n.length > 0);
-
-  const details: InterviewDetails = { type: values.interview_type };
-  if (values.interview_scheduled_at) {
-    details.scheduled_at = new Date(values.interview_scheduled_at).toISOString();
-  }
-  if (values.interview_duration_minutes) {
-    const n = Number(values.interview_duration_minutes);
-    if (Number.isFinite(n) && n > 0) details.duration_minutes = n;
-  }
-  if (values.interview_location_or_link.trim()) {
-    details.location_or_link = values.interview_location_or_link.trim();
-  }
-  if (names.length > 0) {
-    details.interviewer_names = names;
-  }
-  return details;
-}
-
-export type LogEventDialogMode = "create" | "edit";
-
 export interface LogEventDialogProps {
   applicationId: string;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  mode?: LogEventDialogMode;
-  /**
-   * The event to edit when `mode === "edit"`. Ignored in create mode.
-   * Must be an `interview_scheduled` or `interview_completed` event —
-   * the backend will return 422 for any other type.
-   */
-  eventToEdit?: ApplicationEvent | null;
 }
 
 export default function LogEventDialog({
   applicationId,
   open,
   onOpenChange,
-  mode = "create",
-  eventToEdit = null,
 }: LogEventDialogProps) {
-  const isEdit = mode === "edit" && eventToEdit !== null;
-  const [logEvent, { isLoading: isLogging }] = useLogApplicationEventMutation();
-  const [updateEvent, { isLoading: isUpdating }] = useUpdateApplicationEventMutation();
-  const isLoading = isEdit ? isUpdating : isLogging;
+  const [logEvent, { isLoading }] = useLogApplicationEventMutation();
 
   const {
     register,
@@ -156,60 +55,36 @@ export default function LogEventDialog({
   });
 
   const eventType = watch("event_type");
-  // In edit mode the dialog only ever opens for interview events, so the
-  // interview fields always show. In create mode they show only when the
-  // selected event_type calls for them.
-  const showInterviewFields = isEdit || INTERVIEW_EVENT_TYPES.has(eventType);
+  const showInterviewFields = INTERVIEW_EVENT_TYPES.has(eventType);
 
   useEffect(() => {
     if (!open) return;
-    if (isEdit && eventToEdit) {
-      reset(eventToFormValues(eventToEdit));
-    } else {
-      reset(emptyFormValues());
-    }
-  }, [open, isEdit, eventToEdit, reset]);
+    reset(emptyFormValues());
+  }, [open, reset]);
 
   const onSubmit: SubmitHandler<LogEventFormValues> = async (values) => {
     try {
-      if (isEdit && eventToEdit) {
-        await updateEvent({
-          applicationId,
-          eventId: eventToEdit.id,
-          body: {
-            interview_details: buildInterviewDetails(values),
-            note: values.note.trim() || null,
-          },
-        }).unwrap();
-        showSuccess("Interview details updated");
-      } else {
-        // datetime-local is naive; promote to UTC ISO so the backend stores
-        // a tz-aware datetime.
-        const occurredIso = new Date(values.occurred_at).toISOString();
-        await logEvent({
-          applicationId,
-          body: {
-            event_type: values.event_type,
-            occurred_at: occurredIso,
-            source: "manual",
-            note: values.note.trim() || null,
-            interview_details: INTERVIEW_EVENT_TYPES.has(values.event_type)
-              ? buildInterviewDetails(values)
-              : null,
-          },
-        }).unwrap();
-        showSuccess("Event logged");
-      }
+      // datetime-local is naive; promote to UTC ISO so the backend stores
+      // a tz-aware datetime.
+      const occurredIso = new Date(values.occurred_at).toISOString();
+      await logEvent({
+        applicationId,
+        body: {
+          event_type: values.event_type,
+          occurred_at: occurredIso,
+          source: "manual",
+          note: values.note.trim() || null,
+          interview_details: INTERVIEW_EVENT_TYPES.has(values.event_type)
+            ? buildInterviewDetails(values)
+            : null,
+        },
+      }).unwrap();
+      showSuccess("Event logged");
       onOpenChange(false);
     } catch (err) {
-      const verb = isEdit ? "update" : "log";
-      showError(`Couldn't ${verb} event: ${extractErrorMessage(err)}`);
+      showError(`Couldn't log event: ${extractErrorMessage(err)}`);
     }
   };
-
-  const title = isEdit ? "Edit interview details" : "Log event";
-  const submitLabel = isEdit ? "Save changes" : "Log event";
-  const loadingLabel = isEdit ? "Saving..." : "Logging...";
 
   return (
     <Dialog.Root open={open} onOpenChange={onOpenChange}>
@@ -217,7 +92,7 @@ export default function LogEventDialog({
         <Dialog.Overlay className="fixed inset-0 bg-black/50 z-40" />
         <Dialog.Content className="fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 w-full max-w-md max-h-[90vh] overflow-y-auto bg-card border rounded-lg shadow-lg z-50 p-6">
           <div className="flex items-center justify-between mb-4">
-            <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+            <Dialog.Title className="text-lg font-semibold">Log event</Dialog.Title>
             <Dialog.Close asChild>
               <button
                 aria-label="Close"
@@ -229,39 +104,35 @@ export default function LogEventDialog({
           </div>
 
           <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
-            {isEdit ? null : (
-              <>
-                <div>
-                  <label htmlFor="log-event-type" className="block text-sm font-medium mb-1">
-                    Event <span className="text-destructive">*</span>
-                  </label>
-                  <select
-                    id="log-event-type"
-                    {...register("event_type", { required: true })}
-                    className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-                  >
-                    {EVENT_TYPE_OPTIONS.map((o) => (
-                      <option key={o.value} value={o.value}>{o.label}</option>
-                    ))}
-                  </select>
-                </div>
+            <div>
+              <label htmlFor="log-event-type" className="block text-sm font-medium mb-1">
+                Event <span className="text-destructive">*</span>
+              </label>
+              <select
+                id="log-event-type"
+                {...register("event_type", { required: true })}
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+              >
+                {EVENT_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>{o.label}</option>
+                ))}
+              </select>
+            </div>
 
-                <div>
-                  <label htmlFor="log-event-when" className="block text-sm font-medium mb-1">
-                    When <span className="text-destructive">*</span>
-                  </label>
-                  <input
-                    id="log-event-when"
-                    type="datetime-local"
-                    {...register("occurred_at", { required: "Date is required" })}
-                    className="w-full border rounded-md px-3 py-2 text-sm bg-background"
-                  />
-                  {errors.occurred_at ? (
-                    <p className="text-xs text-destructive mt-1">{errors.occurred_at.message}</p>
-                  ) : null}
-                </div>
-              </>
-            )}
+            <div>
+              <label htmlFor="log-event-when" className="block text-sm font-medium mb-1">
+                When <span className="text-destructive">*</span>
+              </label>
+              <input
+                id="log-event-when"
+                type="datetime-local"
+                {...register("occurred_at", { required: "Date is required" })}
+                className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+              />
+              {errors.occurred_at ? (
+                <p className="text-xs text-destructive mt-1">{errors.occurred_at.message}</p>
+              ) : null}
+            </div>
 
             {showInterviewFields ? (
               <InterviewDetailsFields register={register} errors={errors} />
@@ -287,8 +158,8 @@ export default function LogEventDialog({
                   Cancel
                 </button>
               </Dialog.Close>
-              <LoadingButton type="submit" isLoading={isLoading} loadingText={loadingLabel}>
-                {submitLabel}
+              <LoadingButton type="submit" isLoading={isLoading} loadingText="Logging...">
+                Log event
               </LoadingButton>
             </div>
           </form>

--- a/apps/myjobhunter/frontend/src/features/applications/__tests__/LogEventDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/__tests__/LogEventDialog.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for the interview_details path in LogEventDialog.
+ * Tests for the interview_details path in LogEventDialog (create mode only).
  *
  * Covers:
  * - Interview sub-form only appears when event_type is interview_*.
@@ -7,17 +7,18 @@
  * - Submitting a non-interview event sends `interview_details: null`.
  * - Submitting a full interview event serialises the JSONB-safe payload.
  * - Optional sub-fields are omitted when empty (no empty strings reach the API).
+ *
+ * The edit-mode path was moved out of this component into the inline edit
+ * surface inside EventListItem (see EventListItem.test.tsx for those tests).
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const logEventMock = vi.fn();
-const updateEventMock = vi.fn();
 
 vi.mock("@/lib/applicationsApi", () => ({
   useLogApplicationEventMutation: () => [logEventMock, { isLoading: false }],
-  useUpdateApplicationEventMutation: () => [updateEventMock, { isLoading: false }],
 }));
 
 vi.mock("@radix-ui/react-dialog", async (importOriginal) => {
@@ -54,7 +55,6 @@ describe("LogEventDialog — interview_details", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     logEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
-    updateEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
   });
 
   it("does not show interview fields for non-interview event types", () => {
@@ -149,95 +149,5 @@ describe("LogEventDialog — interview_details", () => {
     await userEvent.click(screen.getByRole("button", { name: /Log event/i }));
     expect(logEventMock).not.toHaveBeenCalled();
     expect(screen.getByText(/Between 1 and 1440/i)).toBeInTheDocument();
-  });
-});
-
-describe("LogEventDialog — edit mode", () => {
-  const existingEvent = {
-    id: "event-1",
-    user_id: "user-1",
-    application_id: "app-1",
-    event_type: "interview_scheduled" as const,
-    occurred_at: "2026-05-20T15:00:00.000Z",
-    source: "manual" as const,
-    email_message_id: null,
-    raw_payload: null,
-    interview_details: {
-      type: "video" as const,
-      scheduled_at: "2026-05-22T19:00:00.000Z",
-      duration_minutes: 45,
-      location_or_link: "https://meet.google.com/abc-def",
-      interviewer_names: ["Alex Kim", "Jordan Lee"],
-    },
-    note: "original note",
-    created_at: "2026-05-20T15:00:00.000Z",
-    updated_at: "2026-05-20T15:00:00.000Z",
-  };
-
-  function renderEdit() {
-    return render(
-      <LogEventDialog
-        applicationId="app-1"
-        open={true}
-        onOpenChange={() => {}}
-        mode="edit"
-        eventToEdit={existingEvent}
-      />,
-    );
-  }
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    logEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
-    updateEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
-  });
-
-  it("uses the edit title and submit copy", () => {
-    renderEdit();
-    expect(screen.getByText(/Edit interview details/i)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: /Save changes/i })).toBeInTheDocument();
-  });
-
-  it("hides the event_type select and the top-level When field in edit mode", () => {
-    renderEdit();
-    expect(screen.queryByLabelText(/^Event/i)).not.toBeInTheDocument();
-    // The interview's own "Scheduled at" field is still visible; the
-    // top-level "When" (occurred_at) is what should be hidden.
-    expect(screen.queryByLabelText(/^When/i)).not.toBeInTheDocument();
-  });
-
-  it("preloads the form with the existing event's values", () => {
-    renderEdit();
-    expect(screen.getByLabelText(/Type/i)).toHaveValue("video");
-    expect(screen.getByLabelText(/Duration/i)).toHaveValue(45);
-    expect(screen.getByLabelText(/Location or link/i)).toHaveValue(
-      "https://meet.google.com/abc-def",
-    );
-    expect(screen.getByLabelText(/Interviewer names/i)).toHaveValue(
-      "Alex Kim\nJordan Lee",
-    );
-    expect(screen.getByLabelText(/^Note/i)).toHaveValue("original note");
-  });
-
-  it("submits via update mutation and forwards eventId", async () => {
-    renderEdit();
-    const note = screen.getByLabelText(/^Note/i);
-    await userEvent.clear(note);
-    await userEvent.type(note, "updated note");
-
-    await userEvent.click(screen.getByRole("button", { name: /Save changes/i }));
-
-    expect(updateEventMock).toHaveBeenCalledTimes(1);
-    expect(logEventMock).not.toHaveBeenCalled();
-    const arg = updateEventMock.mock.calls[0][0];
-    expect(arg.applicationId).toBe("app-1");
-    expect(arg.eventId).toBe("event-1");
-    expect(arg.body.note).toBe("updated note");
-    expect(arg.body.interview_details).toMatchObject({
-      type: "video",
-      duration_minutes: 45,
-      location_or_link: "https://meet.google.com/abc-def",
-      interviewer_names: ["Alex Kim", "Jordan Lee"],
-    });
   });
 });

--- a/apps/myjobhunter/frontend/src/features/applications/interviewEventForm.ts
+++ b/apps/myjobhunter/frontend/src/features/applications/interviewEventForm.ts
@@ -1,0 +1,100 @@
+/**
+ * Shared react-hook-form types and (de)serialisation helpers for the
+ * interview_details + note sub-form. Used by:
+ *
+ * - `LogEventDialog` — create-mode form for any event_type
+ * - `EventListItem` — inline edit-in-place for an existing interview event
+ *
+ * Keeping these in one place ensures the same field names, defaults, and
+ * (de)serialisation rules are shared across both surfaces.
+ */
+import type {
+  ApplicationEvent,
+  ApplicationEventType,
+} from "@/types/application-event";
+import type {
+  InterviewType,
+  InterviewDetails,
+} from "@/types/interview-details";
+
+export interface LogEventFormValues {
+  event_type: ApplicationEventType;
+  occurred_at: string;
+  note: string;
+  interview_type: InterviewType | "";
+  interview_scheduled_at: string;
+  interview_duration_minutes: string;
+  interview_location_or_link: string;
+  interview_interviewer_names: string;
+}
+
+export function defaultOccurredAt(): string {
+  const now = new Date();
+  const tzOffsetMs = now.getTimezoneOffset() * 60_000;
+  const local = new Date(now.getTime() - tzOffsetMs);
+  return local.toISOString().slice(0, 16);
+}
+
+export function isoToDatetimeLocalInput(iso: string | null | undefined): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  const tzOffsetMs = d.getTimezoneOffset() * 60_000;
+  const local = new Date(d.getTime() - tzOffsetMs);
+  return local.toISOString().slice(0, 16);
+}
+
+export function emptyFormValues(): LogEventFormValues {
+  return {
+    event_type: "applied",
+    occurred_at: defaultOccurredAt(),
+    note: "",
+    interview_type: "",
+    interview_scheduled_at: "",
+    interview_duration_minutes: "",
+    interview_location_or_link: "",
+    interview_interviewer_names: "",
+  };
+}
+
+export function eventToFormValues(event: ApplicationEvent): LogEventFormValues {
+  const details = event.interview_details;
+  return {
+    event_type: event.event_type,
+    occurred_at: isoToDatetimeLocalInput(event.occurred_at),
+    note: event.note ?? "",
+    interview_type: (details?.type as InterviewType) ?? "",
+    interview_scheduled_at: isoToDatetimeLocalInput(details?.scheduled_at),
+    interview_duration_minutes:
+      details?.duration_minutes != null ? String(details.duration_minutes) : "",
+    interview_location_or_link: details?.location_or_link ?? "",
+    interview_interviewer_names: (details?.interviewer_names ?? []).join("\n"),
+  };
+}
+
+export function buildInterviewDetails(
+  values: LogEventFormValues,
+): InterviewDetails | null {
+  if (!values.interview_type) return null;
+
+  const names = values.interview_interviewer_names
+    .split("\n")
+    .map((n) => n.trim())
+    .filter((n) => n.length > 0);
+
+  const details: InterviewDetails = { type: values.interview_type };
+  if (values.interview_scheduled_at) {
+    details.scheduled_at = new Date(values.interview_scheduled_at).toISOString();
+  }
+  if (values.interview_duration_minutes) {
+    const n = Number(values.interview_duration_minutes);
+    if (Number.isFinite(n) && n > 0) details.duration_minutes = n;
+  }
+  if (values.interview_location_or_link.trim()) {
+    details.location_or_link = values.interview_location_or_link.trim();
+  }
+  if (names.length > 0) {
+    details.interviewer_names = names;
+  }
+  return details;
+}

--- a/apps/myjobhunter/frontend/src/features/applications/sections/EventListItem.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/EventListItem.tsx
@@ -1,6 +1,15 @@
-import { Badge } from "@platform/ui";
+import { useEffect } from "react";
+import { Badge, LoadingButton, showSuccess, showError, extractErrorMessage } from "@platform/ui";
 import { Pencil } from "lucide-react";
+import { useForm, type SubmitHandler } from "react-hook-form";
 import InterviewDetailsSummary from "@/features/applications/InterviewDetailsSummary";
+import InterviewDetailsFields from "@/features/applications/InterviewDetailsFields";
+import {
+  buildInterviewDetails,
+  eventToFormValues,
+  type LogEventFormValues,
+} from "@/features/applications/interviewEventForm";
+import { useUpdateApplicationEventMutation } from "@/lib/applicationsApi";
 import type {
   ApplicationEvent,
   ApplicationEventType,
@@ -71,14 +80,133 @@ function SourceBlock({ source }: SourceBlockProps) {
   return <p className="text-xs text-muted-foreground mt-1">via {source}</p>;
 }
 
-interface Props {
+interface InlineEditFormProps {
+  applicationId: string;
   event: ApplicationEvent;
-  onEditClick?: (event: ApplicationEvent) => void;
+  onCancel: () => void;
+  onSaved: () => void;
 }
 
-export default function EventListItem({ event, onEditClick }: Props) {
+function InlineEditForm({
+  applicationId,
+  event,
+  onCancel,
+  onSaved,
+}: InlineEditFormProps) {
+  const [updateEvent, { isLoading: isSaving }] = useUpdateApplicationEventMutation();
+  const idPrefix = `inline-edit-${event.id}`;
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<LogEventFormValues>({
+    defaultValues: eventToFormValues(event),
+  });
+
+  useEffect(() => {
+    // Move keyboard focus into the form so the user can type immediately
+    // after pressing pencil. The Type select carries the focus per spec.
+    document.getElementById(`${idPrefix}-type`)?.focus();
+  }, [idPrefix]);
+
+  const onSubmit: SubmitHandler<LogEventFormValues> = async (values) => {
+    try {
+      await updateEvent({
+        applicationId,
+        eventId: event.id,
+        body: {
+          interview_details: buildInterviewDetails(values),
+          note: values.note.trim() || null,
+        },
+      }).unwrap();
+      showSuccess("Interview details updated");
+      onSaved();
+    } catch (err) {
+      showError(`Couldn't save: ${extractErrorMessage(err)}`);
+    }
+  };
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLFormElement>) {
+    if (e.key === "Escape" && !isSaving) {
+      e.preventDefault();
+      onCancel();
+    }
+  }
+
+  const noteFieldId = `${idPrefix}-note`;
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      onKeyDown={handleKeyDown}
+      className="mt-2 space-y-3"
+      noValidate
+    >
+      <InterviewDetailsFields
+        register={register}
+        errors={errors}
+        stackedLayout
+        idPrefix={idPrefix}
+      />
+
+      <div>
+        <label htmlFor={noteFieldId} className="block text-sm font-medium mb-1">
+          Note
+        </label>
+        <textarea
+          id={noteFieldId}
+          {...register("note")}
+          rows={3}
+          className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+          placeholder="Anything to remember about this event..."
+        />
+      </div>
+
+      <div className="flex justify-end gap-2">
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={isSaving}
+          className="px-3 py-2 text-sm border rounded-md hover:bg-muted disabled:opacity-50"
+        >
+          Cancel
+        </button>
+        <LoadingButton
+          type="submit"
+          isLoading={isSaving}
+          loadingText="Saving..."
+        >
+          Save changes
+        </LoadingButton>
+      </div>
+    </form>
+  );
+}
+
+interface Props {
+  applicationId: string;
+  event: ApplicationEvent;
+  isEditing?: boolean;
+  onEditClick?: (event: ApplicationEvent) => void;
+  onCancelEdit?: () => void;
+  onSaved?: () => void;
+}
+
+export default function EventListItem({
+  applicationId,
+  event,
+  isEditing = false,
+  onEditClick,
+  onCancelEdit,
+  onSaved,
+}: Props) {
   const isInterviewEvent = INTERVIEW_EVENT_TYPES.has(event.event_type);
-  const showEditButton = isInterviewEvent && onEditClick !== undefined;
+  const showEditButton =
+    isInterviewEvent && onEditClick !== undefined && !isEditing;
+  const editingInline =
+    isEditing && isInterviewEvent && onCancelEdit !== undefined && onSaved !== undefined;
+
   return (
     <li className="border rounded-lg p-3 bg-muted/20">
       <div className="flex items-center justify-between gap-2">
@@ -102,8 +230,19 @@ export default function EventListItem({ event, onEditClick }: Props) {
           ) : null}
         </div>
       </div>
-      <InterviewBlock event={event} />
-      <NoteBlock note={event.note} />
+      {editingInline ? (
+        <InlineEditForm
+          applicationId={applicationId}
+          event={event}
+          onCancel={onCancelEdit}
+          onSaved={onSaved}
+        />
+      ) : (
+        <>
+          <InterviewBlock event={event} />
+          <NoteBlock note={event.note} />
+        </>
+      )}
       <SourceBlock source={event.source} />
     </li>
   );

--- a/apps/myjobhunter/frontend/src/features/applications/sections/EventsSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/EventsSection.tsx
@@ -2,10 +2,11 @@
  * Events section of the ApplicationDrawer.
  *
  * Renders the chronological event log newest-first. The "Log event"
- * affordance opens LogEventDialog in create mode. Interview events
- * (interview_scheduled / interview_completed) show an inline pencil
- * button that opens the same dialog in edit mode, preloaded with the
- * existing interview_details + note.
+ * affordance opens LogEventDialog in create mode. Interview events show
+ * an inline pencil button that swaps the read-only summary in
+ * EventListItem for an edit-in-place form. Only one event can be in
+ * edit mode at a time; clicking pencil on a different event silently
+ * cancels whatever was open.
  */
 import { useState } from "react";
 import { Plus } from "lucide-react";
@@ -22,7 +23,19 @@ export default function EventsSection({ applicationId }: EventsSectionProps) {
   const { data: eventsData } = useListApplicationEventsQuery(applicationId);
   const events = eventsData?.items ?? [];
   const [createDialogOpen, setCreateDialogOpen] = useState(false);
-  const [editingEvent, setEditingEvent] = useState<ApplicationEvent | null>(null);
+  const [editingEventId, setEditingEventId] = useState<string | null>(null);
+
+  function handleEditClick(event: ApplicationEvent) {
+    setEditingEventId(event.id);
+  }
+
+  function handleCancelEdit() {
+    setEditingEventId(null);
+  }
+
+  function handleSaved() {
+    setEditingEventId(null);
+  }
 
   return (
     <section>
@@ -49,8 +62,12 @@ export default function EventsSection({ applicationId }: EventsSectionProps) {
           {events.map((event) => (
             <EventListItem
               key={event.id}
+              applicationId={applicationId}
               event={event}
-              onEditClick={setEditingEvent}
+              isEditing={editingEventId === event.id}
+              onEditClick={handleEditClick}
+              onCancelEdit={handleCancelEdit}
+              onSaved={handleSaved}
             />
           ))}
         </ol>
@@ -60,16 +77,6 @@ export default function EventsSection({ applicationId }: EventsSectionProps) {
         applicationId={applicationId}
         open={createDialogOpen}
         onOpenChange={setCreateDialogOpen}
-        mode="create"
-      />
-      <LogEventDialog
-        applicationId={applicationId}
-        open={editingEvent !== null}
-        onOpenChange={(open) => {
-          if (!open) setEditingEvent(null);
-        }}
-        mode="edit"
-        eventToEdit={editingEvent}
       />
     </section>
   );

--- a/apps/myjobhunter/frontend/src/features/applications/sections/__tests__/EventListItem.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/__tests__/EventListItem.test.tsx
@@ -1,19 +1,37 @@
 /**
  * Tests for the inline edit affordance on EventListItem.
  *
- * The pencil button is shown ONLY when:
- * - `event.event_type` is interview_scheduled or interview_completed
- * - the parent passed `onEditClick`
- *
- * For every other event type the button is absent (no DOM, no aria
- * label) so non-editable rows do not advertise an edit capability.
+ * Covers:
+ * - Pencil visibility rules (interview events only, and only when the
+ *   parent supplies an onEditClick callback).
+ * - Inline edit mode: read-only summary swaps for the form when
+ *   `isEditing` is true.
+ * - Save submits via the update mutation with the right payload.
+ * - Cancel reverts without submitting.
+ * - Escape inside the form fires onCancelEdit.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import EventListItem from "../EventListItem";
 import type { ApplicationEvent } from "@/types/application-event";
+
+const updateEventMock = vi.fn();
+
+vi.mock("@/lib/applicationsApi", () => ({
+  useUpdateApplicationEventMutation: () => [updateEventMock, { isLoading: false }],
+}));
+
+vi.mock("@platform/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@platform/ui")>();
+  return {
+    ...actual,
+    showSuccess: vi.fn(),
+    showError: vi.fn(),
+    extractErrorMessage: (err: unknown) => (err as { message?: string }).message ?? "error",
+  };
+});
 
 function makeEvent(overrides: Partial<ApplicationEvent> = {}): ApplicationEvent {
   return {
@@ -35,13 +53,20 @@ function makeEvent(overrides: Partial<ApplicationEvent> = {}): ApplicationEvent 
 
 describe("EventListItem — edit button visibility", () => {
   it("renders the pencil button for interview_scheduled events", () => {
-    render(<EventListItem event={makeEvent()} onEditClick={() => {}} />);
+    render(
+      <EventListItem
+        applicationId="app-1"
+        event={makeEvent()}
+        onEditClick={() => {}}
+      />,
+    );
     expect(screen.getByLabelText(/Edit interview details/i)).toBeInTheDocument();
   });
 
   it("renders the pencil button for interview_completed events", () => {
     render(
       <EventListItem
+        applicationId="app-1"
         event={makeEvent({ event_type: "interview_completed" })}
         onEditClick={() => {}}
       />,
@@ -53,6 +78,7 @@ describe("EventListItem — edit button visibility", () => {
     for (const eventType of ["applied", "rejected", "offer_received", "note_added"] as const) {
       const { unmount } = render(
         <EventListItem
+          applicationId="app-1"
           event={makeEvent({ event_type: eventType, interview_details: null })}
           onEditClick={() => {}}
         />,
@@ -65,7 +91,23 @@ describe("EventListItem — edit button visibility", () => {
   });
 
   it("does NOT render the pencil button when onEditClick is omitted", () => {
-    render(<EventListItem event={makeEvent()} />);
+    render(<EventListItem applicationId="app-1" event={makeEvent()} />);
+    expect(
+      screen.queryByLabelText(/Edit interview details/i),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does NOT render the pencil button while the event is being edited", () => {
+    render(
+      <EventListItem
+        applicationId="app-1"
+        event={makeEvent()}
+        isEditing
+        onEditClick={() => {}}
+        onCancelEdit={() => {}}
+        onSaved={() => {}}
+      />,
+    );
     expect(
       screen.queryByLabelText(/Edit interview details/i),
     ).not.toBeInTheDocument();
@@ -74,9 +116,119 @@ describe("EventListItem — edit button visibility", () => {
   it("fires onEditClick with the event when the pencil is clicked", async () => {
     const handle = vi.fn();
     const event = makeEvent();
-    render(<EventListItem event={event} onEditClick={handle} />);
+    render(
+      <EventListItem
+        applicationId="app-1"
+        event={event}
+        onEditClick={handle}
+      />,
+    );
     await userEvent.click(screen.getByLabelText(/Edit interview details/i));
     expect(handle).toHaveBeenCalledTimes(1);
     expect(handle).toHaveBeenCalledWith(event);
+  });
+});
+
+describe("EventListItem — inline edit form", () => {
+  const populatedEvent = makeEvent({
+    interview_details: {
+      type: "video",
+      scheduled_at: "2026-05-22T19:00:00.000Z",
+      duration_minutes: 45,
+      location_or_link: "https://meet.google.com/abc-def",
+      interviewer_names: ["Alex Kim", "Jordan Lee"],
+    },
+    note: "original note",
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    updateEventMock.mockReturnValue({ unwrap: () => Promise.resolve(undefined) });
+  });
+
+  function renderEditing(event = populatedEvent) {
+    const onCancelEdit = vi.fn();
+    const onSaved = vi.fn();
+    const utils = render(
+      <EventListItem
+        applicationId="app-1"
+        event={event}
+        isEditing
+        onEditClick={() => {}}
+        onCancelEdit={onCancelEdit}
+        onSaved={onSaved}
+      />,
+    );
+    return { onCancelEdit, onSaved, ...utils };
+  }
+
+  it("swaps the read-only summary for the form when isEditing is true", () => {
+    renderEditing();
+    expect(screen.getByLabelText(/^Type/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Scheduled at/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Duration/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Location or link/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Interviewer names/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/^Note/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Save changes/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^Cancel/i })).toBeInTheDocument();
+  });
+
+  it("preloads the form with the existing event's values", () => {
+    renderEditing();
+    expect(screen.getByLabelText(/^Type/i)).toHaveValue("video");
+    expect(screen.getByLabelText(/Duration/i)).toHaveValue(45);
+    expect(screen.getByLabelText(/Location or link/i)).toHaveValue(
+      "https://meet.google.com/abc-def",
+    );
+    expect(screen.getByLabelText(/Interviewer names/i)).toHaveValue(
+      "Alex Kim\nJordan Lee",
+    );
+    expect(screen.getByLabelText(/^Note/i)).toHaveValue("original note");
+  });
+
+  it("submits via update mutation with the event id and current values", async () => {
+    const { onSaved } = renderEditing();
+    const note = screen.getByLabelText(/^Note/i);
+    await userEvent.clear(note);
+    await userEvent.type(note, "updated note");
+
+    await userEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+
+    expect(updateEventMock).toHaveBeenCalledTimes(1);
+    const arg = updateEventMock.mock.calls[0][0];
+    expect(arg.applicationId).toBe("app-1");
+    expect(arg.eventId).toBe("evt-1");
+    expect(arg.body.note).toBe("updated note");
+    expect(arg.body.interview_details).toMatchObject({
+      type: "video",
+      duration_minutes: 45,
+      location_or_link: "https://meet.google.com/abc-def",
+      interviewer_names: ["Alex Kim", "Jordan Lee"],
+    });
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onCancelEdit when Cancel is clicked, without submitting", async () => {
+    const { onCancelEdit } = renderEditing();
+    await userEvent.click(screen.getByRole("button", { name: /^Cancel/i }));
+    expect(updateEventMock).not.toHaveBeenCalled();
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires onCancelEdit when Escape is pressed inside the form", async () => {
+    const { onCancelEdit } = renderEditing();
+    await userEvent.click(screen.getByLabelText(/^Type/i));
+    await userEvent.keyboard("{Escape}");
+    expect(onCancelEdit).toHaveBeenCalledTimes(1);
+    expect(updateEventMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks save when the type was cleared", async () => {
+    renderEditing();
+    await userEvent.selectOptions(screen.getByLabelText(/^Type/i), "");
+    await userEvent.click(screen.getByRole("button", { name: /Save changes/i }));
+    expect(updateEventMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/Pick the interview type/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes the bug where clicking the pencil to edit interview details inside the application drawer immediately dismisses the modal. Root cause: drawer was at \`z-[60]\`, modal overlay/content at \`z-40\`/\`z-50\`, so the modal rendered *behind* the drawer's overlay; clicks landed on the drawer's overlay and Radix dispatched them as outside-pointer to the modal layer, instantly dismissing it.
- Replaces the modal entirely with **inline edit-in-place** inside \`EventListItem\`. UX design pass via \`g-design-ux\` ran first (this was the rule violation that produced #725's UX issues).
- Single source of truth: shared form helpers extracted to \`interviewEventForm.ts\` so the create modal and the inline form serialise identically. No drift risk between the two surfaces.

## Behaviour

- Pencil swaps the dt/dd summary for a react-hook-form sub-form (interview_details + note) with Save/Cancel at the card's bottom right.
- Only one event can be in edit mode at a time; clicking pencil on another silently cancels the in-flight edit (per spec — lightweight UX, no confirmation prompt for optional metadata).
- Esc cancels. Focus moves to the Type select on entry. Cancel button disabled during save.
- \`scheduled_at\` + \`duration_minutes\` stack vertically in the narrow drawer panel (the 2-col grid clips at ~448px); modal keeps the 2-col grid.

## Files

- \`interviewEventForm.ts\` (new) — shared types + (de)serialisers
- \`LogEventDialog.tsx\` — edit-mode path removed; only renders for "Log event" create now
- \`InterviewDetailsFields.tsx\` — \`stackedLayout\` + \`idPrefix\` props for the narrow-panel + multi-instance cases
- \`EventListItem.tsx\` — accepts \`isEditing\` / \`onCancelEdit\` / \`onSaved\`; renders inline form when editing
- \`EventsSection.tsx\` — replaces \`editingEvent: ApplicationEvent | null\` with \`editingEventId: string | null\`; removes the edit-mode dialog mount

## Test plan

- [x] \`npm run typecheck\` — passes
- [x] \`npm run build\` — passes
- [x] \`npm test -- --run src/features/applications\` — all 54 tests pass (covers new inline edit submit/cancel/escape paths, pencil visibility, type-cleared block-on-save)
- [x] \`npm run lint\` — no new errors (10 pre-existing warnings, unrelated)
- [ ] **Manual visual verification** — not done locally; the dev server is running in the user's primary worktree. Recommend smoke-testing after merge: open an application, click pencil on an interview event, edit fields, hit Save, verify the new values render in the read-only summary. Then click pencil again → Cancel → values unchanged. Then click pencil → Esc → values unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)