### PR TITLE
fix(mga): GRID prompt — STAND and AIM are distinct moments, not interchangeable

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classifier_service.py
@@ -128,11 +128,10 @@ CLASSIFICATION ORDER — YOU MUST FOLLOW THIS SEQUENCE:
    (b) which map you identified, and (c) why you chose the zones you chose.
 """
 
-# Strategy A grid schema. The model is given N numbered candidate frames
-# sampled across the chapter and must (a) decide whether the chapter is a real
-# utility-lineup demo at all, and (b) pick which frame best shows the throwing
-# stance and which best shows the aim/result. The aim_anchor_* coordinates are
-# relative to the chosen best_aim_index frame.
+# Strategy A grid schema. The model decides whether the chapter is a real
+# lineup demo and picks two DISTINCT frames: one for the player's standing
+# position (best_stand_index) and one for the crosshair on the alignment
+# marker (best_aim_index). aim_anchor_* are relative to best_aim_index.
 _GRID_OUTPUT_SCHEMA_DOC = """\
 You are given {n} numbered candidate frames (Frame 1 .. Frame {n}) sampled at
 even intervals across ONE YouTube chapter from a tactical-FPS video. The
@@ -168,12 +167,21 @@ Rules:
 - game_slug: follow CLASSIFICATION ORDER above — determine from visual cues first, then
   constrain all map/zone/utility slugs to entries tagged [<your game_slug>] in the
   reference list.
-- best_stand_index: the 1-based frame number that best shows the player STANDING
-  at the throw position lining up the utility (crosshair on the alignment
-  marker, throwable equipped, before release). null if is_lineup is false.
-- best_aim_index: the 1-based frame number that best shows the AIM/RESULT — the
-  crosshair placement for the throw or the utility landing on target. May equal
-  best_stand_index if one frame shows both. null if is_lineup is false.
+- best_stand_index: the frame showing the PLAYER POSITION at the throw spot.
+  Feet/ground/local environment dominant; crosshair on a LOCAL reference
+  (standing tile, doorframe, nearby corner), NOT the throw's alignment
+  marker. The "I am at the spot" frame — after arrival, before rotating to
+  aim. Utility equipped, projectile not airborne. null if is_lineup is false.
+- best_aim_index: the frame showing the CROSSHAIR ON THE ALIGNMENT MARKER —
+  the specific visual point (skybox feature, building corner, antenna, wire,
+  texture detail) the player is throwing toward. Sky/skybox or distant-map
+  dominant; camera angled UP or across, NOT down at the ground. The
+  "crosshair is on the marker" frame, immediately before release. MUST be a
+  DIFFERENT frame from best_stand_index AND come AFTER it in time (arrive →
+  STAND → rotate up → AIM → release). If no separate aim-on-marker frame
+  exists (player throws on arrival, aim moment off-camera), set
+  best_aim_index to null and reduce confidence — do NOT duplicate
+  best_stand_index. null if is_lineup is false.
 - aim_anchor_x / aim_anchor_y: normalized (0-1) crosshair position IN THE
   best_aim_index FRAME. x=0 left, x=1 right; y=0 top, y=1 bottom. null if
   is_lineup is false or you cannot locate the crosshair.

--- a/apps/mygamingassistant/backend/tests/test_classifier_service.py
+++ b/apps/mygamingassistant/backend/tests/test_classifier_service.py
@@ -877,6 +877,30 @@ class TestGameFirstPromptWiring:
         # Grid schema body still present.
         assert "is_lineup" in prompt
 
+    def test_grid_prompt_distinguishes_stand_from_aim(self):
+        """STAND and AIM must be defined as distinct moments (PR R3 fix).
+
+        Operator surfaced (lineup 7bd971c3) that the grid classifier picked
+        near-duplicate STAND/AIM frames because the old schema doc described
+        both as "crosshair on the alignment marker" and explicitly allowed
+        them to collapse via "May equal best_stand_index if one frame shows
+        both". The fix splits them: STAND = player position with local
+        environment; AIM = crosshair on the alignment marker, distinct frame.
+        """
+        prompt = self._grid_system_prompt()
+        # STAND is anchored on the player-position moment, NOT the aim moment.
+        assert "PLAYER POSITION at the throw spot" in prompt
+        assert '"I am at the spot"' in prompt
+        # AIM is anchored on the crosshair-on-marker moment.
+        assert "CROSSHAIR ON THE ALIGNMENT MARKER" in prompt
+        assert '"crosshair is on the marker"' in prompt
+        # The two indices MUST differ and AIM comes after STAND in time.
+        assert "DIFFERENT frame from best_stand_index" in prompt
+        assert "come AFTER it in time" in prompt
+        # The collapse-allowing clause from the old prompt MUST be gone —
+        # this is the specific phrase that caused the operator-visible bug.
+        assert "May equal best_stand_index" not in prompt
+
     def test_grid_schema_format_does_not_break(self):
         """_GRID_OUTPUT_SCHEMA_DOC.format(n=...) must still substitute n cleanly.
 

--- a/scripts/file-size-allowlist.yml
+++ b/scripts/file-size-allowlist.yml
@@ -25,4 +25,12 @@ over_1000_loc:
       pipeline stabilises.
 
 # Files allowed to grow even when already over 500 LOC (rare — use sparingly).
-allow_growth_over_500: []
+allow_growth_over_500:
+  - path: apps/mygamingassistant/backend/app/services/classification/classifier_service.py
+    reason: >
+      Same file as the over_1000_loc entry above — active extraction in
+      progress. The remaining single-image vs grid classifier split is
+      planned; until that lands, prompt-text corrections (operator-visible
+      defects like the STAND/AIM disambiguation in PR R3) can add LOC.
+      Remove this entry once the file falls below 500 LOC OR once the
+      pending extraction ships.


### PR DESCRIPTION
## Summary

Operator surfaced on lineup \`7bd971c3\` that the STAND pane "looks like AIM" and the AIM pane is "random." Diagnosis: \`_GRID_OUTPUT_SCHEMA_DOC\` defined both indices as targeting the same moment (crosshair on the alignment marker) AND explicitly permitted them to collapse via the \`May equal best_stand_index if one frame shows both\` clause.

## The rewrite

- **\`best_stand_index\`** now anchors on the **PLAYER POSITION** at the throw spot — feet/ground/local environment dominant; crosshair on a LOCAL reference (standing tile, doorframe, corner), NOT the alignment marker. The "I am at the spot" frame, after arrival but before rotating to aim.
- **\`best_aim_index\`** now anchors on the **CROSSHAIR ON THE ALIGNMENT MARKER** — the specific visual point (skybox feature, building corner, antenna, wire, texture detail) the player is throwing toward. Sky/skybox or distant-map dominant; camera angled UP or across, NOT down. The "crosshair is on the marker" frame, immediately before release.
- Hard constraint: \`best_aim_index\` **MUST be a DIFFERENT frame** from \`best_stand_index\` **AND come AFTER it in time** (arrive → STAND → rotate → AIM → release). If no separate aim-on-marker frame exists, the model is instructed to null + reduce confidence rather than duplicate STAND.
- The collapse-allowing \`May equal best_stand_index\` clause is **removed**.

## Tests

- New \`test_grid_prompt_distinguishes_stand_from_aim\` asserts the new phrasing is present, the temporal constraint is stated, and the collapse-allowing clause is GONE — a specific guard against the operator-surfaced regression.
- Full backend suite (676 tests) green.

## LOC

\`classifier_service.py\`: 1017 → 1025 (+8). Already in \`over_1000_loc\` allowlist for the active extraction. Added to \`allow_growth_over_500\` with a focused reason — this is the legitimate active-refactor case the secondary allowlist exists for. Remove that entry once the planned single-image vs grid classifier split lands.

## Post-ship validation

Re-run \`python -m app.cli backfill-micro-clips\` on \`7bd971c3\` to restore \`stand_clip_url\` + \`aim_clip_url\` with the new prompt and visually confirm the panes are now distinct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)