### PR TITLE
feat(shared): Support/donation page in @platform/ui (PR1 of 4)

### DIFF
--- a/packages/shared-frontend/src/__tests__/KofiButton.test.tsx
+++ b/packages/shared-frontend/src/__tests__/KofiButton.test.tsx
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import KofiButton from "../components/widgets/KofiButton";
+
+describe("KofiButton", () => {
+  it("renders an anchor to the Ko-fi URL that opens safely in a new tab", () => {
+    render(<KofiButton url="https://ko-fi.com/example" />);
+    const link = screen.getByRole("link", { name: /support on ko-fi/i });
+    expect(link).toHaveAttribute("href", "https://ko-fi.com/example");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link.getAttribute("rel")).toContain("noopener");
+  });
+
+  it("announces the new-tab behavior to screen readers", () => {
+    render(<KofiButton url="https://ko-fi.com/example" />);
+    expect(screen.getByText(/opens in a new tab/i)).toBeInTheDocument();
+  });
+
+  it("hides the decorative external-link icon from assistive tech", () => {
+    render(<KofiButton url="https://ko-fi.com/example" />);
+    const link = screen.getByRole("link", { name: /support on ko-fi/i });
+    expect(link.querySelector('[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it("supports a custom label", () => {
+    render(<KofiButton url="https://ko-fi.com/example" label="Buy me a coffee" />);
+    expect(screen.getByRole("link", { name: /buy me a coffee/i })).toBeInTheDocument();
+  });
+});

--- a/packages/shared-frontend/src/__tests__/ProgressBar.test.tsx
+++ b/packages/shared-frontend/src/__tests__/ProgressBar.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ProgressBar from "../components/ui/ProgressBar";
+
+describe("ProgressBar", () => {
+  it("exposes the progressbar role with aria values and label", () => {
+    render(<ProgressBar value={57} label="57% to break-even" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "57");
+    expect(bar).toHaveAttribute("aria-valuemin", "0");
+    expect(bar).toHaveAttribute("aria-valuemax", "100");
+    expect(bar).toHaveAttribute("aria-valuetext", "57%");
+    expect(bar).toHaveAttribute("aria-label", "57% to break-even");
+  });
+
+  it("clamps values above 100", () => {
+    render(<ProgressBar value={140} label="over" />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "100");
+  });
+
+  it("clamps negative values to 0", () => {
+    render(<ProgressBar value={-20} label="under" />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("applies the success fill for the success tone", () => {
+    const { container } = render(<ProgressBar value={100} label="done" tone="success" />);
+    const fill = container.querySelector('[role="progressbar"] > div');
+    expect(fill?.className).toMatch(/bg-green-500/);
+  });
+});

--- a/packages/shared-frontend/src/__tests__/Support.test.tsx
+++ b/packages/shared-frontend/src/__tests__/Support.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import Support from "../pages/Support";
+
+// The transparency widget self-fetches; stub it as "not configured" so it
+// renders nothing and the page layout is exercised cleanly.
+vi.mock("../components/widgets/useTransparency", () => ({
+  useTransparency: () => ({
+    status: "ok",
+    data: { month: "June 2026", costs_cents: 0, donations_cents: 0, updated_at: null, configured: false },
+  }),
+}));
+
+function renderSupport(props: Partial<Parameters<typeof Support>[0]> = {}) {
+  return render(
+    <MemoryRouter>
+      <Support appName="MyBookkeeper" {...props} />
+    </MemoryRouter>,
+  );
+}
+
+describe("Support page", () => {
+  it("renders the heading and a back link to the host app", () => {
+    renderSupport();
+    expect(screen.getByRole("heading", { level: 1, name: /why myfreeapps is free/i })).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to mybookkeeper/i })).toBeInTheDocument();
+  });
+
+  it("shows a video placeholder when no video id is given", () => {
+    renderSupport();
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+  });
+
+  it("embeds the video when an id is provided", () => {
+    const { container } = renderSupport({ youtubeVideoId: "xyz" });
+    expect(container.querySelector("iframe")?.getAttribute("src")).toContain(
+      "youtube-nocookie.com/embed/xyz",
+    );
+  });
+
+  it("links the donate CTA to the provided Ko-fi url", () => {
+    renderSupport({ kofiUrl: "https://ko-fi.com/test" });
+    expect(screen.getByRole("link", { name: /support on ko-fi/i })).toHaveAttribute(
+      "href",
+      "https://ko-fi.com/test",
+    );
+  });
+});

--- a/packages/shared-frontend/src/__tests__/TransparencyWidget.test.tsx
+++ b/packages/shared-frontend/src/__tests__/TransparencyWidget.test.tsx
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import TransparencyWidget from "../components/widgets/TransparencyWidget";
+import {
+  useTransparency,
+  type TransparencyData,
+  type TransparencyResult,
+} from "../components/widgets/useTransparency";
+
+vi.mock("../components/widgets/useTransparency", () => ({
+  useTransparency: vi.fn(),
+}));
+
+const mocked = vi.mocked(useTransparency);
+
+const CONFIGURED: TransparencyData = {
+  month: "June 2026",
+  costs_cents: 8200,
+  donations_cents: 4700,
+  updated_at: "2026-06-01T00:00:00Z",
+  configured: true,
+};
+
+function ok(over: Partial<TransparencyData> = {}): TransparencyResult {
+  return { status: "ok", data: { ...CONFIGURED, ...over } };
+}
+
+beforeEach(() => {
+  mocked.mockReset();
+});
+
+describe("TransparencyWidget", () => {
+  it("shows a skeleton (no live data) while loading", () => {
+    mocked.mockReturnValue({ status: "loading" });
+    render(<TransparencyWidget />);
+    expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
+    expect(screen.queryByText(/running costs/i)).not.toBeInTheDocument();
+  });
+
+  it("shows a quiet message on error", () => {
+    mocked.mockReturnValue({ status: "error" });
+    render(<TransparencyWidget />);
+    expect(screen.getByText(/temporarily unavailable/i)).toBeInTheDocument();
+  });
+
+  it("renders nothing until costs are configured", () => {
+    mocked.mockReturnValue(ok({ configured: false }));
+    const { container } = render(<TransparencyWidget />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("invites the first donation when none received", () => {
+    mocked.mockReturnValue(ok({ donations_cents: 0 }));
+    render(<TransparencyWidget />);
+    expect(screen.getByText(/be the first/i)).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("shows the percentage covered for a partial month", () => {
+    mocked.mockReturnValue(ok());
+    render(<TransparencyWidget />);
+    expect(screen.getByText(/57% of this month/i)).toBeInTheDocument();
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "57");
+  });
+
+  it("marks the goal met when donations cover costs", () => {
+    mocked.mockReturnValue(ok({ donations_cents: 9000 }));
+    render(<TransparencyWidget />);
+    expect(screen.getByText("Goal met this month")).toBeInTheDocument();
+    expect(screen.getByText(/thank you/i)).toBeInTheDocument();
+  });
+
+  it("formats the dollar figures from cents", () => {
+    mocked.mockReturnValue(ok());
+    render(<TransparencyWidget />);
+    expect(screen.getByText("$47.00")).toBeInTheDocument();
+    expect(screen.getByText("$82.00")).toBeInTheDocument();
+  });
+});

--- a/packages/shared-frontend/src/__tests__/YouTubeEmbed.test.tsx
+++ b/packages/shared-frontend/src/__tests__/YouTubeEmbed.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import YouTubeEmbed from "../components/embed/YouTubeEmbed";
+
+describe("YouTubeEmbed", () => {
+  it("renders a privacy-friendly nocookie iframe when a videoId is provided", () => {
+    const { container } = render(<YouTubeEmbed videoId="abc123" title="My video" />);
+    const iframe = container.querySelector("iframe");
+    expect(iframe).not.toBeNull();
+    expect(iframe?.getAttribute("src")).toContain("youtube-nocookie.com/embed/abc123");
+    expect(iframe?.getAttribute("title")).toBe("My video");
+  });
+
+  it("shows a placeholder and no iframe when videoId is missing", () => {
+    const { container } = render(<YouTubeEmbed />);
+    expect(container.querySelector("iframe")).toBeNull();
+    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+  });
+});

--- a/packages/shared-frontend/src/__tests__/breakEven.test.ts
+++ b/packages/shared-frontend/src/__tests__/breakEven.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { deriveBreakEven, breakEvenStatusLine } from "../components/widgets/breakEven";
+
+describe("deriveBreakEven", () => {
+  it("returns 0% / warning when there are no donations", () => {
+    const s = deriveBreakEven(0, 8200);
+    expect(s.pct).toBe(0);
+    expect(s.tone).toBe("warning");
+    expect(s.goalMet).toBe(false);
+    expect(s.noDonations).toBe(true);
+  });
+
+  it("uses the warning tone below 50%", () => {
+    const s = deriveBreakEven(2000, 8200); // ~24%
+    expect(Math.round(s.pct)).toBe(24);
+    expect(s.tone).toBe("warning");
+    expect(s.noDonations).toBe(false);
+  });
+
+  it("uses the primary tone from 50% up to break-even", () => {
+    const s = deriveBreakEven(4700, 8200); // ~57%
+    expect(s.tone).toBe("primary");
+    expect(s.goalMet).toBe(false);
+  });
+
+  it("flags goalMet with the success tone when donations equal costs", () => {
+    const s = deriveBreakEven(8200, 8200);
+    expect(s.goalMet).toBe(true);
+    expect(s.tone).toBe("success");
+  });
+
+  it("flags goalMet when donations exceed costs (pct can exceed 100)", () => {
+    const s = deriveBreakEven(11000, 8200);
+    expect(s.goalMet).toBe(true);
+    expect(s.pct).toBeGreaterThan(100);
+  });
+
+  it("treats unconfigured (zero) costs as 0% and not goalMet", () => {
+    const s = deriveBreakEven(0, 0);
+    expect(s.pct).toBe(0);
+    expect(s.goalMet).toBe(false);
+    expect(s.noDonations).toBe(true);
+  });
+});
+
+describe("breakEvenStatusLine", () => {
+  it("thanks the donor when the goal is met", () => {
+    expect(breakEvenStatusLine(deriveBreakEven(9000, 8200))).toMatch(/thank you/i);
+  });
+
+  it("invites the first donation when there are none", () => {
+    expect(breakEvenStatusLine(deriveBreakEven(0, 8200))).toMatch(/be the first/i);
+  });
+
+  it("reports the percentage covered otherwise", () => {
+    expect(breakEvenStatusLine(deriveBreakEven(4700, 8200))).toMatch(/57% of this month/i);
+  });
+});

--- a/packages/shared-frontend/src/__tests__/useTransparency.test.tsx
+++ b/packages/shared-frontend/src/__tests__/useTransparency.test.tsx
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+import { useTransparency } from "../components/widgets/useTransparency";
+
+const DATA = {
+  month: "June 2026",
+  costs_cents: 8200,
+  donations_cents: 4700,
+  updated_at: null,
+  configured: true,
+};
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("useTransparency", () => {
+  it("returns ok with data on a successful response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(DATA) })),
+    );
+    const { result } = renderHook(() => useTransparency());
+    await waitFor(() => expect(result.current.status).toBe("ok"));
+    expect(result.current).toEqual({ status: "ok", data: DATA });
+  });
+
+  it("omits credentials so no session token leaks to the public endpoint", async () => {
+    const fetchMock = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(DATA) }));
+    vi.stubGlobal("fetch", fetchMock);
+    renderHook(() => useTransparency());
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/transparency",
+      expect.objectContaining({ credentials: "omit" }),
+    );
+  });
+
+  it("returns error on a non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.resolve({ ok: false, status: 500 })));
+    const { result } = renderHook(() => useTransparency());
+    await waitFor(() => expect(result.current.status).toBe("error"));
+  });
+
+  it("returns error when the request rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("network"))));
+    const { result } = renderHook(() => useTransparency());
+    await waitFor(() => expect(result.current.status).toBe("error"));
+  });
+});

--- a/packages/shared-frontend/src/components/embed/YouTubeEmbed.tsx
+++ b/packages/shared-frontend/src/components/embed/YouTubeEmbed.tsx
@@ -1,0 +1,39 @@
+import { cn } from "../../utils/cn";
+
+interface Props {
+  /** YouTube video ID. When omitted, a "coming soon" placeholder renders instead of an iframe. */
+  videoId?: string;
+  title?: string;
+  className?: string;
+}
+
+/**
+ * Responsive 16:9 YouTube embed using the privacy-friendly nocookie host.
+ * The app CSP must allow `frame-src https://www.youtube-nocookie.com`.
+ */
+export default function YouTubeEmbed({ videoId, title = "Inspiration video", className }: Props) {
+  if (!videoId) {
+    return (
+      <div
+        className={cn(
+          "flex aspect-video w-full items-center justify-center rounded-lg bg-muted text-sm text-muted-foreground",
+          className,
+        )}
+      >
+        Video coming soon
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn("relative aspect-video w-full overflow-hidden rounded-lg bg-black", className)}>
+      <iframe
+        src={`https://www.youtube-nocookie.com/embed/${videoId}`}
+        title={title}
+        className="absolute inset-0 h-full w-full border-0"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/ui/ProgressBar.tsx
+++ b/packages/shared-frontend/src/components/ui/ProgressBar.tsx
@@ -1,0 +1,39 @@
+import { cn } from "../../utils/cn";
+
+export type ProgressTone = "warning" | "primary" | "success";
+
+interface Props {
+  /** Percentage 0–100. Values outside the range are clamped. */
+  value: number;
+  /** Human-readable description for assistive tech, e.g. "57% to break-even — $47 of $82 raised". */
+  label: string;
+  tone?: ProgressTone;
+  className?: string;
+}
+
+const TONE_FILL: Record<ProgressTone, string> = {
+  warning: "bg-yellow-400 dark:bg-yellow-500",
+  primary: "bg-primary",
+  success: "bg-green-500 dark:bg-green-400",
+};
+
+/** Accessible progress bar. Exposes role=progressbar + aria-value* so the fill is not invisible to screen readers. */
+export default function ProgressBar({ value, label, tone = "primary", className }: Props) {
+  const clamped = Math.max(0, Math.min(100, Math.round(value)));
+  return (
+    <div
+      role="progressbar"
+      aria-valuenow={clamped}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      aria-valuetext={`${clamped}%`}
+      aria-label={label}
+      className={cn("h-3 w-full overflow-hidden rounded-full bg-muted", className)}
+    >
+      <div
+        className={cn("h-full rounded-full transition-[width] duration-500", TONE_FILL[tone])}
+        style={{ width: `${clamped}%` }}
+      />
+    </div>
+  );
+}

--- a/packages/shared-frontend/src/components/widgets/KofiButton.tsx
+++ b/packages/shared-frontend/src/components/widgets/KofiButton.tsx
@@ -1,0 +1,36 @@
+import { cn } from "../../utils/cn";
+import ExternalLink from "../icons/ExternalLink";
+
+interface Props {
+  /** The Ko-fi page URL to open. */
+  url: string;
+  label?: string;
+  className?: string;
+}
+
+/**
+ * Primary donate CTA. Renders a real `<a>` (not a button) so middle-click,
+ * ctrl-click, and "copy link" work, and opens Ko-fi in a new tab. Mirrors the
+ * `Button` primary variant's classes — Button renders a `<button>` and can't be
+ * an anchor; a future `as` prop on Button could de-duplicate this.
+ */
+export default function KofiButton({ url, label = "Support on Ko-fi", className }: Props) {
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={cn(
+        "inline-flex items-center justify-center gap-2 rounded-md px-4 py-2 text-sm font-medium min-h-[44px]",
+        "bg-primary text-primary-foreground hover:opacity-90",
+        className,
+      )}
+    >
+      {label}
+      <span className="sr-only">(opens in a new tab)</span>
+      <span aria-hidden="true">
+        <ExternalLink className="h-4 w-4" />
+      </span>
+    </a>
+  );
+}

--- a/packages/shared-frontend/src/components/widgets/TransparencySkeleton.tsx
+++ b/packages/shared-frontend/src/components/widgets/TransparencySkeleton.tsx
@@ -1,0 +1,23 @@
+import Card from "../ui/Card";
+import Skeleton from "../ui/Skeleton";
+
+/** Loading placeholder that mirrors the TransparencyWidget layout to avoid layout shift. */
+export default function TransparencySkeleton() {
+  return (
+    <Card>
+      <div className="space-y-4">
+        <Skeleton className="h-5 w-48" />
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+        <div className="flex items-center justify-between">
+          <Skeleton className="h-4 w-24" />
+          <Skeleton className="h-4 w-16" />
+        </div>
+        <Skeleton className="h-3 w-full rounded-full" />
+        <Skeleton className="h-4 w-40" />
+      </div>
+    </Card>
+  );
+}

--- a/packages/shared-frontend/src/components/widgets/TransparencyWidget.tsx
+++ b/packages/shared-frontend/src/components/widgets/TransparencyWidget.tsx
@@ -1,0 +1,73 @@
+import { formatCurrency } from "../../utils/currency";
+import { timeAgo } from "../../utils/date";
+import Card from "../ui/Card";
+import ProgressBar from "../ui/ProgressBar";
+import StatusBadge from "../ui/StatusBadge";
+import TransparencySkeleton from "./TransparencySkeleton";
+import { useTransparency } from "./useTransparency";
+import { deriveBreakEven, breakEvenStatusLine } from "./breakEven";
+
+/**
+ * Platform-wide cost-transparency widget: this month's server costs vs donations
+ * received, with a break-even progress bar. Self-fetches the shared, public
+ * transparency endpoint. Renders nothing until the operator has configured costs,
+ * so apps can ship this before any numbers exist.
+ */
+export default function TransparencyWidget() {
+  const result = useTransparency();
+
+  if (result.status === "loading") return <TransparencySkeleton />;
+
+  // Read-only page — a visitor can't fix a backend outage, so stay quiet (no retry).
+  if (result.status === "error") {
+    return (
+      <Card>
+        <p className="text-center text-sm text-muted-foreground">
+          Cost and donation data is temporarily unavailable.
+        </p>
+      </Card>
+    );
+  }
+
+  const { data } = result;
+
+  // Costs not configured yet (fresh deploy) — hide entirely rather than show "$0 of $0".
+  if (!data.configured) return null;
+
+  const donations = data.donations_cents / 100;
+  const costs = data.costs_cents / 100;
+  const state = deriveBreakEven(data.donations_cents, data.costs_cents);
+  const statusLine = breakEvenStatusLine(state);
+
+  return (
+    <Card>
+      <div className="space-y-4">
+        <div className="flex items-baseline justify-between gap-4">
+          <h2 className="text-base font-medium">{data.month} — running costs</h2>
+          {state.goalMet ? <StatusBadge tone="success" label="Goal met this month" /> : null}
+        </div>
+
+        <div className="space-y-2 text-sm">
+          <div className="flex items-baseline justify-between gap-4">
+            <span className="text-muted-foreground">Donations</span>
+            <span className="font-semibold tabular-nums">{formatCurrency(donations)}</span>
+          </div>
+          <div className="flex items-baseline justify-between gap-4">
+            <span className="text-muted-foreground">Server costs</span>
+            <span className="font-semibold tabular-nums">{formatCurrency(costs)}</span>
+          </div>
+        </div>
+
+        <ProgressBar value={state.pct} tone={state.tone} label="Monthly hosting cost coverage" />
+
+        <p className="text-sm text-muted-foreground">{statusLine}</p>
+
+        {data.updated_at ? (
+          <p className="text-xs text-muted-foreground">
+            Updated automatically — last synced {timeAgo(data.updated_at)}.
+          </p>
+        ) : null}
+      </div>
+    </Card>
+  );
+}

--- a/packages/shared-frontend/src/components/widgets/breakEven.ts
+++ b/packages/shared-frontend/src/components/widgets/breakEven.ts
@@ -1,0 +1,29 @@
+import type { ProgressTone } from "../ui/ProgressBar";
+
+export interface BreakEvenState {
+  /** Donations as a percentage of costs (0–∞; the bar clamps the visual to 100). */
+  pct: number;
+  tone: ProgressTone;
+  goalMet: boolean;
+  noDonations: boolean;
+}
+
+/** Pure derivation of the break-even state from raw cent amounts. */
+export function deriveBreakEven(donationsCents: number, costsCents: number): BreakEvenState {
+  const pct = costsCents > 0 ? (donationsCents / costsCents) * 100 : 0;
+  const goalMet = costsCents > 0 && donationsCents >= costsCents;
+  const noDonations = donationsCents === 0;
+
+  let tone: ProgressTone = "warning";
+  if (goalMet) tone = "success";
+  else if (pct >= 50) tone = "primary";
+
+  return { pct, tone, goalMet, noDonations };
+}
+
+/** Short, human status line shown under the progress bar. */
+export function breakEvenStatusLine(state: BreakEvenState): string {
+  if (state.goalMet) return "You've covered this month's costs — thank you.";
+  if (state.noDonations) return "No donations yet this month — be the first.";
+  return `${Math.round(state.pct)}% of this month's costs covered.`;
+}

--- a/packages/shared-frontend/src/components/widgets/useTransparency.ts
+++ b/packages/shared-frontend/src/components/widgets/useTransparency.ts
@@ -1,0 +1,54 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Platform-wide cost-transparency figures for the current month.
+ * Served by the shared, public `GET /transparency` endpoint (platform_shared, PR2).
+ * Amounts are in cents to avoid float rounding — divide by 100 for display.
+ */
+export interface TransparencyData {
+  /** Display label for the period, e.g. "June 2026". */
+  month: string;
+  /** Total platform server costs for the month, in cents. */
+  costs_cents: number;
+  /** Donations received for the month, in cents (net of processor fees). */
+  donations_cents: number;
+  /** ISO timestamp of the last automated sync, or null if never synced. */
+  updated_at: string | null;
+  /** False until the operator has configured monthly costs — the widget hides itself. */
+  configured: boolean;
+}
+
+export type TransparencyResult =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "ok"; data: TransparencyData };
+
+/**
+ * Fetches the public cost-transparency figures with a plain unauthenticated
+ * request rather than the shared RTK `baseApi`. This keeps the widget truly
+ * drop-in: it behaves identically whether the host app registers the shared
+ * baseApi (MGA/MJH/MPT) or its own (MBK), and it never sends a session token
+ * to a public endpoint.
+ */
+export function useTransparency(baseUrl = "/api"): TransparencyResult {
+  const [result, setResult] = useState<TransparencyResult>({ status: "loading" });
+
+  useEffect(() => {
+    const controller = new AbortController();
+    setResult({ status: "loading" });
+
+    fetch(`${baseUrl}/transparency`, { credentials: "omit", signal: controller.signal })
+      .then((res) =>
+        res.ok ? (res.json() as Promise<TransparencyData>) : Promise.reject(new Error(`HTTP ${res.status}`)),
+      )
+      .then((data) => setResult({ status: "ok", data }))
+      .catch((err: unknown) => {
+        if (err instanceof DOMException && err.name === "AbortError") return;
+        setResult({ status: "error" });
+      });
+
+    return () => controller.abort();
+  }, [baseUrl]);
+
+  return result;
+}

--- a/packages/shared-frontend/src/index.ts
+++ b/packages/shared-frontend/src/index.ts
@@ -32,6 +32,8 @@ export { default as Badge } from "./components/ui/Badge";
 export { default as StatusBadge } from "./components/ui/StatusBadge";
 export type { StatusBadgeProps, BadgeTone } from "./components/ui/StatusBadge";
 export { default as Card } from "./components/ui/Card";
+export { default as ProgressBar } from "./components/ui/ProgressBar";
+export type { ProgressTone } from "./components/ui/ProgressBar";
 export { default as FormField } from "./components/ui/FormField";
 export { default as Toaster } from "./components/ui/Toaster";
 export { default as TurnstileWidget } from "./components/ui/TurnstileWidget";
@@ -69,6 +71,12 @@ export type { PaginationProps } from "./components/data/Pagination";
 // Upload components
 export { default as FileUploadDropzone } from "./components/upload/FileUploadDropzone";
 export type { FileUploadDropzoneProps } from "./components/upload/FileUploadDropzone";
+
+// Support / donation page (shared across all apps)
+export { default as Support } from "./pages/Support";
+export { default as TransparencyWidget } from "./components/widgets/TransparencyWidget";
+export { default as KofiButton } from "./components/widgets/KofiButton";
+export { default as YouTubeEmbed } from "./components/embed/YouTubeEmbed";
 
 // Hooks
 export { useMediaQuery } from "./hooks/useMediaQuery";

--- a/packages/shared-frontend/src/pages/Support.tsx
+++ b/packages/shared-frontend/src/pages/Support.tsx
@@ -1,0 +1,82 @@
+import { Link } from "react-router-dom";
+import YouTubeEmbed from "../components/embed/YouTubeEmbed";
+import KofiButton from "../components/widgets/KofiButton";
+import TransparencyWidget from "../components/widgets/TransparencyWidget";
+
+/** Shared Ko-fi page for all MyFreeApps. PLACEHOLDER — operator updates to the real handle. */
+const DEFAULT_KOFI_URL = "https://ko-fi.com/myfreeapps";
+
+interface Props {
+  /** Host app name, used in the "← Back to {appName}" link, e.g. "MyBookkeeper". */
+  appName: string;
+  /** Where the back link points. Defaults to the app root. */
+  homePath?: string;
+  /** Override the shared Ko-fi page URL. */
+  kofiUrl?: string;
+  /** Unlisted YouTube video ID for the inspiration video. Omit to show a "coming soon" placeholder. */
+  youtubeVideoId?: string;
+}
+
+/**
+ * Public "Support" page shared across every MyFreeApps app: the maker's story,
+ * an inspiration video, a live cost-transparency widget, and a single Ko-fi
+ * donate CTA. Renders as a standalone page (no auth, no app shell) so logged-out
+ * visitors can reach it. Content is platform-wide and identical across apps;
+ * only the back-link target differs per app.
+ */
+export default function Support({
+  appName,
+  homePath = "/",
+  kofiUrl = DEFAULT_KOFI_URL,
+  youtubeVideoId,
+}: Props) {
+  return (
+    <div className="min-h-screen bg-background">
+      <div className="max-w-3xl mx-auto px-6 py-12">
+        <div className="mb-8">
+          <Link to={homePath} className="text-sm text-muted-foreground hover:underline">
+            ← Back to {appName}
+          </Link>
+        </div>
+
+        <h1 className="text-3xl font-bold mb-2">Why MyFreeApps is free</h1>
+        <p className="text-sm text-muted-foreground mb-10">
+          A solo-developer project, supported by the people who use it.
+        </p>
+
+        <div className="space-y-10">
+          <section className="space-y-3 text-sm leading-relaxed">
+            <h2 className="sr-only">About MyFreeApps</h2>
+            <p>
+              I build these apps for my own use and decided not to charge for them — they're more
+              useful to me, and to everyone, the more people use them. {appName} and the other
+              MyFreeApps tools are free: no ads, no trackers, and nothing sold.
+            </p>
+            <p>
+              I pay for the servers that run them out of my own pocket. If one of these apps has saved
+              you time or money, a small donation helps cover hosting and keeps them running and
+              maintained — every dollar goes straight to costs.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="sr-only">The story behind these apps</h2>
+            <YouTubeEmbed videoId={youtubeVideoId} title="Why I built MyFreeApps" />
+          </section>
+
+          <section>
+            <TransparencyWidget />
+          </section>
+
+          <section className="flex flex-col items-center gap-3 text-center">
+            <h2 className="sr-only">Support these apps</h2>
+            <KofiButton url={kofiUrl} />
+            <p className="text-xs text-muted-foreground">
+              Donations are handled securely by Ko-fi — you don't need an account.
+            </p>
+          </section>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What & why

PR1 of 4 for a public **/support page on every MyFreeApps app** — the maker's story, an inspiration video, a single **Ko-fi** donate button, and a live **cost-transparency widget** (this month's server costs vs donations, with a break-even progress bar). Goal: break even on hosting.

This PR adds the shared UI to **`@platform/ui`** only. It is **not wired into any app yet** (that's PR3), so merging it is low-risk — it just adds unused, fully-tested shared components.

## What's in this PR

New under `packages/shared-frontend/src`:
- **`pages/Support.tsx`** — first shared *page* in the lib; standalone public shell mirroring `PrivacyPolicy.tsx` (no auth, no app shell). Per-app only the back-link target differs.
- **`components/widgets/TransparencyWidget`** (+ extracted `TransparencySkeleton`, + pure `breakEven.ts`) — self-fetches the public transparency endpoint; handles loading (skeleton) / error (quiet) / not-configured (hides) / zero ("be the first") / over-100% ("Goal met").
- **`components/widgets/useTransparency.ts`** — plain unauthenticated `fetch` rather than the shared RTK `baseApi`. See note below.
- **`components/widgets/KofiButton`** — real `<a>` (new tab, `rel=noopener`, sr-only hint, `aria-hidden` icon).
- **`components/embed/YouTubeEmbed`** — responsive 16:9 `youtube-nocookie` iframe; "coming soon" placeholder when no video id.
- **`components/ui/ProgressBar`** — accessible (`role=progressbar` + `aria-value*`/`aria-valuetext`).
- Barrel exports + 7 Vitest specs.

## Design / review

- **g-design-ux** pass up front: proof-before-ask section order, skeleton/empty/error states, ARIA on the progress bar, real-anchor Ko-fi CTA.
- **g-review-frontend** pass caught a real **P0**: injecting the transparency endpoint into the shared `baseApi` would have **silently broken MyBookkeeper** (it registers its own `baseApi`; MGA/MJH/MPT use the shared one). Fixed by switching to a self-contained `fetch` hook (`credentials: "omit"`) — works identically in all 4 apps and never sends a session token to a public endpoint.

## Tests

`npm run typecheck` clean; all 7 new specs green. (2 unrelated **pre-existing** failures in `InlineBoldText.test.tsx` — a whitespace-normalization assertion — were not touched by this PR.)

## Deferred to follow-up PRs

- **PR2** (`platform_shared`): Ko-fi webhook receiver + `GET /transparency` (public, aggregate, cached) returning `{month, costs_cents, donations_cents, updated_at, configured}` + shared-MinIO-object store + optional Anthropic cost poller + boot guard + operational-migration docs.
- **PR3**: wire `/support` route + footer/nav/login links into all 4 apps + add `frame-src https://www.youtube-nocookie.com` to each `docker/Caddyfile.docker`.
- **PR4**: wire into `infra/templates/scaffold/` so future apps inherit it.

## Operator inputs needed (non-blocking — placeholders ship)

- Inspiration story copy (bullets → I'll draft)
- Unlisted YouTube video id
- Real Ko-fi page URL (placeholder: `ko-fi.com/myfreeapps` in `Support.tsx`)
- Decide: auto-pull Claude API cost via Anthropic admin key, or a manual monthly constant

🤖 Generated with [Claude Code](https://claude.com/claude-code)