### PR TITLE
ci(deps): harden dependabot automation — robust relock + hold @types/node majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,6 +31,12 @@ updates:
     groups:
       npm-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # @types/node must track the Node runtime, not leap ahead. Major bumps
+      # (e.g. 25 -> 26) desync the lock / break tsc against the version we
+      # actually run. Allow minor+patch; hold majors until the runtime moves.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "npm"
     directory: "/packages/shared-frontend"
@@ -41,6 +47,12 @@ updates:
     groups:
       npm-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # @types/node must track the Node runtime, not leap ahead. Major bumps
+      # (e.g. 25 -> 26) desync the lock / break tsc against the version we
+      # actually run. Allow minor+patch; hold majors until the runtime moves.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions versions
   - package-ecosystem: "github-actions"
@@ -69,6 +81,12 @@ updates:
     groups:
       npm-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # @types/node must track the Node runtime, not leap ahead. Major bumps
+      # (e.g. 25 -> 26) desync the lock / break tsc against the version we
+      # actually run. Allow minor+patch; hold majors until the runtime moves.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   # Docker base images (one per app as docker-compose files are added)
   - package-ecosystem: "docker"
@@ -105,6 +123,12 @@ updates:
     groups:
       npm-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # @types/node must track the Node runtime, not leap ahead. Major bumps
+      # (e.g. 25 -> 26) desync the lock / break tsc against the version we
+      # actually run. Allow minor+patch; hold majors until the runtime moves.
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "docker"
     directory: "/apps/myrecipes"

--- a/.github/workflows/dependabot-relock.yml
+++ b/.github/workflows/dependabot-relock.yml
@@ -91,14 +91,13 @@ jobs:
             [ -f "$d/pyproject.toml" ] || continue
             echo "::group::relock $d"
             ( cd "$d" && uv lock )
-            # Regenerate requirements.txt using the exact command recorded in its
-            # own header (apps differ on --no-emit-project), so the format matches.
+            # Regenerate requirements.txt with the canonical export command (every
+            # app + the scaffold template use this exact form — see each file's
+            # header). Hardcoded rather than parsed from the header: the previous
+            # sed + `bash -c` approach mis-handled the command on the runner and
+            # streamed the export to stdout instead of the file, failing the job.
             if [ -f "$d/requirements.txt" ]; then
-              cmd="$(sed -n '2{s/^#[[:space:]]*//p;}' "$d/requirements.txt")"
-              case "$cmd" in
-                "uv export"*) ( cd "$d" && bash -c "$cmd" ) ;;
-                *) ( cd "$d" && uv export --format requirements-txt --no-hashes --no-emit-project --output-file requirements.txt ) ;;
-              esac
+              ( cd "$d" && uv export --format requirements-txt --no-hashes --no-emit-project --output-file requirements.txt )
             fi
             echo "::endgroup::"
           done


### PR DESCRIPTION
## What

Two fixes to the Dependabot automation, surfaced while clearing the open-PR backlog:

1. **`dependabot-relock.yml`** — the `requirements.txt` regen parsed the export command from each file's header via `sed` + `bash -c`, which mis-handled it on the runner (streamed the export to stdout instead of the file, failing the relock job on shared-package PRs like #917). Now hardcodes the canonical export command, which is identical across all apps + the scaffold template.

2. **`dependabot.yml`** — ignore `@types/node` **major** bumps on every frontend. `@types/node` must track the Node runtime; a major (25 → 26, e.g. #907/#908) desyncs the npm lock and breaks `tsc` against the version we actually run. Minor/patch still flow.

## Why now

#917 (shared-backend bump) exposed the relock bug; #907/#908 (`@types/node` 26) are being closed in favor of the ignore rule so they stop recurring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)