### PR TITLE
chore(mga): defer desktop (Tauri) CI — manual-only while development is paused

### DIFF
--- a/.github/workflows/ci-mygamingassistant-desktop.yml
+++ b/.github/workflows/ci-mygamingassistant-desktop.yml
@@ -2,9 +2,16 @@ name: MyGamingAssistant Desktop CI
 
 # Builds the Tauri desktop binary on Linux, macOS, and Windows.
 #
-# This workflow runs in parallel with the existing deploy-mygamingassistant.yml
-# (which ships the web app). PR 7 only adds this new workflow; it does not
-# change or replace any existing deploy path.
+# DEFERRED (2026-06-01): MyGamingAssistant desktop (Tauri) development is paused.
+# The web app — the read-only lineup library — is the active, deployed product
+# (shipped via deploy-mygamingassistant.yml). The desktop CS2 live screen-capture
+# build is not under active development, and its slow cross-OS native builds were
+# running on every frontend / shared-frontend PR for no current benefit.
+#
+# This workflow is therefore MANUAL-ONLY (workflow_dispatch) — it no longer runs
+# automatically on pull_request / push. The build recipe (jobs below) and all
+# desktop code are intentionally kept intact. To RESUME desktop development,
+# restore the pull_request + push triggers from this file's git history.
 #
 # Signing / notarization: deferred. Binaries are uploaded as workflow artifacts
 # only. Operator setup will be needed before public distribution:
@@ -13,24 +20,11 @@ name: MyGamingAssistant Desktop CI
 #   - Linux:   no signing (or optional Snap/Flatpak publishing later)
 
 on:
-  pull_request:
-    branches: [main]
-    paths:
-      - 'apps/mygamingassistant/desktop/**'
-      - 'apps/mygamingassistant/frontend/**'
-      - 'packages/shared-frontend/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/ci-mygamingassistant-desktop.yml'
-  push:
-    branches: [main]
-    paths:
-      - 'apps/mygamingassistant/desktop/**'
-      - 'apps/mygamingassistant/frontend/**'
-      - 'packages/shared-frontend/**'
-      - 'package.json'
-      - 'package-lock.json'
-      - '.github/workflows/ci-mygamingassistant-desktop.yml'
+  # Manual-only while desktop development is deferred. To resume automatic
+  # builds, re-add the pull_request + push triggers (branches: [main]; paths:
+  # apps/mygamingassistant/desktop/**, apps/mygamingassistant/frontend/**,
+  # packages/shared-frontend/**, package.json, package-lock.json, and this file).
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Defer MyGamingAssistant **desktop (Tauri) development** entirely: switch `ci-mygamingassistant-desktop.yml` to **`workflow_dispatch` (manual) only**. It no longer runs on `pull_request` / `push`.

## Why

The active, deployed MGA product is the **web read-only lineup library** (shipped via `deploy-mygamingassistant.yml`). The desktop CS2 live screen-capture build is not under active development, yet its slow cross-OS native builds (`build / {linux-x64, macos-arm64, windows-x64}` + `rust-checks`) ran on **every** `frontend/**` and `packages/shared-frontend/**` PR — pure CI cost for no current benefit.

## Scope / reversibility

- **Kept intact:** the full build recipe (both jobs) and **all desktop code** under `apps/mygamingassistant/desktop/`. Nothing is deleted.
- **To resume:** restore the `pull_request` + `push` triggers from this file's git history (documented inline in the workflow header).
- Can still be run on demand via the Actions tab (`workflow_dispatch`).

No effect on the web app, its CI, or the deploy path.