### PR TITLE
feat(shared): Support page — disabled 'coming soon' donate button until Ko-fi is set up

### DIFF
--- a/packages/shared-frontend/src/__tests__/Support.test.tsx
+++ b/packages/shared-frontend/src/__tests__/Support.test.tsx
@@ -27,7 +27,7 @@ describe("Support page", () => {
 
   it("shows a video placeholder when no video id is given", () => {
     renderSupport();
-    expect(screen.getByText(/coming soon/i)).toBeInTheDocument();
+    expect(screen.getByText(/video coming soon/i)).toBeInTheDocument();
   });
 
   it("embeds the video when an id is provided", () => {
@@ -43,6 +43,14 @@ describe("Support page", () => {
       "href",
       "https://ko-fi.com/test",
     );
+  });
+
+  it("renders a disabled 'coming soon' donate button when no Ko-fi url is set", () => {
+    renderSupport();
+    const cta = screen.getByRole("button", { name: /support on ko-fi/i });
+    expect(cta).toBeDisabled();
+    expect(screen.queryByRole("link", { name: /support on ko-fi/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/donations coming soon/i)).toBeInTheDocument();
   });
 
   it("renders the cost-transparency widget by default", () => {

--- a/packages/shared-frontend/src/pages/Support.tsx
+++ b/packages/shared-frontend/src/pages/Support.tsx
@@ -1,17 +1,18 @@
 import { Link } from "react-router-dom";
+import Button from "../components/ui/Button";
 import YouTubeEmbed from "../components/embed/YouTubeEmbed";
 import KofiButton from "../components/widgets/KofiButton";
 import TransparencyWidget from "../components/widgets/TransparencyWidget";
-
-/** Shared Ko-fi page for all MyFreeApps. PLACEHOLDER — operator updates to the real handle. */
-const DEFAULT_KOFI_URL = "https://ko-fi.com/myfreeapps";
 
 interface Props {
   /** Host app name, used in the "← Back to {appName}" link, e.g. "MyBookkeeper". */
   appName: string;
   /** Where the back link points. Defaults to the app root. */
   homePath?: string;
-  /** Override the shared Ko-fi page URL. */
+  /**
+   * The app's Ko-fi donate URL. When omitted, the donate button renders disabled
+   * ("Donations coming soon") — set this once a real Ko-fi account exists.
+   */
   kofiUrl?: string;
   /** Unlisted YouTube video ID for the inspiration video. Omit to show a "coming soon" placeholder. */
   youtubeVideoId?: string;
@@ -34,7 +35,7 @@ interface Props {
 export default function Support({
   appName,
   homePath = "/",
-  kofiUrl = DEFAULT_KOFI_URL,
+  kofiUrl,
   youtubeVideoId,
   showTransparency = true,
 }: Props) {
@@ -80,10 +81,21 @@ export default function Support({
 
           <section className="flex flex-col items-center gap-3 text-center">
             <h2 className="sr-only">Support these apps</h2>
-            <KofiButton url={kofiUrl} />
-            <p className="text-xs text-muted-foreground">
-              Donations are handled securely by Ko-fi — you don't need an account.
-            </p>
+            {kofiUrl ? (
+              <>
+                <KofiButton url={kofiUrl} />
+                <p className="text-xs text-muted-foreground">
+                  Donations are handled securely by Ko-fi — you don't need an account.
+                </p>
+              </>
+            ) : (
+              <>
+                <Button variant="primary" disabled>
+                  Support on Ko-fi
+                </Button>
+                <p className="text-xs text-muted-foreground">Donations coming soon.</p>
+              </>
+            )}
           </section>
         </div>
       </div>


### PR DESCRIPTION
## What
The shared `@platform/ui` Support page (`/support` on all 4 apps) no longer ships a live donate button pointing at the placeholder handle `ko-fi.com/myfreeapps` — which the operator doesn't own, so a click could misroute a donation.

- Drops the `DEFAULT_KOFI_URL` placeholder.
- `kofiUrl` is now a no-default optional prop. Provided → live `KofiButton`; absent → a **disabled "Support on Ko-fi" button + "Donations coming soon"**.
- No app passes `kofiUrl` today, so all apps + future scaffolds show the coming-soon state until the operator has a real Ko-fi account; then pass `kofiUrl` per app to go live.

## Tests
- `Support.test.tsx`: 7/7 (new disabled-button test; video-placeholder test tightened to `/video coming soon/i` to avoid colliding with the new copy).
- The 2 failing `InlineBoldText` tests are pre-existing/unrelated; this change passes in isolation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)