### PR TITLE
fix(mga): landing clip opens at result_ts, not +1.5s past it

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/landing_clip_generator.py
@@ -25,8 +25,8 @@ End-to-end:
   2. Anchor the clip on the LANDING moment (``result_ts``). PR2's throw clip
      covers ``[release - 2.0, result + 0.5]`` — the throw motion — and crops
      the post-landing tail tight. PR5's landing clip inverts the framing:
-     start just before the landing and dwell on the AFTER (``[result - 0.5,
-     result + 3.0]`` ≈ 3.5s). The two clips are deliberately offset so a
+     start AT the landing (``result_ts``) and dwell on the deploy
+     (``[result, result + 3.5]``). The two clips are deliberately offset so a
      viewer sees motion in BOTH panes for the same lineup.
 
   3. Cut + encode the muted MP4 via :func:`cut_clip` (re-uses PR2's ffmpeg
@@ -81,11 +81,11 @@ logger = logging.getLogger(__name__)
 # Frozen design-contract constants. The 0.55 gate matches PR2's throw clip —
 # if PR2 cleared its gate, the landing pass shares that judgment.
 _CLIP_CONFIDENCE_GATE = 0.55
-# result_ts is the throw-timing prompt's "first visible wisp" — typically
-# 1.5-3.0s after release, so the first ~1.5s is still very faint. Pad
-# forward so the clip opens once bloom is actually visible (lineup
-# 7bd971c3 after PR #751).
-_POST_RESULT_PRE_PAD = 1.5
+# result_ts is the throw-timing prompt's "first VISIBLE wisp" of the result.
+# Open the landing clip AT result_ts: the pane shows the deploy from its
+# visible onset. A forward pad opened ~1.5s late, past the informative moment
+# (operator audit 2026-05-29, lineup 69704f4a "Market Door"; was 1.5 pre-fix).
+_POST_RESULT_PRE_PAD = 0.0
 _LANDING_CLIP_DURATION = 3.5
 _MIN_CLIP_SECONDS = 1.0
 
@@ -155,12 +155,12 @@ def _compute_landing_bounds(
 ) -> Optional[tuple[float, float]]:
     """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
 
-    Starts AFTER result_ts (``+ _POST_RESULT_PRE_PAD``) to skip the faint-wisp
-    lead-in that result_ts anchors on. Target duration ``_LANDING_CLIP_DURATION``,
-    clamped to the chapter. Returns None when the chapter ends too close to
-    result_ts to leave ``>= _MIN_CLIP_SECONDS`` of bloom — for landing-clip the
-    WHERE is more important than the HOW-LONG, and a clamped sliver is more
-    informative than a fabricated one displaced to a different chapter region.
+    Starts at result_ts (``+ _POST_RESULT_PRE_PAD``, currently 0) — the
+    result's first visible wisp — so the pane opens on the deploy onset.
+    Target duration ``_LANDING_CLIP_DURATION``, clamped to the chapter.
+    Returns None when the chapter ends too close to result_ts to leave
+    ``>= _MIN_CLIP_SECONDS`` of bloom — a clamped sliver is more informative
+    than a fabricated one displaced to a different chapter region.
     """
     start = max(result_ts + _POST_RESULT_PRE_PAD, chapter_start)
     if start >= chapter_end:

--- a/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_landing_clip_generator.py
@@ -69,43 +69,43 @@ def _lineup(video_id="vid123", chapter_title="B smoke"):
 # ---------------------------------------------------------------------------
 
 class TestComputeLandingBounds:
-    def test_normal_window_starts_after_result(self):
-        # result 24, chapter [10,40]: [24+1.5, 24+1.5+3.5] = [25.5, 29.0] = 3.5s.
-        # Anchored AFTER result_ts to skip the faint-wisp lead-in.
+    def test_normal_window_starts_at_result(self):
+        # result 24, chapter [10,40]: [24, 24+3.5] = [24.0, 27.5] = 3.5s.
+        # Anchored AT result_ts (the result's first visible wisp).
         start, dur = _compute_landing_bounds(24.0, 10.0, 40.0)
-        assert start == pytest.approx(25.5)
+        assert start == pytest.approx(24.0)
         assert dur == pytest.approx(3.5)
 
     def test_clamped_to_chapter_start_when_result_precedes_chapter(self):
-        # Pathological: result_ts before chapter_start. start = max(result+1.5,
-        # chapter_start). E.g., result -10, chapter [0, 10] → start = max(-8.5, 0)
+        # Pathological: result_ts before chapter_start. start = max(result,
+        # chapter_start). E.g., result -10, chapter [0, 10] → start = max(-10, 0)
         # = 0, end = min(3.5, 10) = 3.5, dur 3.5.
         start, dur = _compute_landing_bounds(-10.0, 0.0, 10.0)
         assert start == pytest.approx(0.0)
         assert dur == pytest.approx(3.5)
 
     def test_clamped_to_chapter_end(self):
-        # result 39, chapter [10,40]: start = max(40.5, 10) = 40.5, which is
-        # past chapter_end (40) → no headroom → None. Chapters that end <1.5s
-        # after result_ts cannot carry a landing clip with the new anchor.
-        assert _compute_landing_bounds(39.0, 10.0, 40.0) is None
+        # result 39.5, chapter [10,40]: start = max(39.5, 10) = 39.5, end =
+        # min(43, 40) = 40, dur = 0.5 < _MIN_CLIP_SECONDS → None. Chapters that
+        # end <1s after result_ts cannot carry a landing clip.
+        assert _compute_landing_bounds(39.5, 10.0, 40.0) is None
 
     def test_partial_window_when_chapter_just_barely_fits(self):
-        # result 17, chapter [10, 22]: start = 18.5, end = min(22, 22) = 22,
+        # result 18.5, chapter [10, 22]: start = 18.5, end = min(22, 22) = 22,
         # dur = 3.5. Exactly fits.
-        start, dur = _compute_landing_bounds(17.0, 10.0, 22.0)
+        start, dur = _compute_landing_bounds(18.5, 10.0, 22.0)
         assert start == pytest.approx(18.5)
         assert dur == pytest.approx(3.5)
 
     def test_chapter_too_short_returns_none(self):
-        # 0.4s chapter — start 21.5 > chapter_end 20.3 → skip signal.
+        # 0.4s chapter — start 20.0, end 20.3, dur 0.3 < _MIN_CLIP_SECONDS → skip.
         assert _compute_landing_bounds(20.0, 19.9, 20.3) is None
 
     def test_clip_never_exceeds_chapter_end(self):
-        # result 19, chapter [10, 22]: start 20.5, end min(24, 22) = 22, dur 1.5.
-        start, dur = _compute_landing_bounds(19.0, 10.0, 22.0)
+        # result 20, chapter [10, 22]: start 20, end min(23.5, 22) = 22, dur 2.0.
+        start, dur = _compute_landing_bounds(20.0, 10.0, 22.0)
         assert start + dur <= 22.0 + 1e-9
-        assert dur == pytest.approx(1.5)
+        assert dur == pytest.approx(2.0)
 
 
 def test_pending_landing_clip_key_is_deterministic():
@@ -566,7 +566,7 @@ async def test_persist_failure_returns_failed():
 
 @pytest.mark.asyncio
 async def test_widen_source_persists_offsets_for_landing():
-    """Happy wide path: landing tight is [24-0.5, 24+3.0] = [23.5, 3.5]; wide
+    """Happy wide path: landing tight is [24, 24+3.5] = [24.0, 27.5]; wide
     spans chapter + padding starting at source_start=10. set_landing_clip_url
     is called with source_key + the offset pair so the slider opens at the
     tight landing bounds within the wider source."""
@@ -608,11 +608,11 @@ async def test_widen_source_persists_offsets_for_landing():
     set_url_mock.assert_awaited_once()
     set_kwargs = set_url_mock.await_args.kwargs
     assert set_kwargs["source_key"] == "pending/vid123/10-landing-source.mp4"
-    # Landing tight: result_ts=24 → clip_start=24+1.5=25.5, clip_duration=3.5;
-    # source_start=10 → trim_start_s = 25.5 - 10 = 15.5;
-    # trim_end_s = 25.5 + 3.5 - 10 = 19.0
-    assert set_kwargs["trim_start_s"] == pytest.approx(15.5)
-    assert set_kwargs["trim_end_s"] == pytest.approx(19.0)
+    # Landing tight: result_ts=24 → clip_start=24, clip_duration=3.5;
+    # source_start=10 → trim_start_s = 24 - 10 = 14.0;
+    # trim_end_s = 24 + 3.5 - 10 = 17.5
+    assert set_kwargs["trim_start_s"] == pytest.approx(14.0)
+    assert set_kwargs["trim_end_s"] == pytest.approx(17.5)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What

The 2×2 storyboard's **landing pane** opened **1.5s after `result_ts`** (`_POST_RESULT_PRE_PAD = 1.5`), pushing well-localized lineups past the informative deploy moment. Operator flagged **Market Door (`69704f4a`)** opening ~1.5s too late.

`result_ts` is already the throw-timing classifier's **"first VISIBLE wisp"** of the result (`throw_timing_classifier.py` RESULT cues), so the landing pane should open **at** it. The `+1.5` was a global bandaid compensating for per-lineup localization noise (originally tuned for `7bd971c3` / PR #751). Removed per no-bandaid — lineups whose `result_ts` is mis-localized get fixed individually, not masked by a global pad.

## Change

- `_POST_RESULT_PRE_PAD` 1.5 → 0.0 (`landing_clip_generator.py`)
- Module + `_compute_landing_bounds` docstrings reconciled with the real framing (stale `[result-0.5, result+3.0]` → `[result, result+3.5]`)
- 7 assertions in `test_landing_clip_generator.py` updated to the new bounds

## Verification

- **788/788** backend tests pass
- File held at **540 LOC** (no-growth check; commit diff is 35/35)
- Re-cut landing clips for Market Door (fix) + Market Window (regression canary — the lineup `+1.5` was tuned for) + Mid Cross / Connector controls, for operator visual confirmation that each opens on the deploy onset and the canary is not too-faint

## Notes

- Local dev-only app; no operational migration. Existing landing clips are re-populated via `python -m app.cli backfill-landing-clips` (idempotent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)