### PR TITLE
feat(mga): SAME-PERSPECTIVE rule for LANDING pane (throw-timing prompt)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -1318,15 +1318,37 @@ Rules:
   the projectile is first airborne; the throw-animation follow-through; the HUD
   grenade/ability slot empties. If no frame catches the exact release, choose
   the frame immediately BEFORE the effect first appears.
-- result_index: the 1-based frame where the RESULT is first clearly visible. It
-  MUST be at or after release_index — a result cannot precede its own release.
-  RESULT cues by utility:
-    SMOKE   - grey/white cloud expanding (count the FIRST wisp; a canister
-              still in flight is NOT yet the result).
-    MOLOTOV - orange floor flame spreading.
+- result_index: the 1-based frame where the RESULT is first clearly visible
+  FROM THE THROWER'S LINEUP POSITION. It MUST be at or after release_index —
+  a result cannot precede its own release.
+  SAME-PERSPECTIVE RULE (highest priority, beats "first clearly visible"):
+    The result frame MUST be from the SAME player position and viewing
+    direction as release_index. Disqualifiers — if any apply, search EARLIER
+    in the window for a valid frame:
+      - background scenery has materially changed (new building, interior,
+        different skyline, a window now framing it from the opposite side)
+      - the player has rotated > ~45° from the release-frame's aim vector
+      - the utility-in-hand has changed in a way that signals abandoning the
+        lineup moment: smoke → molotov, smoke → flash, smoke → HE
+        (smoke → rifle/pistol is fine — they switched back to their primary)
+      - the player has walked into a different room or zone
+    Pick a partial-deploy frame from the lineup position OVER a fully-bloomed
+    frame from a rotated perspective.
+  RESULT cues by utility (use the EARLIEST same-perspective frame that matches):
+    SMOKE   - the FIRST visible wisp (typically 1.5-3.0s after release). Do
+              NOT pick a late frame where the smoke is fully bloomed if an
+              earlier same-perspective frame shows even partial deployment.
+    MOLOTOV - the FIRST flame on the floor (typically 1.0-2.0s after release).
+              Same earliness rule.
     FLASH   - white wash / detonation. If it is too fast to land on its own
               frame, set result_index = release_index and confidence <= 0.45.
     HE      - explosion burst / debris.
+  MAX-GAP FALLBACK: result_index should normally be within ~6 frames (~2-4s)
+    after release_index. If no valid same-perspective result frame exists in
+    that range — because the utility traveled out of view, the player rotated
+    immediately, or the chapter cut away — set result_index = release_index
+    and confidence <= 0.5. Downstream consumers gate on confidence and will
+    skip emitting a landing clip rather than ship a misleading one.
 - confidence: 0-1 that you localised the throw correctly. Low when the throw is
   off-screen, cut away from, or only inferred from trajectory; high only when
   the release and the result are both directly visible.
@@ -1412,6 +1434,8 @@ async def classify_throw_timing_from_frames(
         "shown several timestamped frames from one chapter of a lineup "
         "tutorial and must pinpoint exactly when the utility is released and "
         "when its effect first lands.\n\n"
+        + _GAME_VISUAL_CUES
+        + "\n"
         + _THROW_TIMING_SCHEMA_DOC.format(n=n)
     )
 

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -273,3 +273,79 @@ class TestThrowTimingErrorHandling:
             )
         assert result.success is False
         assert result.error_codes == ["json_parse_error"]
+
+
+class TestThrowTimingPerspectivePrompt:
+    """Prompt-presence tests for the LANDING-pane perspective fix.
+
+    The throw-timing classifier picks ``result_index``, which becomes the
+    LANDING clip's anchor. Without these instructions the model picks
+    fully-bloomed-but-rotated frames over partially-deployed same-perspective
+    frames, producing landing clips from the wrong POV. If a refactor
+    accidentally drops any of these blocks, fail loud here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_game_visual_cues(self):
+        """``_GAME_VISUAL_CUES`` must be injected so the model can read HUD
+        cues (weapon-in-hand, ability icons, etc.) to detect that the player
+        has switched utilities or rotated to a different perspective."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "HOW TO IDENTIFY THE GAME FROM THE SCREEN" in system_text, (
+            "_GAME_VISUAL_CUES block is required so the timing model can "
+            "spot weapon swaps / HUD changes that signal perspective change."
+        )
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_same_perspective_rule(self):
+        """The SAME-PERSPECTIVE rule must be the top-priority constraint on
+        result_index — it beats the 'first clearly visible' rule. Removing
+        this re-introduces the rotated-POV landing-clip bug."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "SAME-PERSPECTIVE RULE" in system_text
+        assert "highest priority" in system_text
+        assert "rotated > ~45°" in system_text
+        assert "utility-in-hand has changed" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_max_gap_fallback(self):
+        """The MAX-GAP FALLBACK must instruct the model to set
+        result_index = release_index + confidence <= 0.5 when no valid
+        same-perspective frame exists in the ~2-4s window after release.
+        This is what makes the downstream landing-clip generator skip
+        emitting a misleading clip."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "MAX-GAP FALLBACK" in system_text
+        assert "within ~6 frames" in system_text
+        assert "result_index = release_index" in system_text
+        assert "confidence <= 0.5" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_tightens_smoke_first_wisp_cue(self):
+        """SMOKE cue must explicitly prefer the FIRST same-perspective wisp
+        over a fully-bloomed frame from a rotated angle."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        # The smoke cue must call out the "earlier same-perspective frame"
+        # preference, not just the generic "FIRST wisp" language.
+        assert "the FIRST visible wisp" in system_text
+        assert "earlier same-perspective frame shows even partial deployment" in system_text


### PR DESCRIPTION
## Summary

The LANDING pane was picking rotated-perspective frames as the landing
moment. Diagnosed against a B-site Market Window smoke lineup where the
classifier picked a frame 16s after release showing the smoke
*through Market Window from inside Market* — different room, different
weapon in hand (molotov out, not smoke), wrong POV for a "verify your
throw landed correctly" reference.

Three targeted edits to `_THROW_TIMING_SCHEMA_DOC` in
`classifier_service.py`:

1. **SAME-PERSPECTIVE RULE** — new top-priority constraint on
   `result_index`. Disqualifies frames where:
   - background scenery has materially changed
   - player rotated >~45° from release-frame aim vector
   - utility-in-hand swapped to a *different* utility (smoke → molly is
     a perspective change; smoke → rifle is fine)
   - player walked into a different room or zone
   Pick a partial-deploy frame from the lineup position OVER a
   fully-bloomed frame from a rotated angle.

2. **EARLIEST same-perspective wisp** — SMOKE / MOLOTOV cues now
   prefer the FIRST visible deployment at the lineup POV (1.5-3.0s for
   smokes, 1.0-2.0s for mollies) rather than later fully-bloomed
   frames at rotated angles.

3. **MAX-GAP FALLBACK** — when no valid same-perspective frame exists
   within ~6 frames (~2-4s) after release, set
   `result_index = release_index` and `confidence ≤ 0.5`. The
   downstream landing-clip generator gates on confidence and skips
   emitting a clip rather than ship a misleading one.

Also inject `_GAME_VISUAL_CUES` into the timing prompt's system text
(previously only in the lineup + grid classifiers) so the model can
recognize HUD weapon-swap as a perspective-change signal.

## Test plan

- [x] 4 new prompt-presence tests guard against a refactor accidentally
      dropping any of these blocks
- [x] All 19 throw-timing tests pass
- [x] All 81 classifier tests pass (no regressions in lineup / grid /
      throw-technique paths)
- [ ] Operator backfills the example lineup post-merge:
      `python -m app.cli backfill-landing-clips --force-rerun --lineup-id <id>`
      (or delete the existing `landing_clip_url` and re-run the
      orchestrator path)
- [ ] Validate visually in the storyboard tile — LANDING pane should
      now show the smoke deploying from the thrower's POV at Mid
      Window, not from inside Market

## Notes

- Pure prompt change — no migration, no schema change, no env vars.
- This is Layer 1 of the multi-layer accuracy plan
  (prompt audit → corrections-fed few-shot → auto-regenerate
  neighbors). Future operator corrections logged in a
  `lineup_corrections` table would be injected as few-shot examples in
  this same prompt; the wiring point is the `system_prompt` builder at
  line ~1410.
- Existing LANDING clips on `accepted` lineups are not affected until
  re-classified. Operator triggers re-classification per-lineup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)