### PR TITLE
fix(mga): re-anchor THROW prompt on operator audit heuristics (parallel to #773)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
@@ -96,11 +96,48 @@ Rules:
     - REPLAY / KILL-CAM / SCOREBOARD / MENU / MAP-OVERVIEW frame: not the
       live first-person main game view.
 - release_index: the 1-based frame where the utility is released, chosen from
-  frames that pass CANDIDATE-FRAME EXCLUSIONS. RELEASE cues: the projectile
-  is first airborne; the throw-animation follow-through; the HUD
-  grenade/ability slot empties. If no eligible frame catches the exact
-  release, choose the eligible frame immediately BEFORE the effect first
-  appears.
+  frames that pass CANDIDATE-FRAME EXCLUSIONS.
+  RELEASE-INSTANT ANCHOR (operator audit 2026-05-25, highest priority within
+  release-frame selection):
+    The release_index is the FIRST frame where the utility OBJECT has LEFT
+    the player's hand. Two equally reliable signals — use whichever is
+    visible in the candidate set; both together when both are visible:
+      - HUD GRENADE-SLOT DECREMENT: the utility icon in the bottom HUD (CS2:
+        bottom-right grenade slot; Valorant: ability key indicator) flips
+        from "ready / count-N" to "spent / count-(N-1) / icon-greyed". This
+        is a SHARP single-frame transition and is the most reliable cue
+        when the HUD is visible. Use it as the primary signal.
+      - HAND-EMPTY AFTER ARM EXTENSION: the throwing arm has finished its
+        forward swing and the hand is now EMPTY (no utility in or near it).
+        The projectile is already in the air or just out of frame. Pick the
+        FIRST such hand-empty frame — not later frames where the hand is
+        also empty but the result is already visible.
+    DO NOT use "throw-animation follow-through" or "projectile arc visible
+    mid-flight" as standalone release cues — both fire frames AFTER the
+    true release instant and shift the clip into result territory.
+  ANTI-LANDING CONFUSION (the dominant failure mode per operator audit):
+    If smoke / flames / flash-wash / HE-debris is visible IN THE WORLD on a
+    candidate frame, the release ALREADY HAPPENED some frames earlier — do
+    NOT pick the bloom-onset frame as release. Search BACKWARD in the
+    candidate set for the hand-empty / HUD-decrement transition. Picking
+    the bloom instant as release shifts the entire clip 0.3-1.5s into result
+    territory and the viewer sees the smoke unfurling instead of the throw
+    arc. The bloom belongs on result_index, NEVER on release_index.
+  ANTI-PRE-WINDUP (the opposite failure mode):
+    If the utility is STILL in the player's hand on a candidate frame — held
+    statically, charged-up, aimed-with, or mid-wind-up arc — that frame is
+    BEFORE release. Search FORWARD in the candidate set for the hand-empty
+    frame. The wind-up, the lined-up aim, and the charge-up belong on the
+    AIM pane, not the THROW clip.
+  STRADDLE RULE:
+    If the candidate set straddles release (frame N shows utility-in-hand;
+    frame N+1 shows hand-empty AND bloom already visible), pick frame N+1 —
+    it is the closest sample to the true release instant. The clip window
+    pulls 1.0s of pre-release coverage so the viewer still sees the wind-up
+    arc even when the chosen index is slightly past the literal release.
+  Fallback: if no eligible frame shows a hand-empty / HUD-decrement
+  transition, choose the eligible frame immediately BEFORE the smoke / flame
+  / flash / debris first appears in the world.
 - result_index: the 1-based frame where the RESULT is first clearly visible
   FROM THE THROWER'S LINEUP POSITION, chosen from frames that pass
   CANDIDATE-FRAME EXCLUSIONS. It MUST be at or after release_index — a

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -455,3 +455,109 @@ class TestThrowTimingCandidateExclusions:
         system = client.messages.create.call_args.kwargs["system"]
         system_text = "\n".join(b["text"] for b in system)
         assert "skipped F3 title-card" in system_text
+
+
+class TestThrowTimingReleaseAnchor:
+    """Prompt-presence tests for the RELEASE-INSTANT ANCHOR section.
+
+    Per the 2026-05-25 operator audit of the dev DB's 12 lineups, 4 throw
+    clips showed wrong-frame content (#1 / #5 / #6 / #10): two showed the
+    bloom-onset instead of the throw arc ("ANTI-LANDING"), one ended before
+    the throw happened ("ANTI-PRE-WINDUP"). The pre-audit prompt listed
+    "throw-animation follow-through" as a release cue, which licenses the
+    model to pick post-release frames; the audit-driven prompt demotes that
+    cue and elevates HUD-slot decrement + hand-empty as the primary signals.
+    If a refactor accidentally drops any of these blocks the dominant
+    failure mode comes back, so fail loud here.
+    """
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_release_instant_anchor(self):
+        """The RELEASE-INSTANT ANCHOR section must establish hand-empty +
+        HUD-slot-decrement as the primary release cues."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "RELEASE-INSTANT ANCHOR" in system_text
+        # Both primary cues must be present by name so the model knows which
+        # signal to anchor on when the HUD is occluded.
+        assert "HUD GRENADE-SLOT DECREMENT" in system_text
+        assert "HAND-EMPTY AFTER ARM EXTENSION" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_demotes_follow_through_cue(self):
+        """The pre-audit "throw-animation follow-through" wording was the
+        suspected root cause for #1 / #6 / #10's "shows landing" failures
+        — it licensed the model to pick post-release frames. The new prompt
+        MUST explicitly DO-NOT-USE it as a standalone release cue."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        # The literal "DO NOT use" phrasing is the explicit demotion — if a
+        # future refactor collapses the warning back into a plain bullet,
+        # the model loses the anti-follow-through guard.
+        assert "DO NOT use" in system_text
+        assert "throw-animation follow-through" in system_text
+        assert "projectile arc visible" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_anti_landing_confusion(self):
+        """The dominant audit failure mode (#1, #6): release picked at bloom
+        onset instead of hand-empty. The ANTI-LANDING CONFUSION block must
+        explicitly tell the model to search BACKWARD when smoke / flame /
+        flash / debris is visible in the world on a candidate frame."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "ANTI-LANDING CONFUSION" in system_text
+        # Specific phrasing that tells the model what to DO when it sees the
+        # smoke — search backward, not just "don't pick the bloom".
+        assert "Search BACKWARD" in system_text
+        # The reason is load-bearing — the model needs to understand WHY
+        # picking the bloom is wrong (clip shifts into result territory).
+        assert "bloom belongs on result_index" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_anti_pre_windup(self):
+        """The opposite failure mode (#5): release picked at pre-windup
+        when the utility was still in hand. The ANTI-PRE-WINDUP block must
+        tell the model to search FORWARD when the utility is still being
+        held / charged / aimed."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "ANTI-PRE-WINDUP" in system_text
+        assert "Search FORWARD" in system_text
+        # The "belongs on the AIM pane" line decouples the two panes
+        # explicitly — pre-windup content is AIM data, not THROW data.
+        assert "AIM pane, not the THROW clip" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_straddle_rule(self):
+        """When the candidate set straddles release (frame N in-hand,
+        frame N+1 hand-empty + bloom visible), the model must pick N+1.
+        Without this rule the model can split-the-difference and return
+        frame N, shifting the clip earlier than the true release."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "STRADDLE RULE" in system_text
+        # The clip-window justification ("1.0s of pre-release coverage") is
+        # what tells the model it's safe to pick the slightly-late frame —
+        # the wind-up isn't lost.
+        assert "1.0s of pre-release coverage" in system_text


### PR DESCRIPTION
## Summary

- 2026-05-25 operator audit of the dev DB's 12 lineups found 4/12 throw clips showed wrong-frame content: #1 / #6 / #10 showed bloom-onset (\"shows landing\") and #5 ended before the actual throw. Operator's per-lineup notes are at \`~/.claude/projects/C--Users-jason-Documents-Git-MyFreeApps/lineup-audit.md\`.
- Pre-audit prompt listed \"throw-animation follow-through\" as a release cue, licensing post-release picks; combined with the symmetric \`[release−1s, release+1s]\` clip window this shifted clips 0.3-1.5s into result territory. Operator confirmed the trim window itself is correct — the anchor is the bug.
- Adds four operator-audit-derived sections inside \`release_index\`: **RELEASE-INSTANT ANCHOR** (HUD-slot decrement + hand-empty as primary cues; explicit \"DO NOT use follow-through\"), **ANTI-LANDING CONFUSION** (search BACKWARD when bloom visible), **ANTI-PRE-WINDUP** (search FORWARD when utility still in hand), **STRADDLE RULE**. Sister PR to #773 which did the same re-anchor for STAND / AIM.
- Five new prompt-presence tests in \`TestThrowTimingReleaseAnchor\`. Every existing test-asserted prompt string preserved.

## Operational migration

None. Prompt-only change, effective on next classifier call. After merge run \`python -m app.cli backfill-clips\` on the dev DB to retest #1, #5, #6, #10.

## Test plan

- [x] \`pytest tests/test_throw_timing_classifier.py\` — 30 passed (5 new + 25 existing)
- [x] \`pytest tests/test_throw_timing_classifier.py tests/test_throw_localizer.py tests/test_clip_generator.py\` — 77 passed
- [ ] CI green
- [ ] Post-merge: backfill-clips on dev DB; operator re-audits the four target lineups

🤖 Generated with [Claude Code](https://claude.com/claude-code)