### PR TITLE
feat(mbk): guest welcome manual PDF + email delivery (PR 3)

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/wmanualsend260530_add_welcome_manual_sends.py
+++ b/apps/mybookkeeper/backend/alembic/versions/wmanualsend260530_add_welcome_manual_sends.py
@@ -1,0 +1,75 @@
+"""add welcome_manual_sends
+
+Revision ID: wmanualsend260530
+Revises: wmanualimg260530
+Create Date: 2026-05-30
+
+Guest welcome manual — PR 3 (PDF + email delivery). One row per send attempt,
+attached to a manual, cascade-deleted with it.
+
+Conventions:
+- ``recipient_email`` / ``recipient_name`` are guest PII stored as Fernet
+  ciphertext via the ``EncryptedString`` TypeDecorator. The DB column is plain
+  TEXT (ciphertext is longer than the plaintext bound) — no DDL difference from
+  any other text column, same as the inquiries domain.
+- ``key_version smallint`` lets future key rotation re-encrypt rows
+  non-destructively.
+- ``status`` is String(20) + CheckConstraint (never SQLAlchemy Enum).
+- Tenant isolation is via the parent manual FK — no organization_id/user_id
+  column (mirrors welcome_manual_section_images).
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "wmanualsend260530"
+down_revision: Union[str, None] = "wmanualimg260530"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "welcome_manual_sends",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("manual_id", postgresql.UUID(as_uuid=True), nullable=False),
+        # PII columns — stored as TEXT, encrypted application-side via EncryptedString.
+        sa.Column("recipient_email", sa.Text(), nullable=False),
+        sa.Column("recipient_name", sa.Text(), nullable=True),
+        sa.Column("key_version", sa.SmallInteger(), nullable=False, server_default="1"),
+        sa.Column("status", sa.String(length=20), nullable=False),
+        sa.Column("error_reason", sa.String(length=255), nullable=True),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["manual_id"], ["welcome_manuals.id"], ondelete="CASCADE"),
+        sa.CheckConstraint(
+            "status IN ('sent', 'failed', 'skipped')",
+            name="chk_welcome_manual_send_status",
+        ),
+    )
+    op.create_index(
+        "ix_welcome_manual_sends_manual_id",
+        "welcome_manual_sends",
+        ["manual_id"],
+    )
+    op.create_index(
+        "ix_welcome_manual_sends_manual_created",
+        "welcome_manual_sends",
+        ["manual_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_welcome_manual_sends_manual_created",
+        table_name="welcome_manual_sends",
+    )
+    op.drop_index(
+        "ix_welcome_manual_sends_manual_id",
+        table_name="welcome_manual_sends",
+    )
+    op.drop_table("welcome_manual_sends")

--- a/apps/mybookkeeper/backend/app/api/welcome_manuals.py
+++ b/apps/mybookkeeper/backend/app/api/welcome_manuals.py
@@ -13,8 +13,14 @@ from app.schemas.welcome_manuals.welcome_manual_section_image_update_request imp
 from app.schemas.welcome_manuals.welcome_manual_create_request import (
     WelcomeManualCreateRequest,
 )
+from app.schemas.welcome_manuals.welcome_manual_email_request import (
+    WelcomeManualEmailRequest,
+)
 from app.schemas.welcome_manuals.welcome_manual_list_response import (
     WelcomeManualListResponse,
+)
+from app.schemas.welcome_manuals.welcome_manual_send_response import (
+    WelcomeManualSendResponse,
 )
 from app.schemas.welcome_manuals.welcome_manual_response import WelcomeManualResponse
 from app.schemas.welcome_manuals.welcome_manual_section_create_request import (
@@ -33,6 +39,7 @@ from app.schemas.welcome_manuals.welcome_manual_update_request import (
     WelcomeManualUpdateRequest,
 )
 from app.services.welcome_manuals import (
+    welcome_manual_email_service,
     welcome_manual_section_image_service,
     welcome_manual_section_service,
     welcome_manual_service,
@@ -109,6 +116,31 @@ async def delete_welcome_manual(
     except LookupError as exc:
         raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
     return Response(status_code=204)
+
+
+@router.post("/{manual_id}/email", response_model=WelcomeManualSendResponse)
+async def email_welcome_manual(
+    manual_id: uuid.UUID,
+    payload: WelcomeManualEmailRequest,
+    ctx: RequestContext = Depends(require_write_access),
+) -> WelcomeManualSendResponse:
+    """Render the manual to a PDF and email it to a free-typed guest.
+
+    Returns the recorded send (HTTP 200) including when the outcome is
+    ``failed``/``skipped`` — the body's ``status`` field communicates the
+    result so the frontend shows a clear message rather than a network error.
+    An SMTP failure is NOT surfaced as a 5xx.
+    """
+    try:
+        return await welcome_manual_email_service.send_manual_to_guest(
+            organization_id=ctx.organization_id,
+            user_id=ctx.user_id,
+            manual_id=manual_id,
+            recipient_email=str(payload.recipient_email),
+            recipient_name=payload.recipient_name,
+        )
+    except welcome_manual_email_service.ManualNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="Welcome manual not found") from exc
 
 
 # ---------------------------------------------------------------------------

--- a/apps/mybookkeeper/backend/app/core/audit.py
+++ b/apps/mybookkeeper/backend/app/core/audit.py
@@ -54,6 +54,11 @@ MBK_SENSITIVE_FIELDS: frozenset[str] = frozenset({
     # intentionally plaintext) or other unrelated columns.
     "contact_email",
     "contact_phone",
+    # Welcome-manual send-log PII (PR 3) — free-typed guest recipient,
+    # encrypted at rest via EncryptedString. Field names are specific
+    # (``recipient_*``) so the audit listener doesn't mask unrelated columns.
+    "recipient_email",
+    "recipient_name",
     # Insurance domain PII — policy numbers are PII-adjacent (can identify
     # individuals with insurers), encrypted at rest via EncryptedString.
     "policy_number",

--- a/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
+++ b/apps/mybookkeeper/backend/app/core/welcome_manual_constants.py
@@ -7,6 +7,9 @@ service-layer seed and the schema validation a single source of truth.
 WELCOME_MANUAL_TITLE_MAX_LEN = 200
 WELCOME_MANUAL_SECTION_TITLE_MAX_LEN = 200
 WELCOME_MANUAL_IMAGE_CAPTION_MAX_LEN = 500
+# Guest recipient display name (welcome_manual_sends.recipient_name) — bounded
+# to fit the encrypted String(255) column with room for the Fernet ciphertext.
+WELCOME_MANUAL_RECIPIENT_NAME_MAX_LEN = 200
 
 # Object-key prefix for welcome-manual section images. Combined with the org id
 # for tenant isolation: ``{org_id}/welcome-manuals`` → keys land under
@@ -17,6 +20,15 @@ WELCOME_MANUAL_STORAGE_DOMAIN = "welcome-manuals"
 # single manual into an unbounded number of rows. 50 is far above any real
 # welcome guide (Wi-Fi, trash, laundry, parking, check-out, house rules…).
 WELCOME_MANUAL_MAX_SECTIONS = 50
+
+# Outcome statuses for a welcome-manual email send (welcome_manual_sends.status).
+# Stored as String(20) + CheckConstraint (never SQLAlchemy Enum, per the schema
+# convention). ``sent`` = SMTP accepted; ``failed`` = SMTP rejected/errored;
+# ``skipped`` = preconditions unmet (e.g. SMTP not configured on this deploy).
+WELCOME_MANUAL_SEND_STATUSES: tuple[str, ...] = ("sent", "failed", "skipped")
+WELCOME_MANUAL_SEND_STATUSES_SQL = (
+    "(" + ", ".join(f"'{s}'" for s in WELCOME_MANUAL_SEND_STATUSES) + ")"
+)
 
 # Stub sections seeded into a new manual when the host opts in
 # (``seed_default_sections=True`` on create). Titles only — the host fills in

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -19,6 +19,7 @@ from app.models.listings.listing_blackout_attachment import ListingBlackoutAttac
 from app.models.welcome_manuals.welcome_manual import WelcomeManual
 from app.models.welcome_manuals.welcome_manual_section import WelcomeManualSection
 from app.models.welcome_manuals.welcome_manual_section_image import WelcomeManualSectionImage
+from app.models.welcome_manuals.welcome_manual_send import WelcomeManualSend
 from app.models.calendar.calendar_email_review_queue import CalendarEmailReviewQueue
 from app.models.calendar.calendar_listing_blocklist import CalendarListingBlocklist
 from app.models.inquiries.inquiry import Inquiry

--- a/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual_send.py
+++ b/apps/mybookkeeper/backend/app/models/welcome_manuals/welcome_manual_send.py
@@ -1,0 +1,74 @@
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    SmallInteger,
+    String,
+    func,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.core.encrypted_string_type import EncryptedString
+from app.core.welcome_manual_constants import WELCOME_MANUAL_SEND_STATUSES_SQL
+from app.db.base import Base
+
+
+class WelcomeManualSend(Base):
+    """A record of one attempt to email a welcome manual to a guest.
+
+    Tenant isolation is via the parent manual: the service always loads the
+    manual org-scoped before inserting a send row, so this table carries no
+    ``organization_id``/``user_id`` of its own (mirrors the section/image
+    tables). Cascade-deleted with its manual.
+
+    ``recipient_email``/``recipient_name`` are free-typed guest PII, encrypted
+    at rest via ``EncryptedString``. ``status`` records the outcome so the
+    frontend can render a clear success / couldn't-send message; ``error_reason``
+    is a short machine-readable diagnostic (e.g. ``smtp_not_configured``,
+    ``send_failed``) for the operator.
+    """
+
+    __tablename__ = "welcome_manual_sends"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    manual_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("welcome_manuals.id", ondelete="CASCADE"),
+        index=True,
+        nullable=False,
+    )
+
+    # Guest PII — encrypted at rest via EncryptedString TypeDecorator.
+    recipient_email: Mapped[str] = mapped_column(EncryptedString(255), nullable=False)
+    recipient_name: Mapped[str | None] = mapped_column(EncryptedString(255), nullable=True)
+
+    key_version: Mapped[int] = mapped_column(
+        SmallInteger, nullable=False, default=1, server_default="1",
+    )
+
+    status: Mapped[str] = mapped_column(String(20), nullable=False)
+    error_reason: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        CheckConstraint(
+            f"status IN {WELCOME_MANUAL_SEND_STATUSES_SQL}",
+            name="chk_welcome_manual_send_status",
+        ),
+        # "Sends for this manual, newest first" lookup.
+        Index(
+            "ix_welcome_manual_sends_manual_created",
+            "manual_id", "created_at",
+        ),
+    )

--- a/apps/mybookkeeper/backend/app/repositories/__init__.py
+++ b/apps/mybookkeeper/backend/app/repositories/__init__.py
@@ -41,6 +41,7 @@ from app.repositories.listings import listing_blackout_attachment_repo
 from app.repositories.welcome_manuals import welcome_manual_repo
 from app.repositories.welcome_manuals import welcome_manual_section_repo
 from app.repositories.welcome_manuals import welcome_manual_section_image_repo
+from app.repositories.welcome_manuals import welcome_manual_send_repo
 from app.repositories.calendar import calendar_repository
 from app.repositories.calendar import review_queue_repo
 from app.repositories.calendar import blocklist_repo

--- a/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_send_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/welcome_manuals/welcome_manual_send_repo.py
@@ -1,0 +1,42 @@
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.welcome_manuals.welcome_manual_send import WelcomeManualSend
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    manual_id: uuid.UUID,
+    recipient_email: str,
+    recipient_name: str | None,
+    status: str,
+    error_reason: str | None = None,
+) -> WelcomeManualSend:
+    """Insert a send-log row. The caller has already loaded the parent manual
+    org-scoped, so no tenant column is needed here (isolation is via the FK)."""
+    send = WelcomeManualSend(
+        manual_id=manual_id,
+        recipient_email=recipient_email,
+        recipient_name=recipient_name,
+        status=status,
+        error_reason=error_reason,
+    )
+    db.add(send)
+    await db.flush()
+    return send
+
+
+async def list_by_manual(
+    db: AsyncSession,
+    manual_id: uuid.UUID,
+) -> list[WelcomeManualSend]:
+    """List send-log rows for a manual, newest first."""
+    result = await db.execute(
+        select(WelcomeManualSend)
+        .where(WelcomeManualSend.manual_id == manual_id)
+        .order_by(WelcomeManualSend.created_at.desc())
+    )
+    return list(result.scalars().all())

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_email_request.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_email_request.py
@@ -1,0 +1,20 @@
+"""Pydantic schema for POST /welcome-manuals/{id}/email request body.
+
+The host free-types the guest's contact details here. ``recipient_email`` is
+validated as an email address (bad input → 422); ``recipient_name`` is an
+optional display name used in the email greeting.
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
+
+from app.core.welcome_manual_constants import WELCOME_MANUAL_RECIPIENT_NAME_MAX_LEN
+
+
+class WelcomeManualEmailRequest(BaseModel):
+    recipient_email: EmailStr
+    recipient_name: str | None = Field(
+        default=None, max_length=WELCOME_MANUAL_RECIPIENT_NAME_MAX_LEN,
+    )
+
+    model_config = ConfigDict(extra="forbid")

--- a/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_send_response.py
+++ b/apps/mybookkeeper/backend/app/schemas/welcome_manuals/welcome_manual_send_response.py
@@ -1,0 +1,25 @@
+import uuid
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict
+
+
+class WelcomeManualSendResponse(BaseModel):
+    """Send-log record returned to the HOST after a send attempt.
+
+    Returning ``recipient_email``/``recipient_name`` is NOT cross-tenant
+    leakage — the host owns the manual and just typed these values. ``status``
+    communicates the outcome (sent / failed / skipped) so the frontend can
+    render a clear success or couldn't-send message; ``error_reason`` is a
+    short diagnostic for failed/skipped attempts.
+    """
+
+    id: uuid.UUID
+    manual_id: uuid.UUID
+    recipient_email: str
+    recipient_name: str | None = None
+    status: str
+    error_reason: str | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/apps/mybookkeeper/backend/app/services/system/email_service.py
+++ b/apps/mybookkeeper/backend/app/services/system/email_service.py
@@ -64,16 +64,23 @@ def send_email(
     body_html: str,
     *,
     attachments: Sequence[EmailAttachment] | None = None,
+    reply_to: str | None = None,
 ) -> bool:
     """Best-effort send. Returns True on success, False on failure.
 
     Use for non-critical emails (cost alerts, demos, inquiry
     notifications). Critical-path callers (verification, password
     reset, organization invites) MUST use ``send_email_or_raise``.
+
+    ``reply_to`` (optional) sets the ``Reply-To`` header — e.g. a host
+    emailing a guest welcome guide wants guest replies to reach the
+    host's own inbox rather than the system SMTP account.
     """
     if not to:
         return False
-    return _get_email_service().send(to, subject, body_html, attachments=attachments)
+    return _get_email_service().send(
+        to, subject, body_html, attachments=attachments, reply_to=reply_to,
+    )
 
 
 def send_email_or_raise(
@@ -82,8 +89,12 @@ def send_email_or_raise(
     body_html: str,
     *,
     attachments: Sequence[EmailAttachment] | None = None,
+    reply_to: str | None = None,
 ) -> None:
     """Fail-loud send. Raises on any failure.
+
+    ``reply_to`` (optional) sets the ``Reply-To`` header — see
+    ``send_email`` for the use case.
 
     Raises:
         ValueError: If ``to`` is empty.
@@ -92,7 +103,7 @@ def send_email_or_raise(
             rejected).
     """
     _get_email_service().send_or_raise(
-        to, subject, body_html, attachments=attachments,
+        to, subject, body_html, attachments=attachments, reply_to=reply_to,
     )
 
 

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_email_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_email_service.py
@@ -1,0 +1,255 @@
+"""Service: render a welcome manual to PDF and email it to a guest.
+
+Orchestration only (load → decide → fetch attachment bytes → send → record).
+Mirrors ``app.services.leases.lease_email_service.send_lease_to_tenant``:
+
+- Load the manual org-scoped (404 if missing / other org).
+- Resolve the HOST's own login email (``users.email`` of ``manual.user_id``)
+  to use as the outgoing ``Reply-To`` so guest replies reach the host.
+- If SMTP isn't configured → record a ``skipped`` send row and return it (never
+  raise — mirrors lease skip semantics).
+- Fetch each section image's bytes from storage. On a storage outage the PDF is
+  rendered TEXT-ONLY (per CLAUDE.md "reads must never crash on a storage
+  outage"); an individual image download failure skips just that image.
+- Send the PDF as an attachment; record ``sent`` on success, ``failed`` on a
+  False return.
+
+The endpoint returns the send record (HTTP 200) even on failure/skip — the
+``status`` field communicates the outcome so the frontend shows a clear
+message rather than a network error.
+
+``build_subject`` / ``build_body_html`` are pure helpers exposed for unit tests.
+"""
+from __future__ import annotations
+
+import html as html_mod
+import logging
+import re
+import uuid
+
+from app.core.storage import StorageNotConfiguredError, get_storage
+from app.db.session import unit_of_work
+from app.repositories import (
+    user_repo,
+    welcome_manual_repo,
+    welcome_manual_section_image_repo,
+    welcome_manual_section_repo,
+    welcome_manual_send_repo,
+)
+from app.schemas.welcome_manuals.welcome_manual_send_response import (
+    WelcomeManualSendResponse,
+)
+from app.services.system import email_service
+from app.services.system.email_service import EmailAttachment
+from app.services.welcome_manuals.welcome_manual_pdf_service import (
+    SectionImagePdfData,
+    SectionPdfData,
+    WelcomeManualPdfData,
+    generate_welcome_manual_pdf,
+)
+
+logger = logging.getLogger(__name__)
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+class ManualNotFoundError(LookupError):
+    """The manual doesn't exist, is soft-deleted, or belongs to another org."""
+
+
+def build_subject(*, manual_title: str) -> str:
+    """Pure helper. Subject line for the guest email."""
+    title = manual_title.strip() if manual_title else ""
+    if title:
+        return f"Your welcome guide — {title}"
+    return "Your welcome guide"
+
+
+def build_body_html(*, manual_title: str, recipient_name: str | None) -> str:
+    """Pure helper. Minimal HTML cover note. All interpolated values are
+    HTML-escaped to prevent injection via host-authored / free-typed text."""
+    greeting_name = recipient_name.strip() if recipient_name else ""
+    greeting = (
+        f"Hi {html_mod.escape(greeting_name)},"
+        if greeting_name
+        else "Hi there,"
+    )
+    safe_title = html_mod.escape(manual_title) if manual_title else "your stay"
+    return f"""
+    <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 560px; margin: 0 auto;">
+      <div style="border: 1px solid #e5e7eb; padding: 20px; border-radius: 8px;">
+        <h2 style="margin: 0 0 12px 0; font-size: 18px; color: #111827;">Your welcome guide is attached</h2>
+        <p style="margin: 0 0 12px 0; font-size: 15px; color: #374151;">{greeting}</p>
+        <p style="margin: 0 0 12px 0; font-size: 15px; color: #374151;">
+          Attached is the welcome guide for <strong>{safe_title}</strong> — it
+          has everything you need for your stay. Just reply to this email if you
+          have any questions.
+        </p>
+        <p style="margin: 16px 0 0 0; font-size: 13px; color: #6b7280;">
+          Sent via MyBookkeeper on behalf of your host.
+        </p>
+      </div>
+    </div>
+    """
+
+
+def _filename(manual_title: str) -> str:
+    """Derive a tasteful PDF download filename from the manual title."""
+    slug = _SLUG_RE.sub("-", (manual_title or "").lower()).strip("-")
+    return f"{slug or 'welcome-guide'}.pdf"
+
+
+def _fetch_image_bytes(images, *, manual_id: uuid.UUID) -> dict[uuid.UUID, bytes]:
+    """Download each section image's bytes from storage, keyed by image id.
+
+    On a storage outage (``StorageNotConfiguredError``) returns an empty map so
+    the PDF renders text-only. An individual download failure skips just that
+    image (logged) — a missing photo must not block the whole guide.
+    """
+    if not images:
+        return {}
+    try:
+        storage = get_storage()
+    except StorageNotConfiguredError:
+        logger.warning(
+            "welcome_manual_email.storage_unavailable manual_id=%s — "
+            "rendering PDF text-only",
+            manual_id,
+        )
+        return {}
+
+    by_image: dict[uuid.UUID, bytes] = {}
+    for image in images:
+        try:
+            by_image[image.id] = storage.download_file(image.storage_key)
+        except Exception:  # noqa: BLE001 — skip just this image
+            logger.warning(
+                "welcome_manual_email.image_fetch_failed manual_id=%s storage_key=%s",
+                manual_id, image.storage_key, exc_info=True,
+            )
+    return by_image
+
+
+def _build_pdf_data(manual, sections, images, image_bytes) -> WelcomeManualPdfData:
+    """Assemble the pure PDF data carrier from the loaded ORM rows + bytes."""
+    images_by_section: dict[uuid.UUID, list[SectionImagePdfData]] = {}
+    for image in images:
+        content = image_bytes.get(image.id)
+        if content is None:
+            continue
+        images_by_section.setdefault(image.section_id, []).append(
+            SectionImagePdfData(image_bytes=content, caption=image.caption),
+        )
+    section_data = [
+        SectionPdfData(
+            title=section.title,
+            body=section.body,
+            images=images_by_section.get(section.id, []),
+        )
+        for section in sections
+    ]
+    return WelcomeManualPdfData(
+        title=manual.title,
+        intro_text=manual.intro_text,
+        sections=section_data,
+    )
+
+
+async def send_manual_to_guest(
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,  # noqa: ARG001 — accepted for audit context
+    manual_id: uuid.UUID,
+    recipient_email: str,
+    recipient_name: str | None,
+) -> WelcomeManualSendResponse:
+    """Render ``manual_id`` to a PDF and email it to ``recipient_email``.
+
+    Returns the recorded send (``status`` in {sent, failed, skipped}). Raises
+    ManualNotFoundError if the manual isn't visible to the caller's org.
+    """
+    # Load manual + sections + images + host email in one short transaction.
+    async with unit_of_work() as db:
+        manual = await welcome_manual_repo.get_by_id(db, manual_id, organization_id)
+        if manual is None:
+            raise ManualNotFoundError(f"Welcome manual {manual_id} not found")
+        sections = await welcome_manual_section_repo.list_by_manual(db, manual.id)
+        images = await welcome_manual_section_image_repo.list_by_section_ids(
+            db, [s.id for s in sections],
+        )
+        host = await user_repo.get_by_id(db, manual.user_id)
+        host_email = host.email if host is not None else None
+        manual_title = manual.title
+
+    if not email_service.is_configured():
+        logger.info(
+            "welcome_manual_email.skipped reason=smtp_not_configured manual_id=%s",
+            manual_id,
+        )
+        return await _record_send(
+            manual_id=manual_id,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            status="skipped",
+            error_reason="smtp_not_configured",
+        )
+
+    image_bytes = _fetch_image_bytes(images, manual_id=manual_id)
+    pdf_bytes = generate_welcome_manual_pdf(
+        _build_pdf_data(manual, sections, images, image_bytes),
+    )
+
+    attachment = EmailAttachment(
+        filename=_filename(manual_title),
+        content=pdf_bytes,
+        content_type="application/pdf",
+    )
+    sent = email_service.send_email(
+        [recipient_email],
+        build_subject(manual_title=manual_title),
+        build_body_html(manual_title=manual_title, recipient_name=recipient_name),
+        attachments=[attachment],
+        reply_to=host_email,
+    )
+
+    if not sent:
+        logger.warning(
+            "welcome_manual_email.send_failed manual_id=%s", manual_id,
+        )
+        return await _record_send(
+            manual_id=manual_id,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            status="failed",
+            error_reason="send_failed",
+        )
+
+    logger.info("welcome_manual_email.sent manual_id=%s", manual_id)
+    return await _record_send(
+        manual_id=manual_id,
+        recipient_email=recipient_email,
+        recipient_name=recipient_name,
+        status="sent",
+        error_reason=None,
+    )
+
+
+async def _record_send(
+    *,
+    manual_id: uuid.UUID,
+    recipient_email: str,
+    recipient_name: str | None,
+    status: str,
+    error_reason: str | None,
+) -> WelcomeManualSendResponse:
+    """Persist a send-log row in its own short transaction and return it."""
+    async with unit_of_work() as db:
+        send = await welcome_manual_send_repo.create(
+            db,
+            manual_id=manual_id,
+            recipient_email=recipient_email,
+            recipient_name=recipient_name,
+            status=status,
+            error_reason=error_reason,
+        )
+        return WelcomeManualSendResponse.model_validate(send)

--- a/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_pdf_service.py
+++ b/apps/mybookkeeper/backend/app/services/welcome_manuals/welcome_manual_pdf_service.py
@@ -1,0 +1,160 @@
+"""PDF generation for a guest welcome manual.
+
+Pure function — no DB I/O, no storage, no side effects. Takes the manual's
+already-fetched content (including image BYTES) and returns raw PDF bytes.
+
+Uses ``reportlab`` platypus (``SimpleDocTemplate`` + flowables), mirroring the
+style of ``app.services.leases.renderer.render_pdf_from_text`` (paragraph
+escaping, single-newline → ``<br/>``) and the frozen-dataclass data carrier of
+``app.services.leases.receipt_pdf_service.ReceiptData``. The dataclasses live
+inline here because they're tightly coupled to this renderer — the canonical
+PDF pattern in this codebase keeps the data carrier beside its renderer.
+
+Robustness contract:
+- A single undecodable / corrupt image is SKIPPED (logged), never crashes the
+  whole PDF.
+- An empty manual (no sections), sections with no body, and sections with no
+  images all render cleanly.
+"""
+from __future__ import annotations
+
+import html as html_mod
+import io
+import logging
+from dataclasses import dataclass, field
+
+from reportlab.lib.enums import TA_CENTER
+from reportlab.lib.pagesizes import LETTER
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    Image,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+)
+from reportlab.platypus.flowables import Flowable
+
+logger = logging.getLogger(__name__)
+
+# Cap the rendered height of any embedded image so a tall photo can't push the
+# rest of the section off the page. Width is bounded by the content area.
+_MAX_IMAGE_HEIGHT = 4.0 * inch
+
+
+@dataclass(frozen=True)
+class SectionImagePdfData:
+    image_bytes: bytes
+    caption: str | None = None
+
+
+@dataclass(frozen=True)
+class SectionPdfData:
+    title: str
+    body: str | None = None
+    images: list[SectionImagePdfData] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class WelcomeManualPdfData:
+    title: str
+    intro_text: str | None = None
+    sections: list[SectionPdfData] = field(default_factory=list)
+
+
+def _escape_paragraphs(text: str, style: ParagraphStyle) -> list[Flowable]:
+    """Split ``text`` on blank lines into paragraphs, HTML-escaping each and
+    converting single newlines to ``<br/>`` (mirrors render_pdf_from_text)."""
+    flowables: list[Flowable] = []
+    for raw in text.split("\n\n"):
+        chunk = raw.strip()
+        if not chunk:
+            continue
+        safe = (
+            chunk.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        ).replace("\n", "<br/>")
+        flowables.append(Paragraph(safe, style))
+        flowables.append(Spacer(1, 6))
+    return flowables
+
+
+def _build_image_flowable(
+    image: SectionImagePdfData,
+    content_width: float,
+    caption_style: ParagraphStyle,
+) -> list[Flowable]:
+    """Build the flowables for one image (scaled to fit) + its caption.
+
+    Returns an empty list if the image can't be decoded — a corrupt image must
+    never crash the whole PDF.
+    """
+    try:
+        reader = Image(io.BytesIO(image.image_bytes))
+    except Exception:  # noqa: BLE001 — defensive; skip undecodable images
+        logger.warning(
+            "welcome_manual_pdf.skip_image reason=undecodable bytes=%d",
+            len(image.image_bytes or b""),
+            exc_info=True,
+        )
+        return []
+
+    intrinsic_w = float(reader.drawWidth) or content_width
+    intrinsic_h = float(reader.drawHeight) or _MAX_IMAGE_HEIGHT
+    scale = min(
+        content_width / intrinsic_w,
+        _MAX_IMAGE_HEIGHT / intrinsic_h,
+        1.0,
+    )
+    reader.drawWidth = intrinsic_w * scale
+    reader.drawHeight = intrinsic_h * scale
+
+    flowables: list[Flowable] = [Spacer(1, 4), reader]
+    if image.caption:
+        safe_caption = html_mod.escape(image.caption)
+        flowables.append(Paragraph(safe_caption, caption_style))
+    flowables.append(Spacer(1, 10))
+    return flowables
+
+
+def generate_welcome_manual_pdf(data: WelcomeManualPdfData) -> bytes:
+    """Return raw PDF bytes for a guest welcome manual.
+
+    Pure: depends only on ``data`` (including pre-fetched image bytes).
+    """
+    buffer = io.BytesIO()
+    doc = SimpleDocTemplate(buffer, pagesize=LETTER)
+    styles = getSampleStyleSheet()
+    title_style = styles["Title"]
+    heading_style = styles["Heading2"]
+    body_style = styles["BodyText"]
+    caption_style = ParagraphStyle(
+        "WelcomeManualCaption",
+        parent=styles["Italic"],
+        fontSize=8,
+        textColor="#6b7280",
+        spaceBefore=2,
+        alignment=TA_CENTER,
+    )
+
+    content_width = doc.width
+
+    story: list[Flowable] = [
+        Paragraph(html_mod.escape(data.title), title_style),
+        Spacer(1, 12),
+    ]
+
+    if data.intro_text and data.intro_text.strip():
+        story.extend(_escape_paragraphs(data.intro_text, body_style))
+        story.append(Spacer(1, 8))
+
+    for section in data.sections:
+        story.append(Paragraph(html_mod.escape(section.title), heading_style))
+        story.append(Spacer(1, 4))
+        if section.body and section.body.strip():
+            story.extend(_escape_paragraphs(section.body, body_style))
+        for image in section.images:
+            story.extend(_build_image_flowable(image, content_width, caption_style))
+        story.append(Spacer(1, 10))
+
+    doc.build(story)
+    return buffer.getvalue()

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_email_routes.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_email_routes.py
@@ -1,0 +1,262 @@
+"""End-to-end route tests for POST /welcome-manuals/{id}/email.
+
+Exercises the real email-orchestration service through the route against the
+SQLite test DB, with the SMTP transport (``email_service.send_email``) and
+configuration check monkeypatched. Asserts the send-log row is persisted with
+the right status, the recipient is recorded, and the host's email is passed as
+``reply_to``.
+"""
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.context import RequestContext
+from app.core.permissions import current_org_member, require_write_access
+from app.main import app
+from app.models.organization.organization import Organization
+from app.models.organization.organization_member import OrgRole
+from app.models.user.user import User
+from app.models.welcome_manuals.welcome_manual import WelcomeManual
+from app.repositories.welcome_manuals import welcome_manual_send_repo
+from app.services.welcome_manuals import welcome_manual_email_service
+
+
+def _ctx(org_id: uuid.UUID, user_id: uuid.UUID) -> RequestContext:
+    return RequestContext(organization_id=org_id, user_id=user_id, org_role=OrgRole.OWNER)
+
+
+def _override_auth(org_id: uuid.UUID, user_id: uuid.UUID) -> None:
+    app.dependency_overrides[current_org_member] = lambda: _ctx(org_id, user_id)
+    app.dependency_overrides[require_write_access] = lambda: _ctx(org_id, user_id)
+
+
+def _wire_db(monkeypatch: pytest.MonkeyPatch, db: AsyncSession) -> None:
+    """Point the service's ``unit_of_work`` at the existing test session so the
+    service reads + writes against the same SQLite DB the test seeded."""
+    @asynccontextmanager
+    async def _fake_uow():
+        yield db
+
+    monkeypatch.setattr(
+        "app.services.welcome_manuals.welcome_manual_email_service.unit_of_work",
+        _fake_uow,
+    )
+
+
+async def _seed_manual(
+    db: AsyncSession, *, org: Organization, user: User,
+) -> WelcomeManual:
+    m = WelcomeManual(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        user_id=user.id,
+        title="Beach House Guide",
+        intro_text="Welcome!",
+    )
+    db.add(m)
+    await db.commit()
+    return m
+
+
+class TestAuth:
+    def test_requires_auth(self) -> None:
+        # No dependency override → the real auth dependency rejects.
+        client = TestClient(app)
+        resp = client.post(
+            f"/welcome-manuals/{uuid.uuid4()}/email",
+            json={"recipient_email": "g@example.com"},
+        )
+        assert resp.status_code == 401
+
+
+class TestValidationAndNotFound:
+    @pytest.mark.asyncio
+    async def test_invalid_email_422(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manual = await _seed_manual(db, org=test_org, user=test_user)
+        _wire_db(monkeypatch, db)
+        _override_auth(test_org.id, test_user.id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                f"/welcome-manuals/{manual.id}/email",
+                json={"recipient_email": "not-an-email"},
+            )
+        finally:
+            app.dependency_overrides.clear()
+        assert resp.status_code == 422
+
+    @pytest.mark.asyncio
+    async def test_missing_manual_404(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        _wire_db(monkeypatch, db)
+        _override_auth(test_org.id, test_user.id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                f"/welcome-manuals/{uuid.uuid4()}/email",
+                json={"recipient_email": "g@example.com"},
+            )
+        finally:
+            app.dependency_overrides.clear()
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_other_org_manual_404(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manual = await _seed_manual(db, org=test_org, user=test_user)
+        _wire_db(monkeypatch, db)
+        # Authenticate as a DIFFERENT org — the org-scoped load must 404.
+        _override_auth(uuid.uuid4(), test_user.id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                f"/welcome-manuals/{manual.id}/email",
+                json={"recipient_email": "g@example.com"},
+            )
+        finally:
+            app.dependency_overrides.clear()
+        assert resp.status_code == 404
+
+
+class TestSendOutcomes:
+    @pytest.mark.asyncio
+    async def test_success_records_sent_and_passes_reply_to_host(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manual = await _seed_manual(db, org=test_org, user=test_user)
+        _wire_db(monkeypatch, db)
+        monkeypatch.setattr(
+            welcome_manual_email_service.email_service, "is_configured",
+            lambda: True,
+        )
+        captured: dict[str, object] = {}
+
+        def _fake_send(to, subject, body_html, *, attachments=None, reply_to=None):
+            captured["to"] = to
+            captured["subject"] = subject
+            captured["attachments"] = attachments
+            captured["reply_to"] = reply_to
+            return True
+
+        monkeypatch.setattr(
+            welcome_manual_email_service.email_service, "send_email", _fake_send,
+        )
+
+        _override_auth(test_org.id, test_user.id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                f"/welcome-manuals/{manual.id}/email",
+                json={"recipient_email": "guest@example.com", "recipient_name": "Jane"},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "sent"
+        assert body["recipient_email"] == "guest@example.com"
+        assert body["recipient_name"] == "Jane"
+        assert body["error_reason"] is None
+
+        # The host's own login email was passed as Reply-To.
+        assert captured["reply_to"] == test_user.email
+        assert captured["to"] == ["guest@example.com"]
+        # A single PDF attachment was built.
+        attachments = captured["attachments"]
+        assert attachments is not None and len(attachments) == 1
+        assert attachments[0].content_type == "application/pdf"
+        assert attachments[0].content.startswith(b"%PDF")
+
+        # A send-log row was persisted with the recipient + status.
+        rows = await welcome_manual_send_repo.list_by_manual(db, manual.id)
+        assert len(rows) == 1
+        assert rows[0].status == "sent"
+        assert rows[0].recipient_email == "guest@example.com"
+        assert rows[0].recipient_name == "Jane"
+
+    @pytest.mark.asyncio
+    async def test_smtp_not_configured_records_skipped(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manual = await _seed_manual(db, org=test_org, user=test_user)
+        _wire_db(monkeypatch, db)
+        monkeypatch.setattr(
+            welcome_manual_email_service.email_service, "is_configured",
+            lambda: False,
+        )
+        # send_email must NOT be called when unconfigured.
+        def _explode(*a, **k):  # pragma: no cover - asserts it's never called
+            raise AssertionError("send_email should not be called when SMTP unconfigured")
+
+        monkeypatch.setattr(
+            welcome_manual_email_service.email_service, "send_email", _explode,
+        )
+
+        _override_auth(test_org.id, test_user.id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                f"/welcome-manuals/{manual.id}/email",
+                json={"recipient_email": "guest@example.com"},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "skipped"
+        assert body["error_reason"] == "smtp_not_configured"
+
+        rows = await welcome_manual_send_repo.list_by_manual(db, manual.id)
+        assert len(rows) == 1
+        assert rows[0].status == "skipped"
+
+    @pytest.mark.asyncio
+    async def test_send_failure_records_failed(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        manual = await _seed_manual(db, org=test_org, user=test_user)
+        _wire_db(monkeypatch, db)
+        monkeypatch.setattr(
+            welcome_manual_email_service.email_service, "is_configured",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            welcome_manual_email_service.email_service, "send_email",
+            lambda *a, **k: False,
+        )
+
+        _override_auth(test_org.id, test_user.id)
+        try:
+            client = TestClient(app)
+            resp = client.post(
+                f"/welcome-manuals/{manual.id}/email",
+                json={"recipient_email": "guest@example.com"},
+            )
+        finally:
+            app.dependency_overrides.clear()
+
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "failed"
+        assert body["error_reason"] == "send_failed"
+
+        rows = await welcome_manual_send_repo.list_by_manual(db, manual.id)
+        assert len(rows) == 1
+        assert rows[0].status == "failed"

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_pdf_service.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_pdf_service.py
@@ -1,0 +1,171 @@
+"""Unit tests for the pure welcome-manual PDF renderer.
+
+The renderer takes already-fetched image BYTES and returns raw PDF bytes —
+no DB, no storage. Covers: valid output, empty manual, sections with/without
+body, sections with/without images, image embedding, and the robustness
+contract (a corrupt image is skipped, never crashes the PDF).
+"""
+from __future__ import annotations
+
+import io
+
+from PIL import Image
+
+from app.services.welcome_manuals.welcome_manual_pdf_service import (
+    SectionImagePdfData,
+    SectionPdfData,
+    WelcomeManualPdfData,
+    generate_welcome_manual_pdf,
+)
+
+
+def _png_bytes(size: tuple[int, int] = (16, 16)) -> bytes:
+    img = Image.new("RGB", size, (10, 120, 200))
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestRenderBasics:
+    def test_returns_pdf_bytes(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Beach House Guide",
+                intro_text="Welcome! Here's everything you need.",
+                sections=[
+                    SectionPdfData(title="Wi-Fi", body="Network: BeachHouse\nPassword: sunny123"),
+                ],
+            ),
+        )
+        assert isinstance(pdf, bytes)
+        assert pdf.startswith(b"%PDF")
+        assert len(pdf) > 100
+
+    def test_empty_manual_renders(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(title="Empty Guide", intro_text=None, sections=[]),
+        )
+        assert pdf.startswith(b"%PDF")
+
+    def test_section_without_body_renders(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[SectionPdfData(title="Parking", body=None)],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+    def test_section_without_images_renders(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[SectionPdfData(title="Laundry", body="Use pods only.", images=[])],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+    def test_no_intro_text_renders(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                intro_text=None,
+                sections=[SectionPdfData(title="Trash", body="Pickup is Tuesday.")],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+
+class TestImages:
+    def test_valid_png_embeds(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[
+                    SectionPdfData(
+                        title="Trash bins",
+                        body="The bins are by the side gate.",
+                        images=[
+                            SectionImagePdfData(image_bytes=_png_bytes(), caption="Side gate bins"),
+                        ],
+                    ),
+                ],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+        # A PDF embedding an image is meaningfully larger than a text-only one.
+        text_only = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[SectionPdfData(title="Trash bins", body="The bins are by the side gate.")],
+            ),
+        )
+        assert len(pdf) > len(text_only)
+
+    def test_image_without_caption_renders(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[
+                    SectionPdfData(
+                        title="View",
+                        images=[SectionImagePdfData(image_bytes=_png_bytes(), caption=None)],
+                    ),
+                ],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+    def test_corrupt_image_is_skipped_not_crashed(self) -> None:
+        # A garbage byte-string is undecodable — the renderer must skip it and
+        # still produce a valid PDF rather than raising.
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[
+                    SectionPdfData(
+                        title="Broken photo",
+                        body="This section has a corrupt image.",
+                        images=[
+                            SectionImagePdfData(image_bytes=b"not-an-image", caption="oops"),
+                        ],
+                    ),
+                ],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+    def test_mixed_valid_and_corrupt_images(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Guide",
+                sections=[
+                    SectionPdfData(
+                        title="Photos",
+                        images=[
+                            SectionImagePdfData(image_bytes=b"\x00\x01garbage", caption="bad"),
+                            SectionImagePdfData(image_bytes=_png_bytes(), caption="good"),
+                        ],
+                    ),
+                ],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")
+
+
+class TestEscaping:
+    def test_html_special_chars_do_not_break_render(self) -> None:
+        pdf = generate_welcome_manual_pdf(
+            WelcomeManualPdfData(
+                title="Tom & Jerry's <Place>",
+                intro_text="Rules: be < 10 people & > 0 adults.",
+                sections=[
+                    SectionPdfData(
+                        title="House <rules>",
+                        body="No <script> tags & be nice.",
+                        images=[SectionImagePdfData(image_bytes=_png_bytes(), caption="A & B <c>")],
+                    ),
+                ],
+            ),
+        )
+        assert pdf.startswith(b"%PDF")

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_send_audit_masking.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_send_audit_masking.py
@@ -1,0 +1,72 @@
+"""Verify the audit listener masks the welcome-manual send-log PII columns.
+
+``recipient_email`` / ``recipient_name`` are encrypted at rest, but the audit
+listener captures values BEFORE the bind-time encryption hook fires — so
+without an entry in MBK_SENSITIVE_FIELDS the plaintext would leak into
+audit_logs. This asserts both columns are masked as ``***``.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.audit import register_audit_listeners
+from app.models.organization.organization import Organization
+from app.models.system.audit_log import AuditLog
+from app.models.user.user import User
+from app.models.welcome_manuals.welcome_manual import WelcomeManual
+from app.models.welcome_manuals.welcome_manual_send import WelcomeManualSend
+
+
+@pytest.fixture(autouse=True)
+def _audit():
+    register_audit_listeners()
+
+
+class TestWelcomeManualSendAuditMasking:
+    @pytest.mark.asyncio
+    async def test_recipient_pii_masked_on_insert(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        manual = WelcomeManual(
+            id=uuid.uuid4(),
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            title="Guide",
+        )
+        db.add(manual)
+        await db.flush()
+
+        plaintext_email = "guest.secret@example.com"
+        plaintext_name = "Jane Q Guest"
+        send = WelcomeManualSend(
+            id=uuid.uuid4(),
+            manual_id=manual.id,
+            recipient_email=plaintext_email,
+            recipient_name=plaintext_name,
+            status="sent",
+        )
+        db.add(send)
+        await db.commit()
+
+        rows = (await db.execute(
+            select(AuditLog).where(
+                AuditLog.table_name == "welcome_manual_sends",
+                AuditLog.record_id == str(send.id),
+                AuditLog.operation == "INSERT",
+            ),
+        )).scalars().all()
+
+        masked = {r.field_name: r.new_value for r in rows}
+        assert masked.get("recipient_email") == "***"
+        assert masked.get("recipient_name") == "***"
+        # Non-sensitive columns are still captured.
+        assert masked.get("status") == "sent"
+        # Plaintext PII never leaks into ANY audit row.
+        for r in rows:
+            if r.new_value is not None:
+                assert plaintext_email not in r.new_value
+                assert plaintext_name not in r.new_value

--- a/apps/mybookkeeper/backend/tests/test_welcome_manual_send_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_welcome_manual_send_repo.py
@@ -1,0 +1,160 @@
+"""Repository tests for welcome_manual_send_repo.
+
+Covers: create + list_by_manual ordering (newest first), encryption round-trip
+(recipient PII reads back as plaintext but is stored as ciphertext), key_version
+default, and tenant scoping (sends are reachable only through their manual).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.organization.organization import Organization
+from app.models.user.user import User
+from app.models.welcome_manuals.welcome_manual import WelcomeManual
+from app.repositories.welcome_manuals import welcome_manual_send_repo
+
+
+@pytest.fixture()
+async def manual(
+    db: AsyncSession, test_user: User, test_org: Organization,
+) -> WelcomeManual:
+    m = WelcomeManual(
+        id=uuid.uuid4(),
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        title="Beach House Guide",
+    )
+    db.add(m)
+    await db.commit()
+    return m
+
+
+class TestCreateAndList:
+    @pytest.mark.asyncio
+    async def test_create_returns_row(
+        self, db: AsyncSession, manual: WelcomeManual,
+    ) -> None:
+        send = await welcome_manual_send_repo.create(
+            db,
+            manual_id=manual.id,
+            recipient_email="guest@example.com",
+            recipient_name="Jane Guest",
+            status="sent",
+        )
+        await db.commit()
+        assert send.id is not None
+        assert send.manual_id == manual.id
+        assert send.status == "sent"
+        assert send.error_reason is None
+
+    @pytest.mark.asyncio
+    async def test_list_by_manual_newest_first(
+        self, db: AsyncSession, manual: WelcomeManual,
+    ) -> None:
+        import datetime as _dt
+
+        s1 = await welcome_manual_send_repo.create(
+            db, manual_id=manual.id, recipient_email="a@example.com",
+            recipient_name=None, status="sent",
+        )
+        s1.created_at = _dt.datetime(2026, 1, 1, tzinfo=_dt.timezone.utc)
+        s2 = await welcome_manual_send_repo.create(
+            db, manual_id=manual.id, recipient_email="b@example.com",
+            recipient_name=None, status="failed", error_reason="send_failed",
+        )
+        s2.created_at = _dt.datetime(2026, 2, 1, tzinfo=_dt.timezone.utc)
+        await db.commit()
+
+        rows = await welcome_manual_send_repo.list_by_manual(db, manual.id)
+        assert [r.id for r in rows] == [s2.id, s1.id]
+
+    @pytest.mark.asyncio
+    async def test_key_version_defaults_to_one(
+        self, db: AsyncSession, manual: WelcomeManual,
+    ) -> None:
+        send = await welcome_manual_send_repo.create(
+            db, manual_id=manual.id, recipient_email="g@example.com",
+            recipient_name=None, status="skipped", error_reason="smtp_not_configured",
+        )
+        await db.commit()
+        await db.refresh(send)
+        assert send.key_version == 1
+
+
+class TestEncryption:
+    @pytest.mark.asyncio
+    async def test_recipient_email_round_trips_and_is_ciphertext_at_rest(
+        self, db: AsyncSession, manual: WelcomeManual,
+    ) -> None:
+        plaintext = "secret.guest@example.com"
+        send = await welcome_manual_send_repo.create(
+            db, manual_id=manual.id, recipient_email=plaintext,
+            recipient_name=None, status="sent",
+        )
+        await db.commit()
+        await db.refresh(send)
+        # ORM read returns plaintext.
+        assert send.recipient_email == plaintext
+
+        # Raw column read returns Fernet ciphertext, NOT the plaintext. Only one
+        # row exists in this test's fresh in-memory DB, so no WHERE is needed
+        # (mirrors test_applicant_encryption — avoids UUID bind-type mismatch on
+        # SQLite).
+        raw = await db.execute(text("SELECT recipient_email FROM welcome_manual_sends"))
+        stored = raw.scalar_one()
+        assert stored is not None
+        assert plaintext not in stored
+        assert stored.startswith("gAAAAA")
+
+    @pytest.mark.asyncio
+    async def test_recipient_name_round_trips_and_is_ciphertext_at_rest(
+        self, db: AsyncSession, manual: WelcomeManual,
+    ) -> None:
+        plaintext = "Jane Q Guest"
+        send = await welcome_manual_send_repo.create(
+            db, manual_id=manual.id, recipient_email="g@example.com",
+            recipient_name=plaintext, status="sent",
+        )
+        await db.commit()
+        await db.refresh(send)
+        assert send.recipient_name == plaintext
+
+        raw = await db.execute(text("SELECT recipient_name FROM welcome_manual_sends"))
+        stored = raw.scalar_one()
+        assert stored is not None
+        assert plaintext not in stored
+        assert stored.startswith("gAAAAA")
+
+
+class TestTenantScoping:
+    @pytest.mark.asyncio
+    async def test_list_only_returns_sends_for_the_given_manual(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+        manual: WelcomeManual,
+    ) -> None:
+        other = WelcomeManual(
+            id=uuid.uuid4(),
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            title="Other Guide",
+        )
+        db.add(other)
+        await db.flush()
+
+        await welcome_manual_send_repo.create(
+            db, manual_id=manual.id, recipient_email="mine@example.com",
+            recipient_name=None, status="sent",
+        )
+        await welcome_manual_send_repo.create(
+            db, manual_id=other.id, recipient_email="theirs@example.com",
+            recipient_name=None, status="sent",
+        )
+        await db.commit()
+
+        rows = await welcome_manual_send_repo.list_by_manual(db, manual.id)
+        assert len(rows) == 1
+        assert rows[0].recipient_email == "mine@example.com"

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -599,6 +599,28 @@
         "insurance-policies.spec.ts"
       ]
     },
+    "welcome_manuals": {
+      "source_paths": [
+        "backend/app/models/welcome_manuals/",
+        "backend/app/repositories/welcome_manuals/",
+        "backend/app/services/welcome_manuals/",
+        "backend/app/schemas/welcome_manuals/",
+        "backend/app/api/welcome_manuals.py",
+        "backend/app/core/welcome_manual_constants.py",
+        "backend/alembic/versions/wmanual260530_add_welcome_manuals_domain.py",
+        "backend/alembic/versions/wmanualimg260530_add_welcome_manual_section_images.py",
+        "backend/alembic/versions/wmanualsend260530_add_welcome_manual_sends.py"
+      ],
+      "backend_tests": [
+        "test_welcome_manual_image_routes.py",
+        "test_welcome_manual_pdf_service.py",
+        "test_welcome_manual_send_repo.py",
+        "test_welcome_manual_email_routes.py",
+        "test_welcome_manual_send_audit_masking.py"
+      ],
+      "frontend_tests": [],
+      "e2e_specs": []
+    },
     "leases": {
       "source_paths": [
         "backend/app/models/leases/",

--- a/packages/shared-backend/platform_shared/services/email_service.py
+++ b/packages/shared-backend/platform_shared/services/email_service.py
@@ -109,6 +109,7 @@ class EmailService:
         body_html: str,
         *,
         attachments: Sequence[EmailAttachment] | None = None,
+        reply_to: str | None = None,
     ) -> None:
         """Send the email, raising on any failure.
 
@@ -116,6 +117,11 @@ class EmailService:
         organization invites. Caller is expected to either propagate
         the exception (so the HTTP request fails 5xx and the user
         retries) or handle it explicitly.
+
+        ``reply_to`` (optional) sets the ``Reply-To`` header so replies
+        route to a different address than the sending mailbox — e.g. a
+        host sending a guest welcome guide wants the guest's reply to
+        land in the host's own inbox, not the system SMTP account.
 
         Raises:
             ValueError: If ``to`` is empty.
@@ -150,6 +156,8 @@ class EmailService:
         msg["From"] = f"{self.from_name} <{self.smtp_user}>"
         msg["To"] = ", ".join(to)
         msg["Subject"] = subject
+        if reply_to:
+            msg["Reply-To"] = reply_to
 
         try:
             with smtplib.SMTP(self.smtp_host, self.smtp_port) as server:
@@ -170,6 +178,7 @@ class EmailService:
         body_html: str,
         *,
         attachments: Sequence[EmailAttachment] | None = None,
+        reply_to: str | None = None,
     ) -> bool:
         """Best-effort send. Returns True on success, False on failure.
 
@@ -178,9 +187,15 @@ class EmailService:
         callers MUST use send_or_raise() instead — silently swallowing
         a failed verification email leaves the user in a broken state
         with no recovery path.
+
+        ``reply_to`` (optional) is threaded to ``send_or_raise`` to set
+        the ``Reply-To`` header — see that method's docstring.
         """
         try:
-            self.send_or_raise(to, subject, body_html, attachments=attachments)
+            self.send_or_raise(
+                to, subject, body_html,
+                attachments=attachments, reply_to=reply_to,
+            )
             return True
         except (ValueError, EmailNotConfiguredError, EmailSendError):
             logger.warning(

--- a/packages/shared-backend/tests/test_email_service.py
+++ b/packages/shared-backend/tests/test_email_service.py
@@ -314,3 +314,56 @@ class TestAttachments:
 
         assert ok is True
         assert "lease" in captured[0] or "x.pdf" in captured[0]
+
+
+class TestReplyTo:
+    """``reply_to`` sets the Reply-To header when passed, absent otherwise.
+
+    Use case: a host emailing a guest welcome guide wants guest replies to land
+    in the host's own inbox rather than the system SMTP account.
+    """
+
+    def _capture_raw(self, reply_to: str | None) -> str:
+        service = _configured_service()
+        mock_server = MagicMock()
+        captured: list[str] = []
+        mock_server.sendmail.side_effect = (
+            lambda from_addr, to, raw: captured.append(raw)
+        )
+
+        with patch("smtplib.SMTP") as mock_smtp_cls:
+            mock_smtp_cls.return_value.__enter__ = lambda s: mock_server
+            mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+            service.send_or_raise(
+                ["guest@example.com"], "subj", "<p>body</p>", reply_to=reply_to,
+            )
+
+        assert len(captured) == 1
+        return captured[0]
+
+    def test_reply_to_header_present_when_passed(self) -> None:
+        raw = self._capture_raw("host@example.com")
+        assert "Reply-To: host@example.com" in raw
+
+    def test_reply_to_header_absent_when_not_passed(self) -> None:
+        raw = self._capture_raw(None)
+        assert "Reply-To:" not in raw
+
+    def test_send_best_effort_threads_reply_to(self) -> None:
+        service = _configured_service()
+        mock_server = MagicMock()
+        captured: list[str] = []
+        mock_server.sendmail.side_effect = (
+            lambda from_addr, to, raw: captured.append(raw)
+        )
+
+        with patch("smtplib.SMTP") as mock_smtp_cls:
+            mock_smtp_cls.return_value.__enter__ = lambda s: mock_server
+            mock_smtp_cls.return_value.__exit__ = MagicMock(return_value=False)
+            ok = service.send(
+                ["guest@example.com"], "subj", "<p>body</p>",
+                reply_to="host@example.com",
+            )
+
+        assert ok is True
+        assert "Reply-To: host@example.com" in captured[0]


### PR DESCRIPTION
PR 3 of the **guest welcome manual** feature (PR 1 = #804, PR 2 = #806, both merged). Renders a manual to a **PDF** and **emails it to a guest**, with the send recorded in an encrypted-PII send-log.

## What's here
- **Endpoint** `POST /welcome-manuals/{id}/email` — host free-types a guest `recipient_email` (required) + `recipient_name` (optional). The system renders the manual → PDF, emails it as an attachment with **Reply-To = the host's own login email** (so guest replies reach the host, not the system SMTP mailbox), and records the outcome.
- **Pure PDF renderer** (`welcome_manual_pdf_service.py`) — reportlab **platypus**, mirroring `leases/renderer.render_pdf_from_text` + the frozen-dataclass carrier of `receipt_pdf_service.ReceiptData`. Title → intro → per-section heading/body/images (scaled to content width, capped height, captions). A corrupt/undecodable image is skipped, never crashes the PDF.
- **New table** `welcome_manual_sends` (migration `wmanualsend260530`): one row per send attempt, `ON DELETE CASCADE` with its manual. `recipient_email`/`recipient_name` are **encrypted at rest** via `EncryptedString` + `key_version`; `status` is `String(20)` + `CheckConstraint('sent','failed','skipped')`. **No `organization_id`/`user_id`** — tenant isolation is via the parent manual (the service always loads it org-scoped first), mirroring `welcome_manual_section_images`.
- **Audit masking** — `recipient_email`/`recipient_name` added to `MBK_SENSITIVE_FIELDS` so the audit log never captures the plaintext or ciphertext.

## Shared change (touches `platform_shared` → all apps)
Added an **optional, keyword-only `reply_to: str | None = None`** to `EmailService.send` / `send_or_raise` (sets `msg["Reply-To"]` only when provided) and threaded it through MBK's `email_service` wrapper. **Backward-compatible** — every existing caller across all apps is unaffected (default `None` → no Reply-To header, no behavior change). This is the parity-correct home for it (Tier 1 shared), not an MBK fork.

## Graceful degradation (mirrors `lease_email_service` skip semantics)
- SMTP not configured → records `status='skipped'` (`smtp_not_configured`), returns HTTP 200.
- Storage outage → PDF renders **text-only** (images skipped), never 503. Individual image fetch failure skips just that image.
- SMTP send failure → `status='failed'` (`send_failed`), HTTP 200. The body's `status` field communicates the outcome so the frontend (PR 4) can show a clear message rather than a network error. Failures logged at WARNING (Sentry-visible).
- Header-injection safe: recipient is `EmailStr`-validated, host email is DB-sourced, body interpolations HTML-escaped.

## Operational migration
**None required.** Purely additive: the `welcome_manual_sends` migration runs automatically on deploy; `reply_to` is optional with no new env / boot guard / required config. Existing deploys keep working unchanged.

## Tests
- PDF (%PDF magic, empty manual, with/without body & images, valid PNG embeds, corrupt image skipped, HTML-escaping), send-repo (create, ordering, key_version default, **encryption round-trip + ciphertext-at-rest** for both columns, tenant scoping), email routes (401/404/422, success asserts `reply_to == host.email` + persisted row + PDF attachment, skipped, failed), audit masking, and 3 shared `reply_to` tests.
- New MBK welcome-manual files: **24 green** locally; shared email: **22 green**. Migration applied to dev DB (`alembic current` = `wmanualsend260530`).
- Built via the g-build-feature pipeline (design → implement → test → review) with a prescriptive spec; reviewed file-by-file and re-run by me before pushing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
