### PR TITLE
fix(mga): cap last-chapter window so throw localization finds early throws

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/chapter_parser.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/chapter_parser.py
@@ -22,7 +22,8 @@ Usage::
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
+from statistics import median
 from typing import Optional
 
 
@@ -216,6 +217,47 @@ def filter_lineup_chapters(
     return kept
 
 
+# Floor for the capped last-chapter window — enough to hold a full demo
+# (walk-in + stand + aim + throw + result) even when this creator's typical
+# chapter is shorter. Kept below clip_window_timestamps's 90s long-chapter
+# threshold so the cap also drops the 0.30 lead-in skip that overshot the throw.
+_LAST_CHAPTER_MAX_WINDOW_FLOOR_SECONDS = 45
+
+
+def _cap_last_chapter_to_typical_duration(
+    chapters: list[Chapter], video_duration: int
+) -> list[Chapter]:
+    """Shrink an artificially-long LAST chapter to this video's typical length.
+
+    The last chapter has no next-chapter boundary, so its ``end_seconds`` is the
+    video tail. On a video that continues past the final lineup demo (outro,
+    extra footage), that tail inflates the chapter duration far past a real demo
+    — and ``clip_window_timestamps`` then applies its long-chapter 0.30 lead-in
+    skip, sampling PAST the (early) throw. Operator audit 2026-05-30, lineup
+    9b2ad4c9 "Stairs - A Site": last chapter 403->508 = 105s, the throw window
+    opened at +27s, and the real throw (~+17s, right after the aim) was never
+    sampled — the localizer locked onto outro content +39s after the aim.
+
+    Cap the last chapter's end at ``start + max(median sibling duration,
+    _LAST_CHAPTER_MAX_WINDOW_FLOOR_SECONDS)`` so its throw-search window matches
+    a normal chapter for this creator. SHRINK-ONLY (never extend a naturally
+    short last chapter) and only with >=2 chapters (so a sibling median exists).
+    The median adapts to each creator's pacing without a hardcoded length.
+
+    Returns a new list (the last chapter ``replace``'d when capped), else the
+    input unchanged.
+    """
+    if len(chapters) < 2:
+        return chapters
+    typical = median(c.end_seconds - c.start_seconds for c in chapters[:-1])
+    last = chapters[-1]
+    cap = last.start_seconds + max(typical, _LAST_CHAPTER_MAX_WINDOW_FLOOR_SECONDS)
+    new_end = min(last.end_seconds, int(cap))
+    if new_end >= last.end_seconds:
+        return chapters  # already tighter than the cap — leave it
+    return chapters[:-1] + [replace(last, end_seconds=new_end)]
+
+
 def parse_chapters(
     description: str,
     video_duration: int,
@@ -250,7 +292,10 @@ def parse_chapters(
             except (ValueError, TypeError, KeyError):
                 continue
         if result:
-            return result
+            return _cap_last_chapter_to_typical_duration(result, video_duration)
 
     # Fallback to description regex.
-    return _parse_chapters_from_description(description, video_duration)
+    return _cap_last_chapter_to_typical_duration(
+        _parse_chapters_from_description(description, video_duration),
+        video_duration,
+    )

--- a/apps/mygamingassistant/backend/tests/test_chapter_parser.py
+++ b/apps/mygamingassistant/backend/tests/test_chapter_parser.py
@@ -48,10 +48,14 @@ class TestDescriptionChapters:
         assert chapters[2].start_seconds == 3945  # 1*3600 + 5*60 + 45
         assert chapters[2].end_seconds == 4000
 
-    def test_last_chapter_end_equals_duration(self):
+    def test_inflated_last_chapter_capped_to_typical_duration(self):
+        # Last chapter [120, 500] (380s) far exceeds the single sibling's 120s.
+        # The last-chapter window cap shrinks it to
+        # start + max(median_sibling=120, floor=45) = 120 + 120 = 240 so the
+        # throw-search window matches a normal chapter (see 9b2ad4c9 "Stairs").
         desc = "0:00 Intro\n2:00 Main content\n"
         chapters = parse_chapters(desc, video_duration=500)
-        assert chapters[-1].end_seconds == 500
+        assert chapters[-1].end_seconds == 240
 
     def test_description_with_non_chapter_lines(self):
         desc = (
@@ -134,7 +138,10 @@ class TestNativeChapters:
         assert chapters[0].start_seconds == 0
         assert chapters[0].end_seconds == 90
         assert chapters[1].start_seconds == 90
-        assert chapters[1].end_seconds == 300
+        # Last chapter [90, 300] (210s) exceeds the sibling's 90s, so the
+        # last-chapter window cap shrinks it to
+        # 90 + max(median_sibling=90, floor=45) = 180.
+        assert chapters[1].end_seconds == 180
 
     def test_empty_native_chapters_falls_back_to_description(self):
         desc = "0:00 Intro\n1:00 Second\n"
@@ -167,6 +174,59 @@ class TestNativeChapters:
         chapters = parse_chapters("", video_duration=120, native_chapters=native)
         # "Bad" has non-numeric start_time — parser skips it gracefully
         assert all(c.title != "Bad" for c in chapters)
+
+
+# ---------------------------------------------------------------------------
+# Last-chapter window cap (_cap_last_chapter_to_typical_duration)
+#
+# The last chapter has no next-chapter boundary, so its end is the video tail.
+# When the video continues past the final lineup demo, that inflates the chapter
+# duration and trips clip_window_timestamps's long-chapter lead-in skip, which
+# samples PAST the (early) throw (operator audit 2026-05-30, lineup 9b2ad4c9
+# "Stairs": last chapter 403->508=105s, throw window opened +27s, real throw
+# ~+17s never sampled). The cap shrinks the last chapter to this creator's
+# typical length: start + max(median sibling duration, 45s floor), shrink-only,
+# only with >=2 chapters.
+# ---------------------------------------------------------------------------
+
+class TestLastChapterCap:
+    def test_inflated_last_chapter_capped_by_median(self):
+        # Siblings 40s + 50s (median 45) > 45 floor → cap window = 45.
+        native = [
+            {"start_time": 0, "end_time": 40, "title": "L1"},
+            {"start_time": 40, "end_time": 90, "title": "L2"},
+            {"start_time": 90, "end_time": 290, "title": "L3 (inflated)"},
+        ]
+        chapters = parse_chapters("", video_duration=290, native_chapters=native)
+        # last [90, 290] (200s) capped to 90 + max(median=45, 45) = 135.
+        assert chapters[-1].end_seconds == 135
+
+    def test_floor_applies_when_typical_below_floor(self):
+        # Siblings 20s each (median 20 < 45) → floor 45 governs.
+        native = [
+            {"start_time": 0, "end_time": 20, "title": "L1"},
+            {"start_time": 20, "end_time": 40, "title": "L2"},
+            {"start_time": 40, "end_time": 200, "title": "L3 (inflated)"},
+        ]
+        chapters = parse_chapters("", video_duration=200, native_chapters=native)
+        # last [40, 200] (160s) capped to 40 + max(20, 45) = 85.
+        assert chapters[-1].end_seconds == 85
+
+    def test_tight_last_chapter_untouched(self):
+        # Last chapter already shorter than the cap window → never extended.
+        native = [
+            {"start_time": 0, "end_time": 100, "title": "L1"},
+            {"start_time": 100, "end_time": 130, "title": "L2 (short)"},
+        ]
+        chapters = parse_chapters("", video_duration=130, native_chapters=native)
+        assert chapters[-1].end_seconds == 130  # min(130, 100+max(100,45)) = 130
+
+    def test_single_chapter_not_capped(self):
+        # <2 chapters → no sibling median → no-op.
+        native = [{"start_time": 0, "end_time": 300, "title": "Only chapter"}]
+        chapters = parse_chapters("", video_duration=300, native_chapters=native)
+        assert len(chapters) == 1
+        assert chapters[0].end_seconds == 300
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The last chapter has no next-chapter boundary, so `chapter_parser` sets its `end_seconds` to the **video tail**. On a video that continues past the final lineup demo (outro / extra footage), that inflates the chapter duration past 90s — which makes `clip_window_timestamps` apply its long-chapter **0.30 lead-in skip** and sample *past* the (early) throw.

Operator audit, lineup `9b2ad4c9` "Stairs - A Site": last chapter **403→508 (105s)**, the throw window opened at **+27s**, and the real throw (~+15s, right after the aim at 419.24) was never sampled — the localizer locked onto outro content and released at **442.95, +39.3s after the aim** (incoherent storyboard).

This is distinct from the cross-chapter-bleed bug (#802); the recovery passes can't fix it because the real throw is never in the sampled window.

## Fix

`_cap_last_chapter_to_typical_duration` shrinks the last chapter's end to `start + max(median sibling duration, 45s floor)`:
- **shrink-only** — never extends a naturally-short last chapter
- only with **≥2 chapters** (so a sibling median exists)
- the **median** adapts to each creator's pacing (no hardcoded length); the **45s floor** guarantees a full walk→stand→aim→throw→result window stays in range
- applied to both the native-chapters and description-regex parse paths

Capping the chapter end below 90s also drops the 0.30 lead-in skip, so the window opens early enough to sample the throw.

## Validation (cached footage)

`9b2ad4c9` capped end **508→448**; release moves **442.95 (+39.3s) → 418.41 (+15.4s)**, now coherent with stand 410.08 / aim 419.24.

819 backend tests pass — 4 new cap tests (median basis, floor fallback, tight-chapter-untouched, single-chapter no-op) + 2 existing tests updated for the new capped end.

Note: the `release≫aim` scan flag turned out to be **mostly false positives** (legitimate aim→throw gaps where the narrator demos the aim, then throws seconds later — e.g. `f7e8c6b1`, a correctly-localized molotov 9s after a real aim demo). `9b2ad4c9` was the one genuine bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)