### PR TITLE
fix(mbk): stop silently dropping utility-bill notification emails

### DIFF
--- a/apps/mybookkeeper/backend/app/models/extraction/email_extraction_outcome.py
+++ b/apps/mybookkeeper/backend/app/models/extraction/email_extraction_outcome.py
@@ -1,0 +1,16 @@
+"""Outcome of persisting an email's extracted documents.
+
+Carries both the number of transactions/documents created and, when zero
+were created, a human-readable reason. The reason is written to the
+``email_queue`` row so the Sync Sessions UI can explain why an email that
+synced successfully produced no records — closing the "silent drop"
+observability gap where utility bills were fetched, run through Claude, and
+dropped with no trace.
+"""
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EmailExtractionOutcome:
+    records_added: int
+    skip_reason: str | None = None

--- a/apps/mybookkeeper/backend/app/models/extraction/extraction_types.py
+++ b/apps/mybookkeeper/backend/app/models/extraction/extraction_types.py
@@ -16,8 +16,11 @@ class ExtractionData(TypedDict, total=False):
     line_items: list[dict[str, str]]
     document_type: str
     category: str
+    sub_category: str
+    transaction_type: str
     payment_method: str
     payer_name: str
+    payer_handle: str
     sender: str
     file_name: str
 

--- a/apps/mybookkeeper/backend/app/repositories/email/email_queue_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/email/email_queue_repo.py
@@ -161,10 +161,20 @@ async def store_fetched_content(
     item.error = None
 
 
-async def mark_done(db: AsyncSession, item: EmailQueue) -> None:
+async def mark_done(
+    db: AsyncSession, item: EmailQueue, *, reason: str | None = None
+) -> None:
+    """Mark a queue row as done.
+
+    ``reason`` carries an optional human-readable note explaining why the
+    email produced no records (e.g. "Duplicate", "Payment confirmation — no
+    amount"). It is stored on ``error`` (a generic per-row note column) so the
+    Sync Sessions UI can surface it. A done row with no records and no reason
+    simply means the email's documents imported cleanly.
+    """
     item.status = "done"
     item.raw_content = None
-    item.error = None
+    item.error = reason[:1000] if reason else None
 
 
 async def mark_skipped(db: AsyncSession, item: EmailQueue, *, reason: str | None = None) -> None:

--- a/apps/mybookkeeper/backend/app/services/email/email_extraction_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_extraction_service.py
@@ -172,9 +172,10 @@ async def _extract_next_fetched(ctx: RequestContext) -> ExtractResult:
                 extraction = None
 
         records_added = 0
+        skip_reason: str | None = None
         async with unit_of_work() as db:
             if extraction:
-                records_added = await save_email_extraction(
+                outcome = await save_email_extraction(
                     message_id=message_id,
                     subject=email_subject,
                     result=extraction[0],
@@ -184,6 +185,8 @@ async def _extract_next_fetched(ctx: RequestContext) -> ExtractResult:
                     db=db,
                     sender_email=sender_email,
                 )
+                records_added = outcome.records_added
+                skip_reason = outcome.skip_reason
 
             item_ref = await email_queue_repo.get_by_id(db, item_id)
             if item_ref:
@@ -195,7 +198,12 @@ async def _extract_next_fetched(ctx: RequestContext) -> ExtractResult:
                 # ``skipped`` status remains available for explicit use
                 # (e.g. an admin-triggered 're-process this email' flow)
                 # but is NOT applied automatically.
-                await email_queue_repo.mark_done(db, item_ref)
+                #
+                # When the email produced no records, persist the REASON on
+                # the row so the Sync Sessions UI can explain it — closing the
+                # silent-drop observability gap (utility bills used to vanish
+                # here with no trace).
+                await email_queue_repo.mark_done(db, item_ref, reason=skip_reason)
 
             log = await sync_log_repo.get_by_id(db, sync_log_id)
             if log:

--- a/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
@@ -11,6 +11,7 @@ from app.core.tags import transaction_type_for_category
 from app.core.trusted_email_senders import is_trusted_sender
 from app.models.documents.document import Document
 from app.models.email.email_types import Attachment
+from app.models.extraction.email_extraction_outcome import EmailExtractionOutcome
 from app.models.extraction.extraction import Extraction
 from app.models.extraction.extraction_types import ExtractionData, ExtractionResult
 from app.repositories import (
@@ -41,12 +42,23 @@ async def save_email_extraction(
     user_id: uuid.UUID,
     db: AsyncSession,
     sender_email: str | None = None,
-) -> int:
-    """Persist extracted documents from an email. Returns count added.
+) -> EmailExtractionOutcome:
+    """Persist extracted documents from an email.
+
+    Returns an :class:`EmailExtractionOutcome` carrying the number of records
+    created and, when zero were created, a human-readable reason so the Sync
+    Sessions UI can explain why a successfully-synced email produced no
+    transactions.
 
     Shared extraction logic (tag sanitization, property matching, dedup)
     is delegated to helper functions. Email-specific concerns (message dedup,
     low-confidence skip, .eml unwrapping, source="email") are handled here.
+
+    Invariant: a document carrying a valid transaction_date AND a positive
+    amount is a real expense and must never be silently dropped — not by the
+    payment-confirmation skip, not by the low-confidence skip. Utility
+    "bill ready" / "Auto Pay" notifications that state an amount due flow
+    through as a ``utilities`` expense.
     """
     documents_data: list[ExtractionData] = result.get("data", [])
     tokens: int = result.get("tokens", 0)
@@ -72,35 +84,51 @@ async def save_email_extraction(
 
     # Extraction record is created on the first non-skipped, non-duplicate doc
     ext_confidence = documents_data[0].get("confidence") if documents_data else None
-    ext_doc_type = documents_data[0].get("document_type", "invoice") if documents_data else "invoice"
+    ext_doc_type = _normalize_document_type(
+        documents_data[0].get("document_type", "invoice") if documents_data else "invoice",
+        documents_data[0] if documents_data else None,
+    )
 
     records_added = 0
     ext_record: Extraction | None = None
+    skip_reason: str | None = None
 
     # Payment confirmations: skip entirely — they duplicate the original invoice.
-    # Carve-out: peer-to-peer transfers (Zelle/Venmo/Cash App/PayPal etc.) ARE
-    # the source of truth for rent income, not duplicates. If any document in
-    # the batch looks like a P2P payment, we must not short-circuit here.
+    # Two carve-outs prevent silently dropping real money:
+    #   1. Peer-to-peer transfers (Zelle/Venmo/Cash App/PayPal etc.) ARE the
+    #      source of truth for rent income, not duplicates.
+    #   2. Any document carrying a valid date + positive amount is a real
+    #      expense record (a utility "bill ready" / "Auto Pay $232.84"
+    #      notification is the ONLY record of that charge — no paper invoice
+    #      will ever arrive). The "payment confirmation" framing must not drop
+    #      a batch that contains a recordable amount.
     has_p2p = any(_looks_like_p2p_payment(d) for d in documents_data)
-    if not has_p2p and (
+    has_recordable_amount = any(_has_recordable_expense(d) for d in documents_data)
+    if not has_p2p and not has_recordable_amount and (
         ext_doc_type == "payment_confirmation" or _is_payment_confirmation(documents_data)
     ):
-        logger.info(
-            "Skipping payment confirmation email (message_id=%s, subject=%r)",
+        logger.warning(
+            "Skipping payment confirmation email — no recordable amount "
+            "(message_id=%s, subject=%r)",
             message_id, subject,
         )
-        return records_added
+        return EmailExtractionOutcome(
+            records_added=0,
+            skip_reason="Payment confirmation / notification — no amount to record",
+        )
 
     for data in documents_data:
         doc_tags = sanitize_extraction_tags(data.get("tags"))
 
         if data.get("confidence") == "low" and (
             not doc_tags or doc_tags == ["uncategorized"]
-        ):
-            logger.info(
-                "Skipping document: low confidence + uncategorized (vendor=%r)",
+        ) and not _has_recordable_expense(data):
+            logger.warning(
+                "Skipping document: low confidence + uncategorized + no amount "
+                "(vendor=%r)",
                 data.get("vendor"),
             )
+            skip_reason = skip_reason or "Low confidence and no recognizable category"
             continue
 
         property_id = await resolve_property_id(
@@ -111,7 +139,7 @@ async def save_email_extraction(
         vendor = data.get("vendor")
         doc_date = safe_date(data.get("date"))
         amount = safe_decimal(data.get("amount"))
-        doc_type = data.get("document_type", "invoice")
+        doc_type = _normalize_document_type(data.get("document_type", "invoice"), data)
         raw_payer = data.get("payer_name")
 
         decision = await evaluate_dedup(
@@ -128,6 +156,7 @@ async def save_email_extraction(
         )
 
         if decision.action == "skip":
+            skip_reason = skip_reason or "Duplicate of an already-imported document"
             continue
 
         doc = Document(
@@ -161,6 +190,13 @@ async def save_email_extraction(
             await extraction_repo.create(db, ext_record)
 
         # Create Transaction via dedup resolution
+        if not (doc_date and amount is not None and abs(amount) > 0):
+            # A Document was created but no Transaction — Claude returned no
+            # usable date/amount. Record why so the email isn't a silent no-op.
+            skip_reason = skip_reason or (
+                "No amount or date found — saved as a document only, "
+                "no transaction created"
+            )
         if doc_date and amount is not None and abs(amount) > 0:
             category = derive_category(doc_tags)
             if category == "uncategorized" and vendor:
@@ -200,12 +236,23 @@ async def save_email_extraction(
             )
 
             # Email body extractions (no PDF attachment) are less reliable —
-            # mark transactions as "unverified" so users review them. Trusted
-            # payment senders (Airbnb, Zelle, etc.) are exempt: their emails
-            # are unambiguous structured receipts and the review step is
-            # friction without value.
-            if is_email_body and txn and not (
-                sender_email and is_trusted_sender(sender_email)
+            # mark transactions as "unverified" so users review them. Two
+            # exemptions land the transaction directly on the dashboard:
+            #   - Trusted payment senders (Airbnb, Zelle, etc.): unambiguous
+            #     structured receipts; the review step is friction without
+            #     value.
+            #   - Utility / recurring-service bills (Constellation, CenterPoint,
+            #     City of Houston Water, AT&T, etc.): a "bill ready" / "Auto Pay"
+            #     notification with a stated amount IS the record of that
+            #     expense. Leaving it "unverified" hides it from dashboard and
+            #     analytics totals (status=="approved" filter) — the exact
+            #     silent-drop the user reported. These are recurring, low-
+            #     ambiguity charges, so surface them.
+            if (
+                is_email_body
+                and txn
+                and not (sender_email and is_trusted_sender(sender_email))
+                and category != "utilities"
             ):
                 txn.status = "unverified"
 
@@ -245,7 +292,10 @@ async def save_email_extraction(
                         continue
                     await booking_statement_repo.create(db, bs)
 
-    return records_added
+    return EmailExtractionOutcome(
+        records_added=records_added,
+        skip_reason=skip_reason if records_added == 0 else None,
+    )
 
 
 _PAYMENT_CONFIRMATION_PATTERNS = re.compile(
@@ -264,6 +314,70 @@ _PAYMENT_CONFIRMATION_PATTERNS = re.compile(
 _P2P_PLATFORM_VENDORS = frozenset({
     "zelle", "venmo", "cash app", "cashapp", "paypal", "apple pay", "google pay",
 })
+
+
+# Document types that the Extraction.document_type CHECK constraint accepts.
+# A "payment_confirmation" is NOT a valid stored document_type — it is a
+# routing signal only. When such a document actually carries a recordable
+# amount (a utility "bill ready" notification that states an amount due), it
+# is a real invoice and must be stored as one, both to satisfy the DB
+# constraint and because that is what it is.
+_VALID_STORED_DOCUMENT_TYPES = frozenset({
+    "invoice", "statement", "lease", "insurance_policy", "tax_form",
+    "contract", "year_end_statement", "receipt", "1099", "other",
+    "w2", "1099_int", "1099_div", "1099_b", "1099_k",
+    "1099_misc", "1099_nec", "1099_r", "1098", "k1",
+})
+
+
+def _normalize_document_type(doc_type: str, data: dict | None) -> str:
+    """Coerce a Claude document_type to one the DB accepts.
+
+    ``payment_confirmation`` is a routing label, not a storable type. When the
+    document carries a recordable amount (a utility bill notification stating
+    an amount due) it is a real invoice — store it as ``invoice``. An
+    amount-less payment_confirmation is left untouched so the upstream
+    payment-confirmation skip still fires before any persistence happens. Any
+    other unknown type degrades to ``other`` rather than crashing the insert.
+    """
+    if doc_type == "payment_confirmation":
+        if data is not None and _has_recordable_expense(data):
+            return "invoice"
+        return doc_type
+    if doc_type in _VALID_STORED_DOCUMENT_TYPES:
+        return doc_type
+    return "other"
+
+
+def _has_recordable_expense(data: dict) -> bool:
+    """Return True if the extraction carries a real, recordable charge.
+
+    A document with a valid transaction_date AND a positive amount is a real
+    expense/income record that must never be silently dropped — not by the
+    payment-confirmation skip and not by the low-confidence skip. This is the
+    structural guarantee behind the utility-bill fix: a Constellation /
+    CenterPoint / City-of-Houston-Water "bill ready" or "Auto Pay" email that
+    states an amount due is the ONLY record of that charge, so the batch must
+    survive even if Claude mis-tags the document_type as payment_confirmation.
+
+    Claude output is untrusted — a malformed amount/date degrades to "not
+    recordable", never raises.
+    """
+    if not safe_date(data.get("date")):
+        return False
+    amount = safe_decimal(_amount_str(data.get("amount")))
+    return amount is not None and abs(amount) > 0
+
+
+def _amount_str(value: object) -> str | None:
+    """Coerce a Claude amount field to the str safe_decimal expects, or None."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float)):
+        return str(value)
+    return None
 
 
 def _looks_like_p2p_payment(data: dict) -> bool:

--- a/apps/mybookkeeper/backend/app/services/extraction/prompts/base_prompt.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/prompts/base_prompt.py
@@ -33,12 +33,20 @@ Always return this structure (documents is always an array, even for a single re
 
 # Document types
 
-- "invoice" — invoices, bills, payment requests, utility bills, receipts
-- "payment_confirmation" — payment confirmations, payment acknowledgments, AND bill-ready notifications. This includes:
-  - Payment confirmations: "Your payment was accepted", "Payment received", "Thank you for your payment"
-  - Bill-ready notifications: "Your bill is ready to view", "Your statement is available", "View your bill online", "Bill reminder"
-  - Any email that notifies about a bill or payment but does NOT contain the actual bill/invoice document itself
+- "invoice" — invoices, bills, payment requests, utility bills, receipts, AND bill-ready / bill-amount notifications that state a specific amount due
+- "payment_confirmation" — payment confirmations / acknowledgments that do NOT contain a charge to record. This includes:
+  - Payment confirmations: "Your payment was accepted", "Payment received", "Thank you for your payment", "Auto Pay processed your payment"
+  - Bill-ready notifications that show NO amount: "Your bill is ready to view" / "Your statement is available" / "View your bill online" with no dollar figure in the email
+  - Any email that notifies about a bill or payment but does NOT contain the actual bill/invoice document itself AND shows no recordable amount
   When you detect any of these, return a single document entry with document_type "payment_confirmation", the vendor name, a description, amount null, and category "uncategorized" — do NOT extract transaction amounts, as these duplicate the original invoice or bill
+
+  CRITICAL EXCEPTION — bill-ready / billing notifications that DO show an amount due are NOT "payment_confirmation". A utility, telecom, or service-provider email that states a specific amount (e.g. "Your bill of $232.84 is ready", "Amount due: $163.12", "Your Auto Pay of $251.64 is scheduled", "Total balance $187.54") IS the record of that expense — there is no separate paper invoice that will ever arrive. The "Auto Pay" / "bill is ready" / "your statement is available" framing does NOT make it a payment confirmation when a charge amount is present. For ALL of these:
+    - Constellation, Reliant, TXU, Green Mountain, Gexa (electricity retailers)
+    - CenterPoint, Atmos, Texas Gas Service (gas)
+    - City of Houston Water, municipal water/sewer/trash utilities
+    - AT&T, Comcast/Xfinity, Spectrum, Verizon (internet/telecom)
+    - Any other recurring service provider that emails an amount due
+  set document_type "invoice", transaction_type "expense", category "utilities" (for electricity/gas/water/internet/trash/sewer providers — telecom internet is "internet"), the correct sub_category, and EXTRACT the amount and the due/statement date. Use the amount due / current charges / total balance as the amount. confidence "high" when the amount and date are both clearly present.
 
   CRITICAL EXCEPTION — peer-to-peer money transfer emails are NEVER "payment_confirmation". They ARE the source of truth for the income, not a duplicate of any invoice. This includes ALL of:
     - Zelle ("You received money with Zelle", "FN LN sent you $X with Zelle")
@@ -299,6 +307,9 @@ Invoice from a plumber:
 
 Monthly electric bill:
 {"documents": [{"document_type": "invoice", "date": "2025-08-01", "vendor": "Constellation", "amount": "187.54", "description": "Electricity Aug 2025", "transaction_type": "expense", "category": "utilities", "sub_category": "electricity", "payment_method": null, "tags": ["utilities"], "tax_relevant": true, "channel": null, "address": "6732 Peerless St Houston TX", "confidence": "high", "line_items": null}]}
+
+Bill-ready email notification that shows an amount due ("Your Constellation bill is ready. Auto Pay of $232.84 is scheduled for Jun 18."):
+{"documents": [{"document_type": "invoice", "date": "2026-06-18", "vendor": "Constellation", "amount": "232.84", "description": "Electricity bill — Auto Pay scheduled", "transaction_type": "expense", "category": "utilities", "sub_category": "electricity", "payment_method": "bank_transfer", "tags": ["utilities"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
 
 Invoice with towels and sheets:
 {"documents": [{"document_type": "invoice", "date": "2025-07-20", "vendor": "Amazon", "amount": "89.99", "description": "Bath towels and fitted sheets for rental", "transaction_type": "expense", "category": "maintenance", "payment_method": "credit_card", "tags": ["maintenance", "linen"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}

--- a/apps/mybookkeeper/backend/tests/test_claude_service_prompt.py
+++ b/apps/mybookkeeper/backend/tests/test_claude_service_prompt.py
@@ -101,3 +101,22 @@ class TestGetExtractionPromptDbError:
 
             with pytest.raises(RuntimeError, match="unexpected bug"):
                 await get_extraction_prompt(user_id=user_id)
+
+
+class TestBillReadyWithAmountInstruction:
+    """Regression: the prompt must tell Claude that a bill-ready / Auto Pay
+    notification carrying an amount due is an INVOICE (utilities expense), not
+    a payment_confirmation. Without this, Constellation/CenterPoint/AT&T bills
+    were tagged payment_confirmation with amount=null and silently dropped."""
+
+    def test_bill_ready_with_amount_is_invoice_not_confirmation(self) -> None:
+        # The CRITICAL EXCEPTION block must instruct invoice + utilities.
+        assert "bill-ready / billing notifications that DO show an amount" in DEFAULT_PROMPT
+        assert "are NOT \"payment_confirmation\"" in DEFAULT_PROMPT
+
+    def test_auto_pay_framing_does_not_force_confirmation(self) -> None:
+        assert "\"Auto Pay\" / \"bill is ready\"" in DEFAULT_PROMPT
+
+    def test_known_utility_vendors_listed(self) -> None:
+        for vendor in ("Constellation", "CenterPoint", "City of Houston Water", "AT&T"):
+            assert vendor in DEFAULT_PROMPT

--- a/apps/mybookkeeper/backend/tests/test_email_queue_dedup_filter.py
+++ b/apps/mybookkeeper/backend/tests/test_email_queue_dedup_filter.py
@@ -162,3 +162,62 @@ class TestMarkSkipped:
         assert item.status == "skipped"
         assert item.error is not None
         assert len(item.error) == 1000
+
+
+class TestMarkDoneReason:
+    """mark_done carries an optional no-records reason so the Sync Sessions UI
+    can explain why a successfully-synced email produced no transactions."""
+
+    @pytest.mark.asyncio
+    async def test_mark_done_with_reason_persists_note(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-done-reason", status="extracting",
+        )
+        from sqlalchemy import select
+        item = (await db.execute(
+            select(EmailQueue).where(EmailQueue.message_id == "msg-done-reason")
+        )).scalar_one()
+        await email_queue_repo.mark_done(
+            db, item, reason="Duplicate of an already-imported document",
+        )
+        await db.flush()
+        assert item.status == "done"
+        assert item.error == "Duplicate of an already-imported document"
+        assert item.raw_content is None
+
+    @pytest.mark.asyncio
+    async def test_mark_done_without_reason_clears_error(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-done-clean", status="extracting",
+        )
+        from sqlalchemy import select
+        item = (await db.execute(
+            select(EmailQueue).where(EmailQueue.message_id == "msg-done-clean")
+        )).scalar_one()
+        await email_queue_repo.mark_done(db, item)
+        await db.flush()
+        assert item.status == "done"
+        assert item.error is None
+
+    @pytest.mark.asyncio
+    async def test_mark_done_truncates_long_reason(
+        self, db: AsyncSession, test_user: User, test_org: Organization,
+    ) -> None:
+        await _insert_queue_row(
+            db, org_id=test_org.id, user_id=test_user.id,
+            message_id="msg-done-long", status="extracting",
+        )
+        from sqlalchemy import select
+        item = (await db.execute(
+            select(EmailQueue).where(EmailQueue.message_id == "msg-done-long")
+        )).scalar_one()
+        await email_queue_repo.mark_done(db, item, reason="y" * 2000)
+        await db.flush()
+        assert item.error is not None
+        assert len(item.error) == 1000

--- a/apps/mybookkeeper/backend/tests/test_trusted_email_senders.py
+++ b/apps/mybookkeeper/backend/tests/test_trusted_email_senders.py
@@ -132,7 +132,7 @@ class TestEmailBodyApprovalGate:
     ) -> None:
         org_id, user_id = await _seed_org_user(db)
 
-        added = await save_email_extraction(
+        outcome = await save_email_extraction(
             message_id=f"msg-{uuid.uuid4().hex}",
             subject="Reservation confirmed",
             result=_make_extraction_result(amount="425.00", vendor="Airbnb"),
@@ -142,7 +142,8 @@ class TestEmailBodyApprovalGate:
             db=db,
             sender_email="automated@airbnb.com",
         )
-        assert added == 1
+        assert outcome.records_added == 1
+        assert outcome.skip_reason is None
 
         txn = (await db.execute(
             select(Transaction).where(Transaction.organization_id == org_id)

--- a/apps/mybookkeeper/backend/tests/test_utility_bill_silent_drop.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_bill_silent_drop.py
@@ -1,0 +1,280 @@
+"""Regression: utility-bill notification emails must never be silently dropped.
+
+Production symptom (2026-06): Constellation / CenterPoint / AT&T / City of
+Houston Water "your bill is ready" / "Auto Pay" emails were fetched, run
+through Claude, and produced ZERO transactions with NO error — 324 ``done`` /
+0 ``failed`` queue rows, 0 transactions in 7 days, despite the emails carrying
+real amounts ($232.84, $163.12, $251.64).
+
+Root cause: the base prompt instructed Claude to tag "bill ready"
+notifications as ``document_type="payment_confirmation"`` with ``amount=null``,
+and ``save_email_extraction`` dropped the entire email whenever the batch
+document_type was ``payment_confirmation``. The P2P carve-out only protected
+Zelle/Venmo, not utilities.
+
+These tests pin the structural fix at the persistence layer (the prompt is the
+other half, validated separately): a document carrying a valid date + positive
+amount must survive the payment-confirmation skip, must import as a visible
+(``approved``) ``utilities`` expense, and an email that genuinely produces no
+records must record a reason on its queue row.
+"""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.extraction.extraction_types import ExtractionData, ExtractionResult
+from app.models.organization.organization import Organization
+from app.models.transactions.transaction import Transaction
+from app.models.user.user import User
+from app.services.extraction.extraction_persistence import (
+    _has_recordable_expense,
+    save_email_extraction,
+)
+
+
+async def _seed_org_user(db: AsyncSession) -> tuple[uuid.UUID, uuid.UUID]:
+    user = User(
+        id=uuid.uuid4(),
+        email=f"test-{uuid.uuid4().hex[:8]}@example.com",
+        hashed_password="fakehash",
+        is_active=True,
+        is_superuser=False,
+        is_verified=True,
+    )
+    db.add(user)
+    org = Organization(id=uuid.uuid4(), name="Test Org", created_by=user.id)
+    db.add(org)
+    await db.commit()
+    await db.refresh(user)
+    await db.refresh(org)
+    return org.id, user.id
+
+
+def _result(data: ExtractionData) -> ExtractionResult:
+    return {
+        "data": [data],
+        "tokens": 100,
+        "input_tokens": 80,
+        "output_tokens": 20,
+        "model_name": "claude-test",
+    }
+
+
+def _utility_bill_data(
+    *,
+    vendor: str = "Constellation",
+    amount: str = "232.84",
+    document_type: str = "invoice",
+    sub_category: str = "electricity",
+) -> ExtractionData:
+    """A Constellation 'bill ready / Auto Pay' notification with an amount."""
+    return {
+        "vendor": vendor,
+        "amount": amount,
+        "date": "2026-06-18",
+        "document_type": document_type,
+        "category": "utilities",
+        "sub_category": sub_category,
+        "transaction_type": "expense",
+        "confidence": "high",
+        "tags": ["utilities"],
+        "description": "Electricity bill — Auto Pay scheduled",
+    }
+
+
+class TestHasRecordableExpense:
+    def test_valid_date_and_positive_amount(self) -> None:
+        assert _has_recordable_expense(_utility_bill_data()) is True
+
+    def test_null_amount_not_recordable(self) -> None:
+        d = _utility_bill_data()
+        d["amount"] = None
+        assert _has_recordable_expense(d) is False
+
+    def test_zero_amount_not_recordable(self) -> None:
+        d = _utility_bill_data(amount="0.00")
+        assert _has_recordable_expense(d) is False
+
+    def test_missing_date_not_recordable(self) -> None:
+        d = _utility_bill_data()
+        d["date"] = None
+        assert _has_recordable_expense(d) is False
+
+    def test_numeric_amount_coerced(self) -> None:
+        d = _utility_bill_data()
+        d["amount"] = 232.84  # Claude sometimes emits a number, not a string
+        assert _has_recordable_expense(d) is True
+
+    def test_garbage_amount_degrades_to_false(self) -> None:
+        d = _utility_bill_data(amount="not-a-number")
+        assert _has_recordable_expense(d) is False
+
+
+class TestUtilityBillImports:
+    """The core regression: the email must NOT be silently dropped."""
+
+    @pytest.mark.asyncio
+    async def test_bill_ready_invoice_creates_transaction(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = await _seed_org_user(db)
+
+        outcome = await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="Your Constellation bill is ready",
+            result=_result(_utility_bill_data()),
+            source_att=None,  # email body, no attachment
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email="noreply@constellation.com",
+        )
+
+        assert outcome.records_added == 1
+        assert outcome.skip_reason is None
+
+        txn = (
+            await db.execute(
+                select(Transaction).where(Transaction.organization_id == org_id)
+            )
+        ).scalar_one()
+        assert txn.amount == Decimal("232.84")
+        assert txn.category == "utilities"
+
+    @pytest.mark.asyncio
+    async def test_bill_with_amount_survives_payment_confirmation_tag(
+        self, db: AsyncSession
+    ) -> None:
+        """Even if Claude STILL mis-tags the bill as payment_confirmation, a
+        positive amount + valid date must keep the email from being dropped."""
+        org_id, user_id = await _seed_org_user(db)
+
+        outcome = await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="Auto Pay scheduled",
+            result=_result(
+                _utility_bill_data(document_type="payment_confirmation")
+            ),
+            source_att=None,
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email="noreply@constellation.com",
+        )
+
+        assert outcome.records_added == 1
+        txn = (
+            await db.execute(
+                select(Transaction).where(Transaction.organization_id == org_id)
+            )
+        ).scalar_one()
+        assert txn.amount == Decimal("232.84")
+
+    @pytest.mark.asyncio
+    async def test_utility_bill_is_visible_not_unverified(
+        self, db: AsyncSession
+    ) -> None:
+        """The dashboard sums status=='approved'. A utility bill from a
+        non-trusted sender used to land 'unverified' (hidden). It must now be
+        visible."""
+        org_id, user_id = await _seed_org_user(db)
+
+        await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="Your CenterPoint bill",
+            result=_result(
+                _utility_bill_data(vendor="CenterPoint", sub_category="gas")
+            ),
+            source_att=None,
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email="ebill@centerpointenergy.com",  # NOT a trusted sender
+        )
+
+        txn = (
+            await db.execute(
+                select(Transaction).where(Transaction.organization_id == org_id)
+            )
+        ).scalar_one()
+        assert txn.status == "approved"
+
+
+class TestGenuinePaymentConfirmationStillSkipped:
+    """Do not regress the legitimate payment_confirmation skip."""
+
+    @pytest.mark.asyncio
+    async def test_amountless_payment_confirmation_skipped_with_reason(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = await _seed_org_user(db)
+
+        data: ExtractionData = {
+            "vendor": "Constellation",
+            "amount": None,
+            "date": None,
+            "document_type": "payment_confirmation",
+            "category": "uncategorized",
+            "confidence": "high",
+            "tags": ["uncategorized"],
+            "description": "Thank you for your payment",
+        }
+
+        outcome = await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="Payment received",
+            result=_result(data),
+            source_att=None,
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email="noreply@constellation.com",
+        )
+
+        assert outcome.records_added == 0
+        assert outcome.skip_reason is not None
+        # No transaction was created.
+        rows = (
+            await db.execute(
+                select(Transaction).where(Transaction.organization_id == org_id)
+            )
+        ).scalars().all()
+        assert rows == []
+
+
+class TestP2PStillProtected:
+    """Do not regress the peer-to-peer carve-out."""
+
+    @pytest.mark.asyncio
+    async def test_zelle_payment_still_imports(self, db: AsyncSession) -> None:
+        org_id, user_id = await _seed_org_user(db)
+
+        data: ExtractionData = {
+            "vendor": "Zelle",
+            "payer_name": "Sonu King",
+            "amount": "701.20",
+            "date": "2026-05-03",
+            "document_type": "invoice",
+            "category": "rental_revenue",
+            "transaction_type": "income",
+            "confidence": "high",
+            "tags": ["rental_revenue"],
+        }
+
+        outcome = await save_email_extraction(
+            message_id=f"msg-{uuid.uuid4().hex}",
+            subject="You received money with Zelle",
+            result=_result(data),
+            source_att=None,
+            organization_id=org_id,
+            user_id=user_id,
+            db=db,
+            sender_email="alerts@zellepay.com",
+        )
+
+        assert outcome.records_added == 1

--- a/apps/mybookkeeper/frontend/src/__tests__/EmailQueueSection.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/EmailQueueSection.test.tsx
@@ -183,8 +183,18 @@ describe("EmailQueueSection", () => {
     expect(screen.getByText(errorMsg)).toBeInTheDocument();
   });
 
-  it("non-failed items do not show error text", () => {
-    setupMocks([makeItem({ status: "done", error: "stale error" })]);
+  it("done items show their no-records reason note", () => {
+    // Closes the silent-drop observability gap: an email that synced fine but
+    // produced no transaction (utility payment-confirmation, duplicate) now
+    // explains why on the row.
+    const reason = "Payment confirmation / notification — no amount to record";
+    setupMocks([makeItem({ status: "done", error: reason })]);
+    render(<EmailQueueSection />);
+    expect(screen.getByText(reason)).toBeInTheDocument();
+  });
+
+  it("pending/fetched/extracting items do not show error text", () => {
+    setupMocks([makeItem({ status: "fetched", error: "stale error" })]);
     render(<EmailQueueSection />);
     expect(screen.queryByText("stale error")).not.toBeInTheDocument();
   });

--- a/apps/mybookkeeper/frontend/src/app/features/integrations/QueueItem.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/integrations/QueueItem.tsx
@@ -40,6 +40,11 @@ export default function QueueItem({ item, onRetry, onDismiss }: QueueItemProps) 
         {item.status === "failed" && item.error ? (
           <p className="text-xs text-red-600 mt-0.5 break-all">{item.error}</p>
         ) : null}
+        {item.status === "done" && item.error ? (
+          <p className="text-xs text-muted-foreground mt-0.5 break-all">
+            {item.error}
+          </p>
+        ) : null}
       </div>
       <div className="flex items-center gap-2 shrink-0 ml-3">
         {item.status === "extracting" ? (

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -175,6 +175,7 @@
       ],
       "backend_tests": [
         "test_email_queue_split.py",
+        "test_email_queue_dedup_filter.py",
         "test_email_sync_worker.py",
         "test_gmail_auth_expired.py",
         "test_email_discovery_last_synced.py",
@@ -209,7 +210,9 @@
         "test_prompt_service.py",
         "test_property_matcher.py",
         "test_self_healing.py",
-        "test_trusted_email_senders.py"
+        "test_trusted_email_senders.py",
+        "test_claude_service_prompt.py",
+        "test_utility_bill_silent_drop.py"
       ],
       "frontend_tests": [],
       "e2e_specs": [


### PR DESCRIPTION
## Symptom
Utility-bill notification emails (Constellation, CenterPoint, AT&T, City of Houston Water) were fetched, run through Claude, and produced zero transactions with no error (prod: 324 done / 0 failed, 0 transactions in 7 days) despite carrying real amounts ($232.84, $163.12, $251.64).

## Root cause
The prompt instructed Claude to tag "bill-ready notifications" as document_type=payment_confirmation with amount=null; save_email_extraction then dropped the entire email on that document_type. The carve-out only protected P2P (Zelle/Venmo), not utilities. Exact skip that fired: the batch-level payment-confirmation skip in extraction_persistence.py. Compounding: surviving bills landed status="unverified" (hidden, dashboard filters status=="approved"); 0-doc outcome logged at INFO + marked done with no trace. Latent crash uncovered: payment_confirmation is not an allowed Extraction.document_type (chk_ext_doc_type) — masked by the old always-skip path.

## Fix
Principle: a document with a valid date + positive amount is a real expense and must NEVER be silently dropped.
- Prompt: bill-ready notification stating an amount due is an invoice (utilities), not payment_confirmation; amount-less confirmations still skip.
- Persistence: valid date + positive amount survives the payment-confirmation and low-confidence skips even on mis-tag; non-storable payment_confirmation type normalized to invoice when an amount is present (prevents chk_ext_doc_type crash).
- Visibility: utility-category email-body extractions land status="approved" (default to visible).
- Observability: per-item reason persisted on the email_queue row (new EmailExtractionOutcome) + surfaced in Sync Sessions UI for done items; silent skip logs INFO -> WARNING.

## Tests (same commit)
test_utility_bill_silent_drop.py (reproduces the skip; import + visibility + mis-tag survival + genuine-confirmation-still-skips + P2P), test_claude_service_prompt.py, test_email_queue_dedup_filter.py (mark_done reason), EmailQueueSection.test.tsx. Full backend suite green (3022 passed). Frontend integrations green (59). tsc clean. File-size check passes. 11 pre-existing frontend failures in unrelated domains are present on origin/main baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
