### PR TITLE
fix(mjh): show JD inline without disclosure toggle on application detail

### DIFF
--- a/apps/myjobhunter/frontend/src/features/applications/sections/OverviewSection.tsx
+++ b/apps/myjobhunter/frontend/src/features/applications/sections/OverviewSection.tsx
@@ -75,14 +75,14 @@ export default function OverviewSection({ application }: OverviewSectionProps) {
       </dl>
 
       {application.jd_text ? (
-        <details className="rounded-md border bg-card" open>
-          <summary className="cursor-pointer select-none px-4 py-2 text-xs uppercase tracking-wide text-muted-foreground hover:bg-muted/50">
+        <div className="rounded-md border bg-card">
+          <p className="px-4 py-2 text-xs uppercase tracking-wide text-muted-foreground border-b">
             Job description
-          </summary>
+          </p>
           <div className="px-4 pb-4 pt-2 text-sm whitespace-pre-wrap break-words">
             {application.jd_text}
           </div>
-        </details>
+        </div>
       ) : null}
     </section>
   );


### PR DESCRIPTION
## Summary

- The job description on the application drawer / detail page was wrapped in `<details open>`. Even with `open` set, the `<summary>` reads as a clickable toggle ("Job description" header) and operators interpret it as needing a click to reveal.
- Replaced the `<details>/<summary>` with a plain bordered card so the JD is always visible when present, no interaction required.

## Test plan
- [x] `npm run typecheck` passes
- [ ] Open an application created via Add Application Dialog (paste JD path) — JD body is visible inline immediately under the field grid, no click required
- [ ] Open an application with `jd_text` null — Job description section is hidden (unchanged)