### PR TITLE
fix(mga): exclude intro-card chapters at ingest (video-framing + title-match)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/chapter_parser.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/chapter_parser.py
@@ -110,24 +110,77 @@ _NON_LINEUP_TITLE_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Whole-video *framing* titles — a creator's video-level name, not an
+# individual lineup demonstration. These routinely appear as the 0:00 chapter
+# (YouTube seeds the first chapter with the video title) and on standalone
+# promo / title cards. Suffix-anchored on the framing noun so a real lineup
+# whose title merely contains the word mid-string ("Smoke guide line on B") is
+# NOT dropped. Added 2026-05-28 after "Best Anubis Smokes Guide" — the video's
+# own title reused as a 0:00 intro-card chapter — slipped past the
+# prefix-anchored denylist above and became a junk accepted lineup.
+_VIDEO_FRAMING_SUFFIX_RE = re.compile(
+    r"\b(?:guide|guides|tutorial|tutorials|walkthrough|walkthroughs|"
+    r"compilation|montage|breakdown|masterclass)\s*$",
+    re.IGNORECASE,
+)
+
 # Minimum chapter length for a plausible lineup demo. A real lineup
 # demonstration (walk to spot, line up the throw, throw, show result) is rarely
 # shorter than this; sub-15s chapters are almost always transitions/stings.
 _MIN_LINEUP_CHAPTER_SECONDS = 15
 
 
+def _normalize_title(title: str) -> str:
+    """Lowercase + collapse to space-separated alnum tokens for comparison."""
+    return re.sub(r"[^a-z0-9]+", " ", title.lower()).strip()
+
+
+def _is_video_title_intro(chapter: Chapter, video_title: Optional[str]) -> bool:
+    """True when *chapter* is the 0:00 chapter whose title IS the video title.
+
+    YouTube seeds the first chapter with the video's own name. When a creator
+    opens with a promo / title card (rather than launching straight into a
+    lineup), that 0:00 chapter is the whole-video framing, not a lineup — e.g.
+    a chapter "Best Anubis Smokes Guide" on a video of the same name.
+
+    Matching the video title (exact, or a >=60%-length prefix to tolerate
+    " | Channel" / " (CS2)" suffixes YouTube appends to the *video* title) is a
+    near-zero-false-positive signal: a genuine lineup chapter is never titled
+    identically to the whole video. The 60% length guard protects a short real
+    first-lineup title that merely prefixes the video title ("A Site" on
+    "A Site Smokes").
+    """
+    if not video_title or chapter.start_seconds != 0:
+        return False
+    nt = _normalize_title(chapter.title)
+    nv = _normalize_title(video_title)
+    if not nt or not nv:
+        return False
+    if nt == nv:
+        return True
+    return nv.startswith(nt) and len(nt) >= 0.6 * len(nv)
+
+
 def filter_lineup_chapters(
     chapters: list[Chapter],
     *,
     min_duration_seconds: int = _MIN_LINEUP_CHAPTER_SECONDS,
+    video_title: Optional[str] = None,
 ) -> list[Chapter]:
     """Drop chapters that are video structure, not lineup demonstrations.
 
-    Two heuristics applied *after* ``parse_chapters``:
+    Four heuristics applied *after* ``parse_chapters``:
 
       1. **Title denylist** — intro / outro / "tip N" / subscribe / sponsor /
-         credits / etc.
-      2. **Minimum duration** — chapters shorter than *min_duration_seconds*
+         credits / etc. (prefix-anchored on the stripped title).
+      2. **Video-framing suffix** — titles ending in "... Guide" / "Tutorial" /
+         "Walkthrough" / "Compilation" etc. are the creator's video-level name,
+         never a single lineup.
+      3. **Video-title intro card** — the 0:00 chapter whose title matches the
+         *video_title* (when supplied). YouTube seeds the first chapter with
+         the video's own name; when the creator opens on a title/promo card
+         that chapter is whole-video framing, not a lineup.
+      4. **Minimum duration** — chapters shorter than *min_duration_seconds*
          are transitions/stings, not a walk-aim-throw demo.
 
     ``parse_chapters`` stays a pure structural parser (its existing test
@@ -138,6 +191,10 @@ def filter_lineup_chapters(
     Args:
         chapters: Parsed chapters from ``parse_chapters``.
         min_duration_seconds: Chapters shorter than this are dropped.
+        video_title: The source video's title (``VideoMeta.title``). When
+            supplied, enables heuristic 3 (the video-title intro-card drop).
+            Omit (None) to skip it — the function stays usable without video
+            context for isolated testing.
 
     Returns:
         The subset of *chapters* that are plausibly real lineups, in order.
@@ -146,7 +203,12 @@ def filter_lineup_chapters(
     """
     kept: list[Chapter] = []
     for ch in chapters:
-        if _NON_LINEUP_TITLE_RE.match(ch.title.strip()):
+        title = ch.title.strip()
+        if _NON_LINEUP_TITLE_RE.match(title):
+            continue
+        if _VIDEO_FRAMING_SUFFIX_RE.search(title):
+            continue
+        if _is_video_title_intro(ch, video_title):
             continue
         if (ch.end_seconds - ch.start_seconds) < min_duration_seconds:
             continue

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -579,7 +579,7 @@ async def _process_video(
     # download + frame extraction + classifier calls — they only produce junk
     # pending lineups and waste a Claude call each. See chapter_parser.
     parsed_count = len(chapters)
-    chapters = filter_lineup_chapters(chapters)
+    chapters = filter_lineup_chapters(chapters, video_title=video_meta.title)
     dropped = parsed_count - len(chapters)
     if dropped:
         logger.info(

--- a/apps/mygamingassistant/backend/tests/test_chapter_parser.py
+++ b/apps/mygamingassistant/backend/tests/test_chapter_parser.py
@@ -293,3 +293,90 @@ class TestFilterLineupChapters:
             "A-site smoke from CT",
             "B-site flash from mid",
         ]
+
+
+# ---------------------------------------------------------------------------
+# filter_lineup_chapters — video-framing suffix + video-title intro card
+# (added 2026-05-28 after "Best Anubis Smokes Guide" became a junk lineup)
+# ---------------------------------------------------------------------------
+
+class TestVideoFramingAndIntroCard:
+    def _ch(self, title: str, start: int = 0, end: int = 120) -> Chapter:
+        return Chapter(start_seconds=start, end_seconds=end, title=title)
+
+    @pytest.mark.parametrize(
+        "title",
+        [
+            "Best Anubis Smokes Guide",
+            "CS2 Smoke Guide",
+            "Mirage Lineups Tutorial",
+            "Full Dust2 Walkthrough",
+            "Top 10 Smokes Compilation",
+            "Insane Clutch Montage",
+            "Complete Utility Breakdown",
+            "Pro Smokes Masterclass",
+        ],
+    )
+    def test_drops_video_framing_suffix(self, title: str):
+        """Titles ending in a video-level framing noun are never a single
+        lineup — dropped regardless of video_title."""
+        assert filter_lineup_chapters([self._ch(title, 0, 300)]) == []
+
+    def test_framing_suffix_anchored_at_end_not_substring(self):
+        """A real lineup whose title merely CONTAINS a framing word mid-string
+        must NOT be dropped — the framing match is suffix-anchored."""
+        chapters = [
+            self._ch("Smoke guide line on B ramp", 0, 60),
+            self._ch("Tutorial-style flash for A main", 60, 120),
+        ]
+        kept = filter_lineup_chapters(chapters)
+        assert len(kept) == 2
+
+    def test_drops_intro_card_matching_video_title(self):
+        """The exact regression: a 0:00 chapter whose title is the video
+        title is the intro card, not a lineup."""
+        chapters = [
+            self._ch("Best Anubis Smokes Guide", 0, 45),
+            self._ch("A site from ramp", 45, 200),
+        ]
+        kept = filter_lineup_chapters(
+            chapters, video_title="Best Anubis Smokes Guide"
+        )
+        assert [c.title for c in kept] == ["A site from ramp"]
+
+    def test_intro_card_tolerates_video_title_suffix(self):
+        """YouTube appends a short ' (CS2)' / ' | Channel' suffix to the video
+        title; the 0:00 chapter still matches as a >=60%-length prefix."""
+        chapters = [self._ch("Best Anubis Smokes", 0, 45)]
+        kept = filter_lineup_chapters(
+            chapters, video_title="Best Anubis Smokes (CS2)"
+        )
+        assert kept == []
+
+    def test_short_real_first_lineup_prefixing_title_is_kept(self):
+        """A short genuine first-lineup title that merely prefixes the video
+        title must survive — the 60% length guard protects it."""
+        chapters = [self._ch("A Site", 0, 60)]
+        kept = filter_lineup_chapters(
+            chapters, video_title="A Site Smokes And Flashes For Mirage"
+        )
+        assert [c.title for c in kept] == ["A Site"]
+
+    def test_intro_card_only_applies_to_zero_start(self):
+        """A chapter that matches the video title but is NOT at 0:00 is a
+        real (oddly-named) lineup, not the intro card — kept."""
+        chapters = [self._ch("Real lineup at start", 0, 60),
+                    self._ch("Anubis Smokes", 120, 200)]
+        kept = filter_lineup_chapters(
+            chapters, video_title="Anubis Smokes"
+        )
+        assert [c.title for c in kept] == [
+            "Real lineup at start", "Anubis Smokes"
+        ]
+
+    def test_no_video_title_skips_intro_heuristic(self):
+        """Without video_title the intro-card heuristic is inert (back-compat);
+        the framing-suffix and denylist heuristics still apply."""
+        chapters = [self._ch("Best Anubis Smokes", 0, 45)]  # no 'guide' suffix
+        kept = filter_lineup_chapters(chapters)  # video_title omitted
+        assert [c.title for c in kept] == ["Best Anubis Smokes"]


### PR DESCRIPTION
## Problem

A YouTube tutorial's 0:00 chapter is frequently the video's own title or a promo title card, not a lineup. The chapter **"Best Anubis Smokes Guide"** slipped past the prefix-anchored structural denylist in `filter_lineup_chapters` and became a junk *accepted* lineup whose two screenshot panes were both the intro card — root cause of the #12 partial-failure from the library clip audit.

The existing denylist (`_NON_LINEUP_TITLE_RE`) is anchored to intro/outro/tip/subscribe **prefixes** — "Best …" matches none of them.

## Fix

Two new near-zero-false-positive heuristics in `filter_lineup_chapters`:

1. **Video-framing suffix** (`_VIDEO_FRAMING_SUFFIX_RE`) — titles ending in `… Guide / Guides / Tutorial / Walkthrough / Compilation / Montage / Breakdown / Masterclass` are whole-video framings, never a single lineup. Suffix-anchored, so a real lineup that merely *contains* the word mid-string ("Smoke guide line on B") is kept.
2. **Video-title intro card** (`_is_video_title_intro`) — the `start==0` chapter whose normalized title equals the video title, or is a `>=60%`-length prefix of it (tolerates the `" (CS2)"` / `" | Channel"` suffixes YouTube appends to the *video* title). The 60% length guard protects a short genuine first-lineup title that merely prefixes the video title ("A Site" on "A Site Smokes").

`video_meta.title` is threaded through the single orchestrator call site. `parse_chapters` stays a pure structural parser.

## Tests

13 new unit tests (`TestVideoFramingAndIntroCard`): the exact Anubis regression case, each framing suffix, the mid-string false-positive guard, video-title-suffix tolerance, the 60%-length false-positive guard, the `start==0`-only restriction, and back-compat when `video_title` is omitted. Full `test_chapter_parser.py` green (74 passed).

## Notes

- The already-ingested Anubis row (`4ee6ccef`) was separately hidden in the dev DB; this PR prevents the class from re-entering the review queue on future ingests.
- Purely the structural chapter filter — does not touch the grid classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)