### PR TITLE
fix(mga): operator map-scope hint hard-locks classifier to a source's map

### DIFF
--- a/apps/mygamingassistant/backend/app/api/sources.py
+++ b/apps/mygamingassistant/backend/app/api/sources.py
@@ -38,10 +38,15 @@ router = APIRouter(
 def _source_to_read(source) -> SourceRead:
     last_synced = source.last_synced_at.isoformat() if source.last_synced_at else None
     created = source.created_at.isoformat() if source.created_at else ""
+    config = source.config_json or {}
     return SourceRead(
         id=source.id,
         kind=source.kind,
         config_json=source.config_json,
+        # Lift the classification scope out of config_json so the operator can
+        # see it directly (set at create time, validated in source_service).
+        game_hint=config.get("game_hint"),
+        map_hint=config.get("map_hint"),
         last_synced_at=last_synced,
         created_at=created,
     )

--- a/apps/mygamingassistant/backend/app/repositories/game/reference_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/reference_repo.py
@@ -275,3 +275,31 @@ async def resolve_slugs(
         failures,
         codes,
     )
+
+
+async def get_game_slug_for_map(db: AsyncSession, map_slug: str) -> Optional[str]:
+    """Return the game slug a map slug belongs to, or None if no such map.
+
+    Used to validate + normalize an operator source ``map_hint``: a map scope
+    implies its game, so the source service stores both. Keeping the query here
+    keeps ``select``/ORM out of the service layer (MGA CLAUDE.md Architecture
+    Rules: routes → services → repositories).
+    """
+    return (
+        await db.execute(
+            select(Game.slug)
+            .join(Map, Map.game_id == Game.id)
+            .where(Map.slug == map_slug)
+        )
+    ).scalar_one_or_none()
+
+
+async def game_slug_exists(db: AsyncSession, game_slug: str) -> bool:
+    """Return True if a game with this slug exists.
+
+    Used to validate an operator source ``game_hint`` without the service
+    layer issuing its own ORM query.
+    """
+    return (
+        await db.execute(select(Game.slug).where(Game.slug == game_slug))
+    ).scalar_one_or_none() is not None

--- a/apps/mygamingassistant/backend/app/schemas/game/source_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/source_schemas.py
@@ -10,6 +10,14 @@ from pydantic import BaseModel, field_validator
 class SourceCreate(BaseModel):
     kind: str
     url: str
+    # Optional classification scope. ``map_hint`` (a map slug) hard-locks every
+    # lineup ingested from this source to that map — the recurrence fix for a
+    # single-map source being mis-classified onto another map. ``game_hint``
+    # (a game slug) is the coarser game-only scope; ``map_hint`` implies and
+    # overrides it to the map's game. Slug existence is validated in
+    # source_service (needs DB access); a bad slug surfaces as a 422.
+    game_hint: Optional[str] = None
+    map_hint: Optional[str] = None
 
     @field_validator("kind")
     @classmethod
@@ -23,6 +31,10 @@ class SourceRead(BaseModel):
     id: uuid.UUID
     kind: str
     config_json: dict
+    # Surfaced from config_json so the operator can see a source's classification
+    # scope without parsing the raw dict.
+    game_hint: Optional[str] = None
+    map_hint: Optional[str] = None
     last_synced_at: Optional[str] = None
     created_at: str
 

--- a/apps/mygamingassistant/backend/app/services/classification/grid_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/grid_classifier.py
@@ -17,7 +17,7 @@ slug resolution.
 Shared helpers live in their own sibling modules:
   - ``prompts``: ``GAME_VISUAL_CUES``, ``GAME_FIRST_RULE``, ``build_reference_text``
   - ``response_parsing``: ``strip_json_fences``, ``validate_aim_coord``, ``validate_grid_index``
-  - ``scope_guards``: ``check_game_map_consistency``
+  - ``scope_guards``: ``check_game_map_consistency``, ``apply_map_hint``
 """
 from __future__ import annotations
 
@@ -45,7 +45,10 @@ from app.services.classification.response_parsing import (
     validate_aim_coord,
     validate_grid_index,
 )
-from app.services.classification.scope_guards import check_game_map_consistency
+from app.services.classification.scope_guards import (
+    apply_map_hint,
+    check_game_map_consistency,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -135,8 +138,16 @@ async def classify_frames_for_lineup_decision(
     chapter_title: Optional[str],
     attribution_author: Optional[str],
     game_hint: Optional[str] = None,
+    map_hint: Optional[str] = None,
 ) -> ClassificationResult:
-    """Strategy A: classify a chapter from N candidate frames at ingest time."""
+    """Strategy A: classify a chapter from N candidate frames at ingest time.
+
+    ``map_hint`` is the operator's per-source map scope (Source.config_json
+    ``map_hint``). When set, the chosen map is hard-locked to it (see
+    :func:`app.services.classification.scope_guards.apply_map_hint`) so a
+    single-map source can never spawn lineups on a different map — the
+    recurrence fix for cross-map misclassification.
+    """
     if not settings.anthropic_api_key:
         logger.warning(
             "classify_frames: ANTHROPIC_API_KEY not configured — skipping "
@@ -158,7 +169,15 @@ async def classify_frames_for_lineup_decision(
     n = len(frames)
 
     ref = await load_reference_data(db, game_id=None)
-    reference_text = build_reference_text(ref, game_hint=game_hint)
+    # A map scope implies its game; surface that to the game line too (the map
+    # list itself is restricted to map_hint inside build_reference_text).
+    effective_game_hint = game_hint
+    if map_hint:
+        _map_game = {m["slug"]: m["game_slug"] for m in ref.get("maps", [])}
+        effective_game_hint = _map_game.get(map_hint, game_hint)
+    reference_text = build_reference_text(
+        ref, game_hint=effective_game_hint, map_hint=map_hint
+    )
 
     chapter_context_parts: list[str] = []
     if chapter_title:
@@ -268,7 +287,14 @@ async def classify_frames_for_lineup_decision(
     failures: list[str] = []
     structured_codes: list[str] = []
 
-    parsed = check_game_map_consistency(parsed, ref, failures, structured_codes)
+    # When the source is map-scoped, hard-lock the map (the load-bearing
+    # recurrence fix); otherwise fall back to the cross-game contamination
+    # guard. map_hint forces the map's own game, so the cross-game check is
+    # moot in that branch.
+    if map_hint:
+        parsed = apply_map_hint(parsed, ref, map_hint, failures, structured_codes)
+    else:
+        parsed = check_game_map_consistency(parsed, ref, failures, structured_codes)
 
     is_lineup = bool(parsed.get("is_lineup"))
 

--- a/apps/mygamingassistant/backend/app/services/classification/prompts.py
+++ b/apps/mygamingassistant/backend/app/services/classification/prompts.py
@@ -69,17 +69,43 @@ CLASSIFICATION ORDER — YOU MUST FOLLOW THIS SEQUENCE:
 """
 
 
-def build_reference_text(ref: dict[str, Any], game_hint: Optional[str] = None) -> str:
+def build_reference_text(
+    ref: dict[str, Any],
+    game_hint: Optional[str] = None,
+    map_hint: Optional[str] = None,
+) -> str:
     """Build the reference text block passed to Claude.
 
-    Constant across calls for the same game → prime candidate for prompt
-    caching. The reference data comes from
+    Constant across calls for the same (game_hint, map_hint) → prime candidate
+    for prompt caching. The reference data comes from
     :func:`app.repositories.game.reference_repo.load_reference_data`; this
     function shapes it into the system-prompt text Claude reads.
+
+    ``map_hint`` is the operator's per-source map scope (Source.config_json
+    ``map_hint``). When set, the map section is restricted to that single map
+    and a HARD scope instruction is emitted, so Claude classifies zones using
+    only that map's zone set. The map itself is additionally hard-locked
+    post-parse by
+    :func:`app.services.classification.scope_guards.apply_map_hint` — the prompt
+    scope improves zone accuracy; the post-parse lock is the load-bearing
+    correctness guarantee.
     """
     lines: list[str] = []
 
-    if game_hint:
+    map_game = {m["slug"]: m["game_slug"] for m in ref.get("maps", [])}
+    if map_hint:
+        mg = map_game.get(map_hint)
+        lines.append(
+            f"SOURCE MAP SCOPE: every chapter in this source is on map "
+            f"'{map_hint}'" + (f" (game '{mg}')" if mg else "") + "."
+        )
+        lines.append(
+            f"You MUST set map_slug='{map_hint}' and pick target_zone_slug / "
+            "stand_zone_slug ONLY from that map's zones listed below. Do NOT "
+            "choose another map, regardless of chapter-title wording."
+        )
+        lines.append("")
+    elif game_hint:
         lines.append(f"Expected game: {game_hint}")
         lines.append("")
 
@@ -93,6 +119,8 @@ def build_reference_text(ref: dict[str, Any], game_hint: Optional[str] = None) -
     lines.append("")
     lines.append("Valid maps with zones (map_slug → game_slug, [zone_slugs]):")
     for m in ref["maps"]:
+        if map_hint and m["slug"] != map_hint:
+            continue
         zone_slugs = ", ".join(z["slug"] for z in m["zones"]) if m["zones"] else "(no zones)"
         lines.append(f"  {m['slug']} [{m['game_slug']}]: {zone_slugs}")
 

--- a/apps/mygamingassistant/backend/app/services/classification/scope_guards.py
+++ b/apps/mygamingassistant/backend/app/services/classification/scope_guards.py
@@ -6,8 +6,9 @@ the parsed dict + reference data — no DB, no SDK. Shared by the grid +
 single-image entrypoints.
 
 Extracted from the former ``classifier_service.py`` (a utility grab-bag) so the
-scope guards have a cohesive home with PUBLIC names. (The operator map-scope
-hard-lock, ``apply_map_hint``, lands here in a follow-up.)
+scope guards have a cohesive home with PUBLIC names. Both the cross-game
+contamination guard (``check_game_map_consistency``) and the operator map-scope
+hard-lock (``apply_map_hint``) live here.
 """
 from __future__ import annotations
 
@@ -72,3 +73,56 @@ def check_game_map_consistency(
                 result["confidence"] = 0.0
         return result
     return parsed
+
+
+def apply_map_hint(
+    parsed: dict[str, Any],
+    ref: dict[str, Any],
+    map_hint: str,
+    failures: list[str],
+    codes: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Hard-lock classification to the operator-supplied source map scope.
+
+    The operator scopes a single-map source by setting ``map_hint`` (a map
+    slug) in Source.config_json. This is the load-bearing recurrence fix for
+    cross-MAP-within-one-game misclassification: a pure-Mirage video whose
+    "Catwalk" / "Jungle" / "Ticket" chapter titles led the classifier to guess
+    dust2 / ancient (callout names that are more famous on those maps, even
+    though all three are also Mirage zones). The prompt-only chapter-title
+    consistency nudge proved insufficient on real footage, so this overrides
+    Claude's map selection outright.
+
+    Behaviour when ``map_hint`` is a known map:
+      - force ``game_slug`` to that map's game and ``map_slug`` to ``map_hint``
+      - if Claude returned a DIFFERENT map, emit a structured override code +
+        human note (so the override is visible in telemetry, per
+        check-third-party-error-codes). The returned zone slugs are KEPT:
+        ``resolve_slugs`` scopes zone lookups to the (now-forced) map, so a slug
+        that also exists on the hinted map (catwalk, b-site, …) resolves
+        correctly, while one that does not (e.g. ancient-only ``a-main``)
+        cleanly nulls out for the operator to set during review.
+
+    Returns a COPY (never mutates ``parsed``), matching
+    :func:`check_game_map_consistency`. A ``map_hint`` absent from the
+    reference data is a no-op with a logged note (defensive — the source
+    service validates the slug at write time).
+    """
+    map_game = {m["slug"]: m["game_slug"] for m in ref.get("maps", [])}
+    if map_hint not in map_game:
+        failures.append(
+            f"map_hint '{map_hint}' not found in reference data — scope not applied"
+        )
+        return parsed
+    result = dict(parsed)
+    claude_map = result.get("map_slug")
+    if claude_map and claude_map != map_hint:
+        failures.append(
+            f"MAP-SCOPE OVERRIDE: classifier chose map='{claude_map}' but source is "
+            f"scoped to '{map_hint}' — forcing '{map_hint}' (zones re-resolved on it)"
+        )
+        if codes is not None:
+            codes.append(f"map_hint_override:claude={claude_map}:forced={map_hint}")
+    result["game_slug"] = map_game[map_hint]
+    result["map_slug"] = map_hint
+    return result

--- a/apps/mygamingassistant/backend/app/services/game/source_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/source_service.py
@@ -12,6 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import unit_of_work
 from app.models.game.source import Source
+from app.repositories.game.reference_repo import (
+    game_slug_exists,
+    get_game_slug_for_map,
+)
 from app.repositories.game.source_repo import (
     create_source,
     get_source,
@@ -75,6 +79,30 @@ def _build_config_json(kind: str, url: str) -> dict:
     return {"url": url}
 
 
+async def _resolve_hints(
+    db: AsyncSession, game_hint: str | None, map_hint: str | None
+) -> dict:
+    """Validate + normalize the source classification hints into config keys.
+
+    ``map_hint`` implies (and overrides) ``game_hint`` to the map's own game,
+    so a single ``map_hint=mirage`` drives both the map lock and the game
+    scope. Raises ``ValueError`` on an unknown slug so the route surfaces a 422
+    rather than silently storing a hint that can never match a real map/game
+    (which would make the scope a no-op — see apply_map_hint). Slug lookups go
+    through reference_repo, so this service issues no ORM queries of its own.
+    """
+    if map_hint:
+        game_slug = await get_game_slug_for_map(db, map_hint)
+        if game_slug is None:
+            raise ValueError(f"map_hint '{map_hint}' is not a known map slug")
+        return {"map_hint": map_hint, "game_hint": game_slug}  # map implies its game
+    if game_hint:
+        if not await game_slug_exists(db, game_hint):
+            raise ValueError(f"game_hint '{game_hint}' is not a known game slug")
+        return {"game_hint": game_hint}
+    return {}
+
+
 async def create(payload: SourceCreate) -> Source:
     """Create a new Source after validating the URL.
 
@@ -88,6 +116,7 @@ async def create(payload: SourceCreate) -> Source:
         raise ValueError(error)
     config = _build_config_json(payload.kind, payload.url)
     async with unit_of_work() as db:
+        config.update(await _resolve_hints(db, payload.game_hint, payload.map_hint))
         return await create_source(db, kind=payload.kind, config_json=config)
 
 

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -257,9 +257,8 @@ async def _process_chapter(
         )
         return False
 
-    game_hint = (
-        source.config_json.get("game_hint") if source.config_json else None
-    )
+    cfg = source.config_json or {}
+    game_hint, map_hint = cfg.get("game_hint"), cfg.get("map_hint")
 
     # Strategy A core: the classifier IS the lineup detector + frame picker.
     # When the classifier is disabled we cannot make the is_lineup judgement,
@@ -277,6 +276,7 @@ async def _process_chapter(
                 chapter_title=chapter.title,
                 attribution_author=video_meta.channel_name,
                 game_hint=game_hint,
+                map_hint=map_hint,
             )
             classifier_ran = True
         except Exception as exc:

--- a/apps/mygamingassistant/backend/tests/test_classifier_service.py
+++ b/apps/mygamingassistant/backend/tests/test_classifier_service.py
@@ -484,6 +484,43 @@ class TestReferenceTextBuilder:
         text = build_reference_text(ref, game_hint=None)
         assert "Expected game" not in text
 
+    def test_map_hint_restricts_map_list_and_emits_scope(self):
+        from app.services.classification.prompts import build_reference_text
+
+        ref = {
+            "games": [
+                {"slug": "cs2", "name": "Counter-Strike 2", "side_a_label": "T", "side_b_label": "CT"},
+            ],
+            "maps": [
+                {"slug": "mirage", "name": "Mirage", "game_slug": "cs2", "zones": [{"slug": "a-site", "name": "A Site"}]},
+                {"slug": "dust2", "name": "Dust II", "game_slug": "cs2", "zones": [{"slug": "long-a", "name": "Long A"}]},
+            ],
+            "utility_types": [{"slug": "smoke", "name": "Smoke", "game_slug": "cs2"}],
+        }
+        text = build_reference_text(ref, map_hint="mirage")
+        # Hard scope instruction emitted, naming the locked map + its game.
+        assert "SOURCE MAP SCOPE" in text
+        assert "You MUST set map_slug='mirage'" in text
+        assert "(game 'cs2')" in text
+        # The hinted map + its zones are present...
+        assert "a-site" in text
+        # ...and the OTHER map is filtered out of the maps list entirely.
+        assert "dust2" not in text
+        assert "long-a" not in text
+
+    def test_map_hint_takes_precedence_over_game_hint(self):
+        from app.services.classification.prompts import build_reference_text
+
+        ref = {
+            "games": [{"slug": "cs2", "name": "CS2", "side_a_label": "T", "side_b_label": "CT"}],
+            "maps": [{"slug": "mirage", "name": "Mirage", "game_slug": "cs2", "zones": []}],
+            "utility_types": [],
+        }
+        # map_hint branch wins — the coarser "Expected game" line is NOT used.
+        text = build_reference_text(ref, game_hint="valorant", map_hint="mirage")
+        assert "SOURCE MAP SCOPE" in text
+        assert "Expected game: valorant" not in text
+
 
 # ---------------------------------------------------------------------------
 # Tests: Strategy A grid classifier (classify_frames_for_lineup_decision)
@@ -700,6 +737,72 @@ class TestClassifyFramesForLineupDecision:
         assert result.best_aim_index is None
         assert "best_stand_index" in result.reasoning
         assert "best_aim_index" in result.reasoning
+
+    @pytest.mark.asyncio
+    async def test_map_hint_forces_map_and_surfaces_override_code(
+        self,
+        db: AsyncSession,
+        grid_game: Game,
+        grid_map: Map,
+        grid_zone: MapZone,
+    ):
+        """map_hint hard-locks the classified map even when Claude picks another,
+        forces the map's game, and surfaces the override as a structured code.
+
+        The recurrence fix for cross-map misclassification: a Mirage-scoped
+        source whose 'Catwalk'/'Jungle' chapter titles led the classifier to
+        guess dust2/ancient now lands on the scoped map regardless.
+        """
+        from app.services.classification.grid_classifier import (
+            classify_frames_for_lineup_decision,
+        )
+
+        # Claude returns a DIFFERENT (bogus) map; the source is scoped to grid_map.
+        payload = {
+            "is_lineup": True,
+            "best_stand_index": 1,
+            "best_aim_index": 2,
+            "game_slug": "some-other-game",
+            "map_slug": "some-other-map",
+            "target_zone_slug": grid_zone.slug,
+            "stand_zone_slug": None,
+            "side": "any",
+            "utility_type_slug": None,
+            "aim_anchor_x": 0.5,
+            "aim_anchor_y": 0.5,
+            "confidence": 0.9,
+            "reasoning": "Catwalk — guessed the wrong map from the title.",
+        }
+
+        with (
+            patch("app.services.classification.grid_classifier.settings") as mock_settings,
+            patch("app.services.classification.grid_classifier.anthropic.Anthropic") as mock_cls,
+        ):
+            mock_settings.anthropic_api_key = "sk-test"
+            mock_settings.claude_classifier_model = "claude-haiku-4-5-20251001"
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+            mock_client.messages.create.return_value = _make_anthropic_response(payload)
+
+            result = await classify_frames_for_lineup_decision(
+                db,
+                frames=_THREE_FRAMES,
+                chapter_title="Catwalk smoke",
+                attribution_author="TestCreator",
+                map_hint=grid_map.slug,
+            )
+
+        assert result.success is True
+        assert result.is_lineup is True
+        # Map forced to the hint → its game + zone resolve to the real FKs.
+        assert result.suggested_map_id == grid_map.id
+        assert result.suggested_game_id == grid_game.id
+        assert result.suggested_target_zone_id == grid_zone.id
+        # Override surfaced as a structured, machine-readable code (not prose-only).
+        assert any(
+            c == f"map_hint_override:claude=some-other-map:forced={grid_map.slug}"
+            for c in result.error_codes
+        ), result.error_codes
 
     @pytest.mark.asyncio
     async def test_empty_frames_returns_error(self, db: AsyncSession):
@@ -1045,6 +1148,79 @@ class TestCheckGameMapConsistency:
         assert result["map_slug"] is None
         assert result["confidence"] == pytest.approx(0.0)
         assert len(failures) == 1
+
+
+class TestApplyMapHint:
+    """Operator map-scope hard-lock — force the classified map to the source's
+    map_hint regardless of Claude's guess (recurrence fix for cross-MAP
+    misclassification within one game)."""
+
+    def test_overrides_different_map_and_emits_code(self):
+        from app.services.classification.scope_guards import apply_map_hint
+
+        # Claude guessed dust2 (Catwalk is more famous there) but the source is
+        # scoped to mirage. apply_map_hint does NOT validate Claude's wrong map
+        # against the ref — it only needs map_hint ('mirage') to be a real map.
+        parsed = {
+            "game_slug": "cs2",
+            "map_slug": "dust2",
+            "target_zone_slug": "catwalk",
+            "stand_zone_slug": "t-spawn",
+            "confidence": 0.8,
+        }
+        failures: list[str] = []
+        codes: list[str] = []
+        result = apply_map_hint(parsed, _CROSS_GAME_REF, "mirage", failures, codes)
+
+        assert result["map_slug"] == "mirage"
+        assert result["game_slug"] == "cs2"  # forced to mirage's own game
+        # Zone slugs are KEPT — resolve_slugs re-scopes them to the forced map.
+        assert result["target_zone_slug"] == "catwalk"
+        assert result["stand_zone_slug"] == "t-spawn"
+        # Structured override code emitted (machine-readable telemetry).
+        assert codes == ["map_hint_override:claude=dust2:forced=mirage"]
+        assert any("MAP-SCOPE OVERRIDE" in f for f in failures)
+        # Original dict not mutated (returns a copy, like check_game_map_consistency).
+        assert parsed["map_slug"] == "dust2"
+
+    def test_matching_map_no_override_code(self):
+        from app.services.classification.scope_guards import apply_map_hint
+
+        parsed = {"game_slug": "cs2", "map_slug": "mirage", "confidence": 0.9}
+        failures: list[str] = []
+        codes: list[str] = []
+        result = apply_map_hint(parsed, _CROSS_GAME_REF, "mirage", failures, codes)
+
+        assert result["map_slug"] == "mirage"
+        assert result["game_slug"] == "cs2"
+        assert codes == []  # Claude already agreed — no override needed
+        assert failures == []
+
+    def test_forces_game_even_when_claude_map_null(self):
+        from app.services.classification.scope_guards import apply_map_hint
+
+        parsed = {"game_slug": None, "map_slug": None, "confidence": 0.5}
+        failures: list[str] = []
+        result = apply_map_hint(parsed, _CROSS_GAME_REF, "mirage", failures)
+
+        assert result["map_slug"] == "mirage"
+        assert result["game_slug"] == "cs2"
+        # No "different map" note when Claude returned no map of its own.
+        assert failures == []
+
+    def test_unknown_map_hint_is_noop_with_note(self):
+        """A map_hint absent from the reference data is a defensive no-op (the
+        source service validates the slug at write time, so this is belt only)."""
+        from app.services.classification.scope_guards import apply_map_hint
+
+        parsed = {"game_slug": "cs2", "map_slug": "mirage", "confidence": 0.7}
+        failures: list[str] = []
+        codes: list[str] = []
+        result = apply_map_hint(parsed, _CROSS_GAME_REF, "no-such-map", failures, codes)
+
+        assert result == parsed  # unchanged
+        assert codes == []
+        assert any("not found in reference data" in f for f in failures)
 
 
 class TestGridMaxTokens:

--- a/apps/mygamingassistant/backend/tests/test_sources.py
+++ b/apps/mygamingassistant/backend/tests/test_sources.py
@@ -236,6 +236,123 @@ async def test_deleted_source_excluded_from_list_and_detail(
     assert (await auth_client.delete(f"/api/sources/{sid}")).status_code == 204
 
 
+# ---------------------------------------------------------------------------
+# Map-scope hint (map_hint / game_hint): validation at create + read surfacing.
+# The source-create path opens its own unit_of_work, which the `client` fixture
+# binds to the test `db` session — so fixture-seeded game/map rows are visible
+# to _resolve_hints. Slugs are suffixed to be isolation-safe vs a pre-seeded
+# dev DB (same discipline as test_classifier_service.py).
+# ---------------------------------------------------------------------------
+
+_HINT_SUFFIX = uuid.uuid4().hex[:8]
+
+
+@pytest_asyncio.fixture
+async def hint_game_map(db: AsyncSession):
+    from app.models.game.game import Game
+    from app.models.game.map import Map
+
+    g = Game(
+        slug=f"cs2-{_HINT_SUFFIX}",
+        name="Counter-Strike 2",
+        side_a_label="T",
+        side_b_label="CT",
+    )
+    db.add(g)
+    await db.flush()
+    m = Map(game_id=g.id, slug=f"mirage-{_HINT_SUFFIX}", name="Mirage")
+    db.add(m)
+    await db.flush()
+    return g, m
+
+
+@pytest.mark.asyncio
+async def test_create_source_with_map_hint_implies_game(
+    auth_client: AsyncClient, hint_game_map
+):
+    """A valid map_hint is stored AND implies its game; both are surfaced and
+    persisted into config_json (which drives the ingest classifier scope)."""
+    game, mp = hint_game_map
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_playlist",
+            "url": "https://www.youtube.com/playlist?list=PLmaphint",
+            "map_hint": mp.slug,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["map_hint"] == mp.slug
+    assert body["game_hint"] == game.slug  # map implies its game
+    assert body["config_json"]["map_hint"] == mp.slug
+    assert body["config_json"]["game_hint"] == game.slug
+
+
+@pytest.mark.asyncio
+async def test_create_source_with_game_hint_only(
+    auth_client: AsyncClient, hint_game_map
+):
+    """A valid game_hint (no map_hint) is stored; map_hint stays null."""
+    game, _ = hint_game_map
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_playlist",
+            "url": "https://www.youtube.com/playlist?list=PLgamehint",
+            "game_hint": game.slug,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["game_hint"] == game.slug
+    assert body["map_hint"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_source_unknown_map_hint_returns_422(auth_client: AsyncClient):
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_playlist",
+            "url": "https://www.youtube.com/playlist?list=PLbadmap",
+            "map_hint": "no-such-map-xyz",
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "no-such-map-xyz" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_source_unknown_game_hint_returns_422(auth_client: AsyncClient):
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_playlist",
+            "url": "https://www.youtube.com/playlist?list=PLbadgame",
+            "game_hint": "no-such-game-xyz",
+        },
+    )
+    assert resp.status_code == 422, resp.text
+    assert "no-such-game-xyz" in resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_source_without_hints_surfaces_null(auth_client: AsyncClient):
+    """Omitting hints leaves both null — back-compat with hint-less sources."""
+    resp = await auth_client.post(
+        "/api/sources",
+        json={
+            "kind": "youtube_playlist",
+            "url": "https://www.youtube.com/playlist?list=PLnohint",
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["game_hint"] is None
+    assert body["map_hint"] is None
+
+
 def test_lineup_read_serializes_pending_row_with_null_game_map():
     """pending_review lineups have NULL game_id/map_id — LineupRead must
     accept them so the review queue can load (regression: 2 uuid errors).


### PR DESCRIPTION
## What

Adds an optional per-source **`map_hint`** (and coarser `game_hint`) that **hard-locks** the ingest grid classifier to a known map, overriding the model's map guess.

## Why

Recurrence fix for cross-MAP-within-one-game misclassification. A pure-Mirage source whose **"Catwalk" / "Jungle" / "Ticket"** chapter titles led the classifier to guess **dust2 / ancient** — those callouts are more famous on those maps even though all three are also Mirage zones. The prompt-only chapter-title nudge (#779-era) proved insufficient on real footage, so when the operator scopes a source to a map, that scope now wins outright.

Built on top of the #781 classifier-module refactor (re-homed from the pre-refactor WIP `3724b718`).

## Changes

**Classifier (post-#781 modules):**
- `prompts.build_reference_text` — `map_hint` restricts the maps list to the one map + emits a HARD scope instruction.
- `scope_guards.apply_map_hint` (new) — post-parse hard-lock: forces game+map to the hint, **keeps** zone slugs (the resolver re-scopes them to the forced map), emits a structured `map_hint_override:claude=<x>:forced=<y>` code when the model disagreed (per `check-third-party-error-codes`).
- `grid_classifier` — map-scoped branch calls `apply_map_hint` instead of the cross-game guard; game scope derived from the map's own game.

**Source plumbing:**
- `SourceCreate` / `SourceRead` gain optional `game_hint` / `map_hint`.
- `source_service._resolve_hints` validates the slug (map implies its game), raises `ValueError` → **422** on an unknown slug. Slug lookups go through new `reference_repo.get_game_slug_for_map` / `game_slug_exists` — **the service issues no ORM queries of its own** (MGA Architecture Rules: routes → services → repositories).
- `sources._source_to_read` surfaces the hints from `config_json`.
- `ingestion_orchestrator` passes `map_hint` through (**net-0 LOC** for the size guard on that 733-LOC file).

## Schema / migration

Hints live in `Source.config_json` (JSON column) — **no new columns, no Alembic migration.** Additive and optional; hint-less sources are unchanged.

## Operational migration

**None.** Purely additive-optional; existing deploys keep working with no env or config changes.

## Deliberately deferred (fast-follows)

- **Reclassify path** (`single_image_classifier` / `lineup_service.reclassify`) not yet map-hint-aware — deferred until `lineup_service` (>500 LOC) is split.
- **Frontend picker** — `map_hint` is settable via `POST /api/sources`; a game→map dropdown on the `/sources` add form is a planned UI fast-follow (`gamesApi` already exposes the data).

## Tests

13 new tests — `build_reference_text` map scoping, `apply_map_hint` force/override/no-op, grid-classifier integration (forces map + surfaces override code), source create validation (map implies game, unknown slug → 422) + read surfacing. **Full backend suite: 788 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)