### PR TITLE
fix(mbk): align react-router-dom to v7 — fixes /support crash

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/support-page.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/support-page.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from "@playwright/test";
+
+// Regression guard for the react-router duplicate-context crash.
+//
+// /support renders the shared `@platform/ui` Support page, whose <Link> reads
+// React Router's context. When MBK was pinned to react-router-dom v6 while the
+// shared package used v7, two physical react-router copies existed: MBK's
+// <BrowserRouter> populated one RouterContext, but the shared <Link> read the
+// other (unprovided) one, throwing `TypeError: useContext(...) is null` — caught
+// by the app ErrorBoundary, which then stayed stuck on back-navigation.
+//
+// Aligning MBK to react-router-dom v7 collapses the workspace to a single copy,
+// so the contexts unify and the page renders. These tests fail loudly if that
+// drift ever returns.
+
+test.describe("Support page — public", () => {
+  test("renders without crashing (react-router context regression guard)", async ({ page }) => {
+    await page.goto("/support");
+    await expect(
+      page.getByRole("heading", { name: /why myfreeapps is free/i }),
+    ).toBeVisible();
+    // The ErrorBoundary fallback must NOT appear.
+    await expect(page.getByText(/something went wrong/i)).toHaveCount(0);
+  });
+
+  test("is reachable from the footer Support link", async ({ page }) => {
+    await page.goto("/login");
+    await page.getByRole("link", { name: /^support$/i }).click();
+    await expect(page).toHaveURL(/\/support/);
+    await expect(
+      page.getByRole("heading", { name: /why myfreeapps is free/i }),
+    ).toBeVisible();
+    await expect(page.getByText(/something went wrong/i)).toHaveCount(0);
+  });
+});

--- a/apps/mybookkeeper/frontend/package.json
+++ b/apps/mybookkeeper/frontend/package.json
@@ -41,7 +41,7 @@
     "react-hook-form": "^7.74.0",
     "react-markdown": "^10.1.0",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^6.26.2",
+    "react-router-dom": "^7.14.2",
     "recharts": "^3.8.1",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "react-hook-form": "^7.74.0",
         "react-markdown": "^10.1.0",
         "react-redux": "^9.2.0",
-        "react-router-dom": "^6.26.2",
+        "react-router-dom": "^7.14.2",
         "recharts": "^3.8.1",
         "remark-gfm": "^4.0.1",
         "tailwind-merge": "^3.5.0",
@@ -553,21 +553,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "apps/mygamingassistant/frontend/node_modules/react-router-dom": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
-      "dependencies": {
-        "react-router": "7.15.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
     "apps/mygamingassistant/frontend/node_modules/tailwindcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
@@ -971,21 +956,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "apps/myjobhunter/frontend/node_modules/react-router-dom": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
-      "dependencies": {
-        "react-router": "7.15.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
     "apps/myjobhunter/frontend/node_modules/tailwindcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
@@ -1365,21 +1335,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "apps/mypizzatracker/frontend/node_modules/react-router-dom": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
-      "dependencies": {
-        "react-router": "7.15.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "apps/mypizzatracker/frontend/node_modules/tailwindcss": {
@@ -4026,14 +3981,6 @@
         }
       }
     },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.2",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
-      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
@@ -6392,6 +6339,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
       "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -10058,9 +10006,10 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.15.0.tgz",
-      "integrity": "sha512-HW9vYwuM8f4yx66Izy8xfrzCM+SBJluoZcCbww9A1TySax11S5Vgw6fi3ZjMONw9J4gQwngL7PzkyIpJJpJ7RQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
         "set-cookie-parser": "^2.6.0"
@@ -10079,33 +10028,19 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
-      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.2",
-        "react-router": "6.30.3"
+        "react-router": "7.16.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/react-router-dom/node_modules/react-router": {
-      "version": "6.30.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
-      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
-      "dependencies": {
-        "@remix-run/router": "1.23.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/react-style-singleton": {
@@ -10468,7 +10403,8 @@
     "node_modules/set-cookie-parser": {
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
-      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/setimmediate": {
       "version": "1.0.5",
@@ -11568,22 +11504,6 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
-      }
-    },
-    "packages/shared-frontend/node_modules/react-router-dom": {
-      "version": "7.15.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.15.0.tgz",
-      "integrity": "sha512-VcrVg64Fo8nwBvDscajG8gRTLIuTC6N50nb22l2HOOV4PTOHgoGp8mUjy9wLiHYoYTSYI36tUnXZgasSRFZorQ==",
-      "dev": true,
-      "dependencies": {
-        "react-router": "7.15.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
       }
     },
     "packages/shared-frontend/node_modules/typescript": {


### PR DESCRIPTION
## Problem
`/support` crashed in production with `TypeError: useContext(...) is null` (caught by the app ErrorBoundary, which then stayed stuck on back-navigation).

## Root cause
MBK was the **only** app pinned to `react-router-dom@^6` while `@platform/ui` and the other 3 apps (MJH/MGA/MPT) use **v7**. The major-version mismatch can't hoist to one copy, so two physical `react-router-dom` modules existed. MBK's `<BrowserRouter>` populated one `RouterContext`; the shared Support page's `<Link>` read the *other* (unprovided) one → null → crash. Support was the first MBK-mounted `@platform/ui` component to use a router hook, which is why only `/support` died.

## Fix
Bump MBK `react-router-dom` `^6.26.2 → ^7.14.2`, matching the other apps. The workspace now resolves a **single** `react-router-dom@7.16.0` copy, so the contexts unify. No Vite `dedupe` divergence needed — the same setup the other 3 apps already run Support on.

## Validation
- `tsc -b && vite build` pass clean (v7's component API — `BrowserRouter/Routes/Route/Navigate/Link/NavLink/Outlet/useNavigate/...` — is compatible with MBK's usage; MBK uses no data-router/`json`/`defer` APIs).
- New Playwright guard (`e2e/support-page.spec.ts`): `/support` renders its heading (not the ErrorBoundary fallback), via direct nav and via the footer link.
- The 8 pre-existing unit-test failures (incl. a pure `formatHourlyRate` util) are **unchanged** — identical 8 failures on the v6 baseline — so this bump introduces zero regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)