### PR TITLE
feat(mga): auto-import lineup library on deploy + one-command local ship

### DIFF
--- a/.github/workflows/deploy-mygamingassistant.yml
+++ b/.github/workflows/deploy-mygamingassistant.yml
@@ -90,6 +90,16 @@ jobs:
             echo "--- Run database migrations ---"
             docker compose -f apps/mygamingassistant/docker-compose.yml exec -T api alembic upgrade head
 
+            echo "--- Run post-deploy commands (app-specific, idempotent) ---"
+            # In-container steps that run on EVERY deploy after the schema is
+            # migrated. Each must be idempotent (re-runs on packages/** fan-out
+            # deploys too). Driven by apps/<slug>/app.yaml post_deploy_commands;
+            # empty for most apps. MGA uses it to auto-seed its public lineup
+            # library (load-fixtures + import-lineups) so a merged pack update
+            # goes live with no manual VPS step.
+            docker compose -f apps/mygamingassistant/docker-compose.yml exec -T api python -m app.cli load-fixtures
+            docker compose -f apps/mygamingassistant/docker-compose.yml exec -T api python -m app.cli import-lineups
+
             echo "--- Wait for API health check ---"
             for i in $(seq 1 30); do
               if docker compose -f apps/mygamingassistant/docker-compose.yml exec -T api python -c "import urllib.request; urllib.request.urlopen('http://localhost:8004/health')" 2>/dev/null; then

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,8 @@ dist/
 .env.local
 .env.*.local
 *.env.docker
+# Local Cloudflare R2 publish creds for the MGA ship-library tool (never commit).
+.env.r2
 
 # OS
 .DS_Store

--- a/apps/mybookkeeper/app.yaml
+++ b/apps/mybookkeeper/app.yaml
@@ -18,3 +18,5 @@ workers:
     command: ["python", "-m", "app.workers.upload_processor_worker"]
   - name: scheduler
     command: ["python", "-m", "app.workers.scheduler_worker"]
+# No app-specific post-deploy steps — deploy runs migrate only.
+post_deploy_commands: []

--- a/apps/mygamingassistant/app.yaml
+++ b/apps/mygamingassistant/app.yaml
@@ -34,3 +34,12 @@ env_seed_command: create from .env.example first
 # host the bundle actually loads from — both are pre-allowed here so either works.
 csp: "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; media-src 'self' https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com https://mga-clips.myfreeapps.org https://*.r2.cloudflarestorage.com; frame-src 'self' https://challenges.cloudflare.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
 workers: []
+# Run on EVERY deploy, in-container, AFTER migrate. Both idempotent:
+# load-fixtures upserts the game taxonomy (incl. any new map fixture like
+# de_cache); import-lineups reconciles the public library to the image-baked
+# pack (backend/data/lineup_library.json). This is the prod half of "merge a
+# library update -> it goes live"; the local clip-publish half is
+# backend/scripts/ship-library.ps1. Other apps keep this empty.
+post_deploy_commands:
+  - python -m app.cli load-fixtures
+  - python -m app.cli import-lineups

--- a/apps/myjobhunter/app.yaml
+++ b/apps/myjobhunter/app.yaml
@@ -16,3 +16,5 @@ csp: "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86
 workers:
   - name: resume-parser
     command: ["python", "-m", "app.workers.resume_parser_worker"]
+# No app-specific post-deploy steps — deploy runs migrate only.
+post_deploy_commands: []

--- a/apps/mypizzatracker/app.yaml
+++ b/apps/mypizzatracker/app.yaml
@@ -18,3 +18,5 @@ csp: 'default-src ''self''; script-src ''self'' https://challenges.cloudflare.co
   frame-ancestors ''none''; base-uri ''self''; form-action ''self''; object-src ''none'';
   upgrade-insecure-requests'
 workers: []
+# No app-specific post-deploy steps — deploy runs migrate only.
+post_deploy_commands: []

--- a/infra/templates/.github/workflows/deploy.yml.j2
+++ b/infra/templates/.github/workflows/deploy.yml.j2
@@ -89,6 +89,19 @@ jobs:
 
             echo "--- Run database migrations ---"
             docker compose -f apps/{{ app_slug }}/docker-compose.yml exec -T api alembic upgrade head
+{%- if post_deploy_commands %}
+
+            echo "--- Run post-deploy commands (app-specific, idempotent) ---"
+            # In-container steps that run on EVERY deploy after the schema is
+            # migrated. Each must be idempotent (re-runs on packages/** fan-out
+            # deploys too). Driven by apps/<slug>/app.yaml post_deploy_commands;
+            # empty for most apps. MGA uses it to auto-seed its public lineup
+            # library (load-fixtures + import-lineups) so a merged pack update
+            # goes live with no manual VPS step.
+{%- for cmd in post_deploy_commands %}
+            docker compose -f apps/{{ app_slug }}/docker-compose.yml exec -T api {{ cmd }}
+{%- endfor %}
+{%- endif %}
 
             echo "--- Wait for API health check ---"
             for i in $(seq 1 30); do

--- a/packages/shared-backend/platform_shared/infra/new_app.py
+++ b/packages/shared-backend/platform_shared/infra/new_app.py
@@ -160,6 +160,7 @@ def _write_app_yaml(repo_root: Path, slug: str, *,
             "upgrade-insecure-requests"
         ),
         "workers": [],
+        "post_deploy_commands": [],
     }
     path = repo_root / "apps" / slug / "app.yaml"
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -465,6 +465,58 @@ class TestInfraTemplateDrift:
         )
 
 
+# Apps whose deploy workflow runs in-container steps after migrate (driven by
+# app.yaml `post_deploy_commands`). MGA auto-seeds its public lineup library on
+# every deploy; the canonical apps keep the list empty. The inverse check guards
+# against the auto-import leaking into an app with no library to import.
+_POST_DEPLOY_APPS = {"mygamingassistant"}
+
+
+class TestPostDeployCommands:
+    """`post_deploy_commands` in app.yaml must render into the deploy workflow
+    as in-container `docker compose exec` steps AFTER `alembic upgrade head`.
+
+    MGA uses this to auto-seed its public lineup library (load-fixtures +
+    import-lineups) so a merged library-pack update goes live with no manual
+    VPS step. Empty for every other app — and the inverse test below asserts
+    their deploy workflow has no post-deploy block, so the auto-import can't
+    silently run where there is no library.
+    """
+
+    @pytest.mark.parametrize("app", sorted(_POST_DEPLOY_APPS))
+    def test_deploy_workflow_runs_post_deploy_commands(self, app: str) -> None:
+        wf = _read(".github", "workflows", f"deploy-{app}.yml")
+        assert "Run post-deploy commands" in wf, (
+            f"deploy-{app}.yml must contain the post-deploy block rendered from "
+            f"apps/{app}/app.yaml `post_deploy_commands`. Re-run "
+            f"`python -m platform_shared.infra.render --app {app}`."
+        )
+        assert "python -m app.cli load-fixtures" in wf, (
+            f"deploy-{app}.yml must run `load-fixtures` in-container so a new map "
+            f"fixture is seeded before import-lineups resolves its slugs."
+        )
+        assert "python -m app.cli import-lineups" in wf, (
+            f"deploy-{app}.yml must run `import-lineups` in-container so the "
+            f"image-baked lineup pack is reconciled into prod on every deploy."
+        )
+        assert wf.index("alembic upgrade head") < wf.index("import-lineups"), (
+            f"deploy-{app}.yml: post-deploy commands must run AFTER "
+            f"`alembic upgrade head` (import resolves against migrated tables)."
+        )
+
+    @pytest.mark.parametrize("app", sorted(set(_APPS) - _POST_DEPLOY_APPS))
+    def test_no_post_deploy_block_for_other_apps(self, app: str) -> None:
+        wf = _read(".github", "workflows", f"deploy-{app}.yml")
+        assert "Run post-deploy commands" not in wf, (
+            f"deploy-{app}.yml has a post-deploy block but {app}'s "
+            f"`post_deploy_commands` is empty in app.yaml. Re-render."
+        )
+        assert "import-lineups" not in wf, (
+            f"deploy-{app}.yml references import-lineups but {app} is not a "
+            f"post-deploy app — the MGA-only auto-import leaked into it."
+        )
+
+
 class TestScaffolderProducesBootableApp:
     """Tier 5 -- the scaffolder must produce a complete, fully-substituted app dir.
 


### PR DESCRIPTION
## What this does

Automates shipping a MyGamingAssistant lineup-library update to prod, split into the two halves the architecture forces apart.

**Prod import (this PR):** A new `post_deploy_commands` list in the shared deploy template (`infra/templates/.github/workflows/deploy.yml.j2`) runs each command in-container right after `alembic upgrade head`. MGA sets it to `load-fixtures` + `import-lineups` (both idempotent) so every deploy reconciles the public library to the image-baked pack — no manual VPS step. The list defaults empty, so MBK/MJH/MPT render byte-identical (drift test green), and the scaffolder writes the field for future apps (StrictUndefined requires it).

**Clip publish (local tooling, not in this PR):** `apps/mygamingassistant/backend/scripts/ship-library.ps1` (untracked, like the rest of `scripts/`) does export → publish-clips-to-R2 → commit → PR → admin-merge-on-green. The clip bytes live only on the authoring box's local MinIO, so that half can't move into CI; only the import half can.

## What merging this does

Triggers an MGA deploy whose new post-deploy step **auto-imports the current 54-lineup pack to prod** (idempotent). The 35 existing clips already render; the 19 new Cache clips render once their bytes are published to R2 (one-time operator step below).

## Post-merge (one-time, operator)

The Cache clips (#827) were merged before this automation existed, so publish them to R2 once:
1. `cp scripts/.env.r2.example scripts/.env.r2` and fill in R2 creds (gitignored).
2. From `apps/mygamingassistant/backend`, with local MinIO up: `python scripts/publish_clips_to_r2.py` after loading `.env.r2` (expect `copied=238 missing=0`).

After that, future updates are one command: `.\scripts\ship-library.ps1 -Message "..."`.

## Tests
- `TestPostDeployCommands` — MGA's deploy runs load-fixtures + import-lineups after migrate; the canonical apps' deploys don't.
- `TestInfraTemplateDrift` — rendered output matches templates (all 4 apps).
- 12/12 green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)