### PR TITLE
feat(mga): AIM pane zooms 2× on persisted anchor (replaces red dot)

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -147,9 +147,24 @@ describe("GlanceBoardTile storyboard (4 panes)", () => {
     expect(video.getAttribute("poster")).toBe("https://ex.com/stand.png");
   });
 
-  it("renders the aim anchor dot when coords are set on the AIM pane", () => {
-    render(<GlanceBoardTile lineup={makeLineup()} />);
-    expect(screen.getByLabelText(/aim anchor/i)).toBeInTheDocument();
+  it("AIM pane zooms 2× centered on the persisted anchor coords (still variant)", () => {
+    render(<GlanceBoardTile lineup={makeLineup({ aim_anchor_x: 0.5, aim_anchor_y: 0.4 })} />);
+    const aimImg = screen.getByAltText(/aim reference/i) as HTMLImageElement;
+    expect(aimImg.style.transform).toBe("scale(2)");
+    expect(aimImg.style.transformOrigin).toBe("50% 40%");
+    // The red dot is gone — the zoomed crop is the affordance now.
+    expect(screen.queryByLabelText(/aim anchor/i)).toBeNull();
+  });
+
+  it("AIM pane falls back to center origin when anchor coords are null", () => {
+    render(
+      <GlanceBoardTile
+        lineup={makeLineup({ aim_anchor_x: null, aim_anchor_y: null })}
+      />,
+    );
+    const aimImg = screen.getByAltText(/aim reference/i) as HTMLImageElement;
+    expect(aimImg.style.transform).toBe("scale(2)");
+    expect(aimImg.style.transformOrigin).toBe("50% 50%");
   });
 });
 
@@ -337,18 +352,27 @@ describe("GlanceBoardTile PR6 micro-clips (STAND + AIM)", () => {
     expect(aimVideo).not.toBeNull();
   });
 
-  it("AIM anchor dot still renders when aim_clip_url is set (overlay invariant)", () => {
-    // The whole point of anchoring the AIM clip on the same classifier-chosen
-    // timestamp as the still is that the persisted aim_anchor_x/y dot stays
-    // pixel-accurate over the clip. If the dot dropped when AimPane swapped
-    // to ClipView, the overlay would silently disappear — exactly the PR6
-    // contract this test protects.
+  it("AIM clip variant carries the same zoom transform as the still variant", () => {
+    // The AIM clip is anchored on the same classifier-chosen timestamp as the
+    // still — so the zoom origin from the persisted aim_anchor stays accurate
+    // when AimPane swaps from still to ClipView. This is the contract that
+    // protects the still→clip visual continuity.
     render(
       <GlanceBoardTile
-        lineup={makeLineup({ aim_clip_url: "https://ex.com/aim.mp4" })}
+        lineup={makeLineup({
+          aim_clip_url: "https://ex.com/aim.mp4",
+          aim_anchor_x: 0.5,
+          aim_anchor_y: 0.4,
+        })}
       />,
     );
-    expect(screen.getByLabelText(/aim anchor/i)).toBeInTheDocument();
+    const aimVideo = document.querySelector(
+      'video[aria-label*="looping aim clip"]',
+    ) as HTMLVideoElement;
+    expect(aimVideo).not.toBeNull();
+    expect(aimVideo.style.transform).toBe("scale(2)");
+    expect(aimVideo.style.transformOrigin).toBe("50% 40%");
+    expect(screen.queryByLabelText(/aim anchor/i)).toBeNull();
   });
 
   it("all four panes show motion when every clip URL is set", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -122,17 +122,21 @@ describe("LineupCard", () => {
     expect(screen.getByText("8s")).toBeDefined();
   });
 
-  it("expanded variant renders aim anchor when coords are set", () => {
+  it("expanded variant AIM still zooms 2× centered on the persisted anchor", () => {
     render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
-    const anchor = screen.getByLabelText(/aim anchor/i);
-    expect(anchor).toBeDefined();
+    const aimImg = screen.getByAltText(/aim reference/i) as HTMLImageElement;
+    expect(aimImg.style.transform).toBe("scale(2)");
+    expect(aimImg.style.transformOrigin).toBe("50% 40%");
+    // No literal anchor dot in the AIM pane — the zoom replaces it.
+    expect(screen.queryByLabelText(/aim anchor/i)).toBeNull();
   });
 
-  it("expanded variant omits aim anchor when coords are null", () => {
+  it("expanded variant AIM still falls back to center origin when anchor coords are null", () => {
     const lineup: Lineup = { ...BASE_LINEUP, aim_anchor_x: null, aim_anchor_y: null };
     render(<LineupCard lineup={lineup} variant="expanded" />);
-    const anchor = screen.queryByLabelText(/aim anchor/i);
-    expect(anchor).toBeNull();
+    const aimImg = screen.getByAltText(/aim reference/i) as HTMLImageElement;
+    expect(aimImg.style.transform).toBe("scale(2)");
+    expect(aimImg.style.transformOrigin).toBe("50% 50%");
   });
 
   it("expanded variant renders 'No screenshot' when screenshot URL is null", () => {
@@ -329,15 +333,22 @@ describe("LineupCard", () => {
     expect(aimVideo).not.toBeNull();
   });
 
-  it("expanded variant AIM anchor dot still renders when aim_clip_url is set", () => {
-    // Critical PR6 invariant: the anchor dot must overlay the AIM clip just
-    // as it overlays the AIM still. See LineupPanes.AimPane.
+  it("expanded variant AIM clip variant carries the same zoom transform as the still", () => {
+    // Still→clip continuity: AimPane applies the same zoom transform whether
+    // the active surface is the still <img> or the looping <video>, so the
+    // operator's view of the anchor stays consistent during the swap.
     const lineup: Lineup = {
       ...BASE_LINEUP,
       aim_clip_url: "https://ex.com/aim.mp4",
     };
     render(<LineupCard lineup={lineup} variant="expanded" />);
-    expect(screen.getByLabelText(/aim anchor/i)).toBeInTheDocument();
+    const aimVideo = document.querySelector(
+      'video[aria-label*="looping aim clip"]',
+    ) as HTMLVideoElement;
+    expect(aimVideo).not.toBeNull();
+    expect(aimVideo.style.transform).toBe("scale(2)");
+    expect(aimVideo.style.transformOrigin).toBe("50% 40%");
+    expect(screen.queryByLabelText(/aim anchor/i)).toBeNull();
   });
 
   it("expanded variant renders four <video> elements when all four clip URLs are set", () => {

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -8,8 +8,8 @@
  *   ┌────────────────────────────────────────────────┐
  *   │ [UTIL]  <title>                 <side>·<from>  │  header
  *   ├──────────────────────┬─────────────────────────┤
- *   │   STAND screenshot   │   AIM screenshot         │  top row
- *   │                      │       ● anchor dot      │
+ *   │   STAND screenshot   │   AIM (2× zoom on       │  top row
+ *   │                      │   persisted anchor)     │
  *   ├──────────────────────┼─────────────────────────┤
  *   │   THROW (clip loop)  │   LANDING (text card)   │  bottom row
  *   │                      │   Lands in: <zone>      │
@@ -20,17 +20,13 @@
  * Each pane does a distinct executional job: arrive (stand), look (aim),
  * throw (clip motion), land (target zone). All four render unconditionally
  * — gracefully degrades per-pane when its data is null. Same height as
- * today's single-clip tile (~346px at 500px wide); same per-pane size as
- * today's stand|aim fallback so the aim anchor dot keeps its accuracy.
+ * today's single-clip tile (~346px at 500px wide). The AIM pane applies a
+ * 2× zoom transform centered on the persisted aim_anchor coords (fallback
+ * 50% 50%) — the magnified crop replaces the older red anchor-dot overlay.
  *
- * Today: STAND/AIM are stills; THROW is the PR2 looping clip; LANDING is a
- * placeholder text card. PR5 will replace LANDING with a real landing clip;
- * PR6 will replace stand/aim stills with 1s micro-clips. The 2×2 framework
- * is the same; panes just upgrade their content.
- *
- * Pane primitives (ScreenshotHalf, AimAnchorDot, ClipView, ThrowPlaceholder,
- * LandingPane) live in LineupPanes.tsx so LineupCard's expanded variant
- * renders the identical shape inside the detail-panel.
+ * Pane primitives (ScreenshotHalf, ClipView, ThrowPlaceholder, LandingPane,
+ * StandPane, AimPane) live in LineupPanes.tsx so LineupCard's expanded
+ * variant renders the identical shape inside the detail-panel.
  *
  * notes are NOT displayed inline; they live in a title= tooltip.
  */

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupCard.tsx
@@ -4,10 +4,11 @@
  *                + notes + zone context, used by LineupDetailPanel
  *   thumbnail  — stand image only (small), title underneath, used in lists
  *
- * The expanded variant shares its pane primitives (ScreenshotHalf, AimAnchorDot,
+ * The expanded variant shares its pane primitives (StandPane, AimPane,
  * ClipView, ThrowPlaceholder, LandingPane) with GlanceBoardTile via
  * LineupPanes.tsx — both surfaces converge on the same 4-pane shape so a
- * change in pane behavior lands on both at once.
+ * change in pane behavior lands on both at once. AimPane applies a 2× zoom
+ * centered on the persisted anchor coords (replacing the older red dot).
  *
  * Pin toggle:
  *   Pass isPinned + onPinToggle to show the pin button in either variant.

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
@@ -2,13 +2,13 @@
  * LineupPanes — shared pane primitives for the 4-pane lineup storyboard.
  *
  * Both GlanceBoardTile (glance-board surface) and LineupCard (detail-panel
- * surface) render the same 2×2 grid: STAND (still), AIM (still + anchor),
- * THROW (clip loop or empty state), LANDING (text card until PR5).
+ * surface) render the same 2×2 grid: STAND, AIM (2× zoom centered on the
+ * persisted anchor coords), THROW (clip loop or empty state), LANDING.
  *
- * Extracted here so the two surfaces stay byte-equivalent — if the throw-
- * pane behavior or the landing pane content evolves in PR5/PR6 we change
- * it once and both surfaces follow. None of these primitives manage their
- * own grid; the caller arranges them inside a flex row container.
+ * Extracted here so the two surfaces stay byte-equivalent — if pane
+ * behaviour evolves we change it once and both surfaces follow. None of
+ * these primitives manage their own grid; the caller arranges them inside a
+ * flex row container.
  */
 import { useEffect, useRef, useState } from "react";
 
@@ -16,8 +16,10 @@ import { useEffect, useRef, useState } from "react";
 // Aim anchor dot — 12px red filled circle, white outline, drop shadow.
 //
 // Positioned via CSS-absolute at (x*width, y*height) within an aspect-video
-// pane. Receives normalized coords (0..1). Use as a child of ScreenshotHalf
-// inside the AIM pane only.
+// pane. Receives normalized coords (0..1). The 4-pane storyboard's AIM pane
+// no longer renders this — AimPane now zooms into the anchor instead (the
+// zoomed crop is the affordance). Kept as an exported primitive for any
+// future caller that wants a literal dot overlay.
 // ---------------------------------------------------------------------------
 export function AimAnchorDot({ x, y }: { x: number; y: number }) {
   return (
@@ -44,17 +46,18 @@ export function AimAnchorDot({ x, y }: { x: number; y: number }) {
 //
 // Used for STAND and AIM panes (the two stand-in jobs). Renders the image
 // when url is non-null, otherwise a "No screenshot" empty state. Corner
-// label overlays in top-left. Children render on top (used by AIM to host
-// the anchor dot).
+// label overlays in top-left. ``imgStyle`` lets the caller apply CSS to the
+// <img> (used by AimPane to zoom into the persisted anchor — overflow-hidden
+// on the wrapper crops the zoomed content to pane bounds).
 // ---------------------------------------------------------------------------
 interface ScreenshotHalfProps {
   url: string | null;
   alt: string;
   label: string;
-  children?: React.ReactNode;
+  imgStyle?: React.CSSProperties;
 }
 
-export function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProps) {
+export function ScreenshotHalf({ url, alt, label, imgStyle }: ScreenshotHalfProps) {
   return (
     <div className="flex-1 min-w-0 relative bg-muted/20 aspect-video overflow-hidden">
       {url ? (
@@ -62,6 +65,7 @@ export function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProp
           src={url}
           alt={alt}
           className="absolute inset-0 w-full h-full object-cover"
+          style={imgStyle}
           draggable={false}
         />
       ) : (
@@ -70,7 +74,6 @@ export function ScreenshotHalf({ url, alt, label, children }: ScreenshotHalfProp
         </div>
       )}
       <CornerLabel>{label}</CornerLabel>
-      {children}
     </div>
   );
 }
@@ -109,15 +112,14 @@ interface ClipViewProps {
   // that forgets to pass it gets the historical behaviour, not a blank
   // label.
   label?: string;
-  // PR6 — overlay slot. AimPane mounts ``AimAnchorDot`` here so the dot sits
-  // ON the clip pane (same aspect-video container, so the dot's normalized
-  // coords still resolve to the same pixel position as the still-pane
-  // counterpart). Optional; ClipView callers that don't need an overlay
-  // (THROW, LANDING) pass nothing.
-  children?: React.ReactNode;
+  // Optional CSS on the <video> element. AimPane uses this to apply a
+  // ``transform: scale(2)`` with ``transformOrigin`` set from the persisted
+  // aim-anchor coords — the zoomed crop is the affordance that replaced the
+  // old red dot. Wrapper has ``overflow-hidden`` so the zoom is bounded.
+  videoStyle?: React.CSSProperties;
 }
 
-export function ClipView({ clipUrl, posterUrl, title, label = "THROW", children }: ClipViewProps) {
+export function ClipView({ clipUrl, posterUrl, title, label = "THROW", videoStyle }: ClipViewProps) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   // ``armed`` controls whether the <video> has a src attached. The tile arms
   // on viewport entry and DISARMS on viewport exit (post-perf-fix; was
@@ -209,14 +211,12 @@ export function ClipView({ clipUrl, posterUrl, title, label = "THROW", children 
         aria-label={`${title} — looping ${label.toLowerCase()} clip (muted)`}
         onError={() => setLoadFailed(true)}
         className="absolute inset-0 w-full h-full object-cover"
+        style={videoStyle}
       />
       {/* Hide the corner affordance when the clip fails to load (e.g. an
           expired presigned URL mid-session) — the poster stays as the
           graceful fallback rather than a misleading badge. */}
       {!loadFailed && <CornerLabel>{label}</CornerLabel>}
-      {/* PR6 — overlay slot for absolutely-positioned children (AimPane's
-          anchor dot). Renders last so it sits on top of the video. */}
-      {children}
     </div>
   );
 }
@@ -263,24 +263,38 @@ export function StandPane({ standScreenshotUrl, standClipUrl, title }: StandPane
 }
 
 // ---------------------------------------------------------------------------
-// AimPane (PR6) — top-right pane. Shows the player's crosshair-aim view.
+// AimPane — top-right pane. Shows the player's crosshair-aim view.
 //
-// Same upgrade-with-still-fallback shape as ``StandPane`` plus the persisted
-// aim anchor overlay dot, which renders ON TOP of whichever surface is active
-// (still or clip). Both surfaces are the same ``aspect-video`` container, so
-// the dot's normalized coords resolve to the same pixel position regardless
-// of which one is showing. The clip's first frame IS the still — anchoring on
-// the same classifier-chosen timestamp keeps this invariant.
+// Same upgrade-with-still-fallback shape as ``StandPane``. Where StandPane
+// renders the source frame as-is, AimPane applies a 2× zoom centered on the
+// persisted aim-anchor coords (fallback 50% 50%) — the operator sees a
+// magnified crop around where the crosshair was, which replaces the old red
+// anchor dot. Both surfaces (still and clip) are the same ``aspect-video``
+// container with ``overflow-hidden``, so the transform crops identically
+// regardless of which one is showing. The clip's first frame IS the still,
+// so the zoom target stays consistent during the still→clip swap.
 // ---------------------------------------------------------------------------
 interface AimPaneProps {
   aimScreenshotUrl: string | null;
   aimClipUrl?: string | null;
-  // Persisted normalized anchor coords. Null when the classifier didn't
-  // produce them (manual upload / pre-classifier ingest) — the dot then
-  // omits cleanly.
+  // Persisted normalized anchor coords (0..1). Null when the classifier
+  // didn't produce them (manual upload / pre-classifier ingest) — the zoom
+  // then falls back to the pane center.
   aimAnchorX: number | null;
   aimAnchorY: number | null;
   title: string;
+}
+
+function aimZoomStyle(
+  aimAnchorX: number | null,
+  aimAnchorY: number | null,
+): React.CSSProperties {
+  const xPct = (aimAnchorX ?? 0.5) * 100;
+  const yPct = (aimAnchorY ?? 0.5) * 100;
+  return {
+    transform: "scale(2)",
+    transformOrigin: `${xPct}% ${yPct}%`,
+  };
 }
 
 export function AimPane({
@@ -290,16 +304,7 @@ export function AimPane({
   aimAnchorY,
   title,
 }: AimPaneProps) {
-  // Only render the anchor when both axes are set AND there's a base surface
-  // to anchor over — a dot floating on the "No screenshot" empty state has no
-  // meaning.
-  const renderAnchor =
-    aimAnchorX != null &&
-    aimAnchorY != null &&
-    (aimClipUrl != null || aimScreenshotUrl != null);
-  const anchor = renderAnchor ? (
-    <AimAnchorDot x={aimAnchorX!} y={aimAnchorY!} />
-  ) : null;
+  const zoom = aimZoomStyle(aimAnchorX, aimAnchorY);
 
   if (aimClipUrl) {
     return (
@@ -308,9 +313,8 @@ export function AimPane({
         posterUrl={aimScreenshotUrl}
         title={title}
         label="AIM"
-      >
-        {anchor}
-      </ClipView>
+        videoStyle={zoom}
+      />
     );
   }
   return (
@@ -318,9 +322,8 @@ export function AimPane({
       url={aimScreenshotUrl}
       alt={`${title} — aim reference`}
       label="AIM"
-    >
-      {anchor}
-    </ScreenshotHalf>
+      imgStyle={zoom}
+    />
   );
 }
 


### PR DESCRIPTION
## Summary

The 4-pane storyboard's AIM pane no longer renders the red anchor-dot overlay. Instead, both the still `<img>` and the looping `<video>` variants get a CSS `transform: scale(2)` with `transformOrigin` set from the persisted `aim_anchor_x/y` coords (fallback `50% 50%`). The pane's `overflow-hidden` wrapper crops the zoomed content so the operator sees a magnified view centered on where the player's crosshair was.

The zoomed crop is now the affordance — clearer at glance-board scale than a 12px dot floating over a small thumbnail. Still→clip continuity is preserved because the AIM clip's first frame IS the still (anchored on the same classifier-chosen timestamp), so the transform target stays identical during the swap.

## Plumbing

- `ScreenshotHalf` and `ClipView` each gain an optional CSS-style prop (`imgStyle` / `videoStyle`). No other caller passes them.
- `ScreenshotHalf` and `ClipView` drop their unused `children` slots — `AimPane` was the only caller (via the old anchor-dot overlay).
- `AimAnchorDot` stays as an exported primitive (no in-tree callers today; kept so a future caller can mount a literal dot if needed).
- Doc comments in `LineupPanes` / `LineupCard` / `GlanceBoardTile` updated to describe the zoom in place of the dot.

`ReviewCard` / `ReviewScreenshot`'s interactive anchor dot (operator clicks to set the anchor) is a separate inlined code path and is unaffected.

## Test plan

- [x] `GlanceBoardTile.test.tsx`: replaces two "renders aim anchor" assertions with new ones asserting the AIM still and clip carry the zoom transform + transformOrigin matching the persisted coords + fall back to `50% 50%` when coords are null + the literal dot is gone.
- [x] `LineupCard.test.tsx`: same swap for the expanded-variant tests.
- [x] `npm run typecheck` clean.
- [x] 385/386 frontend tests pass; one pre-existing failure in `MicroClipShiftOverlay.test.tsx` is unrelated (same failure as on main; documented on the open PR #736 description).

🤖 Generated with [Claude Code](https://claude.com/claude-code)