### PR TITLE
fix(mga): allow presigned R2 endpoint in CSP so clips load without the CDN domain

### DIFF
--- a/apps/mygamingassistant/app.yaml
+++ b/apps/mygamingassistant/app.yaml
@@ -19,10 +19,18 @@ include_bundle_tripwire: true
 # false — they are fully auth-gated and have no serve-only mode.
 serve_only_build_arg: true
 env_seed_command: create from .env.example first
-# mga-clips.myfreeapps.org is the R2 public clip/screenshot domain (a first-level
-# subdomain so it's covered by Cloudflare's free *.myfreeapps.org Universal SSL).
-# It must appear in img-src (screenshots), media-src (clips), and connect-src
-# (blob fetches). If the operator binds R2 to a different hostname, this CSP,
-# MINIO_PUBLIC_BASE_URL, and the R2 binding must all match.
-csp: "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://mga-clips.myfreeapps.org; media-src 'self' https://mga-clips.myfreeapps.org; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://mga-clips.myfreeapps.org; frame-src 'self' https://challenges.cloudflare.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+# R2 clips/screenshots reach the browser by ONE of two serving modes, so the CSP
+# allows both hosts in img-src (screenshots), media-src (clips), and connect-src
+# (blob fetches):
+#   1. CDN custom domain — mga-clips.myfreeapps.org. Used when MINIO_PUBLIC_BASE_URL
+#      is set; requires binding the R2 bucket to this domain, which needs the zone
+#      on Cloudflare (a first-level subdomain → free *.myfreeapps.org Universal SSL).
+#   2. Presigned S3 URLs — https://*.r2.cloudflarestorage.com (the account R2
+#      endpoint). Used when MINIO_PUBLIC_BASE_URL is EMPTY (the lineup service
+#      presigns each URL). This is the mode when the DNS zone is NOT on Cloudflare
+#      (e.g. registrar-managed), so the R2 custom domain can't be bound. Wildcard
+#      avoids committing the account-specific endpoint id.
+# Whichever mode is used, MINIO_PUBLIC_BASE_URL and the R2 setup must match the
+# host the bundle actually loads from — both are pre-allowed here so either works.
+csp: "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; media-src 'self' https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; frame-src 'self' https://challenges.cloudflare.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
 workers: []

--- a/apps/mygamingassistant/docker/Caddyfile.docker
+++ b/apps/mygamingassistant/docker/Caddyfile.docker
@@ -29,7 +29,7 @@
         X-Content-Type-Options "nosniff"
         Referrer-Policy "strict-origin-when-cross-origin"
         Permissions-Policy "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=(), interest-cohort=(), browsing-topics=()"
-        Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://mga-clips.myfreeapps.org; media-src 'self' https://mga-clips.myfreeapps.org; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://mga-clips.myfreeapps.org; frame-src 'self' https://challenges.cloudflare.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+        Content-Security-Policy "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; media-src 'self' https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; frame-src 'self' https://challenges.cloudflare.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
         -Server
     }
 


### PR DESCRIPTION
## What

Add `https://*.r2.cloudflarestorage.com` to `img-src`, `media-src`, and `connect-src` in the MGA CSP (`apps/mygamingassistant/app.yaml` → re-rendered `docker/Caddyfile.docker`).

## Why

MGA prod serves clips/screenshots from Cloudflare R2. When the DNS zone is **not** on Cloudflare (e.g. registrar-managed at Porkbun), the R2 bucket can't be bound to the `mga-clips.myfreeapps.org` custom domain, so `MINIO_PUBLIC_BASE_URL` is left empty and the lineup service **presigns** each URL against the account S3 endpoint `<account>.r2.cloudflarestorage.com`.

The CSP previously allowed only `mga-clips.myfreeapps.org` for those three directives — so presigned URLs would be **browser-blocked** and every clip/screenshot would fail to load (the glance board renders, but all panes are broken images). The CSP lives in committed config (not `.env.docker`), so this is a code fix, not operator env.

## Notes

- Wildcard `*.r2.cloudflarestorage.com` avoids committing the account-specific endpoint id.
- `mga-clips.myfreeapps.org` is **kept** so the CDN custom-domain mode still works if the zone is later moved to Cloudflare — both serving modes are pre-allowed.
- Conformance drift test (`TestInfraTemplateDrift`) green; only `app.yaml` + rendered `Caddyfile.docker` change.