### PR TITLE
fix(mjh): bound the discovery "Scoring" spinner + surface coverage; clarify JSearch 429

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 22 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 5 [1 blocked-on-react-19, 1 public-launch cost guardrail, 3 triage-2026-05-28] / Medium: 7 [5 prior + 2 triage-2026-05-28: pagination, rejection-visibility] / Low: 8 [6 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
+**Open issues: 22 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 4 [1 blocked-on-react-19, 1 public-launch cost guardrail, 2 triage-2026-05-28] / Medium: 8 [5 prior + 2 triage-2026-05-28: pagination, rejection-visibility + 1 discovery content_hash dedup] / Low: 8 [6 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
 
 > Status (2026-05-08 PM): All actionable audit items resolved across batches PR #492-#528 (~30 PRs). Remaining open entries are either (a) blocked on the React 18→19 monorepo bump (5 items), (b) deferred-by-design conventions or follow-ups (4), (c) environmental issues unrelated to code (3: asyncpg Windows, test hang on Windows, Quality Gate false-positive), or (d) intentional accepted lint warnings (2).
 
@@ -718,15 +718,12 @@ This rules a lot of work in and out: **don't** invest in a relevance-overhaul or
 **Hypothesis (confirm):** Some application-creation paths (promote-from-discovery and/or apply-from-analysis, and the "Job Description" document upload path) persist the JD as a Document but never set `application.jd_text`, so OverviewSection has nothing to show. Fix is either (a) those paths also populate `jd_text`, or (b) OverviewSection falls back to the latest `job_description` Document body when `jd_text` is empty.
 **Fix considerations:** pick a single source of truth for JD text (application column vs. Document body) — don't render from two divergent places. Read view must show the JD without an edit click.
 
-### HIGH — Discover: cards stuck on "Scoring" spinner forever; JSearch fetch returning 429
+### ~~HIGH — Discover: cards stuck on "Scoring" spinner forever; JSearch fetch returning 429~~ RESOLVED
 
-**Reported:** operator, prod — "senior software engineer" saved search.
-**Symptom:** Inbox cards show a "Scoring" badge + spinner that never resolves. Saved search shows "Fetch failed — JSearch returned 429 (retry-after=None)", last fetched 49 min ago.
-**Two distinct problems:**
-1. **Spinner never terminates.** Two-stage scoring (#570) embeds all postings locally, then sends only the top-N (`discovery_score_top_n=20`, `app/core/config.py:52`) to Claude, stopping at the daily budget (`discovery_daily_budget_usd=0.30`, `config.py:41-42`). Postings outside the top-N — or beyond budget, or when the fetch failed so the score pass never ran — are never scored, yet the frontend appears to show a perpetual "Scoring" spinner for any unscored job. This violates `visible-loading-feedback` (a spinner must terminate to a real state). Need: frontend must distinguish *scored* / *scoring-in-progress* / *not-scored-this-cycle*, and never spin indefinitely.
-2. **JSearch 429.** RapidAPI returned HTTP 429 (rate-limited), `retry-after=None`. Confirm: is the daily 5-pages-per-fetch (#594) exceeding the RapidAPI plan quota? Is backoff/retry-after handled? Does a failed fetch leave previously-fetched inbox jobs stuck in the unscored state above?
-**Evidence:** `app/services/discovery/discovery_score_service.py` (score loop), `config.py:41-42,52`, fetch pages #594. Frontend "Scoring" badge condition not yet located — find in `apps/myjobhunter/frontend/src/features/discover/`.
-**Fix-time step:** check Sentry (project `myjobhunter-api`) for score-loop / JSearch errors before shell diagnostics (per check-Sentry-first). No Sentry MCP connected this session.
+**Resolved:** branch `fix/mjh-discovery-scoring-state` (2026-05-29). Both problems fixed (scope-disciplined — scoring *coverage* mechanics, the rubric, and fetch cadence were deliberately left for separate PRs).
+1. **Spinner never terminated.** Root cause: `DiscoveredJobCard` showed an animated spinner whenever `isUnscored && isScoringInFlight`, and `isScoringInFlight` was a *list-wide* boolean (`items.some(score===null)`) passed to every card, while the inbox polled every 4s **forever** with no stop condition. Because the scorer only rates the daily prefilter top-N, most rows stay `score IS NULL` permanently → every unscored card spun forever and the tab polled forever. Fix: a `score===null` card now renders a STATIC "Not scored" pill (no animation); the animated spinner is reserved for a **bounded** client-side window (`SCORING_WINDOW_MS=60s`) opened only when a fresh fetch lands (detected by a jump in the unscored count) and closed on timeout or when every row is scored. Polling runs ONLY while that window is open (`pollingInterval: 0` otherwise), satisfying `visible-loading-feedback`. Coverage is surfaced as "Scored N of M — the rest await the next daily scoring pass" so the unscored tail reads as expected, not broken: new `scored_count`/`total_count` on `DiscoveredJobListResponse` (repo `count_inbox_coverage`, inbox state only) + matching TS type.
+2. **JSearch 429.** `sources/jsearch.py` now honors `Retry-After`: a 429 with a short `Retry-After` sleeps the advised interval (bounded to 30s) and retries as transient; a header-less 429 (or `Retry-After` beyond the bound) is treated as monthly-quota exhaustion → new `JSearchQuotaError` (fatal, not retried) with a distinct actionable message ("JSearch monthly quota reached…"). The fetch service already persists `str(exc)` as the source's `last_error_message`, so the saved-search row now shows the actionable reason; the route maps `JSearchQuotaError` → HTTP 429 with the same string. Captures `x-ratelimit-requests-remaining` + status in structured logs per `check-third-party-error-codes`.
+**Tests:** frontend `DiscoverInboxView.test.tsx` (poll off in steady state, static signal to cards, coverage line) + `DiscoveredJobCard.test.tsx` (static "Not scored" pill, no spinner); backend `test_jsearch_adapter.py` (Retry-After honored + retried; header-less/long-Retry-After → quota, not retried; parser unit) + `test_discover_endpoints.py` (inbox coverage counts scored-vs-total).
 
 ### ~~HIGH — Discovery feed surfaces closed/expired postings; should only show active jobs~~ RESOLVED
 
@@ -740,6 +737,12 @@ This rules a lot of work in and out: **don't** invest in a relevance-overhaul or
 1. **Truncated / recency-only profile snapshot.** Job analysis sends a *bounded* profile snapshot (~8 most-recent work roles, 5 educations, 40 skills) to Claude (prompt builder in `app/services/job_analysis/job_analysis_service.py`; 50K-char content cap in `app/services/extraction/claude_service.py:46`). If the directly-relevant role sits below the 8 most-recent (or is trimmed by the char cap), the scorer never sees it and scores blind. → select roles by *relevance to the JD*, not just recency; or summarize older roles so they still register.
 2. **Rubric under-weights prior direct experience.** `JOB_ANALYSIS_PROMPT` may not treat "has already performed this role" as a dominant positive. → audit the scoring rubric/weighting.
 **Fix-time step:** reproduce with a synthetic profile carrying the matching role at position >8 to isolate truncation vs. rubric; inspect the scored-payload context in Sentry if logged (without surfacing PII). This is the most product-damaging issue in the batch — a job-fit tool that rejects people from jobs they've done erodes all trust in the score.
+
+### MEDIUM — [Discovery] No adapter sets `content_hash` → cross-source dedup index is inert
+
+**Discovered during #791 (active-only-inbox).** No source adapter (jsearch / greenhouse / lever) populates `discovered_jobs.content_hash`, so the `(user_id, content_hash)` cross-source dedup index is inert — the same posting surfaced by two boards (e.g. a role on both Greenhouse and Google Jobs/JSearch) is stored as two rows and shows up twice in the inbox. Today's dedup only catches same-source repeats via `(user_id, source, source_external_id)`. Needs a content-hashing strategy (normalize title + company + a description fingerprint; decide casing/whitespace/locale handling) plus a backfill for existing rows. Follow-up PR.
+
+---
 
 ### MEDIUM — Discovery results need pagination
 

--- a/apps/myjobhunter/backend/app/api/discover.py
+++ b/apps/myjobhunter/backend/app/api/discover.py
@@ -32,7 +32,10 @@ from app.core.config import settings
 from app.core.rate_limit import RateLimiter
 from app.db.session import get_db
 from app.models.user.user import User
-from app.repositories.discovery import discovery_repository
+from app.repositories.discovery import (
+    discovery_inbox_repository,
+    discovery_repository,
+)
 from app.schemas.application.application_response import ApplicationResponse
 from app.schemas.discovery.discovery_schemas import (
     DiscoveredJobDismissRequest,
@@ -66,6 +69,7 @@ from app.services.discovery.discovery_fetch_service import (
 from app.services.discovery.sources.jsearch import (
     JSearchAuthError,
     JSearchInvalidResponseError,
+    JSearchQuotaError,
     JSearchTransientError,
 )
 
@@ -202,7 +206,8 @@ async def refresh_source(
     - 200 — fetch completed (status field tells you success/partial/error)
     - 404 — source not found or doesn't belong to caller
     - 409 — source is deactivated
-    - 429 — per-IP rate limit (30 / 5 min)
+    - 429 — per-IP rate limit (30 / 5 min) OR the JSearch RapidAPI plan's
+            monthly quota is exhausted (distinct, actionable detail)
     - 502 — adapter raised transient error after retries exhausted
     - 503 — JSEARCH_API_KEY not configured (or invalid)
     - 501 — no adapter for this source kind (shouldn't happen; defensive)
@@ -229,6 +234,13 @@ async def refresh_source(
                 "set JSEARCH_API_KEY in the backend environment"
             ),
         ) from exc
+    except JSearchQuotaError as exc:
+        # Monthly RapidAPI quota spent (or throttled beyond a single
+        # fetch's wait). 429 with the adapter's actionable detail string —
+        # the same message the fetch service persisted as the source's
+        # last_error_message, so the saved-search row and the HTTP reply
+        # agree.
+        raise HTTPException(status_code=429, detail=str(exc)) from exc
     except JSearchTransientError as exc:
         raise HTTPException(
             status_code=502,
@@ -280,10 +292,25 @@ async def list_discovered(
     rows = await discovery_repository.list_discovered(
         db, user.id, state=state, limit=limit, offset=offset, source_id=source_id,
     )
+
+    # Coverage is only meaningful for the triage inbox: most fetched rows
+    # stay unscored (the scorer only rates the prefilter top-N per day),
+    # and the frontend surfaces "Scored N of M" so that tail reads as
+    # "daily limit reached" rather than "broken". The saved/all views
+    # don't carry the framing, so leave the counts null there.
+    scored_count: int | None = None
+    total_count: int | None = None
+    if state == "inbox":
+        scored_count, total_count = await discovery_inbox_repository.count_inbox_coverage(
+            db, user.id, source_id=source_id,
+        )
+
     return DiscoveredJobListResponse(
         items=[DiscoveredJobResponse.model_validate(r) for r in rows],
         total=len(rows),
         state=state,
+        scored_count=scored_count,
+        total_count=total_count,
     )
 
 

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_inbox_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_inbox_repository.py
@@ -1,0 +1,82 @@
+"""Inbox-aggregate queries for the /discover surface.
+
+Split out of ``discovery_repository`` (which is already a large module) to
+keep that file from growing further per the project's no-growth file-size
+policy. Holds read-only aggregate queries over the inbox population that
+reuse the same active-only predicate as ``discovery_repository.list_discovered``
+so the counts always describe the same rows the list endpoint returns.
+"""
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import func, or_, outerjoin, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.discovery.discovered_job import DiscoveredJob
+from app.models.discovery.discovery_fetch import DiscoveryFetch
+
+
+def active_only_predicate() -> tuple:
+    """Shared "active" predicate for the inbox/saved views.
+
+    A row is active unless we observed it vanish upstream (``expired_at``
+    set) or its feed-declared close date is in the past.
+    ``source_expires_at IS NULL`` rows (no declared expiry — e.g. all
+    Greenhouse/Lever rows) stay active. Single source of truth, imported by
+    ``discovery_repository.list_discovered`` and reused by the coverage
+    count below, so the two populations never drift apart. Lives here
+    (rather than in ``discovery_repository``) to keep that already-large
+    module from growing under the no-growth file-size policy.
+    """
+    return (
+        DiscoveredJob.expired_at.is_(None),
+        or_(
+            DiscoveredJob.source_expires_at.is_(None),
+            DiscoveredJob.source_expires_at >= func.now(),
+        ),
+    )
+
+
+async def count_inbox_coverage(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    source_id: uuid.UUID | None = None,
+) -> tuple[int, int]:
+    """Return ``(scored_count, total_count)`` for the active inbox.
+
+    Both counts use the exact same active-only + triage predicate as the
+    ``state="inbox"`` branch of ``discovery_repository.list_discovered``
+    (via the shared ``active_only_predicate``), so the coverage line the
+    frontend renders ("Scored N of M") matches the rows actually shown —
+    not a different population. The counts span the WHOLE inbox,
+    independent of the list endpoint's ``limit``/``offset`` page, which is
+    why this is a separate aggregate rather than ``len(items)``.
+
+    ``scored_count`` = inbox rows with a non-null ``score``.
+    ``total_count``  = all active inbox rows.
+    """
+    base = select(func.count(DiscoveredJob.id)).where(
+        DiscoveredJob.user_id == user_id,
+        DiscoveredJob.dismissed_at.is_(None),
+        DiscoveredJob.saved_at.is_(None),
+        DiscoveredJob.promoted_application_id.is_(None),
+        *active_only_predicate(),
+    )
+    if source_id is not None:
+        # Mirror list_discovered's source filter: join the fetch row and
+        # restrict to fetches belonging to this saved search.
+        base = base.select_from(
+            outerjoin(
+                DiscoveredJob,
+                DiscoveryFetch,
+                DiscoveredJob.fetch_id == DiscoveryFetch.id,
+            )
+        ).where(DiscoveryFetch.discovery_source_id == source_id)
+
+    total_count = (await db.execute(base)).scalar_one()
+    scored_count = (
+        await db.execute(base.where(DiscoveredJob.score.isnot(None)))
+    ).scalar_one()
+    return scored_count, total_count

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_repository.py
@@ -16,13 +16,16 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy import desc, func, nulls_last, or_, outerjoin, select, update
+from sqlalchemy import desc, func, nulls_last, outerjoin, select, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.models.discovery.discovered_job import DiscoveredJob
 from app.models.discovery.discovery_fetch import DiscoveryFetch
 from app.models.discovery.discovery_source import DiscoverySource
+from app.repositories.discovery.discovery_inbox_repository import (
+    active_only_predicate,
+)
 
 
 # ===========================================================================
@@ -420,17 +423,10 @@ async def list_discovered(
         )
         .where(DiscoveredJob.user_id == user_id)
     )
-    # Active-only predicate, shared by the inbox and saved views: a row is
-    # active unless we observed it vanish upstream (``expired_at`` set) or its
-    # feed-declared close date is in the past. ``source_expires_at IS NULL``
-    # rows (no declared expiry — e.g. all Greenhouse/Lever rows) stay active.
-    active_only = (
-        DiscoveredJob.expired_at.is_(None),
-        or_(
-            DiscoveredJob.source_expires_at.is_(None),
-            DiscoveredJob.source_expires_at >= func.now(),
-        ),
-    )
+    # Active-only predicate, shared by the inbox and saved views (and the
+    # coverage-count query) via ``active_only_predicate`` — one source of
+    # truth so the populations never drift.
+    active_only = active_only_predicate()
 
     if state == "inbox":
         stmt = stmt.where(

--- a/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
@@ -300,3 +300,12 @@ class DiscoveredJobListResponse(BaseModel):
     items: list[DiscoveredJobResponse]
     total: int
     state: Literal["inbox", "saved", "all"]
+    # Inbox scoring coverage, spanning the WHOLE active inbox (not just the
+    # returned page). ``scored_count`` of ``total_count`` rows carry an AI
+    # score; the rest are awaiting scoring or fell outside the day's scoring
+    # budget. The frontend renders this as "Scored N of M" so a large
+    # unscored tail reads as "daily limit reached", not "broken". Both are
+    # None for the ``saved`` / ``all`` views, where the coverage framing
+    # doesn't apply.
+    scored_count: int | None = None
+    total_count: int | None = None

--- a/apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py
+++ b/apps/myjobhunter/backend/app/services/discovery/sources/jsearch.py
@@ -24,6 +24,7 @@ the worker to upsert. No DB writes here; the worker owns persistence.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 from datetime import datetime
 from typing import Any
@@ -49,10 +50,26 @@ JSEARCH_HOST = "jsearch.p.rapidapi.com"
 # always identifies.
 USER_AGENT = "MyJobHunter/1.0 (+https://myjobhunter.myfreeapps.org)"
 
-# HTTP statuses that warrant exponential backoff + retry. 429 also goes
-# here — JSearch does not document a Retry-After header but tenacity's
-# wait_exponential gives the API time to recover.
-_TRANSIENT_STATUS = frozenset({429, 500, 502, 503, 504})
+# HTTP statuses that warrant exponential backoff + retry. 429 is handled
+# separately below (it distinguishes a transient throttle — which carries a
+# Retry-After — from monthly-quota exhaustion, which does not).
+_TRANSIENT_STATUS = frozenset({500, 502, 503, 504})
+
+# RapidAPI returns 429 both for short-window throttling (carries a
+# ``Retry-After`` header telling us when the window resets — usually
+# seconds) AND for monthly-plan quota exhaustion (no ``Retry-After``;
+# the plan is simply spent until the billing cycle rolls over). We honor
+# the header when present and treat a header-less 429 as quota exhaustion
+# so the operator gets an actionable, distinct failure reason instead of
+# a generic "upstream unavailable".
+_HTTP_TOO_MANY_REQUESTS = 429
+
+# Upper bound (seconds) we are willing to block a request thread waiting
+# on a Retry-After before giving up and letting tenacity's own backoff
+# take over. A short-window RapidAPI throttle resets in seconds; a
+# Retry-After far beyond this is effectively a quota wall and we should
+# not hold the worker hostage for it.
+_MAX_RETRY_AFTER_SECONDS = 30.0
 
 # JSearch returns salary period as YEAR / MONTH / HOUR. Map to the
 # discovered_jobs.salary_period CHECK constraint values.
@@ -82,11 +99,57 @@ class JSearchAuthError(JSearchError):
 
 
 class JSearchTransientError(JSearchError):
-    """Network error, 429, or 5xx — retry with backoff."""
+    """Network error, short-window 429 throttle, or 5xx — retry with backoff."""
+
+
+class JSearchQuotaError(JSearchError):
+    """RapidAPI monthly quota exhausted — fatal until the plan resets.
+
+    Distinct from ``JSearchTransientError`` so the fetch service can
+    persist an actionable operator-facing reason ("JSearch monthly quota
+    reached") rather than a generic "upstream unavailable". Not retried:
+    retrying a spent plan just burns the rate-limit window without ever
+    succeeding. Surfaced to the route layer as a 429.
+    """
 
 
 class JSearchInvalidResponseError(JSearchError):
     """Non-JSON body or unexpected envelope shape — fatal, surface to ops."""
+
+
+# ---------------------------------------------------------------------------
+# Internal — Retry-After parsing
+# ---------------------------------------------------------------------------
+
+
+def _parse_retry_after_seconds(value: str | None) -> float | None:
+    """Parse an RFC 7231 ``Retry-After`` header into a delay in seconds.
+
+    The header is either a non-negative integer count of seconds
+    (``Retry-After: 12``) or an HTTP-date. RapidAPI uses the integer
+    form. Returns ``None`` when the header is absent or unparseable —
+    a header-less 429 is the signal we use to distinguish monthly-quota
+    exhaustion from a short-window throttle.
+
+    A negative or non-numeric value is treated as absent (``None``)
+    rather than guessed at, so a malformed header degrades to the
+    quota-exhaustion path rather than a bogus sleep.
+    """
+    if value is None:
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    try:
+        seconds = float(cleaned)
+    except ValueError:
+        # HTTP-date form — RapidAPI doesn't emit it; parsing dates here
+        # would add a dependency for a case we don't observe. Treat as
+        # absent so the caller falls through to quota-exhaustion.
+        return None
+    if seconds < 0:
+        return None
+    return seconds
 
 
 # ---------------------------------------------------------------------------
@@ -140,8 +203,11 @@ async def search(
     Raises:
         JSearchAuthError: 401/403 or empty key. Caller should pause the
             saved-search and surface to the operator.
-        JSearchTransientError: 429 / 5xx / network — retried up to 3
-            times before propagating.
+        JSearchQuotaError: 429 without a (short) ``Retry-After`` — the
+            RapidAPI monthly plan is spent. Not retried; surfaced as a
+            distinct, actionable reason.
+        JSearchTransientError: 5xx / network / short-window 429 throttle —
+            retried up to 3 times before propagating.
         JSearchInvalidResponseError: Non-JSON body or unexpected envelope.
         JSearchError: Any other 4xx.
     """
@@ -194,16 +260,59 @@ async def search(
             f"JSearch returned {resp.status_code} — check JSEARCH_API_KEY",
         )
 
-    if resp.status_code in _TRANSIENT_STATUS:
-        retry_after = resp.headers.get("Retry-After")
+    if resp.status_code == _HTTP_TOO_MANY_REQUESTS:
+        # Capture the structured rate-limit signals per the third-party
+        # error-codes rule. RapidAPI surfaces remaining quota in
+        # ``x-ratelimit-requests-remaining`` and the reset window in
+        # ``Retry-After``. We log both, then route on them.
+        retry_after_raw = resp.headers.get("Retry-After")
+        retry_after = _parse_retry_after_seconds(retry_after_raw)
+        requests_remaining = resp.headers.get("x-ratelimit-requests-remaining")
         logger.warning(
-            "JSearch transient error: status=%s retry_after=%s body=%s",
+            "JSearch 429: retry_after=%s requests_remaining=%s body=%s",
+            retry_after_raw,
+            requests_remaining,
+            resp.text[:300],
+        )
+
+        # No (usable) Retry-After → treat as monthly-quota exhaustion.
+        # Retrying a spent plan can't succeed; raise a distinct, fatal,
+        # actionable error the fetch service persists as the source's
+        # failure reason.
+        if retry_after is None:
+            raise JSearchQuotaError(
+                "JSearch monthly quota reached — the RapidAPI plan is "
+                "exhausted until it resets. Upgrade the plan tier or wait "
+                "for the next billing cycle.",
+            )
+
+        # Short-window throttle with an actionable Retry-After: honor it
+        # by sleeping the advised interval (bounded), then raise a
+        # transient error so tenacity re-attempts the call.
+        if retry_after > _MAX_RETRY_AFTER_SECONDS:
+            # A Retry-After well past our bound is effectively a quota
+            # wall — don't hold the worker for minutes. Surface it as
+            # quota exhaustion with the advised wait so the reason is
+            # actionable.
+            raise JSearchQuotaError(
+                "JSearch rate limit reached — the RapidAPI plan is "
+                f"throttled for ~{int(retry_after)}s, beyond what a "
+                "single fetch will wait. Upgrade the plan tier or retry "
+                "later.",
+            )
+        await asyncio.sleep(retry_after)
+        raise JSearchTransientError(
+            f"JSearch throttled (429); honored Retry-After={retry_after}s",
+        )
+
+    if resp.status_code in _TRANSIENT_STATUS:
+        logger.warning(
+            "JSearch transient error: status=%s body=%s",
             resp.status_code,
-            retry_after,
             resp.text[:300],
         )
         raise JSearchTransientError(
-            f"JSearch returned {resp.status_code} (retry-after={retry_after})",
+            f"JSearch returned {resp.status_code}",
         )
 
     if resp.status_code != 200:

--- a/apps/myjobhunter/backend/tests/test_discover_endpoints.py
+++ b/apps/myjobhunter/backend/tests/test_discover_endpoints.py
@@ -287,6 +287,52 @@ async def test_list_discovered_inbox_default(
     assert body["items"][0]["title"] == "Senior Backend Engineer"
     assert body["items"][0]["dismissed_at"] is None
     assert body["items"][0]["saved_at"] is None
+    # Coverage: one unscored posting → scored 0 of 1. These drive the
+    # frontend's "Scored N of M" line so the unscored tail reads as
+    # "awaiting the daily pass", not "broken".
+    assert body["scored_count"] == 0
+    assert body["total_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_inbox_coverage_counts_scored_vs_total(
+    client: AsyncClient, user_factory, as_user, db,
+):
+    """The inbox coverage counts reflect the WHOLE active inbox and track
+    scored-vs-total as rows get scored — independent of the list page."""
+    from app.repositories.discovery import discovery_repository
+
+    user = await user_factory()
+    async with await as_user(user) as a:
+        created = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "x"}},
+        )
+        source_id = created.json()["id"]
+
+        with patch(
+            _SEARCH_PATH,
+            new_callable=AsyncMock,
+            return_value=[
+                _posting(),
+                _posting(source_external_id="ext-2", raw_payload={"job_id": "ext-2"}),
+            ],
+        ):
+            await a.post(f"/discover/sources/{source_id}/refresh")
+
+        # Both unscored initially.
+        before = (await a.get("/discover")).json()
+        assert before["scored_count"] == 0
+        assert before["total_count"] == 2
+
+        # Score one row directly, then re-read coverage.
+        rows = await discovery_repository.list_discovered(db, user.id, state="inbox")
+        rows[0].score = 90
+        await db.commit()
+
+        after = (await a.get("/discover")).json()
+        assert after["scored_count"] == 1
+        assert after["total_count"] == 2
 
 
 @pytest.mark.asyncio

--- a/apps/myjobhunter/backend/tests/test_jsearch_adapter.py
+++ b/apps/myjobhunter/backend/tests/test_jsearch_adapter.py
@@ -6,8 +6,12 @@ RapidAPI calls happen. Verifies:
 - Happy path: 200 OK with realistic JSearch envelope → list of
   normalized RawPosting dicts
 - Auth errors: 401/403 / missing API key → JSearchAuthError
-- Transient errors: 429 / 500 / 502 → JSearchTransientError; tenacity
-  retries up to 3 times before propagating
+- Transient errors: 500 / 502 → JSearchTransientError; tenacity retries
+  up to 3 times before propagating
+- 429 handling: a 429 carrying a (short) Retry-After is honored + retried
+  as transient; a header-less 429 (or one with a Retry-After beyond the
+  per-fetch bound) is monthly-quota exhaustion → JSearchQuotaError (fatal,
+  not retried, distinct actionable message)
 - Invalid envelopes: non-JSON body, status != "OK", non-list jobs →
   JSearchInvalidResponseError
 - Field mapping: each JSearch field lands on the right RawPosting key
@@ -29,6 +33,7 @@ from app.services.discovery.sources.jsearch import (
     JSearchAuthError,
     JSearchError,
     JSearchInvalidResponseError,
+    JSearchQuotaError,
     JSearchTransientError,
     search,
 )
@@ -189,23 +194,6 @@ async def test_search_raises_auth_error_on_403() -> None:
 
 
 @pytest.mark.asyncio
-async def test_search_retries_on_429_then_propagates(monkeypatch) -> None:
-    # Disable tenacity's wait so the test runs in milliseconds.
-    monkeypatch.setattr(jsearch, "search", jsearch.search.retry_with(wait=lambda _: 0))
-    call_count = {"n": 0}
-
-    def handler(request: httpx.Request) -> httpx.Response:
-        call_count["n"] += 1
-        return httpx.Response(429, text="rate-limited")
-
-    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
-        with pytest.raises(JSearchTransientError):
-            await jsearch.search(query="x", api_key="test-key")
-
-    assert call_count["n"] == 3  # tenacity attempts 3 times total
-
-
-@pytest.mark.asyncio
 async def test_search_retries_on_502(monkeypatch) -> None:
     monkeypatch.setattr(jsearch, "search", jsearch.search.retry_with(wait=lambda _: 0))
     call_count = {"n": 0}
@@ -221,15 +209,55 @@ async def test_search_retries_on_502(monkeypatch) -> None:
     assert call_count["n"] == 3
 
 
+# ===========================================================================
+# 429 handling — Retry-After honored as transient; header-less = quota
+# ===========================================================================
+
+
 @pytest.mark.asyncio
-async def test_search_succeeds_after_one_429_then_200(monkeypatch) -> None:
+async def test_search_honors_short_retry_after_and_retries(monkeypatch) -> None:
+    """A 429 carrying a short Retry-After is a transient throttle: we sleep
+    the advised interval (stubbed here) and retry. Three such 429s exhaust
+    tenacity and propagate as JSearchTransientError — NOT quota."""
     monkeypatch.setattr(jsearch, "search", jsearch.search.retry_with(wait=lambda _: 0))
+    # Stub the Retry-After sleep so the test runs instantly.
+    sleeps: list[float] = []
+
+    async def _fake_sleep(secs: float) -> None:
+        sleeps.append(secs)
+
+    monkeypatch.setattr(jsearch.asyncio, "sleep", _fake_sleep)
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(429, headers={"Retry-After": "2"}, text="slow down")
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(JSearchTransientError):
+            await jsearch.search(query="x", api_key="test-key")
+
+    assert call_count["n"] == 3  # retried as transient
+    # Retry-After (2s) honored once per attempt. tenacity's own back-off also
+    # routes through the patched sleep (stubbed to 0), so filter to the
+    # adapter's Retry-After sleeps rather than asserting exact ordering.
+    assert [s for s in sleeps if s == 2.0] == [2.0, 2.0, 2.0]
+
+
+@pytest.mark.asyncio
+async def test_search_succeeds_after_one_throttled_429_then_200(monkeypatch) -> None:
+    monkeypatch.setattr(jsearch, "search", jsearch.search.retry_with(wait=lambda _: 0))
+
+    async def _fake_sleep(_secs: float) -> None:
+        return None
+
+    monkeypatch.setattr(jsearch.asyncio, "sleep", _fake_sleep)
     call_count = {"n": 0}
 
     def handler(request: httpx.Request) -> httpx.Response:
         call_count["n"] += 1
         if call_count["n"] == 1:
-            return httpx.Response(429)
+            return httpx.Response(429, headers={"Retry-After": "1"})
         return httpx.Response(200, json=_ok_envelope())
 
     with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
@@ -237,6 +265,57 @@ async def test_search_succeeds_after_one_429_then_200(monkeypatch) -> None:
 
     assert call_count["n"] == 2
     assert len(results) == 1
+
+
+@pytest.mark.asyncio
+async def test_search_headerless_429_is_quota_error_not_retried(monkeypatch) -> None:
+    """A 429 with NO Retry-After means the monthly RapidAPI plan is spent.
+    It must raise JSearchQuotaError on the FIRST call (retrying a spent plan
+    can't succeed) and carry an actionable, distinct message."""
+    monkeypatch.setattr(jsearch, "search", jsearch.search.retry_with(wait=lambda _: 0))
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        return httpx.Response(429, text="exceeded the MONTHLY quota")
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(JSearchQuotaError) as exc_info:
+            await jsearch.search(query="x", api_key="test-key")
+
+    assert call_count["n"] == 1  # NOT retried
+    assert "quota" in str(exc_info.value).lower()
+
+
+@pytest.mark.asyncio
+async def test_search_long_retry_after_is_quota_error(monkeypatch) -> None:
+    """A Retry-After beyond the per-fetch bound is effectively a quota wall —
+    surface as JSearchQuotaError rather than blocking the worker for minutes."""
+    monkeypatch.setattr(jsearch, "search", jsearch.search.retry_with(wait=lambda _: 0))
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        # 3600s is far beyond _MAX_RETRY_AFTER_SECONDS (30s).
+        return httpx.Response(429, headers={"Retry-After": "3600"})
+
+    with patch.object(httpx, "AsyncClient", lambda *a, **kw: _client_with_handler(handler)):
+        with pytest.raises(JSearchQuotaError):
+            await jsearch.search(query="x", api_key="test-key")
+
+    assert call_count["n"] == 1  # NOT retried
+
+
+def test_parse_retry_after_seconds() -> None:
+    """Unit-cover the Retry-After parser: integer seconds, absent, malformed,
+    and negative all resolve correctly (negative/malformed → None = quota)."""
+    assert jsearch._parse_retry_after_seconds("12") == 12.0
+    assert jsearch._parse_retry_after_seconds("  5  ") == 5.0
+    assert jsearch._parse_retry_after_seconds(None) is None
+    assert jsearch._parse_retry_after_seconds("") is None
+    assert jsearch._parse_retry_after_seconds("-3") is None
+    # HTTP-date form is not emitted by RapidAPI → treated as absent.
+    assert jsearch._parse_retry_after_seconds("Wed, 21 Oct 2026 07:28:00 GMT") is None
 
 
 # ===========================================================================

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef, useState } from "react";
 import { Telescope } from "lucide-react";
 import { EmptyState } from "@platform/ui";
 import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
@@ -9,9 +10,19 @@ import { useGetProfileQuery } from "@/lib/profileApi";
 import { useListSkillsQuery } from "@/lib/skillsApi";
 
 // Background scoring runs after /refresh as a FastAPI BackgroundTask
-// (~30s for 20 postings). Poll while the inbox is visible so score badges
-// fill in without the operator refreshing manually.
+// (~30s for the prefilter top-N). While a fetch is plausibly still
+// scoring we poll so the new verdicts fill in without a manual reload —
+// but ONLY for a bounded window (see SCORING_WINDOW_MS). The scorer rates
+// only the daily prefilter top-N, so most fetched rows stay unscored
+// permanently; an unbounded poll would spin forever against a tail that
+// never resolves. Once the window closes, polling goes idle and unscored
+// cards settle into a static "Not scored" pill.
 const INBOX_POLL_INTERVAL_MS = 4000;
+
+// How long after a fresh fetch lands we keep polling + show the animated
+// "Scoring" affordance. Comfortably covers the background scorer's ~30s
+// pass for the top-N with headroom, then terminates to a real state.
+const SCORING_WINDOW_MS = 60_000;
 
 interface DiscoverInboxViewProps {
   hasSources: boolean;
@@ -29,10 +40,76 @@ export default function DiscoverInboxView({
     ? { state: "inbox" as const, source_id: activeSourceId }
     : { state: "inbox" as const };
 
+  // Bounded scoring window. We poll (and show the animated spinner) only
+  // while this is true; it auto-closes after SCORING_WINDOW_MS. Opened
+  // when a fresh fetch lands — detected below by a jump in the unscored
+  // count, which is what /refresh produces.
+  const [isScoringWindowOpen, setIsScoringWindowOpen] = useState(false);
+  const windowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const prevUnscoredRef = useRef<number | null>(null);
+
   const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery(
     queryArgs,
-    { pollingInterval: INBOX_POLL_INTERVAL_MS },
+    // Poll only while the bounded scoring window is open. `0` disables
+    // polling in RTK Query, so the steady state makes no network noise.
+    // The window auto-closes via timer (SCORING_WINDOW_MS) or earlier once
+    // every row is scored (see isScoringActive below), so this never polls
+    // indefinitely.
+    { pollingInterval: isScoringWindowOpen ? INBOX_POLL_INTERVAL_MS : 0 },
   );
+
+  const totalCount = jobsData?.total_count ?? null;
+  const scoredCount = jobsData?.scored_count ?? null;
+  const unscoredCount =
+    totalCount !== null && scoredCount !== null ? totalCount - scoredCount : null;
+
+  // Open the bounded scoring window when a fresh fetch lands. A /refresh
+  // adds new (unscored) rows, so a jump in the unscored count is our
+  // signal. We compare against the previous observed count rather than
+  // "any unscored exist", so a steady tail of permanently-unscored rows
+  // does NOT keep re-opening the window (which would resurrect the
+  // forever-poll this fix removes). This effect only ever OPENS the
+  // window (and arms the close-timer); it never closes synchronously, so
+  // it can't trigger cascading renders.
+  useEffect(() => {
+    if (unscoredCount === null) {
+      return;
+    }
+    const prev = prevUnscoredRef.current;
+    prevUnscoredRef.current = unscoredCount;
+
+    // First observation just seeds the baseline — never opens the window.
+    if (prev === null) {
+      return;
+    }
+    if (unscoredCount > prev) {
+      setIsScoringWindowOpen(true);
+      if (windowTimerRef.current !== null) {
+        clearTimeout(windowTimerRef.current);
+      }
+      windowTimerRef.current = setTimeout(() => {
+        setIsScoringWindowOpen(false);
+        windowTimerRef.current = null;
+      }, SCORING_WINDOW_MS);
+    }
+  }, [unscoredCount]);
+
+  // Clean up the timer on unmount so it can't fire after the view is gone.
+  useEffect(() => {
+    return () => {
+      if (windowTimerRef.current !== null) {
+        clearTimeout(windowTimerRef.current);
+      }
+    };
+  }, []);
+
+  // Effective "scoring in flight" signal: the window is open AND there is
+  // still something unscored to wait for. Deriving the "all scored → done"
+  // close at render time (rather than in a setState-in-effect) avoids
+  // cascading renders — once every row is scored the spinner stops and
+  // polling idles immediately, even before the timer elapses. The timer
+  // remains the upper bound for the never-resolves case.
+  const isScoringActive = isScoringWindowOpen && unscoredCount !== 0;
 
   const { data: sources } = useListDiscoverySourcesQuery();
   const { data: profile } = useGetProfileQuery();
@@ -90,14 +167,18 @@ export default function DiscoverInboxView({
     );
   }
 
-  // PR 4b: when ANY card in the inbox is unscored, the inbox polls
-  // every 4s (INBOX_POLL_INTERVAL_MS) until scores fill in. Pass that
-  // signal to each unscored card so it can render a spinner in the
-  // verdict-badge slot instead of an empty space — the operator sees
-  // their fresh postings are being rated, not silently ignored.
-  // Once every card has a verdict, polling continues but the spinner
-  // simply has nothing to attach to.
-  const hasUnscored = items.some((job) => job.score === null);
+  // Coverage line: the scorer only rates the daily prefilter top-N, so a
+  // large unscored tail is expected, not a failure. Surfacing "Scored N of
+  // M" makes that legible — without it, rows stuck on a "Not scored" pill
+  // read as broken.
+  const showCoverage =
+    scoredCount !== null && totalCount !== null && totalCount > 0;
+  const coverageLine = showCoverage
+    ? `Scored ${scoredCount} of ${totalCount}` +
+      (unscoredCount !== null && unscoredCount > 0
+        ? " — the rest await the next daily scoring pass"
+        : "")
+    : null;
 
   // Pass profile.updated_at to each card so the card can detect
   // when its score was computed against an older profile snapshot
@@ -107,11 +188,19 @@ export default function DiscoverInboxView({
   return (
     <div className="space-y-3">
       {profileBanner}
+      {coverageLine && (
+        <p
+          className="text-xs text-muted-foreground"
+          data-testid="inbox-scoring-coverage"
+        >
+          {coverageLine}
+        </p>
+      )}
       {items.map((job) => (
         <DiscoveredJobCard
           key={job.id}
           job={job}
-          isScoringInFlight={hasUnscored}
+          isScoringInFlight={isScoringActive}
           profileUpdatedAt={profileUpdatedAt}
           sources={sources ?? []}
         />

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx
@@ -26,15 +26,18 @@ import UndoDismissToast from "./UndoDismissToast";
 interface DiscoveredJobCardProps {
   job: DiscoveredJob;
   /**
-   * True when the inbox view is currently polling for fresh scores
-   * (i.e. another card in the same list has score=null). Lets the
-   * unscored card show a small spinner in the verdict-badge slot so
-   * the operator knows the rating is in flight, not stuck. When
-   * false, an unscored card shows a static "Awaiting AI score" pill
-   * — same information, lower visual noise once polling stops.
+   * True only during the BOUNDED window right after a refresh the client
+   * itself triggered (and which the inbox times out — see
+   * ``DiscoverInboxView``). While true, an unscored card shows a small
+   * animated spinner so the operator sees their fresh postings are being
+   * rated. While false — the steady state — an unscored card shows a
+   * STATIC "Not scored" pill with no animation, because most fetched rows
+   * never get scored (the scorer only rates the daily prefilter top-N) and
+   * a perpetual spinner would falsely read as "stuck". The pill is a real
+   * terminal state, not a spinner that never resolves.
    *
-   * Optional for backward compatibility — defaults to false so
-   * existing callers (and tests) keep their current behaviour.
+   * Optional for backward compatibility — defaults to false so existing
+   * callers (and tests) get the static, non-animated state.
    */
   isScoringInFlight?: boolean;
   /**
@@ -135,7 +138,7 @@ export default function DiscoveredJobCard({
   // this pill lets the operator know the current score may not reflect their
   // latest skills/experience without waiting for the worker to run.
   // Only applies when the card actually has a score — truly unscored cards
-  // already show "Awaiting AI score" / the scoring spinner.
+  // already show the "Not scored" pill / the bounded scoring spinner.
   const isScoreStale =
     !isUnscored &&
     job.scored_at !== null &&
@@ -197,8 +200,9 @@ export default function DiscoveredJobCard({
             <span
               className="px-2 py-0.5 text-xs text-muted-foreground border border-muted rounded"
               data-testid="discovered-job-awaiting-score"
+              title="Not scored yet. The AI rates the most promising postings each day; the rest stay unscored until the next pass."
             >
-              Awaiting AI score
+              Not scored
             </span>
           )}
           {job.source_publisher && (

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoverInboxView.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoverInboxView.test.tsx
@@ -1,0 +1,177 @@
+/**
+ * Tests for DiscoverInboxView — the bounded scoring window and coverage line
+ * (fix/mjh-discovery-scoring-state).
+ *
+ * Regression focus: a steady inbox with a permanently-unscored tail must NOT
+ * poll forever, and unscored cards must render the static state (not the
+ * animated spinner). The scorer only rates the daily prefilter top-N, so a
+ * large unscored tail is expected — the coverage line makes that legible.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import DiscoverInboxView from "@/features/discover/DiscoverInboxView";
+import type { DiscoveredJob } from "@/types/discovery/discovered-job";
+import type { DiscoveredJobListResponse } from "@/types/discovery/discovered-job-list-response";
+
+vi.mock("@/store/discoverApi", () => ({
+  useListDiscoveredJobsQuery: vi.fn(),
+  useListDiscoverySourcesQuery: vi.fn(),
+}));
+
+vi.mock("@/lib/profileApi", () => ({
+  useGetProfileQuery: vi.fn(() => ({ data: undefined })),
+}));
+
+vi.mock("@/lib/skillsApi", () => ({
+  useListSkillsQuery: vi.fn(() => ({ data: undefined })),
+}));
+
+vi.mock("@platform/ui", () => ({
+  EmptyState: ({ heading }: { heading: string }) => <div>{heading}</div>,
+}));
+
+vi.mock("@/features/discover/DiscoveredJobsSkeleton", () => ({
+  default: () => <div data-testid="skeleton" />,
+}));
+
+vi.mock("@/features/discover/ProfileCompletenessBanner", () => ({
+  default: () => null,
+}));
+
+// Capture the isScoringInFlight prop each card receives so we can assert
+// the steady state passes a STATIC (false) signal, not an animated one.
+const cardSpy = vi.fn();
+vi.mock("@/features/discover/DiscoveredJobCard", () => ({
+  default: (props: { job: DiscoveredJob; isScoringInFlight?: boolean }) => {
+    cardSpy(props.isScoringInFlight);
+    return <div data-testid="job-card">{props.job.title}</div>;
+  },
+}));
+
+import {
+  useListDiscoveredJobsQuery,
+  useListDiscoverySourcesQuery,
+} from "@/store/discoverApi";
+
+const mockListJobs = vi.mocked(useListDiscoveredJobsQuery);
+const mockListSources = vi.mocked(useListDiscoverySourcesQuery);
+
+function makeJob(overrides: Partial<DiscoveredJob> = {}): DiscoveredJob {
+  return {
+    id: "job-1",
+    source: "jsearch",
+    source_publisher: null,
+    source_url: null,
+    title: "Senior Backend Engineer",
+    company_name: "Acme Corp",
+    location: "Remote",
+    remote_type: "remote",
+    description: null,
+    posted_at: null,
+    discovered_at: "2026-05-08T10:00:00Z",
+    salary_min: null,
+    salary_max: null,
+    salary_currency: "USD",
+    salary_period: null,
+    score: null,
+    score_reason: null,
+    scored_at: null,
+    dismissed_at: null,
+    dismissed_reason: null,
+    saved_at: null,
+    promoted_application_id: null,
+    verdict: null,
+    discovery_source_id: null,
+    ...overrides,
+  };
+}
+
+function makeResponse(
+  overrides: Partial<DiscoveredJobListResponse> = {},
+): DiscoveredJobListResponse {
+  return {
+    items: [makeJob()],
+    total: 1,
+    state: "inbox",
+    scored_count: 0,
+    total_count: 1,
+    ...overrides,
+  };
+}
+
+function renderInbox() {
+  return render(
+    <MemoryRouter>
+      <DiscoverInboxView hasSources activeSourceId={null} />
+    </MemoryRouter>,
+  );
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function jobsResult(data: DiscoveredJobListResponse): any {
+  return { data, isLoading: false, isError: false };
+}
+
+describe("DiscoverInboxView — bounded scoring window", () => {
+  beforeEach(() => {
+    cardSpy.mockClear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockListSources.mockReturnValue({ data: [] } as any);
+  });
+
+  it("does NOT poll in the steady state (a permanently-unscored tail must not poll forever)", () => {
+    mockListJobs.mockReturnValue(
+      jobsResult(makeResponse({ scored_count: 20, total_count: 100 })),
+    );
+    renderInbox();
+
+    // The second positional arg to useListDiscoveredJobsQuery is the
+    // options bag. On first render (no fresh fetch detected) the window is
+    // closed → pollingInterval must be 0 (RTK Query: 0 disables polling).
+    expect(mockListJobs).toHaveBeenCalled();
+    const optionsArg = mockListJobs.mock.calls[0][1];
+    expect(optionsArg).toMatchObject({ pollingInterval: 0 });
+  });
+
+  it("passes a static (false) isScoringInFlight to cards in the steady state", () => {
+    mockListJobs.mockReturnValue(
+      jobsResult(makeResponse({ scored_count: 0, total_count: 1 })),
+    );
+    renderInbox();
+    // Every card render in the steady state must receive false → static
+    // "Not scored" pill, never the animated spinner.
+    expect(cardSpy).toHaveBeenCalled();
+    expect(cardSpy.mock.calls.every(([flag]) => flag === false)).toBe(true);
+  });
+
+  it("renders the coverage line 'Scored N of M' from the response counts", () => {
+    mockListJobs.mockReturnValue(
+      jobsResult(makeResponse({ scored_count: 20, total_count: 100 })),
+    );
+    renderInbox();
+    const coverage = screen.getByTestId("inbox-scoring-coverage");
+    expect(coverage).toHaveTextContent("Scored 20 of 100");
+    // Unscored tail → the "next daily scoring pass" framing so it doesn't
+    // read as broken.
+    expect(coverage).toHaveTextContent(/next daily scoring pass/i);
+  });
+
+  it("omits the unscored-tail framing when every row is scored", () => {
+    mockListJobs.mockReturnValue(
+      jobsResult(makeResponse({ scored_count: 5, total_count: 5 })),
+    );
+    renderInbox();
+    const coverage = screen.getByTestId("inbox-scoring-coverage");
+    expect(coverage).toHaveTextContent("Scored 5 of 5");
+    expect(coverage).not.toHaveTextContent(/next daily scoring pass/i);
+  });
+
+  it("hides the coverage line when counts are absent (saved/all views)", () => {
+    mockListJobs.mockReturnValue(
+      jobsResult(makeResponse({ scored_count: null, total_count: null })),
+    );
+    renderInbox();
+    expect(screen.queryByTestId("inbox-scoring-coverage")).toBeNull();
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoveredJobCard.test.tsx
@@ -111,22 +111,25 @@ describe("DiscoveredJobCard — verdict badge", () => {
 });
 
 describe("DiscoveredJobCard — unscored visual signal (PR 4b)", () => {
-  it("shows 'Awaiting AI score' pill when unscored and polling is idle", () => {
+  it("shows the static 'Not scored' pill when unscored and the scoring window is closed", () => {
     renderInRouter(
       <DiscoveredJobCard
         job={makeJob({ verdict: null, score: null })}
         isScoringInFlight={false}
       />,
     );
-    expect(
-      screen.getByTestId("discovered-job-awaiting-score"),
-    ).toBeInTheDocument();
+    const pill = screen.getByTestId("discovered-job-awaiting-score");
+    expect(pill).toBeInTheDocument();
+    expect(pill).toHaveTextContent("Not scored");
+    // Regression: a score===null card in the steady state must NOT animate.
+    // The perpetual "Scoring" spinner was the bug — the static pill is a
+    // real terminal state, not a spinner that never resolves.
     expect(
       screen.queryByTestId("discovered-job-scoring-spinner"),
     ).toBeNull();
   });
 
-  it("shows a spinner when unscored and polling is in flight", () => {
+  it("shows a spinner when unscored and the scoring window is open", () => {
     renderInRouter(
       <DiscoveredJobCard
         job={makeJob({ verdict: null, score: null })}
@@ -156,12 +159,15 @@ describe("DiscoveredJobCard — unscored visual signal (PR 4b)", () => {
     ).toBeNull();
   });
 
-  it("defaults isScoringInFlight to false when omitted", () => {
+  it("defaults isScoringInFlight to false when omitted (static pill, no spinner)", () => {
     renderInRouter(<DiscoveredJobCard job={makeJob({ verdict: null, score: null })} />);
     // Default falsy → static pill, not the spinner.
     expect(
       screen.getByTestId("discovered-job-awaiting-score"),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("discovered-job-scoring-spinner"),
+    ).toBeNull();
   });
 });
 

--- a/apps/myjobhunter/frontend/src/types/discovery/discovered-job-list-response.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovered-job-list-response.ts
@@ -4,4 +4,12 @@ export interface DiscoveredJobListResponse {
   items: DiscoveredJob[];
   total: number;
   state: "inbox" | "saved" | "all";
+  /**
+   * Inbox scoring coverage across the WHOLE active inbox (not just the
+   * returned page): ``scored_count`` of ``total_count`` rows carry an AI
+   * score. Null on the ``saved`` / ``all`` views, where the coverage
+   * framing doesn't apply.
+   */
+  scored_count: number | null;
+  total_count: number | null;
 }


### PR DESCRIPTION
Discovery inbox cards were stuck on a perpetual "Scoring" spinner (driven by a list-wide flag + a 4s-forever poll, while the scorer only rates the daily top-N), and JSearch 429s failed opaquely.

**Frontend**
- Static "Not scored" pill for unscored cards (no perpetual animation).
- Animated spinner only inside a bounded ~60s post-refresh window; polling runs only while that window is open, then idles (per visible-loading-feedback: the affordance terminates).
- "Scored N of M — the rest await the next daily scoring pass" coverage line so unscored ≠ broken.

**Backend**
- Honor `Retry-After`; distinguish monthly-quota exhaustion (`JSearchQuotaError` → HTTP 429, a distinct actionable reason persisted on the saved-search row) from transient (per check-third-party-error-codes).
- `GET /discover` returns whole-inbox `scored_count`/`total_count` (separate aggregate sharing the active-only predicate), surfaced in the TS type for cross-stack parity.

**Scope discipline:** scoring coverage mechanics (top-N/budget), the scoring rubric/calibration, and fetch cadence are deliberately left to separate PRs.

Adds regression tests (frontend: static pill + bounded poll + coverage; backend: Retry-After honored + quota reason). TECH_DEBT: "stuck Scoring + JSearch 429" HIGH resolved; new MEDIUM logged (no adapter sets `content_hash` → cross-source dedup index inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)