### PR TITLE
fix(infra): stop the shared VPS disk from filling up

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -207,5 +207,19 @@ jobs:
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
 
+            echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"
+            # Registry-pull deploys (registry_images) fetch a fresh SHA-tagged
+            # image from GHCR every time but never remove the prior one, so
+            # orphaned image layers accumulate across ALL apps on this shared
+            # 24GB droplet until the disk fills and the next deploy's "Deploy to
+            # VPS" step fails (observed 2026-06-23 at 99% full). The new
+            # containers are already up and the health check above has passed,
+            # so the in-use image is safe — `image prune -af` only removes
+            # dangling + unreferenced images (never the running one). Run on
+            # every app's deploy; the first one to fire after a fan-out reclaims
+            # the shared layers, the rest are cheap no-ops.
+            docker image prune -af || true
+            docker builder prune -af || true
+
             echo "--- Clean up GHCR credentials ---"
             docker logout ghcr.io || true

--- a/.github/workflows/deploy-mygamingassistant.yml
+++ b/.github/workflows/deploy-mygamingassistant.yml
@@ -218,5 +218,19 @@ jobs:
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
 
+            echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"
+            # Registry-pull deploys (registry_images) fetch a fresh SHA-tagged
+            # image from GHCR every time but never remove the prior one, so
+            # orphaned image layers accumulate across ALL apps on this shared
+            # 24GB droplet until the disk fills and the next deploy's "Deploy to
+            # VPS" step fails (observed 2026-06-23 at 99% full). The new
+            # containers are already up and the health check above has passed,
+            # so the in-use image is safe — `image prune -af` only removes
+            # dangling + unreferenced images (never the running one). Run on
+            # every app's deploy; the first one to fire after a fan-out reclaims
+            # the shared layers, the rest are cheap no-ops.
+            docker image prune -af || true
+            docker builder prune -af || true
+
             echo "--- Clean up GHCR credentials ---"
             docker logout ghcr.io || true

--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -207,5 +207,19 @@ jobs:
               echo "Bundle freshness OK: $DEPLOYED_JS present in caddy"
             fi
 
+            echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"
+            # Registry-pull deploys (registry_images) fetch a fresh SHA-tagged
+            # image from GHCR every time but never remove the prior one, so
+            # orphaned image layers accumulate across ALL apps on this shared
+            # 24GB droplet until the disk fills and the next deploy's "Deploy to
+            # VPS" step fails (observed 2026-06-23 at 99% full). The new
+            # containers are already up and the health check above has passed,
+            # so the in-use image is safe — `image prune -af` only removes
+            # dangling + unreferenced images (never the running one). Run on
+            # every app's deploy; the first one to fire after a fan-out reclaims
+            # the shared layers, the rest are cheap no-ops.
+            docker image prune -af || true
+            docker builder prune -af || true
+
             echo "--- Clean up GHCR credentials ---"
             docker logout ghcr.io || true

--- a/.github/workflows/deploy-mypizzatracker.yml
+++ b/.github/workflows/deploy-mypizzatracker.yml
@@ -187,5 +187,19 @@ jobs:
               echo "Host Caddyfile already up to date"
             fi
 
+            echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"
+            # Registry-pull deploys (registry_images) fetch a fresh SHA-tagged
+            # image from GHCR every time but never remove the prior one, so
+            # orphaned image layers accumulate across ALL apps on this shared
+            # 24GB droplet until the disk fills and the next deploy's "Deploy to
+            # VPS" step fails (observed 2026-06-23 at 99% full). The new
+            # containers are already up and the health check above has passed,
+            # so the in-use image is safe — `image prune -af` only removes
+            # dangling + unreferenced images (never the running one). Run on
+            # every app's deploy; the first one to fire after a fan-out reclaims
+            # the shared layers, the rest are cheap no-ops.
+            docker image prune -af || true
+            docker builder prune -af || true
+
             echo "--- Clean up GHCR credentials ---"
             docker logout ghcr.io || true

--- a/.github/workflows/deploy-myrecipes.yml
+++ b/.github/workflows/deploy-myrecipes.yml
@@ -187,5 +187,19 @@ jobs:
               echo "Host Caddyfile already up to date"
             fi
 
+            echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"
+            # Registry-pull deploys (registry_images) fetch a fresh SHA-tagged
+            # image from GHCR every time but never remove the prior one, so
+            # orphaned image layers accumulate across ALL apps on this shared
+            # 24GB droplet until the disk fills and the next deploy's "Deploy to
+            # VPS" step fails (observed 2026-06-23 at 99% full). The new
+            # containers are already up and the health check above has passed,
+            # so the in-use image is safe — `image prune -af` only removes
+            # dangling + unreferenced images (never the running one). Run on
+            # every app's deploy; the first one to fire after a fan-out reclaims
+            # the shared layers, the rest are cheap no-ops.
+            docker image prune -af || true
+            docker builder prune -af || true
+
             echo "--- Clean up GHCR credentials ---"
             docker logout ghcr.io || true

--- a/infra/harden-vps-disk.sh
+++ b/infra/harden-vps-disk.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+# Idempotent host hardening to stop the shared 24GB droplet from filling up.
+#
+# Usage:
+#   sudo bash infra/harden-vps-disk.sh
+#   sudo bash infra/harden-vps-disk.sh --check   # report drift only, change nothing
+#
+# Two unbounded growth sources filled the disk to 99% on 2026-06-23:
+#   1. Docker container logs — the default json-file driver has NO rotation,
+#      so a chatty container's stdout grows without limit.
+#   2. systemd journald — uncapped, observed at ~2GB.
+#
+# The registry-image accumulation (the third source) is handled separately by
+# the per-deploy `docker image prune` step in the deploy workflow
+# (infra/templates/.github/workflows/deploy.yml.j2). This script handles the
+# two host-daemon configs that a deploy step cannot reach.
+#
+# What this script does (each step is idempotent + a no-op when already set):
+#   1. /etc/docker/daemon.json — set json-file logging with rotation
+#      (max-size 10m, max-file 3). MERGES with any existing keys (notably
+#      `data-root`) instead of clobbering. Restarts dockerd only if changed.
+#   2. /etc/systemd/journald.conf — set SystemMaxUse=200M. Restarts
+#      systemd-journald only if changed.
+#
+# Re-running is safe: if both configs already match, the script makes no
+# change and restarts nothing. Run it on every (re-)provision of a host so a
+# rebuilt droplet inherits the caps automatically.
+#
+# Note on existing containers: the daemon.json log-opts apply to containers
+# CREATED after dockerd restarts. Already-running containers keep their old
+# (uncapped) log config until their next recreate — which the next deploy
+# does anyway (`docker compose up -d` recreates on image change). No manual
+# per-container surgery is required.
+set -euo pipefail
+
+DOCKER_DAEMON_JSON="/etc/docker/daemon.json"
+JOURNALD_CONF="/etc/systemd/journald.conf"
+LOG_MAX_SIZE="10m"
+LOG_MAX_FILE="3"
+JOURNALD_MAX_USE="200M"
+
+CHECK_ONLY=0
+for arg in "$@"; do
+  case "$arg" in
+    --check) CHECK_ONLY=1 ;;
+    -h|--help)
+      sed -n '1,/^set -euo/p' "$0" | sed 's/^# \?//'
+      exit 0
+      ;;
+    *)
+      echo "unknown arg: $arg" >&2
+      echo "usage: sudo bash $0 [--check]" >&2
+      exit 2
+      ;;
+  esac
+done
+
+red()    { printf '\033[31m%s\033[0m\n' "$*"; }
+green()  { printf '\033[32m%s\033[0m\n' "$*"; }
+yellow() { printf '\033[33m%s\033[0m\n' "$*"; }
+blue()   { printf '\033[34m%s\033[0m\n' "$*"; }
+
+if [[ "$CHECK_ONLY" != "1" ]] && [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+  red "Run as root: sudo bash $0"
+  exit 1
+fi
+
+DOCKER_CHANGED=0
+JOURNALD_CHANGED=0
+
+# ──────────────────────────────────────────────────────────────────────────
+# 1. Docker daemon log rotation — merge into existing daemon.json
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 1/2: Docker container-log rotation ($DOCKER_DAEMON_JSON)"
+
+# Desired log-opts as JSON. We MERGE these into whatever already exists so a
+# pre-existing `data-root` (or any other key) is preserved. python3 is present
+# on every Ubuntu host and gives us a real JSON parser (no jq dependency).
+read -r -d '' MERGE_PY <<'PY' || true
+import json, sys
+
+path = sys.argv[1]
+max_size = sys.argv[2]
+max_file = sys.argv[3]
+
+try:
+    with open(path, "r", encoding="utf-8") as f:
+        current = json.load(f)
+    if not isinstance(current, dict):
+        current = {}
+except FileNotFoundError:
+    current = {}
+except json.JSONDecodeError:
+    # Malformed file — do not silently clobber. Surface and bail.
+    sys.stderr.write("MALFORMED")
+    sys.exit(3)
+
+desired = dict(current)
+desired["log-driver"] = "json-file"
+log_opts = dict(desired.get("log-opts", {}))
+log_opts["max-size"] = max_size
+log_opts["max-file"] = max_file
+desired["log-opts"] = log_opts
+
+if desired == current:
+    print("UNCHANGED")
+else:
+    # Emit the merged document on stdout for the caller to write.
+    sys.stdout.write("CHANGED\n")
+    sys.stdout.write(json.dumps(desired, indent=2, sort_keys=True) + "\n")
+PY
+
+DAEMON_OUT="$(python3 -c "$MERGE_PY" "$DOCKER_DAEMON_JSON" "$LOG_MAX_SIZE" "$LOG_MAX_FILE" 2>/dev/null || echo "ERROR")"
+
+if [[ "$DAEMON_OUT" == "ERROR" ]] || [[ "$DAEMON_OUT" == *MALFORMED* ]]; then
+  red "  $DOCKER_DAEMON_JSON is malformed JSON — refusing to overwrite."
+  red "  Fix it by hand, then re-run. Desired keys:"
+  red "    \"log-driver\": \"json-file\", \"log-opts\": {\"max-size\": \"$LOG_MAX_SIZE\", \"max-file\": \"$LOG_MAX_FILE\"}"
+  exit 1
+fi
+
+if [[ "$DAEMON_OUT" == "UNCHANGED" ]]; then
+  green "  already capped (max-size=$LOG_MAX_SIZE, max-file=$LOG_MAX_FILE) — no change"
+else
+  MERGED_JSON="${DAEMON_OUT#CHANGED$'\n'}"
+  if [[ "$CHECK_ONLY" == "1" ]]; then
+    yellow "  [check] would update $DOCKER_DAEMON_JSON to:"
+    echo "$MERGED_JSON" | sed 's/^/      /'
+  else
+    mkdir -p "$(dirname "$DOCKER_DAEMON_JSON")"
+    [[ -f "$DOCKER_DAEMON_JSON" ]] && cp "$DOCKER_DAEMON_JSON" "${DOCKER_DAEMON_JSON}.bak"
+    printf '%s\n' "$MERGED_JSON" > "$DOCKER_DAEMON_JSON"
+    DOCKER_CHANGED=1
+    green "  wrote rotation config (backup at ${DOCKER_DAEMON_JSON}.bak)"
+  fi
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# 2. journald size cap
+# ──────────────────────────────────────────────────────────────────────────
+blue "Step 2/2: journald size cap ($JOURNALD_CONF SystemMaxUse=$JOURNALD_MAX_USE)"
+
+journald_is_capped() {
+  [[ -f "$JOURNALD_CONF" ]] && grep -Eq "^[[:space:]]*SystemMaxUse=${JOURNALD_MAX_USE}[[:space:]]*$" "$JOURNALD_CONF"
+}
+
+if journald_is_capped; then
+  green "  already set (SystemMaxUse=$JOURNALD_MAX_USE) — no change"
+elif [[ "$CHECK_ONLY" == "1" ]]; then
+  yellow "  [check] would set SystemMaxUse=$JOURNALD_MAX_USE in $JOURNALD_CONF"
+else
+  [[ -f "$JOURNALD_CONF" ]] && cp "$JOURNALD_CONF" "${JOURNALD_CONF}.bak"
+  # Remove any existing SystemMaxUse line (commented or not) then append ours.
+  if [[ -f "$JOURNALD_CONF" ]]; then
+    sed -i -E '/^[[:space:]]*#?[[:space:]]*SystemMaxUse=/d' "$JOURNALD_CONF"
+  else
+    printf '[Journal]\n' > "$JOURNALD_CONF"
+  fi
+  # Ensure a [Journal] section header exists.
+  grep -q '^\[Journal\]' "$JOURNALD_CONF" || printf '[Journal]\n' >> "$JOURNALD_CONF"
+  printf 'SystemMaxUse=%s\n' "$JOURNALD_MAX_USE" >> "$JOURNALD_CONF"
+  JOURNALD_CHANGED=1
+  green "  set SystemMaxUse=$JOURNALD_MAX_USE (backup at ${JOURNALD_CONF}.bak)"
+fi
+
+# ──────────────────────────────────────────────────────────────────────────
+# Restart only the daemons whose config actually changed.
+# ──────────────────────────────────────────────────────────────────────────
+if [[ "$CHECK_ONLY" == "1" ]]; then
+  blue "Check-only mode — no daemons restarted."
+  exit 0
+fi
+
+if [[ "$DOCKER_CHANGED" == "1" ]]; then
+  blue "Restarting dockerd to apply log rotation…"
+  systemctl restart docker
+  green "  dockerd restarted"
+fi
+
+if [[ "$JOURNALD_CHANGED" == "1" ]]; then
+  blue "Restarting systemd-journald to apply size cap…"
+  systemctl restart systemd-journald
+  # Vacuum existing journal down to the new cap immediately.
+  journalctl --vacuum-size="$JOURNALD_MAX_USE" >/dev/null 2>&1 || true
+  green "  systemd-journald restarted + vacuumed to $JOURNALD_MAX_USE"
+fi
+
+green ""
+if [[ "$DOCKER_CHANGED" == "0" && "$JOURNALD_CHANGED" == "0" ]]; then
+  green "Nothing to do — host already hardened against disk fill."
+else
+  green "Done. Host disk-fill caps applied."
+fi

--- a/infra/templates/.github/workflows/deploy.yml.j2
+++ b/infra/templates/.github/workflows/deploy.yml.j2
@@ -248,6 +248,20 @@ jobs:
 {%- endif %}
 {%- if registry_images | default(false) %}
 
+            echo "--- Reclaim disk: prune images + build cache superseded by this deploy ---"
+            # Registry-pull deploys (registry_images) fetch a fresh SHA-tagged
+            # image from GHCR every time but never remove the prior one, so
+            # orphaned image layers accumulate across ALL apps on this shared
+            # 24GB droplet until the disk fills and the next deploy's "Deploy to
+            # VPS" step fails (observed 2026-06-23 at 99% full). The new
+            # containers are already up and the health check above has passed,
+            # so the in-use image is safe — `image prune -af` only removes
+            # dangling + unreferenced images (never the running one). Run on
+            # every app's deploy; the first one to fire after a fan-out reclaims
+            # the shared layers, the rest are cheap no-ops.
+            docker image prune -af || true
+            docker builder prune -af || true
+
             echo "--- Clean up GHCR credentials ---"
             docker logout ghcr.io || true
 {%- endif %}

--- a/packages/shared-backend/tests/test_app_conformance.py
+++ b/packages/shared-backend/tests/test_app_conformance.py
@@ -399,6 +399,34 @@ class TestTurnstileBundleWiring:
                 f"pull` the prebuilt images on the VPS instead of building "
                 f"them. Re-render from the template."
             )
+            # Registry-pull deploys fetch a fresh SHA-tagged image every time
+            # but never remove the prior one, so orphaned layers accumulate
+            # across all apps on the shared droplet until the disk fills (the
+            # next deploy's SSH step then fails). The per-deploy prune reclaims
+            # them AFTER the health check passes (the in-use image is safe).
+            # This assertion fails if the prune step is ever dropped from the
+            # template — re-render from deploy.yml.j2.
+            assert "docker image prune -af" in workflow_src, (
+                f"deploy-{app}.yml registry path must run `docker image prune "
+                f"-af` after the health check so superseded GHCR image layers "
+                f"are reclaimed instead of accumulating until the shared "
+                f"droplet fills. Re-render from the template."
+            )
+            assert "docker builder prune -af" in workflow_src, (
+                f"deploy-{app}.yml registry path must run `docker builder prune "
+                f"-af` to reclaim build cache alongside the image prune. "
+                f"Re-render from the template."
+            )
+            # The prune must come AFTER the health check, never before — pruning
+            # before the new containers are confirmed healthy could remove the
+            # only good image on a failed roll-forward.
+            assert workflow_src.index("API is healthy") < workflow_src.index(
+                "docker image prune -af"
+            ), (
+                f"deploy-{app}.yml: the image prune must run AFTER the "
+                f"`API is healthy` check, so the in-use image is never removed "
+                f"on a failed deploy. Re-render from the template."
+            )
             return
         # Match a `docker compose ... --env-file ...backend/.env.docker ... build`
         # invocation, allowing shell line-continuations (backslash + newline)


### PR DESCRIPTION
## Symptom

The production droplet (single 24GB DigitalOcean droplet hosting all MyFreeApps apps) filled to **99%** and `deploy-mybookkeeper`'s **"Deploy to VPS"** step failed. A one-time `docker system prune -af` + journal vacuum freed ~12GB (99% → 44%), but nothing prevented recurrence.

## Root cause — three unbounded growth sources

1. **Orphaned GHCR image layers.** Since the registry-pull deploy model (#899), every deploy pulls a fresh SHA-tagged image from GHCR but never removes the prior one. Layers accumulate across **all** apps until the disk fills.
2. **Uncapped Docker container logs.** Docker's default `json-file` driver has **no rotation** — a chatty container's stdout grows without limit.
3. **Uncapped journald** — observed at ~2GB.

## Fix

### 1. Auto-prune on every deploy (automatic from the next deploy onward)

Added to the shared deploy template `infra/templates/.github/workflows/deploy.yml.j2` (a **Tier-2 operational template** per `rules/monorepo-parity-discipline.md`) and re-rendered to all 5 `deploy-*.yml` via `python -m platform_shared.infra.render --all`:

```bash
docker image prune -af || true
docker builder prune -af || true
```

Placed **AFTER** the new containers are up and the **API health check passes** (and after the Caddyfile sync), gated on `registry_images` — so the in-use image is never removed, even on a failed roll-forward. The first app's deploy after a `packages/**` fan-out reclaims the shared layers; the rest are cheap no-ops.

### 2. Host daemon caps (idempotent provisioning script)

New `infra/harden-vps-disk.sh` — root-gated, idempotent, `--check` dry-run mode, matches the house style of the other `infra/*.sh` operational scripts:

- **`/etc/docker/daemon.json`** → `{"log-driver":"json-file","log-opts":{"max-size":"10m","max-file":"3"}}`, **merged** with any existing keys (notably `data-root`) via a real JSON parser — never clobbered. Refuses to overwrite malformed JSON (fails loud).
- **`/etc/systemd/journald.conf`** → `SystemMaxUse=200M`.
- Restarts **only** the daemon whose config actually changed; re-running is a no-op.

Run it on every (re-)provision so a rebuilt host inherits the caps automatically.

## Regression test

`TestDeployWorkflowBuildArgs` gains three assertions (× 5 registry apps) that every workflow runs `docker image prune -af` + `docker builder prune -af` **AFTER** the `API is healthy` check — so the prune step can never silently drop out of the template again. The embedded `daemon.json` merge logic was unit-validated for: missing file, existing-`data-root` (preserved), already-correct (no-op), and malformed (refuse).

## ⚠️ Operational migration required

The per-deploy prune is **automatic** from the next deploy. But the **existing VPS will not pick up the daemon.json / journald.conf caps automatically** — they are host-daemon configs a deploy step can't reach. The operator must run the one-time steps below (or run `infra/harden-vps-disk.sh` once after this merges, which does all of it idempotently).

### Option A — run the script (recommended)

```bash
cd /srv/myfreeapps && git pull --ff-only
sudo bash infra/harden-vps-disk.sh
```

### Option B — manual equivalent

```bash
# 1. Docker log rotation — MERGE with the existing daemon.json (preserve data-root).
sudo cat /etc/docker/daemon.json   # note any existing keys (e.g. "data-root")
sudoedit /etc/docker/daemon.json   # add: "log-driver": "json-file",
                                   #      "log-opts": {"max-size": "10m", "max-file": "3"}
sudo systemctl restart docker

# 2. journald cap.
sudoedit /etc/systemd/journald.conf   # set: SystemMaxUse=200M
sudo systemctl restart systemd-journald
sudo journalctl --vacuum-size=200M    # reclaim the existing ~2GB immediately
```

### How to verify

```bash
# Docker log rotation is live (data-root, if any, still present):
docker info --format '{{.LoggingDriver}}'                       # -> json-file
cat /etc/docker/daemon.json                                     # log-opts present, data-root intact

# journald cap is live:
grep -E '^SystemMaxUse=' /etc/systemd/journald.conf             # -> SystemMaxUse=200M
journalctl --disk-usage                                         # -> at or under 200M

# Prune step ran on the next deploy:
df -h /                                                          # disk no longer climbing per-deploy
```

### How to recover if disk is already full again before this merges

```bash
docker system prune -af          # remove all unused images/containers/networks
docker builder prune -af         # remove build cache
sudo journalctl --vacuum-size=200M
df -h /
```

### Rollback path

This PR is additive and safe to revert: the prune step only removes **unused** images (the running app keeps working), and the host caps are independent of the app. Reverting restores the previous (recurrence-prone) behavior without breaking any running service. `daemon.json` and `journald.conf` backups are written to `*.bak` by the script.

## Note on existing containers

`daemon.json` log-opts apply to containers **created after** dockerd restarts. Already-running containers keep their old (uncapped) log config until their next recreate — which the next `docker compose up -d` (on image change) does anyway. No per-container surgery needed.

## Files changed

- `infra/templates/.github/workflows/deploy.yml.j2` — prune step in the shared template
- `.github/workflows/deploy-{mybookkeeper,mygamingassistant,myjobhunter,mypizzatracker,myrecipes}.yml` — re-rendered output (drift-checked clean)
- `infra/harden-vps-disk.sh` — new idempotent host-hardening provisioning script
- `packages/shared-backend/tests/test_app_conformance.py` — prune-step regression assertions

## Validation

- `render --all --check` → exit 0 (no drift)
- All 5 workflows parse as valid YAML
- Conformance suite: 20 passed (drift + deploy + registry classes)
- `daemon.json` merge logic unit-validated (create / merge-preserve-data-root / unchanged / malformed)
- `bash -n` clean on the new script; `check-file-size.py` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)