### PR TITLE
fix(mjh): rename user-facing "Discover" → "Discovery" (#8)

### DIFF
--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 18 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 2 [1 blocked-on-react-19, 1 public-launch cost guardrail] / Medium: 6 [4 prior + 1 triage-2026-05-28: rejection-visibility + 1 discovery content_hash dedup] / Low: 8 [6 prior + 2 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
+**Open issues: 17 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 2 [1 blocked-on-react-19, 1 public-launch cost guardrail] / Medium: 6 [4 prior + 1 triage-2026-05-28: rejection-visibility + 1 discovery content_hash dedup] / Low: 7 [6 prior + 1 triage-2026-05-28 cosmetic] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
 
 > Status (2026-05-08 PM): All actionable audit items resolved across batches PR #492-#528 (~30 PRs). Remaining open entries are either (a) blocked on the React 18→19 monorepo bump (5 items), (b) deferred-by-design conventions or follow-ups (4), (c) environmental issues unrelated to code (3: asyncpg Windows, test hang on Windows, Quality Gate false-positive), or (d) intentional accepted lint warnings (2).
 
@@ -772,11 +772,10 @@ This rules a lot of work in and out: **don't** invest in a relevance-overhaul or
 **Reported:** operator, with screenshot — the three pills in a card's top-right (status "Scoring", publisher "JobLeads", saved-search name "senior software engineer") sit at slightly different vertical positions / heights.
 **Hypothesis:** the badge row mixes pill components with inconsistent padding / line-height / vertical-align, or the flex row lacks `items-center`. Likely in `apps/myjobhunter/frontend/src/features/discover/DiscoveredJobCard.tsx` (header/badge row). Normalize to one badge primitive + `items-center`.
 
-### LOW — Rename user-facing "Discover" → "Discovery"
+### ~~LOW — Rename user-facing "Discover" → "Discovery"~~ RESOLVED
 
+**Resolved:** 2026-05-30, branch `fix/mjh-rename-discover-to-discovery`. Renamed the three user-facing labels only: nav item (`src/constants/nav.ts`), page `<h1>` heading (`src/pages/Discover.tsx`), and the tablist `aria-label` (`src/features/discover/DiscoverViewTabs.tsx`, "Discover views" → "Discovery views"). The empty-state copy (`src/constants/empty-states.ts`) contained no "Discover" literal, so it was untouched. Per the recommendation, the `/discover` route path, the `discover.py` API module, the `discover`/`discovery` internal module/component naming, and code comments were left as-is (larger blast radius, no user-visible benefit). No redirect needed.
 **Reported:** operator.
-**Scope:** rename the user-facing label only — nav item (`src/constants/nav.ts`), page heading ("Discover" → "Discovery"), and any empty-state copy (`src/constants/empty-states.ts`). 
-**Decision needed:** whether to also rename the route path `/discover` → `/discovery` (would need a redirect for existing bookmarks) and the backend `discover.py` API module / `discovery` service naming. Recommendation: change display copy now; keep the route + internal `discover`/`discovery` module naming as-is unless there's a reason to churn it (larger blast radius, no user-visible benefit). Confirm during the fix.
 
 ### FEATURE — Upload & store raw resume documents (resume-specific, mirror MBK Documents)
 

--- a/apps/myjobhunter/frontend/src/constants/nav.ts
+++ b/apps/myjobhunter/frontend/src/constants/nav.ts
@@ -19,7 +19,7 @@ export const NAV_DESCRIPTORS: NavDescriptor[] = [
   // Listed first per session decision: the application page is no
   // longer the first step in the new-job workflow.
   { path: "/analyze", label: "Analyze a job", iconName: "Search" },
-  { path: "/discover", label: "Discover", iconName: "Telescope" },
+  { path: "/discover", label: "Discovery", iconName: "Telescope" },
   { path: "/dashboard", label: "Dashboard", iconName: "LayoutDashboard" },
   { path: "/applications", label: "Applications", iconName: "Briefcase" },
   { path: "/companies", label: "Companies", iconName: "Building2" },

--- a/apps/myjobhunter/frontend/src/features/discover/DiscoverViewTabs.tsx
+++ b/apps/myjobhunter/frontend/src/features/discover/DiscoverViewTabs.tsx
@@ -13,7 +13,7 @@ export default function DiscoverViewTabs({
   return (
     <div
       role="tablist"
-      aria-label="Discover views"
+      aria-label="Discovery views"
       className="flex gap-1 border-b border-border"
     >
       <DiscoverTabButton

--- a/apps/myjobhunter/frontend/src/pages/Discover.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Discover.tsx
@@ -71,7 +71,7 @@ export default function Discover() {
     <main className="p-4 sm:p-8 space-y-6">
       <header className="flex items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold">Discover</h1>
+          <h1 className="text-2xl font-semibold">Discovery</h1>
           <p className="text-sm text-muted-foreground mt-1">
             New postings from LinkedIn, Indeed, Glassdoor, and ZipRecruiter
             via Google Jobs. Refresh a saved search to pull the latest.


### PR DESCRIPTION
Operator asked for the user-facing label to read **"Discovery"**. Renames the three user-facing strings only:

- nav item label — `src/constants/nav.ts`
- page `<h1>` heading — `src/pages/Discover.tsx`
- tablist `aria-label` "Discover views" → "Discovery views" — `src/features/discover/DiscoverViewTabs.tsx`

**Intentionally left as-is** (per the TECH_DEBT recommendation — larger blast radius, no user-visible benefit): the `/discover` route path (renaming would need a redirect for existing bookmarks), the `discover.py` API module, the `discover`/`discovery` internal module + component names, and code comments. Empty-state copy had no "Discover" literal.

Typecheck ✓, lint ✓, 156 `Discover` page + `features/discover` tests ✓.

Resolves the #8 TECH_DEBT cosmetic item (Low 8→7, open 18→17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)