### PR TITLE
fix(mga): anchor AIM micro-clip on release_ts (not sparse grid aim_idx)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -466,13 +466,23 @@ async def _process_chapter(
                     str(exc), exc_info=True,
                 )
 
-        # PR6: best-effort STAND + AIM 1s micro-clips. Anchored on the SAME
-        # grid timestamps the classifier already chose for the stand/aim
-        # stills, so the AIM clip's first frame IS today's aim still and the
-        # persisted aim_anchor_x/y overlay stays pixel-accurate. Zero extra
-        # Claude spend — just two ffmpeg cuts + two MinIO uploads per chapter.
-        # Same non-fatal contract as the surrounding clip / landing / technique
+        # PR6 (revised 2026-05-23): best-effort STAND + AIM micro-clips.
+        # STAND still anchors on the grid classifier's chosen stand timestamp
+        # (the 9-frame grid reliably catches the "I am at the spot" moment,
+        # which is many seconds long). AIM anchors on release_ts (from the
+        # PR2 throw-localizer above) minus a small pre-release offset — the
+        # sub-second aim moment is invisible to the sparse grid but lives
+        # inside the throw-localizer's dense pass. When the THROW clip step
+        # above skipped/failed, release_ts is None and the AIM side skips
+        # cleanly; STAND still generates. Zero extra Claude spend in the
+        # ingest path — both classifier outputs already exist. Same
+        # non-fatal contract as the surrounding clip / landing / technique
         # blocks (a micro-clip failure must not roll back the lineup).
+        precomputed_release_ts: float | None = (
+            clip_result.release_ts
+            if clip_result is not None and clip_result.status == "generated"
+            else None
+        )
         try:
             micro_result = await generate_micro_clips_for_lineup(
                 db,
@@ -481,7 +491,7 @@ async def _process_chapter(
                 chapter_end=float(chapter.end_seconds),
                 video_path=video_path,
                 precomputed_stand_ts=timestamps[stand_idx],
-                precomputed_aim_ts=timestamps[aim_idx],
+                precomputed_release_ts=precomputed_release_ts,
             )
             logger.info(
                 "Micro-clip generation (ingest): source_id=%s video_id=%s "

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -466,23 +466,11 @@ async def _process_chapter(
                     str(exc), exc_info=True,
                 )
 
-        # PR6 (revised 2026-05-23): best-effort STAND + AIM micro-clips.
-        # STAND still anchors on the grid classifier's chosen stand timestamp
-        # (the 9-frame grid reliably catches the "I am at the spot" moment,
-        # which is many seconds long). AIM anchors on release_ts (from the
-        # PR2 throw-localizer above) minus a small pre-release offset — the
-        # sub-second aim moment is invisible to the sparse grid but lives
-        # inside the throw-localizer's dense pass. When the THROW clip step
-        # above skipped/failed, release_ts is None and the AIM side skips
-        # cleanly; STAND still generates. Zero extra Claude spend in the
-        # ingest path — both classifier outputs already exist. Same
-        # non-fatal contract as the surrounding clip / landing / technique
-        # blocks (a micro-clip failure must not roll back the lineup).
-        precomputed_release_ts: float | None = (
-            clip_result.release_ts
-            if clip_result is not None and clip_result.status == "generated"
-            else None
-        )
+        # PR6 (revised 2026-05-23): STAND anchors on grid stand_idx; AIM
+        # anchors on release_ts − 0.8s (see micro_clip_generator docstring).
+        # release_ts is None when THROW skipped/failed → AIM skips, STAND
+        # still generates. Non-fatal — failure must not roll back the row.
+        _release_ts = clip_result.release_ts if (clip_result and clip_result.status == "generated") else None
         try:
             micro_result = await generate_micro_clips_for_lineup(
                 db,
@@ -491,7 +479,7 @@ async def _process_chapter(
                 chapter_end=float(chapter.end_seconds),
                 video_path=video_path,
                 precomputed_stand_ts=timestamps[stand_idx],
-                precomputed_release_ts=precomputed_release_ts,
+                precomputed_release_ts=_release_ts,
             )
             logger.info(
                 "Micro-clip generation (ingest): source_id=%s video_id=%s "

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_backfill.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_backfill.py
@@ -3,9 +3,18 @@
 Lineups created before PR6 (and any whose micro-clip generation failed at
 ingest time) have ``stand_clip_url IS NULL`` and/or ``aim_clip_url IS NULL``.
 This walks that set, re-fetches each source video ONCE per video (not once
-per lineup — a tutorial video usually backs many lineups), runs the grid
-classifier to recover the stand/aim anchor timestamps, and generates the
-micro-clips. Mirrors :mod:`landing_clip_backfill` (PR5) shape exactly.
+per lineup — a tutorial video usually backs many lineups), and asks the
+generator to localise anchors + cut clips. Mirrors :mod:`landing_clip_backfill`
+(PR5) shape exactly.
+
+Anchor sources (operator-tuned 2026-05-23):
+  - STAND comes from the grid classifier (the 9-frame grid reliably catches
+    the "I am at the spot" window — many seconds long).
+  - AIM comes from ``release_ts - _AIM_PRE_RELEASE_SECONDS``, where release_ts
+    is from the throw-timing classifier's dense pass. The grid is too sparse
+    to localise the sub-second aim moment, so prior AIM clips were random.
+The generator orchestrates both classifier calls itself in the backfill
+path; this module just hands it the source video.
 
 Independent of :mod:`clip_backfill` (PR2) and :mod:`landing_clip_backfill`
 (PR5) by design: a lineup can have any combination of NULL micro-clip
@@ -204,9 +213,10 @@ async def backfill_micro_clips(db: AsyncSession) -> MicroClipBackfillStats:
                         # generator re-download per lineup.
                         video_path=video_path,
                         # Backfill: no precomputed timestamps; the generator
-                        # re-runs the grid classifier itself.
+                        # re-runs the grid classifier (stand) AND the
+                        # throw-localizer (release → aim) itself.
                         precomputed_stand_ts=None,
-                        precomputed_aim_ts=None,
+                        precomputed_release_ts=None,
                     )
                 except Exception as exc:  # defensive: never abort the batch
                     logger.warning(

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
@@ -1,73 +1,45 @@
-"""Stand + Aim micro-clip generator — 1s looped clips for the STAND and AIM
-panes of the 2×2 storyboard tile (PR6).
+"""Stand + Aim micro-clip generator — 1s looped clips for the storyboard.
 
-PR4 introduced the four-pane storyboard (STAND still | AIM still+anchor | THROW
-clip | LANDING text). PR5 replaced the LANDING text with a real landing clip.
-PR6 replaces the STAND and AIM stills with **1-second looping micro-clips**.
-
-**Anchor sources differ per side** (operator-tuned 2026-05-23 after AIM was
-shown to be random):
+PR6 introduced the 1-second STAND + AIM micro-clips replacing static stills.
+Anchor sources differ per side (operator-tuned 2026-05-23):
 
   - **STAND** anchors on the grid classifier's chosen ``stand`` frame
-    (``timestamps[stand_idx]``). The 9-frame grid samples evenly across the
-    chapter — coarse, but the STAND moment ("I am at the spot") is many seconds
-    long, so the grid reliably catches it.
-
-  - **AIM** anchors on **release_ts − _AIM_PRE_RELEASE_SECONDS** (0.8s before
-    the throw-localizer's release frame). The aim moment ("crosshair locked on
-    the alignment marker, immediately before release") is sub-second; the
-    9-frame grid is far too sparse to catch it reliably (~2-3s spacing on a
-    typical chapter), so Claude was picking a random distant frame for AIM.
-    The throw-timing classifier's dense pass (0.5s spacing around release)
-    already sees the locked-aim moment — its first 2 seconds before
-    release_ts IS the aim moment. So AIM derives off release_ts, not the
-    grid. The 1.0s AIM clip spans [release − 0.8s, release + 0.2s] — locked-
-    aim plus the first 0.2s of throw initiation.
+    (``timestamps[stand_idx]``). The 9-frame grid reliably catches the
+    "I am at the spot" window (many seconds long).
+  - **AIM** anchors on ``release_ts − _AIM_PRE_RELEASE_SECONDS`` (0.8s
+    before the throw-localizer's release frame). The aim moment is
+    sub-second; the grid is far too sparse to catch it reliably — Claude
+    was picking random distant frames. The throw-timing dense pass
+    (0.5s spacing around release) already sees the locked-aim moment.
 
 Two entry paths share one contract:
 
-  1. **Ingest path** — orchestrator already ran the grid classifier (for
-     ``stand_idx``) AND the throw-localizer (for ``release_ts``). It passes
-     ``precomputed_stand_ts`` (= ``timestamps[stand_idx]``) and
-     ``precomputed_release_ts`` (= the dense-pass release frame timestamp).
-     Generator skips both classifier calls entirely. Cost: zero extra Claude
-     spend; two ffmpeg cuts + two MinIO uploads per chapter.
+  1. **Ingest path** — orchestrator passes ``precomputed_stand_ts`` (from
+     its grid run) AND ``precomputed_release_ts`` (from the throw-localizer
+     it already ran for the THROW clip). Generator skips both Claude calls.
+  2. **Backfill path** — both precomputed values are None; generator runs
+     the grid classifier (stand) AND ``localize_throw_with_refinement``
+     (release → aim) itself. Cost: 1 grid + 1-2 throw-timing calls.
 
-  2. **Backfill path** — standalone CLI. Both precomputed values are None;
-     generator runs the grid classifier itself to recover ``stand_ts`` AND
-     calls ``localize_throw_with_refinement`` to recover ``release_ts``.
-     Cost: 1 grid call + 1-2 throw-timing calls per lineup. The two sides
-     remain independent: a stand-side failure NEVER rolls back the
-     already-committed aim clip, and vice versa.
-
-The AIM still + the persisted ``aim_anchor_x/y`` overlay coords are NOT
-recut here — they continue to derive from the grid classifier's aim frame.
-This is intentional Phase-1 scope: the AIM clip (what the operator actually
-sees in the default clip-mode view) is fixed; the brief poster flash and
-the rarely-used still-mode fallback are accepted-imperfections, listed in
-TECH_DEBT.md for a follow-up that re-extracts a single PNG at AIM_TS too.
-See ``project_mga_aim_anchor_center_screen_invariant.md`` in auto-memory.
-
-Cut + encode the muted MP4 via :func:`cut_clip` (re-uses the PR2 ffmpeg
-wrapper — same encode contract, same ``+faststart``), upload to MinIO under
-a deterministic key, persist the bare key via the matching repo setter.
-
-Idempotent: keys are ``pending/{video_id}/{int(chapter_start)}-stand-micro.mp4``
-and ``pending/{video_id}/{int(chapter_start)}-aim-micro.mp4``. Re-running
-overwrites the same objects instead of orphaning new ones. The DB writes are
-**two separate one-column commits** (``set_stand_clip_url`` +
-``set_aim_clip_url``) so a stand-side failure NEVER rolls back the already-
-committed aim clip, and vice versa. Mirrors PR2 / PR5 exactly.
+Per-side independence: a stand-side failure NEVER rolls back the already-
+committed aim side, and vice versa. The AIM still + persisted aim_anchor
+coords are NOT recut — phase-1 scope is the clip only; the brief poster
+flash + rarely-used still-mode fallback are accepted-imperfections. See
+``project_mga_aim_anchor_center_screen_invariant.md`` in auto-memory.
 
 Failure handling (rules/no-bandaid-solutions.md +
-rules/check-third-party-error-codes.md): yt-dlp / ffmpeg / Claude failures
-are captured with structured codes, logged at WARNING, and returned in
-``stand_error_codes`` / ``aim_error_codes``. ``*_clip_url`` is left NULL and
-the matching pane renders its still fallback. Nothing silent-fails.
+rules/check-third-party-error-codes.md): every yt-dlp / ffmpeg / Claude
+failure is captured with structured codes, logged at WARNING, and returned
+in the per-side error_codes; the matching ``*_clip_url`` is left NULL and
+the pane renders its still fallback. Nothing silent-fails.
+
+Sibling helpers (``_resolve_stand_ts_via_grid_classifier``,
+``_resolve_release_ts_via_throw_localizer``, ``_cut_upload_persist_one_side``)
+live in :mod:`micro_clip_helpers` to keep this file under the file-size
+growth guard (per per-app Tech Debt Policy).
 """
 from __future__ import annotations
 
-import asyncio
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -76,22 +48,15 @@ from typing import Optional
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.config import settings
-from app.core.storage import get_storage
 from app.models.game.lineup import Lineup
 from app.repositories.game import lineup_repo
-from app.services.classification.classifier_service import (
-    classify_frames_for_lineup_decision,
-)
 from app.services.ingestion.frame_extractor import (
-    ClipCutError,
-    FrameExtractionError,
-    cut_clip,
-    extract_frames,
-    grid_timestamps,
     wide_source_bounds,
 )
-from app.services.ingestion.throw_localizer import (
-    localize_throw_with_refinement,
+from app.services.ingestion.micro_clip_helpers import (
+    _cut_upload_persist_one_side,
+    _resolve_release_ts_via_throw_localizer,
+    _resolve_stand_ts_via_grid_classifier,
 )
 from app.services.ingestion.youtube_fetcher import (
     VideoDownloadError,
@@ -100,28 +65,17 @@ from app.services.ingestion.youtube_fetcher import (
 
 logger = logging.getLogger(__name__)
 
-# Frozen design-contract constants.
-# Per-pane micro-clip durations. STAND is 2.0s (operator-tuned: 1.0s was
-# cutting off mid-stance, before the player begins the throw motion). AIM
-# stays at 1.0s — the AIM pane's whole point is the locked-aim moment;
-# longer would bleed deeper into the throw animation (which is what the
-# THROW pane already shows).
+# Per-pane micro-clip durations. STAND is 2.0s (operator-tuned: 1.0s cut
+# off mid-stance). AIM stays at 1.0s — longer bleeds into the THROW pane's
+# window.
 _STAND_MICRO_CLIP_SECONDS = 2.0
 _AIM_MICRO_CLIP_SECONDS = 1.0
-# Seconds BEFORE release_ts the AIM clip starts at. Result: the 1.0s AIM
-# clip spans [release − 0.8s, release + 0.2s] — locked-aim moment with a
-# tiny peek of throw initiation as a natural end-cue. Smaller would risk
-# dropping the lock-on frame on edge cases (slight release-frame error
-# from the dense pass); larger would step on the THROW pane's window.
+# Seconds BEFORE release_ts the AIM clip starts at. The 1.0s AIM clip
+# spans [release − 0.8s, release + 0.2s] — locked-aim with a tiny throw-
+# initiation peek as a natural end-cue.
 _AIM_PRE_RELEASE_SECONDS = 0.8
-# Minimum acceptable clamped duration. A near-end timestamp may clip short;
-# under this threshold we skip rather than ship a useless ~200ms sliver.
+# Minimum acceptable clamped duration. Below: skip rather than ship a sliver.
 _MIN_CLIP_SECONDS = 0.5
-# Grid sample count + edge padding — must match the ingest orchestrator's
-# ingestion_orchestrator._GRID_FRAME_COUNT / _GRID_EDGE_PADDING_SECONDS so
-# the backfill recovers the SAME timestamps the ingest pass extracted.
-_GRID_FRAME_COUNT = 9
-_GRID_EDGE_PADDING_SECONDS = 1.0
 
 
 @dataclass
@@ -222,139 +176,6 @@ def _micro_clip_seconds_for_side(side: str) -> float:
     if side == "aim":
         return _AIM_MICRO_CLIP_SECONDS
     raise ValueError(f"unknown micro-clip side: {side!r}")
-
-
-async def _resolve_stand_ts_via_grid_classifier(
-    db: AsyncSession,
-    lineup: Lineup,
-    video_path: Path,
-    chapter_start: float,
-    chapter_end: float,
-) -> tuple[Optional[float], list[str], str]:
-    """Backfill helper: re-run the grid classifier to recover stand_ts.
-
-    Returns ``(stand_ts, error_codes, reasoning)``. The grid classifier also
-    returns an ``aim_idx`` but it is intentionally discarded — AIM_TS is now
-    derived from release_ts (see module docstring); the grid pass is too
-    sparse to localise the sub-second aim moment. STAND is unaffected
-    because the standing-at-spot window is many seconds long and the
-    9-frame grid reliably catches it.
-    """
-    timestamps = grid_timestamps(
-        float(chapter_start),
-        float(chapter_end),
-        _GRID_FRAME_COUNT,
-        edge_padding_seconds=_GRID_EDGE_PADDING_SECONDS,
-    )
-    if not timestamps:
-        return None, ["empty_grid_window"], "chapter window produced no grid frames"
-
-    try:
-        frames = await extract_frames(video_path, timestamps)
-    except FrameExtractionError as exc:
-        logger.warning(
-            "micro_clip_generator: grid frame extraction failed: "
-            "lineup=%s returncode=%s stderr=%s",
-            lineup.id, exc.returncode, exc.stderr[:300],
-        )
-        return None, [f"frame_extract:rc={exc.returncode}"], str(exc)
-
-    if not frames:
-        return None, ["grid_frames_empty"], "ffmpeg returned no frames"
-
-    try:
-        result = await classify_frames_for_lineup_decision(
-            db,
-            frames=frames,
-            chapter_title=lineup.chapter_title or "",
-            attribution_author=lineup.attribution_author,
-            game_hint=None,
-        )
-    except Exception as exc:
-        logger.warning(
-            "micro_clip_generator: grid classifier raised: lineup=%s error=%s",
-            lineup.id, str(exc),
-        )
-        return None, [f"classifier_raised:{type(exc).__name__}"], str(exc)
-
-    if not result.success:
-        logger.warning(
-            "micro_clip_generator: grid classifier call failed: lineup=%s "
-            "error_codes=%s",
-            lineup.id, result.error_codes,
-        )
-        return None, list(result.error_codes), "grid classifier reported failure"
-
-    if not result.is_lineup:
-        # The backfill candidate is an accepted lineup, so the classifier
-        # judging it "not a lineup" here would be a regression — keep the
-        # signal but skip cleanly rather than fabricate a timestamp.
-        return None, [], "backfill grid says not_a_lineup (skip)"
-
-    # 1-based → 0-based, clamped to the grid range. Falls back to first
-    # index when the model omitted it — same shape as the orchestrator's
-    # classifier-disabled fallback.
-    stand_idx = (result.best_stand_index or 1) - 1
-    stand_idx = max(0, min(stand_idx, len(timestamps) - 1))
-    return timestamps[stand_idx], [], result.reasoning or ""
-
-
-async def _resolve_release_ts_via_throw_localizer(
-    lineup: Lineup,
-    video_path: Path,
-    chapter_start: float,
-    chapter_end: float,
-) -> tuple[Optional[float], list[str], str]:
-    """Backfill helper: run the throw-timing classifier to recover release_ts.
-
-    Returns ``(release_ts, error_codes, reasoning)``. AIM_TS is then
-    ``release_ts - _AIM_PRE_RELEASE_SECONDS`` (see module docstring on why
-    AIM derives from release, not the grid). When the localizer judges the
-    chapter not-a-throw or returns no release frame, we surface that as an
-    empty error_codes + structured reasoning (skip cleanly, not fail) — the
-    AIM clip is best-effort and a non-throw lineup is a real signal, not an
-    operational fault.
-    """
-    try:
-        refined = await localize_throw_with_refinement(
-            video_path,
-            chapter_start=float(chapter_start),
-            chapter_end=float(chapter_end),
-            chapter_title=lineup.chapter_title or "",
-            utility_hint=None,
-        )
-    except FrameExtractionError as exc:
-        # Coarse frame-extract failure propagates per throw_localizer's
-        # contract — capture as a structured code so the side-tally surfaces
-        # it instead of crashing.
-        logger.warning(
-            "micro_clip_generator: throw localizer extract failed: "
-            "lineup=%s returncode=%s stderr=%s",
-            lineup.id, exc.returncode, exc.stderr[:300],
-        )
-        return None, [f"throw_localizer_extract:rc={exc.returncode}"], str(exc)
-    except Exception as exc:  # defensive
-        logger.warning(
-            "micro_clip_generator: throw localizer raised: lineup=%s error=%s",
-            lineup.id, str(exc),
-        )
-        return None, [f"throw_localizer_raised:{type(exc).__name__}"], str(exc)
-
-    timing = refined.timing
-    if not timing.success:
-        logger.warning(
-            "micro_clip_generator: throw localizer call failed: lineup=%s "
-            "error_codes=%s",
-            lineup.id, timing.error_codes,
-        )
-        return None, list(timing.error_codes), "throw localizer reported failure"
-
-    if not timing.is_lineup_throw or timing.release_index is None:
-        # Not a throw OR no usable release frame — clean skip, not a fault.
-        return None, [], "throw localizer found no usable release frame"
-
-    release_ts = refined.frame_timestamps[timing.release_index - 1]
-    return release_ts, [], timing.reasoning or ""
 
 
 async def generate_micro_clips_for_lineup(
@@ -628,12 +449,14 @@ async def generate_micro_clips_for_lineup(
             stand_outcome = await _cut_upload_persist_one_side(
                 db, lineup, video_id, local_video,
                 anchor_ts=stand_ts,
+                clip_seconds=_STAND_MICRO_CLIP_SECONDS,
                 chapter_start=chapter_start,
                 chapter_end=chapter_end,
                 side="stand",
                 key_fn=pending_stand_clip_key,
                 persist_fn=lineup_repo.set_stand_clip_url,
                 wider_source_start_s=wider_source_start_s,
+                min_clip_seconds=_MIN_CLIP_SECONDS,
             )
         if aim_ts is None:
             aim_outcome = {
@@ -645,12 +468,14 @@ async def generate_micro_clips_for_lineup(
             aim_outcome = await _cut_upload_persist_one_side(
                 db, lineup, video_id, local_video,
                 anchor_ts=aim_ts,
+                clip_seconds=_AIM_MICRO_CLIP_SECONDS,
                 chapter_start=chapter_start,
                 chapter_end=chapter_end,
                 side="aim",
                 key_fn=pending_aim_clip_key,
                 persist_fn=lineup_repo.set_aim_clip_url,
                 wider_source_start_s=wider_source_start_s,
+                min_clip_seconds=_MIN_CLIP_SECONDS,
             )
 
         return MicroClipGenerationResult(
@@ -678,110 +503,3 @@ async def generate_micro_clips_for_lineup(
                 )
 
 
-async def _cut_upload_persist_one_side(
-    db: AsyncSession,
-    lineup: Lineup,
-    video_id: str,
-    local_video: Path,
-    *,
-    anchor_ts: float,
-    chapter_start: float,
-    chapter_end: float,
-    side: str,
-    key_fn,
-    persist_fn,
-    wider_source_start_s: float | None = None,
-) -> dict:
-    """Cut + upload + persist exactly ONE side (stand or aim).
-
-    Returns a flat dict consumed by ``generate_micro_clips_for_lineup`` —
-    not a dataclass because the caller flattens the two sides into the
-    composite ``MicroClipGenerationResult``. The same shape is used for
-    both sides so a future third pane (unlikely but possible) can be added
-    without touching this function.
-
-    *wider_source_start_s* is the seconds-into-source-video start of the
-    SHARED wider clip (``clip_url_original``) the operator's shift-window
-    slider will be positioned against. When set, this function computes
-    ``offset_s = clip_start - wider_source_start_s`` and persists it via the
-    setter's ``offset_s=`` kwarg so the shift overlay opens at the right
-    initial thumb position. When None (no wider source for this lineup),
-    the offset is left untouched in the DB and the shift overlay opens at 0.
-    """
-    bounds = _compute_micro_bounds(
-        anchor_ts,
-        chapter_start,
-        chapter_end,
-        clip_seconds=_micro_clip_seconds_for_side(side),
-    )
-    if bounds is None:
-        return {
-            "status": "skipped",
-            "skip_reason": "chapter_too_short_for_microclip",
-        }
-    clip_start, clip_duration = bounds
-
-    try:
-        clip_bytes = await cut_clip(local_video, clip_start, clip_duration)
-    except ClipCutError as exc:
-        logger.warning(
-            "micro_clip_generator: %s clip cut failed: lineup=%s video_id=%s "
-            "start=%.2f dur=%.2f returncode=%s stderr=%s",
-            side, lineup.id, video_id, clip_start, clip_duration,
-            exc.returncode, exc.stderr[:300],
-        )
-        return {
-            "status": "failed",
-            "error_codes": [f"clip_cut:rc={exc.returncode}"],
-        }
-
-    clip_key = key_fn(video_id, chapter_start)
-    try:
-        storage = get_storage()
-        loop = asyncio.get_running_loop()
-        await loop.run_in_executor(
-            None, storage.upload_file, clip_key, clip_bytes, "video/mp4"
-        )
-    except Exception as exc:
-        logger.warning(
-            "micro_clip_generator: %s clip upload failed: lineup=%s key=%s "
-            "error=%s",
-            side, lineup.id, clip_key, str(exc),
-        )
-        return {
-            "status": "failed",
-            "error_codes": ["clip_upload_failed"],
-        }
-
-    # Compute the in-source offset (only when a shared wider source exists for
-    # this lineup). The setter writes ``*_clip_offset_s`` so the PR2 shift
-    # overlay opens its slider at the position the ingest pipeline cut from.
-    if wider_source_start_s is not None:
-        offset_s: float | None = clip_start - wider_source_start_s
-    else:
-        offset_s = None
-
-    try:
-        await persist_fn(db, lineup, clip_key, offset_s=offset_s)
-    except Exception as exc:
-        # Object uploaded but column did not commit. The key is deterministic
-        # so a later backfill recomputes the same key and overwrites the same
-        # object — no orphan, safe to retry.
-        logger.warning(
-            "micro_clip_generator: %s_clip_url persist failed (object "
-            "uploaded, column not committed; backfill is idempotent): "
-            "lineup=%s key=%s error=%s",
-            side, lineup.id, clip_key, str(exc),
-        )
-        return {
-            "status": "failed",
-            "error_codes": [f"{side}_clip_url_persist_failed"],
-        }
-
-    logger.info(
-        "micro_clip_generator: %s clip generated: lineup=%s video_id=%s "
-        "key=%s anchor_ts=%.2f clip=[%.2f,+%.2fs]",
-        side, lineup.id, video_id, clip_key, anchor_ts,
-        clip_start, clip_duration,
-    )
-    return {"status": "generated", "clip_key": clip_key}

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
@@ -3,30 +3,50 @@ panes of the 2×2 storyboard tile (PR6).
 
 PR4 introduced the four-pane storyboard (STAND still | AIM still+anchor | THROW
 clip | LANDING text). PR5 replaced the LANDING text with a real landing clip.
-PR6 replaces the STAND and AIM stills with **1-second looping micro-clips**
-anchored on the **same chapter timestamps** the Strategy-A classifier already
-chose for ``stand_screenshot_url`` and ``aim_screenshot_url``. The still
-remains the always-valid graceful degradation when no micro-clip exists.
+PR6 replaces the STAND and AIM stills with **1-second looping micro-clips**.
 
-Two entry paths share a single contract:
+**Anchor sources differ per side** (operator-tuned 2026-05-23 after AIM was
+shown to be random):
 
-  1. **Ingest path** — orchestrator already ran the grid classifier and knows
-     ``timestamps[stand_idx]`` / ``timestamps[aim_idx]``. It passes them via
-     ``precomputed_stand_ts`` / ``precomputed_aim_ts``. The generator skips
-     the classifier call entirely (cost saving: zero extra Claude spend) and
-     just ffmpeg-cuts + uploads + commits.
+  - **STAND** anchors on the grid classifier's chosen ``stand`` frame
+    (``timestamps[stand_idx]``). The 9-frame grid samples evenly across the
+    chapter — coarse, but the STAND moment ("I am at the spot") is many seconds
+    long, so the grid reliably catches it.
 
-  2. **Backfill path** — standalone CLI. ``precomputed_*_ts`` are None, so we
-     re-run ``classify_frames_for_lineup_decision`` over the same grid the
-     ingest path uses, recover the indices, and turn them back into
-     timestamps via the deterministic ``grid_timestamps``. Cost: one grid-
-     classifier call per lineup.
+  - **AIM** anchors on **release_ts − _AIM_PRE_RELEASE_SECONDS** (0.8s before
+    the throw-localizer's release frame). The aim moment ("crosshair locked on
+    the alignment marker, immediately before release") is sub-second; the
+    9-frame grid is far too sparse to catch it reliably (~2-3s spacing on a
+    typical chapter), so Claude was picking a random distant frame for AIM.
+    The throw-timing classifier's dense pass (0.5s spacing around release)
+    already sees the locked-aim moment — its first 2 seconds before
+    release_ts IS the aim moment. So AIM derives off release_ts, not the
+    grid. The 1.0s AIM clip spans [release − 0.8s, release + 0.2s] — locked-
+    aim plus the first 0.2s of throw initiation.
 
-Why anchor on the **classifier-chosen** timestamps rather than fixed offsets
-(chapter_start + 0 / chapter_start + 4): the first frame of the AIM clip IS
-the existing aim still (same timestamp), so the persisted ``aim_anchor_x/y``
-normalized overlay stays pixel-accurate when StandPane / AimPane swap from
-``ScreenshotHalf`` to ``ClipView``. Fixed offsets would invalidate the anchor.
+Two entry paths share one contract:
+
+  1. **Ingest path** — orchestrator already ran the grid classifier (for
+     ``stand_idx``) AND the throw-localizer (for ``release_ts``). It passes
+     ``precomputed_stand_ts`` (= ``timestamps[stand_idx]``) and
+     ``precomputed_release_ts`` (= the dense-pass release frame timestamp).
+     Generator skips both classifier calls entirely. Cost: zero extra Claude
+     spend; two ffmpeg cuts + two MinIO uploads per chapter.
+
+  2. **Backfill path** — standalone CLI. Both precomputed values are None;
+     generator runs the grid classifier itself to recover ``stand_ts`` AND
+     calls ``localize_throw_with_refinement`` to recover ``release_ts``.
+     Cost: 1 grid call + 1-2 throw-timing calls per lineup. The two sides
+     remain independent: a stand-side failure NEVER rolls back the
+     already-committed aim clip, and vice versa.
+
+The AIM still + the persisted ``aim_anchor_x/y`` overlay coords are NOT
+recut here — they continue to derive from the grid classifier's aim frame.
+This is intentional Phase-1 scope: the AIM clip (what the operator actually
+sees in the default clip-mode view) is fixed; the brief poster flash and
+the rarely-used still-mode fallback are accepted-imperfections, listed in
+TECH_DEBT.md for a follow-up that re-extracts a single PNG at AIM_TS too.
+See ``project_mga_aim_anchor_center_screen_invariant.md`` in auto-memory.
 
 Cut + encode the muted MP4 via :func:`cut_clip` (re-uses the PR2 ffmpeg
 wrapper — same encode contract, same ``+faststart``), upload to MinIO under
@@ -70,6 +90,9 @@ from app.services.ingestion.frame_extractor import (
     grid_timestamps,
     wide_source_bounds,
 )
+from app.services.ingestion.throw_localizer import (
+    localize_throw_with_refinement,
+)
 from app.services.ingestion.youtube_fetcher import (
     VideoDownloadError,
     download_video,
@@ -80,11 +103,17 @@ logger = logging.getLogger(__name__)
 # Frozen design-contract constants.
 # Per-pane micro-clip durations. STAND is 2.0s (operator-tuned: 1.0s was
 # cutting off mid-stance, before the player begins the throw motion). AIM
-# stays at 1.0s — the AIM pane's whole point is the static crosshair
-# placement, and a longer window risks bleeding into the throw animation
-# which is what the THROW pane already shows.
+# stays at 1.0s — the AIM pane's whole point is the locked-aim moment;
+# longer would bleed deeper into the throw animation (which is what the
+# THROW pane already shows).
 _STAND_MICRO_CLIP_SECONDS = 2.0
 _AIM_MICRO_CLIP_SECONDS = 1.0
+# Seconds BEFORE release_ts the AIM clip starts at. Result: the 1.0s AIM
+# clip spans [release − 0.8s, release + 0.2s] — locked-aim moment with a
+# tiny peek of throw initiation as a natural end-cue. Smaller would risk
+# dropping the lock-on frame on edge cases (slight release-frame error
+# from the dense pass); larger would step on the THROW pane's window.
+_AIM_PRE_RELEASE_SECONDS = 0.8
 # Minimum acceptable clamped duration. A near-end timestamp may clip short;
 # under this threshold we skip rather than ship a useless ~200ms sliver.
 _MIN_CLIP_SECONDS = 0.5
@@ -195,19 +224,21 @@ def _micro_clip_seconds_for_side(side: str) -> float:
     raise ValueError(f"unknown micro-clip side: {side!r}")
 
 
-async def _resolve_anchor_timestamps_via_classifier(
+async def _resolve_stand_ts_via_grid_classifier(
     db: AsyncSession,
     lineup: Lineup,
     video_path: Path,
     chapter_start: float,
     chapter_end: float,
-) -> tuple[Optional[float], Optional[float], list[str], str]:
-    """Backfill helper: re-run the grid classifier to recover stand/aim ts.
+) -> tuple[Optional[float], list[str], str]:
+    """Backfill helper: re-run the grid classifier to recover stand_ts.
 
-    Returns ``(stand_ts, aim_ts, error_codes, reasoning)``. On any failure
-    the timestamps are None and ``error_codes`` carries the structured
-    reason. The caller then converts both sides to ``status="failed"`` /
-    ``status="skipped"`` per the failure shape.
+    Returns ``(stand_ts, error_codes, reasoning)``. The grid classifier also
+    returns an ``aim_idx`` but it is intentionally discarded — AIM_TS is now
+    derived from release_ts (see module docstring); the grid pass is too
+    sparse to localise the sub-second aim moment. STAND is unaffected
+    because the standing-at-spot window is many seconds long and the
+    9-frame grid reliably catches it.
     """
     timestamps = grid_timestamps(
         float(chapter_start),
@@ -216,7 +247,7 @@ async def _resolve_anchor_timestamps_via_classifier(
         edge_padding_seconds=_GRID_EDGE_PADDING_SECONDS,
     )
     if not timestamps:
-        return None, None, ["empty_grid_window"], "chapter window produced no grid frames"
+        return None, ["empty_grid_window"], "chapter window produced no grid frames"
 
     try:
         frames = await extract_frames(video_path, timestamps)
@@ -226,10 +257,10 @@ async def _resolve_anchor_timestamps_via_classifier(
             "lineup=%s returncode=%s stderr=%s",
             lineup.id, exc.returncode, exc.stderr[:300],
         )
-        return None, None, [f"frame_extract:rc={exc.returncode}"], str(exc)
+        return None, [f"frame_extract:rc={exc.returncode}"], str(exc)
 
     if not frames:
-        return None, None, ["grid_frames_empty"], "ffmpeg returned no frames"
+        return None, ["grid_frames_empty"], "ffmpeg returned no frames"
 
     try:
         result = await classify_frames_for_lineup_decision(
@@ -244,7 +275,7 @@ async def _resolve_anchor_timestamps_via_classifier(
             "micro_clip_generator: grid classifier raised: lineup=%s error=%s",
             lineup.id, str(exc),
         )
-        return None, None, [f"classifier_raised:{type(exc).__name__}"], str(exc)
+        return None, [f"classifier_raised:{type(exc).__name__}"], str(exc)
 
     if not result.success:
         logger.warning(
@@ -252,22 +283,78 @@ async def _resolve_anchor_timestamps_via_classifier(
             "error_codes=%s",
             lineup.id, result.error_codes,
         )
-        return None, None, list(result.error_codes), "grid classifier reported failure"
+        return None, list(result.error_codes), "grid classifier reported failure"
 
     if not result.is_lineup:
         # The backfill candidate is an accepted lineup, so the classifier
         # judging it "not a lineup" here would be a regression — keep the
-        # signal but skip cleanly rather than fabricate timestamps.
-        return None, None, [], "backfill grid says not_a_lineup (skip)"
+        # signal but skip cleanly rather than fabricate a timestamp.
+        return None, [], "backfill grid says not_a_lineup (skip)"
 
-    # 1-based → 0-based, clamped to the grid range. Falls back to
-    # first/last index when the model omitted one — same shape as
-    # ingestion_orchestrator's classifier-disabled fallback.
+    # 1-based → 0-based, clamped to the grid range. Falls back to first
+    # index when the model omitted it — same shape as the orchestrator's
+    # classifier-disabled fallback.
     stand_idx = (result.best_stand_index or 1) - 1
-    aim_idx = (result.best_aim_index or len(frames)) - 1
     stand_idx = max(0, min(stand_idx, len(timestamps) - 1))
-    aim_idx = max(0, min(aim_idx, len(timestamps) - 1))
-    return timestamps[stand_idx], timestamps[aim_idx], [], result.reasoning or ""
+    return timestamps[stand_idx], [], result.reasoning or ""
+
+
+async def _resolve_release_ts_via_throw_localizer(
+    lineup: Lineup,
+    video_path: Path,
+    chapter_start: float,
+    chapter_end: float,
+) -> tuple[Optional[float], list[str], str]:
+    """Backfill helper: run the throw-timing classifier to recover release_ts.
+
+    Returns ``(release_ts, error_codes, reasoning)``. AIM_TS is then
+    ``release_ts - _AIM_PRE_RELEASE_SECONDS`` (see module docstring on why
+    AIM derives from release, not the grid). When the localizer judges the
+    chapter not-a-throw or returns no release frame, we surface that as an
+    empty error_codes + structured reasoning (skip cleanly, not fail) — the
+    AIM clip is best-effort and a non-throw lineup is a real signal, not an
+    operational fault.
+    """
+    try:
+        refined = await localize_throw_with_refinement(
+            video_path,
+            chapter_start=float(chapter_start),
+            chapter_end=float(chapter_end),
+            chapter_title=lineup.chapter_title or "",
+            utility_hint=None,
+        )
+    except FrameExtractionError as exc:
+        # Coarse frame-extract failure propagates per throw_localizer's
+        # contract — capture as a structured code so the side-tally surfaces
+        # it instead of crashing.
+        logger.warning(
+            "micro_clip_generator: throw localizer extract failed: "
+            "lineup=%s returncode=%s stderr=%s",
+            lineup.id, exc.returncode, exc.stderr[:300],
+        )
+        return None, [f"throw_localizer_extract:rc={exc.returncode}"], str(exc)
+    except Exception as exc:  # defensive
+        logger.warning(
+            "micro_clip_generator: throw localizer raised: lineup=%s error=%s",
+            lineup.id, str(exc),
+        )
+        return None, [f"throw_localizer_raised:{type(exc).__name__}"], str(exc)
+
+    timing = refined.timing
+    if not timing.success:
+        logger.warning(
+            "micro_clip_generator: throw localizer call failed: lineup=%s "
+            "error_codes=%s",
+            lineup.id, timing.error_codes,
+        )
+        return None, list(timing.error_codes), "throw localizer reported failure"
+
+    if not timing.is_lineup_throw or timing.release_index is None:
+        # Not a throw OR no usable release frame — clean skip, not a fault.
+        return None, [], "throw localizer found no usable release frame"
+
+    release_ts = refined.frame_timestamps[timing.release_index - 1]
+    return release_ts, [], timing.reasoning or ""
 
 
 async def generate_micro_clips_for_lineup(
@@ -279,22 +366,33 @@ async def generate_micro_clips_for_lineup(
     video_path: Optional[Path] = None,
     download_dir: Optional[Path] = None,
     precomputed_stand_ts: Optional[float] = None,
-    precomputed_aim_ts: Optional[float] = None,
+    precomputed_release_ts: Optional[float] = None,
 ) -> MicroClipGenerationResult:
-    """Cut + persist STAND and AIM 1s micro-clips for *lineup*.
+    """Cut + persist STAND and AIM micro-clips for *lineup*.
+
+    AIM anchors on ``release_ts - _AIM_PRE_RELEASE_SECONDS`` (NOT on the
+    grid classifier's aim_idx — that pass is too sparse for the sub-second
+    aim moment; see module docstring). STAND still anchors on the grid's
+    stand_idx.
 
     Two entry paths:
 
     **Ingest path** — caller (orchestrator) passes ``precomputed_stand_ts``
-    AND ``precomputed_aim_ts`` from the grid classifier output it already
-    has. The generator skips its own classifier call entirely. Cost: zero
-    extra Claude spend; two extra ffmpeg cuts + two MinIO uploads per
-    chapter.
+    (from the grid run it already did) AND ``precomputed_release_ts`` (from
+    the throw-localizer run it already did for the THROW clip). The
+    generator skips both Claude calls entirely. Cost: zero extra Claude
+    spend; two extra ffmpeg cuts + two MinIO uploads per chapter.
 
-    **Backfill path** — caller is the CLI; ``precomputed_*_ts`` are None.
-    We re-run ``classify_frames_for_lineup_decision`` ourselves over the
-    same grid the ingest path uses (cost: one Claude call per lineup),
-    then cut both clips.
+    Partial-ingest case: if the orchestrator's THROW clip step skipped or
+    failed, ``precomputed_release_ts`` is None and the AIM side is skipped
+    with reason ``no_release_ts_for_aim`` — STAND still generates from the
+    precomputed grid stand_ts.
+
+    **Backfill path** — caller is the CLI; both precomputed values are
+    None. We re-run the grid classifier (for stand_ts) AND the
+    throw-localizer (for release_ts → AIM_TS). Cost: 1 grid call + 1-2
+    throw-timing calls per lineup. Stand- and aim-side failures are tallied
+    independently.
 
     Per-side independence: a stand-side failure NEVER rolls back the
     already-committed aim side, and vice versa. Each side has its own
@@ -311,10 +409,14 @@ async def generate_micro_clips_for_lineup(
             backfill that batches per video). When None the video is
             re-fetched into *download_dir* and deleted afterwards.
         download_dir: Required when *video_path* is None.
-        precomputed_stand_ts / precomputed_aim_ts: Ingest path — pass the
-            ``timestamps[stand_idx]`` / ``timestamps[aim_idx]`` the
-            orchestrator already computed. Either both set or both None;
-            mixed is a wiring bug.
+        precomputed_stand_ts: Ingest path — ``timestamps[stand_idx]`` from
+            the grid classifier output the orchestrator already has.
+            Backfill path — None; generator re-runs the grid classifier.
+        precomputed_release_ts: Ingest path — the throw-localizer's release
+            frame timestamp (from clip_generator's returned ClipGenerationResult).
+            None when the orchestrator's THROW clip step skipped/failed
+            (AIM is then skipped too). Backfill path — None; generator
+            runs the throw-localizer itself.
 
     Returns:
         MicroClipGenerationResult — never raises for expected failures.
@@ -333,20 +435,27 @@ async def generate_micro_clips_for_lineup(
             aim_skip_reason="no_source_video",
         )
 
-    # Validate the precomputed pair — either both supplied or both None.
-    if (precomputed_stand_ts is None) != (precomputed_aim_ts is None):
+    # Two valid input shapes:
+    #   - Backfill: both precomputed values None → generator runs both
+    #     classifier pipelines internally.
+    #   - Ingest:  precomputed_stand_ts set; precomputed_release_ts MAY be
+    #     None (when the orchestrator's THROW clip step skipped/failed —
+    #     STAND still generates, AIM is skipped).
+    # The only invalid shape is "stand None but release set", which would
+    # mean the caller has release_ts without stand_ts — a wiring bug. There
+    # is no concept of "AIM-only" without STAND on the ingest path.
+    if precomputed_stand_ts is None and precomputed_release_ts is not None:
         logger.warning(
-            "micro_clip_generator: lineup %s — precomputed_stand_ts / "
-            "precomputed_aim_ts must both be set or both None; got "
-            "stand=%s aim=%s",
-            lineup.id, precomputed_stand_ts, precomputed_aim_ts,
+            "micro_clip_generator: lineup %s — precomputed_release_ts set "
+            "without precomputed_stand_ts; got stand=None release=%s",
+            lineup.id, precomputed_release_ts,
         )
         return MicroClipGenerationResult(
             stand_status="failed",
             aim_status="failed",
             stand_error_codes=["precomputed_pair_mismatch"],
             aim_error_codes=["precomputed_pair_mismatch"],
-            reasoning="precomputed stand/aim timestamps must be paired",
+            reasoning="precomputed_release_ts requires precomputed_stand_ts",
         )
 
     owns_video = video_path is None
@@ -385,12 +494,37 @@ async def generate_micro_clips_for_lineup(
                 )
 
         # ---- Resolve anchor timestamps ------------------------------------
+        # STAND and AIM resolve independently:
+        #   - STAND comes from the grid classifier (precomputed on ingest;
+        #     re-run on backfill).
+        #   - AIM comes from release_ts − _AIM_PRE_RELEASE_SECONDS, where
+        #     release_ts is from the throw-localizer (precomputed on ingest;
+        #     re-run on backfill).
+        # Either side can independently end up "skipped" with structured
+        # reasoning so the operator can see why per-side without inspecting
+        # logs. The other side still runs normally.
+        stand_ts: Optional[float] = None
+        aim_ts: Optional[float] = None
+        stand_skip_reason: Optional[str] = None
+        aim_skip_reason: Optional[str] = None
+        stand_err_codes: list[str] = []
+        aim_err_codes: list[str] = []
+        reasoning_parts: list[str] = []
+
         if precomputed_stand_ts is not None:
+            # Ingest path — caller already has both sides' Claude output.
             stand_ts = float(precomputed_stand_ts)
-            aim_ts = float(precomputed_aim_ts)  # type: ignore[arg-type]
-            reasoning = ""
+            if precomputed_release_ts is not None:
+                aim_ts = float(precomputed_release_ts) - _AIM_PRE_RELEASE_SECONDS
+            else:
+                # Orchestrator's THROW clip step skipped/failed — STAND
+                # generates, AIM is skipped (the previous grid-based AIM
+                # was unreliable; refusing is preferable to faking).
+                aim_skip_reason = "no_release_ts_for_aim"
         else:
-            # Backfill path — re-run the grid classifier.
+            # Backfill path — generator orchestrates both classifier passes
+            # itself. Stand and aim resolve independently so a failure on
+            # one side doesn't poison the other.
             if not settings.enable_classifier:
                 return MicroClipGenerationResult(
                     stand_status="skipped",
@@ -408,32 +542,48 @@ async def generate_micro_clips_for_lineup(
                     reasoning="anthropic_api_key not configured",
                 )
 
-            (
-                stand_ts,
-                aim_ts,
-                err_codes,
-                reasoning,
-            ) = await _resolve_anchor_timestamps_via_classifier(
-                db, lineup, local_video, chapter_start, chapter_end,
-            )
-            if stand_ts is None or aim_ts is None:
-                # Either real failure (err_codes set) or "not a lineup"
-                # backfill regression (err_codes empty, skip cleanly).
-                if err_codes:
-                    return MicroClipGenerationResult(
-                        stand_status="failed",
-                        aim_status="failed",
-                        stand_error_codes=list(err_codes),
-                        aim_error_codes=list(err_codes),
-                        reasoning=reasoning,
-                    )
-                return MicroClipGenerationResult(
-                    stand_status="skipped",
-                    aim_status="skipped",
-                    stand_skip_reason="backfill_not_a_lineup",
-                    aim_skip_reason="backfill_not_a_lineup",
-                    reasoning=reasoning,
+            # STAND from grid classifier.
+            stand_ts, stand_err_codes, stand_reasoning = (
+                await _resolve_stand_ts_via_grid_classifier(
+                    db, lineup, local_video, chapter_start, chapter_end,
                 )
+            )
+            if stand_reasoning:
+                reasoning_parts.append(f"stand: {stand_reasoning}")
+            if stand_ts is None and not stand_err_codes:
+                stand_skip_reason = "backfill_not_a_lineup"
+
+            # AIM from throw-localizer (independent — runs even if stand failed).
+            release_ts, aim_err_codes, aim_reasoning = (
+                await _resolve_release_ts_via_throw_localizer(
+                    lineup, local_video, chapter_start, chapter_end,
+                )
+            )
+            if aim_reasoning:
+                reasoning_parts.append(f"aim: {aim_reasoning}")
+            if release_ts is not None:
+                aim_ts = release_ts - _AIM_PRE_RELEASE_SECONDS
+            elif not aim_err_codes:
+                aim_skip_reason = "backfill_no_throw_release"
+
+        reasoning = " | ".join(reasoning_parts) if reasoning_parts else ""
+
+        # Hard fail-out only when BOTH sides resolved to nothing AND both
+        # have hard errors — the symmetric ingest-skipped case (no release
+        # → AIM skipped, STAND generates) must not be turned into a failure.
+        if (
+            stand_ts is None
+            and aim_ts is None
+            and stand_err_codes
+            and aim_err_codes
+        ):
+            return MicroClipGenerationResult(
+                stand_status="failed",
+                aim_status="failed",
+                stand_error_codes=list(stand_err_codes),
+                aim_error_codes=list(aim_err_codes),
+                reasoning=reasoning,
+            )
 
         # Compute the wider-source start the served 1s clip's offset will be
         # measured against. The micro-clip "shift window" editor (PR2) reads
@@ -463,26 +613,45 @@ async def generate_micro_clips_for_lineup(
             wider_source_start_s = source_start
 
         # ---- Cut + upload + persist each side independently ---------------
-        stand_outcome = await _cut_upload_persist_one_side(
-            db, lineup, video_id, local_video,
-            anchor_ts=stand_ts,
-            chapter_start=chapter_start,
-            chapter_end=chapter_end,
-            side="stand",
-            key_fn=pending_stand_clip_key,
-            persist_fn=lineup_repo.set_stand_clip_url,
-            wider_source_start_s=wider_source_start_s,
-        )
-        aim_outcome = await _cut_upload_persist_one_side(
-            db, lineup, video_id, local_video,
-            anchor_ts=aim_ts,
-            chapter_start=chapter_start,
-            chapter_end=chapter_end,
-            side="aim",
-            key_fn=pending_aim_clip_key,
-            persist_fn=lineup_repo.set_aim_clip_url,
-            wider_source_start_s=wider_source_start_s,
-        )
+        # A None anchor_ts means the side's resolution step already decided
+        # to skip / fail this side. Short-circuit before the cut so we don't
+        # ffmpeg-attempt against missing data; the outcome dict matches the
+        # _cut_upload_persist_one_side shape so the result composition below
+        # is unchanged.
+        if stand_ts is None:
+            stand_outcome = {
+                "status": "failed" if stand_err_codes else "skipped",
+                "error_codes": list(stand_err_codes),
+                "skip_reason": stand_skip_reason,
+            }
+        else:
+            stand_outcome = await _cut_upload_persist_one_side(
+                db, lineup, video_id, local_video,
+                anchor_ts=stand_ts,
+                chapter_start=chapter_start,
+                chapter_end=chapter_end,
+                side="stand",
+                key_fn=pending_stand_clip_key,
+                persist_fn=lineup_repo.set_stand_clip_url,
+                wider_source_start_s=wider_source_start_s,
+            )
+        if aim_ts is None:
+            aim_outcome = {
+                "status": "failed" if aim_err_codes else "skipped",
+                "error_codes": list(aim_err_codes),
+                "skip_reason": aim_skip_reason,
+            }
+        else:
+            aim_outcome = await _cut_upload_persist_one_side(
+                db, lineup, video_id, local_video,
+                anchor_ts=aim_ts,
+                chapter_start=chapter_start,
+                chapter_end=chapter_end,
+                side="aim",
+                key_fn=pending_aim_clip_key,
+                persist_fn=lineup_repo.set_aim_clip_url,
+                wider_source_start_s=wider_source_start_s,
+            )
 
         return MicroClipGenerationResult(
             stand_status=stand_outcome["status"],

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_helpers.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_helpers.py
@@ -1,0 +1,273 @@
+"""Internal helpers for :mod:`micro_clip_generator` — kept in a sibling
+module so the generator stays under the file-size growth guard (the
+generator was already over the 500-LOC threshold; growth requires a
+matching split per TECH_DEBT.md "no-growth on flagged files").
+
+What lives here:
+  - ``_resolve_stand_ts_via_grid_classifier`` — backfill stand anchor.
+  - ``_resolve_release_ts_via_throw_localizer`` — backfill aim anchor.
+  - ``_cut_upload_persist_one_side`` — per-side ffmpeg cut + MinIO upload
+    + repo commit (shared by both stand and aim).
+
+The generator imports these directly; no re-export shim is needed because
+they are private (``_``-prefixed) and the only caller is the generator
+module. Tests patch them via the generator's ``_MOD`` because the generator
+re-binds the names at import time.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.storage import get_storage
+from app.models.game.lineup import Lineup
+from app.services.classification.classifier_service import (
+    classify_frames_for_lineup_decision,
+)
+from app.services.ingestion.frame_extractor import (
+    ClipCutError,
+    FrameExtractionError,
+    cut_clip,
+    extract_frames,
+    grid_timestamps,
+)
+from app.services.ingestion.throw_localizer import (
+    localize_throw_with_refinement,
+)
+
+logger = logging.getLogger(__name__)
+
+# Grid sample count + edge padding — must match the ingest orchestrator's
+# ingestion_orchestrator._GRID_FRAME_COUNT / _GRID_EDGE_PADDING_SECONDS so
+# the backfill recovers the SAME timestamps the ingest pass extracted.
+_GRID_FRAME_COUNT = 9
+_GRID_EDGE_PADDING_SECONDS = 1.0
+
+
+async def _resolve_stand_ts_via_grid_classifier(
+    db: AsyncSession,
+    lineup: Lineup,
+    video_path: Path,
+    chapter_start: float,
+    chapter_end: float,
+) -> tuple[Optional[float], list[str], str]:
+    """Backfill helper: re-run the grid classifier to recover stand_ts.
+
+    Returns ``(stand_ts, error_codes, reasoning)``. The grid classifier also
+    returns an ``aim_idx`` but it is intentionally discarded — AIM_TS is now
+    derived from release_ts (see micro_clip_generator module docstring); the
+    grid pass is too sparse to localise the sub-second aim moment. STAND is
+    unaffected because the standing-at-spot window is many seconds long.
+    """
+    timestamps = grid_timestamps(
+        float(chapter_start),
+        float(chapter_end),
+        _GRID_FRAME_COUNT,
+        edge_padding_seconds=_GRID_EDGE_PADDING_SECONDS,
+    )
+    if not timestamps:
+        return None, ["empty_grid_window"], "chapter window produced no grid frames"
+
+    try:
+        frames = await extract_frames(video_path, timestamps)
+    except FrameExtractionError as exc:
+        logger.warning(
+            "micro_clip_helpers: grid frame extraction failed: "
+            "lineup=%s returncode=%s stderr=%s",
+            lineup.id, exc.returncode, exc.stderr[:300],
+        )
+        return None, [f"frame_extract:rc={exc.returncode}"], str(exc)
+
+    if not frames:
+        return None, ["grid_frames_empty"], "ffmpeg returned no frames"
+
+    try:
+        result = await classify_frames_for_lineup_decision(
+            db,
+            frames=frames,
+            chapter_title=lineup.chapter_title or "",
+            attribution_author=lineup.attribution_author,
+            game_hint=None,
+        )
+    except Exception as exc:
+        logger.warning(
+            "micro_clip_helpers: grid classifier raised: lineup=%s error=%s",
+            lineup.id, str(exc),
+        )
+        return None, [f"classifier_raised:{type(exc).__name__}"], str(exc)
+
+    if not result.success:
+        logger.warning(
+            "micro_clip_helpers: grid classifier call failed: lineup=%s "
+            "error_codes=%s",
+            lineup.id, result.error_codes,
+        )
+        return None, list(result.error_codes), "grid classifier reported failure"
+
+    if not result.is_lineup:
+        # Accepted lineup but classifier says "not a lineup" → keep the
+        # signal but skip cleanly rather than fabricate a timestamp.
+        return None, [], "backfill grid says not_a_lineup (skip)"
+
+    # 1-based → 0-based, clamped to the grid range. Falls back to first
+    # index when the model omitted it (mirrors orchestrator's fallback).
+    stand_idx = (result.best_stand_index or 1) - 1
+    stand_idx = max(0, min(stand_idx, len(timestamps) - 1))
+    return timestamps[stand_idx], [], result.reasoning or ""
+
+
+async def _resolve_release_ts_via_throw_localizer(
+    lineup: Lineup,
+    video_path: Path,
+    chapter_start: float,
+    chapter_end: float,
+) -> tuple[Optional[float], list[str], str]:
+    """Backfill helper: run the throw-timing classifier to recover release_ts.
+
+    Returns ``(release_ts, error_codes, reasoning)``. AIM_TS is then
+    ``release_ts - _AIM_PRE_RELEASE_SECONDS`` in the caller. A non-throw or
+    no-release verdict surfaces as ``([], reasoning)`` (skip cleanly) — the
+    AIM clip is best-effort.
+    """
+    try:
+        refined = await localize_throw_with_refinement(
+            video_path,
+            chapter_start=float(chapter_start),
+            chapter_end=float(chapter_end),
+            chapter_title=lineup.chapter_title or "",
+            utility_hint=None,
+        )
+    except FrameExtractionError as exc:
+        logger.warning(
+            "micro_clip_helpers: throw localizer extract failed: "
+            "lineup=%s returncode=%s stderr=%s",
+            lineup.id, exc.returncode, exc.stderr[:300],
+        )
+        return None, [f"throw_localizer_extract:rc={exc.returncode}"], str(exc)
+    except Exception as exc:  # defensive
+        logger.warning(
+            "micro_clip_helpers: throw localizer raised: lineup=%s error=%s",
+            lineup.id, str(exc),
+        )
+        return None, [f"throw_localizer_raised:{type(exc).__name__}"], str(exc)
+
+    timing = refined.timing
+    if not timing.success:
+        logger.warning(
+            "micro_clip_helpers: throw localizer call failed: lineup=%s "
+            "error_codes=%s",
+            lineup.id, timing.error_codes,
+        )
+        return None, list(timing.error_codes), "throw localizer reported failure"
+
+    if not timing.is_lineup_throw or timing.release_index is None:
+        return None, [], "throw localizer found no usable release frame"
+
+    release_ts = refined.frame_timestamps[timing.release_index - 1]
+    return release_ts, [], timing.reasoning or ""
+
+
+async def _cut_upload_persist_one_side(
+    db: AsyncSession,
+    lineup: Lineup,
+    video_id: str,
+    local_video: Path,
+    *,
+    anchor_ts: float,
+    clip_seconds: float,
+    chapter_start: float,
+    chapter_end: float,
+    side: str,
+    key_fn,
+    persist_fn,
+    wider_source_start_s: float | None = None,
+    min_clip_seconds: float,
+) -> dict:
+    """Cut + upload + persist exactly ONE side (stand or aim).
+
+    Returns a flat dict consumed by the generator — not a dataclass because
+    the caller flattens the two sides into the composite
+    ``MicroClipGenerationResult``. Same shape for both sides so a future
+    third pane (unlikely) could be added without touching this function.
+
+    *wider_source_start_s* is the seconds-into-source-video start of the
+    SHARED wider clip (``clip_url_original``) the operator's shift-window
+    slider will be positioned against. When set, this function computes
+    ``offset_s = clip_start - wider_source_start_s`` and persists it via the
+    setter's ``offset_s=`` kwarg. When None, offset is left untouched.
+    """
+    start = max(float(anchor_ts), float(chapter_start))
+    end = min(start + float(clip_seconds), float(chapter_end))
+    duration = end - start
+    if duration < min_clip_seconds:
+        return {
+            "status": "skipped",
+            "skip_reason": "chapter_too_short_for_microclip",
+        }
+    clip_start, clip_duration = start, duration
+
+    try:
+        clip_bytes = await cut_clip(local_video, clip_start, clip_duration)
+    except ClipCutError as exc:
+        logger.warning(
+            "micro_clip_helpers: %s clip cut failed: lineup=%s video_id=%s "
+            "start=%.2f dur=%.2f returncode=%s stderr=%s",
+            side, lineup.id, video_id, clip_start, clip_duration,
+            exc.returncode, exc.stderr[:300],
+        )
+        return {
+            "status": "failed",
+            "error_codes": [f"clip_cut:rc={exc.returncode}"],
+        }
+
+    clip_key = key_fn(video_id, chapter_start)
+    try:
+        storage = get_storage()
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None, storage.upload_file, clip_key, clip_bytes, "video/mp4"
+        )
+    except Exception as exc:
+        logger.warning(
+            "micro_clip_helpers: %s clip upload failed: lineup=%s key=%s "
+            "error=%s",
+            side, lineup.id, clip_key, str(exc),
+        )
+        return {
+            "status": "failed",
+            "error_codes": ["clip_upload_failed"],
+        }
+
+    offset_s: float | None = (
+        clip_start - wider_source_start_s
+        if wider_source_start_s is not None
+        else None
+    )
+
+    try:
+        await persist_fn(db, lineup, clip_key, offset_s=offset_s)
+    except Exception as exc:
+        # Object uploaded but column didn't commit. Key is deterministic so
+        # backfill recomputes the same key and overwrites — no orphan.
+        logger.warning(
+            "micro_clip_helpers: %s_clip_url persist failed (object uploaded, "
+            "column not committed; backfill is idempotent): lineup=%s key=%s "
+            "error=%s",
+            side, lineup.id, clip_key, str(exc),
+        )
+        return {
+            "status": "failed",
+            "error_codes": [f"{side}_clip_url_persist_failed"],
+        }
+
+    logger.info(
+        "micro_clip_helpers: %s clip generated: lineup=%s video_id=%s "
+        "key=%s anchor_ts=%.2f clip=[%.2f,+%.2fs]",
+        side, lineup.id, video_id, clip_key, anchor_ts,
+        clip_start, clip_duration,
+    )
+    return {"status": "generated", "clip_key": clip_key}

--- a/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
@@ -20,13 +20,16 @@ import pytest
 
 from app.services.classification.classification_result import (
     ClassificationResult,
+    ThrowTimingResult,
 )
+from app.services.ingestion.throw_localizer import RefinedThrowTiming
 from app.services.ingestion.frame_extractor import (
     ClipCutError,
     FrameExtractionError,
 )
 from app.services.ingestion.micro_clip_generator import (
     _AIM_MICRO_CLIP_SECONDS,
+    _AIM_PRE_RELEASE_SECONDS,
     _STAND_MICRO_CLIP_SECONDS,
     _compute_micro_bounds,
     _micro_clip_seconds_for_side,
@@ -204,7 +207,8 @@ async def test_ingest_path_generates_both_clips_without_classifier_call():
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
             precomputed_stand_ts=12.0,
-            precomputed_aim_ts=24.0,
+            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
+            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
         )
 
     assert result.stand_status == "generated"
@@ -223,21 +227,65 @@ async def test_ingest_path_generates_both_clips_without_classifier_call():
 
 
 @pytest.mark.asyncio
-async def test_ingest_path_mixed_precomputed_is_wiring_bug():
-    """One side precomputed, the other None → caller error (both fail)."""
+async def test_ingest_path_release_without_stand_is_wiring_bug():
+    """release_ts set without stand_ts → caller error (both fail).
+
+    Post-2026-05-23: the validation surface changed. AIM-without-STAND is
+    not a meaningful ingest shape (the orchestrator always knows stand_idx
+    when it knows release_ts), so this is the only mixed-precomputed case
+    left that's a true wiring bug. STAND-without-RELEASE is now a normal
+    partial-ingest case (clip generation skipped/failed; AIM skips cleanly).
+    """
     db = AsyncMock()
     lineup = _lineup()
     result = await generate_micro_clips_for_lineup(
         db, lineup,
         chapter_start=10.0, chapter_end=40.0,
         video_path=Path("/tmp/x.mp4"),
-        precomputed_stand_ts=12.0,
-        precomputed_aim_ts=None,  # missing!
+        precomputed_stand_ts=None,  # missing!
+        precomputed_release_ts=24.8,
     )
     assert result.stand_status == "failed"
     assert result.aim_status == "failed"
     assert "precomputed_pair_mismatch" in result.stand_error_codes
     assert "precomputed_pair_mismatch" in result.aim_error_codes
+
+
+@pytest.mark.asyncio
+async def test_ingest_path_stand_only_generates_stand_skips_aim():
+    """precomputed_stand_ts set, precomputed_release_ts None → STAND
+    generates from grid; AIM is skipped with no_release_ts_for_aim.
+
+    This is the partial-ingest case: the orchestrator's THROW clip step
+    skipped or failed, so release_ts is not available. STAND still
+    benefits from the grid pass (which is reliable for STAND) — refusing
+    AIM is preferable to faking it with the previously-random grid aim_idx.
+    """
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_stand_mock = AsyncMock(return_value=lineup)
+    set_aim_mock = AsyncMock(return_value=lineup)
+
+    with (
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
+        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=40.0,
+            video_path=Path("/tmp/x.mp4"),
+            precomputed_stand_ts=12.0,
+            precomputed_release_ts=None,
+        )
+
+    assert result.stand_status == "generated"
+    assert result.aim_status == "skipped"
+    assert result.aim_skip_reason == "no_release_ts_for_aim"
+    set_stand_mock.assert_awaited_once()
+    set_aim_mock.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -250,7 +298,8 @@ async def test_ingest_path_chapter_too_short_skips_both():
         chapter_start=19.9, chapter_end=20.3,
         video_path=Path("/tmp/x.mp4"),
         precomputed_stand_ts=20.0,
-        precomputed_aim_ts=20.1,
+        # AIM_TS = release_ts - 0.8 = 20.1
+        precomputed_release_ts=20.1 + _AIM_PRE_RELEASE_SECONDS,
     )
     assert result.stand_status == "skipped"
     assert result.aim_status == "skipped"
@@ -279,15 +328,53 @@ def _grid(**kw):
     return ClassificationResult(**base)
 
 
+def _refined(release_ts=30.8, **kw):
+    """Build a RefinedThrowTiming with the given release_ts.
+
+    Sets up so the throw_localizer mock returns release_index=1 +
+    frame_timestamps=[release_ts] — caller-side ``release_ts =
+    frame_timestamps[release_index - 1]`` resolves to the wanted value.
+    """
+    timing = ThrowTimingResult(
+        success=True,
+        is_lineup_throw=True,
+        release_index=1,
+        result_index=1,
+        confidence=0.9,
+        reasoning="ok",
+        error_codes=[],
+    )
+    base = dict(
+        timing=timing,
+        frame_timestamps=[release_ts],
+        stage="refined",
+        coarse_timing=None,
+    )
+    base.update(kw)
+    return RefinedThrowTiming(**base)
+
+
+def _localizer_mock(refined=None, **refined_kw):
+    """Mock for localize_throw_with_refinement. AsyncMock returning ``refined``."""
+    if refined is None:
+        refined = _refined(**refined_kw)
+    return AsyncMock(return_value=refined)
+
+
 @pytest.mark.asyncio
 async def test_backfill_path_runs_classifier_and_generates():
+    """Backfill runs grid (stand) + throw_localizer (release → aim) and
+    generates both clips. STAND from grid_timestamps[stand_idx]; AIM from
+    release_ts − _AIM_PRE_RELEASE_SECONDS."""
     db = AsyncMock()
     lineup = _lineup()
     storage = _storage_mock()
     set_stand_mock = AsyncMock(return_value=lineup)
     set_aim_mock = AsyncMock(return_value=lineup)
-    grid = _grid(best_stand_index=2, best_aim_index=5)
+    grid = _grid(best_stand_index=2)
     timestamps = [12.0, 18.0, 24.0, 30.0, 36.0]
+    # release_ts = 36.8 → AIM_TS = 36.0
+    refined = _refined(release_ts=36.0 + _AIM_PRE_RELEASE_SECONDS)
 
     with (
         patch(f"{_MOD}.settings", _settings()),
@@ -296,6 +383,8 @@ async def test_backfill_path_runs_classifier_and_generates():
               AsyncMock(return_value=[_FAKE_PNG] * 5)),
         patch(f"{_MOD}.classify_frames_for_lineup_decision",
               AsyncMock(return_value=grid)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              _localizer_mock(refined=refined)),
         patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
         patch(f"{_MOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
@@ -311,17 +400,23 @@ async def test_backfill_path_runs_classifier_and_generates():
     assert result.stand_status == "generated"
     assert result.aim_status == "generated"
     # best_stand_index 2 (1-based) → timestamps[1] = 18.0.
-    # best_aim_index 5 (1-based) → timestamps[4] = 36.0.
+    # AIM = release_ts (36.8) − 0.8 = 36.0.
     assert result.stand_ts == pytest.approx(18.0)
     assert result.aim_ts == pytest.approx(36.0)
 
 
 @pytest.mark.asyncio
-async def test_backfill_path_skips_not_a_lineup():
+async def test_backfill_path_grid_not_a_lineup_skips_stand_but_aim_independent():
+    """Grid says not_a_lineup → STAND skips. Throw localizer still runs
+    independently (it's a separate Claude pass with its own decision).
+    Here we let throw_localizer succeed → AIM still generates."""
     db = AsyncMock()
     lineup = _lineup()
+    storage = _storage_mock()
+    set_aim_mock = AsyncMock(return_value=lineup)
     grid = _grid(is_lineup=False, best_stand_index=None, best_aim_index=None)
     timestamps = [12.0, 18.0, 24.0]
+    refined = _refined(release_ts=22.0 + _AIM_PRE_RELEASE_SECONDS)
 
     with (
         patch(f"{_MOD}.settings", _settings()),
@@ -330,6 +425,11 @@ async def test_backfill_path_skips_not_a_lineup():
               AsyncMock(return_value=[_FAKE_PNG] * 3)),
         patch(f"{_MOD}.classify_frames_for_lineup_decision",
               AsyncMock(return_value=grid)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              _localizer_mock(refined=refined)),
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
         result = await generate_micro_clips_for_lineup(
             db, lineup,
@@ -337,9 +437,51 @@ async def test_backfill_path_skips_not_a_lineup():
             video_path=Path("/tmp/x.mp4"),
         )
     assert result.stand_status == "skipped"
-    assert result.aim_status == "skipped"
     assert result.stand_skip_reason == "backfill_not_a_lineup"
-    assert result.aim_skip_reason == "backfill_not_a_lineup"
+    assert result.aim_status == "generated"
+    assert result.aim_ts == pytest.approx(22.0)
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_throw_localizer_no_release_skips_aim_but_stand_independent():
+    """Throw localizer says not-a-throw / no release → AIM skips cleanly.
+    Grid still runs independently — STAND still generates."""
+    db = AsyncMock()
+    lineup = _lineup()
+    storage = _storage_mock()
+    set_stand_mock = AsyncMock(return_value=lineup)
+    grid = _grid(best_stand_index=2)
+    timestamps = [12.0, 18.0, 24.0]
+    not_a_throw = ThrowTimingResult(
+        success=True, is_lineup_throw=False,
+        release_index=None, result_index=None,
+        confidence=0.1, reasoning="no throw", error_codes=[],
+    )
+    refined = _refined(release_ts=99.0)
+    refined.timing = not_a_throw
+
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames",
+              AsyncMock(return_value=[_FAKE_PNG] * 3)),
+        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+              AsyncMock(return_value=grid)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              _localizer_mock(refined=refined)),
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=10.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.stand_status == "generated"
+    assert result.stand_ts == pytest.approx(18.0)
+    assert result.aim_status == "skipped"
+    assert result.aim_skip_reason == "backfill_no_throw_release"
 
 
 @pytest.mark.asyncio
@@ -375,14 +517,20 @@ async def test_backfill_path_classifier_missing_key_skips_both():
 
 
 @pytest.mark.asyncio
-async def test_backfill_path_classifier_api_failure_returns_failed():
+async def test_backfill_path_grid_classifier_api_failure_fails_stand_aim_independent():
+    """Grid call fails (overloaded) → STAND fails with the structured code.
+    Throw localizer is separate; here it succeeds and AIM still generates."""
     db = AsyncMock()
     lineup = _lineup()
+    storage = _storage_mock()
+    set_aim_mock = AsyncMock(return_value=lineup)
     grid = ClassificationResult(
         success=False, error_codes=["overloaded_error"],
         reasoning="rate limited",
     )
     timestamps = [12.0, 18.0, 24.0]
+    refined = _refined(release_ts=22.0 + _AIM_PRE_RELEASE_SECONDS)
+
     with (
         patch(f"{_MOD}.settings", _settings()),
         patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
@@ -390,6 +538,53 @@ async def test_backfill_path_classifier_api_failure_returns_failed():
               AsyncMock(return_value=[_FAKE_PNG] * 3)),
         patch(f"{_MOD}.classify_frames_for_lineup_decision",
               AsyncMock(return_value=grid)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              _localizer_mock(refined=refined)),
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
+    ):
+        result = await generate_micro_clips_for_lineup(
+            db, lineup,
+            chapter_start=0.0, chapter_end=30.0,
+            video_path=Path("/tmp/x.mp4"),
+        )
+    assert result.stand_status == "failed"
+    assert "overloaded_error" in result.stand_error_codes
+    assert result.aim_status == "generated"
+
+
+@pytest.mark.asyncio
+async def test_backfill_path_both_classifiers_fail_returns_both_failed():
+    """When BOTH the grid call and the throw localizer fail with API errors,
+    both sides fail with structured codes (no fabrication)."""
+    db = AsyncMock()
+    lineup = _lineup()
+    grid = ClassificationResult(
+        success=False, error_codes=["overloaded_error"],
+        reasoning="rate limited",
+    )
+    bad_timing = ThrowTimingResult(
+        success=False, error_codes=["rate_limit_error"],
+        reasoning="rate limited",
+    )
+    refined = RefinedThrowTiming(
+        timing=bad_timing,
+        frame_timestamps=[],
+        stage="coarse_failed",
+        coarse_timing=bad_timing,
+    )
+    timestamps = [12.0, 18.0, 24.0]
+
+    with (
+        patch(f"{_MOD}.settings", _settings()),
+        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_MOD}.extract_frames",
+              AsyncMock(return_value=[_FAKE_PNG] * 3)),
+        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+              AsyncMock(return_value=grid)),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              _localizer_mock(refined=refined)),
     ):
         result = await generate_micro_clips_for_lineup(
             db, lineup,
@@ -399,14 +594,20 @@ async def test_backfill_path_classifier_api_failure_returns_failed():
     assert result.stand_status == "failed"
     assert result.aim_status == "failed"
     assert "overloaded_error" in result.stand_error_codes
-    assert "overloaded_error" in result.aim_error_codes
+    assert "rate_limit_error" in result.aim_error_codes
 
 
 @pytest.mark.asyncio
-async def test_backfill_path_frame_extract_failure_returns_failed():
+async def test_backfill_path_grid_frame_extract_failure_fails_stand_only():
+    """Grid extract fails → STAND fails; throw_localizer is independent.
+    Here the localizer succeeds → AIM generates."""
     db = AsyncMock()
     lineup = _lineup()
+    storage = _storage_mock()
+    set_aim_mock = AsyncMock(return_value=lineup)
     timestamps = [12.0, 18.0, 24.0]
+    refined = _refined(release_ts=22.0 + _AIM_PRE_RELEASE_SECONDS)
+
     with (
         patch(f"{_MOD}.settings", _settings()),
         patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
@@ -416,6 +617,11 @@ async def test_backfill_path_frame_extract_failure_returns_failed():
                 "boom", timestamp=18.0, returncode=1, stderr="x",
             )),
         ),
+        patch(f"{_MOD}.localize_throw_with_refinement",
+              _localizer_mock(refined=refined)),
+        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
         result = await generate_micro_clips_for_lineup(
             db, lineup,
@@ -423,8 +629,8 @@ async def test_backfill_path_frame_extract_failure_returns_failed():
             video_path=Path("/tmp/x.mp4"),
         )
     assert result.stand_status == "failed"
-    assert result.aim_status == "failed"
     assert any("frame_extract" in c for c in result.stand_error_codes)
+    assert result.aim_status == "generated"
 
 
 @pytest.mark.asyncio
@@ -507,7 +713,8 @@ async def test_stand_cut_failure_does_not_affect_aim():
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
             precomputed_stand_ts=12.0,
-            precomputed_aim_ts=24.0,
+            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
+            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
         )
 
     assert result.stand_status == "failed"
@@ -571,7 +778,8 @@ async def test_offset_persisted_when_wider_source_exists():
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
             precomputed_stand_ts=12.0,  # → offset 12 - (10 - 2) = 4.0
-            precomputed_aim_ts=30.0,    # → offset 30 - 8 = 22.0
+            # AIM_TS = release_ts - 0.8 = 30.0; → offset 30 - 8 = 22.0
+            precomputed_release_ts=30.0 + _AIM_PRE_RELEASE_SECONDS,
         )
 
     stand_call = set_stand_mock.await_args
@@ -613,7 +821,8 @@ async def test_offset_not_persisted_when_no_wider_source():
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
             precomputed_stand_ts=12.0,
-            precomputed_aim_ts=24.0,
+            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
+            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
         )
 
     assert _offset_kwarg(set_stand_mock.await_args) is None
@@ -648,7 +857,8 @@ async def test_offset_not_persisted_when_original_matches_clip():
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
             precomputed_stand_ts=12.0,
-            precomputed_aim_ts=24.0,
+            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
+            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
         )
 
     assert _offset_kwarg(set_stand_mock.await_args) is None
@@ -679,7 +889,8 @@ async def test_stand_persist_failure_does_not_affect_aim():
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
             precomputed_stand_ts=12.0,
-            precomputed_aim_ts=24.0,
+            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
+            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
         )
     assert result.stand_status == "failed"
     assert "stand_clip_url_persist_failed" in result.stand_error_codes
@@ -702,7 +913,8 @@ async def test_upload_failure_per_side_returns_failed():
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
             precomputed_stand_ts=12.0,
-            precomputed_aim_ts=24.0,
+            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
+            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
         )
     # Storage down → both sides fail (same underlying fault per side).
     assert result.stand_status == "failed"

--- a/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
@@ -40,6 +40,9 @@ from app.services.ingestion.micro_clip_generator import (
 from app.services.ingestion.youtube_fetcher import VideoDownloadError
 
 _MOD = "app.services.ingestion.micro_clip_generator"
+# Most ffmpeg / storage / classifier / repo calls now live in the sibling
+# helpers module (PR #761). Patches that target those resolve here.
+_HMOD = "app.services.ingestion.micro_clip_helpers"
 _FAKE_PNG = b"\x89PNG\r\n\x1a\n"
 _FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
 
@@ -196,11 +199,11 @@ async def test_ingest_path_generates_both_clips_without_classifier_call():
     classifier_mock = AsyncMock()  # MUST NOT be called
 
     with (
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()) as cut,
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()) as cut,
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
-        patch(f"{_MOD}.classify_frames_for_lineup_decision", classifier_mock),
+        patch(f"{_HMOD}.classify_frames_for_lineup_decision", classifier_mock),
     ):
         result = await generate_micro_clips_for_lineup(
             db, lineup,
@@ -268,8 +271,8 @@ async def test_ingest_path_stand_only_generates_stand_skips_aim():
     set_aim_mock = AsyncMock(return_value=lineup)
 
     with (
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
@@ -378,15 +381,15 @@ async def test_backfill_path_runs_classifier_and_generates():
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames",
+        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_HMOD}.extract_frames",
               AsyncMock(return_value=[_FAKE_PNG] * 5)),
-        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
               AsyncMock(return_value=grid)),
-        patch(f"{_MOD}.localize_throw_with_refinement",
+        patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
@@ -420,15 +423,15 @@ async def test_backfill_path_grid_not_a_lineup_skips_stand_but_aim_independent()
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames",
+        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_HMOD}.extract_frames",
               AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
               AsyncMock(return_value=grid)),
-        patch(f"{_MOD}.localize_throw_with_refinement",
+        patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
         result = await generate_micro_clips_for_lineup(
@@ -462,15 +465,15 @@ async def test_backfill_path_throw_localizer_no_release_skips_aim_but_stand_inde
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames",
+        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_HMOD}.extract_frames",
               AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
               AsyncMock(return_value=grid)),
-        patch(f"{_MOD}.localize_throw_with_refinement",
+        patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
     ):
         result = await generate_micro_clips_for_lineup(
@@ -533,15 +536,15 @@ async def test_backfill_path_grid_classifier_api_failure_fails_stand_aim_indepen
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames",
+        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_HMOD}.extract_frames",
               AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
               AsyncMock(return_value=grid)),
-        patch(f"{_MOD}.localize_throw_with_refinement",
+        patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
         result = await generate_micro_clips_for_lineup(
@@ -578,12 +581,12 @@ async def test_backfill_path_both_classifiers_fail_returns_both_failed():
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_MOD}.extract_frames",
+        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_HMOD}.extract_frames",
               AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_MOD}.classify_frames_for_lineup_decision",
+        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
               AsyncMock(return_value=grid)),
-        patch(f"{_MOD}.localize_throw_with_refinement",
+        patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
     ):
         result = await generate_micro_clips_for_lineup(
@@ -610,17 +613,17 @@ async def test_backfill_path_grid_frame_extract_failure_fails_stand_only():
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_MOD}.grid_timestamps", return_value=timestamps),
+        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
         patch(
-            f"{_MOD}.extract_frames",
+            f"{_HMOD}.extract_frames",
             AsyncMock(side_effect=FrameExtractionError(
                 "boom", timestamp=18.0, returncode=1, stderr="x",
             )),
         ),
-        patch(f"{_MOD}.localize_throw_with_refinement",
+        patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
         result = await generate_micro_clips_for_lineup(
@@ -703,8 +706,8 @@ async def test_stand_cut_failure_does_not_affect_aim():
         return outcome
 
     with (
-        patch(f"{_MOD}.cut_clip", AsyncMock(side_effect=cut_clip_impl)),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", AsyncMock(side_effect=cut_clip_impl)),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
@@ -768,8 +771,8 @@ async def test_offset_persisted_when_wider_source_exists():
 
     with (
         patch(f"{_MOD}.settings", fake_settings),
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
@@ -811,8 +814,8 @@ async def test_offset_not_persisted_when_no_wider_source():
     set_aim_mock = AsyncMock(return_value=lineup)
 
     with (
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
@@ -847,8 +850,8 @@ async def test_offset_not_persisted_when_original_matches_clip():
     set_aim_mock = AsyncMock(return_value=lineup)
 
     with (
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
@@ -873,8 +876,8 @@ async def test_stand_persist_failure_does_not_affect_aim():
     storage = _storage_mock()
 
     with (
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(
             f"{_MOD}.lineup_repo.set_stand_clip_url",
             AsyncMock(side_effect=RuntimeError("db down")),
@@ -905,8 +908,8 @@ async def test_upload_failure_per_side_returns_failed():
     storage.upload_file = MagicMock(side_effect=RuntimeError("minio down"))
 
     with (
-        patch(f"{_MOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_MOD}.get_storage", return_value=storage),
+        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
+        patch(f"{_HMOD}.get_storage", return_value=storage),
     ):
         result = await generate_micro_clips_for_lineup(
             db, lineup,

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -149,16 +149,21 @@ describe("GlanceBoardTile storyboard (4 panes)", () => {
     expect(video.getAttribute("poster")).toBe("https://ex.com/stand.png");
   });
 
-  it("AIM pane zooms 2× centered on the persisted anchor coords (still variant)", () => {
+  it("AIM pane zooms 2× pinned to center regardless of persisted anchor coords", () => {
+    // Post-2026-05-23: anchor coords are ignored at render time — AIM_TS now
+    // derives from the throw-localizer's release_ts (not the grid frame the
+    // anchor was computed against), so trusting the coords would re-introduce
+    // drift. Crosshair in FPS is always at screen center, so origin is
+    // hardcoded to (50%, 50%).
     render(<GlanceBoardTile lineup={makeLineup({ aim_anchor_x: 0.5, aim_anchor_y: 0.4 })} />);
     const aimImg = screen.getByAltText(/aim reference/i) as HTMLImageElement;
     expect(aimImg.style.transform).toBe("scale(2)");
-    expect(aimImg.style.transformOrigin).toBe("50% 40%");
+    expect(aimImg.style.transformOrigin).toBe("50% 50%");
     // The red dot is gone — the zoomed crop is the affordance now.
     expect(screen.queryByLabelText(/aim anchor/i)).toBeNull();
   });
 
-  it("AIM pane falls back to center origin when anchor coords are null", () => {
+  it("AIM pane keeps the center origin even with null anchor coords", () => {
     render(
       <GlanceBoardTile
         lineup={makeLineup({ aim_anchor_x: null, aim_anchor_y: null })}
@@ -354,11 +359,11 @@ describe("GlanceBoardTile PR6 micro-clips (STAND + AIM)", () => {
     expect(aimVideo).not.toBeNull();
   });
 
-  it("AIM clip variant carries the same zoom transform as the still variant", () => {
-    // The AIM clip is anchored on the same classifier-chosen timestamp as the
-    // still — so the zoom origin from the persisted aim_anchor stays accurate
-    // when AimPane swaps from still to ClipView. This is the contract that
-    // protects the still→clip visual continuity.
+  it("AIM clip variant carries the same center-pinned 2× zoom as the still", () => {
+    // Both still and clip apply scale(2) at (50%, 50%). The AIM clip is now
+    // anchored on release_ts - 0.8s (throw-localizer), not the grid's aim
+    // frame, so trusting the persisted aim_anchor for zoom origin would
+    // introduce drift. Center-pin is the correct invariant.
     render(
       <GlanceBoardTile
         lineup={makeLineup({
@@ -373,7 +378,7 @@ describe("GlanceBoardTile PR6 micro-clips (STAND + AIM)", () => {
     ) as HTMLVideoElement;
     expect(aimVideo).not.toBeNull();
     expect(aimVideo.style.transform).toBe("scale(2)");
-    expect(aimVideo.style.transformOrigin).toBe("50% 40%");
+    expect(aimVideo.style.transformOrigin).toBe("50% 50%");
     expect(screen.queryByLabelText(/aim anchor/i)).toBeNull();
   });
 

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -124,16 +124,22 @@ describe("LineupCard", () => {
     expect(screen.getByText("8s")).toBeDefined();
   });
 
-  it("expanded variant AIM still zooms 2× centered on the persisted anchor", () => {
+  it("expanded variant AIM still zooms 2× pinned to center (anchor coords ignored)", () => {
+    // Post-2026-05-23: AIM_TS now derives from release_ts (throw-localizer),
+    // not the grid classifier's aim_idx. The persisted aim_anchor_x/y was
+    // computed against the old grid frame — trusting it for zoom origin
+    // would re-introduce drift on the new release-anchored frame. Crosshair
+    // is always at screen center in tactical FPS, so origin is hardcoded
+    // to (50%, 50%) regardless of the persisted coords.
     render(<LineupCard lineup={BASE_LINEUP} variant="expanded" />);
     const aimImg = screen.getByAltText(/aim reference/i) as HTMLImageElement;
     expect(aimImg.style.transform).toBe("scale(2)");
-    expect(aimImg.style.transformOrigin).toBe("50% 40%");
+    expect(aimImg.style.transformOrigin).toBe("50% 50%");
     // No literal anchor dot in the AIM pane — the zoom replaces it.
     expect(screen.queryByLabelText(/aim anchor/i)).toBeNull();
   });
 
-  it("expanded variant AIM still falls back to center origin when anchor coords are null", () => {
+  it("expanded variant AIM still keeps the center origin even with null anchor coords", () => {
     const lineup: Lineup = { ...BASE_LINEUP, aim_anchor_x: null, aim_anchor_y: null };
     render(<LineupCard lineup={lineup} variant="expanded" />);
     const aimImg = screen.getByAltText(/aim reference/i) as HTMLImageElement;
@@ -335,10 +341,11 @@ describe("LineupCard", () => {
     expect(aimVideo).not.toBeNull();
   });
 
-  it("expanded variant AIM clip variant carries the same zoom transform as the still", () => {
+  it("expanded variant AIM clip carries the same center-pinned 2× zoom as the still", () => {
     // Still→clip continuity: AimPane applies the same zoom transform whether
-    // the active surface is the still <img> or the looping <video>, so the
-    // operator's view of the anchor stays consistent during the swap.
+    // the active surface is the still <img> or the looping <video>. Origin
+    // is always pinned to (50%, 50%) — see the "AIM still" test above for
+    // the rationale.
     const lineup: Lineup = {
       ...BASE_LINEUP,
       aim_clip_url: "https://ex.com/aim.mp4",
@@ -349,7 +356,7 @@ describe("LineupCard", () => {
     ) as HTMLVideoElement;
     expect(aimVideo).not.toBeNull();
     expect(aimVideo.style.transform).toBe("scale(2)");
-    expect(aimVideo.style.transformOrigin).toBe("50% 40%");
+    expect(aimVideo.style.transformOrigin).toBe("50% 50%");
     expect(screen.queryByLabelText(/aim anchor/i)).toBeNull();
   });
 

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupPanes.tsx
@@ -267,45 +267,44 @@ export function StandPane({ standScreenshotUrl, standClipUrl, title }: StandPane
 //
 // Same upgrade-with-still-fallback shape as ``StandPane``. Where StandPane
 // renders the source frame as-is, AimPane applies a 2× zoom centered on the
-// persisted aim-anchor coords (fallback 50% 50%) — the operator sees a
-// magnified crop around where the crosshair was, which replaces the old red
-// anchor dot. Both surfaces (still and clip) are the same ``aspect-video``
-// container with ``overflow-hidden``, so the transform crops identically
-// regardless of which one is showing. The clip's first frame IS the still,
-// so the zoom target stays consistent during the still→clip swap.
+// frame middle — the operator sees a magnified crop on the crosshair area,
+// which replaces the old red anchor dot.
+//
+// Zoom origin is pinned to (50%, 50%) (operator-confirmed 2026-05-23: the
+// crosshair in tactical FPS is always at screen center, so the alignment
+// marker at the aim moment is also at screen center). The persisted
+// ``aim_anchor_x/y`` coords (still passed through ``aimAnchorX/Y`` props
+// for legacy / backward-compat reasons) are intentionally ignored — they
+// were grid-classifier-derived from a different aim frame than the AIM
+// clip is now anchored on (PR shifting AIM_TS to release_ts − 0.8s), so
+// trusting them would re-introduce drift. The DB column itself is
+// vestigial and can be cleaned up in a follow-up PR.
 // ---------------------------------------------------------------------------
 interface AimPaneProps {
   aimScreenshotUrl: string | null;
   aimClipUrl?: string | null;
-  // Persisted normalized anchor coords (0..1). Null when the classifier
-  // didn't produce them (manual upload / pre-classifier ingest) — the zoom
-  // then falls back to the pane center.
+  // Persisted anchor coords. Vestigial since 2026-05-23 — ignored at render
+  // time (zoom is always centered). Kept on the prop for now so callers
+  // don't break; remove when the DB column is dropped.
   aimAnchorX: number | null;
   aimAnchorY: number | null;
   title: string;
 }
 
-function aimZoomStyle(
-  aimAnchorX: number | null,
-  aimAnchorY: number | null,
-): React.CSSProperties {
-  const xPct = (aimAnchorX ?? 0.5) * 100;
-  const yPct = (aimAnchorY ?? 0.5) * 100;
-  return {
-    transform: "scale(2)",
-    transformOrigin: `${xPct}% ${yPct}%`,
-  };
-}
+const AIM_ZOOM_STYLE: React.CSSProperties = {
+  transform: "scale(2)",
+  transformOrigin: "50% 50%",
+};
 
 export function AimPane({
   aimScreenshotUrl,
   aimClipUrl,
-  aimAnchorX,
-  aimAnchorY,
+  // aim_anchor_x/y are vestigial (see component header). Destructure them so
+  // the prop interface stays unchanged for callers, then ignore.
+  aimAnchorX: _aimAnchorX,
+  aimAnchorY: _aimAnchorY,
   title,
 }: AimPaneProps) {
-  const zoom = aimZoomStyle(aimAnchorX, aimAnchorY);
-
   if (aimClipUrl) {
     return (
       <ClipView
@@ -313,7 +312,7 @@ export function AimPane({
         posterUrl={aimScreenshotUrl}
         title={title}
         label="AIM"
-        videoStyle={zoom}
+        videoStyle={AIM_ZOOM_STYLE}
       />
     );
   }
@@ -322,7 +321,7 @@ export function AimPane({
       url={aimScreenshotUrl}
       alt={`${title} — aim reference`}
       label="AIM"
-      imgStyle={zoom}
+      imgStyle={AIM_ZOOM_STYLE}
     />
   );
 }


### PR DESCRIPTION
## Summary

- AIM micro-clip was showing a completely random frame — operator surfaced 2026-05-23 with screenshot. Root cause: AIM was picked from the 9-frame grid sampling the whole chapter (~2-3s spacing), but the aim-on-marker moment is sub-second, so Claude almost never had a frame at the right moment to pick.
- THROW already shows the aim moment correctly because the throw-localizer runs a dense pass (0.5s spacing around release). Reuse its `release_ts`: new AIM_TS = `release_ts − 0.8s`. The 1.0s AIM clip now spans `[release − 0.8s, release + 0.2s]` — locked-aim with a tiny throw-initiation peek.
- Pin AIM's 2× zoom origin to `(50%, 50%)`. Crosshair in tactical FPS is always at screen center; the persisted `aim_anchor_x/y` was computed from a (random) grid frame AIM no longer uses, so trusting it would re-introduce drift.

## Plumbing

- **micro_clip_generator**: replaces `precomputed_aim_ts` → `precomputed_release_ts`. New constant `_AIM_PRE_RELEASE_SECONDS = 0.8`. Backfill path now calls `localize_throw_with_refinement` itself to recover `release_ts` (independent from the grid pass for stand — failure on one side doesn't poison the other).
- **ingestion_orchestrator**: captures `release_ts` from `generate_clip_for_lineup` and passes it to micro-clip generator. When the THROW clip step skipped/failed, AIM skips with reason `no_release_ts_for_aim` (STAND still generates from grid).
- **micro_clip_backfill**: docstring update + kwarg rename. Classifier orchestration lives in the generator.
- **LineupPanes.AimPane**: zoom origin pinned to `\"50% 50%\"`. `aim_anchor_x/y` accepted on the prop interface for backward-compat; ignored at render time.

## Out of scope (intentional follow-up)

- Recutting `aim_screenshot` at the new AIM_TS. The still is briefly visible as the clip poster before play; on clip-generation failures, it's the only artifact shown. The clip itself (what operator sees) is now correct.
- `aim_anchor_x/y` DB column + `showAimDot` knob are now vestigial. Cleanup PR later.

## Operational

After merge, re-run on the VPS / locally to refresh existing accepted lineups:

\`\`\`
python -m app.cli backfill-micro-clips
\`\`\`

Backfill cost: 1 grid call + 1-2 throw-timing calls per lineup (was: 1 grid). The throw-timing pass is the same one \`backfill-clips\` uses.

## Test plan

- [x] \`pytest\` — 679 passed (+5 new for per-side-independent backfill paths, replacing the now-obsolete paired-precomputed test).
- [x] Frontend: LineupCard + GlanceBoardTile AIM zoom tests updated to expect \`50% 50%\` always. 50/50 pass.
- [x] \`tsc --noEmit\` clean.
- [x] Pre-existing \`MicroClipShiftOverlay\` failure on main confirmed unrelated to this PR.
- [ ] Operator validation: re-run \`backfill-micro-clips\` on lineup \`7bd971c3\` (the lineup in the bug report) and confirm AIM pane now looks similar to THROW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)