### PR TITLE
feat(mbk): guest welcome manual section images (PR 2)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/wmanualimg260530_add_welcome_manual_section_images.py
+++ b/apps/mybookkeeper/backend/alembic/versions/wmanualimg260530_add_welcome_manual_section_images.py
@@ -1,0 +1,54 @@
+"""add welcome_manual_section_images
+
+Revision ID: wmanualimg260530
+Revises: wmanual260530
+Create Date: 2026-05-30
+
+Guest welcome manual — PR 2 (section images). One image per row, attached to a
+section, cascade-deleted with it. MinIO object cleanup is handled by the service.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "wmanualimg260530"
+down_revision: Union[str, None] = "wmanual260530"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "welcome_manual_section_images",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("section_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("storage_key", sa.String(length=255), nullable=False),
+        sa.Column("caption", sa.String(length=500), nullable=True),
+        sa.Column("display_order", sa.SmallInteger(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.func.now()),
+        sa.ForeignKeyConstraint(["section_id"], ["welcome_manual_sections.id"], ondelete="CASCADE"),
+    )
+    op.create_index(
+        "ix_welcome_manual_section_images_section_id",
+        "welcome_manual_section_images",
+        ["section_id"],
+    )
+    op.create_index(
+        "ix_welcome_manual_section_images_section_order",
+        "welcome_manual_section_images",
+        ["section_id", "display_order"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_welcome_manual_section_images_section_order",
+        table_name="welcome_manual_section_images",
+    )
+    op.drop_index(
+        "ix_welcome_manual_section_images_section_id",
+        table_name="welcome_manual_section_images",
+    )
+    op.drop_table("welcome_manual_section_images")

--- a/apps/mybookkeeper/backend/app/api/welcome_manuals.py
+++ b/apps/mybookkeeper/backend/app/api/welcome_manuals.py
@@ -1,9 +1,15 @@
 import uuid
 
-from fastapi import APIRouter, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Depends, File, HTTPException, Query, Response, UploadFile
 
 from app.core.context import RequestContext
 from app.core.permissions import current_org_member, require_write_access
+from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
+    WelcomeManualSectionImageResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_section_image_update_request import (
+    WelcomeManualSectionImageUpdateRequest,
+)
 from app.schemas.welcome_manuals.welcome_manual_create_request import (
     WelcomeManualCreateRequest,
 )
@@ -27,6 +33,7 @@ from app.schemas.welcome_manuals.welcome_manual_update_request import (
     WelcomeManualUpdateRequest,
 )
 from app.services.welcome_manuals import (
+    welcome_manual_section_image_service,
     welcome_manual_section_service,
     welcome_manual_service,
 )
@@ -189,4 +196,87 @@ async def delete_section(
         raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
     except welcome_manual_section_service.SectionNotFoundError as exc:
         raise HTTPException(status_code=404, detail="Section not found") from exc
+    return Response(status_code=204)
+
+
+# ---------------------------------------------------------------------------
+# Section images
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/{manual_id}/sections/{section_id}/images",
+    response_model=list[WelcomeManualSectionImageResponse],
+    status_code=201,
+)
+async def upload_section_images(
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    files: list[UploadFile] = File(...),
+    ctx: RequestContext = Depends(require_write_access),
+) -> list[WelcomeManualSectionImageResponse]:
+    payloads: list[tuple[bytes, str | None, str | None]] = []
+    for f in files:
+        content = await f.read()
+        payloads.append((content, f.filename, f.content_type))
+    try:
+        return await welcome_manual_section_image_service.upload_images(
+            ctx.organization_id, ctx.user_id, manual_id, section_id, payloads,
+        )
+    except welcome_manual_section_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_section_service.SectionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Section not found") from exc
+    except welcome_manual_section_image_service.StorageNotConfiguredError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    except welcome_manual_section_image_service.ImageRejected as exc:
+        # 413 (payload too large) for size; 415 for everything else.
+        status = 413 if "MB" in exc.reason else 415
+        raise HTTPException(status_code=status, detail=exc.reason) from exc
+
+
+@router.patch(
+    "/{manual_id}/sections/{section_id}/images/{image_id}",
+    response_model=WelcomeManualSectionImageResponse,
+)
+async def update_section_image(
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    image_id: uuid.UUID,
+    payload: WelcomeManualSectionImageUpdateRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> WelcomeManualSectionImageResponse:
+    try:
+        return await welcome_manual_section_image_service.update_image(
+            ctx.organization_id, ctx.user_id, manual_id, section_id, image_id,
+            payload.to_update_dict(),
+        )
+    except welcome_manual_section_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_section_service.SectionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Section not found") from exc
+    except welcome_manual_section_image_service.ImageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Image not found") from exc
+
+
+@router.delete(
+    "/{manual_id}/sections/{section_id}/images/{image_id}",
+    status_code=204,
+)
+async def delete_section_image(
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    image_id: uuid.UUID,
+    ctx: RequestContext = Depends(require_write_access),
+) -> Response:
+    try:
+        await welcome_manual_section_image_service.delete_image(
+            ctx.organization_id, ctx.user_id, manual_id, section_id, image_id,
+        )
+    except welcome_manual_section_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
+    except welcome_manual_section_service.SectionNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Section not found") from exc
+    except welcome_manual_section_image_service.ImageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Image not found") from exc
     return Response(status_code=204)

--- a/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
+++ b/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
@@ -6,6 +6,12 @@ service-layer seed and the schema validation a single source of truth.
 
 WELCOME_MANUAL_TITLE_MAX_LEN = 200
 WELCOME_MANUAL_SECTION_TITLE_MAX_LEN = 200
+WELCOME_MANUAL_IMAGE_CAPTION_MAX_LEN = 500
+
+# Object-key prefix for welcome-manual section images. Combined with the org id
+# for tenant isolation: ``{org_id}/welcome-manuals`` → keys land under
+# ``{org_id}/welcome-manuals/{uuid}/{filename}`` in the bucket.
+WELCOME_MANUAL_STORAGE_DOMAIN = "welcome-manuals"
 
 # Upper bound on sections per manual — a guard against a client expanding a
 # single manual into an unbounded number of rows. 50 is far above any real

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -18,6 +18,7 @@ from app.models.listings.listing_blackout import ListingBlackout
 from app.models.listings.listing_blackout_attachment import ListingBlackoutAttachment
 from app.models.welcome_manuals.welcome_manual import WelcomeManual
 from app.models.welcome_manuals.welcome_manual_section import WelcomeManualSection
+from app.models.welcome_manuals.welcome_manual_section_image import WelcomeManualSectionImage
 from app.models.calendar.calendar_email_review_queue import CalendarEmailReviewQueue
 from app.models.calendar.calendar_listing_blocklist import CalendarListingBlocklist
 from app.models.inquiries.inquiry import Inquiry

--- a/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual_section_image.py
+++ b/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual_section_image.py
@@ -1,0 +1,40 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Index, SmallInteger, String, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.db.base import Base
+
+
+class WelcomeManualSectionImage(Base):
+    """An image attached to a welcome-manual section (e.g. a photo of the
+    trash bins or the washing machine dial). Cascade-deleted with its section;
+    the MinIO object is cleaned up best-effort by the service on delete.
+    """
+
+    __tablename__ = "welcome_manual_section_images"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    section_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("welcome_manual_sections.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    storage_key: Mapped[str] = mapped_column(String(255), nullable=False)
+    caption: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    display_order: Mapped[int] = mapped_column(SmallInteger, nullable=False, default=0, server_default="0")
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_welcome_manual_section_images_section_order", "section_id", "display_order"),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/__init__.py
+++ b/apps/mybookkeeper/backend/app/repositories/__init__.py
@@ -40,6 +40,7 @@ from app.repositories.listings import listing_blackout_repo
 from app.repositories.listings import listing_blackout_attachment_repo
 from app.repositories.welcome_manuals import welcome_manual_repo
 from app.repositories.welcome_manuals import welcome_manual_section_repo
+from app.repositories.welcome_manuals import welcome_manual_section_image_repo
 from app.repositories.calendar import calendar_repository
 from app.repositories.calendar import review_queue_repo
 from app.repositories.calendar import blocklist_repo

--- a/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_section_image_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_section_image_repo.py
@@ -1,0 +1,142 @@
+import uuid
+from typing import Any
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.welcome_manuals.welcome_manual_section_image import (
+    WelcomeManualSectionImage,
+)
+
+# Columns mutable via PATCH. ``section_id`` and ``storage_key`` are immutable
+# post-create — moving an image between sections or rewriting its key is not a
+# supported flow.
+_UPDATABLE_COLUMNS: frozenset[str] = frozenset({
+    "caption",
+    "display_order",
+})
+
+
+async def list_by_section(
+    db: AsyncSession,
+    section_id: uuid.UUID,
+) -> list[WelcomeManualSectionImage]:
+    """List images for a section in display order (then by creation time)."""
+    result = await db.execute(
+        select(WelcomeManualSectionImage)
+        .where(WelcomeManualSectionImage.section_id == section_id)
+        .order_by(
+            WelcomeManualSectionImage.display_order.asc(),
+            WelcomeManualSectionImage.created_at.asc(),
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def list_by_section_ids(
+    db: AsyncSession,
+    section_ids: list[uuid.UUID],
+) -> list[WelcomeManualSectionImage]:
+    """List images for many sections in one query (ordered).
+
+    Used when building a full manual response so the per-section image load
+    is a single round trip rather than an N+1. Caller groups by section_id.
+    """
+    if not section_ids:
+        return []
+    result = await db.execute(
+        select(WelcomeManualSectionImage)
+        .where(WelcomeManualSectionImage.section_id.in_(section_ids))
+        .order_by(
+            WelcomeManualSectionImage.display_order.asc(),
+            WelcomeManualSectionImage.created_at.asc(),
+        )
+    )
+    return list(result.scalars().all())
+
+
+async def get_by_id(
+    db: AsyncSession,
+    image_id: uuid.UUID,
+    section_id: uuid.UUID,
+) -> WelcomeManualSectionImage | None:
+    """Return the image iff it exists and belongs to the given section."""
+    result = await db.execute(
+        select(WelcomeManualSectionImage).where(
+            WelcomeManualSectionImage.id == image_id,
+            WelcomeManualSectionImage.section_id == section_id,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def next_display_order(
+    db: AsyncSession,
+    section_id: uuid.UUID,
+) -> int:
+    """Return the next display_order slot for a section (max + 1, or 0 if empty)."""
+    result = await db.execute(
+        select(func.max(WelcomeManualSectionImage.display_order)).where(
+            WelcomeManualSectionImage.section_id == section_id,
+        )
+    )
+    current = result.scalar_one_or_none()
+    return 0 if current is None else int(current) + 1
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    section_id: uuid.UUID,
+    storage_key: str,
+    caption: str | None,
+    display_order: int,
+) -> WelcomeManualSectionImage:
+    image = WelcomeManualSectionImage(
+        section_id=section_id,
+        storage_key=storage_key,
+        caption=caption,
+        display_order=display_order,
+    )
+    db.add(image)
+    await db.flush()
+    return image
+
+
+async def update(
+    db: AsyncSession,
+    image_id: uuid.UUID,
+    section_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> WelcomeManualSectionImage | None:
+    """Apply allowlisted updates to an image. None if it doesn't exist /
+    belongs to a different section."""
+    image = await get_by_id(db, image_id, section_id)
+    if image is None:
+        return None
+    safe_fields = {k: v for k, v in fields.items() if k in _UPDATABLE_COLUMNS}
+    if not safe_fields:
+        return image
+    for key, value in safe_fields.items():
+        setattr(image, key, value)
+    await db.flush()
+    return image
+
+
+async def delete_by_id(
+    db: AsyncSession,
+    image_id: uuid.UUID,
+    section_id: uuid.UUID,
+) -> WelcomeManualSectionImage | None:
+    """Delete an image and return the deleted row (so the caller can reach the
+    storage_key for object-store cleanup). None if no row matched."""
+    image = await get_by_id(db, image_id, section_id)
+    if image is None:
+        return None
+    await db.execute(
+        delete(WelcomeManualSectionImage).where(
+            WelcomeManualSectionImage.id == image_id,
+            WelcomeManualSectionImage.section_id == section_id,
+        )
+    )
+    return image

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_image_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_image_response.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WelcomeManualSectionImageResponse(BaseModel):
+    id: uuid.UUID
+    section_id: uuid.UUID
+    storage_key: str
+    caption: str | None = None
+    display_order: int
+    created_at: datetime
+    # Short-lived signed URL minted per request via the single presigned seam.
+    presigned_url: str | None = None
+    # ``False`` means the underlying MinIO object is missing — the UI renders a
+    # placeholder + "re-upload" affordance instead of a broken image.
+    is_available: bool = True
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_image_update_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_image_update_request.py
@@ -1,0 +1,19 @@
+"""Pydantic schema for PATCH .../sections/{section_id}/images/{image_id}.
+
+Allows caption editing and reordering (display_order).
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from app.core.welcome_manual_constants import WELCOME_MANUAL_IMAGE_CAPTION_MAX_LEN
+
+
+class WelcomeManualSectionImageUpdateRequest(BaseModel):
+    caption: str | None = Field(default=None, max_length=WELCOME_MANUAL_IMAGE_CAPTION_MAX_LEN)
+    display_order: int | None = Field(default=None, ge=0)
+
+    model_config = ConfigDict(extra="forbid")
+
+    def to_update_dict(self) -> dict[str, object]:
+        return self.model_dump(exclude_unset=True)

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_section_response.py
@@ -3,16 +3,25 @@ from datetime import datetime
 
 from pydantic import BaseModel, ConfigDict
 
+from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
+    WelcomeManualSectionImageResponse,
+)
+
 
 class WelcomeManualSectionResponse(BaseModel):
-    """One section of a welcome manual. Section images are added to this shape
-    in PR 2 (the ``images`` field)."""
+    """One section of a welcome manual, with its ordered images.
+
+    ``images`` is populated (with presigned URLs) on the full-manual read
+    paths. Section-mutation responses (add / update / reorder) return an empty
+    list — the frontend refetches the manual after those edits.
+    """
 
     id: uuid.UUID
     manual_id: uuid.UUID
     title: str
     body: str | None = None
     display_order: int
+    images: list[WelcomeManualSectionImageResponse] = []
     created_at: datetime
     updated_at: datetime
 

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/section_image_response_builder.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/section_image_response_builder.py
@@ -1,0 +1,24 @@
+"""Inject per-request presigned URLs into WelcomeManualSectionImageResponse rows.
+
+Single-seam rule (same as listings' photo_response_builder): presigned URLs for
+welcome-manual images are minted ONLY through this module. Each row is
+HEAD-checked; missing objects are flagged ``is_available=False`` so the UI can
+render a placeholder instead of a broken image.
+"""
+from __future__ import annotations
+
+from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
+    WelcomeManualSectionImageResponse,
+)
+from app.services.storage.presigned_url_attacher import (
+    attach_presigned_url_with_head_check,
+)
+
+
+def attach_presigned_urls(
+    images: list[WelcomeManualSectionImageResponse],
+) -> list[WelcomeManualSectionImageResponse]:
+    return attach_presigned_url_with_head_check(
+        images,
+        sentry_event_name="welcome_manual_image_storage_object_missing",
+    )

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_section_image_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_section_image_service.py
@@ -1,0 +1,172 @@
+"""Welcome-manual section image upload pipeline.
+
+Mirrors listing_photo_service: size check → content sniff → allowlist →
+EXIF strip → storage put → repo insert. Scope is enforced by re-fetching the
+parent manual (org-scoped) and the section (manual-scoped) before touching any
+image. EXIF stripping is mandatory — a host's GPS coordinates must never reach
+the bucket (see image_processor).
+"""
+import logging
+import uuid
+from typing import Any
+
+from platform_shared.core.storage import StorageNotConfiguredError  # noqa: F401 — re-exported for the route
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.storage import get_storage
+from app.core.welcome_manual_constants import WELCOME_MANUAL_STORAGE_DOMAIN
+from app.db.session import unit_of_work
+from app.models.welcome_manuals.welcome_manual_section import WelcomeManualSection
+from app.repositories import (
+    welcome_manual_repo,
+    welcome_manual_section_image_repo,
+    welcome_manual_section_repo,
+)
+from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
+    WelcomeManualSectionImageResponse,
+)
+from app.services.storage.image_processor import ImageRejected, process_image  # noqa: F401 — ImageRejected re-exported for the route
+from app.services.welcome_manuals.section_image_response_builder import (
+    attach_presigned_urls,
+)
+from app.services.welcome_manuals.welcome_manual_section_service import (
+    ManualNotFoundError,
+    SectionNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ImageNotFoundError(LookupError):
+    """The image doesn't exist or belongs to a different section."""
+
+
+async def _load_section(
+    db: AsyncSession,
+    organization_id: uuid.UUID,
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+) -> WelcomeManualSection:
+    """Resolve the section, enforcing org → manual → section scoping. Raises
+    ManualNotFoundError / SectionNotFoundError."""
+    manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+    if manual is None:
+        raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+    section = await welcome_manual_section_repo.get_by_id(db, section_id, manual.id)
+    if section is None:
+        raise SectionNotFoundError(f"Section {section_id} not found")
+    return section
+
+
+async def upload_images(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    files: list[tuple[bytes, str | None, str | None]],
+) -> list[WelcomeManualSectionImageResponse]:
+    """Validate and persist a batch of section-image uploads.
+
+    Each file is `(content, filename, declared_content_type)`. Every image is
+    EXIF-stripped and re-encoded before storage. A single bad file aborts the
+    whole batch (no partial persist).
+
+    Raises:
+        ManualNotFoundError / SectionNotFoundError: scope failures.
+        StorageNotConfiguredError: object storage unavailable.
+        ImageRejected: any file fails size / format / decode validation.
+    """
+    if not files:
+        return []
+
+    storage = get_storage()
+    if storage is None:
+        raise StorageNotConfiguredError("Object storage is not configured")
+
+    # Pre-validate every file before touching storage so one bad file doesn't
+    # leave half a batch persisted.
+    processed: list[tuple[bytes, str, str]] = []
+    for content, filename, declared in files:
+        result = process_image(content, declared_content_type=declared)
+        safe_name = filename or f"image-{uuid.uuid4().hex}"
+        processed.append((result.content, result.content_type, safe_name))
+
+    async with unit_of_work() as db:
+        section = await _load_section(db, organization_id, manual_id, section_id)
+
+        next_order = await welcome_manual_section_image_repo.next_display_order(db, section.id)
+        prefix = f"{organization_id}/{WELCOME_MANUAL_STORAGE_DOMAIN}"
+        created: list[Any] = []
+        for index, (clean_bytes, content_type, safe_name) in enumerate(processed):
+            storage_key = storage.generate_key(prefix, safe_name)
+            # Upload BEFORE the DB insert so a storage failure rolls back the
+            # transaction cleanly. On DB-insert failure after a successful
+            # upload, best-effort delete the orphan object.
+            storage.upload_file(storage_key, clean_bytes, content_type)
+            try:
+                image = await welcome_manual_section_image_repo.create(
+                    db,
+                    section_id=section.id,
+                    storage_key=storage_key,
+                    caption=None,
+                    display_order=next_order + index,
+                )
+            except Exception:
+                try:
+                    storage.delete_file(storage_key)
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to delete orphan welcome-manual image %s after DB error",
+                        storage_key, exc_info=True,
+                    )
+                raise
+            created.append(image)
+
+        responses = [WelcomeManualSectionImageResponse.model_validate(i) for i in created]
+        return attach_presigned_urls(responses)
+
+
+async def update_image(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    image_id: uuid.UUID,
+    fields: dict[str, Any],
+) -> WelcomeManualSectionImageResponse:
+    """Update an image's caption and/or display_order."""
+    async with unit_of_work() as db:
+        section = await _load_section(db, organization_id, manual_id, section_id)
+        image = await welcome_manual_section_image_repo.update(db, image_id, section.id, fields)
+        if image is None:
+            raise ImageNotFoundError(f"Image {image_id} not found")
+        response = WelcomeManualSectionImageResponse.model_validate(image)
+        return attach_presigned_urls([response])[0]
+
+
+async def delete_image(
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    section_id: uuid.UUID,
+    image_id: uuid.UUID,
+) -> None:
+    """Delete an image from both the DB and object storage."""
+    async with unit_of_work() as db:
+        section = await _load_section(db, organization_id, manual_id, section_id)
+        deleted = await welcome_manual_section_image_repo.delete_by_id(db, image_id, section.id)
+        if deleted is None:
+            raise ImageNotFoundError(f"Image {image_id} not found")
+        storage_key = deleted.storage_key
+
+    # Storage cleanup outside the unit_of_work — the row is already gone; the
+    # user expects the image removed immediately, and orphans can be swept later.
+    storage = get_storage()
+    if storage is not None:
+        try:
+            storage.delete_file(storage_key)
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "Failed to delete welcome-manual image object %s from storage",
+                storage_key, exc_info=True,
+            )

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_section_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_section_service.py
@@ -3,15 +3,23 @@ a manual. Every operation re-verifies the parent manual belongs to the caller's
 organization before touching a section (the section table carries no org column;
 the manual is the scope gate).
 """
+import logging
 import uuid
 from typing import Any
 
+from app.core.storage import get_storage
 from app.core.welcome_manual_constants import WELCOME_MANUAL_MAX_SECTIONS
 from app.db.session import unit_of_work
-from app.repositories import welcome_manual_repo, welcome_manual_section_repo
+from app.repositories import (
+    welcome_manual_repo,
+    welcome_manual_section_image_repo,
+    welcome_manual_section_repo,
+)
 from app.schemas.welcome_manuals.welcome_manual_section_response import (
     WelcomeManualSectionResponse,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ManualNotFoundError(LookupError):
@@ -88,9 +96,27 @@ async def delete_section(
         manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
         if manual is None:
             raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
-        deleted = await welcome_manual_section_repo.delete_by_id(db, section_id, manual.id)
-        if deleted is None:
+        section = await welcome_manual_section_repo.get_by_id(db, section_id, manual.id)
+        if section is None:
             raise SectionNotFoundError(f"Section {section_id} not found")
+        # Capture image storage keys before the cascade removes the rows.
+        images = await welcome_manual_section_image_repo.list_by_section(db, section.id)
+        storage_keys = [image.storage_key for image in images]
+        await welcome_manual_section_repo.delete_by_id(db, section_id, manual.id)
+
+    # Best-effort MinIO cleanup outside the transaction — the section (and its
+    # image rows) are already gone; orphaned objects can be swept later.
+    if storage_keys:
+        storage = get_storage()
+        if storage is not None:
+            for key in storage_keys:
+                try:
+                    storage.delete_file(key)
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Failed to delete welcome-manual image object %s after section delete",
+                        key, exc_info=True,
+                    )
 
 
 async def reorder_sections(

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_service.py
@@ -11,6 +11,7 @@ from app.db.session import AsyncSessionLocal, unit_of_work
 from app.repositories import (
     property_repo,
     welcome_manual_repo,
+    welcome_manual_section_image_repo,
     welcome_manual_section_repo,
 )
 from app.schemas.welcome_manuals.welcome_manual_create_request import (
@@ -20,6 +21,9 @@ from app.schemas.welcome_manuals.welcome_manual_list_response import (
     WelcomeManualListResponse,
 )
 from app.schemas.welcome_manuals.welcome_manual_response import WelcomeManualResponse
+from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
+    WelcomeManualSectionImageResponse,
+)
 from app.schemas.welcome_manuals.welcome_manual_section_response import (
     WelcomeManualSectionResponse,
 )
@@ -27,18 +31,41 @@ from app.schemas.welcome_manuals.welcome_manual_summary import WelcomeManualSumm
 from app.schemas.welcome_manuals.welcome_manual_update_request import (
     WelcomeManualUpdateRequest,
 )
+from app.services.welcome_manuals.section_image_response_builder import (
+    attach_presigned_urls,
+)
 
 
-def _to_response(manual, sections=()) -> WelcomeManualResponse:
-    """Convert an ORM manual + its sections to a response model.
+def _build_section_responses(sections, images) -> list[WelcomeManualSectionResponse]:
+    """Build ordered section responses with each section's images attached.
+
+    ``images`` is a flat list of ORM image rows spanning ALL the sections;
+    presigned URLs are minted once over the flat list (one HEAD per image),
+    then grouped by section. No SQLAlchemy ``images`` relationship exists on the
+    section model — ``model_validate`` falls back to the field default, and we
+    overwrite it here — which keeps this safe under async (no lazy load).
+    """
+    image_responses = [WelcomeManualSectionImageResponse.model_validate(img) for img in images]
+    signed = attach_presigned_urls(image_responses)
+    by_section: dict[uuid.UUID, list[WelcomeManualSectionImageResponse]] = {}
+    for image in signed:
+        by_section.setdefault(image.section_id, []).append(image)
+    return [
+        WelcomeManualSectionResponse.model_validate(s).model_copy(
+            update={"images": by_section.get(s.id, [])},
+        )
+        for s in sections
+    ]
+
+
+def _to_response(manual, section_responses=()) -> WelcomeManualResponse:
+    """Convert an ORM manual + pre-built section responses to a response model.
 
     Centralising this construction prevents drift between get / create /
     update response shapes.
     """
     base = WelcomeManualResponse.model_validate(manual)
-    return base.model_copy(update={
-        "sections": [WelcomeManualSectionResponse.model_validate(s) for s in sections],
-    })
+    return base.model_copy(update={"sections": list(section_responses)})
 
 
 async def get_manual(
@@ -56,7 +83,10 @@ async def get_manual(
         if manual is None:
             raise LookupError(f"Welcome manual {manual_id} not found")
         sections = await welcome_manual_section_repo.list_by_manual(db, manual.id)
-    return _to_response(manual, sections)
+        images = await welcome_manual_section_image_repo.list_by_section_ids(
+            db, [s.id for s in sections],
+        )
+    return _to_response(manual, _build_section_responses(sections, images))
 
 
 async def list_manuals(
@@ -129,7 +159,8 @@ async def create_manual(
                 )
                 sections.append(section)
 
-        return _to_response(manual, sections)
+        # Freshly-seeded sections never have images yet.
+        return _to_response(manual, _build_section_responses(sections, []))
 
 
 async def update_manual(
@@ -160,7 +191,10 @@ async def update_manual(
             raise LookupError(f"Welcome manual {manual_id} not found")
 
         sections = await welcome_manual_section_repo.list_by_manual(db, manual.id)
-        return _to_response(manual, sections)
+        images = await welcome_manual_section_image_repo.list_by_section_ids(
+            db, [s.id for s in sections],
+        )
+        return _to_response(manual, _build_section_responses(sections, images))
 
 
 async def soft_delete_manual(

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_image_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_image_routes.py
@@ -1,0 +1,236 @@
+"""API route tests for welcome-manual section images. Mocks the service layer."""
+from __future__ import annotations
+
+import io
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization_member import OrgRole
+from app.schemas.welcome_manuals.welcome_manual_section_image_response import (
+    WelcomeManualSectionImageResponse,
+)
+from app.services.welcome_manuals import (
+    welcome_manual_section_image_service,
+    welcome_manual_section_service,
+)
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER)
+
+
+def _override_auth(org_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+    app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+
+def _jpeg_bytes() -> bytes:
+    img = Image.new("RGB", (8, 8), (1, 2, 3))
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _image_response(section_id: uuid.UUID, *, order: int = 0, caption: str | None = None) -> WelcomeManualSectionImageResponse:
+    return WelcomeManualSectionImageResponse(
+        id=uuid.uuid4(),
+        section_id=section_id,
+        storage_key="org/welcome-manuals/x/a.jpg",
+        caption=caption,
+        display_order=order,
+        created_at=datetime.now(timezone.utc),
+        presigned_url="https://signed/a.jpg",
+        is_available=True,
+    )
+
+
+def patch_image_service(name: str, **kwargs):
+    return patch.object(welcome_manual_section_image_service, name, **kwargs)
+
+
+class TestUpload:
+    @pytest.mark.asyncio
+    async def test_upload_201(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service("upload_images", return_value=[_image_response(section_id)]):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images",
+                    files=[("files", ("a.jpg", _jpeg_bytes(), "image/jpeg"))],
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 201
+        body = response.json()
+        assert len(body) == 1
+        assert body[0]["presigned_url"] == "https://signed/a.jpg"
+
+    @pytest.mark.asyncio
+    async def test_upload_manual_404(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service(
+                "upload_images",
+                side_effect=welcome_manual_section_service.ManualNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images",
+                    files=[("files", ("a.jpg", _jpeg_bytes(), "image/jpeg"))],
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_upload_section_404(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service(
+                "upload_images",
+                side_effect=welcome_manual_section_service.SectionNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images",
+                    files=[("files", ("a.jpg", _jpeg_bytes(), "image/jpeg"))],
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_upload_415_unsupported(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service(
+                "upload_images",
+                side_effect=welcome_manual_section_image_service.ImageRejected("unsupported file type"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images",
+                    files=[("files", ("a.pdf", b"%PDF-1.7", "application/pdf"))],
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 415
+
+    @pytest.mark.asyncio
+    async def test_upload_413_too_large(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service(
+                "upload_images",
+                side_effect=welcome_manual_section_image_service.ImageRejected("file exceeds 10MB limit"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images",
+                    files=[("files", ("big.jpg", _jpeg_bytes(), "image/jpeg"))],
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 413
+
+    @pytest.mark.asyncio
+    async def test_upload_503_storage(self) -> None:
+        org_id, user_id, manual_id, section_id = (uuid.uuid4() for _ in range(4))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service(
+                "upload_images",
+                side_effect=welcome_manual_section_image_service.StorageNotConfiguredError("down"),
+            ):
+                client = TestClient(app)
+                response = client.post(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images",
+                    files=[("files", ("a.jpg", _jpeg_bytes(), "image/jpeg"))],
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 503
+
+
+class TestUpdateDelete:
+    @pytest.mark.asyncio
+    async def test_update_200(self) -> None:
+        org_id, user_id, manual_id, section_id, image_id = (uuid.uuid4() for _ in range(5))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service(
+                "update_image",
+                return_value=_image_response(section_id, caption="renamed"),
+            ):
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images/{image_id}",
+                    json={"caption": "renamed"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 200
+        assert response.json()["caption"] == "renamed"
+
+    @pytest.mark.asyncio
+    async def test_update_image_404(self) -> None:
+        org_id, user_id, manual_id, section_id, image_id = (uuid.uuid4() for _ in range(5))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service(
+                "update_image",
+                side_effect=welcome_manual_section_image_service.ImageNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.patch(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images/{image_id}",
+                    json={"caption": "x"},
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_delete_204(self) -> None:
+        org_id, user_id, manual_id, section_id, image_id = (uuid.uuid4() for _ in range(5))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service("delete_image", return_value=None):
+                client = TestClient(app)
+                response = client.delete(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images/{image_id}",
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_delete_image_404(self) -> None:
+        org_id, user_id, manual_id, section_id, image_id = (uuid.uuid4() for _ in range(5))
+        _override_auth(org_id, user_id)
+        try:
+            with patch_image_service(
+                "delete_image",
+                side_effect=welcome_manual_section_image_service.ImageNotFoundError("nope"),
+            ):
+                client = TestClient(app)
+                response = client.delete(
+                    f"/welcome-manuals/{manual_id}/sections/{section_id}/images/{image_id}",
+                )
+        finally:
+            app.dependency_overrides.clear()
+        assert response.status_code == 404

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_section_image_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_section_image_repo.py
@@ -1,0 +1,107 @@
+"""Repository tests for welcome_manual_section_images."""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.welcome_manuals import (
+    welcome_manual_repo,
+    welcome_manual_section_image_repo,
+    welcome_manual_section_repo,
+)
+
+
+async def _make_section(db: AsyncSession, org: Organization, user: User):
+    manual = await welcome_manual_repo.create_manual(
+        db, organization_id=org.id, user_id=user.id,
+        property_id=None, title="G", intro_text=None,
+    )
+    await db.flush()
+    section = await welcome_manual_section_repo.create(
+        db, manual_id=manual.id, title="Wi-Fi", body=None, display_order=0,
+    )
+    await db.flush()
+    return section
+
+
+class TestOrderingAndCreate:
+    @pytest.mark.asyncio
+    async def test_create_and_list_in_order(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        await welcome_manual_section_image_repo.create(db, section_id=section.id, storage_key="b", caption=None, display_order=1)
+        await welcome_manual_section_image_repo.create(db, section_id=section.id, storage_key="a", caption=None, display_order=0)
+        await db.commit()
+        images = await welcome_manual_section_image_repo.list_by_section(db, section.id)
+        assert [i.storage_key for i in images] == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_next_display_order(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        assert await welcome_manual_section_image_repo.next_display_order(db, section.id) == 0
+        await welcome_manual_section_image_repo.create(db, section_id=section.id, storage_key="a", caption=None, display_order=0)
+        await db.flush()
+        assert await welcome_manual_section_image_repo.next_display_order(db, section.id) == 1
+
+
+class TestListBySectionIds:
+    @pytest.mark.asyncio
+    async def test_groups_across_sections(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        s1 = await _make_section(db, test_org, test_user)
+        s2 = await _make_section(db, test_org, test_user)
+        await welcome_manual_section_image_repo.create(db, section_id=s1.id, storage_key="a", caption=None, display_order=0)
+        await welcome_manual_section_image_repo.create(db, section_id=s1.id, storage_key="b", caption=None, display_order=1)
+        await welcome_manual_section_image_repo.create(db, section_id=s2.id, storage_key="c", caption=None, display_order=0)
+        await db.commit()
+        images = await welcome_manual_section_image_repo.list_by_section_ids(db, [s1.id, s2.id])
+        by_section: dict = {}
+        for img in images:
+            by_section.setdefault(img.section_id, []).append(img)
+        assert len(by_section[s1.id]) == 2
+        assert len(by_section[s2.id]) == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_input(self, db: AsyncSession) -> None:
+        assert await welcome_manual_section_image_repo.list_by_section_ids(db, []) == []
+
+
+class TestUpdateDelete:
+    @pytest.mark.asyncio
+    async def test_update_allowlist(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        image = await welcome_manual_section_image_repo.create(
+            db, section_id=section.id, storage_key="k", caption=None, display_order=0,
+        )
+        await db.commit()
+        updated = await welcome_manual_section_image_repo.update(
+            db, image.id, section.id,
+            {"caption": "Router is here", "display_order": 3, "storage_key": "hacked", "section_id": uuid.uuid4()},
+        )
+        assert updated is not None
+        assert updated.caption == "Router is here"
+        assert updated.display_order == 3
+        assert updated.storage_key == "k"  # immutable
+        assert updated.section_id == section.id  # immutable
+
+    @pytest.mark.asyncio
+    async def test_get_wrong_section_returns_none(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        image = await welcome_manual_section_image_repo.create(
+            db, section_id=section.id, storage_key="k", caption=None, display_order=0,
+        )
+        await db.commit()
+        assert await welcome_manual_section_image_repo.get_by_id(db, image.id, uuid.uuid4()) is None
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_row_then_none(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        section = await _make_section(db, test_org, test_user)
+        image = await welcome_manual_section_image_repo.create(
+            db, section_id=section.id, storage_key="k", caption=None, display_order=0,
+        )
+        await db.commit()
+        deleted = await welcome_manual_section_image_repo.delete_by_id(db, image.id, section.id)
+        assert deleted is not None and deleted.storage_key == "k"
+        assert await welcome_manual_section_image_repo.delete_by_id(db, image.id, section.id) is None

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_section_image_service.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_section_image_service.py
@@ -1,0 +1,187 @@
+"""Service-layer tests for welcome_manual_section_image_service.
+
+Uses the autouse in-memory storage fake (conftest ``_patch_storage_for_tests``)
+plus a patched ``unit_of_work`` pointing at the SQLite test session.
+"""
+from __future__ import annotations
+
+import io
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import patch
+
+import pytest
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.repositories.welcome_manuals import (
+    welcome_manual_repo,
+    welcome_manual_section_image_repo,
+    welcome_manual_section_repo,
+)
+from app.services.welcome_manuals import (
+    welcome_manual_section_image_service,
+    welcome_manual_service,
+)
+
+
+def _jpeg_bytes(color: tuple[int, int, int] = (10, 20, 30)) -> bytes:
+    img = Image.new("RGB", (16, 16), color)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG")
+    return buf.getvalue()
+
+
+def _patch_uow(db: AsyncSession):
+    @asynccontextmanager
+    async def _fake():
+        yield db
+
+    return patch(
+        "app.services.welcome_manuals.welcome_manual_section_image_service.unit_of_work",
+        _fake,
+    )
+
+
+async def _make_section(db: AsyncSession, org: Organization, user: User):
+    manual = await welcome_manual_repo.create_manual(
+        db, organization_id=org.id, user_id=user.id,
+        property_id=None, title="G", intro_text=None,
+    )
+    await db.flush()
+    section = await welcome_manual_section_repo.create(
+        db, manual_id=manual.id, title="Wi-Fi", body=None, display_order=0,
+    )
+    await db.flush()
+    return manual, section
+
+
+class TestUpload:
+    @pytest.mark.asyncio
+    async def test_appends_images_with_presigned_urls(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        files = [
+            (_jpeg_bytes((1, 2, 3)), "router.jpg", "image/jpeg"),
+            (_jpeg_bytes((4, 5, 6)), "bins.jpg", "image/jpeg"),
+        ]
+        with _patch_uow(db):
+            result = await welcome_manual_section_image_service.upload_images(
+                test_org.id, test_user.id, manual.id, section.id, files,
+            )
+        assert [r.display_order for r in result] == [0, 1]
+        assert all(r.presigned_url and r.presigned_url.startswith("https://signed/") for r in result)
+        assert all(r.is_available for r in result)
+
+    @pytest.mark.asyncio
+    async def test_manual_not_found(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_image_service.ManualNotFoundError):
+                await welcome_manual_section_image_service.upload_images(
+                    test_org.id, test_user.id, uuid.uuid4(), uuid.uuid4(),
+                    [(_jpeg_bytes(), "a.jpg", "image/jpeg")],
+                )
+
+    @pytest.mark.asyncio
+    async def test_section_not_found(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, _section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_image_service.SectionNotFoundError):
+                await welcome_manual_section_image_service.upload_images(
+                    test_org.id, test_user.id, manual.id, uuid.uuid4(),
+                    [(_jpeg_bytes(), "a.jpg", "image/jpeg")],
+                )
+
+    @pytest.mark.asyncio
+    async def test_cross_org_manual_not_found(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_image_service.ManualNotFoundError):
+                await welcome_manual_section_image_service.upload_images(
+                    uuid.uuid4(), test_user.id, manual.id, section.id,
+                    [(_jpeg_bytes(), "a.jpg", "image/jpeg")],
+                )
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_image(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_image_service.ImageRejected):
+                await welcome_manual_section_image_service.upload_images(
+                    test_org.id, test_user.id, manual.id, section.id,
+                    [(b"%PDF-1.7\n%not an image", "doc.pdf", "application/pdf")],
+                )
+
+
+class TestUpdateDelete:
+    @pytest.mark.asyncio
+    async def test_update_caption(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        image = await welcome_manual_section_image_repo.create(
+            db, section_id=section.id, storage_key="k", caption=None, display_order=0,
+        )
+        await db.commit()
+        with _patch_uow(db):
+            updated = await welcome_manual_section_image_service.update_image(
+                test_org.id, test_user.id, manual.id, section.id, image.id,
+                {"caption": "The router"},
+            )
+        assert updated.caption == "The router"
+        assert updated.presigned_url is not None
+
+    @pytest.mark.asyncio
+    async def test_update_image_not_found(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        await db.commit()
+        with _patch_uow(db):
+            with pytest.raises(welcome_manual_section_image_service.ImageNotFoundError):
+                await welcome_manual_section_image_service.update_image(
+                    test_org.id, test_user.id, manual.id, section.id, uuid.uuid4(),
+                    {"caption": "x"},
+                )
+
+    @pytest.mark.asyncio
+    async def test_delete_image(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        image = await welcome_manual_section_image_repo.create(
+            db, section_id=section.id, storage_key="k", caption=None, display_order=0,
+        )
+        await db.commit()
+        with _patch_uow(db):
+            await welcome_manual_section_image_service.delete_image(
+                test_org.id, test_user.id, manual.id, section.id, image.id,
+            )
+            with pytest.raises(welcome_manual_section_image_service.ImageNotFoundError):
+                await welcome_manual_section_image_service.delete_image(
+                    test_org.id, test_user.id, manual.id, section.id, image.id,
+                )
+
+
+class TestImagesSurfaceInManualResponse:
+    @pytest.mark.asyncio
+    async def test_get_manual_includes_section_images(self, db: AsyncSession, test_user: User, test_org: Organization) -> None:
+        manual, section = await _make_section(db, test_org, test_user)
+        await welcome_manual_section_image_repo.create(
+            db, section_id=section.id, storage_key="k1", caption="cap", display_order=0,
+        )
+        await db.commit()
+
+        @asynccontextmanager
+        async def _fake_session():
+            yield db
+
+        with patch(
+            "app.services.welcome_manuals.welcome_manual_service.AsyncSessionLocal",
+            _fake_session,
+        ):
+            resp = await welcome_manual_service.get_manual(test_org.id, test_user.id, manual.id)
+
+        assert len(resp.sections) == 1
+        assert len(resp.sections[0].images) == 1
+        assert resp.sections[0].images[0].caption == "cap"
+        assert resp.sections[0].images[0].presigned_url is not None


### PR DESCRIPTION
PR 2 of the **guest welcome manual** feature (PR 1 = #804, merged). Adds **images** to manual sections.

## What's here
- **Table** (`migration wmanualimg260530`): `welcome_manual_section_images` — one image per row, `ON DELETE CASCADE` with its section.
- **Upload pipeline** mirroring `listing_photo_service`: size cap → content-type sniff → allowlist (JPEG/PNG/HEIC) → **mandatory EXIF strip** (no host GPS leaks) → MinIO put → DB insert, with best-effort orphan cleanup on failure.
- **Serving**: section responses now carry their images with per-request **presigned URLs**, minted through a single seam (`section_image_response_builder`). Images for a whole manual load in **one grouped query** (no N+1).
- **Endpoints**: `POST/PATCH/DELETE /welcome-manuals/{id}/sections/{section_id}/images[/{image_id}]`.
- **Cleanup**: deleting a section also best-effort-deletes its image objects; deleting an image removes the object too.

## Scoping
Images have no org/manual column by design (mirrors `listing_photos`). Every image op resolves **org → manual → section** first, so cross-tenant access is impossible.

## Parity note
This faithfully mirrors the canonical `listings`/`listing_photos` domain (presigned-seam, storage-before-DB ordering, transaction boundaries, index shape). A backend review flagged a few items (presigned HEAD inside the write txn, no `server_default` on the UUID PK, single+composite index) — all are pre-existing canonical patterns shared with `listing_photos`, so they're kept for parity rather than introducing one-table drift.

## Tests
26 new tests (repo / service / route, incl. a test that images surface in the manual GET). Full welcome-manual suite: **86 green**. Migration applied to dev DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)