### PR TITLE
feat(mga): STAND +1s, THROW +1s clip durations

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
@@ -71,12 +71,15 @@ logger = logging.getLogger(__name__)
 # artifact.
 _CLIP_CONFIDENCE_GATE = 0.55
 # Lead-in kept before release / tail kept after the result first shows.
+# The 1.5s tail is the operator-tuned amount of bloom needed to see the smoke
+# clear the obstacle / molly catch / flash fade — earlier 0.5s was cutting off
+# while the utility was still unfolding on screen.
 _PRE_RELEASE_SECONDS = 2.0
-_POST_RESULT_SECONDS = 0.5
-# Accepted clip-length band; outside it we rebuild a throw-centric ~6s window.
+_POST_RESULT_SECONDS = 1.5
+# Accepted clip-length band; outside it we rebuild a throw-centric ~7s window.
 _MIN_CLIP_SECONDS = 2.0
 _MAX_CLIP_SECONDS = 12.0
-_TARGET_CLIP_SECONDS = 6.0
+_TARGET_CLIP_SECONDS = 7.0
 # Below this even the rebuilt window is unusable (chapter too short) → skip.
 _ABSOLUTE_MIN_CLIP_SECONDS = 1.0
 
@@ -149,9 +152,9 @@ def _compute_clip_bounds(
 ) -> Optional[tuple[float, float]]:
     """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
 
-    [release-2.0, result+0.5] clamped to the chapter. If that is outside the
+    [release-2.0, result+1.5] clamped to the chapter. If that is outside the
     [~2s, ~12s] band (e.g. a long gap between release and result, or a missing
-    result frame collapsing it), rebuild a throw-centric ~6s window anchored
+    result frame collapsing it), rebuild a throw-centric ~7s window anchored
     at release. Returns None when even the rebuilt window is shorter than ~1s
     (the chapter is too short to carry a meaningful clip) so the caller skips.
     """

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
@@ -78,9 +78,13 @@ from app.services.ingestion.youtube_fetcher import (
 logger = logging.getLogger(__name__)
 
 # Frozen design-contract constants.
-# 1-second micro-clip per pane — matches the operator's stated ideal of
-# "at most each lineup should be 4 seconds total" with four 1s panes.
-_MICRO_CLIP_SECONDS = 1.0
+# Per-pane micro-clip durations. STAND is 2.0s (operator-tuned: 1.0s was
+# cutting off mid-stance, before the player begins the throw motion). AIM
+# stays at 1.0s — the AIM pane's whole point is the static crosshair
+# placement, and a longer window risks bleeding into the throw animation
+# which is what the THROW pane already shows.
+_STAND_MICRO_CLIP_SECONDS = 2.0
+_AIM_MICRO_CLIP_SECONDS = 1.0
 # Minimum acceptable clamped duration. A near-end timestamp may clip short;
 # under this threshold we skip rather than ship a useless ~200ms sliver.
 _MIN_CLIP_SECONDS = 0.5
@@ -152,14 +156,21 @@ def _compute_micro_bounds(
     anchor_ts: float,
     chapter_start: float,
     chapter_end: float,
+    clip_seconds: float,
 ) -> Optional[tuple[float, float]]:
     """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
 
     Starts AT the anchor timestamp (the classifier-chosen frame), runs
-    forward for ``_MICRO_CLIP_SECONDS``, clamped to the chapter end. The
+    forward for ``clip_seconds``, clamped to the chapter end. The
     important property is that ``clip_start == anchor_ts`` exactly — that
     is what keeps the AIM clip's first frame identical to the existing aim
     still, so the persisted ``aim_anchor_x/y`` overlay stays pixel-accurate.
+
+    ``clip_seconds`` is supplied by the caller per-pane (STAND uses
+    ``_STAND_MICRO_CLIP_SECONDS``, AIM uses ``_AIM_MICRO_CLIP_SECONDS``).
+    Explicit at the call site rather than a default — the two panes have
+    deliberately different durations and silently sharing one default
+    would obscure the asymmetry.
 
     Returns None when the clamped duration is shorter than
     ``_MIN_CLIP_SECONDS`` (the anchor is too close to the chapter end to
@@ -167,11 +178,21 @@ def _compute_micro_bounds(
     ``chapter_too_short_for_microclip``.
     """
     start = max(float(anchor_ts), float(chapter_start))
-    end = min(start + _MICRO_CLIP_SECONDS, float(chapter_end))
+    end = min(start + float(clip_seconds), float(chapter_end))
     duration = end - start
     if duration < _MIN_CLIP_SECONDS:
         return None
     return start, duration
+
+
+def _micro_clip_seconds_for_side(side: str) -> float:
+    """Resolve the per-pane micro-clip duration. Centralized so both ingest
+    and backfill paths get the same answer for the same side string."""
+    if side == "stand":
+        return _STAND_MICRO_CLIP_SECONDS
+    if side == "aim":
+        return _AIM_MICRO_CLIP_SECONDS
+    raise ValueError(f"unknown micro-clip side: {side!r}")
 
 
 async def _resolve_anchor_timestamps_via_classifier(
@@ -518,7 +539,12 @@ async def _cut_upload_persist_one_side(
     initial thumb position. When None (no wider source for this lineup),
     the offset is left untouched in the DB and the shift overlay opens at 0.
     """
-    bounds = _compute_micro_bounds(anchor_ts, chapter_start, chapter_end)
+    bounds = _compute_micro_bounds(
+        anchor_ts,
+        chapter_start,
+        chapter_end,
+        clip_seconds=_micro_clip_seconds_for_side(side),
+    )
     if bounds is None:
         return {
             "status": "skipped",

--- a/apps/mygamingassistant/backend/tests/test_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_generator.py
@@ -62,28 +62,29 @@ def _lineup(video_id="vid123", chapter_title="B smoke"):
 
 class TestComputeClipBounds:
     def test_normal_window_within_band(self):
-        # release 20, result 24, chapter [10,40]: [18, 24.5] = 6.5s in [2,12].
+        # release 20, result 24, chapter [10,40]: [18, 25.5] = 7.5s in [2,12].
+        # Operator-tuned: 1.5s tail after result (was 0.5s) to capture bloom.
         start, dur = _compute_clip_bounds(20.0, 24.0, 10.0, 40.0)
         assert start == pytest.approx(18.0)
-        assert dur == pytest.approx(6.5)
+        assert dur == pytest.approx(7.5)
 
     def test_clamped_to_chapter_start(self):
         # release 11 → 11-2=9 but chapter starts at 10 → clamp to 10.
         start, dur = _compute_clip_bounds(11.0, 13.0, 10.0, 40.0)
         assert start == pytest.approx(10.0)
 
-    def test_too_long_rebuilds_throw_centric_6s(self):
-        # release 20, result 60, chapter [10,90]: raw 42.5s > 12 → rebuild to
-        # ~6s anchored at release: [18, 24].
+    def test_too_long_rebuilds_throw_centric_7s(self):
+        # release 20, result 60, chapter [10,90]: raw 41.5s > 12 → rebuild to
+        # ~7s anchored at release: [18, 25].
         start, dur = _compute_clip_bounds(20.0, 60.0, 10.0, 90.0)
         assert start == pytest.approx(18.0)
-        assert dur == pytest.approx(6.0)
+        assert dur == pytest.approx(7.0)
 
-    def test_missing_result_collapses_to_25s_clip(self):
-        # result_ts == release_ts (no result frame): [release-2, release+0.5]
-        # = 2.5s, which is within the [2,12] band by frozen-contract design.
+    def test_missing_result_collapses_to_35s_clip(self):
+        # result_ts == release_ts (no result frame): [release-2, release+1.5]
+        # = 3.5s, which is within the [2,12] band by frozen-contract design.
         start, dur = _compute_clip_bounds(20.0, 20.0, 0.0, 60.0)
-        assert dur == pytest.approx(2.5)
+        assert dur == pytest.approx(3.5)
 
     def test_chapter_too_short_returns_none(self):
         # 0.5s chapter — even the rebuilt window is < 1s → skip signal.
@@ -224,7 +225,7 @@ class TestGenerateClipWideSourceWiring:
             patch(f"{_MOD}.settings", _settings()),
             # 6 frames spread across [9..24]; release_index=2 → release_ts=12,
             # result_index=4 → result_ts=18. _compute_clip_bounds gives
-            # [12-2, 18+0.5] = [10, 18.5] = 8.5s within band.
+            # [12-2, 18+1.5] = [10, 19.5] = 9.5s within band.
             patch(f"{_MOD}.clip_window_timestamps",
                   return_value=[9.0, 12.0, 15.0, 18.0, 21.0, 24.0]),
             patch(f"{_MOD}.extract_frames_downscaled",
@@ -254,10 +255,10 @@ class TestGenerateClipWideSourceWiring:
         mock_set.assert_awaited_once()
         set_kwargs = mock_set.await_args.kwargs
         assert set_kwargs["source_key"] == "pending/vid123/0-clip-source.mp4"
-        # tight bounds: clip_start=10, clip_duration=8.5; source_start=0
-        # → trim_start_s = 10 - 0 = 10; trim_end_s = 10 + 8.5 - 0 = 18.5
+        # tight bounds: clip_start=10, clip_duration=9.5; source_start=0
+        # → trim_start_s = 10 - 0 = 10; trim_end_s = 10 + 9.5 - 0 = 19.5
         assert set_kwargs["trim_start_s"] == pytest.approx(10.0)
-        assert set_kwargs["trim_end_s"] == pytest.approx(18.5)
+        assert set_kwargs["trim_end_s"] == pytest.approx(19.5)
 
     @pytest.mark.asyncio
     async def test_wide_failure_falls_back_to_legacy_posture(self, tmp_path: Path):

--- a/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
@@ -26,7 +26,10 @@ from app.services.ingestion.frame_extractor import (
     FrameExtractionError,
 )
 from app.services.ingestion.micro_clip_generator import (
+    _AIM_MICRO_CLIP_SECONDS,
+    _STAND_MICRO_CLIP_SECONDS,
     _compute_micro_bounds,
+    _micro_clip_seconds_for_side,
     generate_micro_clips_for_lineup,
     pending_aim_clip_key,
     pending_stand_clip_key,
@@ -65,41 +68,79 @@ def _lineup(
 # ---------------------------------------------------------------------------
 
 class TestComputeMicroBounds:
-    def test_normal_window(self):
-        # anchor 24, chapter [10,40]: [24, 25] = 1.0s.
-        start, dur = _compute_micro_bounds(24.0, 10.0, 40.0)
+    def test_normal_window_aim(self):
+        # AIM uses 1.0s: anchor 24, chapter [10,40]: [24, 25] = 1.0s.
+        start, dur = _compute_micro_bounds(24.0, 10.0, 40.0, clip_seconds=1.0)
         assert start == pytest.approx(24.0)
         assert dur == pytest.approx(1.0)
 
+    def test_normal_window_stand(self):
+        # STAND uses 2.0s: anchor 24, chapter [10,40]: [24, 26] = 2.0s.
+        start, dur = _compute_micro_bounds(24.0, 10.0, 40.0, clip_seconds=2.0)
+        assert start == pytest.approx(24.0)
+        assert dur == pytest.approx(2.0)
+
     def test_clamped_to_chapter_start(self):
         # anchor 9.5 (before start 10): start clamps to 10, duration 1.0.
-        start, dur = _compute_micro_bounds(9.5, 10.0, 40.0)
+        start, dur = _compute_micro_bounds(9.5, 10.0, 40.0, clip_seconds=1.0)
         assert start == pytest.approx(10.0)
         assert dur == pytest.approx(1.0)
 
     def test_clamped_to_chapter_end_tail(self):
         # anchor 39.7, chapter ends 40 → clip [39.7, 40] = 0.3s — too short.
-        assert _compute_micro_bounds(39.7, 10.0, 40.0) is None
+        assert _compute_micro_bounds(39.7, 10.0, 40.0, clip_seconds=1.0) is None
 
     def test_clamped_tail_above_threshold_is_kept(self):
         # anchor 39.4, chapter ends 40 → [39.4, 40] = 0.6s, above 0.5s threshold.
-        start, dur = _compute_micro_bounds(39.4, 10.0, 40.0)
+        start, dur = _compute_micro_bounds(39.4, 10.0, 40.0, clip_seconds=1.0)
         assert start == pytest.approx(39.4)
         assert dur == pytest.approx(0.6)
 
+    def test_stand_clamped_tail_still_2s_when_room(self):
+        # STAND anchor 30, chapter ends 40 → [30, 32] = 2.0s (room for full window).
+        start, dur = _compute_micro_bounds(30.0, 10.0, 40.0, clip_seconds=2.0)
+        assert start == pytest.approx(30.0)
+        assert dur == pytest.approx(2.0)
+
+    def test_stand_clamped_to_chapter_end_when_no_room(self):
+        # STAND anchor 39.0, chapter ends 40 → asks for [39, 41], clamps to 40 = 1.0s.
+        # Above the 0.5s min so it's kept (1.0s STAND > original 1.0s AIM).
+        start, dur = _compute_micro_bounds(39.0, 10.0, 40.0, clip_seconds=2.0)
+        assert start == pytest.approx(39.0)
+        assert dur == pytest.approx(1.0)
+
     def test_chapter_too_short_returns_none(self):
         # 0.4s chapter — clamped window < 0.5s → skip signal.
-        assert _compute_micro_bounds(20.0, 19.9, 20.3) is None
+        assert _compute_micro_bounds(20.0, 19.9, 20.3, clip_seconds=1.0) is None
 
     def test_clip_never_exceeds_chapter_end(self):
-        start, dur = _compute_micro_bounds(21.5, 10.0, 22.0)
+        start, dur = _compute_micro_bounds(21.5, 10.0, 22.0, clip_seconds=1.0)
         assert start + dur <= 22.0 + 1e-9
 
     def test_start_equals_anchor_for_overlay_accuracy(self):
         """The first frame of the AIM clip MUST equal the anchor still —
         otherwise the persisted aim_anchor_x/y pixel coords don't apply."""
-        start, _dur = _compute_micro_bounds(24.0, 10.0, 40.0)
+        start, _dur = _compute_micro_bounds(24.0, 10.0, 40.0, clip_seconds=1.0)
         assert start == pytest.approx(24.0)
+
+
+class TestMicroClipSecondsForSide:
+    """STAND is operator-tuned to 2s (was cutting off mid-stance at 1s);
+    AIM stays at 1s. The asymmetry MUST be load-bearing per-side, not a
+    single shared constant — losing the split here re-introduces the
+    "STAND cuts off too soon" complaint."""
+
+    def test_stand_is_two_seconds(self):
+        assert _micro_clip_seconds_for_side("stand") == pytest.approx(2.0)
+        assert _STAND_MICRO_CLIP_SECONDS == pytest.approx(2.0)
+
+    def test_aim_is_one_second(self):
+        assert _micro_clip_seconds_for_side("aim") == pytest.approx(1.0)
+        assert _AIM_MICRO_CLIP_SECONDS == pytest.approx(1.0)
+
+    def test_unknown_side_raises(self):
+        with pytest.raises(ValueError, match="unknown micro-clip side"):
+            _micro_clip_seconds_for_side("landing")
 
 
 def test_pending_micro_clip_keys_are_deterministic():


### PR DESCRIPTION
## Summary

Operator feedback: STAND and THROW panes are cutting off too soon. STAND was hitting the cap mid-stance, before the player begins the throw motion. THROW was ending 0.5s after the result became visible — not enough bloom to see the smoke clear its target / molly catch / flash fade.

**STAND** (\`micro_clip_generator.py\`):
- Split \`_MICRO_CLIP_SECONDS\` into per-pane constants:
  - \`_STAND_MICRO_CLIP_SECONDS = 2.0\` (was 1.0 — adds 1s of throw-prep motion)
  - \`_AIM_MICRO_CLIP_SECONDS = 1.0\` (unchanged — AIM's whole point is the static crosshair; longer would bleed into the throw animation which THROW already shows)
- \`_compute_micro_bounds\` now takes an explicit \`clip_seconds\` parameter (no default — per-side asymmetry is deliberately load-bearing at call sites)
- New \`_micro_clip_seconds_for_side(side)\` resolver centralizes the lookup so ingest and backfill paths agree

**THROW** (\`clip_generator.py\`):
- \`_POST_RESULT_SECONDS\`: 0.5 → 1.5 (1s longer tail to see the bloom land)
- \`_TARGET_CLIP_SECONDS\`: 6.0 → 7.0 (rebuild window also 1s longer for consistency when result is missing/out-of-band)
- Pre-release lead-in (2.0s) unchanged; MIN/MAX band unchanged

**LANDING** (\`landing_clip_generator.py\`) intentionally unchanged — operator explicitly scoped this bump to STAND and THROW only.

## Test plan

- [x] 91 clip-touching tests pass (test_clip_generator + test_micro_clip_generator + test_landing_clip_generator + test_micro_clip_backfill)
- [x] Existing micro-clip bounds tests updated to pass \`clip_seconds=1.0\` explicitly (preserves behaviour)
- [x] New tests: per-side resolver + STAND-uses-2s window + STAND-clamps-to-chapter-end + AIM-stays-1s
- [x] Existing THROW window tests updated for the new bounds: \`[release-2, result+1.5]\`
- [ ] Operator backfills the example lineup post-merge:
      \`python -m app.cli backfill-clips --force\` and \`python -m app.cli backfill-micro-clips --force\`
      (or delete existing \`clip_url\` / \`stand_clip_url\` and re-run the orchestrator)
- [ ] Validate visually — STAND pane should now include 1s of throw-prep motion before the cut; THROW should run an extra second after the bloom

## Notes

- Pure constant + parameter-threading change; no migration, no schema change, no env vars.
- Sibling PR #744 (LANDING perspective rule) ships in parallel — they touch disjoint files and merge independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)