### PR TITLE
fix(mga): recover throw release on causality-inverted coarse pass (multi-demo chapters)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/classification_result.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classification_result.py
@@ -91,12 +91,23 @@ class ThrowTimingResult:
     window the call was shown. The parser guarantees
     ``result_index >= release_index`` when both are set (a result cannot
     precede its own release).
+
+    ``causality_inverted_earlier_index`` is the diagnostic breadcrumb left
+    when the model returned ``result_index < release_index`` (a result
+    cannot precede its own release). The parser still forces
+    ``result_index = release_index`` for the frozen contract, but records
+    the ORIGINAL earlier index here so a caller can recognise the
+    multi-demonstration signature (the model paired a LATE demo's release
+    with an EARLY demo's result) and re-localise around the first event.
+    ``None`` whenever no inversion occurred. See
+    ``throw_localizer.localize_throw_with_refinement`` (causality recovery).
     """
 
     success: bool
     is_lineup_throw: Optional[bool] = None
     release_index: Optional[int] = None
     result_index: Optional[int] = None
+    causality_inverted_earlier_index: Optional[int] = None
     confidence: Optional[float] = None
     reasoning: str = ""
     error_codes: list[str] = field(default_factory=list)

--- a/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
@@ -432,6 +432,7 @@ async def classify_throw_timing_from_frames(
     # release. If the model returned both but inverted, force result to the
     # release frame and log (do NOT silently swap — the operator/dash should
     # be able to see this happened).
+    causality_inverted_earlier_index: Optional[int] = None
     if (
         release_index is not None
         and result_index is not None
@@ -445,6 +446,12 @@ async def classify_throw_timing_from_frames(
             "result_index = release_index: chapter=%r",
             result_index, release_index, chapter_title,
         )
+        # Preserve the ORIGINAL earlier index before forcing. An inversion is
+        # the multi-demonstration signature (the model paired a LATE demo's
+        # release with an EARLY demo's result); the localizer uses this to
+        # re-localise densely around the first event. The frozen contract
+        # (result_index >= release_index in the returned value) is unchanged.
+        causality_inverted_earlier_index = result_index
         result_index = release_index
 
     if failures:
@@ -463,6 +470,7 @@ async def classify_throw_timing_from_frames(
         is_lineup_throw=True,
         release_index=release_index,
         result_index=result_index,
+        causality_inverted_earlier_index=causality_inverted_earlier_index,
         confidence=confidence,
         reasoning=reasoning,
         error_codes=list(structured_codes),

--- a/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer.py
@@ -31,6 +31,23 @@ otherwise the coarse result. Either way the caller gets back the
 ``timestamps[release_index - 1]`` exactly as before. The caller is
 otherwise unchanged.
 
+  Causality recovery (NEW, multi-demonstration chapters):
+    When the coarse pass reports ``result_index < release_index`` (the
+    classifier preserves the original earlier index on
+    ``ThrowTimingResult.causality_inverted_earlier_index``), the model
+    paired a LATE demonstration's release with an EARLY demonstration's
+    result — the signature of a chapter that demonstrates the same lineup
+    more than once. Instead of cratering confidence and gating the clip
+    out, the orchestrator re-localises densely around the FIRST event (the
+    earlier index is that demo's result, so the true release precedes it —
+    the recovery window is weighted backward from it). Fires BEFORE the
+    confidence gate, because the inversion is exactly why coarse confidence
+    cratered, and OWNS the outcome — a failed recovery returns the coarse
+    result tagged with a ``recovery_*`` stage (no regression), it does not
+    fall through to the normal dense pass (which would only refine around
+    the wrong late-demo release). (operator audit 2026-05-29, lineup
+    69704f4a "Market Door".)
+
 The refinement gate matches the clip pipeline's existing 0.55 confidence
 threshold:
   * If coarse is below 0.55, the clip would have been skipped anyway —
@@ -94,6 +111,25 @@ _DENSE_FRAME_COUNT = 8
 # under ~4 dense is a regression.
 _MIN_DENSE_FRAMES = 4
 
+# ---- Causality recovery (multi-demonstration chapters) -------------------
+# When the coarse pass reports result_index < release_index (the classifier
+# preserves the original earlier index on
+# ThrowTimingResult.causality_inverted_earlier_index), the model paired a
+# LATE demo's release with an EARLY demo's result — the signature of a
+# chapter that demonstrates the same lineup more than once (operator audit
+# 2026-05-29, lineup 69704f4a "Market Door"). Rather than crater confidence
+# and gate the clip out, re-localise densely around the FIRST event: the
+# earlier index is that demo's RESULT, so the true release precedes it —
+# weight the recovery window heavily BACKWARD from the earlier event.
+#
+# pre=7.0 covers a fully-bloomed smoke result (release→bloom up to ~3s) plus
+# the coarse sampler's own ~3.4s spacing slop; post=1.0 keeps a touch of
+# coverage past the event in case the model keyed on the first wisp. N=14
+# over the ~8s window ≈ 0.6s spacing — tight enough to pin the release.
+_RECOVERY_PRE_RELEASE_SECONDS = 7.0
+_RECOVERY_POST_RELEASE_SECONDS = 1.0
+_RECOVERY_FRAME_COUNT = 14
+
 # Diagnostic stage labels — surfaced on RefinedThrowTiming.stage for
 # logging / metrics. Each maps to a specific reason the dense pass was
 # (or wasn't) used. Keep stable for log-grepping.
@@ -107,6 +143,15 @@ STAGE_DENSE_WINDOW_TOO_SMALL = "dense_window_too_small"
 STAGE_DENSE_EXTRACT_FAILED = "dense_extract_failed"
 STAGE_DENSE_CLASSIFIER_FAILED = "dense_classifier_failed"
 STAGE_DENSE_REJECTED = "dense_rejected"
+# Causality-recovery stages (fired only when the coarse pass was inverted —
+# the multi-demonstration signature). RECOVERED uses the recovery dense
+# result; the REJECTED / *_FAILED / *_TOO_SMALL stages all fall back to the
+# coarse result (same "recovery can only improve, never regress" contract as
+# the dense pass).
+STAGE_RECOVERED_FIRST_EVENT = "recovered_first_event"
+STAGE_RECOVERY_REJECTED = "recovery_rejected"
+STAGE_RECOVERY_WINDOW_TOO_SMALL = "recovery_window_too_small"
+STAGE_RECOVERY_EXTRACT_FAILED = "recovery_extract_failed"
 
 
 @dataclass
@@ -179,6 +224,153 @@ def _should_refine(coarse: ThrowTimingResult) -> Optional[str]:
     return None
 
 
+async def _attempt_first_event_recovery(
+    video_path: Path,
+    coarse: ThrowTimingResult,
+    coarse_timestamps: list[float],
+    *,
+    chapter_start: float,
+    chapter_end: float,
+    chapter_title: Optional[str],
+    utility_hint: Optional[str],
+) -> RefinedThrowTiming:
+    """Re-localise around the FIRST event after a causality-inverted coarse pass.
+
+    Precondition (checked by the caller): ``coarse`` is a successful,
+    throw-positive result whose
+    ``causality_inverted_earlier_index`` is set — i.e. the model paired a
+    late demonstration's release with an earlier demonstration's result.
+    The earlier index points at the FIRST demo's RESULT, so the true release
+    precedes it; we sample a backward-weighted dense window around that event
+    and re-run the throw-timing classifier on the (now single-throw) window.
+
+    Always returns a RefinedThrowTiming so the caller can return it directly:
+      * ``STAGE_RECOVERED_FIRST_EVENT`` — recovery produced a clean,
+        non-re-inverted, throw-positive result with a release; ``timing`` is
+        the recovery result and ``frame_timestamps`` is the recovery window
+        (so the caller maps the recovered indices correctly).
+      * ``STAGE_RECOVERY_*`` — recovery could not improve on coarse; ``timing``
+        is the coarse result and ``frame_timestamps`` is the coarse window.
+        Same "never regress" contract as the dense pass.
+    """
+    earlier_index = coarse.causality_inverted_earlier_index
+    if earlier_index is None or not (1 <= earlier_index <= len(coarse_timestamps)):
+        # Defensive: caller gates on `is not None`, but a stale/out-of-range
+        # index must not index-error — fall back to coarse.
+        return RefinedThrowTiming(
+            timing=coarse,
+            frame_timestamps=coarse_timestamps,
+            stage=STAGE_RECOVERY_REJECTED,
+            coarse_timing=coarse,
+        )
+
+    earlier_event_ts = coarse_timestamps[earlier_index - 1]
+    recovery_timestamps = dense_window_timestamps(
+        earlier_event_ts,
+        chapter_start,
+        chapter_end,
+        pre_release_seconds=_RECOVERY_PRE_RELEASE_SECONDS,
+        post_release_seconds=_RECOVERY_POST_RELEASE_SECONDS,
+        n=_RECOVERY_FRAME_COUNT,
+    )
+
+    if len(recovery_timestamps) < _MIN_DENSE_FRAMES:
+        logger.info(
+            "throw_localizer: stage=%s earlier_event_ts=%.2f recovery_n=%d "
+            "(< %d); returning coarse: chapter=%r",
+            STAGE_RECOVERY_WINDOW_TOO_SMALL,
+            earlier_event_ts,
+            len(recovery_timestamps),
+            _MIN_DENSE_FRAMES,
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=coarse,
+            frame_timestamps=coarse_timestamps,
+            stage=STAGE_RECOVERY_WINDOW_TOO_SMALL,
+            coarse_timing=coarse,
+        )
+
+    try:
+        recovery_frames = await extract_frames_downscaled(
+            video_path, recovery_timestamps
+        )
+    except FrameExtractionError as exc:
+        # A recovery-pass extraction failure must NEVER regress the pipeline —
+        # fall back to coarse (same contract as the dense pass).
+        logger.warning(
+            "throw_localizer: stage=%s earlier_event_ts=%.2f returncode=%s "
+            "stderr=%s; returning coarse: chapter=%r",
+            STAGE_RECOVERY_EXTRACT_FAILED,
+            earlier_event_ts,
+            exc.returncode,
+            exc.stderr[:200],
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=coarse,
+            frame_timestamps=coarse_timestamps,
+            stage=STAGE_RECOVERY_EXTRACT_FAILED,
+            coarse_timing=coarse,
+        )
+
+    recovered = await classify_throw_timing_from_frames(
+        frames=recovery_frames,
+        frame_timestamps=recovery_timestamps,
+        chapter_title=chapter_title,
+        chapter_duration=float(chapter_end) - float(chapter_start),
+        utility_hint=utility_hint,
+    )
+
+    # Accept only a clean, throw-positive recovery with a release that did NOT
+    # itself invert — a re-inverted recovery means the window still spans more
+    # than one demonstration, so it is no more trustworthy than coarse.
+    if (
+        not recovered.success
+        or not recovered.is_lineup_throw
+        or recovered.release_index is None
+        or recovered.causality_inverted_earlier_index is not None
+    ):
+        logger.info(
+            "throw_localizer: stage=%s earlier_event_ts=%.2f "
+            "recovered_success=%s recovered_is_lineup_throw=%s "
+            "recovered_release_index=%s recovered_reinverted=%s; "
+            "returning coarse: chapter=%r",
+            STAGE_RECOVERY_REJECTED,
+            earlier_event_ts,
+            recovered.success,
+            recovered.is_lineup_throw,
+            recovered.release_index,
+            recovered.causality_inverted_earlier_index is not None,
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=coarse,
+            frame_timestamps=coarse_timestamps,
+            stage=STAGE_RECOVERY_REJECTED,
+            coarse_timing=coarse,
+        )
+
+    recovered_release_ts = recovery_timestamps[recovered.release_index - 1]
+    logger.info(
+        "throw_localizer: stage=%s earlier_event_ts=%.2f "
+        "recovered_release_ts=%.2f coarse_conf=%.2f recovered_conf=%.2f "
+        "chapter=%r",
+        STAGE_RECOVERED_FIRST_EVENT,
+        earlier_event_ts,
+        recovered_release_ts,
+        coarse.confidence or 0.0,
+        recovered.confidence or 0.0,
+        chapter_title,
+    )
+    return RefinedThrowTiming(
+        timing=recovered,
+        frame_timestamps=recovery_timestamps,
+        stage=STAGE_RECOVERED_FIRST_EVENT,
+        coarse_timing=coarse,
+    )
+
+
 async def localize_throw_with_refinement(
     video_path: Path,
     *,
@@ -232,6 +424,31 @@ async def localize_throw_with_refinement(
         chapter_duration=chapter_duration,
         utility_hint=utility_hint,
     )
+
+    # ---- Causality recovery (multi-demonstration chapters) --------------
+    # An inverted coarse pass (the classifier preserved the original earlier
+    # index) means the model paired a late demo's release with an early
+    # demo's result. The recovery path OWNS the outcome here: it re-localises
+    # densely around the first event and returns either the recovered result
+    # (STAGE_RECOVERED_FIRST_EVENT) or the coarse result tagged with the
+    # recovery-failure stage (never a regression — same contract as dense).
+    # We don't fall through to the normal refine path because the standard
+    # dense pass would centre on the WRONG (late-demo) release the inversion
+    # produced, and the cratered confidence would gate it out anyway.
+    if (
+        coarse.success
+        and coarse.is_lineup_throw
+        and coarse.causality_inverted_earlier_index is not None
+    ):
+        return await _attempt_first_event_recovery(
+            video_path,
+            coarse,
+            coarse_timestamps,
+            chapter_start=chapter_start,
+            chapter_end=chapter_end,
+            chapter_title=chapter_title,
+            utility_hint=utility_hint,
+        )
 
     skip_stage = _should_refine(coarse)
     if skip_stage is not None:

--- a/apps/mygamingassistant/backend/tests/test_throw_localizer.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_localizer.py
@@ -37,6 +37,10 @@ from app.services.ingestion.throw_localizer import (
     STAGE_DENSE_EXTRACT_FAILED,
     STAGE_DENSE_REJECTED,
     STAGE_DENSE_WINDOW_TOO_SMALL,
+    STAGE_RECOVERED_FIRST_EVENT,
+    STAGE_RECOVERY_EXTRACT_FAILED,
+    STAGE_RECOVERY_REJECTED,
+    STAGE_RECOVERY_WINDOW_TOO_SMALL,
     STAGE_REFINED,
     RefinedThrowTiming,
     _should_refine,
@@ -489,3 +493,220 @@ class TestLocalizeThrowOrchestrator:
         assert result.frame_timestamps == _DENSE_TIMESTAMPS
         # And the index→ts resolution: dense.release_index=5 → 16.0
         assert result.frame_timestamps[result.timing.release_index - 1] == 16.0
+
+
+# ---------------------------------------------------------------------------
+# Causality recovery — multi-demonstration chapters
+#
+# When the coarse pass reports result_index < release_index (the classifier
+# preserves the original earlier index on causality_inverted_earlier_index),
+# the model paired a late demo's release with an early demo's result. The
+# orchestrator re-localises densely around the FIRST event BEFORE the normal
+# confidence gate. These tests pin: recovery fires on the inversion signal,
+# uses the recovery window's timestamps on success, and falls back to coarse
+# (never regresses) on every recovery failure mode.
+# ---------------------------------------------------------------------------
+
+
+def _inverted_coarse(**overrides) -> ThrowTimingResult:
+    """Coarse result with the multi-demo inversion signature.
+
+    After the classifier's forcing, release_index == result_index and the
+    ORIGINAL earlier index lives on causality_inverted_earlier_index. The
+    low confidence mirrors the real Market Door case (the inversion is what
+    craters it) — proving recovery fires ahead of the below-gate path.
+    """
+    base = dict(
+        success=True,
+        is_lineup_throw=True,
+        release_index=7,
+        result_index=7,
+        causality_inverted_earlier_index=3,  # → _COARSE_TIMESTAMPS[2] = 14.0
+        confidence=0.28,
+        reasoning="result before release — multi-demo",
+    )
+    base.update(overrides)
+    return ThrowTimingResult(**base)
+
+
+class TestCausalityRecovery:
+    @pytest.mark.asyncio
+    async def test_inversion_recovers_first_event(self):
+        """Inverted coarse + clean recovery → use the recovery result and the
+        recovery window's timestamps (so the caller maps indices correctly)."""
+        coarse = _inverted_coarse()
+        recovered = _coarse(release_index=2, result_index=5, confidence=0.82)
+        patches, extract_mock, classifier_mock = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=recovered
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="multi-demo smoke",
+            )
+        assert result.stage == STAGE_RECOVERED_FIRST_EVENT
+        assert result.timing is recovered
+        # Recovery window timestamps (the patched dense list), NOT coarse.
+        assert result.frame_timestamps == _DENSE_TIMESTAMPS
+        assert result.coarse_timing is coarse
+        # recovery release_index=2 → _DENSE_TIMESTAMPS[1] = 14.5
+        assert result.frame_timestamps[result.timing.release_index - 1] == 14.5
+        # Two passes ran (coarse + recovery).
+        assert extract_mock.await_count == 2
+        assert classifier_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_recovery_fires_ahead_of_below_gate(self):
+        """The inverted coarse has confidence 0.28 — below the 0.55 refine
+        gate. Without recovery this returns STAGE_COARSE_BELOW_GATE; recovery
+        must take precedence and never fall to the gate when it succeeds."""
+        coarse = _inverted_coarse(confidence=0.28)
+        recovered = _coarse(release_index=3, result_index=6, confidence=0.9)
+        patches, _, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=recovered
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERED_FIRST_EVENT
+        assert result.stage != STAGE_COARSE_BELOW_GATE
+
+    @pytest.mark.asyncio
+    async def test_recovery_reinverted_falls_back_to_coarse(self):
+        """A recovery pass that itself inverts means the window still spans
+        more than one demo — reject and fall back to coarse."""
+        coarse = _inverted_coarse()
+        recovered = _coarse(
+            release_index=6, result_index=6,
+            causality_inverted_earlier_index=2, confidence=0.4,
+        )
+        patches, extract_mock, classifier_mock = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=recovered
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERY_REJECTED
+        assert result.timing is coarse
+        assert result.frame_timestamps == _COARSE_TIMESTAMPS
+        assert extract_mock.await_count == 2
+        assert classifier_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_recovery_not_a_throw_falls_back_to_coarse(self):
+        coarse = _inverted_coarse()
+        recovered = _coarse(
+            is_lineup_throw=False, release_index=None, result_index=None,
+            causality_inverted_earlier_index=None, confidence=0.2,
+        )
+        patches, _, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=recovered
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERY_REJECTED
+        assert result.timing is coarse
+
+    @pytest.mark.asyncio
+    async def test_recovery_no_release_falls_back_to_coarse(self):
+        coarse = _inverted_coarse()
+        recovered = _coarse(
+            release_index=None, causality_inverted_earlier_index=None,
+            confidence=0.6,
+        )
+        patches, _, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=recovered
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERY_REJECTED
+        assert result.timing is coarse
+
+    @pytest.mark.asyncio
+    async def test_recovery_window_too_small_falls_back(self):
+        """Chapter boundaries collapse the recovery window → fall back to
+        coarse WITHOUT attempting a recovery extract/classify."""
+        coarse = _inverted_coarse()
+        extract_mock = AsyncMock(
+            return_value=[_FAKE_PNG] * len(_COARSE_TIMESTAMPS)
+        )
+        classifier_mock = AsyncMock(side_effect=[coarse])
+        with (
+            patch(f"{_MOD}.extract_frames_downscaled", extract_mock),
+            patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                lambda *a, **k: list(_COARSE_TIMESTAMPS),
+            ),
+            patch(
+                f"{_MOD}.dense_window_timestamps",
+                lambda *a, **k: [14.0, 14.5],  # only 2 < 4 minimum
+            ),
+        ):
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERY_WINDOW_TOO_SMALL
+        assert result.timing is coarse
+        assert result.frame_timestamps == _COARSE_TIMESTAMPS
+        assert extract_mock.await_count == 1  # recovery extract NOT attempted
+        assert classifier_mock.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_recovery_extract_failure_falls_back(self):
+        """A recovery-pass ffmpeg failure must NEVER regress the pipeline."""
+        coarse = _inverted_coarse()
+        extract_mock = AsyncMock()
+        extract_mock.side_effect = [
+            [_FAKE_PNG] * len(_COARSE_TIMESTAMPS),  # coarse OK
+            FrameExtractionError(
+                "boom", timestamp=14.0, returncode=1, stderr="ffmpeg lost"
+            ),
+        ]
+        classifier_mock = AsyncMock(side_effect=[coarse])
+        with (
+            patch(f"{_MOD}.extract_frames_downscaled", extract_mock),
+            patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                lambda *a, **k: list(_COARSE_TIMESTAMPS),
+            ),
+            patch(
+                f"{_MOD}.dense_window_timestamps",
+                lambda *a, **k: list(_DENSE_TIMESTAMPS),
+            ),
+        ):
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERY_EXTRACT_FAILED
+        assert result.timing is coarse
+        assert result.frame_timestamps == _COARSE_TIMESTAMPS
+        assert extract_mock.await_count == 2  # recovery extract attempted
+        assert classifier_mock.await_count == 1  # recovery classify NOT reached

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -137,7 +137,8 @@ class TestThrowTimingVerdictAndParser:
 
     @pytest.mark.asyncio
     async def test_result_before_release_is_forced_equal(self):
-        """A result cannot precede its own release — parser forces equality."""
+        """A result cannot precede its own release — parser forces equality
+        AND preserves the original earlier index for causality recovery."""
         result, _ = await _call(
             {
                 "is_lineup_throw": True,
@@ -149,6 +150,25 @@ class TestThrowTimingVerdictAndParser:
         )
         assert result.release_index == 5
         assert result.result_index == 5
+        # The original earlier index (the first demo's result) is the
+        # multi-demonstration breadcrumb the localizer recovers around.
+        assert result.causality_inverted_earlier_index == 3
+
+    @pytest.mark.asyncio
+    async def test_non_inverted_result_leaves_earlier_index_none(self):
+        """No inversion → no recovery breadcrumb (field stays None)."""
+        result, _ = await _call(
+            {
+                "is_lineup_throw": True,
+                "release_index": 3,
+                "result_index": 5,
+                "confidence": 0.7,
+                "reasoning": "x",
+            }
+        )
+        assert result.release_index == 3
+        assert result.result_index == 5
+        assert result.causality_inverted_earlier_index is None
 
     @pytest.mark.asyncio
     async def test_out_of_range_indices_nulled(self):


### PR DESCRIPTION
## Problem

Multi-demonstration lineup chapters — where a creator shows the same throw 2–3× in one chapter — break the coarse throw-localizer. With ~3.4s sampling over the chapter, the model pairs a **late** demonstration's release with an **early** demonstration's smoke result, tripping the `result_index < release_index` causality guard. The guard forces `result=release` and the model craters confidence, so the **throw clip + landing gate out** and **STAND/AIM mis-anchor onto the smoke**.

Confirmed on lineup `69704f4a` "Market Door - B Site" (`Y - - -`):
- Real primary throw releases **~298.5s**, but coarse picked **317.6s** (a second demo's arc) paired with the first demo's smoke at 304s → conf **0.28** → throw/landing NULL, STAND caught the throw at 302.

## Fix

A clean, generalizing recovery that turns the existing causality guard into a recovery trigger:

1. **`ThrowTimingResult.causality_inverted_earlier_index`** — the classifier now preserves the original earlier index when it forces `result=release`. The frozen `result >= release` contract on the returned value is **unchanged**.
2. **`localize_throw_with_refinement`** — when coarse reports the inversion, it re-localizes densely around the **first event** *before* the confidence gate (the inversion is exactly why coarse confidence cratered). The earlier index is that demo's *result*, so the true release precedes it → the recovery window is weighted **backward** (pre 7.0s / post 1.0s, N=14 ≈ 0.6s spacing).
3. The recovery **owns the outcome** on inversion: a clean, non-re-inverted result is used (`recovered_first_event`); any failure mode falls back to coarse with a `recovery_*` diagnostic stage — **never a regression**. Recovery fires *only* on the inversion signal, so the 8 working lineups are untouched.

All four generators (clip / landing / micro / micro-helpers) flow through `localize_throw_with_refinement`, so this single-point fix covers the throw clip, landing clip, and STAND/AIM panes uniformly.

## Verification

Re-ran the real Market Door frames with the recovery active:
- Coarse: inversion (`result 3 < release 7`), conf 0.42 → recovery on earlier index (304.0s)
- Recovery: **release_ts = 298.87s**, result_ts = 302.56s, **confidence 0.92** (clears the 0.55 clip gate)
- Stage: `recovered_first_event` — matches the operator-confirmed visual throw (~298.5s)

**776 backend tests pass** (13 new: 7 localizer-recovery decision-tree cases + classifier earlier-index preservation/non-inversion).

## Post-merge

Run `backfill-clips` + `backfill-micro-clips` to regenerate affected clips. Market Door needs its `stand_*`/`aim_*` localization + throw/landing clip fields NULLed to force re-localize off the corrected release (other multi-demo chapters will recover automatically on their next backfill).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
