### PR TITLE
fix(mga): localize the first thrower-POV throw on multi-demo chapters

### DIFF
--- a/apps/mygamingassistant/backend/app/services/classification/classification_result.py
+++ b/apps/mygamingassistant/backend/app/services/classification/classification_result.py
@@ -101,6 +101,19 @@ class ThrowTimingResult:
     with an EARLY demo's result) and re-localise around the first event.
     ``None`` whenever no inversion occurred. See
     ``throw_localizer.localize_throw_with_refinement`` (causality recovery).
+
+    ``earlier_demonstration_result_index`` is the GENERAL multi-demonstration
+    signal (the inversion above is only the special case where the model
+    happens to pair across demos). When the chapter demonstrates the SAME
+    lineup more than once and the model localised release on a LATER repeat,
+    it reports here the 1-based frame where an EARLIER demonstration's RESULT
+    is first visible — strictly ``< release_index``. The localizer fires the
+    SAME first-event recovery on it as on an inversion, re-centring on the
+    first demonstration so the throw matches STAND / AIM (operator audit
+    2026-05-30, lineup 69704f4a "Market Door": the throw-clip coarse pass
+    confidently localised the 2nd demo at ~317 while STAND/AIM/LANDING sat on
+    the 1st throw at ~298 — no inversion fired, so nothing pulled it back).
+    ``None`` when there is one demonstration or release is already the earliest.
     """
 
     success: bool
@@ -108,6 +121,7 @@ class ThrowTimingResult:
     release_index: Optional[int] = None
     result_index: Optional[int] = None
     causality_inverted_earlier_index: Optional[int] = None
+    earlier_demonstration_result_index: Optional[int] = None
     confidence: Optional[float] = None
     reasoning: str = ""
     error_codes: list[str] = field(default_factory=list)

--- a/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
@@ -91,6 +91,36 @@ Rules:
       live first-person main game view.
 - release_index: the 1-based frame where the utility is released, chosen from
   frames that pass CANDIDATE-FRAME EXCLUSIONS.
+  THROWER-POV REQUIREMENT (highest-priority release gate; operator audit
+  2026-05-30, lineup 8f92c010 "Catwalk - B Site" — the localizer kept anchoring
+  release on a later observer / destination view instead of the thrower's own
+  throw):
+    release_index MUST be a frame from the THROWER's OWN first-person view in
+    the act of throwing: their own viewmodel arm/hand is swinging the utility
+    forward AND the crosshair is on the lineup's aiming landmark (a building
+    edge, antenna, rooftop, skybox marker, wall spot). The following are NOT
+    releases — they are observer / result views, eligible at most as a
+    result_index and NEVER as release_index, EVEN WHEN a grenade or its bloom
+    is clearly visible in them:
+      - a "fly to where it lands" / destination / spectator / free-cam shot
+        (camera at or near the LANDING spot, often looking back or down at the
+        impact, frequently with a knife out and NO throwing arm in the frame)
+      - any frame where smoke / flame / flash / debris is already deploying in
+        the world while the player's OWN throw-swing is not happening in-frame
+        (that is the RESULT, not the release)
+      - a teammate's or a spectator's POV
+    If the cleanest "object-leaves-a-hand" frame is a destination / observer
+    angle, it belongs to the WRONG view of the demonstration: search the set
+    for the thrower's own aligned aim-and-release motion and prefer it even
+    when its separation instant is less crisp than the observer frame's.
+  WHICH THROW FIRST (multi-demo — decide before choosing the frame): see
+  "MULTI-DEMONSTRATION CHAPTERS" under Discipline below. The frames where the
+  player is looking at / aligning their crosshair on the target landmark with
+  the utility (about to throw) are the lineup AIM — they are the SETUP for the
+  real throw, the MOST important part of the demonstration, NOT "walking
+  between throws" / repositioning. Do NOT exclude the aligned-at-a-landmark
+  throw as a knife-walk just because a knife is briefly visible before the
+  utility is equipped, and do NOT prefer an earlier casual/setup toss over it.
   RELEASE-INSTANT ANCHOR (operator audit 2026-05-25, highest priority within
   release-frame selection):
     The release_index is the FIRST frame where the utility OBJECT has
@@ -169,21 +199,48 @@ Rules:
     MOLOTOV - the FIRST flame on the floor (typically 1.0-2.0s after release).
               Same earliness rule.
     FLASH   - white wash / detonation. If it is too fast to land on its own
-              frame, set result_index = release_index and confidence <= 0.45.
+              frame, set result_index = null (the landing pane is skipped);
+              keep confidence based on the RELEASE, not the missing flash.
     HE      - explosion burst / debris.
-  MAX-GAP FALLBACK: result_index should normally be within ~6 frames (~2-4s)
-    after release_index. If no valid same-perspective result frame exists in
-    that range — because the utility traveled out of view, the player rotated
-    immediately, or the chapter cut away — set result_index = release_index
-    and confidence <= 0.5. Downstream consumers gate on confidence and will
-    skip emitting a landing clip rather than ship a misleading one.
-- confidence: 0-1 that you localised the throw correctly. Low when the throw is
-  off-screen, cut away from, or only inferred from trajectory; high only when
-  the release and the result are both directly visible AND both indices are
-  on candidate-eligible frames.
+  SAME-THROW RULE (HARD — a result belongs to its OWN release): a utility's
+    effect appears within ~3s of its release (smoke wisp 1.5-3.0s, molotov
+    flame 1.0-2.0s, flash / HE near-instant). release_index and result_index
+    MUST belong to the SAME throw. NEVER select a result_index more than ~4s
+    after release_index: a far-later "result" is a DIFFERENT demonstration's
+    effect, or the same smoke viewed after the player walked over to it — it
+    is NOT this throw's result. If no genuine same-perspective result is
+    visible within ~4s of the release, set result_index = null (do NOT fall
+    back to release_index, and do NOT reach for a far frame). A null result is
+    correct and common: long-range lineups often reveal the landing only from
+    a different position, or the chapter cuts away before it deploys.
+    Downstream skips only the landing pane — far better than a misplaced or
+    cross-demonstration one.
+- confidence: 0-1 in your RELEASE localization specifically — NOT a joint
+  release+result score. A clearly-visible release on a candidate-eligible
+  frame is HIGH confidence (>= 0.8) EVEN WHEN result_index is null: a missing
+  result only gates the landing pane, never the throw itself. Lower confidence
+  only when the RELEASE is uncertain — off-screen, cut away from, inferred from
+  trajectory, or you had to guess among mostly-excluded frames.
 - Discipline:
-  - If the throw is shown repeatedly or from multiple angles, use the FIRST
-    clean throw only.
+  - MULTI-DEMONSTRATION CHAPTERS: the chapter may show the SAME lineup more
+    than once — a quick casual/setup toss THEN the real aligned throw; the
+    throw repeated; or the throw plus a "walk over to where it lands" segment
+    shot from a DIFFERENT position. There is exactly ONE lineup being taught.
+    Select the DELIBERATE LINEUP THROW: the throw where the player has
+    deliberately aligned their crosshair on a specific aiming landmark
+    (a building edge, antenna, rooftop, skybox marker, or wall spot) and then
+    releases. This is frequently NOT the first motion in the chapter — a
+    casual toss, weapon-handling, or walking commonly precedes the real
+    aligned throw. Prefer the aligned-at-a-landmark release over any earlier
+    casual toss, and NEVER pair one demonstration's release with another
+    demonstration's result (see the SAME-THROW RULE under result_index).
+  - TITLE-CARD ANCHOR: tutorial chapters usually place a section banner /
+    title card ("SMOKE #N", "B SITE - CATWALK", "LINEUP 3") immediately
+    BEFORE the demonstration it labels. If a title card appears partway
+    through the frames, the lineup throw is the FIRST clean aligned release
+    AFTER the most recent title card — treat any throw-like motion BEFORE that
+    title card as a leftover / preview from the previous section and do NOT
+    select it, even if it is the cleanest utility-separation in the set.
   - Ignore picture-in-picture, facecam, killfeed, scoreboard, title cards and
     replays — judge from the main game view only.
   - A chapter that is ENTIRELY talking-head / knife-only-walking / menus /

--- a/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/throw_timing_classifier.py
@@ -51,6 +51,7 @@ keys:
   "is_lineup_throw": boolean,
   "release_index": integer (1-{n}) or null,
   "result_index": integer (1-{n}) or null,
+  "earlier_demonstration_result_index": integer (1-{n}) or null,
   "confidence": number (0.0-1.0),
   "reasoning": string (<= 80 words)
 }}
@@ -215,6 +216,15 @@ Rules:
     a different position, or the chapter cuts away before it deploys.
     Downstream skips only the landing pane — far better than a misplaced or
     cross-demonstration one.
+- earlier_demonstration_result_index: the 1-based frame where an EARLIER
+  demonstration's RESULT (smoke wisp / flame / flash / debris) is first
+  visible, when this chapter demonstrates the SAME lineup MORE THAN ONCE and
+  that earlier demonstration occurs BEFORE your chosen release_index. It MUST
+  be < release_index. Set it as a SAFETY SIGNAL even when you believe your
+  release pick is right — it lets the pipeline re-center on the first
+  demonstration (see FIRST OF REPEATED DEMONSTRATIONS under Discipline). null
+  when there is only ONE demonstration, or when your release_index is already
+  the earliest demonstration, or when no earlier result is visible in the set.
 - confidence: 0-1 in your RELEASE localization specifically — NOT a joint
   release+result score. A clearly-visible release on a candidate-eligible
   frame is HIGH confidence (>= 0.8) EVEN WHEN result_index is null: a missing
@@ -234,6 +244,18 @@ Rules:
     aligned throw. Prefer the aligned-at-a-landmark release over any earlier
     casual toss, and NEVER pair one demonstration's release with another
     demonstration's result (see the SAME-THROW RULE under result_index).
+  - FIRST OF REPEATED DEMONSTRATIONS (operator audit 2026-05-30, lineup
+    69704f4a "Market Door"): when the same lineup is shown as TWO OR MORE
+    genuine aligned demonstrations (a repeat for emphasis — often a cleaner or
+    closer second take), release_index MUST be the EARLIEST such full
+    demonstration, NOT the cleaner later repeat. STAND and AIM anchor on the
+    first demonstration; if the throw picks a later repeat the storyboard
+    splits across two takes. This is DISTINCT from the casual-toss rule above:
+    a casual non-aligned warm-up is excluded entirely, but between two GENUINE
+    aligned demonstrations the FIRST wins. Concretely: if — after picking
+    release_index — you can still see an earlier genuine aligned throw of this
+    same lineup in the frames before it, you picked the wrong take; move
+    release_index back to that earlier throw.
   - TITLE-CARD ANCHOR: tutorial chapters usually place a section banner /
     title card ("SMOKE #N", "B SITE - CATWALK", "LINEUP 3") immediately
     BEFORE the demonstration it labels. If a title card appears partway
@@ -478,6 +500,20 @@ async def classify_throw_timing_from_frames(
     result_index = validate_grid_index(
         parsed.get("result_index"), "result_index", n, failures
     )
+    earlier_demonstration_result_index = validate_grid_index(
+        parsed.get("earlier_demonstration_result_index"),
+        "earlier_demonstration_result_index", n, failures,
+    )
+    # Only a genuine multi-demonstration signal when it points EARLIER than the
+    # release the model picked: it means "an earlier demonstration's result
+    # precedes your release", i.e. the release likely landed on a later repeat.
+    # A value >= release_index (or with release_index missing) is not an
+    # earlier-demo signal — drop it so the localizer never re-centres spuriously.
+    if earlier_demonstration_result_index is not None and (
+        release_index is None
+        or earlier_demonstration_result_index >= release_index
+    ):
+        earlier_demonstration_result_index = None
 
     # Frozen-contract parser enforcement: a result cannot precede its own
     # release. If the model returned both but inverted, force result to the
@@ -512,8 +548,9 @@ async def classify_throw_timing_from_frames(
 
     logger.info(
         "throw_timing: is_lineup_throw=True chapter=%r n=%d release_idx=%s "
-        "result_idx=%s confidence=%.2f",
-        chapter_title, n, release_index, result_index, confidence or 0.0,
+        "result_idx=%s earlier_demo_idx=%s confidence=%.2f",
+        chapter_title, n, release_index, result_index,
+        earlier_demonstration_result_index, confidence or 0.0,
     )
 
     return ThrowTimingResult(
@@ -522,6 +559,7 @@ async def classify_throw_timing_from_frames(
         release_index=release_index,
         result_index=result_index,
         causality_inverted_earlier_index=causality_inverted_earlier_index,
+        earlier_demonstration_result_index=earlier_demonstration_result_index,
         confidence=confidence,
         reasoning=reasoning,
         error_codes=list(structured_codes),

--- a/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer.py
@@ -109,20 +109,23 @@ async def _attempt_first_event_recovery(
     coarse: ThrowTimingResult,
     coarse_timestamps: list[float],
     *,
+    earlier_index: int,
     chapter_start: float,
     chapter_end: float,
     chapter_title: Optional[str],
     utility_hint: Optional[str],
 ) -> RefinedThrowTiming:
-    """Re-localise around the FIRST event after a causality-inverted coarse pass.
+    """Re-localise around the FIRST event of a multi-demonstration chapter.
 
-    Precondition (checked by the caller): ``coarse`` is a successful,
-    throw-positive result whose ``causality_inverted_earlier_index`` is set —
-    the model paired a late demonstration's release with an earlier
-    demonstration's result. The earlier index points at the FIRST demo's
-    RESULT, so the true release precedes it; we sample a backward-weighted dense
-    window around that event and re-run the throw-timing classifier on the (now
-    single-throw) window.
+    Precondition (resolved by the caller): ``coarse`` is a successful,
+    throw-positive result for which an EARLIER demonstration's event was
+    flagged — either by a causality inversion (``result_index <
+    release_index`` → ``causality_inverted_earlier_index``) or by the general
+    multi-demonstration signal (``earlier_demonstration_result_index``). Both
+    point at an earlier demonstration's RESULT, so the true first release
+    precedes it; the caller passes that 1-based index as ``earlier_index``. We
+    sample a backward-weighted dense window around that event and re-run the
+    throw-timing classifier on the (now single-throw) window.
 
     Always returns a RefinedThrowTiming so the caller can return it directly:
       * ``STAGE_RECOVERED_FIRST_EVENT`` — clean, non-re-inverted, throw-positive
@@ -132,10 +135,9 @@ async def _attempt_first_event_recovery(
         is the coarse result and ``frame_timestamps`` is the coarse window.
         Same "never regress" contract as the dense pass.
     """
-    earlier_index = coarse.causality_inverted_earlier_index
-    if earlier_index is None or not (1 <= earlier_index <= len(coarse_timestamps)):
-        # Defensive: caller gates on `is not None`, but a stale/out-of-range
-        # index must not index-error — fall back to coarse.
+    if not (1 <= earlier_index <= len(coarse_timestamps)):
+        # Defensive: the caller resolved this from a model-reported index, but
+        # a stale/out-of-range value must not index-error — fall back to coarse.
         return RefinedThrowTiming(
             timing=coarse,
             frame_timestamps=coarse_timestamps,
@@ -209,18 +211,20 @@ async def _attempt_first_event_recovery(
         or not recovered.is_lineup_throw
         or recovered.release_index is None
         or recovered.causality_inverted_earlier_index is not None
+        or recovered.earlier_demonstration_result_index is not None
     ):
         logger.info(
             "throw_localizer: stage=%s earlier_event_ts=%.2f "
             "recovered_success=%s recovered_is_lineup_throw=%s "
-            "recovered_release_index=%s recovered_reinverted=%s; "
-            "returning coarse: chapter=%r",
+            "recovered_release_index=%s recovered_reinverted=%s "
+            "recovered_still_multidemo=%s; returning coarse: chapter=%r",
             STAGE_RECOVERY_REJECTED,
             earlier_event_ts,
             recovered.success,
             recovered.is_lineup_throw,
             recovered.release_index,
             recovered.causality_inverted_earlier_index is not None,
+            recovered.earlier_demonstration_result_index is not None,
             chapter_title,
         )
         return RefinedThrowTiming(
@@ -302,21 +306,32 @@ async def localize_throw_with_refinement(
         utility_hint=utility_hint,
     )
 
-    # ---- Causality recovery (multi-demonstration chapters) --------------
-    # An inverted coarse pass means the model paired a late demo's release with
-    # an early demo's result. The recovery path OWNS the outcome and never falls
-    # through to the normal refine path (which would centre on the WRONG
-    # late-demo release).
-    if (
-        coarse.success
-        and coarse.is_lineup_throw
-        and coarse.causality_inverted_earlier_index is not None
-    ):
+    # ---- First-event recovery (multi-demonstration chapters) ------------
+    # The coarse pass localised a LATER demonstration's release when an EARLIER
+    # one exists. Two signals flag this, and either fires the same recovery:
+    #   * causality inversion — the model paired a late demo's release with an
+    #     early demo's result (result_index < release_index).
+    #   * multi-demonstration report — earlier_demonstration_result_index, set
+    #     even WITHOUT an inversion (lineup 69704f4a "Market Door": the 2nd
+    #     demo's release was confidently localised at ~317 with a consistent
+    #     later result, so no inversion fired, while the real 1st throw sat at
+    #     ~298 — STAND/AIM/LANDING anchored there but the throw clip didn't).
+    # Re-localise around the earlier event. This path OWNS the outcome and never
+    # falls through to the refine pass (which would centre on the WRONG late
+    # release). Prefer the inversion index when both are set — it is the
+    # tighter, already-shipped signal.
+    earlier_index = (
+        coarse.causality_inverted_earlier_index
+        if coarse.causality_inverted_earlier_index is not None
+        else coarse.earlier_demonstration_result_index
+    )
+    if coarse.success and coarse.is_lineup_throw and earlier_index is not None:
         return apply_gap_invariant(
             await _attempt_first_event_recovery(
                 video_path,
                 coarse,
                 coarse_timestamps,
+                earlier_index=earlier_index,
                 chapter_start=chapter_start,
                 chapter_end=chapter_end,
                 chapter_title=chapter_title,

--- a/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer.py
@@ -1,4 +1,4 @@
-"""Throw localizer — two-stage release-frame refinement.
+"""Throw localizer — two-stage release-frame refinement (orchestrator).
 
 The clip pipeline's coarse pass samples N=12 frames over a 30-180s chapter
 window, putting frames roughly 2-15 seconds apart. Even a perfect classifier
@@ -6,75 +6,52 @@ prompt cannot pick a frame the sampler never extracted — so the final clip
 anchor is at best "release ± 1.5s" on a typical chapter. That cadence is the
 underlying defect; PR #749 / #750 only chip at its symptoms.
 
-This module wraps :func:`classify_throw_timing_from_frames` with a second
-dense pass once the coarse pass has localised the throw to a particular
-region of the chapter:
+This module orchestrates the throw-timing classifier across one coarse pass and
+up to one refinement / recovery pass. The pure leaf helpers (the return
+dataclass, the stage/constant tables, the window-timestamp math, the gate
+decision, and the gap invariant) live in the sibling ``throw_localizer_recovery``
+module (split out so this orchestrator stays under the file-size growth guard —
+see ``apps/mygamingassistant/CLAUDE.md`` "Tech Debt Policy"); they are
+re-exported below so existing import sites are unchanged. The I/O-calling passes
+stay HERE so their ``extract_frames_downscaled`` / ``classify_*`` /
+``dense_window_timestamps`` lookups all resolve in this one namespace.
 
-  Stage 1 — coarse pass (unchanged):
-    * ``clip_window_timestamps`` builds the trimmed throw window
-    * ``extract_frames_downscaled`` pulls those 12 frames
-    * ``classify_throw_timing_from_frames`` returns a coarse
-      ``release_index``
+  Stage 1 — coarse pass:
+    ``clip_window_timestamps`` → ``extract_frames_downscaled`` →
+    ``classify_throw_timing_from_frames`` returns a coarse release/result.
 
-  Stage 2 — dense pass (NEW, only when Stage 1 cleared its gate):
-    * ``dense_window_timestamps`` builds 8 frames at ~0.5s spacing,
-      asymmetric around coarse-release (more post-release coverage for the
-      result frame too)
-    * ``extract_frames_downscaled`` pulls those 8 frames
-    * ``classify_throw_timing_from_frames`` runs a SECOND time with the
-      tighter set — returns a frame-accurate release/result on the same
-      ThrowTimingResult schema
+  Stage 2 — dense pass (only when Stage 1 cleared its 0.55 gate):
+    ``dense_window_timestamps`` builds 8 frames at ~0.5s spacing around the
+    coarse release; a second classify call returns a frame-accurate release.
 
-The orchestrator returns the dense result when the dense pass succeeded,
-otherwise the coarse result. Either way the caller gets back the
-``frame_timestamps`` the returned indices map back to, so it can do
-``timestamps[release_index - 1]`` exactly as before. The caller is
-otherwise unchanged.
+  Recovery passes, each fired on a specific failure signature and each owning
+  the "can only improve, never regress" contract:
+    * Causality recovery — coarse paired a LATE demo's release with an EARLY
+      demo's result (``result_index < release_index``). Re-localise around the
+      first event. (#780 / lineup 69704f4a "Market Door".)
+    * Dense-floor-pin recovery — the dense pass selected its own window floor
+      (``release_index == 1``): the true release is earlier than the window
+      opened. Re-search a backward-shifted window. (Lineup 8f92c010
+      "Catwalk - B Site": coarse late → dense floored at the smoke-in-flight
+      frame; the real aim-up-at-tower release is ~3s earlier.)
 
-  Causality recovery (NEW, multi-demonstration chapters):
-    When the coarse pass reports ``result_index < release_index`` (the
-    classifier preserves the original earlier index on
-    ``ThrowTimingResult.causality_inverted_earlier_index``), the model
-    paired a LATE demonstration's release with an EARLY demonstration's
-    result — the signature of a chapter that demonstrates the same lineup
-    more than once. Instead of cratering confidence and gating the clip
-    out, the orchestrator re-localises densely around the FIRST event (the
-    earlier index is that demo's result, so the true release precedes it —
-    the recovery window is weighted backward from it). Fires BEFORE the
-    confidence gate, because the inversion is exactly why coarse confidence
-    cratered, and OWNS the outcome — a failed recovery returns the coarse
-    result tagged with a ``recovery_*`` stage (no regression), it does not
-    fall through to the normal dense pass (which would only refine around
-    the wrong late-demo release). (operator audit 2026-05-29, lineup
-    69704f4a "Market Door".)
-
-The refinement gate matches the clip pipeline's existing 0.55 confidence
-threshold:
-  * If coarse is below 0.55, the clip would have been skipped anyway —
-    a dense pass over a wrongly-localised coarse region would burn a
-    second Claude call for no expected gain, and the cost is real on a
-    casual / single-user app (see project_mygamingassistant_plan ⇒
-    "App posture"). Skip the refinement.
-  * If coarse is at or above 0.55, the dense window is centred on a
-    release the model is confident about — refining is high-value:
-    "release ± 1.5s" becomes "release ± 0.25s".
-
-Cost: refinement doubles the throw-timing Claude calls per generated
-clip (one coarse + one dense). Non-generated clips (gated out by
-not-a-throw / low confidence / no release) pay only the coarse call as
-before — the gating is the cost control. Net effect at typical accept
-rates is ~1.7-1.9× of pre-refinement cost on clip-generation calls.
+  Gap invariant (``apply_gap_invariant``, applied to every returned result): a
+  result more than ~4.5s after its release cannot be that release's own result
+  (a smoke blooms within ~3s). On a multi-demonstration chapter the classifier
+  confidently pairs one demo's release with another's bloom; the orchestration
+  nulls the offending ``result_index`` so the landing pane gates out, leaving
+  release_index (STAND / AIM / THROW) untouched.
 
 Failure handling (per rules/no-bandaid-solutions.md +
-rules/check-third-party-error-codes.md): the dense pass can ONLY improve
-the result; any dense-pass failure falls through to the coarse pass
-result so the clip pipeline never regresses. The diagnostic ``stage``
-field carries which path was taken.
+rules/check-third-party-error-codes.md): the dense / recovery passes can ONLY
+improve the result; any failure falls through to the prior result so the clip
+pipeline never regresses. The diagnostic ``stage`` field carries which path was
+taken. A coarse-pass extraction failure re-raises so the caller surfaces its
+structured codes.
 """
 from __future__ import annotations
 
 import logging
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -86,142 +63,45 @@ from app.services.ingestion.frame_extractor import (
     FrameExtractionError,
     clip_window_timestamps,
     extract_frames_downscaled,
-    grid_timestamps,
+)
+
+# Pure helpers from the sibling, re-exported into THIS namespace so:
+#   (1) existing import sites (tests / clip_generator / landing_clip_generator /
+#       micro_clip_helpers / diag scripts) keep importing from ``throw_localizer``;
+#   (2) the recovery passes below call ``dense_window_timestamps`` via this
+#       module's namespace, so a test ``patch("...throw_localizer.dense_window_timestamps")``
+#       affects the dense pass AND the recovery passes uniformly.
+from app.services.ingestion.throw_localizer_recovery import (  # noqa: F401
+    STAGE_COARSE_BELOW_GATE,
+    STAGE_COARSE_FAILED,
+    STAGE_COARSE_NO_RELEASE,
+    STAGE_COARSE_NOT_A_THROW,
+    STAGE_COARSE_ONLY,
+    STAGE_DENSE_CLASSIFIER_FAILED,
+    STAGE_DENSE_EXTRACT_FAILED,
+    STAGE_DENSE_REJECTED,
+    STAGE_DENSE_WINDOW_TOO_SMALL,
+    STAGE_FLOOR_PIN_EXTRACT_FAILED,
+    STAGE_FLOOR_PIN_REJECTED,
+    STAGE_FLOOR_PIN_WINDOW_TOO_SMALL,
+    STAGE_RECOVERED_FIRST_EVENT,
+    STAGE_RECOVERED_FLOOR_PIN,
+    STAGE_RECOVERY_EXTRACT_FAILED,
+    STAGE_RECOVERY_REJECTED,
+    STAGE_RECOVERY_WINDOW_TOO_SMALL,
+    STAGE_REFINED,
+    RefinedThrowTiming,
+    _MIN_DENSE_FRAMES,
+    _RECOVERY_FRAME_COUNT,
+    _RECOVERY_POST_RELEASE_SECONDS,
+    _RECOVERY_PRE_RELEASE_SECONDS,
+    _should_refine,
+    apply_gap_invariant,
+    attempt_floor_pin_recovery,
+    dense_window_timestamps,
 )
 
 logger = logging.getLogger(__name__)
-
-# Refine only when the coarse pass cleared the clip-pipeline confidence
-# gate. Below this we don't trust the coarse release region enough to
-# spend a second Claude call densely sampling around it (and the clip
-# would be skipped anyway — see module docstring).
-_REFINE_CONFIDENCE_GATE = 0.55
-
-# Dense window shape around the coarse-pass release frame. Asymmetric:
-# more post-release coverage so the dense pass also catches the result
-# frame (typical SMOKE result is 1.5-3.0s after release). Total window
-# is 4s with N=8 → 0.5s spacing between dense candidates.
-_DENSE_PRE_RELEASE_SECONDS = 1.0
-_DENSE_POST_RELEASE_SECONDS = 3.0
-_DENSE_FRAME_COUNT = 8
-
-# Don't bother refining if chapter-boundary clamping leaves the dense
-# window with fewer than this many candidates — too few to meaningfully
-# tighten the release frame. Coarse is already 12 frames so anything
-# under ~4 dense is a regression.
-_MIN_DENSE_FRAMES = 4
-
-# ---- Causality recovery (multi-demonstration chapters) -------------------
-# When the coarse pass reports result_index < release_index (the classifier
-# preserves the original earlier index on
-# ThrowTimingResult.causality_inverted_earlier_index), the model paired a
-# LATE demo's release with an EARLY demo's result — the signature of a
-# chapter that demonstrates the same lineup more than once (operator audit
-# 2026-05-29, lineup 69704f4a "Market Door"). Rather than crater confidence
-# and gate the clip out, re-localise densely around the FIRST event: the
-# earlier index is that demo's RESULT, so the true release precedes it —
-# weight the recovery window heavily BACKWARD from the earlier event.
-#
-# pre=7.0 covers a fully-bloomed smoke result (release→bloom up to ~3s) plus
-# the coarse sampler's own ~3.4s spacing slop; post=1.0 keeps a touch of
-# coverage past the event in case the model keyed on the first wisp. N=14
-# over the ~8s window ≈ 0.6s spacing — tight enough to pin the release.
-_RECOVERY_PRE_RELEASE_SECONDS = 7.0
-_RECOVERY_POST_RELEASE_SECONDS = 1.0
-_RECOVERY_FRAME_COUNT = 14
-
-# Diagnostic stage labels — surfaced on RefinedThrowTiming.stage for
-# logging / metrics. Each maps to a specific reason the dense pass was
-# (or wasn't) used. Keep stable for log-grepping.
-STAGE_REFINED = "refined"
-STAGE_COARSE_ONLY = "coarse_only"
-STAGE_COARSE_BELOW_GATE = "coarse_below_refine_gate"
-STAGE_COARSE_NO_RELEASE = "coarse_no_release_index"
-STAGE_COARSE_NOT_A_THROW = "coarse_not_a_throw"
-STAGE_COARSE_FAILED = "coarse_failed"
-STAGE_DENSE_WINDOW_TOO_SMALL = "dense_window_too_small"
-STAGE_DENSE_EXTRACT_FAILED = "dense_extract_failed"
-STAGE_DENSE_CLASSIFIER_FAILED = "dense_classifier_failed"
-STAGE_DENSE_REJECTED = "dense_rejected"
-# Causality-recovery stages (fired only when the coarse pass was inverted —
-# the multi-demonstration signature). RECOVERED uses the recovery dense
-# result; the REJECTED / *_FAILED / *_TOO_SMALL stages all fall back to the
-# coarse result (same "recovery can only improve, never regress" contract as
-# the dense pass).
-STAGE_RECOVERED_FIRST_EVENT = "recovered_first_event"
-STAGE_RECOVERY_REJECTED = "recovery_rejected"
-STAGE_RECOVERY_WINDOW_TOO_SMALL = "recovery_window_too_small"
-STAGE_RECOVERY_EXTRACT_FAILED = "recovery_extract_failed"
-
-
-@dataclass
-class RefinedThrowTiming:
-    """Return shape of :func:`localize_throw_with_refinement`.
-
-    ``timing`` is the ThrowTimingResult the caller should treat as the
-    final answer — dense when the refinement succeeded, otherwise coarse.
-    ``frame_timestamps`` is the timestamp list whose 1-based indices the
-    caller maps ``timing.release_index`` / ``timing.result_index`` back to.
-
-    ``stage`` and ``coarse_timing`` are diagnostics (logs / future
-    metrics). Always populated so a log scan can answer "of N clip
-    generations, how many cleared the refine gate, how many fell back".
-    """
-
-    timing: ThrowTimingResult
-    frame_timestamps: list[float]
-    stage: str
-    coarse_timing: Optional[ThrowTimingResult] = None
-
-
-def dense_window_timestamps(
-    coarse_release_ts: float,
-    chapter_start: float,
-    chapter_end: float,
-    *,
-    pre_release_seconds: float = _DENSE_PRE_RELEASE_SECONDS,
-    post_release_seconds: float = _DENSE_POST_RELEASE_SECONDS,
-    n: int = _DENSE_FRAME_COUNT,
-) -> list[float]:
-    """Dense-pass timestamps for Stage 2 of two-stage refinement.
-
-    Builds an asymmetric window around the coarse-pass release frame
-    (more weight post-release so the dense pass also catches the result),
-    then evenly spaces *n* timestamps across it. Clamped to the chapter
-    bounds so a release near the chapter start/end doesn't sample frames
-    outside the source video.
-
-    Returns the dense timestamp list (length N at most, fewer when the
-    clamped window collapses below N items via grid_timestamps's
-    degenerate-window behaviour — see its docstring).
-    """
-    lo = max(float(chapter_start), float(coarse_release_ts) - pre_release_seconds)
-    hi = min(float(chapter_end), float(coarse_release_ts) + post_release_seconds)
-    if hi <= lo:
-        # Chapter is degenerate or the release is outside the chapter — no
-        # dense window possible. Caller will fall back to coarse.
-        return []
-    # edge_padding_seconds=0.0 — dense window is already pre-trimmed,
-    # don't pull MORE padding off it (would lose candidates near release
-    # for tight chapters).
-    return grid_timestamps(lo, hi, n, edge_padding_seconds=0.0)
-
-
-def _should_refine(coarse: ThrowTimingResult) -> Optional[str]:
-    """Return None if refinement should proceed, else the SKIP stage label.
-
-    Centralises the gate-decision so the orchestrator stays linear and
-    so tests can pin the decision rules independently.
-    """
-    if not coarse.success:
-        return STAGE_COARSE_FAILED
-    if not coarse.is_lineup_throw:
-        return STAGE_COARSE_NOT_A_THROW
-    if coarse.release_index is None:
-        return STAGE_COARSE_NO_RELEASE
-    if coarse.confidence is None or coarse.confidence < _REFINE_CONFIDENCE_GATE:
-        return STAGE_COARSE_BELOW_GATE
-    return None
 
 
 async def _attempt_first_event_recovery(
@@ -237,18 +117,17 @@ async def _attempt_first_event_recovery(
     """Re-localise around the FIRST event after a causality-inverted coarse pass.
 
     Precondition (checked by the caller): ``coarse`` is a successful,
-    throw-positive result whose
-    ``causality_inverted_earlier_index`` is set — i.e. the model paired a
-    late demonstration's release with an earlier demonstration's result.
-    The earlier index points at the FIRST demo's RESULT, so the true release
-    precedes it; we sample a backward-weighted dense window around that event
-    and re-run the throw-timing classifier on the (now single-throw) window.
+    throw-positive result whose ``causality_inverted_earlier_index`` is set —
+    the model paired a late demonstration's release with an earlier
+    demonstration's result. The earlier index points at the FIRST demo's
+    RESULT, so the true release precedes it; we sample a backward-weighted dense
+    window around that event and re-run the throw-timing classifier on the (now
+    single-throw) window.
 
     Always returns a RefinedThrowTiming so the caller can return it directly:
-      * ``STAGE_RECOVERED_FIRST_EVENT`` — recovery produced a clean,
-        non-re-inverted, throw-positive result with a release; ``timing`` is
-        the recovery result and ``frame_timestamps`` is the recovery window
-        (so the caller maps the recovered indices correctly).
+      * ``STAGE_RECOVERED_FIRST_EVENT`` — clean, non-re-inverted, throw-positive
+        result with a release; ``timing`` is the recovery result and
+        ``frame_timestamps`` is the recovery window.
       * ``STAGE_RECOVERY_*`` — recovery could not improve on coarse; ``timing``
         is the coarse result and ``frame_timestamps`` is the coarse window.
         Same "never regress" contract as the dense pass.
@@ -379,26 +258,25 @@ async def localize_throw_with_refinement(
     chapter_title: Optional[str],
     utility_hint: Optional[str] = None,
 ) -> RefinedThrowTiming:
-    """Localise the throw with optional dense-pass refinement.
+    """Localise the throw with optional dense-pass refinement + recovery.
 
-    See module docstring for the two-stage design. Always returns a
-    RefinedThrowTiming — the dense result when the refine pass succeeded,
-    otherwise the coarse result. The caller can treat the returned
-    ``timing`` exactly as it would treat ``classify_throw_timing_from_frames``'s
-    raw result (same dataclass, same gate semantics), and use
-    ``frame_timestamps`` to map the returned indices back to seconds.
+    See module docstring for the full decision tree. Always returns a
+    RefinedThrowTiming — the dense result when refinement succeeded, a recovery
+    result when a recovery pass improved, otherwise the coarse result. Every
+    return path runs through :func:`apply_gap_invariant`, which nulls a
+    result_index implausibly far from release_index (cross-demonstration /
+    hallucinated bloom) so the landing pane gates out rather than anchoring on
+    a wrong frame.
 
     Args:
-        video_path: Local source video file. Caller owns its lifecycle
-            (download / cleanup); this function only reads from it.
+        video_path: Local source video file. Caller owns its lifecycle.
         chapter_start / chapter_end: Source chapter bounds in seconds.
         chapter_title: Per-call context surfaced to Claude.
-        utility_hint: Optional utility slug from a prior grid
-            classification at confidence > 0.6.
+        utility_hint: Optional utility slug from a prior grid classification.
     """
     chapter_duration = float(chapter_end) - float(chapter_start)
 
-    # ---- Stage 1: coarse pass (existing behaviour) ----------------------
+    # ---- Stage 1: coarse pass -------------------------------------------
     coarse_timestamps = clip_window_timestamps(chapter_start, chapter_end)
 
     try:
@@ -406,10 +284,9 @@ async def localize_throw_with_refinement(
             video_path, coarse_timestamps
         )
     except FrameExtractionError as exc:
-        # Caller's existing FrameExtractionError handling lives in
-        # clip_generator / landing_clip_generator. Re-raise so they can
-        # surface structured codes (this function does not own the failure
-        # surface for downscale-extract; the callers do).
+        # The caller (clip_generator / landing_clip_generator) owns the
+        # downscale-extract failure surface — re-raise so it can surface
+        # structured codes.
         logger.warning(
             "throw_localizer: coarse frame extraction failed: video=%s "
             "returncode=%s stderr=%s",
@@ -426,28 +303,25 @@ async def localize_throw_with_refinement(
     )
 
     # ---- Causality recovery (multi-demonstration chapters) --------------
-    # An inverted coarse pass (the classifier preserved the original earlier
-    # index) means the model paired a late demo's release with an early
-    # demo's result. The recovery path OWNS the outcome here: it re-localises
-    # densely around the first event and returns either the recovered result
-    # (STAGE_RECOVERED_FIRST_EVENT) or the coarse result tagged with the
-    # recovery-failure stage (never a regression — same contract as dense).
-    # We don't fall through to the normal refine path because the standard
-    # dense pass would centre on the WRONG (late-demo) release the inversion
-    # produced, and the cratered confidence would gate it out anyway.
+    # An inverted coarse pass means the model paired a late demo's release with
+    # an early demo's result. The recovery path OWNS the outcome and never falls
+    # through to the normal refine path (which would centre on the WRONG
+    # late-demo release).
     if (
         coarse.success
         and coarse.is_lineup_throw
         and coarse.causality_inverted_earlier_index is not None
     ):
-        return await _attempt_first_event_recovery(
-            video_path,
-            coarse,
-            coarse_timestamps,
-            chapter_start=chapter_start,
-            chapter_end=chapter_end,
-            chapter_title=chapter_title,
-            utility_hint=utility_hint,
+        return apply_gap_invariant(
+            await _attempt_first_event_recovery(
+                video_path,
+                coarse,
+                coarse_timestamps,
+                chapter_start=chapter_start,
+                chapter_end=chapter_end,
+                chapter_title=chapter_title,
+                utility_hint=utility_hint,
+            )
         )
 
     skip_stage = _should_refine(coarse)
@@ -464,14 +338,16 @@ async def localize_throw_with_refinement(
             coarse.confidence,
             chapter_title,
         )
-        return RefinedThrowTiming(
-            timing=coarse,
-            frame_timestamps=coarse_timestamps,
-            stage=skip_stage,
-            coarse_timing=coarse,
+        return apply_gap_invariant(
+            RefinedThrowTiming(
+                timing=coarse,
+                frame_timestamps=coarse_timestamps,
+                stage=skip_stage,
+                coarse_timing=coarse,
+            )
         )
 
-    # ---- Stage 2: dense refinement ---------------------------------------
+    # ---- Stage 2: dense refinement --------------------------------------
     # release_index is non-None (gated above); resolve to a timestamp.
     assert coarse.release_index is not None  # for type checker
     coarse_release_ts = coarse_timestamps[coarse.release_index - 1]
@@ -489,11 +365,13 @@ async def localize_throw_with_refinement(
             _MIN_DENSE_FRAMES,
             chapter_title,
         )
-        return RefinedThrowTiming(
-            timing=coarse,
-            frame_timestamps=coarse_timestamps,
-            stage=STAGE_DENSE_WINDOW_TOO_SMALL,
-            coarse_timing=coarse,
+        return apply_gap_invariant(
+            RefinedThrowTiming(
+                timing=coarse,
+                frame_timestamps=coarse_timestamps,
+                stage=STAGE_DENSE_WINDOW_TOO_SMALL,
+                coarse_timing=coarse,
+            )
         )
 
     try:
@@ -502,8 +380,7 @@ async def localize_throw_with_refinement(
         )
     except FrameExtractionError as exc:
         # A dense-pass extraction failure must NEVER regress the pipeline:
-        # the coarse result already cleared the clip gates and is the
-        # right thing to use. Log so we can see how often this happens.
+        # the coarse result already cleared the clip gates.
         logger.warning(
             "throw_localizer: stage=%s coarse_release_ts=%.2f "
             "returncode=%s stderr=%s; returning coarse: chapter=%r",
@@ -513,11 +390,13 @@ async def localize_throw_with_refinement(
             exc.stderr[:200],
             chapter_title,
         )
-        return RefinedThrowTiming(
-            timing=coarse,
-            frame_timestamps=coarse_timestamps,
-            stage=STAGE_DENSE_EXTRACT_FAILED,
-            coarse_timing=coarse,
+        return apply_gap_invariant(
+            RefinedThrowTiming(
+                timing=coarse,
+                frame_timestamps=coarse_timestamps,
+                stage=STAGE_DENSE_EXTRACT_FAILED,
+                coarse_timing=coarse,
+            )
         )
 
     dense = await classify_throw_timing_from_frames(
@@ -547,11 +426,34 @@ async def localize_throw_with_refinement(
             dense.release_index,
             chapter_title,
         )
-        return RefinedThrowTiming(
-            timing=coarse,
-            frame_timestamps=coarse_timestamps,
-            stage=STAGE_DENSE_REJECTED,
-            coarse_timing=coarse,
+        return apply_gap_invariant(
+            RefinedThrowTiming(
+                timing=coarse,
+                frame_timestamps=coarse_timestamps,
+                stage=STAGE_DENSE_REJECTED,
+                coarse_timing=coarse,
+            )
+        )
+
+    # ---- Dense-floor-pin recovery ---------------------------------------
+    # The dense pass selected its OWN window floor (release_index == 1): the
+    # true release is at or before the earliest frame it was shown — the coarse
+    # pick was late and the dense window opened past the actual release.
+    # Re-search a backward-shifted window. The recovery owns the outcome (a
+    # re-search failure / re-pin returns the dense result tagged with a
+    # floor-pin stage — never a regression).
+    if dense.release_index == 1:
+        return apply_gap_invariant(
+            await attempt_floor_pin_recovery(
+                video_path,
+                dense,
+                dense_timestamps,
+                coarse,
+                chapter_start=chapter_start,
+                chapter_end=chapter_end,
+                chapter_title=chapter_title,
+                utility_hint=utility_hint,
+            )
         )
 
     # Dense pass succeeded — use it. Caller maps the returned indices via
@@ -569,9 +471,11 @@ async def localize_throw_with_refinement(
         dense.confidence or 0.0,
         chapter_title,
     )
-    return RefinedThrowTiming(
-        timing=dense,
-        frame_timestamps=dense_timestamps,
-        stage=STAGE_REFINED,
-        coarse_timing=coarse,
+    return apply_gap_invariant(
+        RefinedThrowTiming(
+            timing=dense,
+            frame_timestamps=dense_timestamps,
+            stage=STAGE_REFINED,
+            coarse_timing=coarse,
+        )
     )

--- a/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer_recovery.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/throw_localizer_recovery.py
@@ -1,0 +1,386 @@
+"""Throw-localizer pure helpers — sibling of ``throw_localizer``.
+
+Extracted from ``throw_localizer`` so the orchestrator stays under the
+file-size growth guard (it was over the 500-LOC threshold and the floor-pin
+recovery pass would have pushed it further; growth requires a matching split
+per ``apps/mygamingassistant/CLAUDE.md`` "Tech Debt Policy" — ``micro_clip_helpers``
+was split from ``micro_clip_generator`` for the same reason).
+
+ONLY pure, side-effect-free helpers live here — the return dataclass, the
+stage/constant tables, the window-timestamp math, the gate decision, and the
+gap invariant. The I/O-calling passes (coarse / dense / causality recovery /
+floor-pin recovery) stay in ``throw_localizer`` so every mockable call
+(``extract_frames_downscaled`` / ``classify_throw_timing_from_frames`` /
+``dense_window_timestamps``) resolves in that one module's namespace and the
+existing test patch sites are unchanged. ``throw_localizer`` re-exports these
+names so other import sites (tests, clip_generator, landing_clip_generator,
+micro_clip_helpers, diag scripts) are unchanged.
+"""
+from __future__ import annotations
+
+import dataclasses
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from app.services.classification.classification_result import ThrowTimingResult
+from app.services.classification.throw_timing_classifier import (
+    classify_throw_timing_from_frames,
+)
+from app.services.ingestion.frame_extractor import (
+    FrameExtractionError,
+    extract_frames_downscaled,
+    grid_timestamps,
+)
+
+logger = logging.getLogger(__name__)
+
+# Refine only when the coarse pass cleared the clip-pipeline confidence
+# gate. Below this we don't trust the coarse release region enough to
+# spend a second Claude call densely sampling around it (and the clip
+# would be skipped anyway — see throw_localizer module docstring).
+_REFINE_CONFIDENCE_GATE = 0.55
+
+# Dense window shape around the coarse-pass release frame. Spans both the
+# pre-release WINDUP (so the model can see the arm wind up and pin the
+# separation instant, not drift late into follow-through) and post-release
+# coverage (so the dense pass also catches the RESULT frame — typical SMOKE
+# result is 1.5-3.0s after release; result_ts feeds the landing clip).
+#
+# pre=2.0 (operator audit 2026-05-30, lineup 8f92c010 "Catwalk - B Site"): with
+# only 1.0s pre-coverage the dense window opened essentially ON the release, so
+# the model had no windup frames to anchor against and picked the cleaner-looking
+# follow-through ~1.5s late (236.03 vs the real ~234.5). 2.0s puts the windup in
+# view so the UTILITY-SEPARATION / ANTI-PRE-WINDUP rules can land the release
+# instant. Total window is 5s with N=12 → ~0.45s spacing between candidates.
+_DENSE_PRE_RELEASE_SECONDS = 2.0
+_DENSE_POST_RELEASE_SECONDS = 3.0
+_DENSE_FRAME_COUNT = 12
+
+# Don't bother refining if chapter-boundary clamping leaves the dense
+# window with fewer than this many candidates — too few to meaningfully
+# tighten the release frame. Coarse is already 12 frames so anything
+# under ~4 dense is a regression.
+_MIN_DENSE_FRAMES = 4
+
+# ---- Gap invariant (cross-demonstration / hallucinated result) -----------
+# A utility's effect appears within ~3s of its release (smoke wisp 1.5-3.0s,
+# molotov flame 1.0-2.0s, flash / HE near-instant). A result_index more than
+# this far after release_index cannot be THIS throw's result — it is a
+# different demonstration's effect, the same smoke viewed after the player
+# walked to it, or a hallucinated bloom. 4.5s = the 3s physical max + coarse
+# sampler slop (~1.5s). When violated we null result_index so the landing pane
+# gates out (release_index, which STAND / AIM / THROW hang off, is untouched).
+_MAX_PLAUSIBLE_RESULT_GAP_SECONDS = 4.5
+
+# ---- Causality recovery (multi-demonstration chapters) -------------------
+# pre=7.0 covers a fully-bloomed smoke result (release→bloom up to ~3s) plus
+# the coarse sampler's own ~3.4s spacing slop; post=1.0 keeps a touch of
+# coverage past the event. N=14 over the ~8s window ≈ 0.6s spacing.
+_RECOVERY_PRE_RELEASE_SECONDS = 7.0
+_RECOVERY_POST_RELEASE_SECONDS = 1.0
+_RECOVERY_FRAME_COUNT = 14
+
+# ---- Dense-floor-pin recovery (coarse pick was late) ---------------------
+# When the dense pass picks its OWN window floor (release_index == 1) the true
+# release is at or before the earliest frame it was shown — the coarse pick
+# landed AFTER the real release and the dense window opened too late. Re-search
+# a window shifted BACKWARD from the floor.
+#
+# pre=8.0 (operator audit 2026-05-30, lineup 8f92c010 "Catwalk - B Site"): on a
+# MULTI-PERSPECTIVE chapter the coarse pass anchors on a LATER observer / bloom /
+# destination view, so the dense window opens several seconds AFTER the real
+# thrower-POV throw. Here the genuine release (~234.5, thrower aiming up at the
+# tower) sat ~6.5s before the dense floor (241.05) — out of reach of the original
+# pre=4.0, which could only reach ~237 and re-pinned on the wrong-POV archway
+# frame (~237.8). 8.0 spans back past the whole observer-view run to the thrower's
+# own aim-and-release; the THROWER-POV REQUIREMENT in the classifier prompt
+# rejects the intervening observer / destination frames so the re-search lands on
+# the real throw rather than re-picking one of them. post=1.0 keeps the floor in
+# view so a genuinely-at-the-floor release is still selectable. N=14 over the ~9s
+# window ≈ 0.7s spacing — fine enough to anchor the release (clip is release ±1s).
+_FLOOR_PIN_PRE_SECONDS = 8.0
+_FLOOR_PIN_POST_SECONDS = 1.0
+_FLOOR_PIN_FRAME_COUNT = 14
+
+# Diagnostic stage labels — surfaced on RefinedThrowTiming.stage for
+# logging / metrics. Keep stable for log-grepping.
+STAGE_REFINED = "refined"
+STAGE_COARSE_ONLY = "coarse_only"
+STAGE_COARSE_BELOW_GATE = "coarse_below_refine_gate"
+STAGE_COARSE_NO_RELEASE = "coarse_no_release_index"
+STAGE_COARSE_NOT_A_THROW = "coarse_not_a_throw"
+STAGE_COARSE_FAILED = "coarse_failed"
+STAGE_DENSE_WINDOW_TOO_SMALL = "dense_window_too_small"
+STAGE_DENSE_EXTRACT_FAILED = "dense_extract_failed"
+STAGE_DENSE_CLASSIFIER_FAILED = "dense_classifier_failed"
+STAGE_DENSE_REJECTED = "dense_rejected"
+# Causality-recovery stages (coarse pass was inverted). RECOVERED uses the
+# recovery result; REJECTED / *_FAILED / *_TOO_SMALL fall back to coarse.
+STAGE_RECOVERED_FIRST_EVENT = "recovered_first_event"
+STAGE_RECOVERY_REJECTED = "recovery_rejected"
+STAGE_RECOVERY_WINDOW_TOO_SMALL = "recovery_window_too_small"
+STAGE_RECOVERY_EXTRACT_FAILED = "recovery_extract_failed"
+# Dense-floor-pin recovery stages (dense pass picked its own window floor).
+# RECOVERED uses the backward re-search; REJECTED / *_FAILED / *_TOO_SMALL
+# fall back to the dense result.
+STAGE_RECOVERED_FLOOR_PIN = "recovered_floor_pin"
+STAGE_FLOOR_PIN_REJECTED = "floor_pin_rejected"
+STAGE_FLOOR_PIN_WINDOW_TOO_SMALL = "floor_pin_window_too_small"
+STAGE_FLOOR_PIN_EXTRACT_FAILED = "floor_pin_extract_failed"
+
+
+@dataclass
+class RefinedThrowTiming:
+    """Return shape of :func:`throw_localizer.localize_throw_with_refinement`.
+
+    ``timing`` is the ThrowTimingResult the caller should treat as the
+    final answer — dense when the refinement succeeded, otherwise coarse.
+    ``frame_timestamps`` is the timestamp list whose 1-based indices the
+    caller maps ``timing.release_index`` / ``timing.result_index`` back to.
+
+    ``stage`` and ``coarse_timing`` are diagnostics (logs / future
+    metrics). Always populated so a log scan can answer "of N clip
+    generations, how many cleared the refine gate, how many fell back".
+    """
+
+    timing: ThrowTimingResult
+    frame_timestamps: list[float]
+    stage: str
+    coarse_timing: Optional[ThrowTimingResult] = None
+
+
+def dense_window_timestamps(
+    coarse_release_ts: float,
+    chapter_start: float,
+    chapter_end: float,
+    *,
+    pre_release_seconds: float = _DENSE_PRE_RELEASE_SECONDS,
+    post_release_seconds: float = _DENSE_POST_RELEASE_SECONDS,
+    n: int = _DENSE_FRAME_COUNT,
+) -> list[float]:
+    """Dense-pass timestamps for Stage 2 of two-stage refinement.
+
+    Builds an asymmetric window around the coarse-pass release frame
+    (more weight post-release so the dense pass also catches the result),
+    then evenly spaces *n* timestamps across it. Clamped to the chapter
+    bounds so a release near the chapter start/end doesn't sample frames
+    outside the source video.
+
+    Returns the dense timestamp list (length N at most, fewer when the
+    clamped window collapses below N items via grid_timestamps's
+    degenerate-window behaviour — see its docstring).
+    """
+    lo = max(float(chapter_start), float(coarse_release_ts) - pre_release_seconds)
+    hi = min(float(chapter_end), float(coarse_release_ts) + post_release_seconds)
+    if hi <= lo:
+        # Chapter is degenerate or the release is outside the chapter — no
+        # dense window possible. Caller will fall back to coarse.
+        return []
+    # edge_padding_seconds=0.0 — dense window is already pre-trimmed,
+    # don't pull MORE padding off it (would lose candidates near release
+    # for tight chapters).
+    return grid_timestamps(lo, hi, n, edge_padding_seconds=0.0)
+
+
+def _should_refine(coarse: ThrowTimingResult) -> Optional[str]:
+    """Return None if refinement should proceed, else the SKIP stage label.
+
+    Centralises the gate-decision so the orchestrator stays linear and
+    so tests can pin the decision rules independently.
+    """
+    if not coarse.success:
+        return STAGE_COARSE_FAILED
+    if not coarse.is_lineup_throw:
+        return STAGE_COARSE_NOT_A_THROW
+    if coarse.release_index is None:
+        return STAGE_COARSE_NO_RELEASE
+    if coarse.confidence is None or coarse.confidence < _REFINE_CONFIDENCE_GATE:
+        return STAGE_COARSE_BELOW_GATE
+    return None
+
+
+def apply_gap_invariant(refined: RefinedThrowTiming) -> RefinedThrowTiming:
+    """Null an implausibly-far result_index (cross-demonstration / hallucination).
+
+    HARD physical invariant applied to the FINAL timing the orchestrator is
+    about to return, regardless of which pass produced it: a result more than
+    ``_MAX_PLAUSIBLE_RESULT_GAP_SECONDS`` after its release cannot be that
+    release's own result. The classifier prompt asks for this, but the model
+    violates it on multi-demonstration chapters (it confidently pairs one
+    demo's release with another's bloom — operator audit 2026-05-29, lineup
+    8f92c010 "Catwalk - B Site": coarse paired release ~242 with a bloom ~252,
+    a 10s gap, at confidence 0.85). Nulling result_index here gates the landing
+    pane out — release_index (which STAND / AIM / THROW hang off) is untouched.
+
+    Returns *refined* unchanged when the gap is plausible or either index is
+    None; otherwise a copy whose ``timing`` has ``result_index=None``.
+    """
+    timing = refined.timing
+    if timing.release_index is None or timing.result_index is None:
+        return refined
+    ts = refined.frame_timestamps
+    # Defensive: indices are 1-based into ts; an out-of-range index would
+    # IndexError. The classifier validates them, but never trust blindly.
+    if not (1 <= timing.release_index <= len(ts)) or not (
+        1 <= timing.result_index <= len(ts)
+    ):
+        return refined
+    gap = ts[timing.result_index - 1] - ts[timing.release_index - 1]
+    if gap <= _MAX_PLAUSIBLE_RESULT_GAP_SECONDS:
+        return refined
+    logger.info(
+        "throw_localizer: gap invariant nulled result_index: stage=%s gap=%.2fs "
+        "(> %.1fs) release_idx=%s result_idx=%s — landing pane gates out",
+        refined.stage, gap, _MAX_PLAUSIBLE_RESULT_GAP_SECONDS,
+        timing.release_index, timing.result_index,
+    )
+    gated = dataclasses.replace(timing, result_index=None)
+    return dataclasses.replace(refined, timing=gated)
+
+
+async def attempt_floor_pin_recovery(
+    video_path: Path,
+    dense: ThrowTimingResult,
+    dense_timestamps: list[float],
+    coarse: ThrowTimingResult,
+    *,
+    chapter_start: float,
+    chapter_end: float,
+    chapter_title: Optional[str],
+    utility_hint: Optional[str],
+) -> RefinedThrowTiming:
+    """Re-localise EARLIER after the dense pass pinned its own window floor.
+
+    Precondition (checked by the caller): the dense pass returned a clean,
+    throw-positive result with ``release_index == 1`` — it selected the
+    earliest frame of its window, i.e. the true release is at or before the
+    dense window's floor. The coarse pick landed AFTER the real release and the
+    dense window opened too late. Re-search a window shifted BACKWARD from the
+    floor and re-run the classifier.
+
+    Lives in this sibling module (not ``throw_localizer``) so the orchestrator
+    stays under the file-size growth guard — the new recovery pass would push it
+    over (see ``apps/mygamingassistant/CLAUDE.md`` "Tech Debt Policy"). Because
+    it now calls ``extract_frames_downscaled`` / ``classify_throw_timing_from_frames``
+    / ``dense_window_timestamps`` resolved in THIS module's namespace, its tests
+    patch ``...throw_localizer_recovery.*`` (the orchestrator's coarse/dense
+    passes still patch ``...throw_localizer.*``). The causality recovery stays
+    in ``throw_localizer`` — moving shipped, tested code risks regressing Market
+    Door; only the new floor-pin pass moves here.
+
+    Always returns a RefinedThrowTiming:
+      * ``STAGE_RECOVERED_FLOOR_PIN`` — the backward re-search produced a clean,
+        throw-positive result whose release is NOT pinned to the new window's
+        floor (``release_index > 1``) — meaning we bracketed the actual release
+        rather than pinning again. ``timing`` is the re-search result and
+        ``frame_timestamps`` is the backward window.
+      * ``STAGE_FLOOR_PIN_*`` — the re-search could not improve; ``timing`` is
+        the dense result and ``frame_timestamps`` is the dense window. A re-pin
+        counts as no improvement (the release is earlier than this chapter can
+        sample cleanly — the dense floor stays the best available anchor rather
+        than chasing an even-earlier guess that may cross a prior demonstration).
+    """
+    floor_ts = dense_timestamps[0]
+    backward_timestamps = dense_window_timestamps(
+        floor_ts,
+        chapter_start,
+        chapter_end,
+        pre_release_seconds=_FLOOR_PIN_PRE_SECONDS,
+        post_release_seconds=_FLOOR_PIN_POST_SECONDS,
+        n=_FLOOR_PIN_FRAME_COUNT,
+    )
+
+    if len(backward_timestamps) < _MIN_DENSE_FRAMES:
+        logger.info(
+            "throw_localizer: stage=%s floor_ts=%.2f backward_n=%d (< %d); "
+            "returning dense: chapter=%r",
+            STAGE_FLOOR_PIN_WINDOW_TOO_SMALL,
+            floor_ts,
+            len(backward_timestamps),
+            _MIN_DENSE_FRAMES,
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=dense,
+            frame_timestamps=dense_timestamps,
+            stage=STAGE_FLOOR_PIN_WINDOW_TOO_SMALL,
+            coarse_timing=coarse,
+        )
+
+    try:
+        backward_frames = await extract_frames_downscaled(
+            video_path, backward_timestamps
+        )
+    except FrameExtractionError as exc:
+        logger.warning(
+            "throw_localizer: stage=%s floor_ts=%.2f returncode=%s stderr=%s; "
+            "returning dense: chapter=%r",
+            STAGE_FLOOR_PIN_EXTRACT_FAILED,
+            floor_ts,
+            exc.returncode,
+            exc.stderr[:200],
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=dense,
+            frame_timestamps=dense_timestamps,
+            stage=STAGE_FLOOR_PIN_EXTRACT_FAILED,
+            coarse_timing=coarse,
+        )
+
+    rescanned = await classify_throw_timing_from_frames(
+        frames=backward_frames,
+        frame_timestamps=backward_timestamps,
+        chapter_title=chapter_title,
+        chapter_duration=float(chapter_end) - float(chapter_start),
+        utility_hint=utility_hint,
+    )
+
+    # Accept only a clean, throw-positive re-search whose release is bracketed
+    # by the new window (release_index > 1). A re-pin (release_index == 1 again)
+    # means the true release is still earlier than we can sample — the dense
+    # floor stays the best available anchor; do not regress to an even-earlier
+    # guess that may have crossed into a prior demonstration.
+    if (
+        not rescanned.success
+        or not rescanned.is_lineup_throw
+        or rescanned.release_index is None
+        or rescanned.release_index == 1
+        or rescanned.causality_inverted_earlier_index is not None
+    ):
+        logger.info(
+            "throw_localizer: stage=%s floor_ts=%.2f rescanned_success=%s "
+            "rescanned_is_lineup_throw=%s rescanned_release_index=%s; "
+            "returning dense: chapter=%r",
+            STAGE_FLOOR_PIN_REJECTED,
+            floor_ts,
+            rescanned.success,
+            rescanned.is_lineup_throw,
+            rescanned.release_index,
+            chapter_title,
+        )
+        return RefinedThrowTiming(
+            timing=dense,
+            frame_timestamps=dense_timestamps,
+            stage=STAGE_FLOOR_PIN_REJECTED,
+            coarse_timing=coarse,
+        )
+
+    rescanned_release_ts = backward_timestamps[rescanned.release_index - 1]
+    logger.info(
+        "throw_localizer: stage=%s floor_ts=%.2f rescanned_release_ts=%.2f "
+        "shift=%+.2fs chapter=%r",
+        STAGE_RECOVERED_FLOOR_PIN,
+        floor_ts,
+        rescanned_release_ts,
+        rescanned_release_ts - floor_ts,
+        chapter_title,
+    )
+    return RefinedThrowTiming(
+        timing=rescanned,
+        frame_timestamps=backward_timestamps,
+        stage=STAGE_RECOVERED_FLOOR_PIN,
+        coarse_timing=coarse,
+    )

--- a/apps/mygamingassistant/backend/tests/test_throw_localizer.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_localizer.py
@@ -22,8 +22,9 @@ result with the matching diagnostic stage.
 """
 from __future__ import annotations
 
+import contextlib
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -37,19 +38,38 @@ from app.services.ingestion.throw_localizer import (
     STAGE_DENSE_EXTRACT_FAILED,
     STAGE_DENSE_REJECTED,
     STAGE_DENSE_WINDOW_TOO_SMALL,
+    STAGE_FLOOR_PIN_EXTRACT_FAILED,
+    STAGE_FLOOR_PIN_REJECTED,
+    STAGE_FLOOR_PIN_WINDOW_TOO_SMALL,
     STAGE_RECOVERED_FIRST_EVENT,
+    STAGE_RECOVERED_FLOOR_PIN,
     STAGE_RECOVERY_EXTRACT_FAILED,
     STAGE_RECOVERY_REJECTED,
     STAGE_RECOVERY_WINDOW_TOO_SMALL,
     STAGE_REFINED,
     RefinedThrowTiming,
     _should_refine,
+    apply_gap_invariant,
     dense_window_timestamps,
     localize_throw_with_refinement,
 )
 
 _MOD = "app.services.ingestion.throw_localizer"
+_MOD_RECOVERY = "app.services.ingestion.throw_localizer_recovery"
 _FAKE_VIDEO = Path("/tmp/fake.mp4")
+
+
+@contextlib.contextmanager
+def _with_all(patchers):
+    """Enter several patch() context managers as one (exit together).
+
+    Lets a single tuple slot patch the SAME function on two module namespaces
+    (the orchestrator + the recovery sibling) so tests apply it with one
+    ``with patches[i]`` entry."""
+    with contextlib.ExitStack() as stack:
+        for p in patchers:
+            stack.enter_context(p)
+        yield
 _FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
 
 
@@ -60,18 +80,22 @@ _FAKE_PNG = b"\x89PNG\r\n\x1a\n" + b"\x00" * 64
 
 class TestDenseWindowTimestamps:
     def test_returns_n_timestamps_centered_asymmetrically_on_release(self):
-        """4s asymmetric window (release - 1.0, release + 3.0) @ N=8."""
+        """5s asymmetric window (release - 2.0, release + 3.0) @ N=12.
+
+        pre=2.0 (raised from 1.0, 2026-05-30) gives the dense pass windup
+        context so it can pin the separation instant instead of drifting late
+        into follow-through; post=3.0 still catches the result frame."""
         result = dense_window_timestamps(
             coarse_release_ts=100.0,
             chapter_start=0.0,
             chapter_end=200.0,
         )
-        assert len(result) == 8
-        # Window spans [99.0, 103.0] — strictly inside, edge_padding=0.
-        assert result[0] == pytest.approx(99.0)
+        assert len(result) == 12
+        # Window spans [98.0, 103.0] — strictly inside, edge_padding=0.
+        assert result[0] == pytest.approx(98.0)
         assert result[-1] == pytest.approx(103.0)
-        # More post-release than pre-release coverage: release is closer
-        # to the START of the window than the end.
+        # Still more post-release than pre-release coverage: release is closer
+        # to the START of the window than the end (2.0s pre vs 3.0s post).
         release_offset_from_start = 100.0 - result[0]
         release_offset_from_end = result[-1] - 100.0
         assert release_offset_from_end > release_offset_from_start
@@ -112,11 +136,16 @@ class TestDenseWindowTimestamps:
 
 
 def _coarse(**overrides) -> ThrowTimingResult:
+    # result_index=5 keeps the default release→result gap at ~2s over
+    # _COARSE_TIMESTAMPS (2s spacing) — well under the 4.5s gap invariant — so
+    # fallback-identity assertions (`result.timing is coarse`) are not tripped
+    # by apply_gap_invariant nulling a synthetic far-gap result. Gap-invariant
+    # behaviour is covered explicitly in TestGapInvariant.
     base = dict(
         success=True,
         is_lineup_throw=True,
         release_index=4,
-        result_index=6,
+        result_index=5,
         confidence=0.72,
         reasoning="x",
     )
@@ -710,3 +739,278 @@ class TestCausalityRecovery:
         assert result.frame_timestamps == _COARSE_TIMESTAMPS
         assert extract_mock.await_count == 2  # recovery extract attempted
         assert classifier_mock.await_count == 1  # recovery classify NOT reached
+
+
+# ---------------------------------------------------------------------------
+# Gap invariant — cross-demonstration / hallucinated result nulling
+#
+# A result more than 4.5s after its release cannot be that release's own result
+# (smoke blooms within ~3s). The classifier prompt asks for this but the model
+# violates it on multi-demonstration chapters; apply_gap_invariant is the
+# model-independent backstop applied to every orchestrator return. Nulling
+# result_index gates the landing pane out WITHOUT disturbing release_index
+# (which STAND / AIM / THROW hang off).
+# ---------------------------------------------------------------------------
+
+
+def _refined(release_index, result_index, timestamps, stage=STAGE_REFINED):
+    timing = ThrowTimingResult(
+        success=True,
+        is_lineup_throw=True,
+        release_index=release_index,
+        result_index=result_index,
+        confidence=0.8,
+        reasoning="x",
+    )
+    return RefinedThrowTiming(
+        timing=timing,
+        frame_timestamps=list(timestamps),
+        stage=stage,
+        coarse_timing=timing,
+    )
+
+
+class TestGapInvariant:
+    def test_plausible_gap_returns_same_object(self):
+        """Gap <= 4.5s → unchanged (identity preserved, no needless copy)."""
+        refined = _refined(1, 2, [10.0, 13.0])  # 3.0s
+        assert apply_gap_invariant(refined) is refined
+
+    def test_boundary_gap_kept(self):
+        """Exactly 4.5s is kept (the bound is <=, not <)."""
+        refined = _refined(1, 2, [10.0, 14.5])
+        assert apply_gap_invariant(refined) is refined
+
+    def test_far_result_nulled_release_preserved(self):
+        """Gap > 4.5s → result_index nulled; release_index untouched."""
+        refined = _refined(1, 2, [10.0, 40.0])  # 30s — Catwalk-B cross-pair
+        out = apply_gap_invariant(refined)
+        assert out.timing.result_index is None
+        assert out.timing.release_index == 1
+        # Original is not mutated (dataclasses.replace returns a copy).
+        assert refined.timing.result_index == 2
+
+    def test_ten_second_gap_nulled(self):
+        """The Catwalk-B run-B case: 10s gap at high model confidence."""
+        out = apply_gap_invariant(_refined(1, 2, [242.0, 252.0]))
+        assert out.timing.result_index is None
+
+    def test_none_result_unchanged(self):
+        refined = _refined(1, None, [10.0, 11.0])
+        assert apply_gap_invariant(refined) is refined
+
+    def test_none_release_unchanged(self):
+        refined = _refined(None, 2, [10.0, 50.0])
+        assert apply_gap_invariant(refined) is refined
+
+    @pytest.mark.asyncio
+    async def test_orchestrator_nulls_far_coarse_result(self):
+        """End-to-end: a dense-rejected fall back to a coarse pick with a far
+        result has that result nulled (landing gates out) while release_index
+        survives (STAND / AIM / THROW unaffected)."""
+        # release_index=2 → _COARSE_TIMESTAMPS[1]=12.0;
+        # result_index=11 → _COARSE_TIMESTAMPS[10]=30.0 → 18s gap.
+        coarse = _coarse(release_index=2, result_index=11, confidence=0.7)
+        dense_fail = ThrowTimingResult(
+            success=False, error_codes=["api"], reasoning="x"
+        )
+        patches, _, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=dense_fail
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="multi-demo",
+            )
+        assert result.stage == STAGE_DENSE_REJECTED
+        assert result.timing.release_index == 2
+        assert result.timing.result_index is None
+
+
+# ---------------------------------------------------------------------------
+# Dense-floor-pin recovery — coarse pick was late, dense pinned its own floor
+#
+# When the dense pass selects release_index == 1 (its earliest frame) the true
+# release is at or before the window floor; the orchestrator re-searches a
+# backward-shifted window. dense_window_timestamps returns the dense window on
+# its first call and the backward window on its second so a recovered result is
+# distinguishable by its frame_timestamps.
+# ---------------------------------------------------------------------------
+
+_BACKWARD_TIMESTAMPS = [9.0, 9.6, 10.2, 10.8, 11.4, 12.0, 12.6, 13.2]
+
+
+def _floor_pin_patches(
+    *,
+    coarse,
+    dense,
+    rescanned=None,
+    extract_side_effect=None,
+    dense_window_side_effect=None,
+):
+    """Patch context for the coarse → dense → backward-rescan chain.
+
+    dense_window_timestamps yields the dense window first (Stage 2) and the
+    backward window second (floor-pin recovery), so a recovered result is
+    identifiable by ``frame_timestamps == _BACKWARD_TIMESTAMPS``.
+    """
+    extract_mock = AsyncMock()
+    extract_mock.side_effect = extract_side_effect or [
+        [_FAKE_PNG] * len(_COARSE_TIMESTAMPS),
+        [_FAKE_PNG] * len(_DENSE_TIMESTAMPS),
+        [_FAKE_PNG] * len(_BACKWARD_TIMESTAMPS),
+    ]
+    classifier_side = [coarse, dense]
+    if rescanned is not None:
+        classifier_side.append(rescanned)
+    classifier_mock = AsyncMock(side_effect=classifier_side)
+    dense_window_mock = Mock(
+        side_effect=dense_window_side_effect
+        or [list(_DENSE_TIMESTAMPS), list(_BACKWARD_TIMESTAMPS)]
+    )
+    # The floor-pin re-scan lives in throw_localizer_recovery, so its
+    # extract / classify / dense_window calls resolve in THAT namespace, while
+    # the coarse + dense passes resolve in throw_localizer. Patch each function
+    # on BOTH namespaces (same mock) so a single tuple slot covers both and the
+    # shared side_effect lists are consumed across all three calls in order.
+    return (
+        _with_all((
+            patch(f"{_MOD}.extract_frames_downscaled", extract_mock),
+            patch(f"{_MOD_RECOVERY}.extract_frames_downscaled", extract_mock),
+        )),
+        _with_all((
+            patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+            patch(f"{_MOD_RECOVERY}.classify_throw_timing_from_frames", classifier_mock),
+        )),
+        patch(
+            f"{_MOD}.clip_window_timestamps",
+            lambda *a, **k: list(_COARSE_TIMESTAMPS),
+        ),
+        _with_all((
+            patch(f"{_MOD}.dense_window_timestamps", dense_window_mock),
+            patch(f"{_MOD_RECOVERY}.dense_window_timestamps", dense_window_mock),
+        )),
+    ), extract_mock, classifier_mock
+
+
+class TestFloorPinRecovery:
+    @pytest.mark.asyncio
+    async def test_recovers_earlier_release(self):
+        """Dense floored (release_index=1) → backward re-search brackets the
+        real release (release_index>1) → use it + the backward window."""
+        coarse = _coarse(release_index=4, confidence=0.7)
+        dense = _coarse(release_index=1, result_index=3, confidence=0.8)
+        rescanned = _coarse(release_index=4, result_index=6, confidence=0.85)
+        patches, extract_mock, classifier_mock = _floor_pin_patches(
+            coarse=coarse, dense=dense, rescanned=rescanned
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="catwalk late coarse",
+            )
+        assert result.stage == STAGE_RECOVERED_FLOOR_PIN
+        assert result.timing is rescanned
+        assert result.frame_timestamps == _BACKWARD_TIMESTAMPS
+        # backward release_index=4 → _BACKWARD_TIMESTAMPS[3] = 10.8
+        assert result.frame_timestamps[result.timing.release_index - 1] == 10.8
+        assert extract_mock.await_count == 3  # coarse + dense + backward
+        assert classifier_mock.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_repin_falls_back_to_dense(self):
+        """Backward re-search ALSO floors (release_index=1) → no improvement →
+        return the dense result (the floor is the best available anchor)."""
+        coarse = _coarse(release_index=4, confidence=0.7)
+        dense = _coarse(release_index=1, result_index=3, confidence=0.8)
+        rescanned = _coarse(release_index=1, result_index=4, confidence=0.7)
+        patches, _, _ = _floor_pin_patches(
+            coarse=coarse, dense=dense, rescanned=rescanned
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_FLOOR_PIN_REJECTED
+        assert result.timing is dense
+        assert result.frame_timestamps == _DENSE_TIMESTAMPS
+
+    @pytest.mark.asyncio
+    async def test_rescan_not_a_throw_falls_back_to_dense(self):
+        coarse = _coarse(release_index=4, confidence=0.7)
+        dense = _coarse(release_index=1, result_index=3, confidence=0.8)
+        rescanned = _coarse(
+            is_lineup_throw=False, release_index=None, result_index=None,
+            confidence=0.2,
+        )
+        patches, _, _ = _floor_pin_patches(
+            coarse=coarse, dense=dense, rescanned=rescanned
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_FLOOR_PIN_REJECTED
+        assert result.timing is dense
+
+    @pytest.mark.asyncio
+    async def test_window_too_small_falls_back_without_extract(self):
+        """Backward window collapses below the minimum → fall back to dense
+        WITHOUT a recovery extract / classify."""
+        coarse = _coarse(release_index=4, confidence=0.7)
+        dense = _coarse(release_index=1, result_index=3, confidence=0.8)
+        patches, extract_mock, classifier_mock = _floor_pin_patches(
+            coarse=coarse,
+            dense=dense,
+            dense_window_side_effect=[list(_DENSE_TIMESTAMPS), [9.0, 9.6]],
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_FLOOR_PIN_WINDOW_TOO_SMALL
+        assert result.timing is dense
+        assert result.frame_timestamps == _DENSE_TIMESTAMPS
+        assert extract_mock.await_count == 2  # backward extract NOT attempted
+        assert classifier_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_extract_failure_falls_back_to_dense(self):
+        """A backward-pass ffmpeg failure must NEVER regress — fall back."""
+        coarse = _coarse(release_index=4, confidence=0.7)
+        dense = _coarse(release_index=1, result_index=3, confidence=0.8)
+        patches, extract_mock, classifier_mock = _floor_pin_patches(
+            coarse=coarse,
+            dense=dense,
+            extract_side_effect=[
+                [_FAKE_PNG] * len(_COARSE_TIMESTAMPS),
+                [_FAKE_PNG] * len(_DENSE_TIMESTAMPS),
+                FrameExtractionError(
+                    "boom", timestamp=9.0, returncode=1, stderr="ffmpeg lost"
+                ),
+            ],
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_FLOOR_PIN_EXTRACT_FAILED
+        assert result.timing is dense
+        assert extract_mock.await_count == 3  # backward extract attempted
+        assert classifier_mock.await_count == 2  # backward classify NOT reached

--- a/apps/mygamingassistant/backend/tests/test_throw_localizer.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_localizer.py
@@ -742,6 +742,158 @@ class TestCausalityRecovery:
 
 
 # ---------------------------------------------------------------------------
+# Multi-demonstration first-event recovery (general signal, no inversion)
+#
+# The causality-inversion signal only fires when the model happens to pair a
+# late demo's release with an early demo's result. On lineup 69704f4a "Market
+# Door" the throw-clip coarse pass instead localised the 2nd demo's release at
+# HIGH confidence with a CONSISTENT later result — no inversion — so nothing
+# pulled it back to the 1st throw while STAND/AIM/LANDING sat there (operator
+# audit 2026-05-30). The classifier now reports earlier_demonstration_result_index
+# on that case and the orchestrator fires the SAME first-event recovery on it.
+# ---------------------------------------------------------------------------
+
+
+def _multidemo_coarse(**overrides) -> ThrowTimingResult:
+    """Coarse result with the GENERAL multi-demonstration signal (no inversion).
+
+    Mirrors the real Market Door throw-clip coarse pass: a CONFIDENT (0.85)
+    release on a LATER demo with a consistent later result (result_index >
+    release_index → NO inversion), plus earlier_demonstration_result_index=3
+    flagging the 1st demo's result (→ _COARSE_TIMESTAMPS[2] = 14.0). The high
+    confidence is the crux — without the signal this REFINES the wrong late
+    release rather than recovering. release→result gap stays 2s (under the gap
+    invariant) so fallback-identity asserts aren't tripped by result nulling.
+    """
+    base = dict(
+        success=True,
+        is_lineup_throw=True,
+        release_index=7,
+        result_index=8,
+        earlier_demonstration_result_index=3,
+        confidence=0.85,
+        reasoning="2nd-demo release; 1st-demo result at F3",
+    )
+    base.update(overrides)
+    return ThrowTimingResult(**base)
+
+
+class TestMultiDemoFirstEventRecovery:
+    @pytest.mark.asyncio
+    async def test_multidemo_signal_recovers_first_event(self):
+        """earlier_demonstration_result_index set (no inversion) → first-event
+        recovery fires and uses the recovery window's timestamps."""
+        coarse = _multidemo_coarse()
+        recovered = _coarse(release_index=2, result_index=5, confidence=0.85)
+        patches, extract_mock, classifier_mock = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=recovered
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="multi-demo smoke (no inversion)",
+            )
+        assert result.stage == STAGE_RECOVERED_FIRST_EVENT
+        assert result.timing is recovered
+        assert result.frame_timestamps == _DENSE_TIMESTAMPS
+        assert result.coarse_timing is coarse
+        # recovery release_index=2 → _DENSE_TIMESTAMPS[1] = 14.5
+        assert result.frame_timestamps[result.timing.release_index - 1] == 14.5
+        assert extract_mock.await_count == 2
+        assert classifier_mock.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_recovery_fires_ahead_of_refine_at_high_confidence(self):
+        """THE Market Door bug encoded: coarse confidence 0.85 clears the 0.55
+        refine gate, so WITHOUT the multi-demo signal this refines the wrong
+        (late) release. The signal must make first-event recovery take
+        precedence over the dense-refine pass."""
+        coarse = _multidemo_coarse(confidence=0.85)
+        recovered = _coarse(release_index=3, result_index=6, confidence=0.9)
+        patches, _, _ = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=recovered
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERED_FIRST_EVENT
+        assert result.stage != STAGE_REFINED
+
+    @pytest.mark.asyncio
+    async def test_inversion_index_takes_precedence_when_both_set(self):
+        """Both signals present → the inversion index (3 → ts 14.0) drives the
+        recovery window, NOT the multi-demo index (5 → ts 18.0)."""
+        coarse = _multidemo_coarse(
+            causality_inverted_earlier_index=3,
+            result_index=7,
+            earlier_demonstration_result_index=5,
+        )
+        recovered = _coarse(release_index=2, result_index=4, confidence=0.85)
+        recovery_window_centers: list[float] = []
+
+        def _dense_window(*args, **kwargs):
+            recovery_window_centers.append(args[0] if args else None)
+            return list(_DENSE_TIMESTAMPS)
+
+        extract_mock = AsyncMock(
+            side_effect=[
+                [_FAKE_PNG] * len(_COARSE_TIMESTAMPS),
+                [_FAKE_PNG] * len(_DENSE_TIMESTAMPS),
+            ]
+        )
+        classifier_mock = AsyncMock(side_effect=[coarse, recovered])
+        with (
+            patch(f"{_MOD}.extract_frames_downscaled", extract_mock),
+            patch(f"{_MOD}.classify_throw_timing_from_frames", classifier_mock),
+            patch(
+                f"{_MOD}.clip_window_timestamps",
+                lambda *a, **k: list(_COARSE_TIMESTAMPS),
+            ),
+            patch(f"{_MOD}.dense_window_timestamps", _dense_window),
+        ):
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERED_FIRST_EVENT
+        # earlier_index resolved to the inversion's 3 → _COARSE_TIMESTAMPS[2].
+        assert recovery_window_centers and recovery_window_centers[0] == 14.0
+
+    @pytest.mark.asyncio
+    async def test_recovery_still_multidemo_falls_back_to_coarse(self):
+        """A recovery pass that STILL reports an earlier demonstration means the
+        window spans more than one demo — reject and fall back to coarse."""
+        coarse = _multidemo_coarse()
+        recovered = _coarse(
+            release_index=6, result_index=7,
+            earlier_demonstration_result_index=2, confidence=0.6,
+        )
+        patches, extract_mock, classifier_mock = _patch_chain(
+            coarse_classifier=coarse, dense_classifier=recovered
+        )
+        with patches[0], patches[1], patches[2], patches[3]:
+            result = await localize_throw_with_refinement(
+                _FAKE_VIDEO,
+                chapter_start=0.0,
+                chapter_end=60.0,
+                chapter_title="x",
+            )
+        assert result.stage == STAGE_RECOVERY_REJECTED
+        assert result.timing is coarse
+        assert result.frame_timestamps == _COARSE_TIMESTAMPS
+        assert extract_mock.await_count == 2
+        assert classifier_mock.await_count == 2
+
+
+# ---------------------------------------------------------------------------
 # Gap invariant — cross-demonstration / hallucinated result nulling
 #
 # A result more than 4.5s after its release cannot be that release's own result

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -171,6 +171,62 @@ class TestThrowTimingVerdictAndParser:
         assert result.causality_inverted_earlier_index is None
 
     @pytest.mark.asyncio
+    async def test_earlier_demonstration_index_parsed_when_before_release(self):
+        """The GENERAL multi-demo signal (no inversion needed) is kept when it
+        points EARLIER than the chosen release — an earlier demonstration's
+        result precedes the late take the model localised (Market Door case)."""
+        result, _ = await _call(
+            {
+                "is_lineup_throw": True,
+                "release_index": 5,
+                "result_index": 6,
+                "earlier_demonstration_result_index": 2,
+                "confidence": 0.85,
+                "reasoning": "late-demo release F5; 1st-demo smoke at F2",
+            }
+        )
+        assert result.release_index == 5
+        assert result.result_index == 6
+        assert result.earlier_demonstration_result_index == 2
+        # result 6 > release 5 → no inversion; the signal stands on its own.
+        assert result.causality_inverted_earlier_index is None
+
+    @pytest.mark.asyncio
+    async def test_earlier_demonstration_index_dropped_when_not_before_release(
+        self,
+    ):
+        """A value >= release_index is not an 'earlier demo' signal — drop it
+        so the localizer never re-centres around a non-earlier frame."""
+        result, _ = await _call(
+            {
+                "is_lineup_throw": True,
+                "release_index": 3,
+                "result_index": 4,
+                "earlier_demonstration_result_index": 5,
+                "confidence": 0.8,
+                "reasoning": "x",
+            }
+        )
+        assert result.release_index == 3
+        assert result.earlier_demonstration_result_index is None
+
+    @pytest.mark.asyncio
+    async def test_earlier_demonstration_index_dropped_when_release_null(self):
+        """No release → the earlier-demo signal has no anchor to precede → drop."""
+        result, _ = await _call(
+            {
+                "is_lineup_throw": True,
+                "release_index": None,
+                "result_index": None,
+                "earlier_demonstration_result_index": 2,
+                "confidence": 0.4,
+                "reasoning": "x",
+            }
+        )
+        assert result.release_index is None
+        assert result.earlier_demonstration_result_index is None
+
+    @pytest.mark.asyncio
     async def test_out_of_range_indices_nulled(self):
         result, _ = await _call(
             {
@@ -336,6 +392,22 @@ class TestThrowTimingPerspectivePrompt:
         assert "highest priority" in system_text
         assert "rotated > ~45°" in system_text
         assert "utility-in-hand has changed" in system_text
+
+    @pytest.mark.asyncio
+    async def test_system_prompt_includes_first_of_repeated_demonstrations(self):
+        """On a repeated demonstration the EARLIEST aligned throw wins, and the
+        model must report earlier_demonstration_result_index so the localizer
+        can re-center on it. Removing either re-introduces the Market Door
+        split-brain (THROW on the 2nd demo, STAND/AIM/LANDING on the 1st)."""
+        _, client = await _call(
+            {"is_lineup_throw": True, "release_index": 1, "result_index": 2,
+             "confidence": 0.6, "reasoning": "x"},
+        )
+        system = client.messages.create.call_args.kwargs["system"]
+        system_text = "\n".join(b["text"] for b in system)
+        assert "FIRST OF REPEATED DEMONSTRATIONS" in system_text
+        assert "earlier_demonstration_result_index" in system_text
+        assert "EARLIEST such full" in system_text
 
     @pytest.mark.asyncio
     async def test_system_prompt_includes_max_gap_fallback(self):

--- a/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_timing_classifier.py
@@ -350,10 +350,12 @@ class TestThrowTimingPerspectivePrompt:
         )
         system = client.messages.create.call_args.kwargs["system"]
         system_text = "\n".join(b["text"] for b in system)
-        assert "MAX-GAP FALLBACK" in system_text
-        assert "within ~6 frames" in system_text
-        assert "result_index = release_index" in system_text
-        assert "confidence <= 0.5" in system_text
+        # The MAX-GAP FALLBACK (result_index = release_index) was replaced by the
+        # SAME-THROW RULE: a far / cross-demonstration result is nulled, not
+        # forced onto the release frame — the landing clip is skipped instead.
+        assert "SAME-THROW RULE" in system_text
+        assert "set result_index = null" in system_text
+        assert "do NOT fall" in system_text
 
     @pytest.mark.asyncio
     async def test_system_prompt_tightens_smoke_first_wisp_cue(self):


### PR DESCRIPTION
## Problem
On multi-perspective / multi-demonstration lineup chapters the throw-localizer anchored `release_ts` on a later observer/destination view instead of the early thrower-POV throw. Catwalk-B (`8f92c010`) anchored ~241/238 vs the real **~234.5** — cratering STAND / AIM / THROW for the whole lineup.

## Changes
- **Prompt (`throw_timing_classifier`)** — add a **THROWER-POV release gate**: `release_index` must be the thrower's own aim-and-release (own viewmodel arm + crosshair on the aiming landmark); destination / observer / spectator / bloom-only frames are never `release_index`. Plus multi-demo / title-card / same-throw selection and confidence-decoupled-from-result.
- **Localizer (`throw_localizer` + `throw_localizer_recovery`)**
  - Gap invariant nulls a cross-demonstration result (>4.5s after release) → landing pane gates out instead of fabricating one.
  - Deepen the dense-floor-pin back-search (pre 4→8s, n 8→14) to reach a release several seconds before the dense floor.
  - Widen the dense window (pre 1→2s, n 8→12) so the pass has windup context and pins the separation instant rather than drifting late into follow-through.
  - Move the floor-pin pass + shared helpers into `throw_localizer_recovery.py` so `throw_localizer.py` stays under the file-size gate.

## Verification
- Catwalk-B lands release **234.8–235.1** (oracle ~234.5) robustly across both coarse paths, correct thrower-POV, landing correctly gated. Operator visually confirmed the re-cut throw clip captures the throw.
- **42/42** `test_throw_localizer.py` unit tests pass.
- 7bd971c3 (known-good) spot-check: release 267.41 healthy (dense refined earlier, not regressed).

## Notes
- MGA is dev-only (no prod deploy) → no operational migration required.
- Follow-ups (separate): dev-library re-cut via `backfill-micro-clips`; **movement-aware THROW framing** (jump/strafe/walk technique detection → adaptive pre-pad).

🤖 Generated with [Claude Code](https://claude.com/claude-code)