### PR TITLE
feat(mjh-infra): registry deploys — build in CI + push to GHCR

### DIFF
--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -23,8 +23,67 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Build images on the GitHub runner (fast, layer-cached via type=gha) and push
+  # to GHCR. The deploy job below PULLS these prebuilt images instead of building
+  # on the VPS — cutting deploy time from ~20m to ~2-3m and shrinking the
+  # container-recreate downtime window. Each image is tagged with the commit SHA
+  # (immutable; enables rollback via `IMAGE_TAG=<old-sha> docker compose up -d`)
+  # plus :latest. GHCR namespace = the repo owner (jykwon91).
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/myjobhunter/docker/backend.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jykwon91/myfreeapps-myjobhunter-backend:${{ github.sha }}
+            ghcr.io/jykwon91/myfreeapps-myjobhunter-backend:latest
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+          cache-from: type=gha,scope=myjobhunter-backend
+          cache-to: type=gha,mode=max,scope=myjobhunter-backend
+
+      - name: Build and push caddy image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/myjobhunter/docker/caddy.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jykwon91/myfreeapps-myjobhunter-caddy:${{ github.sha }}
+            ghcr.io/jykwon91/myfreeapps-myjobhunter-caddy:latest
+          # VITE_* values are inlined into the frozen bundle at build time. They
+          # now come from GitHub Actions variables (public values — the Turnstile
+          # site key is rendered into the HTML) instead of the VPS .env.docker,
+          # because the build no longer runs on the VPS. See
+          # rules/verify-frontend-build-args.md.
+          build-args: |
+            VITE_TURNSTILE_SITE_KEY=${{ vars.MYJOBHUNTER_VITE_TURNSTILE_SITE_KEY }}
+          cache-from: type=gha,scope=myjobhunter-caddy
+          cache-to: type=gha,mode=max,scope=myjobhunter-caddy
+
   deploy:
     runs-on: ubuntu-latest
+    needs: build-and-push
 
     steps:
       - name: Checkout code
@@ -32,10 +91,18 @@ jobs:
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          # Forwarded into the remote script via `envs:` below. IMAGE_TAG pins the
+          # exact images the build-and-push job just pushed; GHCR_* authenticate
+          # the VPS to pull the (private) packages.
+          IMAGE_TAG: ${{ github.sha }}
+          GHCR_USER: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: IMAGE_TAG,GHCR_USER,GHCR_TOKEN
           # Generous: deploys are serialized via the flock below, so a
           # later app can wait through several earlier app deploys before
           # its own runs. 10m was too tight once deploys serialize.
@@ -79,14 +146,14 @@ jobs:
             }
             echo "Env files present — proceeding"
 
-            echo "--- Build and deploy with Docker ---"
-            # --env-file exposes backend/.env.docker variables to docker compose's
-            # build args (caddy.build.args reads VITE_TURNSTILE_SITE_KEY from the
-            # shell). Without --env-file the bundle gets baked with an empty
-            # site key and TurnstileWidget renders null in production.
-            docker compose -f apps/myjobhunter/docker-compose.yml \
-              --env-file apps/myjobhunter/backend/.env.docker \
-              build
+            echo "--- Authenticate to GHCR and pull prebuilt images ---"
+            # Images were built + pushed by the build-and-push job on the runner.
+            # The VPS only pulls — no on-box build. IMAGE_TAG pins this commit's
+            # images; docker-compose resolves ${IMAGE_TAG:-latest} against it for
+            # `pull`, `up`, and any later `create`.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            export IMAGE_TAG
+            docker compose -f apps/myjobhunter/docker-compose.yml pull
             docker compose -f apps/myjobhunter/docker-compose.yml up -d --remove-orphans
 
             echo "--- One-time cleanup: remove obsolete frontend_dist volume ---"
@@ -139,3 +206,6 @@ jobs:
             else
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
+
+            echo "--- Clean up GHCR credentials ---"
+            docker logout ghcr.io || true

--- a/.github/workflows/integration-myjobhunter.yml
+++ b/.github/workflows/integration-myjobhunter.yml
@@ -78,7 +78,19 @@ jobs:
           DB_PASSWORD: integration_pw
           DOMAIN: http://localhost
         run: |
-          docker compose up -d --build
+          # docker-compose.yml references prebuilt GHCR image tags
+          # (registry_images: true); those images are only built + pushed by
+          # the deploy workflow on merge to main, so on a PR they don't exist
+          # and `docker compose up` would fail pulling them. Build them locally
+          # under the same tags first — `docker compose up` then finds the
+          # local images and skips the pull (postgres still pulls normally).
+          # This is the same build work the old `up --build` did; it's just
+          # explicit now that the app services use `image:` not `build:`.
+          docker build -f docker/backend.Dockerfile \
+            -t ghcr.io/jykwon91/myfreeapps-myjobhunter-backend:latest ../..
+          docker build -f docker/caddy.Dockerfile \
+            -t ghcr.io/jykwon91/myfreeapps-myjobhunter-caddy:latest ../..
+          docker compose up -d
           echo "Waiting for stack to become healthy..."
 
       - name: Wait for api health

--- a/apps/myjobhunter/app.yaml
+++ b/apps/myjobhunter/app.yaml
@@ -13,7 +13,7 @@ automated_deploy: true
 # On-VPS Docker build (legacy path). Flip to true to build in CI + pull from
 # GHCR (needs GHCR_PULL_TOKEN secret + MYJOBHUNTER_VITE_TURNSTILE_SITE_KEY var).
 # See apps/mybookkeeper/app.yaml — mbk is the first app on the registry path.
-registry_images: false
+registry_images: true
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false

--- a/apps/myjobhunter/docker-compose.yml
+++ b/apps/myjobhunter/docker-compose.yml
@@ -35,12 +35,7 @@ services:
       start_period: 30s
 
   migrate:
-    build:
-      # Build context is the monorepo root so the image can pull in
-      # packages/shared-backend (the `platform_shared` library) alongside
-      # apps/myjobhunter/.
-      context: ../..
-      dockerfile: apps/myjobhunter/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-myjobhunter-backend:${IMAGE_TAG:-latest}
     command: ["alembic", "upgrade", "head"]
     # One-shot migration — caps guard a runaway migration, not steady state.
     mem_limit: 512m
@@ -54,9 +49,7 @@ services:
         condition: service_healthy
 
   api:
-    build:
-      context: ../..
-      dockerfile: apps/myjobhunter/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-myjobhunter-backend:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # Highest single consumer on the box (the busiest app's API steady-states
     # well under this); cap leaves headroom for request-handling spikes while
@@ -80,9 +73,7 @@ services:
       retries: 3
 
   resume-parser:
-    build:
-      context: ../..
-      dockerfile: apps/myjobhunter/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-myjobhunter-backend:${IMAGE_TAG:-latest}
     restart: unless-stopped
     command: ["python", "-m", "app.workers.resume_parser_worker"]
     mem_limit: 512m
@@ -103,16 +94,10 @@ services:
     # at /srv/frontend + Caddyfile baked at /etc/caddy/Caddyfile. No shared
     # volume, no entrypoint copy, no drift between deploys. See
     # docker/caddy.Dockerfile for the full rationale.
-    build:
-      context: ../..
-      dockerfile: apps/myjobhunter/docker/caddy.Dockerfile
-      args:
-        # Frontend public env baked into the Vite bundle at build time.
-        # Read from the host shell environment when `docker compose build`
-        # runs; the deploy workflow / operator passes these via
-        # `--env-file backend/.env.docker`. Empty values produce a bundle
-        # where TurnstileWidget returns null and registration silently 400s.
-        VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
+    # Registry path: this image is built + pushed by the deploy workflow's
+    # build-and-push job (VITE_* build args sourced from GitHub Actions vars
+    # there, not the VPS .env.docker). The VPS pulls it; no on-box build.
+    image: ghcr.io/jykwon91/myfreeapps-myjobhunter-caddy:${IMAGE_TAG:-latest}
     restart: unless-stopped
     mem_limit: 128m
     cpus: 0.5


### PR DESCRIPTION
## What

Flip **myjobhunter** to the registry deploy path (`registry_images: true`), mirroring mybookkeeper (#894). Re-rendered the deploy workflow + `docker-compose.yml` via `platform_shared.infra.render` (caddy.Dockerfile/Caddyfile unchanged).

The deploy workflow now builds the backend + caddy images on the GitHub runner and pushes to GHCR; the VPS pulls prebuilt images instead of building on-box — ~20m → ~2-3m deploys, no build-window outage.

## Deploy mechanics — prereqs already satisfied (no operator action needed)

- `GHCR_PULL_TOKEN` secret — already set.
- `MYJOBHUNTER_VITE_TURNSTILE_SITE_KEY` variable — set to the app's **public** Turnstile site key (`0x4AAA…`), matching the value currently inlined in the live `myjobhunter.myfreeapps.org` bundle. The caddy bundle's Turnstile key now comes from this variable at CI build time instead of the VPS `.env.docker` (per `rules/verify-frontend-build-args.md`).

**Rollback:** `IMAGE_TAG=<old-sha> docker compose -f apps/myjobhunter/docker-compose.yml up -d` pins a previous image.

## Verification
- `platform_shared.infra.render --app myjobhunter --check` → clean (no drift).
- On merge, the deploy job inlines `vars.MYJOBHUNTER_VITE_TURNSTILE_SITE_KEY` into the bundle; will confirm the live bundle still carries the key post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)