### PR TITLE
feat(mjh): paginate discovery inbox — real total + has_more (#5 backend)

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -750,6 +750,8 @@ This rules a lot of work in and out: **don't** invest in a relevance-overhaul or
 
 ### MEDIUM — Discovery results need pagination
 
+**Status (2026-05-29):** Backend SHIPPED — `GET /discover` now returns a real `total` (full matching-row count via `discovery_inbox_repository.count_discovered`, reusing the inbox coverage count for the inbox state) + `has_more`, and `DiscoveredJobListResponse` subclasses the shared `ListResponse[DiscoveredJobResponse]` — MJH's first paginated list endpoint, which satisfies the "Pagination response envelopes — adopt early in MJH" convention entry above. **Frontend FOLLOW-UP still open:** `features/discover/DiscoverInboxView.tsx` must send `limit`/`offset` and add a `has_more`-driven load-more control (today it ignores them → one growing list). Backend tests: `test_discover_endpoints.py::test_inbox_pagination_total_is_full_count_and_has_more`.
+
 **Reported:** operator.
 **Symptom:** The discovery inbox renders results without pagination (a single growing list). Fetches pull ~5 pages (~50 postings) per cycle and accumulate.
 **Cross-link — this is the trigger for the existing convention entry:** see "MEDIUM — Pagination response envelopes — adopt early in MJH" above. That entry parked the shared `ListResponse[ItemT]` (`platform_shared/schemas/pagination.py`, landed #492) waiting for MJH's *first* list endpoint that actually needs pagination. The discovery inbox is that endpoint. Implement discovery-inbox pagination by subclassing `ListResponse[DiscoveredJobResponse]` rather than inventing a new envelope; pair with frontend infinite-scroll or page controls on `features/discover/`. Resolving this should also tick the convention entry.

--- a/apps/myjobhunter/backend/app/api/discover.py
+++ b/apps/myjobhunter/backend/app/api/discover.py
@@ -304,10 +304,18 @@ async def list_discovered(
         scored_count, total_count = await discovery_inbox_repository.count_inbox_coverage(
             db, user.id, source_id=source_id,
         )
+        # The inbox pagination total IS the active-inbox row count, which
+        # count_inbox_coverage already computed — reuse it (no second COUNT).
+        total = total_count
+    else:
+        total = await discovery_inbox_repository.count_discovered(
+            db, user.id, state=state, source_id=source_id,
+        )
 
     return DiscoveredJobListResponse(
         items=[DiscoveredJobResponse.model_validate(r) for r in rows],
-        total=len(rows),
+        total=total,
+        has_more=offset + len(rows) < total,
         state=state,
         scored_count=scored_count,
         total_count=total_count,

--- a/apps/myjobhunter/backend/app/repositories/discovery/discovery_inbox_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/discovery/discovery_inbox_repository.py
@@ -80,3 +80,49 @@ async def count_inbox_coverage(
         await db.execute(base.where(DiscoveredJob.score.isnot(None)))
     ).scalar_one()
     return scored_count, total_count
+
+
+async def count_discovered(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    *,
+    state: str = "inbox",
+    source_id: uuid.UUID | None = None,
+) -> int:
+    """Total rows matching the ``state`` / ``source_id`` filter — the pagination
+    ``total`` for ``GET /discover``.
+
+    Mirrors the WHERE logic of ``discovery_repository.list_discovered`` (same
+    state branches + the shared ``active_only_predicate``) so ``total``
+    describes exactly the population the list endpoint paginates over,
+    independent of ``limit`` / ``offset``. The route reuses
+    ``count_inbox_coverage``'s ``total_count`` for the inbox (same population),
+    so this is called for the ``saved`` / ``all`` views.
+    """
+    stmt = select(func.count(DiscoveredJob.id)).where(
+        DiscoveredJob.user_id == user_id,
+    )
+    active_only = active_only_predicate()
+    if state == "inbox":
+        stmt = stmt.where(
+            DiscoveredJob.dismissed_at.is_(None),
+            DiscoveredJob.saved_at.is_(None),
+            DiscoveredJob.promoted_application_id.is_(None),
+            *active_only,
+        )
+    elif state == "saved":
+        stmt = stmt.where(
+            DiscoveredJob.saved_at.isnot(None),
+            DiscoveredJob.dismissed_at.is_(None),
+            *active_only,
+        )
+    # else "all": no extra filter — counts expired/closed rows too.
+    if source_id is not None:
+        stmt = stmt.select_from(
+            outerjoin(
+                DiscoveredJob,
+                DiscoveryFetch,
+                DiscoveredJob.fetch_id == DiscoveryFetch.id,
+            )
+        ).where(DiscoveryFetch.discovery_source_id == source_id)
+    return (await db.execute(stmt)).scalar_one()

--- a/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
+++ b/apps/myjobhunter/backend/app/schemas/discovery/discovery_schemas.py
@@ -7,6 +7,8 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
+from platform_shared.schemas.pagination import ListResponse
+
 from app.schemas.discovery.greenhouse_source_config import GreenhouseSourceConfig
 from app.schemas.discovery.jsearch_source_config import JSearchSourceConfig
 from app.schemas.discovery.lever_source_config import LeverSourceConfig
@@ -294,11 +296,16 @@ class DiscoveredJobDismissRequest(BaseModel):
     )
 
 
-class DiscoveredJobListResponse(BaseModel):
-    """Returned by ``GET /discover``."""
+class DiscoveredJobListResponse(ListResponse[DiscoveredJobResponse]):
+    """Returned by ``GET /discover``.
 
-    items: list[DiscoveredJobResponse]
-    total: int
+    Inherits ``items`` / ``total`` / ``has_more`` from the shared
+    ``ListResponse`` — the discovery inbox is MJH's first paginated list
+    endpoint (see the TECH_DEBT pagination-convention entry). ``total`` is the
+    full matching-row count for the ``state`` / ``source_id`` filter, NOT the
+    returned page length, so ``has_more`` drives the frontend's load-more.
+    """
+
     state: Literal["inbox", "saved", "all"]
     # Inbox scoring coverage, spanning the WHOLE active inbox (not just the
     # returned page). ``scored_count`` of ``total_count`` rows carry an AI

--- a/apps/myjobhunter/backend/tests/test_discover_endpoints.py
+++ b/apps/myjobhunter/backend/tests/test_discover_endpoints.py
@@ -292,6 +292,46 @@ async def test_list_discovered_inbox_default(
     # "awaiting the daily pass", not "broken".
     assert body["scored_count"] == 0
     assert body["total_count"] == 1
+    # has_more is inherited from the shared ListResponse; a single row fits one page.
+    assert body["has_more"] is False
+
+
+@pytest.mark.asyncio
+async def test_inbox_pagination_total_is_full_count_and_has_more(
+    client: AsyncClient, user_factory, as_user,
+):
+    """``total`` is the full matching-row count (not the returned page length),
+    and ``has_more`` flips across pages — what the frontend load-more relies on."""
+    user = await user_factory()
+    async with await as_user(user) as a:
+        created = await a.post(
+            "/discover/sources",
+            json={"source": "jsearch", "config": {"query": "x"}},
+        )
+        source_id = created.json()["id"]
+
+        postings = [
+            _posting(
+                source_external_id=f"fake-id-{i}",
+                source_url=f"https://www.linkedin.com/jobs/view/{i}",
+                raw_payload={"job_id": f"fake-id-{i}"},
+            )
+            for i in range(3)
+        ]
+        with patch(_SEARCH_PATH, new_callable=AsyncMock, return_value=postings):
+            await a.post(f"/discover/sources/{source_id}/refresh")
+
+        page1 = (await a.get("/discover?limit=2&offset=0")).json()
+        page2 = (await a.get("/discover?limit=2&offset=2")).json()
+
+    # Page 1: 2 of 3 rows, but total reflects ALL matching rows.
+    assert page1["total"] == 3
+    assert len(page1["items"]) == 2
+    assert page1["has_more"] is True
+    # Page 2: the remaining row, nothing after it.
+    assert page2["total"] == 3
+    assert len(page2["items"]) == 1
+    assert page2["has_more"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## #5 — Discovery pagination (backend foundation)

The discovery inbox renders as "a single growing list" (operator). `GET /discover` already accepted `limit`/`offset`, but returned `total = len(rows)` (the returned page length) — so the client had no way to know more rows existed. This ships the backend half; the frontend load-more is a tracked follow-up.

### Changes
- **`DiscoveredJobListResponse` now subclasses the shared `ListResponse[DiscoveredJobResponse]`** (`platform_shared.schemas.pagination`). This is MJH's **first paginated list endpoint**, which satisfies the parked *"Pagination response envelopes — adopt early in MJH"* convention (landed in #492, waiting for this). It gains `items` / `total` / `has_more` and keeps `state` + the #793 `scored_count` / `total_count` coverage fields.
- **`total` is now the full matching-row COUNT** for the `(state, source_id)` filter — new `discovery_inbox_repository.count_discovered` mirrors `list_discovered`'s state branches + the shared `active_only_predicate`, so it counts exactly the population the list paginates over. The **inbox reuses `count_inbox_coverage`'s `total_count`** (identical population) to avoid a second COUNT; `saved`/`all` use `count_discovered`.
- **`has_more = offset + len(rows) < total`.**

### Why backend-only here
Pagination is a two-layer feature. This PR makes the API correct and adopts the shared envelope (a real, independently-valuable foundation that resolves a parked convention). The user-visible fix — `DiscoverInboxView` sending `limit`/`offset` + a `has_more`-driven load-more — is the **follow-up PR**, tracked in `TECH_DEBT.md`. (Split for reviewability + because it's genuinely two layers.)

### Tests
`test_discover_endpoints.py::test_inbox_pagination_total_is_full_count_and_has_more` — `total` is the full count across two pages and `has_more` flips True→False; the existing single-row inbox test now also asserts `has_more`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)