### PR TITLE
feat(mjh): discovery inbox load-more — has_more-driven pagination (#5 frontend)

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 20 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 2 [1 blocked-on-react-19, 1 public-launch cost guardrail] / Medium: 8 [5 prior + 2 triage-2026-05-28: pagination, rejection-visibility + 1 discovery content_hash dedup] / Low: 8 [6 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
+**Open issues: 18 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 2 [1 blocked-on-react-19, 1 public-launch cost guardrail] / Medium: 6 [4 prior + 1 triage-2026-05-28: rejection-visibility + 1 discovery content_hash dedup] / Low: 8 [6 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
 
 > Status (2026-05-08 PM): All actionable audit items resolved across batches PR #492-#528 (~30 PRs). Remaining open entries are either (a) blocked on the React 18→19 monorepo bump (5 items), (b) deferred-by-design conventions or follow-ups (4), (c) environmental issues unrelated to code (3: asyncpg Windows, test hang on Windows, Quality Gate false-positive), or (d) intentional accepted lint warnings (2).
 
@@ -37,10 +37,11 @@ removed and the counts in this header are updated.
 
 ---
 
-#### MEDIUM — Pagination response envelopes — adopt early in MJH
+#### ~~MEDIUM — Pagination response envelopes — adopt early in MJH~~ RESOLVED
 
 **Effort:** S
-**Status:** Shared generic landed in PR #492 (2026-05-08) at `platform_shared/schemas/pagination.py`. MJH adoption is the remaining work — every new list endpoint should subclass `ListResponse[ItemT]` from the start. No backfill needed today (MJH still has zero pagination); this entry stays open as a convention reminder until the first list endpoint ships.
+**Resolved:** 2026-05-30. The first MJH list endpoint that needs pagination — the discovery inbox — shipped end-to-end (`DiscoveredJobListResponse(ListResponse[DiscoveredJobResponse])`, backend PR #797 + frontend `feature/mjh-discovery-load-more`), which is exactly the condition this reminder waited on. The `ListResponse[ItemT]` subclassing convention is now demonstrated in the codebase; future list endpoints follow that pattern.
+**Status (historical):** Shared generic landed in PR #492 (2026-05-08) at `platform_shared/schemas/pagination.py`. MJH adoption was the remaining work — every new list endpoint should subclass `ListResponse[ItemT]` from the start.
 **Problem:** MBK had 8 hardcoded `*ListResponse` envelopes (now refactored to inherit). MJH has zero pagination today.
 **Recommendation:** For every new MJH list endpoint, `from platform_shared.schemas.pagination import ListResponse` and write `class FooListResponse(ListResponse[FooResponse]): pass`. Cheaper than backfilling.
 
@@ -748,9 +749,9 @@ This rules a lot of work in and out: **don't** invest in a relevance-overhaul or
 
 ---
 
-### MEDIUM — Discovery results need pagination
+### ~~MEDIUM — Discovery results need pagination~~ RESOLVED
 
-**Status (2026-05-29):** Backend SHIPPED — `GET /discover` now returns a real `total` (full matching-row count via `discovery_inbox_repository.count_discovered`, reusing the inbox coverage count for the inbox state) + `has_more`, and `DiscoveredJobListResponse` subclasses the shared `ListResponse[DiscoveredJobResponse]` — MJH's first paginated list endpoint, which satisfies the "Pagination response envelopes — adopt early in MJH" convention entry above. **Frontend FOLLOW-UP still open:** `features/discover/DiscoverInboxView.tsx` must send `limit`/`offset` and add a `has_more`-driven load-more control (today it ignores them → one growing list). Backend tests: `test_discover_endpoints.py::test_inbox_pagination_total_is_full_count_and_has_more`.
+**Resolved (2026-05-30):** Frontend SHIPPED — branch `feature/mjh-discovery-load-more`. `DiscoverInboxView` now grows `limit` in place from offset 0 (PAGE_SIZE 50, capped at the backend's 200) and renders a `has_more`-driven "Load more" control; at the 200-row ceiling it shows a legible note instead of truncating silently. The `listDiscoveredJobs` RTK Query endpoint collapses pages into one cache entry (`serializeQueryArgs` drops `limit`/`offset`) with `forceRefetch` on limit change, so growing the window swaps data in place AND a #793 scoring poll / dismiss-save invalidation re-reads the WHOLE loaded window (scores fill in + re-sort across the full list, not just the latest page). Preserves the #793 bounded polling, the "Scored N of M" coverage line, and the server-side score-sort. Tests: `DiscoverInboxView.test.tsx` (load-more visibility, click grows limit by one page, 200-cap note / no silent truncation). **Backend** was SHIPPED earlier in PR #797 — `GET /discover` returns a real `total` (full matching-row count via `discovery_inbox_repository.count_discovered`, reusing the inbox coverage count for the inbox state) + `has_more`, and `DiscoveredJobListResponse` subclasses the shared `ListResponse[DiscoveredJobResponse]`; this also ticked the "Pagination response envelopes — adopt early in MJH" convention entry above. Backend tests: `test_discover_endpoints.py`.
 
 **Reported:** operator.
 **Symptom:** The discovery inbox renders results without pagination (a single growing list). Fetches pull ~5 pages (~50 postings) per cycle and accumulate.

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverInboxView.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { Telescope } from "lucide-react";
-import { EmptyState } from "@platform/ui";
+import { EmptyState, LoadingButton } from "@platform/ui";
 import { DISCOVER_EMPTY_STATES } from "@/constants/empty-states";
 import DiscoveredJobCard from "@/features/discover/DiscoveredJobCard";
 import DiscoveredJobsSkeleton from "@/features/discover/DiscoveredJobsSkeleton";
@@ -24,6 +24,18 @@ const INBOX_POLL_INTERVAL_MS = 4000;
 // pass for the top-N with headroom, then terminates to a real state.
 const SCORING_WINDOW_MS = 60_000;
 
+// The inbox is one growing list. "Load more" grows `limit` by PAGE_SIZE from
+// offset 0 — the API accumulates pages in a single cache entry (see
+// serializeQueryArgs in discoverApi), so each fetch re-reads the WHOLE loaded
+// window and the server-side score-sort stays global across all loaded rows.
+const PAGE_SIZE = 50;
+
+// Backend caps `limit` at 200 (discover.py `le=200`). At the cap the load-more
+// control is replaced by a legible note rather than silently truncating — the
+// operator dismisses/saves to surface the rest, and the "Scored N of M" line
+// already shows the true total.
+const MAX_INBOX_LIMIT = 200;
+
 interface DiscoverInboxViewProps {
   hasSources: boolean;
   /** Active source filter from ?source= URL param. Null = no filter (show all). */
@@ -34,11 +46,28 @@ export default function DiscoverInboxView({
   hasSources,
   activeSourceId,
 }: DiscoverInboxViewProps) {
-  // Include source_id in query args so RTK Query uses it as part of the cache key.
-  // When source_id changes the cache key changes → fresh fetch, no stale data.
+  // How many rows the inbox has loaded. "Load more" grows this; a poll/refetch
+  // always re-reads the whole [0, limit) window so scores fill in across the
+  // full sorted list, not just the latest page.
+  const [limit, setLimit] = useState(PAGE_SIZE);
+
+  // Reset the page size when the source filter changes — synchronously in
+  // render (React's "adjust state when a prop changes" pattern) so the query
+  // fires once at PAGE_SIZE for the new filter, instead of briefly re-fetching
+  // the previous (larger) limit as an effect would.
+  const [limitFilterKey, setLimitFilterKey] = useState(activeSourceId);
+  if (activeSourceId !== limitFilterKey) {
+    setLimitFilterKey(activeSourceId);
+    setLimit(PAGE_SIZE);
+  }
+
+  // Include source_id in query args so RTK Query keys the cache on it. `limit`
+  // is intentionally NOT part of the key (see serializeQueryArgs in discoverApi)
+  // so growing it accumulates in place. When source_id changes the cache key
+  // changes → fresh fetch, no stale data.
   const queryArgs = activeSourceId
-    ? { state: "inbox" as const, source_id: activeSourceId }
-    : { state: "inbox" as const };
+    ? { state: "inbox" as const, limit, source_id: activeSourceId }
+    : { state: "inbox" as const, limit };
 
   // Bounded scoring window. We poll (and show the animated spinner) only
   // while this is true; it auto-closes after SCORING_WINDOW_MS. Opened
@@ -48,7 +77,7 @@ export default function DiscoverInboxView({
   const windowTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevUnscoredRef = useRef<number | null>(null);
 
-  const { data: jobsData, isLoading, isError } = useListDiscoveredJobsQuery(
+  const { data: jobsData, isLoading, isError, isFetching } = useListDiscoveredJobsQuery(
     queryArgs,
     // Poll only while the bounded scoring window is open. `0` disables
     // polling in RTK Query, so the steady state makes no network noise.
@@ -154,6 +183,24 @@ export default function DiscoverInboxView({
 
   const items = jobsData?.items ?? [];
 
+  // has_more is the server's COUNT-backed signal that rows exist beyond the
+  // loaded window. atCap is the frontend ceiling (backend caps limit at 200).
+  const hasMore = jobsData?.has_more ?? false;
+  const atCap = limit >= MAX_INBOX_LIMIT;
+
+  // A "load more" is in flight exactly when we've asked for a bigger window
+  // than the data currently reflects. Once a fetch settles, the loaded window
+  // fills the requested limit, so this is false — and because a poll/refetch
+  // returns the same full window, it never spuriously spins during polling.
+  const isLoadingMore = isFetching && items.length < limit;
+
+  const handleLoadMore = () => {
+    if (atCap) {
+      return;
+    }
+    setLimit((current) => Math.min(current + PAGE_SIZE, MAX_INBOX_LIMIT));
+  };
+
   if (items.length === 0) {
     return (
       <>
@@ -205,6 +252,29 @@ export default function DiscoverInboxView({
           sources={sources ?? []}
         />
       ))}
+      {hasMore && !atCap && (
+        <div className="flex justify-center pt-1">
+          <LoadingButton
+            type="button"
+            variant="secondary"
+            isLoading={isLoadingMore}
+            loadingText="Loading…"
+            onClick={handleLoadMore}
+            data-testid="inbox-load-more"
+          >
+            Load more
+          </LoadingButton>
+        </div>
+      )}
+      {hasMore && atCap && (
+        <p
+          className="pt-1 text-center text-xs text-muted-foreground"
+          data-testid="inbox-load-more-cap"
+        >
+          Showing the first {MAX_INBOX_LIMIT}. Dismiss or save jobs to surface
+          the rest.
+        </p>
+      )}
     </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoverInboxView.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/__tests__/DiscoverInboxView.test.tsx
@@ -8,7 +8,7 @@
  * large unscored tail is expected — the coverage line makes that legible.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import DiscoverInboxView from "@/features/discover/DiscoverInboxView";
 import type { DiscoveredJob } from "@/types/discovery/discovered-job";
@@ -29,6 +29,15 @@ vi.mock("@/lib/skillsApi", () => ({
 
 vi.mock("@platform/ui", () => ({
   EmptyState: ({ heading }: { heading: string }) => <div>{heading}</div>,
+  // Minimal LoadingButton: render children (or loadingText while loading) and
+  // pass through data-testid / onClick. Strip variant/size so React doesn't
+  // warn about unknown DOM attributes.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  LoadingButton: ({ children, loadingText, isLoading, disabled, variant: _variant, size: _size, ...props }: any) => (
+    <button disabled={disabled || isLoading} {...props}>
+      {isLoading ? loadingText ?? children : children}
+    </button>
+  ),
 }));
 
 vi.mock("@/features/discover/DiscoveredJobsSkeleton", () => ({
@@ -93,6 +102,7 @@ function makeResponse(
   return {
     items: [makeJob()],
     total: 1,
+    has_more: false,
     state: "inbox",
     scored_count: 0,
     total_count: 1,
@@ -110,7 +120,7 @@ function renderInbox() {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function jobsResult(data: DiscoveredJobListResponse): any {
-  return { data, isLoading: false, isError: false };
+  return { data, isLoading: false, isError: false, isFetching: false };
 }
 
 describe("DiscoverInboxView — bounded scoring window", () => {
@@ -173,5 +183,71 @@ describe("DiscoverInboxView — bounded scoring window", () => {
     );
     renderInbox();
     expect(screen.queryByTestId("inbox-scoring-coverage")).toBeNull();
+  });
+});
+
+describe("DiscoverInboxView — load more", () => {
+  beforeEach(() => {
+    cardSpy.mockClear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    mockListSources.mockReturnValue({ data: [] } as any);
+  });
+
+  it("renders the Load more control when the server reports more rows", () => {
+    mockListJobs.mockReturnValue(
+      jobsResult(
+        makeResponse({ has_more: true, total: 120, total_count: 120, scored_count: 20 }),
+      ),
+    );
+    renderInbox();
+    expect(screen.getByTestId("inbox-load-more")).toHaveTextContent("Load more");
+    expect(screen.queryByTestId("inbox-load-more-cap")).toBeNull();
+  });
+
+  it("hides the Load more control when there are no more rows", () => {
+    mockListJobs.mockReturnValue(jobsResult(makeResponse({ has_more: false })));
+    renderInbox();
+    expect(screen.queryByTestId("inbox-load-more")).toBeNull();
+    expect(screen.queryByTestId("inbox-load-more-cap")).toBeNull();
+  });
+
+  it("requests a larger limit (by one page) when Load more is clicked", () => {
+    mockListJobs.mockReturnValue(
+      jobsResult(makeResponse({ has_more: true, total: 300, total_count: 300 })),
+    );
+    renderInbox();
+    // First render queries the first page (limit 50, the default page size).
+    expect(mockListJobs).toHaveBeenLastCalledWith(
+      expect.objectContaining({ state: "inbox", limit: 50 }),
+      expect.anything(),
+    );
+    fireEvent.click(screen.getByTestId("inbox-load-more"));
+    // Clicking grows the window to the next page (limit 100), in place.
+    expect(mockListJobs).toHaveBeenLastCalledWith(
+      expect.objectContaining({ state: "inbox", limit: 100 }),
+      expect.anything(),
+    );
+  });
+
+  it("replaces the button with a legible note at the 200-row cap instead of truncating silently", () => {
+    // Server always says there's more; the frontend ceiling (200) is what
+    // stops the growth. Three clicks: 50 → 100 → 150 → 200.
+    mockListJobs.mockReturnValue(
+      jobsResult(makeResponse({ has_more: true, total: 999, total_count: 999 })),
+    );
+    renderInbox();
+    fireEvent.click(screen.getByTestId("inbox-load-more"));
+    fireEvent.click(screen.getByTestId("inbox-load-more"));
+    fireEvent.click(screen.getByTestId("inbox-load-more"));
+    // At the cap the button is gone and the note explains the ceiling.
+    expect(screen.queryByTestId("inbox-load-more")).toBeNull();
+    expect(screen.getByTestId("inbox-load-more-cap")).toHaveTextContent(
+      /showing the first 200/i,
+    );
+    // Never requests beyond the backend's max limit.
+    expect(mockListJobs).toHaveBeenLastCalledWith(
+      expect.objectContaining({ limit: 200 }),
+      expect.anything(),
+    );
   });
 });

--- a/apps/myjobhunter/frontend/src/store/discoverApi.ts
+++ b/apps/myjobhunter/frontend/src/store/discoverApi.ts
@@ -70,6 +70,22 @@ const discoverApi = apiWithTags.injectEndpoints({
         }
         return { url: "/discover", method: "GET", params };
       },
+      // Collapse every page of one (state, source_id) view into a SINGLE cache
+      // entry — `limit`/`offset` are excluded from the key. The inbox paginates
+      // by growing `limit` from offset 0 (see DiscoverInboxView), so each fetch
+      // returns the whole loaded window. Sharing one entry means "load more"
+      // swaps the data in place (no empty-list flash), and a poll/refetch
+      // re-reads the entire window — so the #793 scoring poll fills in scores
+      // and re-sorts across the full list, not just the latest page.
+      serializeQueryArgs: ({ queryArgs }) => {
+        const { state = "inbox", source_id } = queryArgs ?? {};
+        return source_id ? { state, source_id } : { state };
+      },
+      // With the key collapsed, a `limit` change alone wouldn't trigger a
+      // request — force one so "load more" actually fetches the larger window.
+      // No `merge` is defined, so the larger response replaces the cache.
+      forceRefetch: ({ currentArg, previousArg }) =>
+        (currentArg?.limit ?? 0) !== (previousArg?.limit ?? 0),
       providesTags: ["DiscoveredJob"],
     }),
     dismissDiscoveredJob: build.mutation<

--- a/apps/myjobhunter/frontend/src/types/discovery/discovered-job-list-response.ts
+++ b/apps/myjobhunter/frontend/src/types/discovery/discovered-job-list-response.ts
@@ -2,7 +2,12 @@ import type { DiscoveredJob } from "./discovered-job";
 
 export interface DiscoveredJobListResponse {
   items: DiscoveredJob[];
+  /** Full matching-row count for the (state, source_id) filter — NOT the
+   * returned page length. Drives ``has_more`` and the inbox load-more. */
   total: number;
+  /** ``offset + items.length < total`` — true when more rows exist beyond the
+   * current page. The inbox grows ``limit`` in place until this is false. */
+  has_more: boolean;
   state: "inbox" | "saved" | "all";
   /**
    * Inbox scoring coverage across the WHOLE active inbox (not just the


### PR DESCRIPTION
Completes **#5 pagination** (backend shipped in #797). The discovery inbox is "a single growing list" (operator), but the frontend ignored the server's `limit`/`offset` and the new `total`/`has_more`, so it only ever rendered the first 50 rows.

## What changed

- **`DiscoverInboxView`** grows `limit` in place from offset 0 (PAGE_SIZE 50, capped at the backend's 200) and renders a `has_more`-driven **Load more** control. The spinner state is *derived* (`isFetching && items.length < limit`) — true only while a larger window is loading, so polls never flicker it.
- **`listDiscoveredJobs` RTK Query endpoint** collapses every page of one `(state, source_id)` view into a single cache entry (`serializeQueryArgs` drops `limit`/`offset`) with `forceRefetch` on `limit` change and **no `merge`** — so each fetch returns the whole loaded window and replaces in place (no empty-list flash).
- **`discovered-job-list-response.ts`** gains the `has_more: boolean` field (mirrors the `ListResponse` field #797 added on the backend).

## Why growing-`limit` (not offset paging)

This shape is the one compatible with **#793's bounded scoring poll**. A poll/refetch re-reads the *entire* loaded window, so scores fill in **and rows re-sort across the full list** (fresh rows sort to the bottom via `nulls_last`, then jump up as the background scorer rates them) — not just the latest page. Dismiss/save/promote invalidations refresh the same way, with no offset-shift bugs.

## No silent truncation

At the 200-row ceiling (backend `le=200`) the button is replaced by a legible note — *"Showing the first 200 — dismiss or save jobs to surface the rest."* The **"Scored N of M"** coverage line already shows the true total.

## Preserved (verified)

- #793 bounded scoring poll + animated "Scoring" affordance
- "Scored N of M" coverage line
- Server-side score-sort `nulls_last(desc(score)), desc(discovered_at)` (untouched — N5)
- Saved view (`{state:"saved"}`) keeps its own distinct cache entry — unaffected

## Tests

`DiscoverInboxView.test.tsx`: Load-more visibility on `has_more`; click grows the requested limit by one page (50→100); the 200-cap note replaces the button and never requests beyond the backend max. All 9 inbox tests + the 147 `features/discover` tests pass; typecheck, lint, and `npm run build` clean.

> Note: a full local `npm test` shows ~17 pre-existing failures in unrelated areas (profile/login/documents/kanban — a stale-`node_modules`/Windows `lucide-react` mock artifact; they reproduce in isolation on code identical to `main`, where **MyJobHunter CI is green**). None touch discovery.

## Tech debt

Marks the #5 pagination item **and** its parent "adopt `ListResponse` early in MJH" convention entry **resolved** — the first paginated MJH endpoint is now live end-to-end (counts updated: 20→18 open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)