### PR TITLE
fix(mga): tighten throw / landing clip bounds — release-anchored + post-result lead-in skip

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
@@ -18,8 +18,8 @@ End-to-end (the frozen design contract, pr2-clip-localization-design.md):
      game/map grid classifier).
   4. Gate: skip (keep stills) when it is not a throw, confidence < 0.55, or no
      release frame was found.
-  5. Turn the returned indices back into timestamps, compute a throw-centric
-     ~6s clip window, clamp to the chapter.
+  5. Turn the release index back into a timestamp, compute a tight
+     ~3s clip window anchored entirely on release_ts, clamp to the chapter.
   6. Re-use the already-downloaded video (ingest) or re-fetch it by
      ``youtube_video_id`` (backfill), cut + encode a small muted MP4, upload
      to MinIO under a deterministic key, and persist the bare key on the row.
@@ -68,17 +68,17 @@ logger = logging.getLogger(__name__)
 # below 0.55 the dense window missed the throw and the stills are the right
 # artifact.
 _CLIP_CONFIDENCE_GATE = 0.55
-# Lead-in kept before release / tail kept after the result first shows.
-# The 1.5s tail is the operator-tuned amount of bloom needed to see the smoke
-# clear the obstacle / molly catch / flash fade — earlier 0.5s was cutting off
-# while the utility was still unfolding on screen.
+# Throw clip is anchored ENTIRELY on release_ts: the throw pane's job is the
+# throw MOTION, which completes within ~0.5-1.0s of release. The prior
+# implementation used `result_ts + 1.5s` for the tail, but result_ts is the
+# throw-timing prompt's "first visible wisp" (1.5-3.0s after release) — which
+# left 2-3s of useless post-motion tail (operator surfaced this on lineup
+# 7bd971c3 after PR #751 made the release frame accurate). The smoke / molly /
+# flash AFTER-the-throw is what the LANDING pane shows; the THROW pane should
+# end when the throw is done.
 _PRE_RELEASE_SECONDS = 2.0
-_POST_RESULT_SECONDS = 1.5
-# Accepted clip-length band; outside it we rebuild a throw-centric ~7s window.
-_MIN_CLIP_SECONDS = 2.0
-_MAX_CLIP_SECONDS = 12.0
-_TARGET_CLIP_SECONDS = 7.0
-# Below this even the rebuilt window is unusable (chapter too short) → skip.
+_POST_RELEASE_SECONDS = 1.0
+# Below this the chapter-clamped window is unusable → skip.
 _ABSOLUTE_MIN_CLIP_SECONDS = 1.0
 
 
@@ -144,28 +144,20 @@ def pending_clip_source_key(video_id: str, chapter_start_seconds: float) -> str:
 
 def _compute_clip_bounds(
     release_ts: float,
-    result_ts: float,
     chapter_start: float,
     chapter_end: float,
 ) -> Optional[tuple[float, float]]:
     """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
 
-    [release-2.0, result+1.5] clamped to the chapter. If that is outside the
-    [~2s, ~12s] band (e.g. a long gap between release and result, or a missing
-    result frame collapsing it), rebuild a throw-centric ~7s window anchored
-    at release. Returns None when even the rebuilt window is shorter than ~1s
-    (the chapter is too short to carry a meaningful clip) so the caller skips.
+    [release - _PRE_RELEASE_SECONDS, release + _POST_RELEASE_SECONDS] clamped
+    to the chapter. The throw pane's job is the throw MOTION; anchoring the
+    tail on release_ts (not result_ts, the "first visible wisp") keeps the
+    clip tight on the action. Returns None when the chapter-clamped window
+    is shorter than ``_ABSOLUTE_MIN_CLIP_SECONDS`` so the caller skips.
     """
     start = max(release_ts - _PRE_RELEASE_SECONDS, chapter_start)
-    end = min(result_ts + _POST_RESULT_SECONDS, chapter_end)
+    end = min(release_ts + _POST_RELEASE_SECONDS, chapter_end)
     duration = end - start
-
-    if duration < _MIN_CLIP_SECONDS or duration > _MAX_CLIP_SECONDS:
-        # Throw-centric ~6s rebuild: keep the 2s pre-release lead-in, take the
-        # rest after release. Re-clamp to the chapter.
-        start = max(release_ts - _PRE_RELEASE_SECONDS, chapter_start)
-        end = min(start + _TARGET_CLIP_SECONDS, chapter_end)
-        duration = end - start
 
     if duration < _ABSOLUTE_MIN_CLIP_SECONDS:
         return None
@@ -339,16 +331,16 @@ async def generate_clip_for_lineup(
 
         # ---- Indices → timestamps → clip bounds ------------------------
         release_ts = timestamps[timing.release_index - 1]
-        # result_index is guaranteed >= release_index by the parser when set;
-        # when the model omitted it we anchor the tail at release (the
-        # standard 2.5s window then still passes the >=2s contract band).
+        # result_ts is no longer load-bearing for the clip window (the throw
+        # pane is anchored entirely on release_ts) but is still surfaced on
+        # the result row for diagnostics and used by the landing-clip path.
         if timing.result_index is not None:
             result_ts = timestamps[timing.result_index - 1]
         else:
             result_ts = release_ts
 
         bounds = _compute_clip_bounds(
-            release_ts, result_ts, float(chapter_start), float(chapter_end)
+            release_ts, float(chapter_start), float(chapter_end)
         )
         if bounds is None:
             return ClipGenerationResult(

--- a/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
@@ -79,22 +79,14 @@ from app.services.ingestion.youtube_fetcher import (
 logger = logging.getLogger(__name__)
 
 # Frozen design-contract constants. The 0.55 gate matches PR2's throw clip —
-# if PR2 cleared its gate, the landing pass shares that judgment (so a clip
-# is generated or both are skipped together, never one without the other).
+# if PR2 cleared its gate, the landing pass shares that judgment.
 _CLIP_CONFIDENCE_GATE = 0.55
-# Where the landing clip starts relative to result_ts. result_ts is the
-# throw-timing prompt's "first visible wisp" — typically 1.5-3.0s after the
-# actual release — so the first 1.5-2s after result_ts is still very faint.
-# Starting AT result_ts (or before) gives the operator a clip with a blank /
-# barely-visible lead-in (surfaced on lineup 7bd971c3 after PR #751 made the
-# release frame accurate). Pad forward so the clip starts when the bloom is
-# actually visible.
+# result_ts is the throw-timing prompt's "first visible wisp" — typically
+# 1.5-3.0s after release, so the first ~1.5s is still very faint. Pad
+# forward so the clip opens once bloom is actually visible (lineup
+# 7bd971c3 after PR #751).
 _POST_RESULT_PRE_PAD = 1.5
-# Target clip duration. Kept around the previous ~3.5s total — long enough
-# to show full deployment / molly burn pattern / flash radius without
-# dwelling pointlessly after the effect has settled.
 _LANDING_CLIP_DURATION = 3.5
-# Below this the chapter-clamped window is unusable → skip.
 _MIN_CLIP_SECONDS = 1.0
 
 

--- a/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
@@ -82,15 +82,20 @@ logger = logging.getLogger(__name__)
 # if PR2 cleared its gate, the landing pass shares that judgment (so a clip
 # is generated or both are skipped together, never one without the other).
 _CLIP_CONFIDENCE_GATE = 0.55
-# Lead-in kept before landing / dwell time on the post-landing scene. The
-# 3.0s tail is the visible distinction from PR2's clip — PR2 cuts at result
-# + 0.5s, so landing gets a separate 3.5s pane focused on the after-effect
-# (smoke at full coverage, molly burn pattern, flash radius).
-_PRE_LANDING_SECONDS = 0.5
-_POST_LANDING_SECONDS = 3.0
-# Tight bounds — the landing pane is the smallest of the 2×2 storyboard.
+# Where the landing clip starts relative to result_ts. result_ts is the
+# throw-timing prompt's "first visible wisp" — typically 1.5-3.0s after the
+# actual release — so the first 1.5-2s after result_ts is still very faint.
+# Starting AT result_ts (or before) gives the operator a clip with a blank /
+# barely-visible lead-in (surfaced on lineup 7bd971c3 after PR #751 made the
+# release frame accurate). Pad forward so the clip starts when the bloom is
+# actually visible.
+_POST_RESULT_PRE_PAD = 1.5
+# Target clip duration. Kept around the previous ~3.5s total — long enough
+# to show full deployment / molly burn pattern / flash radius without
+# dwelling pointlessly after the effect has settled.
+_LANDING_CLIP_DURATION = 3.5
+# Below this the chapter-clamped window is unusable → skip.
 _MIN_CLIP_SECONDS = 1.0
-_TARGET_CLIP_SECONDS = _PRE_LANDING_SECONDS + _POST_LANDING_SECONDS  # 3.5s
 
 
 @dataclass
@@ -158,16 +163,18 @@ def _compute_landing_bounds(
 ) -> Optional[tuple[float, float]]:
     """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
 
-    Centered on the landing: ``[result - 0.5, result + 3.0]`` clamped to the
-    chapter. Returns None when the clamped window is shorter than 1s (the
-    chapter has no headroom around the landing to carry a meaningful clip),
-    so the caller skips. We deliberately do NOT rebuild a target-length
-    window — for landing-clip the WHERE is more important than the
-    HOW-LONG, and a clamped sliver is more informative than a fabricated
-    one displaced to a different chapter region.
+    Starts AFTER result_ts (``+ _POST_RESULT_PRE_PAD``) to skip the faint-wisp
+    lead-in that result_ts anchors on. Target duration ``_LANDING_CLIP_DURATION``,
+    clamped to the chapter. Returns None when the chapter ends too close to
+    result_ts to leave ``>= _MIN_CLIP_SECONDS`` of bloom — for landing-clip the
+    WHERE is more important than the HOW-LONG, and a clamped sliver is more
+    informative than a fabricated one displaced to a different chapter region.
     """
-    start = max(result_ts - _PRE_LANDING_SECONDS, chapter_start)
-    end = min(result_ts + _POST_LANDING_SECONDS, chapter_end)
+    start = max(result_ts + _POST_RESULT_PRE_PAD, chapter_start)
+    if start >= chapter_end:
+        # No headroom: the post-pad start is already at/past the chapter end.
+        return None
+    end = min(start + _LANDING_CLIP_DURATION, chapter_end)
     duration = end - start
     if duration < _MIN_CLIP_SECONDS:
         return None

--- a/apps/mygamingassistant/backend/tests/test_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_generator.py
@@ -66,37 +66,27 @@ def _lineup(video_id="vid123", chapter_title="B smoke"):
 # ---------------------------------------------------------------------------
 
 class TestComputeClipBounds:
-    def test_normal_window_within_band(self):
-        # release 20, result 24, chapter [10,40]: [18, 25.5] = 7.5s in [2,12].
-        # Operator-tuned: 1.5s tail after result (was 0.5s) to capture bloom.
-        start, dur = _compute_clip_bounds(20.0, 24.0, 10.0, 40.0)
+    def test_normal_window_anchored_on_release(self):
+        # release 20, chapter [10,40]: [20-2, 20+1] = [18, 21] = 3.0s.
+        # Anchored entirely on release_ts — the throw pane shows the MOTION,
+        # not the bloom that follows (the landing pane covers that).
+        start, dur = _compute_clip_bounds(20.0, 10.0, 40.0)
         assert start == pytest.approx(18.0)
-        assert dur == pytest.approx(7.5)
+        assert dur == pytest.approx(3.0)
 
     def test_clamped_to_chapter_start(self):
         # release 11 → 11-2=9 but chapter starts at 10 → clamp to 10.
-        start, dur = _compute_clip_bounds(11.0, 13.0, 10.0, 40.0)
+        start, dur = _compute_clip_bounds(11.0, 10.0, 40.0)
         assert start == pytest.approx(10.0)
-
-    def test_too_long_rebuilds_throw_centric_7s(self):
-        # release 20, result 60, chapter [10,90]: raw 41.5s > 12 → rebuild to
-        # ~7s anchored at release: [18, 25].
-        start, dur = _compute_clip_bounds(20.0, 60.0, 10.0, 90.0)
-        assert start == pytest.approx(18.0)
-        assert dur == pytest.approx(7.0)
-
-    def test_missing_result_collapses_to_35s_clip(self):
-        # result_ts == release_ts (no result frame): [release-2, release+1.5]
-        # = 3.5s, which is within the [2,12] band by frozen-contract design.
-        start, dur = _compute_clip_bounds(20.0, 20.0, 0.0, 60.0)
-        assert dur == pytest.approx(3.5)
+        assert dur == pytest.approx(2.0)  # [10, 12]
 
     def test_chapter_too_short_returns_none(self):
-        # 0.5s chapter — even the rebuilt window is < 1s → skip signal.
-        assert _compute_clip_bounds(20.0, 20.0, 20.0, 20.5) is None
+        # 0.5s chapter — clamped window is < _ABSOLUTE_MIN_CLIP_SECONDS → skip.
+        assert _compute_clip_bounds(20.0, 20.0, 20.5) is None
 
     def test_clip_never_exceeds_chapter_end(self):
-        start, dur = _compute_clip_bounds(20.0, 24.0, 10.0, 23.0)
+        # release near chapter_end → tail clamped to chapter_end.
+        start, dur = _compute_clip_bounds(22.5, 10.0, 23.0)
         assert start + dur <= 23.0 + 1e-9
 
 
@@ -246,7 +236,7 @@ class TestGenerateClipWideSourceWiring:
 
     @pytest.mark.asyncio
     async def test_widened_source_persists_offsets(self, tmp_path: Path):
-        """Happy path: tight is at [release-2, result+0.5]; wide spans the
+        """Happy path: tight is at [release-2, release+1]; wide spans the
         whole chapter + padding. set_clip_url is called with source_key +
         the offset pair so the slider opens at the tight bounds."""
         video = tmp_path / "v.mp4"
@@ -259,9 +249,10 @@ class TestGenerateClipWideSourceWiring:
 
         with (
             patch(f"{_MOD}.settings", _settings()),
-            # 6 frames spread across [9..24]; release_index=2 → release_ts=12,
-            # result_index=4 → result_ts=18. _compute_clip_bounds gives
-            # [12-2, 18+1.5] = [10, 19.5] = 9.5s within band.
+            # 6 frames spread across [9..24]; release_index=2 → release_ts=12.
+            # _compute_clip_bounds anchors entirely on release_ts:
+            # [12-2, 12+1] = [10, 13] = 3.0s. result_ts (18) is surfaced on
+            # the result row but no longer influences the clip window.
             patch(f"{_MOD}.localize_throw_with_refinement",
                   new=AsyncMock(return_value=_refined(
                       timestamps=[9.0, 12.0, 15.0, 18.0, 21.0, 24.0],
@@ -288,10 +279,10 @@ class TestGenerateClipWideSourceWiring:
         mock_set.assert_awaited_once()
         set_kwargs = mock_set.await_args.kwargs
         assert set_kwargs["source_key"] == "pending/vid123/0-clip-source.mp4"
-        # tight bounds: clip_start=10, clip_duration=9.5; source_start=0
-        # → trim_start_s = 10 - 0 = 10; trim_end_s = 10 + 9.5 - 0 = 19.5
+        # tight bounds: clip_start=10, clip_duration=3.0; source_start=0
+        # → trim_start_s = 10 - 0 = 10; trim_end_s = 10 + 3.0 - 0 = 13.0
         assert set_kwargs["trim_start_s"] == pytest.approx(10.0)
-        assert set_kwargs["trim_end_s"] == pytest.approx(19.5)
+        assert set_kwargs["trim_end_s"] == pytest.approx(13.0)
 
     @pytest.mark.asyncio
     async def test_wide_failure_falls_back_to_legacy_posture(self, tmp_path: Path):

--- a/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
@@ -69,31 +69,43 @@ def _lineup(video_id="vid123", chapter_title="B smoke"):
 # ---------------------------------------------------------------------------
 
 class TestComputeLandingBounds:
-    def test_normal_window(self):
-        # result 24, chapter [10,40]: [23.5, 27] = 3.5s.
+    def test_normal_window_starts_after_result(self):
+        # result 24, chapter [10,40]: [24+1.5, 24+1.5+3.5] = [25.5, 29.0] = 3.5s.
+        # Anchored AFTER result_ts to skip the faint-wisp lead-in.
         start, dur = _compute_landing_bounds(24.0, 10.0, 40.0)
-        assert start == pytest.approx(23.5)
+        assert start == pytest.approx(25.5)
         assert dur == pytest.approx(3.5)
 
-    def test_clamped_to_chapter_start(self):
-        # result 10.2 → 10.2-0.5=9.7 but chapter starts at 10 → clamp to 10.
-        start, _dur = _compute_landing_bounds(10.2, 10.0, 40.0)
-        assert start == pytest.approx(10.0)
+    def test_clamped_to_chapter_start_when_result_precedes_chapter(self):
+        # Pathological: result_ts before chapter_start. start = max(result+1.5,
+        # chapter_start). E.g., result -10, chapter [0, 10] → start = max(-8.5, 0)
+        # = 0, end = min(3.5, 10) = 3.5, dur 3.5.
+        start, dur = _compute_landing_bounds(-10.0, 0.0, 10.0)
+        assert start == pytest.approx(0.0)
+        assert dur == pytest.approx(3.5)
 
     def test_clamped_to_chapter_end(self):
-        # result 39, chapter [10,40]: 39+3=42 → clamp to 40.
-        start, dur = _compute_landing_bounds(39.0, 10.0, 40.0)
-        assert start == pytest.approx(38.5)
-        # 40 - 38.5 = 1.5s — clamped tail but still >= 1s.
-        assert dur == pytest.approx(1.5)
+        # result 39, chapter [10,40]: start = max(40.5, 10) = 40.5, which is
+        # past chapter_end (40) → no headroom → None. Chapters that end <1.5s
+        # after result_ts cannot carry a landing clip with the new anchor.
+        assert _compute_landing_bounds(39.0, 10.0, 40.0) is None
+
+    def test_partial_window_when_chapter_just_barely_fits(self):
+        # result 17, chapter [10, 22]: start = 18.5, end = min(22, 22) = 22,
+        # dur = 3.5. Exactly fits.
+        start, dur = _compute_landing_bounds(17.0, 10.0, 22.0)
+        assert start == pytest.approx(18.5)
+        assert dur == pytest.approx(3.5)
 
     def test_chapter_too_short_returns_none(self):
-        # 0.4s chapter — clamped window < 1s → skip signal.
+        # 0.4s chapter — start 21.5 > chapter_end 20.3 → skip signal.
         assert _compute_landing_bounds(20.0, 19.9, 20.3) is None
 
     def test_clip_never_exceeds_chapter_end(self):
-        start, dur = _compute_landing_bounds(20.0, 10.0, 22.0)
+        # result 19, chapter [10, 22]: start 20.5, end min(24, 22) = 22, dur 1.5.
+        start, dur = _compute_landing_bounds(19.0, 10.0, 22.0)
         assert start + dur <= 22.0 + 1e-9
+        assert dur == pytest.approx(1.5)
 
 
 def test_pending_landing_clip_key_is_deterministic():
@@ -596,10 +608,11 @@ async def test_widen_source_persists_offsets_for_landing():
     set_url_mock.assert_awaited_once()
     set_kwargs = set_url_mock.await_args.kwargs
     assert set_kwargs["source_key"] == "pending/vid123/10-landing-source.mp4"
-    # Landing tight: clip_start=23.5, clip_duration=3.5; source_start=10
-    # → trim_start_s = 23.5 - 10 = 13.5; trim_end_s = 23.5 + 3.5 - 10 = 17.0
-    assert set_kwargs["trim_start_s"] == pytest.approx(13.5)
-    assert set_kwargs["trim_end_s"] == pytest.approx(17.0)
+    # Landing tight: result_ts=24 → clip_start=24+1.5=25.5, clip_duration=3.5;
+    # source_start=10 → trim_start_s = 25.5 - 10 = 15.5;
+    # trim_end_s = 25.5 + 3.5 - 10 = 19.0
+    assert set_kwargs["trim_start_s"] == pytest.approx(15.5)
+    assert set_kwargs["trim_end_s"] == pytest.approx(19.0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Operator surfaced two clip-bounds defects on lineup `7bd971c3` after PR #751 made the release frame accurate:

- **Throw clip had ~3s of useless tail.** `_compute_clip_bounds` anchored the end on `result_ts + 1.5s`, but `result_ts` is the throw-timing prompt's "first visible wisp" (1.5–3.0s after release) — so the THROW pane was showing the early bloom, which is the LANDING pane's job. **Fix:** anchor end on `release_ts + 1.0s`. The throw pane shows the throw MOTION (which completes within ~1s of release) and stops. Drops the `[2s, 12s]` rebuild path entirely — it existed only because the old result-anchored end could collapse or balloon.
- **Landing clip had ~1.5–2s of useless lead-in.** `_compute_landing_bounds` started at `result_ts - 0.5s`, but `result_ts` is the faint-wisp moment so the first 1.5–2s was blank. **Fix:** start clip AFTER `result_ts` (`_POST_RESULT_PRE_PAD = +1.5s`) so it opens once the bloom is actually visible. Keep ~3.5s total.

## Key code changes

- `_compute_clip_bounds(release_ts, chapter_start, chapter_end)` — drops `result_ts` parameter; the throw pane no longer depends on result_ts. Removes `_POST_RESULT_SECONDS`, `_MIN_CLIP_SECONDS`, `_MAX_CLIP_SECONDS`, `_TARGET_CLIP_SECONDS` (the rebuild path is gone).
- `_compute_landing_bounds`: `_PRE_LANDING_SECONDS = 0.5` → `_POST_RESULT_PRE_PAD = +1.5`. `_TARGET_CLIP_SECONDS` → `_LANDING_CLIP_DURATION = 3.5`. Adds early-return for chapters ending before `result_ts + 1.5s`.

## Tests

- [x] `TestComputeClipBounds` rewritten for 3-arg signature. Dropped `test_too_long_rebuilds_throw_centric_7s` + `test_missing_result_collapses_to_35s_clip` (exercised dropped rebuild path).
- [x] `TestComputeLandingBounds` rewritten for post-result anchor; added `test_partial_window_when_chapter_just_barely_fits`.
- [x] Integration tests (`test_widened_source_persists_offsets`, `test_widen_source_persists_offsets_for_landing`) updated for the new `trim_start_s` / `trim_end_s` values.
- [x] Full backend suite (675 tests) green.

## Post-ship validation

Re-run `python -m app.cli backfill-clips` on `7bd971c3` and visually confirm:
- Throw clip ends at the end of the throw motion, not 3s later
- Landing clip opens with bloom visible, not blank lead-in

🤖 Generated with [Claude Code](https://claude.com/claude-code)