### PR TITLE
feat(mga): movement-aware throw-clip framing (adaptive pre-release pad)

### DIFF
--- a/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/clip_generator.py
@@ -49,6 +49,9 @@ from app.services.ingestion.frame_extractor import (
     FrameExtractionError,
     cut_clip,
 )
+from app.services.ingestion.throw_framing import (
+    pre_release_seconds_for_technique,
+)
 from app.services.ingestion.throw_localizer import (
     localize_throw_with_refinement,
 )
@@ -76,6 +79,9 @@ _CLIP_CONFIDENCE_GATE = 0.55
 # Tail unchanged: prior `result_ts + 1.5s` was already replaced (PR #755) with
 # release-anchored 1.0s because result_ts is the "first visible wisp"
 # (1.5-3.0s after release) → bloom belongs in LANDING, not THROW.
+# This is the STANDING default; moving throws (jump/run/walk) widen the PRE
+# pad per-lineup via throw_framing.pre_release_seconds_for_technique() so the
+# windup is in frame without re-showing the AIM pane on standing throws.
 _PRE_RELEASE_SECONDS = 1.0
 _POST_RELEASE_SECONDS = 1.0
 # Below this the chapter-clamped window is unusable → skip.
@@ -146,16 +152,20 @@ def _compute_clip_bounds(
     release_ts: float,
     chapter_start: float,
     chapter_end: float,
+    pre_release_seconds: float = _PRE_RELEASE_SECONDS,
 ) -> Optional[tuple[float, float]]:
     """Return ``(clip_start, clip_duration)`` seconds, or None if too short.
 
-    [release - _PRE_RELEASE_SECONDS, release + _POST_RELEASE_SECONDS] clamped
+    [release - pre_release_seconds, release + _POST_RELEASE_SECONDS] clamped
     to the chapter. The throw pane's job is the throw MOTION; anchoring the
     tail on release_ts (not result_ts, the "first visible wisp") keeps the
-    clip tight on the action. Returns None when the chapter-clamped window
-    is shorter than ``_ABSOLUTE_MIN_CLIP_SECONDS`` so the caller skips.
+    clip tight on the action. ``pre_release_seconds`` is movement-aware — the
+    caller widens it for jump/run/walk throws so the windup is in frame (see
+    ``throw_framing``) — and defaults to the standing ``_PRE_RELEASE_SECONDS``.
+    Returns None when the chapter-clamped window is shorter than
+    ``_ABSOLUTE_MIN_CLIP_SECONDS`` so the caller skips.
     """
-    start = max(release_ts - _PRE_RELEASE_SECONDS, chapter_start)
+    start = max(release_ts - pre_release_seconds, chapter_start)
     end = min(release_ts + _POST_RELEASE_SECONDS, chapter_end)
     duration = end - start
 
@@ -339,8 +349,14 @@ async def generate_clip_for_lineup(
         else:
             result_ts = release_ts
 
+        # Movement-aware framing: widen the pre-release pad for jump/run/walk
+        # throws so the windup is in frame, keyed on the lineup's already-named
+        # technique (PR3 footer). Null / standing / Valorant cast → the
+        # standing default, identical to the pre-feature window (no regression).
+        pre_release_seconds = pre_release_seconds_for_technique(lineup.technique)
         bounds = _compute_clip_bounds(
-            release_ts, float(chapter_start), float(chapter_end)
+            release_ts, float(chapter_start), float(chapter_end),
+            pre_release_seconds,
         )
         if bounds is None:
             return ClipGenerationResult(
@@ -461,9 +477,11 @@ async def generate_clip_for_lineup(
 
         logger.info(
             "clip_generator: clip generated: lineup=%s video_id=%s key=%s "
-            "release_ts=%.2f result_ts=%.2f clip=[%.2f,+%.2fs] confidence=%.2f",
+            "release_ts=%.2f result_ts=%.2f clip=[%.2f,+%.2fs] "
+            "technique=%r pre_release_s=%.2f confidence=%.2f",
             lineup.id, video_id, clip_key, release_ts, result_ts,
-            clip_start, clip_duration, timing.confidence or 0.0,
+            clip_start, clip_duration, lineup.technique, pre_release_seconds,
+            timing.confidence or 0.0,
         )
         return ClipGenerationResult(
             status="generated",

--- a/apps/mygamingassistant/backend/app/services/ingestion/throw_framing.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/throw_framing.py
@@ -1,0 +1,112 @@
+"""Throw-clip framing — movement-aware pre-release padding.
+
+The throw pane shows the throw MOTION (windup -> release -> follow-through).
+How much *windup* precedes the release depends on HOW the throw is executed: a
+standing throw is a quick flick (the locked aim sits right up to the release),
+whereas a jump-throw, run-throw or walk-throw begins its defining movement well
+before the grenade leaves the hand. A single flat pre-release pad cannot frame
+both — the 1.0s tuned for standing throws (a longer pad duplicated the AIM pane
+on lineup 7bd971c3, 2026-05-24; see ``clip_generator._PRE_RELEASE_SECONDS``)
+clips into the middle of a jump / run windup, cutting off the very movement the
+pane exists to teach.
+
+This module maps a lineup's already-extracted ``technique`` phrase — the PR3
+glance-board footer, e.g. ``"Jumpthrow + LMB"`` / ``"Run + RMB"`` /
+``"Standing + LMB"`` — to the right pre-release pad. It is a PURE function over
+the persisted technique string:
+
+  - It makes NO Claude call and does NO frame extraction.
+  - It does NOT touch the load-bearing throw-timing localiser. ``release_ts`` is
+    unchanged; only the clip window *around* it widens. (Decoupling the framing
+    decision from the freshly-stabilised release localiser is deliberate — see
+    PRs #799/#802/#803.)
+  - Only the PRE pad varies; the post-release follow-through is
+    movement-independent.
+
+``technique`` is the single source of throw-type truth (named once by
+``throw_technique_classifier``); the clip path reads it rather than re-detecting
+movement, so the two surfaces never disagree. When technique is absent — null,
+not yet extracted at ingest time, or a Valorant ability cast with no movement
+component (``"E + 2-charge"``) — the pad falls back to the standing default,
+identical to the pre-feature behaviour, so nothing regresses.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+# The standing/default pre-release pad: the historical flat value, tuned DOWN
+# from 2.0 to avoid duplicating the AIM pane on standing throws. Mirrors
+# ``clip_generator._PRE_RELEASE_SECONDS`` by design — they are the same
+# "stationary throw" default expressed once on each surface.
+_STANDING_PRE_RELEASE_SECONDS = 1.0
+
+# Pre-release clip pad (seconds) per throw movement. INITIAL values pending an
+# operator full-res re-cut eyeball (clip framing is operator-judged at full
+# resolution, never asserted from timestamps alone — see the throw-localizer
+# memory's process lesson). Tune here without touching the clip geometry.
+#
+#   - Stationary techniques (standing, crouch) keep the 1.0s default — the
+#     locked aim sits right up to a flick/crouch release, so a wider pad would
+#     re-show the AIM pane.
+#   - Moving techniques widen the PRE pad to capture the run-up / jump windup
+#     the throw pane exists to demonstrate (a jump-throw's leap, a run-throw's
+#     stride). The POST pad is unchanged (follow-through is movement-agnostic).
+_PRE_RELEASE_SECONDS_BY_MOVEMENT: dict[str, float] = {
+    "standing": _STANDING_PRE_RELEASE_SECONDS,
+    "crouch": _STANDING_PRE_RELEASE_SECONDS,
+    "jump": 1.5,
+    "walk": 1.5,
+    "run": 2.0,
+}
+
+
+def _movement_from_technique(technique: Optional[str]) -> Optional[str]:
+    """Classify the throw MOVEMENT from a ``technique`` footer phrase.
+
+    Reads only the head token — the substring before the first ``"+"``, which
+    separates the movement+throw-type from the input (mouse button / ability
+    charge). So ``"Jumpthrow + LMB"`` -> ``"jump"``, ``"Run + RMB"`` ->
+    ``"run"``, ``"Standing + LMB"`` -> ``"standing"``.
+
+    The CS2 technique vocabulary's movement words (standing / jumpthrow[-bind]
+    / run[-throw] / walk[-throw] / crouch[-throw]) are matched by substring on
+    that head, so both the compact form (``"Run"``) and the full form
+    (``"run-throw"``) resolve, as does a partial answer that is just the
+    movement (``"Jumpthrow"``).
+
+    Returns ``None`` for a Valorant ability key (``"E + 2-charge"``), an empty
+    or ``None`` phrase, or anything without a recognised movement word — the
+    caller then uses the standing default.
+    """
+    if not technique:
+        return None
+    head = technique.split("+", 1)[0].strip().lower()
+    if not head:
+        return None
+    # Substring tests on the constrained vocabulary head are unambiguous — no
+    # two CS2 movement words share a stem, and Valorant heads are single keys.
+    if "jump" in head:
+        return "jump"
+    if "run" in head:
+        return "run"
+    if "walk" in head:
+        return "walk"
+    if "crouch" in head:
+        return "crouch"
+    if "stand" in head:
+        return "standing"
+    return None
+
+
+def pre_release_seconds_for_technique(technique: Optional[str]) -> float:
+    """Pre-release clip pad (seconds) for a lineup's throw ``technique``.
+
+    Movement-aware: moving throws (jump / run / walk) widen the pad to include
+    their windup; stationary throws (standing / crouch) and any
+    unknown / absent / Valorant technique use the standing default. Pure and
+    total — safe to call with ``None``.
+    """
+    movement = _movement_from_technique(technique)
+    return _PRE_RELEASE_SECONDS_BY_MOVEMENT.get(
+        movement or "standing", _STANDING_PRE_RELEASE_SECONDS
+    )

--- a/apps/mygamingassistant/backend/tests/test_clip_generator.py
+++ b/apps/mygamingassistant/backend/tests/test_clip_generator.py
@@ -52,12 +52,13 @@ def _wide_fail():
     return WideSourceResult(error_codes=["wide_source_cut:rc=1"])
 
 
-def _lineup(video_id="vid123", chapter_title="B smoke"):
+def _lineup(video_id="vid123", chapter_title="B smoke", technique=None):
     return types.SimpleNamespace(
         id=uuid.uuid4(),
         youtube_video_id=video_id,
         chapter_title=chapter_title,
         clip_url=None,
+        technique=technique,
     )
 
 
@@ -90,6 +91,14 @@ class TestComputeClipBounds:
         # release near chapter_end → tail clamped to chapter_end.
         start, dur = _compute_clip_bounds(22.5, 10.0, 23.0)
         assert start + dur <= 23.0 + 1e-9
+
+    def test_movement_aware_pre_release_widens_window(self):
+        # A wider pre pad (jump/run framing) opens the clip EARLIER; the post
+        # pad is unchanged. release 20, pre 1.5 → [18.5, 21] = 2.5s. The
+        # default pre (no arg) stays 1.0 → [19, 21] = 2.0s (asserted above).
+        start, dur = _compute_clip_bounds(20.0, 10.0, 40.0, pre_release_seconds=1.5)
+        assert start == pytest.approx(18.5)
+        assert dur == pytest.approx(2.5)
 
 
 def test_pending_clip_key_is_deterministic():
@@ -542,3 +551,64 @@ class TestGenerateClipFailures:
         assert result.status == "failed"
         assert result.error_codes == ["clip_upload_failed"]
         mock_set.assert_not_awaited()  # nothing persisted on upload failure
+
+
+class TestMovementAwareFraming:
+    """The throw-clip PRE pad widens for moving throws (jump/run/walk) and
+    stays at the standing default otherwise — keyed on ``lineup.technique``.
+    release_ts and the POST pad are unchanged; only clip_start moves. This is
+    the end-to-end proof that throw_framing is wired into the generated window.
+    """
+
+    async def _bounds_for(self, technique, video):
+        # release_index=2 over [10,20,30] → release_ts=20.0; chapter [0,40].
+        with (
+            patch(f"{_MOD}.settings", _settings()),
+            patch(f"{_MOD}.localize_throw_with_refinement",
+                  new=AsyncMock(return_value=_refined(
+                      timestamps=[10.0, 20.0, 30.0],
+                      release_index=2, result_index=3))),
+            patch(f"{_MOD}.cut_clip", new=AsyncMock(return_value=_FAKE_MP4)),
+            patch(f"{_MOD}.get_storage", return_value=MagicMock()),
+            patch(f"{_MOD}.cut_and_upload_wide_source",
+                  new=AsyncMock(return_value=_wide_fail())),
+            patch(f"{_MOD}.lineup_repo.set_clip_url", new=AsyncMock()),
+        ):
+            return await generate_clip_for_lineup(
+                MagicMock(), _lineup(technique=technique),
+                chapter_start=0.0, chapter_end=40.0, video_path=video,
+            )
+
+    @pytest.mark.asyncio
+    async def test_jump_opens_clip_earlier(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        result = await self._bounds_for("Jumpthrow + LMB", v)
+        assert result.status == "generated"
+        # jump pre=1.5 → [20-1.5, 20+1.0] = [18.5, +2.5]
+        assert result.clip_start == pytest.approx(18.5)
+        assert result.clip_duration == pytest.approx(2.5)
+
+    @pytest.mark.asyncio
+    async def test_run_opens_clip_earliest(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        result = await self._bounds_for("Run + RMB", v)
+        # run pre=2.0 → [18.0, +3.0]
+        assert result.clip_start == pytest.approx(18.0)
+        assert result.clip_duration == pytest.approx(3.0)
+
+    @pytest.mark.asyncio
+    async def test_standing_uses_default_window(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        result = await self._bounds_for("Standing + LMB", v)
+        # standing pre=1.0 → [19.0, +2.0]
+        assert result.clip_start == pytest.approx(19.0)
+        assert result.clip_duration == pytest.approx(2.0)
+
+    @pytest.mark.asyncio
+    async def test_null_technique_matches_pre_feature_window(self, tmp_path: Path):
+        v = tmp_path / "v.mp4"; v.write_bytes(b"x")
+        result = await self._bounds_for(None, v)
+        # No technique (e.g. ingest-time, before extraction) → identical to
+        # today's flat 1.0s window: the no-regression guarantee.
+        assert result.clip_start == pytest.approx(19.0)
+        assert result.clip_duration == pytest.approx(2.0)

--- a/apps/mygamingassistant/backend/tests/test_throw_framing.py
+++ b/apps/mygamingassistant/backend/tests/test_throw_framing.py
@@ -1,0 +1,88 @@
+"""Unit tests for movement-aware throw-clip framing (``throw_framing``).
+
+Pure mapping from a lineup's technique-footer phrase to the pre-release clip
+pad — no I/O, no Claude, no DB. The end-to-end wiring (technique -> wider
+generated clip window) is asserted in ``test_clip_generator.py``
+``TestMovementAwareFraming``.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.services.ingestion.throw_framing import (
+    _STANDING_PRE_RELEASE_SECONDS,
+    _movement_from_technique,
+    pre_release_seconds_for_technique,
+)
+
+
+class TestMovementFromTechnique:
+    @pytest.mark.parametrize(
+        "technique,expected",
+        [
+            ("Standing + LMB", "standing"),
+            ("Jumpthrow + LMB", "jump"),
+            ("Jumpthrow-bind + LMB", "jump"),
+            ("Run + RMB", "run"),
+            ("run-throw + LMB", "run"),
+            ("Walk + LMB+RMB", "walk"),
+            ("walk-throw", "walk"),
+            ("Crouch + LMB", "crouch"),
+            ("crouch-throw + RMB", "crouch"),
+            # Partial answer — just the movement, no input component.
+            ("Jumpthrow", "jump"),
+            # Case / surrounding whitespace insensitivity.
+            ("  JUMPTHROW + lmb  ", "jump"),
+        ],
+    )
+    def test_recognised_movements(self, technique, expected):
+        assert _movement_from_technique(technique) == expected
+
+    @pytest.mark.parametrize(
+        "technique",
+        [
+            None,
+            "",
+            "   ",
+            # Valorant ability casts carry no movement component.
+            "E + 2-charge + 1-bounce",
+            "C + aimed",
+            "Q + full-charge",
+            "X + held-cast",
+            # Head with no recognised movement word.
+            "Lineup + LMB",
+        ],
+    )
+    def test_no_movement(self, technique):
+        assert _movement_from_technique(technique) is None
+
+
+class TestPreReleaseSecondsForTechnique:
+    def test_standing_is_default(self):
+        assert pre_release_seconds_for_technique("Standing + LMB") == pytest.approx(1.0)
+
+    def test_crouch_is_default(self):
+        # Crouch is near-stationary — same pad as standing.
+        assert pre_release_seconds_for_technique("Crouch + LMB") == pytest.approx(1.0)
+
+    def test_jump_widens(self):
+        assert pre_release_seconds_for_technique("Jumpthrow + LMB") == pytest.approx(1.5)
+
+    def test_walk_widens(self):
+        assert pre_release_seconds_for_technique("Walk + LMB") == pytest.approx(1.5)
+
+    def test_run_widens_most(self):
+        assert pre_release_seconds_for_technique("Run + RMB") == pytest.approx(2.0)
+
+    @pytest.mark.parametrize("technique", [None, "", "E + 2-charge", "C + aimed"])
+    def test_absent_or_valorant_uses_default(self, technique):
+        assert pre_release_seconds_for_technique(technique) == pytest.approx(
+            _STANDING_PRE_RELEASE_SECONDS
+        )
+
+    def test_moving_pad_strictly_exceeds_standing(self):
+        # The whole point: a moving throw opens the clip earlier than a
+        # standing one so the run-up / jump windup is in frame.
+        standing = pre_release_seconds_for_technique("Standing + LMB")
+        for moving in ("Jumpthrow + LMB", "Run + RMB", "Walk + LMB"):
+            assert pre_release_seconds_for_technique(moving) > standing


### PR DESCRIPTION
## What

The throw pane shows the throw **motion** (windup → release → follow-through), but the clip window used a **flat 1.0s pre-release pad** for every throw. That value was tuned down from 2.0s so standing throws wouldn't re-show the AIM pane (lineup 7bd971c3) — but it clips into the middle of a **jump / run / walk** windup, cutting off the very movement the pane exists to teach.

This makes the pre-release pad **movement-aware**, keyed on the lineup's already-extracted `technique` footer (PR3):

| technique | pre-release pad |
|---|---|
| standing, crouch | 1.0s (unchanged default) |
| jumpthrow, walk | 1.5s |
| run | 2.0s |
| absent / Valorant cast / unknown | 1.0s (default) |

The post-release pad is unchanged (follow-through is movement-independent), and the **load-bearing throw-timing localiser is untouched** — `release_ts` is unchanged; only the window *around* it widens. Deliberately decoupled from the release localiser that #799/#802/#803 just stabilised.

## How

- New **pure** module `throw_framing.pre_release_seconds_for_technique()` maps the technique phrase → pad. No Claude call, no DB.
- `clip_generator._compute_clip_bounds` gains a defaulted `pre_release_seconds` param; `generate_clip_for_lineup` computes it from `lineup.technique`.
- `technique` is the single source of throw-type truth (named once by `throw_technique_classifier`); the clip path **reads** it rather than re-detecting movement, so the two surfaces can't disagree.

## No regression

When `technique` is absent — null, not yet extracted at ingest time, or a Valorant ability cast — the pad falls back to the standing default, i.e. **today's exact flat 1.0s window**. Asserted end-to-end (`test_null_technique_matches_pre_feature_window`).

## Realizing it on existing lineups (NOT deploy-critical)

No schema change, no env change, no migration. New ingests frame correctly once `technique` is set. To re-frame the existing library, run (idempotent):

```
python -m app.cli backfill-technique   # ensure technique is populated first
python -m app.cli backfill-clips        # re-cuts with movement-aware framing
```

## Pad values are initial

The pad seconds live in one dict in `throw_framing.py`, easy to tune after an operator full-res re-cut eyeball (clip framing is operator-judged, not asserted from timestamps).

## Testing

- `tests/test_throw_framing.py` — pure technique→pad mapping (CS2 movements, Valorant casts, partials, case/whitespace, null).
- `tests/test_clip_generator.py::TestMovementAwareFraming` — end-to-end: jump opens the clip earlier (18.5 vs 19.0), run earliest (18.0), standing/null unchanged.
- 167 ingestion-pipeline tests pass locally; file-size + import smoke clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)