### PR TITLE
ci(deps): auto-merge Dependabot on green + monthly cadence; hold majors

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,7 +4,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/apps/myjobhunter/backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "python", "myjobhunter"]
     groups:
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/packages/shared-backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "python", "shared"]
     groups:
@@ -25,7 +25,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/apps/myjobhunter/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "npm", "myjobhunter"]
     groups:
@@ -41,7 +41,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/packages/shared-frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "npm", "shared"]
     groups:
@@ -58,14 +58,14 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "github-actions"]
 
   - package-ecosystem: "pip"
     directory: "/apps/mybookkeeper/backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "python", "mybookkeeper"]
     groups:
@@ -75,7 +75,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/apps/mybookkeeper/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "npm", "mybookkeeper"]
     groups:
@@ -92,14 +92,14 @@ updates:
   - package-ecosystem: "docker"
     directory: "/apps/myjobhunter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 3
     labels: ["dependencies", "docker", "myjobhunter"]
 
   - package-ecosystem: "docker"
     directory: "/apps/mybookkeeper"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 3
     labels: ["dependencies", "docker", "mybookkeeper"]
 
@@ -107,7 +107,7 @@ updates:
   - package-ecosystem: "pip"
     directory: "/apps/myrecipes/backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "python", "myrecipes"]
     groups:
@@ -117,7 +117,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/apps/myrecipes/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "npm", "myrecipes"]
     groups:
@@ -133,6 +133,6 @@ updates:
   - package-ecosystem: "docker"
     directory: "/apps/myrecipes"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     open-pull-requests-limit: 3
     labels: ["dependencies", "docker", "myrecipes"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,14 @@ updates:
     groups:
       python-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # fastapi held < 0.137: 0.137's _IncludedRouter refactor breaks our
+      # route-introspection tests. Without this, Dependabot keeps proposing the
+      # bump, CI goes red, and it must be hand-relocked every cycle. Ignore
+      # >= 0.137 until those tests are migrated for _IncludedRouter, then drop
+      # this block. See project_dependabot_autorelock_and_fastapi_hold.
+      - dependency-name: "fastapi"
+        versions: [">=0.137"]
 
   - package-ecosystem: "pip"
     directory: "/packages/shared-backend"
@@ -71,6 +79,14 @@ updates:
     groups:
       python-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # fastapi held < 0.137: 0.137's _IncludedRouter refactor breaks our
+      # route-introspection tests. Without this, Dependabot keeps widening the
+      # pin (and an auto-merge would silently land it green). Ignore >= 0.137
+      # until those tests are migrated for _IncludedRouter, then drop this
+      # block. See project_dependabot_autorelock_and_fastapi_hold.
+      - dependency-name: "fastapi"
+        versions: [">=0.137"]
 
   - package-ecosystem: "npm"
     directory: "/apps/mybookkeeper/frontend"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,50 @@
+name: Dependabot auto-merge
+
+# Auto-merges Dependabot PRs once required checks pass — EXCEPT major bumps,
+# which are labelled and held for manual review. Effect: patch / minor / security
+# updates flow through invisibly; only a breaking-change major ever needs your
+# attention.
+#
+# The merge is enabled via `gh pr merge --auto`, which GitHub performs
+# server-side after checks go green. Because GitHub (not this token) does the
+# actual merge, this also lands github-actions PRs that edit workflow files —
+# which an OAuth/PAT token cannot merge without the `workflow` scope.
+#
+# Security: pull_request_target runs in base context with a write token, but this
+# job NEVER checks out or executes PR code — it only reads Dependabot metadata and
+# calls the gh API. Gated to the first-party dependabot[bot] actor.
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: auto-merge
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Hold majors for manual review
+        if: ${{ steps.meta.outputs.update-type == 'version-update:semver-major' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr edit "$PR_URL" --add-label "dependabot-major" || true
+          gh pr comment "$PR_URL" --body \
+            "🚧 Major version bump — held for manual review, not auto-merged. Merge deliberately once you've assessed the breaking changes."
+
+      - name: Enable auto-merge for patch / minor / security
+        if: ${{ steps.meta.outputs.update-type != 'version-update:semver-major' }}
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
Stops the weekly version-bump treadmill and makes routine updates invisible.

## Changes
- **`dependabot.yml`**: `weekly` → `monthly` across all ecosystems (keeps grouping + the `@types/node`-major hold from #928).
- **`dependabot.yml`**: hold **fastapi `>=0.137`** on the MBK + MJH backend pip ecosystems (`ignore` rule). 0.137's `_IncludedRouter` refactor breaks our route-introspection tests; without this Dependabot re-proposes the bump every cycle and it must be hand-relocked. **This is the piece that makes auto-merge safe** — otherwise an MBK pin-widening PR (passes CI green) would silently land >=0.137. Remove once those tests are migrated for `_IncludedRouter`.
- **New `dependabot-auto-merge.yml`**: enables `gh pr merge --auto` for **patch / minor / security** Dependabot PRs (GitHub merges them server-side once required checks pass) and **labels + holds majors** (`dependabot-major`) for manual review.

## Why this is safe
- Security updates stay on (repo-level automated-security-fixes already enabled). Nothing here *ignores* patch/minor, so security patches (which usually ship as patch/minor) are **never suppressed** — they auto-merge.
- The held fastapi range is the one exception, and it's held precisely because the bump is *not* safe (breaks tests). Holding it via `ignore` is what lets auto-merge run without eroding the pin.
- The auto-merge job never checks out or runs PR code (only reads Dependabot metadata + calls the gh API), gated to `dependabot[bot]`.

## Bonus
Because GitHub performs the merge server-side, this also lands **github-actions PRs that edit workflow files** — the ones a PAT/OAuth token can't merge without the `workflow` scope.

## Net effect
You only ever see a Dependabot PR for a **major/breaking change** (held + labelled) or a **security fix that failed CI**. Everything else merges itself, monthly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)