### PR TITLE
fix(mbk): auto-attribution verifies the payment so recurring rent reaches the dashboard

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/attrverify260602_promote_attributed_unverified.py
+++ b/apps/mybookkeeper/backend/alembic/versions/attrverify260602_promote_attributed_unverified.py
@@ -1,0 +1,50 @@
+"""promote already-attributed unverified transactions to approved
+
+Revision ID: attrverify260602
+Revises: payerhandle260530
+Create Date: 2026-06-02
+
+One-time data backfill paired with the attribution-verifies fix.
+
+The dashboard sums only ``status='approved'`` transactions. Before this change,
+auto-attribution (learned payer alias / exact name match / Airbnb-auto) linked a
+payment to a tenant + property but never promoted its status, and the manual
+attribution paths only began promoting in the prior PR. As a result, payments
+that were genuinely attributed (``attribution_source IS NOT NULL``) but extracted
+from a non-trusted email sender (e.g. a bank-routed Zelle alert) stayed
+``unverified`` and never reached the dashboard.
+
+This migration promotes those rows to ``approved``. It is scoped to rows that
+already carry an ``attribution_source`` — i.e. the host (or the auto-pipeline)
+already decided whose payment this is — so it only verifies payments an explicit
+attribution had already vouched for. Pending review-queue rows (no
+``attribution_source``) are untouched and still require host review.
+
+Idempotent: re-running matches nothing once the rows are approved. Engine-
+agnostic SQL so it behaves identically on SQLite (tests) and PostgreSQL (prod).
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+revision: str = "attrverify260602"
+down_revision: Union[str, None] = "payerhandle260530"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        "UPDATE transactions SET status = 'approved' "
+        "WHERE status = 'unverified' "
+        "AND attribution_source IS NOT NULL "
+        "AND deleted_at IS NULL"
+    )
+
+
+def downgrade() -> None:
+    # No-op: this is a forward-only data correction. The set of rows promoted
+    # here is indistinguishable after the fact from rows that were always
+    # approved, so reverting would wrongly re-hide legitimately attributed
+    # payments from the dashboard.
+    pass

--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -119,6 +119,10 @@ async def maybe_attribute_payment(
             txn.applicant_id = applicant.id
             txn.attribution_source = "auto_alias"
             txn.category = "rental_revenue"
+            # Auto-attributing a payment verifies it — promote out of the
+            # unverified state so it counts in the dashboard, exactly as the
+            # manual confirm/link paths do.
+            txn.status = "approved"
             if property_id and txn.property_id is None:
                 txn.property_id = property_id
             logger.info(
@@ -160,6 +164,8 @@ async def maybe_attribute_payment(
         txn.applicant_id = best.id
         txn.attribution_source = "auto_exact"
         txn.category = "rental_revenue"
+        # Auto-attributing a payment verifies it (see auto_alias branch above).
+        txn.status = "approved"
         if property_id and txn.property_id is None:
             txn.property_id = property_id
         logger.info(
@@ -233,6 +239,9 @@ async def _attribute_airbnb_payout(
             txn.property_id = match.property_id
         txn.attribution_source = "auto_exact"
         txn.category = "rental_revenue"
+        # Auto-attributing a payout to a property verifies it (see the tenant
+        # auto-attribution branches in maybe_attribute_payment).
+        txn.status = "approved"
         logger.info(
             "Auto-attributed Airbnb payout %s to property %s (res_code=%s)",
             txn.id, match.property_id, res_code,

--- a/apps/mybookkeeper/backend/tests/test_attribution_service_auto_verifies.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_service_auto_verifies.py
@@ -1,0 +1,155 @@
+"""Auto-attribution verifies the payment (status -> approved).
+
+The dashboard sums only ``status='approved'``. A payment extracted from a
+non-trusted email sender (e.g. a bank-routed Zelle alert) is created
+``unverified``; when the auto-pipeline confidently attributes it (learned payer
+alias, exact name match, or Airbnb-auto), that attribution must promote it to
+``approved`` — exactly as the manual confirm/link paths do — so recurring rent
+reaches the dashboard without the host re-approving every month.
+
+The negative case (fuzzy / unmatched) must NOT promote: those go to the review
+queue and stay ``unverified`` until the host confirms.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.properties.property import Property
+from app.models.transactions.booking_statement import BookingStatement
+from app.models.transactions.rent_attribution_review_queue import (
+    RentAttributionReviewQueue,
+)
+from app.models.transactions.transaction import Transaction
+from app.repositories.transactions import payer_alias_repo
+from app.services.transactions.attribution_service import maybe_attribute_payment
+
+_RECEIPT_PATCH = (
+    "app.services.transactions.attribution_service.receipt_service"
+    ".create_pending_receipt_in_session"
+)
+
+
+async def _make_applicant(db, org_id, user_id, name="Prince Kapoor") -> Applicant:
+    applicant = Applicant(
+        id=uuid.uuid4(), organization_id=org_id, user_id=user_id,
+        stage="lease_signed", legal_name=name,
+    )
+    db.add(applicant)
+    await db.flush()
+    return applicant
+
+
+async def _make_unverified_txn(db, org_id, user_id, *, payer_name=None, description=None) -> Transaction:
+    txn = Transaction(
+        id=uuid.uuid4(), organization_id=org_id, user_id=user_id,
+        transaction_date=_dt.date(2026, 6, 1), tax_year=2026, amount="1595.00",
+        transaction_type="income", category="uncategorized", status="unverified",
+        is_manual=False, payer_name=payer_name, description=description,
+    )
+    db.add(txn)
+    await db.flush()
+    return txn
+
+
+async def _status_of(db: AsyncSession, txn_id: uuid.UUID) -> str:
+    return (
+        await db.execute(select(Transaction.status).where(Transaction.id == txn_id))
+    ).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_alias_auto_attribution_promotes_unverified_to_approved(db: AsyncSession):
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prince = await _make_applicant(db, org_id, user_id, "Prince Kapoor")
+    await payer_alias_repo.upsert(
+        db, user_id=user_id, organization_id=org_id,
+        payer_name="Tushar Kapoor", applicant_id=prince.id, source="manual_link",
+    )
+    txn = await _make_unverified_txn(db, org_id, user_id, payer_name="Tushar Kapoor")
+
+    with patch(_RECEIPT_PATCH, new_callable=AsyncMock):
+        await maybe_attribute_payment(
+            db, txn=txn, payer_name="Tushar Kapoor",
+            organization_id=org_id, user_id=user_id,
+        )
+
+    assert txn.applicant_id == prince.id
+    assert txn.attribution_source == "auto_alias"
+    assert await _status_of(db, txn.id) == "approved"
+
+
+@pytest.mark.asyncio
+async def test_exact_name_match_promotes_unverified_to_approved(db: AsyncSession):
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prince = await _make_applicant(db, org_id, user_id, "Prince Kapoor")
+    txn = await _make_unverified_txn(db, org_id, user_id, payer_name="Prince Kapoor")
+
+    with patch(_RECEIPT_PATCH, new_callable=AsyncMock):
+        await maybe_attribute_payment(
+            db, txn=txn, payer_name="Prince Kapoor",
+            organization_id=org_id, user_id=user_id,
+        )
+
+    assert txn.applicant_id == prince.id
+    assert txn.attribution_source == "auto_exact"
+    assert await _status_of(db, txn.id) == "approved"
+
+
+@pytest.mark.asyncio
+async def test_airbnb_auto_attribution_promotes_unverified_to_approved(db: AsyncSession):
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = Property(id=uuid.uuid4(), organization_id=org_id, user_id=user_id, name="Beach House")
+    stmt = BookingStatement(
+        id=uuid.uuid4(), organization_id=org_id, property_id=prop.id, res_code="HM12345",
+        check_in=_dt.date(2026, 5, 20), check_out=_dt.date(2026, 5, 25),
+    )
+    txn = await _make_unverified_txn(
+        db, org_id, user_id, description="Payout for reservation HM12345"
+    )
+    db.add_all([prop, stmt])
+    await db.flush()
+
+    with patch(
+        "app.services.transactions.attribution_service.listing_repo.list_by_channel",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        await maybe_attribute_payment(
+            db, txn=txn, payer_name=None, organization_id=org_id, user_id=user_id,
+            is_airbnb_payout=True,
+        )
+
+    assert txn.property_id == prop.id
+    assert txn.attribution_source == "auto_exact"
+    assert await _status_of(db, txn.id) == "approved"
+
+
+@pytest.mark.asyncio
+async def test_unmatched_payment_stays_unverified(db: AsyncSession):
+    """No alias, no name candidate → review queue; status must NOT be promoted."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    txn = await _make_unverified_txn(db, org_id, user_id, payer_name="Nobody Known")
+
+    with patch(_RECEIPT_PATCH, new_callable=AsyncMock) as receipt_mock:
+        await maybe_attribute_payment(
+            db, txn=txn, payer_name="Nobody Known",
+            organization_id=org_id, user_id=user_id,
+        )
+
+    assert txn.applicant_id is None
+    receipt_mock.assert_not_awaited()
+    assert await _status_of(db, txn.id) == "unverified"
+    review = (
+        await db.execute(
+            select(RentAttributionReviewQueue).where(
+                RentAttributionReviewQueue.transaction_id == txn.id
+            )
+        )
+    ).scalar_one()
+    assert review.confidence == "unmatched"

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -899,12 +899,14 @@
         "backend/app/models/transactions/rent_attribution_review_queue.py",
         "backend/app/repositories/transactions/attribution_repo.py",
         "backend/app/services/transactions/attribution_service.py",
+        "backend/app/services/transactions/attribution_helpers.py",
         "backend/app/services/transactions/airbnb_payout_matcher.py",
         "backend/app/services/transactions/property_pnl_service.py",
         "backend/app/schemas/transactions/attribution.py",
         "backend/app/api/attribution.py",
         "backend/alembic/versions/txnattr260504_rent_attribution.py",
         "backend/alembic/versions/rarqprop260517_add_proposed_property.py",
+        "backend/alembic/versions/attrverify260602_promote_attributed_unverified.py",
         "frontend/src/shared/store/attributionApi.ts",
         "frontend/src/shared/types/attribution/",
         "frontend/src/app/features/attribution/",
@@ -919,7 +921,9 @@
         "test_attribution_service_attribute_manually.py",
         "test_attribution_service_confirm_property.py",
         "test_airbnb_payout_matcher.py",
-        "test_attribution_service_airbnb_payout.py"
+        "test_attribution_service_airbnb_payout.py",
+        "test_attribution_service_payer_alias.py",
+        "test_attribution_service_auto_verifies.py"
       ],
       "frontend_tests": [
         "AttributionReviewPanel.test.tsx",


### PR DESCRIPTION
## Problem

The dashboard sums only `status='approved'` transactions. Tenant rent from a **non-trusted email sender** (e.g. a bank-routed Zelle alert, which isn't `zellepay.com`) is created `unverified`. PR #830 fixed the **manual** attribution paths to promote status — but the **auto-attribution** path never did.

So once a tenant's payer alias is learned (or their name exactly matches an applicant), every future rent payment **auto-attributes** (tenant + property + `rental_revenue` all set) yet **silently stays `unverified`** → invisible on the dashboard. This is why an attributed payment was "still not showing" after #830.

## Fix

Set `status='approved'` on all three auto-attribution success branches — learned alias, exact name match (`maybe_attribute_payment`), and the Airbnb-auto cascade (`_attribute_airbnb_payout`) — mirroring #830's principle that *attributing a payment verifies it*. Fuzzy / unmatched payments still route to the review queue and stay `unverified` until the host confirms.

## Backfill

A one-time, idempotent Alembic data migration (`attrverify260602`) promotes the existing backlog — rows with `attribution_source IS NOT NULL` AND `status='unverified'` — to `approved`. This clears payments attributed before this fix (incl. pre-#830). Scoped to already-attributed rows only; pending review-queue rows are untouched.

## Tests

`test_attribution_service_auto_verifies.py` — `unverified`→`approved` on all three auto paths + the unmatched-stays-`unverified` negative. All 27 attribution tests pass locally. `test-map.json` updated (also registers the previously-unmapped `payer_alias` test + `attribution_helpers` source).

## Operational migration

None required. The data migration runs automatically on deploy via `alembic upgrade head`; it's an additive data correction with no schema/env change.

## Not included (follow-ups)

- **Duplicate rows** (the other half of your report) — caused by the dedup matcher scoping to `property_id IS NULL`, so a 2nd notification of an already-attributed payment isn't matched. Separate PR with the full composite-key test matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)