### PR TITLE
fix(infra): traffic-resilience hardening (Caddy body-cap + timeouts + XFF, uvicorn load-shed, DB pool)

### DIFF
--- a/apps/mybookkeeper/docker/Caddyfile.docker
+++ b/apps/mybookkeeper/docker/Caddyfile.docker
@@ -9,6 +9,17 @@
     servers {
         trusted_proxies static private_ranges
         client_ip_headers X-Forwarded-For
+        # Slowloris / slow-request protection. `read_header` is tight (headers
+        # are tiny, so near-zero false positives); `read_body` is generous
+        # enough for the largest legitimate upload (see request_body cap below)
+        # on a slow link; `idle` bounds kept-alive connections. `write` is
+        # deliberately left at the Caddy default (no limit) so large/slow file
+        # downloads through the storage handler are never truncated.
+        timeouts {
+            read_header 15s
+            read_body 2m
+            idle 2m
+        }
     }
 }
 
@@ -18,6 +29,15 @@
 # redirect from HTTP→HTTPS, but host Caddy proxies plain HTTP into this
 # container, so the redirect bounces back to the same URL → infinite loop.
 :80 {
+    # Coarse request-body cap — a DoS backstop, NOT the per-endpoint limit.
+    # Caddy rejects an oversized body with 413 at the proxy, before the ASGI
+    # app reads it into memory (the app's `await file.read()` happens before
+    # its own size check, so without this a multi-GB body OOMs the worker).
+    # 30 MB clears the largest legitimate upload (a 25 MB resume); apps still
+    # enforce their own tighter per-route limits below this ceiling.
+    request_body {
+        max_size 30MB
+    }
     # Storage subdomain — fronts MinIO for browser GETs of presigned URLs.
     # The storage matcher comes first so the per-handler security header
     # block below isn't applied to MinIO responses (CSP too tight breaks
@@ -56,7 +76,14 @@
         # designed for.
         handle /api/* {
             uri strip_prefix /api
-            reverse_proxy api:8000
+            reverse_proxy api:8000 {
+                # Overwrite X-Forwarded-For with Caddy's trusted computed
+                # client IP. Otherwise the app reads the FIRST XFF value, which
+                # the client sets directly — spoofing the per-IP rate-limit key
+                # and poisoning audit IPs. `{client_ip}` is derived from the
+                # trusted-proxy chain in the global block, so it is unforgeable.
+                header_up X-Forwarded-For {client_ip}
+            }
         }
 
         # SPA fallback for frontend. XFO + CSP `frame-ancestors` belong on the

--- a/apps/mybookkeeper/docker/backend.Dockerfile
+++ b/apps/mybookkeeper/docker/backend.Dockerfile
@@ -45,4 +45,7 @@ COPY apps/mybookkeeper/backend/ /app/
 
 EXPOSE 8000
 
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+# --limit-concurrency sheds load with 503 once in-flight requests exceed the
+# cap, instead of queueing unboundedly (a flood would otherwise grow memory
+# until OOM). Per-worker, so the effective ceiling is 2x this number.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2", "--limit-concurrency", "64"]

--- a/apps/mygamingassistant/docker/Caddyfile.docker
+++ b/apps/mygamingassistant/docker/Caddyfile.docker
@@ -9,6 +9,17 @@
     servers {
         trusted_proxies static private_ranges
         client_ip_headers X-Forwarded-For
+        # Slowloris / slow-request protection. `read_header` is tight (headers
+        # are tiny, so near-zero false positives); `read_body` is generous
+        # enough for the largest legitimate upload (see request_body cap below)
+        # on a slow link; `idle` bounds kept-alive connections. `write` is
+        # deliberately left at the Caddy default (no limit) so large/slow file
+        # downloads through the storage handler are never truncated.
+        timeouts {
+            read_header 15s
+            read_body 2m
+            idle 2m
+        }
     }
 }
 
@@ -18,6 +29,15 @@
 # redirect from HTTP→HTTPS, but host Caddy proxies plain HTTP into this
 # container, so the redirect bounces back to the same URL → infinite loop.
 :80 {
+    # Coarse request-body cap — a DoS backstop, NOT the per-endpoint limit.
+    # Caddy rejects an oversized body with 413 at the proxy, before the ASGI
+    # app reads it into memory (the app's `await file.read()` happens before
+    # its own size check, so without this a multi-GB body OOMs the worker).
+    # 30 MB clears the largest legitimate upload (a 25 MB resume); apps still
+    # enforce their own tighter per-route limits below this ceiling.
+    request_body {
+        max_size 30MB
+    }
     # Security response headers — applied to every response (API + SPA).
     # `defer` lets these headers also override anything the upstream FastAPI
     # process might emit, so we never accidentally regress on a stricter
@@ -36,7 +56,14 @@
     # API proxy (strip /api prefix)
     handle /api/* {
         uri strip_prefix /api
-        reverse_proxy api:8004
+        reverse_proxy api:8004 {
+            # Overwrite X-Forwarded-For with Caddy's trusted computed client
+            # IP. Otherwise the app reads the FIRST XFF value, which the client
+            # sets directly — spoofing the per-IP rate-limit key and poisoning
+            # audit IPs. `{client_ip}` is derived from the trusted-proxy chain
+            # in the global block, so it is unforgeable.
+            header_up X-Forwarded-For {client_ip}
+        }
     }
 
     # SPA fallback for frontend

--- a/apps/mygamingassistant/docker/backend.Dockerfile
+++ b/apps/mygamingassistant/docker/backend.Dockerfile
@@ -30,4 +30,7 @@ RUN chmod +x /entrypoint.sh
 EXPOSE 8004
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8004", "--workers", "2"]
+# --limit-concurrency sheds load with 503 once in-flight requests exceed the
+# cap, instead of queueing unboundedly (a flood would otherwise grow memory
+# until OOM). Per-worker, so the effective ceiling is 2x this number.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8004", "--workers", "2", "--limit-concurrency", "64"]

--- a/apps/myjobhunter/docker/Caddyfile.docker
+++ b/apps/myjobhunter/docker/Caddyfile.docker
@@ -9,6 +9,17 @@
     servers {
         trusted_proxies static private_ranges
         client_ip_headers X-Forwarded-For
+        # Slowloris / slow-request protection. `read_header` is tight (headers
+        # are tiny, so near-zero false positives); `read_body` is generous
+        # enough for the largest legitimate upload (see request_body cap below)
+        # on a slow link; `idle` bounds kept-alive connections. `write` is
+        # deliberately left at the Caddy default (no limit) so large/slow file
+        # downloads through the storage handler are never truncated.
+        timeouts {
+            read_header 15s
+            read_body 2m
+            idle 2m
+        }
     }
 }
 
@@ -18,6 +29,15 @@
 # redirect from HTTP→HTTPS, but host Caddy proxies plain HTTP into this
 # container, so the redirect bounces back to the same URL → infinite loop.
 :80 {
+    # Coarse request-body cap — a DoS backstop, NOT the per-endpoint limit.
+    # Caddy rejects an oversized body with 413 at the proxy, before the ASGI
+    # app reads it into memory (the app's `await file.read()` happens before
+    # its own size check, so without this a multi-GB body OOMs the worker).
+    # 30 MB clears the largest legitimate upload (a 25 MB resume); apps still
+    # enforce their own tighter per-route limits below this ceiling.
+    request_body {
+        max_size 30MB
+    }
     # Security response headers — applied to every response (API + SPA).
     # `defer` lets these headers also override anything the upstream FastAPI
     # process might emit, so we never accidentally regress on a stricter
@@ -36,7 +56,14 @@
     # API proxy (strip /api prefix)
     handle /api/* {
         uri strip_prefix /api
-        reverse_proxy api:8002
+        reverse_proxy api:8002 {
+            # Overwrite X-Forwarded-For with Caddy's trusted computed client
+            # IP. Otherwise the app reads the FIRST XFF value, which the client
+            # sets directly — spoofing the per-IP rate-limit key and poisoning
+            # audit IPs. `{client_ip}` is derived from the trusted-proxy chain
+            # in the global block, so it is unforgeable.
+            header_up X-Forwarded-For {client_ip}
+        }
     }
 
     # SPA fallback for frontend

--- a/apps/myjobhunter/docker/backend.Dockerfile
+++ b/apps/myjobhunter/docker/backend.Dockerfile
@@ -55,4 +55,7 @@ RUN mkdir -p "$FASTEMBED_CACHE_PATH" \
 EXPOSE 8002
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002", "--workers", "2"]
+# --limit-concurrency sheds load with 503 once in-flight requests exceed the
+# cap, instead of queueing unboundedly (a flood would otherwise grow memory
+# until OOM). Per-worker, so the effective ceiling is 2x this number.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002", "--workers", "2", "--limit-concurrency", "64"]

--- a/apps/mypizzatracker/docker/Caddyfile.docker
+++ b/apps/mypizzatracker/docker/Caddyfile.docker
@@ -9,6 +9,17 @@
     servers {
         trusted_proxies static private_ranges
         client_ip_headers X-Forwarded-For
+        # Slowloris / slow-request protection. `read_header` is tight (headers
+        # are tiny, so near-zero false positives); `read_body` is generous
+        # enough for the largest legitimate upload (see request_body cap below)
+        # on a slow link; `idle` bounds kept-alive connections. `write` is
+        # deliberately left at the Caddy default (no limit) so large/slow file
+        # downloads through the storage handler are never truncated.
+        timeouts {
+            read_header 15s
+            read_body 2m
+            idle 2m
+        }
     }
 }
 
@@ -18,6 +29,15 @@
 # redirect from HTTP→HTTPS, but host Caddy proxies plain HTTP into this
 # container, so the redirect bounces back to the same URL → infinite loop.
 :80 {
+    # Coarse request-body cap — a DoS backstop, NOT the per-endpoint limit.
+    # Caddy rejects an oversized body with 413 at the proxy, before the ASGI
+    # app reads it into memory (the app's `await file.read()` happens before
+    # its own size check, so without this a multi-GB body OOMs the worker).
+    # 30 MB clears the largest legitimate upload (a 25 MB resume); apps still
+    # enforce their own tighter per-route limits below this ceiling.
+    request_body {
+        max_size 30MB
+    }
     # Security response headers — applied to every response (API + SPA).
     # `defer` lets these headers also override anything the upstream FastAPI
     # process might emit, so we never accidentally regress on a stricter
@@ -36,7 +56,14 @@
     # API proxy (strip /api prefix)
     handle /api/* {
         uri strip_prefix /api
-        reverse_proxy api:8006
+        reverse_proxy api:8006 {
+            # Overwrite X-Forwarded-For with Caddy's trusted computed client
+            # IP. Otherwise the app reads the FIRST XFF value, which the client
+            # sets directly — spoofing the per-IP rate-limit key and poisoning
+            # audit IPs. `{client_ip}` is derived from the trusted-proxy chain
+            # in the global block, so it is unforgeable.
+            header_up X-Forwarded-For {client_ip}
+        }
     }
 
     # SPA fallback for frontend

--- a/apps/mypizzatracker/docker/backend.Dockerfile
+++ b/apps/mypizzatracker/docker/backend.Dockerfile
@@ -29,4 +29,7 @@ RUN chmod +x /entrypoint.sh
 EXPOSE 8006
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8006", "--workers", "2"]
+# --limit-concurrency sheds load with 503 once in-flight requests exceed the
+# cap, instead of queueing unboundedly (a flood would otherwise grow memory
+# until OOM). Per-worker, so the effective ceiling is 2x this number.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8006", "--workers", "2", "--limit-concurrency", "64"]

--- a/infra/templates/Caddyfile.docker.j2
+++ b/infra/templates/Caddyfile.docker.j2
@@ -9,6 +9,17 @@
     servers {
         trusted_proxies static private_ranges
         client_ip_headers X-Forwarded-For
+        # Slowloris / slow-request protection. `read_header` is tight (headers
+        # are tiny, so near-zero false positives); `read_body` is generous
+        # enough for the largest legitimate upload (see request_body cap below)
+        # on a slow link; `idle` bounds kept-alive connections. `write` is
+        # deliberately left at the Caddy default (no limit) so large/slow file
+        # downloads through the storage handler are never truncated.
+        timeouts {
+            read_header 15s
+            read_body 2m
+            idle 2m
+        }
     }
 }
 
@@ -18,6 +29,15 @@
 # redirect from HTTP→HTTPS, but host Caddy proxies plain HTTP into this
 # container, so the redirect bounces back to the same URL → infinite loop.
 :80 {
+    # Coarse request-body cap — a DoS backstop, NOT the per-endpoint limit.
+    # Caddy rejects an oversized body with 413 at the proxy, before the ASGI
+    # app reads it into memory (the app's `await file.read()` happens before
+    # its own size check, so without this a multi-GB body OOMs the worker).
+    # 30 MB clears the largest legitimate upload (a 25 MB resume); apps still
+    # enforce their own tighter per-route limits below this ceiling.
+    request_body {
+        max_size 30MB
+    }
 {%- if has_minio_subdomain %}
     # Storage subdomain — fronts MinIO for browser GETs of presigned URLs.
     # The storage matcher comes first so the per-handler security header
@@ -60,7 +80,14 @@
         # designed for.
         handle /api/* {
             uri strip_prefix /api
-            reverse_proxy api:{{ api_port }}
+            reverse_proxy api:{{ api_port }} {
+                # Overwrite X-Forwarded-For with Caddy's trusted computed
+                # client IP. Otherwise the app reads the FIRST XFF value, which
+                # the client sets directly — spoofing the per-IP rate-limit key
+                # and poisoning audit IPs. `{client_ip}` is derived from the
+                # trusted-proxy chain in the global block, so it is unforgeable.
+                header_up X-Forwarded-For {client_ip}
+            }
         }
 
         # SPA fallback for frontend. XFO + CSP `frame-ancestors` belong on the
@@ -110,7 +137,14 @@
     # API proxy (strip /api prefix)
     handle /api/* {
         uri strip_prefix /api
-        reverse_proxy api:{{ api_port }}
+        reverse_proxy api:{{ api_port }} {
+            # Overwrite X-Forwarded-For with Caddy's trusted computed client
+            # IP. Otherwise the app reads the FIRST XFF value, which the client
+            # sets directly — spoofing the per-IP rate-limit key and poisoning
+            # audit IPs. `{client_ip}` is derived from the trusted-proxy chain
+            # in the global block, so it is unforgeable.
+            header_up X-Forwarded-For {client_ip}
+        }
     }
 
     # SPA fallback for frontend

--- a/infra/templates/scaffold/docker/backend.Dockerfile
+++ b/infra/templates/scaffold/docker/backend.Dockerfile
@@ -29,4 +29,7 @@ RUN chmod +x /entrypoint.sh
 EXPOSE __API_PORT__
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "__API_PORT__", "--workers", "2"]
+# --limit-concurrency sheds load with 503 once in-flight requests exceed the
+# cap, instead of queueing unboundedly (a flood would otherwise grow memory
+# until OOM). Per-worker, so the effective ceiling is 2x this number.
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "__API_PORT__", "--workers", "2", "--limit-concurrency", "64"]

--- a/packages/shared-backend/platform_shared/db/session.py
+++ b/packages/shared-backend/platform_shared/db/session.py
@@ -37,11 +37,24 @@ def create_session_factory(
     database_url: str,
     *,
     echo: bool = False,
-    pool_size: int = 10,
-    max_overflow: int = 20,
-    pool_timeout: int = 30,
+    pool_size: int = 5,
+    max_overflow: int = 10,
+    pool_timeout: int = 10,
     pool_recycle: int = 1800,
+    pool_pre_ping: bool = True,
 ) -> SessionFactory:
+    # Pool sizing is bounded by Postgres `max_connections` (default 100),
+    # shared across every engine that targets the same database. Each uvicorn
+    # worker process AND each background-worker container opens its own engine,
+    # so the per-app total is `engines * (pool_size + max_overflow)`. With the
+    # canonical app's 4 engines (2 api workers + upload-processor + scheduler)
+    # and 5+10, that's 60 < 100 — comfortable headroom. The previous 10+20
+    # could demand 120 and exhaust Postgres under load, hanging every request
+    # for `pool_timeout` seconds. `pool_timeout=10` makes backpressure fail
+    # fast instead of piling up; `pool_pre_ping` transparently replaces a
+    # stale connection (e.g. after a Postgres restart) instead of erroring the
+    # first request that draws it.
+    #
     # SQLite (used in unit tests) doesn't support pool sizing — its async driver
     # pairs with StaticPool, and passing pool_size/max_overflow/pool_timeout
     # raises TypeError at engine creation. Skip pool kwargs for SQLite URLs.
@@ -55,6 +68,7 @@ def create_session_factory(
             max_overflow=max_overflow,
             pool_timeout=pool_timeout,
             pool_recycle=pool_recycle,
+            pool_pre_ping=pool_pre_ping,
         )
     session_maker = async_sessionmaker(engine, expire_on_commit=False)
 

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -465,6 +465,53 @@ class TestInfraTemplateDrift:
         )
 
 
+class TestEdgeHardeningDirectives:
+    """Traffic-resilience hardening must be present in every app's edge.
+
+    These are the platform's first line against a traffic spike / DoS, living
+    in the shared Caddy template + each app's backend.Dockerfile. The drift
+    test alone wouldn't catch their removal (every rendered file would lose
+    the directive together and still match the template), so assert the
+    directives explicitly.
+    """
+
+    @pytest.mark.parametrize("app", _APPS)
+    def test_caddy_has_body_size_cap(self, app: str) -> None:
+        caddy = _read("apps", app, "docker", "Caddyfile.docker")
+        assert "request_body {" in caddy and "max_size 30MB" in caddy, (
+            f"{app} docker Caddyfile is missing the request-body size cap — a "
+            f"large-body flood would buffer into the worker's memory (OOM). "
+            f"Restore it in infra/templates/Caddyfile.docker.j2 and re-render."
+        )
+
+    @pytest.mark.parametrize("app", _APPS)
+    def test_caddy_has_slowloris_timeouts(self, app: str) -> None:
+        caddy = _read("apps", app, "docker", "Caddyfile.docker")
+        assert all(d in caddy for d in ("read_header", "read_body", "idle")), (
+            f"{app} docker Caddyfile is missing the Slowloris timeouts "
+            f"(read_header/read_body/idle). Restore them in the template and re-render."
+        )
+
+    @pytest.mark.parametrize("app", _APPS)
+    def test_caddy_overwrites_forwarded_for(self, app: str) -> None:
+        caddy = _read("apps", app, "docker", "Caddyfile.docker")
+        assert "header_up X-Forwarded-For {client_ip}" in caddy, (
+            f"{app} docker Caddyfile must overwrite X-Forwarded-For with Caddy's "
+            f"trusted {{client_ip}} on the API reverse_proxy — otherwise the app "
+            f"trusts an attacker-set first hop, defeating per-IP rate limits. "
+            f"Restore it in the template and re-render."
+        )
+
+    @pytest.mark.parametrize("app", _APPS)
+    def test_uvicorn_sheds_load(self, app: str) -> None:
+        dockerfile = _read("apps", app, "docker", "backend.Dockerfile")
+        assert "--limit-concurrency" in dockerfile, (
+            f"{app} backend.Dockerfile uvicorn CMD must set --limit-concurrency "
+            f"so a request flood sheds load with 503 instead of queueing "
+            f"unboundedly into OOM."
+        )
+
+
 # Apps whose deploy workflow runs in-container steps after migrate (driven by
 # app.yaml `post_deploy_commands`). MGA auto-seeds its public lineup library on
 # every deploy; the canonical apps keep the list empty. The inverse check guards

--- a/packages/shared-backend/tests/test_session_pool.py
+++ b/packages/shared-backend/tests/test_session_pool.py
@@ -1,0 +1,50 @@
+"""Tests for the DB connection-pool configuration in create_session_factory.
+
+Pool sizing is a traffic-resilience control: every uvicorn worker and every
+background-worker container opens its own engine against the same per-app
+Postgres (default max_connections=100), so an oversized pool can exhaust
+Postgres under load and hang every request for pool_timeout seconds. These
+tests pin the contract (the exact kwargs passed to create_async_engine)
+without depending on SQLAlchemy pool internals.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from platform_shared.db.session import create_session_factory
+
+_ENGINE = "platform_shared.db.session.create_async_engine"
+_PG_URL = "postgresql+asyncpg://u:p@db/app"
+
+
+class TestPoolConfig:
+    def test_postgres_pool_defaults_bounded(self) -> None:
+        with patch(_ENGINE, return_value=MagicMock()) as mk:
+            create_session_factory(_PG_URL)
+        kwargs = mk.call_args.kwargs
+        assert kwargs["pool_size"] == 5
+        assert kwargs["max_overflow"] == 10
+        assert kwargs["pool_timeout"] == 10
+        assert kwargs["pool_pre_ping"] is True
+        # Per-engine ceiling × the canonical app's 4 engines (2 api workers +
+        # upload-processor + scheduler) must stay under Postgres max_connections.
+        assert (kwargs["pool_size"] + kwargs["max_overflow"]) * 4 < 100
+
+    def test_sqlite_skips_pool_kwargs(self) -> None:
+        # SQLite's async StaticPool rejects pool sizing kwargs — the factory
+        # must not pass them (unit tests run on SQLite).
+        with patch(_ENGINE, return_value=MagicMock()) as mk:
+            create_session_factory("sqlite+aiosqlite:///:memory:")
+        kwargs = mk.call_args.kwargs
+        assert "pool_size" not in kwargs
+        assert "max_overflow" not in kwargs
+        assert "pool_pre_ping" not in kwargs
+
+    def test_explicit_overrides_respected(self) -> None:
+        with patch(_ENGINE, return_value=MagicMock()) as mk:
+            create_session_factory(_PG_URL, pool_size=8, max_overflow=4)
+        kwargs = mk.call_args.kwargs
+        assert kwargs["pool_size"] == 8
+        assert kwargs["max_overflow"] == 4
+        # Untouched defaults still apply.
+        assert kwargs["pool_pre_ping"] is True


### PR DESCRIPTION
## Summary

Closes the **no-facts-needed half** of the audit's DDoS / traffic-resilience findings. Platform-wide — the Caddy template renders to all 4 apps and the DB-pool default lives in the shared factory — so one PR hardens every app's edge.

## Changes

**Caddy** (`infra/templates/Caddyfile.docker.j2` → re-rendered to all 4 apps):
- **`request_body { max_size 30MB }`** — coarse body cap; an oversized upload is rejected with 413 at the proxy **before** the ASGI app reads it into memory (the app's `await file.read()` runs before its own size check, so without this a multi-GB body OOMs the worker). 30 MB clears the largest legit upload (25 MB resume); per-route app limits still apply below it.
- **`timeouts { read_header 15s; read_body 2m; idle 2m }`** — Slowloris / slow-request protection. `write` left at default so large/slow file downloads are never truncated.
- **`header_up X-Forwarded-For {client_ip}`** on the API `reverse_proxy` — overwrite XFF with Caddy's trusted computed client IP. Previously the app read the **first (client-settable)** XFF value, so an attacker could spoof the per-IP rate-limit key and poison audit IPs. `{client_ip}` derives from the trusted-proxy chain, so it's unforgeable.

**uvicorn** (all 4 `backend.Dockerfile` + scaffold):
- **`--limit-concurrency 64`** — shed load with 503 once in-flight requests exceed the cap instead of queueing unboundedly into OOM. (Deliberately did **not** touch `--timeout-keep-alive`: its 5 s default is already protective; raising it keeps idle connections alive longer — counterproductive.)

**DB pool** (`platform_shared/db/session.py` defaults; all apps use defaults):
- `pool_size` 10→5, `max_overflow` 20→10, `pool_timeout` 30→10 s, add `pool_pre_ping=True`. Per-app Postgres `max_connections` defaults to 100, shared across every engine; the canonical app's 4 engines (2 api workers + upload-processor + scheduler) at the old 30/engine could demand **120** and exhaust Postgres, hanging every request 30 s. 15/engine → **60 < 100**. `pool_timeout=10` makes backpressure fail fast; `pool_pre_ping` replaces stale connections after a Postgres restart instead of erroring the first request.

## Tests
- `test_session_pool.py` — pins the pool kwargs (postgres bounded, SQLite skips them, explicit overrides respected).
- `test_app_conformance.py::TestEdgeHardeningDirectives` — asserts every app's rendered Caddyfile carries the body cap / timeouts / XFF overwrite and every `backend.Dockerfile` sets `--limit-concurrency`, so a future template edit can't silently drop them (the drift test alone wouldn't catch a uniform removal).
- Drift test (`TestInfraTemplateDrift`) green — rendered files match the edited template byte-for-byte.

## Behaviour change
Uploads >30 MB now 413 at the edge (documented limit is 10 MB; largest legit is the 25 MB resume) — **no env / config / operator action required**.

## Out of scope (follow-ups)
- **Edge rate limiting** (single-IP flood) → Cloudflare free-tier work, which also absorbs the storage-subdomain bandwidth finding.
- **Container resource limits** (`mem_limit`/`cpus`/`pids_limit`) → pending the VPS RAM/vCPU budget.

> CI note: the `shared-backend-tests` job shows 4 **pre-existing** `TestSupportPageWired` failures (auth-page footers missing a `/support` link, from the #835–#837 support-page refactor) — unrelated to this PR; my new tests are in the passing set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)