### PR TITLE
feat(mga): two-stage throw-timing sampling — frame-accurate release

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
@@ -44,15 +44,13 @@ from app.core.config import settings
 from app.core.storage import get_storage
 from app.models.game.lineup import Lineup
 from app.repositories.game import lineup_repo
-from app.services.classification.classifier_service import (
-    classify_throw_timing_from_frames,
-)
 from app.services.ingestion.frame_extractor import (
     ClipCutError,
     FrameExtractionError,
-    clip_window_timestamps,
     cut_clip,
-    extract_frames_downscaled,
+)
+from app.services.ingestion.throw_localizer import (
+    localize_throw_with_refinement,
 )
 from app.services.ingestion.wide_source import (
     cut_and_upload_wide_source,
@@ -235,13 +233,6 @@ async def generate_clip_for_lineup(
             status="skipped", skip_reason="classifier_unavailable:missing_api_key"
         )
 
-    chapter_duration = float(chapter_end) - float(chapter_start)
-    timestamps = clip_window_timestamps(chapter_start, chapter_end)
-    if not timestamps:
-        return ClipGenerationResult(
-            status="skipped", skip_reason="empty_clip_window"
-        )
-
     owns_video = video_path is None
     local_video: Optional[Path] = video_path
     try:
@@ -272,9 +263,23 @@ async def generate_clip_for_lineup(
                     reasoning=f"Video re-fetch failed: {exc}",
                 )
 
-        # ---- Dense downscaled frames over the throw window --------------
+        # ---- Two-stage throw localisation -------------------------------
+        # Coarse N=12 grid over the throw window, then (when coarse cleared
+        # the 0.55 refine gate) a dense N=8 pass at ~0.5s spacing around
+        # the coarse-pass release for frame-accurate timing. The
+        # orchestrator returns the dense result on success and falls back
+        # to coarse on any dense-pass failure — never regresses the
+        # pipeline (throw_localizer.py docstring covers the full decision
+        # tree). FrameExtractionError on the *coarse* pass re-raises so
+        # we surface the same structured failure we always have.
         try:
-            frames = await extract_frames_downscaled(local_video, timestamps)
+            refined = await localize_throw_with_refinement(
+                local_video,
+                chapter_start=chapter_start,
+                chapter_end=chapter_end,
+                chapter_title=lineup.chapter_title,
+                utility_hint=utility_hint,
+            )
         except FrameExtractionError as exc:
             logger.warning(
                 "clip_generator: downscaled frame extraction failed: "
@@ -287,19 +292,14 @@ async def generate_clip_for_lineup(
                 reasoning=f"Downscaled frame extraction failed: {exc}",
             )
 
-        # ---- Localise the throw ----------------------------------------
-        timing = await classify_throw_timing_from_frames(
-            frames=frames,
-            frame_timestamps=timestamps,
-            chapter_title=lineup.chapter_title,
-            chapter_duration=chapter_duration,
-            utility_hint=utility_hint,
-        )
+        timing = refined.timing
+        timestamps = refined.frame_timestamps
         if not timing.success:
             logger.warning(
                 "clip_generator: throw-timing call failed: lineup=%s "
-                "video_id=%s error_codes=%s reasoning=%s",
-                lineup.id, video_id, timing.error_codes, timing.reasoning,
+                "video_id=%s stage=%s error_codes=%s reasoning=%s",
+                lineup.id, video_id, refined.stage,
+                timing.error_codes, timing.reasoning,
             )
             return ClipGenerationResult(
                 status="failed",

--- a/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
@@ -59,15 +59,13 @@ from app.core.config import settings
 from app.core.storage import get_storage
 from app.models.game.lineup import Lineup
 from app.repositories.game import lineup_repo
-from app.services.classification.classifier_service import (
-    classify_throw_timing_from_frames,
-)
 from app.services.ingestion.frame_extractor import (
     ClipCutError,
     FrameExtractionError,
-    clip_window_timestamps,
     cut_clip,
-    extract_frames_downscaled,
+)
+from app.services.ingestion.throw_localizer import (
+    localize_throw_with_refinement,
 )
 from app.services.ingestion.wide_source import (
     cut_and_upload_wide_source,
@@ -250,12 +248,6 @@ async def generate_landing_clip_for_lineup(
                 skip_reason="classifier_unavailable:missing_api_key",
             )
 
-        timestamps = clip_window_timestamps(chapter_start, chapter_end)
-        if not timestamps:
-            return LandingClipGenerationResult(
-                status="skipped", skip_reason="empty_clip_window"
-            )
-
         owns_video = video_path is None
         local_video: Optional[Path] = video_path
         try:
@@ -285,8 +277,18 @@ async def generate_landing_clip_for_lineup(
                         reasoning=f"Video re-fetch failed: {exc}",
                     )
 
+            # Two-stage throw localisation (see clip_generator + the
+            # throw_localizer docstring). Backfill path needs frame-accurate
+            # release just as much as the ingest path — a coarse-only landing
+            # anchor inherits the same 3s cadence cost.
             try:
-                frames = await extract_frames_downscaled(local_video, timestamps)
+                refined = await localize_throw_with_refinement(
+                    local_video,
+                    chapter_start=chapter_start,
+                    chapter_end=chapter_end,
+                    chapter_title=lineup.chapter_title,
+                    utility_hint=utility_hint,
+                )
             except FrameExtractionError as exc:
                 logger.warning(
                     "landing_clip_generator: downscaled frame extraction "
@@ -299,19 +301,14 @@ async def generate_landing_clip_for_lineup(
                     reasoning=f"Downscaled frame extraction failed: {exc}",
                 )
 
-            chapter_duration = float(chapter_end) - float(chapter_start)
-            timing = await classify_throw_timing_from_frames(
-                frames=frames,
-                frame_timestamps=timestamps,
-                chapter_title=lineup.chapter_title,
-                chapter_duration=chapter_duration,
-                utility_hint=utility_hint,
-            )
+            timing = refined.timing
+            timestamps = refined.frame_timestamps
             if not timing.success:
                 logger.warning(
                     "landing_clip_generator: throw-timing call failed: "
-                    "lineup=%s video_id=%s error_codes=%s reasoning=%s",
-                    lineup.id, video_id, timing.error_codes, timing.reasoning,
+                    "lineup=%s video_id=%s stage=%s error_codes=%s reasoning=%s",
+                    lineup.id, video_id, refined.stage,
+                    timing.error_codes, timing.reasoning,
                 )
                 return LandingClipGenerationResult(
                     status="failed",

--- a/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer.py
@@ -1,0 +1,360 @@
+"""Throw localizer — two-stage release-frame refinement.
+
+The clip pipeline's coarse pass samples N=12 frames over a 30-180s chapter
+window, putting frames roughly 2-15 seconds apart. Even a perfect classifier
+prompt cannot pick a frame the sampler never extracted — so the final clip
+anchor is at best "release ± 1.5s" on a typical chapter. That cadence is the
+underlying defect; PR #749 / #750 only chip at its symptoms.
+
+This module wraps :func:`classify_throw_timing_from_frames` with a second
+dense pass once the coarse pass has localised the throw to a particular
+region of the chapter:
+
+  Stage 1 — coarse pass (unchanged):
+    * ``clip_window_timestamps`` builds the trimmed throw window
+    * ``extract_frames_downscaled`` pulls those 12 frames
+    * ``classify_throw_timing_from_frames`` returns a coarse
+      ``release_index``
+
+  Stage 2 — dense pass (NEW, only when Stage 1 cleared its gate):
+    * ``dense_window_timestamps`` builds 8 frames at ~0.5s spacing,
+      asymmetric around coarse-release (more post-release coverage for the
+      result frame too)
+    * ``extract_frames_downscaled`` pulls those 8 frames
+    * ``classify_throw_timing_from_frames`` runs a SECOND time with the
+      tighter set — returns a frame-accurate release/result on the same
+      ThrowTimingResult schema
+
+The orchestrator returns the dense result when the dense pass succeeded,
+otherwise the coarse result. Either way the caller gets back the
+``frame_timestamps`` the returned indices map back to, so it can do
+``timestamps[release_index - 1]`` exactly as before. The caller is
+otherwise unchanged.
+
+The refinement gate matches the clip pipeline's existing 0.55 confidence
+threshold:
+  * If coarse is below 0.55, the clip would have been skipped anyway —
+    a dense pass over a wrongly-localised coarse region would burn a
+    second Claude call for no expected gain, and the cost is real on a
+    casual / single-user app (see project_mygamingassistant_plan ⇒
+    "App posture"). Skip the refinement.
+  * If coarse is at or above 0.55, the dense window is centred on a
+    release the model is confident about — refining is high-value:
+    "release ± 1.5s" becomes "release ± 0.25s".
+
+Cost: refinement doubles the throw-timing Claude calls per generated
+clip (one coarse + one dense). Non-generated clips (gated out by
+not-a-throw / low confidence / no release) pay only the coarse call as
+before — the gating is the cost control. Net effect at typical accept
+rates is ~1.7-1.9× of pre-refinement cost on clip-generation calls.
+
+Failure handling (per rules/no-bandaid-solutions.md +
+rules/check-third-party-error-codes.md): the dense pass can ONLY improve
+the result; any dense-pass failure falls through to the coarse pass
+result so the clip pipeline never regresses. The diagnostic ``stage``
+field carries which path was taken.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from app.services.classification.classification_result import ThrowTimingResult
+from app.services.classification.classifier_service import (
+    classify_throw_timing_from_frames,
+)
+from app.services.ingestion.frame_extractor import (
+    FrameExtractionError,
+    clip_window_timestamps,
+    extract_frames_downscaled,
+    grid_timestamps,
+)
+
+logger = logging.getLogger(__name__)
+
+# Refine only when the coarse pass cleared the clip-pipeline confidence
+# gate. Below this we don't trust the coarse release region enough to
+# spend a second Claude call densely sampling around it (and the clip
+# would be skipped anyway — see module docstring).
+_REFINE_CONFIDENCE_GATE = 0.55
+
+# Dense window shape around the coarse-pass release frame. Asymmetric:
+# more post-release coverage so the dense pass also catches the result
+# frame (typical SMOKE result is 1.5-3.0s after release). Total window
+# is 4s with N=8 → 0.5s spacing between dense candidates.
+_DENSE_PRE_RELEASE_SECONDS = 1.0
+_DENSE_POST_RELEASE_SECONDS = 3.0
+_DENSE_FRAME_COUNT = 8
+
+# Don't bother refining if chapter-boundary clamping leaves the dense
+# window with fewer than this many candidates — too few to meaningfully
+# tighten the release frame. Coarse is already 12 frames so anything
+# under ~4 dense is a regression.
+_MIN_DENSE_FRAMES = 4
+
+# Diagnostic stage labels — surfaced on RefinedThrowTiming.stage for
+# logging / metrics. Each maps to a specific reason the dense pass was
+# (or wasn't) used. Keep stable for log-grepping.
+STAGE_REFINED = "refined"
+STAGE_COARSE_ONLY = "coarse_only"
+STAGE_COARSE_BELOW_GATE = "coarse_below_refine_gate"
+STAGE_COARSE_NO_RELEASE = "coarse_no_release_index"
+STAGE_COARSE_NOT_A_THROW = "coarse_not_a_throw"
+STAGE_COARSE_FAILED = "coarse_failed"
+STAGE_DENSE_WINDOW_TOO_SMALL = "dense_window_too_small"
+STAGE_DENSE_EXTRACT_FAILED = "dense_extract_failed"
+STAGE_DENSE_CLASSIFIER_FAILED = "dense_classifier_failed"
+STAGE_DENSE_REJECTED = "dense_rejected"
+
+
+@dataclass
+class RefinedThrowTiming:
+    """Return shape of :func:`localize_throw_with_refinement`.
+
+    ``timing`` is the ThrowTimingResult the caller should treat as the
+    final answer — dense when the refinement succeeded, otherwise coarse.
+    ``frame_timestamps`` is the timestamp list whose 1-based indices the
+    caller maps ``timing.release_index`` / ``timing.result_index`` back to.
+
+    ``stage`` and ``coarse_timing`` are diagnostics (logs / future
+    metrics). Always populated so a log scan can answer "of N clip
+    generations, how many cleared the refine gate, how many fell back".
+    """
+
+    timing: ThrowTimingResult
+    frame_timestamps: list[float]
+    stage: str
+    coarse_timing: Optional[ThrowTimingResult] = None
+
+
+def dense_window_timestamps(
+    coarse_release_ts: float,
+    chapter_start: float,
+    chapter_end: float,
+    *,
+    pre_release_seconds: float = _DENSE_PRE_RELEASE_SECONDS,
+    post_release_seconds: float = _DENSE_POST_RELEASE_SECONDS,
+    n: int = _DENSE_FRAME_COUNT,
+) -> list[float]:
+    """Dense-pass timestamps for Stage 2 of two-stage refinement.
+
+    Builds an asymmetric window around the coarse-pass release frame
+    (more weight post-release so the dense pass also catches the result),
+    then evenly spaces *n* timestamps across it. Clamped to the chapter
+    bounds so a release near the chapter start/end doesn't sample frames
+    outside the source video.
+
+    Returns the dense timestamp list (length N at most, fewer when the
+    clamped window collapses below N items via grid_timestamps's
+    degenerate-window behaviour — see its docstring).
+    """
+    lo = max(float(chapter_start), float(coarse_release_ts) - pre_release_seconds)
+    hi = min(float(chapter_end), float(coarse_release_ts) + post_release_seconds)
+    if hi <= lo:
+        # Chapter is degenerate or the release is outside the chapter — no
+        # dense window possible. Caller will fall back to coarse.
+        return []
+    # edge_padding_seconds=0.0 — dense window is already pre-trimmed,
+    # don't pull MORE padding off it (would lose candidates near release
+    # for tight chapters).
+    return grid_timestamps(lo, hi, n, edge_padding_seconds=0.0)
+
+
+def _should_refine(coarse: ThrowTimingResult) -> Optional[str]:
+    """Return None if refinement should proceed, else the SKIP stage label.
+
+    Centralises the gate-decision so the orchestrator stays linear and
+    so tests can pin the decision rules independently.
+    """
+    if not coarse.success:
+        return STAGE_COARSE_FAILED
+    if not coarse.is_lineup_throw:
+        return STAGE_COARSE_NOT_A_THROW
+    if coarse.release_index is None:
+        return STAGE_COARSE_NO_RELEASE
+    if coarse.confidence is None or coarse.confidence < _REFINE_CONFIDENCE_GATE:
+        return STAGE_COARSE_BELOW_GATE
+    return None
+
+
+async def localize_throw_with_refinement(
+    video_path: Path,
+    *,
+    chapter_start: float,
+    chapter_end: float,
+    chapter_title: Optional[str],
+    utility_hint: Optional[str] = None,
+) -> RefinedThrowTiming:
+    """Localise the throw with optional dense-pass refinement.
+
+    See module docstring for the two-stage design. Always returns a
+    RefinedThrowTiming — the dense result when the refine pass succeeded,
+    otherwise the coarse result. The caller can treat the returned
+    ``timing`` exactly as it would treat ``classify_throw_timing_from_frames``'s
+    raw result (same dataclass, same gate semantics), and use
+    ``frame_timestamps`` to map the returned indices back to seconds.
+
+    Args:
+        video_path: Local source video file. Caller owns its lifecycle
+            (download / cleanup); this function only reads from it.
+        chapter_start / chapter_end: Source chapter bounds in seconds.
+        chapter_title: Per-call context surfaced to Claude.
+        utility_hint: Optional utility slug from a prior grid
+            classification at confidence > 0.6.
+    """
+    chapter_duration = float(chapter_end) - float(chapter_start)
+
+    # ---- Stage 1: coarse pass (existing behaviour) ----------------------
+    coarse_timestamps = clip_window_timestamps(chapter_start, chapter_end)
+
+    try:
+        coarse_frames = await extract_frames_downscaled(
+            video_path, coarse_timestamps
+        )
+    except FrameExtractionError as exc:
+        # Caller's existing FrameExtractionError handling lives in
+        # clip_generator / landing_clip_generator. Re-raise so they can
+        # surface structured codes (this function does not own the failure
+        # surface for downscale-extract; the callers do).
+        logger.warning(
+            "throw_localizer: coarse frame extraction failed: video=%s "
+            "returncode=%s stderr=%s",
+            video_path, exc.returncode, exc.stderr[:200],
+        )
+        raise
+
+    coarse = await classify_throw_timing_from_frames(
+        frames=coarse_frames,
+        frame_timestamps=coarse_timestamps,
+        chapter_title=chapter_title,
+        chapter_duration=chapter_duration,
+        utility_hint=utility_hint,
+    )
+
+    skip_stage = _should_refine(coarse)
+    if skip_stage is not None:
+        # Coarse pass cleared no gate we'd refine through — return as-is.
+        logger.info(
+            "throw_localizer: stage=%s coarse_success=%s "
+            "is_lineup_throw=%s release_index=%s confidence=%s "
+            "chapter=%r",
+            skip_stage,
+            coarse.success,
+            coarse.is_lineup_throw,
+            coarse.release_index,
+            coarse.confidence,
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=coarse,
+            frame_timestamps=coarse_timestamps,
+            stage=skip_stage,
+            coarse_timing=coarse,
+        )
+
+    # ---- Stage 2: dense refinement ---------------------------------------
+    # release_index is non-None (gated above); resolve to a timestamp.
+    assert coarse.release_index is not None  # for type checker
+    coarse_release_ts = coarse_timestamps[coarse.release_index - 1]
+    dense_timestamps = dense_window_timestamps(
+        coarse_release_ts, chapter_start, chapter_end
+    )
+
+    if len(dense_timestamps) < _MIN_DENSE_FRAMES:
+        logger.info(
+            "throw_localizer: stage=%s coarse_release_ts=%.2f "
+            "dense_n=%d (< %d); returning coarse: chapter=%r",
+            STAGE_DENSE_WINDOW_TOO_SMALL,
+            coarse_release_ts,
+            len(dense_timestamps),
+            _MIN_DENSE_FRAMES,
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=coarse,
+            frame_timestamps=coarse_timestamps,
+            stage=STAGE_DENSE_WINDOW_TOO_SMALL,
+            coarse_timing=coarse,
+        )
+
+    try:
+        dense_frames = await extract_frames_downscaled(
+            video_path, dense_timestamps
+        )
+    except FrameExtractionError as exc:
+        # A dense-pass extraction failure must NEVER regress the pipeline:
+        # the coarse result already cleared the clip gates and is the
+        # right thing to use. Log so we can see how often this happens.
+        logger.warning(
+            "throw_localizer: stage=%s coarse_release_ts=%.2f "
+            "returncode=%s stderr=%s; returning coarse: chapter=%r",
+            STAGE_DENSE_EXTRACT_FAILED,
+            coarse_release_ts,
+            exc.returncode,
+            exc.stderr[:200],
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=coarse,
+            frame_timestamps=coarse_timestamps,
+            stage=STAGE_DENSE_EXTRACT_FAILED,
+            coarse_timing=coarse,
+        )
+
+    dense = await classify_throw_timing_from_frames(
+        frames=dense_frames,
+        frame_timestamps=dense_timestamps,
+        chapter_title=chapter_title,
+        chapter_duration=chapter_duration,
+        utility_hint=utility_hint,
+    )
+
+    # The dense pass must produce a usable, throw-positive answer with a
+    # release_index. Any miss falls back to coarse — same "dense can only
+    # improve" contract as the extraction failure above.
+    if (
+        not dense.success
+        or not dense.is_lineup_throw
+        or dense.release_index is None
+    ):
+        logger.info(
+            "throw_localizer: stage=%s coarse_release_ts=%.2f "
+            "dense_success=%s dense_is_lineup_throw=%s "
+            "dense_release_index=%s; returning coarse: chapter=%r",
+            STAGE_DENSE_REJECTED,
+            coarse_release_ts,
+            dense.success,
+            dense.is_lineup_throw,
+            dense.release_index,
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=coarse,
+            frame_timestamps=coarse_timestamps,
+            stage=STAGE_DENSE_REJECTED,
+            coarse_timing=coarse,
+        )
+
+    # Dense pass succeeded — use it. Caller maps the returned indices via
+    # dense_timestamps.
+    dense_release_ts = dense_timestamps[dense.release_index - 1]
+    logger.info(
+        "throw_localizer: stage=%s coarse_release_ts=%.2f "
+        "dense_release_ts=%.2f shift=%+.2fs coarse_conf=%.2f "
+        "dense_conf=%.2f chapter=%r",
+        STAGE_REFINED,
+        coarse_release_ts,
+        dense_release_ts,
+        dense_release_ts - coarse_release_ts,
+        coarse.confidence or 0.0,
+        dense.confidence or 0.0,
+        chapter_title,
+    )
+    return RefinedThrowTiming(
+        timing=dense,
+        frame_timestamps=dense_timestamps,
+        stage=STAGE_REFINED,
+        coarse_timing=coarse,
+    )

--- a/apps/mygamingassistant/backend/tests/test_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_generator.py
@@ -24,6 +24,11 @@ from app.services.ingestion.clip_generator import (
     pending_clip_source_key,
 )
 from app.services.ingestion.frame_extractor import ClipCutError, FrameExtractionError
+from app.services.ingestion.throw_localizer import (
+    STAGE_COARSE_FAILED,
+    STAGE_REFINED,
+    RefinedThrowTiming,
+)
 from app.services.ingestion.wide_source import WideSourceResult
 from app.services.ingestion.youtube_fetcher import VideoDownloadError
 
@@ -131,6 +136,37 @@ def _timing(**kw):
     return ThrowTimingResult(**base)
 
 
+def _refined(
+    *,
+    timestamps: list[float] | None = None,
+    stage: str = STAGE_REFINED,
+    timing: ThrowTimingResult | None = None,
+    **timing_kwargs,
+) -> RefinedThrowTiming:
+    """Build a RefinedThrowTiming wrapper for the orchestrator's return.
+
+    After the two-stage refactor, clip_generator calls
+    ``localize_throw_with_refinement`` instead of running the timestamp /
+    extract / classify chain itself. Tests therefore mock the orchestrator
+    and shape its return as a RefinedThrowTiming. ``timing`` kwargs are
+    forwarded to :func:`_timing`; ``timestamps`` is the list whose
+    1-based indices the caller maps the release/result indices back to.
+
+    Pass ``stage=STAGE_COARSE_*`` when the test wants to assert the
+    coarse-fallback branch was taken; the wrapped ``timing`` should be a
+    ThrowTimingResult shaped accordingly.
+    """
+    timing_obj = timing if timing is not None else _timing(**timing_kwargs)
+    if timestamps is None:
+        timestamps = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    return RefinedThrowTiming(
+        timing=timing_obj,
+        frame_timestamps=timestamps,
+        stage=stage,
+        coarse_timing=timing_obj,
+    )
+
+
 class TestGenerateClipGeneratedPath:
     @pytest.mark.asyncio
     async def test_generated_reuses_provided_video_and_persists_key(
@@ -144,9 +180,9 @@ class TestGenerateClipGeneratedPath:
 
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]),
-            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 6)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames", new=AsyncMock(return_value=_timing())),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timestamps=[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]))),
             patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)) as mock_cut,
             patch(f"{_MOD}.get_storage", return_value=storage),
             patch(f"{_MOD}.download_video", new=AsyncMock()) as mock_dl,
@@ -178,10 +214,10 @@ class TestGenerateClipGeneratedPath:
 
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0, 4.0]),
-            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 4)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames",
-                  new=AsyncMock(return_value=_timing(release_index=1, result_index=2))),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timestamps=[1.0, 2.0, 3.0, 4.0],
+                      release_index=1, result_index=2))),
             patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
             patch(f"{_MOD}.get_storage", return_value=MagicMock()),
             patch(f"{_MOD}.download_video", new=AsyncMock(return_value=fetched)) as mock_dl,
@@ -226,12 +262,9 @@ class TestGenerateClipWideSourceWiring:
             # 6 frames spread across [9..24]; release_index=2 → release_ts=12,
             # result_index=4 → result_ts=18. _compute_clip_bounds gives
             # [12-2, 18+1.5] = [10, 19.5] = 9.5s within band.
-            patch(f"{_MOD}.clip_window_timestamps",
-                  return_value=[9.0, 12.0, 15.0, 18.0, 21.0, 24.0]),
-            patch(f"{_MOD}.extract_frames_downscaled",
-                  new=AsyncMock(return_value=[_FAKE_PNG] * 6)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames",
-                  new=AsyncMock(return_value=_timing(
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timestamps=[9.0, 12.0, 15.0, 18.0, 21.0, 24.0],
                       release_index=2, result_index=4))),
             patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
             patch(f"{_MOD}.get_storage", return_value=MagicMock()),
@@ -271,12 +304,10 @@ class TestGenerateClipWideSourceWiring:
 
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps",
-                  return_value=[1.0, 2.0, 3.0, 4.0]),
-            patch(f"{_MOD}.extract_frames_downscaled",
-                  new=AsyncMock(return_value=[_FAKE_PNG] * 4)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames",
-                  new=AsyncMock(return_value=_timing(release_index=1, result_index=2))),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timestamps=[1.0, 2.0, 3.0, 4.0],
+                      release_index=1, result_index=2))),
             patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
             patch(f"{_MOD}.get_storage", return_value=MagicMock()),
             patch(f"{_MOD}.cut_and_upload_wide_source",
@@ -299,12 +330,14 @@ class TestGenerateClipWideSourceWiring:
 
 class TestGenerateClipSkips:
     async def _skip(self, *, timing=None, settings=None, lineup=None, video=None):
+        refined_return = _refined(
+            timestamps=[1.0, 2.0, 3.0],
+            timing=timing or _timing(),
+        )
         with (
             patch(f"{_MOD}.settings", settings or _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0]),
-            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 3)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames",
-                  new=AsyncMock(return_value=timing or _timing())),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=refined_return)),
             patch(f"{_MOD}.cut_clip", new=AsyncMock()) as mock_cut,
             patch(f"{_MOD}.get_storage", return_value=MagicMock()),
             patch(f"{_MOD}.download_video", new=AsyncMock()),
@@ -385,10 +418,10 @@ class TestGenerateClipSkips:
         # release==result and a sub-second chapter → bounds None → skip.
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[20.0, 20.1, 20.2]),
-            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 3)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames",
-                  new=AsyncMock(return_value=_timing(release_index=1, result_index=1))),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timestamps=[20.0, 20.1, 20.2],
+                      release_index=1, result_index=1))),
             patch(f"{_MOD}.cut_clip", new=AsyncMock()) as mock_cut,
             patch(f"{_MOD}.get_storage", return_value=MagicMock()),
             patch(f"{_MOD}.download_video", new=AsyncMock()),
@@ -406,10 +439,9 @@ class TestGenerateClipSkips:
 class TestGenerateClipFailures:
     @pytest.mark.asyncio
     async def test_refetch_without_download_dir_fails_loud(self):
-        with (
-            patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
-        ):
+        # No-download-dir check happens BEFORE the orchestrator runs, so
+        # nothing needs to be patched on the timing-localiser surface.
+        with patch(f"{_MOD}.settings", _settings()):
             result = await generate_clip_for_lineup(
                 MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
                 video_path=None, download_dir=None,
@@ -425,7 +457,6 @@ class TestGenerateClipFailures:
         )
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
             patch(f"{_MOD}.download_video", new=AsyncMock(side_effect=exc)),
         ):
             result = await generate_clip_for_lineup(
@@ -437,12 +468,14 @@ class TestGenerateClipFailures:
 
     @pytest.mark.asyncio
     async def test_frame_extract_failure(self, tmp_path: Path):
+        """The orchestrator re-raises a coarse-pass FrameExtractionError so
+        the existing structured-failure surface is unchanged."""
         v = tmp_path / "v.mp4"; v.write_bytes(b"x")
         exc = FrameExtractionError("boom", timestamp=5.0, returncode=1, stderr="e")
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
-            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(side_effect=exc)),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(side_effect=exc)),
         ):
             result = await generate_clip_for_lineup(
                 MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
@@ -453,6 +486,9 @@ class TestGenerateClipFailures:
 
     @pytest.mark.asyncio
     async def test_throw_timing_call_failure(self, tmp_path: Path):
+        """A coarse-pass classifier failure surfaces as
+        RefinedThrowTiming(timing.success=False, stage=COARSE_FAILED) —
+        the caller routes on timing.error_codes exactly as before."""
         v = tmp_path / "v.mp4"; v.write_bytes(b"x")
         failed_timing = ThrowTimingResult(
             success=False, error_codes=["rate_limit_error"],
@@ -460,10 +496,10 @@ class TestGenerateClipFailures:
         )
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0]),
-            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 2)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames",
-                  new=AsyncMock(return_value=failed_timing)),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timing=failed_timing, stage=STAGE_COARSE_FAILED,
+                      timestamps=[]))),
         ):
             result = await generate_clip_for_lineup(
                 MagicMock(), _lineup(), chapter_start=0.0, chapter_end=30.0,
@@ -478,10 +514,10 @@ class TestGenerateClipFailures:
         exc = ClipCutError("nope", start=1.0, duration=6.0, returncode=1, stderr="e")
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0, 4.0]),
-            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 4)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames",
-                  new=AsyncMock(return_value=_timing(release_index=1, result_index=2))),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timestamps=[1.0, 2.0, 3.0, 4.0],
+                      release_index=1, result_index=2))),
             patch(f"{_MOD}.cut_clip", new=AsyncMock(side_effect=exc)),
         ):
             result = await generate_clip_for_lineup(
@@ -498,10 +534,10 @@ class TestGenerateClipFailures:
         storage.upload_file.side_effect = RuntimeError("minio down")
         with (
             patch(f"{_MOD}.settings", _settings()),
-            patch(f"{_MOD}.clip_window_timestamps", return_value=[1.0, 2.0, 3.0, 4.0]),
-            patch(f"{_MOD}.extract_frames_downscaled", new=AsyncMock(return_value=[_FAKE_PNG] * 4)),
-            patch(f"{_MOD}.classify_throw_timing_from_frames",
-                  new=AsyncMock(return_value=_timing(release_index=1, result_index=2))),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timestamps=[1.0, 2.0, 3.0, 4.0],
+                      release_index=1, result_index=2))),
             patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
             patch(f"{_MOD}.get_storage", return_value=storage),
             patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()) as mock_set,

--- a/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
@@ -27,6 +27,11 @@ from app.services.ingestion.landing_clip_generator import (
     pending_landing_clip_key,
     pending_landing_clip_source_key,
 )
+from app.services.ingestion.throw_localizer import (
+    STAGE_COARSE_FAILED,
+    STAGE_REFINED,
+    RefinedThrowTiming,
+)
 from app.services.ingestion.wide_source import WideSourceResult
 from app.services.ingestion.youtube_fetcher import VideoDownloadError
 
@@ -157,13 +162,13 @@ async def test_ingest_path_generates_clip_without_classifier_call():
     storage = _storage_mock()
     set_url_mock = AsyncMock(return_value=lineup)
 
-    classifier_mock = AsyncMock()  # MUST NOT be called
+    localizer_mock = AsyncMock()  # MUST NOT be called
 
     with (
         patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()) as cut,
         patch(f"{_MOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_landing_clip_url", set_url_mock),
-        patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+        patch(f"{_MOD}.localize_throw_with_refinement", localizer_mock),
         # Wide source mocked out — it has its own explicit tests below.
         patch(f"{_MOD}.cut_and_upload_wide_source",
               new=AsyncMock(return_value=_wide_fail())),
@@ -183,8 +188,9 @@ async def test_ingest_path_generates_clip_without_classifier_call():
     cut.assert_awaited_once()
     storage.upload_file.assert_called_once()
     set_url_mock.assert_awaited_once()
-    classifier_mock.assert_not_awaited(), (
-        "Ingest path must NOT call the classifier — cost regression"
+    localizer_mock.assert_not_awaited(), (
+        "Ingest path must NOT call the localizer/classifier — both the "
+        "coarse and dense Claude calls would be cost regressions"
     )
 
 
@@ -244,22 +250,45 @@ def _timing(**kw):
     return ThrowTimingResult(**base)
 
 
+def _refined(
+    *,
+    timestamps: list[float] | None = None,
+    stage: str = STAGE_REFINED,
+    timing: ThrowTimingResult | None = None,
+    **timing_kwargs,
+) -> RefinedThrowTiming:
+    """Mirrors test_clip_generator._refined — build a RefinedThrowTiming
+    wrapper for landing_clip_generator's localize_throw_with_refinement
+    mock. After the two-stage refactor, landing_clip_generator no longer
+    calls clip_window_timestamps / extract_frames_downscaled /
+    classify_throw_timing_from_frames directly; the orchestrator owns
+    that chain. Tests therefore mock the orchestrator and shape its
+    return as RefinedThrowTiming.
+    """
+    timing_obj = timing if timing is not None else _timing(**timing_kwargs)
+    if timestamps is None:
+        timestamps = [12.0, 18.0, 24.0, 30.0, 36.0]
+    return RefinedThrowTiming(
+        timing=timing_obj,
+        frame_timestamps=timestamps,
+        stage=stage,
+        coarse_timing=timing_obj,
+    )
+
+
 @pytest.mark.asyncio
 async def test_backfill_path_runs_classifier_and_generates():
     db = AsyncMock()
     lineup = _lineup()
     storage = _storage_mock()
     set_url_mock = AsyncMock(return_value=lineup)
-    timing = _timing(result_index=5)
     timestamps = [12.0, 18.0, 24.0, 30.0, 36.0]
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames_downscaled",
-              AsyncMock(return_value=[_FAKE_PNG] * 5)),
-        patch(f"{_MOD}.classify_throw_timing_from_frames",
-              AsyncMock(return_value=timing)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              AsyncMock(return_value=_refined(
+                  timestamps=timestamps, result_index=5))),
         patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
         patch(f"{_MOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_landing_clip_url", set_url_mock),
@@ -282,16 +311,11 @@ async def test_backfill_path_runs_classifier_and_generates():
 async def test_backfill_path_skips_not_a_throw():
     db = AsyncMock()
     lineup = _lineup()
-    timing = _timing(is_lineup_throw=False)
-    timestamps = [12.0, 18.0, 24.0]
-
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames_downscaled",
-              AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_MOD}.classify_throw_timing_from_frames",
-              AsyncMock(return_value=timing)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              AsyncMock(return_value=_refined(
+                  timestamps=[12.0, 18.0, 24.0], is_lineup_throw=False))),
     ):
         result = await generate_landing_clip_for_lineup(
             db, lineup,
@@ -306,16 +330,11 @@ async def test_backfill_path_skips_not_a_throw():
 async def test_backfill_path_skips_low_confidence():
     db = AsyncMock()
     lineup = _lineup()
-    timing = _timing(confidence=0.4)
-    timestamps = [12.0, 18.0, 24.0]
-
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames_downscaled",
-              AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_MOD}.classify_throw_timing_from_frames",
-              AsyncMock(return_value=timing)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              AsyncMock(return_value=_refined(
+                  timestamps=[12.0, 18.0, 24.0], confidence=0.4))),
     ):
         result = await generate_landing_clip_for_lineup(
             db, lineup,
@@ -330,16 +349,11 @@ async def test_backfill_path_skips_low_confidence():
 async def test_backfill_path_skips_no_result_frame():
     db = AsyncMock()
     lineup = _lineup()
-    timing = _timing(result_index=None)
-    timestamps = [12.0, 18.0, 24.0]
-
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames_downscaled",
-              AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_MOD}.classify_throw_timing_from_frames",
-              AsyncMock(return_value=timing)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              AsyncMock(return_value=_refined(
+                  timestamps=[12.0, 18.0, 24.0], result_index=None))),
     ):
         result = await generate_landing_clip_for_lineup(
             db, lineup,
@@ -382,18 +396,16 @@ async def test_backfill_path_classifier_missing_key_skips():
 async def test_backfill_path_classifier_api_failure_returns_failed():
     db = AsyncMock()
     lineup = _lineup()
-    timing = ThrowTimingResult(
+    failed_timing = ThrowTimingResult(
         success=False, error_codes=["overloaded_error"],
         reasoning="rate limited",
     )
-    timestamps = [12.0, 18.0, 24.0]
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames_downscaled",
-              AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_MOD}.classify_throw_timing_from_frames",
-              AsyncMock(return_value=timing)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              AsyncMock(return_value=_refined(
+                  timing=failed_timing, stage=STAGE_COARSE_FAILED,
+                  timestamps=[]))),
     ):
         result = await generate_landing_clip_for_lineup(
             db, lineup,
@@ -406,18 +418,17 @@ async def test_backfill_path_classifier_api_failure_returns_failed():
 
 @pytest.mark.asyncio
 async def test_backfill_path_frame_extract_failure_returns_failed():
+    """A coarse-pass FrameExtractionError is re-raised by the orchestrator
+    so landing_clip_generator's existing structured-failure surface is
+    unchanged."""
     db = AsyncMock()
     lineup = _lineup()
-    timestamps = [12.0, 18.0, 24.0]
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.clip_window_timestamps", return_value=timestamps),
-        patch(
-            f"{_MOD}.extract_frames_downscaled",
-            AsyncMock(side_effect=FrameExtractionError(
-                "boom", timestamp=18.0, returncode=1, stderr="x",
-            )),
-        ),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              AsyncMock(side_effect=FrameExtractionError(
+                  "boom", timestamp=18.0, returncode=1, stderr="x",
+              ))),
     ):
         result = await generate_landing_clip_for_lineup(
             db, lineup,

--- a/apps/mygamingassistant/backend/tests/test_throw_localizer.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_localizer.py
@@ -1,0 +1,491 @@
+"""Unit tests for throw_localizer (two-stage release-frame refinement).
+
+The orchestrator wraps ``classify_throw_timing_from_frames`` with a second
+dense pass when the coarse pass cleared a refine gate. All Anthropic calls
+and ffmpeg frame extraction are mocked at the orchestrator's local import
+sites so the tests can pin the decision tree exactly.
+
+Coverage:
+
+  * ``dense_window_timestamps``: window asymmetry, chapter clamping at
+    both ends, degenerate-chapter empty return.
+  * ``_should_refine``: every reason the coarse result blocks refinement.
+  * ``localize_throw_with_refinement``: every documented stage —
+    refined / coarse_only_* fallback paths / dense failure handling.
+  * Frame-timestamp contract: when stage=refined, returned
+    ``frame_timestamps`` MUST be the dense list (so the caller maps the
+    dense indices correctly); when fallback, the coarse list.
+
+The "dense can only improve, never regress" contract is the load-bearing
+guarantee these tests pin: any dense-pass failure mode returns the coarse
+result with the matching diagnostic stage.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from app.services.classification.classification_result import ThrowTimingResult
+from app.services.ingestion.frame_extractor import FrameExtractionError
+from app.services.ingestion.throw_localizer import (
+    STAGE_COARSE_BELOW_GATE,
+    STAGE_COARSE_FAILED,
+    STAGE_COARSE_NO_RELEASE,
+    STAGE_COARSE_NOT_A_THROW,
+    STAGE_DENSE_EXTRACT_FAILED,
+    STAGE_DENSE_REJECTED,
+    STAGE_DENSE_WINDOW_TOO_SMALL,
+    STAGE_REFINED,
+    RefinedThrowTiming,
+    _should_refine,
+    dense_window_timestamps,
+    localize_throw_with_refinement,
+)
+
+_MOD = "app.services.ingestion.throw_localizer"
+_FAKE_VIDEO = Path("/tmp/fake.mp4")
+_FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
+
+
+# ---------------------------------------------------------------------------
+# dense_window_timestamps
+# ---------------------------------------------------------------------------
+
+
+class TestDenseWindowTimestamps:
+    def test_returns_n_timestamps_centered_asymmetrically_on_release(self):
+        """4s asymmetric window (release - 1.0, release + 3.0) @ N=8."""
+        result = dense_window_timestamps(
+            coarse_release_ts=100.0,
+            chapter_start=0.0,
+            chapter_end=200.0,
+        )
+        assert len(result) == 8
+        # Window spans [99.0, 103.0] — strictly inside, edge_padding=0.
+        assert result[0] == pytest.approx(99.0)
+        assert result[-1] == pytest.approx(103.0)
+        # More post-release than pre-release coverage: release is closer
+        # to the START of the window than the end.
+        release_offset_from_start = 100.0 - result[0]
+        release_offset_from_end = result[-1] - 100.0
+        assert release_offset_from_end > release_offset_from_start
+
+    def test_clamps_to_chapter_start(self):
+        """A release near chapter_start can't sample pre-chapter frames."""
+        result = dense_window_timestamps(
+            coarse_release_ts=10.5,  # 10.5 - 1.0 = 9.5, below start
+            chapter_start=10.0,
+            chapter_end=200.0,
+        )
+        assert result[0] >= 10.0  # never below chapter_start
+        assert result[0] == pytest.approx(10.0)
+
+    def test_clamps_to_chapter_end(self):
+        """A release near chapter_end can't sample post-chapter frames."""
+        result = dense_window_timestamps(
+            coarse_release_ts=99.0,  # 99.0 + 3.0 = 102.0, above end
+            chapter_start=0.0,
+            chapter_end=100.0,
+        )
+        assert result[-1] <= 100.0  # never above chapter_end
+        assert result[-1] == pytest.approx(100.0)
+
+    def test_empty_when_window_collapses(self):
+        """Degenerate / inverted chapter → empty list (caller falls back)."""
+        result = dense_window_timestamps(
+            coarse_release_ts=50.0,
+            chapter_start=60.0,
+            chapter_end=50.0,
+        )
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _should_refine
+# ---------------------------------------------------------------------------
+
+
+def _coarse(**overrides) -> ThrowTimingResult:
+    base = dict(
+        success=True,
+        is_lineup_throw=True,
+        release_index=4,
+        result_index=6,
+        confidence=0.72,
+        reasoning="x",
+    )
+    base.update(overrides)
+    return ThrowTimingResult(**base)
+
+
+class TestShouldRefine:
+    def test_none_means_refine(self):
+        assert _should_refine(_coarse()) is None
+
+    def test_coarse_api_failure_blocks(self):
+        assert (
+            _should_refine(_coarse(success=False, error_codes=["x"]))
+            == STAGE_COARSE_FAILED
+        )
+
+    def test_not_a_throw_blocks(self):
+        assert (
+            _should_refine(
+                _coarse(is_lineup_throw=False, release_index=None, result_index=None)
+            )
+            == STAGE_COARSE_NOT_A_THROW
+        )
+
+    def test_missing_release_index_blocks(self):
+        assert _should_refine(_coarse(release_index=None)) == STAGE_COARSE_NO_RELEASE
+
+    def test_confidence_below_gate_blocks(self):
+        assert _should_refine(_coarse(confidence=0.54)) == STAGE_COARSE_BELOW_GATE
+
+    def test_confidence_at_gate_refines(self):
+        """The gate is >= 0.55, not > 0.55 — exact match passes."""
+        assert _should_refine(_coarse(confidence=0.55)) is None
+
+    def test_none_confidence_blocks(self):
+        """A null confidence is below ANY numeric gate by definition."""
+        assert _should_refine(_coarse(confidence=None)) == STAGE_COARSE_BELOW_GATE
+
+
+# ---------------------------------------------------------------------------
+# localize_throw_with_refinement — orchestrator decision tree
+# ---------------------------------------------------------------------------
+
+
+_COARSE_TIMESTAMPS = [10.0, 12.0, 14.0, 16.0, 18.0, 20.0, 22.0, 24.0,
+                      26.0, 28.0, 30.0, 32.0]
+_DENSE_TIMESTAMPS = [14.0, 14.5, 15.0, 15.5, 16.0, 16.5, 17.0, 17.5]
+
+
+def _patch_chain(
+    *,
+    coarse_classifier: AsyncMock,
+    dense_classifier: AsyncMock | None = None,
+    extract_side_effect=None,
+):
+    """Build the patch context for the orchestrator's chain.
+
+    Patches at the orchestrator's local import sites (its module path).
+    Extraction is one async function called twice (coarse + dense); a
+    side-effect list controls per-call behavior. The classifier is one
+    function called once or twice — when the orchestrator runs both
+    passes, we want the second call to use ``dense_classifier``.
+    """
+    extract_mock = AsyncMock()
+    if extract_side_effect is not None:
+        extract_mock.side_effect = extract_side_effect
+    else:
+        # Default: both extracts succeed and return distinct frame lists
+        # (so the test can assert which list reached the classifier).
+        extract_mock.side_effect = [
+            [_FAKE_PNG] * len(_COARSE_TIMESTAMPS),
+            [_FAKE_PNG] * len(_DENSE_TIMESTAMPS),
+        ]
+
+    classifier_mock = AsyncMock()
+    if dense_classifier is None:
+        classifier_mock.side_effect = [coarse_classifier]
+    else:
+        classifier_mock.side_effect = [coarse_classifier, dense_classifier]
+
+    timestamps_mock = lambda *a, **k: list(_COARSE_TIMESTAMPS)  # noqa: E731
+    dense_window_mock = lambda *a, **k: list(_DENSE_TIMESTAMPS)  # noqa: E731
+
+    return (
+        patch(f"{_MOD}.extract_frames_downscaled", extract_mock),
+        patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+        patch(f"{_MOD}.clip_window_timestamps", timestamps_mock),
+        patch(f"{_MOD}.dense_window_timestamps", dense_window_mock),
+    ), extract_mock, classifier_mock
+
+
+class TestLocalizeThrowOrchestrator:
+    @pytest.mark.asyncio
+    async def test_refined_when_coarse_clears_gate(self):
+        """Happy path: coarse confidence 0.72 + dense returns a refined
+        release. Result uses DENSE timing + DENSE timestamps so the
+        caller's index→ts mapping is frame-accurate."""
+        coarse = _coarse(release_index=3, confidence=0.72)
+        # Coarse release_index=3 → coarse_release_ts=14.0; dense window
+        # centred there. Dense picks frame 5 → dense_release_ts=16.0
+        # (refined +2.0s from the coarse pick).
+        dense = _coarse(release_index=5, result_index=7, confidence=0.88)
+        patches, extract_mock, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=dense
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="B-site smoke",
+            )
+        assert result.stage == STAGE_REFINED
+        assert result.timing is dense
+        assert result.frame_timestamps == _DENSE_TIMESTAMPS
+        assert result.coarse_timing is coarse
+        # Both extracts ran (coarse + dense).
+        assert extract_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_coarse_failed_returns_coarse(self):
+        coarse = ThrowTimingResult(
+            success=False, error_codes=["rate_limit"], reasoning="api"
+        )
+        patches, extract_mock, classifier_mock = _patch_chain(
+            coarse_classifier=coarse
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_COARSE_FAILED
+        assert result.timing is coarse
+        assert result.frame_timestamps == _COARSE_TIMESTAMPS
+        # Dense pass NOT triggered → only the coarse extract + classify ran.
+        assert extract_mock.await_count == 1
+        assert classifier_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_coarse_not_a_throw_returns_coarse(self):
+        coarse = _coarse(
+            is_lineup_throw=False, release_index=None, result_index=None,
+            confidence=0.05,
+        )
+        patches, extract_mock, classifier_mock = _patch_chain(
+            coarse_classifier=coarse
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_COARSE_NOT_A_THROW
+        assert result.timing is coarse
+        assert extract_mock.await_count == 1
+        assert classifier_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_coarse_no_release_index_returns_coarse(self):
+        coarse = _coarse(release_index=None, confidence=0.7)
+        patches, _, classifier_mock = _patch_chain(coarse_classifier=coarse)
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_COARSE_NO_RELEASE
+        assert result.timing is coarse
+        assert classifier_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_coarse_below_gate_returns_coarse(self):
+        """0.54 just below the 0.55 refine gate — no dense pass."""
+        coarse = _coarse(confidence=0.54)
+        patches, _, classifier_mock = _patch_chain(coarse_classifier=coarse)
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_COARSE_BELOW_GATE
+        assert result.timing is coarse
+        assert classifier_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_dense_window_too_small_returns_coarse(self):
+        """Chapter boundaries collapse the dense window — fall back."""
+        coarse = _coarse(release_index=3, confidence=0.7)
+        # Override dense_window mock to return < _MIN_DENSE_FRAMES items.
+        extract_mock = AsyncMock(
+            return_value=[_FAKE_PNG] * len(_COARSE_TIMESTAMPS)
+        )
+        classifier_mock = AsyncMock(side_effect=[coarse])
+        with (
+            patch(f"{_MOD}.extract_frames_downscaled", extract_mock),
+            patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                lambda *a, **k: list(_COARSE_TIMESTAMPS),
+            ),
+            patch(
+                f"{_MOD}.dense_window_timestamps",
+                lambda *a, **k: [14.0, 14.5],  # only 2 < 4 minimum
+            ),
+        ):
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_DENSE_WINDOW_TOO_SMALL
+        assert result.timing is coarse
+        assert result.frame_timestamps == _COARSE_TIMESTAMPS
+        # Dense extract NOT invoked because the window was too small.
+        assert extract_mock.await_count == 1
+        assert classifier_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_dense_extract_failure_returns_coarse(self):
+        """Dense pass ffmpeg failure must NEVER regress the pipeline."""
+        coarse = _coarse(release_index=3, confidence=0.7)
+        extract_mock = AsyncMock()
+        extract_mock.side_effect = [
+            [_FAKE_PNG] * len(_COARSE_TIMESTAMPS),  # coarse OK
+            FrameExtractionError(
+                "boom", timestamp=14.0, returncode=1, stderr="ffmpeg lost"
+            ),
+        ]
+        classifier_mock = AsyncMock(side_effect=[coarse])
+        with (
+            patch(f"{_MOD}.extract_frames_downscaled", extract_mock),
+            patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                lambda *a, **k: list(_COARSE_TIMESTAMPS),
+            ),
+            patch(
+                f"{_MOD}.dense_window_timestamps",
+                lambda *a, **k: list(_DENSE_TIMESTAMPS),
+            ),
+        ):
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_DENSE_EXTRACT_FAILED
+        assert result.timing is coarse
+        assert result.frame_timestamps == _COARSE_TIMESTAMPS
+        # Dense extract WAS attempted (and failed); dense classifier NEVER ran.
+        assert extract_mock.await_count == 2
+        assert classifier_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_coarse_extract_failure_reraises(self):
+        """Coarse extract failure is the caller's surface to handle —
+        the orchestrator must propagate, not swallow."""
+        extract_mock = AsyncMock()
+        extract_mock.side_effect = FrameExtractionError(
+            "boom", timestamp=10.0, returncode=1, stderr="ffmpeg lost",
+        )
+        classifier_mock = AsyncMock()  # never called
+        with (
+            patch(f"{_MOD}.extract_frames_downscaled", extract_mock),
+            patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                lambda *a, **k: list(_COARSE_TIMESTAMPS),
+            ),
+        ):
+            with pytest.raises(FrameExtractionError):
+                await localize_throw_with_refinement(
+                    _FAKE_VIDEO,
+                    chapter_start=0.0,
+                    chapter_end=60.0,
+                    chapter_title="x",
+                )
+        assert classifier_mock.await_count == 0
+
+    @pytest.mark.asyncio
+    async def test_dense_classifier_api_failure_returns_coarse(self):
+        coarse = _coarse(release_index=3, confidence=0.7)
+        dense_fail = ThrowTimingResult(
+            success=False, error_codes=["api"], reasoning="x"
+        )
+        patches, extract_mock, classifier_mock = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=dense_fail
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_DENSE_REJECTED
+        assert result.timing is coarse
+        assert result.frame_timestamps == _COARSE_TIMESTAMPS
+        assert extract_mock.await_count == 2
+        assert classifier_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_dense_not_a_throw_returns_coarse(self):
+        """Dense pass might decide the dense region isn't a throw (e.g.
+        sampled too tight on a non-throw frame). Coarse already cleared
+        the gate, so fall back — don't downgrade coarse's verdict."""
+        coarse = _coarse(release_index=3, confidence=0.7)
+        dense_not_throw = _coarse(
+            is_lineup_throw=False, release_index=None, result_index=None,
+            confidence=0.2,
+        )
+        patches, _, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=dense_not_throw
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_DENSE_REJECTED
+        assert result.timing is coarse
+
+    @pytest.mark.asyncio
+    async def test_dense_no_release_returns_coarse(self):
+        coarse = _coarse(release_index=3, confidence=0.7)
+        dense_no_rel = _coarse(release_index=None, confidence=0.6)
+        patches, _, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=dense_no_rel
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_DENSE_REJECTED
+        assert result.timing is coarse
+
+    @pytest.mark.asyncio
+    async def test_refined_frame_timestamps_are_dense_list(self):
+        """Critical invariant: stage=refined returns DENSE timestamps so
+        the caller's ``timestamps[release_index - 1]`` gives the dense
+        release time, not the coarse one. If this regresses, the clip
+        anchor goes back to coarse-resolution."""
+        coarse = _coarse(release_index=3, confidence=0.7)
+        dense = _coarse(release_index=5, result_index=7, confidence=0.8)
+        patches, _, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=dense
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert isinstance(result, RefinedThrowTiming)
+        assert result.frame_timestamps is not _COARSE_TIMESTAMPS
+        assert result.frame_timestamps == _DENSE_TIMESTAMPS
+        # And the index→ts resolution: dense.release_index=5 → 16.0
+        assert result.frame_timestamps[result.timing.release_index - 1] == 16.0


### PR DESCRIPTION
## Summary

The 3s sampling cadence is the underlying defect from PR #749 / #750 — even a perfect prompt cannot pick a frame the sampler never extracted. PR #750 made the model better at choosing among the 12 coarse frames; this PR gives it a frame-accurate set to choose from.

Adds `app/services/ingestion/throw_localizer.py` — a two-stage refinement orchestrator that wraps `classify_throw_timing_from_frames`:

- **Stage 1** (coarse, unchanged): 12 frames across the chapter throw window. Same prompt, same gates.
- **Stage 2** (dense, NEW, gated on coarse confidence ≥ 0.55): build an asymmetric ±~2s window around the coarse release (`release − 1.0s, release + 3.0s` @ N=8, ~0.5s spacing), extract those frames, re-call the same classifier. Final clip anchor goes from `release ± 1.5s` → `release ± 0.25s`.

The orchestrator returns the dense result when refinement succeeded and falls back to coarse on any dense-pass failure (extract, classifier API, not-a-throw, no release, window too small). **Dense pass can ONLY improve the result — never regresses the pipeline.**

## Cost

Refinement doubles the throw-timing Claude calls per *generated* clip. Skipped clips (not-a-throw / low confidence / no release) pay only the coarse call — the existing gates control cost. Net effect at typical accept rates is ~1.7-1.9× of pre-refinement spend on clip-generation calls.

The 0.55 gate (not 0) is intentional: refining a "we don't know where the throw is" coarse pass spends a second call to densely sample a wrong region. Per MGA's "casual app" posture (`project_mygamingassistant_plan`), cost-aware gating is correct here.

## Changes

- **`throw_localizer.py`** — new module with `dense_window_timestamps`, `_should_refine`, `RefinedThrowTiming`, `localize_throw_with_refinement`. Stage labels are diagnostic constants so logs / future metrics can answer "of N generations, how many cleared the refine gate vs fell back."
- **`clip_generator.py`** — replaces the 3-step coarse chain (timestamps + extract + classify) with one `localize_throw_with_refinement` call. Removes unused imports.
- **`landing_clip_generator.py`** — same swap on its backfill path. Ingest path unchanged (still reuses PR2's `precomputed_result_ts`; zero refinement cost on that branch — pure cost win).

## Test plan

- [x] 23 new tests in `tests/test_throw_localizer.py`: dense window geometry, every `_should_refine` reason, every orchestrator fallback path, and the "stage=refined returns DENSE timestamps" invariant
- [x] Migrated 26 `test_clip_generator.py` + 26 `test_landing_clip_generator.py` tests to mock `localize_throw_with_refinement` (new patch target). Helper `_refined()` builds `RefinedThrowTiming` wrappers
- [x] PR #750's 25 throw-timing classifier tests still pass — candidate-exclusion contract preserved end-to-end
- [x] Full backend unit sweep: **676/676 pass**
- [ ] Operator: re-run `python -m app.cli backfill-clips` on a few representative lineups and grep logs for `stage=refined coarse_release_ts=… dense_release_ts=… shift=…` to see the typical refinement shift in real numbers

## Related

- Track A of two with #750 (title-card immunity). Combined: title cards aren't candidates, AND the picked release is frame-accurate.
- Diagnostic evidence for the 3s cadence pre-PR: `~/.claude/projects/C--Users-jason-Documents-Git-MyFreeApps/diagnostics/mga-throw-timing-sampling-cadence/` (12 frames at 3s spacing + replay script). Use to compare before/after on a known-bad lineup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)