### PR TITLE
feat(support): shorten Support page copy to the donation essentials

### DIFF
--- a/packages/shared-frontend/src/pages/Support.tsx
+++ b/packages/shared-frontend/src/pages/Support.tsx
@@ -57,14 +57,9 @@ export default function Support({
           <section className="space-y-3 text-sm leading-relaxed">
             <h2 className="sr-only">About MyFreeApps</h2>
             <p>
-              I build these apps for my own use and decided not to charge for them — they're more
-              useful to me, and to everyone, the more people use them. {appName} and the other
-              MyFreeApps tools are free: no ads, no trackers, and nothing sold.
-            </p>
-            <p>
-              I pay for the servers that run them out of my own pocket. If one of these apps has saved
-              you time or money, a small donation helps cover hosting and keeps them running and
-              maintained — every dollar goes straight to costs.
+              {appName} and the other MyFreeApps tools are free — no ads, no trackers,
+              nothing sold. Donations help cover the server and API costs that keep them
+              running.
             </p>
           </section>
 


### PR DESCRIPTION
Heavily trims the Support page story copy per request — keep it short, lead with why donations matter.

**Before:** two maker-story paragraphs (~6 lines).
**After:** one line —

> _{appName} and the other MyFreeApps tools are free — no ads, no trackers, nothing sold. Donations help cover the server and API costs that keep them running._

Only `packages/shared-frontend/src/pages/Support.tsx` (shared across all 4 apps). Heading ("Why MyFreeApps is free"), subtitle, video, transparency widget, and the "Donations coming soon" button caption are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)