### PR TITLE
feat(infra): per-container resource caps (mem/cpu/pids) for OOM-cascade containment

### DIFF
--- a/apps/mybookkeeper/docker-compose.yml
+++ b/apps/mybookkeeper/docker-compose.yml
@@ -6,6 +6,17 @@ services:
   postgres:
     image: postgres:16-alpine
     restart: unless-stopped
+    # Resource caps — blast-radius containment on a small shared VPS. The apps
+    # share one host with no swap headroom, so a single runaway/compromised
+    # container must not exhaust RAM and trigger the kernel OOM-killer against a
+    # sibling app's Postgres (the open blast-radius gap this closes). These are
+    # CEILINGS, not reservations — sized well above observed steady-state working
+    # sets, so the lighter apps never approach them. They pair with a host swap
+    # file (see the PR's operational notes): with swap present, a container that
+    # reaches its mem_limit soft-lands into swap instead of an instant hard kill.
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 256
     environment:
       POSTGRES_USER: mybookkeeper
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -31,6 +42,10 @@ services:
       context: ../..
       dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
     command: ["alembic", "upgrade", "head"]
+    # One-shot migration — caps guard a runaway migration, not steady state.
+    mem_limit: 512m
+    cpus: 1.5
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
@@ -43,6 +58,12 @@ services:
       context: ../..
       dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
     restart: unless-stopped
+    # Highest single consumer on the box (the busiest app's API steady-states
+    # well under this); cap leaves headroom for request-handling spikes while
+    # still bounding a runaway. See the postgres service for the full rationale.
+    mem_limit: 1024m
+    cpus: 1.5
+    pids_limit: 256
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
@@ -74,6 +95,9 @@ services:
       dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
     restart: unless-stopped
     command: ["python", "-m", "app.workers.upload_processor_worker"]
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
@@ -90,6 +114,9 @@ services:
       dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
     restart: unless-stopped
     command: ["python", "-m", "app.workers.scheduler_worker"]
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
@@ -116,6 +143,9 @@ services:
         # where TurnstileWidget returns null and registration silently 400s.
         VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
     restart: unless-stopped
+    mem_limit: 128m
+    cpus: 0.5
+    pids_limit: 64
     ports:
       # Bind only to localhost — host Caddy is the public front door and proxies here.
       - "127.0.0.1:8094:80"

--- a/apps/mygamingassistant/docker-compose.yml
+++ b/apps/mygamingassistant/docker-compose.yml
@@ -6,6 +6,17 @@ services:
   postgres:
     image: postgres:16
     restart: unless-stopped
+    # Resource caps — blast-radius containment on a small shared VPS. The apps
+    # share one host with no swap headroom, so a single runaway/compromised
+    # container must not exhaust RAM and trigger the kernel OOM-killer against a
+    # sibling app's Postgres (the open blast-radius gap this closes). These are
+    # CEILINGS, not reservations — sized well above observed steady-state working
+    # sets, so the lighter apps never approach them. They pair with a host swap
+    # file (see the PR's operational notes): with swap present, a container that
+    # reaches its mem_limit soft-lands into swap instead of an instant hard kill.
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 256
     environment:
       POSTGRES_USER: mygamingassistant
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -31,6 +42,10 @@ services:
       context: ../..
       dockerfile: apps/mygamingassistant/docker/backend.Dockerfile
     command: ["alembic", "upgrade", "head"]
+    # One-shot migration — caps guard a runaway migration, not steady state.
+    mem_limit: 512m
+    cpus: 1.5
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mygamingassistant:${DB_PASSWORD}@postgres/mygamingassistant
@@ -43,6 +58,12 @@ services:
       context: ../..
       dockerfile: apps/mygamingassistant/docker/backend.Dockerfile
     restart: unless-stopped
+    # Highest single consumer on the box (the busiest app's API steady-states
+    # well under this); cap leaves headroom for request-handling spikes while
+    # still bounding a runaway. See the postgres service for the full rationale.
+    mem_limit: 1024m
+    cpus: 1.5
+    pids_limit: 256
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mygamingassistant:${DB_PASSWORD}@postgres/mygamingassistant
@@ -76,6 +97,9 @@ services:
         # bundle. Empty/unset keeps the full auth UI.
         VITE_SERVE_ONLY: ${SERVE_ONLY:-}
     restart: unless-stopped
+    mem_limit: 128m
+    cpus: 0.5
+    pids_limit: 64
     ports:
       # Bind only to localhost — host Caddy is the public front door and proxies here.
       - "127.0.0.1:8096:80"

--- a/apps/myjobhunter/docker-compose.yml
+++ b/apps/myjobhunter/docker-compose.yml
@@ -6,6 +6,17 @@ services:
   postgres:
     image: pgvector/pgvector:pg16
     restart: unless-stopped
+    # Resource caps — blast-radius containment on a small shared VPS. The apps
+    # share one host with no swap headroom, so a single runaway/compromised
+    # container must not exhaust RAM and trigger the kernel OOM-killer against a
+    # sibling app's Postgres (the open blast-radius gap this closes). These are
+    # CEILINGS, not reservations — sized well above observed steady-state working
+    # sets, so the lighter apps never approach them. They pair with a host swap
+    # file (see the PR's operational notes): with swap present, a container that
+    # reaches its mem_limit soft-lands into swap instead of an instant hard kill.
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 256
     environment:
       POSTGRES_USER: myjobhunter
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -31,6 +42,10 @@ services:
       context: ../..
       dockerfile: apps/myjobhunter/docker/backend.Dockerfile
     command: ["alembic", "upgrade", "head"]
+    # One-shot migration — caps guard a runaway migration, not steady state.
+    mem_limit: 512m
+    cpus: 1.5
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://myjobhunter:${DB_PASSWORD}@postgres/myjobhunter
@@ -43,6 +58,12 @@ services:
       context: ../..
       dockerfile: apps/myjobhunter/docker/backend.Dockerfile
     restart: unless-stopped
+    # Highest single consumer on the box (the busiest app's API steady-states
+    # well under this); cap leaves headroom for request-handling spikes while
+    # still bounding a runaway. See the postgres service for the full rationale.
+    mem_limit: 1024m
+    cpus: 1.5
+    pids_limit: 256
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://myjobhunter:${DB_PASSWORD}@postgres/myjobhunter
@@ -64,6 +85,9 @@ services:
       dockerfile: apps/myjobhunter/docker/backend.Dockerfile
     restart: unless-stopped
     command: ["python", "-m", "app.workers.resume_parser_worker"]
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://myjobhunter:${DB_PASSWORD}@postgres/myjobhunter
@@ -90,6 +114,9 @@ services:
         # where TurnstileWidget returns null and registration silently 400s.
         VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
     restart: unless-stopped
+    mem_limit: 128m
+    cpus: 0.5
+    pids_limit: 64
     ports:
       # Bind only to localhost — host Caddy is the public front door and proxies here.
       - "127.0.0.1:8092:80"

--- a/apps/mypizzatracker/docker-compose.yml
+++ b/apps/mypizzatracker/docker-compose.yml
@@ -6,6 +6,17 @@ services:
   postgres:
     image: postgres:16
     restart: unless-stopped
+    # Resource caps — blast-radius containment on a small shared VPS. The apps
+    # share one host with no swap headroom, so a single runaway/compromised
+    # container must not exhaust RAM and trigger the kernel OOM-killer against a
+    # sibling app's Postgres (the open blast-radius gap this closes). These are
+    # CEILINGS, not reservations — sized well above observed steady-state working
+    # sets, so the lighter apps never approach them. They pair with a host swap
+    # file (see the PR's operational notes): with swap present, a container that
+    # reaches its mem_limit soft-lands into swap instead of an instant hard kill.
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 256
     environment:
       POSTGRES_USER: mypizzatracker
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -31,6 +42,10 @@ services:
       context: ../..
       dockerfile: apps/mypizzatracker/docker/backend.Dockerfile
     command: ["alembic", "upgrade", "head"]
+    # One-shot migration — caps guard a runaway migration, not steady state.
+    mem_limit: 512m
+    cpus: 1.5
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mypizzatracker:${DB_PASSWORD}@postgres/mypizzatracker
@@ -43,6 +58,12 @@ services:
       context: ../..
       dockerfile: apps/mypizzatracker/docker/backend.Dockerfile
     restart: unless-stopped
+    # Highest single consumer on the box (the busiest app's API steady-states
+    # well under this); cap leaves headroom for request-handling spikes while
+    # still bounding a runaway. See the postgres service for the full rationale.
+    mem_limit: 1024m
+    cpus: 1.5
+    pids_limit: 256
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mypizzatracker:${DB_PASSWORD}@postgres/mypizzatracker
@@ -74,6 +95,9 @@ services:
         # where TurnstileWidget returns null and registration silently 400s.
         VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
     restart: unless-stopped
+    mem_limit: 128m
+    cpus: 0.5
+    pids_limit: 64
     ports:
       # Bind only to localhost — host Caddy is the public front door and proxies here.
       - "127.0.0.1:8098:80"

--- a/infra/templates/docker-compose.yml.j2
+++ b/infra/templates/docker-compose.yml.j2
@@ -6,6 +6,17 @@ services:
   postgres:
     image: {{ postgres_image }}
     restart: unless-stopped
+    # Resource caps — blast-radius containment on a small shared VPS. The apps
+    # share one host with no swap headroom, so a single runaway/compromised
+    # container must not exhaust RAM and trigger the kernel OOM-killer against a
+    # sibling app's Postgres (the open blast-radius gap this closes). These are
+    # CEILINGS, not reservations — sized well above observed steady-state working
+    # sets, so the lighter apps never approach them. They pair with a host swap
+    # file (see the PR's operational notes): with swap present, a container that
+    # reaches its mem_limit soft-lands into swap instead of an instant hard kill.
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 256
     environment:
       POSTGRES_USER: {{ app_slug }}
       POSTGRES_PASSWORD: ${DB_PASSWORD}
@@ -31,6 +42,10 @@ services:
       context: ../..
       dockerfile: apps/{{ app_slug }}/docker/backend.Dockerfile
     command: ["alembic", "upgrade", "head"]
+    # One-shot migration — caps guard a runaway migration, not steady state.
+    mem_limit: 512m
+    cpus: 1.5
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://{{ app_slug }}:${DB_PASSWORD}@postgres/{{ app_slug }}
@@ -43,6 +58,12 @@ services:
       context: ../..
       dockerfile: apps/{{ app_slug }}/docker/backend.Dockerfile
     restart: unless-stopped
+    # Highest single consumer on the box (the busiest app's API steady-states
+    # well under this); cap leaves headroom for request-handling spikes while
+    # still bounding a runaway. See the postgres service for the full rationale.
+    mem_limit: 1024m
+    cpus: 1.5
+    pids_limit: 256
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://{{ app_slug }}:${DB_PASSWORD}@postgres/{{ app_slug }}
@@ -78,6 +99,9 @@ services:
       dockerfile: apps/{{ app_slug }}/docker/backend.Dockerfile
     restart: unless-stopped
     command: {{ w.command | tojson }}
+    mem_limit: 512m
+    cpus: 1.0
+    pids_limit: 128
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://{{ app_slug }}:${DB_PASSWORD}@postgres/{{ app_slug }}
@@ -113,6 +137,9 @@ services:
         VITE_SERVE_ONLY: ${SERVE_ONLY:-}
 {%- endif %}
     restart: unless-stopped
+    mem_limit: 128m
+    cpus: 0.5
+    pids_limit: 64
     ports:
       # Bind only to localhost — host Caddy is the public front door and proxies here.
       - "127.0.0.1:{{ caddy_host_port }}:80"

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -512,6 +512,43 @@ class TestEdgeHardeningDirectives:
         )
 
 
+class TestContainerResourceLimits:
+    """Every app's compose must cap per-container memory, CPU, and PIDs.
+
+    Blast-radius containment on the shared VPS: with no per-container caps a
+    single runaway or compromised container can exhaust host RAM and trigger
+    the kernel OOM-killer against a sibling app's Postgres. Like the
+    edge-hardening directives, the drift test alone wouldn't catch their
+    removal (every rendered compose would drop the caps together and still
+    match the template), so assert them explicitly. Restore in
+    infra/templates/docker-compose.yml.j2 and re-render on failure.
+    """
+
+    @pytest.mark.parametrize("app", _APPS)
+    def test_compose_sets_all_three_limit_kinds(self, app: str) -> None:
+        compose = _read("apps", app, "docker-compose.yml")
+        for key in ("mem_limit:", "cpus:", "pids_limit:"):
+            assert key in compose, (
+                f"{app}/docker-compose.yml is missing `{key}` — per-container "
+                f"resource caps were removed. A runaway container could then OOM "
+                f"the shared VPS and cascade into a sibling app's Postgres. "
+                f"Restore in infra/templates/docker-compose.yml.j2 and re-render."
+            )
+
+    @pytest.mark.parametrize("app", _APPS)
+    def test_api_and_caddy_keep_expected_mem_caps(self, app: str) -> None:
+        compose = _read("apps", app, "docker-compose.yml")
+        assert "mem_limit: 1024m" in compose, (
+            f"{app}/docker-compose.yml api service must keep its 1024m mem_limit "
+            f"(sized above the busiest app's API working set with spike headroom). "
+            f"Restore in the template and re-render."
+        )
+        assert "mem_limit: 128m" in compose, (
+            f"{app}/docker-compose.yml caddy service must keep its 128m mem_limit. "
+            f"Restore in the template and re-render."
+        )
+
+
 # Apps whose deploy workflow runs in-container steps after migrate (driven by
 # app.yaml `post_deploy_commands`). MGA auto-seeds its public lineup library on
 # every deploy; the canonical apps keep the list empty. The inverse check guards


### PR DESCRIPTION
@
## What

Adds `mem_limit` / `cpus` / `pids_limit` to **every service** in the shared `infra/templates/docker-compose.yml.j2`, re-renders all four app composes, and adds a conformance guard. This is **PR #3** of the post-audit security-hardening initiative (after #839 SSRF and #844 traffic-resilience).

## Why

The audit flagged one open blast-radius gap: the apps share a single small VPS, so a runaway or compromised container can exhaust host RAM and let the **kernel OOM-killer take down a sibling app's Postgres**. Per-container caps bound that.

## Sizing (caps are ceilings, not reservations)

Measured live working sets via `docker stats` on the box and sized each cap with headroom:

| Service | Observed | `mem_limit` | `cpus` | `pids_limit` |
|---|---|---|---|---|
| api | 227–**668** MiB (MJH busiest) | 1024m | 1.5 | 256 |
| worker | 92–122 MiB | 512m | 1.0 | 128 |
| postgres | 33–61 MiB | 512m | 1.0 | 256 |
| caddy | 10–32 MiB | 128m | 0.5 | 64 |
| migrate (one-shot) | — | 512m | 1.5 | 128 |

The lighter apps (MBK/MGA api at 227–340 MiB) share the same `api` cap and simply never approach it — that "wasted" headroom costs nothing because caps don't reserve. A single runaway `api` hitting 1024m still leaves the box (~2.4 GiB of everything-else + host) under the 3.8 GiB total — it gets killed, Postgres survives.

## ⚠️ Operational notes

**The caps apply automatically** on the next deploy — `docker compose up -d` recreates containers when the compose file changes. No env-var or pre-deploy action is required, and the previous image keeps working if reverted, so this is **not a fail-loud migration**.

**Strongly recommended companion — add host swap (do in the same maintenance window).** The box currently has **0 swap** and sits at ~110 MiB free. Without swap, every `mem_limit` is a hard cliff: a container that legitimately spikes toward its cap gets hard-killed instead of paging cold memory out. A 2 GiB swapfile turns the cap into "swap first, then kill" and relieves baseline pressure:

```bash
sudo fallocate -l 2G /swapfile && sudo chmod 600 /swapfile
sudo mkswap /swapfile && sudo swapon /swapfile
echo "/swapfile none swap sw 0 0" | sudo tee -a /etc/fstab   # persist across reboot
free -h   # verify Swap: 2.0Gi
```

(Even without swap, these caps are still a net improvement over today's "kernel kills a random process" behavior — swap just makes them strictly safer.)

**Verify the caps are live after deploy:**

```bash
docker stats --no-stream --format "table {{.Name}}\t{{.MemUsage}}"
# the LIMIT half of "MEM USAGE / LIMIT" should now read 1GiB (api) / 512MiB / 128MiB (caddy), not 3.824GiB
```

**Rollback:** revert this PR and redeploy — the prior compose has no caps and the image is unchanged.

## Tests

- `TestContainerResourceLimits` (new) — asserts all three cap kinds plus the api/caddy mem caps survive in every app compose; the drift test alone can't catch removal (every compose would drop them together and still match the template).
- `TestInfraTemplateDrift` — all four apps re-rendered, zero drift.
- Full conformance suite: **117 passed, 4 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@