### PR TITLE
fix(mga): re-anchor STAND on arrival-instant + end-anchor clip (recover #777)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/stand_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/stand_timing_classifier.py
@@ -165,42 +165,62 @@ NOT exclusions (allowed for STAND, unlike the throw-timing classifier):
     See NON-UTILITY HELD-WEAPON DISAMBIGUATION above for the motion
     qualifier.
 
-STRUCTURAL ANCHOR — MIDDLE OF SETTLED-STANCE (operator audit 2026-05-25)
-STAND is a frame from the MIDDLE of the settled-stance phase — NOT the
-edges of it. A ~1 second clip is cut centred on the picked frame
-downstream, and an edge-of-phase pick lets that clip extend into the
-preceding walk-up OR the following look-up-to-aim transition. Both
-distort what the viewer is supposed to learn: the FIXED starting
-position before any movement.
+STRUCTURAL ANCHOR — ARRIVAL INSTANT (operator audit 2026-05-25, replaces
+the prior "MIDDLE OF SETTLED-STANCE" rule which anchored too late):
 
-Prefer a frame where:
-  - The narrator is stationary at the throwing spot AND has been
-    stationary for AT LEAST one prior frame in the candidate set.
-  - The next frame in the candidate set is ALSO stationary at the same
-    spot — the camera has not yet started tilting up to aim.
-  - The camera is held still (not panning or sweeping mid-arrival).
-  - The chapter-intro overlay, if any, has faded out, transitioned, or
-    no longer dominates the frame.
+STAND is the ARRIVAL INSTANT — the FIRST frame where the player has
+arrived at the throwing position AND the camera has come to rest. A
+~3 second clip is cut END-ANCHORED on the picked frame downstream
+(``clip = [stand_ts − 3.0s, stand_ts]``), so the picked frame is the
+FINAL frame of the clip and the pre-side captures the LAST seconds of
+approach. The walk-up content on the pre-side is the VALUE — it shows
+the path, the environmental cues, and the final alignment that the
+operator needs for pixel-perfect positioning. An "already-settled"
+pick (well past arrival) defeats the purpose of the STAND pane: the
+clip then shows the player standing still with no information about
+how to navigate to that exact spot.
 
-REJECT these edge-of-phase picks:
-  - FIRST settled frame right after walk-up arrival (the prior frame
-    shows motion). A clip centred here catches the walk-up on the
-    pre-side, blurring "where to stand" with "how to get there".
-  - LAST settled frame before the camera tilts up to aim (the next
-    frame shows camera motion). A clip centred here catches the
-    look-up on the post-side, blurring stand with aim.
+The visual signal is a motion → stationary TRANSITION:
+  - PRIOR frame(s) show APPROACH motion: walking forward, view-bobbing,
+    panning toward the destination, the camera angle still changing
+    as the player navigates to the spot.
+  - The PICKED frame is the FIRST frame where the camera is STATIONARY
+    on the throwing-location framing — the player has fully arrived,
+    motion has stopped, the composition has stabilized.
+  - The NEXT frame(s) (if any) show the player still at the same spot
+    — confirm arrival by checking that motion has genuinely ended, not
+    just paused mid-stride.
 
-If the candidate set only contains edges (no stationary frames on
-BOTH sides of any pick), accept the cleanest available — partial
-information is still better than skipping the demo.
+PICK the FIRST settled frame after the walk-up. DO NOT skip past it
+into "middle of settled stance" — that anchors too late and the
+downstream end-anchored clip misses the approach.
+
+DISQUALIFIED PICKS (search elsewhere if a candidate matches):
+  - SHOWING FROM AFAR: a frame where the player is looking at the
+    throwing spot from a distance (panning a wider area, showing the
+    target on the map, narrating the overview) is NOT arrival. Arrival
+    requires the player to BE at the spot, with the surrounding
+    geometry framed as the throwing position.
+  - MID-WALK PAUSE: a frame where the player is briefly stationary
+    mid-approach (waiting for animation, checking the minimap) but the
+    NEXT frame shows resumed motion is NOT arrival. Genuine arrival
+    has continued stillness.
+  - DEEP-SETTLED: a frame several seconds past the actual arrival,
+    where the player has been stationary for a while AND has started
+    tilting up to line up the throw. Search BACKWARD for the FIRST
+    settled frame.
+
+If the chapter has NO walk-up (the player is already at the spot at
+chapter_start — common for fast-cut tutorial styles), set
+``stand_index = 1`` (the first candidate is the arrival).
 
 WHEN MULTIPLE DEMONSTRATIONS EXIST
-The narrator may show the spot more than once (afar → walking up →
-settled at spot → small re-adjustment). Per the STRUCTURAL ANCHOR
-above, prefer a MIDDLE-of-phase frame from the LONGEST contiguous
-settled-stance segment. Length of stationary stance dominates: a 4-
-frame settled segment with a clean middle frame is preferable to a
-2-frame settled segment, even if the 2-frame segment came first.
+The narrator may visit the throwing position multiple times (afar
+preview → walk-up → arrival → small re-adjustment → continued
+positioning before the throw). Pick the LATEST arrival — the one
+immediately preceding the throw demonstration. Earlier visits /
+previews are not the operator's target; the final arrival before
+windup is.
 
 WHEN NO DEMONSTRATION EXISTS
 Some chapters skip the stand-demo entirely (narrator walks to spot, then

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
@@ -83,12 +83,10 @@ from app.services.ingestion.youtube_fetcher import (
 
 logger = logging.getLogger(__name__)
 
-# STAND is 3.0s END-ANCHORED on ``stand_ts`` (operator audit 2026-05-25:
-# stand_ts now means the ARRIVAL INSTANT — last walk-up frame — so the clip
-# should END there and reach BACKWARD to capture the approach + alignment
-# cues that teach pixel-perfect positioning). AIM is 1.0s end-anchored on
-# ``aim_ts``. Both panes are now end-anchored on their classifier-chosen
-# anchor frame; centering is no longer used.
+# STAND + AIM are both END-ANCHORED on their classifier-chosen anchor frame
+# (post 2026-05-25 audit — STAND was previously centered). stand_ts is now
+# the ARRIVAL INSTANT; clip = [stand_ts − 3.0, stand_ts] captures the
+# approach. aim_ts is the lock instant; clip = [aim_ts − 1.0, aim_ts].
 _STAND_MICRO_CLIP_SECONDS = 3.0
 _AIM_MICRO_CLIP_SECONDS = 1.0
 # Minimum acceptable clamped duration. Below: skip rather than ship a sliver.
@@ -438,12 +436,9 @@ async def generate_micro_clips_for_lineup(
                 ),
             }
         else:
-            # END-ANCHORED on stand_ts (the arrival instant — last walk-up
-            # frame). Clip = [stand_ts − 3.0, stand_ts], clamped to
-            # chapter_start. Mirrors AIM's end-anchored shape. No release
-            # buffer needed: stand_ts is the arrival, which is upstream of
-            # any windup; the localizer's _COARSE_PRE_RELEASE_PAD already
-            # keeps stand_ts below release_ts. See module docstring.
+            # END-ANCHORED on stand_ts (the arrival instant); the
+            # localizer's _COARSE_PRE_RELEASE_PAD already keeps stand_ts
+            # below release_ts, so no release-side clamp needed here.
             stand_outcome = await _cut_upload_persist_one_side(
                 db, lineup, video_id, local_video,
                 anchor_ts=stand_ts - _STAND_MICRO_CLIP_SECONDS,

--- a/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/micro_clip_generator.py
@@ -83,14 +83,14 @@ from app.services.ingestion.youtube_fetcher import (
 
 logger = logging.getLogger(__name__)
 
-# STAND is 2.0s centered on ``stand_ts``; AIM is 1.0s end-anchored on
-# ``aim_ts``. STAND's upper end is clamped to ``release_ts − _STAND_POST_TS_BUFFER``;
-# AIM needs no release buffer because aim_ts is guaranteed pre-windup by the
-# AIM localizer's pre-windup pad. See module docstring.
-_STAND_MICRO_CLIP_SECONDS = 2.0
+# STAND is 3.0s END-ANCHORED on ``stand_ts`` (operator audit 2026-05-25:
+# stand_ts now means the ARRIVAL INSTANT — last walk-up frame — so the clip
+# should END there and reach BACKWARD to capture the approach + alignment
+# cues that teach pixel-perfect positioning). AIM is 1.0s end-anchored on
+# ``aim_ts``. Both panes are now end-anchored on their classifier-chosen
+# anchor frame; centering is no longer used.
+_STAND_MICRO_CLIP_SECONDS = 3.0
 _AIM_MICRO_CLIP_SECONDS = 1.0
-_STAND_HALF_CLIP_SECONDS = 1.0
-_STAND_POST_TS_BUFFER = 0.3
 # Minimum acceptable clamped duration. Below: skip rather than ship a sliver.
 _MIN_CLIP_SECONDS = 0.5
 
@@ -438,15 +438,18 @@ async def generate_micro_clips_for_lineup(
                 ),
             }
         else:
+            # END-ANCHORED on stand_ts (the arrival instant — last walk-up
+            # frame). Clip = [stand_ts − 3.0, stand_ts], clamped to
+            # chapter_start. Mirrors AIM's end-anchored shape. No release
+            # buffer needed: stand_ts is the arrival, which is upstream of
+            # any windup; the localizer's _COARSE_PRE_RELEASE_PAD already
+            # keeps stand_ts below release_ts. See module docstring.
             stand_outcome = await _cut_upload_persist_one_side(
                 db, lineup, video_id, local_video,
-                anchor_ts=stand_ts - _STAND_HALF_CLIP_SECONDS,
+                anchor_ts=stand_ts - _STAND_MICRO_CLIP_SECONDS,
                 clip_seconds=_STAND_MICRO_CLIP_SECONDS,
                 chapter_start=chapter_start,
-                chapter_end=min(
-                    chapter_end,
-                    (release_ts or chapter_end) - _STAND_POST_TS_BUFFER,
-                ),
+                chapter_end=chapter_end,
                 side="stand",
                 key_fn=pending_stand_clip_key,
                 persist_fn=lineup_repo.set_stand_clip_url,

--- a/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_micro_clip_generator.py
@@ -133,9 +133,12 @@ class TestMicroClipSecondsForSide:
     single shared constant — losing the split here re-introduces the
     "STAND cuts off too soon" complaint."""
 
-    def test_stand_is_two_seconds(self):
-        assert _micro_clip_seconds_for_side("stand") == pytest.approx(2.0)
-        assert _STAND_MICRO_CLIP_SECONDS == pytest.approx(2.0)
+    def test_stand_is_three_seconds(self):
+        # Post 2026-05-25 audit: STAND is 3.0s end-anchored (was 2.0s
+        # centered). Operator wants the LAST 3s of approach ending at
+        # arrival, not 2s centered on settled stance.
+        assert _micro_clip_seconds_for_side("stand") == pytest.approx(3.0)
+        assert _STAND_MICRO_CLIP_SECONDS == pytest.approx(3.0)
 
     def test_aim_is_one_second(self):
         assert _micro_clip_seconds_for_side("aim") == pytest.approx(1.0)
@@ -640,10 +643,12 @@ async def test_offset_persisted_when_wider_source_exists():
         patch(f"{_MOD}._resolve_aim_ts", AsyncMock(return_value=(14.2, [], ""))),
     ):
         # release_ts = 15.0; STAND_TS = mocked 12.0; AIM_TS = mocked 14.2.
-        # STAND is CENTERED:  clip_start = 12.0 - 1.0 = 11.0  (half-window 1.0s)
-        # AIM   is END-ANCHORED: clip_start = 14.2 - 1.0 = 13.2  (clip ends at aim_ts)
+        # STAND is END-ANCHORED (post 2026-05-25 audit — was CENTERED):
+        #   anchor_ts = 12.0 - 3.0 = 9.0; clamped UP to chapter_start (10.0)
+        #   so clip_start = 10.0, duration shrinks to 2.0s.
+        # AIM is END-ANCHORED: clip_start = 14.2 - 1.0 = 13.2 (ends at aim_ts)
         # wider_source_start = 10 - 2 = 8.0.
-        #   STAND offset = 11.0 - 8.0 = 3.0
+        #   STAND offset = 10.0 - 8.0 = 2.0
         #   AIM   offset = 13.2 - 8.0 = 5.2
         await generate_micro_clips_for_lineup(
             db, lineup,
@@ -654,12 +659,13 @@ async def test_offset_persisted_when_wider_source_exists():
 
     stand_call = set_stand_mock.await_args
     aim_call = set_aim_mock.await_args
-    assert _offset_kwarg(stand_call) == pytest.approx(3.0), (
+    assert _offset_kwarg(stand_call) == pytest.approx(2.0), (
         "STAND offset must equal clip_start - wider_source_start. "
-        "STAND clip is CENTERED on stand_ts: clip_start = "
-        "stand_ts - _STAND_HALF_CLIP_SECONDS (1.0) = 12.0 - 1.0 = 11.0. "
-        "wider_source_start = chapter_start - PRE = 10.0 - 2.0 = 8.0. "
-        "offset = 11.0 - 8.0 = 3.0. "
+        "STAND clip is END-ANCHORED on stand_ts (post 2026-05-25 audit, "
+        "was CENTERED): anchor_ts = stand_ts - _STAND_MICRO_CLIP_SECONDS "
+        "(3.0) = 12.0 - 3.0 = 9.0; CLAMPED UP to chapter_start (10.0), "
+        "so clip_start = 10.0. wider_source_start = chapter_start - PRE "
+        "= 10.0 - 2.0 = 8.0. offset = 10.0 - 8.0 = 2.0. "
         f"Got setter call: args={stand_call.args} kwargs={stand_call.kwargs}"
     )
     assert _offset_kwarg(aim_call) == pytest.approx(5.2), (

--- a/apps/mygamingassistant/backend/tests/test_stand_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_stand_timing_classifier.py
@@ -156,13 +156,15 @@ class TestStandTimingPromptShape:
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_structural_anchor(self):
-        """STRUCTURAL ANCHOR — MIDDLE of settled-stance — is the post-
-        2026-05-25 operator-audit fix. The prior EARLIEST rule put the
-        anchor at the edge of the settled phase; the downstream 1s clip
-        then caught walk-up motion on the pre-side. The new rule
-        requires the picked frame to be in the MIDDLE of the settled-
-        stance phase (stationary frames on BOTH sides) so the clip
-        stays stationary."""
+        """STRUCTURAL ANCHOR — ARRIVAL INSTANT — is the post-2026-05-25
+        operator-audit fix. The prior MIDDLE-OF-SETTLED-STANCE rule put
+        the anchor too late: the operator wanted the walk-up content on
+        the pre-side (it teaches the approach + alignment cues needed
+        for pixel-perfect positioning) but the prompt explicitly
+        REJECTED the first settled frame for centering reasons. The
+        downstream clip shape is now END-ANCHORED ([stand_ts-3.0,
+        stand_ts]) so the FIRST settled frame is correct — the
+        operator sees the LAST 3s of approach ending at arrival."""
         _, client = await _call(
             {"has_stand_demonstration": True, "stand_index": 1,
              "confidence": 0.6, "reasoning": "x"},
@@ -170,14 +172,11 @@ class TestStandTimingPromptShape:
         system = client.messages.create.call_args.kwargs["system"]
         system_text = "\n".join(b["text"] for b in system)
         assert "STRUCTURAL ANCHOR" in system_text
-        assert "MIDDLE" in system_text
-        assert "MIDDLE OF SETTLED-STANCE" in system_text
-        # WHEN MULTIPLE DEMONSTRATIONS EXIST must agree with the anchor
-        # — prefer the longest contiguous settled segment, NOT the first
-        # settled frame. Substring-checked piece-wise to survive prompt
-        # line-wrapping.
-        assert "LONGEST contiguous" in system_text
-        assert "Length of stationary stance dominates" in system_text
+        assert "ARRIVAL INSTANT" in system_text
+        # The "FIRST settled frame" + "DO NOT skip" wording is the load-
+        # bearing reversal of the prior "MIDDLE OF" rule.
+        assert "FIRST settled frame" in system_text
+        assert "DO NOT skip past it" in system_text
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_concrete_anchored_examples(self):


### PR DESCRIPTION
Recovery PR for orphaned #777 — original PR was closed without merging when the post-tool cleanup hook fired on the GraphQL auto-merge call, deleting the branch before GitHub merged.

Functionally identical to #777. Commits cherry-pickable from reflog:
- 182b79a — re-anchor STAND on arrival-instant + end-anchor clip (3s walk-up)
- ef06cef — tighten STAND comment block to satisfy 500-LOC guard

## What changed

Per operator audit: STAND value is "how do I navigate to this pixel-perfect spot" — the LAST 2-3 seconds of walking up to the position, NOT the settled-stance frame.

- `stand_timing_classifier.py` — prompt now anchors on ARRIVAL INSTANT (motion → stationary transition, FIRST settled frame). Opposite of PR #773's "MIDDLE OF SETTLED-STANCE".
- `micro_clip_generator.py` — STAND clip window now END-anchored `[stand_ts − 3.0s, stand_ts]` (3s of approach walk-up). AIM clip behavior unchanged.
- Tests updated for new window shape.

## After merge

NULL `#11 Stairs` stand_clip_url in dev DB + run `python -m app.cli backfill-micro-clips` to validate operator can see the walk-up content.