### PR TITLE
fix(mga): AIM localizer prompt + drop utility_hint (knife misread on 7bd971c3)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/aim_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/aim_timing_classifier.py
@@ -77,21 +77,65 @@ the world the crosshair is locked onto. The narrator is typically:
   - Standing still at the throwing spot, crosshair held on a specific
     landmark (window pixel, antenna tip, ledge corner, skybox feature,
     pixel-perfect alignment mark).
-  - Utility VISIBLE IN HAND (grenade pulled out, smoke held, molotov
-    primed) — pre-windup, not mid-throw.
+  - View often TILTED UP toward a sky/tower/rooftop landmark; the
+    narrator's hands and utility may sit BELOW the bottom of the frame
+    when the camera is angled up far enough — this is normal, not a
+    disqualifier (see POSITIVE AIM CUES below).
   - HUD may overlay the target ("AIM HERE", crosshair circle, arrow on
     the landmark, ALIGN-PIXEL marker).
 All valid.
 
-POSITIVE AIM CUES
-  - Crosshair locked on a far landmark used as an aim reference
-    (window pixel, antenna, ledge, skybox feature).
-  - Tight composition centred on the aim landmark — minimal camera
-    motion, view stable over several frames.
-  - Utility visible in hand, in READY pose (held up, not in windup arc).
-  - HUD callouts naming/pointing at the aim target.
-  - Pixel-alignment marks / on-screen reticle annotation.
-  - Latest "settled" frame BEFORE any windup motion begins.
+POSITIVE AIM CUES (ranked — primary cue outranks the others)
+  1. PRIMARY: crosshair locked on a far landmark used as an aim
+     reference (window pixel, antenna, ledge, sky/tower, rooftop,
+     skybox feature). A locked crosshair on a clear landmark IS the
+     aim demo — hand visibility is secondary.
+  2. Tight composition centred on the aim landmark — minimal camera
+     motion, view stable over several frames.
+  3. HUD callouts naming/pointing at the aim target ("AIM HERE",
+     arrow on landmark, ALIGN-PIXEL annotation).
+  4. Pixel-alignment marks / on-screen reticle annotation.
+  5. Latest "settled" frame BEFORE any windup motion begins.
+  6. Utility visible in hand in READY pose, when present — NEUTRAL
+     when absent. The narrator may tilt the camera up so the hands
+     leave the bottom of the frame; that does NOT disqualify the
+     frame. A crosshair-on-landmark frame with no visible hands IS
+     a valid aim-demo composition.
+
+CRITICAL — KNIFE DISAMBIGUATION
+A KNIFE (karambit, butterfly, bayonet, M9, huntsman, gut, flip, falchion,
+shadow daggers, ursus, navaja, stiletto, talon, classic, paracord,
+survival, nomad, skeleton) IN ANY SKIN is NEVER a grenade. Knives include
+exotic, gold, marble-fade, case-hardened, doppler, fade, slaughter,
+crimson-web, tiger-tooth, lore, autotronic, and "inspector" finishes
+that can look unusual or ornate — these are STILL knives, not utility.
+
+  - A CS2 SMOKE GRENADE is a short gray cylinder with a green stripe
+    near the top and a metallic pull-ring; it is NOT a long blade.
+  - A CS2 FLASH is a small black/grey cylinder with red markings.
+  - A CS2 HE is olive-green and round-ended.
+  - A CS2 MOLOTOV/INCENDIARY is a clear bottle with visible liquid.
+  - A KARAMBIT is a curved blade with a finger ring; gold/marble-fade
+    variants are still curved blades, not smoke grenades.
+  - A KNIFE is held with the blade visible — long, sharp, single edge
+    (or curved). If the visible weapon is a BLADE of any kind, REJECT
+    the frame regardless of other cues. The narrator has not yet
+    equipped the utility; this is walk-up territory.
+
+CHAPTER-INTRO EXCLUSION
+Frames featuring a full-opacity intro overlay — typically lower-left
+text like "SMOKE #N", "SITE - LANDMARK", "B SITE - MARKET WINDOW",
+"FLASH #N - SHORT", or other "chapter title" callouts — are WALK-IN /
+INTRODUCTION cues, NOT aim demos. The aim demo is structurally AFTER
+these overlays have faded and the narrator has equipped the utility.
+
+  - If the chapter title text is rendered in-frame at full opacity,
+    REJECT the frame. The narrator is still walking up to the spot.
+  - Prefer frames where the intro overlay is absent, faded, or
+    transitioned out.
+  - The aim demo arrives a few seconds AFTER the intro overlay clears;
+    don't let the overlay's "SITE - LANDMARK" text bias you into
+    picking the intro frame just because the chapter title matches.
 
 CANDIDATE-FRAME EXCLUSIONS
 Do NOT return aim_index on a frame matching ANY of:
@@ -102,10 +146,14 @@ Do NOT return aim_index on a frame matching ANY of:
     surroundings (wall behind, cover, floor markings) — that is the
     STAND demo, not AIM. Subject is the location, not the target.
   - MAP OVERLAY / MINIMAP ZOOM: those are STAND demos, not AIM.
-  - KNIFE-ONLY / UTILITY-HOLSTERED: no utility in hand → not yet aiming.
-    The narrator may be walking up; wait for utility-out frames.
-  - WALKING / CAMERA SWEEPING: view is in motion, crosshair not held
-    on a single landmark.
+  - KNIFE-IN-HAND / UTILITY-HOLSTERED: any visible blade → not yet
+    aiming. The narrator may be walking up; wait for utility-out
+    frames. (See CRITICAL — KNIFE DISAMBIGUATION above; do not
+    misread an ornate knife skin as a grenade.)
+  - WALKING / CAMERA SWEEPING: view is in motion AND crosshair is
+    not held on a single landmark. A still camera tilted up at a
+    sky/tower landmark is NOT "camera sweeping" — it is the aim
+    demo. Reject only on actual motion across multiple frames.
   - REPLAY / KILL-CAM / SCOREBOARD / MENU.
   - PURE TALKING-HEAD / FACECAM-DOMINANT frame with the aim view not
     visible or not the primary subject.
@@ -154,7 +202,6 @@ async def classify_aim_timing_from_frames(
     frame_timestamps: list[float],
     chapter_title: Optional[str],
     chapter_duration: Optional[float],
-    utility_hint: Optional[str] = None,
 ) -> AimTimingResult:
     """Locate the AIM demonstration frame within ONE chapter.
 
@@ -173,11 +220,6 @@ async def classify_aim_timing_from_frames(
             returned 1-based index back to seconds.
         chapter_title: YouTube chapter title — per-call context.
         chapter_duration: Chapter length in seconds — per-call context.
-        utility_hint: Optional utility slug from a prior grid
-            classification (passed only when confidence > 0.6) — helps
-            the model reason about what kind of aim posture to look for
-            (e.g., a smoke usually has a long settled aim on a precise
-            landmark whereas a flash may be a quicker target check).
 
     Returns:
         AimTimingResult. ``success=True`` with
@@ -251,10 +293,6 @@ async def classify_aim_timing_from_frames(
         context_parts.append(f"Chapter title: {chapter_title}")
     if chapter_duration is not None:
         context_parts.append(f"Chapter duration: {chapter_duration:.0f}s")
-    if utility_hint:
-        context_parts.append(
-            f"Utility type (from prior classification): {utility_hint}"
-        )
     if context_parts:
         user_content.append({"type": "text", "text": "\n".join(context_parts)})
 

--- a/apps/mygamingassistant/backend/app/services/ingestion/aim_localizer.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/aim_localizer.py
@@ -203,7 +203,6 @@ async def localize_aim_with_refinement(
     chapter_start: float,
     release_ts: float,
     chapter_title: Optional[str],
-    utility_hint: Optional[str] = None,
 ) -> RefinedAimTiming:
     """Localise the AIM demonstration with optional dense-pass refinement.
 
@@ -215,8 +214,6 @@ async def localize_aim_with_refinement(
             bound of the pre-windup search window — AIM demos must
             precede the windup which itself precedes the release.
         chapter_title: Per-call context surfaced to Claude.
-        utility_hint: Optional utility slug from a prior grid
-            classification at confidence > 0.6.
     """
     chapter_duration = float(release_ts) - float(chapter_start)
 
@@ -267,7 +264,6 @@ async def localize_aim_with_refinement(
         frame_timestamps=coarse_timestamps,
         chapter_title=chapter_title,
         chapter_duration=chapter_duration,
-        utility_hint=utility_hint,
     )
 
     skip_stage = _should_refine(coarse)
@@ -340,7 +336,6 @@ async def localize_aim_with_refinement(
         frame_timestamps=dense_timestamps,
         chapter_title=chapter_title,
         chapter_duration=chapter_duration,
-        utility_hint=utility_hint,
     )
 
     if (

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_helpers.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_helpers.py
@@ -257,7 +257,6 @@ async def _resolve_aim_ts(
             chapter_start=float(chapter_start),
             release_ts=float(release_ts),
             chapter_title=lineup.chapter_title or "",
-            utility_hint=None,
         )
     except FrameExtractionError as exc:
         logger.warning(

--- a/apps/mygamingassistant/backend/tests/test_aim_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_aim_timing_classifier.py
@@ -66,7 +66,6 @@ async def _call(payload_or_exc, *, frames=None, timestamps=None, **kwargs):
             frame_timestamps=timestamps,
             chapter_title=kwargs.get("chapter_title", "B-site smoke"),
             chapter_duration=kwargs.get("chapter_duration", 30.0),
-            utility_hint=kwargs.get("utility_hint"),
         )
     return result, mock_client
 
@@ -101,17 +100,6 @@ class TestAimTimingHappyPath:
         texts = [b["text"] for b in content if b["type"] == "text"]
         assert "Frame 1 (t=10.0s):" in texts
         assert "Frame 2 (t=12.5s):" in texts
-
-    @pytest.mark.asyncio
-    async def test_utility_hint_passed_as_context(self):
-        _, client = await _call(
-            {"has_aim_demonstration": True, "aim_index": 1,
-             "confidence": 0.7, "reasoning": "x"},
-            utility_hint="molotov",
-        )
-        content = client.messages.create.call_args.kwargs["messages"][0]["content"]
-        joined = "\n".join(b["text"] for b in content if b["type"] == "text")
-        assert "molotov" in joined
 
     @pytest.mark.asyncio
     async def test_system_prompt_is_cache_controlled(self):
@@ -325,19 +313,21 @@ class TestAimTimingPromptShape:
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_utility_in_ready_pose(self):
-        """A locked-aim frame should have the utility VISIBLE IN HAND in
-        READY pose — if this drops, the model would happily pick
-        knife-only-walking frames as aim demos."""
+        """The prompt should keep the utility-in-ready-pose cue (now ranked
+        as NEUTRAL when absent — the camera-up case can hide hands) AND
+        the KNIFE-IN-HAND exclusion that distinguishes knife-only walk-up
+        frames from utility-out aim frames."""
         _, client = await _call(
             {"has_aim_demonstration": True, "aim_index": 1,
              "confidence": 0.6, "reasoning": "x"},
         )
         system = client.messages.create.call_args.kwargs["system"]
         system_text = "\n".join(b["text"] for b in system)
-        # Two of the three places the prompt mentions ready-pose / hand
-        # — the prompt would not still make sense if these dropped.
-        assert "VISIBLE IN HAND" in system_text
+        # Ready-pose cue still present (downgraded to cue #6 but kept) and
+        # the KNIFE-IN-HAND exclusion is the regression backstop for the
+        # 7bd971c3 misread.
         assert "READY" in system_text.upper()
+        assert "KNIFE-IN-HAND" in system_text
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_game_visual_cues(self):
@@ -350,3 +340,24 @@ class TestAimTimingPromptShape:
         system = client.messages.create.call_args.kwargs["system"]
         system_text = "\n".join(b["text"] for b in system)
         assert "HOW TO IDENTIFY THE GAME FROM THE SCREEN" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_knife_and_chapter_intro_blocks(self):
+        """Regression lock for 7bd971c3 ("Market Window - B Site", 2026-05-24):
+        Claude misread a karambit knife as a smoke grenade in F3 of the coarse
+        window AND was biased into picking an intro-overlay frame because the
+        overlay text matched the chapter title. Two new prompt sections —
+        KNIFE DISAMBIGUATION and CHAPTER-INTRO EXCLUSION — counter both
+        biases. If a future refactor drops either heading, fail CI here."""
+        _, client = await _call(
+            {"has_aim_demonstration": True, "aim_index": 1,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "KNIFE DISAMBIGUATION" in system_text
+        assert "CHAPTER-INTRO EXCLUSION" in system_text
+        # Crosshair-on-landmark must be ranked as the PRIMARY positive cue
+        # so the model doesn't require hands-in-frame to accept aim demos
+        # where the narrator has tilted the camera up at a sky/tower target.
+        assert "PRIMARY" in system_text


### PR DESCRIPTION
## Summary

Lineup `7bd971c3` ("Market Window - B Site", CS2 Mirage) shipped a wrong AIM micro-clip: the pane showed the player holding a karambit knife during walk-up. PR #766 tightened the clip window but didn't help because `aim_ts` itself was wrong.

**Root cause** (verified by re-invoking `localize_aim_with_refinement` with logging + dumping coarse frames):

- Claude misread a gold karambit knife in F3 as a smoke grenade and fabricated "camera sweeping" reasoning to exclude F5-F8 (the actual sky/tower aim demos where the narrator tilted the camera up and hands left the bottom of the frame).
- The "Utility VISIBLE IN HAND" cue created a bias toward hand-visible frames over true camera-up aim demos.
- The chapter-intro overlay biased the model into picking the intro frame because the text matched the chapter title.

**Fix** (one PR, two changes):

1. `aim_timing_classifier.py` prompt rewrite:
   - Rank crosshair-on-landmark as the **PRIMARY** positive cue; demote hand-visibility to **NEUTRAL** (camera-up cases hide hands by design).
   - Add **CRITICAL — KNIFE DISAMBIGUATION** block enumerating CS2 knife types/skins and CS2 utility shapes so an ornate karambit can't be misread as a smoke.
   - Add **CHAPTER-INTRO EXCLUSION** block: full-opacity intro overlay text is walk-in territory, not aim demo.
   - Tighten the WALKING / CAMERA SWEEPING exclusion to require actual motion across frames.

2. Drop `utility_hint` from the AIM chain (production already passes None — dead defensive code that could have amplified the smoke misread):
   - `classify_aim_timing_from_frames` parameter + 3 prompt-context lines.
   - `localize_aim_with_refinement` parameter + 2 pass-through calls.
   - `micro_clip_helpers._resolve_aim_ts` `utility_hint=None` kwarg.
   - STAND + THROW localizers/classifiers untouched per scope.

3. Tests: drop `utility_hint`-passed test; add `test_system_prompt_includes_knife_and_chapter_intro_blocks` regression backstop.

LOC: `aim_timing_classifier.py` 385 → 423 (under 500 threshold).

## Test plan

- [x] 46/46 `test_aim_localizer.py` + `test_aim_timing_classifier.py` green
- [x] 46/46 adjacent tests (`test_micro_clip_generator`, `test_clip_backfill`, `test_ingestion_with_classifier`) green
- [x] Live diagnostic re-run: Claude picks F8 coarse (t=267.44s) citing "tower/skybox landmark", "knife (excluded)", "WALK-IN/INTRO" overlay; dense refines to t=266.79s
- [x] Local backfill of `7bd971c3`: `aim_ts` 259.34s → 266.64s (+7.30s into real aim-demo territory); `aim_clip_url` regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)