### PR TITLE
fix(scaffold): platform 0001 must match the models it ships (user_role enum + plural audit/auth tables)

### DIFF
--- a/infra/templates/scaffold/CLAUDE.md
+++ b/infra/templates/scaffold/CLAUDE.md
@@ -101,8 +101,14 @@ missing. If either env var is absent in production, the app refuses to start.
 - One model per file, one schema per file
 
 **Enums:**
-- All enums are `String(N)` + `CheckConstraint("col IN (...)")` -- never SQLAlchemy Enum type
-- Table names are singular (`user`, etc. -- matches MBK convention)
+- App domain enums are `String(N)` + `CheckConstraint("col IN (...)")` -- never SQLAlchemy Enum type
+- Exception: the platform `user.role` column uses the postgres `user_role` ENUM
+  (the shared User model binds `SAEnum(Role, name="user_role")`); migration `0001`
+  creates the type. Don't model `user.role` as `String` -- that mismatches the model
+  and the app fails the first auth INSERT with `type "user_role" does not exist`.
+- Table names are singular (`user`, etc.). Multi-user apps that mount the register
+  router use the plural `users` (matches MyBookkeeper + MyJobHunter + the shared
+  register test factory's raw SQL); rename the table when converting to multi-user.
 
 **Timestamps:**
 - `DateTime(timezone=True)` on every datetime column

--- a/infra/templates/scaffold/backend/alembic/versions/0001_initial_schema.py
+++ b/infra/templates/scaffold/backend/alembic/versions/0001_initial_schema.py
@@ -1,7 +1,18 @@
-"""Initial schema -- user + audit_log + auth_event
+"""Initial schema -- user + audit_logs + auth_events
 
 Tier-1 platform tables only. App-specific domain tables go in later
 revisions.
+
+These tables MUST match the models the app imports: the ``User`` model binds
+``role`` to ``SAEnum(Role, name="user_role")`` and ``app/models/__init__.py``
+registers the shared ``AuditLog`` (``audit_logs``) + ``AuthEvent``
+(``auth_events``) tables from platform_shared. An earlier version of this
+template created ``role`` as ``String(20)`` and the audit/auth tables in the
+singular, pre-promotion shape; apps rendered from it failed at the first auth
+INSERT (``type "user_role" does not exist``) and on every auth-event write
+(``relation "auth_events" does not exist``), and each had to add an
+``align_with_platform_shared`` migration. This revision is the corrected
+source so future apps are born matching the models.
 
 Revision ID: 0001
 Revises:
@@ -21,7 +32,18 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     # ------------------------------------------------------------------ user
-    # Singular table name -- mirrors MBK convention.
+    # Singular table name -- single-user app convention. (Multi-user apps that
+    # mount the register router + the shared register test factory use the
+    # plural ``users``; convert the table name when converting to multi-user.)
+    #
+    # ``role`` is the one column that uses a postgres ENUM rather than the
+    # String+CheckConstraint convention: the shared User model binds
+    # ``SAEnum(Role, name="user_role")``. Values mirror exactly what the
+    # model's ``values_callable`` yields for
+    # platform_shared.core.permissions.Role (``admin``, ``user``) so the
+    # migrate path and a metadata ``create_all`` path produce an identical type.
+    user_role = postgresql.ENUM("admin", "user", name="user_role", create_type=False)
+    user_role.create(op.get_bind(), checkfirst=True)
     op.create_table(
         "user",
         sa.Column(
@@ -34,7 +56,7 @@ def upgrade() -> None:
         sa.Column("is_superuser", sa.Boolean(), nullable=False, server_default=sa.text("false")),
         sa.Column("is_verified", sa.Boolean(), nullable=False, server_default=sa.text("false")),
         sa.Column("display_name", sa.String(100), nullable=False, server_default=""),
-        sa.Column("role", sa.String(20), nullable=False, server_default="user"),
+        sa.Column("role", user_role, nullable=False, server_default="user"),
         sa.Column("totp_secret", sa.String(500), nullable=True),
         sa.Column("totp_enabled", sa.Boolean(), nullable=False, server_default=sa.text("false")),
         sa.Column("totp_recovery_codes", sa.String(1000), nullable=True),
@@ -42,58 +64,65 @@ def upgrade() -> None:
         sa.Column("failed_login_count", sa.SmallInteger(), nullable=False, server_default="0"),
         sa.Column("locked_until", sa.DateTime(timezone=True), nullable=True),
         sa.Column("last_failed_login_at", sa.DateTime(timezone=True), nullable=True),
-        sa.CheckConstraint(
-            "role IN ('user','admin','superuser')",
-            name="ck_user_role",
-        ),
     )
     op.create_index("ix_user_email", "user", ["email"], unique=True)
 
-    # ---------------------------------------------------------------- audit_log
+    # --------------------------------------------------------------- audit_logs
+    # Matches platform_shared.db.models.audit_log.AuditLog (the shape
+    # platform_shared.core.audit's listener writes).
     op.create_table(
-        "audit_log",
-        sa.Column(
-            "id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False,
-            server_default=sa.text("gen_random_uuid()"),
-        ),
-        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
+        "audit_logs",
+        sa.Column("id", sa.Integer(), primary_key=True, autoincrement=True),
         sa.Column("table_name", sa.String(100), nullable=False),
+        sa.Column("record_id", sa.String(255), nullable=False),
         sa.Column("operation", sa.String(10), nullable=False),
-        sa.Column("row_id", sa.Text(), nullable=True),
-        sa.Column("old_values", postgresql.JSONB(), nullable=True),
-        sa.Column("new_values", postgresql.JSONB(), nullable=True),
+        sa.Column("field_name", sa.String(255), nullable=True),
+        sa.Column("old_value", sa.Text(), nullable=True),
+        sa.Column("new_value", sa.Text(), nullable=True),
+        sa.Column("changed_by", sa.String(255), nullable=True),
         sa.Column(
-            "created_at", sa.DateTime(timezone=True), nullable=False,
+            "changed_at", sa.DateTime(timezone=True), nullable=False,
             server_default=sa.text("now()"),
         ),
     )
-    op.create_index("ix_audit_log_user_id", "audit_log", ["user_id"])
-    op.create_index("ix_audit_log_created_at", "audit_log", ["created_at"])
+    op.create_index("ix_audit_table_record", "audit_logs", ["table_name", "record_id"])
+    op.execute("CREATE INDEX ix_audit_changed_at ON audit_logs (changed_at DESC)")
 
-    # -------------------------------------------------------------- auth_event
+    # -------------------------------------------------------------- auth_events
+    # Matches platform_shared.db.models.auth_event.AuthEvent. ``metadata`` is
+    # the SQL column the model maps its ``event_metadata`` attr to.
     op.create_table(
-        "auth_event",
+        "auth_events",
         sa.Column(
             "id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False,
             server_default=sa.text("gen_random_uuid()"),
         ),
         # No FK to user -- events survive account deletion (intentional).
         sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=True),
-        sa.Column("event_type", sa.String(60), nullable=False),
+        sa.Column("event_type", sa.String(50), nullable=False),
         sa.Column("ip_address", sa.String(45), nullable=True),
-        sa.Column("user_agent", sa.Text(), nullable=True),
-        sa.Column("metadata_json", postgresql.JSONB(), nullable=True),
+        sa.Column("user_agent", sa.String(500), nullable=True),
+        sa.Column(
+            "metadata", postgresql.JSONB(), nullable=False, server_default="{}",
+        ),
+        sa.Column("succeeded", sa.Boolean(), nullable=False),
         sa.Column(
             "created_at", sa.DateTime(timezone=True), nullable=False,
             server_default=sa.text("now()"),
         ),
     )
-    op.create_index("ix_auth_event_user_id", "auth_event", ["user_id"])
-    op.create_index("ix_auth_event_event_type", "auth_event", ["event_type"])
-    op.create_index("ix_auth_event_created_at", "auth_event", ["created_at"])
+    op.create_index("ix_auth_events_user_id", "auth_events", ["user_id"])
+    op.create_index("ix_auth_events_event_type", "auth_events", ["event_type"])
+    op.create_index("ix_auth_events_created_at", "auth_events", ["created_at"])
+    op.create_index(
+        "ix_auth_events_user_event_time", "auth_events",
+        ["user_id", "event_type", "created_at"],
+    )
+    op.create_index("ix_auth_events_ip_time", "auth_events", ["ip_address", "created_at"])
 
 
 def downgrade() -> None:
-    op.drop_table("auth_event")
-    op.drop_table("audit_log")
+    op.drop_table("auth_events")
+    op.drop_table("audit_logs")
     op.drop_table("user")
+    postgresql.ENUM(name="user_role").drop(op.get_bind(), checkfirst=True)

--- a/infra/templates/scaffold/backend/app/models/user/user.py
+++ b/infra/templates/scaffold/backend/app/models/user/user.py
@@ -14,7 +14,9 @@ __all__ = ["User", "Role"]
 
 
 class User(SQLAlchemyBaseUserTableUUID, Base):
-    # Singular table name — consistent with MBK convention.
+    # Singular table name — single-user app convention. Multi-user apps use
+    # the plural "users" (MyBookkeeper + MyJobHunter + the shared register test
+    # factory); rename this when converting to multi-user.
     __tablename__ = "user"
 
     display_name: Mapped[str] = mapped_column(String(100), default="")


### PR DESCRIPTION
## What

Corrects `infra/templates/scaffold` so apps rendered from it are **born matching their own models**, instead of needing an `align_with_platform_shared` migration after the fact.

- **`backend/alembic/versions/0001_initial_schema.py`**
  - `user.role`: `String(20)` + CheckConstraint → postgres **`user_role` ENUM** (values `admin`, `user`, matching `platform_shared.core.permissions.Role`). The scaffold's `User` model already binds `SAEnum(Role, name="user_role")`.
  - `audit_log` → **`audit_logs`** (the `platform_shared.db.models.audit_log.AuditLog` shape: int id, `field_name`/`old_value`/`new_value`/`changed_by`/`changed_at`).
  - `auth_event` → **`auth_events`** (the `AuthEvent` shape: `+succeeded`, `metadata_json` → `metadata`).
  - `user` stays **singular** — single-user scaffold convention.
- **`CLAUDE.md`** — the "Enums" rule said *"never SQLAlchemy Enum type"*, which contradicted the model and bred the bug. Now documents the `user.role` enum exception and the multi-user `users` table-name nuance.
- **`backend/app/models/user/user.py`** — fixed the misleading `# consistent with MBK convention` comment (MBK actually uses plural `users`).

## Why

The scaffold's `User` model uses `SAEnum(Role, name="user_role")` and its `app/models/__init__.py` registers the shared `AuditLog`/`AuthEvent` (plural `audit_logs`/`auth_events`), but `0001` created `String` role + singular tables. So **every app rendered from the scaffold was born with a schema that doesn't match its own models** — failing the first auth INSERT (`type "user_role" does not exist`) and every auth-event write (`relation "auth_events" does not exist`).

This only executes against real Postgres, so it stayed hidden until **myrecipes was added to CI (#884)** and its behavioral tests ran for the first time. MGA (`0004`) and MPT (`0004`) each already carry an `align_with_platform_shared` migration that undoes exactly this drift — fixing the source stops the pattern from recurring.

## Blast radius

- Affects **only apps scaffolded after this merges**. Existing apps own their own copies of `0001` and are untouched.
- `new_app.py` copies `0001` verbatim (no placeholders in it), so the corrected file ships as-is.

## Validation

Ran the corrected `0001` against a throwaway Postgres via a minimal alembic harness:

```
alembic upgrade head   → exit 0   (user / audit_logs / auth_events + user_role enum [admin,user])
alembic downgrade base → exit 0   (reversible)
```

`shared-backend-tests` (conformance suite — runs on every PR, no paths filter) re-validates the scaffold in CI.

## Related

Follow-up to #884 (which fixed the same drift inside myrecipes itself). This addresses the upstream **template** root cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)