### PR TITLE
feat(infra): exclude apps from automated deploys

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -5,6 +5,13 @@
 name: Deploy MyBookkeeper
 
 on:
+  # Manual "Run workflow" button — always available so any app can be
+  # deployed on demand, even when push-triggered auto-deploy is off.
+  workflow_dispatch:
+  # Push-triggered auto-deploy. Rendered ONLY when `automated_deploy` is
+  # truthy in apps/<slug>/app.yaml. A missing key defaults to enabled, so
+  # existing apps keep auto-deploying. Set `automated_deploy: false` to make
+  # an app manual-dispatch-only (e.g. not yet ready for production).
   push:
     branches: [main]
     paths:

--- a/.github/workflows/deploy-mygamingassistant.yml
+++ b/.github/workflows/deploy-mygamingassistant.yml
@@ -5,6 +5,13 @@
 name: Deploy MyGamingAssistant
 
 on:
+  # Manual "Run workflow" button — always available so any app can be
+  # deployed on demand, even when push-triggered auto-deploy is off.
+  workflow_dispatch:
+  # Push-triggered auto-deploy. Rendered ONLY when `automated_deploy` is
+  # truthy in apps/<slug>/app.yaml. A missing key defaults to enabled, so
+  # existing apps keep auto-deploying. Set `automated_deploy: false` to make
+  # an app manual-dispatch-only (e.g. not yet ready for production).
   push:
     branches: [main]
     paths:

--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -5,6 +5,13 @@
 name: Deploy MyJobHunter
 
 on:
+  # Manual "Run workflow" button — always available so any app can be
+  # deployed on demand, even when push-triggered auto-deploy is off.
+  workflow_dispatch:
+  # Push-triggered auto-deploy. Rendered ONLY when `automated_deploy` is
+  # truthy in apps/<slug>/app.yaml. A missing key defaults to enabled, so
+  # existing apps keep auto-deploying. Set `automated_deploy: false` to make
+  # an app manual-dispatch-only (e.g. not yet ready for production).
   push:
     branches: [main]
     paths:

--- a/.github/workflows/deploy-mypizzatracker.yml
+++ b/.github/workflows/deploy-mypizzatracker.yml
@@ -5,11 +5,13 @@
 name: Deploy MyPizzaTracker
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'apps/mypizzatracker/**'
-      - 'packages/**'
+  # Manual "Run workflow" button — always available so any app can be
+  # deployed on demand, even when push-triggered auto-deploy is off.
+  workflow_dispatch:
+  # Push-triggered auto-deploy. Rendered ONLY when `automated_deploy` is
+  # truthy in apps/<slug>/app.yaml. A missing key defaults to enabled, so
+  # existing apps keep auto-deploying. Set `automated_deploy: false` to make
+  # an app manual-dispatch-only (e.g. not yet ready for production).
 
 concurrency:
   group: deploy-mypizzatracker

--- a/.github/workflows/deploy-myrecipes.yml
+++ b/.github/workflows/deploy-myrecipes.yml
@@ -5,11 +5,13 @@
 name: Deploy MyRecipes
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'apps/myrecipes/**'
-      - 'packages/**'
+  # Manual "Run workflow" button — always available so any app can be
+  # deployed on demand, even when push-triggered auto-deploy is off.
+  workflow_dispatch:
+  # Push-triggered auto-deploy. Rendered ONLY when `automated_deploy` is
+  # truthy in apps/<slug>/app.yaml. A missing key defaults to enabled, so
+  # existing apps keep auto-deploying. Set `automated_deploy: false` to make
+  # an app manual-dispatch-only (e.g. not yet ready for production).
 
 concurrency:
   group: deploy-myrecipes

--- a/apps/mybookkeeper/app.yaml
+++ b/apps/mybookkeeper/app.yaml
@@ -8,6 +8,8 @@ has_minio_subdomain: true
 joins_minio_network: true
 block_api_docs: true
 include_bundle_tripwire: true
+# Push to main auto-deploys this app. Set false to make it manual-dispatch-only.
+automated_deploy: true
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false

--- a/apps/mygamingassistant/app.yaml
+++ b/apps/mygamingassistant/app.yaml
@@ -12,6 +12,8 @@ has_minio_subdomain: false
 joins_minio_network: false
 block_api_docs: false
 include_bundle_tripwire: true
+# Push to main auto-deploys this app. Set false to make it manual-dispatch-only.
+automated_deploy: true
 # MGA-only: render the VITE_SERVE_ONLY frontend build-arg chain (caddy.Dockerfile
 # ARG/ENV + docker-compose caddy build.args). MGA's production deploy is a pure
 # public read-only library with no auth (SERVE_ONLY=true); the bundle needs the

--- a/apps/myjobhunter/app.yaml
+++ b/apps/myjobhunter/app.yaml
@@ -8,6 +8,8 @@ has_minio_subdomain: false
 joins_minio_network: true
 block_api_docs: false
 include_bundle_tripwire: true
+# Push to main auto-deploys this app. Set false to make it manual-dispatch-only.
+automated_deploy: true
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false

--- a/apps/mypizzatracker/app.yaml
+++ b/apps/mypizzatracker/app.yaml
@@ -8,6 +8,9 @@ has_minio_subdomain: false
 joins_minio_network: true
 block_api_docs: false
 include_bundle_tripwire: false
+# Manual-dispatch-only: no push-triggered auto-deploy. Not deployed until
+# converted to a mobile app. Flip to true + re-render to re-enable auto-deploy.
+automated_deploy: false
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false

--- a/apps/myrecipes/app.yaml
+++ b/apps/myrecipes/app.yaml
@@ -8,6 +8,9 @@ has_minio_subdomain: false
 joins_minio_network: true
 block_api_docs: false
 include_bundle_tripwire: false
+# Manual-dispatch-only: no push-triggered auto-deploy. Not deployed until local
+# development is complete. Flip to true + re-render to re-enable auto-deploy.
+automated_deploy: false
 serve_only_build_arg: false
 env_seed_command: create from .env.example first
 csp: 'default-src ''self''; script-src ''self'' https://challenges.cloudflare.com;

--- a/infra/templates/.github/workflows/deploy.yml.j2
+++ b/infra/templates/.github/workflows/deploy.yml.j2
@@ -5,11 +5,20 @@
 name: Deploy {{ app_display_name }}
 
 on:
+  # Manual "Run workflow" button — always available so any app can be
+  # deployed on demand, even when push-triggered auto-deploy is off.
+  workflow_dispatch:
+  # Push-triggered auto-deploy. Rendered ONLY when `automated_deploy` is
+  # truthy in apps/<slug>/app.yaml. A missing key defaults to enabled, so
+  # existing apps keep auto-deploying. Set `automated_deploy: false` to make
+  # an app manual-dispatch-only (e.g. not yet ready for production).
+{%- if automated_deploy | default(true) %}
   push:
     branches: [main]
     paths:
       - 'apps/{{ app_slug }}/**'
       - 'packages/**'
+{%- endif %}
 
 concurrency:
   group: deploy-{{ app_slug }}

--- a/packages/shared-backend/platform_shared/infra/new_app.py
+++ b/packages/shared-backend/platform_shared/infra/new_app.py
@@ -144,6 +144,11 @@ def _write_app_yaml(repo_root: Path, slug: str, *,
         "joins_minio_network": True,
         "block_api_docs": False,
         "include_bundle_tripwire": False,
+        # New apps auto-deploy on push to main by default. The deploy
+        # workflow template gates the push trigger on this flag (a missing
+        # key also defaults to enabled). Flip to False to scaffold an app
+        # as manual-dispatch-only.
+        "automated_deploy": True,
         "env_seed_command": "create from .env.example first",
         "csp": (
             "default-src 'self'; "

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -607,6 +607,70 @@ class TestPostDeployCommands:
         )
 
 
+# Apps that have intentionally opted OUT of push-triggered automated deploys.
+# Their deploy workflow renders ONLY a `workflow_dispatch:` trigger (manual
+# "Run workflow" button) — no `push: branches: [main]` block — driven by
+# `automated_deploy: false` in apps/<slug>/app.yaml. The template defaults a
+# missing key to enabled, so every other app keeps auto-deploying. The tests
+# below enforce the opt-out in BOTH directions: a no-auto-deploy app must have
+# no push trigger AND must carry the flag in app.yaml, and every other app must
+# keep its push trigger.
+#
+# - mypizzatracker: paused until it is converted to a mobile app.
+# - myrecipes: paused until local development is complete.
+_NO_AUTO_DEPLOY = {"mypizzatracker", "myrecipes"}
+
+
+class TestAutomatedDeployExclusion:
+    """`automated_deploy: false` in app.yaml must drop the push trigger from
+    the rendered deploy workflow, leaving only the manual workflow_dispatch.
+
+    Same shape as TestPostDeployCommands: a reviewed opt-out set enforced in
+    both directions so neither (a) an excluded app silently regains a push
+    trigger nor (b) a normal app silently loses one can slip through review.
+    """
+
+    @pytest.mark.parametrize("app", sorted(_NO_AUTO_DEPLOY))
+    def test_excluded_app_is_manual_dispatch_only(self, app: str) -> None:
+        wf = _read(".github", "workflows", f"deploy-{app}.yml")
+        assert "workflow_dispatch:" in wf, (
+            f"deploy-{app}.yml must keep the manual `workflow_dispatch:` "
+            f"trigger so the app can still be deployed on demand. Re-run "
+            f"`python -m platform_shared.infra.render --app {app}`."
+        )
+        assert "branches: [main]" not in wf, (
+            f"deploy-{app}.yml still has a `push: branches: [main]` trigger but "
+            f"{app} is in _NO_AUTO_DEPLOY. To keep it manual-dispatch-only, set "
+            f"`automated_deploy: false` in apps/{app}/app.yaml and re-render. "
+            f"To RE-ENABLE auto-deploy, set `automated_deploy: true` (or remove "
+            f"the key) in apps/{app}/app.yaml, re-render, and drop {app} from "
+            f"_NO_AUTO_DEPLOY."
+        )
+        ay = _read("apps", app, "app.yaml")
+        assert "automated_deploy: false" in ay, (
+            f"apps/{app}/app.yaml must declare `automated_deploy: false` — it is "
+            f"the source of truth the template gates the push trigger on. To "
+            f"re-enable auto-deploy, set it to true (or remove the key), "
+            f"re-render, and drop {app} from _NO_AUTO_DEPLOY."
+        )
+
+    @pytest.mark.parametrize("app", sorted(set(_APPS) - _NO_AUTO_DEPLOY))
+    def test_normal_app_keeps_push_trigger(self, app: str) -> None:
+        wf = _read(".github", "workflows", f"deploy-{app}.yml")
+        assert "branches: [main]" in wf, (
+            f"deploy-{app}.yml lost its `push: branches: [main]` trigger but "
+            f"{app} is not in _NO_AUTO_DEPLOY. If this app should stop "
+            f"auto-deploying, add it to _NO_AUTO_DEPLOY and set "
+            f"`automated_deploy: false` in apps/{app}/app.yaml; otherwise set "
+            f"`automated_deploy: true` (or remove the key) and re-render."
+        )
+        assert "workflow_dispatch:" in wf, (
+            f"deploy-{app}.yml must also expose the manual `workflow_dispatch:` "
+            f"trigger (every app gets a Run-workflow button). Re-run "
+            f"`python -m platform_shared.infra.render --app {app}`."
+        )
+
+
 class TestScaffolderProducesBootableApp:
     """Tier 5 -- the scaffolder must produce a complete, fully-substituted app dir.
 


### PR DESCRIPTION
## Summary

Adds a per-app `automated_deploy` flag (Tier-2 operational template) that controls whether an app's deploy workflow is triggered by pushes to `main`. The goal is to stop automated (push-triggered) deploys for apps that aren't ready for production while keeping a manual deploy escape hatch, and keeping all other apps auto-deploying.

Parity model: config lives in `app.yaml`, behavior lives in `infra/templates/.github/workflows/deploy.yml.j2`, and the invariant is locked by a conformance test.

## Mechanism

In `deploy.yml.j2`, the `on:` block now renders:

- `workflow_dispatch:` **always** — every app gets a manual "Run workflow" button, even when push-triggered auto-deploy is off.
- `push: branches: [main]` (paths `apps/<slug>/**` + `packages/**`) **only when** `automated_deploy` is truthy in `apps/<slug>/app.yaml`.

The gate is `{% if automated_deploy | default(true) %}`, so a **missing key defaults to enabled** and never throws under the renderer's Jinja `StrictUndefined`. Jinja whitespace control (`{%- ... -%}`) keeps the YAML indentation valid with no stray blank lines.

## Per-app result

| App | `automated_deploy` | Rendered `on:` triggers |
|---|---|---|
| mybookkeeper | `true` | `workflow_dispatch` + `push` |
| myjobhunter | `true` | `workflow_dispatch` + `push` |
| mygamingassistant | `true` | `workflow_dispatch` + `push` |
| **mypizzatracker** | `false` | `workflow_dispatch` only |
| **myrecipes** | `false` | `workflow_dispatch` only |

Why the two excluded apps are manual-dispatch-only:

- **mypizzatracker** — not deployed until it is converted to a mobile app.
- **myrecipes** — not deployed until local development is complete.

## How to re-enable auto-deploy for an excluded app

1. Set `automated_deploy: true` (or remove the key) in `apps/<slug>/app.yaml`.
2. Re-render: `python -m platform_shared.infra.render --all`.
3. Drop the app from `_NO_AUTO_DEPLOY` in `packages/shared-backend/tests/test_app_conformance.py`.

## Changes

- `infra/templates/.github/workflows/deploy.yml.j2` — `on:` block reworked (always-on `workflow_dispatch`, gated `push`), with an explanatory comment on the flag.
- `apps/{mybookkeeper,myjobhunter,mygamingassistant}/app.yaml` — `automated_deploy: true`.
- `apps/{mypizzatracker,myrecipes}/app.yaml` — `automated_deploy: false` with an inline reason on each.
- `packages/shared-backend/platform_shared/infra/new_app.py` — `_write_app_yaml` now emits `automated_deploy: True` so future scaffolds are explicit and auto-deploy by default.
- All five `deploy-<app>.yml` workflows re-rendered.
- `packages/shared-backend/tests/test_app_conformance.py` — new `_NO_AUTO_DEPLOY` set + `TestAutomatedDeployExclusion` (mirrors the `_POST_DEPLOY_APPS` set+test pattern), enforcing the opt-out in both directions.

## Verification

- `python -m platform_shared.infra.render --all --check` exits 0 (no drift).
- Full `test_app_conformance.py`: **150 passed, 5 skipped** (the 5 skips are the pre-existing MGA Sentry-opt-out / cost-widget skips). The new `TestAutomatedDeployExclusion` + `TestInfraTemplateDrift` subset: 10 passed.

No backend domain tests were run (no local Postgres); the file-based conformance suite is the check for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
