### PR TITLE
fix(mbk): discover utility bill-ready / bill-due notification emails

### DIFF
--- a/apps/mybookkeeper/backend/app/core/config.py
+++ b/apps/mybookkeeper/backend/app/core/config.py
@@ -45,6 +45,12 @@ class Settings(BaseAppSettings):
     #   - Airbnb host payouts (subject:payout)
     #   - Peer-to-peer rent payments (Zelle/Venmo/Cash App/PayPal/Apple Pay)
     #     across multiple banks (Chase, BoA, Wells, Citi, Capital One, etc.)
+    #   - Utility "bill is ready / due" notifications (water/electric/gas)
+    #     whose amount lives in the email BODY, not an attachment or a
+    #     statement-subject (City of Houston Water, AT&T, Constellation,
+    #     CenterPoint). These never matched the document-extractor clauses,
+    #     so the bills were silently never fetched even though extraction
+    #     handles them once discovered.
     gmail_search_query: str = (
         # --- Document-extractor patterns ------------------------------------
         "subject:invoice OR subject:receipt OR subject:payment OR subject:payout OR "
@@ -80,7 +86,26 @@ class Settings(BaseAppSettings):
         # notifications, NOT marketing copy.
         "\"sent you money with zelle\" OR \"with zelle®\" OR "
         "\"received money with zelle\" OR \"venmo payment received\" OR "
-        "\"you received\" OR \"sent you money\""
+        "\"you received\" OR \"sent you money\" OR "
+        # --- Utility bill-ready / due notifications -------------------------
+        # Utility providers email a "your bill is ready / your bill is due"
+        # notification carrying the amount in the BODY (e.g. City of Houston
+        # Water "Total Balance: 61.82", AT&T, Constellation, CenterPoint).
+        # They rarely carry invoice/statement/billing in the subject and never
+        # an attachment, so NONE of the document-extractor clauses above match
+        # and the bills were silently never fetched. The subject phrases are
+        # scoped to bill-ready wording — a bare ``subject:bill`` is avoided
+        # because it also matches "billing address", marketing, etc. The
+        # senders are the known utility notification domains (houstontx.gov +
+        # its tmr3.com billing vendor for City of Houston Water, AT&T's
+        # att-mail.com edges, constellation.com), so a body/subject phrasing
+        # change at the provider still gets the email discovered.
+        "subject:\"bill is ready\" OR subject:\"bill is due\" OR "
+        "subject:\"bill is now\" OR subject:\"bill is available\" OR "
+        "subject:\"water bill\" OR "
+        "from:houstontx.gov OR from:emailff.att-mail.com OR "
+        "from:emaildl.att-mail.com OR from:tmr3.com OR "
+        "from:constellation.com"
     )
     gmail_label: str = ""
 

--- a/apps/mybookkeeper/backend/tests/test_gmail_search_query.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_search_query.py
@@ -1,0 +1,71 @@
+"""Tests for ``settings.gmail_search_query`` — the Gmail discovery filter.
+
+Anything that doesn't match this query at API-list time is never fetched, so
+the query defines the full universe of mail MBK can react to. Utility "bill is
+ready / bill is due" notifications (City of Houston Water, AT&T, Constellation,
+CenterPoint) carry the amount in the email BODY rather than an attachment or a
+statement-subject, so none of the document-extractor clauses matched them and
+the bills were silently never discovered. These tests pin the targeted
+utility-notification clauses (and guard the pre-existing clauses against
+accidental removal) so a future edit can't regress discovery.
+
+The extraction side that turns a discovered bill into a transaction is covered
+by ``test_utility_bill_silent_drop.py`` / ``test_claude_service_prompt.py``;
+this file is purely about discovery.
+"""
+from app.core.config import settings
+
+
+class TestUtilityBillSubjectClauses:
+    """The bill-ready / bill-due subject phrases must be in the query."""
+
+    def test_bill_ready_phrases_present(self) -> None:
+        query = settings.gmail_search_query
+        for phrase in (
+            'subject:"bill is ready"',
+            'subject:"bill is due"',
+            'subject:"bill is now"',
+            'subject:"bill is available"',
+            'subject:"water bill"',
+        ):
+            assert phrase in query, f"missing utility subject clause: {phrase}"
+
+    def test_no_bare_subject_bill_clause(self) -> None:
+        """A bare ``subject:bill`` would be far too noisy (matches "billing
+        address", marketing, etc.) — the utility clauses must stay scoped to
+        quoted bill-ready phrases. ``subject:billing`` (no trailing space)
+        is the pre-existing document-extractor clause and is allowed."""
+        assert "subject:bill " not in settings.gmail_search_query
+
+
+class TestUtilityBillSenderClauses:
+    """The known utility notification sender domains must be in the query."""
+
+    def test_utility_sender_domains_present(self) -> None:
+        query = settings.gmail_search_query
+        for sender in (
+            "from:houstontx.gov",
+            "from:emailff.att-mail.com",
+            "from:emaildl.att-mail.com",
+            "from:tmr3.com",
+            "from:constellation.com",
+        ):
+            assert sender in query, f"missing utility sender clause: {sender}"
+
+
+class TestExistingClausesPreserved:
+    """The change is additive — pre-existing clauses must not be dropped."""
+
+    def test_document_extractor_clauses_preserved(self) -> None:
+        query = settings.gmail_search_query
+        for clause in ("subject:invoice", "subject:statement", "has:attachment"):
+            assert clause in query, f"regressed document-extractor clause: {clause}"
+
+    def test_p2p_payment_clauses_preserved(self) -> None:
+        query = settings.gmail_search_query
+        for clause in (
+            "from:zellepay.com",
+            "from:venmo.com",
+            '"received money with zelle"',
+        ):
+            assert clause in query, f"regressed P2P clause: {clause}"

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -178,6 +178,7 @@
         "test_email_queue_dedup_filter.py",
         "test_email_sync_worker.py",
         "test_gmail_auth_expired.py",
+        "test_gmail_search_query.py",
         "test_email_discovery_last_synced.py",
         "test_gmail_skipped_messages.py",
         "test_silent_fail_audit_fixes.py",


### PR DESCRIPTION
## Problem

The Gmail discovery query (`settings.gmail_search_query`) never matched utility
**"bill is ready / bill is due"** notification emails — so AT&T and City of
Houston Water bills were **never ingested**, even though the amount is present
in the email body (e.g. Houston Water `Total Balance: 61.82`).

These notifications slip through every existing clause: they rarely carry
`invoice` / `statement` / `billing` in the subject, and they never carry an
attachment, so none of the document-extractor clauses fetch them. This is
purely a **discovery** gap — the extraction side already handles these bills
correctly (Constellation / CenterPoint import fine post-#918).

## Change

Broaden `gmail_search_query` with targeted, additive clauses (all existing
clauses preserved):

- **Subjects** (scoped, no noisy bare `subject:bill`):
  `subject:"bill is ready"`, `subject:"bill is due"`, `subject:"bill is now"`,
  `subject:"bill is available"`, `subject:"water bill"`
- **Senders**: `from:houstontx.gov`, `from:emailff.att-mail.com`,
  `from:emaildl.att-mail.com`, `from:tmr3.com` (City of Houston Water's billing
  vendor), `from:constellation.com`

Adds `tests/test_gmail_search_query.py` pinning the new phrases/senders and
guarding the pre-existing clauses against accidental removal, and registers it
in the `email` domain of `scripts/test-map.json`.

## Rollout

**Additive — no operational migration required.** After this deploys, the
already-forwarded AT&T / Houston Water emails will be discovered and imported
on the **next Gmail sync**; nothing needs to be re-sent.

## Validation

- `tests/test_gmail_search_query.py` — 5 passed
- shared-backend conformance suite — 150 passed, 5 skipped
- file-size check — clean
- `config.py` imports cleanly (the query is a valid Gmail search string)

## Out-of-scope follow-ups (not addressed here)

These are pre-existing extraction/classification behaviours surfaced by
unblocking discovery — flagged for a separate PR:

1. **Utility bills sometimes land `needs_review` instead of `approved`** — the
   amount-in-body bill-ready shape can land in the review queue rather than
   auto-approving.
2. **`transaction_date` uses the due date, not the statement month** — for
   these notifications the extracted date reflects when payment is due rather
   than the billing period the charge belongs to.
