### PR TITLE
feat(mga): list view + minimap-click zone filter (drops MapPage CPU)

### DIFF
--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardMinimapSidebar.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardMinimapSidebar.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * GlanceBoardMinimapSidebar unit tests.
+ *
+ * Two click modes:
+ *  - Default (no onZoneClick): polygon clicks call scrollToZone (smooth-
+ *    scroll to the section anchor). We assert the default DOES NOT raise
+ *    when no onZoneClick is provided.
+ *  - With onZoneClick: polygon clicks invoke the parent callback so MapPage
+ *    can set the zone filter URL param. activeZoneSlug highlights the
+ *    matching polygon.
+ *
+ * Includes the text-list fallback (minimap unavailable) and the active-zone
+ * highlight in both surfaces.
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import GlanceBoardMinimapSidebar from "@/components/lineup/GlanceBoardMinimapSidebar";
+import type { MapZone, ZoneDensity } from "@/types/game";
+
+const ZONES: MapZone[] = [
+  {
+    id: "z1",
+    slug: "a-site",
+    name: "A Site",
+    polygon_points: [
+      { x: 0.1, y: 0.1 },
+      { x: 0.4, y: 0.1 },
+      { x: 0.4, y: 0.4 },
+      { x: 0.1, y: 0.4 },
+    ],
+  },
+  {
+    id: "z2",
+    slug: "b-site",
+    name: "B Site",
+    polygon_points: [
+      { x: 0.6, y: 0.1 },
+      { x: 0.9, y: 0.1 },
+      { x: 0.9, y: 0.4 },
+      { x: 0.6, y: 0.4 },
+    ],
+  },
+];
+
+const DENSITY: ZoneDensity = {
+  z1: { count: 5, by_utility: { smoke: 3, flash: 2 } },
+  z2: { count: 3, by_utility: { smoke: 2, molotov: 1 } },
+};
+
+describe("GlanceBoardMinimapSidebar (text-list fallback)", () => {
+  it("renders zone buttons when minimapUrl is null", () => {
+    const onZoneClick = vi.fn();
+    render(
+      <GlanceBoardMinimapSidebar
+        minimapUrl={null}
+        zones={ZONES}
+        density={DENSITY}
+        onZoneClick={onZoneClick}
+        activeZoneSlug={null}
+      />,
+    );
+    expect(screen.getByText("A Site")).toBeInTheDocument();
+    expect(screen.getByText("B Site")).toBeInTheDocument();
+  });
+
+  it("invokes onZoneClick from the fallback list when provided", () => {
+    const onZoneClick = vi.fn();
+    render(
+      <GlanceBoardMinimapSidebar
+        minimapUrl={null}
+        zones={ZONES}
+        density={DENSITY}
+        onZoneClick={onZoneClick}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /A Site/ }));
+    expect(onZoneClick).toHaveBeenCalledWith("a-site");
+  });
+
+  it("marks the active zone with aria-pressed in the fallback list", () => {
+    render(
+      <GlanceBoardMinimapSidebar
+        minimapUrl={null}
+        zones={ZONES}
+        density={DENSITY}
+        onZoneClick={vi.fn()}
+        activeZoneSlug="a-site"
+      />,
+    );
+    expect(screen.getByRole("button", { name: /A Site/ })).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /B Site/ })).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+});
+
+describe("GlanceBoardMinimapSidebar (svg polygon mode)", () => {
+  it("invokes onZoneClick when a polygon is clicked", () => {
+    const onZoneClick = vi.fn();
+    render(
+      <GlanceBoardMinimapSidebar
+        minimapUrl="/mock/minimap.png"
+        zones={ZONES}
+        density={DENSITY}
+        onZoneClick={onZoneClick}
+      />,
+    );
+    // The polygons are aria-labelled with zone name + action hint
+    const aSitePoly = screen.getByLabelText(/A Site/);
+    fireEvent.click(aSitePoly);
+    expect(onZoneClick).toHaveBeenCalledWith("a-site");
+  });
+
+  it("does NOT throw when no onZoneClick is provided (default scroll-to-section path)", () => {
+    expect(() => {
+      render(
+        <GlanceBoardMinimapSidebar
+          minimapUrl="/mock/minimap.png"
+          zones={ZONES}
+          density={DENSITY}
+        />,
+      );
+      const aSitePoly = screen.getByLabelText(/A Site/);
+      fireEvent.click(aSitePoly);
+    }).not.toThrow();
+  });
+
+  it("annotates the active polygon with aria-pressed=true", () => {
+    render(
+      <GlanceBoardMinimapSidebar
+        minimapUrl="/mock/minimap.png"
+        zones={ZONES}
+        density={DENSITY}
+        onZoneClick={vi.fn()}
+        activeZoneSlug="b-site"
+      />,
+    );
+    expect(screen.getByLabelText(/B Site.*currently filtered/)).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    expect(screen.getByLabelText(/A Site.*click to filter/)).toHaveAttribute(
+      "aria-pressed",
+      "false",
+    );
+  });
+
+  it("uses the scroll aria-label text when no onZoneClick is provided", () => {
+    render(
+      <GlanceBoardMinimapSidebar
+        minimapUrl="/mock/minimap.png"
+        zones={ZONES}
+        density={DENSITY}
+      />,
+    );
+    expect(screen.getByLabelText(/A Site.*click to scroll/)).toBeInTheDocument();
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
@@ -5,7 +5,7 @@
  * exercised by LineupListRow's own tests.
  */
 import { render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import LineupListBoard from "@/components/lineup/LineupListBoard";
 import type { Lineup, Game } from "@/types/game";
 

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
@@ -1,0 +1,196 @@
+/**
+ * LineupListBoard unit tests — list-mode alternate to GlanceBoard.
+ *
+ * Covers grouping + skeleton + empty-state behavior. Row internals are
+ * exercised by LineupListRow's own tests.
+ */
+import { render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LineupListBoard from "@/components/lineup/LineupListBoard";
+import type { Lineup, Game } from "@/types/game";
+
+const GAME: Game = {
+  id: "g1",
+  slug: "cs2",
+  name: "CS2",
+  side_a_label: "T",
+  side_b_label: "CT",
+};
+
+function makeLineup(over: Partial<Lineup> = {}): Lineup {
+  return {
+    id: "l1",
+    game_id: "g1",
+    map_id: "m1",
+    target_zone_id: "z1",
+    stand_zone_id: "z2",
+    side: "side_a",
+    utility_type_id: "u1",
+    title: "Test lineup",
+    notes: null,
+    stand_screenshot_url: null,
+    aim_screenshot_url: null,
+    clip_url: null,
+    landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
+    stand_clip_offset_s: null,
+    aim_clip_offset_s: null,
+    clip_url_original: null,
+    clip_trim_start_s: null,
+    clip_trim_end_s: null,
+    clip_source_start_in_video_s: null,
+    landing_clip_url_original: null,
+    landing_clip_trim_start_s: null,
+    landing_clip_trim_end_s: null,
+    landing_clip_source_start_in_video_s: null,
+    technique: null,
+    aim_anchor_x: null,
+    aim_anchor_y: null,
+    stand_anchor_x: null,
+    stand_anchor_y: null,
+    target_anchor_x: null,
+    target_anchor_y: null,
+    effective_stand_x: null,
+    effective_stand_y: null,
+    effective_target_x: null,
+    effective_target_y: null,
+    setup_seconds: 7,
+    attribution_url: null,
+    attribution_author: null,
+    status: "accepted",
+    youtube_video_id: "vid1",
+    chapter_start_seconds: 12,
+    chapter_title: "",
+    suggested_game_id: null,
+    suggested_map_id: null,
+    suggested_target_zone_id: null,
+    suggested_stand_zone_id: null,
+    suggested_side: null,
+    suggested_utility_type_id: null,
+    classification_confidence: null,
+    classification_reasoning: null,
+    target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
+    stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke" },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  // Stub for any incidental tile mount via expanded rows in test trees
+  (globalThis as any).IntersectionObserver = class {
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+  };
+});
+
+afterEach(() => {
+  delete (globalThis as any).IntersectionObserver;
+});
+
+describe("LineupListBoard", () => {
+  it("renders the skeleton when isFetching is true", () => {
+    const { container } = render(
+      <LineupListBoard
+        lineups={[]}
+        isFetching={true}
+        mapName="Mirage"
+        filteredUtils={[]}
+        side="any"
+        game={GAME}
+      />,
+    );
+    // Skeleton rows use animate-pulse — count > 0 proves we got the loader
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+  });
+
+  it("renders the unfiltered empty state when no lineups", () => {
+    render(
+      <LineupListBoard
+        lineups={[]}
+        isFetching={false}
+        mapName="Mirage"
+        filteredUtils={[]}
+        side="any"
+        game={GAME}
+      />,
+    );
+    expect(screen.getByText(/No lineups on Mirage yet/)).toBeInTheDocument();
+  });
+
+  it("renders the filtered empty state hint when side/util filters are active", () => {
+    render(
+      <LineupListBoard
+        lineups={[]}
+        isFetching={false}
+        mapName="Mirage"
+        filteredUtils={["smoke"]}
+        side="side_a"
+        game={GAME}
+      />,
+    );
+    expect(screen.getByText(/Try clearing filters/)).toBeInTheDocument();
+  });
+
+  it("groups lineups by target zone with section headers + counts", () => {
+    const lineups = [
+      makeLineup({
+        id: "l1",
+        target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
+      }),
+      makeLineup({
+        id: "l2",
+        target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
+      }),
+      makeLineup({
+        id: "l3",
+        target_zone: { id: "z2", slug: "a-site", name: "A Site", polygon_points: [] },
+      }),
+    ];
+    render(
+      <LineupListBoard
+        lineups={lineups}
+        isFetching={false}
+        mapName="Mirage"
+        filteredUtils={[]}
+        side="any"
+        game={GAME}
+      />,
+    );
+
+    // Zone group headers (h2). Each row also contains the zone name as
+    // text inside the row span, so we target by heading role to avoid the
+    // multi-match.
+    const headings = screen.getAllByRole("heading", { level: 2 });
+    expect(headings).toHaveLength(2);
+    expect(headings[0]).toHaveTextContent(/A Site/);
+    expect(headings[0]).toHaveTextContent("(1)");
+    expect(headings[1]).toHaveTextContent(/B Site/);
+    expect(headings[1]).toHaveTextContent("(2)");
+
+    // Three row buttons (one per lineup, all collapsed by default)
+    expect(screen.getAllByRole("button", { name: /click to expand/i })).toHaveLength(
+      3,
+    );
+  });
+
+  it("does not mount any GlanceBoardTile when all rows are collapsed", () => {
+    render(
+      <LineupListBoard
+        lineups={[makeLineup(), makeLineup({ id: "l2" })]}
+        isFetching={false}
+        mapName="Mirage"
+        filteredUtils={[]}
+        side="any"
+        game={GAME}
+      />,
+    );
+    // The storyboard's pane labels are not in the DOM until an operator
+    // clicks-to-expand. This is the perf invariant of list view.
+    expect(screen.queryByText("STAND")).not.toBeInTheDocument();
+    expect(screen.queryByText("AIM")).not.toBeInTheDocument();
+    expect(screen.queryByText("THROW")).not.toBeInTheDocument();
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListRow.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListRow.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * LineupListRow unit tests — compact-list-row primitive.
+ *
+ * Stub IntersectionObserver + HTMLMediaElement methods because the expanded
+ * state mounts GlanceBoardTile (which contains ClipView <video> elements).
+ */
+import { render, screen, fireEvent } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import LineupListRow from "@/components/lineup/LineupListRow";
+import type { Lineup, Game } from "@/types/game";
+
+function makeLineup(over: Partial<Lineup> = {}): Lineup {
+  return {
+    id: "l1",
+    game_id: "g1",
+    map_id: "m1",
+    target_zone_id: "z1",
+    stand_zone_id: "z2",
+    side: "side_a",
+    utility_type_id: "u1",
+    title: "B Site smoke from T Spawn",
+    notes: null,
+    stand_screenshot_url: null,
+    aim_screenshot_url: null,
+    clip_url: null,
+    landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
+    stand_clip_offset_s: null,
+    aim_clip_offset_s: null,
+    clip_url_original: null,
+    clip_trim_start_s: null,
+    clip_trim_end_s: null,
+    clip_source_start_in_video_s: null,
+    landing_clip_url_original: null,
+    landing_clip_trim_start_s: null,
+    landing_clip_trim_end_s: null,
+    landing_clip_source_start_in_video_s: null,
+    technique: null,
+    aim_anchor_x: null,
+    aim_anchor_y: null,
+    stand_anchor_x: null,
+    stand_anchor_y: null,
+    target_anchor_x: null,
+    target_anchor_y: null,
+    effective_stand_x: null,
+    effective_stand_y: null,
+    effective_target_x: null,
+    effective_target_y: null,
+    setup_seconds: 7,
+    attribution_url: null,
+    attribution_author: null,
+    status: "accepted",
+    youtube_video_id: "vid1",
+    chapter_start_seconds: 12,
+    chapter_title: "B smoke",
+    suggested_game_id: null,
+    suggested_map_id: null,
+    suggested_target_zone_id: null,
+    suggested_stand_zone_id: null,
+    suggested_side: null,
+    suggested_utility_type_id: null,
+    classification_confidence: null,
+    classification_reasoning: null,
+    target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
+    stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke" },
+    ...over,
+  };
+}
+
+const GAME: Game = {
+  id: "g1",
+  slug: "cs2",
+  name: "CS2",
+  side_a_label: "T",
+  side_b_label: "CT",
+};
+
+beforeEach(() => {
+  // jsdom doesn't implement these — required only when the row is expanded
+  // (mounts GlanceBoardTile → ClipView).
+  (globalThis as any).IntersectionObserver = class {
+    observe() {}
+    disconnect() {}
+    unobserve() {}
+  };
+  Object.defineProperty(HTMLMediaElement.prototype, "play", {
+    configurable: true,
+    value: vi.fn().mockResolvedValue(undefined),
+  });
+  Object.defineProperty(HTMLMediaElement.prototype, "pause", {
+    configurable: true,
+    value: vi.fn(),
+  });
+});
+
+afterEach(() => {
+  delete (globalThis as any).IntersectionObserver;
+});
+
+describe("LineupListRow", () => {
+  it("renders target zone, stand zone, side, and utility on a single row", () => {
+    render(<LineupListRow lineup={makeLineup()} game={GAME} />);
+    expect(screen.getByText("B Site")).toBeInTheDocument();
+    expect(screen.getByText("T Spawn")).toBeInTheDocument();
+    expect(screen.getByText("T")).toBeInTheDocument(); // side label
+    expect(screen.getAllByText("Smoke").length).toBeGreaterThan(0);
+  });
+
+  it("renders technique when present", () => {
+    render(
+      <LineupListRow
+        lineup={makeLineup({ technique: "standing jumpthrow" })}
+        game={GAME}
+      />,
+    );
+    expect(screen.getByText(/standing jumpthrow/)).toBeInTheDocument();
+  });
+
+  it("falls back gracefully when target_zone is null", () => {
+    render(
+      <LineupListRow lineup={makeLineup({ target_zone: null })} game={GAME} />,
+    );
+    expect(screen.getByText("Unknown")).toBeInTheDocument();
+  });
+
+  it("collapses by default — does not mount the storyboard tile", () => {
+    render(<LineupListRow lineup={makeLineup()} game={GAME} />);
+    // The corner labels (STAND / AIM / THROW / LANDING) only appear inside
+    // the expanded GlanceBoardTile. Absence here proves the tile is unmounted.
+    expect(screen.queryByText("THROW")).not.toBeInTheDocument();
+    expect(screen.queryByText("LANDING")).not.toBeInTheDocument();
+  });
+
+  it("expands on click and mounts the storyboard tile", () => {
+    render(<LineupListRow lineup={makeLineup()} game={GAME} />);
+    const button = screen.getByRole("button", { name: /click to expand/i });
+    expect(button).toHaveAttribute("aria-expanded", "false");
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "true");
+
+    // Storyboard's corner labels are now in the DOM
+    expect(screen.getByText("STAND")).toBeInTheDocument();
+    expect(screen.getByText("AIM")).toBeInTheDocument();
+  });
+
+  it("collapses on second click — unmounts the storyboard tile", () => {
+    render(<LineupListRow lineup={makeLineup()} game={GAME} />);
+    const button = screen.getByRole("button", { name: /click to expand/i });
+    fireEvent.click(button);
+    expect(screen.getByText("STAND")).toBeInTheDocument();
+
+    fireEvent.click(button);
+    expect(button).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByText("STAND")).not.toBeInTheDocument();
+  });
+
+  it("uses Valorant side labels when game has them", () => {
+    const valGame: Game = {
+      id: "g2",
+      slug: "valorant",
+      name: "Valorant",
+      side_a_label: "Atk",
+      side_b_label: "Def",
+    };
+    render(
+      <LineupListRow
+        lineup={makeLineup({ side: "side_b" })}
+        game={valGame}
+      />,
+    );
+    expect(screen.getByText("Def")).toBeInTheDocument();
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardMinimapSidebar.tsx
@@ -1,14 +1,23 @@
 /**
- * GlanceBoardMinimapSidebar — passive spatial index for the glance board.
+ * GlanceBoardMinimapSidebar — spatial index for the glance board.
  *
  * Renders the minimap image with zone SVG polygons (density coloring,
- * same as MapZoneOverlay). Clicking or hovering a zone smooth-scrolls
- * the main board area to that zone's section header.
+ * same as MapZoneOverlay). Behaviour depends on which click handler the
+ * parent provides:
  *
- * No filter-gate behavior — this is read-only spatial navigation only.
+ *  - **Default (no onZoneClick)** — polygon clicks smooth-scroll the
+ *    main board area to that zone's section header. Read-only spatial
+ *    navigation, the original glance-board behaviour.
+ *
+ *  - **With onZoneClick** — polygon clicks invoke the callback (parent
+ *    typically uses it to set a zone filter URL param). Clicking the
+ *    currently-active zone is the toggle: parent should clear the filter.
+ *    The active zone gets distinct fill + stroke so the operator can see
+ *    which zone is currently selected.
  *
  * Fallback: if the minimap image fails to load, renders a scrollable text
- * list of zone names that still trigger scroll-to-section on click.
+ * list of zone names that runs the same handler on click (filter when
+ * onZoneClick is provided, scroll otherwise).
  */
 import { useState } from "react";
 import type { MapZone, ZoneDensity } from "@/types/game";
@@ -19,6 +28,14 @@ interface Props {
   zones: MapZone[];
   density: ZoneDensity;
   viewBoxSize?: number;
+  /** When provided, polygon + zone-list clicks invoke this instead of the
+   *  default scroll-to-section behaviour. Used by MapPage to set a zone
+   *  filter URL param. */
+  onZoneClick?: (zoneSlug: string) => void;
+  /** When set, the matching polygon is rendered with active fill/stroke
+   *  so the operator can see the current filter. Pass null when no zone
+   *  filter is active. */
+  activeZoneSlug?: string | null;
 }
 
 // Density fill/stroke — same tokens as MapZoneOverlay
@@ -28,6 +45,10 @@ const STROKE_HAS_LINEUPS = "rgba(34,197,94,0.7)";
 const STROKE_EMPTY       = "rgba(255,255,255,0.25)";
 const STROKE_HOVER       = "rgba(251,191,36,0.9)";
 const FILL_HOVER         = "rgba(251,191,36,0.18)";
+// Active (currently-filtered) zone — primary accent so it stands out
+// from hover (amber) and from has-lineups (green).
+const FILL_ACTIVE        = "rgba(59,130,246,0.32)";
+const STROKE_ACTIVE      = "rgba(59,130,246,0.95)";
 
 function pointsToSvg(
   polygon_points: Array<{ x: number; y: number }>,
@@ -50,9 +71,18 @@ export default function GlanceBoardMinimapSidebar({
   zones,
   density,
   viewBoxSize = 1000,
+  onZoneClick,
+  activeZoneSlug = null,
 }: Props) {
   const [minimapFailed, setMinimapFailed] = useState(false);
   const [hoveredZoneSlug, setHoveredZoneSlug] = useState<string | null>(null);
+
+  // Pick the handler once: a filter action (parent-provided) takes
+  // precedence over the default scroll-to-section behaviour. The fallback
+  // text list and the polygon ``onClick`` both use the same handler so the
+  // two surfaces stay consistent.
+  const handleZoneClick = onZoneClick ?? scrollToZone;
+  const usingFilterMode = onZoneClick !== undefined;
 
   // Fallback: text zone list when minimap unavailable
   if (!minimapUrl || minimapFailed) {
@@ -66,12 +96,17 @@ export default function GlanceBoardMinimapSidebar({
         </p>
         {zones.map((zone) => {
           const count = density[zone.id]?.count ?? 0;
+          const isActive = usingFilterMode && zone.slug === activeZoneSlug;
           return (
             <button
               key={zone.id}
               type="button"
-              onClick={() => scrollToZone(zone.slug)}
-              className="text-left px-2 py-1 rounded text-[12px] hover:bg-muted/40 transition-colors flex items-center justify-between gap-2"
+              onClick={() => handleZoneClick(zone.slug)}
+              aria-pressed={usingFilterMode ? isActive : undefined}
+              className={[
+                "text-left px-2 py-1 rounded text-[12px] hover:bg-muted/40 transition-colors flex items-center justify-between gap-2",
+                isActive && "bg-primary/15 text-primary font-medium",
+              ].filter(Boolean).join(" ")}
             >
               <span className="truncate">{zone.name}</span>
               {count > 0 && (
@@ -90,7 +125,11 @@ export default function GlanceBoardMinimapSidebar({
     <nav
       className="relative rounded-lg border overflow-hidden bg-card"
       style={{ aspectRatio: "1 / 1" }}
-      aria-label="Zone minimap — click a zone to scroll to it"
+      aria-label={
+        usingFilterMode
+          ? "Zone minimap — click a zone to filter, click again to clear"
+          : "Zone minimap — click a zone to scroll to it"
+      }
     >
       <img
         src={minimapUrl}
@@ -107,12 +146,36 @@ export default function GlanceBoardMinimapSidebar({
         {zones.map((zone) => {
           const count = density[zone.id]?.count ?? 0;
           const isHovered = zone.slug === hoveredZoneSlug;
+          const isActive = usingFilterMode && zone.slug === activeZoneSlug;
           const hasPolygon = zone.polygon_points.length > 0;
           if (!hasPolygon) return null;
 
           const points = pointsToSvg(zone.polygon_points, viewBoxSize);
-          const fill   = isHovered ? FILL_HOVER   : count > 0 ? FILL_HAS_LINEUPS   : FILL_EMPTY;
-          const stroke = isHovered ? STROKE_HOVER : count > 0 ? STROKE_HAS_LINEUPS : STROKE_EMPTY;
+          // Priority: active (filter selection) > hover > density. Active
+          // wins so the filtered zone stays visually anchored even while
+          // the operator hovers other zones to see counts.
+          const fill = isActive
+            ? FILL_ACTIVE
+            : isHovered
+              ? FILL_HOVER
+              : count > 0
+                ? FILL_HAS_LINEUPS
+                : FILL_EMPTY;
+          const stroke = isActive
+            ? STROKE_ACTIVE
+            : isHovered
+              ? STROKE_HOVER
+              : count > 0
+                ? STROKE_HAS_LINEUPS
+                : STROKE_EMPTY;
+          const strokeWidth = isActive ? 2.5 : isHovered ? 2 : 1;
+
+          const ariaLabelBase = `${zone.name} — ${count} lineup${count !== 1 ? "s" : ""}`;
+          const ariaLabelAction = usingFilterMode
+            ? isActive
+              ? " — currently filtered (click to clear)"
+              : " — click to filter"
+            : " — click to scroll";
 
           return (
             <polygon
@@ -120,12 +183,13 @@ export default function GlanceBoardMinimapSidebar({
               points={points}
               fill={fill}
               stroke={stroke}
-              strokeWidth={isHovered ? 2 : 1}
+              strokeWidth={strokeWidth}
               className="cursor-pointer transition-all duration-150"
-              onClick={() => scrollToZone(zone.slug)}
+              onClick={() => handleZoneClick(zone.slug)}
               onMouseEnter={() => setHoveredZoneSlug(zone.slug)}
               onMouseLeave={() => setHoveredZoneSlug(null)}
-              aria-label={`${zone.name} — ${count} lineup${count !== 1 ? "s" : ""} — click to scroll`}
+              aria-label={`${ariaLabelBase}${ariaLabelAction}`}
+              aria-pressed={usingFilterMode ? isActive : undefined}
             />
           );
         })}

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupListBoard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupListBoard.tsx
@@ -1,0 +1,184 @@
+/**
+ * LineupListBoard — alternate-of-GlanceBoard render mode that shows lineups
+ * as compact text rows (LineupListRow). Click a row to inline-expand its
+ * full 4-pane storyboard tile.
+ *
+ * Same data + same grouping shape as GlanceBoard — just a different render
+ * strategy. The view toggle in MapPage chooses between the two; URL state
+ * is shared (?zone, ?side, ?util) so switching modes doesn't lose filters.
+ *
+ * Render cost vs GlanceBoard: a list-view row mounts zero ``<video>``
+ * decoders by default. The full tile (with its 4 panes) only mounts when
+ * the operator clicks a specific row to expand it. On a 60-80 lineup map
+ * this drops idle browser CPU from ~10% to near zero.
+ */
+import { useMemo } from "react";
+import type { Lineup, Game } from "@/types/game";
+import { zoneAnchorId } from "./glanceBoardUtils";
+import LineupListRow from "./LineupListRow";
+import { DEFAULT_KNOBS } from "@/hooks/useDesignKnobs";
+import type { DesignKnobs } from "@/hooks/useDesignKnobs";
+import { utilDisplay } from "@/constants/utilityDisplay";
+
+interface LineupListBoardProps {
+  lineups: Lineup[];
+  isFetching: boolean;
+  mapName: string;
+  filteredUtils: string[];
+  side: string;
+  /** Optional reference to the current game — drives side labels on rows. */
+  game?: Game | null;
+  knobs?: DesignKnobs;
+  showOperatorOverlays?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Grouping & ordering — match GlanceBoard's contract so switching views
+// keeps zone-section order + within-zone lineup order identical.
+// ---------------------------------------------------------------------------
+const ZONE_ORDER_PREFIXES = [
+  "a site", "a-site", "a_site",
+  "b site", "b-site", "b_site",
+  "mid",
+];
+
+function zoneOrder(zoneName: string): number {
+  const lower = zoneName.toLowerCase();
+  const idx = ZONE_ORDER_PREFIXES.findIndex((prefix) => lower.startsWith(prefix));
+  return idx === -1 ? ZONE_ORDER_PREFIXES.length : idx;
+}
+
+function compareZones(a: string, b: string): number {
+  const orderDiff = zoneOrder(a) - zoneOrder(b);
+  if (orderDiff !== 0) return orderDiff;
+  return a.localeCompare(b);
+}
+
+const SIDE_ORDER: Record<string, number> = {
+  side_a: 0,
+  side_b: 1,
+  any: 2,
+};
+
+function compareLineups(a: Lineup, b: Lineup): number {
+  const utilA = utilDisplay(a.utility_type?.slug).sortOrder;
+  const utilB = utilDisplay(b.utility_type?.slug).sortOrder;
+  if (utilA !== utilB) return utilA - utilB;
+  const sideA = SIDE_ORDER[a.side ?? "any"] ?? 99;
+  const sideB = SIDE_ORDER[b.side ?? "any"] ?? 99;
+  return sideA - sideB;
+}
+
+interface ZoneGroup {
+  zoneName: string;
+  zoneSlug: string;
+  lineups: Lineup[];
+}
+
+function groupByZone(lineups: Lineup[]): ZoneGroup[] {
+  const map = new Map<string, ZoneGroup>();
+  for (const l of lineups) {
+    const name = l.target_zone?.name ?? "Unknown Zone";
+    const slug = l.target_zone?.slug ?? "unknown";
+    if (!map.has(name)) {
+      map.set(name, { zoneName: name, zoneSlug: slug, lineups: [] });
+    }
+    map.get(name)!.lineups.push(l);
+  }
+  const groups = [...map.values()];
+  for (const g of groups) {
+    g.lineups.sort(compareLineups);
+  }
+  return groups.sort((a, b) => compareZones(a.zoneName, b.zoneName));
+}
+
+function buildEmptyMessage(mapName: string, side: string, filteredUtils: string[]): string {
+  const sideLabel = side === "side_a" ? "T" : side === "side_b" ? "CT" : null;
+  const utilLabel = filteredUtils.length > 0 ? filteredUtils.join(", ") : null;
+  if (!sideLabel && !utilLabel) return `No lineups on ${mapName} yet.`;
+  const parts: string[] = [];
+  if (utilLabel) parts.push(utilLabel);
+  if (sideLabel) parts.push(sideLabel);
+  return `No ${parts.join(" ")} lineups on this map.`;
+}
+
+function LineupListSkeleton() {
+  return (
+    <div className="space-y-6">
+      {[1, 2].map((s) => (
+        <div key={s} className="space-y-2">
+          <div className="h-5 w-48 bg-muted/40 rounded animate-pulse" />
+          <div className="rounded-lg border divide-y">
+            {[1, 2, 3, 4].map((r) => (
+              <div key={r} className="h-9 bg-muted/30 animate-pulse" />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function LineupListBoard({
+  lineups,
+  isFetching,
+  mapName,
+  filteredUtils,
+  side,
+  game,
+  knobs = DEFAULT_KNOBS,
+  showOperatorOverlays = false,
+}: LineupListBoardProps) {
+  const groups = useMemo(() => groupByZone(lineups), [lineups]);
+
+  if (isFetching) {
+    return <LineupListSkeleton />;
+  }
+
+  if (lineups.length === 0) {
+    const isFiltered = filteredUtils.length > 0 || side !== "any";
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-3">
+        <p className="text-sm text-muted-foreground text-center">
+          {buildEmptyMessage(mapName, side, filteredUtils)}
+        </p>
+        {isFiltered && (
+          <span className="text-xs text-muted-foreground/60">
+            Try clearing filters in the top bar.
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {groups.map((group) => (
+        <section key={group.zoneSlug} id={zoneAnchorId(group.zoneSlug)}>
+          <h2 className="text-[13px] font-semibold text-muted-foreground mb-2 flex items-center gap-2">
+            <span className="flex-1 border-t border-border" />
+            <span>
+              {group.zoneName}
+              <span className="ml-1.5 font-normal text-muted-foreground/60">
+                ({group.lineups.length})
+              </span>
+            </span>
+            <span className="flex-1 border-t border-border" />
+          </h2>
+
+          <div className="rounded-lg border bg-card/30 overflow-hidden">
+            {group.lineups.map((lineup) => (
+              <LineupListRow
+                key={lineup.id}
+                lineup={lineup}
+                game={game}
+                knobs={knobs}
+                showOperatorOverlays={showOperatorOverlays}
+              />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupListRow.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupListRow.tsx
@@ -1,0 +1,166 @@
+/**
+ * LineupListRow — compact one-line row for the list-view rendering of the
+ * glance board. Click anywhere on the row to expand the full 4-pane
+ * GlanceBoardTile inline below the row.
+ *
+ * Why the list view exists: the default card-grid renders every lineup
+ * card as a full 4-pane storyboard, which mounts up to 4 simultaneous
+ * looping ``<video>`` decoders per card. On a map with 60-80 lineups,
+ * even with viewport-gating that's 16-24 concurrent H.264 decodes any
+ * given moment — enough to push the browser tab to ~10% CPU. The list
+ * view defers decoding entirely: rows are pure text + an expand
+ * affordance, and only the rows the operator clicks-to-expand mount the
+ * storyboard tile (and therefore the videos).
+ *
+ * Layout (compact ~36-44px tall):
+ *
+ *   ┌─────────────────────────────────────────────────────────────────┐
+ *   │ [icon] Target ← Stand  · Side · Util · Technique          [▾]   │
+ *   └─────────────────────────────────────────────────────────────────┘
+ *   (expanded below: GlanceBoardTile with all 4 panes + footer)
+ *
+ * Expansion state lives in this component (useState) — the board does
+ * NOT track which rows are expanded; multiple rows can be expanded
+ * simultaneously and the operator chooses freely.
+ */
+import { useState } from "react";
+import { ChevronDown } from "lucide-react";
+import type { Lineup } from "@/types/game";
+import type { Game } from "@/types/game";
+import { utilDisplay } from "@/constants/utilityDisplay";
+import GlanceBoardTile from "./GlanceBoardTile";
+import type { DesignKnobs } from "@/hooks/useDesignKnobs";
+import { DEFAULT_KNOBS } from "@/hooks/useDesignKnobs";
+
+interface LineupListRowProps {
+  lineup: Lineup;
+  game?: Game | null;
+  knobs?: DesignKnobs;
+  showOperatorOverlays?: boolean;
+}
+
+function sideLabel(side: Lineup["side"], game: Game | null | undefined): string {
+  if (side === "side_a") return game?.side_a_label ?? "T";
+  if (side === "side_b") return game?.side_b_label ?? "CT";
+  return "Both";
+}
+
+export default function LineupListRow({
+  lineup,
+  game,
+  knobs = DEFAULT_KNOBS,
+  showOperatorOverlays = false,
+}: LineupListRowProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const target = lineup.target_zone?.name ?? "Unknown";
+  const stand = lineup.stand_zone?.name ?? null;
+  const util = utilDisplay(lineup.utility_type?.slug);
+  const technique = lineup.technique?.trim() || null;
+  const side = sideLabel(lineup.side, game);
+
+  // Title is treated as supplementary — many ingested lineups inherit the
+  // chapter title which restates target/stand. Only render it if it adds
+  // something beyond the zone names.
+  const titleAddsContext = (() => {
+    if (!lineup.title) return false;
+    const lower = lineup.title.toLowerCase();
+    if (target && lower.includes(target.toLowerCase())) return false;
+    if (stand && lower.includes(stand.toLowerCase())) return false;
+    return true;
+  })();
+
+  return (
+    <div className="border-b last:border-b-0">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+        aria-label={`${target}${stand ? ` from ${stand}` : ""} — ${util.chipLabel} — ${side} side. Click to ${expanded ? "collapse" : "expand"} storyboard.`}
+        className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-muted/30 transition-colors min-h-[36px]"
+      >
+        {/* Utility color dot — reuses the badge tokens from utilDisplay so
+            row color-coding matches the storyboard tile's header chip. */}
+        <span
+          aria-hidden
+          className={[
+            "shrink-0 w-2.5 h-2.5 rounded-full",
+            util.badgeBg,
+          ].join(" ")}
+          title={util.chipLabel}
+        />
+        {/* Visually-hidden text for screen readers / typeahead */}
+        <span className="sr-only">{util.chipLabel}: </span>
+
+        {/* Target ← Stand */}
+        <span className="text-sm font-medium text-foreground truncate">
+          {target}
+          {stand && (
+            <span className="text-muted-foreground font-normal">
+              {" "}
+              <span aria-hidden>←</span> {stand}
+            </span>
+          )}
+        </span>
+
+        {/* Side chip */}
+        <span
+          className={[
+            "shrink-0 px-1.5 py-0.5 rounded text-[10px] font-medium tracking-wide uppercase",
+            lineup.side === "side_a"
+              ? "bg-orange-500/15 text-orange-700 dark:text-orange-300"
+              : lineup.side === "side_b"
+                ? "bg-sky-500/15 text-sky-700 dark:text-sky-300"
+                : "bg-muted/60 text-muted-foreground",
+          ].join(" ")}
+        >
+          {side}
+        </span>
+
+        {/* Util label (text — duplicates the icon for accessibility / when
+            the operator doesn't know the icon glyph) */}
+        <span className="shrink-0 text-xs text-muted-foreground">
+          {util.chipLabel}
+        </span>
+
+        {/* Technique (when present) */}
+        {technique && (
+          <span className="shrink-0 text-xs text-muted-foreground/80 truncate max-w-[200px]">
+            · {technique}
+          </span>
+        )}
+
+        {/* Title (only when it adds context beyond zone names) */}
+        {titleAddsContext && (
+          <span className="shrink-0 text-xs text-muted-foreground/60 italic truncate max-w-[160px]">
+            · {lineup.title}
+          </span>
+        )}
+
+        {/* Spacer + expand chevron */}
+        <span className="flex-1" />
+        <ChevronDown
+          aria-hidden
+          className={[
+            "w-4 h-4 shrink-0 text-muted-foreground transition-transform",
+            expanded && "rotate-180",
+          ].filter(Boolean).join(" ")}
+        />
+      </button>
+
+      {/* Inline expanded storyboard — only mounts (and therefore only
+          attaches video decoders) when the row is expanded. Collapse
+          unmounts the tile so the decoders are released. This is the
+          whole point of the list view. */}
+      {expanded && (
+        <div className="px-3 pb-3 pt-1">
+          <GlanceBoardTile
+            lineup={lineup}
+            knobs={knobs}
+            showOperatorOverlays={showOperatorOverlays}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/map/MapPageTopBar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/MapPageTopBar.tsx
@@ -1,0 +1,238 @@
+/**
+ * MapPageTopBar — the slim sticky filter strip across the top of MapPage.
+ *
+ * Extracted from MapPage.tsx so the page stays under the 500-LOC growth
+ * guard set in scripts/file-size-allowlist.yml. Pure presentation +
+ * callbacks — no URL state, no data fetching; the parent owns those.
+ *
+ * Layout (~40px tall, single horizontal row, x-scrolls if needed):
+ *
+ *   [← Game · Map] | [Side chips] | [Util chips] | [Loadout chips]
+ *                                              ⋯  [Δ List|Grid] [?] [⚙]
+ */
+import { ArrowLeft, HelpCircle, LayoutGrid, List } from "lucide-react";
+import GlanceBoardOperatorMenu from "@/components/lineup/GlanceBoardOperatorMenu";
+
+interface ChipOption {
+  value: string;
+  label: string;
+}
+
+interface MapPageTopBarProps {
+  gameSlug: string;
+  mapSlug: string;
+  gameName: string;
+  mapName: string;
+
+  // Side filter
+  side: string;
+  sideChips: ChipOption[];
+  onSideChange: (newSide: string) => void;
+
+  // Utility-type filter
+  utilOptions: ChipOption[];
+  selectedUtils: string[];
+  onUtilChipToggle: (slug: string) => void;
+
+  // Loadout chips (same option set as utilOptions but persisted separately)
+  loadout: string[];
+  onLoadoutToggle: (slug: string) => void;
+
+  // View mode (list / grid) — drives the right-side toggle pill.
+  viewMode: "list" | "grid";
+  onViewToggle: (next: "list" | "grid") => void;
+
+  // Operator menu surface
+  isSuperuser: boolean;
+  unplaceableCount: number;
+  onReplaceMinimapClick: () => void;
+
+  // Navigation + dialogs
+  onBackClick: () => void;
+  onShortcutsClick: () => void;
+}
+
+export default function MapPageTopBar({
+  gameSlug,
+  mapSlug,
+  gameName,
+  mapName,
+  side,
+  sideChips,
+  onSideChange,
+  utilOptions,
+  selectedUtils,
+  onUtilChipToggle,
+  loadout,
+  onLoadoutToggle,
+  viewMode,
+  onViewToggle,
+  isSuperuser,
+  unplaceableCount,
+  onReplaceMinimapClick,
+  onBackClick,
+  onShortcutsClick,
+}: MapPageTopBarProps) {
+  return (
+    <header className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm border-b h-10 flex items-center gap-2 px-3 shrink-0 overflow-x-auto">
+
+      {/* Back + map name */}
+      <button
+        type="button"
+        onClick={onBackClick}
+        className="flex items-center gap-1.5 text-sm font-medium hover:text-foreground text-muted-foreground transition-colors shrink-0"
+        aria-label="Back to maps"
+      >
+        <ArrowLeft className="w-3.5 h-3.5" aria-hidden />
+        <span className="hidden sm:inline text-xs text-muted-foreground">{gameName} ·</span>
+        <span className="text-sm font-semibold text-foreground capitalize">{mapName}</span>
+      </button>
+
+      <span className="text-border shrink-0">|</span>
+
+      {/* Side chips */}
+      <div className="flex items-center gap-0.5 shrink-0" role="group" aria-label="Side filter">
+        {sideChips.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onSideChange(opt.value)}
+            className={[
+              "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors",
+              side === opt.value
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+            ].join(" ")}
+            aria-pressed={side === opt.value}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+
+      <span className="text-border shrink-0">|</span>
+
+      {/* Utility type chips */}
+      {utilOptions.length > 0 && (
+        <div className="flex items-center gap-0.5 shrink-0" role="group" aria-label="Utility type filter">
+          {utilOptions.map((opt) => {
+            const active = selectedUtils.includes(opt.value);
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => onUtilChipToggle(opt.value)}
+                className={[
+                  "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors",
+                  active
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+                ].join(" ")}
+                aria-pressed={active}
+              >
+                {opt.label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Loadout chips — persistent inline toggle strip. Composable with
+          utility chips; default empty = no filter. */}
+      {utilOptions.length > 0 && (
+        <>
+          <span className="text-border shrink-0">|</span>
+          <div
+            className="flex items-center gap-0.5 shrink-0"
+            role="group"
+            aria-label="Loadout filter — utilities you are carrying this round"
+          >
+            {utilOptions.map((opt) => {
+              const inLoadout = loadout.includes(opt.value);
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => onLoadoutToggle(opt.value)}
+                  className={[
+                    "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors border",
+                    inLoadout
+                      ? "bg-amber-500/20 border-amber-500/50 text-amber-700 dark:text-amber-400"
+                      : "border-transparent text-muted-foreground hover:text-foreground hover:bg-muted/60",
+                  ].join(" ")}
+                  aria-pressed={inLoadout}
+                  title={`${inLoadout ? "Remove" : "Add"} ${opt.label} from loadout`}
+                >
+                  {opt.label}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      )}
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* View toggle — List (default) vs Grid. List defers all video
+          decoding until the operator expands a row; Grid auto-loops every
+          visible tile's 4 panes. Persisted via ?view URL param by parent. */}
+      <div
+        className="flex items-center rounded-md border bg-card/40 shrink-0"
+        role="group"
+        aria-label="Lineup view mode"
+      >
+        <button
+          type="button"
+          onClick={() => onViewToggle("list")}
+          aria-pressed={viewMode === "list"}
+          aria-label="List view — compact text rows, click a row to expand"
+          title="List view (default — lower browser CPU)"
+          className={[
+            "p-1 transition-colors rounded-l-md",
+            viewMode === "list"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+          ].join(" ")}
+        >
+          <List className="w-3.5 h-3.5" aria-hidden />
+        </button>
+        <button
+          type="button"
+          onClick={() => onViewToggle("grid")}
+          aria-pressed={viewMode === "grid"}
+          aria-label="Grid view — full storyboard tiles always visible"
+          title="Grid view (auto-loops every visible tile)"
+          className={[
+            "p-1 transition-colors rounded-r-md",
+            viewMode === "grid"
+              ? "bg-primary text-primary-foreground"
+              : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+          ].join(" ")}
+        >
+          <LayoutGrid className="w-3.5 h-3.5" aria-hidden />
+        </button>
+      </div>
+
+      {/* Help shortcut */}
+      <button
+        type="button"
+        onClick={onShortcutsClick}
+        className="p-1 rounded hover:bg-muted/40 text-muted-foreground transition-colors shrink-0"
+        aria-label="Keyboard shortcuts (?)"
+        title="Keyboard shortcuts"
+      >
+        <HelpCircle className="w-3.5 h-3.5" aria-hidden />
+      </button>
+
+      {/* Operator ⚙ menu */}
+      <GlanceBoardOperatorMenu
+        gameSlug={gameSlug}
+        mapSlug={mapSlug}
+        isSuperuser={isSuperuser}
+        unplaceableCount={unplaceableCount}
+        onReplaceMinimapClick={onReplaceMinimapClick}
+      />
+    </header>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -28,15 +28,16 @@
  *  - Round mode (?round=1): only pinned lineups, no map, no chrome
  *  - Compact mode (?compact=1): borderless — app shell hides itself
  */
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { ArrowLeft, HelpCircle } from "lucide-react";
+import { ArrowLeft, HelpCircle, LayoutGrid, List, X } from "lucide-react";
 import { useGetGamesQuery, useGetMapDetailQuery } from "@/store/gamesApi";
 import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
 import { countUnplaceableLineups } from "@/components/lineup/MapLineupPins";
 import type { PinMode } from "@/components/lineup/MapLineupPins";
 import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
 import GlanceBoard from "@/components/lineup/GlanceBoard";
+import LineupListBoard from "@/components/lineup/LineupListBoard";
 import GlanceBoardMinimapSidebar from "@/components/lineup/GlanceBoardMinimapSidebar";
 import GlanceBoardOperatorMenu from "@/components/lineup/GlanceBoardOperatorMenu";
 import DesignKnobsPanel from "@/components/lineup/DesignKnobsPanel";
@@ -59,6 +60,16 @@ export default function MapPage() {
   const side               = searchParams.get("side")   ?? "any";
   const util               = searchParams.get("util")   ?? "";
   const isRoundMode        = searchParams.get("round")  === "1";
+  // Zone filter — narrows the rendered lineups to a single target zone.
+  // Set by clicking a zone polygon (or zone-name in the fallback list)
+  // on the minimap sidebar. Click the active zone again to clear.
+  const zoneFilter         = searchParams.get("zone")   ?? null;
+  // Render mode — list (default; compact rows, click-to-expand storyboard)
+  // or grid (the original full-tile glance-board). List view is the default
+  // because the grid mounts up to 4 looping <video> tags per visible card,
+  // pushing browser CPU to ~10% on a dense map. List defers all video
+  // decoding until the operator clicks a specific row.
+  const viewMode           = searchParams.get("view") === "grid" ? "grid" : "list";
   const pinModeParam       = searchParams.get("pins");
   const pinMode: PinMode | null =
     pinModeParam === "stand" || pinModeParam === "target" || pinModeParam === "both"
@@ -196,6 +207,33 @@ export default function MapPage() {
       : [...selectedUtils, slug];
     handleUtilToggle(next);
   }
+
+  // Zone-filter toggle — clicking the active zone clears the filter so the
+  // minimap polygon acts as a two-state toggle (apply / clear). Switching
+  // to a different zone replaces the filter. Side / util / view filters are
+  // preserved across zone changes.
+  function handleZoneClick(slug: string) {
+    updateParam("zone", slug === zoneFilter ? null : slug);
+  }
+
+  function handleViewToggle(next: "list" | "grid") {
+    // Persist "grid" explicitly; "list" is the default so we strip the
+    // param to keep URLs short.
+    updateParam("view", next === "grid" ? "grid" : null);
+  }
+
+  // Pre-filter the fetched lineups by zone slug on the client. The /api
+  // /lineups endpoint takes a target_zone_id, not a slug, so client-side
+  // filtering is cheaper than another round-trip + a slug→ID resolver per
+  // click. Lineups whose target_zone is null never match a zone filter.
+  const visibleLineups = useMemo(() => {
+    if (!zoneFilter) return allMapLineups;
+    return allMapLineups.filter((l) => l.target_zone?.slug === zoneFilter);
+  }, [allMapLineups, zoneFilter]);
+
+  const activeZone = zoneFilter
+    ? mapDetail?.zones?.find((z) => z.slug === zoneFilter) ?? null
+    : null;
 
   // ---------------------------------------------------------------------------
   // Keyboard shortcuts (kept for power users — ? for help)
@@ -426,6 +464,46 @@ export default function MapPage() {
           {/* Spacer */}
           <div className="flex-1" />
 
+          {/* View toggle — List (default) vs Grid. List defers all video
+              decoding until the operator expands a row; Grid auto-loops
+              every visible tile's 4 panes. Persisted via ?view URL param. */}
+          <div
+            className="flex items-center rounded-md border bg-card/40 shrink-0"
+            role="group"
+            aria-label="Lineup view mode"
+          >
+            <button
+              type="button"
+              onClick={() => handleViewToggle("list")}
+              aria-pressed={viewMode === "list"}
+              aria-label="List view — compact text rows, click a row to expand"
+              title="List view (default — lower browser CPU)"
+              className={[
+                "p-1 transition-colors rounded-l-md",
+                viewMode === "list"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+              ].join(" ")}
+            >
+              <List className="w-3.5 h-3.5" aria-hidden />
+            </button>
+            <button
+              type="button"
+              onClick={() => handleViewToggle("grid")}
+              aria-pressed={viewMode === "grid"}
+              aria-label="Grid view — full storyboard tiles always visible"
+              title="Grid view (auto-loops every visible tile)"
+              className={[
+                "p-1 transition-colors rounded-r-md",
+                viewMode === "grid"
+                  ? "bg-primary text-primary-foreground"
+                  : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
+              ].join(" ")}
+            >
+              <LayoutGrid className="w-3.5 h-3.5" aria-hidden />
+            </button>
+          </div>
+
           {/* Help shortcut */}
           <button
             type="button"
@@ -450,7 +528,8 @@ export default function MapPage() {
         {/* ── Body: sidebar + main ─────────────────────────────────────── */}
         <div className="flex flex-1 min-h-0">
 
-          {/* Passive minimap sidebar */}
+          {/* Minimap sidebar — polygon clicks now set the zone filter via
+              handleZoneClick. The active zone (if any) is highlighted. */}
           <aside
             className="hidden lg:block w-[200px] shrink-0 p-3 border-r overflow-y-auto sticky top-10 h-[calc(100vh-40px)]"
             aria-label="Map zone navigation"
@@ -459,19 +538,44 @@ export default function MapPage() {
               minimapUrl={mapDetail.minimap_url}
               zones={mapDetail.zones}
               density={density}
+              onZoneClick={handleZoneClick}
+              activeZoneSlug={zoneFilter}
             />
           </aside>
 
           {/* Main scrollable area */}
           <main className="flex-1 min-w-0 p-4 lg:p-6 overflow-y-auto">
-            {allMapLineups.length === 0 && !allMapFetching && (
-              effectiveUtils.length > 0 || side !== "any"
+
+            {/* Active zone-filter chip — only when a zone is selected.
+                Click the × to clear; clicking the active zone polygon on
+                the minimap also clears (toggle behaviour). */}
+            {activeZone && (
+              <div className="mb-4 flex items-center gap-2">
+                <span className="text-xs text-muted-foreground">Filtered to:</span>
+                <button
+                  type="button"
+                  onClick={() => updateParam("zone", null)}
+                  className="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-primary/15 text-primary hover:bg-primary/25 transition-colors"
+                  aria-label={`Clear zone filter (currently ${activeZone.name})`}
+                >
+                  <span>{activeZone.name}</span>
+                  <X className="w-3 h-3" aria-hidden />
+                </button>
+                <span className="text-xs text-muted-foreground">
+                  ({visibleLineups.length} lineup{visibleLineups.length !== 1 ? "s" : ""})
+                </span>
+              </div>
+            )}
+
+            {visibleLineups.length === 0 && !allMapFetching && (
+              effectiveUtils.length > 0 || side !== "any" || zoneFilter
             ) ? (
               /* Filtered empty state */
               <div className="flex flex-col items-center justify-center py-20 gap-3">
                 <p className="text-sm text-muted-foreground text-center">
                   No{effectiveUtils.length > 0 ? ` ${effectiveUtils.join("/")}` : ""} lineups
-                  {side !== "any" ? ` for ${side === "side_a" ? sideA : sideB}` : ""} on this map.
+                  {side !== "any" ? ` for ${side === "side_a" ? sideA : sideB}` : ""}
+                  {activeZone ? ` in ${activeZone.name}` : ""}.
                 </p>
                 <button
                   type="button"
@@ -479,15 +583,27 @@ export default function MapPage() {
                     handleSideChange("any");
                     handleUtilToggle([]);
                     clearLoadout();
+                    updateParam("zone", null);
                   }}
                   className="text-sm text-primary hover:underline"
                 >
                   Clear filters
                 </button>
               </div>
+            ) : viewMode === "list" ? (
+              <LineupListBoard
+                lineups={visibleLineups}
+                isFetching={allMapFetching}
+                mapName={mapDetail.name}
+                filteredUtils={effectiveUtils}
+                side={side}
+                game={game}
+                knobs={knobs}
+                showOperatorOverlays={isSuperuser}
+              />
             ) : (
               <GlanceBoard
-                lineups={allMapLineups}
+                lineups={visibleLineups}
                 isFetching={allMapFetching}
                 mapName={mapDetail.name}
                 filteredUtils={effectiveUtils}
@@ -497,8 +613,9 @@ export default function MapPage() {
               />
             )}
 
-            {/* Add lineup CTA at bottom if empty and no filters */}
-            {allMapLineups.length === 0 && !allMapFetching && effectiveUtils.length === 0 && side === "any" && (
+            {/* Add lineup CTA at bottom if completely empty (no lineups AND
+                no filters applied) — the truly-empty-map state. */}
+            {allMapLineups.length === 0 && !allMapFetching && effectiveUtils.length === 0 && side === "any" && !zoneFilter && (
               <div className="mt-6 text-center">
                 <Link
                   to={`/lineups/new?game=${gameSlug}&map=${mapSlug}`}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -30,7 +30,7 @@
  */
 import { useEffect, useMemo, useState } from "react";
 import { Link, useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { ArrowLeft, HelpCircle, LayoutGrid, List, X } from "lucide-react";
+import { ArrowLeft, X } from "lucide-react";
 import { useGetGamesQuery, useGetMapDetailQuery } from "@/store/gamesApi";
 import { useGetLineupsQuery, useGetZoneDensityQuery } from "@/store/lineupsApi";
 import { countUnplaceableLineups } from "@/components/lineup/MapLineupPins";
@@ -39,7 +39,7 @@ import KeyboardShortcutsHelp from "@/components/lineup/KeyboardShortcutsHelp";
 import GlanceBoard from "@/components/lineup/GlanceBoard";
 import LineupListBoard from "@/components/lineup/LineupListBoard";
 import GlanceBoardMinimapSidebar from "@/components/lineup/GlanceBoardMinimapSidebar";
-import GlanceBoardOperatorMenu from "@/components/lineup/GlanceBoardOperatorMenu";
+import MapPageTopBar from "@/components/map/MapPageTopBar";
 import DesignKnobsPanel from "@/components/lineup/DesignKnobsPanel";
 import { useDesignKnobs } from "@/hooks/useDesignKnobs";
 import MinimapUploadDialog from "@/components/game/MinimapUploadDialog";
@@ -361,169 +361,27 @@ export default function MapPage() {
       {/* ── Full-height flex container ──────────────────────────────────── */}
       <div className="flex flex-col min-h-screen">
 
-        {/* ── Slim sticky top bar (~40px) ─────────────────────────────── */}
-        <header className="sticky top-0 z-20 bg-background/95 backdrop-blur-sm border-b h-10 flex items-center gap-2 px-3 shrink-0 overflow-x-auto">
-
-          {/* Back + map name */}
-          <button
-            type="button"
-            onClick={() => navigate(`/${gameSlug}`)}
-            className="flex items-center gap-1.5 text-sm font-medium hover:text-foreground text-muted-foreground transition-colors shrink-0"
-            aria-label="Back to maps"
-          >
-            <ArrowLeft className="w-3.5 h-3.5" aria-hidden />
-            <span className="hidden sm:inline text-xs text-muted-foreground">{game?.name ?? gameSlug} ·</span>
-            <span className="text-sm font-semibold text-foreground capitalize">{mapDetail.name}</span>
-          </button>
-
-          <span className="text-border shrink-0">|</span>
-
-          {/* Side chips */}
-          <div className="flex items-center gap-0.5 shrink-0" role="group" aria-label="Side filter">
-            {sideChips.map((opt) => (
-              <button
-                key={opt.value}
-                type="button"
-                onClick={() => handleSideChange(opt.value)}
-                className={[
-                  "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors",
-                  side === opt.value
-                    ? "bg-primary text-primary-foreground"
-                    : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
-                ].join(" ")}
-                aria-pressed={side === opt.value}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-
-          <span className="text-border shrink-0">|</span>
-
-          {/* Utility type chips */}
-          {utilOptions.length > 0 && (
-            <div className="flex items-center gap-0.5 shrink-0" role="group" aria-label="Utility type filter">
-              {utilOptions.map((opt) => {
-                const active = selectedUtils.includes(opt.value);
-                return (
-                  <button
-                    key={opt.value}
-                    type="button"
-                    onClick={() => handleUtilChipToggle(opt.value)}
-                    className={[
-                      "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors",
-                      active
-                        ? "bg-primary text-primary-foreground"
-                        : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
-                    ].join(" ")}
-                    aria-pressed={active}
-                  >
-                    {opt.label}
-                  </button>
-                );
-              })}
-            </div>
-          )}
-
-          {/* Loadout chips — persistent inline toggle strip.
-              Composable with utility chips; default empty = no filter.
-              Keyboard shortcut 'l' from old popover removed; inline chips
-              are always accessible without shortcut. */}
-          {utilOptions.length > 0 && (
-            <>
-              <span className="text-border shrink-0">|</span>
-              <div
-                className="flex items-center gap-0.5 shrink-0"
-                role="group"
-                aria-label="Loadout filter — utilities you are carrying this round"
-              >
-                {utilOptions.map((opt) => {
-                  const inLoadout = loadout.includes(opt.value);
-                  return (
-                    <button
-                      key={opt.value}
-                      type="button"
-                      onClick={() => toggleLoadout(opt.value)}
-                      className={[
-                        "px-2.5 py-0.5 rounded-full text-[11px] font-medium transition-colors border",
-                        inLoadout
-                          ? "bg-amber-500/20 border-amber-500/50 text-amber-700 dark:text-amber-400"
-                          : "border-transparent text-muted-foreground hover:text-foreground hover:bg-muted/60",
-                      ].join(" ")}
-                      aria-pressed={inLoadout}
-                      title={`${inLoadout ? "Remove" : "Add"} ${opt.label} from loadout`}
-                    >
-                      {opt.label}
-                    </button>
-                  );
-                })}
-              </div>
-            </>
-          )}
-
-          {/* Spacer */}
-          <div className="flex-1" />
-
-          {/* View toggle — List (default) vs Grid. List defers all video
-              decoding until the operator expands a row; Grid auto-loops
-              every visible tile's 4 panes. Persisted via ?view URL param. */}
-          <div
-            className="flex items-center rounded-md border bg-card/40 shrink-0"
-            role="group"
-            aria-label="Lineup view mode"
-          >
-            <button
-              type="button"
-              onClick={() => handleViewToggle("list")}
-              aria-pressed={viewMode === "list"}
-              aria-label="List view — compact text rows, click a row to expand"
-              title="List view (default — lower browser CPU)"
-              className={[
-                "p-1 transition-colors rounded-l-md",
-                viewMode === "list"
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
-              ].join(" ")}
-            >
-              <List className="w-3.5 h-3.5" aria-hidden />
-            </button>
-            <button
-              type="button"
-              onClick={() => handleViewToggle("grid")}
-              aria-pressed={viewMode === "grid"}
-              aria-label="Grid view — full storyboard tiles always visible"
-              title="Grid view (auto-loops every visible tile)"
-              className={[
-                "p-1 transition-colors rounded-r-md",
-                viewMode === "grid"
-                  ? "bg-primary text-primary-foreground"
-                  : "text-muted-foreground hover:text-foreground hover:bg-muted/60",
-              ].join(" ")}
-            >
-              <LayoutGrid className="w-3.5 h-3.5" aria-hidden />
-            </button>
-          </div>
-
-          {/* Help shortcut */}
-          <button
-            type="button"
-            onClick={() => setShowShortcutsHelp(true)}
-            className="p-1 rounded hover:bg-muted/40 text-muted-foreground transition-colors shrink-0"
-            aria-label="Keyboard shortcuts (?)"
-            title="Keyboard shortcuts"
-          >
-            <HelpCircle className="w-3.5 h-3.5" aria-hidden />
-          </button>
-
-          {/* Operator ⚙ menu */}
-          <GlanceBoardOperatorMenu
-            gameSlug={gameSlug!}
-            mapSlug={mapSlug!}
-            isSuperuser={isSuperuser}
-            unplaceableCount={unplaceableCount}
-            onReplaceMinimapClick={() => setShowMinimapUpload(true)}
-          />
-        </header>
+        <MapPageTopBar
+          gameSlug={gameSlug!}
+          mapSlug={mapSlug!}
+          gameName={game?.name ?? gameSlug ?? ""}
+          mapName={mapDetail.name}
+          side={side}
+          sideChips={sideChips}
+          onSideChange={handleSideChange}
+          utilOptions={utilOptions}
+          selectedUtils={selectedUtils}
+          onUtilChipToggle={handleUtilChipToggle}
+          loadout={loadout}
+          onLoadoutToggle={toggleLoadout}
+          viewMode={viewMode}
+          onViewToggle={handleViewToggle}
+          isSuperuser={isSuperuser}
+          unplaceableCount={unplaceableCount}
+          onReplaceMinimapClick={() => setShowMinimapUpload(true)}
+          onBackClick={() => navigate(`/${gameSlug}`)}
+          onShortcutsClick={() => setShowShortcutsHelp(true)}
+        />
 
         {/* ── Body: sidebar + main ─────────────────────────────────────── */}
         <div className="flex flex-1 min-h-0">


### PR DESCRIPTION
## Why

Operator reported ~10% browser CPU when MapPage tab is visible with clips looping. Diagnosis: each lineup card mounts up to **4 simultaneous `<video>` H.264 decoders** (STAND + AIM + THROW + LANDING after PR6). On a glance board with 4-6 visible tiles that's 16-24 concurrent decodes. `ClipView` already viewport-gates lazily, so the remaining cost is real in-view decoding — optimising per-decoder would either cut quality (FPS) or revert PR6's "every pane is motion" decision. Operator explicitly asked to **preserve panel quality**; the right fix is rendering fewer cards, not making each card cheaper.

Two complementary attack vectors in one PR:

## Part A — minimap polygon click sets a zone filter

`GlanceBoardMinimapSidebar` grows optional `onZoneClick` + `activeZoneSlug` props. When the parent provides them, polygon clicks (and zone-name clicks in the text-list fallback) call the callback instead of the previous scroll-to-section. `MapPage` uses this to set a new `?zone=<slug>` URL param; clicking the active zone again clears the filter (toggle). The active polygon gets primary-blue fill + 2.5px stroke. A "Filtered to: B Site (4 lineups) [×]" chip above the board exposes the active filter + click-to-clear.

**CPU win:** typical zone holds 5-15 lineups vs 60-80 for a full map → **4-10× fewer rendered cards**.

## Part B — list view as the new default

New `LineupListBoard` + `LineupListRow` mirror `GlanceBoard`'s grouping + ordering but render lineups as compact ~36px text rows: util color dot · target ← stand zones · side chip · util label · technique · expand chevron. Click a row → inline-expand the full 4-pane `GlanceBoardTile` below it. Multiple rows can be expanded; collapse unmounts the tile (and therefore its `<video>` decoders). View toggle pill in the top bar persists via `?view=list|grid`; list is default since it defers video decoding entirely until the operator picks specific rows.

**CPU win:** zero `<video>` decoders on initial load. Operator pays decode cost only for rows they expand.

## Combined

A + B compose: in list view with a zone filter, you see ~5-15 text rows for the selected zone. Pick the one you care about → that single tile mounts its 4 panes. Total in-flight decoders: 4 (not 16-24).

## UX preserved

- Panel quality byte-for-byte unchanged (same `GlanceBoardTile`)
- Grid view still available via `?view=grid` for operators who want today's behaviour
- All existing URL params (`?side`, `?util`, `?loadout`, `?round`, `?compact`) untouched and compose freely
- Zone filter chip + minimap highlight make filter state always visible
- Sidebar text-list fallback (when minimap fails) honors the same click handler so filter-vs-scroll behaviour is consistent across both surfaces

## Tests

19 new tests across 3 files:
- `LineupListRow.test.tsx` (7) — renders fields, collapse-by-default, expand mounts tile, collapse unmounts tile, Val side labels
- `LineupListBoard.test.tsx` (5) — skeleton, two empty-state shapes, zone-group ordering + counts, no `<video>` mounts when all collapsed
- `GlanceBoardMinimapSidebar.test.tsx` (7) — text-list fallback rendering + click + active-state aria-pressed; polygon click → onZoneClick; safe when no onZoneClick; active polygon aria-pressed=true; scroll-vs-filter aria-label distinction

Backend test count unchanged (404/405 frontend; the one failure is a pre-existing flake in `MicroClipShiftOverlay.test.tsx`, verified to fail on `main` without these changes).

## Test plan

- [x] `npm test` passes the 19 new tests
- [x] `npm run typecheck` clean
- [x] `npm run lint` — no NEW errors in changed files (pre-existing lint issues elsewhere unchanged)
- [ ] CI green on push (in flight)
- [ ] Manual: load MapPage, default is list view, click a B Site polygon → zone filter active + only B Site rows shown
- [ ] Manual: toggle to grid view via top-bar pill, confirm the original card grid renders unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)