### PR TITLE
fix(mjh): discovery inbox shows active postings only (expire vanished + closed)

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 24 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 6 [1 blocked-on-react-19, 1 public-launch cost guardrail, 4 triage-2026-05-28] / Medium: 7 [5 prior + 2 triage-2026-05-28: pagination, rejection-visibility] / Low: 9 [7 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
+**Open issues: 22 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 5 [1 blocked-on-react-19, 1 public-launch cost guardrail, 3 triage-2026-05-28] / Medium: 7 [5 prior + 2 triage-2026-05-28: pagination, rejection-visibility] / Low: 8 [6 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
 
 > Status (2026-05-08 PM): All actionable audit items resolved across batches PR #492-#528 (~30 PRs). Remaining open entries are either (a) blocked on the React 18→19 monorepo bump (5 items), (b) deferred-by-design conventions or follow-ups (4), (c) environmental issues unrelated to code (3: asyncpg Windows, test hang on Windows, Quality Gate false-positive), or (d) intentional accepted lint warnings (2).
 
@@ -371,17 +371,9 @@ Column-width alignment (`applications.role_title` 200 vs `discovered_jobs.title`
 
 ---
 
-### [Backend / Discovery] `expired_at` column exists but no path sets it — unused-column tech debt
+### ~~[Backend / Discovery] `expired_at` column exists but no path sets it — unused-column tech debt~~ RESOLVED
 
-**Severity:** Low
-**Effort:** L
-**Location:** `apps/myjobhunter/backend/app/models/discovery/discovered_job.py:113-115`
-
-**Problem:** Model has `expired_at: datetime | None` for "set when source removes posting upstream" per docstring. Nothing writes it. Upsert clears it on re-fetch (line 222 of repo) but no path SETS it on first observed disappearance.
-
-**Recommendation:** When the next refresh of a source returns a posting set that no longer includes a previously-seen `source_external_id`, mark missing rows `expired_at = now()`. Follow-up scope.
-
-**Why Low:** Pure follow-up scope, currently unused. But shipping a column without the writer is debt to clean up.
+**Resolved:** branch `fix/mjh-discovery-active-only` (2026-05-28). `discovery_fetch_service.fetch_source` now calls the new `discovery_repository.mark_missing_as_expired`, which sets `expired_at=now()` on previously-active `(user_id, source)` rows whose `source_external_id` is absent from the set a fetch returned — exactly the "missing from a re-fetch" recommendation. Guarded to fire only after a successful, non-empty fetch so a 429/error/empty cycle never mass-expires the inbox. The inbox/saved queries now also exclude `expired_at`-set rows. Folded into the active-only HIGH fix above; see that entry for full scope.
 
 ---
 
@@ -736,12 +728,9 @@ This rules a lot of work in and out: **don't** invest in a relevance-overhaul or
 **Evidence:** `app/services/discovery/discovery_score_service.py` (score loop), `config.py:41-42,52`, fetch pages #594. Frontend "Scoring" badge condition not yet located — find in `apps/myjobhunter/frontend/src/features/discover/`.
 **Fix-time step:** check Sentry (project `myjobhunter-api`) for score-loop / JSearch errors before shell diagnostics (per check-Sentry-first). No Sentry MCP connected this session.
 
-### HIGH — Discovery feed surfaces closed/expired postings; should only show active jobs
+### ~~HIGH — Discovery feed surfaces closed/expired postings; should only show active jobs~~ RESOLVED
 
-**Reported:** operator — opening discovered postings in a new tab lands on already-closed listings.
-**Symptom:** The inbox includes postings that are no longer open when the operator clicks through. Operator wants active-only results.
-**Related existing debt:** the "[Backend / Discovery] `expired_at` column exists but no path sets it" entry below (`app/models/discovery/discovered_job.py:113-115`) — the model has `expired_at` for "posting removed upstream" but **nothing writes it**, and nothing filters on it. That gap is the same root issue.
-**Hypothesis (confirm):** the JSearch/aggregator feed returns stale/closed postings (or postings go stale between fetch and view), and there is no liveness/expiry filter on the inbox query. Options: (a) honor any closed/expired/`job_offer_expiration` signal the feed provides at ingest and skip/flag those rows; (b) implement the `expired_at` writer (mark rows missing from a re-fetch as expired) and exclude expired rows from the inbox; (c) re-validate posting liveness before display. Likely a combination — decide during design.
+**Resolved:** branch `fix/mjh-discovery-active-only` (2026-05-28). Implemented both liveness signals the hypothesis called for and excluded inactive rows from the inbox. (1) Capture the feed's declared expiry: `sources/jsearch.py` `_normalize` now reads `job_offer_expiration_datetime_utc` into a new normalized `source_expires_at`; Greenhouse/Lever feeds carry no expiry field (active-only feeds) so they map None. (2) New `source_expires_at` timezone-aware column on `discovered_jobs` (migration `discexp260528`), wired through `upsert_postings`. (3) `expired_at` writer: `discovery_fetch_service.fetch_source` now computes the `source_external_id` set returned each cycle and calls the new `discovery_repository.mark_missing_as_expired` to set `expired_at=now()` on previously-active rows absent from the set — guarded to fire ONLY after a successful, non-empty fetch (never on 429/error/empty, which would mass-expire the inbox). (4) `list_discovered` inbox + saved branches now exclude rows where `expired_at IS NOT NULL` OR `source_expires_at < now()`; `state="all"` still returns everything. Regression tests in `tests/test_discovery_active_only.py` (writer, guard, inbox/saved exclusion, end-to-end) + `tests/test_jsearch_adapter.py` (normalize capture). Closes the related Low entry below in the same change.
 
 ### HIGH — Fit-scoring rejected a candidate for a role they have already held (Daniel Leba)
 

--- a/apps/myjobhunter/backend/alembic/versions/discexp260528_discovered_jobs_source_expires_at.py
+++ b/apps/myjobhunter/backend/alembic/versions/discexp260528_discovered_jobs_source_expires_at.py
@@ -1,0 +1,53 @@
+"""Add source_expires_at column to discovered_jobs.
+
+The discovery inbox should surface ACTIVE postings only. Two expiry
+signals drive that:
+
+1. ``expired_at`` (already on the table) — set by the fetch service when
+   a previously-seen posting disappears from a successful, non-empty
+   fetch (we observed it vanish upstream).
+2. ``source_expires_at`` (this migration) — a feed-declared close date
+   the source hands us directly. JSearch returns
+   ``job_offer_expiration_datetime_utc``; we normalize it onto this
+   column. Greenhouse / Lever feeds carry no such field, so it stays
+   NULL for those sources.
+
+The inbox / saved queries exclude a row when ``expired_at`` is set OR
+``source_expires_at`` is in the past. Keeping the two columns distinct
+preserves the provenance of WHY a listing is inactive (operator-visible
+later if we surface it) and lets a re-appearing posting clear
+``expired_at`` on upsert without touching the feed-declared date.
+
+Nullable, no backfill: existing rows have no captured expiry signal
+(``source_expires_at`` was never populated before this PR); they remain
+NULL and continue to be governed solely by ``expired_at``.
+
+Revision ID: discexp260528
+Revises: evtupd260521
+Create Date: 2026-05-28
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "discexp260528"
+down_revision: Union[str, None] = "evtupd260521"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "discovered_jobs",
+        sa.Column(
+            "source_expires_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("discovered_jobs", "source_expires_at")

--- a/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
+++ b/apps/myjobhunter/backend/app/models/discovery/discovered_job.py
@@ -14,7 +14,12 @@ Lifecycle:
 3. Operator triages: ``dismissed_at`` (won't reappear) /
    ``saved_at`` (kept for later) / ``promoted_application_id``
    (promoted into the applications kanban).
-4. ``expired_at`` set when the source removes the posting upstream.
+4. ``expired_at`` set when the posting disappears from a successful,
+   non-empty fetch (we observed it vanish upstream). Separately,
+   ``source_expires_at`` records a feed-declared close date when the
+   source supplies one (JSearch). A row is treated as inactive — and
+   excluded from the inbox / saved views — if ``expired_at`` is set OR
+   ``source_expires_at`` is in the past.
 
 State invariants:
 
@@ -117,6 +122,15 @@ class DiscoveredJob(Base):
         nullable=False,
     )
     expired_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    # Feed-declared expiry: the source told us "this listing closes at X"
+    # (e.g. JSearch ``job_offer_expiration_datetime_utc``). Distinct from
+    # ``expired_at`` above, which we set ourselves when a posting vanishes
+    # from a successful fetch. A row is inactive if EITHER ``expired_at`` is
+    # set OR ``source_expires_at`` is in the past. Greenhouse / Lever feeds
+    # carry no declared expiry, so this stays NULL for those sources.
+    source_expires_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True,
     )
 

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
@@ -16,7 +16,7 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import desc, nulls_last, outerjoin, select, update
+from sqlalchemy import desc, func, nulls_last, or_, outerjoin, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -304,11 +304,14 @@ async def upsert_postings(
                 "salary_max": stmt.excluded.salary_max,
                 "salary_currency": stmt.excluded.salary_currency,
                 "salary_period": stmt.excluded.salary_period,
+                # Feed-declared expiry — refresh it from the latest fetch so
+                # a re-listed posting that pushed its close date out is honored.
+                "source_expires_at": stmt.excluded.source_expires_at,
                 "raw_payload": stmt.excluded.raw_payload,
                 "fetch_id": stmt.excluded.fetch_id,
                 "updated_at": datetime.now(timezone.utc),
                 # Clear expired_at — if we see a posting again, it's
-                # not expired anymore.
+                # not expired anymore (it reappeared in a fetch).
                 "expired_at": None,
             },
         ).returning(
@@ -327,6 +330,52 @@ async def upsert_postings(
     return (new_count, updated_count)
 
 
+async def mark_missing_as_expired(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    source: str,
+    seen_external_ids: list[str],
+) -> int:
+    """Mark previously-active postings that vanished from this fetch as expired.
+
+    Given the full set of ``source_external_id`` values a fetch returned for
+    ``(user_id, source)``, set ``expired_at = now()`` on every still-active row
+    for that pair whose id is NOT in the returned set. "Active" means
+    ``expired_at IS NULL`` — already-expired rows are left untouched so we
+    don't churn their timestamp.
+
+    Returns the number of rows newly marked expired (for audit logging).
+
+    CRITICAL: the caller MUST only invoke this after a fetch that genuinely
+    succeeded AND returned a non-empty result set. Calling it on an empty or
+    failed cycle would mark the entire ``(user_id, source)`` inbox expired,
+    because every active id would be "missing" from an empty returned set.
+    This function does not re-check that guard — it trusts the caller — so the
+    guard lives in ``discovery_fetch_service.fetch_source`` where success and
+    non-emptiness are known.
+    """
+    if not seen_external_ids:
+        # Defensive backstop for the caller's guard: never mass-expire on an
+        # empty set. The service is responsible for not calling us here, but
+        # a no-op is the only safe behavior if it slips through.
+        return 0
+
+    now = datetime.now(timezone.utc)
+    stmt = (
+        update(DiscoveredJob)
+        .where(
+            DiscoveredJob.user_id == user_id,
+            DiscoveredJob.source == source,
+            DiscoveredJob.expired_at.is_(None),
+            DiscoveredJob.source_external_id.notin_(seen_external_ids),
+        )
+        .values(expired_at=now)
+    )
+    result = await db.execute(stmt)
+    return result.rowcount or 0
+
+
 async def list_discovered(
     db: AsyncSession,
     user_id: uuid.UUID,
@@ -339,9 +388,17 @@ async def list_discovered(
     """List discovered jobs scoped to user.
 
     state:
-      - "inbox": not dismissed, not saved, not promoted (the triage view)
-      - "saved": saved_at IS NOT NULL AND dismissed_at IS NULL
-      - "all": every non-expired row
+      - "inbox": not dismissed, not saved, not promoted, AND active
+        (the triage view) — active means not expired upstream and not
+        past its feed-declared close date.
+      - "saved": saved_at IS NOT NULL AND dismissed_at IS NULL AND active
+      - "all": every row (no active filter — the operator explicitly
+        asked for everything, including expired/closed listings).
+
+    "Active" excludes a row when ``expired_at IS NOT NULL`` (we observed it
+    vanish upstream) OR ``source_expires_at < now()`` (the feed told us it
+    closed). The operator wants active-ONLY in the inbox, so these are
+    excluded rather than greyed out.
 
     source_id:
       When provided, restricts results to rows whose fetch_id points to a
@@ -363,18 +420,32 @@ async def list_discovered(
         )
         .where(DiscoveredJob.user_id == user_id)
     )
+    # Active-only predicate, shared by the inbox and saved views: a row is
+    # active unless we observed it vanish upstream (``expired_at`` set) or its
+    # feed-declared close date is in the past. ``source_expires_at IS NULL``
+    # rows (no declared expiry — e.g. all Greenhouse/Lever rows) stay active.
+    active_only = (
+        DiscoveredJob.expired_at.is_(None),
+        or_(
+            DiscoveredJob.source_expires_at.is_(None),
+            DiscoveredJob.source_expires_at >= func.now(),
+        ),
+    )
+
     if state == "inbox":
         stmt = stmt.where(
             DiscoveredJob.dismissed_at.is_(None),
             DiscoveredJob.saved_at.is_(None),
             DiscoveredJob.promoted_application_id.is_(None),
+            *active_only,
         )
     elif state == "saved":
         stmt = stmt.where(
             DiscoveredJob.saved_at.isnot(None),
             DiscoveredJob.dismissed_at.is_(None),
+            *active_only,
         )
-    # else "all": no extra filter
+    # else "all": no extra filter — include expired/closed rows on request
 
     if source_id is not None:
         stmt = stmt.where(DiscoveryFetch.discovery_source_id == source_id)

--- a/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
+++ b/apps/myjobhunter/backend/app/services/discovery/discovery_fetch_service.py
@@ -369,6 +369,18 @@ async def fetch_source(
 
     fetched_count = len(postings)
 
+    # Capture the set of source_external_ids this fetch returned BEFORE the
+    # operator's post-fetch filters run. Disappearance detection compares
+    # against what the SOURCE returned, not what survived our filters — a
+    # posting the operator excluded by keyword/salary is still live upstream
+    # and must not be marked expired. ``str(...)`` mirrors the normalization
+    # in each adapter (source_external_id is always coerced to str there).
+    seen_external_ids = [
+        str(p["source_external_id"])
+        for p in postings
+        if p.get("source_external_id") is not None
+    ]
+
     # ---- Apply operator's post-fetch filters (min salary, excluded keywords) ----
     postings = _apply_post_fetch_filters(postings, source.config or {})
 
@@ -387,6 +399,28 @@ async def fetch_source(
                 max_posted_at is None or posted_at > max_posted_at
             ):
                 max_posted_at = posted_at
+
+    # ---- Expire postings that vanished from this fetch ----
+    # A posting we previously stored that the source no longer returns has
+    # been taken down upstream — mark it expired so it drops out of the
+    # active-only inbox. CRITICAL GUARD: only when this fetch genuinely
+    # succeeded (status still "success" — the adapter didn't raise) AND the
+    # SOURCE returned a non-empty result (``fetched_count`` is the raw count
+    # before our post-fetch filters). On a 429 / error the adapter raised and
+    # we never reach here; on a legitimately-empty cycle ``fetched_count`` is
+    # 0 and we skip — never mass-expire the whole inbox on a transient blank.
+    if status == "success" and fetched_count > 0 and seen_external_ids:
+        expired_count = await discovery_repository.mark_missing_as_expired(
+            db,
+            user_id=user_id,
+            source=source.source,
+            seen_external_ids=seen_external_ids,
+        )
+        if expired_count:
+            logger.info(
+                "discovery expired %d vanished posting(s): source=%s id=%s",
+                expired_count, source.source, source.id,
+            )
 
     # ---- Persist Greenhouse company name cache ----
     # When the adapter resolved a company display name that differs from

--- a/apps/myjobhunter/backend/app/services/discovery/sources/greenhouse.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/greenhouse.py
@@ -309,6 +309,11 @@ def _normalize(raw: dict, *, company_name: str) -> dict:
         "remote_type": remote_type,
         "description": description,
         "posted_at": _parse_updated_at(raw.get("updated_at")),
+        # The Greenhouse boards feed lists only currently-active postings and
+        # carries no declared-expiry field, so there is nothing to map here.
+        # Expiry for Greenhouse is detected by disappearance from the feed
+        # (the fetch service sets ``expired_at`` on rows that stop appearing).
+        "source_expires_at": None,
         "salary_min": None,
         "salary_max": None,
         "salary_currency": "USD",

--- a/apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py
@@ -299,6 +299,13 @@ def _normalize(raw: dict[str, Any]) -> dict:
         "remote_type": _remote_type(raw),
         "description": description,
         "posted_at": _parse_datetime(raw.get("job_posted_at_datetime_utc")),
+        # Feed-declared expiry ("this listing closes at X"). Distinct from
+        # ``expired_at``, which we set ourselves when a posting vanishes
+        # upstream. JSearch surfaces it as an ISO-8601 UTC string; absent /
+        # unparseable → None (the listing simply carries no declared expiry).
+        "source_expires_at": _parse_datetime(
+            raw.get("job_offer_expiration_datetime_utc"),
+        ),
         "salary_min": _safe_float(raw.get("job_min_salary")),
         "salary_max": _safe_float(raw.get("job_max_salary")),
         "salary_currency": "USD",

--- a/apps/myjobhunter/backend/app/services/discovery/sources/lever.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/lever.py
@@ -249,6 +249,11 @@ def _normalize(raw: dict, *, company_name: str) -> dict:
         "remote_type": remote_type,
         "description": description,
         "posted_at": _parse_epoch_ms(raw.get("createdAt")),
+        # The Lever v0 postings feed lists only currently-active postings and
+        # carries no declared-expiry field, so there is nothing to map here.
+        # Expiry for Lever is detected by disappearance from the feed (the
+        # fetch service sets ``expired_at`` on rows that stop appearing).
+        "source_expires_at": None,
         "salary_min": None,
         "salary_max": None,
         "salary_currency": "USD",

--- a/apps/myjobhunter/backend/tests/test_discovery_active_only.py
+++ b/apps/myjobhunter/backend/tests/test_discovery_active_only.py
@@ -1,0 +1,345 @@
+"""Tests for the discovery active-only inbox (dead-listing exclusion).
+
+Covers the four guarantees of the active-only fix:
+
+a. ``mark_missing_as_expired`` sets ``expired_at`` on a previously-seen
+   posting that disappears from a successful, non-empty fetch.
+b. The guard: ``mark_missing_as_expired`` is a no-op on an empty seen-set
+   (the service skips the call entirely on empty/failed cycles; this test
+   asserts the repository's own defensive backstop too).
+c. ``list_discovered`` (inbox + saved) excludes both ``expired_at``-set rows
+   and rows whose ``source_expires_at`` is in the past, while keeping active
+   rows; ``state="all"`` still returns everything.
+d. ``fetch_source`` does NOT mass-expire the inbox when a cycle returns
+   empty (end-to-end guard via a stubbed adapter).
+
+DB-backed; uses the rolled-back ``db`` session + ``user_factory`` fixtures.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.discovery.discovered_job import DiscoveredJob
+from app.models.discovery.discovery_source import DiscoverySource
+from app.repositories.discovery import discovery_repository
+from app.services.discovery import discovery_fetch_service
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _uid(user: dict) -> uuid.UUID:
+    return uuid.UUID(user["id"])
+
+
+async def _make_source(
+    db: AsyncSession, user_id: uuid.UUID, *, source: str = "jsearch",
+) -> DiscoverySource:
+    src = DiscoverySource(user_id=user_id, source=source, config={})
+    db.add(src)
+    await db.flush()
+    return src
+
+
+async def _make_job(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    source: str = "jsearch",
+    external_id: str,
+    expired_at: datetime | None = None,
+    source_expires_at: datetime | None = None,
+    dismissed_at: datetime | None = None,
+    saved_at: datetime | None = None,
+) -> DiscoveredJob:
+    job = DiscoveredJob(
+        user_id=user_id,
+        source=source,
+        source_external_id=external_id,
+        title="Senior Backend Engineer",
+        company_name="Acme",
+        remote_type="remote",
+        expired_at=expired_at,
+        source_expires_at=source_expires_at,
+        dismissed_at=dismissed_at,
+        saved_at=saved_at,
+    )
+    db.add(job)
+    await db.flush()
+    return job
+
+
+# ---------------------------------------------------------------------------
+# (a) mark_missing_as_expired sets expired_at on vanished postings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_missing_expires_vanished_posting(
+    db: AsyncSession, user_factory,
+):
+    user = await user_factory()
+    uid = _uid(user)
+    await _make_source(db, uid)
+
+    kept = await _make_job(db, uid, external_id="still-here")
+    gone = await _make_job(db, uid, external_id="vanished")
+
+    # This fetch returned only "still-here" → "vanished" should expire.
+    count = await discovery_repository.mark_missing_as_expired(
+        db, user_id=uid, source="jsearch", seen_external_ids=["still-here"],
+    )
+
+    await db.refresh(kept)
+    await db.refresh(gone)
+
+    assert count == 1
+    assert gone.expired_at is not None
+    assert kept.expired_at is None
+
+
+@pytest.mark.asyncio
+async def test_mark_missing_is_source_scoped(db: AsyncSession, user_factory):
+    """A posting on a different source must not be expired by another
+    source's fetch (greenhouse fetch can't expire a jsearch row)."""
+    user = await user_factory()
+    uid = _uid(user)
+
+    jsearch_job = await _make_job(
+        db, uid, source="jsearch", external_id="js-1",
+    )
+    gh_job = await _make_job(
+        db, uid, source="greenhouse", external_id="gh-1",
+    )
+
+    # A greenhouse fetch that returned nothing matching gh-1's id.
+    count = await discovery_repository.mark_missing_as_expired(
+        db, user_id=uid, source="greenhouse", seen_external_ids=["gh-2"],
+    )
+
+    await db.refresh(jsearch_job)
+    await db.refresh(gh_job)
+
+    assert count == 1
+    assert gh_job.expired_at is not None
+    # The jsearch row is untouched — different source.
+    assert jsearch_job.expired_at is None
+
+
+@pytest.mark.asyncio
+async def test_mark_missing_does_not_rechurn_already_expired(
+    db: AsyncSession, user_factory,
+):
+    """An already-expired row keeps its original timestamp (active-only
+    filter excludes ``expired_at IS NULL`` candidates)."""
+    user = await user_factory()
+    uid = _uid(user)
+    original = _now() - timedelta(days=3)
+    already = await _make_job(
+        db, uid, external_id="old", expired_at=original,
+    )
+
+    count = await discovery_repository.mark_missing_as_expired(
+        db, user_id=uid, source="jsearch", seen_external_ids=["something-else"],
+    )
+
+    await db.refresh(already)
+    assert count == 0
+    assert already.expired_at == original
+
+
+# ---------------------------------------------------------------------------
+# (b) the guard — empty seen-set is a no-op
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_missing_empty_set_is_noop(db: AsyncSession, user_factory):
+    """Empty seen-set must NOT mass-expire the inbox — repository backstop."""
+    user = await user_factory()
+    uid = _uid(user)
+    a = await _make_job(db, uid, external_id="a")
+    b = await _make_job(db, uid, external_id="b")
+
+    count = await discovery_repository.mark_missing_as_expired(
+        db, user_id=uid, source="jsearch", seen_external_ids=[],
+    )
+
+    await db.refresh(a)
+    await db.refresh(b)
+    assert count == 0
+    assert a.expired_at is None
+    assert b.expired_at is None
+
+
+# ---------------------------------------------------------------------------
+# (c) list_discovered excludes expired + past-source_expires_at rows
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_inbox_excludes_expired_and_past_expiry(
+    db: AsyncSession, user_factory,
+):
+    user = await user_factory()
+    uid = _uid(user)
+
+    active = await _make_job(db, uid, external_id="active")
+    expired = await _make_job(
+        db, uid, external_id="expired", expired_at=_now(),
+    )
+    closed = await _make_job(
+        db,
+        uid,
+        external_id="closed",
+        source_expires_at=_now() - timedelta(hours=1),
+    )
+    future_close = await _make_job(
+        db,
+        uid,
+        external_id="future",
+        source_expires_at=_now() + timedelta(days=7),
+    )
+
+    rows = await discovery_repository.list_discovered(db, uid, state="inbox")
+    ids = {r.source_external_id for r in rows}
+
+    assert "active" in ids
+    assert "future" in ids  # future expiry is still active
+    assert "expired" not in ids
+    assert "closed" not in ids
+    # silence unused-var linters; the rows are asserted via ids
+    assert {active.id, future_close.id} == {
+        r.id for r in rows if r.source_external_id in {"active", "future"}
+    }
+    assert expired.id and closed.id
+
+
+@pytest.mark.asyncio
+async def test_saved_view_excludes_expired(db: AsyncSession, user_factory):
+    user = await user_factory()
+    uid = _uid(user)
+    now = _now()
+
+    saved_active = await _make_job(
+        db, uid, external_id="s-active", saved_at=now,
+    )
+    saved_expired = await _make_job(
+        db, uid, external_id="s-expired", saved_at=now, expired_at=now,
+    )
+    saved_closed = await _make_job(
+        db,
+        uid,
+        external_id="s-closed",
+        saved_at=now,
+        source_expires_at=now - timedelta(minutes=5),
+    )
+
+    rows = await discovery_repository.list_discovered(db, uid, state="saved")
+    ids = {r.source_external_id for r in rows}
+
+    assert "s-active" in ids
+    assert "s-expired" not in ids
+    assert "s-closed" not in ids
+    assert saved_active.id and saved_expired.id and saved_closed.id
+
+
+@pytest.mark.asyncio
+async def test_all_state_includes_expired(db: AsyncSession, user_factory):
+    """state="all" deliberately returns expired/closed rows too."""
+    user = await user_factory()
+    uid = _uid(user)
+    await _make_job(db, uid, external_id="active")
+    await _make_job(db, uid, external_id="expired", expired_at=_now())
+    await _make_job(
+        db,
+        uid,
+        external_id="closed",
+        source_expires_at=_now() - timedelta(hours=1),
+    )
+
+    rows = await discovery_repository.list_discovered(db, uid, state="all")
+    ids = {r.source_external_id for r in rows}
+
+    assert {"active", "expired", "closed"} <= ids
+
+
+# ---------------------------------------------------------------------------
+# (d) fetch_source end-to-end guard — empty cycle does not mass-expire
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fetch_empty_cycle_does_not_expire_inbox(
+    db: AsyncSession, user_factory, monkeypatch: pytest.MonkeyPatch,
+):
+    """A successful but EMPTY fetch must leave existing active rows alone."""
+    user = await user_factory()
+    uid = _uid(user)
+    src = await _make_source(db, uid, source="jsearch")
+    existing = await _make_job(db, uid, external_id="pre-existing")
+
+    async def _empty_adapter(_config: dict) -> list[dict]:
+        return []
+
+    monkeypatch.setitem(
+        discovery_fetch_service._ADAPTERS, "jsearch", _empty_adapter,
+    )
+
+    result = await discovery_fetch_service.fetch_source(db, uid, src.id)
+
+    await db.refresh(existing)
+    assert result["fetched_count"] == 0
+    # The guard held — the pre-existing active row was NOT expired.
+    assert existing.expired_at is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_nonempty_cycle_expires_vanished(
+    db: AsyncSession, user_factory, monkeypatch: pytest.MonkeyPatch,
+):
+    """A successful non-empty fetch expires a previously-seen posting that
+    is absent from the returned set, end-to-end through fetch_source."""
+    user = await user_factory()
+    uid = _uid(user)
+    src = await _make_source(db, uid, source="jsearch")
+    vanished = await _make_job(db, uid, external_id="will-vanish")
+
+    async def _adapter(_config: dict) -> list[dict]:
+        return [
+            {
+                "source": "jsearch",
+                "source_external_id": "fresh-1",
+                "source_publisher": "LinkedIn",
+                "source_url": "https://example.com/1",
+                "title": "New Role",
+                "company_name": "NewCo",
+                "location": "Remote",
+                "remote_type": "remote",
+                "description": "desc",
+                "posted_at": None,
+                "source_expires_at": None,
+                "salary_min": None,
+                "salary_max": None,
+                "salary_currency": "USD",
+                "salary_period": None,
+                "raw_payload": {"job_id": "fresh-1"},
+            },
+        ]
+
+    monkeypatch.setitem(
+        discovery_fetch_service._ADAPTERS, "jsearch", _adapter,
+    )
+
+    result = await discovery_fetch_service.fetch_source(db, uid, src.id)
+
+    await db.refresh(vanished)
+    assert result["fetched_count"] == 1
+    # The previously-seen posting absent from this fetch is now expired.
+    assert vanished.expired_at is not None

--- a/apps/myjobhunter/backend/tests/test_jsearch_adapter.py
+++ b/apps/myjobhunter/backend/tests/test_jsearch_adapter.py
@@ -342,3 +342,39 @@ async def test_normalize_falls_back_to_city_state_country_for_location() -> None
         results = await search(query="x", api_key="test-key")
 
     assert results[0]["location"] == "Chicago, Illinois, US"
+
+
+@pytest.mark.asyncio
+async def test_normalize_captures_source_expires_at() -> None:
+    """job_offer_expiration_datetime_utc → source_expires_at (parsed UTC)."""
+    job = _realistic_job(
+        job_offer_expiration_datetime_utc="2026-06-15T23:59:00.000Z",
+    )
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_ok_envelope([job]))
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await search(query="x", api_key="test-key")
+
+    expires = results[0]["source_expires_at"]
+    assert expires is not None
+    assert expires.year == 2026
+    assert expires.month == 6
+    assert expires.day == 15
+    assert expires.tzinfo is not None  # timezone-aware
+
+
+@pytest.mark.asyncio
+async def test_normalize_source_expires_at_none_when_absent() -> None:
+    """No expiration field in the feed → source_expires_at is None, not a crash."""
+    job = _realistic_job()  # _realistic_job omits the expiration field
+    assert "job_offer_expiration_datetime_utc" not in job
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=_ok_envelope([job]))
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        results = await search(query="x", api_key="test-key")
+
+    assert results[0]["source_expires_at"] is None


### PR DESCRIPTION
**What the operator saw:** the discovery inbox surfaced closed/expired postings — clicking through landed on dead listings. *"Only send me active job postings."*

**Root cause (3 gaps):**
1. `discovered_jobs.expired_at` existed but nothing ever wrote it.
2. JSearch's declared close date (`job_offer_expiration_datetime_utc`) was discarded into `raw_payload`.
3. The inbox query had no liveness filter.

**Fix:**
- Capture the feed's declared expiry → new normalized `source_expires_at` (JSearch only; Greenhouse/Lever feeds list only active postings and expose no expiry field).
- New nullable tz-aware `source_expires_at` column (migration `discexp260528`), wired through upsert; kept distinct from `expired_at` (feed-declared close vs. observed vanish-upstream).
- `expired_at` writer: `fetch_source` expires previously-active rows absent from a cycle's returned id-set, **guarded to fire only after a successful, non-empty fetch** (never on 429/error/empty — that would mass-expire the inbox). The id-set is computed from the **raw** adapter result (pre post-fetch-filter) so an operator-excluded-but-still-live posting isn't falsely expired. 429 handling unchanged (separate PR).
- Inbox + saved views exclude `expired_at IS NOT NULL` OR `source_expires_at < now()`. Active-only (exclude, not grey-out). `state="all"` unchanged. Sort untouched (already score-desc).

**Tests:** writer, guard (repo + e2e empty cycle), inbox/saved exclusion, normalize capture. Server-side filtering only — no frontend/TS-union change. MJH-only (Tier 3); no platform_shared/MBK changes.

Resolves the "surfaces closed/expired postings" HIGH and "expired_at has no writer" Low in TECH_DEBT.md.

Follow-up surfaced (separate PR): no adapter sets `content_hash`, so the `(user_id, content_hash)` cross-source dedup index is currently inert.

⚠️ No operational-migration section needed: the migration is additive (nullable column, no backfill, old code runs fine without it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)