### PR TITLE
fix(mbk): let Unverified payments be approved so they reach the dashboard

### DIFF
--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_helpers.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_helpers.py
@@ -1,0 +1,61 @@
+"""DB-aware helpers shared by the attribution pipeline and the review API.
+
+Extracted from ``attribution_service`` so that module stays under the
+file-size growth guard. These two helpers resolve tenant→property links and
+fetch the org's active ``lease_signed`` applicants; both the ingestion-time
+auto-attribution pipeline and the host-facing review/manual-attribute paths
+depend on them.
+"""
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.repositories.applicants import applicant_repo
+from app.repositories.leases import signed_lease_repo
+from app.repositories.listings import listing_repo
+
+
+async def _get_lease_signed_applicants(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+) -> list[Applicant]:
+    """Fetch all active lease_signed applicants for the org/user."""
+    return await applicant_repo.list_for_user(
+        db,
+        organization_id=organization_id,
+        user_id=user_id,
+        stage="lease_signed",
+        include_deleted=False,
+        limit=500,
+        offset=0,
+    )
+
+
+async def _get_property_id_for_applicant(
+    db: AsyncSession,
+    applicant: Applicant,
+    organization_id: uuid.UUID,
+) -> uuid.UUID | None:
+    """Resolve the property_id linked to an applicant via their signed lease.
+
+    Walks: applicant → signed_lease → listing → property_id.
+    Returns the first non-null property_id found, or None.
+    """
+    leases = await signed_lease_repo.list_for_tenant(
+        db,
+        user_id=applicant.user_id,
+        organization_id=organization_id,
+        applicant_id=applicant.id,
+        include_deleted=False,
+        limit=5,
+    )
+    for lease in leases:
+        if not lease.listing_id:
+            continue
+        listing = await listing_repo.get_by_id(db, lease.listing_id, organization_id)
+        if listing and listing.property_id:
+            return listing.property_id
+    return None

--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -17,13 +17,11 @@ import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.db.session import AsyncSessionLocal, unit_of_work
-from app.models.applicants.applicant import Applicant
 from app.models.transactions.transaction import Transaction
 from app.repositories import attribution_repo
 from app.repositories import payer_alias_repo
 from app.repositories import booking_statement_repo
 from app.repositories.applicants import applicant_repo
-from app.repositories.leases import signed_lease_repo
 from app.repositories.listings import listing_repo
 from app.repositories.properties import property_repo
 from app.repositories import transaction_repo as txn_repo
@@ -32,58 +30,13 @@ from app.services.transactions.airbnb_payout_matcher import (
     decide_airbnb_attribution,
     parse_res_code,
 )
+from app.services.transactions.attribution_helpers import (
+    _get_lease_signed_applicants,
+    _get_property_id_for_applicant,
+)
 from app.services.transactions.attribution_matcher import find_best_match, resolve_alias
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# DB-aware helpers
-# ---------------------------------------------------------------------------
-
-async def _get_lease_signed_applicants(
-    db: AsyncSession,
-    *,
-    organization_id: uuid.UUID,
-    user_id: uuid.UUID,
-) -> list[Applicant]:
-    """Fetch all active lease_signed applicants for the org/user."""
-    return await applicant_repo.list_for_user(
-        db,
-        organization_id=organization_id,
-        user_id=user_id,
-        stage="lease_signed",
-        include_deleted=False,
-        limit=500,
-        offset=0,
-    )
-
-
-async def _get_property_id_for_applicant(
-    db: AsyncSession,
-    applicant: Applicant,
-    organization_id: uuid.UUID,
-) -> uuid.UUID | None:
-    """Resolve the property_id linked to an applicant via their signed lease.
-
-    Walks: applicant → signed_lease → listing → property_id.
-    Returns the first non-null property_id found, or None.
-    """
-    leases = await signed_lease_repo.list_for_tenant(
-        db,
-        user_id=applicant.user_id,
-        organization_id=organization_id,
-        applicant_id=applicant.id,
-        include_deleted=False,
-        limit=5,
-    )
-    for lease in leases:
-        if not lease.listing_id:
-            continue
-        listing = await listing_repo.get_by_id(db, lease.listing_id, organization_id)
-        if listing and listing.property_id:
-            return listing.property_id
-    return None
 
 
 # ---------------------------------------------------------------------------

--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -388,6 +388,9 @@ async def confirm_review(
             txn.applicant_id = applicant.id
             txn.attribution_source = "auto_fuzzy_confirmed"
             txn.category = "rental_revenue"
+            # Confirming an attribution verifies the payment — promote it out of
+            # the pending / unverified review state so it counts in the dashboard.
+            txn.status = "approved"
 
             # Resolve property from applicant's active lease if not already set
             if txn.property_id is None:
@@ -435,6 +438,8 @@ async def confirm_review(
             txn.applicant_id = None
             txn.attribution_source = "manual"
             txn.category = "rental_revenue"
+            # Confirming the payout against a property verifies it.
+            txn.status = "approved"
             await attribution_repo.resolve(db, row, "confirmed")
             return {"ok": True, "transaction_id": str(txn.id)}
 
@@ -487,6 +492,9 @@ async def attribute_manually(
         txn.applicant_id = applicant.id
         txn.attribution_source = "manual"
         txn.category = "rental_revenue"
+        # Manually linking a tenant verifies the payment — promote it to
+        # approved so it counts in the dashboard.
+        txn.status = "approved"
 
         if txn.property_id is None:
             property_id = await _get_property_id_for_applicant(db, applicant, organization_id)

--- a/apps/mybookkeeper/backend/tests/test_attribution_service_attribute_manually.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_service_attribute_manually.py
@@ -162,3 +162,62 @@ async def test_attribute_manually_no_review_row_works(db: AsyncSession):
         await db.execute(select(Transaction).where(Transaction.id == txn.id))
     ).scalar_one()
     assert refreshed_txn.applicant_id == applicant.id
+
+
+@pytest.mark.asyncio
+async def test_attribute_manually_promotes_unverified_to_approved(db: AsyncSession):
+    """Manually linking a tenant verifies an unverified payment → status approved.
+
+    Reproduces the reported bug: a Zelle payment extracted from an email body
+    lands as ``unverified`` with no UI affordance to approve it. Attributing it
+    to a tenant must promote it to ``approved`` so it reaches the dashboard.
+    """
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+
+    applicant = Applicant(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        stage="lease_signed",
+        legal_name="Andrew Le",
+    )
+    db.add(applicant)
+
+    txn = Transaction(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        transaction_date=_dt.date(2026, 6, 1),
+        tax_year=2026,
+        amount="1595.00",
+        transaction_type="income",
+        category="uncategorized",
+        status="unverified",
+        is_manual=False,
+    )
+    db.add(txn)
+    await db.flush()
+
+    fake_uow = _make_fake_uow(db)
+
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        fake_uow,
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        new_callable=AsyncMock,
+    ):
+        result = await attribute_manually(
+            transaction_id=txn.id,
+            applicant_id=applicant.id,
+            organization_id=org_id,
+            user_id=user_id,
+        )
+
+    assert result["ok"] is True
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.applicant_id == applicant.id
+    assert refreshed_txn.status == "approved"

--- a/apps/mybookkeeper/backend/tests/test_attribution_service_confirm_property.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_service_confirm_property.py
@@ -39,7 +39,9 @@ def _property(org_id: uuid.UUID, user_id: uuid.UUID, name: str = "Beach House") 
     return Property(id=uuid.uuid4(), organization_id=org_id, user_id=user_id, name=name)
 
 
-def _txn(org_id: uuid.UUID, user_id: uuid.UUID) -> Transaction:
+def _txn(
+    org_id: uuid.UUID, user_id: uuid.UUID, *, status: str = "approved"
+) -> Transaction:
     return Transaction(
         id=uuid.uuid4(),
         organization_id=org_id,
@@ -49,7 +51,7 @@ def _txn(org_id: uuid.UUID, user_id: uuid.UUID) -> Transaction:
         amount="2500.00",
         transaction_type="income",
         category="uncategorized",
-        status="approved",
+        status=status,
         is_manual=False,
     )
 
@@ -247,3 +249,67 @@ async def test_confirm_no_applicant_or_property_raises(db: AsyncSession):
             await confirm_review(
                 review_id=review.id, organization_id=org_id, user_id=user_id,
             )
+
+
+@pytest.mark.asyncio
+async def test_confirm_property_promotes_unverified_to_approved(db: AsyncSession):
+    """Confirming an unverified payout against a property promotes it to
+    approved so it counts in the dashboard (the bug behind unattributable
+    Zelle/payout rows being stuck out of revenue totals)."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = _property(org_id, user_id)
+    txn = _txn(org_id, user_id, status="unverified")
+    review = _review(org_id, user_id, txn.id, proposed_property_id=prop.id)
+    db.add_all([prop, txn, review])
+    await db.flush()
+
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        _make_fake_uow(db),
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        new_callable=AsyncMock,
+    ):
+        await confirm_review(
+            review_id=review.id, organization_id=org_id, user_id=user_id,
+        )
+
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.status == "approved"
+
+
+@pytest.mark.asyncio
+async def test_confirm_applicant_promotes_unverified_to_approved(db: AsyncSession):
+    """Confirming an unverified rent payment against a tenant promotes it to
+    approved."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    applicant = Applicant(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        stage="lease_signed",
+        legal_name="Andrew Le",
+    )
+    txn = _txn(org_id, user_id, status="unverified")
+    review = _review(org_id, user_id, txn.id, proposed_applicant_id=applicant.id)
+    db.add_all([applicant, txn, review])
+    await db.flush()
+
+    with patch(
+        "app.services.transactions.attribution_service.unit_of_work",
+        _make_fake_uow(db),
+    ), patch(
+        "app.services.transactions.attribution_service.receipt_service.create_pending_receipt_in_session",
+        new_callable=AsyncMock,
+    ):
+        await confirm_review(
+            review_id=review.id, organization_id=org_id, user_id=user_id,
+        )
+
+    refreshed_txn = (
+        await db.execute(select(Transaction).where(Transaction.id == txn.id))
+    ).scalar_one()
+    assert refreshed_txn.applicant_id == applicant.id
+    assert refreshed_txn.status == "approved"

--- a/apps/mybookkeeper/frontend/src/__tests__/Transactions.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/Transactions.test.tsx
@@ -157,7 +157,11 @@ vi.mock("@/shared/hooks/useOrgRole", () => ({
   useCanWrite: vi.fn(() => true),
 }));
 
-import { useListTransactionsQuery } from "@/shared/store/transactionsApi";
+import {
+  useListTransactionsQuery,
+  useUpdateTransactionMutation,
+  useBulkApproveTransactionsMutation,
+} from "@/shared/store/transactionsApi";
 import { useCanWrite } from "@/shared/hooks/useOrgRole";
 
 function renderWithProviders(ui: React.ReactElement) {
@@ -310,5 +314,96 @@ describe("Transactions — viewer role", () => {
     renderWithProviders(<Transactions />);
 
     expect(screen.getByText("Export")).toBeInTheDocument();
+  });
+});
+
+describe("Transactions — approve affordance for unverified rows", () => {
+  // Reproduces the reported bug: an Unverified payment with a property assigned
+  // had no way to be approved (the inline ✓ and bulk Approve both skipped the
+  // "unverified" status), so it never reached the dashboard.
+  const unverifiedWithProperty: Transaction = {
+    ...mockTransactions[1],
+    id: "txn-unverified",
+    vendor: "Zelle",
+    status: "unverified",
+    property_id: "prop-1",
+  };
+  const unverifiedNoProperty: Transaction = {
+    ...unverifiedWithProperty,
+    id: "txn-unverified-np",
+    property_id: null,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useCanWrite).mockReturnValue(true);
+  });
+
+  it("shows the inline Approve button for an unverified row that has a property", () => {
+    vi.mocked(useListTransactionsQuery).mockReturnValue({
+      data: [unverifiedWithProperty],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useListTransactionsQuery>);
+
+    renderWithProviders(<Transactions />);
+
+    expect(screen.getAllByTitle("Approve").length).toBeGreaterThan(0);
+  });
+
+  it("does not show the inline Approve button for an unverified row with no property", () => {
+    vi.mocked(useListTransactionsQuery).mockReturnValue({
+      data: [unverifiedNoProperty],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useListTransactionsQuery>);
+
+    renderWithProviders(<Transactions />);
+
+    expect(screen.queryByTitle("Approve")).toBeNull();
+  });
+
+  it("approves an unverified row to status 'approved' when the inline button is clicked", async () => {
+    const user = userEvent.setup();
+    const updateTrigger = vi.fn(() => ({ unwrap: () => Promise.resolve({}) }));
+    vi.mocked(useListTransactionsQuery).mockReturnValue({
+      data: [unverifiedWithProperty],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useListTransactionsQuery>);
+    vi.mocked(useUpdateTransactionMutation).mockReturnValue([
+      updateTrigger,
+      { isLoading: false },
+    ] as unknown as ReturnType<typeof useUpdateTransactionMutation>);
+
+    renderWithProviders(<Transactions />);
+
+    await user.click(screen.getAllByTitle("Approve")[0]);
+
+    expect(updateTrigger).toHaveBeenCalledWith({
+      id: "txn-unverified",
+      data: { status: "approved" },
+    });
+  });
+
+  it("bulk-approves a selected unverified row with a property", async () => {
+    const user = userEvent.setup();
+    const bulkTrigger = vi.fn(() => ({
+      unwrap: () => Promise.resolve({ approved: 1, skipped: 0 }),
+    }));
+    vi.mocked(useListTransactionsQuery).mockReturnValue({
+      data: [unverifiedWithProperty],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useListTransactionsQuery>);
+    vi.mocked(useBulkApproveTransactionsMutation).mockReturnValue([
+      bulkTrigger,
+      { isLoading: false },
+    ] as unknown as ReturnType<typeof useBulkApproveTransactionsMutation>);
+
+    renderWithProviders(<Transactions />);
+
+    // Select the row, then click the bulk-bar Approve (visible text — distinct
+    // from the icon-only inline ✓ which exposes its label via `title`).
+    await user.click(screen.getAllByRole("checkbox")[1]);
+    await user.click(screen.getByText("Approve"));
+
+    expect(bulkTrigger).toHaveBeenCalledWith(["txn-unverified"]);
   });
 });

--- a/apps/mybookkeeper/frontend/src/app/pages/Transactions.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Transactions.tsx
@@ -13,6 +13,7 @@ import {
 import { Plus, Upload, Sparkles } from "lucide-react";
 import { cn } from "@/shared/utils/cn";
 import { useTransactionColumns } from "@/shared/hooks/useTransactionColumns";
+import { APPROVABLE_STATUSES } from "@/shared/lib/transaction-config";
 import { useTransactionPageState } from "@/app/features/transactions/hooks/useTransactionPageState";
 import { formatTag } from "@/shared/utils/tag";
 import TransactionTable from "@/app/features/transactions/TransactionTable";
@@ -144,11 +145,9 @@ export default function Transactions() {
   const colCount = table.getAllLeafColumns().length;
   const selectedRows = table.getSelectedRowModel().rows;
   const selectedCount = selectedRows.length;
-  const hasApprovable = selectedRows.some(
-    (r) =>
-      r.original.property_id &&
-      (r.original.status === "pending" || r.original.status === "needs_review"),
-  );
+  const isRowApprovable = (r: (typeof selectedRows)[number]) =>
+    !!r.original.property_id && APPROVABLE_STATUSES.includes(r.original.status);
+  const hasApprovable = selectedRows.some(isRowApprovable);
 
   const deleteTarget = confirmDeleteId ? transactions.find((t) => t.id === confirmDeleteId) : null;
 
@@ -236,13 +235,7 @@ export default function Transactions() {
               isDeleting={bulkAction === "delete"}
               onApprove={() =>
                 handleBulkApprove(
-                  selectedRows
-                    .filter(
-                      (r) =>
-                        r.original.property_id &&
-                        (r.original.status === "pending" || r.original.status === "needs_review"),
-                    )
-                    .map((r) => r.original.id),
+                  selectedRows.filter(isRowApprovable).map((r) => r.original.id),
                 )
               }
               onDelete={() => setConfirmBulkDelete(true)}

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useTransactionColumns.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useTransactionColumns.tsx
@@ -7,6 +7,7 @@ import { formatCurrency } from "@/shared/utils/currency";
 import { formatDate } from "@/shared/utils/date";
 import { formatTag } from "@/shared/utils/tag";
 import { TAG_COLORS } from "@/shared/lib/constants";
+import { APPROVABLE_STATUSES } from "@/shared/lib/transaction-config";
 import type { Transaction } from "@/shared/types/transaction/transaction";
 import { Button } from "@platform/ui";
 import Badge from "@/shared/components/ui/Badge";
@@ -176,11 +177,11 @@ export function useTransactionColumns(propertyMap: ReadonlyMap<string, string>, 
       enableSorting: false,
       header: () => null,
       cell: ({ row }) => {
-        const isPending = row.original.status === "pending" || row.original.status === "needs_review";
+        const isApprovable = APPROVABLE_STATUSES.includes(row.original.status);
         if (!canWrite) return null;
         return (
           <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
-            {isPending && row.original.property_id && (
+            {isApprovable && row.original.property_id && (
               <Button
                 variant="ghost"
                 size="sm"

--- a/apps/mybookkeeper/frontend/src/shared/lib/transaction-config.ts
+++ b/apps/mybookkeeper/frontend/src/shared/lib/transaction-config.ts
@@ -1,5 +1,6 @@
 import { EXPENSE_CATEGORY_LIST } from "@/shared/lib/constants";
 import type { Filters } from "@/shared/types/transaction/transaction-filters";
+import type { TransactionStatus } from "@/shared/types/transaction/transaction";
 
 export const EMPTY_FILTERS: Filters = {
   property_id: "",
@@ -12,6 +13,15 @@ export const EMPTY_FILTERS: Filters = {
 };
 
 export const STATUS_OPTIONS = ["pending", "approved", "needs_review", "duplicate", "unverified"] as const;
+
+// Statuses that can be promoted to "approved" via the inline ✓ / bulk Approve
+// actions (the row must also have a property assigned). Mirrors the backend
+// allowlist in transaction_bulk_repo.bulk_approve.
+export const APPROVABLE_STATUSES: readonly TransactionStatus[] = [
+  "pending",
+  "needs_review",
+  "unverified",
+];
 
 export const TYPE_OPTIONS = ["income", "expense"] as const;
 


### PR DESCRIPTION
## Problem

The dashboard (`summary_repo._build_txn_filters`) sums **only** `status == "approved"` transactions. Payments extracted from email bodies from non-trusted senders land as `unverified`; suspected dups land as `needs_review`. These were impossible to approve:

- The inline ✓ approve button (`useTransactionColumns`) and bulk-Approve enable check (`Transactions.tsx`) only handled `pending`/`needs_review`.
- The Payment Review attribution flow (`confirm_review` / `attribute_manually`) attached a tenant/property but never promoted `status`.

Net effect: a Zelle rent payment could be attributed to a tenant **and** have a property assigned, yet stay `unverified` forever and never count in revenue totals. (Reported: June Zelle payments from tenants missing from the dashboard.)

## Fix

Product decision: **attributing a payment = verifying it.**

**Frontend** — one shared `APPROVABLE_STATUSES` allowlist (`pending`/`needs_review`/`unverified`, mirroring `transaction_bulk_repo.bulk_approve`) consumed by a single `isRowApprovable` predicate across the inline approve button, the bulk-Approve enable check, **and** the bulk-Approve click filter. The click filter previously carried its own copy of the old condition and silently no-op'd unverified rows — caught in pre-commit review and folded into the shared predicate. The `property_id` guard is preserved everywhere.

**Backend** — `confirm_review` (applicant + property paths) and `attribute_manually` now set `status = "approved"` when a payment is attributed.

## Tests

- Backend: `unverified → approved` on all three attribution paths (`test_attribution_service_attribute_manually.py`, `test_attribution_service_confirm_property.py`).
- Frontend: inline approve fires `status: approved`; bulk approve calls the mutation with the row id; no-property row shows no approve affordance (`Transactions.test.tsx`).

Local: backend touched-file tests pass, 20/20 frontend Transactions tests, `tsc -b` + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)