### PR TITLE
fix(mga): shrink storyboard tiles + widen minimap sidebar (audit-time sizing)

### DIFF
--- a/apps/mygamingassistant/TECH_DEBT.md
+++ b/apps/mygamingassistant/TECH_DEBT.md
@@ -331,6 +331,15 @@ backend/app/services/ingestion/clip_pipeline.py
 
 ## Low
 
+### [UX] No direct-link route for a single lineup - audit / share / debug workflow forced to scroll the map glance-board
+
+- **Severity:** Low
+- **Effort:** S (1-2 hours)
+- **Category:** UX / debuggability
+- **Location:** frontend/src/routes.tsx (no `/lineups/:id` path); frontend/src/pages/MapPage.tsx (no `?lineup=<id>` searchParam handling)
+- **Problem:** Lineup cards render only inside MapPage's glance-board (grouped/filtered). To reference a single lineup (during operator review, in a bug report, in chat with the assistant), you have to navigate to the right map page, possibly toggle filters, and scroll to find it by chapter title. Surfaced 2026-05-25 during full-12-lineup audit walk-through — the assistant had to point the operator at `/cs2/<map>?util=smoke&side=side_a` + a chapter-title hint instead of a deterministic URL.
+- **Recommendation:** Two viable shapes — (a) add a route `/lineups/:id` that renders a single GlanceBoardTile (or list-row in expanded state) in a centered shell, OR (b) add `?lineup=<id>` searchParam to MapPage that auto-scrolls + highlights the matching card. (a) is more direct-share-friendly; (b) preserves the surrounding map context. Pick (a) for the audit/share use case.
+
 ### [Architecture] Schemas - lineup_schemas.py is a 13-class catch-all (381 LOC) - Pydantic forms, response shapes, validators all inline
 
 - **Severity:** Low

--- a/apps/mygamingassistant/frontend/src/hooks/useDesignKnobs.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/useDesignKnobs.ts
@@ -32,7 +32,7 @@ export const DEFAULT_KNOBS: DesignKnobs = {
   aimMode: "clip",
   showAimDot: true,
   landingMode: "clip",
-  tilesPerRow: 2,
+  tilesPerRow: 3,
 };
 
 function parsePaneMode(raw: string | null, fallback: PaneMode): PaneMode {

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -389,7 +389,7 @@ export default function MapPage() {
           {/* Minimap sidebar — polygon clicks now set the zone filter via
               handleZoneClick. The active zone (if any) is highlighted. */}
           <aside
-            className="hidden lg:block w-[200px] shrink-0 p-3 border-r overflow-y-auto sticky top-10 h-[calc(100vh-40px)]"
+            className="hidden lg:block w-[320px] shrink-0 p-3 border-r overflow-y-auto sticky top-10 h-[calc(100vh-40px)]"
             aria-label="Map zone navigation"
           >
             <GlanceBoardMinimapSidebar


### PR DESCRIPTION
## Why

During an operator review walk-through of all 12 lineups in the local DB, the operator flagged that the storyboard tiles dominate the viewport and the 200px minimap is hard to read. This blocks visual diagnosis of clip accuracy because there's not enough room to compare panes side-by-side comfortably.

## What changed

Two coupled default tweaks — pure sizing, no structural changes:

- **`apps/mygamingassistant/frontend/src/pages/MapPage.tsx`** — minimap sidebar `w-[200px]` → `w-[320px]` (+60%)
- **`apps/mygamingassistant/frontend/src/hooks/useDesignKnobs.ts`** — `DEFAULT_KNOBS.tilesPerRow` `2` → `3` (each tile ~−38% wide)

Net on a 1920px display:
- Before: 200 sidebar + (1672 / 2) = **836px-wide tile**, each pane ~418px
- After:  320 sidebar + (1552 / 3) = **517px-wide tile**, each pane ~258px

Operator can still override via the design-knobs panel (`?cols=1|2|3` URL param) — only defaults changed.

## Also bundled

`apps/mygamingassistant/TECH_DEBT.md` — added Low-severity entry for a future `/lineups/:id` direct-link route. Surfaced during the same audit walk-through when the assistant had to hand the operator a glance-board URL + chapter-title hint instead of a per-lineup link. Deferred per operator direction.

## Verification

- `npm run typecheck` — clean
- `npm test` — 404 pass, 1 pre-existing `MicroClipShiftOverlay.test.tsx` failure (documented in STATE.md as exists-on-main, unrelated to this PR)

## Test plan

- [ ] Open `/cs2/mirage` on a 1920px display — confirm minimap is readable and 3 tiles fit per row without horizontal scroll
- [ ] Toggle to `?cols=2` via the design-knobs panel — confirm operator override still works
- [ ] Toggle to `?cols=1` — confirm single wide column also fits

🤖 Generated with [Claude Code](https://claude.com/claude-code)