### PR TITLE
feat(mbk): tie utility bills to a property via a learned account number

### DIFF
--- a/apps/mybookkeeper/backend/alembic/versions/utillink260624_add_utility_account_links.py
+++ b/apps/mybookkeeper/backend/alembic/versions/utillink260624_add_utility_account_links.py
@@ -1,0 +1,90 @@
+"""add utility_account_link — learned utility account -> property
+
+Revision ID: utillink260624
+Revises: attrverify260602
+Create Date: 2026-06-24
+
+Ties utility "bill is ready / due" notification emails (AT&T, City of Houston
+Water, CenterPoint, etc.) to a property via a learned map keyed on
+``(sender_domain, account_number)`` — these notifications carry an account
+number + amount but NO service address, so the address matcher can't resolve
+them. The link is learned the first time the bill IS resolvable (explicit pick
+or an address-matched bill that also exposes the account number).
+
+Conventions (mirrors payer_alias):
+- ``source`` is String(20) + CheckConstraint (never SQLAlchemy Enum).
+- Tenant isolation via ``organization_id`` (+ ``user_id``), both ON DELETE
+  CASCADE; ``property_id`` CASCADE so a deleted property's links go with it.
+- UUID PK (python ``uuid.uuid4`` default — no server_default on the PK);
+  created_at/updated_at carry a server default per the timestamp convention.
+- ``account_number`` is PLAINTEXT String(100) — equality lookup needs a
+  deterministic value, which rules out EncryptedString.
+- Unique on (organization_id, sender_domain, account_number).
+- Explicit indexes on property_id + user_id (Postgres does not auto-index FKs;
+  needed for CASCADE delete and reverse list-by-property lookups). The unique
+  constraint's leftmost (organization_id) column serves org-scoped scans.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+revision: str = "utillink260624"
+down_revision: Union[str, None] = "attrverify260602"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "utility_account_link",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("organization_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("property_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("sender_domain", sa.String(length=255), nullable=False),
+        sa.Column("account_number", sa.String(length=100), nullable=False),
+        sa.Column("provider_label", sa.String(length=100), nullable=True),
+        sa.Column("source", sa.String(length=20), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.ForeignKeyConstraint(["organization_id"], ["organizations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["property_id"], ["properties.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "organization_id", "sender_domain", "account_number",
+            name="uq_utility_account_link",
+        ),
+        sa.CheckConstraint(
+            "source IN ('auto_learn', 'manual_link')",
+            name="chk_utility_account_link_source",
+        ),
+    )
+    op.create_index(
+        "ix_utility_account_link_organization_id",
+        "utility_account_link",
+        ["organization_id"],
+    )
+    op.create_index(
+        "ix_utility_link_property_id", "utility_account_link", ["property_id"]
+    )
+    op.create_index(
+        "ix_utility_link_user_id", "utility_account_link", ["user_id"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_utility_link_user_id", table_name="utility_account_link")
+    op.drop_index("ix_utility_link_property_id", table_name="utility_account_link")
+    op.drop_index(
+        "ix_utility_account_link_organization_id",
+        table_name="utility_account_link",
+    )
+    op.drop_table("utility_account_link")

--- a/apps/mybookkeeper/backend/app/core/audit.py
+++ b/apps/mybookkeeper/backend/app/core/audit.py
@@ -83,6 +83,11 @@ MBK_SENSITIVE_FIELDS: frozenset[str] = frozenset({
     # contact info, so mask them in audit_logs to be safe.
     "client_ip",
     "user_agent",
+    # Utility-account-link account number — a provider account identifier,
+    # stored plaintext on utility_account_link for equality lookup. PII-adjacent
+    # (already in core/pii.py PII_FIELD_IDS for frontend masking); mask it in
+    # audit_logs too so the plaintext never lands there.
+    "account_number",
 })
 
 # MBK skip-tables — high-volume / secret-bearing tables we don't audit.

--- a/apps/mybookkeeper/backend/app/core/utility_account_constants.py
+++ b/apps/mybookkeeper/backend/app/core/utility_account_constants.py
@@ -1,0 +1,19 @@
+"""Utility-account-link constants.
+
+``PROVIDER_LABELS`` maps a learned ``sender_domain`` (registrable domain,
+sub-mailer-collapsed) to a human-readable provider name stored on the
+``utility_account_link`` row for display. A domain not in this map yields a
+null ``provider_label`` — the link still works (the lookup key is the domain +
+account number), it just lacks a friendly name until the map is extended.
+
+Validated against real notification senders:
+  - AT&T:                  update@emailff.att-mail.com, update@emaildl.att-mail.com
+  - CenterPoint:           centerpoint.energy@tmr3.com
+  - City of Houston Water: cityofhoustonwaterbill@houstontx.gov
+"""
+
+PROVIDER_LABELS: dict[str, str] = {
+    "att-mail.com": "AT&T",
+    "tmr3.com": "CenterPoint",
+    "houstontx.gov": "City of Houston Water",
+}

--- a/apps/mybookkeeper/backend/app/models/__init__.py
+++ b/apps/mybookkeeper/backend/app/models/__init__.py
@@ -9,6 +9,7 @@ from app.models.properties.property import Property, PropertyType
 from app.models.properties.activity_period import ActivityPeriod
 from app.models.properties.tenant import Tenant
 from app.models.properties.lease import Lease, LeaseStatus
+from app.models.properties.utility_account_link import UtilityAccountLink
 from app.models.listings.listing import Listing
 from app.models.listings.listing_photo import ListingPhoto
 from app.models.listings.listing_external_id import ListingExternalId

--- a/apps/mybookkeeper/backend/app/models/extraction/extraction_types.py
+++ b/apps/mybookkeeper/backend/app/models/extraction/extraction_types.py
@@ -13,6 +13,7 @@ class ExtractionData(TypedDict, total=False):
     tax_relevant: bool
     channel: str
     address: str
+    account_number: str | None
     line_items: list[dict[str, str]]
     document_type: str
     category: str

--- a/apps/mybookkeeper/backend/app/models/properties/utility_account_link.py
+++ b/apps/mybookkeeper/backend/app/models/properties/utility_account_link.py
@@ -1,0 +1,100 @@
+"""ORM model for ``utility_account_link`` — learned utility account → property.
+
+Utility "bill is ready / due" notification emails (AT&T, City of Houston Water,
+CenterPoint, etc.) carry an ACCOUNT NUMBER and an AMOUNT but NO service
+address, so the address matcher in ``property_matcher_service`` cannot tie them
+to a property. This table remembers the mapping the first time it CAN be
+resolved — from an explicit property pick, or from an address-matched bill that
+also exposes the account number — keyed on ``(sender_domain, account_number)``.
+Future thin notifications from the same provider account then resolve to the
+right property without an address.
+
+The link is keyed on ``(organization_id, sender_domain, account_number)``:
+
+  - ``sender_domain`` is the registrable domain of the From address, lowercased
+    and collapsed past provider sub-mailers (``emailff.att-mail.com`` and
+    ``emaildl.att-mail.com`` both → ``att-mail.com``) so a single provider maps
+    to a single key regardless of which mailer host sent the notification.
+  - ``account_number`` is stored in PLAINTEXT (not ``EncryptedString``) — the
+    lookup is an equality match, and Fernet ciphertext is non-deterministic, so
+    an encrypted column would never match on read. It is normalized (upper,
+    spaces/dashes/dots stripped) identically on learn-write and lookup.
+
+``source`` records how the link was learned: ``auto_learn`` (derived during
+extraction when an address-matched or explicitly-picked bill exposed an account
+number) or ``manual_link`` (a future UI where the host picks the property
+directly). A ``manual_link`` row is authoritative and is never clobbered by a
+later ``auto_learn`` write — that rule lives in
+``utility_account_service.learn_account_link``.
+"""
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class UtilityAccountLink(Base):
+    __tablename__ = "utility_account_link"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    organization_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="CASCADE"), nullable=False, index=True)
+    # user_id is indexed via the explicit ``ix_utility_link_user_id`` in
+    # __table_args__ (FK CASCADE perf), not a column-level index, to avoid two
+    # indexes on the same column.
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+
+    # The property this provider account bills for. CASCADE: a deleted property's
+    # account links are meaningless, so they go with it.
+    property_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("properties.id", ondelete="CASCADE"), nullable=False)
+
+    # The provider's registrable domain, lowercased + sub-mailer-collapsed (e.g.
+    # "att-mail.com"). Part of the lookup key alongside account_number.
+    sender_domain: Mapped[str] = mapped_column(String(255), nullable=False)
+    # The provider account number, normalized (upper, spaces/dashes/dots
+    # stripped). PLAINTEXT — equality lookup needs a deterministic value, which
+    # rules out EncryptedString (its ciphertext is non-deterministic).
+    account_number: Mapped[str] = mapped_column(String(100), nullable=False)
+
+    # Human-readable provider name ("AT&T", "CenterPoint", "City of Houston
+    # Water") filled from a known-domain map; null for an unrecognized domain.
+    provider_label: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    # How the link was learned: "auto_learn" (derived during extraction) or
+    # "manual_link" (host picked the property). manual_link is authoritative.
+    source: Mapped[str] = mapped_column(String(20), nullable=False)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        # One row per (org, provider domain, account). Re-learning the SAME
+        # account for the SAME property touches the existing row; re-learning it
+        # for a DIFFERENT property updates property_id (the account moved).
+        UniqueConstraint(
+            "organization_id",
+            "sender_domain",
+            "account_number",
+            name="uq_utility_account_link",
+        ),
+        CheckConstraint(
+            "source IN ('auto_learn', 'manual_link')",
+            name="chk_utility_account_link_source",
+        ),
+        # Postgres does not auto-index FKs; index property_id and user_id for the
+        # CASCADE delete and reverse (list-by-property) lookups.
+        Index("ix_utility_link_property_id", "property_id"),
+        Index("ix_utility_link_user_id", "user_id"),
+    )
+
+    property = relationship("Property", lazy="noload")

--- a/apps/mybookkeeper/backend/app/repositories/__init__.py
+++ b/apps/mybookkeeper/backend/app/repositories/__init__.py
@@ -32,6 +32,7 @@ from app.repositories.organization import taxpayer_profile_repo
 from app.repositories.properties import property_repo
 from app.repositories.properties import tenant_repo
 from app.repositories.properties import lease_repo
+from app.repositories.properties import utility_account_link_repo
 from app.repositories.listings import listing_repo
 from app.repositories.listings import listing_photo_repo
 from app.repositories.listings import listing_external_id_repo

--- a/apps/mybookkeeper/backend/app/repositories/properties/utility_account_link_repo.py
+++ b/apps/mybookkeeper/backend/app/repositories/properties/utility_account_link_repo.py
@@ -1,0 +1,111 @@
+"""Repository for ``utility_account_link`` — learned utility account -> property.
+
+All queries filter by ``organization_id`` for tenant isolation. The lookup key
+is the unique triple ``(organization_id, sender_domain, account_number)``;
+``sender_domain`` and ``account_number`` are normalized by the service
+(``utility_account_service``) BEFORE they reach this layer, so a learn-write and
+a lookup compare the same key.
+
+Upsert strategy: select-then-insert/update (mirrors ``payer_alias_repo.upsert``)
+rather than a Postgres-only ``on_conflict_do_update``. This keeps the repo a
+straightforward, single upsert that behaves identically on SQLite (tests) and
+PostgreSQL (prod), and lets the "manual_link is authoritative" rule live cleanly
+in the service (which decides whether to call this at all) instead of leaking a
+conditional ``WHERE`` into a dialect-specific ``DO UPDATE``.
+"""
+import uuid
+from collections.abc import Sequence
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.properties.utility_account_link import UtilityAccountLink
+
+
+async def get_by_account(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    sender_domain: str,
+    account_number: str,
+) -> UtilityAccountLink | None:
+    """Return the link for (org, sender_domain, account_number), or None.
+
+    Selects on the unique triple. Callers pass already-normalized values — the
+    service applies the same normalization on learn-write and lookup so the
+    equality match holds.
+    """
+    result = await db.execute(
+        select(UtilityAccountLink).where(
+            UtilityAccountLink.organization_id == organization_id,
+            UtilityAccountLink.sender_domain == sender_domain,
+            UtilityAccountLink.account_number == account_number,
+        )
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_link(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    sender_domain: str,
+    account_number: str,
+    property_id: uuid.UUID,
+    source: str,
+    provider_label: str | None = None,
+) -> UtilityAccountLink:
+    """Insert a link, or update the existing row for the unique triple.
+
+    Re-learning the SAME account for the SAME property touches the existing row
+    (and refreshes ``source`` / ``provider_label``); re-learning it for a
+    DIFFERENT property updates ``property_id`` (the account moved to a new
+    property). The "don't clobber a manual_link with an auto_learn" rule is
+    enforced in the service before this is called.
+    """
+    existing = await get_by_account(
+        db,
+        organization_id=organization_id,
+        sender_domain=sender_domain,
+        account_number=account_number,
+    )
+    if existing is not None:
+        existing.property_id = property_id
+        existing.source = source
+        if provider_label is not None:
+            existing.provider_label = provider_label
+        await db.flush()
+        return existing
+
+    row = UtilityAccountLink(
+        organization_id=organization_id,
+        user_id=user_id,
+        property_id=property_id,
+        sender_domain=sender_domain,
+        account_number=account_number,
+        provider_label=provider_label,
+        source=source,
+    )
+    db.add(row)
+    await db.flush()
+    return row
+
+
+async def list_by_property(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    property_id: uuid.UUID,
+) -> Sequence[UtilityAccountLink]:
+    """Return every learned account link for a property in this org.
+
+    Supports a future UI that lists the utility accounts tied to a property.
+    """
+    result = await db.execute(
+        select(UtilityAccountLink).where(
+            UtilityAccountLink.organization_id == organization_id,
+            UtilityAccountLink.property_id == property_id,
+        )
+    )
+    return result.scalars().all()

--- a/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/extraction_persistence.py
@@ -26,6 +26,7 @@ from app.mappers.booking_statement_mapper import build_booking_statement_from_li
 from app.mappers.transaction_mapper import build_transaction_from_extraction_data
 from app.services.extraction.property_matcher_service import resolve_property_id
 from app.services.extraction.sender_category_service import match_sender_category
+from app.services.extraction.utility_account_service import sender_domain_from_email
 from app.services.classification.rule_engine import classify
 from app.services.transactions.attribution_service import maybe_attribute_payment
 
@@ -134,6 +135,8 @@ async def save_email_extraction(
         property_id = await resolve_property_id(
             data.get("address"), None, organization_id, db,
             user_id=user_id, tags=doc_tags,
+            account_number=data.get("account_number"),
+            sender_domain=sender_domain_from_email(sender_email),
         )
 
         vendor = data.get("vendor")

--- a/apps/mybookkeeper/backend/app/services/extraction/prompts/base_prompt.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/prompts/base_prompt.py
@@ -25,6 +25,7 @@ Always return this structure (documents is always an array, even for a single re
       "tax_relevant": true or false,
       "channel": "airbnb | vrbo | booking.com | direct | null",
       "address": "property street address or null",
+      "account_number": "utility/service/insurance account number as shown, or null",
       "confidence": "high | medium | low",
       "line_items": null
     }
@@ -231,6 +232,7 @@ When the document is a tax source form (W-2, any 1099, 1098, or K-1), use the sp
       "tax_relevant": true,
       "channel": null,
       "address": null,
+      "account_number": null,
       "confidence": "high",
       "line_items": null,
       "tax_form_data": {
@@ -288,6 +290,7 @@ For lease, tax_form, contract, other:
 - payer_handle: the sender's STABLE account identifier when the notification exposes one, used to tell apart two different people who share a name. Extract ONLY a value actually shown — Zelle: the sender's email or phone (e.g. "jdoe@gmail.com" or "+1 555-123-4567"); Venmo: the @username (e.g. "@john-doe"); Cash App: the $cashtag (e.g. "$johndoe"); PayPal: the sender's email. Do NOT invent or infer a handle from the name. Most Zelle bank deposit alerts show only a name — set payer_handle to null in that case. Always null for platform payouts and non-payment documents.
 - vendor: single company name, never combine with "/" or "and". Use the company that issued the bill. For utilities, use the retail provider (e.g. "Constellation" not "Constellation / CenterPoint").
 - address: physical property street address, NOT the vendor's address
+- account_number: for utility, telecom, insurance, property-tax, and other account-based recurring bills, extract the account number / account ID EXACTLY as shown — preserve dashes, spaces, and leading zeros; do NOT normalize, reformat, or strip them. Capture a masked form verbatim ("Account ending in 1234", "Acct: ****5678") and NEVER invent or fill in hidden digits. If multiple account numbers appear, prefer the primary billed account; if you cannot tell, join them with " | ". Do NOT use an invoice number, statement number, meter number, confirmation number, or reference number as the account_number. Set account_number to null for documents that don't have a provider account (plumbers and other one-off contractors, peer-to-peer payments, PM statements).
 - tax_relevant: true for business expenses and taxable income
 - confidence: "low" if amount or date is missing/unclear, "medium" if partially uncertain, "high" if all fields are clear
 
@@ -299,33 +302,37 @@ For utility bills (electric, gas, water, internet), insurance policies, and prop
 - Many bills show both a mailing address and a service address — always use the service address
 - If only one address appears, use it
 - If multiple addresses appear and you cannot determine which is the service address, return all addresses in the "address" field separated by " | " so the system can match against known properties
+- Many notification emails (AT&T, CenterPoint, City of Houston Water) show an account number but NO service address at all. In that case set "address" to null and put the value in "account_number" — the system ties the bill to a property by the learned account number instead of by address.
 
 # Examples
 
 Invoice from a plumber:
-{"documents": [{"document_type": "invoice", "date": "2025-09-15", "vendor": "ABC Plumbing", "amount": "425.00", "description": "Water heater replacement at 6738 Peerless St", "transaction_type": "expense", "category": "contract_work", "payment_method": null, "tags": ["contract_work"], "tax_relevant": true, "channel": null, "address": "6738 Peerless St Houston TX", "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "invoice", "date": "2025-09-15", "vendor": "ABC Plumbing", "amount": "425.00", "description": "Water heater replacement at 6738 Peerless St", "transaction_type": "expense", "category": "contract_work", "payment_method": null, "tags": ["contract_work"], "tax_relevant": true, "channel": null, "address": "6738 Peerless St Houston TX", "account_number": null, "confidence": "high", "line_items": null}]}
 
 Monthly electric bill:
-{"documents": [{"document_type": "invoice", "date": "2025-08-01", "vendor": "Constellation", "amount": "187.54", "description": "Electricity Aug 2025", "transaction_type": "expense", "category": "utilities", "sub_category": "electricity", "payment_method": null, "tags": ["utilities"], "tax_relevant": true, "channel": null, "address": "6732 Peerless St Houston TX", "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "invoice", "date": "2025-08-01", "vendor": "Constellation", "amount": "187.54", "description": "Electricity Aug 2025", "transaction_type": "expense", "category": "utilities", "sub_category": "electricity", "payment_method": null, "tags": ["utilities"], "tax_relevant": true, "channel": null, "address": "6732 Peerless St Houston TX", "account_number": "1234567890", "confidence": "high", "line_items": null}]}
 
 Bill-ready email notification that shows an amount due ("Your Constellation bill is ready. Auto Pay of $232.84 is scheduled for Jun 18."):
-{"documents": [{"document_type": "invoice", "date": "2026-06-18", "vendor": "Constellation", "amount": "232.84", "description": "Electricity bill — Auto Pay scheduled", "transaction_type": "expense", "category": "utilities", "sub_category": "electricity", "payment_method": "bank_transfer", "tags": ["utilities"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "invoice", "date": "2026-06-18", "vendor": "Constellation", "amount": "232.84", "description": "Electricity bill — Auto Pay scheduled", "transaction_type": "expense", "category": "utilities", "sub_category": "electricity", "payment_method": "bank_transfer", "tags": ["utilities"], "tax_relevant": true, "channel": null, "address": null, "account_number": null, "confidence": "high", "line_items": null}]}
+
+AT&T notification email that shows an amount due but no service address ("Your AT&T bill of $89.99 is ready. Account ending in 1234."):
+{"documents": [{"document_type": "invoice", "date": "2026-06-20", "vendor": "AT&T", "amount": "89.99", "description": "AT&T internet bill", "transaction_type": "expense", "category": "utilities", "sub_category": "internet", "payment_method": "bank_transfer", "tags": ["utilities"], "tax_relevant": true, "channel": null, "address": null, "account_number": "Account ending in 1234", "confidence": "high", "line_items": null}]}
 
 Invoice with towels and sheets:
-{"documents": [{"document_type": "invoice", "date": "2025-07-20", "vendor": "Amazon", "amount": "89.99", "description": "Bath towels and fitted sheets for rental", "transaction_type": "expense", "category": "maintenance", "payment_method": "credit_card", "tags": ["maintenance", "linen"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "invoice", "date": "2025-07-20", "vendor": "Amazon", "amount": "89.99", "description": "Bath towels and fitted sheets for rental", "transaction_type": "expense", "category": "maintenance", "payment_method": "credit_card", "tags": ["maintenance", "linen"], "tax_relevant": true, "channel": null, "address": null, "account_number": null, "confidence": "high", "line_items": null}]}
 
 Mortgage statement with interest and principal breakdown:
-{"documents": [{"document_type": "statement", "date": "2025-10-01", "vendor": "Chase Mortgage", "amount": "1250.00", "description": "Oct 2025 mortgage interest", "transaction_type": "expense", "category": "mortgage_interest", "payment_method": "bank_transfer", "tags": ["mortgage_interest"], "tax_relevant": true, "channel": null, "address": "6738 Peerless St Houston TX", "confidence": "high", "line_items": null}, {"document_type": "statement", "date": "2025-10-01", "vendor": "Chase Mortgage", "amount": "450.00", "description": "Oct 2025 mortgage principal", "transaction_type": "expense", "category": "mortgage_principal", "payment_method": "bank_transfer", "tags": ["mortgage_principal"], "tax_relevant": false, "channel": null, "address": "6738 Peerless St Houston TX", "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "statement", "date": "2025-10-01", "vendor": "Chase Mortgage", "amount": "1250.00", "description": "Oct 2025 mortgage interest", "transaction_type": "expense", "category": "mortgage_interest", "payment_method": "bank_transfer", "tags": ["mortgage_interest"], "tax_relevant": true, "channel": null, "address": "6738 Peerless St Houston TX", "account_number": null, "confidence": "high", "line_items": null}, {"document_type": "statement", "date": "2025-10-01", "vendor": "Chase Mortgage", "amount": "450.00", "description": "Oct 2025 mortgage principal", "transaction_type": "expense", "category": "mortgage_principal", "payment_method": "bank_transfer", "tags": ["mortgage_principal"], "tax_relevant": false, "channel": null, "address": "6738 Peerless St Houston TX", "account_number": null, "confidence": "high", "line_items": null}]}
 
 Airbnb payout:
-{"documents": [{"document_type": "statement", "date": "2025-09-20", "vendor": "Airbnb", "amount": "850.00", "description": "Payout for reservation HM12345", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": "airbnb", "address": "6738 Peerless St Houston TX", "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "statement", "date": "2025-09-20", "vendor": "Airbnb", "amount": "850.00", "description": "Payout for reservation HM12345", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": "airbnb", "address": "6738 Peerless St Houston TX", "account_number": null, "confidence": "high", "line_items": null}]}
 
 Zelle payment ("You received money with Zelle" — Sonu King sent $701.20, no handle shown):
-{"documents": [{"document_type": "invoice", "date": "2026-05-03", "vendor": "Zelle", "payer_name": "Sonu King", "payer_handle": null, "amount": "701.20", "description": "Zelle from Sonu King", "transaction_type": "income", "category": "rental_revenue", "payment_method": "bank_transfer", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "invoice", "date": "2026-05-03", "vendor": "Zelle", "payer_name": "Sonu King", "payer_handle": null, "amount": "701.20", "description": "Zelle from Sonu King", "transaction_type": "income", "category": "rental_revenue", "payment_method": "bank_transfer", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "account_number": null, "confidence": "high", "line_items": null}]}
 
 Venmo payment ("@john-doe paid you $1500.00"):
-{"documents": [{"document_type": "invoice", "date": "2026-05-01", "vendor": "Venmo", "payer_name": "John Doe", "payer_handle": "@john-doe", "amount": "1500.00", "description": "Venmo from John Doe", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "invoice", "date": "2026-05-01", "vendor": "Venmo", "payer_name": "John Doe", "payer_handle": "@john-doe", "amount": "1500.00", "description": "Venmo from John Doe", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "account_number": null, "confidence": "high", "line_items": null}]}
 
 Cash App payment ("$800.00 from Jane Smith ($janesmith)"):
-{"documents": [{"document_type": "invoice", "date": "2026-05-02", "vendor": "Cash App", "payer_name": "Jane Smith", "payer_handle": "$janesmith", "amount": "800.00", "description": "Cash App from Jane Smith", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "confidence": "high", "line_items": null}]}
+{"documents": [{"document_type": "invoice", "date": "2026-05-02", "vendor": "Cash App", "payer_name": "Jane Smith", "payer_handle": "$janesmith", "amount": "800.00", "description": "Cash App from Jane Smith", "transaction_type": "income", "category": "rental_revenue", "payment_method": "platform_payout", "tags": ["rental_revenue"], "tax_relevant": true, "channel": null, "address": null, "account_number": null, "confidence": "high", "line_items": null}]}
 """

--- a/apps/mybookkeeper/backend/app/services/extraction/property_matcher_service.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/property_matcher_service.py
@@ -5,6 +5,11 @@ import uuid
 from sqlalchemy.ext.asyncio import AsyncSession
 from app.models.properties.property import Property
 from app.repositories import property_repo
+from app.repositories.properties import utility_account_link_repo
+from app.services.extraction.utility_account_service import (
+    learn_account_link,
+    normalize_account_number,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -178,19 +183,70 @@ async def resolve_property_id(
     *,
     user_id: uuid.UUID | None = None,
     tags: list[str] | None = None,
+    account_number: str | None = None,
+    sender_domain: str | None = None,
 ) -> uuid.UUID | None:
+    has_account_key = bool(account_number and sender_domain)
+
+    # 1) Explicit pick wins — and is the strongest signal to learn the account
+    #    link from, so a future thin notification (no address) resolves here.
     if explicit_property_id:
+        if has_account_key and user_id:
+            await learn_account_link(
+                db,
+                organization_id=organization_id,
+                user_id=user_id,
+                sender_domain=sender_domain,
+                account_number=account_number,
+                property_id=explicit_property_id,
+            )
         return explicit_property_id
-    if not extracted_address or not extracted_address.strip():
+
+    # 2) Address match. When the bill exposes an account number too, learn the
+    #    link so future address-less notifications for this account resolve.
+    has_address = bool(extracted_address and extracted_address.strip())
+    prop_list: list[Property] = []
+    if has_address:
+        prop_list = list(await property_repo.list_by_org(db, organization_id))
+        matched = match_property_id(extracted_address, prop_list)
+        if matched:
+            if has_account_key and user_id:
+                await learn_account_link(
+                    db,
+                    organization_id=organization_id,
+                    user_id=user_id,
+                    sender_domain=sender_domain,
+                    account_number=account_number,
+                    property_id=matched,
+                )
+            return matched
+
+    # 3) Account-link lookup — the thin-notification path. A "bill is ready"
+    #    email shows an account number but no service address; resolve it via a
+    #    previously learned (sender_domain, account_number) -> property link.
+    if has_account_key:
+        assert account_number is not None and sender_domain is not None
+        link = await utility_account_link_repo.get_by_account(
+            db,
+            organization_id=organization_id,
+            sender_domain=sender_domain,
+            account_number=normalize_account_number(account_number),
+        )
+        if link is not None:
+            return link.property_id
+
+    if not has_address:
         return None
 
-    properties = await property_repo.list_by_org(db, organization_id)
-    prop_list = list(properties)
-    matched = match_property_id(extracted_address, prop_list)
-    if matched:
-        return matched
-
     if not user_id:
+        return None
+
+    # 4) Auto-create-if-property-tag. GUARD: a utility notification that carries
+    #    only an account number (no resolvable service address) is a thin
+    #    notification — its address field is the mailing address, not a real
+    #    property. Do NOT mint a junk property from it; leave property_id null so
+    #    a future learned link (or a host's manual link) can resolve it cleanly.
+    if tags and "utilities" in tags and account_number:
         return None
 
     # Only auto-create if the tags indicate this is a rental property address,

--- a/apps/mybookkeeper/backend/app/services/extraction/utility_account_service.py
+++ b/apps/mybookkeeper/backend/app/services/extraction/utility_account_service.py
@@ -1,0 +1,117 @@
+"""Service for learning + resolving utility account -> property links.
+
+Utility "bill is ready / due" notification emails carry a provider account
+number + amount but NO service address, so ``property_matcher_service`` can't
+resolve them by address. This service remembers the mapping the first time a
+bill IS resolvable — keyed on ``(sender_domain, account_number)`` — so future
+thin notifications from the same provider account resolve to the right property.
+
+Two pure helpers normalize the lookup key. They MUST be applied identically on
+the learn-write and the lookup, or the equality match silently misses:
+  - :func:`normalize_account_number` — upper-cases and strips spaces/dashes/dots
+    so "12-3456-7890" and "1234567890" map to one key.
+  - :func:`sender_domain_from_email` — extracts the domain and collapses provider
+    sub-mailers to the registrable domain (last two labels), so
+    ``emailff.att-mail.com`` and ``emaildl.att-mail.com`` both → ``att-mail.com``.
+
+This module does NOT import ``property_matcher_service`` — that module imports
+this one (the resolver calls ``learn_account_link``). Keeping the dependency
+one-directional avoids an import cycle.
+"""
+import logging
+import uuid
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.trusted_email_senders import _extract_domain
+from app.core.utility_account_constants import PROVIDER_LABELS
+from app.repositories.properties import utility_account_link_repo
+
+logger = logging.getLogger(__name__)
+
+
+def normalize_account_number(raw: str) -> str:
+    """Normalize a provider account number to its lookup-key form.
+
+    Upper-cases and removes spaces, dashes, and dots so the same account written
+    different ways ("12-3456-7890" vs "1234567890") maps to a single key.
+    """
+    cleaned = raw.upper()
+    for ch in (" ", "-", "."):
+        cleaned = cleaned.replace(ch, "")
+    return cleaned
+
+
+def sender_domain_from_email(sender_email: str | None) -> str | None:
+    """Return the registrable provider domain for ``sender_email``, or None.
+
+    Reuses ``_extract_domain`` (lowercase + angle-bracket strip), then collapses
+    provider sub-mailers to the registrable domain by keeping the last two
+    labels: ``emailff.att-mail.com`` -> ``att-mail.com``, ``tmr3.com`` ->
+    ``tmr3.com``, ``houstontx.gov`` -> ``houstontx.gov``. A single provider thus
+    maps to a single key regardless of which mailer host sent the notification.
+    """
+    if not sender_email:
+        return None
+    domain = _extract_domain(sender_email)
+    if not domain:
+        return None
+    labels = domain.split(".")
+    if len(labels) <= 2:
+        return domain
+    return ".".join(labels[-2:])
+
+
+async def learn_account_link(
+    db: AsyncSession,
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    sender_domain: str | None,
+    account_number: str | None,
+    property_id: uuid.UUID,
+) -> None:
+    """Remember that (sender_domain, account_number) bills for ``property_id``.
+
+    No-op when ``sender_domain`` or ``account_number`` is falsy (a thin
+    notification that didn't expose an account number, or a non-email path).
+    Normalizes the key, fills ``provider_label`` from the known-domain map, and
+    upserts with ``source='auto_learn'``.
+
+    A ``manual_link`` row is authoritative: if one already exists for this key it
+    is NOT overwritten by this auto-learn write (the host's explicit choice
+    wins). Re-learning the same account for the same property, or moving the
+    account to a new property, updates the existing auto-learned row.
+    """
+    if not sender_domain or not account_number:
+        return
+
+    normalized_account = normalize_account_number(account_number)
+    if not normalized_account:
+        return
+
+    existing = await utility_account_link_repo.get_by_account(
+        db,
+        organization_id=organization_id,
+        sender_domain=sender_domain,
+        account_number=normalized_account,
+    )
+    if existing is not None and existing.source == "manual_link":
+        # Manual link is authoritative — the host explicitly tied this account
+        # to a property; an auto-learn must never override that choice.
+        logger.debug(
+            "Skipping auto_learn for (%s, %s) — manual_link is authoritative",
+            sender_domain, normalized_account,
+        )
+        return
+
+    await utility_account_link_repo.upsert_link(
+        db,
+        organization_id=organization_id,
+        user_id=user_id,
+        sender_domain=sender_domain,
+        account_number=normalized_account,
+        property_id=property_id,
+        source="auto_learn",
+        provider_label=PROVIDER_LABELS.get(sender_domain),
+    )

--- a/apps/mybookkeeper/backend/tests/test_claude_service_prompt.py
+++ b/apps/mybookkeeper/backend/tests/test_claude_service_prompt.py
@@ -120,3 +120,34 @@ class TestBillReadyWithAmountInstruction:
     def test_known_utility_vendors_listed(self) -> None:
         for vendor in ("Constellation", "CenterPoint", "City of Houston Water", "AT&T"):
             assert vendor in DEFAULT_PROMPT
+
+
+class TestAccountNumberInstruction:
+    """The prompt must tell Claude to extract a utility/telecom/insurance
+    account number into ``account_number`` — the key the learned account ->
+    property map is built on — and to NOT use invoice/meter/reference numbers."""
+
+    def test_account_number_in_schema_block(self) -> None:
+        # The response-format JSON schema must declare the field.
+        assert '"account_number": "utility/service/insurance account number as shown, or null"' in DEFAULT_PROMPT
+
+    def test_field_rule_present(self) -> None:
+        # The # Field rules section must carry the account_number rule.
+        assert "- account_number:" in DEFAULT_PROMPT
+        assert "preserve dashes, spaces, and leading zeros" in DEFAULT_PROMPT
+
+    def test_address_section_note_present(self) -> None:
+        # The # Address extraction section must note address-less notifications.
+        assert (
+            "show an account number but NO service address" in DEFAULT_PROMPT
+        )
+
+    def test_negative_rule_excludes_invoice_and_reference_numbers(self) -> None:
+        # Must NOT mine invoice / statement / meter / confirmation / reference
+        # numbers as the account_number; null for non-account documents.
+        assert "Do NOT use an invoice number" in DEFAULT_PROMPT
+        assert "Set account_number to null" in DEFAULT_PROMPT
+
+    def test_att_example_carries_masked_account(self) -> None:
+        # The new AT&T notification example demonstrates a masked account value.
+        assert '"account_number": "Account ending in 1234"' in DEFAULT_PROMPT

--- a/apps/mybookkeeper/backend/tests/test_property_matcher_account_link.py
+++ b/apps/mybookkeeper/backend/tests/test_property_matcher_account_link.py
@@ -1,0 +1,219 @@
+"""Tests for resolve_property_id's account-link path (utility bill -> property).
+
+Covers the new flow added on top of the address matcher:
+  - account-link lookup resolves an address-less notification to the learned
+    property
+  - an address-matched bill that also exposes an account number auto-learns the
+    link
+  - the GUARD: utilities + account_number + an UNMATCHED address must NOT
+    auto-create a junk property (returns None)
+  - non-utility / no-account documents still auto-create as before
+  - the upload-path call shape (no new kwargs) is unaffected
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.properties.property import Property
+from app.models.properties.utility_account_link import UtilityAccountLink
+from app.repositories.properties import utility_account_link_repo
+from app.services.extraction.property_matcher_service import resolve_property_id
+
+
+async def _make_property(
+    db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID, address: str
+) -> Property:
+    prop = Property(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        name=address,
+        address=address,
+    )
+    db.add(prop)
+    await db.flush()
+    return prop
+
+
+async def _count_properties(db: AsyncSession, org_id: uuid.UUID) -> int:
+    rows = (
+        await db.execute(
+            select(Property).where(Property.organization_id == org_id)
+        )
+    ).scalars().all()
+    return len(rows)
+
+
+class TestAccountLinkLookup:
+    @pytest.mark.asyncio
+    async def test_address_less_notification_resolves_via_learned_link(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St Houston TX")
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+            property_id=prop.id, source="auto_learn",
+        )
+
+        # A thin notification: no address, only an account number (raw, dashed).
+        resolved = await resolve_property_id(
+            None, None, org_id, db,
+            user_id=user_id, tags=["utilities"],
+            account_number="12-3456-7890", sender_domain="att-mail.com",
+        )
+        assert resolved == prop.id
+
+    @pytest.mark.asyncio
+    async def test_no_link_no_address_returns_none_and_creates_nothing(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        resolved = await resolve_property_id(
+            None, None, org_id, db,
+            user_id=user_id, tags=["utilities"],
+            account_number="1234567890", sender_domain="att-mail.com",
+        )
+        assert resolved is None
+        assert await _count_properties(db, org_id) == 0
+
+
+class TestAutoLearnOnAddressMatch:
+    @pytest.mark.asyncio
+    async def test_address_match_with_account_learns_link(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St Houston TX")
+
+        resolved = await resolve_property_id(
+            "6732 Peerless St Houston TX", None, org_id, db,
+            user_id=user_id, tags=["utilities"],
+            account_number="12-3456-7890", sender_domain="att-mail.com",
+        )
+        assert resolved == prop.id
+
+        # A link was learned, normalized, with the AT&T provider label.
+        link = await utility_account_link_repo.get_by_account(
+            db, organization_id=org_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+        )
+        assert link is not None
+        assert link.property_id == prop.id
+        assert link.source == "auto_learn"
+        assert link.provider_label == "AT&T"
+
+    @pytest.mark.asyncio
+    async def test_explicit_property_with_account_learns_link(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St Houston TX")
+
+        resolved = await resolve_property_id(
+            None, prop.id, org_id, db,
+            user_id=user_id, tags=["utilities"],
+            account_number="1234567890", sender_domain="att-mail.com",
+        )
+        assert resolved == prop.id
+
+        link = await utility_account_link_repo.get_by_account(
+            db, organization_id=org_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+        )
+        assert link is not None
+        assert link.property_id == prop.id
+
+
+class TestAutoCreateGuard:
+    @pytest.mark.asyncio
+    async def test_utilities_plus_account_no_match_returns_none_no_create(
+        self, db: AsyncSession
+    ) -> None:
+        """A utility notification whose (mailing) address matches nothing and
+        carries an account number must NOT mint a junk property."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+
+        resolved = await resolve_property_id(
+            "PO Box 5000 Carol Stream IL 60197",  # mailing address, not a property
+            None, org_id, db,
+            user_id=user_id, tags=["utilities"],
+            account_number="1234567890", sender_domain="att-mail.com",
+        )
+        assert resolved is None
+        assert await _count_properties(db, org_id) == 0
+
+    @pytest.mark.asyncio
+    async def test_utilities_without_account_still_auto_creates(
+        self, db: AsyncSession
+    ) -> None:
+        """A real utility bill (service address, no account number) keeps the
+        existing auto-create behavior — the guard only fires WITH an account."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+
+        resolved = await resolve_property_id(
+            "9001 Westheimer Rd Houston TX", None, org_id, db,
+            user_id=user_id, tags=["utilities"],
+            account_number=None, sender_domain=None,
+        )
+        assert resolved is not None
+        assert await _count_properties(db, org_id) == 1
+
+    @pytest.mark.asyncio
+    async def test_non_utility_with_account_still_auto_creates(
+        self, db: AsyncSession
+    ) -> None:
+        """The guard is utilities-specific: a property-related non-utility tag
+        with an account number still auto-creates (guard does not fire)."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+
+        resolved = await resolve_property_id(
+            "9001 Westheimer Rd Houston TX", None, org_id, db,
+            user_id=user_id, tags=["insurance"],
+            account_number="POL-998877", sender_domain="someinsurer.com",
+        )
+        assert resolved is not None
+        assert await _count_properties(db, org_id) == 1
+
+
+class TestUploadPathUnchanged:
+    @pytest.mark.asyncio
+    async def test_no_new_kwargs_behaves_as_before(self, db: AsyncSession) -> None:
+        """The document-upload call site passes no account/sender kwargs — the
+        defaults (None) must keep the old behavior: match an existing property,
+        and never touch the link table."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id, "6732 Peerless St Houston TX")
+
+        resolved = await resolve_property_id(
+            "6732 Peerless St Houston TX", None, org_id, db,
+            user_id=user_id, tags=["utilities"],
+        )
+        assert resolved == prop.id
+
+        # No link was created on the upload path.
+        rows = (
+            await db.execute(
+                select(UtilityAccountLink).where(
+                    UtilityAccountLink.organization_id == org_id
+                )
+            )
+        ).scalars().all()
+        assert list(rows) == []
+
+    @pytest.mark.asyncio
+    async def test_no_new_kwargs_auto_creates_as_before(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        resolved = await resolve_property_id(
+            "9001 Westheimer Rd Houston TX", None, org_id, db,
+            user_id=user_id, tags=["utilities"],
+        )
+        assert resolved is not None
+        assert await _count_properties(db, org_id) == 1

--- a/apps/mybookkeeper/backend/tests/test_utility_account_link_repo.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_account_link_repo.py
@@ -1,0 +1,301 @@
+"""Tests for utility_account_link_repo — learned utility account -> property.
+
+Covers the full dedup matrix on the (organization_id, sender_domain,
+account_number) unique key plus the normalization-parity that makes the
+equality lookup hold. The service (utility_account_service) owns the
+"manual_link is authoritative" rule; one test here pins that the repo upsert
+itself is a straight update (the guard lives a layer up).
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.properties.property import Property
+from app.models.properties.utility_account_link import UtilityAccountLink
+from app.repositories.properties import utility_account_link_repo
+from app.services.extraction.utility_account_service import (
+    learn_account_link,
+    normalize_account_number,
+    sender_domain_from_email,
+)
+
+
+async def _make_property(
+    db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID, name: str = "6732 Peerless St"
+) -> Property:
+    prop = Property(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        name=name,
+        address=name,
+    )
+    db.add(prop)
+    await db.flush()
+    return prop
+
+
+async def _all_links(db: AsyncSession, org_id: uuid.UUID) -> list[UtilityAccountLink]:
+    rows = (
+        await db.execute(
+            select(UtilityAccountLink).where(
+                UtilityAccountLink.organization_id == org_id
+            )
+        )
+    ).scalars().all()
+    return list(rows)
+
+
+class TestNormalization:
+    def test_account_number_strips_separators_and_uppercases(self) -> None:
+        assert normalize_account_number("12-3456-7890") == "1234567890"
+        assert normalize_account_number("1234567890") == "1234567890"
+        assert normalize_account_number("ab 12.34-56") == "AB123456"
+
+    def test_dashed_and_plain_map_to_one_key(self) -> None:
+        assert normalize_account_number("12-3456-7890") == normalize_account_number(
+            "1234567890"
+        )
+
+    def test_sender_domain_collapses_att_submailers(self) -> None:
+        assert sender_domain_from_email("update@emailff.att-mail.com") == "att-mail.com"
+        assert sender_domain_from_email("update@emaildl.att-mail.com") == "att-mail.com"
+
+    def test_sender_domain_two_label_unchanged(self) -> None:
+        assert sender_domain_from_email("centerpoint.energy@tmr3.com") == "tmr3.com"
+        assert (
+            sender_domain_from_email("cityofhoustonwaterbill@houstontx.gov")
+            == "houstontx.gov"
+        )
+
+    def test_sender_domain_none_for_garbage(self) -> None:
+        assert sender_domain_from_email(None) is None
+        assert sender_domain_from_email("not-an-email") is None
+
+
+class TestUpsertDedupMatrix:
+    @pytest.mark.asyncio
+    async def test_same_key_idempotent_upsert(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        for _ in range(2):
+            await utility_account_link_repo.upsert_link(
+                db,
+                organization_id=org_id,
+                user_id=user_id,
+                sender_domain="att-mail.com",
+                account_number="1234567890",
+                property_id=prop.id,
+                source="auto_learn",
+            )
+
+        rows = await _all_links(db, org_id)
+        assert len(rows) == 1
+        assert rows[0].property_id == prop.id
+
+    @pytest.mark.asyncio
+    async def test_same_key_different_property_updates_property_id(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop_a = await _make_property(db, org_id, user_id, "A")
+        prop_b = await _make_property(db, org_id, user_id, "B")
+
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+            property_id=prop_a.id, source="auto_learn",
+        )
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+            property_id=prop_b.id, source="auto_learn",
+        )
+
+        rows = await _all_links(db, org_id)
+        assert len(rows) == 1
+        assert rows[0].property_id == prop_b.id
+
+    @pytest.mark.asyncio
+    async def test_same_account_different_sender_domain_two_rows(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+            property_id=prop.id, source="auto_learn",
+        )
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="tmr3.com", account_number="1234567890",
+            property_id=prop.id, source="auto_learn",
+        )
+
+        rows = await _all_links(db, org_id)
+        assert len(rows) == 2
+        assert {r.sender_domain for r in rows} == {"att-mail.com", "tmr3.com"}
+
+    @pytest.mark.asyncio
+    async def test_same_domain_different_account_two_rows(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1111111111",
+            property_id=prop.id, source="auto_learn",
+        )
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="2222222222",
+            property_id=prop.id, source="auto_learn",
+        )
+
+        rows = await _all_links(db, org_id)
+        assert len(rows) == 2
+        assert {r.account_number for r in rows} == {"1111111111", "2222222222"}
+
+    @pytest.mark.asyncio
+    async def test_different_org_same_key_two_rows(self, db: AsyncSession) -> None:
+        org_a, org_b, user_id = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        prop_a = await _make_property(db, org_a, user_id, "A")
+        prop_b = await _make_property(db, org_b, user_id, "B")
+
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_a, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+            property_id=prop_a.id, source="auto_learn",
+        )
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_b, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+            property_id=prop_b.id, source="auto_learn",
+        )
+
+        assert len(await _all_links(db, org_a)) == 1
+        assert len(await _all_links(db, org_b)) == 1
+        # And tenant isolation on get_by_account.
+        link_b = await utility_account_link_repo.get_by_account(
+            db, organization_id=org_b,
+            sender_domain="att-mail.com", account_number="1234567890",
+        )
+        assert link_b is not None
+        assert link_b.property_id == prop_b.id
+
+    @pytest.mark.asyncio
+    async def test_manual_link_not_clobbered_by_auto_learn(
+        self, db: AsyncSession
+    ) -> None:
+        """The 'manual_link is authoritative' rule lives in the service.
+
+        learn_account_link (auto_learn) must NOT overwrite a manual_link row.
+        """
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        manual_prop = await _make_property(db, org_id, user_id, "Manual")
+        auto_prop = await _make_property(db, org_id, user_id, "Auto")
+
+        # Host manually links the account to manual_prop.
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+            property_id=manual_prop.id, source="manual_link",
+        )
+
+        # A later auto-learn from an address-matched bill points elsewhere — it
+        # must be ignored.
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="12-3456-7890",
+            property_id=auto_prop.id,
+        )
+
+        rows = await _all_links(db, org_id)
+        assert len(rows) == 1
+        assert rows[0].source == "manual_link"
+        assert rows[0].property_id == manual_prop.id
+
+
+class TestNormalizationParityOnLearnAndLookup:
+    @pytest.mark.asyncio
+    async def test_dashed_learn_matches_plain_lookup(self, db: AsyncSession) -> None:
+        """A learn-write with "12-3456-7890" must resolve a "1234567890" lookup."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="12-3456-7890",
+            property_id=prop.id,
+        )
+
+        link = await utility_account_link_repo.get_by_account(
+            db, organization_id=org_id,
+            sender_domain="att-mail.com",
+            account_number=normalize_account_number("1234567890"),
+        )
+        assert link is not None
+        assert link.property_id == prop.id
+        assert link.account_number == "1234567890"
+
+    @pytest.mark.asyncio
+    async def test_both_att_submailers_collapse_to_one_key(
+        self, db: AsyncSession
+    ) -> None:
+        """emailff. and emaildl. both -> att-mail.com -> one learned row."""
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        for sender in (
+            "update@emailff.att-mail.com",
+            "update@emaildl.att-mail.com",
+        ):
+            domain = sender_domain_from_email(sender)
+            await learn_account_link(
+                db, organization_id=org_id, user_id=user_id,
+                sender_domain=domain, account_number="1234567890",
+                property_id=prop.id,
+            )
+
+        rows = await _all_links(db, org_id)
+        assert len(rows) == 1
+        assert rows[0].sender_domain == "att-mail.com"
+
+
+class TestListByProperty:
+    @pytest.mark.asyncio
+    async def test_lists_links_for_property(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+        other = await _make_property(db, org_id, user_id, "Other")
+
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="1111111111",
+            property_id=prop.id, source="auto_learn",
+        )
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="tmr3.com", account_number="2222222222",
+            property_id=prop.id, source="auto_learn",
+        )
+        await utility_account_link_repo.upsert_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="houstontx.gov", account_number="3333333333",
+            property_id=other.id, source="auto_learn",
+        )
+
+        links = await utility_account_link_repo.list_by_property(
+            db, organization_id=org_id, property_id=prop.id
+        )
+        assert len(links) == 2
+        assert {l.sender_domain for l in links} == {"att-mail.com", "tmr3.com"}

--- a/apps/mybookkeeper/backend/tests/test_utility_account_service.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_account_service.py
@@ -1,0 +1,167 @@
+"""Tests for utility_account_service — learn helper + pure normalizers.
+
+The pure normalizers are covered in depth in test_utility_account_link_repo.py;
+here we pin learn_account_link's no-op guards, the provider_label fill, and that
+auto_learn writes use source='auto_learn'.
+"""
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.properties.property import Property
+from app.repositories.properties import utility_account_link_repo
+from app.services.extraction.utility_account_service import (
+    learn_account_link,
+    normalize_account_number,
+    sender_domain_from_email,
+)
+
+
+async def _make_property(
+    db: AsyncSession, org_id: uuid.UUID, user_id: uuid.UUID
+) -> Property:
+    prop = Property(
+        id=uuid.uuid4(),
+        organization_id=org_id,
+        user_id=user_id,
+        name="6732 Peerless St",
+        address="6732 Peerless St",
+    )
+    db.add(prop)
+    await db.flush()
+    return prop
+
+
+class TestNormalizeFns:
+    def test_normalize_account_number(self) -> None:
+        assert normalize_account_number("  12-3456 .7890 ") == "1234567890"
+        assert normalize_account_number("acct123") == "ACCT123"
+
+    def test_sender_domain_from_email(self) -> None:
+        assert sender_domain_from_email("update@emailff.att-mail.com") == "att-mail.com"
+        assert sender_domain_from_email("x@tmr3.com") == "tmr3.com"
+        assert sender_domain_from_email("") is None
+
+
+class TestLearnAccountLinkNoOps:
+    @pytest.mark.asyncio
+    async def test_noop_when_sender_domain_falsy(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain=None, account_number="1234567890",
+            property_id=prop.id,
+        )
+        links = await utility_account_link_repo.list_by_property(
+            db, organization_id=org_id, property_id=prop.id
+        )
+        assert links == []
+
+    @pytest.mark.asyncio
+    async def test_noop_when_account_number_falsy(self, db: AsyncSession) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number=None,
+            property_id=prop.id,
+        )
+        links = await utility_account_link_repo.list_by_property(
+            db, organization_id=org_id, property_id=prop.id
+        )
+        assert links == []
+
+    @pytest.mark.asyncio
+    async def test_noop_when_account_number_normalizes_to_empty(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        # All separators -> normalizes to "" -> nothing to remember.
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="--  ..",
+            property_id=prop.id,
+        )
+        links = await utility_account_link_repo.list_by_property(
+            db, organization_id=org_id, property_id=prop.id
+        )
+        assert links == []
+
+
+class TestLearnAccountLinkWrites:
+    @pytest.mark.asyncio
+    async def test_writes_auto_learn_with_provider_label(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="att-mail.com", account_number="12-3456-7890",
+            property_id=prop.id,
+        )
+
+        link = await utility_account_link_repo.get_by_account(
+            db, organization_id=org_id,
+            sender_domain="att-mail.com", account_number="1234567890",
+        )
+        assert link is not None
+        assert link.source == "auto_learn"
+        assert link.provider_label == "AT&T"
+        assert link.property_id == prop.id
+
+    @pytest.mark.asyncio
+    async def test_provider_label_null_for_unknown_domain(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="unknown-utility.com", account_number="999",
+            property_id=prop.id,
+        )
+
+        link = await utility_account_link_repo.get_by_account(
+            db, organization_id=org_id,
+            sender_domain="unknown-utility.com", account_number="999",
+        )
+        assert link is not None
+        assert link.provider_label is None
+
+    @pytest.mark.asyncio
+    async def test_centerpoint_and_houston_water_labels(
+        self, db: AsyncSession
+    ) -> None:
+        org_id, user_id = uuid.uuid4(), uuid.uuid4()
+        prop = await _make_property(db, org_id, user_id)
+
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="tmr3.com", account_number="111",
+            property_id=prop.id,
+        )
+        await learn_account_link(
+            db, organization_id=org_id, user_id=user_id,
+            sender_domain="houstontx.gov", account_number="222",
+            property_id=prop.id,
+        )
+
+        cp = await utility_account_link_repo.get_by_account(
+            db, organization_id=org_id, sender_domain="tmr3.com", account_number="111",
+        )
+        water = await utility_account_link_repo.get_by_account(
+            db, organization_id=org_id, sender_domain="houstontx.gov", account_number="222",
+        )
+        assert cp is not None and cp.provider_label == "CenterPoint"
+        assert water is not None and water.provider_label == "City of Houston Water"

--- a/apps/mybookkeeper/backend/tests/test_utility_bill_silent_drop.py
+++ b/apps/mybookkeeper/backend/tests/test_utility_bill_silent_drop.py
@@ -84,6 +84,7 @@ def _utility_bill_data(
         "confidence": "high",
         "tags": ["utilities"],
         "description": "Electricity bill — Auto Pay scheduled",
+        "account_number": None,
     }
 
 
@@ -223,6 +224,7 @@ class TestGenuinePaymentConfirmationStillSkipped:
             "confidence": "high",
             "tags": ["uncategorized"],
             "description": "Thank you for your payment",
+            "account_number": None,
         }
 
         outcome = await save_email_extraction(
@@ -264,6 +266,7 @@ class TestP2PStillProtected:
             "transaction_type": "income",
             "confidence": "high",
             "tags": ["rental_revenue"],
+            "account_number": None,
         }
 
         outcome = await save_email_extraction(

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -197,7 +197,8 @@
         "backend/app/repositories/extraction/",
         "backend/app/schemas/extraction/",
         "backend/app/mappers/extraction_mapper.py",
-        "backend/app/core/trusted_email_senders.py"
+        "backend/app/core/trusted_email_senders.py",
+        "backend/app/core/utility_account_constants.py"
       ],
       "backend_tests": [
         "test_dedup_resolution.py",
@@ -210,10 +211,13 @@
         "test_airbnb_payout_detection.py",
         "test_prompt_service.py",
         "test_property_matcher.py",
+        "test_property_matcher_account_link.py",
         "test_self_healing.py",
         "test_trusted_email_senders.py",
         "test_claude_service_prompt.py",
-        "test_utility_bill_silent_drop.py"
+        "test_utility_bill_silent_drop.py",
+        "test_utility_account_service.py",
+        "test_utility_account_link_repo.py"
       ],
       "frontend_tests": [],
       "e2e_specs": [
@@ -300,11 +304,15 @@
         "backend/app/services/properties/",
         "backend/app/schemas/properties/",
         "backend/app/api/properties.py",
+        "backend/alembic/versions/utillink260624_add_utility_account_links.py",
         "frontend/src/pages/Properties.tsx",
         "frontend/src/features/properties/"
       ],
       "backend_tests": [
-        "test_property_duplicate.py"
+        "test_property_duplicate.py",
+        "test_utility_account_link_repo.py",
+        "test_utility_account_service.py",
+        "test_property_matcher_account_link.py"
       ],
       "frontend_tests": [
         "Properties.test.tsx"


### PR DESCRIPTION
## Problem

Utility **"bill is ready / due"** notification emails just unblocked for discovery in #920 (AT&T, City of Houston Water, CenterPoint) carry an **account number + amount** but **no service address**. The existing address matcher (`property_matcher_service`) therefore can't tie them to a property — they'd land unattributed, or worse, a utility-tagged email's *mailing* address would auto-mint a junk property.

Validated against the operator's real emails before designing:

| Email | Account number | Amount | Service address |
|---|---|---|---|
| AT&T (`*.att-mail.com`) | ✅ | ✅ | ❌ absent |
| City of Houston Water (`houstontx.gov`) | ✅ | ✅ "Total Balance" | ❌ absent |
| CenterPoint (`tmr3.com`) | ✅ | ✅ | ❌ absent |

The account number is the only stable join key present.

## Change (PR 1 of 2 — backend mechanism)

A learned **account → property** map keyed on `(sender_domain, account_number)`, modeled byte-for-byte on the shipped `payer_alias` learned map:

- **`utility_account_link` table** — org/user/property FKs (CASCADE), `source` (`auto_learn`/`manual_link`) as `String`+CheckConstraint, unique on `(organization_id, sender_domain, account_number)` (doubles as the lookup index). `sender_domain` collapses provider sub-mailers (`emailff`/`emaildl.att-mail.com` → `att-mail.com`).
- **`account_number` stored plaintext** — the lookup is an equality match, and MBK's `EncryptedString` ciphertext is non-deterministic (would never match). Direct precedent: `issuer_ein`. Protected by **both** masking layers: already in `core/pii.py` (frontend read masking), and this PR adds it to **`MBK_SENSITIVE_FIELDS`** in `core/audit.py` (audit-log masking) — the one real gap, since plaintext would otherwise leak into `audit_logs`.
- **Prompt** extracts `account_number` for utility/telecom/insurance/property-tax bills (as-shown; masked forms — "Account ending in 1234" — kept verbatim, never invented; never an invoice/statement/meter number).
- **`resolve_property_id`** gains: address-match → **account-link lookup** (the thin-notification path) → **auto-learn** the link whenever an address-bearing bill resolves a property → **guard** that suppresses junk auto-create for the no-service-address utility shape. Only the email path threads the new args; the upload path is untouched.

## How it ties together

1. An address-bearing bill (PDF or rich email) resolves a property by address **and** carries an account number → the link is auto-learned.
2. Every later thin notification from that account resolves to the property with no address — silently, automatically.
3. For providers that *never* send an address (AT&T, Houston Water), the link is seeded by a one-time manual property pick — **that picker is PR 2** (frontend).

## Validation

- New + touched backend tests: full dedup matrix (idempotent upsert, account-moved-property, cross-provider collision, multi-account, cross-org, manual-link-not-clobbered) + normalization parity + resolver lookup/learn/guard + prompt assertions — **270 passed** (59 in the targeted re-run).
- `alembic` chain linear (`utillink260624`, down_revision `attrverify260602`).
- file-size check clean; shared-backend conformance **150 passed, 5 skipped**.

## Follow-ups

- **PR 2** — the manual property picker (review-queue surface) that seeds links for notification-only providers, and surfaces the "I'll remember this account" confirmation.
- Minor: #920's `config.py` comment mislabels `tmr3.com` as City of Houston Water's vendor — it's actually **CenterPoint**'s. Trivial comment-only fix, tracked separately.
