### PR TITLE
fix(myrecipes): reconcile uv.lock + requirements with pyproject (post #887)

### DIFF
--- a/apps/myrecipes/backend/requirements.txt
+++ b/apps/myrecipes/backend/requirements.txt
@@ -123,7 +123,7 @@ pydantic==2.13.4
     #   myrecipes-backend
     #   platform-shared
     #   pydantic-settings
-pydantic-core==2.47.0
+pydantic-core==2.46.4
     # via pydantic
 pydantic-settings==2.14.1
     # via

--- a/apps/myrecipes/backend/uv.lock
+++ b/apps/myrecipes/backend/uv.lock
@@ -494,7 +494,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = "==2.13.0" },
     { name = "pyotp", specifier = "==2.10.0" },
     { name = "qrcode", extras = ["pil"], specifier = "==8.2" },
-    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.62.0" },
+    { name = "sentry-sdk", extras = ["fastapi"], specifier = "==2.63.0" },
     { name = "sqlalchemy", specifier = "==2.0.51" },
     { name = "uvicorn", extras = ["standard"], specifier = "==0.49.0" },
 ]
@@ -860,15 +860,15 @@ pil = [
 
 [[package]]
 name = "sentry-sdk"
-version = "2.62.0"
+version = "2.63.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f6/5d/a343201726150e05f2036eeb6e493e2e2f8bf8a66f5aa70f2f4ac96f9ca3/sentry_sdk-2.62.0.tar.gz", hash = "sha256:3c870b9f50d9fd15b58c817dbde1c7cfaa9fe3f05df0a4c6edd5571cb82f5491", size = 463986, upload-time = "2026-06-08T13:23:49.223Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/c8/b3c970a5b186722d276cd40a05b3254e03bccc0208560aff20f612e018e8/sentry_sdk-2.63.0.tar.gz", hash = "sha256:2a1502bf864769275dbc8c2c9fc7a0f7f5e18358180b615d262d13a31ffba216", size = 912449, upload-time = "2026-06-16T12:45:57.553Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/07/05440381627877aae223fd68f330df9b9fc6641d08bf65328b55235617a2/sentry_sdk-2.62.0-py3-none-any.whl", hash = "sha256:27f61d13a86c3c1648dec666dd5a64f79772dd6a84b446f11866601ecab24f6f", size = 490586, upload-time = "2026-06-08T13:23:47.486Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/cb205f7d93373120f666b9c5736dc0815524d96a9b278e7a728f018dc22a/sentry_sdk-2.63.0-py3-none-any.whl", hash = "sha256:3a9b5ddd403f79eb73bd670f75f04485819db53d28f76ced7bc09041cb0dfd6a", size = 495950, upload-time = "2026-06-16T12:45:55.819Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Fixes the red `backend-deps-resolve / myrecipes` check on main. #887 (dependabot) bumped pyproject/requirements but not `uv.lock`, and forced `pydantic-core==2.47.0` (conflicts with the `pydantic==2.13.4` pin → 2.46.4). Regenerated via `uv lock` + `uv export`; `uv lock --check` passes. No deploy (myrecipes is manual-dispatch-only).