### PR TITLE
feat(mga): yt-dlp cookies-file env var + permissive format spec

### DIFF
--- a/apps/mygamingassistant/backend/.env.docker.example
+++ b/apps/mygamingassistant/backend/.env.docker.example
@@ -108,6 +108,12 @@ INGESTION_DOWNLOAD_DIR_MAX_GB=10
 # helper no-ops. Unknown values are logged at WARNING and no cookies are
 # injected.
 YOUTUBE_COOKIES_FROM_BROWSER=
+# Path to a Netscape cookies.txt file. Takes precedence over
+# YOUTUBE_COOKIES_FROM_BROWSER. Export from a logged-in YouTube session
+# using a browser extension (e.g. "Get cookies.txt LOCALLY") and save to
+# this path. Re-export when YouTube rotates the session (typically every
+# few weeks). Leave blank to fall back to YOUTUBE_COOKIES_FROM_BROWSER.
+# YOUTUBE_COOKIES_FILE=/srv/myfreeapps/secrets/youtube-cookies.txt
 
 # APScheduler — background source sync cron (PR 6+).
 # SCHEDULER_ENABLED=false disables automatic syncing entirely (manual-only via

--- a/apps/mygamingassistant/backend/app/core/config.py
+++ b/apps/mygamingassistant/backend/app/core/config.py
@@ -94,6 +94,14 @@ class Settings(BaseAppSettings):
     # opera, brave, vivaldi, whale. Empty (default) disables cookie injection,
     # which is the right shape for CI / fresh deploys where no browser exists.
     youtube_cookies_from_browser: str = ""
+    # Optional: path to a Netscape cookies.txt file exported from a logged-in
+    # YouTube session. Takes precedence over YOUTUBE_COOKIES_FROM_BROWSER when
+    # set — bypasses Chrome's DPAPI encryption entirely (Chrome 127+ App-Bound
+    # Encryption breaks yt-dlp's browser cookie extraction on Windows). Export
+    # using a browser extension ("Get cookies.txt LOCALLY") and re-export every
+    # few weeks when YouTube rotates the session. Empty (default) disables file
+    # cookie injection and falls back to YOUTUBE_COOKIES_FROM_BROWSER.
+    youtube_cookies_file: str = ""
 
     # ------------------------------------------------------------------
     # Pane-editor wide-source window (for the trim editor)

--- a/apps/mygamingassistant/backend/app/services/ingestion/youtube_fetcher.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/youtube_fetcher.py
@@ -39,6 +39,41 @@ _SUPPORTED_COOKIE_BROWSERS = frozenset(
 )
 
 
+def _apply_cookies_file(opts: dict) -> dict:
+    """Inject ``cookiefile`` into a yt-dlp options dict if configured.
+
+    ``YOUTUBE_COOKIES_FILE`` points to a Netscape cookies.txt file exported
+    from a logged-in YouTube session (e.g. via the "Get cookies.txt LOCALLY"
+    browser extension). When set, yt-dlp reads cookies directly from the file,
+    bypassing Chrome's DPAPI encryption entirely — the canonical fix for the
+    Chrome 127+ App-Bound Encryption issue that breaks ``cookiesfrombrowser``
+    on Windows.
+
+    **Precedence:** when both ``YOUTUBE_COOKIES_FILE`` and
+    ``YOUTUBE_COOKIES_FROM_BROWSER`` are set, both options land in *opts* and
+    yt-dlp prefers ``cookiefile`` at request time (documented behaviour). The
+    browser option is harmless side-cargo and the file wins.
+
+    No-op when the setting is empty. If the path is set but doesn't resolve to
+    an existing file, logs a single WARNING and leaves *opts* unchanged — the
+    request proceeds without file cookies and will fail loudly with the
+    underlying yt-dlp error if no other auth path is available.
+    """
+    raw = (settings.youtube_cookies_file or "").strip()
+    if not raw:
+        return opts
+    cookie_path = Path(raw)
+    if not cookie_path.exists():
+        logger.warning(
+            "youtube_fetcher: YOUTUBE_COOKIES_FILE=%r does not exist — not "
+            "injecting file cookies. Create the file or unset the variable.",
+            raw,
+        )
+        return opts
+    opts["cookiefile"] = str(cookie_path)
+    return opts
+
+
 def _apply_browser_cookies(opts: dict) -> dict:
     """Inject ``cookiesfrombrowser`` into a yt-dlp options dict if configured.
 
@@ -181,13 +216,13 @@ async def list_videos(source: Source) -> list[VideoMeta]:
     # the /videos tab so the flat extraction returns actual videos.
     url = _normalize_listing_url(raw_url)
 
-    ydl_opts = _apply_browser_cookies({
+    ydl_opts = _apply_cookies_file(_apply_browser_cookies({
         "quiet": True,
         "no_warnings": True,
         "extract_flat": True,
         "skip_download": True,
         "ignoreerrors": False,
-    })
+    }))
 
     def _fetch() -> list[VideoMeta]:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
@@ -289,12 +324,12 @@ async def fetch_video_detail(video_id: str) -> VideoMeta:
     YouTubeFetchError.
     """
     url = f"https://www.youtube.com/watch?v={video_id}"
-    ydl_opts = _apply_browser_cookies({
+    ydl_opts = _apply_cookies_file(_apply_browser_cookies({
         "quiet": True,
         "no_warnings": True,
         "skip_download": True,
         "ignoreerrors": False,
-    })
+    }))
 
     def _fetch() -> VideoMeta:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:
@@ -369,14 +404,18 @@ async def download_video(video_id: str, download_dir: Path) -> Path:
     download_dir.mkdir(parents=True, exist_ok=True)
     output_template = str(download_dir / f"{video_id}.%(ext)s")
 
-    ydl_opts = _apply_browser_cookies({
+    ydl_opts = _apply_cookies_file(_apply_browser_cookies({
         "quiet": True,
         "no_warnings": True,
         "outtmpl": output_template,
-        "format": "bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best",
+        # Permissive format selector: let yt-dlp pick best video+audio from any
+        # codec — merge_output_format=mp4 below coerces the merged file to mp4
+        # regardless of source codecs. The old ext=mp4 filter excluded webm/vp9
+        # streams, which is all YouTube hands to anonymous/non-Premium sessions.
+        "format": "bestvideo*+bestaudio/best",
         "merge_output_format": "mp4",
         "ignoreerrors": False,
-    })
+    }))
 
     def _download() -> Path:
         with yt_dlp.YoutubeDL(ydl_opts) as ydl:

--- a/apps/mygamingassistant/backend/tests/test_youtube_fetcher.py
+++ b/apps/mygamingassistant/backend/tests/test_youtube_fetcher.py
@@ -25,6 +25,7 @@ from app.services.ingestion.youtube_fetcher import (
     VideoMeta,
     YouTubeFetchError,
     _apply_browser_cookies,
+    _apply_cookies_file,
     download_video,
     fetch_video_detail,
     list_videos,
@@ -484,3 +485,142 @@ class TestCookiesWireUp:
             await list_videos(_make_source())
 
         assert "cookiesfrombrowser" not in constructor.call_args.args[0]
+
+
+# ---------------------------------------------------------------------------
+# Cookies-file helper + wire-up
+#
+# YOUTUBE_COOKIES_FILE is the Windows-safe alternative to the browser-cookies
+# path. Chrome 127+ App-Bound Encryption broke yt-dlp's DPAPI extraction;
+# a Netscape cookies.txt file exported from a live session sidesteps DPAPI.
+#
+# Precedence rule: when both settings are set, cookiefile wins (yt-dlp
+# prefers it at request time). The browser option stays in the dict as
+# harmless side-cargo — both can coexist without conflict.
+# ---------------------------------------------------------------------------
+
+class TestApplyCookiesFile:
+    def test_empty_setting_is_noop(self, monkeypatch: pytest.MonkeyPatch):
+        monkeypatch.setattr(settings, "youtube_cookies_file", "")
+        opts = {"quiet": True}
+        out = _apply_cookies_file(opts)
+        assert "cookiefile" not in out
+        assert out is opts  # same dict, no defensive copy
+
+    def test_injects_cookiefile_for_existing_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        cookie_file = tmp_path / "cookies.txt"
+        cookie_file.write_text("# Netscape HTTP Cookie File\n")
+        monkeypatch.setattr(settings, "youtube_cookies_file", str(cookie_file))
+        out = _apply_cookies_file({"quiet": True})
+        assert out["cookiefile"] == str(cookie_file)
+
+    def test_missing_path_warns_and_is_noop(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        import logging
+        missing = str(tmp_path / "nonexistent-cookies.txt")
+        monkeypatch.setattr(settings, "youtube_cookies_file", missing)
+        with caplog.at_level(logging.WARNING, logger="app.services.ingestion.youtube_fetcher"):
+            out = _apply_cookies_file({"quiet": True})
+        assert "cookiefile" not in out
+        assert any("nonexistent-cookies.txt" in r.message for r in caplog.records)
+
+    def test_file_and_browser_both_coexist_in_dict(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        """Both options can be present simultaneously — yt-dlp prefers cookiefile
+        at request time, browser option is harmless side-cargo."""
+        cookie_file = tmp_path / "cookies.txt"
+        cookie_file.write_text("# Netscape HTTP Cookie File\n")
+        monkeypatch.setattr(settings, "youtube_cookies_file", str(cookie_file))
+        monkeypatch.setattr(settings, "youtube_cookies_from_browser", "firefox")
+
+        opts = _apply_cookies_file(_apply_browser_cookies({}))
+        assert opts["cookiefile"] == str(cookie_file)
+        assert opts["cookiesfrombrowser"] == ("firefox",)
+
+
+class TestCookiesFileWireUp:
+    """Each yt-dlp call site MUST pass its options dict through
+    _apply_cookies_file. These tests fail if a future refactor drops
+    the wrapper from any one of them."""
+
+    @pytest.mark.asyncio
+    async def test_list_videos_passes_cookiefile(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        cookie_file = tmp_path / "cookies.txt"
+        cookie_file.write_text("# Netscape HTTP Cookie File\n")
+        monkeypatch.setattr(settings, "youtube_cookies_file", str(cookie_file))
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value={"id": "PLempty", "entries": []})
+
+        constructor = MagicMock(return_value=mock_ydl)
+        with patch("yt_dlp.YoutubeDL", constructor):
+            await list_videos(_make_source())
+
+        assert constructor.call_args.args[0].get("cookiefile") == str(cookie_file)
+
+    @pytest.mark.asyncio
+    async def test_fetch_video_detail_passes_cookiefile(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        cookie_file = tmp_path / "cookies.txt"
+        cookie_file.write_text("# Netscape HTTP Cookie File\n")
+        monkeypatch.setattr(settings, "youtube_cookies_file", str(cookie_file))
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value={
+            "id": "vid000", "title": "x", "duration": 1, "upload_date": "20260101",
+            "channel": "c", "description": "", "chapters": [],
+        })
+
+        constructor = MagicMock(return_value=mock_ydl)
+        with patch("yt_dlp.YoutubeDL", constructor):
+            await fetch_video_detail("vid000")
+
+        assert constructor.call_args.args[0].get("cookiefile") == str(cookie_file)
+
+    @pytest.mark.asyncio
+    async def test_download_video_passes_cookiefile(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ):
+        cookie_file = tmp_path / "cookies.txt"
+        cookie_file.write_text("# Netscape HTTP Cookie File\n")
+        monkeypatch.setattr(settings, "youtube_cookies_file", str(cookie_file))
+        (tmp_path / "vid001.mp4").write_bytes(b"x")
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.download = MagicMock(return_value=None)
+
+        constructor = MagicMock(return_value=mock_ydl)
+        with patch("yt_dlp.YoutubeDL", constructor):
+            await download_video("vid001", download_dir=tmp_path)
+
+        assert constructor.call_args.args[0].get("cookiefile") == str(cookie_file)
+
+    @pytest.mark.asyncio
+    async def test_no_cookiefile_key_when_setting_empty(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Empty YOUTUBE_COOKIES_FILE must NOT add cookiefile to the opts."""
+        monkeypatch.setattr(settings, "youtube_cookies_file", "")
+        mock_ydl = MagicMock()
+        mock_ydl.__enter__ = MagicMock(return_value=mock_ydl)
+        mock_ydl.__exit__ = MagicMock(return_value=False)
+        mock_ydl.extract_info = MagicMock(return_value={"id": "PLempty", "entries": []})
+
+        constructor = MagicMock(return_value=mock_ydl)
+        with patch("yt_dlp.YoutubeDL", constructor):
+            await list_videos(_make_source())
+
+        assert "cookiefile" not in constructor.call_args.args[0]


### PR DESCRIPTION
## Why

Two compounding failures blocked the MGA ingestion path:

1. Chrome 127+ App-Bound Encryption on Windows breaks yt-dlp's `cookiesfrombrowser=chrome` with a DPAPI decryption error (not fixable in our code).
2. The download format spec `"bestvideo[ext=mp4]+bestaudio[ext=m4a]/best[ext=mp4]/best"` rejected modern YouTube anonymous-session formats, so even when Firefox cookies authenticated, `"Requested format is not available"` fired.

Symptom: every video download / detail fetch / channel sync fails. AIM/STAND/THROW micro-clip backfills can't run. PR #764's content-aware AIM-localizer could not be runtime-validated.

## What changed

- Adds `YOUTUBE_COOKIES_FILE` env var alongside the existing `YOUTUBE_COOKIES_FROM_BROWSER`. File path takes precedence — bypasses Chrome's DPAPI entirely. Stable for weeks between re-exports.
- Loosens the download format spec to `"bestvideo*+bestaudio/best"`. `merge_output_format=mp4` already coerces the merged output to mp4, so we don't need the on-disk codec; this just lets yt-dlp pick from the wider candidate set YouTube exposes to anonymous + non-Premium sessions.
- Existing `YOUTUBE_COOKIES_FROM_BROWSER` continues to work for callers who can use it; new var is purely additive.

## ⚠️ Operational migration required

After this PR merges and before the next ingestion / backfill run, do ONCE:

1. **Export cookies.txt from a logged-in YouTube session.**
   - In Firefox or Chrome, install the extension "Get cookies.txt LOCALLY" (open-source, no telemetry — verify by repo before installing).
   - Log into YouTube in that browser.
   - Visit youtube.com. Click the extension icon. Export → "Save As" → choose a path the backend can read (suggest `~/.config/mga/youtube-cookies.txt` on Linux/Mac, `%USERPROFILE%\.config\mga\youtube-cookies.txt` on Windows; on the VPS the deploy path is `/srv/myfreeapps/secrets/youtube-cookies.txt` per the .env.docker.example).
2. **Set the env var.**
   - Local dev: add `YOUTUBE_COOKIES_FILE=<path>` to `apps/mygamingassistant/backend/.env.docker` (or wherever local env lives).
   - Production VPS: append the same line to `/srv/myfreeapps/apps/mygamingassistant/backend/.env.docker`.
3. **Verify** by running `python -m app.cli backfill-micro-clips` and watching for a successful download.
4. **Re-export** every few weeks when YouTube rotates the session (symptom: the bot-protection error returns).

### Rollback path

This PR is purely additive — empty `YOUTUBE_COOKIES_FILE` falls back to the old browser-cookies path. Reverting the format-spec change alone would not break anything because the new spec is strictly more permissive. No DB / migration changes.

## Validation

After merge + operator cookies.txt export:
- Run `python -m app.cli backfill-micro-clips`. Lineup 7bd971c3 ("Market Window - B Site") should re-localize its AIM (state was cleared in the PR #764 session). Operator visual inspection of the AIM clip in the storyboard confirms the throw-motion regression is fixed.

## Tests

8 new unit tests in `tests/test_youtube_fetcher.py`:
- `TestApplyCookiesFile`: empty no-op, valid path injection, missing-path warn+noop, coexistence with browser option
- `TestCookiesFileWireUp`: regression guards for all three call sites (list_videos, fetch_video_detail, download_video) — same pattern as the existing `TestCookiesWireUp` class

739 total pass (731 pre-existing + 8 new).