### PR TITLE
fix(mga): further shrink tiles + widen minimap to 440px (audit v2)

### DIFF
--- a/apps/mygamingassistant/frontend/src/components/lineup/DesignKnobsPanel.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/DesignKnobsPanel.tsx
@@ -148,6 +148,7 @@ export default function DesignKnobsPanel() {
           { label: "1", value: 1 },
           { label: "2", value: 2 },
           { label: "3", value: 3 },
+          { label: "4", value: 4 },
         ]}
         onChange={(v) => setKnob("tilesPerRow", v)}
       />

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoard.tsx
@@ -36,10 +36,11 @@ interface GlanceBoardProps {
   showOperatorOverlays?: boolean;
 }
 
-const GRID_COLS_CLASS: Record<1 | 2 | 3, string> = {
+const GRID_COLS_CLASS: Record<1 | 2 | 3 | 4, string> = {
   1: "grid-cols-1",
   2: "grid-cols-2",
   3: "grid-cols-3",
+  4: "grid-cols-4",
 };
 
 // ---------------------------------------------------------------------------

--- a/apps/mygamingassistant/frontend/src/hooks/useDesignKnobs.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/useDesignKnobs.ts
@@ -10,14 +10,14 @@
  *   aim=still|clip         — AIM pane content
  *   dot=on|off             — AIM anchor dot
  *   landing=clip|text      — LANDING pane content
- *   cols=1|2|3             — tiles per row in the grid
+ *   cols=1|2|3|4           — tiles per row in the grid
  */
 import { useCallback, useMemo } from "react";
 import { useSearchParams } from "react-router-dom";
 
 export type PaneMode = "still" | "clip";
 export type LandingMode = "clip" | "text";
-export type TilesPerRow = 1 | 2 | 3;
+export type TilesPerRow = 1 | 2 | 3 | 4;
 
 export interface DesignKnobs {
   standMode: PaneMode;
@@ -32,7 +32,7 @@ export const DEFAULT_KNOBS: DesignKnobs = {
   aimMode: "clip",
   showAimDot: true,
   landingMode: "clip",
-  tilesPerRow: 3,
+  tilesPerRow: 4,
 };
 
 function parsePaneMode(raw: string | null, fallback: PaneMode): PaneMode {
@@ -45,7 +45,7 @@ function parseLandingMode(raw: string | null, fallback: LandingMode): LandingMod
 
 function parseTilesPerRow(raw: string | null, fallback: TilesPerRow): TilesPerRow {
   const n = Number(raw);
-  return n === 1 || n === 2 || n === 3 ? (n as TilesPerRow) : fallback;
+  return n === 1 || n === 2 || n === 3 || n === 4 ? (n as TilesPerRow) : fallback;
 }
 
 export interface UseDesignKnobsReturn {

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -389,7 +389,7 @@ export default function MapPage() {
           {/* Minimap sidebar — polygon clicks now set the zone filter via
               handleZoneClick. The active zone (if any) is highlighted. */}
           <aside
-            className="hidden lg:block w-[320px] shrink-0 p-3 border-r overflow-y-auto sticky top-10 h-[calc(100vh-40px)]"
+            className="hidden lg:block w-[440px] shrink-0 p-3 border-r overflow-y-auto sticky top-10 h-[calc(100vh-40px)]"
             aria-label="Map zone navigation"
           >
             <GlanceBoardMinimapSidebar


### PR DESCRIPTION
## Why

Operator review of #770 said the storyboard is still too big. Continuing to tighten.

## What changed

- `MapPage.tsx`: minimap sidebar `w-[320px]` → `w-[440px]` (+37%)
- `useDesignKnobs.ts`: `TilesPerRow` union gains `4`, default `3` → `4`, parser accepts `cols=4`
- `GlanceBoard.tsx`: `GRID_COLS_CLASS` gains `grid-cols-4`
- `DesignKnobsPanel.tsx`: segmented control gains a "4" option

## Sizing trajectory (1920px display)

| | Sidebar | Tile width | Pane width |
|---|---|---|---|
| Pre-#770 | 200 | 836 | 418 |
| #770 | 320 | 517 | 258 |
| **This PR** | **440** | **358** | **179** |

Operator can still drop back to `?cols=2` or `?cols=3` via the design-knobs panel if any specific zone view needs more pane detail.

## Verification

- `npm run typecheck` — clean
- Pre-existing `MicroClipShiftOverlay.test.tsx` failure unchanged (per STATE.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)