### PR TITLE
fix(mga): anchor STAND micro-clip on release_ts (not sparse grid stand_idx)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -466,10 +466,13 @@ async def _process_chapter(
                     str(exc), exc_info=True,
                 )
 
-        # PR6 (revised 2026-05-23): STAND anchors on grid stand_idx; AIM
-        # anchors on release_ts − 0.8s (see micro_clip_generator docstring).
-        # release_ts is None when THROW skipped/failed → AIM skips, STAND
-        # still generates. Non-fatal — failure must not roll back the row.
+        # PR6 (revised 2026-05-24): BOTH STAND and AIM anchor on
+        # release_ts (see micro_clip_generator docstring). The grid
+        # stand_idx is kept here only for the still-image upload above
+        # (stand_screenshot_url); it is NOT used to anchor the STAND
+        # clip. release_ts is None when THROW skipped/failed → both
+        # micro-clips skip cleanly. Non-fatal — a failure must not roll
+        # back the row; the panes gracefully render their stills.
         _release_ts = clip_result.release_ts if (clip_result and clip_result.status == "generated") else None
         try:
             micro_result = await generate_micro_clips_for_lineup(
@@ -478,7 +481,6 @@ async def _process_chapter(
                 chapter_start=float(chapter.start_seconds),
                 chapter_end=float(chapter.end_seconds),
                 video_path=video_path,
-                precomputed_stand_ts=timestamps[stand_idx],
                 precomputed_release_ts=_release_ts,
             )
             logger.info(

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -467,12 +467,10 @@ async def _process_chapter(
                 )
 
         # PR6 (revised 2026-05-24): BOTH STAND and AIM anchor on
-        # release_ts (see micro_clip_generator docstring). The grid
-        # stand_idx is kept here only for the still-image upload above
-        # (stand_screenshot_url); it is NOT used to anchor the STAND
-        # clip. release_ts is None when THROW skipped/failed → both
-        # micro-clips skip cleanly. Non-fatal — a failure must not roll
-        # back the row; the panes gracefully render their stills.
+        # release_ts (see micro_clip_generator docstring; grid stand_idx
+        # is kept only for the still-image upload above, not the clip).
+        # release_ts=None when THROW skipped/failed → both sides skip
+        # cleanly. Non-fatal — failure must not roll back the row.
         _release_ts = clip_result.release_ts if (clip_result and clip_result.status == "generated") else None
         try:
             micro_result = await generate_micro_clips_for_lineup(

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_backfill.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_backfill.py
@@ -4,17 +4,22 @@ Lineups created before PR6 (and any whose micro-clip generation failed at
 ingest time) have ``stand_clip_url IS NULL`` and/or ``aim_clip_url IS NULL``.
 This walks that set, re-fetches each source video ONCE per video (not once
 per lineup — a tutorial video usually backs many lineups), and asks the
-generator to localise anchors + cut clips. Mirrors :mod:`landing_clip_backfill`
-(PR5) shape exactly.
+generator to localise the anchor + cut clips. Mirrors
+:mod:`landing_clip_backfill` (PR5) shape exactly.
 
-Anchor sources (operator-tuned 2026-05-23):
-  - STAND comes from the grid classifier (the 9-frame grid reliably catches
-    the "I am at the spot" window — many seconds long).
-  - AIM comes from ``release_ts - _AIM_PRE_RELEASE_SECONDS``, where release_ts
-    is from the throw-timing classifier's dense pass. The grid is too sparse
-    to localise the sub-second aim moment, so prior AIM clips were random.
-The generator orchestrates both classifier calls itself in the backfill
-path; this module just hands it the source video.
+Anchor source (operator-tuned 2026-05-24):
+  Both STAND and AIM derive from a single ``release_ts`` from the
+  throw-timing classifier's dense pass:
+    - STAND_TS = release_ts − _STAND_PRE_RELEASE_SECONDS (3.0s before)
+    - AIM_TS   = release_ts − _AIM_PRE_RELEASE_SECONDS (0.8s before)
+  The earlier grid-based STAND anchor was abandoned (PR following #761) —
+  the 9-frame grid frequently picked the walk-up or windup frame rather
+  than the settled stance. The throw-localizer's dense pass produces a
+  reliable release frame (THROW + LANDING already depend on it), so
+  STAND/AIM riding the same anchor is the no-bandaid fix.
+
+The generator runs the throw-localizer itself on the backfill path; this
+module just hands it the source video.
 
 Independent of :mod:`clip_backfill` (PR2) and :mod:`landing_clip_backfill`
 (PR5) by design: a lineup can have any combination of NULL micro-clip
@@ -26,12 +31,12 @@ Idempotent by construction: the work set is
 NULL OR aim_clip_url IS NULL)`` (``lineup_repo.list_accepted_lineups_needing_micro_clips``).
 A generated clip sets the matching column and may drop the lineup out of
 the set. The generator handles partial state internally — uploading both
-sides per call is cheap (the heavy cost is the grid classifier + download,
-done once per video). A ``failed`` side leaves its column NULL and is
-retried on the next run (transient yt-dlp / ffmpeg / Claude failures
-self-heal). A ``skipped`` side (no source video / chapter too short /
-classifier disabled) also stays NULL and will be re-evaluated on a future
-run.
+sides per call is cheap (the heavy cost is the throw-localizer call +
+download, done once per video). A ``failed`` side leaves its column NULL
+and is retried on the next run (transient yt-dlp / ffmpeg / Claude
+failures self-heal). A ``skipped`` side (no source video / chapter too
+short / classifier disabled / no throw release in chapter) also stays
+NULL and will be re-evaluated on a future run.
 
 Per rules/no-bandaid-solutions.md + rules/check-third-party-error-codes.md:
 every yt-dlp / ffmpeg / Claude failure is captured with its structured
@@ -212,11 +217,9 @@ async def backfill_micro_clips(db: AsyncSession) -> MicroClipBackfillStats:
                         # Reuse the once-downloaded file — do NOT let the
                         # generator re-download per lineup.
                         video_path=video_path,
-                        # Backfill: no precomputed timestamps; the generator
-                        # re-runs the grid classifier (stand) AND the
-                        # throw-localizer (release → aim) itself.
-                        precomputed_stand_ts=None,
-                        precomputed_release_ts=None,
+                        # Omit precomputed_release_ts — its _UNRESOLVED
+                        # sentinel default tells the generator "I am the
+                        # backfill path; run the throw-localizer yourself".
                     )
                 except Exception as exc:  # defensive: never abort the batch
                     logger.warning(

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
@@ -1,30 +1,44 @@
 """Stand + Aim micro-clip generator — 1s looped clips for the storyboard.
 
 PR6 introduced the 1-second STAND + AIM micro-clips replacing static stills.
-Anchor sources differ per side (operator-tuned 2026-05-23):
+Both panes anchor on ``release_ts`` from the throw-localizer's dense pass
+(operator-tuned 2026-05-23/24):
 
-  - **STAND** anchors on the grid classifier's chosen ``stand`` frame
-    (``timestamps[stand_idx]``). The 9-frame grid reliably catches the
-    "I am at the spot" window (many seconds long).
   - **AIM** anchors on ``release_ts − _AIM_PRE_RELEASE_SECONDS`` (0.8s
-    before the throw-localizer's release frame). The aim moment is
-    sub-second; the grid is far too sparse to catch it reliably — Claude
-    was picking random distant frames. The throw-timing dense pass
-    (0.5s spacing around release) already sees the locked-aim moment.
+    before release) → 1.0s clip ``[release − 0.8, release + 0.2]``.
+  - **STAND** anchors on ``release_ts − _STAND_PRE_RELEASE_SECONDS`` (3.0s
+    before release) → 2.0s clip ``[release − 3.0, release − 1.0]``.
+
+The earlier grid-stand_idx anchor was abandoned because the 9-frame grid
+sampling across the whole chapter (~3.5s spacing) frequently picked the
+walk-up or windup frame instead of the settled stance. The throw-localizer's
+dense pass produces a reliable release_ts (THROW + LANDING already depend
+on it), so deriving STAND from it gives a stable "settled at spot ~3s
+before the throw" window that ends before the windup begins.
 
 Two entry paths share one contract:
 
-  1. **Ingest path** — orchestrator passes ``precomputed_stand_ts`` (from
-     its grid run) AND ``precomputed_release_ts`` (from the throw-localizer
-     it already ran for the THROW clip). Generator skips both Claude calls.
-  2. **Backfill path** — both precomputed values are None; generator runs
-     the grid classifier (stand) AND ``localize_throw_with_refinement``
-     (release → aim) itself. Cost: 1 grid + 1-2 throw-timing calls.
+  1. **Ingest path** — orchestrator passes ``precomputed_release_ts``
+     (from the throw-localizer it already ran for the THROW clip).
+     Generator skips its Claude call entirely. Cost: zero extra Claude
+     spend; two extra ffmpeg cuts + two MinIO uploads per chapter.
+  2. **Backfill path** — caller omits the kwarg, leaving it at its
+     ``_UNRESOLVED`` sentinel default; generator runs
+     ``localize_throw_with_refinement`` itself to recover release_ts.
+     Cost: 1-2 throw-timing calls per lineup (the SAME calls
+     ``backfill-clips`` makes — no extra spend on a combined backfill).
 
-Per-side independence: a stand-side failure NEVER rolls back the already-
-committed aim side, and vice versa. The AIM still + persisted aim_anchor
-coords are NOT recut — phase-1 scope is the clip only; the brief poster
-flash + rarely-used still-mode fallback are accepted-imperfections. See
+When ``release_ts`` is unavailable (orchestrator's THROW step skipped or
+the backfill throw-localizer found no release frame), BOTH sides skip
+with structured reasoning. The earlier "STAND from grid when release
+unknown" fallback is gone — fabricating an unreliable STAND is worse
+than the pane gracefully showing its still.
+
+Per-side independence: a stand-side failure (ffmpeg cut / MinIO upload /
+DB commit) NEVER rolls back the already-committed aim side, and vice
+versa. The AIM still + persisted aim_anchor coords are NOT recut —
+phase-1 scope is the clip only; the brief poster flash + rarely-used
+still-mode fallback are accepted-imperfections. See
 ``project_mga_aim_anchor_center_screen_invariant.md`` in auto-memory.
 
 Failure handling (rules/no-bandaid-solutions.md +
@@ -33,17 +47,16 @@ failure is captured with structured codes, logged at WARNING, and returned
 in the per-side error_codes; the matching ``*_clip_url`` is left NULL and
 the pane renders its still fallback. Nothing silent-fails.
 
-Sibling helpers (``_resolve_stand_ts_via_grid_classifier``,
-``_resolve_release_ts_via_throw_localizer``, ``_cut_upload_persist_one_side``)
-live in :mod:`micro_clip_helpers` to keep this file under the file-size
-growth guard (per per-app Tech Debt Policy).
+Sibling helpers (``_resolve_release_ts_via_throw_localizer``,
+``_cut_upload_persist_one_side``) live in :mod:`micro_clip_helpers` to keep
+this file under the file-size growth guard (per per-app Tech Debt Policy).
 """
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Union
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -56,7 +69,6 @@ from app.services.ingestion.frame_extractor import (
 from app.services.ingestion.micro_clip_helpers import (
     _cut_upload_persist_one_side,
     _resolve_release_ts_via_throw_localizer,
-    _resolve_stand_ts_via_grid_classifier,
 )
 from app.services.ingestion.youtube_fetcher import (
     VideoDownloadError,
@@ -74,8 +86,28 @@ _AIM_MICRO_CLIP_SECONDS = 1.0
 # spans [release − 0.8s, release + 0.2s] — locked-aim with a tiny throw-
 # initiation peek as a natural end-cue.
 _AIM_PRE_RELEASE_SECONDS = 0.8
+# Seconds BEFORE release_ts the STAND clip starts at. The 2.0s STAND clip
+# spans [release − 3.0s, release − 1.0s] — "settled at the spot, ready
+# to throw", ending before the windup so the player is shown stationary
+# at the throwing position. Tuned far enough back that even a fast
+# windup (~0.5-0.8s) does not bleed into the clip.
+_STAND_PRE_RELEASE_SECONDS = 3.0
 # Minimum acceptable clamped duration. Below: skip rather than ship a sliver.
 _MIN_CLIP_SECONDS = 0.5
+
+
+class _Unresolved:
+    """Sentinel — ``precomputed_release_ts=`` was not specified by the caller.
+
+    Distinguishes the backfill path ("generator owns the throw-localizer
+    call") from the ingest path's partial-failure case ("orchestrator ran
+    the throw-localizer and it gave None — both micro clips should skip").
+    Default value of the kwarg; only the backfill leaves it at the
+    default — every ingest call passes an explicit ``float | None``.
+    """
+
+
+_UNRESOLVED: _Unresolved = _Unresolved()
 
 
 @dataclass
@@ -186,38 +218,43 @@ async def generate_micro_clips_for_lineup(
     chapter_end: float,
     video_path: Optional[Path] = None,
     download_dir: Optional[Path] = None,
-    precomputed_stand_ts: Optional[float] = None,
-    precomputed_release_ts: Optional[float] = None,
+    precomputed_release_ts: Union[float, None, _Unresolved] = _UNRESOLVED,
 ) -> MicroClipGenerationResult:
     """Cut + persist STAND and AIM micro-clips for *lineup*.
 
-    AIM anchors on ``release_ts - _AIM_PRE_RELEASE_SECONDS`` (NOT on the
-    grid classifier's aim_idx — that pass is too sparse for the sub-second
-    aim moment; see module docstring). STAND still anchors on the grid's
-    stand_idx.
+    Both panes anchor on ``release_ts``:
+      - STAND_TS = ``release_ts - _STAND_PRE_RELEASE_SECONDS`` (3.0s before)
+      - AIM_TS   = ``release_ts - _AIM_PRE_RELEASE_SECONDS`` (0.8s before)
+
+    The earlier grid-based STAND anchor was abandoned because the 9-frame
+    grid sampling across the whole chapter (~3.5s spacing) frequently
+    picked the walk-up or windup frame rather than the settled stance.
+    Same critique that retired the grid AIM anchor; see module docstring.
 
     Two entry paths:
 
-    **Ingest path** — caller (orchestrator) passes ``precomputed_stand_ts``
-    (from the grid run it already did) AND ``precomputed_release_ts`` (from
-    the throw-localizer run it already did for the THROW clip). The
-    generator skips both Claude calls entirely. Cost: zero extra Claude
-    spend; two extra ffmpeg cuts + two MinIO uploads per chapter.
+    **Ingest path** — caller (orchestrator) passes ``precomputed_release_ts``
+    (the throw-localizer's release frame timestamp from the THROW clip
+    generator's result). Generator skips its Claude call entirely. Cost:
+    zero extra Claude spend; two extra ffmpeg cuts + two MinIO uploads
+    per chapter.
 
-    Partial-ingest case: if the orchestrator's THROW clip step skipped or
-    failed, ``precomputed_release_ts`` is None and the AIM side is skipped
-    with reason ``no_release_ts_for_aim`` — STAND still generates from the
-    precomputed grid stand_ts.
+    Partial-ingest case: when the orchestrator's THROW clip step
+    skipped/failed, ``precomputed_release_ts`` is None and BOTH sides
+    skip with reason ``no_release_ts``. The lineup still has its stand
+    and aim stills; the panes render the still fallback.
 
-    **Backfill path** — caller is the CLI; both precomputed values are
-    None. We re-run the grid classifier (for stand_ts) AND the
-    throw-localizer (for release_ts → AIM_TS). Cost: 1 grid call + 1-2
-    throw-timing calls per lineup. Stand- and aim-side failures are tallied
-    independently.
+    **Backfill path** — caller is the CLI and omits the kwarg (leaving
+    it at the ``_UNRESOLVED`` sentinel default). The generator runs
+    ``localize_throw_with_refinement`` itself. Cost: 1-2 throw-timing
+    calls per lineup (same calls a combined backfill makes for the
+    THROW clip — no extra Claude spend when backfilling both together).
 
     Per-side independence: a stand-side failure NEVER rolls back the
     already-committed aim side, and vice versa. Each side has its own
-    status / error_codes in the returned result.
+    status / error_codes in the returned result. When both sides derive
+    from the SAME release_ts, the only path to per-side divergence is
+    downstream of resolution: ffmpeg cut, MinIO upload, or DB commit.
 
     Args:
         db: Active async session. On success each clip's bare key is
@@ -230,14 +267,15 @@ async def generate_micro_clips_for_lineup(
             backfill that batches per video). When None the video is
             re-fetched into *download_dir* and deleted afterwards.
         download_dir: Required when *video_path* is None.
-        precomputed_stand_ts: Ingest path — ``timestamps[stand_idx]`` from
-            the grid classifier output the orchestrator already has.
-            Backfill path — None; generator re-runs the grid classifier.
-        precomputed_release_ts: Ingest path — the throw-localizer's release
-            frame timestamp (from clip_generator's returned ClipGenerationResult).
-            None when the orchestrator's THROW clip step skipped/failed
-            (AIM is then skipped too). Backfill path — None; generator
-            runs the throw-localizer itself.
+        precomputed_release_ts: Ingest path — pass the throw-localizer's
+            release frame timestamp (from clip_generator's returned
+            ClipGenerationResult). Pass ``None`` when the orchestrator's
+            THROW clip step skipped/failed (both sides then skip).
+            Backfill path — omit the kwarg entirely (leave at
+            ``_UNRESOLVED`` default); generator runs the throw-localizer
+            itself. The sentinel default distinguishes "caller doesn't
+            know" (backfill) from "caller checked and got nothing"
+            (ingest partial).
 
     Returns:
         MicroClipGenerationResult — never raises for expected failures.
@@ -254,29 +292,6 @@ async def generate_micro_clips_for_lineup(
             aim_status="skipped",
             stand_skip_reason="no_source_video",
             aim_skip_reason="no_source_video",
-        )
-
-    # Two valid input shapes:
-    #   - Backfill: both precomputed values None → generator runs both
-    #     classifier pipelines internally.
-    #   - Ingest:  precomputed_stand_ts set; precomputed_release_ts MAY be
-    #     None (when the orchestrator's THROW clip step skipped/failed —
-    #     STAND still generates, AIM is skipped).
-    # The only invalid shape is "stand None but release set", which would
-    # mean the caller has release_ts without stand_ts — a wiring bug. There
-    # is no concept of "AIM-only" without STAND on the ingest path.
-    if precomputed_stand_ts is None and precomputed_release_ts is not None:
-        logger.warning(
-            "micro_clip_generator: lineup %s — precomputed_release_ts set "
-            "without precomputed_stand_ts; got stand=None release=%s",
-            lineup.id, precomputed_release_ts,
-        )
-        return MicroClipGenerationResult(
-            stand_status="failed",
-            aim_status="failed",
-            stand_error_codes=["precomputed_pair_mismatch"],
-            aim_error_codes=["precomputed_pair_mismatch"],
-            reasoning="precomputed_release_ts requires precomputed_stand_ts",
         )
 
     owns_video = video_path is None
@@ -314,38 +329,24 @@ async def generate_micro_clips_for_lineup(
                     reasoning=f"video re-fetch failed: {exc}",
                 )
 
-        # ---- Resolve anchor timestamps ------------------------------------
-        # STAND and AIM resolve independently:
-        #   - STAND comes from the grid classifier (precomputed on ingest;
-        #     re-run on backfill).
-        #   - AIM comes from release_ts − _AIM_PRE_RELEASE_SECONDS, where
-        #     release_ts is from the throw-localizer (precomputed on ingest;
-        #     re-run on backfill).
-        # Either side can independently end up "skipped" with structured
-        # reasoning so the operator can see why per-side without inspecting
-        # logs. The other side still runs normally.
+        # ---- Resolve release_ts (shared anchor source for both sides) -----
+        # STAND and AIM both derive from a single ``release_ts``:
+        #   - STAND_TS = release_ts − _STAND_PRE_RELEASE_SECONDS
+        #   - AIM_TS   = release_ts − _AIM_PRE_RELEASE_SECONDS
+        # When release_ts is unavailable, both sides skip with the same
+        # structured reason — fabricating an unreliable STAND (the abandoned
+        # grid pick) is worse than the panes gracefully showing their stills.
         stand_ts: Optional[float] = None
         aim_ts: Optional[float] = None
-        stand_skip_reason: Optional[str] = None
-        aim_skip_reason: Optional[str] = None
-        stand_err_codes: list[str] = []
-        aim_err_codes: list[str] = []
-        reasoning_parts: list[str] = []
+        shared_skip_reason: Optional[str] = None
+        shared_err_codes: list[str] = []
+        reasoning = ""
+        release_ts: Optional[float] = None
 
-        if precomputed_stand_ts is not None:
-            # Ingest path — caller already has both sides' Claude output.
-            stand_ts = float(precomputed_stand_ts)
-            if precomputed_release_ts is not None:
-                aim_ts = float(precomputed_release_ts) - _AIM_PRE_RELEASE_SECONDS
-            else:
-                # Orchestrator's THROW clip step skipped/failed — STAND
-                # generates, AIM is skipped (the previous grid-based AIM
-                # was unreliable; refusing is preferable to faking).
-                aim_skip_reason = "no_release_ts_for_aim"
-        else:
-            # Backfill path — generator orchestrates both classifier passes
-            # itself. Stand and aim resolve independently so a failure on
-            # one side doesn't poison the other.
+        if isinstance(precomputed_release_ts, _Unresolved):
+            # Backfill path — generator owns the throw-localizer call.
+            # The orchestrator (ingest) always passes float|None explicitly;
+            # only the backfill leaves the kwarg at its sentinel default.
             if not settings.enable_classifier:
                 return MicroClipGenerationResult(
                     stand_status="skipped",
@@ -362,47 +363,39 @@ async def generate_micro_clips_for_lineup(
                     aim_skip_reason="classifier_unavailable:missing_api_key",
                     reasoning="anthropic_api_key not configured",
                 )
-
-            # STAND from grid classifier.
-            stand_ts, stand_err_codes, stand_reasoning = (
-                await _resolve_stand_ts_via_grid_classifier(
-                    db, lineup, local_video, chapter_start, chapter_end,
-                )
-            )
-            if stand_reasoning:
-                reasoning_parts.append(f"stand: {stand_reasoning}")
-            if stand_ts is None and not stand_err_codes:
-                stand_skip_reason = "backfill_not_a_lineup"
-
-            # AIM from throw-localizer (independent — runs even if stand failed).
-            release_ts, aim_err_codes, aim_reasoning = (
+            release_ts, shared_err_codes, throw_reasoning = (
                 await _resolve_release_ts_via_throw_localizer(
                     lineup, local_video, chapter_start, chapter_end,
                 )
             )
-            if aim_reasoning:
-                reasoning_parts.append(f"aim: {aim_reasoning}")
-            if release_ts is not None:
-                aim_ts = release_ts - _AIM_PRE_RELEASE_SECONDS
-            elif not aim_err_codes:
-                aim_skip_reason = "backfill_no_throw_release"
+            if throw_reasoning:
+                reasoning = throw_reasoning
+            if release_ts is None and not shared_err_codes:
+                shared_skip_reason = "backfill_no_throw_release"
+        elif precomputed_release_ts is None:
+            # Ingest path, partial: the orchestrator's THROW clip step
+            # skipped/failed and gave us None. Both sides skip cleanly —
+            # the panes render their stand/aim stills.
+            shared_skip_reason = "no_release_ts"
+        else:
+            # Ingest path, happy case: caller already ran the
+            # throw-localizer (for the THROW clip) and passed us the
+            # release timestamp. Skip the Claude call.
+            release_ts = float(precomputed_release_ts)
 
-        reasoning = " | ".join(reasoning_parts) if reasoning_parts else ""
+        if release_ts is not None:
+            stand_ts = release_ts - _STAND_PRE_RELEASE_SECONDS
+            aim_ts = release_ts - _AIM_PRE_RELEASE_SECONDS
 
-        # Hard fail-out only when BOTH sides resolved to nothing AND both
-        # have hard errors — the symmetric ingest-skipped case (no release
-        # → AIM skipped, STAND generates) must not be turned into a failure.
-        if (
-            stand_ts is None
-            and aim_ts is None
-            and stand_err_codes
-            and aim_err_codes
-        ):
+        # Hard fail-out when release_ts resolution had a structured error
+        # (Claude API failure on the backfill throw-localizer call). Both
+        # sides fail with the same error_codes because they share input.
+        if release_ts is None and shared_err_codes:
             return MicroClipGenerationResult(
                 stand_status="failed",
                 aim_status="failed",
-                stand_error_codes=list(stand_err_codes),
-                aim_error_codes=list(aim_err_codes),
+                stand_error_codes=list(shared_err_codes),
+                aim_error_codes=list(shared_err_codes),
                 reasoning=reasoning,
             )
 
@@ -434,16 +427,16 @@ async def generate_micro_clips_for_lineup(
             wider_source_start_s = source_start
 
         # ---- Cut + upload + persist each side independently ---------------
-        # A None anchor_ts means the side's resolution step already decided
-        # to skip / fail this side. Short-circuit before the cut so we don't
-        # ffmpeg-attempt against missing data; the outcome dict matches the
-        # _cut_upload_persist_one_side shape so the result composition below
-        # is unchanged.
+        # release_ts None at this point means the shared resolution skipped
+        # cleanly (no Claude API error, just no release frame). Both sides
+        # short-circuit with the SAME skip reason — they share input.
+        # Downstream per-side independence (ffmpeg / MinIO / DB commit)
+        # still runs through _cut_upload_persist_one_side when ts is set.
         if stand_ts is None:
             stand_outcome = {
-                "status": "failed" if stand_err_codes else "skipped",
-                "error_codes": list(stand_err_codes),
-                "skip_reason": stand_skip_reason,
+                "status": "skipped",
+                "error_codes": [],
+                "skip_reason": shared_skip_reason,
             }
         else:
             stand_outcome = await _cut_upload_persist_one_side(
@@ -460,9 +453,9 @@ async def generate_micro_clips_for_lineup(
             )
         if aim_ts is None:
             aim_outcome = {
-                "status": "failed" if aim_err_codes else "skipped",
-                "error_codes": list(aim_err_codes),
-                "skip_reason": aim_skip_reason,
+                "status": "skipped",
+                "error_codes": [],
+                "skip_reason": shared_skip_reason,
             }
         else:
             aim_outcome = await _cut_upload_persist_one_side(

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_helpers.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_helpers.py
@@ -4,8 +4,9 @@ generator was already over the 500-LOC threshold; growth requires a
 matching split per TECH_DEBT.md "no-growth on flagged files").
 
 What lives here:
-  - ``_resolve_stand_ts_via_grid_classifier`` — backfill stand anchor.
-  - ``_resolve_release_ts_via_throw_localizer`` — backfill aim anchor.
+  - ``_resolve_release_ts_via_throw_localizer`` — backfill anchor source
+    (both STAND and AIM derive from this single release_ts; see
+    :mod:`micro_clip_generator` docstring).
   - ``_cut_upload_persist_one_side`` — per-side ffmpeg cut + MinIO upload
     + repo commit (shared by both stand and aim).
 
@@ -25,99 +26,16 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.storage import get_storage
 from app.models.game.lineup import Lineup
-from app.services.classification.classifier_service import (
-    classify_frames_for_lineup_decision,
-)
 from app.services.ingestion.frame_extractor import (
     ClipCutError,
     FrameExtractionError,
     cut_clip,
-    extract_frames,
-    grid_timestamps,
 )
 from app.services.ingestion.throw_localizer import (
     localize_throw_with_refinement,
 )
 
 logger = logging.getLogger(__name__)
-
-# Grid sample count + edge padding — must match the ingest orchestrator's
-# ingestion_orchestrator._GRID_FRAME_COUNT / _GRID_EDGE_PADDING_SECONDS so
-# the backfill recovers the SAME timestamps the ingest pass extracted.
-_GRID_FRAME_COUNT = 9
-_GRID_EDGE_PADDING_SECONDS = 1.0
-
-
-async def _resolve_stand_ts_via_grid_classifier(
-    db: AsyncSession,
-    lineup: Lineup,
-    video_path: Path,
-    chapter_start: float,
-    chapter_end: float,
-) -> tuple[Optional[float], list[str], str]:
-    """Backfill helper: re-run the grid classifier to recover stand_ts.
-
-    Returns ``(stand_ts, error_codes, reasoning)``. The grid classifier also
-    returns an ``aim_idx`` but it is intentionally discarded — AIM_TS is now
-    derived from release_ts (see micro_clip_generator module docstring); the
-    grid pass is too sparse to localise the sub-second aim moment. STAND is
-    unaffected because the standing-at-spot window is many seconds long.
-    """
-    timestamps = grid_timestamps(
-        float(chapter_start),
-        float(chapter_end),
-        _GRID_FRAME_COUNT,
-        edge_padding_seconds=_GRID_EDGE_PADDING_SECONDS,
-    )
-    if not timestamps:
-        return None, ["empty_grid_window"], "chapter window produced no grid frames"
-
-    try:
-        frames = await extract_frames(video_path, timestamps)
-    except FrameExtractionError as exc:
-        logger.warning(
-            "micro_clip_helpers: grid frame extraction failed: "
-            "lineup=%s returncode=%s stderr=%s",
-            lineup.id, exc.returncode, exc.stderr[:300],
-        )
-        return None, [f"frame_extract:rc={exc.returncode}"], str(exc)
-
-    if not frames:
-        return None, ["grid_frames_empty"], "ffmpeg returned no frames"
-
-    try:
-        result = await classify_frames_for_lineup_decision(
-            db,
-            frames=frames,
-            chapter_title=lineup.chapter_title or "",
-            attribution_author=lineup.attribution_author,
-            game_hint=None,
-        )
-    except Exception as exc:
-        logger.warning(
-            "micro_clip_helpers: grid classifier raised: lineup=%s error=%s",
-            lineup.id, str(exc),
-        )
-        return None, [f"classifier_raised:{type(exc).__name__}"], str(exc)
-
-    if not result.success:
-        logger.warning(
-            "micro_clip_helpers: grid classifier call failed: lineup=%s "
-            "error_codes=%s",
-            lineup.id, result.error_codes,
-        )
-        return None, list(result.error_codes), "grid classifier reported failure"
-
-    if not result.is_lineup:
-        # Accepted lineup but classifier says "not a lineup" → keep the
-        # signal but skip cleanly rather than fabricate a timestamp.
-        return None, [], "backfill grid says not_a_lineup (skip)"
-
-    # 1-based → 0-based, clamped to the grid range. Falls back to first
-    # index when the model omitted it (mirrors orchestrator's fallback).
-    stand_idx = (result.best_stand_index or 1) - 1
-    stand_idx = max(0, min(stand_idx, len(timestamps) - 1))
-    return timestamps[stand_idx], [], result.reasoning or ""
 
 
 async def _resolve_release_ts_via_throw_localizer(

--- a/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
@@ -1,10 +1,11 @@
 """Unit tests for the PR6 stand + aim micro-clip generator.
 
 Pure micro-bounds math + the full generate_micro_clips_for_lineup
-orchestration with every external (download / frame extract / Claude /
-ffmpeg cut / MinIO / repo commit) mocked. Asserts the frozen-contract
-gate sharing with PR5 (precomputed pair skips the classifier entirely)
-and the structured per-side generated / skipped / failed outcomes.
+orchestration with every external (download / throw-localizer Claude
+call / ffmpeg cut / MinIO / repo commit) mocked. Asserts that both
+STAND and AIM derive from a single release_ts (precomputed on ingest,
+re-resolved by the throw-localizer on backfill) and the structured
+per-side generated / skipped / failed outcomes.
 
 Mirrors :mod:`test_landing_clip_generator` so the two pipelines stay
 synchronised. Re-read PR5's tests when porting any behaviour change.
@@ -19,18 +20,15 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.services.classification.classification_result import (
-    ClassificationResult,
     ThrowTimingResult,
 )
 from app.services.ingestion.throw_localizer import RefinedThrowTiming
-from app.services.ingestion.frame_extractor import (
-    ClipCutError,
-    FrameExtractionError,
-)
+from app.services.ingestion.frame_extractor import ClipCutError
 from app.services.ingestion.micro_clip_generator import (
     _AIM_MICRO_CLIP_SECONDS,
     _AIM_PRE_RELEASE_SECONDS,
     _STAND_MICRO_CLIP_SECONDS,
+    _STAND_PRE_RELEASE_SECONDS,
     _compute_micro_bounds,
     _micro_clip_seconds_for_side,
     generate_micro_clips_for_lineup,
@@ -40,10 +38,10 @@ from app.services.ingestion.micro_clip_generator import (
 from app.services.ingestion.youtube_fetcher import VideoDownloadError
 
 _MOD = "app.services.ingestion.micro_clip_generator"
-# Most ffmpeg / storage / classifier / repo calls now live in the sibling
-# helpers module (PR #761). Patches that target those resolve here.
+# Most ffmpeg / storage / throw-localizer / repo calls now live in the
+# sibling helpers module (PR #761 +). Patches that target those resolve
+# here.
 _HMOD = "app.services.ingestion.micro_clip_helpers"
-_FAKE_PNG = b"\x89PNG\r\n\x1a\n"
 _FAKE_MP4 = b"\x00\x00\x00\x18ftypmp42"
 
 
@@ -189,80 +187,59 @@ def _storage_mock():
 
 @pytest.mark.asyncio
 async def test_ingest_path_generates_both_clips_without_classifier_call():
-    """Precomputed stand+aim ts → skip classifier; cut + upload + persist twice."""
+    """Precomputed release_ts → skip classifier; cut + upload + persist twice.
+
+    Both STAND and AIM derive from the same release_ts:
+      - STAND_TS = release_ts − _STAND_PRE_RELEASE_SECONDS (3.0s)
+      - AIM_TS   = release_ts − _AIM_PRE_RELEASE_SECONDS (0.8s)
+    """
     db = AsyncMock()
     lineup = _lineup()
     storage = _storage_mock()
     set_stand_mock = AsyncMock(return_value=lineup)
     set_aim_mock = AsyncMock(return_value=lineup)
 
-    classifier_mock = AsyncMock()  # MUST NOT be called
+    localizer_mock = AsyncMock()  # MUST NOT be called on ingest
 
     with (
         patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()) as cut,
         patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
-        patch(f"{_HMOD}.classify_frames_for_lineup_decision", classifier_mock),
+        patch(f"{_HMOD}.localize_throw_with_refinement", localizer_mock),
     ):
+        # release_ts = 25.0 → STAND_TS = 22.0, AIM_TS = 24.2
         result = await generate_micro_clips_for_lineup(
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            precomputed_stand_ts=12.0,
-            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
-            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
+            precomputed_release_ts=25.0,
         )
 
     assert result.stand_status == "generated"
     assert result.aim_status == "generated"
     assert result.stand_clip_key == "pending/vid123/10-stand-micro.mp4"
     assert result.aim_clip_key == "pending/vid123/10-aim-micro.mp4"
-    assert result.stand_ts == pytest.approx(12.0)
-    assert result.aim_ts == pytest.approx(24.0)
+    assert result.stand_ts == pytest.approx(25.0 - _STAND_PRE_RELEASE_SECONDS)
+    assert result.aim_ts == pytest.approx(25.0 - _AIM_PRE_RELEASE_SECONDS)
     assert cut.await_count == 2
     assert storage.upload_file.call_count == 2
     set_stand_mock.assert_awaited_once()
     set_aim_mock.assert_awaited_once()
-    classifier_mock.assert_not_awaited(), (
-        "Ingest path must NOT call the classifier — cost regression"
+    localizer_mock.assert_not_awaited(), (
+        "Ingest path must NOT call the throw-localizer — cost regression"
     )
 
 
 @pytest.mark.asyncio
-async def test_ingest_path_release_without_stand_is_wiring_bug():
-    """release_ts set without stand_ts → caller error (both fail).
-
-    Post-2026-05-23: the validation surface changed. AIM-without-STAND is
-    not a meaningful ingest shape (the orchestrator always knows stand_idx
-    when it knows release_ts), so this is the only mixed-precomputed case
-    left that's a true wiring bug. STAND-without-RELEASE is now a normal
-    partial-ingest case (clip generation skipped/failed; AIM skips cleanly).
-    """
-    db = AsyncMock()
-    lineup = _lineup()
-    result = await generate_micro_clips_for_lineup(
-        db, lineup,
-        chapter_start=10.0, chapter_end=40.0,
-        video_path=Path("/tmp/x.mp4"),
-        precomputed_stand_ts=None,  # missing!
-        precomputed_release_ts=24.8,
-    )
-    assert result.stand_status == "failed"
-    assert result.aim_status == "failed"
-    assert "precomputed_pair_mismatch" in result.stand_error_codes
-    assert "precomputed_pair_mismatch" in result.aim_error_codes
-
-
-@pytest.mark.asyncio
-async def test_ingest_path_stand_only_generates_stand_skips_aim():
-    """precomputed_stand_ts set, precomputed_release_ts None → STAND
-    generates from grid; AIM is skipped with no_release_ts_for_aim.
+async def test_ingest_path_no_release_ts_skips_both():
+    """precomputed_release_ts=None → BOTH sides skip with no_release_ts.
 
     This is the partial-ingest case: the orchestrator's THROW clip step
-    skipped or failed, so release_ts is not available. STAND still
-    benefits from the grid pass (which is reliable for STAND) — refusing
-    AIM is preferable to faking it with the previously-random grid aim_idx.
+    skipped or failed, so release_ts is not available. Since STAND and
+    AIM now both anchor on release_ts, neither can be cut — the panes
+    render their stills instead. The earlier "STAND still generates
+    from grid" behaviour is gone (the grid anchor was unreliable).
     """
     db = AsyncMock()
     lineup = _lineup()
@@ -270,25 +247,31 @@ async def test_ingest_path_stand_only_generates_stand_skips_aim():
     set_stand_mock = AsyncMock(return_value=lineup)
     set_aim_mock = AsyncMock(return_value=lineup)
 
+    localizer_mock = AsyncMock()  # MUST NOT be called
+
     with (
         patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
         patch(f"{_HMOD}.get_storage", return_value=storage),
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
+        patch(f"{_HMOD}.localize_throw_with_refinement", localizer_mock),
     ):
         result = await generate_micro_clips_for_lineup(
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            precomputed_stand_ts=12.0,
             precomputed_release_ts=None,
         )
 
-    assert result.stand_status == "generated"
+    assert result.stand_status == "skipped"
     assert result.aim_status == "skipped"
-    assert result.aim_skip_reason == "no_release_ts_for_aim"
-    set_stand_mock.assert_awaited_once()
+    assert result.stand_skip_reason == "no_release_ts"
+    assert result.aim_skip_reason == "no_release_ts"
+    set_stand_mock.assert_not_awaited()
     set_aim_mock.assert_not_awaited()
+    localizer_mock.assert_not_awaited(), (
+        "Ingest must not re-run the throw-localizer when caller passed None"
+    )
 
 
 @pytest.mark.asyncio
@@ -296,13 +279,13 @@ async def test_ingest_path_chapter_too_short_skips_both():
     """A sliver chapter clamps below 0.5s → both sides skip."""
     db = AsyncMock()
     lineup = _lineup()
+    # release_ts in middle of tiny chapter → both anchors clamp to start;
+    # both clips clamp below the 0.5s minimum → both skip.
     result = await generate_micro_clips_for_lineup(
         db, lineup,
         chapter_start=19.9, chapter_end=20.3,
         video_path=Path("/tmp/x.mp4"),
-        precomputed_stand_ts=20.0,
-        # AIM_TS = release_ts - 0.8 = 20.1
-        precomputed_release_ts=20.1 + _AIM_PRE_RELEASE_SECONDS,
+        precomputed_release_ts=20.1,
     )
     assert result.stand_status == "skipped"
     assert result.aim_status == "skipped"
@@ -311,7 +294,7 @@ async def test_ingest_path_chapter_too_short_skips_both():
 
 
 # ---------------------------------------------------------------------------
-# generate_micro_clips_for_lineup — backfill path (own classifier call)
+# generate_micro_clips_for_lineup — backfill path (own throw-localizer call)
 # ---------------------------------------------------------------------------
 
 def _settings(enable=True, key="sk-test"):
@@ -319,16 +302,6 @@ def _settings(enable=True, key="sk-test"):
     s.enable_classifier = enable
     s.anthropic_api_key = key
     return s
-
-
-def _grid(**kw):
-    base = dict(
-        success=True, is_lineup=True,
-        best_stand_index=2, best_aim_index=5,
-        reasoning="ok", error_codes=[],
-    )
-    base.update(kw)
-    return ClassificationResult(**base)
 
 
 def _refined(release_ts=30.8, **kw):
@@ -365,27 +338,18 @@ def _localizer_mock(refined=None, **refined_kw):
 
 
 @pytest.mark.asyncio
-async def test_backfill_path_runs_classifier_and_generates():
-    """Backfill runs grid (stand) + throw_localizer (release → aim) and
-    generates both clips. STAND from grid_timestamps[stand_idx]; AIM from
-    release_ts − _AIM_PRE_RELEASE_SECONDS."""
+async def test_backfill_path_runs_throw_localizer_and_generates():
+    """Backfill runs throw_localizer; both STAND and AIM derive from
+    the same release_ts."""
     db = AsyncMock()
     lineup = _lineup()
     storage = _storage_mock()
     set_stand_mock = AsyncMock(return_value=lineup)
     set_aim_mock = AsyncMock(return_value=lineup)
-    grid = _grid(best_stand_index=2)
-    timestamps = [12.0, 18.0, 24.0, 30.0, 36.0]
-    # release_ts = 36.8 → AIM_TS = 36.0
-    refined = _refined(release_ts=36.0 + _AIM_PRE_RELEASE_SECONDS)
+    refined = _refined(release_ts=30.0)
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_HMOD}.extract_frames",
-              AsyncMock(return_value=[_FAKE_PNG] * 5)),
-        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
-              AsyncMock(return_value=grid)),
         patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
         patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
@@ -393,68 +357,29 @@ async def test_backfill_path_runs_classifier_and_generates():
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
+        # Omit precomputed_release_ts → sentinel default → backfill branch.
         result = await generate_micro_clips_for_lineup(
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            # No precomputed → backfill branch.
         )
 
     assert result.stand_status == "generated"
     assert result.aim_status == "generated"
-    # best_stand_index 2 (1-based) → timestamps[1] = 18.0.
-    # AIM = release_ts (36.8) − 0.8 = 36.0.
-    assert result.stand_ts == pytest.approx(18.0)
-    assert result.aim_ts == pytest.approx(36.0)
+    # release_ts 30.0 → STAND_TS = 30 − 3 = 27.0; AIM_TS = 30 − 0.8 = 29.2.
+    assert result.stand_ts == pytest.approx(30.0 - _STAND_PRE_RELEASE_SECONDS)
+    assert result.aim_ts == pytest.approx(30.0 - _AIM_PRE_RELEASE_SECONDS)
 
 
 @pytest.mark.asyncio
-async def test_backfill_path_grid_not_a_lineup_skips_stand_but_aim_independent():
-    """Grid says not_a_lineup → STAND skips. Throw localizer still runs
-    independently (it's a separate Claude pass with its own decision).
-    Here we let throw_localizer succeed → AIM still generates."""
+async def test_backfill_path_throw_localizer_no_release_skips_both():
+    """Throw localizer says not-a-throw / no release → both sides skip.
+
+    Since both panes share the same anchor source, a missing release_ts
+    skips them together. The lineup still has its stills.
+    """
     db = AsyncMock()
     lineup = _lineup()
-    storage = _storage_mock()
-    set_aim_mock = AsyncMock(return_value=lineup)
-    grid = _grid(is_lineup=False, best_stand_index=None, best_aim_index=None)
-    timestamps = [12.0, 18.0, 24.0]
-    refined = _refined(release_ts=22.0 + _AIM_PRE_RELEASE_SECONDS)
-
-    with (
-        patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_HMOD}.extract_frames",
-              AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
-              AsyncMock(return_value=grid)),
-        patch(f"{_HMOD}.localize_throw_with_refinement",
-              _localizer_mock(refined=refined)),
-        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_HMOD}.get_storage", return_value=storage),
-        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
-    ):
-        result = await generate_micro_clips_for_lineup(
-            db, lineup,
-            chapter_start=10.0, chapter_end=30.0,
-            video_path=Path("/tmp/x.mp4"),
-        )
-    assert result.stand_status == "skipped"
-    assert result.stand_skip_reason == "backfill_not_a_lineup"
-    assert result.aim_status == "generated"
-    assert result.aim_ts == pytest.approx(22.0)
-
-
-@pytest.mark.asyncio
-async def test_backfill_path_throw_localizer_no_release_skips_aim_but_stand_independent():
-    """Throw localizer says not-a-throw / no release → AIM skips cleanly.
-    Grid still runs independently — STAND still generates."""
-    db = AsyncMock()
-    lineup = _lineup()
-    storage = _storage_mock()
-    set_stand_mock = AsyncMock(return_value=lineup)
-    grid = _grid(best_stand_index=2)
-    timestamps = [12.0, 18.0, 24.0]
     not_a_throw = ThrowTimingResult(
         success=True, is_lineup_throw=False,
         release_index=None, result_index=None,
@@ -465,25 +390,17 @@ async def test_backfill_path_throw_localizer_no_release_skips_aim_but_stand_inde
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_HMOD}.extract_frames",
-              AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
-              AsyncMock(return_value=grid)),
         patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
-        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_HMOD}.get_storage", return_value=storage),
-        patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
     ):
         result = await generate_micro_clips_for_lineup(
             db, lineup,
             chapter_start=10.0, chapter_end=30.0,
             video_path=Path("/tmp/x.mp4"),
         )
-    assert result.stand_status == "generated"
-    assert result.stand_ts == pytest.approx(18.0)
+    assert result.stand_status == "skipped"
     assert result.aim_status == "skipped"
+    assert result.stand_skip_reason == "backfill_no_throw_release"
     assert result.aim_skip_reason == "backfill_no_throw_release"
 
 
@@ -520,53 +437,11 @@ async def test_backfill_path_classifier_missing_key_skips_both():
 
 
 @pytest.mark.asyncio
-async def test_backfill_path_grid_classifier_api_failure_fails_stand_aim_independent():
-    """Grid call fails (overloaded) → STAND fails with the structured code.
-    Throw localizer is separate; here it succeeds and AIM still generates."""
+async def test_backfill_path_throw_localizer_api_failure_fails_both():
+    """Throw localizer call fails (API error) → both sides fail with the
+    SAME structured codes (they share input)."""
     db = AsyncMock()
     lineup = _lineup()
-    storage = _storage_mock()
-    set_aim_mock = AsyncMock(return_value=lineup)
-    grid = ClassificationResult(
-        success=False, error_codes=["overloaded_error"],
-        reasoning="rate limited",
-    )
-    timestamps = [12.0, 18.0, 24.0]
-    refined = _refined(release_ts=22.0 + _AIM_PRE_RELEASE_SECONDS)
-
-    with (
-        patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_HMOD}.extract_frames",
-              AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
-              AsyncMock(return_value=grid)),
-        patch(f"{_HMOD}.localize_throw_with_refinement",
-              _localizer_mock(refined=refined)),
-        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_HMOD}.get_storage", return_value=storage),
-        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
-    ):
-        result = await generate_micro_clips_for_lineup(
-            db, lineup,
-            chapter_start=0.0, chapter_end=30.0,
-            video_path=Path("/tmp/x.mp4"),
-        )
-    assert result.stand_status == "failed"
-    assert "overloaded_error" in result.stand_error_codes
-    assert result.aim_status == "generated"
-
-
-@pytest.mark.asyncio
-async def test_backfill_path_both_classifiers_fail_returns_both_failed():
-    """When BOTH the grid call and the throw localizer fail with API errors,
-    both sides fail with structured codes (no fabrication)."""
-    db = AsyncMock()
-    lineup = _lineup()
-    grid = ClassificationResult(
-        success=False, error_codes=["overloaded_error"],
-        reasoning="rate limited",
-    )
     bad_timing = ThrowTimingResult(
         success=False, error_codes=["rate_limit_error"],
         reasoning="rate limited",
@@ -577,15 +452,9 @@ async def test_backfill_path_both_classifiers_fail_returns_both_failed():
         stage="coarse_failed",
         coarse_timing=bad_timing,
     )
-    timestamps = [12.0, 18.0, 24.0]
 
     with (
         patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
-        patch(f"{_HMOD}.extract_frames",
-              AsyncMock(return_value=[_FAKE_PNG] * 3)),
-        patch(f"{_HMOD}.classify_frames_for_lineup_decision",
-              AsyncMock(return_value=grid)),
         patch(f"{_HMOD}.localize_throw_with_refinement",
               _localizer_mock(refined=refined)),
     ):
@@ -596,44 +465,8 @@ async def test_backfill_path_both_classifiers_fail_returns_both_failed():
         )
     assert result.stand_status == "failed"
     assert result.aim_status == "failed"
-    assert "overloaded_error" in result.stand_error_codes
+    assert "rate_limit_error" in result.stand_error_codes
     assert "rate_limit_error" in result.aim_error_codes
-
-
-@pytest.mark.asyncio
-async def test_backfill_path_grid_frame_extract_failure_fails_stand_only():
-    """Grid extract fails → STAND fails; throw_localizer is independent.
-    Here the localizer succeeds → AIM generates."""
-    db = AsyncMock()
-    lineup = _lineup()
-    storage = _storage_mock()
-    set_aim_mock = AsyncMock(return_value=lineup)
-    timestamps = [12.0, 18.0, 24.0]
-    refined = _refined(release_ts=22.0 + _AIM_PRE_RELEASE_SECONDS)
-
-    with (
-        patch(f"{_MOD}.settings", _settings()),
-        patch(f"{_HMOD}.grid_timestamps", return_value=timestamps),
-        patch(
-            f"{_HMOD}.extract_frames",
-            AsyncMock(side_effect=FrameExtractionError(
-                "boom", timestamp=18.0, returncode=1, stderr="x",
-            )),
-        ),
-        patch(f"{_HMOD}.localize_throw_with_refinement",
-              _localizer_mock(refined=refined)),
-        patch(f"{_HMOD}.cut_clip", _ffmpeg_cut_mock()),
-        patch(f"{_HMOD}.get_storage", return_value=storage),
-        patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
-    ):
-        result = await generate_micro_clips_for_lineup(
-            db, lineup,
-            chapter_start=0.0, chapter_end=30.0,
-            video_path=Path("/tmp/x.mp4"),
-        )
-    assert result.stand_status == "failed"
-    assert any("frame_extract" in c for c in result.stand_error_codes)
-    assert result.aim_status == "generated"
 
 
 @pytest.mark.asyncio
@@ -686,7 +519,11 @@ async def test_backfill_path_no_source_video_skips_both():
 @pytest.mark.asyncio
 async def test_stand_cut_failure_does_not_affect_aim():
     """The two sides are committed by separate setters; a stand ffmpeg fault
-    must leave aim_status='generated', not 'failed'."""
+    must leave aim_status='generated', not 'failed'.
+
+    Both anchors share release_ts, but the cut/upload/persist runs once
+    per side — a downstream failure on one side must not propagate.
+    """
     db = AsyncMock()
     lineup = _lineup()
     storage = _storage_mock()
@@ -695,7 +532,7 @@ async def test_stand_cut_failure_does_not_affect_aim():
 
     # cut_clip raises on the first call (stand), succeeds on the second (aim).
     cut_side_effects = [
-        ClipCutError("boom", start=12.0, duration=1.0, returncode=1, stderr="x"),
+        ClipCutError("boom", start=22.0, duration=2.0, returncode=1, stderr="x"),
         _FAKE_MP4,
     ]
 
@@ -711,13 +548,12 @@ async def test_stand_cut_failure_does_not_affect_aim():
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
+        # release_ts = 25.0 → STAND_TS = 22.0, AIM_TS = 24.2
         result = await generate_micro_clips_for_lineup(
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            precomputed_stand_ts=12.0,
-            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
-            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
+            precomputed_release_ts=25.0,
         )
 
     assert result.stand_status == "failed"
@@ -776,25 +612,27 @@ async def test_offset_persisted_when_wider_source_exists():
         patch(f"{_MOD}.lineup_repo.set_stand_clip_url", set_stand_mock),
         patch(f"{_MOD}.lineup_repo.set_aim_clip_url", set_aim_mock),
     ):
+        # release_ts = 15.0 → STAND_TS = 12.0, AIM_TS = 14.2.
+        # wider_source_start = 10 - 2 = 8.0.
+        #   STAND offset = 12.0 - 8.0 = 4.0
+        #   AIM   offset = 14.2 - 8.0 = 6.2
         await generate_micro_clips_for_lineup(
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            precomputed_stand_ts=12.0,  # → offset 12 - (10 - 2) = 4.0
-            # AIM_TS = release_ts - 0.8 = 30.0; → offset 30 - 8 = 22.0
-            precomputed_release_ts=30.0 + _AIM_PRE_RELEASE_SECONDS,
+            precomputed_release_ts=15.0,
         )
 
     stand_call = set_stand_mock.await_args
     aim_call = set_aim_mock.await_args
     assert _offset_kwarg(stand_call) == pytest.approx(4.0), (
         "STAND offset must equal clip_start - wider_source_start "
-        "(12.0 - (10.0 - 2.0) = 4.0). "
+        "((15.0 - 3.0) - (10.0 - 2.0) = 4.0). "
         f"Got setter call: args={stand_call.args} kwargs={stand_call.kwargs}"
     )
-    assert _offset_kwarg(aim_call) == pytest.approx(22.0), (
+    assert _offset_kwarg(aim_call) == pytest.approx(6.2), (
         "AIM offset must equal clip_start - wider_source_start "
-        "(30.0 - 8.0 = 22.0). "
+        "((15.0 - 0.8) - 8.0 = 6.2). "
         f"Got setter call: args={aim_call.args} kwargs={aim_call.kwargs}"
     )
 
@@ -823,9 +661,7 @@ async def test_offset_not_persisted_when_no_wider_source():
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            precomputed_stand_ts=12.0,
-            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
-            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
+            precomputed_release_ts=25.0,
         )
 
     assert _offset_kwarg(set_stand_mock.await_args) is None
@@ -859,9 +695,7 @@ async def test_offset_not_persisted_when_original_matches_clip():
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            precomputed_stand_ts=12.0,
-            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
-            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
+            precomputed_release_ts=25.0,
         )
 
     assert _offset_kwarg(set_stand_mock.await_args) is None
@@ -891,9 +725,7 @@ async def test_stand_persist_failure_does_not_affect_aim():
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            precomputed_stand_ts=12.0,
-            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
-            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
+            precomputed_release_ts=25.0,
         )
     assert result.stand_status == "failed"
     assert "stand_clip_url_persist_failed" in result.stand_error_codes
@@ -915,9 +747,7 @@ async def test_upload_failure_per_side_returns_failed():
             db, lineup,
             chapter_start=10.0, chapter_end=40.0,
             video_path=Path("/tmp/x.mp4"),
-            precomputed_stand_ts=12.0,
-            # AIM_TS = release_ts - _AIM_PRE_RELEASE_SECONDS (0.8) = 24.0
-            precomputed_release_ts=24.0 + _AIM_PRE_RELEASE_SECONDS,
+            precomputed_release_ts=25.0,
         )
     # Storage down → both sides fail (same underlying fault per side).
     assert result.stand_status == "failed"


### PR DESCRIPTION
## Summary

- Operator surfaced 2026-05-24 that STAND was showing the wrong moment on "Market Window - B Site" (lineup `7bd971c3`) after PR #761 fixed AIM. STAND is supposed to show the player at the throwing position, ready to throw — but the grid pick frequently lands on the walk-up frame or the windup frame instead.
- Root cause is the same architectural issue PR #761 fixed for AIM: the 9-frame grid sampled across the whole chapter (~3.5s spacing) is too sparse to reliably catch the settled-stance moment. THROW + AIM + LANDING all derive from the throw-localizer's `release_ts` and look correct.
- Fix: anchor STAND on `release_ts` too. `STAND_TS = release_ts − _STAND_PRE_RELEASE_SECONDS` where `_STAND_PRE_RELEASE_SECONDS = 3.0`. The 2.0s STAND clip now spans `[release − 3.0, release − 1.0]` — settled stance ending just before the windup (which is ~0.5-0.8s pre-release).

## Plumbing

- **`micro_clip_generator`**: new constant `_STAND_PRE_RELEASE_SECONDS = 3.0`. Function signature change: `precomputed_stand_ts` removed; `precomputed_release_ts` is now the single shared anchor source. Uses a module-level `_Unresolved` sentinel as the kwarg default to distinguish "backfill (caller doesn't know release_ts)" from "ingest partial (caller checked and got None)". Both sides skip with `no_release_ts` when release_ts is None; on a backfill throw-localizer API failure, both sides fail with the same structured codes.
- **`micro_clip_helpers`**: `_resolve_stand_ts_via_grid_classifier` deleted (dead code) along with the grid-classifier imports and `_GRID_FRAME_COUNT`/`_GRID_EDGE_PADDING_SECONDS` constants.
- **`ingestion_orchestrator`**: drops `precomputed_stand_ts=timestamps[stand_idx]` from the micro-clip call. The grid `stand_idx` is still used for the `stand_screenshot_url` still upload (unchanged); only the clip anchor moved.
- **`micro_clip_backfill`**: omits `precomputed_release_ts` entirely (sentinel default → generator owns the throw-localizer call). Docstring updated.
- **Tests**: `test_micro_clip_generator.py` rewritten for the new contract. Removed obsolete grid-based tests (`grid_not_a_lineup_skips_stand`, `grid_classifier_api_failure`, `grid_frame_extract_failure`, `release_without_stand_is_wiring_bug`, `stand_only_generates_stand_skips_aim`). Added `test_ingest_path_no_release_ts_skips_both` + `test_backfill_path_throw_localizer_api_failure_fails_both`. All 31 micro-clip tests + 675 backend tests pass locally.

## Out of scope (intentional follow-up)

- Recutting `stand_screenshot` at the new STAND_TS. Same convention as PR #761 left the AIM still alone: the still is briefly visible as the clip poster before play; on clip-generation failures it's the only artifact shown. The clip itself (what the operator sees) is correct.
- Cleanup of the now-vestigial grid `stand_idx`/`aim_idx` plumbing in the orchestrator (still used for the stills). Defer to a later refactor.

## Operational

After merge, re-run on the local dev DB (no VPS deploy yet for MGA) to refresh existing accepted lineups:

```
# NULL stand_clip_url for the lineups you want to refresh (the backfill
# query only picks up lineups with a NULL clip URL on either side):
UPDATE lineup SET stand_clip_url = NULL WHERE id::text LIKE '7bd971c3%';

# Re-run:
python -m app.cli backfill-micro-clips
```

Backfill cost drops from "1 grid + 1-2 throw-timing" to just "1-2 throw-timing" per lineup — the grid call is no longer needed.

## Test plan

- [x] `pytest` — 675 passed (31 in `test_micro_clip_generator.py`, no regressions in `test_micro_clip_backfill.py` or `test_ingestion_with_classifier.py`).
- [ ] Operator validation: NULL `stand_clip_url` for `7bd971c3`, re-run `backfill-micro-clips`, confirm STAND pane now shows the settled-stance moment and not the walk-up/windup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)