### PR TITLE
feat(infra): build deploy images in CI + push to GHCR (mybookkeeper)

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -23,8 +23,67 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Build images on the GitHub runner (fast, layer-cached via type=gha) and push
+  # to GHCR. The deploy job below PULLS these prebuilt images instead of building
+  # on the VPS — cutting deploy time from ~20m to ~2-3m and shrinking the
+  # container-recreate downtime window. Each image is tagged with the commit SHA
+  # (immutable; enables rollback via `IMAGE_TAG=<old-sha> docker compose up -d`)
+  # plus :latest. GHCR namespace = the repo owner (jykwon91).
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/mybookkeeper/docker/backend.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jykwon91/myfreeapps-mybookkeeper-backend:${{ github.sha }}
+            ghcr.io/jykwon91/myfreeapps-mybookkeeper-backend:latest
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+          cache-from: type=gha,scope=mybookkeeper-backend
+          cache-to: type=gha,mode=max,scope=mybookkeeper-backend
+
+      - name: Build and push caddy image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/mybookkeeper/docker/caddy.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jykwon91/myfreeapps-mybookkeeper-caddy:${{ github.sha }}
+            ghcr.io/jykwon91/myfreeapps-mybookkeeper-caddy:latest
+          # VITE_* values are inlined into the frozen bundle at build time. They
+          # now come from GitHub Actions variables (public values — the Turnstile
+          # site key is rendered into the HTML) instead of the VPS .env.docker,
+          # because the build no longer runs on the VPS. See
+          # rules/verify-frontend-build-args.md.
+          build-args: |
+            VITE_TURNSTILE_SITE_KEY=${{ vars.MYBOOKKEEPER_VITE_TURNSTILE_SITE_KEY }}
+          cache-from: type=gha,scope=mybookkeeper-caddy
+          cache-to: type=gha,mode=max,scope=mybookkeeper-caddy
+
   deploy:
     runs-on: ubuntu-latest
+    needs: build-and-push
 
     steps:
       - name: Checkout code
@@ -32,10 +91,18 @@ jobs:
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          # Forwarded into the remote script via `envs:` below. IMAGE_TAG pins the
+          # exact images the build-and-push job just pushed; GHCR_* authenticate
+          # the VPS to pull the (private) packages.
+          IMAGE_TAG: ${{ github.sha }}
+          GHCR_USER: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: IMAGE_TAG,GHCR_USER,GHCR_TOKEN
           # Generous: deploys are serialized via the flock below, so a
           # later app can wait through several earlier app deploys before
           # its own runs. 10m was too tight once deploys serialize.
@@ -79,14 +146,14 @@ jobs:
             }
             echo "Env files present — proceeding"
 
-            echo "--- Build and deploy with Docker ---"
-            # --env-file exposes backend/.env.docker variables to docker compose's
-            # build args (caddy.build.args reads VITE_TURNSTILE_SITE_KEY from the
-            # shell). Without --env-file the bundle gets baked with an empty
-            # site key and TurnstileWidget renders null in production.
-            docker compose -f apps/mybookkeeper/docker-compose.yml \
-              --env-file apps/mybookkeeper/backend/.env.docker \
-              build
+            echo "--- Authenticate to GHCR and pull prebuilt images ---"
+            # Images were built + pushed by the build-and-push job on the runner.
+            # The VPS only pulls — no on-box build. IMAGE_TAG pins this commit's
+            # images; docker-compose resolves ${IMAGE_TAG:-latest} against it for
+            # `pull`, `up`, and any later `create`.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            export IMAGE_TAG
+            docker compose -f apps/mybookkeeper/docker-compose.yml pull
             docker compose -f apps/mybookkeeper/docker-compose.yml up -d --remove-orphans
 
             echo "--- One-time cleanup: remove obsolete frontend_dist volume ---"
@@ -139,3 +206,6 @@ jobs:
             else
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
+
+            echo "--- Clean up GHCR credentials ---"
+            docker logout ghcr.io || true

--- a/apps/mybookkeeper/app.yaml
+++ b/apps/mybookkeeper/app.yaml
@@ -10,6 +10,11 @@ block_api_docs: true
 include_bundle_tripwire: true
 # Push to main auto-deploys this app. Set false to make it manual-dispatch-only.
 automated_deploy: true
+# Build images in CI (GitHub runner, layer-cached) + push to GHCR, then the VPS
+# pulls instead of building on-box — ~20m deploys -> ~2-3m, and a much smaller
+# recreate downtime window. Requires repo secret GHCR_PULL_TOKEN (read:packages)
+# and repo variable MYBOOKKEEPER_VITE_TURNSTILE_SITE_KEY. See deploy.yml.j2.
+registry_images: true
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false

--- a/apps/mybookkeeper/docker-compose.yml
+++ b/apps/mybookkeeper/docker-compose.yml
@@ -35,12 +35,7 @@ services:
       start_period: 30s
 
   migrate:
-    build:
-      # Build context is the monorepo root so the image can pull in
-      # packages/shared-backend (the `platform_shared` library) alongside
-      # apps/mybookkeeper/.
-      context: ../..
-      dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-mybookkeeper-backend:${IMAGE_TAG:-latest}
     command: ["alembic", "upgrade", "head"]
     # One-shot migration — caps guard a runaway migration, not steady state.
     mem_limit: 512m
@@ -54,9 +49,7 @@ services:
         condition: service_healthy
 
   api:
-    build:
-      context: ../..
-      dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-mybookkeeper-backend:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # Highest single consumer on the box (the busiest app's API steady-states
     # well under this); cap leaves headroom for request-handling spikes while
@@ -90,9 +83,7 @@ services:
       retries: 3
 
   upload-processor:
-    build:
-      context: ../..
-      dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-mybookkeeper-backend:${IMAGE_TAG:-latest}
     restart: unless-stopped
     command: ["python", "-m", "app.workers.upload_processor_worker"]
     mem_limit: 512m
@@ -109,9 +100,7 @@ services:
       - myfreeapps
 
   scheduler:
-    build:
-      context: ../..
-      dockerfile: apps/mybookkeeper/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-mybookkeeper-backend:${IMAGE_TAG:-latest}
     restart: unless-stopped
     command: ["python", "-m", "app.workers.scheduler_worker"]
     mem_limit: 512m
@@ -132,16 +121,10 @@ services:
     # at /srv/frontend + Caddyfile baked at /etc/caddy/Caddyfile. No shared
     # volume, no entrypoint copy, no drift between deploys. See
     # docker/caddy.Dockerfile for the full rationale.
-    build:
-      context: ../..
-      dockerfile: apps/mybookkeeper/docker/caddy.Dockerfile
-      args:
-        # Frontend public env baked into the Vite bundle at build time.
-        # Read from the host shell environment when `docker compose build`
-        # runs; the deploy workflow / operator passes these via
-        # `--env-file backend/.env.docker`. Empty values produce a bundle
-        # where TurnstileWidget returns null and registration silently 400s.
-        VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
+    # Registry path: this image is built + pushed by the deploy workflow's
+    # build-and-push job (VITE_* build args sourced from GitHub Actions vars
+    # there, not the VPS .env.docker). The VPS pulls it; no on-box build.
+    image: ghcr.io/jykwon91/myfreeapps-mybookkeeper-caddy:${IMAGE_TAG:-latest}
     restart: unless-stopped
     mem_limit: 128m
     cpus: 0.5

--- a/apps/mygamingassistant/app.yaml
+++ b/apps/mygamingassistant/app.yaml
@@ -14,6 +14,10 @@ block_api_docs: false
 include_bundle_tripwire: true
 # Push to main auto-deploys this app. Set false to make it manual-dispatch-only.
 automated_deploy: true
+# On-VPS Docker build (legacy path). Flip to true to build in CI + pull from
+# GHCR (needs GHCR_PULL_TOKEN secret + MYGAMINGASSISTANT_VITE_TURNSTILE_SITE_KEY
+# var; serve-only adds VITE_SERVE_ONLY=true in the build job). See mybookkeeper.
+registry_images: false
 # MGA-only: render the VITE_SERVE_ONLY frontend build-arg chain (caddy.Dockerfile
 # ARG/ENV + docker-compose caddy build.args). MGA's production deploy is a pure
 # public read-only library with no auth (SERVE_ONLY=true); the bundle needs the

--- a/apps/myjobhunter/app.yaml
+++ b/apps/myjobhunter/app.yaml
@@ -10,6 +10,10 @@ block_api_docs: false
 include_bundle_tripwire: true
 # Push to main auto-deploys this app. Set false to make it manual-dispatch-only.
 automated_deploy: true
+# On-VPS Docker build (legacy path). Flip to true to build in CI + pull from
+# GHCR (needs GHCR_PULL_TOKEN secret + MYJOBHUNTER_VITE_TURNSTILE_SITE_KEY var).
+# See apps/mybookkeeper/app.yaml — mbk is the first app on the registry path.
+registry_images: false
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false

--- a/apps/mypizzatracker/app.yaml
+++ b/apps/mypizzatracker/app.yaml
@@ -11,6 +11,10 @@ include_bundle_tripwire: false
 # Manual-dispatch-only: no push-triggered auto-deploy. Not deployed until
 # converted to a mobile app. Flip to true + re-render to re-enable auto-deploy.
 automated_deploy: false
+# On-VPS Docker build (legacy path). Flip to true to build in CI + pull from
+# GHCR (needs GHCR_PULL_TOKEN secret + MYPIZZATRACKER_VITE_TURNSTILE_SITE_KEY var).
+# See apps/mybookkeeper/app.yaml — mbk is the first app on the registry path.
+registry_images: false
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false

--- a/apps/myrecipes/app.yaml
+++ b/apps/myrecipes/app.yaml
@@ -11,6 +11,10 @@ include_bundle_tripwire: false
 # Manual-dispatch-only: no push-triggered auto-deploy. Not deployed until local
 # development is complete. Flip to true + re-render to re-enable auto-deploy.
 automated_deploy: false
+# On-VPS Docker build (legacy path). Flip to true to build in CI + pull from
+# GHCR (needs GHCR_PULL_TOKEN secret + MYRECIPES_VITE_TURNSTILE_SITE_KEY var).
+# See apps/mybookkeeper/app.yaml — mbk is the first app on the registry path.
+registry_images: false
 serve_only_build_arg: false
 env_seed_command: create from .env.example first
 csp: 'default-src ''self''; script-src ''self'' https://challenges.cloudflare.com;

--- a/infra/templates/.github/workflows/deploy.yml.j2
+++ b/infra/templates/.github/workflows/deploy.yml.j2
@@ -25,8 +25,73 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+{%- if registry_images | default(false) %}
+  # Build images on the GitHub runner (fast, layer-cached via type=gha) and push
+  # to GHCR. The deploy job below PULLS these prebuilt images instead of building
+  # on the VPS — cutting deploy time from ~20m to ~2-3m and shrinking the
+  # container-recreate downtime window. Each image is tagged with the commit SHA
+  # (immutable; enables rollback via `IMAGE_TAG=<old-sha> docker compose up -d`)
+  # plus :latest. GHCR namespace = the repo owner (jykwon91).
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ '{{' }} github.actor {{ '}}' }}
+          password: ${{ '{{' }} secrets.GITHUB_TOKEN {{ '}}' }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/{{ app_slug }}/docker/backend.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jykwon91/myfreeapps-{{ app_slug }}-backend:${{ '{{' }} github.sha {{ '}}' }}
+            ghcr.io/jykwon91/myfreeapps-{{ app_slug }}-backend:latest
+          build-args: |
+            GIT_COMMIT=${{ '{{' }} github.sha {{ '}}' }}
+          cache-from: type=gha,scope={{ app_slug }}-backend
+          cache-to: type=gha,mode=max,scope={{ app_slug }}-backend
+
+      - name: Build and push caddy image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/{{ app_slug }}/docker/caddy.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jykwon91/myfreeapps-{{ app_slug }}-caddy:${{ '{{' }} github.sha {{ '}}' }}
+            ghcr.io/jykwon91/myfreeapps-{{ app_slug }}-caddy:latest
+          # VITE_* values are inlined into the frozen bundle at build time. They
+          # now come from GitHub Actions variables (public values — the Turnstile
+          # site key is rendered into the HTML) instead of the VPS .env.docker,
+          # because the build no longer runs on the VPS. See
+          # rules/verify-frontend-build-args.md.
+          build-args: |
+            VITE_TURNSTILE_SITE_KEY=${{ '{{' }} vars.{{ app_slug | upper }}_VITE_TURNSTILE_SITE_KEY {{ '}}' }}
+{%- if serve_only_build_arg %}
+            VITE_SERVE_ONLY=true
+{%- endif %}
+          cache-from: type=gha,scope={{ app_slug }}-caddy
+          cache-to: type=gha,mode=max,scope={{ app_slug }}-caddy
+{% endif %}
   deploy:
     runs-on: ubuntu-latest
+{%- if registry_images | default(false) %}
+    needs: build-and-push
+{%- endif %}
 
     steps:
       - name: Checkout code
@@ -34,10 +99,22 @@ jobs:
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+{%- if registry_images | default(false) %}
+        env:
+          # Forwarded into the remote script via `envs:` below. IMAGE_TAG pins the
+          # exact images the build-and-push job just pushed; GHCR_* authenticate
+          # the VPS to pull the (private) packages.
+          IMAGE_TAG: ${{ '{{' }} github.sha {{ '}}' }}
+          GHCR_USER: ${{ '{{' }} github.repository_owner {{ '}}' }}
+          GHCR_TOKEN: ${{ '{{' }} secrets.GHCR_PULL_TOKEN {{ '}}' }}
+{%- endif %}
         with:
           host: ${{ '{{' }} secrets.SSH_HOST {{ '}}' }}
           username: ${{ '{{' }} secrets.SSH_USER {{ '}}' }}
           key: ${{ '{{' }} secrets.SSH_PRIVATE_KEY {{ '}}' }}
+{%- if registry_images | default(false) %}
+          envs: IMAGE_TAG,GHCR_USER,GHCR_TOKEN
+{%- endif %}
           # Generous: deploys are serialized via the flock below, so a
           # later app can wait through several earlier app deploys before
           # its own runs. 10m was too tight once deploys serialize.
@@ -80,6 +157,18 @@ jobs:
               exit 1
             }
             echo "Env files present — proceeding"
+{%- if registry_images | default(false) %}
+
+            echo "--- Authenticate to GHCR and pull prebuilt images ---"
+            # Images were built + pushed by the build-and-push job on the runner.
+            # The VPS only pulls — no on-box build. IMAGE_TAG pins this commit's
+            # images; docker-compose resolves ${IMAGE_TAG:-latest} against it for
+            # `pull`, `up`, and any later `create`.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            export IMAGE_TAG
+            docker compose -f apps/{{ app_slug }}/docker-compose.yml pull
+            docker compose -f apps/{{ app_slug }}/docker-compose.yml up -d --remove-orphans
+{%- else %}
 
             echo "--- Build and deploy with Docker ---"
             # --env-file exposes backend/.env.docker variables to docker compose's
@@ -90,6 +179,7 @@ jobs:
               --env-file apps/{{ app_slug }}/backend/.env.docker \
               build
             docker compose -f apps/{{ app_slug }}/docker-compose.yml up -d --remove-orphans
+{%- endif %}
 
             echo "--- One-time cleanup: remove obsolete frontend_dist volume ---"
             # The frontend_dist volume was used by the pre-baked-caddy layout.
@@ -155,4 +245,9 @@ jobs:
             else
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
+{%- endif %}
+{%- if registry_images | default(false) %}
+
+            echo "--- Clean up GHCR credentials ---"
+            docker logout ghcr.io || true
 {%- endif %}

--- a/infra/templates/docker-compose.yml.j2
+++ b/infra/templates/docker-compose.yml.j2
@@ -35,12 +35,16 @@ services:
       start_period: 30s
 
   migrate:
+{%- if registry_images | default(false) %}
+    image: ghcr.io/jykwon91/myfreeapps-{{ app_slug }}-backend:${IMAGE_TAG:-latest}
+{%- else %}
     build:
       # Build context is the monorepo root so the image can pull in
       # packages/shared-backend (the `platform_shared` library) alongside
       # apps/{{ app_slug }}/.
       context: ../..
       dockerfile: apps/{{ app_slug }}/docker/backend.Dockerfile
+{%- endif %}
     command: ["alembic", "upgrade", "head"]
     # One-shot migration — caps guard a runaway migration, not steady state.
     mem_limit: 512m
@@ -54,9 +58,13 @@ services:
         condition: service_healthy
 
   api:
+{%- if registry_images | default(false) %}
+    image: ghcr.io/jykwon91/myfreeapps-{{ app_slug }}-backend:${IMAGE_TAG:-latest}
+{%- else %}
     build:
       context: ../..
       dockerfile: apps/{{ app_slug }}/docker/backend.Dockerfile
+{%- endif %}
     restart: unless-stopped
     # Highest single consumer on the box (the busiest app's API steady-states
     # well under this); cap leaves headroom for request-handling spikes while
@@ -94,9 +102,13 @@ services:
       retries: 3
 {% for w in workers %}
   {{ w.name }}:
+{%- if registry_images | default(false) %}
+    image: ghcr.io/jykwon91/myfreeapps-{{ app_slug }}-backend:${IMAGE_TAG:-latest}
+{%- else %}
     build:
       context: ../..
       dockerfile: apps/{{ app_slug }}/docker/backend.Dockerfile
+{%- endif %}
     restart: unless-stopped
     command: {{ w.command | tojson }}
     mem_limit: 512m
@@ -119,6 +131,12 @@ services:
     # at /srv/frontend + Caddyfile baked at /etc/caddy/Caddyfile. No shared
     # volume, no entrypoint copy, no drift between deploys. See
     # docker/caddy.Dockerfile for the full rationale.
+{%- if registry_images | default(false) %}
+    # Registry path: this image is built + pushed by the deploy workflow's
+    # build-and-push job (VITE_* build args sourced from GitHub Actions vars
+    # there, not the VPS .env.docker). The VPS pulls it; no on-box build.
+    image: ghcr.io/jykwon91/myfreeapps-{{ app_slug }}-caddy:${IMAGE_TAG:-latest}
+{%- else %}
     build:
       context: ../..
       dockerfile: apps/{{ app_slug }}/docker/caddy.Dockerfile
@@ -135,6 +153,7 @@ services:
         # single backend/.env.docker line drives both the backend mode and the
         # bundle. Empty/unset keeps the full auth UI.
         VITE_SERVE_ONLY: ${SERVE_ONLY:-}
+{%- endif %}
 {%- endif %}
     restart: unless-stopped
     mem_limit: 128m

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -61,6 +61,18 @@ def _read(*parts: str) -> str:
     return (_REPO_ROOT.joinpath(*parts)).read_text(encoding="utf-8")
 
 
+def _uses_registry_images(app: str) -> bool:
+    """True when the app builds its images in CI + pulls them from GHCR on the
+    VPS (``registry_images: true`` in app.yaml) instead of building on-box.
+
+    Apps on the registry path wire the VITE_* build args through the deploy
+    workflow's build-and-push job rather than docker-compose ``build.args``, so
+    the bundle-wiring conformance assertions below branch on this.
+    """
+    app_yaml = _read("apps", app, "app.yaml")
+    return re.search(r"^registry_images:\s*true\b", app_yaml, re.MULTILINE) is not None
+
+
 @pytest.mark.parametrize("app", _APPS)
 class TestSettingsInheritsBaseAppSettings:
     """Each app's Settings class must inherit from BaseAppSettings.
@@ -310,9 +322,34 @@ class TestTurnstileBundleWiring:
         )
 
     def test_docker_compose_passes_turnstile_arg_to_caddy(self, app: str) -> None:
-        """The caddy service in docker-compose.yml must declare a
-        build.args block that maps VITE_TURNSTILE_SITE_KEY from the shell
-        env (where the operator / deploy workflow sources backend/.env.docker)."""
+        """The VITE_TURNSTILE_SITE_KEY build arg must reach the caddy image at
+        build time. WHERE it's wired depends on the build location:
+
+        - VPS-build apps: through the caddy service's docker-compose
+          ``build.args`` block (sourced from backend/.env.docker via --env-file).
+        - Registry apps (``registry_images: true``): the image is built in the
+          deploy workflow's build-and-push job, so the build arg is wired there
+          (from a GitHub Actions variable) and the compose caddy service just
+          references the prebuilt GHCR image — no build.args block exists.
+        """
+        if _uses_registry_images(app):
+            workflow_src = _read(".github", "workflows", f"deploy-{app}.yml")
+            assert "VITE_TURNSTILE_SITE_KEY=" in workflow_src, (
+                f"deploy-{app}.yml builds the caddy image in CI "
+                f"(registry_images: true) but its build-and-push job does not "
+                f"pass VITE_TURNSTILE_SITE_KEY as a --build-arg. Without it the "
+                f"bundle is baked with an empty key and TurnstileWidget renders "
+                f"null. Add it under the caddy build step's `build-args:` in "
+                f"infra/templates/.github/workflows/deploy.yml.j2 and re-render."
+            )
+            compose_src = _read("apps", app, "docker-compose.yml")
+            assert f"myfreeapps-{app}-caddy:" in compose_src, (
+                f"{app}/docker-compose.yml has registry_images: true but the "
+                f"caddy service does not reference the prebuilt image "
+                f"ghcr.io/jykwon91/myfreeapps-{app}-caddy. Re-render from the "
+                f"template."
+            )
+            return
         compose_src = _read("apps", app, "docker-compose.yml")
         assert "VITE_TURNSTILE_SITE_KEY:" in compose_src, (
             f"{app}/docker-compose.yml must include `VITE_TURNSTILE_SITE_KEY: "
@@ -329,10 +366,40 @@ class TestTurnstileBundleWiring:
         )
 
     def test_deploy_workflow_uses_env_file_for_build(self, app: str) -> None:
-        """The deploy workflow must pass `--env-file backend/.env.docker`
-        to `docker compose build` so the build-args block can resolve
-        TURNSTILE_SITE_KEY from the env file."""
+        """The deploy workflow must build the bundle correctly for its build
+        location:
+
+        - VPS-build apps: `docker compose --env-file backend/.env.docker ...
+          build` so the build-args block can resolve TURNSTILE_SITE_KEY.
+        - Registry apps: build + push the images to GHCR in CI
+          (docker/build-push-action), then the VPS authenticates and pulls
+          them (`docker login ghcr.io` + `docker compose ... pull`) — never
+          building on-box.
+        """
         workflow_src = _read(".github", "workflows", f"deploy-{app}.yml")
+        if _uses_registry_images(app):
+            assert "docker/build-push-action" in workflow_src, (
+                f"deploy-{app}.yml has registry_images: true but no "
+                f"docker/build-push-action step — the backend + caddy images "
+                f"must be built and pushed in CI. Re-render from "
+                f"infra/templates/.github/workflows/deploy.yml.j2."
+            )
+            assert "ghcr.io/jykwon91/myfreeapps-" in workflow_src, (
+                f"deploy-{app}.yml registry path must push to (and pull from) "
+                f"ghcr.io/jykwon91/myfreeapps-{app}-*. Re-render from the "
+                f"template."
+            )
+            assert "docker login ghcr.io" in workflow_src, (
+                f"deploy-{app}.yml registry path must `docker login ghcr.io` "
+                f"on the VPS (using GHCR_PULL_TOKEN) before pulling the "
+                f"private images. Re-render from the template."
+            )
+            assert "docker-compose.yml pull" in workflow_src, (
+                f"deploy-{app}.yml registry path must `docker compose ... "
+                f"pull` the prebuilt images on the VPS instead of building "
+                f"them. Re-render from the template."
+            )
+            return
         # Match a `docker compose ... --env-file ...backend/.env.docker ... build`
         # invocation, allowing shell line-continuations (backslash + newline)
         # between the segments. Re-DOTALL lets `.` cross newlines so the


### PR DESCRIPTION
## Why

MyBookkeeper deploys build both Docker images **on the VPS** (`npm ci` + `vite build` for caddy, `pip install` of the heavy backend deps), which takes **~20–28 min** and recreates the containers afterward — the recreate window is what took mbk down during today's #888 deploy.

This moves image builds to the **GitHub runner** (fast, layer-cached) and has the VPS just **pull** prebuilt images. Result: **~2–3 min deploys** and a tiny swap window instead of a multi-minute outage.

## What changed

- **`infra/templates/.github/workflows/deploy.yml.j2`** — new `build-and-push` job (buildx + `type=gha` cache → builds backend + caddy, pushes to GHCR tagged `:<sha>` + `:latest`). The VPS `deploy` job now `docker login`s GHCR + `docker compose pull` + `up -d` instead of building.
- **`infra/templates/docker-compose.yml.j2`** — services use `image: ghcr.io/jykwon91/myfreeapps-<app>-{backend,caddy}:${IMAGE_TAG:-latest}` on the registry path (caddy `build.args` move into the CI build step).
- **`apps/*/app.yaml`** — new `registry_images` flag. **`mybookkeeper: true`; the other four `false`** (legacy on-VPS build, rendered byte-identical — verified).
- **`test_app_conformance.py`** — the `verify-frontend-build-args` Turnstile tests + the deploy-workflow test are now registry-aware: for registry apps they assert the CI build-arg → GHCR → `docker compose pull` chain (so the bundle can still never ship without the Turnstile key). All 31 wiring/drift tests pass; render-drift is clean.

## Safe rollout

Gated per-app behind `registry_images`, mirroring the existing `automated_deploy` flag. **Only mybookkeeper flips** in this PR — validate one real deploy, then flip mjh / mga / mpt / mr in follow-ups. SHA-tagged images also give free rollback: `IMAGE_TAG=<old-sha> docker compose up -d`.

## ⚠️ Operational migration — REQUIRED before merge

The first registry deploy fails without these. I never need the values — set them in GitHub directly:

1. **Repo secret `GHCR_PULL_TOKEN`** — a `read:packages` PAT so the VPS can pull the private images. *Settings → Secrets and variables → Actions → Secrets → New repository secret.* (Pushing uses the built-in `GITHUB_TOKEN` via `permissions: packages: write` — already in the workflow, no action needed.)
2. **Repo variable `MYBOOKKEEPER_VITE_TURNSTILE_SITE_KEY`** — the **public** Cloudflare Turnstile site key (same value as `TURNSTILE_SITE_KEY` in the VPS `apps/mybookkeeper/backend/.env.docker`). It's now baked into the bundle at **CI** build time. *Settings → Secrets and variables → Actions → Variables → New repository variable.* (It's a public key, so a Variable, not a Secret.)

### Verify after first deploy
```bash
docker compose -f apps/mybookkeeper/docker-compose.yml exec caddy \
  sh -c 'grep -oE "0x4AAA[A-Za-z0-9_-]+" /srv/frontend/assets/*.js | head -1'
```
Non-empty = the Turnstile key made it into the bundle.

### Rollback
Revert this PR (the previous image still builds on the VPS without the new vars), or pin a prior image: `IMAGE_TAG=<old-sha> docker compose -f apps/mybookkeeper/docker-compose.yml up -d`.

## Not in scope (follow-ups)
- Flip mjh / mga (serve-only) / mpt / mr to `registry_images: true`.
- True zero-downtime blue-green swap (this PR shrinks the window; doesn't eliminate it).