### PR TITLE
fix(mjh): show JD inline when it was attached as a document (#6 regression)

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 21 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 3 [1 blocked-on-react-19, 1 public-launch cost guardrail, 1 triage-2026-05-28] / Medium: 8 [5 prior + 2 triage-2026-05-28: pagination, rejection-visibility + 1 discovery content_hash dedup] / Low: 8 [6 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
+**Open issues: 20 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 2 [1 blocked-on-react-19, 1 public-launch cost guardrail] / Medium: 8 [5 prior + 2 triage-2026-05-28: pagination, rejection-visibility + 1 discovery content_hash dedup] / Low: 8 [6 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
 
 > Status (2026-05-08 PM): All actionable audit items resolved across batches PR #492-#528 (~30 PRs). Remaining open entries are either (a) blocked on the React 18→19 monorepo bump (5 items), (b) deferred-by-design conventions or follow-ups (4), (c) environmental issues unrelated to code (3: asyncpg Windows, test hang on Windows, Quality Gate false-positive), or (d) intentional accepted lint warnings (2).
 
@@ -707,7 +707,9 @@ This rules a lot of work in and out: **don't** invest in a relevance-overhaul or
 
 **How to approach (fix-time, not now):** diagnostic-first — pull a real sample of scored postings (via Sentry/observability or a synthetic repro per `feedback_no_diagnostic_apis_for_user_data`; do NOT build a user-data debug endpoint), and *measure* the miscalibration rate and dead-listing rate before changing prompts/filters. This is hard-design / scoring-calibration work — do it at `/effort max`. Likely a dedicated discovery-quality design pass (g-design-ux + prompt design) rather than ad-hoc patches; avoid bandaid prompt tweaks that aren't measured.
 
-### HIGH — Job description not visible in application detail (must open the Document and click Edit to read it)
+### ~~HIGH — Job description not visible in application detail (must open the Document and click Edit to read it)~~ RESOLVED
+
+**Resolved (2026-05-29):** branch `fix/mjh-jd-inline-document-fallback`. Chose option (b) read-time resolution over (a) write-time sync: `GET /applications/{id}` (`get_application_detail`) now falls back to the latest non-deleted `job_description` document body (new `document_repo.latest_job_description_body`, text-body docs only) when `application.jd_text` is empty. `jd_text` stays the single source of truth when set; the frontend keeps rendering one field (`OverviewSection` unchanged — no divergent render paths). Non-destructive (no migration, no write-coupling that could clobber) and reflects document edits/deletes automatically; scoped to the detail read so the kanban list incurs no N+1. Tests in `tests/test_application_jd_fallback.py`.
 
 **Reported:** operator, prod — application "Senior Software Engineer, Full-Stack — GeneDx". Believed to be a regression.
 **Symptom:** Opening an application (kanban card → side drawer; likely the full page too) shows a "Job Description" chip under **Documents** but renders no JD text inline. The only way to read the JD is to open that document and click the Edit (pencil) icon.

--- a/apps/myjobhunter/backend/app/repositories/documents/document_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/documents/document_repo.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from platform_shared.repositories import soft_delete as _soft_delete
 
+from app.core.enums import DocumentKind
 from app.models.application.document import Document
 
 # Allowlist of columns safe to update via the dynamic ``update`` function.
@@ -102,6 +103,37 @@ async def list_by_application(
         .order_by(Document.updated_at.desc(), Document.created_at.desc())
     )
     return list(result.scalars().all())
+
+
+async def latest_job_description_body(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+) -> str | None:
+    """Body of the most-recently-updated, non-deleted ``job_description``
+    document linked to ``application_id`` (text-body documents only).
+
+    Backs the application-detail view's inline-JD fallback: when the
+    application's own ``jd_text`` column is empty because the JD was attached
+    as a document rather than typed in, the read view surfaces this body so
+    the JD is visible without opening + editing the document. File-only
+    uploads (``body IS NULL``/empty) are skipped — there is nothing to render
+    inline. Returns ``None`` when no qualifying document exists.
+    """
+    result = await db.execute(
+        select(Document.body)
+        .where(
+            Document.user_id == user_id,
+            Document.application_id == application_id,
+            Document.kind == DocumentKind.JOB_DESCRIPTION,
+            Document.deleted_at.is_(None),
+            Document.body.isnot(None),
+            Document.body != "",
+        )
+        .order_by(Document.updated_at.desc(), Document.created_at.desc())
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
 
 
 async def create(db: AsyncSession, document: Document) -> Document:

--- a/apps/myjobhunter/backend/app/services/application/application_service.py
+++ b/apps/myjobhunter/backend/app/services/application/application_service.py
@@ -30,6 +30,7 @@ from app.repositories.application import (
     application_repository,
 )
 from app.repositories.company import company_repository
+from app.repositories.documents import document_repo
 from app.schemas.application.application_contact_create_request import ApplicationContactCreateRequest
 from app.schemas.application.application_contact_response import ApplicationContactResponse
 from app.schemas.application.application_create_request import ApplicationCreateRequest
@@ -147,12 +148,25 @@ async def get_application_detail(
     sorted_events = sorted(application.events, key=lambda e: e.occurred_at, reverse=True)
     sorted_contacts = sorted(application.contacts, key=lambda c: c.created_at)
 
-    return ApplicationDetailResponse.model_validate(application).model_copy(
-        update={
-            "events": [ApplicationEventResponse.model_validate(e) for e in sorted_events],
-            "contacts": [ApplicationContactResponse.model_validate(c) for c in sorted_contacts],
-        }
-    )
+    update = {
+        "events": [ApplicationEventResponse.model_validate(e) for e in sorted_events],
+        "contacts": [ApplicationContactResponse.model_validate(c) for c in sorted_contacts],
+    }
+
+    response = ApplicationDetailResponse.model_validate(application)
+    # The inline JD view (OverviewSection) reads ``jd_text``. When the JD was
+    # attached as a job_description document instead of typed into the
+    # application, that column is empty — fall back to the document body so the
+    # read view shows the JD without opening + editing the document. ``jd_text``
+    # stays the source of truth when set; this only fills the gap.
+    if not (response.jd_text and response.jd_text.strip()):
+        fallback = await document_repo.latest_job_description_body(
+            db, user_id, application_id,
+        )
+        if fallback and fallback.strip():
+            update["jd_text"] = fallback
+
+    return response.model_copy(update=update)
 
 
 async def get_application(

--- a/apps/myjobhunter/backend/tests/test_application_jd_fallback.py
+++ b/apps/myjobhunter/backend/tests/test_application_jd_fallback.py
@@ -1,0 +1,176 @@
+"""Inline-JD fallback on the application detail view (#6 regression fix).
+
+When the operator attaches the JD as a ``job_description`` document instead of
+typing it into the application, ``application.jd_text`` is empty and the inline
+JD block (OverviewSection) renders nothing — the only way to read the JD was to
+open the document and click Edit. ``GET /applications/{id}`` now falls back to
+the latest ``job_description`` document body so the read view shows the JD. The
+column stays the source of truth when it is set.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.enums import DocumentKind
+from app.models.application.document import Document
+from app.models.company.company import Company
+
+
+async def _company(db: AsyncSession, user_id: uuid.UUID, name: str = "Acme") -> Company:
+    company = Company(
+        user_id=user_id,
+        name=name,
+        primary_domain=f"{name.lower().replace(' ', '-')}.example.com",
+    )
+    db.add(company)
+    await db.commit()
+    await db.refresh(company)
+    return company
+
+
+def _payload(company_id: uuid.UUID, **overrides: object) -> dict:
+    base = {
+        "company_id": str(company_id),
+        "role_title": "Senior Software Engineer, Full-Stack",
+        "source": "linkedin",
+        "remote_type": "remote",
+    }
+    base.update(overrides)
+    return base
+
+
+async def _add_document(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    application_id: uuid.UUID,
+    *,
+    kind: str,
+    body: str | None,
+    title: str = "doc",
+    when: datetime | None = None,
+) -> Document:
+    doc = Document(
+        user_id=user_id,
+        application_id=application_id,
+        title=title,
+        kind=kind,
+        body=body,
+    )
+    if when is not None:
+        doc.created_at = when
+        doc.updated_at = when
+    db.add(doc)
+    await db.commit()
+    await db.refresh(doc)
+    return doc
+
+
+@pytest.mark.asyncio
+async def test_jd_falls_back_to_job_description_document_body(
+    db: AsyncSession, user_factory, as_user,
+) -> None:
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+    company = await _company(db, user_id)
+
+    async with await as_user(user) as authed:
+        create = await authed.post("/applications", json=_payload(company.id))
+        assert create.status_code == 201, create.text
+        app_id = create.json()["id"]
+
+        jd = "We are hiring a Full-Stack Engineer. Python + React required."
+        await _add_document(
+            db, user_id, uuid.UUID(app_id),
+            kind=DocumentKind.JOB_DESCRIPTION, body=jd,
+        )
+
+        resp = await authed.get(f"/applications/{app_id}")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["jd_text"] == jd
+
+
+@pytest.mark.asyncio
+async def test_application_jd_text_wins_over_document(
+    db: AsyncSession, user_factory, as_user,
+) -> None:
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+    company = await _company(db, user_id)
+
+    typed = "Typed JD on the application itself."
+    async with await as_user(user) as authed:
+        create = await authed.post(
+            "/applications", json=_payload(company.id, jd_text=typed),
+        )
+        assert create.status_code == 201, create.text
+        app_id = create.json()["id"]
+
+        await _add_document(
+            db, user_id, uuid.UUID(app_id),
+            kind=DocumentKind.JOB_DESCRIPTION, body="Different document body.",
+        )
+
+        resp = await authed.get(f"/applications/{app_id}")
+
+    assert resp.status_code == 200, resp.text
+    # The column is authoritative when set — the document must not override it.
+    assert resp.json()["jd_text"] == typed
+
+
+@pytest.mark.asyncio
+async def test_non_job_description_document_is_not_used(
+    db: AsyncSession, user_factory, as_user,
+) -> None:
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+    company = await _company(db, user_id)
+
+    async with await as_user(user) as authed:
+        create = await authed.post("/applications", json=_payload(company.id))
+        assert create.status_code == 201, create.text
+        app_id = create.json()["id"]
+
+        await _add_document(
+            db, user_id, uuid.UUID(app_id),
+            kind=DocumentKind.COVER_LETTER, body="Dear hiring manager...",
+        )
+
+        resp = await authed.get(f"/applications/{app_id}")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["jd_text"] is None
+
+
+@pytest.mark.asyncio
+async def test_latest_job_description_document_wins(
+    db: AsyncSession, user_factory, as_user,
+) -> None:
+    user = await user_factory()
+    user_id = uuid.UUID(user["id"])
+    company = await _company(db, user_id)
+
+    async with await as_user(user) as authed:
+        create = await authed.post("/applications", json=_payload(company.id))
+        assert create.status_code == 201, create.text
+        app_id = create.json()["id"]
+
+        await _add_document(
+            db, user_id, uuid.UUID(app_id),
+            kind=DocumentKind.JOB_DESCRIPTION, body="Older JD.", title="old",
+            when=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        )
+        await _add_document(
+            db, user_id, uuid.UUID(app_id),
+            kind=DocumentKind.JOB_DESCRIPTION, body="Newer JD.", title="new",
+            when=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+
+        resp = await authed.get(f"/applications/{app_id}")
+
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["jd_text"] == "Newer JD."


### PR DESCRIPTION
## #6 — Job description not visible in application detail

**Reported (prod):** opening an application (e.g. "Senior Software Engineer, Full-Stack — GeneDx") shows a "Job Description" chip under Documents but **no JD text inline** — the only way to read it was to open the document and click the Edit pencil.

### Root cause (diagnosed, not assumed)
`OverviewSection` renders the inline JD **only** from `application.jd_text`. Three things became clear tracing the code:
- All three *application*-creation paths (manual, discovery-promote, analysis-apply) already set `jd_text`.
- Nothing auto-creates a `job_description` Document — they come **only** from the generic user-driven document path (`create_text_document`), which writes `document.body` and **never touches `application.jd_text`**.
- So when the operator attaches the JD as a Document, the JD lives in `document.body` while `application.jd_text` stays empty → inline block renders nothing. Two divergent stores.

### Fix — read-time resolution (option b), not write-time sync
`GET /applications/{id}` (`get_application_detail`) now falls back to the latest non-deleted `job_description` document **body** when `jd_text` is empty (new `document_repo.latest_job_description_body`, text-body docs only — a file-only upload has nothing to render inline).

Why this over write-time sync of `jd_text`:
- **Non-destructive** — never clobbers a deliberately-different `jd_text`; the column stays the source of truth when set.
- **No migration, no write-coupling** — reflects document edits/deletes automatically.
- **Single render path** — the frontend still reads one field (`OverviewSection` unchanged); resolution is one documented rule in the backend, satisfying "don't render from two divergent places."
- **No N+1** — scoped to the detail read; the kanban list doesn't render `jd_text`, and the fallback query only fires when the column is empty.

### Tests
`tests/test_application_jd_fallback.py` (endpoint-level via `GET /applications/{id}`): fallback populates `jd_text`; the column wins when set; non-`job_description` kinds are ignored; the latest of multiple JD docs wins.

Closes the #6 TECH_DEBT entry (High 3→2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)