### PR TITLE
feat(shared): transparency backend — Ko-fi webhook + Anthropic cost poll + public GET /transparency (PR2)

### DIFF
--- a/packages/shared-backend/platform_shared/api/transparency_router.py
+++ b/packages/shared-backend/platform_shared/api/transparency_router.py
@@ -1,0 +1,124 @@
+"""Shared transparency router factory — public endpoints, no auth.
+
+Each app mounts this with ``app.include_router(build_transparency_router(settings))``.
+Both routes are PUBLIC (the ``/support`` page is unauthenticated) and use
+resource-level paths — host Caddy strips the ``/api`` prefix and FastAPI's
+``root_path`` records it, so the router itself carries no ``/api`` (matching
+the rest of the platform's routers):
+
+    GET  /transparency             — public, cached-by-CDN-friendly read of
+                                     this month's costs vs donations. Always
+                                     200 with the TransparencyResponse shape;
+                                     ``configured=false`` tells the widget to
+                                     hide itself.
+    POST /donations/kofi-webhook   — Ko-fi donation webhook receiver. Only the
+                                     primary app has a verification token, and
+                                     Ko-fi targets exactly one URL, so only the
+                                     primary ever processes one.
+
+Read-path error mapping mirrors the widget's three states: unconfigured
+storage (dev / pre-setup) → 200 ``configured=false`` (hide); transient /
+corrupt → 503 (widget shows "temporarily unavailable"); object missing →
+200 ``configured=false``.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import ValidationError
+
+from platform_shared.schemas.common import StatusResponse
+from platform_shared.schemas.transparency import (
+    TransparencyDocument,
+    TransparencyResponse,
+)
+from platform_shared.services.transparency import kofi_service, transparency_store
+from platform_shared.services.transparency.transparency_store import (
+    S3Error,
+    StorageNotConfiguredError,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def build_transparency_router(settings: object) -> APIRouter:
+    """Construct the public transparency router bound to ``settings``.
+
+    Args:
+        settings: The app's settings object — must expose the MinIO fields,
+            ``transparency_shared_bucket``, and ``kofi_verification_token``
+            (BaseAppSettings provides all of these). Closed over by the route
+            handlers so platform_shared stays decoupled from any app's
+            concrete Settings subclass.
+    """
+    router = APIRouter(tags=["transparency"])
+
+    @router.get("/transparency", response_model=TransparencyResponse)
+    async def get_transparency() -> TransparencyResponse:
+        now = datetime.now(timezone.utc)
+        try:
+            document = transparency_store.load_document(settings)  # type: ignore[arg-type]
+        except StorageNotConfiguredError:
+            # MinIO unconfigured (local dev / before the operator sets it up).
+            # Report "not configured" so the widget hides rather than erroring.
+            return transparency_store.project_response(None, now)
+        except (S3Error, ValidationError, ValueError) as exc:
+            # Present-but-unreadable (transient outage or corrupt object) is an
+            # honest "temporarily unavailable" — don't masquerade it as "not
+            # configured", which would silently hide a real backend problem.
+            logger.warning("transparency read failed: %s", exc)
+            raise HTTPException(
+                status_code=503, detail="transparency_unavailable",
+            ) from exc
+        return transparency_store.project_response(document, now)
+
+    @router.post("/donations/kofi-webhook", response_model=StatusResponse)
+    async def kofi_webhook(request: Request) -> StatusResponse:
+        raw = await request.body()
+        payload_dict = kofi_service.parse_kofi_form_body(raw)
+        if payload_dict is None:
+            raise HTTPException(status_code=400, detail="invalid_webhook_body")
+        payload = kofi_service.KofiPayload(payload_dict)
+
+        expected = getattr(settings, "kofi_verification_token", "")
+        if not expected:
+            # Not the configured writer. Ko-fi targets exactly one URL, so this
+            # is misrouted traffic against a permanently-wrong endpoint — return
+            # 404 (not 503, which would make Ko-fi retry forever) so it stops.
+            logger.warning(
+                "Ko-fi webhook received but this app has no "
+                "KOFI_VERIFICATION_TOKEN (not the transparency primary)",
+            )
+            raise HTTPException(
+                status_code=404, detail="transparency_writer_not_configured",
+            )
+
+        if not kofi_service.verify_kofi_token(payload, expected_token=expected):
+            logger.warning(
+                "Ko-fi webhook verification_token mismatch: message_id=%s type=%s",
+                payload.message_id,
+                payload.type,
+            )
+            raise HTTPException(status_code=401, detail="invalid_verification_token")
+
+        now = datetime.now(timezone.utc)
+        try:
+            document = transparency_store.load_document(settings) or TransparencyDocument()  # type: ignore[arg-type]
+            newly_recorded = kofi_service.record_donation(document, payload, now)
+            if newly_recorded:
+                transparency_store.save_document(settings, document)  # type: ignore[arg-type]
+        except (StorageNotConfiguredError, S3Error, ValidationError, ValueError) as exc:
+            # Surface a 500 so Ko-fi retries — never silently drop a donation.
+            logger.error("Ko-fi webhook storage failure: %s", exc)
+            raise HTTPException(
+                status_code=500, detail="transparency_store_error",
+            ) from exc
+
+        return StatusResponse(status="ok" if newly_recorded else "duplicate")
+
+    return router
+
+
+__all__ = ["build_transparency_router"]

--- a/packages/shared-backend/platform_shared/core/boot_guards.py
+++ b/packages/shared-backend/platform_shared/core/boot_guards.py
@@ -194,3 +194,55 @@ def check_sms_configured(
             "raises on every send and customers never receive ready-texts. "
             "Set the credentials or set ENVIRONMENT=development."
         )
+
+
+class TransparencyNotConfiguredError(RuntimeError):
+    """Raised at boot when the transparency PRIMARY app is missing its Ko-fi token."""
+
+
+def check_transparency_configured(
+    *,
+    transparency_primary: bool,
+    kofi_verification_token: str,
+    environment: str,
+) -> None:
+    """Fail loud at boot if the transparency WRITER app can't verify webhooks.
+
+    Only the single primary app (``transparency_primary=true``) receives Ko-fi
+    donation webhooks. The receiver compares the payload's ``verification_token``
+    to ``KOFI_VERIFICATION_TOKEN``; an empty configured token rejects EVERY
+    donation as unverified — the silent-degradation failure mode these boot
+    guards exist to prevent (a deploy looks healthy while donations vanish).
+
+    Non-primary apps need nothing here: they only READ the shared object, so
+    the guard is a no-op for them. Dev/test also pass with empty config.
+
+    Args:
+        transparency_primary: Whether this app is the designated transparency
+            writer (receives the Ko-fi webhook + runs the cost poll).
+        kofi_verification_token: The Ko-fi webhook verification token. Required
+            (non-empty) when ``transparency_primary`` is true in a non-dev
+            environment.
+        environment: Deployment environment name. ``"development"`` / ``"test"``
+            allow an empty token; everything else requires it for the primary.
+
+    Raises:
+        TransparencyNotConfiguredError: If ``environment`` is not dev/test,
+            ``transparency_primary`` is true, and ``kofi_verification_token``
+            is empty.
+    """
+    if environment in _DEV_ENVIRONMENTS:
+        return
+    if not transparency_primary:
+        return
+    if kofi_verification_token:
+        return
+    raise TransparencyNotConfiguredError(
+        "TRANSPARENCY_PRIMARY=true but KOFI_VERIFICATION_TOKEN is empty. "
+        "The primary transparency app receives Ko-fi donation webhooks; "
+        "without the verification token it would reject every donation as "
+        "unverified and the /support widget would never count them. Set "
+        "KOFI_VERIFICATION_TOKEN (from your Ko-fi webhook settings), or set "
+        "TRANSPARENCY_PRIMARY=false on this app (only one app should be the "
+        "writer), or set ENVIRONMENT=development."
+    )

--- a/packages/shared-backend/platform_shared/core/lifespan.py
+++ b/packages/shared-backend/platform_shared/core/lifespan.py
@@ -72,6 +72,7 @@ from platform_shared.core.audit import register_audit_listeners
 from platform_shared.core.boot_guards import (
     check_email_configured,
     check_sms_configured,
+    check_transparency_configured,
     check_turnstile_configured,
 )
 
@@ -95,6 +96,8 @@ class _SettingsProtocol(Protocol):
     twilio_account_sid: str
     twilio_auth_token: str
     twilio_from_number: str
+    transparency_primary: bool
+    kofi_verification_token: str
 
 
 # init_sentry needs to be passed in as a callable rather than imported,
@@ -182,6 +185,14 @@ def create_app_lifespan(
                 twilio_from_number=settings.twilio_from_number,
                 environment=settings.environment,
             )
+        # Transparency writer guard — self-gating: a no-op unless this app is
+        # the primary (the single Ko-fi webhook receiver) in a non-dev env.
+        # Every app calls it; only a misconfigured primary fails to boot.
+        check_transparency_configured(
+            transparency_primary=settings.transparency_primary,
+            kofi_verification_token=settings.kofi_verification_token,
+            environment=settings.environment,
+        )
 
         # 3. Side-effect inits — wire SQLAlchemy listeners before any
         #    request handler can run a write, and verify MinIO is

--- a/packages/shared-backend/platform_shared/core/settings.py
+++ b/packages/shared-backend/platform_shared/core/settings.py
@@ -160,4 +160,35 @@ class BaseAppSettings(BaseSettings):
     # ------------------------------------------------------------------
     log_level: str = "INFO"
 
+    # ------------------------------------------------------------------
+    # Cost-transparency / Support page (platform-wide, one shared object)
+    #
+    # Every app serves a public /support page with a cost-transparency
+    # widget reading ONE shared object in ``transparency_shared_bucket``.
+    # Exactly ONE app is the WRITER (``transparency_primary=true``): it
+    # receives the Ko-fi donation webhook and runs the daily Anthropic
+    # cost poll. Every other app only READS. The writer-only secrets
+    # (Ko-fi token, admin key, cost constants) live solely in the primary
+    # app's env; non-primary apps leave them empty.
+    #
+    # ``kofi_verification_token``  Ko-fi webhook secret (compared for
+    #     equality — Ko-fi uses a static token, not HMAC). Writer only.
+    # ``anthropic_admin_api_key``  Optional sk-ant-admin... key for the
+    #     daily Cost Report pull. Empty = costs reflect the fixed
+    #     constants alone (operator declined auto-pull). Writer only.
+    # ``vps_monthly_cost_cents`` / ``domain_monthly_cost_cents``  Fixed
+    #     monthly hosting costs in cents. Writer only.
+    # ``transparency_primary``  Marks the single writer app. Default false
+    #     so every other app is read-only. NOT a secret — set in compose.
+    # ``transparency_shared_bucket``  Name of the shared MinIO bucket the
+    #     transparency object lives in. Default works platform-wide; the
+    #     operator creates the bucket once and grants every app access.
+    # ------------------------------------------------------------------
+    kofi_verification_token: str = ""
+    anthropic_admin_api_key: str = ""
+    vps_monthly_cost_cents: int = 0
+    domain_monthly_cost_cents: int = 0
+    transparency_primary: bool = False
+    transparency_shared_bucket: str = "myfreeapps-shared"
+
     model_config = {"env_file": ".env", "extra": "ignore"}

--- a/packages/shared-backend/platform_shared/schemas/transparency.py
+++ b/packages/shared-backend/platform_shared/schemas/transparency.py
@@ -1,0 +1,82 @@
+"""Schemas for the platform-wide cost-transparency surface.
+
+Two distinct shapes live here:
+
+1. ``TransparencyResponse`` — the PUBLIC wire shape returned by
+   ``GET /transparency``. It MUST match the frontend ``TransparencyData``
+   interface in ``@platform/ui`` (``components/widgets/useTransparency.ts``)
+   field-for-field: ``month``, ``costs_cents``, ``donations_cents``,
+   ``updated_at``, ``configured``. The widget hides itself when
+   ``configured`` is false and shows "temporarily unavailable" on any
+   non-200, so this endpoint always returns 200 with this shape.
+
+2. ``TransparencyDocument`` / ``MonthBucket`` — the PERSISTED shape stored
+   as a single JSON object in the shared MinIO bucket. One app (the
+   ``transparency_primary``) writes it (Ko-fi webhook → donations, daily
+   cost poll → costs); every app reads it. Per-month buckets so the widget
+   can show "this month's donations vs this month's costs"; old buckets are
+   pruned by the cost sync to bound object growth.
+
+Amounts are integer cents throughout to avoid float-rounding drift — the
+same convention the frontend documents ("divide by 100 for display").
+"""
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+# Object key for the single shared transparency document. Lives under a
+# ``transparency/`` prefix so the shared bucket can host other
+# cross-app objects in the future without collision.
+TRANSPARENCY_OBJECT_KEY = "transparency/report.json"
+
+# Number of monthly buckets to retain in the stored document. We only ever
+# display the current month; older buckets are kept briefly for debugging
+# then pruned by the cost sync so the object (and its per-month dedup id
+# lists) can't grow without bound.
+MONTHS_RETAINED = 13
+
+
+class TransparencyResponse(BaseModel):
+    """Public response for ``GET /transparency``.
+
+    Mirrors the frontend ``TransparencyData`` interface exactly. ``month``
+    is a human label (e.g. ``"June 2026"``); the two ``*_cents`` fields are
+    integer cents; ``updated_at`` is an ISO-8601 timestamp or ``None`` when
+    nothing has synced yet; ``configured`` is false until the operator has
+    configured monthly costs, which tells the widget to hide itself.
+    """
+
+    month: str
+    costs_cents: int
+    donations_cents: int
+    updated_at: str | None
+    configured: bool
+
+
+class MonthBucket(BaseModel):
+    """Per-month accumulator inside the stored document.
+
+    ``donation_message_ids`` is the dedup set: Ko-fi can re-deliver a
+    webhook, so each ``message_id`` is recorded once and re-deliveries are
+    no-ops. ``costs_cents`` is computed by the daily poll (fixed monthly
+    constants + that month's Anthropic spend); ``donations_cents`` is
+    accumulated from verified webhooks.
+    """
+
+    donations_cents: int = 0
+    costs_cents: int = 0
+    donation_message_ids: list[str] = Field(default_factory=list)
+
+
+class TransparencyDocument(BaseModel):
+    """The single shared object persisted in the shared MinIO bucket.
+
+    ``schema_version`` lets a future migration recognise older shapes.
+    ``updated_at`` is the timestamp of the most recent write of any kind
+    (donation received OR cost poll), surfaced to the widget as
+    "last synced". ``months`` maps ``"YYYY-MM"`` → :class:`MonthBucket`.
+    """
+
+    schema_version: int = 1
+    updated_at: str | None = None
+    months: dict[str, MonthBucket] = Field(default_factory=dict)

--- a/packages/shared-backend/platform_shared/services/transparency/__init__.py
+++ b/packages/shared-backend/platform_shared/services/transparency/__init__.py
@@ -1,0 +1,23 @@
+"""Platform-wide cost-transparency feature (shared across all apps).
+
+A single PUBLIC ``/support`` page on every MyFreeApps app shows this
+month's platform server costs vs donations received, with a break-even
+bar. The backing data is ONE JSON object in a shared MinIO bucket:
+
+- ONE app (``transparency_primary``) WRITES it — it receives the Ko-fi
+  donation webhook and runs the daily Anthropic cost poll.
+- EVERY app READS it via the public ``GET /transparency`` endpoint.
+
+This package holds the shared, app-agnostic pieces:
+
+- ``transparency_store`` — read/write the shared object; project the
+  current month into the public response shape.
+- ``kofi_service`` — verify + parse Ko-fi donation webhooks (static
+  ``verification_token``, dedup on ``message_id``).
+- ``anthropic_cost_service`` — pull the org's month-to-date spend from
+  the Anthropic Admin Cost Report API.
+- ``cost_sync`` — orchestrate the poll: fetch spend, recompute costs,
+  persist.
+- ``scheduler`` — the daily asyncio cost-sync loop (started only on the
+  primary app, gated by ``transparency_primary``).
+"""

--- a/packages/shared-backend/platform_shared/services/transparency/anthropic_cost_service.py
+++ b/packages/shared-backend/platform_shared/services/transparency/anthropic_cost_service.py
@@ -1,0 +1,170 @@
+"""Anthropic Admin Cost Report API client — month-to-date org spend.
+
+Pulls the organization's spend from the Admin Cost Report API
+(``GET https://api.anthropic.com/v1/organizations/cost_report``), summed
+over the current month, returned as integer cents.
+
+Contract (verified against the Claude API reference, anthropic-version
+2023-06-01):
+
+- Auth header is ``x-api-key`` with an ADMIN key (``sk-ant-admin...``) —
+  distinct from a normal API key. Also send ``anthropic-version``.
+- Query: ``starting_at`` (RFC-3339, required), ``bucket_width=1d``,
+  ``ending_at`` optional, ``limit``, and ``page`` for pagination
+  (``has_more`` / ``next_page``).
+- Response: ``{ data: [ { results: [ { amount, currency, ... } ] } ],
+  has_more, next_page }``. CRUCIAL: ``amount`` is a decimal string in the
+  LOWEST currency unit (cents) — e.g. ``"123.45"`` USD means $1.23. So
+  summing the raw ``amount`` decimals already yields cents; we round the
+  total to an int at the end.
+
+Per rules/check-third-party-error-codes.md: on a non-success response we
+capture the provider's structured error (``error.type`` / ``error.message``),
+log it at WARNING, and raise :class:`AnthropicCostError` rather than
+returning a bare 0 — a silent 0 would read as "no spend" and make the
+widget claim costs are covered when the poll actually failed.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from decimal import ROUND_HALF_UP, Decimal
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+COST_REPORT_URL = "https://api.anthropic.com/v1/organizations/cost_report"
+ANTHROPIC_VERSION = "2023-06-01"
+COST_REPORT_TIMEOUT_S = 30.0
+# A month has at most 31 daily buckets; 40 leaves headroom while keeping a
+# single page the common case. Pagination still runs if has_more is set.
+_PAGE_LIMIT = 40
+# Hard stop on pagination so a misbehaving has_more can't loop forever.
+_MAX_PAGES = 12
+
+
+class AnthropicCostError(RuntimeError):
+    """Raised when the Anthropic Cost Report API call fails.
+
+    Distinct from "spend is zero": the caller (cost sync) logs this and
+    SKIPS the cost update for the cycle, leaving the previously stored value
+    intact rather than zeroing it out on a transient API blip.
+    """
+
+
+def _rfc3339(moment: datetime) -> str:
+    """Format a datetime as an RFC-3339 UTC timestamp (``...Z``)."""
+    return moment.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sum_page_cents(data: list) -> Decimal:
+    """Sum every ``results[].amount`` across the buckets in one page.
+
+    ``amount`` is already in cents (decimal string), so this returns cents.
+    Malformed entries are skipped defensively — one bad row shouldn't sink
+    the whole month's total.
+    """
+    total = Decimal(0)
+    for bucket in data or []:
+        for item in bucket.get("results", []) or []:
+            raw = item.get("amount")
+            if raw is None:
+                continue
+            try:
+                total += Decimal(str(raw))
+            except (ValueError, ArithmeticError):
+                logger.warning("Anthropic cost item had unparseable amount: %r", raw)
+    return total
+
+
+async def fetch_cost_cents(
+    *,
+    api_key: str,
+    starting_at: datetime,
+    ending_at: datetime | None = None,
+) -> int:
+    """Return total Anthropic org spend in integer cents from ``starting_at``.
+
+    An empty ``api_key`` short-circuits to ``0`` WITHOUT a network call — the
+    documented "operator declined the admin key" mode, mirroring the
+    Turnstile dev-mode no-op. The caller then reports costs from the fixed
+    monthly constants alone.
+
+    Raises :class:`AnthropicCostError` on any network error or non-2xx
+    response (after logging the provider's structured error context).
+    """
+    if not api_key:
+        return 0
+
+    params: dict[str, str] = {
+        "starting_at": _rfc3339(starting_at),
+        "bucket_width": "1d",
+        "limit": str(_PAGE_LIMIT),
+    }
+    if ending_at is not None:
+        params["ending_at"] = _rfc3339(ending_at)
+
+    headers = {"x-api-key": api_key, "anthropic-version": ANTHROPIC_VERSION}
+
+    total_cents = Decimal(0)
+    async with httpx.AsyncClient(timeout=COST_REPORT_TIMEOUT_S) as client:
+        page: str | None = None
+        for _ in range(_MAX_PAGES):
+            page_params = dict(params)
+            if page:
+                page_params["page"] = page
+            try:
+                resp = await client.get(
+                    COST_REPORT_URL, params=page_params, headers=headers,
+                )
+            except httpx.RequestError as exc:
+                raise AnthropicCostError(
+                    f"Anthropic Cost Report request failed: {exc}",
+                ) from exc
+
+            if resp.status_code != 200:
+                _log_error_response(resp)
+                raise AnthropicCostError(
+                    f"Anthropic Cost Report returned HTTP {resp.status_code}",
+                )
+
+            body = resp.json()
+            total_cents += _sum_page_cents(body.get("data", []))
+
+            if not body.get("has_more"):
+                break
+            page = body.get("next_page")
+            if not page:
+                break
+
+    return int(total_cents.to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def _log_error_response(resp: httpx.Response) -> None:
+    """Log the provider's structured error context at WARNING.
+
+    Anthropic error bodies are ``{"type":"error","error":{"type":..,
+    "message":..}}``. We surface ``error.type`` + ``error.message`` so log
+    aggregation can group by failure reason (auth vs rate-limit vs invalid
+    request) instead of seeing only an opaque status code.
+    """
+    error_type = ""
+    message = ""
+    try:
+        payload = resp.json()
+        err = payload.get("error") if isinstance(payload, dict) else None
+        if isinstance(err, dict):
+            error_type = str(err.get("type") or "")
+            message = str(err.get("message") or "")
+    except (ValueError, AttributeError):
+        message = resp.text[:200]
+    logger.warning(
+        "Anthropic Cost Report failed: status=%s error_type=%s message=%s",
+        resp.status_code,
+        error_type,
+        message,
+    )
+
+
+__all__ = ["AnthropicCostError", "fetch_cost_cents", "COST_REPORT_URL"]

--- a/packages/shared-backend/platform_shared/services/transparency/cost_sync.py
+++ b/packages/shared-backend/platform_shared/services/transparency/cost_sync.py
@@ -1,0 +1,104 @@
+"""Daily cost sync: recompute this month's platform costs and persist.
+
+``costs_cents`` for a month = the fixed monthly constants the operator sets
+(VPS + domain) PLUS that month's Anthropic API spend pulled from the Admin
+Cost Report. Donations are written by the webhook; this sync owns only the
+cost side of the shared object.
+
+Run by the daily asyncio cost-sync loop (and once at startup) on the primary app.
+It is idempotent — recomputing and overwriting the current month's
+``costs_cents`` each run is correct, so a missed run simply self-heals on
+the next one.
+
+Failure posture (rules/check-third-party-error-codes + no-bandaid): if the
+Anthropic fetch raises, we do NOT write a partial/zero cost — we let the
+error propagate so the caller (the scheduler job wrapper) logs it and the
+PREVIOUS cost figure stays intact rather than the widget flipping to a
+wrong "$0 costs". An empty admin key is not a failure: it yields 0 Anthropic
+cents and the costs reflect the fixed constants alone.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Protocol
+
+from platform_shared.schemas.transparency import TransparencyDocument
+from platform_shared.services.transparency import (
+    anthropic_cost_service,
+    transparency_store,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class _CostSyncSettings(Protocol):
+    """Settings fields the cost sync reads. BaseAppSettings satisfies this."""
+
+    anthropic_admin_api_key: str
+    vps_monthly_cost_cents: int
+    domain_monthly_cost_cents: int
+    # Plus the storage fields consumed by transparency_store.get_shared_storage.
+    minio_endpoint: str
+    minio_access_key: str
+    minio_secret_key: str
+    minio_secure: bool
+    transparency_shared_bucket: str
+
+
+def _month_start(now: datetime) -> datetime:
+    """First instant of ``now``'s month, in UTC."""
+    return now.astimezone(timezone.utc).replace(
+        day=1, hour=0, minute=0, second=0, microsecond=0,
+    )
+
+
+async def run_cost_sync(
+    settings: _CostSyncSettings,
+    now: datetime | None = None,
+) -> int:
+    """Recompute and persist the current month's ``costs_cents``.
+
+    Returns the computed ``costs_cents`` (fixed constants + month-to-date
+    Anthropic spend). Reads the shared document, updates ONLY the current
+    month's cost side (leaving donations untouched), prunes stale months,
+    bumps ``updated_at``, and writes it back.
+
+    Raises :class:`~platform_shared.services.transparency.anthropic_cost_service.AnthropicCostError`
+    if the Anthropic call fails — the caller decides whether to swallow it
+    (it does: a daily job logs + retries tomorrow). Anthropic is fetched
+    BEFORE any write so a failure never leaves a half-updated object.
+    """
+    now = now or datetime.now(timezone.utc)
+
+    anthropic_cents = await anthropic_cost_service.fetch_cost_cents(
+        api_key=settings.anthropic_admin_api_key,
+        starting_at=_month_start(now),
+        ending_at=now,
+    )
+    costs_cents = (
+        int(settings.vps_monthly_cost_cents)
+        + int(settings.domain_monthly_cost_cents)
+        + anthropic_cents
+    )
+
+    document = transparency_store.load_document(settings) or TransparencyDocument()
+    bucket = transparency_store.get_or_create_bucket(document, now)
+    bucket.costs_cents = costs_cents
+    document.updated_at = now.isoformat()
+    transparency_store.prune_old_months(document, now)
+    transparency_store.save_document(settings, document)
+
+    logger.info(
+        "Transparency cost sync: month=%s costs_cents=%d "
+        "(vps=%d domain=%d anthropic=%d)",
+        transparency_store.month_key(now),
+        costs_cents,
+        settings.vps_monthly_cost_cents,
+        settings.domain_monthly_cost_cents,
+        anthropic_cents,
+    )
+    return costs_cents
+
+
+__all__ = ["run_cost_sync"]

--- a/packages/shared-backend/platform_shared/services/transparency/kofi_service.py
+++ b/packages/shared-backend/platform_shared/services/transparency/kofi_service.py
@@ -1,0 +1,205 @@
+"""Ko-fi donation webhook: verify, parse, and record.
+
+Ko-fi delivers a webhook as an ``application/x-www-form-urlencoded`` POST
+with a SINGLE field named ``data`` whose value is a JSON string. Verified
+against Ko-fi's documented contract (help.ko-fi.com "Does Ko-fi have an API
+or webhook"): authentication is a STATIC ``verification_token`` embedded in
+that JSON — the operator copies it from their Ko-fi webhook settings and we
+compare for equality. There is NO HMAC signature header (unlike Stripe /
+GitHub); the token IS the shared secret. We compare it in constant time
+regardless.
+
+Payload fields we use (others ignored): ``verification_token`` (auth),
+``message_id`` (idempotency key — Ko-fi may re-deliver), ``amount`` (decimal
+string in the creator's currency), ``currency``, ``type`` (Donation /
+Subscription / Commission / Shop Order), ``timestamp``.
+
+We count ALL monetary event types toward the break-even total — the
+operator's goal is "did supporters cover hosting", so a subscription
+payment or shop order counts the same as a one-off donation. The widget
+labels the figure "Donations" generically.
+
+Fee note: Ko-fi's webhook reports the GROSS ``amount`` the supporter paid;
+it does NOT report the payment-processor (PayPal/Stripe) fee, so there is no
+"net" field available to honor. We sum gross ``amount`` and document that —
+fabricating a fee deduction would be a made-up number. Ko-fi's own platform
+fee is 0% on the free tier.
+"""
+from __future__ import annotations
+
+import hmac
+import json
+import logging
+from datetime import datetime
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+from urllib.parse import parse_qs
+
+from platform_shared.schemas.transparency import MonthBucket, TransparencyDocument
+from platform_shared.services.transparency import transparency_store
+
+logger = logging.getLogger(__name__)
+
+
+class KofiPayload:
+    """Parsed, normalised view of a Ko-fi webhook payload.
+
+    Holds only the fields the transparency feature needs; ``raw`` keeps the
+    full decoded dict for logging context without re-parsing.
+    """
+
+    def __init__(self, raw: dict) -> None:
+        self.raw = raw
+        self.verification_token: str = str(raw.get("verification_token") or "")
+        self.message_id: str = str(raw.get("message_id") or "")
+        self.amount_str: str = str(raw.get("amount") or "")
+        self.currency: str = str(raw.get("currency") or "")
+        self.type: str = str(raw.get("type") or "")
+
+    @property
+    def amount_cents(self) -> int:
+        """Gross amount in integer cents, or 0 if unparseable / non-positive.
+
+        Ko-fi sends ``amount`` as a decimal string ("5.00", "3", "12.50").
+        A blank or malformed value yields 0 (and is logged by the caller) —
+        we never raise on a bad amount, so one odd payload can't break the
+        webhook for the rest.
+        """
+        try:
+            value = Decimal(self.amount_str)
+        except (InvalidOperation, ValueError):
+            return 0
+        if value <= 0:
+            return 0
+        # Explicit ROUND_HALF_UP (Decimal defaults to banker's rounding) so cents
+        # round the intuitive way and match anthropic_cost_service's rounding.
+        return int((value * 100).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def parse_kofi_form_body(raw_body: bytes) -> dict | None:
+    """Decode a Ko-fi webhook body into its JSON payload dict.
+
+    Ko-fi posts ``data=<url-encoded-json>``. We parse the form body by hand
+    (``urllib.parse.parse_qs``) rather than via FastAPI ``Form(...)`` so the
+    shared package carries no ``python-multipart`` dependency. Returns
+    ``None`` when the body has no ``data`` field or the JSON is invalid.
+    """
+    try:
+        text = raw_body.decode("utf-8")
+    except UnicodeDecodeError:
+        logger.warning("Ko-fi webhook body was not valid UTF-8")
+        return None
+
+    fields = parse_qs(text)
+    data_values = fields.get("data")
+    if not data_values:
+        logger.warning("Ko-fi webhook body missing 'data' field")
+        return None
+
+    try:
+        payload = json.loads(data_values[0])
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Ko-fi webhook 'data' field was not valid JSON")
+        return None
+
+    if not isinstance(payload, dict):
+        logger.warning("Ko-fi webhook 'data' decoded to a non-object")
+        return None
+    return payload
+
+
+def verify_kofi_token(payload: KofiPayload, *, expected_token: str) -> bool:
+    """Whether the payload's verification_token matches the configured one.
+
+    Constant-time comparison. An empty ``expected_token`` always fails — an
+    app that hasn't been configured as the transparency writer must never
+    accept a webhook (the boot guard prevents a production primary app from
+    booting with an empty token, so this only rejects on misrouted traffic).
+    """
+    if not expected_token:
+        return False
+    return hmac.compare_digest(payload.verification_token, expected_token)
+
+
+def record_donation(
+    document: TransparencyDocument,
+    payload: KofiPayload,
+    now: datetime,
+) -> bool:
+    """Add a verified donation to the current month, deduped by message_id.
+
+    Returns ``True`` when newly recorded, ``False`` when ignored — either a
+    duplicate (already-seen ``message_id``, so a Ko-fi re-delivery is a 200
+    no-op) or an event with no ``message_id`` at all (refused, because it can't
+    be deduped and a re-delivery would double-count). Mutates ``document`` in
+    place. Only a POSITIVE amount bumps ``donations_cents`` + ``updated_at``; a
+    zero/blank-amount event is still recorded for dedup but moves no money and
+    leaves ``updated_at`` reflecting the last real change.
+    """
+    if not payload.message_id:
+        # Ko-fi always sends message_id; without it we cannot dedup, so a
+        # re-delivery would double-count. Refuse rather than risk that.
+        logger.warning(
+            "Ko-fi donation missing message_id; refusing to count (cannot dedup): "
+            "type=%s amount=%r",
+            payload.type,
+            payload.amount_str,
+        )
+        return False
+
+    bucket: MonthBucket = transparency_store.get_or_create_bucket(document, now)
+
+    if payload.message_id in bucket.donation_message_ids:
+        logger.info(
+            "Ko-fi donation already recorded (dedup): message_id=%s type=%s",
+            payload.message_id,
+            payload.type,
+        )
+        return False
+
+    # Record the id up front so any re-delivery (even of a zero/odd event) dedups.
+    bucket.donation_message_ids.append(payload.message_id)
+
+    cents = payload.amount_cents
+    if cents <= 0:
+        # Verified but no usable amount — deduped above, but move no money and
+        # don't bump updated_at. Log so a malformed amount is visible.
+        logger.warning(
+            "Ko-fi donation had no positive amount: message_id=%s amount=%r currency=%s",
+            payload.message_id,
+            payload.amount_str,
+            payload.currency,
+        )
+        return True
+
+    if payload.currency and payload.currency.upper() != "USD":
+        # Costs are tracked in USD cents. A non-USD donation is summed at face
+        # value (no FX conversion available) — log it so the operator can spot
+        # currency drift rather than silently mixing units.
+        logger.warning(
+            "Ko-fi donation in non-USD currency summed as USD cents: "
+            "message_id=%s amount=%s currency=%s",
+            payload.message_id,
+            payload.amount_str,
+            payload.currency,
+        )
+
+    bucket.donations_cents += cents
+    document.updated_at = now.isoformat()
+
+    logger.info(
+        "Ko-fi donation recorded: message_id=%s type=%s amount_cents=%d month=%s total_cents=%d",
+        payload.message_id,
+        payload.type,
+        cents,
+        transparency_store.month_key(now),
+        bucket.donations_cents,
+    )
+    return True
+
+
+__all__ = [
+    "KofiPayload",
+    "parse_kofi_form_body",
+    "verify_kofi_token",
+    "record_donation",
+]

--- a/packages/shared-backend/platform_shared/services/transparency/scheduler.py
+++ b/packages/shared-backend/platform_shared/services/transparency/scheduler.py
@@ -1,0 +1,108 @@
+"""Daily cost-sync background task for the transparency feature.
+
+A single, stateless, once-a-day job is a poor fit for a persistent job store
+(APScheduler + a Postgres jobstore, as MJH's discovery scheduler uses) — there
+is nothing to persist, since each run recomputes month-to-date costs from
+scratch. So this is a plain asyncio background task: zero extra dependency,
+and it self-heals on restart (the startup catch-up run repopulates the object).
+
+Lifecycle — started ONLY on the primary app (``settings.transparency_primary``)
+and wired via that app's FastAPI ``on_startup`` / ``on_shutdown`` hooks (PR3),
+NOT by the shared lifespan factory (which stays free of a ``core → services``
+import). Non-primary apps never start it.
+
+Cadence: one catch-up run a few moments after startup (so a fresh deploy fills
+the shared object immediately), then daily at ~00:15 UTC — just after month
+rollover, so a new month's costs appear within minutes instead of waiting up to
+a day. A failed run logs + is retried on the next cycle; it never tears down the
+loop and never overwrites a good figure with a zero (see ``cost_sync``).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from platform_shared.services.transparency import cost_sync
+
+logger = logging.getLogger(__name__)
+
+# Run the daily sync just after midnight UTC so a new month's costs populate
+# promptly at rollover.
+_DAILY_RUN_HOUR = 0
+_DAILY_RUN_MINUTE = 15
+
+# Module-level singleton task — a process runs at most one cost-sync loop.
+# Populated by ``maybe_start_transparency_sync``, cleared by ``stop_transparency_sync``.
+_task: asyncio.Task[None] | None = None
+
+
+def _seconds_until_next_run(now: datetime) -> float:
+    """Seconds from ``now`` until the next ``HH:MM`` UTC daily slot."""
+    target = now.replace(
+        hour=_DAILY_RUN_HOUR, minute=_DAILY_RUN_MINUTE, second=0, microsecond=0,
+    )
+    if target <= now:
+        target += timedelta(days=1)
+    return (target - now).total_seconds()
+
+
+async def _run_once(settings: Any) -> None:
+    """Run one cost sync, swallowing transient errors.
+
+    The loop must never die on a failed run (Anthropic outage, MinIO blip):
+    log at ERROR with the traceback (captured by Sentry where wired) and leave
+    the previously stored figure intact until the next cycle.
+    """
+    try:
+        await cost_sync.run_cost_sync(settings)
+    except Exception:  # noqa: BLE001 — a daily job must not propagate / die
+        logger.exception("Transparency cost sync failed; will retry next cycle")
+
+
+async def _daily_loop(settings: Any) -> None:
+    """Catch-up once at startup, then run daily at the configured UTC slot."""
+    await _run_once(settings)
+    while True:
+        await asyncio.sleep(_seconds_until_next_run(datetime.now(timezone.utc)))
+        await _run_once(settings)
+
+
+def maybe_start_transparency_sync(settings: Any) -> asyncio.Task[None] | None:
+    """Start the daily cost-sync loop iff this app is the primary writer.
+
+    Returns the created task (so the caller can hold a reference), or ``None``
+    when ``transparency_primary`` is false — the no-op path for every read-only
+    app. Idempotent: returns the existing task if one is already running.
+
+    Must be called from within a running event loop (the FastAPI ``on_startup``
+    hook satisfies this).
+    """
+    global _task
+    if not getattr(settings, "transparency_primary", False):
+        return None
+    if _task is not None and not _task.done():
+        return _task
+    _task = asyncio.create_task(_daily_loop(settings), name="transparency-cost-sync")
+    logger.info("Transparency cost-sync loop started (primary app)")
+    return _task
+
+
+async def stop_transparency_sync() -> None:
+    """Cancel the cost-sync loop if running. Idempotent; safe on non-primary apps."""
+    global _task
+    if _task is not None and not _task.done():
+        _task.cancel()
+        try:
+            await _task
+        except asyncio.CancelledError:
+            pass
+        logger.info("Transparency cost-sync loop stopped")
+    _task = None
+
+
+__all__ = [
+    "maybe_start_transparency_sync",
+    "stop_transparency_sync",
+]

--- a/packages/shared-backend/platform_shared/services/transparency/transparency_store.py
+++ b/packages/shared-backend/platform_shared/services/transparency/transparency_store.py
@@ -1,0 +1,211 @@
+"""Read/write the shared cost-transparency object + project the response.
+
+The transparency data is a single JSON object (:class:`TransparencyDocument`)
+in a SHARED MinIO bucket (``settings.transparency_shared_bucket``, default
+``myfreeapps-shared``) — distinct from each app's own per-app bucket. The
+operator creates that bucket once and grants every app's MinIO user
+read+write access (see the PR's Operational migration section).
+
+Why a shared object and not a shared DB: per-app Postgres is isolated by
+design, and the figures are platform-wide (one VPS, identical on every
+app's page). A single object in a shared bucket gives every app the same
+numbers with no cross-app DB coupling — one writer, N readers.
+
+This module owns:
+- a cached storage client bound to the SHARED bucket (separate from the
+  app's own ``get_storage()`` which targets the app bucket),
+- ``load_document`` / ``save_document`` (read-modify-write helpers), and
+- ``project_response`` — turn the stored doc into the public
+  :class:`TransparencyResponse` for the current month.
+
+Concurrency note: writes (rare webhook donations + one daily poll) are
+read-modify-write on a single object with no compare-and-set. The write
+rate is low enough (a handful of donations/day + one poll) that a lost
+update is improbable and self-heals on the next poll; we deliberately do
+NOT reach for object-locking infrastructure the scale doesn't warrant.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Protocol
+
+from minio.error import S3Error
+from pydantic import ValidationError
+
+from platform_shared.core.storage import (
+    StorageClient,
+    StorageNotConfiguredError,
+    build_storage_client,
+)
+from platform_shared.schemas.transparency import (
+    MONTHS_RETAINED,
+    TRANSPARENCY_OBJECT_KEY,
+    MonthBucket,
+    TransparencyDocument,
+    TransparencyResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+_NOT_FOUND_CODES = {"NoSuchKey", "NoSuchObject"}
+
+
+class _StorageSettings(Protocol):
+    """The settings fields the shared-bucket client needs.
+
+    BaseAppSettings satisfies this; using a Protocol keeps this module
+    decoupled from any specific app's Settings subclass.
+    """
+
+    minio_endpoint: str
+    minio_access_key: str
+    minio_secret_key: str
+    minio_secure: bool
+    transparency_shared_bucket: str
+
+
+# Module-level singleton for the SHARED-bucket client. Cached like the
+# per-app ``get_storage()`` singleton; reset via ``reset_shared_storage_cache``
+# in tests. We never presign the transparency object (it is read server-side,
+# not handed to the browser), so no public_endpoint / dual-endpoint client
+# is needed.
+_shared_client: StorageClient | None = None
+
+
+def get_shared_storage(settings: _StorageSettings) -> StorageClient:
+    """Return a cached storage client bound to the SHARED bucket.
+
+    Raises :class:`StorageNotConfiguredError` (from ``build_storage_client``)
+    when MinIO is unconfigured — callers map that to "not configured yet"
+    on the read path and surface it on the write path.
+    """
+    global _shared_client
+    if _shared_client is None:
+        _shared_client = build_storage_client(
+            endpoint=settings.minio_endpoint,
+            access_key=settings.minio_access_key,
+            secret_key=settings.minio_secret_key,
+            bucket=settings.transparency_shared_bucket,
+            # No public_endpoint: the object is never presigned for a browser.
+            public_endpoint=None,
+            secure=settings.minio_secure,
+        )
+    return _shared_client
+
+
+def reset_shared_storage_cache() -> None:
+    """Drop the cached shared-bucket client. Test-only helper."""
+    global _shared_client
+    _shared_client = None
+
+
+def load_document(settings: _StorageSettings) -> TransparencyDocument | None:
+    """Load the stored transparency document.
+
+    Returns ``None`` ONLY when the object does not exist yet (fresh deploy —
+    the "not configured" state). Re-raises on every other failure:
+
+    - :class:`StorageNotConfiguredError` — MinIO unconfigured (dev / pre-setup).
+    - :class:`~minio.error.S3Error` (non-NoSuchKey) — transient outage / auth.
+    - :class:`pydantic.ValidationError` / ``ValueError`` — corrupt object.
+
+    The read path treats unconfigured as "not configured" (hide widget) and
+    transient/corrupt as a 503; the write path lets them propagate so it
+    never overwrites a present-but-unreadable object with a fresh blank one.
+    """
+    client = get_shared_storage(settings)
+    try:
+        raw = client.download_file(TRANSPARENCY_OBJECT_KEY)
+    except S3Error as exc:
+        if exc.code in _NOT_FOUND_CODES:
+            return None
+        raise
+    return TransparencyDocument.model_validate_json(raw)
+
+
+def save_document(settings: _StorageSettings, document: TransparencyDocument) -> None:
+    """Persist the transparency document, overwriting the single object."""
+    client = get_shared_storage(settings)
+    payload = document.model_dump_json().encode("utf-8")
+    client.upload_file(TRANSPARENCY_OBJECT_KEY, payload, "application/json")
+
+
+def month_key(now: datetime) -> str:
+    """Bucket key for a moment in time, e.g. ``"2026-06"`` (UTC-naming)."""
+    return now.strftime("%Y-%m")
+
+
+def month_label(now: datetime) -> str:
+    """Human display label for a moment in time, e.g. ``"June 2026"``."""
+    return now.strftime("%B %Y")
+
+
+def prune_old_months(document: TransparencyDocument, now: datetime) -> None:
+    """Drop all but the most recent ``MONTHS_RETAINED`` monthly buckets.
+
+    Keeps the object (and its per-month dedup id lists) bounded. Sorting by
+    the ``"YYYY-MM"`` key is chronological because the format is
+    zero-padded and fixed-width.
+    """
+    if len(document.months) <= MONTHS_RETAINED:
+        return
+    keep = sorted(document.months.keys(), reverse=True)[:MONTHS_RETAINED]
+    keep_set = set(keep)
+    document.months = {k: v for k, v in document.months.items() if k in keep_set}
+
+
+def project_response(
+    document: TransparencyDocument | None,
+    now: datetime,
+) -> TransparencyResponse:
+    """Project the stored document into the public response for ``now``'s month.
+
+    ``configured`` is ``costs_cents > 0`` — the operator has set up monthly
+    costs (fixed constants and/or Anthropic spend), which is exactly the
+    "has the operator configured costs" signal the widget keys off to decide
+    whether to render. A month with no bucket (object missing, or a brand-new
+    month before the first poll) reports zeros + ``configured=False``.
+    """
+    label = month_label(now)
+    if document is None:
+        return TransparencyResponse(
+            month=label,
+            costs_cents=0,
+            donations_cents=0,
+            updated_at=None,
+            configured=False,
+        )
+    bucket = document.months.get(month_key(now)) or MonthBucket()
+    return TransparencyResponse(
+        month=label,
+        costs_cents=bucket.costs_cents,
+        donations_cents=bucket.donations_cents,
+        updated_at=document.updated_at,
+        configured=bucket.costs_cents > 0,
+    )
+
+
+def get_or_create_bucket(document: TransparencyDocument, now: datetime) -> MonthBucket:
+    """Return the current month's bucket, creating an empty one if absent."""
+    key = month_key(now)
+    bucket = document.months.get(key)
+    if bucket is None:
+        bucket = MonthBucket()
+        document.months[key] = bucket
+    return bucket
+
+
+__all__ = [
+    "get_shared_storage",
+    "reset_shared_storage_cache",
+    "load_document",
+    "save_document",
+    "month_key",
+    "month_label",
+    "prune_old_months",
+    "project_response",
+    "get_or_create_bucket",
+    "StorageNotConfiguredError",
+    "S3Error",
+]

--- a/packages/shared-backend/tests/conftest.py
+++ b/packages/shared-backend/tests/conftest.py
@@ -3,12 +3,46 @@ from collections.abc import AsyncGenerator
 
 import pytest
 import pytest_asyncio
+from minio.error import S3Error
 from sqlalchemy import JSON, event
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from platform_shared.db.base import Base
+
+
+def make_s3_error(code: str, key: str = "obj") -> S3Error:
+    """Build a minio ``S3Error`` with a given code for transparency tests.
+
+    ``code="NoSuchKey"`` exercises the missing-object path; any other code
+    exercises the transient-outage path that callers re-raise. minio's
+    ``S3Error.__init__`` takes ``response`` FIRST, then code/message/...
+    """
+    return S3Error(None, code, f"{code} for {key}", key, "", "")
+
+
+class FakeStorageClient:
+    """In-memory stand-in for ``platform_shared.core.storage.StorageClient``.
+
+    Backs the transparency store tests without a real MinIO. ``download_file``
+    raises a ``NoSuchKey`` ``S3Error`` for absent keys, matching the real
+    client's behaviour that ``transparency_store.load_document`` depends on.
+    """
+
+    def __init__(self) -> None:
+        self.objects: dict[str, bytes] = {}
+        self.uploads: list[tuple[str, bytes, str]] = []
+
+    def upload_file(self, key: str, content: bytes, content_type: str = "application/octet-stream") -> str:
+        self.objects[key] = bytes(content)
+        self.uploads.append((key, bytes(content), content_type))
+        return key
+
+    def download_file(self, key: str) -> bytes:
+        if key not in self.objects:
+            raise make_s3_error("NoSuchKey", key)
+        return self.objects[key]
 
 
 @pytest.fixture

--- a/packages/shared-backend/tests/test_anthropic_cost_service.py
+++ b/packages/shared-backend/tests/test_anthropic_cost_service.py
@@ -1,0 +1,181 @@
+"""Unit tests for platform_shared.services.transparency.anthropic_cost_service.
+
+Uses httpx.MockTransport (same pattern as test_turnstile_service) to stub the
+Admin Cost Report API. Confirms: empty key short-circuits, decimal-cent
+amounts sum correctly, pagination follows next_page, the right headers/params
+go out, and non-2xx / network failures raise AnthropicCostError with the
+provider error logged.
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from platform_shared.services.transparency import anthropic_cost_service
+from platform_shared.services.transparency.anthropic_cost_service import (
+    AnthropicCostError,
+    fetch_cost_cents,
+)
+
+_MONTH_START = datetime(2026, 6, 1, 0, 0, 0, tzinfo=timezone.utc)
+_NOW = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _install_mock_transport(monkeypatch: pytest.MonkeyPatch, handler) -> None:
+    """Inject a MockTransport into every httpx.AsyncClient the module builds."""
+    real_client = httpx.AsyncClient
+
+    def factory(*args, **kwargs):  # noqa: ANN001, ANN002, ANN003
+        kwargs["transport"] = httpx.MockTransport(handler)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(anthropic_cost_service.httpx, "AsyncClient", factory)
+
+
+def _bucket(*amounts: str) -> dict:
+    return {"results": [{"amount": a, "currency": "USD"} for a in amounts]}
+
+
+class TestNoKey:
+    @pytest.mark.anyio
+    async def test_empty_key_returns_zero_without_network(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        hit = {"n": 0}
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            hit["n"] += 1
+            return httpx.Response(500)
+
+        _install_mock_transport(monkeypatch, handler)
+        result = await fetch_cost_cents(api_key="", starting_at=_MONTH_START)
+        assert result == 0
+        assert hit["n"] == 0
+
+
+class TestSummation:
+    @pytest.mark.anyio
+    async def test_sums_amounts_as_cents(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json={"data": [_bucket("12345.00"), _bucket("67.00")], "has_more": False},
+            )
+
+        _install_mock_transport(monkeypatch, handler)
+        # amounts are already in cents → 12345 + 67 = 12412
+        assert await fetch_cost_cents(api_key="sk-ant-admin-x", starting_at=_MONTH_START) == 12412
+
+    @pytest.mark.anyio
+    async def test_multiple_results_in_one_bucket_sum(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200, json={"data": [_bucket("100.00", "50.00", "25.00")], "has_more": False},
+            )
+
+        _install_mock_transport(monkeypatch, handler)
+        assert await fetch_cost_cents(api_key="sk-ant-admin-x", starting_at=_MONTH_START) == 175
+
+    @pytest.mark.anyio
+    async def test_fractional_cents_round_half_up(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": [_bucket("100.50")], "has_more": False})
+
+        _install_mock_transport(monkeypatch, handler)
+        assert await fetch_cost_cents(api_key="sk-ant-admin-x", starting_at=_MONTH_START) == 101
+
+    @pytest.mark.anyio
+    async def test_empty_data_is_zero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json={"data": [], "has_more": False})
+
+        _install_mock_transport(monkeypatch, handler)
+        assert await fetch_cost_cents(api_key="sk-ant-admin-x", starting_at=_MONTH_START) == 0
+
+
+class TestRequestShape:
+    @pytest.mark.anyio
+    async def test_headers_and_params(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        captured: dict = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            captured["x-api-key"] = request.headers.get("x-api-key")
+            captured["anthropic-version"] = request.headers.get("anthropic-version")
+            captured["starting_at"] = request.url.params.get("starting_at")
+            captured["bucket_width"] = request.url.params.get("bucket_width")
+            captured["ending_at"] = request.url.params.get("ending_at")
+            return httpx.Response(200, json={"data": [], "has_more": False})
+
+        _install_mock_transport(monkeypatch, handler)
+        await fetch_cost_cents(api_key="sk-ant-admin-xyz", starting_at=_MONTH_START, ending_at=_NOW)
+        assert captured["x-api-key"] == "sk-ant-admin-xyz"
+        assert captured["anthropic-version"] == "2023-06-01"
+        assert captured["starting_at"] == "2026-06-01T00:00:00Z"
+        assert captured["bucket_width"] == "1d"
+        assert captured["ending_at"] == "2026-06-15T12:00:00Z"
+
+
+class TestPagination:
+    @pytest.mark.anyio
+    async def test_follows_next_page(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        seen_pages: list[str | None] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            page = request.url.params.get("page")
+            seen_pages.append(page)
+            if page is None:
+                return httpx.Response(
+                    200,
+                    json={"data": [_bucket("100.00")], "has_more": True, "next_page": "PAGE2"},
+                )
+            return httpx.Response(
+                200, json={"data": [_bucket("200.00")], "has_more": False},
+            )
+
+        _install_mock_transport(monkeypatch, handler)
+        total = await fetch_cost_cents(api_key="sk-ant-admin-x", starting_at=_MONTH_START)
+        assert total == 300
+        assert seen_pages == [None, "PAGE2"]
+
+    @pytest.mark.anyio
+    async def test_stops_when_next_page_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls = {"n": 0}
+
+        def handler(_: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            # has_more True but no next_page → must stop, not loop forever.
+            return httpx.Response(200, json={"data": [_bucket("10.00")], "has_more": True})
+
+        _install_mock_transport(monkeypatch, handler)
+        total = await fetch_cost_cents(api_key="sk-ant-admin-x", starting_at=_MONTH_START)
+        assert total == 10
+        assert calls["n"] == 1
+
+
+class TestErrors:
+    @pytest.mark.anyio
+    async def test_non_200_raises_and_logs_error_type(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        def handler(_: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                401,
+                json={"type": "error", "error": {"type": "authentication_error", "message": "invalid x-api-key"}},
+            )
+
+        _install_mock_transport(monkeypatch, handler)
+        with caplog.at_level(logging.WARNING, logger="platform_shared.services.transparency.anthropic_cost_service"):
+            with pytest.raises(AnthropicCostError):
+                await fetch_cost_cents(api_key="sk-ant-admin-bad", starting_at=_MONTH_START)
+        assert any("authentication_error" in r.message for r in caplog.records)
+        assert any(r.levelno == logging.WARNING for r in caplog.records)
+
+    @pytest.mark.anyio
+    async def test_network_error_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused", request=request)
+
+        _install_mock_transport(monkeypatch, handler)
+        with pytest.raises(AnthropicCostError):
+            await fetch_cost_cents(api_key="sk-ant-admin-x", starting_at=_MONTH_START)

--- a/packages/shared-backend/tests/test_boot_guards.py
+++ b/packages/shared-backend/tests/test_boot_guards.py
@@ -5,9 +5,11 @@ import pytest
 from platform_shared.core.boot_guards import (
     EmailNotConfiguredError,
     SmsNotConfiguredError,
+    TransparencyNotConfiguredError,
     TurnstileNotConfiguredError,
     check_email_configured,
     check_sms_configured,
+    check_transparency_configured,
     check_turnstile_configured,
 )
 
@@ -213,3 +215,55 @@ class TestCheckSmsConfigured:
 
     def test_inherits_from_runtime_error(self) -> None:
         assert issubclass(SmsNotConfiguredError, RuntimeError)
+
+
+class TestCheckTransparencyConfigured:
+    def test_dev_primary_empty_token_passes(self) -> None:
+        check_transparency_configured(
+            transparency_primary=True,
+            kofi_verification_token="",
+            environment="development",
+        )
+
+    def test_test_primary_empty_token_passes(self) -> None:
+        check_transparency_configured(
+            transparency_primary=True,
+            kofi_verification_token="",
+            environment="test",
+        )
+
+    def test_non_primary_empty_token_passes_in_prod(self) -> None:
+        """Read-only apps need no token even in production."""
+        check_transparency_configured(
+            transparency_primary=False,
+            kofi_verification_token="",
+            environment="production",
+        )
+
+    def test_primary_with_token_passes_in_prod(self) -> None:
+        check_transparency_configured(
+            transparency_primary=True,
+            kofi_verification_token="kofi-secret",
+            environment="production",
+        )
+
+    def test_primary_empty_token_raises_in_prod(self) -> None:
+        with pytest.raises(TransparencyNotConfiguredError) as exc:
+            check_transparency_configured(
+                transparency_primary=True,
+                kofi_verification_token="",
+                environment="production",
+            )
+        assert "KOFI_VERIFICATION_TOKEN" in str(exc.value)
+        assert "TRANSPARENCY_PRIMARY" in str(exc.value)
+
+    def test_primary_empty_token_raises_in_staging(self) -> None:
+        with pytest.raises(TransparencyNotConfiguredError):
+            check_transparency_configured(
+                transparency_primary=True,
+                kofi_verification_token="",
+                environment="staging",
+            )
+
+    def test_inherits_from_runtime_error(self) -> None:
+        assert issubclass(TransparencyNotConfiguredError, RuntimeError)

--- a/packages/shared-backend/tests/test_cost_sync.py
+++ b/packages/shared-backend/tests/test_cost_sync.py
@@ -1,0 +1,109 @@
+"""Unit tests for platform_shared.services.transparency.cost_sync.
+
+Mocks the Anthropic fetch + the shared storage so the orchestration is tested
+in isolation: costs = constants + Anthropic spend, donations are preserved,
+and an Anthropic failure aborts the write (no partial/zero overwrite).
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from platform_shared.schemas.transparency import MonthBucket, TransparencyDocument
+from platform_shared.services.transparency import (
+    anthropic_cost_service,
+    cost_sync,
+    transparency_store,
+)
+from platform_shared.services.transparency.anthropic_cost_service import AnthropicCostError
+from tests.conftest import FakeStorageClient
+
+_NOW = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _settings(**overrides) -> SimpleNamespace:
+    base = dict(
+        anthropic_admin_api_key="sk-ant-admin-x",
+        vps_monthly_cost_cents=1000,
+        domain_monthly_cost_cents=500,
+        minio_endpoint="minio:9000",
+        minio_access_key="k",
+        minio_secret_key="s",
+        minio_secure=False,
+        transparency_shared_bucket="myfreeapps-shared",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+@pytest.fixture
+def fake_storage(monkeypatch: pytest.MonkeyPatch) -> FakeStorageClient:
+    fake = FakeStorageClient()
+    monkeypatch.setattr(transparency_store, "get_shared_storage", lambda settings: fake)
+    transparency_store.reset_shared_storage_cache()
+    return fake
+
+
+def _stub_fetch(monkeypatch: pytest.MonkeyPatch, value: int) -> None:
+    async def _fetch(*, api_key, starting_at, ending_at=None):  # noqa: ANN001, ANN003
+        return value
+
+    monkeypatch.setattr(anthropic_cost_service, "fetch_cost_cents", _fetch)
+
+
+class TestRunCostSync:
+    @pytest.mark.anyio
+    async def test_computes_and_persists_costs(
+        self, monkeypatch: pytest.MonkeyPatch, fake_storage: FakeStorageClient,
+    ) -> None:
+        _stub_fetch(monkeypatch, 4500)
+        costs = await cost_sync.run_cost_sync(_settings(), now=_NOW)
+        # 1000 (vps) + 500 (domain) + 4500 (anthropic)
+        assert costs == 6000
+        loaded = transparency_store.load_document(_settings())
+        assert loaded is not None
+        assert loaded.months["2026-06"].costs_cents == 6000
+        assert loaded.updated_at == _NOW.isoformat()
+
+    @pytest.mark.anyio
+    async def test_preserves_existing_donations(
+        self, monkeypatch: pytest.MonkeyPatch, fake_storage: FakeStorageClient,
+    ) -> None:
+        # Seed a doc that already has donations for the month.
+        seed = TransparencyDocument(
+            months={"2026-06": MonthBucket(donations_cents=2500, donation_message_ids=["m1"])},
+        )
+        transparency_store.save_document(_settings(), seed)
+
+        _stub_fetch(monkeypatch, 0)
+        await cost_sync.run_cost_sync(_settings(), now=_NOW)
+
+        loaded = transparency_store.load_document(_settings())
+        assert loaded.months["2026-06"].donations_cents == 2500
+        assert loaded.months["2026-06"].donation_message_ids == ["m1"]
+        assert loaded.months["2026-06"].costs_cents == 1500  # 1000 + 500 + 0
+
+    @pytest.mark.anyio
+    async def test_no_anthropic_key_uses_constants_only(
+        self, monkeypatch: pytest.MonkeyPatch, fake_storage: FakeStorageClient,
+    ) -> None:
+        # fetch_cost_cents itself returns 0 for an empty key — exercise the real one.
+        costs = await cost_sync.run_cost_sync(
+            _settings(anthropic_admin_api_key=""), now=_NOW,
+        )
+        assert costs == 1500
+
+    @pytest.mark.anyio
+    async def test_anthropic_failure_aborts_write(
+        self, monkeypatch: pytest.MonkeyPatch, fake_storage: FakeStorageClient,
+    ) -> None:
+        async def _boom(*, api_key, starting_at, ending_at=None):  # noqa: ANN001, ANN003
+            raise AnthropicCostError("API down")
+
+        monkeypatch.setattr(anthropic_cost_service, "fetch_cost_cents", _boom)
+        with pytest.raises(AnthropicCostError):
+            await cost_sync.run_cost_sync(_settings(), now=_NOW)
+        # No object was written — the previous figure (none here) stays intact.
+        assert fake_storage.uploads == []

--- a/packages/shared-backend/tests/test_kofi_service.py
+++ b/packages/shared-backend/tests/test_kofi_service.py
@@ -1,0 +1,176 @@
+"""Unit tests for platform_shared.services.transparency.kofi_service.
+
+Covers the three responsibilities: parsing the form-encoded webhook body,
+verifying the static verification_token (NOT HMAC), and recording a
+donation into the monthly bucket with idempotency on message_id.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from urllib.parse import urlencode
+
+import pytest
+
+from platform_shared.schemas.transparency import TransparencyDocument
+from platform_shared.services.transparency import kofi_service
+from platform_shared.services.transparency.kofi_service import (
+    KofiPayload,
+    parse_kofi_form_body,
+    record_donation,
+    verify_kofi_token,
+)
+
+_NOW = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _form_body(payload: dict) -> bytes:
+    """Encode a payload the way Ko-fi does: data=<url-encoded JSON>."""
+    return urlencode({"data": json.dumps(payload)}).encode("utf-8")
+
+
+def _payload(**overrides) -> dict:
+    base = {
+        "verification_token": "tok-123",
+        "message_id": "msg-1",
+        "type": "Donation",
+        "amount": "5.00",
+        "currency": "USD",
+        "is_public": True,
+        "timestamp": "2026-06-15T12:00:00Z",
+    }
+    base.update(overrides)
+    return base
+
+
+class TestAmountCents:
+    @pytest.mark.parametrize(
+        ("amount", "expected"),
+        [
+            ("5.00", 500),
+            ("3", 300),
+            ("12.50", 1250),
+            ("0.99", 99),
+            ("100", 10000),
+            ("0.005", 1),  # half-cent must round UP (not banker's-round to 0)
+            ("", 0),
+            ("abc", 0),
+            ("0", 0),
+            ("-1.00", 0),
+        ],
+    )
+    def test_amount_to_cents(self, amount: str, expected: int) -> None:
+        assert KofiPayload({"amount": amount}).amount_cents == expected
+
+
+class TestParseFormBody:
+    def test_valid_body_parses(self) -> None:
+        payload = parse_kofi_form_body(_form_body(_payload()))
+        assert payload is not None
+        assert payload["verification_token"] == "tok-123"
+        assert payload["message_id"] == "msg-1"
+
+    def test_missing_data_field_returns_none(self) -> None:
+        assert parse_kofi_form_body(b"foo=bar") is None
+
+    def test_invalid_json_returns_none(self) -> None:
+        assert parse_kofi_form_body(urlencode({"data": "not json{"}).encode()) is None
+
+    def test_non_object_json_returns_none(self) -> None:
+        assert parse_kofi_form_body(urlencode({"data": "[1, 2, 3]"}).encode()) is None
+
+    def test_non_utf8_body_returns_none(self) -> None:
+        assert parse_kofi_form_body(b"\xff\xfe\x00bad") is None
+
+
+class TestVerifyToken:
+    def test_matching_token_passes(self) -> None:
+        payload = KofiPayload(_payload(verification_token="secret"))
+        assert verify_kofi_token(payload, expected_token="secret") is True
+
+    def test_mismatched_token_fails(self) -> None:
+        payload = KofiPayload(_payload(verification_token="wrong"))
+        assert verify_kofi_token(payload, expected_token="secret") is False
+
+    def test_empty_expected_token_always_fails(self) -> None:
+        """A writer with no configured token must reject everything."""
+        payload = KofiPayload(_payload(verification_token=""))
+        assert verify_kofi_token(payload, expected_token="") is False
+
+    def test_empty_payload_token_against_real_token_fails(self) -> None:
+        payload = KofiPayload(_payload(verification_token=""))
+        assert verify_kofi_token(payload, expected_token="secret") is False
+
+
+class TestRecordDonation:
+    def test_new_donation_increments_and_returns_true(self) -> None:
+        doc = TransparencyDocument()
+        payload = KofiPayload(_payload(message_id="m1", amount="5.00"))
+        recorded = record_donation(doc, payload, _NOW)
+        assert recorded is True
+        bucket = doc.months["2026-06"]
+        assert bucket.donations_cents == 500
+        assert bucket.donation_message_ids == ["m1"]
+        assert doc.updated_at == _NOW.isoformat()
+
+    def test_two_distinct_donations_sum(self) -> None:
+        doc = TransparencyDocument()
+        record_donation(doc, KofiPayload(_payload(message_id="m1", amount="5.00")), _NOW)
+        record_donation(doc, KofiPayload(_payload(message_id="m2", amount="3.00")), _NOW)
+        assert doc.months["2026-06"].donations_cents == 800
+        assert doc.months["2026-06"].donation_message_ids == ["m1", "m2"]
+
+    def test_duplicate_message_id_is_noop_returns_false(self) -> None:
+        doc = TransparencyDocument()
+        payload = KofiPayload(_payload(message_id="m1", amount="5.00"))
+        record_donation(doc, payload, _NOW)
+        again = record_donation(doc, payload, _NOW)
+        assert again is False
+        assert doc.months["2026-06"].donations_cents == 500
+        assert doc.months["2026-06"].donation_message_ids == ["m1"]
+
+    def test_donations_bucket_by_month(self) -> None:
+        doc = TransparencyDocument()
+        may = datetime(2026, 5, 20, tzinfo=timezone.utc)
+        june = datetime(2026, 6, 1, tzinfo=timezone.utc)
+        record_donation(doc, KofiPayload(_payload(message_id="m1", amount="5.00")), may)
+        record_donation(doc, KofiPayload(_payload(message_id="m2", amount="7.00")), june)
+        assert doc.months["2026-05"].donations_cents == 500
+        assert doc.months["2026-06"].donations_cents == 700
+
+    def test_zero_amount_records_id_but_not_total(self) -> None:
+        """A verified zero/blank-amount event is deduped but moves no money."""
+        doc = TransparencyDocument()
+        payload = KofiPayload(_payload(message_id="m1", amount=""))
+        recorded = record_donation(doc, payload, _NOW)
+        assert recorded is True
+        assert doc.months["2026-06"].donations_cents == 0
+        assert "m1" in doc.months["2026-06"].donation_message_ids
+
+    def test_non_usd_is_summed_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        doc = TransparencyDocument()
+        payload = KofiPayload(_payload(message_id="m1", amount="5.00", currency="EUR"))
+        with caplog.at_level(logging.WARNING, logger="platform_shared.services.transparency.kofi_service"):
+            record_donation(doc, payload, _NOW)
+        assert doc.months["2026-06"].donations_cents == 500
+        assert any("non-USD" in r.message for r in caplog.records)
+
+    def test_missing_message_id_is_refused(self, caplog: pytest.LogCaptureFixture) -> None:
+        """No message_id → can't dedup → refuse to count (avoids double-count on retry)."""
+        doc = TransparencyDocument()
+        payload = KofiPayload(_payload(message_id="", amount="5.00"))
+        with caplog.at_level(logging.WARNING, logger="platform_shared.services.transparency.kofi_service"):
+            recorded = record_donation(doc, payload, _NOW)
+        assert recorded is False
+        assert "2026-06" not in doc.months  # nothing recorded at all
+        assert any("missing message_id" in r.message for r in caplog.records)
+
+    def test_zero_amount_does_not_bump_updated_at(self) -> None:
+        """A zero-amount event is deduped but moves no money and leaves updated_at."""
+        doc = TransparencyDocument()
+        recorded = record_donation(doc, KofiPayload(_payload(message_id="z1", amount="")), _NOW)
+        assert recorded is True
+        assert doc.months["2026-06"].donation_message_ids == ["z1"]
+        assert doc.months["2026-06"].donations_cents == 0
+        assert doc.updated_at is None  # not bumped for a zero-amount event

--- a/packages/shared-backend/tests/test_lifespan.py
+++ b/packages/shared-backend/tests/test_lifespan.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI
 from platform_shared.core.boot_guards import (
     EmailNotConfiguredError,
     SmsNotConfiguredError,
+    TransparencyNotConfiguredError,
     TurnstileNotConfiguredError,
 )
 from platform_shared.core.lifespan import create_app_lifespan
@@ -28,6 +29,8 @@ def _settings(
     twilio_account_sid: str = "",
     twilio_auth_token: str = "",
     twilio_from_number: str = "",
+    transparency_primary: bool = False,
+    kofi_verification_token: str = "",
 ) -> SimpleNamespace:
     """Build a settings-like namespace for tests."""
     return SimpleNamespace(
@@ -41,6 +44,8 @@ def _settings(
         twilio_account_sid=twilio_account_sid,
         twilio_auth_token=twilio_auth_token,
         twilio_from_number=twilio_from_number,
+        transparency_primary=transparency_primary,
+        kofi_verification_token=kofi_verification_token,
     )
 
 
@@ -415,6 +420,84 @@ class TestSmsRequired:
             settings=_settings(environment="development"),
             init_sentry=MagicMock(),
             sms_required=True,
+        )
+        async with lifespan(app):
+            pass
+
+
+class TestTransparencyGuard:
+    """The factory always runs check_transparency_configured; it self-gates so
+    it only fails a misconfigured PRIMARY writer in a non-dev environment."""
+
+    @pytest.mark.asyncio
+    async def test_primary_without_kofi_token_raises_in_prod(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="present",
+                email_backend="smtp",
+                smtp_user="u",
+                smtp_password="p" * 16,
+                transparency_primary=True,
+                kofi_verification_token="",  # missing → must raise
+            ),
+            init_sentry=MagicMock(),
+        )
+        with pytest.raises(TransparencyNotConfiguredError):
+            async with lifespan(app):
+                pass
+
+    @pytest.mark.asyncio
+    async def test_primary_with_kofi_token_passes_in_prod(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="present",
+                email_backend="smtp",
+                smtp_user="u",
+                smtp_password="p" * 16,
+                transparency_primary=True,
+                kofi_verification_token="kofi-secret",
+            ),
+            init_sentry=MagicMock(),
+        )
+        async with lifespan(app):
+            pass
+
+    @pytest.mark.asyncio
+    async def test_non_primary_without_token_passes_in_prod(
+        self, app: FastAPI, monkeypatch,
+    ) -> None:
+        """Read-only apps (default) never need the Ko-fi token."""
+        monkeypatch.setattr(
+            "platform_shared.core.lifespan.register_audit_listeners",
+            MagicMock(),
+        )
+        lifespan = create_app_lifespan(
+            settings=_settings(
+                environment="production",
+                sentry_dsn="https://x@y/1",
+                turnstile_secret_key="present",
+                email_backend="smtp",
+                smtp_user="u",
+                smtp_password="p" * 16,
+                # transparency_primary defaults False
+            ),
+            init_sentry=MagicMock(),
         )
         async with lifespan(app):
             pass

--- a/packages/shared-backend/tests/test_transparency_router.py
+++ b/packages/shared-backend/tests/test_transparency_router.py
@@ -1,0 +1,169 @@
+"""Integration tests for the shared transparency router via FastAPI TestClient.
+
+Storage is faked in-memory. Confirms the public read maps the widget's three
+states (configured / not-configured / unavailable) to the right status codes,
+and the Ko-fi webhook verifies + dedups + persists, returning Ko-fi a 200.
+"""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from urllib.parse import urlencode
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from platform_shared.api.transparency_router import build_transparency_router
+from platform_shared.core.storage import StorageNotConfiguredError
+from platform_shared.schemas.transparency import MonthBucket, TransparencyDocument
+from platform_shared.services.transparency import transparency_store
+from tests.conftest import FakeStorageClient, make_s3_error
+
+_FORM_HEADERS = {"Content-Type": "application/x-www-form-urlencoded"}
+
+
+def _settings(**overrides) -> SimpleNamespace:
+    base = dict(
+        kofi_verification_token="tok-123",
+        transparency_shared_bucket="myfreeapps-shared",
+        minio_endpoint="minio:9000",
+        minio_access_key="k",
+        minio_secret_key="s",
+        minio_secure=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _client(settings: SimpleNamespace) -> TestClient:
+    app = FastAPI()
+    app.include_router(build_transparency_router(settings))
+    return TestClient(app)
+
+
+def _payload(**overrides) -> dict:
+    base = {
+        "verification_token": "tok-123",
+        "message_id": "msg-1",
+        "type": "Donation",
+        "amount": "5.00",
+        "currency": "USD",
+    }
+    base.update(overrides)
+    return base
+
+
+def _form_body(payload: dict) -> bytes:
+    return urlencode({"data": json.dumps(payload)}).encode("utf-8")
+
+
+@pytest.fixture
+def fake_storage(monkeypatch: pytest.MonkeyPatch) -> FakeStorageClient:
+    fake = FakeStorageClient()
+    monkeypatch.setattr(transparency_store, "get_shared_storage", lambda s: fake)
+    transparency_store.reset_shared_storage_cache()
+    return fake
+
+
+class TestGetTransparency:
+    def test_not_configured_when_object_missing(self, fake_storage: FakeStorageClient) -> None:
+        resp = _client(_settings()).get("/transparency")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["configured"] is False
+        assert body["costs_cents"] == 0
+        assert body["donations_cents"] == 0
+        assert body["updated_at"] is None
+        assert body["month"]  # human label always present
+
+    def test_configured_returns_current_month(self, fake_storage: FakeStorageClient) -> None:
+        now = datetime.now(timezone.utc)
+        key = transparency_store.month_key(now)
+        doc = TransparencyDocument(
+            updated_at=now.isoformat(),
+            months={key: MonthBucket(donations_cents=2500, costs_cents=10000)},
+        )
+        transparency_store.save_document(_settings(), doc)
+        resp = _client(_settings()).get("/transparency")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["configured"] is True
+        assert body["costs_cents"] == 10000
+        assert body["donations_cents"] == 2500
+        assert body["updated_at"] == doc.updated_at
+
+    def test_storage_not_configured_hides_widget(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(_s: object) -> None:
+            raise StorageNotConfiguredError("MINIO_ENDPOINT unset")
+
+        monkeypatch.setattr(transparency_store, "get_shared_storage", _raise)
+        resp = _client(_settings()).get("/transparency")
+        assert resp.status_code == 200
+        assert resp.json()["configured"] is False
+
+    def test_transient_storage_error_returns_503(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Boom:
+            def download_file(self, key: str) -> bytes:
+                raise make_s3_error("InternalError", key)
+
+        monkeypatch.setattr(transparency_store, "get_shared_storage", lambda s: _Boom())
+        resp = _client(_settings()).get("/transparency")
+        assert resp.status_code == 503
+
+
+class TestKofiWebhook:
+    def test_valid_donation_records_and_acks(self, fake_storage: FakeStorageClient) -> None:
+        client = _client(_settings(kofi_verification_token="tok-123"))
+        resp = client.post(
+            "/donations/kofi-webhook",
+            content=_form_body(_payload(message_id="m1", amount="5.00")),
+            headers=_FORM_HEADERS,
+        )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ok"
+        loaded = transparency_store.load_document(_settings())
+        key = transparency_store.month_key(datetime.now(timezone.utc))
+        assert loaded.months[key].donations_cents == 500
+
+    def test_duplicate_message_id_acks_without_double_count(
+        self, fake_storage: FakeStorageClient,
+    ) -> None:
+        client = _client(_settings(kofi_verification_token="tok-123"))
+        body = _form_body(_payload(message_id="dup", amount="9.00"))
+        first = client.post("/donations/kofi-webhook", content=body, headers=_FORM_HEADERS)
+        second = client.post("/donations/kofi-webhook", content=body, headers=_FORM_HEADERS)
+        assert first.json()["status"] == "ok"
+        assert second.status_code == 200
+        assert second.json()["status"] == "duplicate"
+        loaded = transparency_store.load_document(_settings())
+        key = transparency_store.month_key(datetime.now(timezone.utc))
+        assert loaded.months[key].donations_cents == 900
+
+    def test_bad_token_rejected_401(self, fake_storage: FakeStorageClient) -> None:
+        client = _client(_settings(kofi_verification_token="tok-123"))
+        resp = client.post(
+            "/donations/kofi-webhook",
+            content=_form_body(_payload(verification_token="WRONG")),
+            headers=_FORM_HEADERS,
+        )
+        assert resp.status_code == 401
+
+    def test_no_token_configured_returns_404(self, fake_storage: FakeStorageClient) -> None:
+        """A non-writer app (empty token) returns 404 so Ko-fi stops retrying a
+        permanently-wrong endpoint (rather than 503, which means 'retry later')."""
+        client = _client(_settings(kofi_verification_token=""))
+        resp = client.post(
+            "/donations/kofi-webhook",
+            content=_form_body(_payload()),
+            headers=_FORM_HEADERS,
+        )
+        assert resp.status_code == 404
+
+    def test_malformed_body_returns_400(self, fake_storage: FakeStorageClient) -> None:
+        client = _client(_settings(kofi_verification_token="tok-123"))
+        resp = client.post(
+            "/donations/kofi-webhook", content=b"not-a-kofi-body", headers=_FORM_HEADERS,
+        )
+        assert resp.status_code == 400

--- a/packages/shared-backend/tests/test_transparency_scheduler.py
+++ b/packages/shared-backend/tests/test_transparency_scheduler.py
@@ -1,0 +1,132 @@
+"""Unit tests for platform_shared.services.transparency.scheduler (asyncio loop).
+
+Confirms primary-only gating, the next-run-time math, startup catch-up,
+idempotent start, clean cancellation, and that one failed run never tears
+down the loop.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from platform_shared.services.transparency import cost_sync, scheduler
+from platform_shared.services.transparency.scheduler import (
+    _run_once,
+    _seconds_until_next_run,
+    maybe_start_transparency_sync,
+    stop_transparency_sync,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_task():
+    """Clear the module singleton around each test (tasks live in per-test loops)."""
+    scheduler._task = None
+    yield
+    scheduler._task = None
+
+
+def _settings(*, primary: bool) -> SimpleNamespace:
+    return SimpleNamespace(transparency_primary=primary)
+
+
+class TestNextRunMath:
+    def test_before_daily_slot(self) -> None:
+        # 00:00 → next 00:15 is 900s away.
+        now = datetime(2026, 6, 15, 0, 0, 0, tzinfo=timezone.utc)
+        assert _seconds_until_next_run(now) == 900
+
+    def test_after_daily_slot_rolls_to_next_day(self) -> None:
+        # 00:20 → next 00:15 is tomorrow: 24h - 5min = 86100s.
+        now = datetime(2026, 6, 15, 0, 20, 0, tzinfo=timezone.utc)
+        assert _seconds_until_next_run(now) == 86100
+
+    def test_midday(self) -> None:
+        # 12:15 → next 00:15 is 12h away = 43200s.
+        now = datetime(2026, 6, 15, 12, 15, 0, tzinfo=timezone.utc)
+        assert _seconds_until_next_run(now) == 43200
+
+
+class TestGating:
+    def test_non_primary_returns_none(self) -> None:
+        assert maybe_start_transparency_sync(_settings(primary=False)) is None
+        assert scheduler._task is None
+
+    def test_missing_attr_treated_as_non_primary(self) -> None:
+        assert maybe_start_transparency_sync(SimpleNamespace()) is None
+
+
+class TestLifecycle:
+    @pytest.mark.anyio
+    async def test_primary_starts_and_runs_startup_sync(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        ran = asyncio.Event()
+        calls: list = []
+
+        async def _fake_sync(settings):  # noqa: ANN001
+            calls.append(settings)
+            ran.set()
+
+        monkeypatch.setattr(cost_sync, "run_cost_sync", _fake_sync)
+        settings = _settings(primary=True)
+        task = maybe_start_transparency_sync(settings)
+        assert task is not None
+        await asyncio.wait_for(ran.wait(), timeout=1.0)
+        assert calls == [settings]  # startup catch-up ran exactly once
+        await stop_transparency_sync()
+        assert scheduler._task is None
+
+    @pytest.mark.anyio
+    async def test_idempotent_returns_same_task(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _fake_sync(settings):  # noqa: ANN001
+            await asyncio.sleep(0)
+
+        monkeypatch.setattr(cost_sync, "run_cost_sync", _fake_sync)
+        first = maybe_start_transparency_sync(_settings(primary=True))
+        second = maybe_start_transparency_sync(_settings(primary=True))
+        assert first is second
+        await stop_transparency_sync()
+
+    @pytest.mark.anyio
+    async def test_stop_cancels_running_loop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        started = asyncio.Event()
+
+        async def _fake_sync(settings):  # noqa: ANN001
+            started.set()
+
+        monkeypatch.setattr(cost_sync, "run_cost_sync", _fake_sync)
+        task = maybe_start_transparency_sync(_settings(primary=True))
+        await asyncio.wait_for(started.wait(), timeout=1.0)
+        await stop_transparency_sync()
+        assert task.cancelled() or task.done()
+        assert scheduler._task is None
+
+    @pytest.mark.anyio
+    async def test_stop_when_never_started_is_noop(self) -> None:
+        await stop_transparency_sync()  # must not raise
+        assert scheduler._task is None
+
+
+class TestRunOnceSwallowsErrors:
+    @pytest.mark.anyio
+    async def test_run_once_runs_sync(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        calls: list = []
+
+        async def _fake_sync(settings):  # noqa: ANN001
+            calls.append(settings)
+
+        monkeypatch.setattr(cost_sync, "run_cost_sync", _fake_sync)
+        sentinel = SimpleNamespace(tag="s")
+        await _run_once(sentinel)
+        assert calls == [sentinel]
+
+    @pytest.mark.anyio
+    async def test_run_once_swallows_errors(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        async def _boom(settings):  # noqa: ANN001
+            raise RuntimeError("anthropic down")
+
+        monkeypatch.setattr(cost_sync, "run_cost_sync", _boom)
+        # Must NOT raise — the loop must survive a failed run.
+        await _run_once(SimpleNamespace())

--- a/packages/shared-backend/tests/test_transparency_store.py
+++ b/packages/shared-backend/tests/test_transparency_store.py
@@ -1,0 +1,155 @@
+"""Unit tests for platform_shared.services.transparency.transparency_store.
+
+Covers the shared-object load/save round-trip (with a fake in-memory storage
+client), the missing-vs-transient error distinction, and the pure
+current-month projection into the public response shape.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from platform_shared.core.storage import StorageNotConfiguredError
+from platform_shared.schemas.transparency import (
+    TRANSPARENCY_OBJECT_KEY,
+    MonthBucket,
+    TransparencyDocument,
+)
+from platform_shared.services.transparency import transparency_store
+from tests.conftest import FakeStorageClient, make_s3_error
+
+_NOW = datetime(2026, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+_SETTINGS = SimpleNamespace(
+    minio_endpoint="minio:9000",
+    minio_access_key="k",
+    minio_secret_key="s",
+    minio_secure=False,
+    transparency_shared_bucket="myfreeapps-shared",
+)
+
+
+@pytest.fixture
+def fake_storage(monkeypatch: pytest.MonkeyPatch) -> FakeStorageClient:
+    """Patch get_shared_storage to a fresh in-memory client + reset cache."""
+    fake = FakeStorageClient()
+    monkeypatch.setattr(transparency_store, "get_shared_storage", lambda settings: fake)
+    transparency_store.reset_shared_storage_cache()
+    return fake
+
+
+class TestLoadSaveRoundTrip:
+    def test_load_missing_object_returns_none(self, fake_storage: FakeStorageClient) -> None:
+        assert transparency_store.load_document(_SETTINGS) is None
+
+    def test_save_then_load_round_trips(self, fake_storage: FakeStorageClient) -> None:
+        doc = TransparencyDocument(
+            updated_at=_NOW.isoformat(),
+            months={"2026-06": MonthBucket(donations_cents=2500, costs_cents=10000)},
+        )
+        transparency_store.save_document(_SETTINGS, doc)
+        loaded = transparency_store.load_document(_SETTINGS)
+        assert loaded is not None
+        assert loaded.updated_at == _NOW.isoformat()
+        assert loaded.months["2026-06"].donations_cents == 2500
+        assert loaded.months["2026-06"].costs_cents == 10000
+
+    def test_save_uses_canonical_key_and_content_type(self, fake_storage: FakeStorageClient) -> None:
+        transparency_store.save_document(_SETTINGS, TransparencyDocument())
+        key, _content, content_type = fake_storage.uploads[-1]
+        assert key == TRANSPARENCY_OBJECT_KEY
+        assert content_type == "application/json"
+
+    def test_transient_s3_error_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        class _Boom:
+            def download_file(self, key: str) -> bytes:
+                raise make_s3_error("InternalError", key)
+
+        monkeypatch.setattr(transparency_store, "get_shared_storage", lambda settings: _Boom())
+        with pytest.raises(Exception) as exc:  # noqa: PT011 — assert it's the S3Error, below
+            transparency_store.load_document(_SETTINGS)
+        assert "InternalError" in str(exc.value)
+
+    def test_storage_not_configured_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def _raise(settings: object) -> None:
+            raise StorageNotConfiguredError("MINIO_ENDPOINT unset")
+
+        monkeypatch.setattr(transparency_store, "get_shared_storage", _raise)
+        with pytest.raises(StorageNotConfiguredError):
+            transparency_store.load_document(_SETTINGS)
+
+
+class TestProjectResponse:
+    def test_none_document_is_not_configured(self) -> None:
+        resp = transparency_store.project_response(None, _NOW)
+        assert resp.configured is False
+        assert resp.costs_cents == 0
+        assert resp.donations_cents == 0
+        assert resp.updated_at is None
+        assert resp.month == "June 2026"
+
+    def test_current_month_with_costs_is_configured(self) -> None:
+        doc = TransparencyDocument(
+            updated_at=_NOW.isoformat(),
+            months={"2026-06": MonthBucket(donations_cents=2500, costs_cents=10000)},
+        )
+        resp = transparency_store.project_response(doc, _NOW)
+        assert resp.configured is True
+        assert resp.costs_cents == 10000
+        assert resp.donations_cents == 2500
+        assert resp.updated_at == _NOW.isoformat()
+        assert resp.month == "June 2026"
+
+    def test_current_month_zero_costs_is_not_configured(self) -> None:
+        """Donations present but costs not yet polled → still hidden."""
+        doc = TransparencyDocument(
+            months={"2026-06": MonthBucket(donations_cents=2500, costs_cents=0)},
+        )
+        resp = transparency_store.project_response(doc, _NOW)
+        assert resp.configured is False
+        assert resp.donations_cents == 2500
+
+    def test_only_prior_month_present_is_not_configured(self) -> None:
+        """A new month before its first poll reports zeros for the new month."""
+        doc = TransparencyDocument(
+            updated_at="2026-05-31T00:00:00+00:00",
+            months={"2026-05": MonthBucket(donations_cents=999, costs_cents=10000)},
+        )
+        resp = transparency_store.project_response(doc, _NOW)
+        assert resp.configured is False
+        assert resp.costs_cents == 0
+        assert resp.donations_cents == 0
+        assert resp.month == "June 2026"
+
+
+class TestHelpers:
+    def test_month_key_and_label(self) -> None:
+        assert transparency_store.month_key(_NOW) == "2026-06"
+        assert transparency_store.month_label(_NOW) == "June 2026"
+
+    def test_get_or_create_bucket_creates_then_reuses(self) -> None:
+        doc = TransparencyDocument()
+        b1 = transparency_store.get_or_create_bucket(doc, _NOW)
+        b1.donations_cents = 100
+        b2 = transparency_store.get_or_create_bucket(doc, _NOW)
+        assert b2 is b1
+        assert doc.months["2026-06"].donations_cents == 100
+
+    def test_prune_keeps_most_recent_months(self) -> None:
+        # Build 15 monthly buckets 2025-04 .. 2026-06.
+        months = {}
+        for year, month in [(2025, m) for m in range(4, 13)] + [(2026, m) for m in range(1, 7)]:
+            months[f"{year}-{month:02d}"] = MonthBucket(costs_cents=1)
+        doc = TransparencyDocument(months=months)
+        assert len(doc.months) == 15
+        transparency_store.prune_old_months(doc, _NOW)
+        assert len(doc.months) == 13
+        assert "2026-06" in doc.months
+        assert "2025-04" not in doc.months  # oldest two dropped
+        assert "2025-05" not in doc.months
+
+    def test_prune_noop_when_under_limit(self) -> None:
+        doc = TransparencyDocument(months={"2026-06": MonthBucket()})
+        transparency_store.prune_old_months(doc, _NOW)
+        assert len(doc.months) == 1


### PR DESCRIPTION
## What this is

PR2 of the cross-app **Support / donation page** (Initiative 10). PR1 (#817) shipped the `@platform/ui` `/support` page + transparency widget. This PR adds the **`platform_shared` backend** the widget reads.

**Model:** one shared JSON object in a shared MinIO bucket holds the figures. Exactly **one** app (`transparency_primary=true`) WRITES it — it receives the Ko-fi donation webhook and runs a daily Anthropic cost poll. **Every** app READS it via the public `GET /transparency`. No shared DB; no cross-app coupling.

The public response matches the frontend `TransparencyData` contract exactly: `{month, costs_cents, donations_cents, updated_at, configured}`.

## What''s in it

- **`schemas/transparency.py`** — `TransparencyResponse` (public wire shape) + persisted `TransparencyDocument`/`MonthBucket` (per-month, integer cents, pruned to 13 months).
- **`services/transparency/`**
  - `transparency_store.py` — shared-bucket client + load/save + current-month projection. Distinguishes missing-object (→ not-configured) from transient/corrupt (→ raise).
  - `kofi_service.py` — parse the form-encoded `data` field; verify the **static `verification_token`** (constant-time; **not HMAC** — confirmed against Ko-fi docs); record with dedup on `message_id` (refuses un-dedupable empties), USD cents, `ROUND_HALF_UP`.
  - `anthropic_cost_service.py` — Admin **Cost Report** API client (`x-api-key` + `anthropic-version`); sums the decimal-cent `amount`s, paginates, and **captures provider error codes at WARNING** (per `check-third-party-error-codes`).
  - `cost_sync.py` — `costs = vps + domain + month-to-date Anthropic`; fetches Anthropic *before* any write so a failure never zeroes a good figure.
  - `scheduler.py` — **asyncio** daily-poll loop (startup catch-up + daily ~00:15 UTC), primary-only. A single stateless daily job doesn''t warrant APScheduler + a jobstore.
- **`api/transparency_router.py`** — public `GET /transparency` + `POST /donations/kofi-webhook` (`build_*_router` factory; resource-level paths since Caddy strips `/api`). Status mapping: read → 200 configured / 200 not-configured / 503 unavailable; webhook → 200 ack / 401 bad token / 404 on a non-writer app / 500 on storage failure (so Ko-fi retries).
- **`settings`** — `kofi_verification_token`, `anthropic_admin_api_key`, `vps_monthly_cost_cents`, `domain_monthly_cost_cents`, `transparency_primary`, `transparency_shared_bucket` (default `myfreeapps-shared`).
- **`boot_guards.check_transparency_configured`** wired into the shared lifespan — fails loud only for a misconfigured **primary** in prod (no Ko-fi token); **no-op for read-only apps + dev**, so existing apps boot unchanged.

No donor PII (name/email) is ever stored, returned, or logged — only `message_id` + amount.

## ⚠️ Operational migration required (only when an app is designated the transparency writer)

This is **inert until** an operator opts one app in. Existing apps (MBK/MJH/MGA/MPT) are unaffected by merging this PR — they all default `transparency_primary=false`. The steps below apply when wiring it up (after PR3 mounts the routes):

1. **Create the shared bucket once** and grant every app''s MinIO user read+write:
   ```
   mc mb <minio-alias>/myfreeapps-shared
   mc anonymous set none <minio-alias>/myfreeapps-shared   # private; apps access via creds
   # grant each app''s MinIO access key get/put on myfreeapps-shared
   ```
2. **On the ONE primary app''s `backend/.env.docker`** (the app whose `/support` URL is registered in Ko-fi):
   ```
   TRANSPARENCY_PRIMARY=true
   KOFI_VERIFICATION_TOKEN=<from Ko-fi webhook settings>     # required when primary in prod
   VPS_MONTHLY_COST_CENTS=<e.g. 1200>
   DOMAIN_MONTHLY_COST_CENTS=<e.g. 100>
   ANTHROPIC_ADMIN_API_KEY=<sk-ant-admin... | omit to use the fixed costs only>
   ```
   **Verify:** `grep -E ^TRANSPARENCY_PRIMARY=|^KOFI_VERIFICATION_TOKEN= apps/<primary>/backend/.env.docker` shows non-empty values. If `TRANSPARENCY_PRIMARY=true` and `KOFI_VERIFICATION_TOKEN` is empty, the app **fails to boot** with `TransparencyNotConfiguredError` (intentional — otherwise every donation would be silently rejected).
3. **All other apps:** nothing — they only need their existing MinIO creds + access to the shared bucket.

**Rollback:** revert this PR; the previous image works without any of the new env vars.

## Notes for the reviewer

- **Daily poll uses asyncio, not APScheduler** (deliberate; chosen with the operator). Adding APScheduler to `platform_shared` would have drifted all 4 apps'' `uv.lock`; an asyncio loop keeps this PR purely `platform_shared` and is the better fit for one stateless daily job. **No new `platform_shared` dependency → consuming apps'' locks are untouched.**
- **Pre-existing, unrelated:** MyJobHunter''s `uv lock --check` already fails on `main` (its committed `uv.lock` lags its `pyproject.toml` pins for uvicorn/pyjwt/sentry-sdk). This PR''s `packages/**` trigger will surface that red on the MJH CI job, but it is **not caused by this PR** (verified: it fails at HEAD with zero changes from this branch). Worth a separate `chore(mjh): relock` PR.

## Tests

Full `platform_shared` suite green: **631 passed, 1 pre-existing skip**. Adds 6 test modules (store / kofi / anthropic / cost-sync / router / scheduler) + extends boot-guard & lifespan tests. File-size gate green.

## Next

- **PR3** mounts the router + adds the `/support` route + `frame-src https://www.youtube-nocookie.com` CSP per app, and opts the one primary app''s `on_startup`/`on_shutdown` into the cost-sync loop.
- **PR4** wires `/support` + CSP into the scaffolder templates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)