### PR TITLE
fix(mga): title-card / non-throw candidate immunity in throw-timing prompt

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -1310,17 +1310,49 @@ keys:
 }}
 
 Rules:
-- is_lineup_throw: true ONLY if these frames show a real first-person utility
-  throw in the main game view. false for intro/outro/title cards, webcam or
-  talking-head, knife-only walking, menus, montages, or anything that is not an
-  actual throw — when false, release_index AND result_index MUST be null.
-- release_index: the 1-based frame where the utility is released. RELEASE cues:
-  the projectile is first airborne; the throw-animation follow-through; the HUD
-  grenade/ability slot empties. If no frame catches the exact release, choose
-  the frame immediately BEFORE the effect first appears.
+- is_lineup_throw: true if AT LEAST ONE frame in this set shows the player
+  releasing a real first-person utility throw in the main game view. false
+  ONLY when NO frame in the set shows a release — e.g., the whole chapter is
+  an intro/outro splash, webcam-only / talking-head, a menu, a montage, or
+  knife-only walking with no utility ever leaving the player's hand. When
+  false, release_index AND result_index MUST be null.
+  IMPORTANT: a chapter where SOME frames are title cards / knife-walking /
+  talking-head but OTHERS show a real throw is still is_lineup_throw=true.
+  The non-throw frames just become ineligible candidates — see
+  CANDIDATE-FRAME EXCLUSIONS below.
+- CANDIDATE-FRAME EXCLUSIONS: a frame matching ANY of the following MUST NOT
+  be returned as release_index OR result_index, EVEN IF a release or result
+  is partially visible behind the overlay. Search for a clean
+  same-perspective frame elsewhere in the window instead. If every frame in
+  the set is excluded, set the affected index to null and reduce confidence
+  rather than forcing a pick on an excluded frame:
+    - TITLE-CARD / LARGE-TEXT-OVERLAY frame: the frame is dominated by an
+      intro splash, chapter banner, "SMOKE #N" / "LINEUP 3" / "PART 2"
+      header, or a semi-transparent block of explanatory text covering
+      >~25% of the frame. The standard HUD (minimap, ammo, money, small
+      crosshair label) is NOT a title card; the disqualifying overlay is
+      the BIG one that obscures the main game view.
+    - KNIFE-ONLY-WALKING frame: the player has ONLY a knife (or no
+      utility) in hand AND no utility is currently airborne / no smoke,
+      flame, flash, or HE effect is unfolding in the world. This is the
+      "walking between throws" state and contains zero release / result
+      information. (Knife-in-hand AFTER a real release while the utility
+      is mid-flight or blooming IS a valid result candidate — knife-alone
+      is not the disqualifier; knife + nothing-happening is.)
+    - WEBCAM / FACECAM dominant frame: a picture-in-picture / face tile
+      covers most of the main game view.
+    - REPLAY / KILL-CAM / SCOREBOARD / MENU / MAP-OVERVIEW frame: not the
+      live first-person main game view.
+- release_index: the 1-based frame where the utility is released, chosen from
+  frames that pass CANDIDATE-FRAME EXCLUSIONS. RELEASE cues: the projectile
+  is first airborne; the throw-animation follow-through; the HUD
+  grenade/ability slot empties. If no eligible frame catches the exact
+  release, choose the eligible frame immediately BEFORE the effect first
+  appears.
 - result_index: the 1-based frame where the RESULT is first clearly visible
-  FROM THE THROWER'S LINEUP POSITION. It MUST be at or after release_index —
-  a result cannot precede its own release.
+  FROM THE THROWER'S LINEUP POSITION, chosen from frames that pass
+  CANDIDATE-FRAME EXCLUSIONS. It MUST be at or after release_index — a
+  result cannot precede its own release.
   SAME-PERSPECTIVE RULE (highest priority, beats "first clearly visible"):
     The result frame MUST be from the SAME player position and viewing
     direction as release_index. Disqualifiers — if any apply, search EARLIER
@@ -1351,16 +1383,22 @@ Rules:
     skip emitting a landing clip rather than ship a misleading one.
 - confidence: 0-1 that you localised the throw correctly. Low when the throw is
   off-screen, cut away from, or only inferred from trajectory; high only when
-  the release and the result are both directly visible.
+  the release and the result are both directly visible AND both indices are
+  on candidate-eligible frames.
 - Discipline:
   - If the throw is shown repeatedly or from multiple angles, use the FIRST
     clean throw only.
   - Ignore picture-in-picture, facecam, killfeed, scoreboard, title cards and
     replays — judge from the main game view only.
-  - Talking-head or knife-only-walking frames are NOT a throw:
-    is_lineup_throw=false, both indices null.
-- reasoning: <= 80 words. State the release cue, the result cue, and which
-  utility you keyed on.
+  - A chapter that is ENTIRELY talking-head / knife-only-walking / menus /
+    title cards with NO release in any frame → is_lineup_throw=false. A
+    chapter that mixes a real throw with non-throw frames →
+    is_lineup_throw=true and the non-throw frames are excluded from
+    candidacy per CANDIDATE-FRAME EXCLUSIONS above (NOT a verdict flip).
+- reasoning: <= 80 words. State the release cue, the result cue, which
+  utility you keyed on, AND — if you skipped over any frames due to
+  CANDIDATE-FRAME EXCLUSIONS — note which frame numbers and which exclusion
+  rule (e.g. "skipped F3 title-card, F7 knife-walking").
 """
 
 

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -349,3 +349,109 @@ class TestThrowTimingPerspectivePrompt:
         # preference, not just the generic "FIRST wisp" language.
         assert "the FIRST visible wisp" in system_text
         assert "earlier same-perspective frame shows even partial deployment" in system_text
+
+
+class TestThrowTimingCandidateExclusions:
+    """Prompt-presence tests for CANDIDATE-FRAME EXCLUSIONS.
+
+    The operator's source channels heavily use title cards / "SMOKE #N"
+    headers / knife-only-walking transition shots. Before this rule was
+    added, those frames were either picked as RELEASE / RESULT (wrong) OR
+    forced the chapter to is_lineup_throw=false (also wrong — the actual
+    throw was hiding elsewhere in the window). The rule decouples
+    "this individual frame can't be the release/result" from "no frame in
+    this chapter shows a throw." If a refactor accidentally drops any of
+    these blocks, fail loud here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_candidate_exclusions_header(self):
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "CANDIDATE-FRAME EXCLUSIONS" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_excludes_title_card_frames(self):
+        """Title cards / large text overlays must be called out by name —
+        the operator's source channels use "SMOKE #N" headers heavily."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "TITLE-CARD" in system_text
+        # The literal "SMOKE #N" example anchors the model to the operator's
+        # source channel's actual overlay style.
+        assert "SMOKE #N" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_excludes_knife_only_walking_frames(self):
+        """Knife-only-walking frames between throws must be explicit
+        non-candidates — but knife-in-hand AFTER a release while the
+        utility is mid-flight is still a valid result candidate."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "KNIFE-ONLY-WALKING" in system_text
+        # The post-release knife-in-hand carve-out must be present, or the
+        # rule would over-exclude legitimate result frames where the
+        # thrower has already switched back to a knife while the smoke
+        # blooms in front of them.
+        assert "mid-flight or" in system_text
+        assert "blooming IS a valid result candidate" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_decouples_chapter_verdict_from_frame_exclusion(
+        self,
+    ):
+        """is_lineup_throw=false ONLY when NO frame shows a release; a
+        chapter that mixes title cards with a real throw is still
+        is_lineup_throw=true. If this drops, the model will start flipping
+        the verdict on any chapter that contains even one title card."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "AT LEAST ONE frame" in system_text
+        assert "ineligible candidates" in system_text
+        # The "NOT a verdict flip" phrase is the explicit decoupling — it's
+        # the one short string that says "mixed-content chapter stays true".
+        assert "NOT a verdict flip" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_directs_model_to_search_elsewhere(self):
+        """When a frame is excluded, the model must look elsewhere — not
+        force a pick on the excluded frame. Without this the model often
+        returns its second-favorite which happens to be the title card."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "Search for a clean" in system_text
+        assert "set the affected index to null" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_asks_for_exclusion_notes_in_reasoning(self):
+        """When the model skips frames due to exclusions, the reasoning
+        field must say which frames + which rule — this is the diagnostic
+        breadcrumb that lets the operator audit the classifier's behavior
+        on a known-bad lineup without re-running it."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "skipped F3 title-card" in system_text


### PR DESCRIPTION
## Summary

PR #749 was a side-fix that kept the throw frame inside the sampled window for short chapters, but it surfaced a sharper root cause: even with a perfect prompt, the classifier sometimes picked **title-card** or **knife-only-walking** frames as `release_index` / `result_index`, OR flipped `is_lineup_throw=false` because some frames in the window weren't throws — when the actual throw was hiding elsewhere in the same window.

The chapter-level verdict (`is_lineup_throw`) and per-frame candidacy (`release_index` / `result_index`) were conflated. This PR decouples them.

## Changes

**`classifier_service.py` — `_THROW_TIMING_SCHEMA_DOC`:**

- New **CANDIDATE-FRAME EXCLUSIONS** block listing four classes of frames that MUST NOT be returned as `release_index` or `result_index` even if a release is partially visible behind the overlay:
  - **TITLE-CARD / LARGE-TEXT-OVERLAY** — intro splash, chapter banner, "SMOKE #N" / "LINEUP 3" / "PART 2" headers, semi-transparent explanatory blocks covering >~25% of the frame. Standard HUD is explicitly NOT a title card.
  - **KNIFE-ONLY-WALKING** — player has only a knife AND no utility is airborne / no effect is unfolding. Explicit carve-out: knife-in-hand AFTER a release while utility is mid-flight or blooming IS a valid result candidate.
  - **WEBCAM / FACECAM dominant** frames.
  - **REPLAY / KILL-CAM / SCOREBOARD / MENU / MAP-OVERVIEW** frames.
- **Re-defined `is_lineup_throw`**: true if AT LEAST ONE frame in the set shows a real release; false ONLY when NO frame does. A chapter that mixes a real throw with title cards / knife-walking stays `is_lineup_throw=true` — the non-throw frames become ineligible candidates, **NOT a verdict flip**.
- The model is told to **search elsewhere** when its favorite is excluded, set the affected index to null if every candidate is excluded (with reduced confidence) rather than forcing a pick, and **surface skipped frames + the matching rule in the `reasoning` field** for operator audit.

**`test_throw_timing_classifier.py` — new `TestThrowTimingCandidateExclusions` class:**

6 prompt-contract tests verifying the new block lands in the system prompt, including a regression guard for the "NOT a verdict flip" decoupling phrase.

## Test plan

- [x] `pytest tests/test_throw_timing_classifier.py` — 25/25 pass (19 existing + 6 new)
- [x] `pytest tests/test_clip_generator.py tests/test_landing_clip_generator.py` — 52/52 pass (no collateral break on the two consumers of `classify_throw_timing_from_frames`)
- [ ] Operator: re-run reclassify on the lineup `7bd971c3` "Market Window - B Site" (the chapter that triggered PR #749) and a representative title-card-heavy chapter — confirm release/result no longer land on title-card / knife-walking frames

## Related

- Track A of two. PR 2 (two-stage sampling that densely re-samples around the picked release frame for frame-accurate clip anchoring; doubles Claude spend per clip and is reviewed independently) will follow.
- Builds on #744 (same-perspective LANDING rule), #745 (STAND/THROW +1s clip durations), #749 (3-tier `skip_fraction`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)