### PR TITLE
fix(mga): re-anchor STAND + AIM prompts on operator audit heuristics

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/aim_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/aim_timing_classifier.py
@@ -227,14 +227,48 @@ NOT exclusions (allowed for AIM, unlike the stand-timing classifier):
     held up in ready pose.
   - Tight target-centric framings — wide framings are STAND, tight is AIM.
 
+STRUCTURAL ANCHOR — CROSSHAIR LOCK-ON INSTANT (operator audit 2026-05-25)
+AIM is the LOCK-ON INSTANT: the frame in the stable-aim phase where
+the crosshair has just finished sweeping to the target landmark and is
+held still. A ~1 second clip is cut centred on the picked frame
+downstream; the picked frame must be far enough from the windup
+boundary that the clip does NOT extend into windup, release,
+projectile flight, or landing.
+
+Prefer a frame where:
+  - Crosshair sweep is over and the crosshair is stationary on the
+    target landmark (zero crosshair velocity across this frame and
+    its neighbours).
+  - At LEAST one prior frame in the candidate set ALSO shows the
+    crosshair on the same landmark (lock is established, not just
+    transient).
+  - At LEAST one following frame in the candidate set ALSO shows the
+    crosshair on the same landmark with NO windup motion yet (the
+    utility is still in ready pose, body not rotating into throw).
+  - The composition is dominated by the target landmark, not by the
+    sweeping motion or the windup transition.
+
+REJECT these edge-of-phase picks:
+  - LATEST pre-windup frame: typically the crosshair is already
+    drifting OR the utility is just starting to pull back. A clip
+    centred here catches windup → release → landing on the post-side,
+    breaking the AIM pane (operator-observed defect, 2026-05-25:
+    several AIM clips showed the smoke landing).
+  - FIRST stable-aim frame right after the sweep: the prior frame
+    shows crosshair motion. A clip centred here catches the sweep on
+    the pre-side, blurring AIM with the look-up transition from STAND.
+
+If the candidate set only contains edges (no stable-aim frames on
+BOTH sides of any pick), accept the cleanest available — partial
+information is still better than skipping the demo.
+
 WHEN MULTIPLE DEMONSTRATIONS EXIST
-The narrator may show the aim more than once (initial show → small
-adjustment → final lock). Prefer the LATEST aim-demo frame that PRECEDES
-any windup motion — the latest demo is freshest in the viewer's memory
-and is closest to where the viewer will actually be aiming. If the latest
-is partial (crosshair drifting, utility starting to pull back) and an
-earlier framing is cleaner, prefer the LATEST CLEAN one — quality
-outranks recency within the pre-windup set.
+The narrator may show the aim more than once (initial glance → small
+adjustment → final lock). Prefer a MIDDLE-of-phase frame from the
+LONGEST contiguous lock-on segment — NOT the latest frame before
+windup. The longest lock segment is where the narrator was most
+confident in the aim and held it steady; downstream re-anchoring is
+most likely to succeed on that segment.
 
 WHEN NO DEMONSTRATION EXISTS
 Some chapters skip the aim-demo entirely (narrator stands and immediately

--- a/apps/mygamingassistant/backend/app/services/classification/stand_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/stand_timing_classifier.py
@@ -165,28 +165,42 @@ NOT exclusions (allowed for STAND, unlike the throw-timing classifier):
     See NON-UTILITY HELD-WEAPON DISAMBIGUATION above for the motion
     qualifier.
 
-STRUCTURAL ANCHOR — EARLIEST SETTLED-STANCE
-STAND is the EARLIEST settled-stance frame after the narrator has
-finished the walk-up to the spot. Prefer the FIRST frame where:
-  - The narrator is stationary at the throwing spot (no running /
-    sliding / jumping motion across adjacent frames).
+STRUCTURAL ANCHOR — MIDDLE OF SETTLED-STANCE (operator audit 2026-05-25)
+STAND is a frame from the MIDDLE of the settled-stance phase — NOT the
+edges of it. A ~1 second clip is cut centred on the picked frame
+downstream, and an edge-of-phase pick lets that clip extend into the
+preceding walk-up OR the following look-up-to-aim transition. Both
+distort what the viewer is supposed to learn: the FIXED starting
+position before any movement.
+
+Prefer a frame where:
+  - The narrator is stationary at the throwing spot AND has been
+    stationary for AT LEAST one prior frame in the candidate set.
+  - The next frame in the candidate set is ALSO stationary at the same
+    spot — the camera has not yet started tilting up to aim.
   - The camera is held still (not panning or sweeping mid-arrival).
   - The chapter-intro overlay, if any, has faded out, transitioned, or
     no longer dominates the frame.
-Do NOT pick frames where the narrator is still adjusting position or
-where the camera is panning — those are part of the walk-in, not the
-settled stand.
+
+REJECT these edge-of-phase picks:
+  - FIRST settled frame right after walk-up arrival (the prior frame
+    shows motion). A clip centred here catches the walk-up on the
+    pre-side, blurring "where to stand" with "how to get there".
+  - LAST settled frame before the camera tilts up to aim (the next
+    frame shows camera motion). A clip centred here catches the
+    look-up on the post-side, blurring stand with aim.
+
+If the candidate set only contains edges (no stationary frames on
+BOTH sides of any pick), accept the cleanest available — partial
+information is still better than skipping the demo.
 
 WHEN MULTIPLE DEMONSTRATIONS EXIST
 The narrator may show the spot more than once (afar → walking up →
 settled at spot → small re-adjustment). Per the STRUCTURAL ANCHOR
-above, prefer the EARLIEST settled-stance frame that follows the
-walk-up — NOT the latest pre-windup frame. The first clean settled
-view is the canonical stand demo; later frames are typically the
-narrator already starting to look up for the aim. Quality still
-outranks earliness: if the earliest settled frame is partial (camera
-still drifting, overlay still opaque), skip to the next clean settled
-frame.
+above, prefer a MIDDLE-of-phase frame from the LONGEST contiguous
+settled-stance segment. Length of stationary stance dominates: a 4-
+frame settled segment with a clean middle frame is preferable to a
+2-frame settled segment, even if the 2-frame segment came first.
 
 WHEN NO DEMONSTRATION EXISTS
 Some chapters skip the stand-demo entirely (narrator walks to spot, then

--- a/apps/mygamingassistant/backend/tests/test_aim_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_aim_timing_classifier.py
@@ -297,18 +297,28 @@ class TestAimTimingPromptShape:
         assert "STAND-LOCATION-CENTERED" in system_text
 
     @pytest.mark.asyncio
-    async def test_system_prompt_says_latest_clean_pre_windup_demo_preferred(self):
-        """The 'prefer the latest CLEAN pre-windup demo' rule is the
-        anti-regression check — without it the model picks the EARLIEST
-        aim frame, which is often a quick reference glance rather than
-        the final settled aim the viewer should reproduce."""
+    async def test_system_prompt_anchors_on_crosshair_lock_on_instant(self):
+        """STRUCTURAL ANCHOR — CROSSHAIR LOCK-ON INSTANT — is the post-
+        2026-05-25 operator-audit fix. The prior 'LATEST pre-windup'
+        rule pushed the anchor against the windup boundary; the 1s
+        clip then extended into windup → release → flight → landing.
+        Operator observed several AIM clips showing the smoke landing.
+        The new rule anchors on a MIDDLE-of-phase frame in the LONGEST
+        contiguous lock-on segment, with stable-aim frames on BOTH
+        sides so the 1s clip stays in the lock-on phase."""
         _, client = await _call(
             {"has_aim_demonstration": True, "aim_index": 1,
              "confidence": 0.6, "reasoning": "x"},
         )
         system = client.messages.create.call_args.kwargs["system"]
         system_text = "\n".join(b["text"] for b in system)
-        assert "LATEST" in system_text
+        assert "STRUCTURAL ANCHOR" in system_text
+        assert "CROSSHAIR LOCK-ON INSTANT" in system_text
+        # Substring-checked piece-wise to survive prompt line-wrapping.
+        assert "LONGEST contiguous lock-on" in system_text
+        # The reject-edges block must call out the LATEST pre-windup
+        # picking error explicitly — that's the regression we're locking.
+        assert "LATEST pre-windup frame" in system_text
         assert "windup" in system_text.lower()
 
     @pytest.mark.asyncio

--- a/apps/mygamingassistant/backend/tests/test_stand_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_stand_timing_classifier.py
@@ -156,10 +156,13 @@ class TestStandTimingPromptShape:
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_structural_anchor(self):
-        """STRUCTURAL ANCHOR — EARLIEST settled-stance — is the post-#768
-        determinism fix. Without it, STAND has too much latitude over
-        'any settled frame works' and the pick drifts later on re-runs
-        (7bd971c3: 258.99s → 260.4s on bulk re-backfill 2026-05-24)."""
+        """STRUCTURAL ANCHOR — MIDDLE of settled-stance — is the post-
+        2026-05-25 operator-audit fix. The prior EARLIEST rule put the
+        anchor at the edge of the settled phase; the downstream 1s clip
+        then caught walk-up motion on the pre-side. The new rule
+        requires the picked frame to be in the MIDDLE of the settled-
+        stance phase (stationary frames on BOTH sides) so the clip
+        stays stationary."""
         _, client = await _call(
             {"has_stand_demonstration": True, "stand_index": 1,
              "confidence": 0.6, "reasoning": "x"},
@@ -167,11 +170,14 @@ class TestStandTimingPromptShape:
         system = client.messages.create.call_args.kwargs["system"]
         system_text = "\n".join(b["text"] for b in system)
         assert "STRUCTURAL ANCHOR" in system_text
-        assert "EARLIEST" in system_text
-        # The "WHEN MULTIPLE DEMONSTRATIONS EXIST" guidance must also flip
-        # from latest-clean (the old AIM-style rule) to earliest-clean
-        # (per the structural anchor) so the two sections agree.
-        assert "EARLIEST settled-stance" in system_text
+        assert "MIDDLE" in system_text
+        assert "MIDDLE OF SETTLED-STANCE" in system_text
+        # WHEN MULTIPLE DEMONSTRATIONS EXIST must agree with the anchor
+        # — prefer the longest contiguous settled segment, NOT the first
+        # settled frame. Substring-checked piece-wise to survive prompt
+        # line-wrapping.
+        assert "LONGEST contiguous" in system_text
+        assert "Length of stationary stance dominates" in system_text
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_concrete_anchored_examples(self):


### PR DESCRIPTION
## Why

Operator-driven audit of all 12 dev-DB lineups (2026-05-25) surfaced two systemic micro-clip defects each affecting 8/12 lineups:

- **STAND clips drift into walk-up motion** before the spot. Operator: "starts in the starting position then moves back", "can't tell where the starting position is", "shows where to aim instead of stand".
- **AIM clips drift into throw/landing** after the aim. Operator: "shows the landing" — several AIM clips literally rendered the smoke bloom.

Root cause: prior STRUCTURAL ANCHOR rules picked frames at the **edges** of each phase:
- STAND said "EARLIEST settled-stance" → at the boundary with walk-up → 1s clip catches walk-up on the pre-side
- AIM said "LATEST clean pre-windup" → at the boundary with windup → 1s clip extends into windup → release → flight → landing on the post-side

## What changed

### `stand_timing_classifier.py`
Replaces "STRUCTURAL ANCHOR — EARLIEST SETTLED-STANCE" with **MIDDLE OF SETTLED-STANCE**. The picked frame must have stationary candidates on BOTH sides (prior AND next). Explicit reject-edges block calls out the FIRST-settled (catches walk-up) and LAST-pre-aim (catches camera tilt up) failure modes. WHEN MULTIPLE DEMONSTRATIONS EXIST flips from earliest-clean → LONGEST contiguous settled segment.

### `aim_timing_classifier.py`
Replaces "WHEN MULTIPLE DEMONSTRATIONS EXIST — prefer the LATEST" with **STRUCTURAL ANCHOR — CROSSHAIR LOCK-ON INSTANT**. The picked frame must have stable-aim candidates on BOTH sides with the crosshair on the same landmark and no windup motion. Explicit reject-edges block calls out the LATEST pre-windup pick (the operator-observed regression) and the FIRST-post-sweep pick (catches camera tilt-up).

### Tests
Regression locks updated:
- `test_system_prompt_includes_structural_anchor` (STAND): now asserts `MIDDLE OF SETTLED-STANCE` + `LONGEST contiguous` + `Length of stationary stance dominates`
- `test_system_prompt_anchors_on_crosshair_lock_on_instant` (AIM, renamed from `test_system_prompt_says_latest_clean_pre_windup_demo_preferred`): now asserts `CROSSHAIR LOCK-ON INSTANT` + `LONGEST contiguous lock-on` + `LATEST pre-windup frame` (called out in reject block)

## Generalization posture

Per the operator's #768/#769 lesson — too abstract regresses, too anchored overfits — both anchors are stated as **game-agnostic principles** ("middle of phase", "lock-on instant"). NO new examples added from this audit's source video. Existing knife/overlay anchor examples are unchanged.

The new rules apply to ANY tactical-FPS lineup video — CS2, Valorant, or future. The "crosshair velocity reaches zero" cue and the "stationary stance on both sides" cue are not creator- or video-specific.

## Verification

- 748/748 backend tests pass (incl. the four affected prompt-shape locks)
- `scripts/check-file-size.py --base origin/main`: clean
- aim_timing_classifier.py grew 485 → 519 LOC. Was under the 500 threshold, so first-time crossing is allowed; future PRs touching this file must not grow it further

## Test plan

After merge, operator runs:
\`\`\`bash
python -m app.cli backfill-clips     # re-run STAND/AIM/throw localizers
python -m app.cli backfill-micro-clips
\`\`\`
…then re-audits the 12 lineups against the original audit at `~/.claude/projects/.../lineup-audit.md`. Expected improvements: 8/12 STAND drifts and 8/12 AIM drifts should land mostly within their target phases; clip windows shouldn't extend into walk-up or landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)