### PR TITLE
chore: flip Tech Debt Policy to no-growth on flagged files

### DIFF
--- a/apps/mybookkeeper/CLAUDE.md
+++ b/apps/mybookkeeper/CLAUDE.md
@@ -379,14 +379,18 @@ sudo mybookkeeper-update
 
 ## Tech Debt Policy
 
-`mode: fix`
+mode: no-growth on flagged files
 
-When `mode: fix`, the pipeline (`g-pipeline`, `g-build-feature`) will actively fix existing issues from `TECH_DEBT.md` during each run — highest severity first, up to `max_fixes_per_run`. When `mode: log-only`, the pipeline only logs new issues and never touches existing ones.
+A PR MAY NOT increase the LOC count of any file currently listed under
+`scripts/file-size-allowlist.yml` `over_1000_loc` OR any source file already
+over 500 LOC. If a PR genuinely needs to add to a flagged file, the same PR
+MUST split that file (extract a sibling module + re-export from the original)
+in the same commit. The CI check at `.github/workflows/file-size-check.yml`
+enforces this.
 
-- `max_fixes_per_run: 3` — cap to prevent scope creep into a full rewrite
-- Priority order: Critical > High > Medium > Low
-- After fixing a tech debt issue, remove it from `TECH_DEBT.md` and update the counts
-- Re-run all test suites after each audit fix to confirm no regressions
+Critical severity items that directly block the current feature can still be
+fixed inline. Everything else logged in `TECH_DEBT.md` and addressed in
+dedicated refactor PRs.
 
 ## Legal
 

--- a/apps/mygamingassistant/CLAUDE.md
+++ b/apps/mygamingassistant/CLAUDE.md
@@ -274,7 +274,15 @@ curl http://127.0.0.1:8096/health
 
 ## Tech Debt Policy
 
-mode: log-only
+mode: no-growth on flagged files
 
-New project. No CI tests yet. Fix only Critical severity items that directly
-block the current feature. Log everything else in TECH_DEBT.md.
+A PR MAY NOT increase the LOC count of any file currently listed under
+`scripts/file-size-allowlist.yml` `over_1000_loc` OR any source file already
+over 500 LOC. If a PR genuinely needs to add to a flagged file, the same PR
+MUST split that file (extract a sibling module + re-export from the original)
+in the same commit. The CI check at `.github/workflows/file-size-check.yml`
+enforces this.
+
+Critical severity items that directly block the current feature can still be
+fixed inline. Everything else logged in `TECH_DEBT.md` and addressed in
+dedicated refactor PRs.

--- a/apps/myjobhunter/CLAUDE.md
+++ b/apps/myjobhunter/CLAUDE.md
@@ -261,3 +261,18 @@ Anything NOT on the divergence list, presume MBK is right and copy.
 ## Known Follow-ups
 
 - GIN indexes on JSONB columns (add when actual query predicates exist)
+
+## Tech Debt Policy
+
+mode: no-growth on flagged files
+
+A PR MAY NOT increase the LOC count of any file currently listed under
+`scripts/file-size-allowlist.yml` `over_1000_loc` OR any source file already
+over 500 LOC. If a PR genuinely needs to add to a flagged file, the same PR
+MUST split that file (extract a sibling module + re-export from the original)
+in the same commit. The CI check at `.github/workflows/file-size-check.yml`
+enforces this.
+
+Critical severity items that directly block the current feature can still be
+fixed inline. Everything else logged in `TECH_DEBT.md` and addressed in
+dedicated refactor PRs.

--- a/apps/mypizzatracker/CLAUDE.md
+++ b/apps/mypizzatracker/CLAUDE.md
@@ -145,7 +145,15 @@ curl http://127.0.0.1:8098/health
 
 ## Tech Debt Policy
 
-mode: log-only
+mode: no-growth on flagged files
 
-New project. Fix only Critical severity items that directly block the current
-feature. Log everything else in TECH_DEBT.md.
+A PR MAY NOT increase the LOC count of any file currently listed under
+`scripts/file-size-allowlist.yml` `over_1000_loc` OR any source file already
+over 500 LOC. If a PR genuinely needs to add to a flagged file, the same PR
+MUST split that file (extract a sibling module + re-export from the original)
+in the same commit. The CI check at `.github/workflows/file-size-check.yml`
+enforces this.
+
+Critical severity items that directly block the current feature can still be
+fixed inline. Everything else logged in `TECH_DEBT.md` and addressed in
+dedicated refactor PRs.


### PR DESCRIPTION
## Summary

- Replaces the per-app `## Tech Debt Policy` section in all four app `CLAUDE.md` files (`mybookkeeper`, `mygamingassistant`, `myjobhunter`, `mypizzatracker`) with a unified `mode: no-growth on flagged files` posture
- The new rule: a PR may not increase the LOC count of any file currently listed in `scripts/file-size-allowlist.yml` `over_1000_loc` OR any source file already over 500 LOC — the PR must split the file instead
- `myjobhunter` previously had no Tech Debt Policy section at all; one is added at the end of the file

## Why

`classifier_service.py` grew from 1,991 → 2,029 LOC across PR #750 despite being flagged in PR #748's rescan. The old `log-only` language contained a "directly block" loophole — 30-LOC prompt edits in PR #750 weren't blocked by anything, so they were waved through. This PR closes the loophole in the human-readable policy text.

## Relationship to PR A

This is the human-readable backstop. PR A (file-size-check CI guard, in a sibling worktree) adds `.github/workflows/file-size-check.yml` and `scripts/file-size-allowlist.yml` which enforce the same rule mechanically at CI time. This PR and PR A should be merged together — this PR first (policy) then PR A (enforcement), or together if CI ordering allows.

## Files changed

- `apps/mybookkeeper/CLAUDE.md` — replaced `mode: fix` block with `no-growth` policy
- `apps/mygamingassistant/CLAUDE.md` — replaced `mode: log-only` block with `no-growth` policy
- `apps/myjobhunter/CLAUDE.md` — added `## Tech Debt Policy` section (was missing entirely)
- `apps/mypizzatracker/CLAUDE.md` — replaced `mode: log-only` block with `no-growth` policy

## Test plan

- [ ] Verify each app's CLAUDE.md now contains `mode: no-growth on flagged files`
- [ ] Verify no other content was displaced (surrounding sections intact)
- [ ] CI is docs-only; no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)