### PR TITLE
feat(mga): lineup library publish pipeline — export pack + import CLI (PR B)

### DIFF
--- a/apps/mygamingassistant/backend/app/cli/__init__.py
+++ b/apps/mygamingassistant/backend/app/cli/__init__.py
@@ -2,6 +2,7 @@
 
 Usage:
     python -m app.cli load-fixtures
+    python -m app.cli import-lineups [pack.json]
     python -m app.cli backfill-clips
     python -m app.cli backfill-technique
     python -m app.cli backfill-landing-clips
@@ -143,6 +144,16 @@ def main() -> None:
         from app.services.game.fixture_loader import load_fixtures_standalone
         asyncio.run(load_fixtures_standalone())
         print("Fixtures loaded successfully.")
+    elif command == "import-lineups":
+        # Seeds the public read-only library from the image-baked pack
+        # (apps/.../backend/data/lineup_library.json → /app/data/...). Run
+        # AFTER load-fixtures (it resolves the pack's game/map/zone/utility
+        # slugs against the seeded taxonomy). Optional path arg overrides the
+        # baked default. See app/services/game/lineup_importer.py.
+        from app.services.game.lineup_importer import import_lineups_standalone
+        pack_path = sys.argv[2] if len(sys.argv) > 2 else None
+        stats = asyncio.run(import_lineups_standalone(pack_path))
+        print(stats.summary())
     elif command == "backfill-clips":
         sys.exit(asyncio.run(_run_backfill_clips()))
     elif command == "backfill-technique":
@@ -157,6 +168,7 @@ def main() -> None:
         print(f"Unknown command: {command!r}")
         print("Available commands:")
         print("  load-fixtures          — load game taxonomy fixtures into the database")
+        print("  import-lineups [pack]  — seed the public library from a published pack (after load-fixtures)")
         print("  backfill-clips         — generate clips for accepted lineups missing one")
         print("  backfill-technique     — name throw-technique for accepted lineups missing one")
         print("  backfill-landing-clips — generate landing clips for accepted lineups missing one")

--- a/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
@@ -200,26 +200,31 @@ async def upsert_map_zone(
     slug: str,
     name: str,
     polygon_points: list[list[float]] | None = None,
+    force_polygon: bool = False,
 ) -> MapZone:
-    """Insert a zone if missing; backfill an empty polygon if the fixture has one.
+    """Insert a zone if missing; backfill/refresh its polygon per the rules below.
 
-    Backfill rule (idempotent, conservative):
-    - The (map_id, slug) zone already exists, AND
-    - its stored ``polygon_points`` is empty/falsy, AND
-    - the incoming ``polygon_points`` is non-empty
-      → write the incoming polygon onto the existing row and flush.
+    Polygon write rule (idempotent, conservative):
+    - existing + EMPTY stored polygon + non-empty incoming → write incoming
+      (the fixture-backfill case; always applies).
+    - existing + NON-EMPTY stored polygon + non-empty incoming → write incoming
+      ONLY when ``force_polygon=True``.
+    - a non-empty stored polygon is NEVER cleared to empty (a falsy incoming
+      is ignored), regardless of ``force_polygon``.
 
-    A zone that already has a non-empty polygon is NEVER overwritten — this
-    protects operator-drawn polygons (the #656 zone editor) from being
-    clobbered by a re-run of ``load-fixtures``. Re-running with the same
-    fixture is a no-op once the polygon is populated.
+    ``load-fixtures`` leaves ``force_polygon=False`` so operator-drawn polygons
+    (the #656 zone editor) are never clobbered by a re-run. The library
+    IMPORTER (``lineup_importer``) passes ``force_polygon=True`` because the
+    published pack is the authoritative source for prod's serve-only library —
+    a polygon the operator refined locally must reach prod, where there is no
+    editor to redraw it.
     """
     result = await db.execute(
         select(MapZone).where(MapZone.map_id == map_id, MapZone.slug == slug)
     )
     existing = result.scalar_one_or_none()
     if existing is not None:
-        if not existing.polygon_points and polygon_points:
+        if polygon_points and (force_polygon or not existing.polygon_points):
             existing.polygon_points = polygon_points
             await db.flush()
         return existing
@@ -232,6 +237,24 @@ async def upsert_map_zone(
     db.add(zone)
     await db.flush()
     return zone
+
+
+async def get_utility_type_by_slug(
+    db: AsyncSession, game_id: uuid.UUID, slug: str
+) -> UtilityType | None:
+    """Return the (game_id, slug) utility type, or None.
+
+    Used by the library importer to resolve a pack lineup's
+    ``utility_type_slug`` to the prod-side UUID. Utility types are seeded by
+    ``load-fixtures`` (which runs before import), so a None here means the
+    fixtures were not loaded — the importer treats that as a hard error.
+    """
+    result = await db.execute(
+        select(UtilityType).where(
+            UtilityType.game_id == game_id, UtilityType.slug == slug
+        )
+    )
+    return result.scalar_one_or_none()
 
 
 async def update_zone_polygons_bulk(

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup/__init__.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup/__init__.py
@@ -30,6 +30,7 @@ from app.repositories.game.lineup.lifecycle import (
     list_lineups,
     list_pending_lineups,
     update_lineup,
+    upsert_imported_lineup,
     write_classifier_suggestions,
 )
 from app.repositories.game.lineup.micro_panes import (
@@ -68,6 +69,7 @@ __all__ = [
     "list_accepted_lineups_needing_widen_source",
     "list_lineups",
     "list_pending_lineups",
+    "upsert_imported_lineup",
     "set_aim_clip_url",
     "set_aim_localization",
     "set_aim_screenshot_url",

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup/lifecycle.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup/lifecycle.py
@@ -66,6 +66,40 @@ async def create_lineup(db: AsyncSession, data: dict) -> Lineup:
     return lineup
 
 
+async def upsert_imported_lineup(
+    db: AsyncSession,
+    *,
+    lineup_id: uuid.UUID,
+    fields: dict,
+) -> Lineup:
+    """Insert (with an EXPLICIT id) or update an accepted lineup from a pack.
+
+    The library importer (``app.services.game.lineup_importer``) calls this
+    once per pack lineup. ``fields`` carries the resolved prod-side FK UUIDs
+    plus the public scalar columns and must NOT include ``status`` — it is
+    forced to 'accepted' (only accepted lineups are ever exported, and the
+    importer publishes a serve-ready library).
+
+    Idempotent by verbatim id: re-importing the same pack updates the existing
+    row in place (never duplicates), so a re-run after a clip re-publish or a
+    pack refresh converges. Flush-only — unlike ``create_lineup`` this does
+    NOT commit, because the importer owns a single ``unit_of_work`` so the
+    whole pack imports atomically (a mid-import failure rolls the entire
+    library back rather than leaving prod half-populated).
+    """
+    existing = await db.get(Lineup, lineup_id)
+    if existing is not None:
+        for key, value in fields.items():
+            setattr(existing, key, value)
+        existing.status = "accepted"
+        await db.flush()
+        return existing
+    lineup = Lineup(id=lineup_id, status="accepted", **fields)
+    db.add(lineup)
+    await db.flush()
+    return lineup
+
+
 async def list_lineups(
     db: AsyncSession,
     filters: LineupFilters,

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup_repo.py
@@ -40,6 +40,7 @@ from app.repositories.game.lineup import (
     set_stand_screenshot_url,
     set_technique,
     update_lineup,
+    upsert_imported_lineup,
     write_classifier_suggestions,
     zone_density,
 )
@@ -73,6 +74,7 @@ __all__ = [
     "set_stand_screenshot_url",
     "set_technique",
     "update_lineup",
+    "upsert_imported_lineup",
     "write_classifier_suggestions",
     "zone_density",
 ]

--- a/apps/mygamingassistant/backend/app/repositories/game/source_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/source_repo.py
@@ -29,6 +29,35 @@ async def create_source(
     return source
 
 
+async def upsert_source(
+    db: AsyncSession,
+    *,
+    source_id: uuid.UUID,
+    kind: str,
+    config_json: dict,
+) -> Source:
+    """Insert a source with an EXPLICIT id, or update an existing one. Flush-only.
+
+    Used by the library importer to re-create the sources a published pack
+    references, carrying their verbatim UUIDs so a lineup's ``source_id`` FK
+    resolves with no slug indirection (sources are not fixtures → their PKs do
+    not collide and are safe to import by id). Idempotent: re-running updates
+    ``kind`` / ``config_json`` in place. Uses ``db.get`` (not ``get_source``)
+    so a soft-deleted row is still located and refreshed rather than
+    duplicated. The caller owns the transaction (no commit here).
+    """
+    existing = await db.get(Source, source_id)
+    if existing is not None:
+        existing.kind = kind
+        existing.config_json = config_json
+        await db.flush()
+        return existing
+    source = Source(id=source_id, kind=kind, config_json=config_json)
+    db.add(source)
+    await db.flush()
+    return source
+
+
 def _is_deleted(source: Source) -> bool:
     return bool((source.config_json or {}).get("deleted"))
 

--- a/apps/mygamingassistant/backend/app/services/game/lineup_exporter.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_exporter.py
@@ -1,0 +1,182 @@
+"""Build a portable, prod-reproducible pack of the accepted lineup library.
+
+The serve-only prod deploy (Cloudflare R2 + read-only library — see
+``memory/project_mga_prod_storage_r2.md``) is seeded from a committed JSON
+pack rather than a DB dump: ``load-fixtures`` upserts game/map/zone/utility
+with non-deterministic ``uuid4`` PKs, so local and prod zone UUIDs differ.
+The pack therefore carries lineup FKs as **slugs** (game / map / target-zone
+/ stand-zone / utility) and the importer (:mod:`app.services.game.lineup_importer`)
+resolves slug→prod-UUID. The lineup's and source's OWN UUIDs travel
+**verbatim** — they are not fixtures, so their PKs never collide and
+re-import by id is idempotent.
+
+This module is the EXPORT half (the importer is the symmetric IMPORT half).
+The local runner ``scripts/export_lineup_pack.py`` is a thin wrapper that
+opens a session, calls :func:`build_pack`, and writes the JSON file; keeping
+the logic here (committed) lets the round-trip test exercise a real
+export→import in CI, where the untracked ``scripts/`` dir does not exist.
+
+Excluded from the pack (deliberately — mirrors the public read shape in
+``lineup_service._build_read``): the operator-only ``*_original`` /
+``*_trim_*`` / ``*_offset_s`` clip-editor state, the ``suggested_*`` /
+``classification_*`` review-queue columns, and the
+``stand_ts`` / ``aim_ts`` / ``*_localized_at`` localization-authoring state.
+None of those are needed to SERVE a finished, accepted lineup; shipping them
+would leak pre-trim frames or stale authoring state to prod.
+"""
+from __future__ import annotations
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.models.game.lineup import Lineup
+
+# Bump when the pack shape changes in a way the importer must branch on. The
+# importer validates this so an old binary can't silently mis-read a newer pack.
+PACK_VERSION = 1
+
+# Public scalar columns copied verbatim into each pack lineup — the subset of
+# the ``LineupRead`` shape that is neither an FK id (carried as a slug) nor
+# operator-only authoring state. ``side`` is a scalar enum string, so it lives
+# here rather than with the resolved FK slugs.
+LINEUP_SCALAR_FIELDS: tuple[str, ...] = (
+    "title",
+    "notes",
+    "side",
+    "stand_screenshot_url",
+    "aim_screenshot_url",
+    "clip_url",
+    "landing_clip_url",
+    "stand_clip_url",
+    "aim_clip_url",
+    "aim_anchor_x",
+    "aim_anchor_y",
+    "stand_anchor_x",
+    "stand_anchor_y",
+    "target_anchor_x",
+    "target_anchor_y",
+    "setup_seconds",
+    "technique",
+    "youtube_video_id",
+    "chapter_start_seconds",
+    "chapter_title",
+    "attribution_url",
+    "attribution_author",
+)
+
+# The 6 public object keys ``publish_clips_to_r2`` ships from local MinIO → R2.
+# One source of truth shared by the publish script (and any verifier) so the
+# set can't drift from what the read path signs in ``lineup_service``.
+PUBLIC_OBJECT_KEY_FIELDS: tuple[str, ...] = (
+    "stand_screenshot_url",
+    "aim_screenshot_url",
+    "clip_url",
+    "landing_clip_url",
+    "stand_clip_url",
+    "aim_clip_url",
+)
+
+
+class MalformedAcceptedLineup(Exception):
+    """An accepted lineup is missing an FK the CHECK constraint should guarantee."""
+
+
+async def build_pack(db: AsyncSession) -> dict:
+    """Return the full accepted-lineup library as a JSON-serializable pack dict.
+
+    Deterministic: zones and sources are sorted by their natural keys, lineups
+    by ``(youtube_video_id, chapter_start_seconds, id)``, and no timestamp is
+    embedded — so re-running against unchanged data yields a byte-identical
+    file (no spurious git churn in the committed ``data/lineup_library.json``).
+
+    Raises :class:`MalformedAcceptedLineup` if any accepted row is missing a
+    classification FK (the ``ck_lineup_accepted_classified`` CHECK should make
+    this impossible; failing loud beats shipping an unresolvable lineup).
+    """
+    rows = (
+        (
+            await db.execute(
+                select(Lineup)
+                .where(Lineup.status == "accepted")
+                .options(
+                    selectinload(Lineup.game),
+                    selectinload(Lineup.map),
+                    selectinload(Lineup.target_zone),
+                    selectinload(Lineup.stand_zone),
+                    selectinload(Lineup.utility_type),
+                    selectinload(Lineup.source),
+                )
+                .order_by(
+                    Lineup.youtube_video_id,
+                    Lineup.chapter_start_seconds,
+                    Lineup.id,
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    # Dedup referenced zones by (game_slug, map_slug, zone_slug) and sources by
+    # id so the pack carries each once even when many lineups share them.
+    zones: dict[tuple[str, str, str], dict] = {}
+    sources: dict[str, dict] = {}
+    lineups_out: list[dict] = []
+
+    for lineup in rows:
+        missing = [
+            attr
+            for attr in ("game", "map", "target_zone", "stand_zone", "utility_type")
+            if getattr(lineup, attr) is None
+        ]
+        if lineup.side is None:
+            missing.append("side")
+        if missing:
+            raise MalformedAcceptedLineup(
+                f"accepted lineup {lineup.id} ({lineup.title!r}) is missing: "
+                + ", ".join(missing)
+            )
+
+        game_slug = lineup.game.slug
+        map_slug = lineup.map.slug
+
+        for zone in (lineup.target_zone, lineup.stand_zone):
+            zones[(game_slug, map_slug, zone.slug)] = {
+                "game_slug": game_slug,
+                "map_slug": map_slug,
+                "zone_slug": zone.slug,
+                "name": zone.name,
+                "polygon_points": zone.polygon_points or [],
+            }
+
+        if lineup.source is not None:
+            sources[str(lineup.source.id)] = {
+                "id": str(lineup.source.id),
+                "kind": lineup.source.kind,
+                "config_json": lineup.source.config_json or {},
+            }
+
+        entry: dict = {
+            "id": str(lineup.id),
+            "game_slug": game_slug,
+            "map_slug": map_slug,
+            "target_zone_slug": lineup.target_zone.slug,
+            "stand_zone_slug": lineup.stand_zone.slug,
+            "utility_type_slug": lineup.utility_type.slug,
+            "source_id": str(lineup.source_id) if lineup.source_id else None,
+        }
+        for field in LINEUP_SCALAR_FIELDS:
+            entry[field] = getattr(lineup, field)
+        lineups_out.append(entry)
+
+    return {
+        "version": PACK_VERSION,
+        "lineup_count": len(lineups_out),
+        "zones": sorted(
+            zones.values(),
+            key=lambda z: (z["game_slug"], z["map_slug"], z["zone_slug"]),
+        ),
+        "sources": sorted(sources.values(), key=lambda s: s["id"]),
+        "lineups": lineups_out,
+    }

--- a/apps/mygamingassistant/backend/app/services/game/lineup_importer.py
+++ b/apps/mygamingassistant/backend/app/services/game/lineup_importer.py
@@ -1,0 +1,220 @@
+"""Import a published lineup-library pack into the database.
+
+The symmetric IMPORT half of :mod:`app.services.game.lineup_exporter`. Unlike
+the export runner this ships in the app image, so prod seeds its read-only
+library with:
+
+    docker compose exec api python -m app.cli import-lineups
+
+The pack is baked into the image at ``/app/data/lineup_library.json`` (the
+committed ``apps/mygamingassistant/backend/data/lineup_library.json`` — it
+lives UNDER ``backend/`` so the backend Dockerfile's ``COPY .../backend/ /app/``
+carries it in; a sibling ``apps/mygamingassistant/data/`` would NOT ship).
+An explicit path argument overrides the baked default.
+
+Resolution model (see :mod:`app.services.game.lineup_exporter` for the why):
+``load-fixtures`` runs first, so game / map / utility / zone slugs already
+exist with prod-side ``uuid4`` PKs. This importer resolves each pack lineup's
+FK SLUGS to those prod UUIDs, upserts the referenced zones (publishing
+operator-refined polygons via ``force_polygon=True``) and sources (by verbatim
+id), then upserts each lineup by verbatim id. The whole pack imports inside ONE
+``unit_of_work`` transaction — atomic: a malformed pack rolls the entire
+library back rather than leaving prod half-populated. Idempotent + re-runnable
+(re-import after a clip re-publish or pack refresh converges).
+"""
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db.session import unit_of_work
+from app.repositories.game import game_repo, source_repo
+from app.repositories.game.lineup import upsert_imported_lineup
+from app.services.game.lineup_exporter import LINEUP_SCALAR_FIELDS, PACK_VERSION
+
+logger = logging.getLogger(__name__)
+
+# Baked into the image by the backend Dockerfile (``COPY .../backend/ /app/``),
+# so ``parents[3]`` is ``/app`` in the container and the backend dir locally:
+#   .../app/services/game/lineup_importer.py
+#   parents[0]=game parents[1]=services parents[2]=app parents[3]=<backend root>
+_DEFAULT_PACK_PATH = (
+    Path(__file__).resolve().parents[3] / "data" / "lineup_library.json"
+)
+
+
+class PackError(Exception):
+    """The pack is unusable — wrong version, or references an unseeded slug.
+
+    Raised (not logged-and-skipped) so a bad pack aborts the whole import
+    transaction; partial libraries are worse than a clear failure the operator
+    can act on (run ``load-fixtures``, rebuild the pack, etc.).
+    """
+
+
+@dataclass
+class ImportStats:
+    zones_upserted: int = 0
+    sources_upserted: int = 0
+    lineups_upserted: int = 0
+
+    def summary(self) -> str:
+        return (
+            f"Imported {self.lineups_upserted} lineup(s), "
+            f"{self.zones_upserted} zone(s), {self.sources_upserted} source(s)."
+        )
+
+
+def _require_zone(
+    zone_id_by_key: dict[tuple[str, str, str], uuid.UUID],
+    lineup: dict,
+    slug_key: str,
+) -> uuid.UUID:
+    """Resolve a lineup's zone slug to the prod zone UUID, or fail loud.
+
+    ``build_pack`` always carries every referenced zone in ``pack["zones"]``,
+    so a miss means a hand-edited or truncated pack — abort rather than create
+    a lineup with a dangling FK.
+    """
+    slug = lineup[slug_key]
+    key = (lineup["game_slug"], lineup["map_slug"], slug)
+    zone_id = zone_id_by_key.get(key)
+    if zone_id is None:
+        raise PackError(
+            f"lineup {lineup['id']} references {slug_key}={slug!r} "
+            f"(map {lineup['map_slug']!r}) which is not in pack['zones']"
+        )
+    return zone_id
+
+
+async def import_pack(db: AsyncSession, pack: dict) -> ImportStats:
+    """Upsert an entire pack into *db* (flush-only; caller owns the commit).
+
+    Used directly by the round-trip test (against a transactional session) and
+    via :func:`import_lineups_standalone` (which wraps it in ``unit_of_work``).
+    """
+    version = pack.get("version")
+    if version != PACK_VERSION:
+        raise PackError(
+            f"pack version {version!r} != supported {PACK_VERSION!r}; "
+            "rebuild the pack (export_lineup_pack.py) or upgrade the app."
+        )
+
+    stats = ImportStats()
+    game_cache: dict[str, object] = {}
+    map_cache: dict[tuple[str, str], object] = {}
+    zone_id_by_key: dict[tuple[str, str, str], uuid.UUID] = {}
+
+    async def _resolve_game(slug: str):
+        if slug not in game_cache:
+            game = await game_repo.get_game_by_slug(db, slug)
+            if game is None:
+                raise PackError(
+                    f"game slug {slug!r} not found — run load-fixtures before import."
+                )
+            game_cache[slug] = game
+        return game_cache[slug]
+
+    async def _resolve_map(game_slug: str, map_slug: str):
+        key = (game_slug, map_slug)
+        if key not in map_cache:
+            game = await _resolve_game(game_slug)
+            map_obj = await game_repo.get_map_by_slug(db, game.id, map_slug)
+            if map_obj is None:
+                raise PackError(
+                    f"map slug {map_slug!r} (game {game_slug!r}) not found — "
+                    "run load-fixtures before import."
+                )
+            map_cache[key] = map_obj
+        return map_cache[key]
+
+    # 1) Sources — verbatim id (not fixtures, no slug indirection).
+    for src in pack.get("sources", []):
+        await source_repo.upsert_source(
+            db,
+            source_id=uuid.UUID(src["id"]),
+            kind=src["kind"],
+            config_json=src.get("config_json") or {},
+        )
+        stats.sources_upserted += 1
+
+    # 2) Zones — upsert (publishing operator-refined polygons) and build the
+    #    (game_slug, map_slug, zone_slug) → prod-UUID lookup the lineups need.
+    for zone in pack.get("zones", []):
+        map_obj = await _resolve_map(zone["game_slug"], zone["map_slug"])
+        upserted = await game_repo.upsert_map_zone(
+            db,
+            map_id=map_obj.id,
+            slug=zone["zone_slug"],
+            name=zone["name"],
+            polygon_points=zone.get("polygon_points") or [],
+            force_polygon=True,
+        )
+        zone_id_by_key[
+            (zone["game_slug"], zone["map_slug"], zone["zone_slug"])
+        ] = upserted.id
+        stats.zones_upserted += 1
+
+    # 3) Lineups — resolve FK slugs → prod UUIDs, upsert by verbatim id.
+    for lineup in pack.get("lineups", []):
+        game = await _resolve_game(lineup["game_slug"])
+        map_obj = await _resolve_map(lineup["game_slug"], lineup["map_slug"])
+        util = await game_repo.get_utility_type_by_slug(
+            db, game.id, lineup["utility_type_slug"]
+        )
+        if util is None:
+            raise PackError(
+                f"utility slug {lineup['utility_type_slug']!r} "
+                f"(game {lineup['game_slug']!r}) not found — "
+                "run load-fixtures before import."
+            )
+
+        fields: dict = {
+            "game_id": game.id,
+            "map_id": map_obj.id,
+            "target_zone_id": _require_zone(zone_id_by_key, lineup, "target_zone_slug"),
+            "stand_zone_id": _require_zone(zone_id_by_key, lineup, "stand_zone_slug"),
+            "utility_type_id": util.id,
+            "source_id": (
+                uuid.UUID(lineup["source_id"]) if lineup.get("source_id") else None
+            ),
+        }
+        # Public scalar columns travel verbatim (same list the exporter wrote).
+        for scalar in LINEUP_SCALAR_FIELDS:
+            fields[scalar] = lineup.get(scalar)
+
+        await upsert_imported_lineup(
+            db, lineup_id=uuid.UUID(lineup["id"]), fields=fields
+        )
+        stats.lineups_upserted += 1
+
+    return stats
+
+
+async def import_lineups_standalone(path: Optional[str] = None) -> ImportStats:
+    """Load a pack file and import it in its own ``unit_of_work``. Used by the CLI.
+
+    *path* defaults to the image-baked pack; pass an explicit path to import a
+    different file (ops / testing). The single ``unit_of_work`` makes the whole
+    import atomic — a ``PackError`` partway through rolls everything back.
+    """
+    pack_path = Path(path) if path else _DEFAULT_PACK_PATH
+    if not pack_path.is_file():
+        raise PackError(f"pack file not found: {pack_path}")
+
+    pack = json.loads(pack_path.read_text(encoding="utf-8"))
+    logger.info(
+        "lineup_importer: importing pack %s (%d lineups)",
+        pack_path,
+        len(pack.get("lineups", [])),
+    )
+    async with unit_of_work() as db:
+        stats = await import_pack(db, pack)
+    logger.info("lineup_importer: %s", stats.summary())
+    return stats

--- a/apps/mygamingassistant/backend/data/lineup_library.json
+++ b/apps/mygamingassistant/backend/data/lineup_library.json
@@ -1,0 +1,1655 @@
+{
+  "version": 1,
+  "lineup_count": 35,
+  "zones": [
+    {
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "zone_slug": "a-main",
+      "name": "A Main",
+      "polygon_points": [
+        {
+          "x": 0.58,
+          "y": 0.46
+        },
+        {
+          "x": 0.73,
+          "y": 0.46
+        },
+        {
+          "x": 0.73,
+          "y": 0.64
+        },
+        {
+          "x": 0.58,
+          "y": 0.64
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "zone_slug": "a-site",
+      "name": "A Site",
+      "polygon_points": [
+        {
+          "x": 0.65,
+          "y": 0.2
+        },
+        {
+          "x": 0.8,
+          "y": 0.2
+        },
+        {
+          "x": 0.8,
+          "y": 0.35
+        },
+        {
+          "x": 0.65,
+          "y": 0.35
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "zone_slug": "b-main",
+      "name": "B Main",
+      "polygon_points": [
+        {
+          "x": 0.27,
+          "y": 0.58
+        },
+        {
+          "x": 0.42,
+          "y": 0.58
+        },
+        {
+          "x": 0.42,
+          "y": 0.74
+        },
+        {
+          "x": 0.27,
+          "y": 0.74
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "zone_slug": "b-site",
+      "name": "B Site",
+      "polygon_points": [
+        {
+          "x": 0.23,
+          "y": 0.43
+        },
+        {
+          "x": 0.38,
+          "y": 0.43
+        },
+        {
+          "x": 0.38,
+          "y": 0.57
+        },
+        {
+          "x": 0.23,
+          "y": 0.57
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "zone_slug": "ct-spawn",
+      "name": "CT Spawn",
+      "polygon_points": [
+        {
+          "x": 0.37,
+          "y": 0.13
+        },
+        {
+          "x": 0.54,
+          "y": 0.13
+        },
+        {
+          "x": 0.54,
+          "y": 0.27
+        },
+        {
+          "x": 0.37,
+          "y": 0.27
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "zone_slug": "mid",
+      "name": "Mid",
+      "polygon_points": [
+        {
+          "x": 0.43,
+          "y": 0.42
+        },
+        {
+          "x": 0.57,
+          "y": 0.42
+        },
+        {
+          "x": 0.57,
+          "y": 0.58
+        },
+        {
+          "x": 0.43,
+          "y": 0.58
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "zone_slug": "t-spawn",
+      "name": "T Spawn",
+      "polygon_points": [
+        {
+          "x": 0.4,
+          "y": 0.76
+        },
+        {
+          "x": 0.57,
+          "y": 0.76
+        },
+        {
+          "x": 0.57,
+          "y": 0.88
+        },
+        {
+          "x": 0.4,
+          "y": 0.88
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "a-main",
+      "name": "A Main",
+      "polygon_points": [
+        {
+          "x": 0.58,
+          "y": 0.46
+        },
+        {
+          "x": 0.73,
+          "y": 0.46
+        },
+        {
+          "x": 0.73,
+          "y": 0.64
+        },
+        {
+          "x": 0.58,
+          "y": 0.64
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "a-palace",
+      "name": "Palace",
+      "polygon_points": [
+        {
+          "x": 0.29,
+          "y": 0.34
+        },
+        {
+          "x": 0.41,
+          "y": 0.34
+        },
+        {
+          "x": 0.41,
+          "y": 0.47
+        },
+        {
+          "x": 0.29,
+          "y": 0.47
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "a-site",
+      "name": "A Site",
+      "polygon_points": [
+        {
+          "x": 0.17,
+          "y": 0.22
+        },
+        {
+          "x": 0.31,
+          "y": 0.22
+        },
+        {
+          "x": 0.32,
+          "y": 0.34
+        },
+        {
+          "x": 0.16,
+          "y": 0.35
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "b-apts",
+      "name": "B Apartments",
+      "polygon_points": [
+        {
+          "x": 0.26,
+          "y": 0.68
+        },
+        {
+          "x": 0.41,
+          "y": 0.68
+        },
+        {
+          "x": 0.41,
+          "y": 0.8
+        },
+        {
+          "x": 0.26,
+          "y": 0.8
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "b-site",
+      "name": "B Site",
+      "polygon_points": [
+        {
+          "x": 0.27,
+          "y": 0.55
+        },
+        {
+          "x": 0.42,
+          "y": 0.55
+        },
+        {
+          "x": 0.42,
+          "y": 0.7
+        },
+        {
+          "x": 0.27,
+          "y": 0.7
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "catwalk",
+      "name": "Catwalk",
+      "polygon_points": [
+        {
+          "x": 0.4,
+          "y": 0.36
+        },
+        {
+          "x": 0.53,
+          "y": 0.36
+        },
+        {
+          "x": 0.53,
+          "y": 0.49
+        },
+        {
+          "x": 0.4,
+          "y": 0.49
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "connector",
+      "name": "Connector",
+      "polygon_points": [
+        {
+          "x": 0.41,
+          "y": 0.47
+        },
+        {
+          "x": 0.52,
+          "y": 0.47
+        },
+        {
+          "x": 0.52,
+          "y": 0.56
+        },
+        {
+          "x": 0.41,
+          "y": 0.56
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "ct-spawn",
+      "name": "CT Spawn",
+      "polygon_points": [
+        {
+          "x": 0.78,
+          "y": 0.3
+        },
+        {
+          "x": 0.92,
+          "y": 0.3
+        },
+        {
+          "x": 0.92,
+          "y": 0.45
+        },
+        {
+          "x": 0.78,
+          "y": 0.45
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "jungle",
+      "name": "Jungle",
+      "polygon_points": [
+        {
+          "x": 0.32,
+          "y": 0.36
+        },
+        {
+          "x": 0.42,
+          "y": 0.36
+        },
+        {
+          "x": 0.42,
+          "y": 0.45
+        },
+        {
+          "x": 0.32,
+          "y": 0.45
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "market",
+      "name": "Market",
+      "polygon_points": [
+        {
+          "x": 0.41,
+          "y": 0.56
+        },
+        {
+          "x": 0.52,
+          "y": 0.56
+        },
+        {
+          "x": 0.52,
+          "y": 0.7
+        },
+        {
+          "x": 0.41,
+          "y": 0.7
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "mid",
+      "name": "Mid",
+      "polygon_points": [
+        {
+          "x": 0.46,
+          "y": 0.49
+        },
+        {
+          "x": 0.59,
+          "y": 0.49
+        },
+        {
+          "x": 0.59,
+          "y": 0.69
+        },
+        {
+          "x": 0.46,
+          "y": 0.69
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "t-spawn",
+      "name": "T Spawn",
+      "polygon_points": [
+        {
+          "x": 0.42,
+          "y": 0.76
+        },
+        {
+          "x": 0.6,
+          "y": 0.76
+        },
+        {
+          "x": 0.6,
+          "y": 0.87
+        },
+        {
+          "x": 0.42,
+          "y": 0.87
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "ticket-booth",
+      "name": "Ticket",
+      "polygon_points": [
+        {
+          "x": 0.42,
+          "y": 0.34
+        },
+        {
+          "x": 0.55,
+          "y": 0.34
+        },
+        {
+          "x": 0.55,
+          "y": 0.42
+        },
+        {
+          "x": 0.42,
+          "y": 0.42
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "top-mid",
+      "name": "Top Mid",
+      "polygon_points": [
+        {
+          "x": 0.62,
+          "y": 0.45
+        },
+        {
+          "x": 0.78,
+          "y": 0.45
+        },
+        {
+          "x": 0.78,
+          "y": 0.55
+        },
+        {
+          "x": 0.62,
+          "y": 0.55
+        }
+      ]
+    },
+    {
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "zone_slug": "window",
+      "name": "Mid Window",
+      "polygon_points": [
+        {
+          "x": 0.53,
+          "y": 0.4
+        },
+        {
+          "x": 0.63,
+          "y": 0.4
+        },
+        {
+          "x": 0.63,
+          "y": 0.5
+        },
+        {
+          "x": 0.53,
+          "y": 0.5
+        }
+      ]
+    }
+  ],
+  "sources": [
+    {
+      "id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "kind": "youtube_playlist",
+      "config_json": {
+        "url": "https://www.youtube.com/playlist?list=PLCv9jk0KUJbeIkPAGvBA_YziLAFZntOU_",
+        "last_synced_at": null,
+        "last_sync_stats": {
+          "synced_at": "2026-05-21T22:03:47.261400+00:00",
+          "error_count": 0,
+          "video_count": 1,
+          "chapter_count": 1
+        }
+      }
+    },
+    {
+      "id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "kind": "youtube_playlist",
+      "config_json": {
+        "url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+        "map_hint": "anubis",
+        "game_hint": "cs2"
+      }
+    },
+    {
+      "id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "kind": "youtube_playlist",
+      "config_json": {
+        "url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+        "map_hint": "mirage",
+        "game_hint": "cs2"
+      }
+    }
+  ],
+  "lineups": [
+    {
+      "id": "7c2e4ddd-b3be-45ea-bc0a-21507140b911",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "mid",
+      "stand_zone_slug": "mid",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "DEEP MID SMOKE",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/22-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/22-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/22-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/22-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 22,
+      "chapter_title": "DEEP MID SMOKE",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "5b2fc963-e870-4911-971a-6fbd1c34b1e6",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "b-main",
+      "stand_zone_slug": "mid",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "MID - E BOX",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/36-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/36-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/36-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/36-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 36,
+      "chapter_title": "MID - E BOX",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "0728a4eb-9005-4123-b3ee-edc6bc37dfa8",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "mid",
+      "stand_zone_slug": "mid",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "MID - TEMPLE",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/88-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/88-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/88-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/88-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 88,
+      "chapter_title": "MID - TEMPLE",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "7d8ce27b-d102-4124-99e6-f644db6ab6ce",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "mid",
+      "stand_zone_slug": "mid",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "MID - CAMERA",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/112-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/112-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/112-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/112-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 112,
+      "chapter_title": "MID - CAMERA",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "c40a153a-fc86-4cb6-95d4-e9c26d5546f8",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "mid",
+      "stand_zone_slug": "ct-spawn",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "CT SIDE - T STAIRS",
+      "notes": null,
+      "side": "side_b",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/134-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/134-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/134-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/134-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 134,
+      "chapter_title": "CT SIDE - T STAIRS",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "aed96742-f5ea-4f2a-ba01-63ad51d7cf6e",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "mid",
+      "stand_zone_slug": "ct-spawn",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "CT SIDE - DEEP MID CROSS",
+      "notes": null,
+      "side": "side_b",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/188-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/188-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/188-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/188-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 188,
+      "chapter_title": "CT SIDE - DEEP MID CROSS",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "62a21add-c0ad-4295-8ceb-ff69b8be5a26",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "a-main",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "A SITE - HEAVEN",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/212-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/212-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/212-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/212-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 212,
+      "chapter_title": "A SITE - HEAVEN",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "64e02461-2178-44ee-8693-b6f1a635eb81",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "a-main",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "A SITE - CAMERA",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/232-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/232-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/232-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/232-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 232,
+      "chapter_title": "A SITE - CAMERA",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "fce5d2ce-5488-4887-b6c4-fd94dd3f743e",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "a-main",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "A SITE - PLAT",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/268-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/268-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/268-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/268-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 268,
+      "chapter_title": "A SITE - PLAT",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "ff8a117c-2e02-40ac-ba18-89987a6d5bdc",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "a-main",
+      "utility_type_slug": "flash",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "A SITE FLASH",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/300-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/300-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/300-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/300-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 300,
+      "chapter_title": "A SITE FLASH",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "dc00a42e-fae4-4793-98b2-311425b18bea",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "b-main",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "B SITE - RIGHT SIDE SITE",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/332-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/332-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/332-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/332-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 332,
+      "chapter_title": "B SITE - RIGHT SIDE SITE",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "f6769e2a-fb09-4b5f-8e71-248b9bdba66c",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "b-main",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "B SITE - LEFT SIDE SITE",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/362-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/362-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/362-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/362-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 362,
+      "chapter_title": "B SITE - LEFT SIDE SITE",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "06592f07-fc3e-4bc8-90f0-623128d7825e",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "b-main",
+      "utility_type_slug": "molotov",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "B SITE - PILLAR",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/378-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/378-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/378-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/378-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 378,
+      "chapter_title": "B SITE - PILLAR",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "db0425df-6870-4c5c-a11b-7a4ab5507547",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "b-main",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "B SITE - E BOX",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/394-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/394-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/394-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/394-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 394,
+      "chapter_title": "B SITE - E BOX",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "19f96e0b-9932-48bf-8a71-5b3a8b99c6aa",
+      "game_slug": "cs2",
+      "map_slug": "anubis",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "t-spawn",
+      "utility_type_slug": "smoke",
+      "source_id": "19aa1ce8-05ad-4f57-80aa-93cab40cfa95",
+      "title": "LEFT SIDE SITE FROM SPAWN",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/et6AZ5a5k3I/430-clip.mp4",
+      "landing_clip_url": "pending/et6AZ5a5k3I/430-landing.mp4",
+      "stand_clip_url": "pending/et6AZ5a5k3I/430-stand-micro.mp4",
+      "aim_clip_url": "pending/et6AZ5a5k3I/430-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing",
+      "youtube_video_id": "et6AZ5a5k3I",
+      "chapter_start_seconds": 430,
+      "chapter_title": "LEFT SIDE SITE FROM SPAWN",
+      "attribution_url": "https://www.youtube.com/watch?v=et6AZ5a5k3I",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "45d89ec3-77bf-4ce4-bf11-68c4bddc10e8",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "mid",
+      "stand_zone_slug": "t-spawn",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Mid Window from T Spawn",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/15-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/15-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/15-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/15-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/15-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/15-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.4,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 15,
+      "chapter_title": "Mid Window from T Spawn",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "f7e8c6b1-7f3e-4f49-8ba2-8b61f08074aa",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "connector",
+      "stand_zone_slug": "t-spawn",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Connector from T Spawn",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/81-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/81-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/81-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/81-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/81-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/81-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.5,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 81,
+      "chapter_title": "Connector from T Spawn",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "5a1ff0a1-c62f-41f5-8f5b-d5418a89e3a3",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "catwalk",
+      "stand_zone_slug": "t-spawn",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Catwalk from T Spawn",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/115-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/115-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/115-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/115-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/115-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/115-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.5,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Run + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 115,
+      "chapter_title": "Catwalk from T Spawn",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "11d47f96-b1d6-46ef-a8de-4de0a84dca15",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "mid",
+      "stand_zone_slug": "t-spawn",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Mid Cross from T spawn",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/141-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/141-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/141-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/141-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/141-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/141-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.5,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 141,
+      "chapter_title": "Mid Cross from T spawn",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "8e151f60-e03c-4851-9b09-24c1489830d9",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "mid",
+      "stand_zone_slug": "t-spawn",
+      "utility_type_slug": "molotov",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Mid Window from Top Mid",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/157-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/157-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/157-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/157-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/157-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/157-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.5,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 157,
+      "chapter_title": "Mid Window from Top Mid",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "8f92c010-89bf-4ea1-92cf-f023cde40931",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "catwalk",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Catwalk - B Site",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/218-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/218-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/218-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/218-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/218-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/218-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.5,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 218,
+      "chapter_title": "Catwalk - B Site",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "7bd971c3-d222-47c2-8ae8-5befa5fb9592",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "window",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Market Window - B Site",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/256-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/256-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/256-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/256-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/256-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/256-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.4,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 256,
+      "chapter_title": "Market Window - B Site",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "69704f4a-5aae-4ebf-bd42-40f763ae6a98",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "market",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Market Door - B Site",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/290-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/290-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/290-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/290-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/290-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/290-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.4,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 290,
+      "chapter_title": "Market Door - B Site",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "89c4bfd9-6ca0-4c7d-a27e-792fea7eaec4",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "ticket-booth",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Ticket/CT - A Site",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/335-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/335-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/335-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/335-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/335-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/335-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.5,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Jumpthrow + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 335,
+      "chapter_title": "Ticket/CT - A Site",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "f88308e3-bfc0-4855-a27e-4b823a8613eb",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "jungle",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Jungle - A Site",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/371-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/371-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/371-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/371-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/371-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/371-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": "Standing + LMB",
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 371,
+      "chapter_title": "Jungle - A Site",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "9b2ad4c9-bc94-45d7-88e7-9fb6e9834f4a",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "a-main",
+      "utility_type_slug": "smoke",
+      "source_id": "1006e6cd-5d9c-46bc-a822-d1728cc5b2bb",
+      "title": "Stairs - A Site",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": "pending/Q4Dwg9Z0wZ0/403-stand.png",
+      "aim_screenshot_url": "pending/Q4Dwg9Z0wZ0/403-aim.png",
+      "clip_url": "pending/Q4Dwg9Z0wZ0/403-clip.mp4",
+      "landing_clip_url": "pending/Q4Dwg9Z0wZ0/403-landing.mp4",
+      "stand_clip_url": "pending/Q4Dwg9Z0wZ0/403-stand-micro.mp4",
+      "aim_clip_url": "pending/Q4Dwg9Z0wZ0/403-aim-micro.mp4",
+      "aim_anchor_x": 0.5,
+      "aim_anchor_y": 0.5,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "Q4Dwg9Z0wZ0",
+      "chapter_start_seconds": 403,
+      "chapter_title": "Stairs - A Site",
+      "attribution_url": "https://www.youtube.com/watch?v=Q4Dwg9Z0wZ0",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "f5091b69-4e3e-4eee-9f0c-da1ffc25897b",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "a-palace",
+      "utility_type_slug": "flash",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "A Site - Site Flash",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/75-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/75-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/75-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/75-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 75,
+      "chapter_title": "A Site - Site Flash",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "be028514-0a46-4205-ac8b-283a2b0fe7fa",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "a-site",
+      "stand_zone_slug": "a-palace",
+      "utility_type_slug": "molotov",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "A Site - Firebox Molotov",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/122-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/122-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/122-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/122-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 122,
+      "chapter_title": "A Site - Firebox Molotov",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "41e5aeb7-31d3-4df3-b207-18b4293be070",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "a-palace",
+      "stand_zone_slug": "ct-spawn",
+      "utility_type_slug": "molotov",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "CT Side - A Main Molotov",
+      "notes": null,
+      "side": "side_b",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/139-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/139-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/139-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/139-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 139,
+      "chapter_title": "CT Side - A Main Molotov",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "af132e36-17a7-4620-bcd6-2788bfcd70aa",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "top-mid",
+      "stand_zone_slug": "mid",
+      "utility_type_slug": "flash",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "Mid - Cross Flash",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/284-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/284-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/284-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/284-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 284,
+      "chapter_title": "Mid - Cross Flash",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "b62a5b2d-4047-4d71-9d7a-8655a5290dde",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "window",
+      "stand_zone_slug": "top-mid",
+      "utility_type_slug": "molotov",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "Top Mid - Window Molotov",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/343-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/343-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/343-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/343-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 343,
+      "chapter_title": "Top Mid - Window Molotov",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "99764d5a-b741-4bf5-a82e-42f9c015a45b",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "b-apts",
+      "utility_type_slug": "molotov",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "B Site - Balcony Molotov",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/452-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/452-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/452-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/452-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 452,
+      "chapter_title": "B Site - Balcony Molotov",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "a9ef72c4-6756-41e9-a540-3828c3499775",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "b-apts",
+      "utility_type_slug": "molotov",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "B Site - Bench Molotov",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/479-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/479-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/479-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/479-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 479,
+      "chapter_title": "B Site - Bench Molotov",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "4d792787-6fa4-4090-b199-143298874ef6",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "b-site",
+      "stand_zone_slug": "b-apts",
+      "utility_type_slug": "flash",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "B Site - Site Flash",
+      "notes": null,
+      "side": "side_a",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/514-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/514-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/514-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/514-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 514,
+      "chapter_title": "B Site - Site Flash",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    },
+    {
+      "id": "bbdbfdcd-4542-42f7-bb82-53a0dc451248",
+      "game_slug": "cs2",
+      "map_slug": "mirage",
+      "target_zone_slug": "b-apts",
+      "stand_zone_slug": "ct-spawn",
+      "utility_type_slug": "molotov",
+      "source_id": "640d7c0d-5325-4302-beda-bb04afe3e38c",
+      "title": "CT Side - Aps Door Molotovs",
+      "notes": null,
+      "side": "side_b",
+      "stand_screenshot_url": null,
+      "aim_screenshot_url": null,
+      "clip_url": "pending/SGeV9W39X68/566-clip.mp4",
+      "landing_clip_url": "pending/SGeV9W39X68/566-landing.mp4",
+      "stand_clip_url": "pending/SGeV9W39X68/566-stand-micro.mp4",
+      "aim_clip_url": "pending/SGeV9W39X68/566-aim-micro.mp4",
+      "aim_anchor_x": null,
+      "aim_anchor_y": null,
+      "stand_anchor_x": null,
+      "stand_anchor_y": null,
+      "target_anchor_x": null,
+      "target_anchor_y": null,
+      "setup_seconds": null,
+      "technique": null,
+      "youtube_video_id": "SGeV9W39X68",
+      "chapter_start_seconds": 566,
+      "chapter_title": "CT Side - Aps Door Molotovs",
+      "attribution_url": "https://www.youtube.com/watch?v=SGeV9W39X68",
+      "attribution_author": "Tigerr"
+    }
+  ]
+}

--- a/apps/mygamingassistant/backend/tests/test_lineup_pack_roundtrip.py
+++ b/apps/mygamingassistant/backend/tests/test_lineup_pack_roundtrip.py
@@ -1,0 +1,335 @@
+"""Round-trip tests for the lineup-library publish pipeline (PR B).
+
+Exercises the real export → clear → import path that seeds prod's read-only
+library from a committed pack (apps/.../backend/data/lineup_library.json):
+
+- ``lineup_exporter.build_pack`` dumps accepted lineups with FKs as SLUGS and
+  verbatim lineup/source UUIDs;
+- ``lineup_importer.import_pack`` resolves those slugs to the local prod-side
+  UUIDs and upserts zones (force-publishing refined polygons) + sources (by
+  id) + lineups (by verbatim id).
+
+Fully transactional — every test runs on the SAVEPOINT-bound ``db`` fixture
+(conftest) and rolls back at teardown, so the shared dev DB is NEVER mutated
+(no DROP, no commit). The CLI-dispatch smoke mocks the importer so even it
+cannot reach a real database.
+
+Isolation note: ``build_pack`` reads the WHOLE accepted library, and the
+shared local dev DB already holds ~35 real accepted lineups. So every test
+seeds its own ``rt-*`` taxonomy and scopes assertions + re-import to that one
+game via :func:`_scope_pack` — it never asserts global counts and never
+deletes a lineup it didn't create.
+"""
+from __future__ import annotations
+
+import sys
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.game.game import Game
+from app.models.game.lineup import Lineup
+from app.models.game.map import Map
+from app.models.game.map_zone import MapZone
+from app.models.game.source import Source
+from app.models.game.utility_type import UtilityType
+from app.services.game.lineup_exporter import (
+    LINEUP_SCALAR_FIELDS,
+    PACK_VERSION,
+    build_pack,
+)
+from app.services.game.lineup_importer import ImportStats, PackError, import_pack
+
+_RT_GAME = "rt-game"
+_A_SITE_POLY = [{"x": 0.10, "y": 0.10}, {"x": 0.20, "y": 0.10}, {"x": 0.20, "y": 0.20}]
+
+
+@pytest_asyncio.fixture
+async def seeded(db: AsyncSession) -> dict:
+    """A self-contained taxonomy: game, map, 2 zones (one with a polygon), util, source.
+
+    Uses ``rt-`` slugs (not real ``cs2`` / ``mirage``) so the fixture never
+    collides with the real taxonomy that already lives in the shared local dev
+    DB — ``game.slug`` is globally unique. The round-trip is self-consistent:
+    build_pack reads whatever slugs we seed and import resolves them back.
+    """
+    game = Game(slug=_RT_GAME, name="RT Game", side_a_label="T", side_b_label="CT")
+    db.add(game)
+    await db.flush()
+
+    map_obj = Map(game_id=game.id, slug="rt-map", name="RT Map")
+    db.add(map_obj)
+    await db.flush()
+
+    zone_a = MapZone(
+        map_id=map_obj.id, slug="rt-a-site", name="A Site", polygon_points=_A_SITE_POLY
+    )
+    zone_t = MapZone(
+        map_id=map_obj.id, slug="rt-t-spawn", name="T Spawn", polygon_points=[]
+    )
+    db.add_all([zone_a, zone_t])
+    await db.flush()
+
+    util = UtilityType(game_id=game.id, slug="rt-smoke", name="Smoke")
+    db.add(util)
+    await db.flush()
+
+    source = Source(
+        kind="youtube_playlist",
+        config_json={"url": "https://youtube.com/playlist?list=ROUNDTRIP"},
+    )
+    db.add(source)
+    await db.flush()
+
+    return {
+        "game": game,
+        "map": map_obj,
+        "zone_a": zone_a,
+        "zone_t": zone_t,
+        "util": util,
+        "source": source,
+    }
+
+
+async def _make_accepted(db: AsyncSession, seeded: dict, *, title: str, **overrides) -> Lineup:
+    fields = dict(
+        game_id=seeded["game"].id,
+        map_id=seeded["map"].id,
+        target_zone_id=seeded["zone_a"].id,
+        stand_zone_id=seeded["zone_t"].id,
+        utility_type_id=seeded["util"].id,
+        side="side_a",
+        title=title,
+        status="accepted",
+        source_id=seeded["source"].id,
+        clip_url="u/l/throw.mp4",
+        stand_screenshot_url="u/l/stand.png",
+        aim_screenshot_url="u/l/aim.png",
+        stand_clip_url="u/l/stand.mp4",
+        aim_clip_url="u/l/aim.mp4",
+        landing_clip_url="u/l/landing.mp4",
+        aim_anchor_x=0.5,
+        aim_anchor_y=0.4,
+        setup_seconds=8,
+        technique="Jumpthrow",
+        youtube_video_id="vid12345",
+        chapter_start_seconds=42,
+        chapter_title="A site smoke",
+        attribution_author="Tigerr",
+    )
+    fields.update(overrides)
+    lineup = Lineup(**fields)
+    db.add(lineup)
+    await db.flush()
+    return lineup
+
+
+def _scope_pack(pack: dict, *, game_slug: str = _RT_GAME) -> dict:
+    """Slice a full library pack down to one game's entities.
+
+    ``build_pack`` exports the whole accepted library (which, in the shared dev
+    DB, includes the real cs2/anubis lineups). Scoping to the test's ``rt-game``
+    keeps assertions and re-import isolated from rows the test didn't create.
+    """
+    lineups = [ln for ln in pack["lineups"] if ln["game_slug"] == game_slug]
+    zones = [z for z in pack["zones"] if z["game_slug"] == game_slug]
+    src_ids = {ln["source_id"] for ln in lineups if ln["source_id"]}
+    sources = [s for s in pack["sources"] if s["id"] in src_ids]
+    return {
+        "version": pack["version"],
+        "lineup_count": len(lineups),
+        "zones": zones,
+        "sources": sources,
+        "lineups": lineups,
+    }
+
+
+async def _scoped_pack(db: AsyncSession) -> dict:
+    return _scope_pack(await build_pack(db))
+
+
+async def _delete(db: AsyncSession, *lineups: Lineup) -> None:
+    """ORM-delete specific lineups (so the importer's db.get upsert sees a miss).
+
+    Only ever deletes lineups the test created — never the real library rows."""
+    for lineup in lineups:
+        await db.delete(lineup)
+    await db.flush()
+
+
+async def _count_by_ids(db: AsyncSession, ids: set[uuid.UUID]) -> int:
+    return (
+        await db.execute(
+            select(func.count()).select_from(Lineup).where(Lineup.id.in_(ids))
+        )
+    ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_export_shape_carries_slugs_and_verbatim_ids(db: AsyncSession, seeded: dict):
+    l1 = await _make_accepted(db, seeded, title="Smoke A")
+
+    pack = await _scoped_pack(db)
+
+    assert pack["version"] == PACK_VERSION
+    assert pack["lineup_count"] == 1
+    entry = pack["lineups"][0]
+    # Identity travels verbatim; FKs travel as slugs.
+    assert entry["id"] == str(l1.id)
+    assert entry["game_slug"] == _RT_GAME
+    assert entry["map_slug"] == "rt-map"
+    assert entry["utility_type_slug"] == "rt-smoke"
+    assert entry["target_zone_slug"] == "rt-a-site"
+    assert entry["stand_zone_slug"] == "rt-t-spawn"
+    assert entry["side"] == "side_a"
+    assert entry["source_id"] == str(seeded["source"].id)
+    # Public scalar columns present; operator-only fields absent.
+    assert entry["clip_url"] == "u/l/throw.mp4"
+    assert entry["technique"] == "Jumpthrow"
+    assert "clip_url_original" not in entry
+    assert "stand_clip_offset_s" not in entry
+    assert "suggested_game_id" not in entry
+    assert "stand_ts" not in entry
+    # Referenced zones + source deduped.
+    assert {z["zone_slug"] for z in pack["zones"]} == {"rt-a-site", "rt-t-spawn"}
+    assert len(pack["sources"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_export_import_roundtrip_resolves_slugs_to_prod_uuids(
+    db: AsyncSession, seeded: dict
+):
+    l1 = await _make_accepted(db, seeded, title="Smoke A")
+    l2 = await _make_accepted(db, seeded, title="Smoke B", clip_url="u/l2/throw.mp4")
+    original_ids = {l1.id, l2.id}
+
+    pack = await _scoped_pack(db)
+    assert pack["lineup_count"] == 2
+
+    await _delete(db, l1, l2)
+    assert await _count_by_ids(db, original_ids) == 0
+
+    stats = await import_pack(db, pack)
+    assert stats.lineups_upserted == 2
+    assert stats.zones_upserted == 2
+    assert stats.sources_upserted == 1
+
+    rows = (
+        await db.execute(
+            select(Lineup).where(Lineup.id.in_(original_ids)).order_by(Lineup.title)
+        )
+    ).scalars().all()
+    assert {r.id for r in rows} == original_ids  # verbatim ids preserved
+    smoke_a = rows[0]
+    assert smoke_a.title == "Smoke A"
+    # Slugs resolved back to the SAME prod-side UUIDs.
+    assert smoke_a.game_id == seeded["game"].id
+    assert smoke_a.map_id == seeded["map"].id
+    assert smoke_a.target_zone_id == seeded["zone_a"].id
+    assert smoke_a.stand_zone_id == seeded["zone_t"].id
+    assert smoke_a.utility_type_id == seeded["util"].id
+    assert smoke_a.source_id == seeded["source"].id
+    # Scalars + forced status survive the round-trip.
+    assert smoke_a.status == "accepted"
+    assert smoke_a.side == "side_a"
+    assert smoke_a.clip_url == "u/l/throw.mp4"
+    assert smoke_a.setup_seconds == 8
+    assert smoke_a.technique == "Jumpthrow"
+    assert smoke_a.attribution_author == "Tigerr"
+
+
+@pytest.mark.asyncio
+async def test_import_is_idempotent(db: AsyncSession, seeded: dict):
+    l1 = await _make_accepted(db, seeded, title="Smoke A")
+    pack = await _scoped_pack(db)
+    await _delete(db, l1)
+
+    await import_pack(db, pack)
+    await import_pack(db, pack)  # re-run must converge, not duplicate
+
+    assert await _count_by_ids(db, {l1.id}) == 1
+
+
+@pytest.mark.asyncio
+async def test_import_force_publishes_refined_polygon(db: AsyncSession, seeded: dict):
+    """A refined polygon in the pack overwrites prod's existing one (serve-only
+    prod has no editor to redraw it). Backfill-only upsert would NOT overwrite."""
+    await _make_accepted(db, seeded, title="Smoke A")
+    zone_a_id = seeded["zone_a"].id  # capture before expire_all (expired attr access = sync IO)
+    pack = await _scoped_pack(db)
+
+    refined = [{"x": 0.50, "y": 0.50}, {"x": 0.60, "y": 0.50}, {"x": 0.60, "y": 0.60}]
+    for zone in pack["zones"]:
+        if zone["zone_slug"] == "rt-a-site":
+            zone["polygon_points"] = refined
+
+    # Prod currently has a DIFFERENT non-empty polygon for rt-a-site.
+    seeded["zone_a"].polygon_points = [
+        {"x": 0.90, "y": 0.90},
+        {"x": 0.80, "y": 0.90},
+        {"x": 0.80, "y": 0.80},
+    ]
+    await db.flush()
+
+    await import_pack(db, pack)
+
+    # Re-read from the DB (not the in-session object) to prove it persisted.
+    db.expire_all()
+    refreshed = (
+        await db.execute(select(MapZone).where(MapZone.id == zone_a_id))
+    ).scalar_one()
+    assert refreshed.polygon_points == refined
+
+
+@pytest.mark.asyncio
+async def test_import_rejects_wrong_pack_version(db: AsyncSession):
+    bad = {"version": PACK_VERSION + 999, "zones": [], "sources": [], "lineups": []}
+    with pytest.raises(PackError, match="version"):
+        await import_pack(db, bad)
+
+
+@pytest.mark.asyncio
+async def test_import_fails_loud_on_unseeded_game_slug(db: AsyncSession):
+    """A lineup whose game slug isn't seeded (fixtures not loaded) aborts the
+    whole import rather than silently skipping."""
+    lineup = {
+        "id": str(uuid.uuid4()),
+        "game_slug": "no-such-game-rt",
+        "map_slug": "rt-map",
+        "target_zone_slug": "rt-a-site",
+        "stand_zone_slug": "rt-t-spawn",
+        "utility_type_slug": "rt-smoke",
+        "source_id": None,
+    }
+    for scalar in LINEUP_SCALAR_FIELDS:
+        lineup[scalar] = None
+    lineup["side"] = "side_a"
+    pack = {"version": PACK_VERSION, "zones": [], "sources": [], "lineups": [lineup]}
+
+    with pytest.raises(PackError, match="game slug"):
+        await import_pack(db, pack)
+
+
+def test_cli_dispatch_routes_import_lineups(monkeypatch):
+    """`python -m app.cli import-lineups <path>` dispatches to the importer with
+    the path. Mocked so the smoke test never opens a real DB session."""
+    import app.cli as cli
+
+    called: dict = {}
+
+    async def _fake_standalone(path=None):
+        called["path"] = path
+        return ImportStats(lineups_upserted=3, zones_upserted=2, sources_upserted=1)
+
+    monkeypatch.setattr(
+        "app.services.game.lineup_importer.import_lineups_standalone",
+        _fake_standalone,
+    )
+    monkeypatch.setattr(sys, "argv", ["app.cli", "import-lineups", "/tmp/pack.json"])
+
+    cli.main()
+
+    assert called["path"] == "/tmp/pack.json"


### PR DESCRIPTION
## Summary

Second half of MyGamingAssistant's first prod deploy. **PR A** (#818) shipped R2 public-CDN serving; **PR B** (this) builds the **local-authoring → publish → prod-serves-a-read-only-library** tooling for the current **35 accepted CS2 lineups** (20 Mirage + 15 Anubis).

Model: the heavy pipeline (download, frame-study, recut, classify) stays local; prod just serves finished clips + metadata. A committed JSON pack makes a fresh deploy reproducible.

## Why a slug-based pack (not a DB dump)

`load-fixtures` upserts game/map/zone/utility with non-deterministic `uuid4` PKs, so **local and prod zone UUIDs differ**. The pack therefore carries lineup FKs as **slugs**; the importer resolves slug→prod-UUID. The lineup's and source's own UUIDs travel **verbatim** (not fixtures → no collision → idempotent re-import by id).

## What ships (committed)

- **`app/services/game/lineup_exporter.py`** — `build_pack(db)`: accepted lineups → pack dict. Excludes operator-only `*_original` / trim / offset / `suggested_*` / localization fields (mirrors the public read shape). Deterministic (sorted, no timestamp) so re-exports don't churn git.
- **`app/services/game/lineup_importer.py`** — `import_pack` + `import_lineups_standalone`: resolve slug→prod-UUID, upsert zones (force-publishing operator-refined polygons), sources (by id), lineups (by verbatim id). **One `unit_of_work` → atomic** (a bad pack rolls the whole library back). Fail-loud on unseeded slug / version mismatch. Idempotent.
- **`app/cli import-lineups [pack]`** — ships in the image; defaults to the baked pack.
- **`data/lineup_library.json`** — the exported 35-lineup pack (52 KB).
- **Repo helpers** — `game_repo.get_utility_type_by_slug` + `upsert_map_zone(force_polygon=…)`; `source_repo.upsert_source` (by id); `lineup_repo.upsert_imported_lineup` (by id, flush-only).
- **`tests/test_lineup_pack_roundtrip.py`** — real export→clear→import round-trip (fully transactional — **never** touches the shared dev DB), slug→UUID resolution, idempotency, force-polygon publish, fail-loud cases, CLI dispatch smoke.

### ⚠️ Pack path note (deviation from plan)
The pack lives at **`apps/mygamingassistant/backend/data/`** (not the planned `apps/mygamingassistant/data/`). The backend Dockerfile does `COPY apps/mygamingassistant/backend/ /app/`, so only paths **under `backend/`** ship in the image. `import-lineups` defaults to the baked `/app/data/lineup_library.json`; a sibling `apps/.../data/` would force a `docker cp` bandaid.

## Local-only authoring tools (untracked `scripts/`, like the rest)
- `export_lineup_pack.py` — regenerates the committed JSON.
- `publish_clips_to_r2.py` — streams the 6 public object keys/lineup local MinIO → R2 (creds from env, never chat; `--dry-run` verified **162 objects all present locally**).

## Go-live (operator — full private runbook)
Merge → deploy → `load-fixtures` → `import-lineups` → `publish_clips_to_r2.py` → verify clips load from the R2 domain. **No boot guard / env change**, so no app-won't-boot migration — import is a manual post-deploy CLI step.

## Testing
- **866** backend tests pass locally (was 859 + 7 new).
- `check-file-size.py` clean (JSON is data, not a scanned source ext).
- Export produced the 35-lineup / 22-zone / 3-source pack; round-trip + publish dry-run both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)