### PR TITLE
chore(deps): bump sentry-sdk 2.62→2.63 (mbk), hold fastapi <0.137

### DIFF
--- a/apps/mybookkeeper/backend/pyproject.toml
+++ b/apps/mybookkeeper/backend/pyproject.toml
@@ -4,7 +4,10 @@ version = "0.1.0"
 description = "MyBookkeeper FastAPI backend — AI-powered invoice extraction and bookkeeping for rental properties."
 requires-python = "==3.12.*"
 dependencies = [
-    "fastapi>=0.118,<0.140",
+    # Held below 0.137: fastapi 0.137's _IncludedRouter breaks our route-introspection
+    # tests (test_login_ip_rate_limit / test_email_verification / test_password_reset).
+    # Widen back to <0.140 in a coordinated fastapi-0.137 migration across all apps.
+    "fastapi>=0.118,<0.137",
     "starlette>=1.0,<2.0",
     "uvicorn[standard]==0.49.0",
     "sqlalchemy==2.0.51",
@@ -31,7 +34,7 @@ dependencies = [
     "httpx==0.28.1",
     "minio==7.2.20",
     "reportlab==4.5.1",
-    "sentry-sdk[fastapi]==2.62.0",
+    "sentry-sdk[fastapi]==2.63.0",
     "pyotp==2.10.0",
     "qrcode[pil]==8.2",
     "pyjwt[crypto]>=2.10",

--- a/apps/mybookkeeper/backend/requirements.txt
+++ b/apps/mybookkeeper/backend/requirements.txt
@@ -263,7 +263,7 @@ requests==2.34.2
     #   requests-oauthlib
 requests-oauthlib==2.0.0
     # via google-auth-oauthlib
-sentry-sdk==2.62.0
+sentry-sdk==2.63.0
     # via
     #   mybookkeeper-backend
     #   platform-shared

--- a/apps/mybookkeeper/backend/uv.lock
+++ b/apps/mybookkeeper/backend/uv.lock
@@ -829,7 +829,7 @@ requires-dist = [
     { name = "clamd", specifier = "==1.0.2" },
     { name = "cryptography", specifier = ">=48" },
     { name = "email-validator", specifier = "==2.3.0" },
-    { name = "fastapi", specifier = ">=0.118,<0.140" },
+    { name = "fastapi", specifier = ">=0.118,<0.137" },
     { name = "fastapi-users", extras = ["sqlalchemy"], specifier = "==15.0.5" },
     { name = "fastapi-users-db-sqlalchemy", specifier = "==7.0.0" },
     { name = "google-api-python-client", specifier = "==2.197.0" },
@@ -857,7 +857,7 @@ requires-dist = [
     { name = "python-multipart", specifier = "==0.0.32" },
     { name = "qrcode", extras = ["pil"], specifier = "==8.2" },
     { name = "reportlab", specifier = "==4.5.1" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.62.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.63.0" },
     { name = "sqlalchemy", specifier = "==2.0.51" },
     { name = "starlette", specifier = ">=1.0,<2.0" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.49.0" },
@@ -1388,15 +1388,15 @@ wheels = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.62.0"
+version = "2.63.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/5d/a343201726150e05f2036eeb6e493e2e2f8bf8a66f5aa70f2f4ac96f9ca3/sentry_sdk-2.62.0.tar.gz", hash = "sha256:3c870b9f50d9fd15b58c817dbde1c7cfaa9fe3f05df0a4c6edd5571cb82f5491", size = 463986, upload-time = "2026-06-08T13:23:49.223Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/c8/b3c970a5b186722d276cd40a05b3254e03bccc0208560aff20f612e018e8/sentry_sdk-2.63.0.tar.gz", hash = "sha256:2a1502bf864769275dbc8c2c9fc7a0f7f5e18358180b615d262d13a31ffba216", size = 912449, upload-time = "2026-06-16T12:45:57.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/07/05440381627877aae223fd68f330df9b9fc6641d08bf65328b55235617a2/sentry_sdk-2.62.0-py3-none-any.whl", hash = "sha256:27f61d13a86c3c1648dec666dd5a64f79772dd6a84b446f11866601ecab24f6f", size = 490586, upload-time = "2026-06-08T13:23:47.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/cb205f7d93373120f666b9c5736dc0815524d96a9b278e7a728f018dc22a/sentry_sdk-2.63.0-py3-none-any.whl", hash = "sha256:3a9b5ddd403f79eb73bd670f75f04485819db53d28f76ced7bc09041cb0dfd6a", size = 495950, upload-time = "2026-06-16T12:45:55.819Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Replaces #889.

Dependabot's group bump (#889) bundled `fastapi 0.136.1 → 0.137.1`, which breaks our route-introspection tests (`test_login_ip_rate_limit` / `test_email_verification` / `test_password_reset`) — fastapi 0.137's `_IncludedRouter` changes how `app.routes` enumerates. A real 0.137 bump needs a coordinated cross-app migration to fix that introspection.

This PR takes the **safe** part of #889 and durably holds the rest:

- `sentry-sdk[fastapi] 2.62.0 → 2.63.0` (the safe minor bump)
- `fastapi` range tightened `>=0.118,<0.140` → `>=0.118,<0.137` with an explanatory comment, so the resolver (and future Dependabot runs) stop re-proposing 0.137 until the migration happens
- `uv.lock` + `requirements.txt` regenerated via `uv lock` + `uv export --format requirements-txt --no-hashes --no-emit-project`; `uv lock --check` passes

fastapi stays pinned at 0.136.1 in the lockfile.