### PR TITLE
fix(mga): anchor THROW prompt on mid-swing utility-separation (#775 follow-up)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
@@ -99,45 +99,58 @@ Rules:
   frames that pass CANDIDATE-FRAME EXCLUSIONS.
   RELEASE-INSTANT ANCHOR (operator audit 2026-05-25, highest priority within
   release-frame selection):
-    The release_index is the FIRST frame where the utility OBJECT has LEFT
-    the player's hand. Two equally reliable signals — use whichever is
-    visible in the candidate set; both together when both are visible:
-      - HUD GRENADE-SLOT DECREMENT: the utility icon in the bottom HUD (CS2:
-        bottom-right grenade slot; Valorant: ability key indicator) flips
-        from "ready / count-N" to "spent / count-(N-1) / icon-greyed". This
-        is a SHARP single-frame transition and is the most reliable cue
-        when the HUD is visible. Use it as the primary signal.
-      - HAND-EMPTY AFTER ARM EXTENSION: the throwing arm has finished its
-        forward swing and the hand is now EMPTY (no utility in or near it).
-        The projectile is already in the air or just out of frame. Pick the
-        FIRST such hand-empty frame — not later frames where the hand is
-        also empty but the result is already visible.
-    DO NOT use "throw-animation follow-through" or "projectile arc visible
-    mid-flight" as standalone release cues — both fire frames AFTER the
-    true release instant and shift the clip into result territory.
+    The release_index is the FIRST frame where the utility OBJECT has
+    SEPARATED from the player's hand. Two equally reliable signals — use
+    whichever is visible in the candidate set; both together when both are
+    visible:
+      - UTILITY-SEPARATION FRAME (primary visual cue): the FIRST frame
+        where the utility OBJECT has visibly separated from the player's
+        hand. This is the canonical release instant — typically MID-SWING
+        (the arm is still moving forward / at or just past peak
+        extension), NOT after the swing has completed. The utility is now
+        in the air a small distance from the hand, and the throwing hand
+        is still extended in the throw direction, NOT yet retracted to a
+        resting pose. Critical: by the time the arm has FULLY RETRACTED
+        and the hand is back near the body, the projectile is already
+        gone and the clip will catch only the tail of the throw motion
+        (operator audit 2026-05-25, lineup 9b2ad4c9). The release instant
+        is the SEPARATION, NOT the post-swing rest.
+      - HUD GRENADE-SLOT DECREMENT: the utility icon in the bottom HUD
+        (CS2: bottom-right grenade slot; Valorant: ability key indicator)
+        flips from "ready / count-N" to "spent / count-(N-1) /
+        icon-greyed". This is a SHARP single-frame transition and is the
+        most reliable cue when the HUD is visible. In CS2 it fires within
+        ~1 frame of UTILITY-SEPARATION; treat it as confirming the same
+        anchor.
+    DO NOT use "throw-animation follow-through" or "projectile arc
+    visible mid-flight" or "post-swing hand-at-rest pose" as standalone
+    release cues — they all fire frames AFTER the true release instant
+    and shift the clip into result territory.
   ANTI-LANDING CONFUSION (the dominant failure mode per operator audit):
-    If smoke / flames / flash-wash / HE-debris is visible IN THE WORLD on a
-    candidate frame, the release ALREADY HAPPENED some frames earlier — do
-    NOT pick the bloom-onset frame as release. Search BACKWARD in the
-    candidate set for the hand-empty / HUD-decrement transition. Picking
-    the bloom instant as release shifts the entire clip 0.3-1.5s into result
-    territory and the viewer sees the smoke unfurling instead of the throw
-    arc. The bloom belongs on result_index, NEVER on release_index.
+    If smoke / flames / flash-wash / HE-debris is visible IN THE WORLD on
+    a candidate frame, the release ALREADY HAPPENED some frames earlier —
+    do NOT pick the bloom-onset frame as release. Search BACKWARD in the
+    candidate set for the UTILITY-SEPARATION frame / HUD-decrement
+    transition. Picking the bloom instant as release shifts the entire
+    clip 0.3-1.5s into result territory and the viewer sees the smoke
+    unfurling instead of the throw arc. The bloom belongs on
+    result_index, NEVER on release_index.
   ANTI-PRE-WINDUP (the opposite failure mode):
-    If the utility is STILL in the player's hand on a candidate frame — held
-    statically, charged-up, aimed-with, or mid-wind-up arc — that frame is
-    BEFORE release. Search FORWARD in the candidate set for the hand-empty
-    frame. The wind-up, the lined-up aim, and the charge-up belong on the
-    AIM pane, not the THROW clip.
+    If the utility is STILL in the player's hand on a candidate frame —
+    held statically, charged-up, aimed-with, or mid-wind-up arc — that
+    frame is BEFORE release. Search FORWARD in the candidate set for the
+    UTILITY-SEPARATION frame. The wind-up, the lined-up aim, and the
+    charge-up belong on the AIM pane, not the THROW clip.
   STRADDLE RULE:
-    If the candidate set straddles release (frame N shows utility-in-hand;
-    frame N+1 shows hand-empty AND bloom already visible), pick frame N+1 —
-    it is the closest sample to the true release instant. The clip window
-    pulls 1.0s of pre-release coverage so the viewer still sees the wind-up
-    arc even when the chosen index is slightly past the literal release.
-  Fallback: if no eligible frame shows a hand-empty / HUD-decrement
-  transition, choose the eligible frame immediately BEFORE the smoke / flame
-  / flash / debris first appears in the world.
+    If the candidate set straddles release (frame N shows
+    utility-still-in-hand; frame N+1 shows utility-separated-in-air AND
+    bloom already visible), pick frame N+1 — it is the closest sample to
+    the true release instant. The clip window pulls 1.0s of pre-release
+    coverage so the viewer still sees the wind-up arc even when the
+    chosen index is slightly past the literal release.
+  Fallback: if no eligible frame shows a UTILITY-SEPARATION / HUD-
+  decrement transition, choose the eligible frame immediately BEFORE the
+  smoke / flame / flash / debris first appears in the world.
 - result_index: the 1-based frame where the RESULT is first clearly visible
   FROM THE THROWER'S LINEUP POSITION, chosen from frames that pass
   CANDIDATE-FRAME EXCLUSIONS. It MUST be at or after release_index — a

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -473,8 +473,12 @@ class TestThrowTimingReleaseAnchor:
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_release_instant_anchor(self):
-        """The RELEASE-INSTANT ANCHOR section must establish hand-empty +
-        HUD-slot-decrement as the primary release cues."""
+        """The RELEASE-INSTANT ANCHOR section must establish
+        UTILITY-SEPARATION + HUD-slot-decrement as the primary release
+        cues. The UTILITY-SEPARATION wording (mid-swing, T4) replaced the
+        original "HAND-EMPTY AFTER ARM EXTENSION" wording (post-swing,
+        T5) on 2026-05-25 because the original anchored on the wrong
+        biomechanical instant — see #775 follow-up."""
         _, client = await _call(
             {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
              "confidence": 0.6, "reasoning": "x"},
@@ -484,15 +488,49 @@ class TestThrowTimingReleaseAnchor:
         assert "RELEASE-INSTANT ANCHOR" in system_text
         # Both primary cues must be present by name so the model knows which
         # signal to anchor on when the HUD is occluded.
+        assert "UTILITY-SEPARATION FRAME" in system_text
         assert "HUD GRENADE-SLOT DECREMENT" in system_text
-        assert "HAND-EMPTY AFTER ARM EXTENSION" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_anchors_on_mid_swing_not_post_swing(self):
+        """The release instant is T4 (utility separates from hand,
+        mid-swing) NOT T5 (arm fully retracted, post-swing). The first
+        cut of this prompt (#775) used "the throwing arm has finished
+        its forward swing and the hand is now EMPTY" wording which
+        anchored on T5 and caused #11 Stairs's clip to catch only the
+        tail of the throw motion (operator audit 2026-05-25). The
+        replacement wording MUST explicitly distinguish mid-swing from
+        post-swing or the bug returns."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        # Mid-swing positive cue
+        assert "MID-SWING" in system_text
+        # Explicit anti-post-swing language (substrings chosen to survive
+        # source-file line wrapping — the joined system_text has newlines
+        # mid-phrase where the source wraps)
+        assert "NOT after the swing has completed" in system_text
+        assert "FULLY RETRACTED" in system_text
+        # Forecast the bug if removed: clip catches only the tail of the
+        # throw motion. This phrase ties the rule to the audit so the
+        # warning survives copy-edits.
+        assert "tail of the throw motion" in system_text
+        # The explicit identity statement is the load-bearing instruction
+        # — "release instant IS separation, NOT post-swing rest"
+        assert "the SEPARATION" in system_text
+        assert "post-swing rest" in system_text
 
     @pytest.mark.asyncio
     async def test_system_prompt_demotes_follow_through_cue(self):
         """The pre-audit "throw-animation follow-through" wording was the
         suspected root cause for #1 / #6 / #10's "shows landing" failures
         — it licensed the model to pick post-release frames. The new prompt
-        MUST explicitly DO-NOT-USE it as a standalone release cue."""
+        MUST explicitly DO-NOT-USE it as a standalone release cue. The
+        follow-up (#775+1) also demotes "post-swing hand-at-rest pose"
+        which was the residual T5 anchor that #11 Stairs hit."""
         _, client = await _call(
             {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
              "confidence": 0.6, "reasoning": "x"},
@@ -504,7 +542,11 @@ class TestThrowTimingReleaseAnchor:
         # the model loses the anti-follow-through guard.
         assert "DO NOT use" in system_text
         assert "throw-animation follow-through" in system_text
-        assert "projectile arc visible" in system_text
+        # Substring chosen to survive source-file line wrapping
+        assert "projectile arc" in system_text
+        # The post-swing demotion was added in the #775 follow-up after
+        # the original wording anchored the model on T5 instead of T4.
+        assert "post-swing hand-at-rest pose" in system_text
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_anti_landing_confusion(self):
@@ -524,7 +566,8 @@ class TestThrowTimingReleaseAnchor:
         assert "Search BACKWARD" in system_text
         # The reason is load-bearing — the model needs to understand WHY
         # picking the bloom is wrong (clip shifts into result territory).
-        assert "bloom belongs on result_index" in system_text
+        # Substring chosen to survive source-file line wrapping.
+        assert "NEVER on release_index" in system_text
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_anti_pre_windup(self):
@@ -559,5 +602,6 @@ class TestThrowTimingReleaseAnchor:
         assert "STRADDLE RULE" in system_text
         # The clip-window justification ("1.0s of pre-release coverage") is
         # what tells the model it's safe to pick the slightly-late frame —
-        # the wind-up isn't lost.
-        assert "1.0s of pre-release coverage" in system_text
+        # the wind-up isn't lost. Substring chosen to survive source-file
+        # line wrapping.
+        assert "1.0s of pre-release" in system_text


### PR DESCRIPTION
## Summary

- Operator audit of lineup `9b2ad4c9` (Stairs - A Site) post-#775: \"throw is only catching the tail end of the throw, I can't tell what the throw mechanics are.\"
- Root cause: #775's \"HAND-EMPTY AFTER ARM EXTENSION\" wording told Claude to pick the frame AFTER the swing has completed (post-swing, ~0.3-0.5s past the true release instant). With the symmetric `[release−1s, release+1s]` clip window anchored on that late point, operator sees the follow-through + bloom-onset instead of the windup→release arc.
- Replaces the language with \"UTILITY-SEPARATION FRAME\" — explicitly mid-swing, with \"NOT after the swing has completed\" / \"NOT yet retracted to a resting pose\" anti-cues + an explicit forecast (\"clip will catch only the tail of the throw motion (operator audit 2026-05-25, lineup 9b2ad4c9)\") tying the rule to the audit so it survives future copy-edits.
- HUD-decrement cue preserved as confirming secondary signal. ANTI-LANDING / ANTI-PRE-WINDUP / STRADDLE rules updated to refer to UTILITY-SEPARATION (consistent vocabulary). The \"DO NOT use\" demotion list extended with \"post-swing hand-at-rest pose\".
- New test `test_system_prompt_anchors_on_mid_swing_not_post_swing` fails loud if the T4-vs-T5 distinction is ever flattened.

## Operational migration

None. Prompt-only. After merge: operator NULLs `#11`'s `throw_clip_url` and re-runs `python -m app.cli backfill-clips` to regenerate under the new anchor.

## Test plan

- [x] \`pytest tests/test_throw_timing_classifier.py tests/test_throw_localizer.py tests/test_clip_generator.py\` — 78 passed (1 new + 77 existing)
- [ ] CI green
- [ ] Post-merge: NULL #11 throw_clip_url + backfill + operator inspects clip mechanics

🤖 Generated with [Claude Code](https://claude.com/claude-code)