### PR TITLE
feat(mbk): guest welcome manual frontend (PR 4b)

### DIFF
--- a/.github/workflows/ci-mybookkeeper.yml
+++ b/.github/workflows/ci-mybookkeeper.yml
@@ -180,7 +180,8 @@ jobs:
             e2e/two-factor-button-alignment.spec.ts \
             e2e/login-totp-button-text-centered.spec.ts \
             e2e/document-viewer-failure-modes.spec.ts \
-            e2e/caddy-headers-blob-iframe.spec.ts
+            e2e/caddy-headers-blob-iframe.spec.ts \
+            e2e/welcome-manuals-layout-mock.spec.ts
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/apps/mybookkeeper/frontend/e2e/fixtures/welcome-manual.ts
+++ b/apps/mybookkeeper/frontend/e2e/fixtures/welcome-manual.ts
@@ -1,0 +1,40 @@
+import type { APIRequestContext } from "@playwright/test";
+
+interface WelcomeManualCreateInput {
+  title?: string;
+  property_id?: string | null;
+  intro_text?: string | null;
+  seed_default_sections?: boolean;
+}
+
+interface CreatedManual {
+  id: string;
+  title: string;
+  sections: Array<{ id: string; title: string; display_order: number }>;
+}
+
+/**
+ * Create a welcome manual via the public API for E2E seeding. There is no
+ * test-helper seed endpoint for this domain — the public POST is the create
+ * path the UI uses, so seeding through it keeps the fixture honest.
+ */
+export async function createWelcomeManual(
+  api: APIRequestContext,
+  overrides: WelcomeManualCreateInput = {},
+): Promise<CreatedManual> {
+  const body = {
+    title: overrides.title ?? "E2E Welcome Manual",
+    property_id: overrides.property_id ?? null,
+    intro_text: overrides.intro_text ?? null,
+    seed_default_sections: overrides.seed_default_sections ?? true,
+  };
+  const res = await api.post("/welcome-manuals", { data: body });
+  if (!res.ok()) {
+    throw new Error(`createWelcomeManual failed: ${res.status()} ${await res.text()}`);
+  }
+  return res.json();
+}
+
+export async function deleteWelcomeManual(api: APIRequestContext, id: string): Promise<void> {
+  await api.delete(`/welcome-manuals/${id}`).catch(() => {});
+}

--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-crud.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-crud.spec.ts
@@ -1,0 +1,190 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import fs from "fs";
+import { test, expect, type APIRequestContext, type Page } from "./fixtures/auth";
+import { deleteWelcomeManual } from "./fixtures/welcome-manual";
+
+/**
+ * PR 4b — Welcome Manuals full-flow behavioural E2E.
+ *
+ * Drives the real user journey through the UI:
+ *   create (seeded) → appears in list → open detail → edit a section
+ *   (title + markdown body) and save → add a section → reorder sections →
+ *   upload a photo to a section → open the email dialog and send → delete.
+ *
+ * Verifies UI state AND backend state via the public API, and cleans up all
+ * seeded rows in `finally` per the project's "never leave test data" rule.
+ */
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PHOTO = path.join(__dirname, "fixtures", "listings", "test-photo-with-gps.jpg");
+
+interface ManualDetail {
+  id: string;
+  title: string;
+  sections: Array<{ id: string; title: string; display_order: number; images: unknown[] }>;
+}
+
+async function fetchManual(api: APIRequestContext, id: string): Promise<ManualDetail> {
+  const res = await api.get(`/welcome-manuals/${id}`);
+  if (!res.ok()) throw new Error(`fetchManual failed: ${res.status()} ${await res.text()}`);
+  return res.json();
+}
+
+async function waitForListPage(page: Page): Promise<void> {
+  await expect(page.getByRole("heading", { name: "Welcome Manuals" })).toBeVisible({
+    timeout: 10000,
+  });
+  await page.waitForLoadState("networkidle");
+}
+
+test.describe("Welcome Manuals CRUD (PR 4b)", () => {
+  test("create, edit a section, add + reorder sections, upload a photo, and delete", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const title = `E2E Welcome Manual ${runId}`;
+    let manualId: string | null = null;
+
+    try {
+      // 1) CREATE via the UI — seed checkbox is checked by default.
+      await page.goto("/welcome-manuals");
+      await waitForListPage(page);
+
+      await page.getByTestId("new-welcome-manual-button").click();
+      await expect(page.getByTestId("welcome-manual-create-form")).toBeVisible();
+      await expect(page.getByTestId("welcome-manual-create-seed")).toBeChecked();
+      await page.getByTestId("welcome-manual-create-title").fill(title);
+      await page.getByTestId("welcome-manual-create-submit").click();
+
+      // Navigates to the new detail page (header heading appears).
+      await expect(page.getByRole("heading", { name: title })).toBeVisible({ timeout: 10000 });
+      const detailUrl = page.url();
+      const match = detailUrl.match(/\/welcome-manuals\/([0-9a-f-]+)/);
+      manualId = match?.[1] ?? null;
+      expect(manualId).toBeTruthy();
+      if (!manualId) throw new Error("Could not parse manual id from URL");
+
+      // Seeded with the default stub sections.
+      await page.waitForLoadState("networkidle");
+      const seeded = await fetchManual(api, manualId);
+      expect(seeded.sections.length).toBeGreaterThanOrEqual(5);
+
+      // 2) Appears in the list.
+      await page.goto("/welcome-manuals");
+      await waitForListPage(page);
+      await expect(page.getByText(title).first()).toBeVisible();
+
+      // Open it again.
+      await page.getByText(title).first().click();
+      await expect(page.getByRole("heading", { name: title })).toBeVisible();
+      await page.waitForLoadState("networkidle");
+
+      // 3) EDIT the first section's title + markdown body, then Save.
+      const firstCard = page.getByTestId("welcome-manual-section-card").first();
+      await expect(firstCard).toBeVisible();
+      const firstTitle = firstCard.getByTestId("welcome-manual-section-title");
+      await firstTitle.fill(`Wi-Fi Details ${runId}`);
+      const firstBody = firstCard.getByTestId("welcome-manual-section-body");
+      await firstBody.fill("**Network:** Lakeview\n\n- Password: hunter2");
+      // Live markdown preview renders.
+      await expect(firstCard.getByTestId("welcome-manual-section-body-preview")).toBeVisible();
+      await firstCard.getByTestId("welcome-manual-section-save").click();
+
+      await expect(async () => {
+        const updated = await fetchManual(api, manualId!);
+        const edited = updated.sections.find((s) => s.title === `Wi-Fi Details ${runId}`);
+        expect(edited).toBeTruthy();
+      }).toPass({ timeout: 10000 });
+
+      // 4) ADD a section — it appears as a new card.
+      const beforeCount = await page.getByTestId("welcome-manual-section-card").count();
+      await page.getByTestId("add-welcome-manual-section-button").click();
+      await expect(async () => {
+        const afterCount = await page.getByTestId("welcome-manual-section-card").count();
+        expect(afterCount).toBe(beforeCount + 1);
+      }).toPass({ timeout: 10000 });
+
+      const afterAdd = await fetchManual(api, manualId);
+      expect(afterAdd.sections.length).toBe(seeded.sections.length + 1);
+
+      // 5) REORDER — move the first section after the second via the order API
+      // through the UI's contract. We assert the order endpoint accepts a full
+      // permutation and the manual reflects the new order. (Drag simulation is
+      // flaky cross-browser; the optimistic UI + invalidation path is unit-tested,
+      // so here we exercise the persisted contract the UI fires.)
+      const current = await fetchManual(api, manualId);
+      const ids = [...current.sections]
+        .sort((a, b) => a.display_order - b.display_order)
+        .map((s) => s.id);
+      const reordered = [ids[1], ids[0], ...ids.slice(2)];
+      const orderRes = await api.put(`/welcome-manuals/${manualId}/sections/order`, {
+        data: { section_ids: reordered },
+      });
+      expect(orderRes.ok()).toBeTruthy();
+      const afterReorder = await fetchManual(api, manualId);
+      const sortedAfter = [...afterReorder.sections]
+        .sort((a, b) => a.display_order - b.display_order)
+        .map((s) => s.id);
+      expect(sortedAfter[0]).toBe(reordered[0]);
+      expect(sortedAfter[1]).toBe(reordered[1]);
+
+      // 6) UPLOAD a photo to the first section (if the fixture exists).
+      if (fs.existsSync(FIXTURE_PHOTO)) {
+        await page.reload();
+        await page.waitForLoadState("networkidle");
+        const card = page.getByTestId("welcome-manual-section-card").first();
+        await expect(card.getByTestId("welcome-manual-image-empty-state")).toBeVisible();
+        await card.getByTestId("welcome-manual-image-file-input").setInputFiles(FIXTURE_PHOTO);
+        await expect(card.getByTestId("welcome-manual-image-card").first()).toBeVisible({
+          timeout: 10000,
+        });
+
+        // Confirm persisted via API.
+        await expect(async () => {
+          const withImage = await fetchManual(api, manualId!);
+          const total = withImage.sections.reduce((n, s) => n + s.images.length, 0);
+          expect(total).toBeGreaterThanOrEqual(1);
+        }).toPass({ timeout: 10000 });
+      }
+
+      // 7) EMAIL dialog — open, send. In CI SMTP is unconfigured, so the send
+      // returns status=skipped; the dialog shows the skipped result (no retry).
+      await page.getByTestId("email-welcome-manual-button").click();
+      await expect(page.getByTestId("welcome-manual-email-dialog")).toBeVisible();
+      await page.getByTestId("welcome-manual-email-input").fill("guest@example.com");
+      await page.getByTestId("welcome-manual-email-send").click();
+      // One of the three result states must render.
+      await expect(
+        page
+          .getByTestId("welcome-manual-email-sent")
+          .or(page.getByTestId("welcome-manual-email-failed"))
+          .or(page.getByTestId("welcome-manual-email-skipped")),
+      ).toBeVisible({ timeout: 15000 });
+      // Close whichever result is showing.
+      const closeBtn = page
+        .getByTestId("welcome-manual-email-done")
+        .or(page.getByTestId("welcome-manual-email-close"));
+      if (await closeBtn.first().isVisible()) {
+        await closeBtn.first().click();
+      }
+
+      // 8) DELETE the manual via the UI and verify navigation + removal.
+      await page.getByTestId("delete-welcome-manual-button").click();
+      await expect(page.getByText(/Delete this welcome manual\?/i)).toBeVisible();
+      await page.getByRole("button", { name: /^delete$/i }).click();
+
+      await expect(page).toHaveURL(/\/welcome-manuals$/, { timeout: 10000 });
+      await page.waitForLoadState("networkidle");
+      await expect(page.getByText(title)).toHaveCount(0);
+
+      // Confirm soft-deleted (404 on read).
+      const afterDelete = await api.get(`/welcome-manuals/${manualId}`);
+      expect(afterDelete.status()).toBe(404);
+      manualId = null; // already deleted — skip cleanup
+    } finally {
+      if (manualId) await deleteWelcomeManual(api, manualId);
+    }
+  });
+});

--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout-mock.spec.ts
@@ -1,0 +1,214 @@
+/**
+ * No-backend layout E2E for the Welcome Manuals list + detail pages.
+ *
+ * Fully mocks the API surface via page.route() so it runs under
+ * playwright.layout.config.ts in the `frontend-layout-e2e` CI job (no backend,
+ * no globalSetup). Mirrors how the listings pages are layout-covered, but in
+ * the mockable shape the CI job requires.
+ *
+ * Verifies:
+ *   - List skeleton mirrors the loaded mobile card / desktop table structure.
+ *   - Mobile shows cards + hides the table; desktop shows the table + hides cards.
+ *   - Detail skeleton mirrors the loaded header + sections structure.
+ *   - No horizontal scroll on either page across mobile / tablet / desktop.
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+const ORG_ID = "00000000-0000-0000-0000-000000000010";
+const MANUAL_ID = "00000000-0000-0000-0000-0000000000a1";
+
+function plantAuth(page: Page): Promise<void> {
+  return page.addInitScript(
+    ([orgId]) => {
+      const futureExp = Math.floor(Date.now() / 1000) + 3600;
+      const header = btoa(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+      const payload = btoa(JSON.stringify({ sub: "test-user", exp: futureExp }));
+      window.localStorage.setItem("token", `${header}.${payload}.fake-signature`);
+      window.localStorage.setItem("v1_activeOrgId", orgId);
+    },
+    [ORG_ID],
+  );
+}
+
+async function stubShell(page: Page): Promise<void> {
+  await page.route("**/api/users/me", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: "00000000-0000-0000-0000-000000000001",
+        email: "test@example.com",
+        name: "Test User",
+        is_active: true,
+        is_superuser: false,
+        is_verified: true,
+        role: "owner",
+      }),
+    }),
+  );
+  await page.route("**/api/organizations", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify([{ id: ORG_ID, name: "Test Workspace", role: "owner" }]),
+    }),
+  );
+  await page.route("**/api/version", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify({ version: "test" }) }),
+  );
+  await page.route("**/api/tax-profile", (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ onboarding_completed: true, tax_situations: [], filing_status: null, dependents_count: 0 }),
+    }),
+  );
+  await page.route("**/api/properties", (route) =>
+    route.fulfill({ status: 200, contentType: "application/json", body: JSON.stringify([]) }),
+  );
+}
+
+function summary(id: string, title: string, sectionCount: number) {
+  return {
+    id,
+    title,
+    property_id: null,
+    section_count: sectionCount,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+  };
+}
+
+async function stubList(page: Page, delayMs = 0): Promise<void> {
+  await page.route("**/api/welcome-manuals?*", async (route, request) => {
+    if (request.method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        items: [
+          summary("00000000-0000-0000-0000-0000000000b1", "Lakeview Guide", 5),
+          summary("00000000-0000-0000-0000-0000000000b2", "Cabin Guide", 0),
+          summary("00000000-0000-0000-0000-0000000000b3", "Downtown Loft Guide", 3),
+        ],
+        total: 3,
+        has_more: false,
+      }),
+    });
+  });
+}
+
+async function stubDetail(page: Page, delayMs = 0): Promise<void> {
+  await page.route(`**/api/welcome-manuals/${MANUAL_ID}`, async (route, request) => {
+    if (request.method() !== "GET") {
+      await route.continue();
+      return;
+    }
+    if (delayMs > 0) await new Promise((r) => setTimeout(r, delayMs));
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({
+        id: MANUAL_ID,
+        organization_id: ORG_ID,
+        user_id: "00000000-0000-0000-0000-000000000001",
+        property_id: null,
+        title: "Lakeview Welcome Guide",
+        intro_text: "Welcome! Here's everything you need.",
+        sections: [0, 1, 2].map((i) => ({
+          id: `00000000-0000-0000-0000-00000000c00${i}`,
+          manual_id: MANUAL_ID,
+          title: `Section ${i + 1}`,
+          body: "Some instructions",
+          display_order: i,
+          images: [],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        })),
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      }),
+    });
+  });
+}
+
+test.describe("Welcome Manuals layout (mocked, no backend)", () => {
+  test("list skeleton slot count is in the ballpark of the loaded card count", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+    await plantAuth(page);
+    await stubShell(page);
+    await stubList(page, 1500);
+
+    await page.goto("/welcome-manuals");
+    await expect(page.getByTestId("welcome-manuals-skeleton")).toBeVisible({ timeout: 5000 });
+    const skeletonCount = await page
+      .locator('[data-testid="welcome-manuals-skeleton"] ul.md\\:hidden li')
+      .count();
+    expect(skeletonCount).toBeGreaterThan(0);
+
+    await expect(page.getByTestId("welcome-manuals-mobile")).toBeVisible({ timeout: 10000 });
+    const loadedCount = await page.locator('[data-testid="welcome-manuals-mobile"] li').count();
+    expect(loadedCount).toBe(3);
+    expect(Math.abs(skeletonCount - loadedCount)).toBeLessThanOrEqual(4);
+  });
+
+  test("mobile shows cards + hides table; desktop shows table + hides cards", async ({ page }) => {
+    await plantAuth(page);
+    await stubShell(page);
+    await stubList(page);
+
+    await page.setViewportSize({ width: 375, height: 800 });
+    await page.goto("/welcome-manuals");
+    await expect(page.getByTestId("welcome-manuals-mobile")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("welcome-manuals-desktop")).toBeHidden();
+
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto("/welcome-manuals");
+    await expect(page.getByTestId("welcome-manuals-desktop")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId("welcome-manuals-mobile")).toBeHidden();
+  });
+
+  test("list has no horizontal scroll across viewports", async ({ page }) => {
+    await plantAuth(page);
+    await stubShell(page);
+    await stubList(page);
+
+    const viewports = [
+      { name: "mobile", width: 375, height: 800 },
+      { name: "tablet", width: 768, height: 1024 },
+      { name: "desktop", width: 1280, height: 900 },
+    ];
+    for (const vp of viewports) {
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/welcome-manuals");
+      await expect(page.getByRole("heading", { name: "Welcome Manuals" })).toBeVisible({
+        timeout: 10000,
+      });
+      const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+      expect(bodyWidth, `Horizontal scroll at ${vp.name}`).toBeLessThanOrEqual(vp.width + 1);
+    }
+  });
+
+  test("detail skeleton renders then resolves to the header + sections", async ({ page }) => {
+    await plantAuth(page);
+    await stubShell(page);
+    await stubDetail(page, 1200);
+
+    await page.goto(`/welcome-manuals/${MANUAL_ID}`);
+    await expect(page.getByTestId("welcome-manual-detail-skeleton")).toBeVisible({ timeout: 5000 });
+
+    await expect(page.getByTestId("welcome-manual-header-card")).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("heading", { name: "Lakeview Welcome Guide" })).toBeVisible();
+    await expect(page.getByTestId("welcome-manual-sections")).toBeVisible();
+    const cards = await page.getByTestId("welcome-manual-section-card").count();
+    expect(cards).toBe(3);
+
+    const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+    const vw = page.viewportSize()?.width ?? 0;
+    expect(bodyWidth).toBeLessThanOrEqual(vw + 1);
+  });
+});

--- a/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/welcome-manuals-layout.spec.ts
@@ -1,0 +1,188 @@
+import { test, expect, type Page } from "./fixtures/auth";
+import { createWelcomeManual, deleteWelcomeManual } from "./fixtures/welcome-manual";
+
+/**
+ * Layout E2E for the Welcome Manuals list + detail pages (PR 4b).
+ *
+ * Verifies:
+ *   1. The list skeleton has card/row slots (no layout shift), and the
+ *      skeleton slot count is in the same ballpark as the loaded list.
+ *   2. Mobile (375), tablet (768), desktop (1280) render both pages without
+ *      horizontal overflow.
+ *   3. Mobile viewport surfaces the card layout; desktop surfaces the table.
+ *   4. The detail page skeleton renders while the manual loads.
+ */
+
+const MANUAL_COUNT = 3;
+
+test.describe("Welcome Manuals layout (PR 4b)", () => {
+  test("list skeleton card count is in the ballpark of the loaded card count on mobile", async ({
+    authedPage: page,
+    api,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 800 });
+
+    const runId = Date.now();
+    const manualIds: string[] = [];
+    try {
+      // Block the list call so the skeleton stays visible long enough to count.
+      await page.route("**/api/welcome-manuals**", async (route) => {
+        await new Promise((r) => setTimeout(r, 1500));
+        await route.continue();
+      });
+
+      const navPromise = page.goto("/welcome-manuals");
+      await expect(page.getByTestId("welcome-manuals-skeleton")).toBeVisible({ timeout: 5000 });
+
+      const skeletonMobileList = page.locator(
+        '[data-testid="welcome-manuals-skeleton"] ul.md\\:hidden li',
+      );
+      const skeletonCount = await skeletonMobileList.count();
+      expect(skeletonCount).toBeGreaterThan(0);
+
+      for (let i = 0; i < MANUAL_COUNT; i++) {
+        const manual = await createWelcomeManual(api, {
+          title: `E2E Layout Manual ${runId}-${i}`,
+          seed_default_sections: false,
+        });
+        manualIds.push(manual.id);
+      }
+      await page.unroute("**/api/welcome-manuals**");
+      await navPromise;
+      await page.reload();
+      await page.waitForLoadState("networkidle");
+
+      const loadedMobileCards = page.locator('[data-testid="welcome-manuals-mobile"] li');
+      const loadedCount = await loadedMobileCards.count();
+      expect(loadedCount).toBeGreaterThanOrEqual(MANUAL_COUNT);
+
+      expect(Math.abs(skeletonCount - loadedCount)).toBeLessThanOrEqual(4);
+    } finally {
+      for (const id of manualIds) await deleteWelcomeManual(api, id);
+    }
+  });
+
+  test("list renders without horizontal scroll at mobile / tablet / desktop", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const manualIds: string[] = [];
+    try {
+      for (let i = 0; i < 3; i++) {
+        const manual = await createWelcomeManual(api, {
+          title: `E2E Multi Layout ${runId}-${i}`,
+          seed_default_sections: false,
+        });
+        manualIds.push(manual.id);
+      }
+
+      const viewports: ReadonlyArray<{ name: string; width: number; height: number }> = [
+        { name: "mobile", width: 375, height: 800 },
+        { name: "tablet", width: 768, height: 1024 },
+        { name: "desktop", width: 1280, height: 900 },
+      ];
+
+      for (const vp of viewports) {
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await page.goto("/welcome-manuals");
+        await page.waitForLoadState("networkidle");
+
+        await expect(
+          page.getByRole("heading", { name: "Welcome Manuals" }),
+          `heading visible at ${vp.name}`,
+        ).toBeVisible();
+
+        const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+        expect(
+          bodyWidth,
+          `Horizontal scroll at ${vp.name} (${vp.width}px) — bodyWidth=${bodyWidth}`,
+        ).toBeLessThanOrEqual(vp.width + 1);
+      }
+    } finally {
+      for (const id of manualIds) await deleteWelcomeManual(api, id);
+    }
+  });
+
+  test("mobile hides the desktop table; desktop hides the mobile list", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const manual = await createWelcomeManual(api, {
+      title: `E2E Toggle ${runId}`,
+      seed_default_sections: false,
+    });
+    try {
+      await assertOnlyMobileVisible(page, "mobile", 375, 800);
+      await assertOnlyDesktopVisible(page, "desktop", 1280, 900);
+    } finally {
+      await deleteWelcomeManual(api, manual.id);
+    }
+  });
+
+  test("detail page skeleton renders while the manual loads, then shows the header", async ({
+    authedPage: page,
+    api,
+  }) => {
+    const runId = Date.now();
+    const manual = await createWelcomeManual(api, {
+      title: `E2E Detail Layout ${runId}`,
+      seed_default_sections: true,
+    });
+    try {
+      // Block the detail call so the skeleton stays visible long enough to assert.
+      await page.route(`**/api/welcome-manuals/${manual.id}`, async (route) => {
+        await new Promise((r) => setTimeout(r, 1200));
+        await route.continue();
+      });
+      const navPromise = page.goto(`/welcome-manuals/${manual.id}`);
+      await expect(page.getByTestId("welcome-manual-detail-skeleton")).toBeVisible({
+        timeout: 5000,
+      });
+      await page.unroute(`**/api/welcome-manuals/${manual.id}`);
+      await navPromise;
+      await page.waitForLoadState("networkidle");
+
+      await expect(
+        page.getByRole("heading", { name: `E2E Detail Layout ${runId}` }),
+      ).toBeVisible();
+      await expect(page.getByTestId("welcome-manual-header-card")).toBeVisible();
+
+      // No horizontal overflow on the detail page either.
+      const bodyWidth = await page.evaluate(() => document.body.scrollWidth);
+      const vw = page.viewportSize()?.width ?? 0;
+      expect(bodyWidth).toBeLessThanOrEqual(vw + 1);
+    } finally {
+      await deleteWelcomeManual(api, manual.id);
+    }
+  });
+});
+
+async function assertOnlyMobileVisible(page: Page, name: string, w: number, h: number): Promise<void> {
+  await page.setViewportSize({ width: w, height: h });
+  await page.goto("/welcome-manuals");
+  await page.waitForLoadState("networkidle");
+  await expect(
+    page.getByTestId("welcome-manuals-mobile"),
+    `mobile list visible at ${name}`,
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("welcome-manuals-desktop"),
+    `desktop table hidden at ${name}`,
+  ).toBeHidden();
+}
+
+async function assertOnlyDesktopVisible(page: Page, name: string, w: number, h: number): Promise<void> {
+  await page.setViewportSize({ width: w, height: h });
+  await page.goto("/welcome-manuals");
+  await page.waitForLoadState("networkidle");
+  await expect(
+    page.getByTestId("welcome-manuals-desktop"),
+    `desktop table visible at ${name}`,
+  ).toBeVisible();
+  await expect(
+    page.getByTestId("welcome-manuals-mobile"),
+    `mobile list hidden at ${name}`,
+  ).toBeHidden();
+}

--- a/apps/mybookkeeper/frontend/src/App.tsx
+++ b/apps/mybookkeeper/frontend/src/App.tsx
@@ -20,6 +20,8 @@ import Documents from "@/app/pages/Documents";
 import Properties from "@/app/pages/Properties";
 import Listings from "@/app/pages/Listings";
 import ListingDetail from "@/app/pages/ListingDetail";
+import WelcomeManuals from "@/app/pages/WelcomeManuals";
+import WelcomeManualDetail from "@/app/pages/WelcomeManualDetail";
 import Calendar from "@/app/pages/Calendar";
 import Inquiries from "@/app/pages/Inquiries";
 import InquiryDetail from "@/app/pages/InquiryDetail";
@@ -114,6 +116,8 @@ export default function App() {
               <Route path="properties" element={<Properties />} />
               <Route path="listings" element={<Listings />} />
               <Route path="listings/:listingId" element={<ListingDetail />} />
+              <Route path="welcome-manuals" element={<WelcomeManuals />} />
+              <Route path="welcome-manuals/:manualId" element={<WelcomeManualDetail />} />
               <Route path="calendar" element={<Calendar />} />
               <Route path="inquiries" element={<Inquiries />} />
               <Route path="inquiries/:inquiryId" element={<InquiryDetail />} />

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualCreateDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualCreateDialog.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the welcome-manual create dialog.
+ *
+ * Verifies:
+ *   - The "start with common sections" seed checkbox defaults to CHECKED.
+ *   - Submitting sends seed_default_sections=true by default and calls
+ *     onCreated with the created manual.
+ *   - Unchecking the seed box sends seed_default_sections=false.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WelcomeManualCreateDialog from "@/app/features/welcome-manuals/WelcomeManualCreateDialog";
+import type { Property } from "@/shared/types/property/property";
+import type { WelcomeManualResponse } from "@/shared/types/welcome-manual/welcome-manual-response";
+
+const createMutationMock = vi.fn();
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+vi.mock("@/shared/store/welcomeManualsApi", () => ({
+  useCreateWelcomeManualMutation: vi.fn(() => [createMutationMock, { isLoading: false }]),
+}));
+
+const PROPERTY: Property = {
+  id: "prop-1",
+  name: "Lakeview Suite",
+  address: null,
+  classification: "investment",
+  type: "short_term",
+  is_active: true,
+  activity_periods: [],
+  created_at: "2026-01-01T00:00:00Z",
+};
+
+const CREATED: WelcomeManualResponse = {
+  id: "m-new",
+  organization_id: "org-1",
+  user_id: "user-1",
+  property_id: null,
+  title: "My Guide",
+  intro_text: null,
+  sections: [],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("WelcomeManualCreateDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("defaults the seed checkbox to checked", () => {
+    render(
+      <WelcomeManualCreateDialog
+        properties={[PROPERTY]}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+    const seed = screen.getByTestId("welcome-manual-create-seed");
+    expect(seed).toBeChecked();
+  });
+
+  it("creates with seed_default_sections=true by default and calls onCreated", async () => {
+    createMutationMock.mockReturnValue({ unwrap: () => Promise.resolve(CREATED) });
+    const onCreated = vi.fn();
+    render(
+      <WelcomeManualCreateDialog
+        properties={[PROPERTY]}
+        onClose={vi.fn()}
+        onCreated={onCreated}
+      />,
+    );
+
+    await userEvent.type(screen.getByTestId("welcome-manual-create-title"), "My Guide");
+    await userEvent.click(screen.getByTestId("welcome-manual-create-submit"));
+
+    await waitFor(() => {
+      expect(createMutationMock).toHaveBeenCalledWith({
+        title: "My Guide",
+        property_id: null,
+        seed_default_sections: true,
+      });
+      expect(onCreated).toHaveBeenCalledWith(CREATED);
+    });
+  });
+
+  it("sends seed_default_sections=false when the seed box is unchecked", async () => {
+    createMutationMock.mockReturnValue({ unwrap: () => Promise.resolve(CREATED) });
+    render(
+      <WelcomeManualCreateDialog
+        properties={[PROPERTY]}
+        onClose={vi.fn()}
+        onCreated={vi.fn()}
+      />,
+    );
+
+    await userEvent.type(screen.getByTestId("welcome-manual-create-title"), "Blank Guide");
+    await userEvent.click(screen.getByTestId("welcome-manual-create-seed"));
+    await userEvent.selectOptions(screen.getByTestId("welcome-manual-create-property"), "prop-1");
+    await userEvent.click(screen.getByTestId("welcome-manual-create-submit"));
+
+    await waitFor(() => {
+      expect(createMutationMock).toHaveBeenCalledWith({
+        title: "Blank Guide",
+        property_id: "prop-1",
+        seed_default_sections: false,
+      });
+    });
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualDetail.test.tsx
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for the WelcomeManualDetail page.
+ *
+ * Verifies:
+ *   - The "Email to guest" button is DISABLED when the manual has 0 sections
+ *     and ENABLED once it has at least one section (operator decision).
+ *   - The loading skeleton renders while the manual query is in-flight.
+ *   - The error state offers a retry.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { store } from "@/shared/store";
+import WelcomeManualDetail from "@/app/pages/WelcomeManualDetail";
+import type { WelcomeManualResponse } from "@/shared/types/welcome-manual/welcome-manual-response";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+
+let mockManual: WelcomeManualResponse | undefined;
+let mockIsLoading = false;
+let mockIsError = false;
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+vi.mock("@/shared/store/welcomeManualsApi", () => ({
+  useGetWelcomeManualByIdQuery: vi.fn(() => ({
+    data: mockManual,
+    isLoading: mockIsLoading,
+    isFetching: false,
+    isError: mockIsError,
+    refetch: vi.fn(),
+  })),
+  useCreateSectionMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useDeleteWelcomeManualMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUpdateSectionMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useDeleteSectionMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useReorderSectionsMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUploadSectionImagesMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUpdateSectionImageMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useDeleteSectionImageMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+}));
+
+vi.mock("@/shared/store/propertiesApi", () => ({
+  useGetPropertiesQuery: vi.fn(() => ({ data: [] })),
+}));
+
+function makeSection(id: string): WelcomeManualSectionResponse {
+  return {
+    id,
+    manual_id: "m-1",
+    title: "Wi-Fi",
+    body: "instructions",
+    display_order: 0,
+    images: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function makeManual(sections: WelcomeManualSectionResponse[]): WelcomeManualResponse {
+  return {
+    id: "m-1",
+    organization_id: "org-1",
+    user_id: "user-1",
+    property_id: null,
+    title: "Lakeview Welcome Guide",
+    intro_text: null,
+    sections,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  };
+}
+
+function renderDetail() {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter initialEntries={["/welcome-manuals/m-1"]}>
+        <Routes>
+          <Route path="/welcome-manuals/:manualId" element={<WelcomeManualDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe("WelcomeManualDetail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockManual = undefined;
+    mockIsLoading = false;
+    mockIsError = false;
+  });
+
+  it("renders the skeleton while loading", () => {
+    mockIsLoading = true;
+    renderDetail();
+    expect(screen.getByTestId("welcome-manual-detail-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows an error + retry when the query errors", () => {
+    mockIsError = true;
+    renderDetail();
+    expect(screen.getByText(/I couldn't load this welcome manual/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("disables the Email button when the manual has 0 sections", () => {
+    mockManual = makeManual([]);
+    renderDetail();
+    expect(screen.getByTestId("email-welcome-manual-button")).toBeDisabled();
+    // Empty-sections placeholder shows instead of section cards.
+    expect(screen.getByTestId("welcome-manual-sections-empty")).toBeInTheDocument();
+  });
+
+  it("enables the Email button once the manual has at least one section", () => {
+    mockManual = makeManual([makeSection("sec-1")]);
+    renderDetail();
+    expect(screen.getByTestId("email-welcome-manual-button")).not.toBeDisabled();
+    expect(screen.getByTestId("welcome-manual-sections")).toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualEmailDialog.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualEmailDialog.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for the welcome-manual email-to-guest dialog.
+ *
+ * Verifies the 3 result states render distinctly and the per-status footer
+ * actions match the spec:
+ *   - sent    → green success, "Done" closes
+ *   - failed  → amber error, "Try again" returns to the form WITH email
+ *               pre-filled + "Close"
+ *   - skipped → blue info, "Close" only (no "Try again" — retry always skips)
+ * Plus: send button disabled until a valid email is entered.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import WelcomeManualEmailDialog from "@/app/features/welcome-manuals/WelcomeManualEmailDialog";
+import type { WelcomeManualSendResponse } from "@/shared/types/welcome-manual/welcome-manual-send-response";
+
+const emailMutationMock = vi.fn();
+const showErrorMock = vi.fn();
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: (msg: string) => showErrorMock(msg),
+  showSuccess: vi.fn(),
+}));
+
+vi.mock("@/shared/store/welcomeManualsApi", () => ({
+  useEmailWelcomeManualMutation: vi.fn(() => [emailMutationMock, { isLoading: false }]),
+}));
+
+function makeSend(overrides: Partial<WelcomeManualSendResponse>): WelcomeManualSendResponse {
+  return {
+    id: "send-1",
+    manual_id: "m-1",
+    recipient_email: "guest@example.com",
+    recipient_name: null,
+    status: "sent",
+    error_reason: null,
+    created_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const onClose = vi.fn();
+
+describe("WelcomeManualEmailDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disables the send button until a valid email is entered", async () => {
+    render(<WelcomeManualEmailDialog manualId="m-1" onClose={onClose} />);
+    const sendBtn = screen.getByTestId("welcome-manual-email-send");
+    expect(sendBtn).toBeDisabled();
+
+    const input = screen.getByTestId("welcome-manual-email-input");
+    await userEvent.type(input, "not-an-email");
+    expect(sendBtn).toBeDisabled();
+
+    await userEvent.clear(input);
+    await userEvent.type(input, "guest@example.com");
+    expect(sendBtn).not.toBeDisabled();
+  });
+
+  it("renders the sent state with a Done button on status=sent", async () => {
+    emailMutationMock.mockReturnValue({
+      unwrap: () => Promise.resolve(makeSend({ status: "sent" })),
+    });
+    render(<WelcomeManualEmailDialog manualId="m-1" onClose={onClose} />);
+    await userEvent.type(screen.getByTestId("welcome-manual-email-input"), "guest@example.com");
+    await userEvent.click(screen.getByTestId("welcome-manual-email-send"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("welcome-manual-email-sent")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Guide sent!")).toBeInTheDocument();
+    expect(screen.getByTestId("welcome-manual-email-done")).toBeInTheDocument();
+    expect(screen.queryByTestId("welcome-manual-email-try-again")).not.toBeInTheDocument();
+  });
+
+  it("renders the failed state with error reason + Try again that pre-fills email", async () => {
+    emailMutationMock.mockReturnValue({
+      unwrap: () =>
+        Promise.resolve(
+          makeSend({ status: "failed", error_reason: "Mailbox does not exist" }),
+        ),
+    });
+    render(<WelcomeManualEmailDialog manualId="m-1" onClose={onClose} />);
+    await userEvent.type(screen.getByTestId("welcome-manual-email-input"), "guest@example.com");
+    await userEvent.click(screen.getByTestId("welcome-manual-email-send"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("welcome-manual-email-failed")).toBeInTheDocument();
+    });
+    expect(screen.getByText("I couldn't send that")).toBeInTheDocument();
+    expect(screen.getByText("Mailbox does not exist")).toBeInTheDocument();
+
+    // Try again returns to the form with the email still filled.
+    await userEvent.click(screen.getByTestId("welcome-manual-email-try-again"));
+    expect(screen.getByTestId("welcome-manual-email-form")).toBeInTheDocument();
+    expect(screen.getByTestId("welcome-manual-email-input")).toHaveValue("guest@example.com");
+  });
+
+  it("renders the skipped state with a Close button and NO Try again", async () => {
+    emailMutationMock.mockReturnValue({
+      unwrap: () => Promise.resolve(makeSend({ status: "skipped" })),
+    });
+    render(<WelcomeManualEmailDialog manualId="m-1" onClose={onClose} />);
+    await userEvent.type(screen.getByTestId("welcome-manual-email-input"), "guest@example.com");
+    await userEvent.click(screen.getByTestId("welcome-manual-email-send"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("welcome-manual-email-skipped")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Email isn't set up yet")).toBeInTheDocument();
+    expect(screen.getByTestId("welcome-manual-email-close")).toBeInTheDocument();
+    expect(screen.queryByTestId("welcome-manual-email-try-again")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("welcome-manual-email-done")).not.toBeInTheDocument();
+  });
+
+  it("shows an error toast when the request throws (transport error)", async () => {
+    emailMutationMock.mockReturnValue({
+      unwrap: () => Promise.reject(new Error("network")),
+    });
+    render(<WelcomeManualEmailDialog manualId="m-1" onClose={onClose} />);
+    await userEvent.type(screen.getByTestId("welcome-manual-email-input"), "guest@example.com");
+    await userEvent.click(screen.getByTestId("welcome-manual-email-send"));
+
+    await waitFor(() => {
+      expect(showErrorMock).toHaveBeenCalled();
+    });
+    // Still on the form — no result state rendered.
+    expect(screen.getByTestId("welcome-manual-email-form")).toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualSectionCard.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManualSectionCard.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * Unit tests for a welcome-manual section card.
+ *
+ * Verifies:
+ *   - Save is disabled when the section is clean (no edits).
+ *   - Editing the body enables Save; saving sends a dirty-only PATCH (only the
+ *     changed field).
+ *   - A freshly-seeded stub (body: null) shows the placeholder prompt, not a
+ *     blank pre-filled field.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DndContext } from "@dnd-kit/core";
+import WelcomeManualSectionCard from "@/app/features/welcome-manuals/WelcomeManualSectionCard";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+
+const updateSectionMock = vi.fn();
+const deleteSectionMock = vi.fn();
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+// Image manager hits these but we only assert section editing here.
+vi.mock("@/shared/store/welcomeManualsApi", () => ({
+  useUpdateSectionMutation: vi.fn(() => [updateSectionMock, { isLoading: false }]),
+  useDeleteSectionMutation: vi.fn(() => [deleteSectionMock, { isLoading: false }]),
+  useUploadSectionImagesMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useUpdateSectionImageMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+  useDeleteSectionImageMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+}));
+
+function makeSection(overrides: Partial<WelcomeManualSectionResponse>): WelcomeManualSectionResponse {
+  return {
+    id: "sec-1",
+    manual_id: "m-1",
+    title: "Wi-Fi",
+    body: "Network: Lakeview, password hunter2",
+    display_order: 0,
+    images: [],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderCard(section: WelcomeManualSectionResponse) {
+  return render(
+    <DndContext>
+      <WelcomeManualSectionCard manualId="m-1" section={section} />
+    </DndContext>,
+  );
+}
+
+describe("WelcomeManualSectionCard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("disables Save when the section is clean", () => {
+    renderCard(makeSection({}));
+    expect(screen.getByTestId("welcome-manual-section-save")).toBeDisabled();
+  });
+
+  it("enables Save after editing the body and sends a dirty-only PATCH", async () => {
+    updateSectionMock.mockReturnValue({ unwrap: () => Promise.resolve(makeSection({})) });
+    renderCard(makeSection({}));
+
+    const body = screen.getByTestId("welcome-manual-section-body");
+    await userEvent.clear(body);
+    await userEvent.type(body, "New Wi-Fi instructions");
+
+    const save = screen.getByTestId("welcome-manual-section-save");
+    expect(save).not.toBeDisabled();
+    await userEvent.click(save);
+
+    await waitFor(() => {
+      expect(updateSectionMock).toHaveBeenCalledWith({
+        manualId: "m-1",
+        sectionId: "sec-1",
+        data: { body: "New Wi-Fi instructions" },
+      });
+    });
+  });
+
+  it("shows the placeholder prompt for a freshly-seeded stub (body: null)", () => {
+    renderCard(makeSection({ body: null }));
+    const body = screen.getByTestId("welcome-manual-section-body") as HTMLTextAreaElement;
+    expect(body.value).toBe("");
+    expect(body.placeholder).toBe("Add instructions for guests…");
+    // No preview rendered when the body is empty.
+    expect(screen.queryByTestId("welcome-manual-section-body-preview")).not.toBeInTheDocument();
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/WelcomeManuals.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/WelcomeManuals.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * Unit tests for the WelcomeManuals list page.
+ *
+ * Verifies:
+ *   - Loading skeleton while query is in-flight.
+ *   - Error state with retry.
+ *   - Empty state with "Create your first guide" CTA.
+ *   - List renders titles + a pluralized section-count badge ("0 sections"
+ *     shown distinctly).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router-dom";
+import { store } from "@/shared/store";
+import WelcomeManuals from "@/app/pages/WelcomeManuals";
+import type { WelcomeManualSummary } from "@/shared/types/welcome-manual/welcome-manual-summary";
+
+const mockRefetch = vi.fn();
+let mockIsLoading = false;
+let mockIsError = false;
+let mockManuals: WelcomeManualSummary[] = [];
+
+vi.mock("@/shared/lib/toast-store", () => ({
+  showError: vi.fn(),
+  showSuccess: vi.fn(),
+}));
+
+vi.mock("@/shared/store/welcomeManualsApi", () => ({
+  useGetWelcomeManualsQuery: vi.fn(() => ({
+    data: { items: mockManuals, total: mockManuals.length, has_more: false },
+    isLoading: mockIsLoading,
+    isError: mockIsError,
+    isFetching: false,
+    refetch: mockRefetch,
+  })),
+  useCreateWelcomeManualMutation: vi.fn(() => [vi.fn(), { isLoading: false }]),
+}));
+
+vi.mock("@/shared/store/propertiesApi", () => ({
+  useGetPropertiesQuery: vi.fn(() => ({ data: [] })),
+}));
+
+function makeSummary(overrides: Partial<WelcomeManualSummary>): WelcomeManualSummary {
+  return {
+    id: "m-1",
+    title: "Lakeview Welcome Guide",
+    property_id: null,
+    section_count: 5,
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderList() {
+  return render(
+    <Provider store={store}>
+      <MemoryRouter>
+        <WelcomeManuals />
+      </MemoryRouter>
+    </Provider>,
+  );
+}
+
+describe("WelcomeManuals", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsLoading = false;
+    mockIsError = false;
+    mockManuals = [];
+  });
+
+  it("renders the skeleton while loading", () => {
+    mockIsLoading = true;
+    renderList();
+    expect(screen.getByTestId("welcome-manuals-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the empty state with a create CTA when there are no manuals", () => {
+    renderList();
+    expect(screen.getByText(/No welcome manuals yet/i)).toBeInTheDocument();
+    expect(screen.getByText(/Create your first guide/i)).toBeInTheDocument();
+  });
+
+  it("renders an error + retry on query error", () => {
+    mockIsError = true;
+    renderList();
+    expect(screen.getByText(/I couldn't load your welcome manuals/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+
+  it("renders manuals with a pluralized section-count badge", () => {
+    mockManuals = [
+      makeSummary({ id: "m-1", title: "Guide A", section_count: 5 }),
+      makeSummary({ id: "m-2", title: "Guide B", section_count: 0 }),
+    ];
+    renderList();
+    expect(screen.getAllByText("Guide A").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("Guide B").length).toBeGreaterThan(0);
+    // "0 sections" shown distinctly for the empty manual.
+    expect(screen.getAllByText("0 sections").length).toBeGreaterThan(0);
+    expect(screen.getAllByText("5 sections").length).toBeGreaterThan(0);
+  });
+});

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/DeleteWelcomeManualModal.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/DeleteWelcomeManualModal.tsx
@@ -1,0 +1,34 @@
+import { ConfirmDialog } from "@platform/ui";
+
+export interface DeleteWelcomeManualModalProps {
+  open: boolean;
+  manualTitle: string;
+  isLoading?: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export default function DeleteWelcomeManualModal({
+  open,
+  manualTitle,
+  isLoading,
+  onConfirm,
+  onCancel,
+}: DeleteWelcomeManualModalProps) {
+  return (
+    <ConfirmDialog
+      open={open}
+      title="Delete this welcome manual?"
+      description={
+        `"${manualTitle}" will be removed. All sections and photos will be ` +
+        "deleted. This can't be undone."
+      }
+      confirmLabel="Delete"
+      cancelLabel="Cancel"
+      variant="danger"
+      isLoading={isLoading}
+      onConfirm={onConfirm}
+      onCancel={onCancel}
+    />
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualCard.tsx
@@ -1,0 +1,40 @@
+import { Link } from "react-router-dom";
+import Badge from "@/shared/components/ui/Badge";
+import { formatSectionCount, formatUpdatedAt } from "@/shared/lib/welcome-manual-format";
+import type { WelcomeManualSummary } from "@/shared/types/welcome-manual/welcome-manual-summary";
+
+export interface WelcomeManualCardProps {
+  manual: WelcomeManualSummary;
+  propertyName: string | null;
+}
+
+/**
+ * Mobile welcome-manual card. Whole card is tappable; touch target ≥ 44px.
+ * Visible data points (per the page spec's information hierarchy):
+ *   - title (primary identifier)
+ *   - property name (which property this guide is for)
+ *   - section count (completeness signal; "0 sections" shown distinctly)
+ *   - updated_at (recency)
+ */
+export default function WelcomeManualCard({ manual, propertyName }: WelcomeManualCardProps) {
+  const isEmpty = manual.section_count === 0;
+
+  return (
+    <Link
+      to={`/welcome-manuals/${manual.id}`}
+      data-testid={`welcome-manual-card-${manual.id}`}
+      className="block border rounded-lg p-4 min-h-[44px] hover:bg-muted/50 transition-colors focus:outline-none focus:ring-2 focus:ring-primary"
+    >
+      <div className="flex items-start justify-between gap-2 mb-1">
+        <p className="font-medium leading-tight">{manual.title}</p>
+        <Badge color={isEmpty ? "gray" : "blue"} label={formatSectionCount(manual.section_count)} />
+      </div>
+      <p className="text-xs text-muted-foreground truncate">
+        {propertyName ?? "No property tagged"}
+      </p>
+      <p className="mt-2 text-xs text-muted-foreground">
+        Updated {formatUpdatedAt(manual.updated_at)}
+      </p>
+    </Link>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualCreateDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualCreateDialog.tsx
@@ -1,0 +1,146 @@
+import { useForm } from "react-hook-form";
+import { X } from "lucide-react";
+import Panel from "@/shared/components/ui/Panel";
+import FormField from "@/shared/components/ui/FormField";
+import { LoadingButton } from "@platform/ui";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useCreateWelcomeManualMutation } from "@/shared/store/welcomeManualsApi";
+import type { Property } from "@/shared/types/property/property";
+import type { WelcomeManualCreateFormValues } from "@/shared/types/welcome-manual/welcome-manual-create-form-values";
+import type { WelcomeManualCreateRequest } from "@/shared/types/welcome-manual/welcome-manual-create-request";
+import type { WelcomeManualResponse } from "@/shared/types/welcome-manual/welcome-manual-response";
+
+export interface WelcomeManualCreateDialogProps {
+  properties: readonly Property[];
+  onClose: () => void;
+  onCreated: (manual: WelcomeManualResponse) => void;
+}
+
+const DEFAULTS: WelcomeManualCreateFormValues = {
+  title: "",
+  property_id: "",
+  seed_default_sections: true,
+};
+
+function formValuesToCreateRequest(values: WelcomeManualCreateFormValues): WelcomeManualCreateRequest {
+  return {
+    title: values.title.trim(),
+    property_id: values.property_id || null,
+    seed_default_sections: values.seed_default_sections,
+  };
+}
+
+export default function WelcomeManualCreateDialog({
+  properties,
+  onClose,
+  onCreated,
+}: WelcomeManualCreateDialogProps) {
+  const [createManual, { isLoading }] = useCreateWelcomeManualMutation();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<WelcomeManualCreateFormValues>({ defaultValues: DEFAULTS });
+
+  async function onSubmit(values: WelcomeManualCreateFormValues) {
+    try {
+      const created = await createManual(formValuesToCreateRequest(values)).unwrap();
+      showSuccess("Welcome manual created.");
+      onCreated(created);
+    } catch {
+      showError("I couldn't create that guide. Want to try again?");
+    }
+  }
+
+  return (
+    <Panel position="right" onClose={onClose}>
+      <div className="flex flex-col flex-1 overflow-hidden">
+        <div className="px-5 py-4 border-b flex items-start justify-between">
+          <div>
+            <h3 className="font-medium text-base">New welcome manual</h3>
+            <p className="text-xs text-muted-foreground">
+              A guide you can email to guests with everything they need to know.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground p-1"
+            aria-label="Close panel"
+            type="button"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form
+          id="welcome-manual-create-form"
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex-1 overflow-y-auto px-5 py-4 space-y-4"
+          data-testid="welcome-manual-create-form"
+        >
+          <FormField label="Title" required>
+            <input
+              {...register("title", { required: "Title is required" })}
+              className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+              placeholder="e.g. Welcome to the Lakeview Suite"
+              data-testid="welcome-manual-create-title"
+            />
+            {errors.title ? (
+              <p className="text-xs text-red-600 mt-1">{errors.title.message}</p>
+            ) : null}
+          </FormField>
+
+          <FormField label="Property (optional)">
+            <select
+              {...register("property_id")}
+              className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+              data-testid="welcome-manual-create-property"
+            >
+              <option value="">No property</option>
+              {properties.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </FormField>
+
+          <label className="flex items-start gap-2 text-sm min-h-[44px]">
+            <input
+              type="checkbox"
+              className="mt-1"
+              {...register("seed_default_sections")}
+              data-testid="welcome-manual-create-seed"
+            />
+            <span>
+              Start with common sections
+              <span className="block text-xs text-muted-foreground">
+                Pre-fills Wi-Fi, Parking, Trash &amp; Recycling, Laundry, and Check-out
+                stubs so you start from a structure instead of a blank page.
+              </span>
+            </span>
+          </label>
+        </form>
+
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-muted-foreground hover:text-foreground min-h-[44px] px-3"
+          >
+            Cancel
+          </button>
+          <LoadingButton
+            type="submit"
+            form="welcome-manual-create-form"
+            isLoading={isLoading}
+            loadingText="Creating..."
+            data-testid="welcome-manual-create-submit"
+          >
+            Create guide
+          </LoadingButton>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualDetailSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualDetailSkeleton.tsx
@@ -1,0 +1,46 @@
+import Skeleton from "@/shared/components/ui/Skeleton";
+
+/**
+ * Mirror of the loaded WelcomeManualDetail layout: header card (title +
+ * intro + actions), then a document of section cards. Same vertical sections
+ * and rough heights so the skeleton swaps in-place without layout shift.
+ */
+export default function WelcomeManualDetailSkeleton() {
+  const sections = [0, 1, 2];
+
+  return (
+    <div data-testid="welcome-manual-detail-skeleton" className="space-y-6">
+      {/* Header card */}
+      <section className="border rounded-lg p-4 space-y-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="space-y-2">
+            <Skeleton className="h-7 w-64" />
+            <Skeleton className="h-5 w-24 rounded-full" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-10 w-16 rounded-md" />
+            <Skeleton className="h-10 w-28 rounded-md" />
+            <Skeleton className="h-10 w-20 rounded-md" />
+          </div>
+        </div>
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+      </section>
+
+      {/* Sections document */}
+      {sections.map((i) => (
+        <section key={i} className="border rounded-lg p-4 space-y-3">
+          <div className="flex items-center justify-between gap-2">
+            <Skeleton className="h-6 w-48" />
+            <Skeleton className="h-8 w-8 rounded" />
+          </div>
+          <Skeleton className="h-24 w-full rounded-md" />
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3">
+            <Skeleton className="aspect-square w-full rounded-md" />
+            <Skeleton className="aspect-square w-full rounded-md" />
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualEmailDialog.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualEmailDialog.tsx
@@ -1,0 +1,191 @@
+import { useState } from "react";
+import { AlertCircle, CheckCircle, Info, X } from "lucide-react";
+import Panel from "@/shared/components/ui/Panel";
+import FormField from "@/shared/components/ui/FormField";
+import { LoadingButton } from "@platform/ui";
+import { showError } from "@/shared/lib/toast-store";
+import { EMAIL_REGEX } from "@/shared/lib/welcome-manual-constants";
+import { useEmailWelcomeManualMutation } from "@/shared/store/welcomeManualsApi";
+import type { WelcomeManualEmailDialogStep } from "@/shared/types/welcome-manual/welcome-manual-email-dialog-step";
+
+export interface WelcomeManualEmailDialogProps {
+  manualId: string;
+  onClose: () => void;
+}
+
+export default function WelcomeManualEmailDialog({ manualId, onClose }: WelcomeManualEmailDialogProps) {
+  const [emailManual, { isLoading }] = useEmailWelcomeManualMutation();
+  const [step, setStep] = useState<WelcomeManualEmailDialogStep>("form");
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [errorReason, setErrorReason] = useState<string | null>(null);
+
+  const emailValid = EMAIL_REGEX.test(email.trim());
+
+  async function handleSend() {
+    if (!emailValid) return;
+    try {
+      const send = await emailManual({
+        manualId,
+        data: { recipient_email: email.trim(), recipient_name: name.trim() || null },
+      }).unwrap();
+      setErrorReason(send.error_reason);
+      setStep(send.status);
+    } catch {
+      // A non-200 (e.g. 404 manual not found) — the send-record path returns
+      // 200 even for failed/skipped, so this only fires on transport errors.
+      showError("I couldn't send that. Want to try again?");
+    }
+  }
+
+  function handleTryAgain() {
+    // Keep the email pre-filled so the host doesn't retype it.
+    setErrorReason(null);
+    setStep("form");
+  }
+
+  return (
+    <Panel position="center" width="28rem" onClose={onClose}>
+      <div className="flex flex-col flex-1 overflow-hidden" data-testid="welcome-manual-email-dialog">
+        <div className="px-5 py-4 border-b flex items-start justify-between">
+          <h3 className="font-medium text-base">Email this guide to a guest</h3>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground p-1"
+            aria-label="Close dialog"
+            type="button"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-4">
+          {step === "form" ? (
+            <div className="space-y-4" data-testid="welcome-manual-email-form">
+              <FormField label="Guest email address" required>
+                <input
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="guest@example.com"
+                  className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+                  data-testid="welcome-manual-email-input"
+                />
+              </FormField>
+              <FormField label="Guest name (optional)">
+                <input
+                  type="text"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="Alex"
+                  className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+                  data-testid="welcome-manual-email-name"
+                />
+              </FormField>
+            </div>
+          ) : null}
+
+          {step === "sent" ? (
+            <div className="text-center space-y-3 py-4" data-testid="welcome-manual-email-sent">
+              <CheckCircle className="h-10 w-10 text-green-600 mx-auto" aria-hidden="true" />
+              <p className="font-medium">Guide sent!</p>
+              <p className="text-sm text-muted-foreground">
+                I sent the guide to {email.trim()}. It should arrive shortly.
+              </p>
+            </div>
+          ) : null}
+
+          {step === "failed" ? (
+            <div className="text-center space-y-3 py-4" data-testid="welcome-manual-email-failed">
+              <AlertCircle className="h-10 w-10 text-amber-500 mx-auto" aria-hidden="true" />
+              <p className="font-medium">I couldn't send that</p>
+              <p className="text-sm text-muted-foreground">
+                {errorReason
+                  ? errorReason
+                  : "Something went wrong on the way out. You can try again."}
+              </p>
+            </div>
+          ) : null}
+
+          {step === "skipped" ? (
+            <div className="text-center space-y-3 py-4" data-testid="welcome-manual-email-skipped">
+              <Info className="h-10 w-10 text-blue-600 mx-auto" aria-hidden="true" />
+              <p className="font-medium">Email isn't set up yet</p>
+              <p className="text-sm text-muted-foreground">
+                Sending email isn't configured on this deployment yet, so I couldn't
+                send the guide. Once it's set up, this will work automatically.
+              </p>
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t">
+          {step === "form" ? (
+            <>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-sm text-muted-foreground hover:text-foreground min-h-[44px] px-3"
+              >
+                Cancel
+              </button>
+              <LoadingButton
+                type="button"
+                onClick={() => void handleSend()}
+                isLoading={isLoading}
+                loadingText="Sending..."
+                disabled={!emailValid}
+                data-testid="welcome-manual-email-send"
+              >
+                Send guide
+              </LoadingButton>
+            </>
+          ) : null}
+
+          {step === "sent" ? (
+            <LoadingButton
+              type="button"
+              isLoading={false}
+              onClick={onClose}
+              data-testid="welcome-manual-email-done"
+            >
+              Done
+            </LoadingButton>
+          ) : null}
+
+          {step === "failed" ? (
+            <>
+              <button
+                type="button"
+                onClick={onClose}
+                className="text-sm text-muted-foreground hover:text-foreground min-h-[44px] px-3"
+              >
+                Close
+              </button>
+              <LoadingButton
+                type="button"
+                isLoading={false}
+                onClick={handleTryAgain}
+                data-testid="welcome-manual-email-try-again"
+              >
+                Try again
+              </LoadingButton>
+            </>
+          ) : null}
+
+          {step === "skipped" ? (
+            <LoadingButton
+              type="button"
+              isLoading={false}
+              variant="secondary"
+              onClick={onClose}
+              data-testid="welcome-manual-email-close"
+            >
+              Close
+            </LoadingButton>
+          ) : null}
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualForm.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualForm.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { X } from "lucide-react";
+import Panel from "@/shared/components/ui/Panel";
+import FormField from "@/shared/components/ui/FormField";
+import Markdown from "@/shared/components/ui/Markdown";
+import { LoadingButton } from "@platform/ui";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useUpdateWelcomeManualMutation } from "@/shared/store/welcomeManualsApi";
+import type { Property } from "@/shared/types/property/property";
+import type { WelcomeManualFormValues } from "@/shared/types/welcome-manual/welcome-manual-form-values";
+import type { WelcomeManualResponse } from "@/shared/types/welcome-manual/welcome-manual-response";
+import type { WelcomeManualUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-update-request";
+
+export interface WelcomeManualFormProps {
+  manual: WelcomeManualResponse;
+  properties: readonly Property[];
+  onClose: () => void;
+  onUpdated: (manual: WelcomeManualResponse) => void;
+}
+
+function manualToFormValues(manual: WelcomeManualResponse): WelcomeManualFormValues {
+  return {
+    title: manual.title,
+    intro_text: manual.intro_text ?? "",
+    property_id: manual.property_id ?? "",
+  };
+}
+
+function formValuesToUpdateRequest(
+  values: WelcomeManualFormValues,
+  dirty: Partial<Record<keyof WelcomeManualFormValues, boolean>>,
+): WelcomeManualUpdateRequest {
+  const out: WelcomeManualUpdateRequest = {};
+  if (dirty.title) out.title = values.title.trim();
+  if (dirty.intro_text) out.intro_text = values.intro_text.trim() || null;
+  if (dirty.property_id) out.property_id = values.property_id || null;
+  return out;
+}
+
+export default function WelcomeManualForm({
+  manual,
+  properties,
+  onClose,
+  onUpdated,
+}: WelcomeManualFormProps) {
+  const [updateManual, { isLoading }] = useUpdateWelcomeManualMutation();
+
+  const defaults = useMemo<WelcomeManualFormValues>(() => manualToFormValues(manual), [manual]);
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    watch,
+    formState: { errors, dirtyFields },
+  } = useForm<WelcomeManualFormValues>({ defaultValues: defaults });
+
+  useEffect(() => {
+    reset(defaults);
+  }, [defaults, reset]);
+
+  const watchIntro = watch("intro_text");
+
+  async function onSubmit(values: WelcomeManualFormValues) {
+    const payload = formValuesToUpdateRequest(values, dirtyFields);
+    if (Object.keys(payload).length === 0) {
+      onClose();
+      return;
+    }
+    try {
+      const updated = await updateManual({ id: manual.id, data: payload }).unwrap();
+      showSuccess("Welcome manual updated.");
+      onUpdated(updated);
+      onClose();
+    } catch {
+      showError("I couldn't save those changes. Want to try again?");
+    }
+  }
+
+  return (
+    <Panel position="right" onClose={onClose}>
+      <div className="flex flex-col flex-1 overflow-hidden">
+        <div className="px-5 py-4 border-b flex items-start justify-between">
+          <div>
+            <h3 className="font-medium text-base">Edit manual</h3>
+            <p className="text-xs text-muted-foreground">Update the title, intro, or property.</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-muted-foreground hover:text-foreground p-1"
+            aria-label="Close panel"
+            type="button"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form
+          id="welcome-manual-edit-form"
+          onSubmit={handleSubmit(onSubmit)}
+          className="flex-1 overflow-y-auto px-5 py-4 space-y-4"
+          data-testid="welcome-manual-edit-form"
+        >
+          <FormField label="Title" required>
+            <input
+              {...register("title", { required: "Title is required" })}
+              className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+              data-testid="welcome-manual-edit-title"
+            />
+            {errors.title ? (
+              <p className="text-xs text-red-600 mt-1">{errors.title.message}</p>
+            ) : null}
+          </FormField>
+
+          <FormField label="Intro">
+            <textarea
+              {...register("intro_text")}
+              rows={4}
+              className="w-full border rounded-md px-3 py-2 text-sm"
+              data-testid="welcome-manual-edit-intro"
+            />
+            <p className="text-xs text-muted-foreground mt-1">
+              Supports markdown — **bold**, *italic*, lists, headings, links.
+            </p>
+          </FormField>
+          {watchIntro ? (
+            <div data-testid="welcome-manual-edit-intro-preview">
+              <p className="text-xs text-muted-foreground mb-1">Preview</p>
+              <div className="border rounded-md px-3 py-2 bg-muted/30 min-h-[60px]">
+                <Markdown content={watchIntro} />
+              </div>
+            </div>
+          ) : null}
+
+          <FormField label="Property (optional)">
+            <select
+              {...register("property_id")}
+              className="w-full border rounded-md px-3 py-2 text-sm min-h-[44px]"
+              data-testid="welcome-manual-edit-property"
+            >
+              <option value="">No property</option>
+              {properties.map((p) => (
+                <option key={p.id} value={p.id}>
+                  {p.name}
+                </option>
+              ))}
+            </select>
+          </FormField>
+        </form>
+
+        <div className="flex items-center justify-end gap-2 px-5 py-4 border-t">
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-sm text-muted-foreground hover:text-foreground min-h-[44px] px-3"
+          >
+            Cancel
+          </button>
+          <LoadingButton
+            type="submit"
+            form="welcome-manual-edit-form"
+            isLoading={isLoading}
+            loadingText="Saving..."
+            data-testid="welcome-manual-edit-submit"
+          >
+            Save
+          </LoadingButton>
+        </div>
+      </div>
+    </Panel>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionCard.tsx
@@ -1,0 +1,165 @@
+import { forwardRef, useState } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, Trash2 } from "lucide-react";
+import { LoadingButton, ConfirmDialog } from "@platform/ui";
+import FormField from "@/shared/components/ui/FormField";
+import Markdown from "@/shared/components/ui/Markdown";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useDeleteSectionMutation } from "@/shared/store/welcomeManualsApi";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+import WelcomeManualSectionImageManager from "./WelcomeManualSectionImageManager";
+import { useSectionEditor } from "./useSectionEditor";
+
+export interface WelcomeManualSectionCardProps {
+  manualId: string;
+  section: WelcomeManualSectionResponse;
+}
+
+const BODY_PLACEHOLDER = "Add instructions for guests…";
+
+const WelcomeManualSectionCard = forwardRef<HTMLElement, WelcomeManualSectionCardProps>(
+  function WelcomeManualSectionCard({ manualId, section }, forwardedRef) {
+    const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+      id: section.id,
+    });
+    const [deleteSection] = useDeleteSectionMutation();
+    const [confirmDelete, setConfirmDelete] = useState(false);
+    const editor = useSectionEditor({ manualId, section });
+
+    const style = {
+      transform: CSS.Transform.toString(transform),
+      transition,
+      opacity: isDragging ? 0.6 : 1,
+    };
+
+    function setRefs(node: HTMLElement | null) {
+      setNodeRef(node);
+      if (typeof forwardedRef === "function") {
+        forwardedRef(node);
+      } else if (forwardedRef) {
+        forwardedRef.current = node;
+      }
+    }
+
+    async function handleConfirmDelete() {
+      setConfirmDelete(false);
+      try {
+        await deleteSection({ manualId, sectionId: section.id }).unwrap();
+        showSuccess("Section deleted.");
+      } catch {
+        showError("I couldn't delete that section. Want to try again?");
+      }
+    }
+
+    return (
+      <section
+        ref={setRefs}
+        style={style}
+        className="border rounded-lg p-4 space-y-3 bg-card"
+        data-testid="welcome-manual-section-card"
+        data-section-id={section.id}
+      >
+        <div className="flex items-start gap-2">
+          <button
+            {...attributes}
+            {...listeners}
+            type="button"
+            className="mt-1 text-muted-foreground hover:text-foreground cursor-grab active:cursor-grabbing min-h-[32px] min-w-[32px] flex items-center justify-center"
+            aria-label={`Drag to reorder section ${section.title}`}
+            data-testid="welcome-manual-section-drag-handle"
+          >
+            <GripVertical size={16} />
+          </button>
+
+          <div className="flex-1 min-w-0">
+            <input
+              {...editor.register("title", { required: "Title is required" })}
+              className="w-full border rounded-md px-3 py-2 text-base font-medium min-h-[44px]"
+              data-testid="welcome-manual-section-title"
+              aria-label="Section title"
+            />
+            {editor.titleError ? (
+              <p className="text-xs text-red-600 mt-1">{editor.titleError}</p>
+            ) : null}
+          </div>
+
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            className="mt-1 text-red-600 hover:bg-red-50 rounded p-1 min-h-[32px] min-w-[32px] flex items-center justify-center"
+            aria-label="Delete section"
+            data-testid="welcome-manual-section-delete-button"
+          >
+            <Trash2 size={16} />
+          </button>
+        </div>
+
+        <FormField label="Instructions">
+          <textarea
+            {...editor.register("body")}
+            rows={4}
+            placeholder={BODY_PLACEHOLDER}
+            className="w-full border rounded-md px-3 py-2 text-sm"
+            data-testid="welcome-manual-section-body"
+          />
+          <p className="text-xs text-muted-foreground mt-1">
+            Supports markdown — **bold**, *italic*, lists, headings, links.
+          </p>
+        </FormField>
+        {editor.bodyValue ? (
+          <div data-testid="welcome-manual-section-body-preview">
+            <p className="text-xs text-muted-foreground mb-1">Preview</p>
+            <div className="border rounded-md px-3 py-2 bg-muted/30 min-h-[60px]">
+              <Markdown content={editor.bodyValue} />
+            </div>
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-end gap-2">
+          <button
+            type="button"
+            onClick={editor.handleCancel}
+            disabled={!editor.isDirty || editor.isSaving}
+            className="text-sm text-muted-foreground hover:text-foreground min-h-[44px] px-3 disabled:opacity-40"
+            data-testid="welcome-manual-section-cancel"
+          >
+            Cancel
+          </button>
+          <LoadingButton
+            type="button"
+            onClick={editor.handleSubmit}
+            isLoading={editor.isSaving}
+            loadingText="Saving..."
+            disabled={!editor.isDirty}
+            data-testid="welcome-manual-section-save"
+          >
+            Save
+          </LoadingButton>
+        </div>
+
+        <div className="border-t pt-3">
+          <p className="text-xs font-medium text-muted-foreground mb-2">Photos</p>
+          <WelcomeManualSectionImageManager
+            manualId={manualId}
+            sectionId={section.id}
+            images={section.images}
+          />
+        </div>
+
+        <ConfirmDialog
+          open={confirmDelete}
+          title="Delete this section?"
+          description="Photos uploaded to it will also be removed. This can't be undone."
+          confirmLabel="Delete"
+          cancelLabel="Cancel"
+          variant="danger"
+          onConfirm={handleConfirmDelete}
+          onCancel={() => setConfirmDelete(false)}
+        />
+      </section>
+    );
+  },
+);
+
+export default WelcomeManualSectionCard;

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionImageCard.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionImageCard.tsx
@@ -1,0 +1,123 @@
+import { useEffect } from "react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { GripVertical, X } from "lucide-react";
+import { reportMissingStorageObject } from "@/shared/lib/storage-observability";
+import { SECTION_IMAGE_STORAGE_DOMAIN } from "@/shared/lib/welcome-manual-constants";
+import type { WelcomeManualSectionImageResponse } from "@/shared/types/welcome-manual/welcome-manual-section-image-response";
+
+export interface WelcomeManualSectionImageCardProps {
+  image: WelcomeManualSectionImageResponse;
+  onDelete: () => void;
+  onOpen: () => void;
+  onCaptionSave: (caption: string) => void;
+}
+
+export default function WelcomeManualSectionImageCard({
+  image,
+  onDelete,
+  onOpen,
+  onCaptionSave,
+}: WelcomeManualSectionImageCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: image.id,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  const isMissing = image.is_available === false;
+
+  useEffect(() => {
+    if (!isMissing) return;
+    reportMissingStorageObject({
+      domain: SECTION_IMAGE_STORAGE_DOMAIN,
+      attachment_id: image.id,
+      storage_key: image.storage_key,
+      parent_id: image.section_id,
+      parent_kind: "welcome_manual_section",
+    });
+  }, [isMissing, image.id, image.storage_key, image.section_id]);
+
+  function handleCaptionBlur(e: React.FocusEvent<HTMLInputElement>) {
+    const trimmed = e.target.value.trim();
+    if (trimmed === (image.caption ?? "")) return;
+    onCaptionSave(trimmed);
+  }
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={style}
+      className="relative border rounded-lg overflow-hidden bg-card group"
+      data-testid="welcome-manual-image-card"
+      data-image-id={image.id}
+    >
+      {!isMissing && image.presigned_url ? (
+        <button
+          type="button"
+          onClick={onOpen}
+          className="block w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          aria-label={`View image ${image.display_order + 1} full size`}
+          data-testid="welcome-manual-image-open-button"
+        >
+          <img
+            src={image.presigned_url}
+            alt={image.caption ?? `Image ${image.display_order + 1}`}
+            loading="lazy"
+            className="aspect-square w-full object-cover bg-muted hover:opacity-90 transition-opacity"
+            data-testid="welcome-manual-image-thumbnail"
+          />
+        </button>
+      ) : (
+        <button
+          type="button"
+          onClick={onOpen}
+          className="aspect-square w-full flex items-center justify-center text-xs focus:outline-none focus-visible:ring-2 focus-visible:ring-ring bg-muted text-muted-foreground"
+          aria-label={`View image ${image.display_order + 1} full size`}
+          data-testid="welcome-manual-image-thumbnail"
+        >
+          Image {image.display_order + 1}
+        </button>
+      )}
+
+      <button
+        {...attributes}
+        {...listeners}
+        type="button"
+        className="absolute top-1 right-8 bg-card/80 hover:bg-card border rounded p-1 cursor-grab active:cursor-grabbing min-h-[32px] min-w-[32px] flex items-center justify-center"
+        aria-label={`Drag to reorder image ${image.display_order + 1}`}
+        data-testid="welcome-manual-image-drag-handle"
+      >
+        <GripVertical size={14} />
+      </button>
+
+      <button
+        type="button"
+        onClick={onDelete}
+        className="absolute top-1 right-1 bg-card/80 hover:bg-red-100 border rounded p-1 min-h-[32px] min-w-[32px] flex items-center justify-center text-red-600"
+        aria-label="Remove image"
+        data-testid="welcome-manual-image-delete-button"
+      >
+        <X size={14} />
+      </button>
+
+      {/* Uncontrolled: ``key`` re-mounts the input when the server caption
+          changes (after a successful save or a revert) so the displayed value
+          re-baselines without a setState-in-effect. Edits live in the DOM and
+          are read on blur. */}
+      <input
+        key={image.caption ?? ""}
+        defaultValue={image.caption ?? ""}
+        onBlur={handleCaptionBlur}
+        placeholder="Add a caption…"
+        className="w-full border-t px-2 py-1 text-xs bg-transparent focus:outline-none focus:bg-muted/40"
+        aria-label="Image caption"
+        data-testid="welcome-manual-image-caption"
+      />
+    </li>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionImageManager.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualSectionImageManager.tsx
@@ -1,0 +1,224 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  rectSortingStrategy,
+  sortableKeyboardCoordinates,
+} from "@dnd-kit/sortable";
+import { Upload } from "lucide-react";
+import { LoadingButton, ConfirmDialog } from "@platform/ui";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { validateSectionImages } from "@/shared/lib/validate-section-images";
+import {
+  useDeleteSectionImageMutation,
+  useUpdateSectionImageMutation,
+  useUploadSectionImagesMutation,
+} from "@/shared/store/welcomeManualsApi";
+import type { SectionImageLightboxTarget } from "@/shared/types/welcome-manual/section-image-lightbox-target";
+import type { WelcomeManualSectionImageResponse } from "@/shared/types/welcome-manual/welcome-manual-section-image-response";
+import PhotoLightbox from "@/app/features/listings/PhotoLightbox";
+import WelcomeManualSectionImageCard from "./WelcomeManualSectionImageCard";
+import { sectionImageToLightboxPhoto } from "./section-image-to-lightbox";
+
+export interface WelcomeManualSectionImageManagerProps {
+  manualId: string;
+  sectionId: string;
+  images: readonly WelcomeManualSectionImageResponse[];
+}
+
+export default function WelcomeManualSectionImageManager({
+  manualId,
+  sectionId,
+  images,
+}: WelcomeManualSectionImageManagerProps) {
+  const [uploadImages, { isLoading: isUploading }] = useUploadSectionImagesMutation();
+  const [deleteImage] = useDeleteSectionImageMutation();
+  const [updateImage] = useUpdateSectionImageMutation();
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  const [orderedIds, setOrderedIds] = useState<string[] | null>(null);
+  const [lightboxTarget, setLightboxTarget] = useState<SectionImageLightboxTarget | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const sortedImages = [...images].sort((a, b) => a.display_order - b.display_order);
+  const displayIds = orderedIds ?? sortedImages.map((img) => img.id);
+  const imagesById = new Map(sortedImages.map((img) => [img.id, img]));
+
+  const handleLightboxNavigate = useCallback(
+    (nextIndex: number) => {
+      setLightboxTarget({ sectionId, index: nextIndex });
+    },
+    [sectionId],
+  );
+
+  async function handleFiles(files: FileList | null) {
+    if (!files || files.length === 0) return;
+    const { valid, rejected } = validateSectionImages(Array.from(files));
+    if (rejected.length > 0) {
+      showError(rejected.join("; "));
+    }
+    if (valid.length === 0) return;
+    try {
+      await uploadImages({ manualId, sectionId, files: valid }).unwrap();
+      showSuccess(valid.length === 1 ? "Photo added." : `${valid.length} photos added.`);
+    } catch {
+      showError("I couldn't upload that. Want to try again?");
+    }
+  }
+
+  async function handleConfirmDelete() {
+    const imageId = confirmDeleteId;
+    if (!imageId) return;
+    setConfirmDeleteId(null);
+    try {
+      await deleteImage({ manualId, sectionId, imageId }).unwrap();
+      showSuccess("Photo removed.");
+    } catch {
+      showError("I couldn't remove that photo. Want to try again?");
+    }
+  }
+
+  async function handleCaptionSave(imageId: string, caption: string) {
+    try {
+      await updateImage({ manualId, sectionId, imageId, caption: caption || null }).unwrap();
+    } catch {
+      showError("I couldn't save that caption. Want to try again?");
+    }
+  }
+
+  async function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = displayIds.indexOf(String(active.id));
+    const newIndex = displayIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const newOrder = arrayMove(displayIds, oldIndex, newIndex);
+    setOrderedIds(newOrder);
+
+    // There's no bulk-order endpoint for section images — fire one PATCH per
+    // image whose display_order changed. Small-N (a handful of photos per
+    // section) keeps this cheap, mirroring ListingPhotoManager.
+    try {
+      await Promise.all(
+        newOrder.map((imageId, index) => {
+          const current = imagesById.get(imageId);
+          if (!current) return Promise.resolve();
+          if (current.display_order === index) return Promise.resolve();
+          return updateImage({ manualId, sectionId, imageId, display_order: index }).unwrap();
+        }),
+      );
+    } catch {
+      showError("I couldn't save the new order. Reverting.");
+      setOrderedIds(null);
+    }
+  }
+
+  const lightboxPhotos = displayIds
+    .map((id) => imagesById.get(id))
+    .filter((img): img is WelcomeManualSectionImageResponse => img !== undefined)
+    .map(sectionImageToLightboxPhoto);
+
+  return (
+    <div className="space-y-3" data-testid="welcome-manual-image-manager">
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">
+          JPEG, PNG, or HEIC. 10MB max each. EXIF metadata (including GPS) is
+          stripped on upload.
+        </p>
+        <LoadingButton
+          variant="secondary"
+          size="sm"
+          isLoading={isUploading}
+          loadingText="Uploading…"
+          onClick={() => fileInputRef.current?.click()}
+          type="button"
+          data-testid="welcome-manual-image-upload-button"
+        >
+          <Upload className="h-4 w-4 mr-1" />
+          Add photos
+        </LoadingButton>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="image/jpeg,image/png,image/heic,.heic,.heif"
+          multiple
+          className="hidden"
+          data-testid="welcome-manual-image-file-input"
+          onChange={(e) => {
+            void handleFiles(e.target.files);
+            e.target.value = "";
+          }}
+        />
+      </div>
+
+      {sortedImages.length === 0 ? (
+        <p
+          className="text-sm text-muted-foreground border rounded-lg p-6 text-center"
+          data-testid="welcome-manual-image-empty-state"
+        >
+          No photos yet. Add a few to show guests exactly what to do.
+        </p>
+      ) : (
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={displayIds} strategy={rectSortingStrategy}>
+            <ul
+              className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-3"
+              data-testid="welcome-manual-image-grid"
+            >
+              {displayIds.map((imageId, index) => {
+                const image = imagesById.get(imageId);
+                if (!image) return null;
+                return (
+                  <WelcomeManualSectionImageCard
+                    key={imageId}
+                    image={image}
+                    onDelete={() => setConfirmDeleteId(imageId)}
+                    onOpen={() => setLightboxTarget({ sectionId, index })}
+                    onCaptionSave={(caption) => void handleCaptionSave(imageId, caption)}
+                  />
+                );
+              })}
+            </ul>
+          </SortableContext>
+        </DndContext>
+      )}
+
+      <ConfirmDialog
+        open={!!confirmDeleteId}
+        title="Remove this photo?"
+        description="The photo will be deleted from this section. This can't be undone."
+        confirmLabel="Remove"
+        cancelLabel="Cancel"
+        variant="danger"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setConfirmDeleteId(null)}
+      />
+
+      {lightboxTarget ? (
+        <PhotoLightbox
+          photos={lightboxPhotos}
+          currentIndex={lightboxTarget.index}
+          onClose={() => setLightboxTarget(null)}
+          onNavigate={handleLightboxNavigate}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualTableRow.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualTableRow.tsx
@@ -1,0 +1,45 @@
+import { useNavigate } from "react-router-dom";
+import Badge from "@/shared/components/ui/Badge";
+import { formatSectionCount, formatUpdatedAt } from "@/shared/lib/welcome-manual-format";
+import type { WelcomeManualSummary } from "@/shared/types/welcome-manual/welcome-manual-summary";
+
+export interface WelcomeManualTableRowProps {
+  manual: WelcomeManualSummary;
+  propertyName: string | null;
+}
+
+/**
+ * Desktop table row for a welcome manual. The whole row is clickable
+ * (programmatic navigation) and keyboard-accessible via tabIndex + key
+ * handling, mirroring ListingTableRow.
+ */
+export default function WelcomeManualTableRow({ manual, propertyName }: WelcomeManualTableRowProps) {
+  const navigate = useNavigate();
+  const goToDetail = () => navigate(`/welcome-manuals/${manual.id}`);
+  const isEmpty = manual.section_count === 0;
+
+  return (
+    <tr
+      role="link"
+      tabIndex={0}
+      data-testid={`welcome-manual-row-${manual.id}`}
+      onClick={goToDetail}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          goToDetail();
+        }
+      }}
+      className="border-t cursor-pointer hover:bg-muted/40 focus:outline-none focus:ring-2 focus:ring-primary"
+    >
+      <td className="px-4 py-3 font-medium">{manual.title}</td>
+      <td className="px-4 py-3 text-muted-foreground">{propertyName ?? "No property tagged"}</td>
+      <td className="px-4 py-3">
+        <Badge color={isEmpty ? "gray" : "blue"} label={formatSectionCount(manual.section_count)} />
+      </td>
+      <td className="px-4 py-3 text-right text-muted-foreground">
+        {formatUpdatedAt(manual.updated_at)}
+      </td>
+    </tr>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualsListBody.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualsListBody.tsx
@@ -1,0 +1,91 @@
+import { LoadingButton } from "@platform/ui";
+import EmptyState from "@/shared/components/ui/EmptyState";
+import type { WelcomeManualsListMode } from "@/shared/types/welcome-manual/welcome-manuals-list-mode";
+import type { WelcomeManualSummary } from "@/shared/types/welcome-manual/welcome-manual-summary";
+import WelcomeManualsSkeleton from "./WelcomeManualsSkeleton";
+import WelcomeManualCard from "./WelcomeManualCard";
+import WelcomeManualTableRow from "./WelcomeManualTableRow";
+
+export interface WelcomeManualsListBodyProps {
+  mode: WelcomeManualsListMode;
+  manuals: WelcomeManualSummary[];
+  propertyName: (m: WelcomeManualSummary) => string | null;
+  hasMore: boolean;
+  isFetching: boolean;
+  onLoadMore: () => void;
+  onCreateFirst: () => void;
+}
+
+export default function WelcomeManualsListBody({
+  mode,
+  manuals,
+  propertyName,
+  hasMore,
+  isFetching,
+  onLoadMore,
+  onCreateFirst,
+}: WelcomeManualsListBodyProps) {
+  switch (mode) {
+    case "loading":
+      return <WelcomeManualsSkeleton />;
+    case "empty":
+      return (
+        <EmptyState
+          message="No welcome manuals yet. Create a guide so your guests have everything they need — Wi-Fi, parking, trash day, check-out — in one place."
+          action={{ label: "Create your first guide", onClick: onCreateFirst }}
+        />
+      );
+    case "list":
+      return (
+        <>
+          {/* Mobile: cards */}
+          <ul className="md:hidden space-y-3" data-testid="welcome-manuals-mobile">
+            {manuals.map((manual) => (
+              <li key={manual.id}>
+                <WelcomeManualCard manual={manual} propertyName={propertyName(manual)} />
+              </li>
+            ))}
+          </ul>
+
+          {/* Desktop: table */}
+          <div
+            className="hidden md:block border rounded-lg overflow-hidden"
+            data-testid="welcome-manuals-desktop"
+          >
+            <table className="w-full text-sm">
+              <thead className="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
+                <tr>
+                  <th className="px-4 py-2 font-medium">Title</th>
+                  <th className="px-4 py-2 font-medium">Property</th>
+                  <th className="px-4 py-2 font-medium">Sections</th>
+                  <th className="px-4 py-2 font-medium text-right">Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                {manuals.map((manual) => (
+                  <WelcomeManualTableRow
+                    key={manual.id}
+                    manual={manual}
+                    propertyName={propertyName(manual)}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {hasMore ? (
+            <div className="flex justify-center">
+              <LoadingButton
+                variant="secondary"
+                onClick={onLoadMore}
+                isLoading={isFetching}
+                loadingText="Loading..."
+              >
+                Load more
+              </LoadingButton>
+            </div>
+          ) : null}
+        </>
+      );
+  }
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualsSkeleton.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/WelcomeManualsSkeleton.tsx
@@ -1,0 +1,56 @@
+import Skeleton from "@/shared/components/ui/Skeleton";
+
+export interface WelcomeManualsSkeletonProps {
+  count?: number;
+}
+
+/**
+ * Skeleton loader for the Welcome Manuals list. Mirrors the loaded layout
+ * exactly — same mobile card slots, same desktop table columns — to prevent
+ * layout shift.
+ */
+export default function WelcomeManualsSkeleton({ count = 4 }: WelcomeManualsSkeletonProps) {
+  const rows = Array.from({ length: count }, (_, i) => i);
+
+  return (
+    <div data-testid="welcome-manuals-skeleton">
+      {/* Mobile: card list */}
+      <ul className="md:hidden space-y-3">
+        {rows.map((i) => (
+          <li key={`m-${i}`} className="border rounded-lg p-4 space-y-2">
+            <div className="flex items-start justify-between gap-2">
+              <Skeleton className="h-5 w-44" />
+              <Skeleton className="h-5 w-20 rounded-full" />
+            </div>
+            <Skeleton className="h-3 w-32" />
+            <Skeleton className="h-3 w-24" />
+          </li>
+        ))}
+      </ul>
+
+      {/* Desktop: table */}
+      <div className="hidden md:block border rounded-lg overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-muted/50 text-left text-xs uppercase text-muted-foreground">
+            <tr>
+              <th className="px-4 py-2">Title</th>
+              <th className="px-4 py-2">Property</th>
+              <th className="px-4 py-2">Sections</th>
+              <th className="px-4 py-2 text-right">Updated</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((i) => (
+              <tr key={`d-${i}`} className="border-t">
+                <td className="px-4 py-3"><Skeleton className="h-4 w-44" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-4 w-32" /></td>
+                <td className="px-4 py-3"><Skeleton className="h-5 w-20 rounded-full" /></td>
+                <td className="px-4 py-3 text-right"><Skeleton className="h-4 w-24 ml-auto" /></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/section-image-to-lightbox.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/section-image-to-lightbox.ts
@@ -1,0 +1,23 @@
+import type { ListingPhoto } from "@/shared/types/listing/listing-photo";
+import type { WelcomeManualSectionImageResponse } from "@/shared/types/welcome-manual/welcome-manual-section-image-response";
+
+/**
+ * Adapt a section image to the shape `PhotoLightbox` consumes. The lightbox
+ * only reads ``presigned_url`` and ``caption`` — the remaining fields are
+ * populated for type-completeness so we can reuse the shared lightbox without
+ * forking it for this domain.
+ */
+export function sectionImageToLightboxPhoto(
+  image: WelcomeManualSectionImageResponse,
+): ListingPhoto {
+  return {
+    id: image.id,
+    listing_id: image.section_id,
+    storage_key: image.storage_key,
+    caption: image.caption,
+    display_order: image.display_order,
+    created_at: image.created_at,
+    presigned_url: image.presigned_url,
+    is_available: image.is_available,
+  };
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/useSectionEditor.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/useSectionEditor.ts
@@ -1,0 +1,87 @@
+import { useEffect, useMemo } from "react";
+import { useForm } from "react-hook-form";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { useUpdateSectionMutation } from "@/shared/store/welcomeManualsApi";
+import type { SectionEditorValues } from "@/shared/types/welcome-manual/section-editor-values";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+import type { WelcomeManualSectionUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-section-update-request";
+
+function sectionToValues(section: WelcomeManualSectionResponse): SectionEditorValues {
+  return { title: section.title, body: section.body ?? "" };
+}
+
+function valuesToUpdateRequest(
+  values: SectionEditorValues,
+  dirty: Partial<Record<keyof SectionEditorValues, boolean>>,
+): WelcomeManualSectionUpdateRequest {
+  const out: WelcomeManualSectionUpdateRequest = {};
+  if (dirty.title) out.title = values.title.trim();
+  if (dirty.body) out.body = values.body.trim() || null;
+  return out;
+}
+
+export interface UseSectionEditorArgs {
+  manualId: string;
+  section: WelcomeManualSectionResponse;
+}
+
+export interface UseSectionEditorResult {
+  register: ReturnType<typeof useForm<SectionEditorValues>>["register"];
+  /** Wrapped submit handler — performs a dirty-only PATCH. */
+  handleSubmit: () => void;
+  /** Reset the form back to the server state (Cancel). */
+  handleCancel: () => void;
+  /** Current body value, for the live markdown preview. */
+  bodyValue: string;
+  /** True when at least one field differs from the server state. */
+  isDirty: boolean;
+  isSaving: boolean;
+  titleError: string | undefined;
+}
+
+/**
+ * Per-section editor state: title input + markdown body, dirty-only PATCH,
+ * cancel-to-server-state. One instance per section card.
+ */
+export function useSectionEditor({ manualId, section }: UseSectionEditorArgs): UseSectionEditorResult {
+  const [updateSection, { isLoading: isSaving }] = useUpdateSectionMutation();
+
+  const defaults = useMemo<SectionEditorValues>(() => sectionToValues(section), [section]);
+
+  const {
+    register,
+    handleSubmit: rhfHandleSubmit,
+    reset,
+    watch,
+    formState: { errors, dirtyFields, isDirty },
+  } = useForm<SectionEditorValues>({ defaultValues: defaults });
+
+  // Re-baseline when the server value changes (after a successful save/refetch
+  // or an external edit) so "dirty" reflects the latest persisted state.
+  useEffect(() => {
+    reset(defaults);
+  }, [defaults, reset]);
+
+  const bodyValue = watch("body");
+
+  async function onSubmit(values: SectionEditorValues) {
+    const payload = valuesToUpdateRequest(values, dirtyFields);
+    if (Object.keys(payload).length === 0) return;
+    try {
+      await updateSection({ manualId, sectionId: section.id, data: payload }).unwrap();
+      showSuccess("Section saved.");
+    } catch {
+      showError("I couldn't save that section. Want to try again?");
+    }
+  }
+
+  return {
+    register,
+    handleSubmit: rhfHandleSubmit(onSubmit),
+    handleCancel: () => reset(defaults),
+    bodyValue,
+    isDirty,
+    isSaving,
+    titleError: errors.title?.message,
+  };
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/useWelcomeManualSectionOrder.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/useWelcomeManualSectionOrder.ts
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import { arrayMove } from "@dnd-kit/sortable";
+import type { DragEndEvent } from "@dnd-kit/core";
+import { showError } from "@/shared/lib/toast-store";
+import { useReorderSectionsMutation } from "@/shared/store/welcomeManualsApi";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+
+export interface UseWelcomeManualSectionOrderArgs {
+  manualId: string;
+  sections: readonly WelcomeManualSectionResponse[];
+}
+
+export interface UseWelcomeManualSectionOrderResult {
+  /** Section ids in their current (possibly optimistic) display order. */
+  orderedIds: string[];
+  handleDragEnd: (event: DragEndEvent) => Promise<void>;
+}
+
+/**
+ * Section-order optimistic state. Mirrors ListingPhotoManager's `orderedIds`
+ * pattern so the order doesn't snap back mid-drag: local state updates
+ * immediately, the full permutation is persisted via `PUT .../sections/order`,
+ * and the `WelcomeManual` tag is invalidated by the mutation so the manual
+ * refetches with `images` intact (the order endpoint returns `images: []` by
+ * design — see welcomeManualsApi). On error we revert to the server order.
+ */
+export function useWelcomeManualSectionOrder({
+  manualId,
+  sections,
+}: UseWelcomeManualSectionOrderArgs): UseWelcomeManualSectionOrderResult {
+  const [reorderSections] = useReorderSectionsMutation();
+  const [localOrder, setLocalOrder] = useState<string[] | null>(null);
+
+  const sortedIds = [...sections]
+    .sort((a, b) => a.display_order - b.display_order)
+    .map((s) => s.id);
+  const orderedIds = localOrder ?? sortedIds;
+
+  async function handleDragEnd(event: DragEndEvent): Promise<void> {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+
+    const oldIndex = orderedIds.indexOf(String(active.id));
+    const newIndex = orderedIds.indexOf(String(over.id));
+    if (oldIndex === -1 || newIndex === -1) return;
+
+    const newOrder = arrayMove(orderedIds, oldIndex, newIndex);
+    setLocalOrder(newOrder);
+
+    try {
+      await reorderSections({ manualId, sectionIds: newOrder }).unwrap();
+      // Let the refetched manual (from tag invalidation) re-drive the order.
+      setLocalOrder(null);
+    } catch {
+      showError("I couldn't save the new order. Reverting.");
+      setLocalOrder(null);
+    }
+  }
+
+  return { orderedIds, handleDragEnd };
+}

--- a/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/useWelcomeManualsListMode.ts
+++ b/apps/mybookkeeper/frontend/src/app/features/welcome-manuals/useWelcomeManualsListMode.ts
@@ -1,0 +1,21 @@
+import type { WelcomeManualsListMode } from "@/shared/types/welcome-manual/welcome-manuals-list-mode";
+
+interface UseWelcomeManualsListModeArgs {
+  isLoading: boolean;
+  isError: boolean;
+  manualCount: number;
+}
+
+/**
+ * Resolves the welcome-manuals list render mode from loaded state. Single
+ * source of truth so the body is a flat switch instead of a ternary chain.
+ */
+export function useWelcomeManualsListMode({
+  isLoading,
+  isError,
+  manualCount,
+}: UseWelcomeManualsListModeArgs): WelcomeManualsListMode {
+  if (isLoading) return "loading";
+  if (manualCount === 0 && !isError) return "empty";
+  return "list";
+}

--- a/apps/mybookkeeper/frontend/src/app/lib/nav.ts
+++ b/apps/mybookkeeper/frontend/src/app/lib/nav.ts
@@ -16,6 +16,7 @@ export const NAV_GROUPS: readonly NavGroup[] = [
     items: [
       { to: "/properties", label: "Properties" },
       { to: "/listings", label: "Listings" },
+      { to: "/welcome-manuals", label: "Welcome Manuals" },
       { to: "/insurance-policies", label: "Insurance" },
       { to: "/calendar", label: "Calendar" },
     ],

--- a/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/WelcomeManualDetail.tsx
@@ -1,0 +1,282 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import { ArrowLeft, Mail, Plus, Trash2 } from "lucide-react";
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import { SortableContext, sortableKeyboardCoordinates, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import SectionHeader from "@/shared/components/ui/SectionHeader";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import Markdown from "@/shared/components/ui/Markdown";
+import { Button, LoadingButton } from "@platform/ui";
+import { showError, showSuccess } from "@/shared/lib/toast-store";
+import { NEW_SECTION_DEFAULT_TITLE } from "@/shared/lib/welcome-manual-constants";
+import {
+  useCreateSectionMutation,
+  useDeleteWelcomeManualMutation,
+  useGetWelcomeManualByIdQuery,
+} from "@/shared/store/welcomeManualsApi";
+import { useGetPropertiesQuery } from "@/shared/store/propertiesApi";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+import WelcomeManualDetailSkeleton from "@/app/features/welcome-manuals/WelcomeManualDetailSkeleton";
+import WelcomeManualSectionCard from "@/app/features/welcome-manuals/WelcomeManualSectionCard";
+import WelcomeManualForm from "@/app/features/welcome-manuals/WelcomeManualForm";
+import WelcomeManualEmailDialog from "@/app/features/welcome-manuals/WelcomeManualEmailDialog";
+import DeleteWelcomeManualModal from "@/app/features/welcome-manuals/DeleteWelcomeManualModal";
+import { useWelcomeManualSectionOrder } from "@/app/features/welcome-manuals/useWelcomeManualSectionOrder";
+
+export default function WelcomeManualDetail() {
+  const { manualId } = useParams<{ manualId: string }>();
+  const navigate = useNavigate();
+  const [showEditForm, setShowEditForm] = useState(false);
+  const [showEmailDialog, setShowEmailDialog] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
+  const [pendingFocusId, setPendingFocusId] = useState<string | null>(null);
+
+  const sectionRefs = useRef<Map<string, HTMLElement>>(new Map());
+
+  const [createSection, { isLoading: isAddingSection }] = useCreateSectionMutation();
+  const [deleteManual, { isLoading: isDeleting }] = useDeleteWelcomeManualMutation();
+
+  const {
+    data: manual,
+    isLoading,
+    isFetching,
+    isError,
+    refetch,
+  } = useGetWelcomeManualByIdQuery(manualId ?? "", { skip: !manualId });
+  const { data: properties = [] } = useGetPropertiesQuery();
+
+  const sections = manual?.sections ?? [];
+  const sortedSections = [...sections].sort((a, b) => a.display_order - b.display_order);
+  const property = manual?.property_id
+    ? properties.find((p) => p.id === manual.property_id)
+    : undefined;
+
+  const { orderedIds, handleDragEnd } = useWelcomeManualSectionOrder({
+    manualId: manual?.id ?? "",
+    sections,
+  });
+
+  const sectionsById = new Map<string, WelcomeManualSectionResponse>(
+    sortedSections.map((s) => [s.id, s]),
+  );
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 200, tolerance: 5 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  const registerSectionRef = useCallback((id: string, node: HTMLElement | null) => {
+    if (node) {
+      sectionRefs.current.set(id, node);
+    } else {
+      sectionRefs.current.delete(id);
+    }
+  }, []);
+
+  // After a new section is added and the manual refetches, scroll the new card
+  // into view and focus its title input.
+  useEffect(() => {
+    if (!pendingFocusId) return;
+    const node = sectionRefs.current.get(pendingFocusId);
+    if (!node) return;
+    node.scrollIntoView({ behavior: "smooth", block: "center" });
+    const titleInput = node.querySelector<HTMLInputElement>(
+      '[data-testid="welcome-manual-section-title"]',
+    );
+    titleInput?.focus();
+    setPendingFocusId(null);
+  }, [pendingFocusId, sortedSections.length]);
+
+  async function handleAddSection() {
+    if (!manual) return;
+    try {
+      const created = await createSection({
+        manualId: manual.id,
+        data: { title: NEW_SECTION_DEFAULT_TITLE },
+      }).unwrap();
+      setPendingFocusId(created.id);
+    } catch {
+      showError("I couldn't add a section. Want to try again?");
+    }
+  }
+
+  async function handleConfirmDelete() {
+    if (!manual) return;
+    try {
+      await deleteManual(manual.id).unwrap();
+      showSuccess("Welcome manual deleted.");
+      setShowDeleteModal(false);
+      navigate("/welcome-manuals");
+    } catch {
+      showError("I couldn't delete that manual. Want to try again?");
+    }
+  }
+
+  const hasSections = sortedSections.length > 0;
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <Link
+        to="/welcome-manuals"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground min-h-[44px]"
+      >
+        <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+        Back to welcome manuals
+      </Link>
+
+      {isError ? (
+        <AlertBox variant="error" className="flex items-center justify-between gap-3">
+          <span>I couldn't load this welcome manual. Want me to try again?</span>
+          <LoadingButton
+            variant="secondary"
+            size="sm"
+            isLoading={isFetching}
+            loadingText="Retrying..."
+            onClick={() => refetch()}
+          >
+            Retry
+          </LoadingButton>
+        </AlertBox>
+      ) : null}
+
+      {isLoading && !isError ? <WelcomeManualDetailSkeleton /> : null}
+
+      {manual ? (
+        <>
+          <section
+            className="border rounded-lg p-4 space-y-3"
+            data-testid="welcome-manual-header-card"
+          >
+            <SectionHeader
+              title={manual.title}
+              subtitle={
+                property ? (
+                  <Link to="/properties" className="text-sm text-primary hover:underline">
+                    {property.name}
+                  </Link>
+                ) : undefined
+              }
+              actions={
+                <>
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    onClick={() => setShowEditForm(true)}
+                    data-testid="edit-welcome-manual-button"
+                  >
+                    Edit
+                  </Button>
+                  <span title={hasSections ? undefined : "Add at least one section before sending."}>
+                    <Button
+                      variant="secondary"
+                      size="md"
+                      onClick={() => setShowEmailDialog(true)}
+                      disabled={!hasSections}
+                      data-testid="email-welcome-manual-button"
+                    >
+                      <Mail className="h-4 w-4 mr-1" />
+                      Email to guest
+                    </Button>
+                  </span>
+                  <Button
+                    variant="secondary"
+                    size="md"
+                    onClick={() => setShowDeleteModal(true)}
+                    className="text-red-600 border-red-200 hover:bg-red-50"
+                    data-testid="delete-welcome-manual-button"
+                  >
+                    <Trash2 className="h-4 w-4 mr-1" />
+                    Delete
+                  </Button>
+                </>
+              }
+            />
+            {manual.intro_text ? (
+              <div data-testid="welcome-manual-intro">
+                <Markdown content={manual.intro_text} />
+              </div>
+            ) : null}
+          </section>
+
+          {hasSections ? (
+            <DndContext
+              sensors={sensors}
+              collisionDetection={closestCenter}
+              onDragEnd={(event) => void handleDragEnd(event)}
+            >
+              <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+                <div className="space-y-4" data-testid="welcome-manual-sections">
+                  {orderedIds.map((id) => {
+                    const section = sectionsById.get(id);
+                    if (!section) return null;
+                    return (
+                      <WelcomeManualSectionCard
+                        key={id}
+                        ref={(node) => registerSectionRef(id, node)}
+                        manualId={manual.id}
+                        section={section}
+                      />
+                    );
+                  })}
+                </div>
+              </SortableContext>
+            </DndContext>
+          ) : (
+            <p
+              className="text-sm text-muted-foreground border rounded-lg p-6 text-center"
+              data-testid="welcome-manual-sections-empty"
+            >
+              No sections yet. Add one to start building this guide.
+            </p>
+          )}
+
+          <div className="flex justify-center">
+            <LoadingButton
+              variant="secondary"
+              onClick={() => void handleAddSection()}
+              isLoading={isAddingSection}
+              loadingText="Adding..."
+              data-testid="add-welcome-manual-section-button"
+            >
+              <Plus className="h-4 w-4 mr-1" />
+              Add section
+            </LoadingButton>
+          </div>
+
+          {showEditForm ? (
+            <WelcomeManualForm
+              manual={manual}
+              properties={properties}
+              onClose={() => setShowEditForm(false)}
+              onUpdated={() => setShowEditForm(false)}
+            />
+          ) : null}
+
+          {showEmailDialog ? (
+            <WelcomeManualEmailDialog
+              manualId={manual.id}
+              onClose={() => setShowEmailDialog(false)}
+            />
+          ) : null}
+
+          <DeleteWelcomeManualModal
+            open={showDeleteModal}
+            manualTitle={manual.title}
+            isLoading={isDeleting}
+            onConfirm={handleConfirmDelete}
+            onCancel={() => setShowDeleteModal(false)}
+          />
+        </>
+      ) : null}
+    </main>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/pages/WelcomeManuals.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/WelcomeManuals.tsx
@@ -1,0 +1,106 @@
+import { useMemo, useState } from "react";
+import { Plus } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import SectionHeader from "@/shared/components/ui/SectionHeader";
+import AlertBox from "@/shared/components/ui/AlertBox";
+import { LoadingButton } from "@platform/ui";
+import { useGetWelcomeManualsQuery } from "@/shared/store/welcomeManualsApi";
+import { useGetPropertiesQuery } from "@/shared/store/propertiesApi";
+import { WELCOME_MANUAL_PAGE_SIZE } from "@/shared/lib/welcome-manual-constants";
+import type { WelcomeManualSummary } from "@/shared/types/welcome-manual/welcome-manual-summary";
+import WelcomeManualsListBody from "@/app/features/welcome-manuals/WelcomeManualsListBody";
+import WelcomeManualCreateDialog from "@/app/features/welcome-manuals/WelcomeManualCreateDialog";
+import { useWelcomeManualsListMode } from "@/app/features/welcome-manuals/useWelcomeManualsListMode";
+
+export default function WelcomeManuals() {
+  const navigate = useNavigate();
+  const [pageCount, setPageCount] = useState(1);
+  const [showCreate, setShowCreate] = useState(false);
+
+  const queryArgs = useMemo(
+    () => ({ limit: WELCOME_MANUAL_PAGE_SIZE * pageCount, offset: 0 }),
+    [pageCount],
+  );
+
+  const { data, isLoading, isFetching, isError, refetch } = useGetWelcomeManualsQuery(queryArgs);
+  const { data: properties = [] } = useGetPropertiesQuery();
+
+  const manuals = data?.items ?? [];
+  const hasMore = data?.has_more ?? false;
+
+  const propertyById = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const p of properties) {
+      map.set(p.id, p.name);
+    }
+    return map;
+  }, [properties]);
+
+  const propertyName = (m: WelcomeManualSummary): string | null =>
+    m.property_id ? propertyById.get(m.property_id) ?? "Unknown property" : null;
+
+  function handleLoadMore() {
+    setPageCount((prev) => prev + 1);
+  }
+
+  const mode = useWelcomeManualsListMode({
+    isLoading,
+    isError,
+    manualCount: manuals.length,
+  });
+
+  return (
+    <main className="p-4 sm:p-8 space-y-6">
+      <SectionHeader
+        title="Welcome Manuals"
+        subtitle="Guest guides you can email as a polished PDF — Wi-Fi, parking, check-out, and more."
+        actions={
+          <LoadingButton
+            onClick={() => setShowCreate(true)}
+            isLoading={false}
+            data-testid="new-welcome-manual-button"
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            New manual
+          </LoadingButton>
+        }
+      />
+
+      {isError ? (
+        <AlertBox variant="error" className="flex items-center justify-between gap-3">
+          <span>I couldn't load your welcome manuals. Want me to try again?</span>
+          <LoadingButton
+            variant="secondary"
+            size="sm"
+            isLoading={isFetching}
+            loadingText="Retrying..."
+            onClick={() => refetch()}
+          >
+            Retry
+          </LoadingButton>
+        </AlertBox>
+      ) : null}
+
+      <WelcomeManualsListBody
+        mode={mode}
+        manuals={manuals}
+        propertyName={propertyName}
+        hasMore={hasMore}
+        isFetching={isFetching}
+        onLoadMore={handleLoadMore}
+        onCreateFirst={() => setShowCreate(true)}
+      />
+
+      {showCreate ? (
+        <WelcomeManualCreateDialog
+          properties={properties}
+          onClose={() => setShowCreate(false)}
+          onCreated={(manual) => {
+            setShowCreate(false);
+            navigate(`/welcome-manuals/${manual.id}`);
+          }}
+        />
+      ) : null}
+    </main>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/validate-section-images.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/validate-section-images.ts
@@ -1,0 +1,33 @@
+import {
+  SECTION_IMAGE_ALLOWED_MIME,
+  SECTION_IMAGE_MAX_BYTES,
+} from "@/shared/lib/welcome-manual-constants";
+
+export interface SectionImageValidationResult {
+  valid: File[];
+  rejected: string[];
+}
+
+/**
+ * Client-side gate for section-image uploads. Mirrors ListingPhotoManager's
+ * validator: size cap + JPEG/PNG/HEIC allowlist (HEIC also matched by
+ * extension because some browsers don't set its content-type). The backend
+ * re-validates and strips EXIF — this is a fast-fail UX layer only.
+ */
+export function validateSectionImages(files: File[]): SectionImageValidationResult {
+  const valid: File[] = [];
+  const rejected: string[] = [];
+  for (const f of files) {
+    if (f.size > SECTION_IMAGE_MAX_BYTES) {
+      rejected.push(`${f.name} is over 10MB`);
+      continue;
+    }
+    const isHeicByExt = /\.(heic|heif)$/i.test(f.name);
+    if (!SECTION_IMAGE_ALLOWED_MIME.includes(f.type) && !isHeicByExt) {
+      rejected.push(`${f.name} is not a supported image type`);
+      continue;
+    }
+    valid.push(f);
+  }
+  return { valid, rejected };
+}

--- a/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-constants.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-constants.ts
@@ -1,0 +1,21 @@
+/** Page size for the welcome-manuals list query. Mirrors the listings page. */
+export const WELCOME_MANUAL_PAGE_SIZE = 25;
+
+/** Default title applied to a freshly-added section before the host renames it. */
+export const NEW_SECTION_DEFAULT_TITLE = "New section";
+
+/** Max upload size per section image, in bytes (10MB). Mirrors listing photos. */
+export const SECTION_IMAGE_MAX_BYTES = 10 * 1024 * 1024;
+
+/** Allowed image MIME types for section uploads. HEIC also matched by extension. */
+export const SECTION_IMAGE_ALLOWED_MIME: readonly string[] = [
+  "image/jpeg",
+  "image/png",
+  "image/heic",
+];
+
+/** Observability domain tag for missing section-image objects. */
+export const SECTION_IMAGE_STORAGE_DOMAIN = "welcome_manual_section_image";
+
+/** RFC-lite email format check for the email-to-guest dialog's submit gate. */
+export const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;

--- a/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-format.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/welcome-manual-format.ts
@@ -1,0 +1,25 @@
+/**
+ * Pure formatting helpers for welcome-manual list/detail views. Kept out of
+ * component files per the project's "constants/config in dedicated modules"
+ * rule.
+ */
+
+/** "0 sections" / "1 section" / "N sections" — pluralized. */
+export function formatSectionCount(count: number): string {
+  if (count === 1) return "1 section";
+  return `${count} sections`;
+}
+
+const DATE_FORMATTER = new Intl.DateTimeFormat("en-US", {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+
+/** Short, locale-aware updated date. Returns "—" for unparseable input. */
+export function formatUpdatedAt(iso: string | null | undefined): string {
+  if (!iso) return "—";
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return "—";
+  return DATE_FORMATTER.format(date);
+}

--- a/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/baseApi.ts
@@ -4,6 +4,6 @@ import { axiosBaseQuery } from "./baseQuery";
 export const baseApi = createApi({
   reducerPath: "api",
   baseQuery: axiosBaseQuery,
-  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy", "AttributionQueue"],
+  tagTypes: ["Document", "Property", "Summary", "Integration", "Auth", "AdminUsers", "AdminStats", "AdminOrgs", "Organization", "Members", "Invites", "Transaction", "BookingStatement", "Reconciliation", "TaxReturn", "ClassificationRule", "Health", "Cost", "TaxProfile", "Demo", "TaxAdvisor", "Totp", "Listing", "Inquiry", "ReplyTemplate", "Applicant", "Vendor", "Screening", "Channel", "ChannelListing", "Calendar", "BlackoutAttachments", "LeaseTemplate", "SignedLease", "ReviewQueue", "InsurancePolicy", "AttributionQueue", "WelcomeManual", "WelcomeManualSend"],
   endpoints: () => ({}),
 });

--- a/apps/mybookkeeper/frontend/src/shared/store/welcomeManualsApi.ts
+++ b/apps/mybookkeeper/frontend/src/shared/store/welcomeManualsApi.ts
@@ -1,0 +1,195 @@
+import { baseApi } from "./baseApi";
+import type { WelcomeManualCreateRequest } from "@/shared/types/welcome-manual/welcome-manual-create-request";
+import type { WelcomeManualEmailRequest } from "@/shared/types/welcome-manual/welcome-manual-email-request";
+import type { WelcomeManualListArgs } from "@/shared/types/welcome-manual/welcome-manual-list-args";
+import type { WelcomeManualListResponse } from "@/shared/types/welcome-manual/welcome-manual-list-response";
+import type { WelcomeManualResponse } from "@/shared/types/welcome-manual/welcome-manual-response";
+import type { WelcomeManualSectionCreateRequest } from "@/shared/types/welcome-manual/welcome-manual-section-create-request";
+import type { WelcomeManualSectionImageResponse } from "@/shared/types/welcome-manual/welcome-manual-section-image-response";
+import type { WelcomeManualSectionResponse } from "@/shared/types/welcome-manual/welcome-manual-section-response";
+import type { WelcomeManualSectionUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-section-update-request";
+import type { WelcomeManualSendResponse } from "@/shared/types/welcome-manual/welcome-manual-send-response";
+import type { WelcomeManualUpdateRequest } from "@/shared/types/welcome-manual/welcome-manual-update-request";
+
+const welcomeManualsApi = baseApi.injectEndpoints({
+  endpoints: (builder) => ({
+    getWelcomeManuals: builder.query<WelcomeManualListResponse, WelcomeManualListArgs | void>({
+      query: (args) => ({
+        url: "/welcome-manuals",
+        params: {
+          ...(args?.limit !== undefined ? { limit: args.limit } : {}),
+          ...(args?.offset !== undefined ? { offset: args.offset } : {}),
+        },
+      }),
+      providesTags: (result) =>
+        result
+          ? [
+              ...result.items.map((m) => ({ type: "WelcomeManual" as const, id: m.id })),
+              { type: "WelcomeManual" as const, id: "LIST" },
+            ]
+          : [{ type: "WelcomeManual" as const, id: "LIST" }],
+    }),
+    getWelcomeManualById: builder.query<WelcomeManualResponse, string>({
+      query: (id) => ({ url: `/welcome-manuals/${id}` }),
+      providesTags: (_result, _error, id) => [{ type: "WelcomeManual", id }],
+    }),
+    createWelcomeManual: builder.mutation<WelcomeManualResponse, WelcomeManualCreateRequest>({
+      query: (body) => ({ url: "/welcome-manuals", method: "POST", data: body }),
+      invalidatesTags: [{ type: "WelcomeManual", id: "LIST" }],
+    }),
+    updateWelcomeManual: builder.mutation<
+      WelcomeManualResponse,
+      { id: string; data: WelcomeManualUpdateRequest }
+    >({
+      query: ({ id, data }) => ({ url: `/welcome-manuals/${id}`, method: "PUT", data }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.id },
+        { type: "WelcomeManual", id: "LIST" },
+      ],
+    }),
+    deleteWelcomeManual: builder.mutation<void, string>({
+      query: (id) => ({ url: `/welcome-manuals/${id}`, method: "DELETE" }),
+      invalidatesTags: (_result, _err, id) => [
+        { type: "WelcomeManual", id },
+        { type: "WelcomeManual", id: "LIST" },
+      ],
+    }),
+    emailWelcomeManual: builder.mutation<
+      WelcomeManualSendResponse,
+      { manualId: string; data: WelcomeManualEmailRequest }
+    >({
+      query: ({ manualId, data }) => ({
+        url: `/welcome-manuals/${manualId}/email`,
+        method: "POST",
+        data,
+      }),
+      invalidatesTags: [{ type: "WelcomeManualSend", id: "LIST" }],
+    }),
+    // ---- Sections ----
+    createSection: builder.mutation<
+      WelcomeManualSectionResponse,
+      { manualId: string; data: WelcomeManualSectionCreateRequest }
+    >({
+      query: ({ manualId, data }) => ({
+        url: `/welcome-manuals/${manualId}/sections`,
+        method: "POST",
+        data,
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    updateSection: builder.mutation<
+      WelcomeManualSectionResponse,
+      { manualId: string; sectionId: string; data: WelcomeManualSectionUpdateRequest }
+    >({
+      query: ({ manualId, sectionId, data }) => ({
+        url: `/welcome-manuals/${manualId}/sections/${sectionId}`,
+        method: "PATCH",
+        data,
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    deleteSection: builder.mutation<
+      void,
+      { manualId: string; sectionId: string }
+    >({
+      query: ({ manualId, sectionId }) => ({
+        url: `/welcome-manuals/${manualId}/sections/${sectionId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    // The reorder endpoint returns sections with ``images: []`` by design. We
+    // deliberately do NOT merge that response — we invalidate the manual tag so
+    // the detail query refetches the manual with full images intact. Merging
+    // the response would make every section's photos vanish until the next load.
+    reorderSections: builder.mutation<
+      WelcomeManualSectionResponse[],
+      { manualId: string; sectionIds: string[] }
+    >({
+      query: ({ manualId, sectionIds }) => ({
+        url: `/welcome-manuals/${manualId}/sections/order`,
+        method: "PUT",
+        data: { section_ids: sectionIds },
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    // ---- Section images ----
+    uploadSectionImages: builder.mutation<
+      WelcomeManualSectionImageResponse[],
+      { manualId: string; sectionId: string; files: File[] }
+    >({
+      query: ({ manualId, sectionId, files }) => {
+        const form = new FormData();
+        for (const f of files) {
+          form.append("files", f);
+        }
+        return {
+          url: `/welcome-manuals/${manualId}/sections/${sectionId}/images`,
+          method: "POST",
+          data: form,
+        };
+      },
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    updateSectionImage: builder.mutation<
+      WelcomeManualSectionImageResponse,
+      {
+        manualId: string;
+        sectionId: string;
+        imageId: string;
+        caption?: string | null;
+        display_order?: number;
+      }
+    >({
+      query: ({ manualId, sectionId, imageId, caption, display_order }) => ({
+        url: `/welcome-manuals/${manualId}/sections/${sectionId}/images/${imageId}`,
+        method: "PATCH",
+        data: {
+          ...(caption !== undefined ? { caption } : {}),
+          ...(display_order !== undefined ? { display_order } : {}),
+        },
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+    deleteSectionImage: builder.mutation<
+      void,
+      { manualId: string; sectionId: string; imageId: string }
+    >({
+      query: ({ manualId, sectionId, imageId }) => ({
+        url: `/welcome-manuals/${manualId}/sections/${sectionId}/images/${imageId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: (_result, _err, arg) => [
+        { type: "WelcomeManual", id: arg.manualId },
+      ],
+    }),
+  }),
+});
+
+export const {
+  useGetWelcomeManualsQuery,
+  useGetWelcomeManualByIdQuery,
+  useCreateWelcomeManualMutation,
+  useUpdateWelcomeManualMutation,
+  useDeleteWelcomeManualMutation,
+  useEmailWelcomeManualMutation,
+  useCreateSectionMutation,
+  useUpdateSectionMutation,
+  useDeleteSectionMutation,
+  useReorderSectionsMutation,
+  useUploadSectionImagesMutation,
+  useUpdateSectionImageMutation,
+  useDeleteSectionImageMutation,
+} = welcomeManualsApi;

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/index.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/index.ts
@@ -1,0 +1,15 @@
+export type { SectionImageLightboxTarget } from "./section-image-lightbox-target";
+export type { WelcomeManualCreateRequest } from "./welcome-manual-create-request";
+export type { WelcomeManualEmailDialogStep } from "./welcome-manual-email-dialog-step";
+export type { WelcomeManualEmailRequest } from "./welcome-manual-email-request";
+export type { WelcomeManualListArgs } from "./welcome-manual-list-args";
+export type { WelcomeManualListResponse } from "./welcome-manual-list-response";
+export type { WelcomeManualResponse } from "./welcome-manual-response";
+export type { WelcomeManualSectionCreateRequest } from "./welcome-manual-section-create-request";
+export type { WelcomeManualSectionImageResponse } from "./welcome-manual-section-image-response";
+export type { WelcomeManualSectionResponse } from "./welcome-manual-section-response";
+export type { WelcomeManualSectionUpdateRequest } from "./welcome-manual-section-update-request";
+export type { WelcomeManualSendResponse } from "./welcome-manual-send-response";
+export type { WelcomeManualSendStatus } from "./welcome-manual-send-status";
+export type { WelcomeManualSummary } from "./welcome-manual-summary";
+export type { WelcomeManualUpdateRequest } from "./welcome-manual-update-request";

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/section-editor-values.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/section-editor-values.ts
@@ -1,0 +1,5 @@
+/** react-hook-form values for a single section's inline editor. */
+export interface SectionEditorValues {
+  title: string;
+  body: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/section-image-lightbox-target.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/section-image-lightbox-target.ts
@@ -1,0 +1,5 @@
+/** Identifies which section's images the lightbox is viewing, and the index. */
+export interface SectionImageLightboxTarget {
+  sectionId: string;
+  index: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-create-form-values.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-create-form-values.ts
@@ -1,0 +1,6 @@
+/** react-hook-form values for the welcome-manual create dialog. */
+export interface WelcomeManualCreateFormValues {
+  title: string;
+  property_id: string;
+  seed_default_sections: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-create-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-create-request.ts
@@ -1,0 +1,11 @@
+/**
+ * Body for POST /welcome-manuals. ``organization_id``/``user_id`` are resolved
+ * server-side. ``seed_default_sections`` defaults to true on the backend, but
+ * the create dialog always sends it explicitly.
+ */
+export interface WelcomeManualCreateRequest {
+  title: string;
+  intro_text?: string | null;
+  property_id?: string | null;
+  seed_default_sections: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-email-dialog-step.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-email-dialog-step.ts
@@ -1,0 +1,11 @@
+/**
+ * Steps of the in-place email-to-guest flow:
+ *   - ``form``    — the recipient form (step 1)
+ *   - ``sent``    — green success result
+ *   - ``failed``  — amber couldn't-send result (offers "Try again")
+ *   - ``skipped`` — blue email-not-configured result (no retry; it's infra)
+ *
+ * The ``sent`` / ``failed`` / ``skipped`` values mirror
+ * ``WelcomeManualSendStatus`` so the send response maps directly to a step.
+ */
+export type WelcomeManualEmailDialogStep = "form" | "sent" | "failed" | "skipped";

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-email-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-email-request.ts
@@ -1,0 +1,5 @@
+/** Body for POST /welcome-manuals/{id}/email. */
+export interface WelcomeManualEmailRequest {
+  recipient_email: string;
+  recipient_name?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-form-values.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-form-values.ts
@@ -1,0 +1,6 @@
+/** react-hook-form values for the welcome-manual edit form (header panel). */
+export interface WelcomeManualFormValues {
+  title: string;
+  intro_text: string;
+  property_id: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-list-args.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-list-args.ts
@@ -1,0 +1,4 @@
+export interface WelcomeManualListArgs {
+  limit?: number;
+  offset?: number;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-list-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-list-response.ts
@@ -1,0 +1,11 @@
+import type { WelcomeManualSummary } from "./welcome-manual-summary";
+
+/**
+ * Paginated envelope returned by GET /welcome-manuals. Mirrors the shared
+ * backend `ListResponse[WelcomeManualSummary]`.
+ */
+export interface WelcomeManualListResponse {
+  items: WelcomeManualSummary[];
+  total: number;
+  has_more: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-response.ts
@@ -1,0 +1,17 @@
+import type { WelcomeManualSectionResponse } from "./welcome-manual-section-response";
+
+/**
+ * Mirrors backend `WelcomeManualResponse` — the full detail payload with
+ * ordered sections (each carrying its ordered images).
+ */
+export interface WelcomeManualResponse {
+  id: string;
+  organization_id: string;
+  user_id: string;
+  property_id: string | null;
+  title: string;
+  intro_text: string | null;
+  sections: WelcomeManualSectionResponse[];
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-create-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-create-request.ts
@@ -1,0 +1,5 @@
+/** Body for POST /welcome-manuals/{id}/sections. */
+export interface WelcomeManualSectionCreateRequest {
+  title: string;
+  body?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-image-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-image-response.ts
@@ -1,0 +1,15 @@
+/**
+ * Mirrors backend `WelcomeManualSectionImageResponse`. ``presigned_url`` is a
+ * short-lived signed URL minted per request; ``is_available === false`` means
+ * the underlying object is missing and the UI renders a placeholder.
+ */
+export interface WelcomeManualSectionImageResponse {
+  id: string;
+  section_id: string;
+  storage_key: string;
+  caption: string | null;
+  display_order: number;
+  created_at: string;
+  presigned_url?: string | null;
+  is_available?: boolean;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-response.ts
@@ -1,0 +1,17 @@
+import type { WelcomeManualSectionImageResponse } from "./welcome-manual-section-image-response";
+
+/**
+ * Mirrors backend `WelcomeManualSectionResponse`. ``images`` is populated on
+ * the full-manual read paths; section-mutation responses (add / update /
+ * reorder) return an empty list and the frontend refetches the manual.
+ */
+export interface WelcomeManualSectionResponse {
+  id: string;
+  manual_id: string;
+  title: string;
+  body: string | null;
+  display_order: number;
+  images: WelcomeManualSectionImageResponse[];
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-update-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-section-update-request.ts
@@ -1,0 +1,9 @@
+/**
+ * Body for PATCH /welcome-manuals/{id}/sections/{sid}. Only dirty fields are
+ * sent. An explicit ``null`` body clears it; title is required so it is never
+ * sent as null.
+ */
+export interface WelcomeManualSectionUpdateRequest {
+  title?: string;
+  body?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-send-response.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-send-response.ts
@@ -1,0 +1,16 @@
+import type { WelcomeManualSendStatus } from "./welcome-manual-send-status";
+
+/**
+ * Mirrors backend `WelcomeManualSendResponse`. Returned at HTTP 200 even on a
+ * failed/skipped send — ``status`` communicates the outcome so the email
+ * dialog can render the correct result step.
+ */
+export interface WelcomeManualSendResponse {
+  id: string;
+  manual_id: string;
+  recipient_email: string;
+  recipient_name: string | null;
+  status: WelcomeManualSendStatus;
+  error_reason: string | null;
+  created_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-send-status.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-send-status.ts
@@ -1,0 +1,8 @@
+/**
+ * Outcome of a welcome-manual email send. Mirrors the backend
+ * ``WELCOME_MANUAL_SEND_STATUSES`` tuple (String(20) + CheckConstraint):
+ *   - ``sent``    — SMTP accepted the message
+ *   - ``failed``  — SMTP rejected/errored (retryable)
+ *   - ``skipped`` — preconditions unmet (e.g. SMTP not configured on this deploy)
+ */
+export type WelcomeManualSendStatus = "sent" | "failed" | "skipped";

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-summary.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-summary.ts
@@ -1,0 +1,12 @@
+/**
+ * Mirrors backend `WelcomeManualSummary` Pydantic schema (GET /welcome-manuals
+ * list items). ``section_count`` is computed server-side, not a column.
+ */
+export interface WelcomeManualSummary {
+  id: string;
+  title: string;
+  property_id: string | null;
+  section_count: number;
+  created_at: string;
+  updated_at: string;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-update-request.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manual-update-request.ts
@@ -1,0 +1,9 @@
+/**
+ * Body for PUT /welcome-manuals/{id}. All fields optional — only dirty fields
+ * are sent. An explicit ``null`` property_id un-tags the manual.
+ */
+export interface WelcomeManualUpdateRequest {
+  title?: string;
+  intro_text?: string | null;
+  property_id?: string | null;
+}

--- a/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manuals-list-mode.ts
+++ b/apps/mybookkeeper/frontend/src/shared/types/welcome-manual/welcome-manuals-list-mode.ts
@@ -1,0 +1,2 @@
+/** Render mode for the welcome-manuals list body. */
+export type WelcomeManualsListMode = "loading" | "empty" | "list";


### PR DESCRIPTION
PR 4b — the **frontend** for the guest welcome manual feature (backend PRs #804/#806/#807/#808 merged). Completes the feature end-to-end.

## What's here
- **List page** `/welcome-manuals` + **detail/editor page** `/welcome-manuals/:manualId` (deep-linkable), in the **Property** nav group below Listings.
- **RTK Query slice** `welcomeManualsApi.ts` (+ `WelcomeManual`/`WelcomeManualSend` tags) covering all backend routes; types one-per-file under `shared/types/welcome-manual/`.
- **Section editor**: inline title + **markdown body editor with live preview** (mirrors `ListingForm` + shared `Markdown`), explicit dirty-only per-section Save, `@dnd-kit` reorder, delete (ConfirmDialog), stub-body placeholder.
- **Per-section image manager** mirroring `ListingPhotoManager` (upload, per-image reorder, blur-save captions, lightbox, missing-object placeholder) — no bulk download/select.
- **Email-to-guest dialog** with 3 distinct result states — **sent** (done), **failed** (shows reason + "Try again", preserves email), **skipped** (SMTP not configured — no retry). Honors the backend's HTTP-200-with-status contract. The button is **disabled at 0 sections** (operator decision) with a tooltip.
- Create dialog defaults the **seed-sections checkbox checked**.

## Key correctness detail
Section reorder fires the full `section_ids` permutation, holds an optimistic local order, then **invalidates the `WelcomeManual` tag** and never merges the order response (which returns `images: []` by design) — so images don't vanish. Mirrors `ListingPhotoManager`.

## Tests
- **Vitest 19/19** (email dialog all 3 states + retry-prefill + send-disabled-until-valid, create dialog seed default, section save dirty-only + null-body placeholder, detail 0-section email-disable + skeleton + error, list skeleton/empty/error/badges).
- **No-backend layout E2E 4/4** (`welcome-manuals-layout-mock.spec.ts`, registered in the `frontend-layout-e2e` CI job) — skeleton-vs-loaded parity, mobile/desktop, no horizontal scroll, detail resolution.
- Backend-driven E2E (`welcome-manuals-crud`, `welcome-manuals-layout`) authored + type-checked; run via CI/operator like the listings E2E (no full-backend E2E CI job exists).
- `npm run build` (tsc + vite) 0 errors; lint clean.

## Operational migration
**None** — frontend-only; no env/schema/config change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
