### PR TITLE
feat(support): rename route to /support-myfreeapps + label to "Support MyFreeApps"

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/support-page.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/support-page.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 // Regression guard for the react-router duplicate-context crash.
 //
-// /support renders the shared `@platform/ui` Support page, whose <Link> reads
+// /support-myfreeapps renders the shared `@platform/ui` Support page, whose <Link> reads
 // React Router's context. When MBK was pinned to react-router-dom v6 while the
 // shared package used v7, two physical react-router copies existed: MBK's
 // <BrowserRouter> populated one RouterContext, but the shared <Link> read the
@@ -15,20 +15,20 @@ import { test, expect } from "@playwright/test";
 
 test.describe("Support page — public", () => {
   test("renders without crashing (react-router context regression guard)", async ({ page }) => {
-    await page.goto("/support");
+    await page.goto("/support-myfreeapps");
     await expect(
-      page.getByRole("heading", { name: /why myfreeapps is free/i }),
+      page.getByRole("heading", { name: /please support myfreeapps/i }),
     ).toBeVisible();
     // The ErrorBoundary fallback must NOT appear.
     await expect(page.getByText(/something went wrong/i)).toHaveCount(0);
   });
 
-  test("is reachable from the footer Support Me link", async ({ page }) => {
+  test("is reachable from the footer Support MyFreeApps link", async ({ page }) => {
     await page.goto("/login");
-    await page.getByRole("link", { name: /^support me$/i }).click();
-    await expect(page).toHaveURL(/\/support/);
+    await page.getByRole("link", { name: /^support myfreeapps$/i }).click();
+    await expect(page).toHaveURL(/\/support-myfreeapps/);
     await expect(
-      page.getByRole("heading", { name: /why myfreeapps is free/i }),
+      page.getByRole("heading", { name: /please support myfreeapps/i }),
     ).toBeVisible();
     await expect(page.getByText(/something went wrong/i)).toHaveCount(0);
   });

--- a/apps/mybookkeeper/frontend/src/App.tsx
+++ b/apps/mybookkeeper/frontend/src/App.tsx
@@ -83,7 +83,7 @@ export default function App() {
             <Route path="/register" element={<Register />} />
             <Route path="/privacy" element={<PrivacyPolicy />} />
             <Route path="/terms" element={<TermsOfService />} />
-            <Route path="/support" element={<Support appName="MyBookkeeper" />} />
+            <Route path="/support-myfreeapps" element={<Support appName="MyBookkeeper" />} />
             <Route path="/forgot-password" element={<ForgotPassword />} />
             <Route path="/reset-password" element={<ResetPassword />} />
             <Route path="/invite/:token" element={<InviteAccept />} />

--- a/apps/mybookkeeper/frontend/src/app/lib/nav.ts
+++ b/apps/mybookkeeper/frontend/src/app/lib/nav.ts
@@ -63,7 +63,7 @@ export const NAV_GROUPS: readonly NavGroup[] = [
     // Headerless trailing group — sits at the bottom of the sidebar, above the
     // theme toggle / user menu. Routes to the standalone public /support page.
     label: null,
-    items: [{ to: "/support", label: "Support Me" }],
+    items: [{ to: "/support-myfreeapps", label: "Support MyFreeApps" }],
   },
 ] as const;
 

--- a/apps/mygamingassistant/frontend/src/constants/nav.ts
+++ b/apps/mygamingassistant/frontend/src/constants/nav.ts
@@ -27,7 +27,7 @@ const NAV_DESCRIPTORS: NavDescriptor[] = [
   { path: "/live/cs2", label: "Live (CS2)", iconName: "Radio", desktopOnly: true },
   { path: "/settings", label: "Settings", iconName: "Settings" },
   { path: "/security", label: "Security", iconName: "Shield" },
-  { path: "/support", label: "Support Me", iconName: "Heart" },
+  { path: "/support-myfreeapps", label: "Support MyFreeApps", iconName: "Heart" },
 ];
 
 /**
@@ -44,7 +44,7 @@ export const PUBLIC_NAV_PATHS: ReadonlySet<string> = new Set([
   "/",            // Games (public lineup library)
   "/packages",    // Packages (public — read-only browsing)
   "/live/cs2",    // Live mode (read-only; setup/calibrate inside are gated)
-  "/support",     // Support Me (public donation / cost-transparency page)
+  "/support-myfreeapps",     // Support MyFreeApps (public donation / cost-transparency page)
 ]);
 
 /**

--- a/apps/mygamingassistant/frontend/src/routes.tsx
+++ b/apps/mygamingassistant/frontend/src/routes.tsx
@@ -140,7 +140,7 @@ export const routes: RouteObject[] = [
   // so it can't read the shared cost-transparency object. Donation CTA + story +
   // video still render; the cost widget is omitted. See platform_shared/services/
   // transparency + memory/project_mga_prod_storage_r2.md.
-  { path: "/support", element: <Support appName="MyGamingAssistant" showTransparency={false} /> },
+  { path: "/support-myfreeapps", element: <Support appName="MyGamingAssistant" showTransparency={false} /> },
   { path: "/login", element: authPageElement(<Login />) },
   { path: "/forgot-password", element: authPageElement(<ForgotPassword />) },
   { path: "/reset-password", element: authPageElement(<ResetPassword />) },

--- a/apps/myjobhunter/frontend/src/constants/nav.ts
+++ b/apps/myjobhunter/frontend/src/constants/nav.ts
@@ -27,7 +27,7 @@ export const NAV_DESCRIPTORS: NavDescriptor[] = [
   { path: "/resume", label: "Resume", iconName: "Sparkles" },
   { path: "/profile", label: "Profile", iconName: "UserCircle" },
   { path: "/settings", label: "Settings", iconName: "Settings" },
-  { path: "/support", label: "Support Me", iconName: "Heart" },
+  { path: "/support-myfreeapps", label: "Support MyFreeApps", iconName: "Heart" },
 ];
 
 /**

--- a/apps/myjobhunter/frontend/src/routes.tsx
+++ b/apps/myjobhunter/frontend/src/routes.tsx
@@ -69,7 +69,7 @@ export const routes: RouteObject[] = [
     ],
   },
   // Public support / donation page — standalone (no shell, no auth).
-  { path: "/support", element: <Support appName="MyJobHunter" /> },
+  { path: "/support-myfreeapps", element: <Support appName="MyJobHunter" /> },
   { path: "/login", element: <Login /> },
   { path: "/register", element: <Register /> },
   { path: "/forgot-password", element: <ForgotPassword /> },

--- a/apps/mypizzatracker/frontend/src/constants/nav.ts
+++ b/apps/mypizzatracker/frontend/src/constants/nav.ts
@@ -21,7 +21,7 @@ const NAV_DESCRIPTORS: NavDescriptor[] = [
   { path: "/customers", label: "Customers", iconName: "Users" },
   { path: "/settings", label: "Settings", iconName: "Settings" },
   { path: "/security", label: "Security", iconName: "Shield" },
-  { path: "/support", label: "Support Me", iconName: "Heart" },
+  { path: "/support-myfreeapps", label: "Support MyFreeApps", iconName: "Heart" },
 ];
 
 /**

--- a/apps/mypizzatracker/frontend/src/routes.tsx
+++ b/apps/mypizzatracker/frontend/src/routes.tsx
@@ -40,7 +40,7 @@ export const routes: RouteObject[] = [
   { path: "/order/status", element: <PublicOrderStatus /> },
   { path: "/order/status/:orderId", element: <PublicOrderStatus /> },
   // Public support / donation page — standalone (no shell, no auth).
-  { path: "/support", element: <Support appName="MyPizzaTracker" /> },
+  { path: "/support-myfreeapps", element: <Support appName="MyPizzaTracker" /> },
   { path: "/login", element: <Login /> },
   { path: "/forgot-password", element: <ForgotPassword /> },
   { path: "/reset-password", element: <ResetPassword /> },

--- a/infra/templates/scaffold/frontend/src/pages/Login.tsx
+++ b/infra/templates/scaffold/frontend/src/pages/Login.tsx
@@ -277,7 +277,7 @@ export default function Login() {
       </div>
 
       <p className="mt-8 text-xs text-muted-foreground">
-        <a href="/support" className="hover:underline hover:text-foreground transition-colors">
+        <a href="/support-myfreeapps" className="hover:underline hover:text-foreground transition-colors">
           Support this project
         </a>
         <span className="mx-2" aria-hidden="true">·</span>

--- a/infra/templates/scaffold/frontend/src/routes.tsx
+++ b/infra/templates/scaffold/frontend/src/routes.tsx
@@ -23,7 +23,7 @@ export const routes: RouteObject[] = [
     ],
   },
   // Public support / donation page — standalone (no shell, no auth).
-  { path: "/support", element: <Support appName="__APP_DISPLAY_NAME__" /> },
+  { path: "/support-myfreeapps", element: <Support appName="__APP_DISPLAY_NAME__" /> },
   { path: "/login", element: <Login /> },
   { path: "/forgot-password", element: <ForgotPassword /> },
   { path: "/reset-password", element: <ResetPassword /> },

--- a/packages/shared-frontend/src/__tests__/AuthPageFooter.test.tsx
+++ b/packages/shared-frontend/src/__tests__/AuthPageFooter.test.tsx
@@ -12,10 +12,10 @@ function renderFooter(appName = "MyTestApp") {
 }
 
 describe("AuthPageFooter", () => {
-  it("renders a 'Support Me' link pointing at /support", () => {
+  it("renders a 'Support MyFreeApps' link pointing at /support-myfreeapps", () => {
     renderFooter();
-    const link = screen.getByRole("link", { name: "Support Me" });
-    expect(link).toHaveAttribute("href", "/support");
+    const link = screen.getByRole("link", { name: "Support MyFreeApps" });
+    expect(link).toHaveAttribute("href", "/support-myfreeapps");
   });
 
   it("renders the app name and current year in the copyright line", () => {

--- a/packages/shared-frontend/src/__tests__/Support.test.tsx
+++ b/packages/shared-frontend/src/__tests__/Support.test.tsx
@@ -21,7 +21,7 @@ function renderSupport(props: Partial<Parameters<typeof Support>[0]> = {}) {
 describe("Support page", () => {
   it("renders the heading and a back link to the host app", () => {
     renderSupport();
-    expect(screen.getByRole("heading", { level: 1, name: /why myfreeapps is free/i })).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 1, name: /please support myfreeapps/i })).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /back to mybookkeeper/i })).toBeInTheDocument();
   });
 

--- a/packages/shared-frontend/src/components/layout/AuthPageFooter.tsx
+++ b/packages/shared-frontend/src/components/layout/AuthPageFooter.tsx
@@ -7,9 +7,9 @@ interface Props {
 
 /**
  * Footer shown on the public auth pages (Login / Register) of every
- * MyFreeApps app. Renders a "Support Me" link to the shared ``/support`` page
+ * MyFreeApps app. Renders a "Support MyFreeApps" link to the shared ``/support-myfreeapps`` page
  * plus a copyright line, so logged-out visitors always have a path to the
- * donation / cost-transparency page even though the in-app "Support Me" nav
+ * donation / cost-transparency page even though the in-app "Support MyFreeApps" nav
  * item is only reachable once the shell is mounted.
  *
  * Extracted from the three byte-identical copies that previously lived inline
@@ -22,10 +22,10 @@ export default function AuthPageFooter({ appName }: Props) {
   return (
     <p className="mt-8 text-xs text-muted-foreground text-center">
       <Link
-        to="/support"
+        to="/support-myfreeapps"
         className="hover:underline hover:text-foreground transition-colors"
       >
-        Support Me
+        Support MyFreeApps
       </Link>
       <span className="mx-2" aria-hidden="true">
         ·

--- a/packages/shared-frontend/src/pages/Support.tsx
+++ b/packages/shared-frontend/src/pages/Support.tsx
@@ -48,7 +48,7 @@ export default function Support({
           </Link>
         </div>
 
-        <h1 className="text-3xl font-bold mb-8">Why MyFreeApps is free</h1>
+        <h1 className="text-3xl font-bold mb-8">Please support MyFreeApps!</h1>
 
         <div className="space-y-10">
           <section>


### PR DESCRIPTION
## What

Renames the public Support page's route and link/nav label across all 4 apps and the shared package, and rewords the page heading.

- **Route:** `/support` → `/support-myfreeapps`
- **Nav / footer label:** "Support Me" → "Support MyFreeApps"
- **Page heading:** "Why MyFreeApps is free" → "Please support MyFreeApps!"

## Files

**Route + label (4 apps):**
- MBK — `App.tsx` (`<Route>`), `app/lib/nav.ts`
- MJH — `routes.tsx`, `constants/nav.ts`
- MGA — `routes.tsx`, `constants/nav.ts` (descriptor + `PUBLIC_NAV_PATHS`)
- MPT — `routes.tsx`, `constants/nav.ts`

**Shared package (`@platform/ui`):**
- `AuthPageFooter.tsx` (logged-out footer `<Link>` + label + doc comment)
- `Support.tsx` (heading)
- `AuthPageFooter.test.tsx`, `Support.test.tsx` (assertions)

**Test:**
- MBK `e2e/support-page.spec.ts` — route, footer-link label, `toHaveURL`, and heading assertions

**Scaffold template (parity — so future apps inherit the renamed route):**
- `infra/templates/scaffold/frontend/src/routes.tsx`
- `infra/templates/scaffold/frontend/src/pages/Login.tsx`

## Verification

- `npm run typecheck` clean on all 4 frontends (MBK via `tsc -b`) + `@platform/ui`
- `npm test -w @platform/ui -- AuthPageFooter Support` → **9 passed**
- MBK Support e2e is gated by CI (needs running servers/browsers)

## Discovered, not fixed (out of scope — flagging for follow-up)

1. **`test_app_conformance.py::TestSupportPageWired::test_support_link_present` is pre-existingly stale.** PR #835 moved the logged-out Support link from MBK's `LegalFooter.tsx` into the shared `<AuthPageFooter>`, but the test still reads `LegalFooter.tsx` (MBK) / the apps' `Login.tsx` (which now render `<AuthPageFooter>` and hold no literal `/support`). Those assertions already don't match `main`; this PR leaves them untouched. The route-substring checks it shares still pass because `/support-myfreeapps` contains `/support`.
2. **The scaffold's `Login.tsx` still uses a pre-#835 inline footer** (`<a>Support this project</a>`) instead of `<AuthPageFooter>`. I renamed its route href for consistency but did not migrate it to the shared component (separate concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)