### PR TITLE
ci(deps): auto-relock uv.lock + requirements.txt on Dependabot backend PRs

### DIFF
--- a/.github/workflows/dependabot-relock.yml
+++ b/.github/workflows/dependabot-relock.yml
@@ -1,0 +1,118 @@
+name: Dependabot Lock Sync
+
+# Keeps the Python backend dependency chain consistent on Dependabot PRs:
+#
+#     pyproject.toml --(uv lock)--> uv.lock --(uv export)--> requirements.txt
+#
+# Dependabot's resolver updates only part of this chain, leaving uv.lock stale,
+# which fails `backend-deps-resolve` (uv lock --check) in each app's CI. This
+# workflow regenerates uv.lock + requirements.txt for every backend and pushes
+# the result back to the PR branch, so the PR goes green without a manual relock.
+#
+# ── One-time operator setup (REQUIRED for this to do anything) ────────────────
+#   Add a *Dependabot* repository secret named DEPENDABOT_RELOCK_TOKEN:
+#     Settings → Secrets and variables → Dependabot → New repository secret
+#   Value: a fine-grained PAT scoped to THIS repo with
+#     Contents: Read and write   +   Pull requests: Read and write
+#   It MUST be a Dependabot secret (not an Actions secret) — Dependabot-triggered
+#   runs only see Dependabot secrets. A push by the default GITHUB_TOKEN would not
+#   re-trigger the required checks, which is why a PAT is needed.
+#   Until the secret exists, this workflow no-ops (green, with a warning) and PRs
+#   continue to need a manual relock — it never blocks existing CI.
+#
+# Security: gated to the first-party dependabot[bot] actor. `uv lock` resolves the
+# PR's pyproject (which can build sdists). The dependency set is your own
+# Dependabot-managed config, so this is bounded; do not widen the actor gate.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "apps/*/backend/pyproject.toml"
+      - "apps/*/backend/uv.lock"
+      - "apps/*/backend/requirements.txt"
+      - "packages/shared-backend/pyproject.toml"
+      - "packages/shared-backend/uv.lock"
+
+# Least privilege: writes go through the PAT, not GITHUB_TOKEN.
+permissions:
+  contents: read
+
+concurrency:
+  group: dependabot-relock-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  relock:
+    name: relock backends
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # First-party Dependabot PRs only. A push by this workflow is authenticated
+    # as the PAT owner (not dependabot[bot]), so the re-triggered run fails this
+    # gate and skips — that is what prevents an infinite relock loop.
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Check relock token is configured
+        id: guard
+        env:
+          RELOCK_TOKEN: ${{ secrets.DEPENDABOT_RELOCK_TOKEN }}
+        run: |
+          if [ -n "$RELOCK_TOKEN" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::DEPENDABOT_RELOCK_TOKEN (Dependabot secret) is not set; skipping auto-relock. See workflow header for setup."
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout PR head
+        if: steps.guard.outputs.enabled == 'true'
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.DEPENDABOT_RELOCK_TOKEN }}
+          fetch-depth: 0
+
+      - name: Set up uv
+        if: steps.guard.outputs.enabled == 'true'
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+
+      - name: Set up Python
+        if: steps.guard.outputs.enabled == 'true'
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Relock every backend (idempotent)
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          for d in apps/*/backend packages/shared-backend; do
+            [ -f "$d/pyproject.toml" ] || continue
+            echo "::group::relock $d"
+            ( cd "$d" && uv lock )
+            # Regenerate requirements.txt using the exact command recorded in its
+            # own header (apps differ on --no-emit-project), so the format matches.
+            if [ -f "$d/requirements.txt" ]; then
+              cmd="$(sed -n '2{s/^#[[:space:]]*//p;}' "$d/requirements.txt")"
+              case "$cmd" in
+                "uv export"*) ( cd "$d" && bash -c "$cmd" ) ;;
+                *) ( cd "$d" && uv export --format requirements-txt --no-hashes --no-emit-project --output-file requirements.txt ) ;;
+              esac
+            fi
+            echo "::endgroup::"
+          done
+
+      - name: Commit and push if the lockfiles changed
+        if: steps.guard.outputs.enabled == 'true'
+        run: |
+          set -euo pipefail
+          if git diff --quiet; then
+            echo "Lockfiles already consistent — nothing to push."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore(deps): sync uv.lock + requirements.txt [dependabot-relock]"
+          git push origin "HEAD:${{ github.head_ref }}"


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-relock.yml`, which regenerates `uv.lock` + `requirements.txt` for every Python backend on Dependabot backend PRs and pushes the result back to the PR branch.

## Why

Each backend keeps a three-file chain:

```
pyproject.toml --(uv lock)--> uv.lock --(uv export)--> requirements.txt
```

CI gates on `uv lock --check` (`backend-deps-resolve`), but the Docker image is built from `requirements.txt`. Dependabot's resolver only updates *part* of this chain, so `uv.lock` goes stale and `backend-deps-resolve` **fails on every backend dependency bump** (e.g. #924, #911) — each one currently needs a manual relock (see the recent "bundle backend dependency bumps" PRs). This workflow eliminates that toil for all 5 apps + shared-backend.

## How it works

- Triggers on `pull_request` for backend dep-file paths, gated to the first-party `dependabot[bot]` actor.
- Runs `uv lock` for every backend (idempotent — unchanged backends produce no diff) and regenerates `requirements.txt` using the exact `uv export` command recorded in each file's own header (apps differ on `--no-emit-project`).
- Pushes back only if something changed, re-triggering `backend-deps-resolve` → green.
- **No loop:** the relock push is authed as the PAT owner, not `dependabot[bot]`, so the re-triggered run fails the actor gate and skips.

## ⚠️ Operational migration required

This workflow **no-ops until a secret is set** (fail-safe: it stays green with a warning and never blocks existing CI — PRs just keep needing manual relocks until then).

### What to set

Add a **Dependabot** repository secret (NOT an Actions secret — Dependabot-triggered runs only see Dependabot secrets):

- **Settings → Secrets and variables → Dependabot → New repository secret**
- Name: `DEPENDABOT_RELOCK_TOKEN`
- Value: a fine-grained PAT scoped to **this repo only** with **Contents: Read and write** + **Pull requests: Read and write**

A PAT is required because a push by the default `GITHUB_TOKEN` does not re-trigger required status checks.

### How to verify

Re-run (or push an empty commit to) any open backend Dependabot PR, e.g. #911. The `relock backends` job should commit a `[dependabot-relock]` sync commit and `backend-deps-resolve` should flip to green automatically.

### Rollback path

Revert this PR; nothing else depends on it and existing CI is unchanged.

## Notes

- #924 was relocked manually in this session to unblock it now; this workflow prevents the recurrence.
- Action SHAs reuse the pins already trusted in `ci-mybookkeeper.yml` (checkout v6.0.3, setup-uv v8.2.0, setup-python v6.2.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)