### PR TITLE
chore(deps): remove unused otplib from myjobhunter frontend

### DIFF
--- a/apps/myjobhunter/frontend/package.json
+++ b/apps/myjobhunter/frontend/package.json
@@ -51,7 +51,6 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "jsdom": "^29.0.2",
-    "otplib": "^12.0.1",
     "postcss": "^8.4.47",
     "tailwindcss": "^4.2.4",
     "typescript": "~6.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -691,7 +691,6 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "jsdom": "^29.0.2",
-        "otplib": "^12.0.1",
         "postcss": "^8.4.47",
         "tailwindcss": "^4.2.4",
         "typescript": "~6.0.3",
@@ -3698,56 +3697,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/@otplib/core": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
-      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
-      "dev": true
-    },
-    "node_modules/@otplib/plugin-crypto": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
-      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
-      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
-      "dev": true,
-      "dependencies": {
-        "@otplib/core": "^12.0.1"
-      }
-    },
-    "node_modules/@otplib/plugin-thirty-two": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
-      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
-      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
-      "dev": true,
-      "dependencies": {
-        "@otplib/core": "^12.0.1",
-        "thirty-two": "^1.0.2"
-      }
-    },
-    "node_modules/@otplib/preset-default": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
-      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
-      "deprecated": "Please upgrade to v13 of otplib. Refer to otplib docs for migration paths",
-      "dev": true,
-      "dependencies": {
-        "@otplib/core": "^12.0.1",
-        "@otplib/plugin-crypto": "^12.0.1",
-        "@otplib/plugin-thirty-two": "^12.0.1"
-      }
-    },
-    "node_modules/@otplib/preset-v11": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
-      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
-      "dev": true,
-      "dependencies": {
-        "@otplib/core": "^12.0.1",
-        "@otplib/plugin-crypto": "^12.0.1",
-        "@otplib/plugin-thirty-two": "^12.0.1"
-      }
-    },
     "node_modules/@oxc-project/types": {
       "version": "0.129.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
@@ -4748,7 +4697,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4765,7 +4713,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4782,7 +4729,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4799,7 +4745,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4816,7 +4761,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4833,7 +4777,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4850,7 +4793,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4867,7 +4809,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4884,7 +4825,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4901,7 +4841,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4918,7 +4857,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4935,7 +4873,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4949,7 +4886,6 @@
       ],
       "dev": true,
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
@@ -4971,7 +4907,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -4988,7 +4923,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       }
@@ -10125,17 +10059,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/otplib": {
-      "version": "12.0.1",
-      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
-      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
-      "dev": true,
-      "dependencies": {
-        "@otplib/core": "^12.0.1",
-        "@otplib/preset-default": "^12.0.1",
-        "@otplib/preset-v11": "^12.0.1"
-      }
-    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -11451,15 +11374,6 @@
       },
       "engines": {
         "node": ">=0.8"
-      }
-    },
-    "node_modules/thirty-two": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
-      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.2.6"
       }
     },
     "node_modules/tiny-invariant": {


### PR DESCRIPTION
`otplib` was a declared devDependency in `apps/myjobhunter/frontend` but is **never imported**. The TOTP e2e test (`e2e/totp.spec.ts`) deliberately uses a hand-rolled SHA-256 TOTP generator because otplib produced codes that mismatched pyotp for SHA-256 (see the comment at the top of that file).

Dependabot #856 tried to bump it 12→13 (which broke the build). Since it is dead code, the correct fix is to **remove** it rather than migrate to v13.

`npm run build` on the mjh frontend passes with otplib gone.

Replaces #856.

🤖 Generated with [Claude Code](https://claude.com/claude-code)