### PR TITLE
feat(mga-infra): registry deploys — build in CI + push to GHCR

### DIFF
--- a/.github/workflows/deploy-mygamingassistant.yml
+++ b/.github/workflows/deploy-mygamingassistant.yml
@@ -23,8 +23,68 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # Build images on the GitHub runner (fast, layer-cached via type=gha) and push
+  # to GHCR. The deploy job below PULLS these prebuilt images instead of building
+  # on the VPS — cutting deploy time from ~20m to ~2-3m and shrinking the
+  # container-recreate downtime window. Each image is tagged with the commit SHA
+  # (immutable; enables rollback via `IMAGE_TAG=<old-sha> docker compose up -d`)
+  # plus :latest. GHCR namespace = the repo owner (jykwon91).
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to GHCR
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push backend image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/mygamingassistant/docker/backend.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jykwon91/myfreeapps-mygamingassistant-backend:${{ github.sha }}
+            ghcr.io/jykwon91/myfreeapps-mygamingassistant-backend:latest
+          build-args: |
+            GIT_COMMIT=${{ github.sha }}
+          cache-from: type=gha,scope=mygamingassistant-backend
+          cache-to: type=gha,mode=max,scope=mygamingassistant-backend
+
+      - name: Build and push caddy image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          file: apps/mygamingassistant/docker/caddy.Dockerfile
+          push: true
+          tags: |
+            ghcr.io/jykwon91/myfreeapps-mygamingassistant-caddy:${{ github.sha }}
+            ghcr.io/jykwon91/myfreeapps-mygamingassistant-caddy:latest
+          # VITE_* values are inlined into the frozen bundle at build time. They
+          # now come from GitHub Actions variables (public values — the Turnstile
+          # site key is rendered into the HTML) instead of the VPS .env.docker,
+          # because the build no longer runs on the VPS. See
+          # rules/verify-frontend-build-args.md.
+          build-args: |
+            VITE_TURNSTILE_SITE_KEY=${{ vars.MYGAMINGASSISTANT_VITE_TURNSTILE_SITE_KEY }}
+            VITE_SERVE_ONLY=true
+          cache-from: type=gha,scope=mygamingassistant-caddy
+          cache-to: type=gha,mode=max,scope=mygamingassistant-caddy
+
   deploy:
     runs-on: ubuntu-latest
+    needs: build-and-push
 
     steps:
       - name: Checkout code
@@ -32,10 +92,18 @@ jobs:
 
       - name: Deploy to VPS
         uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        env:
+          # Forwarded into the remote script via `envs:` below. IMAGE_TAG pins the
+          # exact images the build-and-push job just pushed; GHCR_* authenticate
+          # the VPS to pull the (private) packages.
+          IMAGE_TAG: ${{ github.sha }}
+          GHCR_USER: ${{ github.repository_owner }}
+          GHCR_TOKEN: ${{ secrets.GHCR_PULL_TOKEN }}
         with:
           host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USER }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: IMAGE_TAG,GHCR_USER,GHCR_TOKEN
           # Generous: deploys are serialized via the flock below, so a
           # later app can wait through several earlier app deploys before
           # its own runs. 10m was too tight once deploys serialize.
@@ -79,14 +147,14 @@ jobs:
             }
             echo "Env files present — proceeding"
 
-            echo "--- Build and deploy with Docker ---"
-            # --env-file exposes backend/.env.docker variables to docker compose's
-            # build args (caddy.build.args reads VITE_TURNSTILE_SITE_KEY from the
-            # shell). Without --env-file the bundle gets baked with an empty
-            # site key and TurnstileWidget renders null in production.
-            docker compose -f apps/mygamingassistant/docker-compose.yml \
-              --env-file apps/mygamingassistant/backend/.env.docker \
-              build
+            echo "--- Authenticate to GHCR and pull prebuilt images ---"
+            # Images were built + pushed by the build-and-push job on the runner.
+            # The VPS only pulls — no on-box build. IMAGE_TAG pins this commit's
+            # images; docker-compose resolves ${IMAGE_TAG:-latest} against it for
+            # `pull`, `up`, and any later `create`.
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+            export IMAGE_TAG
+            docker compose -f apps/mygamingassistant/docker-compose.yml pull
             docker compose -f apps/mygamingassistant/docker-compose.yml up -d --remove-orphans
 
             echo "--- One-time cleanup: remove obsolete frontend_dist volume ---"
@@ -149,3 +217,6 @@ jobs:
             else
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
+
+            echo "--- Clean up GHCR credentials ---"
+            docker logout ghcr.io || true

--- a/apps/mygamingassistant/app.yaml
+++ b/apps/mygamingassistant/app.yaml
@@ -17,7 +17,7 @@ automated_deploy: true
 # On-VPS Docker build (legacy path). Flip to true to build in CI + pull from
 # GHCR (needs GHCR_PULL_TOKEN secret + MYGAMINGASSISTANT_VITE_TURNSTILE_SITE_KEY
 # var; serve-only adds VITE_SERVE_ONLY=true in the build job). See mybookkeeper.
-registry_images: false
+registry_images: true
 # MGA-only: render the VITE_SERVE_ONLY frontend build-arg chain (caddy.Dockerfile
 # ARG/ENV + docker-compose caddy build.args). MGA's production deploy is a pure
 # public read-only library with no auth (SERVE_ONLY=true); the bundle needs the

--- a/apps/mygamingassistant/docker-compose.yml
+++ b/apps/mygamingassistant/docker-compose.yml
@@ -35,12 +35,7 @@ services:
       start_period: 30s
 
   migrate:
-    build:
-      # Build context is the monorepo root so the image can pull in
-      # packages/shared-backend (the `platform_shared` library) alongside
-      # apps/mygamingassistant/.
-      context: ../..
-      dockerfile: apps/mygamingassistant/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-mygamingassistant-backend:${IMAGE_TAG:-latest}
     command: ["alembic", "upgrade", "head"]
     # One-shot migration — caps guard a runaway migration, not steady state.
     mem_limit: 512m
@@ -54,9 +49,7 @@ services:
         condition: service_healthy
 
   api:
-    build:
-      context: ../..
-      dockerfile: apps/mygamingassistant/docker/backend.Dockerfile
+    image: ghcr.io/jykwon91/myfreeapps-mygamingassistant-backend:${IMAGE_TAG:-latest}
     restart: unless-stopped
     # Highest single consumer on the box (the busiest app's API steady-states
     # well under this); cap leaves headroom for request-handling spikes while
@@ -81,21 +74,10 @@ services:
     # at /srv/frontend + Caddyfile baked at /etc/caddy/Caddyfile. No shared
     # volume, no entrypoint copy, no drift between deploys. See
     # docker/caddy.Dockerfile for the full rationale.
-    build:
-      context: ../..
-      dockerfile: apps/mygamingassistant/docker/caddy.Dockerfile
-      args:
-        # Frontend public env baked into the Vite bundle at build time.
-        # Read from the host shell environment when `docker compose build`
-        # runs; the deploy workflow / operator passes these via
-        # `--env-file backend/.env.docker`. Empty values produce a bundle
-        # where TurnstileWidget returns null and registration silently 400s.
-        VITE_TURNSTILE_SITE_KEY: ${TURNSTILE_SITE_KEY:-}
-        # VITE_SERVE_ONLY drives the no-auth public-library frontend. Reads the
-        # same SERVE_ONLY var the backend uses (no VITE_ prefix on the RHS) so a
-        # single backend/.env.docker line drives both the backend mode and the
-        # bundle. Empty/unset keeps the full auth UI.
-        VITE_SERVE_ONLY: ${SERVE_ONLY:-}
+    # Registry path: this image is built + pushed by the deploy workflow's
+    # build-and-push job (VITE_* build args sourced from GitHub Actions vars
+    # there, not the VPS .env.docker). The VPS pulls it; no on-box build.
+    image: ghcr.io/jykwon91/myfreeapps-mygamingassistant-caddy:${IMAGE_TAG:-latest}
     restart: unless-stopped
     mem_limit: 128m
     cpus: 0.5

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -472,6 +472,35 @@ class TestServeOnlyBundleWiring:
 
     @pytest.mark.parametrize("app", sorted(_SERVE_ONLY_BUNDLE_APPS))
     def test_docker_compose_passes_serve_only_arg_to_caddy(self, app: str) -> None:
+        """WHERE VITE_SERVE_ONLY is wired depends on the build location (mirrors
+        TestTurnstileBundleWiring):
+
+        - VPS-build apps: through the caddy service's docker-compose
+          ``build.args`` block (sourced from backend/.env.docker via --env-file).
+        - Registry apps (``registry_images: true``): the caddy image is built in
+          the deploy workflow's build-and-push job, so VITE_SERVE_ONLY is wired
+          there (a literal flag) and the compose caddy service just references
+          the prebuilt GHCR image — no build.args block exists.
+        """
+        if _uses_registry_images(app):
+            workflow_src = _read(".github", "workflows", f"deploy-{app}.yml")
+            assert "VITE_SERVE_ONLY=true" in workflow_src, (
+                f"deploy-{app}.yml builds the caddy image in CI "
+                f"(registry_images: true) but its build-and-push job does not "
+                f"pass VITE_SERVE_ONLY=true as a --build-arg. Without it the "
+                f"serve-only bundle re-enables the auth UI in the public "
+                f"library. Add it under the caddy build step's `build-args:` in "
+                f"infra/templates/.github/workflows/deploy.yml.j2 (gated by "
+                f"serve_only_build_arg) and re-render."
+            )
+            compose_src = _read("apps", app, "docker-compose.yml")
+            assert f"myfreeapps-{app}-caddy:" in compose_src, (
+                f"{app}/docker-compose.yml has registry_images: true but the "
+                f"caddy service does not reference the prebuilt image "
+                f"ghcr.io/jykwon91/myfreeapps-{app}-caddy. Re-render from the "
+                f"template."
+            )
+            return
         compose_src = _read("apps", app, "docker-compose.yml")
         assert "VITE_SERVE_ONLY:" in compose_src, (
             f"{app}/docker-compose.yml must include `VITE_SERVE_ONLY: "


### PR DESCRIPTION
## What

Flip **mygamingassistant** to the registry deploy path (`registry_images: true`), mirroring mybookkeeper (#894). Re-rendered the deploy workflow + `docker-compose.yml` via `platform_shared.infra.render`. Part of the fleet-wide registry rollout from the deploy-pipeline handoff (companion to #898 mjh).

The deploy workflow now builds the backend + caddy images on the GitHub runner and pushes to GHCR; the VPS pulls prebuilt images instead of building on-box (~20m → ~2-3m deploys, no build-window outage).

## Serve-only specifics (no operator action needed)

- `GHCR_PULL_TOKEN` secret — already set.
- mga is a **serve-only** public read-only library (`serve_only_build_arg: true`), so the caddy build job passes `VITE_SERVE_ONLY=true`. `VITE_TURNSTILE_SITE_KEY` sources from `MYGAMINGASSISTANT_VITE_TURNSTILE_SITE_KEY` which is intentionally **unset** → empty. That's correct: serve-only hides all auth UI, and the current live `mygamingassistant.myfreeapps.org` bundle already carries **no** Turnstile key. No variable to set.
- R2 object storage (`joins_minio_network: false`) and `post_deploy_commands` (`load-fixtures`, `import-lineups`) are preserved unchanged.

**Rollback:** `IMAGE_TAG=<old-sha> docker compose -f apps/mygamingassistant/docker-compose.yml up -d`.

## Verification
- `platform_shared.infra.render --app mygamingassistant --check` → clean (no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)