### PR TITLE
feat(mga): YOUTUBE_COOKIES_FROM_BROWSER bypasses yt-dlp bot challenge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,8 @@ test-results/
 .~lock.*
 ROADMAP.md
 MEMORY_AUDIT_*.md
+
+# Dev-server stdout/stderr capture (per-app .uvicorn-*.log / .vite-*.log).
+# Useful for ad-hoc inspection of a backgrounded server; never committed.
+**/.uvicorn-*.log
+**/.vite-*.log

--- a/apps/mygamingassistant/backend/.env.docker.example
+++ b/apps/mygamingassistant/backend/.env.docker.example
@@ -100,6 +100,14 @@ MINIO_SECURE=false
 INGESTION_DOWNLOAD_DIR=/tmp/mga-ingestion
 # Hard cap in GB — ingestion refuses to start if the path has less free space.
 INGESTION_DOWNLOAD_DIR_MAX_GB=10
+# Optional: bypass YouTube's "Sign in to confirm you're not a bot" challenge by
+# borrowing cookies from an already-authenticated local browser session
+# (yt-dlp's --cookies-from-browser equivalent). Valid: chrome, firefox, edge,
+# safari, chromium, opera, brave, vivaldi, whale. Leave EMPTY in CI / fresh
+# deploys where no local browser exists — that is the correct shape and the
+# helper no-ops. Unknown values are logged at WARNING and no cookies are
+# injected.
+YOUTUBE_COOKIES_FROM_BROWSER=
 
 # APScheduler — background source sync cron (PR 6+).
 # SCHEDULER_ENABLED=false disables automatic syncing entirely (manual-only via

--- a/apps/mygamingassistant/backend/app/core/config.py
+++ b/apps/mygamingassistant/backend/app/core/config.py
@@ -87,6 +87,13 @@ class Settings(BaseAppSettings):
     # Operator can raise this if they have more disk; lower values are risky
     # for long-form videos (CS2 full-map videos can exceed 1 GB each).
     ingestion_download_dir_max_gb: int = 10
+    # Optional: pass through to yt-dlp's --cookies-from-browser equivalent so
+    # YouTube's "Sign in to confirm you're not a bot" challenges can be bypassed
+    # using the operator's already-authenticated browser session. Accepts a
+    # browser name yt-dlp supports — chrome, firefox, edge, safari, chromium,
+    # opera, brave, vivaldi, whale. Empty (default) disables cookie injection,
+    # which is the right shape for CI / fresh deploys where no browser exists.
+    youtube_cookies_from_browser: str = ""
 
     # ------------------------------------------------------------------
     # Pane-editor wide-source window (for the trim editor)

--- a/apps/mygamingassistant/backend/app/services/ingestion/youtube_fetcher.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/youtube_fetcher.py
@@ -25,9 +25,51 @@ from typing import Optional
 import yt_dlp
 import yt_dlp.utils
 
+from app.core.config import settings
 from app.models.game.source import Source
 
 logger = logging.getLogger(__name__)
+
+# yt-dlp browsers it knows how to read cookies from. Anything else is
+# rejected by the underlying library with a not-very-friendly KeyError, so
+# we gate at the boundary instead.
+_SUPPORTED_COOKIE_BROWSERS = frozenset(
+    {"chrome", "firefox", "edge", "safari", "chromium",
+     "opera", "brave", "vivaldi", "whale"}
+)
+
+
+def _apply_browser_cookies(opts: dict) -> dict:
+    """Inject ``cookiesfrombrowser`` into a yt-dlp options dict if configured.
+
+    YouTube periodically challenges yt-dlp with "Sign in to confirm you're
+    not a bot." The operator-supplied ``YOUTUBE_COOKIES_FROM_BROWSER`` env
+    var (resolved into ``settings.youtube_cookies_from_browser``) names a
+    browser whose existing session yt-dlp can borrow cookies from to clear
+    the challenge — same shape as the ``--cookies-from-browser`` CLI flag.
+
+    No-op (leaves *opts* unchanged) when the setting is empty, which is the
+    correct shape for CI and fresh deploys where no local browser exists.
+    An unknown browser name is treated as a misconfiguration and logged
+    once at WARNING; cookies are NOT injected (the request will still try,
+    and either succeed or fail with the underlying yt-dlp error).
+    """
+    browser = (settings.youtube_cookies_from_browser or "").strip().lower()
+    if not browser:
+        return opts
+    if browser not in _SUPPORTED_COOKIE_BROWSERS:
+        logger.warning(
+            "youtube_fetcher: YOUTUBE_COOKIES_FROM_BROWSER=%r is not a "
+            "yt-dlp-supported browser (supported: %s) — not injecting "
+            "cookies. Either correct the setting or unset it.",
+            browser, sorted(_SUPPORTED_COOKIE_BROWSERS),
+        )
+        return opts
+    # yt-dlp expects a tuple: (browser, profile?, keyring?, container?).
+    # Profile/keyring/container default to None; the single-element tuple
+    # is the form mapped from ``--cookies-from-browser <name>``.
+    opts["cookiesfrombrowser"] = (browser,)
+    return opts
 
 
 @dataclass
@@ -139,13 +181,13 @@ async def list_videos(source: Source) -> list[VideoMeta]:
     # the /videos tab so the flat extraction returns actual videos.
     url = _normalize_listing_url(raw_url)
 
-    ydl_opts = {
+    ydl_opts = _apply_browser_cookies({
         "quiet": True,
         "no_warnings": True,
         "extract_flat": True,
         "skip_download": True,
         "ignoreerrors": False,
-    }
+    })
 
     def _fetch() -> list[VideoMeta]:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
@@ -247,12 +289,12 @@ async def fetch_video_detail(video_id: str) -> VideoMeta:
     YouTubeFetchError.
     """
     url = f"https://www.youtube.com/watch?v={video_id}"
-    ydl_opts = {
+    ydl_opts = _apply_browser_cookies({
         "quiet": True,
         "no_warnings": True,
         "skip_download": True,
         "ignoreerrors": False,
-    }
+    })
 
     def _fetch() -> VideoMeta:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
@@ -327,14 +369,14 @@ async def download_video(video_id: str, download_dir: Path) -> Path:
     download_dir.mkdir(parents=True, exist_ok=True)
     output_template = str(download_dir / f"{video_id}.%(ext)s")
 
-    ydl_opts = {
+    ydl_opts = _apply_browser_cookies({
         "quiet": True,
         "no_warnings": True,
         "outtmpl": output_template,
         "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
         "merge_output_format": "mp4",
         "ignoreerrors": False,
-    }
+    })
 
     def _download() -> Path:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/apps/mygamingassistant/backend/tests/test_youtube_fetcher.py
+++ b/apps/mygamingassistant/backend/tests/test_youtube_fetcher.py
@@ -19,10 +19,12 @@ import pytest
 import yt_dlp.utils
 
 from app.models.game.source import Source
+from app.core.config import settings
 from app.services.ingestion.youtube_fetcher import (
     VideoDownloadError,
     VideoMeta,
     YouTubeFetchError,
+    _apply_browser_cookies,
     download_video,
     fetch_video_detail,
     list_videos,
@@ -346,3 +348,139 @@ class TestDownloadVideo:
         assert err.video_id == "vidPrivate"
         assert "DownloadError" in err.error_type
         assert isinstance(err.original, yt_dlp.utils.DownloadError)
+
+
+# ---------------------------------------------------------------------------
+# Browser-cookies helper + wire-up
+#
+# YOUTUBE_COOKIES_FROM_BROWSER lets the operator bypass YouTube's
+# "Sign in to confirm you're not a bot" challenge by reusing an
+# already-authenticated browser session. The helper is a no-op when unset
+# (the right shape for CI / fresh deploys). The wire-up tests below are
+# regression guards: if a future refactor drops the _apply_browser_cookies
+# call from any of the three yt-dlp option dicts, the feature silently
+# degrades — no symptom until YouTube next throws the bot challenge.
+# ---------------------------------------------------------------------------
+
+class TestApplyBrowserCookies:
+    def test_empty_setting_is_noop(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", "")
+        opts = {"quiet": True}
+        out = _apply_browser_cookies(opts)
+        assert "cookiesfrombrowser" not in out
+        assert out is opts  # same dict, no defensive copy
+
+    def test_valid_browser_injects_tuple(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", "chrome")
+        out = _apply_browser_cookies({"quiet": True})
+        assert out["cookiesfrombrowser"] == ("chrome",)
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("Chrome", "chrome"),
+            ("  firefox  ", "firefox"),
+            ("EDGE", "edge"),
+            ("Brave", "brave"),
+        ],
+    )
+    def test_case_and_whitespace_normalized(
+        self, monkeypatch: pytest.MonkeyPatch, raw: str, expected: str
+    ):
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", raw)
+        out = _apply_browser_cookies({})
+        assert out["cookiesfrombrowser"] == (expected,)
+
+    def test_unsupported_browser_is_noop_with_warning(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ):
+        import logging
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", "internet-explorer")
+        with caplog.at_level(logging.WARNING, logger="app.services.ingestion.youtube_fetcher"):
+            out = _apply_browser_cookies({"quiet": True})
+        assert "cookiesfrombrowser" not in out
+        assert any("internet-explorer" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize("browser", ["chrome", "firefox", "edge", "safari",
+                                          "chromium", "opera", "brave", "vivaldi", "whale"])
+    def test_all_supported_browsers_accepted(
+        self, monkeypatch: pytest.MonkeyPatch, browser: str
+    ):
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", browser)
+        out = _apply_browser_cookies({})
+        assert out["cookiesfrombrowser"] == (browser,)
+
+
+class TestCookiesWireUp:
+    """Each yt-dlp call site MUST pass its options dict through
+    _apply_browser_cookies. These tests fail if a future refactor drops
+    the wrapper from any one of them."""
+
+    @pytest.mark.asyncio
+    async def test_list_videos_passes_cookies(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", "firefox")
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value={"id": "PLempty", "entries": []})
+
+        constructor = MagicMock(return_value=mock_ydl)
+        with patch("yt_dlp.YoutubeDL", constructor):
+            await list_videos(_make_source())
+
+        passed_opts = constructor.call_args.args[0]
+        assert passed_opts.get("cookiesfrombrowser") == ("firefox",)
+
+    @pytest.mark.asyncio
+    async def test_fetch_video_detail_passes_cookies(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", "edge")
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value={
+            "id": "vid000", "title": "x", "duration": 1, "upload_date": "20260101",
+            "channel": "c", "description": "", "chapters": [],
+        })
+
+        constructor = MagicMock(return_value=mock_ydl)
+        with patch("yt_dlp.YoutubeDL", constructor):
+            await fetch_video_detail("vid000")
+
+        passed_opts = constructor.call_args.args[0]
+        assert passed_opts.get("cookiesfrombrowser") == ("edge",)
+
+    @pytest.mark.asyncio
+    async def test_download_video_passes_cookies(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", "brave")
+        (tmp_path / "vid001.mp4").write_bytes(b"x")
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.download = MagicMock(return_value=None)
+
+        constructor = MagicMock(return_value=mock_ydl)
+        with patch("yt_dlp.YoutubeDL", constructor):
+            await download_video("vid001", download_dir=tmp_path)
+
+        passed_opts = constructor.call_args.args[0]
+        assert passed_opts.get("cookiesfrombrowser") == ("brave",)
+
+    @pytest.mark.asyncio
+    async def test_no_cookies_key_when_setting_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """The default shape (empty setting) must NOT add cookiesfrombrowser
+        to the opts — yt-dlp on CI / fresh deploys has no browser to read."""
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", "")
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value={"id": "PLempty", "entries": []})
+
+        constructor = MagicMock(return_value=mock_ydl)
+        with patch("yt_dlp.YoutubeDL", constructor):
+            await list_videos(_make_source())
+
+        assert "cookiesfrombrowser" not in constructor.call_args.args[0]


### PR DESCRIPTION
## Summary

- New optional `YOUTUBE_COOKIES_FROM_BROWSER` setting: when set to a yt-dlp-supported browser name (chrome / firefox / edge / safari / chromium / opera / brave / vivaldi / whale), the YouTube ingestion fetcher reuses that browser's authenticated session cookies via yt-dlp's `--cookies-from-browser` equivalent, bypassing "Sign in to confirm you're not a bot" challenges.
- Wired into all 3 yt-dlp call sites in `youtube_fetcher.py` (`list_videos`, `fetch_video_detail`, `download_video`) via a single `_apply_browser_cookies(opts)` helper. Unknown browser values log a `WARNING` and no-op rather than passing malformed config to yt-dlp.
- Default empty is the correct shape for CI / fresh deploys with no local browser — no operational migration needed (purely additive, defaults-clean).
- Also gitignores per-app `.uvicorn-*.log` / `.vite-*.log` dev-server captures that were leaking into `git status`.

## Test plan

- [x] Helper unit tests: empty no-op, all 9 valid browsers, case + whitespace normalization, unsupported browser logs WARNING + no-op
- [x] **Wire-up regression guards** — one per call site + one verifying no-op for unset; catches a future refactor that drops the helper call from any of the 3 yt-dlp option dicts
- [x] All 41 tests in `test_youtube_fetcher.py` pass locally (20 new + 21 existing)
- [ ] Manual smoke (operator): set `YOUTUBE_COOKIES_FROM_BROWSER=chrome` in `backend/.env`, hit a YouTube source sync that previously failed with the bot challenge

🤖 Generated with [Claude Code](https://claude.com/claude-code)