### PR TITLE
fix(mjh): block SSRF in job-URL fetch

### DIFF
--- a/apps/myjobhunter/backend/app/services/extraction/jd_url_fetcher.py
+++ b/apps/myjobhunter/backend/app/services/extraction/jd_url_fetcher.py
@@ -16,9 +16,11 @@ Errors raised
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 
 import httpx
+
+from platform_shared.core.url_safety import UnsafeURLError, assert_url_safe
 
 
 # ---------------------------------------------------------------------------
@@ -40,6 +42,13 @@ _USER_AGENT = (
 
 # Cap the body we read to bound memory + Claude input tokens.
 _MAX_FETCH_BYTES = 2_000_000  # 2 MB — every legitimate JD page fits.
+
+# Redirect handling. We follow redirects MANUALLY (httpx auto-follow is
+# disabled) so the SSRF guard can re-validate every hop — a public URL can
+# 302 into an internal one. 5 hops is plenty for legitimate ATS chains
+# (http→https, trailing-slash canonicalisation, vanity → real host).
+_MAX_REDIRECTS = 5
+_REDIRECT_STATUSES = frozenset({301, 302, 303, 307, 308})
 
 # Hard-coded auth-walled domains.  Ordered so the most-common cases match
 # first — substring match on ``netloc + path`` keeps the table readable.
@@ -117,10 +126,13 @@ async def fetch_html(url: str) -> str:
         The response body text.
 
     Raises:
+        UnsafeURLError: the URL (or a redirect hop) resolves to a non-public
+            address — an SSRF attempt. Subclasses ``ValueError`` so callers
+            map it to ``400`` alongside other malformed-URL rejections.
         JDFetchTimeoutError: httpx timed out.
         JDFetchAuthRequiredError: upstream returned 401 or 403.
-        JDFetchError: non-2xx response, network error, or body exceeds
-            ``_MAX_FETCH_BYTES``.
+        JDFetchError: non-2xx response, network error, too many redirects,
+            or body exceeds ``_MAX_FETCH_BYTES``.
     """
     headers = {
         "User-Agent": _USER_AGENT,
@@ -133,13 +145,35 @@ async def fetch_html(url: str) -> str:
         "Accept-Language": "en-US,en;q=0.9",
     }
     timeout = httpx.Timeout(_FETCH_TIMEOUT_SECONDS)
+    # Auto-follow is OFF so the SSRF guard sees every hop. We walk redirects
+    # by hand, validating the destination before each request: the original
+    # URL on the first pass, every ``Location`` thereafter.
     try:
         async with httpx.AsyncClient(
-            follow_redirects=True,
+            follow_redirects=False,
             timeout=timeout,
             headers=headers,
         ) as client:
-            resp = await client.get(url)
+            current_url = url
+            for _ in range(_MAX_REDIRECTS + 1):
+                # SSRF guard — never issue a request to a non-public target.
+                # Raises UnsafeURLError (a ValueError) before any egress.
+                await assert_url_safe(current_url)
+                resp = await client.get(current_url)
+                if resp.status_code in _REDIRECT_STATUSES:
+                    location = resp.headers.get("location")
+                    if not location:
+                        break  # redirect status with no target — treat as final
+                    current_url = urljoin(current_url, location)
+                    continue
+                break
+            else:
+                raise JDFetchError(
+                    f"Exceeded {_MAX_REDIRECTS} redirects fetching {url}",
+                )
+    except UnsafeURLError:
+        # Propagate unchanged — it is a ValueError the route maps to 400.
+        raise
     except httpx.TimeoutException as exc:
         raise JDFetchTimeoutError(f"Timed out fetching {url}") from exc
     except httpx.HTTPError as exc:

--- a/apps/myjobhunter/backend/tests/test_jd_url_extractor.py
+++ b/apps/myjobhunter/backend/tests/test_jd_url_extractor.py
@@ -22,6 +22,7 @@ The HTTP endpoint tests run through FastAPI's TestClient via the
 """
 from __future__ import annotations
 
+import ipaddress
 import json
 import uuid
 from typing import Any
@@ -29,6 +30,8 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+
+from platform_shared.core.url_safety import UnsafeURLError
 
 from app.services.extraction.jd_url_extractor import (
     ExtractedJD,
@@ -43,6 +46,34 @@ from app.services.extraction.jd_url_parser import (
     strip_visible_text as _strip_visible_text,
 )
 from bs4 import BeautifulSoup
+
+
+# ---------------------------------------------------------------------------
+# DNS stub — the SSRF guard resolves every fetched host before egress.
+# Test hosts like ``acme.example.com`` don't resolve publicly, so we stub
+# resolution: literal IPs are classified for real (internal IPs still get
+# blocked), while any hostname maps to a fixed public address so the
+# happy-path fetch tests proceed. SSRF tests use literal internal IPs.
+# ---------------------------------------------------------------------------
+
+_PUBLIC_STUB_IP = "93.184.216.34"
+
+
+def _resolve_for_tests(
+    host: str, port: int
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    try:
+        return [ipaddress.ip_address(host)]  # literal IP → real classification
+    except ValueError:
+        return [ipaddress.ip_address(_PUBLIC_STUB_IP)]  # hostname → public
+
+
+@pytest.fixture(autouse=True)
+def _stub_dns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "platform_shared.core.url_safety._resolve_host",
+        _resolve_for_tests,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -761,3 +792,107 @@ class TestExtractFromUrlEndpoint:
                 json={},
             )
         assert resp.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# SSRF guard — server must refuse to fetch internal / metadata targets
+# ---------------------------------------------------------------------------
+
+
+def _redirect_response(location: str, status_code: int = 302) -> httpx.Response:
+    return httpx.Response(
+        status_code=status_code,
+        headers={"location": location},
+        request=httpx.Request("GET", "https://jobs.example.com/job"),
+    )
+
+
+class TestSsrfGuard:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://169.254.169.254/latest/meta-data/iam/security-credentials/",
+            "http://[fd00:ec2::254]/latest/meta-data/",  # IPv6 metadata
+            "http://127.0.0.1/",  # loopback
+            "http://[::1]/",  # IPv6 loopback
+            "http://10.0.0.5/internal",  # RFC1918
+            "http://192.168.1.1/admin",
+            "http://172.16.0.1/",
+            "http://[::ffff:127.0.0.1]/",  # IPv4-mapped loopback
+        ],
+    )
+    @pytest.mark.asyncio
+    async def test_internal_target_blocked_without_egress(self, url: str) -> None:
+        # The fetch must be refused BEFORE any GET is issued — assert the
+        # client's ``get`` was never reached (no SSRF egress).
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response("<html>secret</html>"),
+        )
+        with _patch_httpx(fake_client):
+            with pytest.raises(UnsafeURLError):
+                await extract_from_url(url, user_id=uuid.uuid4())
+        assert fake_client.last_url is None
+
+    @pytest.mark.asyncio
+    async def test_redirect_into_internal_blocked(self) -> None:
+        # A public URL that 302s to a metadata IP must be caught on the
+        # redirect hop — the first (public) GET happens, the second never
+        # does.
+        fake_client = _FakeAsyncClient(
+            response=_redirect_response("http://169.254.169.254/latest/meta-data/"),
+        )
+        with _patch_httpx(fake_client):
+            with pytest.raises(UnsafeURLError):
+                await extract_from_url(
+                    "https://jobs.example.com/job",
+                    user_id=uuid.uuid4(),
+                )
+        # Exactly one egress occurred, to the public origin — never to the
+        # internal redirect target.
+        assert fake_client.last_url == "https://jobs.example.com/job"
+
+    @pytest.mark.asyncio
+    async def test_non_web_port_blocked(self) -> None:
+        # Reaching an internal service on a non-standard port (Postgres,
+        # MinIO, a sibling API) is refused on the port check alone.
+        fake_client = _FakeAsyncClient(
+            response=_build_httpx_response("<html></html>"),
+        )
+        with _patch_httpx(fake_client):
+            with pytest.raises(UnsafeURLError):
+                await extract_from_url(
+                    "http://internal-api.example.com:8000/secrets",
+                    user_id=uuid.uuid4(),
+                )
+        assert fake_client.last_url is None
+
+    @pytest.mark.asyncio
+    async def test_endpoint_internal_url_returns_400(
+        self, user_factory, as_user,
+    ) -> None:
+        # End-to-end: an SSRF attempt through the public route maps to 400
+        # (UnsafeURLError is a ValueError) — not a 500 and not a fetch.
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/applications/extract-from-url",
+                json={"url": "http://169.254.169.254/latest/meta-data/"},
+            )
+        assert resp.status_code == 400, resp.text
+
+    @pytest.mark.asyncio
+    async def test_job_analysis_service_maps_internal_url_to_invalid(self) -> None:
+        # The /jobs/analyze call site wraps the same refusal into its own
+        # invalid-URL error (→ 400), never an opaque 500.
+        from app.services.job_analysis import job_analysis_service
+        from app.services.job_analysis.job_analysis_service import (
+            JobAnalysisInvalidUrlError,
+        )
+
+        with pytest.raises(JobAnalysisInvalidUrlError):
+            await job_analysis_service.analyze(
+                None,  # db is never reached on the SSRF-refusal path
+                uuid.uuid4(),
+                url="http://127.0.0.1/",
+                jd_text=None,
+            )

--- a/packages/shared-backend/platform_shared/core/url_safety.py
+++ b/packages/shared-backend/platform_shared/core/url_safety.py
@@ -1,0 +1,213 @@
+"""SSRF-safe validation for server-side URL fetches.
+
+Any feature where the server fetches a URL chosen (directly or indirectly)
+by a user is a Server-Side Request Forgery vector: the attacker picks the
+destination, so without a guard the server can be coerced into requesting
+internal-only addresses — cloud metadata (``169.254.169.254``), loopback,
+RFC1918 hosts, or sibling services on the same Docker network / VPS — and
+returning the response to the attacker.
+
+This module centralises the defence so every app shares one audited
+implementation (a Tier-1 security primitive per the monorepo parity rules).
+
+Two layers, and callers MUST apply BOTH:
+
+1. :func:`validate_public_url` — parse, require http(s) + an allowed port,
+   resolve the host to *every* address it maps to, and reject if **any**
+   resolved address is non-global (private / loopback / link-local /
+   reserved / multicast / unspecified) or a known cloud-metadata IP.
+   Resolving every record and rejecting on any disallowed one defeats the
+   simple multi-answer DNS-rebinding trick (mixing a public and a private
+   answer in one DNS reply). Relying on the OS resolver also normalises the
+   many alternate IP encodings attackers use (decimal ``2130706433``,
+   octal ``0177.0.0.1``, IPv4-mapped IPv6 ``::ffff:127.0.0.1``) — they all
+   resolve to the real address, which is then classified.
+
+2. The caller MUST disable transparent redirect-following and re-validate
+   every hop with :func:`assert_url_safe`, because a public URL can ``302``
+   into an internal one.
+
+Known residual
+==============
+A pure DNS-rebinding TOCTOU — the authoritative server answers with a
+public IP at validation time and a private IP a few milliseconds later when
+the HTTP client re-resolves to open the socket — is not fully closed here,
+because pinning the socket to the validated IP while preserving TLS
+hostname verification is not cleanly supported by httpx. It is a narrow,
+timing-dependent vector; the resolve-all-reject-any rule above plus a short
+fetch timeout shrink it materially. Closing it completely requires a
+connect-time peer-IP check inside a custom transport — tracked as a
+follow-up rather than shipped as fragile httpcore-internal coupling.
+"""
+from __future__ import annotations
+
+import asyncio
+import ipaddress
+import socket
+from urllib.parse import ParseResult, urlparse
+
+__all__ = [
+    "UnsafeURLError",
+    "validate_public_url",
+    "assert_url_safe",
+]
+
+
+class UnsafeURLError(ValueError):
+    """The URL is syntactically valid but points at a disallowed target.
+
+    Subclasses :class:`ValueError` so existing handlers that map a bad URL
+    to ``400 Bad Request`` route it correctly without new wiring.
+    """
+
+
+# Schemes we are willing to fetch. ``file://``, ``gopher://``, ``ftp://``,
+# ``data:`` etc. are all SSRF/exfil primitives and never legitimate here.
+_ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
+
+# Default port allowlist. Job postings (and every other legitimate public
+# fetch target so far) live on the standard web ports; refusing everything
+# else removes the "reach an internal service on :8000/:9000/:5432" surface
+# even before IP classification.
+_DEFAULT_ALLOWED_PORTS: frozenset[int] = frozenset({80, 443})
+
+# Cloud instance-metadata endpoints. All are already non-global (link-local),
+# so they are caught by the ``is_global`` check below — listed explicitly as
+# documentation of intent and a belt-and-suspenders guard.
+_METADATA_IPS: frozenset[ipaddress.IPv4Address | ipaddress.IPv6Address] = frozenset(
+    {
+        ipaddress.ip_address("169.254.169.254"),  # AWS / GCP / Azure / DO IMDS
+        ipaddress.ip_address("fd00:ec2::254"),  # AWS IMDS over IPv6
+    }
+)
+
+
+def _is_disallowed_ip(
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address,
+) -> bool:
+    """Return True if ``ip`` must never be the target of a server fetch."""
+    # Unwrap IPv4-mapped IPv6 (``::ffff:10.0.0.1``) so the embedded v4
+    # address is classified, not the wrapper — otherwise an attacker tunnels
+    # a private v4 target through a "global" v6 form.
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped is not None:
+        ip = ip.ipv4_mapped
+
+    if ip in _METADATA_IPS:
+        return True
+
+    # ``is_global`` alone is the comprehensive check (its False set is the
+    # union of every special-purpose range); the explicit predicates are
+    # spelled out for readability and to stay correct if a future Python
+    # narrows ``is_global``.
+    return (
+        not ip.is_global
+        or ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def _resolve_host(
+    host: str, port: int
+) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    """Resolve ``host`` to every IP it maps to (A + AAAA).
+
+    Numeric hosts (``127.0.0.1``, ``::1``) are returned without a network
+    lookup by the resolver. Patched in tests to avoid real DNS.
+
+    Raises:
+        UnsafeURLError: the host could not be resolved.
+    """
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except socket.gaierror as exc:
+        raise UnsafeURLError(f"could not resolve host {host!r}") from exc
+
+    addresses: list[ipaddress.IPv4Address | ipaddress.IPv6Address] = []
+    for info in infos:
+        sockaddr = info[4]
+        # sockaddr[0] is the textual IP for both AF_INET and AF_INET6.
+        addresses.append(ipaddress.ip_address(sockaddr[0]))
+    if not addresses:
+        raise UnsafeURLError(f"host {host!r} resolved to no addresses")
+    return addresses
+
+
+def validate_public_url(
+    url: str,
+    *,
+    allowed_ports: frozenset[int] = _DEFAULT_ALLOWED_PORTS,
+) -> ParseResult:
+    """Validate that ``url`` is safe to fetch from the server.
+
+    Enforces scheme + port, then resolves the host and rejects if ANY
+    resolved address is non-public. This performs a (cached, usually
+    sub-millisecond) DNS lookup — prefer :func:`assert_url_safe` from async
+    code so the resolver runs off the event loop.
+
+    Args:
+        url: The absolute http(s) URL to validate.
+        allowed_ports: Ports permitted on the target. Defaults to ``{80, 443}``.
+
+    Returns:
+        The parsed URL on success.
+
+    Raises:
+        UnsafeURLError: scheme/port disallowed, host missing or unresolvable,
+            or the host resolves to a non-public address.
+    """
+    if not isinstance(url, str) or not url.strip():
+        raise UnsafeURLError("url must be a non-empty string")
+
+    parsed = urlparse(url.strip())
+
+    if parsed.scheme not in _ALLOWED_SCHEMES:
+        raise UnsafeURLError(
+            f"url scheme must be http or https, got {parsed.scheme!r}"
+        )
+
+    host = parsed.hostname  # lowercased, IPv6 brackets stripped, userinfo removed
+    if not host:
+        raise UnsafeURLError("url must include a host")
+
+    try:
+        port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    except ValueError as exc:
+        # urlparse raises on out-of-range ports (e.g. ``:99999``).
+        raise UnsafeURLError("url has an invalid port") from exc
+
+    if port not in allowed_ports:
+        raise UnsafeURLError(
+            f"url port {port} is not permitted (allowed: {sorted(allowed_ports)})"
+        )
+
+    for ip in _resolve_host(host, port):
+        if _is_disallowed_ip(ip):
+            raise UnsafeURLError(
+                f"url host {host!r} resolves to a non-public address ({ip})"
+            )
+
+    return parsed
+
+
+async def assert_url_safe(
+    url: str,
+    *,
+    allowed_ports: frozenset[int] = _DEFAULT_ALLOWED_PORTS,
+) -> ParseResult:
+    """Async wrapper around :func:`validate_public_url`.
+
+    Runs the (blocking) DNS resolution in the default executor so the event
+    loop is never blocked on a slow nameserver. Call this once for the
+    original URL and again for every redirect hop before issuing the request.
+
+    Raises:
+        UnsafeURLError: see :func:`validate_public_url`.
+    """
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(
+        None, lambda: validate_public_url(url, allowed_ports=allowed_ports)
+    )

--- a/packages/shared-backend/tests/test_url_safety.py
+++ b/packages/shared-backend/tests/test_url_safety.py
@@ -1,0 +1,238 @@
+"""Tests for the SSRF-safe URL validator (``platform_shared.core.url_safety``).
+
+Coverage is organised by attacker bypass class, because an SSRF guard is
+only as good as the encodings/redirects it fails to anticipate:
+
+- scheme smuggling (``file://``, ``gopher://``, ``data:`` …)
+- non-web ports (reach an internal service on ``:8000`` / ``:5432``)
+- every non-public IP class (loopback, RFC1918, link-local, CGNAT,
+  reserved, unspecified, multicast)
+- cloud metadata IPs (``169.254.169.254``, ``fd00:ec2::254``)
+- IPv4-mapped IPv6 (``::ffff:10.0.0.1``)
+- userinfo host smuggling (``http://trusted.com@127.0.0.1``)
+- multi-answer DNS rebinding (one reply mixing a public + private address)
+- unresolvable hosts
+
+Literal-IP cases need no network — ``getaddrinfo`` recognises numeric forms
+and returns them without a DNS lookup, so they are deterministic on every
+platform. Hostname cases patch ``_resolve_host`` to keep tests offline.
+"""
+from __future__ import annotations
+
+import ipaddress
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from platform_shared.core import url_safety
+from platform_shared.core.url_safety import (
+    UnsafeURLError,
+    assert_url_safe,
+    validate_public_url,
+)
+
+_RESOLVE = "platform_shared.core.url_safety._resolve_host"
+
+
+def _addrs(*ips: str) -> list[ipaddress.IPv4Address | ipaddress.IPv6Address]:
+    return [ipaddress.ip_address(ip) for ip in ips]
+
+
+# ---------------------------------------------------------------------------
+# _is_disallowed_ip — pure IP classification (no network)
+# ---------------------------------------------------------------------------
+
+
+class TestIsDisallowedIp:
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "127.0.0.1",  # loopback
+            "127.0.0.5",
+            "10.0.0.1",  # RFC1918
+            "172.16.5.4",
+            "192.168.1.1",
+            "169.254.169.254",  # link-local / cloud metadata
+            "169.254.1.1",
+            "100.64.0.1",  # CGNAT shared address space
+            "0.0.0.0",  # unspecified
+            "192.0.2.1",  # TEST-NET-1 (reserved/documentation)
+            "224.0.0.1",  # multicast
+            "240.0.0.1",  # reserved (future use)
+            "::1",  # IPv6 loopback
+            "fe80::1",  # IPv6 link-local
+            "fc00::1",  # IPv6 unique-local
+            "fd00:ec2::254",  # IPv6 cloud metadata
+            "::ffff:127.0.0.1",  # IPv4-mapped loopback
+            "::ffff:10.0.0.1",  # IPv4-mapped RFC1918
+            "::",  # IPv6 unspecified
+        ],
+    )
+    def test_non_public_addresses_blocked(self, ip: str) -> None:
+        assert url_safety._is_disallowed_ip(ipaddress.ip_address(ip)) is True
+
+    @pytest.mark.parametrize(
+        "ip",
+        [
+            "8.8.8.8",  # Google DNS
+            "1.1.1.1",  # Cloudflare DNS
+            "93.184.216.34",  # example.com historical
+            "2606:4700:4700::1111",  # Cloudflare IPv6
+        ],
+    )
+    def test_public_addresses_allowed(self, ip: str) -> None:
+        assert url_safety._is_disallowed_ip(ipaddress.ip_address(ip)) is False
+
+
+# ---------------------------------------------------------------------------
+# Scheme + port enforcement
+# ---------------------------------------------------------------------------
+
+
+class TestSchemeAndPort:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "file:///etc/passwd",
+            "ftp://example.com/x",
+            "gopher://example.com/_x",
+            "data:text/plain,hello",
+            "dict://example.com:11211/",
+            "//example.com/x",  # scheme-relative → empty scheme
+        ],
+    )
+    def test_non_http_schemes_rejected(self, url: str) -> None:
+        with pytest.raises(UnsafeURLError, match="scheme"):
+            validate_public_url(url)
+
+    @pytest.mark.parametrize("url", ["", "   "])
+    def test_empty_rejected(self, url: str) -> None:
+        with pytest.raises(UnsafeURLError, match="non-empty"):
+            validate_public_url(url)
+
+    def test_missing_host_rejected(self) -> None:
+        with pytest.raises(UnsafeURLError, match="host"):
+            validate_public_url("https://")
+
+    @pytest.mark.parametrize("port", [8000, 9000, 5432, 22, 6379, 3000])
+    def test_non_web_ports_rejected(self, port: int) -> None:
+        # Public IP so only the port can be the cause.
+        with pytest.raises(UnsafeURLError, match="port"):
+            validate_public_url(f"http://8.8.8.8:{port}/")
+
+    def test_out_of_range_port_rejected(self) -> None:
+        with pytest.raises(UnsafeURLError, match="invalid port"):
+            validate_public_url("http://8.8.8.8:99999/")
+
+    def test_custom_allowed_ports(self) -> None:
+        # An opt-in caller may widen the port allowlist.
+        result = validate_public_url(
+            "https://8.8.8.8:8443/", allowed_ports=frozenset({8443})
+        )
+        assert result.scheme == "https"
+
+
+# ---------------------------------------------------------------------------
+# Literal-IP targets (network-free, deterministic everywhere)
+# ---------------------------------------------------------------------------
+
+
+class TestLiteralIpTargets:
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://127.0.0.1/admin",
+            "http://127.0.0.1/",
+            "http://10.0.0.5/internal",
+            "http://192.168.1.1/",
+            "http://172.16.0.1/",
+            "http://169.254.169.254/latest/meta-data/",  # AWS IMDS
+            "http://100.64.0.1/",  # CGNAT
+            "http://0.0.0.0/",
+            "http://[::1]/",  # IPv6 loopback
+            "http://[fd00:ec2::254]/",  # IPv6 metadata
+            "http://[::ffff:127.0.0.1]/",  # IPv4-mapped loopback
+            "http://[::ffff:10.0.0.1]/",  # IPv4-mapped RFC1918
+        ],
+    )
+    def test_internal_ip_literals_blocked(self, url: str) -> None:
+        with pytest.raises(UnsafeURLError, match="non-public"):
+            validate_public_url(url)
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "http://8.8.8.8/",
+            "https://1.1.1.1/",
+            "https://[2606:4700:4700::1111]/",
+        ],
+    )
+    def test_public_ip_literals_allowed(self, url: str) -> None:
+        result = validate_public_url(url)
+        assert result.hostname is not None
+
+    def test_userinfo_host_smuggling_blocked(self) -> None:
+        # The real host is what's after the ``@`` — must be classified, not
+        # the decoy before it.
+        with pytest.raises(UnsafeURLError, match="non-public"):
+            validate_public_url("http://trusted.example.com@127.0.0.1/")
+
+
+# ---------------------------------------------------------------------------
+# Hostname resolution (patched resolver) — rebinding + metadata DNS names
+# ---------------------------------------------------------------------------
+
+
+class TestHostnameResolution:
+    def test_hostname_resolving_to_public_allowed(self) -> None:
+        with patch(_RESOLVE, return_value=_addrs("93.184.216.34")):
+            result = validate_public_url("https://jobs.example.com/posting/abc")
+        assert result.netloc == "jobs.example.com"
+
+    def test_hostname_resolving_to_private_blocked(self) -> None:
+        # e.g. metadata.google.internal → 169.254.169.254, or an attacker
+        # domain with an A record pointing at an internal host.
+        with patch(_RESOLVE, return_value=_addrs("169.254.169.254")):
+            with pytest.raises(UnsafeURLError, match="non-public"):
+                validate_public_url("http://metadata.attacker.example/")
+
+    def test_multi_answer_rebinding_blocked(self) -> None:
+        # A single DNS reply mixing a public and a private answer must be
+        # rejected — we reject if ANY resolved address is non-public.
+        with patch(_RESOLVE, return_value=_addrs("93.184.216.34", "10.0.0.7")):
+            with pytest.raises(UnsafeURLError, match="non-public"):
+                validate_public_url("https://rebind.attacker.example/")
+
+    def test_all_public_answers_allowed(self) -> None:
+        with patch(_RESOLVE, return_value=_addrs("8.8.8.8", "1.1.1.1")):
+            result = validate_public_url("https://cdn.example.com/")
+        assert result.hostname == "cdn.example.com"
+
+    def test_unresolvable_host_rejected(self) -> None:
+        with patch(
+            "platform_shared.core.url_safety.socket.getaddrinfo",
+            side_effect=socket.gaierror("Name or service not known"),
+        ):
+            with pytest.raises(UnsafeURLError, match="could not resolve"):
+                validate_public_url("https://does-not-exist.invalid/")
+
+
+# ---------------------------------------------------------------------------
+# Async wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestAssertUrlSafe:
+    async def test_allows_public(self) -> None:
+        result = await assert_url_safe("https://1.1.1.1/")
+        assert result.scheme == "https"
+
+    async def test_blocks_internal(self) -> None:
+        with pytest.raises(UnsafeURLError):
+            await assert_url_safe("http://169.254.169.254/latest/meta-data/")
+
+    async def test_blocks_via_patched_resolver(self) -> None:
+        with patch(_RESOLVE, return_value=_addrs("10.1.2.3")):
+            with pytest.raises(UnsafeURLError, match="non-public"):
+                await assert_url_safe("https://internal.attacker.example/")


### PR DESCRIPTION
## Summary

Closes the **CRITICAL SSRF** found in the security audit. MyJobHunter's "analyze/extract job by URL" feature (`POST /jobs/analyze`, `POST /applications/extract-from-url`) fetched any user-supplied URL with only a scheme check and transparent redirect-following. An authenticated user could coerce the server into requesting internal addresses — cloud metadata (`169.254.169.254`), loopback, RFC1918, and **sibling services on the shared VPS / Docker network (MyBookkeeper's Postgres, shared MinIO, other apps)** — and read the response back. Read-SSRF with exfiltration, cross-app reachable.

## What changed

**New Tier-1 shared security primitive** — `platform_shared.core.url_safety` (per monorepo parity: SSRF-safe fetching is a security primitive, so it lives in `platform_shared` for any app to reuse, not in MJH):

- `validate_public_url` — require http(s) + an allowed port (`{80, 443}`), resolve the host to **every** address it maps to, and reject if **any** resolved address is non-global (private / loopback / link-local / reserved / multicast / unspecified) or a cloud-metadata IP. Relying on the OS resolver normalises alternate IP encodings (decimal `2130706433`, octal, IPv4-mapped IPv6 `::ffff:10.0.0.1`); resolve-all-reject-any defeats simple multi-answer DNS rebinding.
- `assert_url_safe` — async wrapper that runs DNS off the event loop.

**Wired into `jd_url_fetcher.fetch_html`** — httpx auto-redirects disabled; redirects walked by hand, validating the original URL **and every `Location` hop** before egress (a public URL can `302` into an internal one).

`UnsafeURLError` subclasses `ValueError`, so both existing call sites already map it to **HTTP 400** with no new wiring.

## Behaviour change

Previously-accepted internal/metadata URLs now return **400** instead of being fetched. No env vars, no migrations, no operator action required.

## Known residual (documented in the module)

A pure single-flip DNS-rebinding TOCTOU is not fully closed — httpx can't cleanly pin the connection to the validated IP while preserving TLS hostname verification. `resolve-all-reject-any` + the 15s fetch timeout shrink it materially; a connect-time peer-IP check in a custom transport is the future fix.

## Tests

- **64 shared cases** covering every bypass class: schemes (`file://`/`gopher://`/`data:`…), non-web ports, all non-public IP classes, cloud metadata (v4 + v6), IPv4-mapped IPv6, userinfo host smuggling (`http://trusted@127.0.0.1`), multi-answer DNS rebinding, unresolvable hosts.
- **MJH integration**: internal targets refused **without egress**, redirect-into-internal blocked on the hop, non-web port refused, endpoint returns 400, `/jobs/analyze` maps to invalid-url.
- All existing JD-URL extractor tests still pass (54/54).

> Note: 3 unrelated `test_job_analysis_service.py` failures exist locally from test-DB migration drift (`application_events.updated_at` missing) — orthogonal to this change; CI runs a freshly-migrated DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)