### PR TITLE
feat(shared): scaffold new apps with the Support/transparency page wired (Initiative 10 PR4)

### DIFF
--- a/infra/templates/scaffold/backend/.env.docker.example
+++ b/infra/templates/scaffold/backend/.env.docker.example
@@ -77,3 +77,33 @@ MINIO_ACCESS_KEY=
 MINIO_SECRET_KEY=
 MINIO_BUCKET=__APP_SLUG__-uploads
 MINIO_SECURE=false
+
+# --- Cost-transparency / Support page (platform-wide, shared) ---
+# The public /support page shows platform-wide monthly server costs vs Ko-fi
+# donations. ONE app — MyBookkeeper — is the designated primary writer: it
+# receives the Ko-fi webhook and runs the daily cost-sync loop, writing a single
+# shared object that every app's /support widget reads. Set TRANSPARENCY_PRIMARY=true
+# + KOFI_VERIFICATION_TOKEN + the cost values on MyBookkeeper ONLY; every other app
+# leaves all of these at their defaults and only reads. See
+# platform_shared/services/transparency.
+#
+# Ko-fi webhook verification token (Ko-fi dashboard → Webhooks → Verification token).
+# Required on the primary in production; empty elsewhere (those apps 404 the
+# webhook so misrouted posts stop retrying).
+KOFI_VERIFICATION_TOKEN=
+# Optional Anthropic Admin API key (sk-ant-admin...) so the daily sync pulls real
+# Claude API spend into the cost figure. Primary only; empty → Claude spend = 0
+# and only the fixed VPS + domain costs below are shown.
+ANTHROPIC_ADMIN_API_KEY=
+# Fixed monthly infrastructure costs, in integer USD cents (primary only).
+# e.g. 1200 = $12.00/mo. Both default to 0.
+VPS_MONTHLY_COST_CENTS=0
+DOMAIN_MONTHLY_COST_CENTS=0
+# Marks the single writer app. EXACTLY ONE app (MyBookkeeper) sets this true in
+# production; all others stay false. The Ko-fi recording + asyncio daily cost-sync
+# loop only run when true.
+TRANSPARENCY_PRIMARY=false
+# Shared MinIO bucket holding the one transparency object every app reads. Must be
+# identical across all apps; the operator creates it once and grants each app's
+# MinIO user access (operational migration). Defaults to myfreeapps-shared.
+TRANSPARENCY_SHARED_BUCKET=myfreeapps-shared

--- a/infra/templates/scaffold/backend/app/main.py
+++ b/infra/templates/scaffold/backend/app/main.py
@@ -19,6 +19,7 @@ from jwt.exceptions import PyJWTError as JWTError
 
 from platform_shared.core.git import resolve_git_commit
 from platform_shared.core.lifespan import create_app_lifespan
+from platform_shared.api.transparency_router import build_transparency_router
 
 from app.api import account, admin, health, totp
 from app.core.audit import current_user_id
@@ -199,6 +200,13 @@ app.include_router(
         current_strict_superuser=current_strict_superuser,
     )
 )
+
+# Public transparency / support endpoints (shared): GET /transparency +
+# POST /donations/kofi-webhook. Unauthenticated by design — the public
+# /support page reads it, and Ko-fi posts donations to the one primary app
+# (the app with kofi_verification_token set; every other app 404s the
+# webhook). Resource-level paths; host Caddy strips the /api prefix.
+app.include_router(build_transparency_router(settings))
 
 # TOTP routes -- /auth/totp/login gets the per-IP throttle.
 for _route in totp.router.routes:

--- a/infra/templates/scaffold/frontend/src/pages/Login.tsx
+++ b/infra/templates/scaffold/frontend/src/pages/Login.tsx
@@ -276,7 +276,13 @@ export default function Login() {
         )}
       </div>
 
-      <p className="mt-8 text-xs text-muted-foreground">&copy; 2026 __APP_DISPLAY_NAME__</p>
+      <p className="mt-8 text-xs text-muted-foreground">
+        <a href="/support" className="hover:underline hover:text-foreground transition-colors">
+          Support this project
+        </a>
+        <span className="mx-2" aria-hidden="true">·</span>
+        &copy; 2026 __APP_DISPLAY_NAME__
+      </p>
     </div>
   );
 }

--- a/infra/templates/scaffold/frontend/src/routes.tsx
+++ b/infra/templates/scaffold/frontend/src/routes.tsx
@@ -1,4 +1,5 @@
 import { type RouteObject } from "react-router-dom";
+import { Support } from "@platform/ui";
 import Home from "@/pages/Home";
 import Security from "@/pages/Security";
 import Settings from "@/pages/Settings";
@@ -21,6 +22,8 @@ export const routes: RouteObject[] = [
       { path: "/security", element: <Security /> },
     ],
   },
+  // Public support / donation page — standalone (no shell, no auth).
+  { path: "/support", element: <Support appName="__APP_DISPLAY_NAME__" /> },
   { path: "/login", element: <Login /> },
   { path: "/forgot-password", element: <ForgotPassword /> },
   { path: "/reset-password", element: <ResetPassword /> },

--- a/packages/shared-backend/platform_shared/infra/new_app.py
+++ b/packages/shared-backend/platform_shared/infra/new_app.py
@@ -152,7 +152,7 @@ def _write_app_yaml(repo_root: Path, slug: str, *,
             "img-src 'self' data: blob:; "
             "font-src 'self'; "
             "connect-src 'self' https://challenges.cloudflare.com; "
-            "frame-src 'self' https://challenges.cloudflare.com; "
+            "frame-src 'self' https://challenges.cloudflare.com https://www.youtube-nocookie.com; "
             "frame-ancestors 'none'; "
             "base-uri 'self'; "
             "form-action 'self'; "

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -521,6 +521,71 @@ class TestScaffolderProducesBootableApp:
                     skip_uv=True,
                 )
 
+    def test_scaffold_wires_support_page(self, tmp_path) -> None:
+        """Initiative 10 PR4 -- a scaffolded app is born with the public
+        /support page + shared transparency router wired, mirroring the four
+        apps wired in PR3 (TestTransparencyRouterMounted / TestSupportPageWired).
+        Guards against a future template edit silently dropping the support
+        wiring from every app scaffolded thereafter.
+        """
+        import shutil
+        try:
+            import yaml
+        except ModuleNotFoundError as e:
+            pytest.skip(f"pyyaml unavailable ({e}); skipping scaffolder check")
+        try:
+            from platform_shared.infra import new_app as _new_app
+        except ModuleNotFoundError as e:
+            pytest.skip(f"new_app module unavailable ({e}); skipping scaffolder check")
+
+        scaffold_src = _REPO_ROOT / "infra" / "templates" / "scaffold"
+        if not scaffold_src.exists():
+            pytest.skip(f"scaffold templates not present at {scaffold_src}")
+        shutil.copytree(scaffold_src, tmp_path / "infra" / "templates" / "scaffold")
+
+        _new_app.scaffold_app(
+            slug="supporttest",
+            display_name="SupportTest",
+            api_port=18997,
+            caddy_host_port=18996,
+            frontend_port=15997,
+            repo_root=tmp_path,
+            skip_render=True,
+            skip_uv=True,
+            skip_npm=True,
+        )
+        app_dir = tmp_path / "apps" / "supporttest"
+
+        # Backend: shared transparency router imported + mounted (GET /transparency
+        # + POST /donations/kofi-webhook). Without it the /support cost widget 404s.
+        main_src = (app_dir / "backend" / "app" / "main.py").read_text(encoding="utf-8")
+        assert (
+            "from platform_shared.api.transparency_router import build_transparency_router"
+            in main_src
+        ), "scaffolded main.py must import build_transparency_router"
+        assert "build_transparency_router(settings)" in main_src, (
+            "scaffolded main.py must mount the shared transparency router"
+        )
+
+        # Frontend: public /support route rendering the shared Support page + a
+        # public link to it from the login page (single-user apps link via Login).
+        routes_src = (app_dir / "frontend" / "src" / "routes.tsx").read_text(encoding="utf-8")
+        assert "/support" in routes_src and "Support" in routes_src, (
+            "scaffolded routes.tsx must register a public /support route"
+        )
+        login_src = (app_dir / "frontend" / "src" / "pages" / "Login.tsx").read_text(encoding="utf-8")
+        assert "/support" in login_src, (
+            "scaffolded Login.tsx must carry a public link to /support"
+        )
+
+        # CSP: the default frame-src must allow the YouTube no-cookie embed used
+        # by the Support page's inspiration video.
+        csp = yaml.safe_load((app_dir / "app.yaml").read_text(encoding="utf-8"))["csp"]
+        assert "https://www.youtube-nocookie.com" in csp, (
+            "scaffolded app.yaml CSP frame-src must allow youtube-nocookie for the "
+            "Support page video embed"
+        )
+
 
 # --- Transparency / Support page wiring (Initiative 10, PR3) -----------------
 


### PR DESCRIPTION
## What

Final PR of **Initiative 10** (Support / donation page). Wires the public `/support` page + shared cost-transparency router into the **scaffolder** (`infra/templates/scaffold/` + `new_app.py`), so every *future* app scaffolded via `python -m platform_shared.infra.new_app` is born with the same wiring the four existing apps got by hand in PR3 (#821). No per-app follow-up after scaffold.

## Changes

**Scaffold templates (`infra/templates/scaffold/`):**
- `backend/app/main.py` — import + mount `build_transparency_router(settings)` (public `GET /transparency` + `POST /donations/kofi-webhook`), mirroring MyPizzaTracker.
- `frontend/src/routes.tsx` — `import { Support } from "@platform/ui"` + a public standalone `/support` route (outside auth, no operator shell).
- `frontend/src/pages/Login.tsx` — footer **"Support this project"** link to `/support`, matching the three single-user apps' login-link pattern from PR3.
- `backend/.env.docker.example` — the 6 transparency env vars with inert defaults (`TRANSPARENCY_PRIMARY=false`, etc.).

**`packages/shared-backend/platform_shared/infra/new_app.py`:**
- `_write_app_yaml` default CSP `frame-src` += `https://www.youtube-nocookie.com` so the Support page's YouTube embed isn't CSP-blocked. (The CSP literal lives here, not in `Caddyfile.docker.j2`, which renders `{{ csp }}` from `app.yaml`.)

## Beyond the literal scope (flagging for review)

The operator's task listed 4 edits; I made two additions for correctness/parity, both inert:
1. **`.env.docker.example` (5th edit).** PR3's per-app pattern for "wire transparency" *included* the 6 env vars in each app's `.env.docker.example`. `.env.example` is a Tier-2 operational template (parity discipline) — skipping it would make every future scaffolded app drift from canonical on day one. All defaults preserve current behavior.
2. **New conformance test** `TestScaffolderProducesBootableApp::test_scaffold_wires_support_page` — scaffolds a temp app and asserts the router mount, `/support` route + login link, and the youtube-nocookie CSP. PR3 added equivalent guards (`TestSupportPageWired`) for the 4 real apps; the scaffolder output had none, so a future template edit could silently drop the wiring.

**Link mechanism:** chose the login-page link (operator-confirmed), consistent with the 3 single-user apps in PR3. `constants/nav.ts` deliberately untouched (no app added a nav entry).

## Tests
- `shared-backend`: **654 passed, 4 skipped** (full suite).
- Operator-required gates green: `TestScaffolderProducesBootableApp` (4/4, incl. new test) + `TestInfraTemplateDrift` (4/4 apps — confirms the `new_app.py` change doesn't perturb existing apps).
- No `render --all` needed: no `app.yaml`/`.j2` changed; the CSP default only affects *future* scaffolds.

## Operational migration
**None.** Inert for existing apps. A newly scaffolded app inherits `TRANSPARENCY_PRIMARY=false` and only *reads* the shared transparency object; MyBookkeeper (the primary) remains the sole writer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
