### PR TITLE
feat(mga): add /lineups/:id direct-link route

### DIFF
--- a/apps/mygamingassistant/TECH_DEBT.md
+++ b/apps/mygamingassistant/TECH_DEBT.md
@@ -1,7 +1,7 @@
 # MyGamingAssistant - Tech Debt Log
 
 > Last scanned: 2026-05-21 (file-size + split-shape audit; previous best-practice findings preserved)
-> Issues: 0 critical, 5 high, 7 medium, 4 low
+> Issues: 0 critical, 5 high, 7 medium, 3 low
 
 mode: log-only - fix only Critical items that block the current feature; log everything else here.
 
@@ -330,15 +330,6 @@ backend/app/services/ingestion/clip_pipeline.py
 ---
 
 ## Low
-
-### [UX] No direct-link route for a single lineup - audit / share / debug workflow forced to scroll the map glance-board
-
-- **Severity:** Low
-- **Effort:** S (1-2 hours)
-- **Category:** UX / debuggability
-- **Location:** frontend/src/routes.tsx (no `/lineups/:id` path); frontend/src/pages/MapPage.tsx (no `?lineup=<id>` searchParam handling)
-- **Problem:** Lineup cards render only inside MapPage's glance-board (grouped/filtered). To reference a single lineup (during operator review, in a bug report, in chat with the assistant), you have to navigate to the right map page, possibly toggle filters, and scroll to find it by chapter title. Surfaced 2026-05-25 during full-12-lineup audit walk-through — the assistant had to point the operator at `/cs2/<map>?util=smoke&side=side_a` + a chapter-title hint instead of a deterministic URL.
-- **Recommendation:** Two viable shapes — (a) add a route `/lineups/:id` that renders a single GlanceBoardTile (or list-row in expanded state) in a centered shell, OR (b) add `?lineup=<id>` searchParam to MapPage that auto-scrolls + highlights the matching card. (a) is more direct-share-friendly; (b) preserves the surrounding map context. Pick (a) for the audit/share use case.
 
 ### [Architecture] Schemas - lineup_schemas.py is a 13-class catch-all (381 LOC) - Pydantic forms, response shapes, validators all inline
 

--- a/apps/mygamingassistant/frontend/e2e/lineup-detail.spec.ts
+++ b/apps/mygamingassistant/frontend/e2e/lineup-detail.spec.ts
@@ -1,0 +1,95 @@
+/**
+ * /lineups/:id direct-link route E2E tests.
+ *
+ * Coverage:
+ *  - Visiting a well-formed but non-existent UUID shows "Lineup not found"
+ *    (public visitor, no lineup at that ID)
+ *  - Visiting /lineups/<uuid> for an accepted lineup shows the tile
+ *    (requires a real accepted lineup; seed via test-helper API when available)
+ *  - The route is accessible without auth (public-read model)
+ *
+ * The seed-and-visit test requires:
+ *  - Backend running with MGA_ENABLE_TEST_HELPERS=1
+ *  - Fixtures loaded (python -m app.cli load-fixtures)
+ *  - E2E_TEST_EMAIL + E2E_TEST_PASSWORD set to the seeded operator credentials
+ *
+ * The 404 test runs in any environment (no backend state required).
+ */
+import { test, expect } from "@playwright/test";
+import { getOperatorCredentials, loginViaUI } from "./fixtures/auth";
+
+const BACKEND_URL = process.env.BACKEND_URL ?? "http://localhost:8004";
+const NON_EXISTENT_ID = "00000000-0000-0000-0000-000000000001";
+
+test.describe("/lineups/:id direct-link route", () => {
+  test("shows 'Lineup not found' for a non-existent UUID (public visitor)", async ({ page }) => {
+    await page.goto(`/lineups/${NON_EXISTENT_ID}`);
+    await expect(page.getByText("Lineup not found.")).toBeVisible();
+    // A back-to-home link is present
+    await expect(page.getByRole("link", { name: /home/i })).toBeVisible();
+  });
+
+  test("route renders without auth (public-read model)", async ({ page }) => {
+    // Navigate to a guaranteed-404 lineup URL without logging in.
+    // The page itself renders (no redirect to /login) and shows the 404 state.
+    await page.goto(`/lineups/${NON_EXISTENT_ID}`);
+    // Still on the /lineups/:id URL — no auth redirect
+    await expect(page).toHaveURL(/\/lineups\//);
+    await expect(page.getByText("Lineup not found.")).toBeVisible();
+  });
+
+  test("renders a tile for an accepted lineup when seeded via test helper", async ({
+    page,
+    request,
+  }) => {
+    // Seed a lineup via the test-helper endpoint (requires MGA_ENABLE_TEST_HELPERS=1).
+    // Gracefully skip if the test-helper endpoint is unavailable.
+    const credentials = getOperatorCredentials();
+    let authToken: string | null = null;
+    try {
+      const loginResp = await request.post(`${BACKEND_URL}/api/auth/jwt/login`, {
+        form: { username: credentials.email, password: credentials.password },
+      });
+      if (loginResp.ok()) {
+        const body = await loginResp.json();
+        authToken = body.access_token ?? null;
+      }
+    } catch {
+      // Backend unavailable — skip
+    }
+
+    if (!authToken) {
+      test.skip();
+      return;
+    }
+
+    // Seed an accepted lineup via the test-helper endpoint
+    let lineupId: string | null = null;
+    try {
+      const seedResp = await request.post(`${BACKEND_URL}/_test/seed-lineup`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+        data: { status: "accepted" },
+      });
+      if (seedResp.ok()) {
+        const body = await seedResp.json();
+        lineupId = body.id ?? null;
+      }
+    } catch {
+      // Test-helper unavailable — skip
+    }
+
+    if (!lineupId) {
+      test.skip();
+      return;
+    }
+
+    await loginViaUI(page, credentials, request);
+    await page.goto(`/lineups/${lineupId}`);
+
+    // The page renders the lineup tile (GlanceBoardTile renders the title in the header)
+    // and a back link.
+    await expect(page.locator("main")).toBeVisible();
+    // Back link is present — exact text depends on game/map resolution
+    await expect(page.locator("main a").first()).toBeVisible();
+  });
+});

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupDetail.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupDetail.test.tsx
@@ -1,0 +1,229 @@
+/**
+ * LineupDetail page unit tests.
+ *
+ * Strategy: mock all RTK Query hooks and the child components that carry
+ * heavy deps (GlanceBoardTile, useDesignKnobs). Tests exercise:
+ *   - Skeleton while loading
+ *   - Renders GlanceBoardTile when the lineup loads
+ *   - Renders "Lineup not found" on 404 (unauthenticated)
+ *   - Falls back to admin query on 404 when authed (isSuperuser=true)
+ *
+ * Back-link rendering is also verified in the success case.
+ */
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import type { Lineup } from "@/types/game";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+const GAME_CS2 = { id: "g-cs2", slug: "cs2", name: "CS2", side_a_label: "T", side_b_label: "CT" };
+const MAP_MIRAGE = { id: "m-mirage", slug: "mirage", name: "Mirage", minimap_url: null };
+
+function makeLineup(over: Partial<Lineup> = {}): Lineup {
+  return {
+    id: "l1",
+    game_id: "g-cs2",
+    map_id: "m-mirage",
+    target_zone_id: "z1",
+    stand_zone_id: "z2",
+    side: "side_a",
+    utility_type_id: "u1",
+    title: "Mid Window smoke from T Spawn",
+    notes: null,
+    stand_screenshot_url: null,
+    aim_screenshot_url: null,
+    clip_url: null,
+    landing_clip_url: null,
+    stand_clip_url: null,
+    aim_clip_url: null,
+    stand_clip_offset_s: null,
+    aim_clip_offset_s: null,
+    clip_url_original: null,
+    clip_trim_start_s: null,
+    clip_trim_end_s: null,
+    clip_source_start_in_video_s: null,
+    landing_clip_url_original: null,
+    landing_clip_trim_start_s: null,
+    landing_clip_trim_end_s: null,
+    landing_clip_source_start_in_video_s: null,
+    technique: null,
+    aim_anchor_x: null,
+    aim_anchor_y: null,
+    stand_anchor_x: null,
+    stand_anchor_y: null,
+    target_anchor_x: null,
+    target_anchor_y: null,
+    effective_stand_x: null,
+    effective_stand_y: null,
+    effective_target_x: null,
+    effective_target_y: null,
+    setup_seconds: null,
+    attribution_url: null,
+    attribution_author: null,
+    status: "accepted",
+    youtube_video_id: null,
+    chapter_start_seconds: null,
+    chapter_title: null,
+    suggested_game_id: null,
+    suggested_map_id: null,
+    suggested_target_zone_id: null,
+    suggested_stand_zone_id: null,
+    suggested_side: null,
+    suggested_utility_type_id: null,
+    classification_confidence: null,
+    classification_reasoning: null,
+    target_zone: { id: "z1", slug: "mid", name: "Mid", polygon_points: [] },
+    stand_zone: null,
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke" },
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock state (mutated per test)
+// ---------------------------------------------------------------------------
+const mockPublicQuery = vi.fn();
+const mockAdminQuery = vi.fn();
+const mockGamesQuery = vi.fn();
+const mockMapsQuery = vi.fn();
+const mockIsSuperuser = vi.fn(() => ({ isSuperuser: false }));
+
+// ---------------------------------------------------------------------------
+// Module mocks — must be declared before any imports that load the module
+// ---------------------------------------------------------------------------
+vi.mock("@/store/lineupsApi", () => ({
+  useGetLineupQuery: (...args: unknown[]) => mockPublicQuery(...args),
+  useGetLineupAdminQuery: (...args: unknown[]) => mockAdminQuery(...args),
+}));
+
+vi.mock("@/store/gamesApi", () => ({
+  useGetGamesQuery: () => mockGamesQuery(),
+  useGetMapsQuery: (...args: unknown[]) => mockMapsQuery(...args),
+}));
+
+vi.mock("@/hooks/useIsSuperuser", () => ({
+  useIsSuperuser: () => mockIsSuperuser(),
+}));
+
+vi.mock("@/hooks/useDesignKnobs", () => ({
+  useDesignKnobs: () => ({
+    knobs: {
+      standMode: "clip",
+      aimMode: "clip",
+      showAimDot: true,
+      landingMode: "clip",
+      tilesPerRow: 3,
+    },
+    setKnob: vi.fn(),
+    reset: vi.fn(),
+  }),
+  DEFAULT_KNOBS: {
+    standMode: "clip",
+    aimMode: "clip",
+    showAimDot: true,
+    landingMode: "clip",
+    tilesPerRow: 3,
+  },
+}));
+
+// GlanceBoardTile has heavy deps (IntersectionObserver, HTMLMediaElement).
+// Mock it so this test focuses on LineupDetail's own logic.
+vi.mock("@/components/lineup/GlanceBoardTile", () => ({
+  default: ({ lineup }: { lineup: Lineup }) => (
+    <div data-testid="glance-board-tile">{lineup.title}</div>
+  ),
+}));
+
+// LineupDetailBackLink delegates to useGetGamesQuery / useGetMapsQuery
+// (mocked above). Let it render for real so back-link tests work.
+// LineupDetailSkeleton is trivial — no mock needed.
+
+// Import page after mocks
+import LineupDetail from "@/pages/LineupDetail";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function renderAt(id = "l1") {
+  return render(
+    <MemoryRouter initialEntries={[`/lineups/${id}`]}>
+      <Routes>
+        <Route path="/lineups/:id" element={<LineupDetail />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockGamesQuery.mockReturnValue({ data: [GAME_CS2] });
+  mockMapsQuery.mockReturnValue({ data: [MAP_MIRAGE] });
+  mockIsSuperuser.mockReturnValue({ isSuperuser: false });
+
+  // Default: public query loading
+  mockPublicQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+  mockAdminQuery.mockReturnValue({ data: undefined, isLoading: false, isError: false });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe("LineupDetail", () => {
+  it("renders skeleton while the public query is loading", () => {
+    mockPublicQuery.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    renderAt();
+    // GlanceBoardTile is NOT rendered while loading
+    expect(screen.queryByTestId("glance-board-tile")).toBeNull();
+    // No error text either
+    expect(screen.queryByText("Lineup not found.")).toBeNull();
+  });
+
+  it("renders GlanceBoardTile when the lineup loads successfully", () => {
+    const lineup = makeLineup();
+    mockPublicQuery.mockReturnValue({ data: lineup, isLoading: false, isError: false });
+    renderAt();
+    expect(screen.getByTestId("glance-board-tile")).toBeDefined();
+    expect(screen.getByText("Mid Window smoke from T Spawn")).toBeDefined();
+  });
+
+  it("renders back link with map name when game + map are resolved", () => {
+    const lineup = makeLineup();
+    mockPublicQuery.mockReturnValue({ data: lineup, isLoading: false, isError: false });
+    renderAt();
+    const backLink = screen.getByRole("link", { name: /back to mirage/i });
+    expect(backLink).toBeDefined();
+    expect(backLink.getAttribute("href")).toBe("/cs2/mirage");
+  });
+
+  it("renders 'Lineup not found' on 404 for an unauthenticated visitor", () => {
+    mockPublicQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    mockIsSuperuser.mockReturnValue({ isSuperuser: false });
+    renderAt();
+    expect(screen.getByText("Lineup not found.")).toBeDefined();
+    // Admin query must NOT have been called (user is not authed)
+    expect(mockAdminQuery).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ skip: true }));
+  });
+
+  it("falls back to admin query on 404 when the user is authed (isSuperuser)", () => {
+    const adminLineup = makeLineup({ status: "pending_review" });
+    mockPublicQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    mockIsSuperuser.mockReturnValue({ isSuperuser: true });
+    mockAdminQuery.mockReturnValue({ data: adminLineup, isLoading: false, isError: false });
+    renderAt();
+    expect(screen.getByTestId("glance-board-tile")).toBeDefined();
+    expect(screen.getByText("Mid Window smoke from T Spawn")).toBeDefined();
+    // Admin query must have been called (skip=false because isSuperuser + is404)
+    expect(mockAdminQuery).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ skip: false }));
+  });
+
+  it("renders 'Lineup not found' when authed but admin query also fails", () => {
+    mockPublicQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    mockIsSuperuser.mockReturnValue({ isSuperuser: true });
+    mockAdminQuery.mockReturnValue({ data: undefined, isLoading: false, isError: true });
+    renderAt();
+    expect(screen.getByText("Lineup not found.")).toBeDefined();
+  });
+});

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupDetailBackLink.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupDetailBackLink.tsx
@@ -1,0 +1,58 @@
+/**
+ * LineupDetailBackLink — back navigation for the /lineups/:id page.
+ *
+ * Resolves game + map slugs from the lineup's FKs (game_id, map_id) so the
+ * link targets /{game.slug}/{map.slug}. Falls back to the game-level page when
+ * map can't be resolved, and to Home when neither can.
+ */
+import { Link } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+import { useGetGamesQuery, useGetMapsQuery } from "@/store/gamesApi";
+
+interface LineupDetailBackLinkProps {
+  gameId: string | null;
+  mapId: string | null;
+}
+
+export default function LineupDetailBackLink({ gameId, mapId }: LineupDetailBackLinkProps) {
+  const { data: games = [] } = useGetGamesQuery();
+  const game = gameId ? games.find((g) => g.id === gameId) ?? null : null;
+  const { data: maps = [] } = useGetMapsQuery(game?.slug ?? "", {
+    skip: !game?.slug,
+  });
+  const map = mapId ? maps.find((m) => m.id === mapId) ?? null : null;
+
+  if (game && map) {
+    return (
+      <Link
+        to={`/${game.slug}/${map.slug}`}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        Back to {map.name}
+      </Link>
+    );
+  }
+
+  if (game) {
+    return (
+      <Link
+        to={`/${game.slug}`}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden />
+        Back to maps
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      to="/"
+      className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+    >
+      <ArrowLeft className="h-4 w-4" aria-hidden />
+      Home
+    </Link>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupDetailSkeleton.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupDetailSkeleton.tsx
@@ -1,0 +1,9 @@
+/** Single-tile skeleton for the /lineups/:id direct-link page. */
+export default function LineupDetailSkeleton() {
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+      <div className="h-5 w-32 bg-muted/40 rounded animate-pulse" />
+      <div className="rounded-lg bg-muted/40 animate-pulse" style={{ aspectRatio: "2 / 1" }} />
+    </div>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/pages/LineupDetail.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/LineupDetail.tsx
@@ -1,0 +1,79 @@
+/**
+ * LineupDetail — single-lineup direct-link page.
+ * Route: /lineups/:id
+ *
+ * Public read: accepted lineups are visible to everyone via useGetLineupQuery.
+ * Operator fallback: if the public fetch returns 404 and the user is authed,
+ * useGetLineupAdminQuery is tried so the operator can deep-link to
+ * pending_review / hidden lineups.
+ *
+ * Design knobs (URL-backed ?stand=still, ?aim=still, etc.) are handled by
+ * useDesignKnobs — same as MapPage, no extra wiring needed.
+ */
+import { Link, useParams } from "react-router-dom";
+import { ArrowLeft } from "lucide-react";
+import { useGetLineupQuery, useGetLineupAdminQuery } from "@/store/lineupsApi";
+import { useIsSuperuser } from "@/hooks/useIsSuperuser";
+import { useDesignKnobs } from "@/hooks/useDesignKnobs";
+import GlanceBoardTile from "@/components/lineup/GlanceBoardTile";
+import LineupDetailSkeleton from "@/components/lineup/LineupDetailSkeleton";
+import LineupDetailBackLink from "@/components/lineup/LineupDetailBackLink";
+
+export default function LineupDetail() {
+  const { id = "" } = useParams<{ id: string }>();
+  const { isSuperuser } = useIsSuperuser();
+  const { knobs } = useDesignKnobs();
+
+  const {
+    data: publicLineup,
+    isLoading: publicLoading,
+    isError: publicError,
+  } = useGetLineupQuery(id, { skip: !id });
+
+  const is404 = publicError && !publicLoading;
+
+  const {
+    data: adminLineup,
+    isLoading: adminLoading,
+    isError: adminError,
+  } = useGetLineupAdminQuery(id, {
+    skip: !id || !is404 || !isSuperuser,
+  });
+
+  const isLoading = publicLoading || (is404 && isSuperuser && adminLoading);
+  const lineup = publicLineup ?? adminLineup ?? null;
+  const notFound = !isLoading && !lineup && (adminError || !isSuperuser);
+
+  if (isLoading) {
+    return <LineupDetailSkeleton />;
+  }
+
+  if (notFound || !lineup) {
+    return (
+      <main className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+        <Link
+          to="/"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ArrowLeft className="h-4 w-4" aria-hidden />
+          Home
+        </Link>
+        <p className="text-sm text-muted-foreground">Lineup not found.</p>
+      </main>
+    );
+  }
+
+  return (
+    <main className="max-w-3xl mx-auto px-4 py-6 space-y-4">
+      <LineupDetailBackLink
+        gameId={lineup.game_id}
+        mapId={lineup.map_id}
+      />
+      <GlanceBoardTile
+        lineup={lineup}
+        knobs={knobs}
+        showOperatorOverlays={isSuperuser}
+      />
+    </main>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/routes.tsx
+++ b/apps/mygamingassistant/frontend/src/routes.tsx
@@ -1,5 +1,6 @@
 import { type RouteObject } from "react-router-dom";
 import GameGrid from "@/pages/GameGrid";
+import LineupDetail from "@/pages/LineupDetail";
 import LineupPackages from "@/pages/LineupPackages";
 import LineupUpload from "@/pages/LineupUpload";
 import LiveCs2 from "@/pages/LiveCs2";
@@ -42,6 +43,10 @@ export const routes: RouteObject[] = [
       { index: true, element: <GameGrid /> },
       { path: "/packages", element: <LineupPackages /> },
       { path: "/live/cs2", element: <LiveCs2 /> },
+      // Direct-link for a single lineup — public for accepted lineups;
+      // operator can also reach pending_review/hidden via the admin fallback.
+      // Must come BEFORE /:gameSlug so "/lineups/..." doesn't match as a game slug.
+      { path: "/lineups/:id", element: <LineupDetail /> },
       { path: "/:gameSlug", element: <MapGrid /> },
       { path: "/:gameSlug/:mapSlug", element: <MapPage /> },
 

--- a/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
@@ -327,6 +327,7 @@ export const {
   useGetUploadUrlMutation,
   useGetLineupsQuery,
   useGetLineupQuery,
+  useGetLineupAdminQuery,
   useLazyGetLineupAdminQuery,
   useCreateLineupMutation,
   useUpdateLineupMutation,


### PR DESCRIPTION
## Summary

- Adds a public \`/lineups/:id\` route that renders a single \`GlanceBoardTile\` in a centered \`max-w-3xl mx-auto\` shell
- Accepted lineups are visible to anyone; when the public endpoint returns 404 and the user is the operator (\`isSuperuser\`), the page transparently retries with the admin endpoint so \`pending_review\`/\`hidden\` lineups are also deep-linkable
- Back link resolves to \`/{game.slug}/{map.slug}\` using the lineup's \`game_id\`/\`map_id\` FKs (falls back to game-level link, then home, for unclassified lineups where FKs are null)
- Design knobs (\`?stand=still\`, \`?aim=still\`, etc.) work out-of-the-box via \`useDesignKnobs\`

**Resolves:** TECH_DEBT.md Low entry: "No direct-link route for a single lineup" (entry removed; low count 4 to 3).

## Files changed

| File | Change |
|---|---|
| \`frontend/src/pages/LineupDetail.tsx\` | New page (one component) |
| \`frontend/src/components/lineup/LineupDetailBackLink.tsx\` | Back-link resolver (one component) |
| \`frontend/src/components/lineup/LineupDetailSkeleton.tsx\` | Single-tile skeleton (one component) |
| \`frontend/src/routes.tsx\` | Add \`/lineups/:id\` under RootLayout (public, before \`/:gameSlug\`) |
| \`frontend/src/store/lineupsApi.ts\` | Export \`useGetLineupAdminQuery\` (non-lazy variant; was missing) |
| \`frontend/src/__tests__/LineupDetail.test.tsx\` | 6 unit tests |
| \`frontend/e2e/lineup-detail.spec.ts\` | E2E spec (404 always runs; seed-and-visit skips if test-helpers unavailable) |
| \`TECH_DEBT.md\` | Remove resolved Low entry |

## Test plan

- [x] \`npm run typecheck\` clean
- [x] \`npm test\` — 6 new tests pass; pre-existing \`MicroClipShiftOverlay\` failure unchanged (410 pass / 1 fail pre-existing)
- [ ] \`http://localhost:5176/lineups/<uuid>\` — single centered tile renders for accepted lineup
- [ ] Same URL for \`pending_review\` lineup while logged in — tile renders via admin fallback
- [ ] Same URL while logged out — "Lineup not found" message
- [ ] \`?stand=still\` on URL — design knob applies to the tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)