### PR TITLE
fix(mbk): give upload-processor + scheduler the MinIO env the api has

### DIFF
--- a/apps/mybookkeeper/backend/tests/test_docker_compose_worker_storage_env.py
+++ b/apps/mybookkeeper/backend/tests/test_docker_compose_worker_storage_env.py
@@ -1,0 +1,56 @@
+"""Regression guard: worker services must receive the same MinIO credentials
+as the api.
+
+The upload-processor reads each document's file back from MinIO during
+extraction (the api stores uploads there and records a ``file_storage_key``).
+Before this guard the worker services omitted the ``MINIO_*`` env passthrough
+that the ``api`` service has, so every storage-backed extraction failed with
+``StorageNotConfiguredError: MinIO storage is required but the following env
+vars are unset: MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY`` — the file
+existed in MinIO but the worker could not reach it.
+"""
+from pathlib import Path
+
+import pytest
+import yaml
+
+_COMPOSE = Path(__file__).resolve().parents[2] / "docker-compose.yml"
+_REQUIRED_MINIO_KEYS = {
+    "MINIO_ENDPOINT",
+    "MINIO_ACCESS_KEY",
+    "MINIO_SECRET_KEY",
+    "MINIO_BUCKET",
+}
+# Services that run the backend image and exercise storage-backed code paths
+# (document extraction / email-sourced document storage).
+_STORAGE_WORKER_SERVICES = ("upload-processor", "scheduler")
+
+
+def _service_env_keys(service: dict) -> set[str]:
+    env = service.get("environment", {})
+    if isinstance(env, list):
+        return {item.split("=", 1)[0] for item in env}
+    return set(env.keys())
+
+
+def _load_services() -> dict:
+    return yaml.safe_load(_COMPOSE.read_text())["services"]
+
+
+def test_api_declares_minio_env() -> None:
+    """Baseline: the api is the source of truth the workers must mirror."""
+    api_keys = _service_env_keys(_load_services()["api"])
+    missing = _REQUIRED_MINIO_KEYS - api_keys
+    assert not missing, f"api service is missing MinIO env keys: {sorted(missing)}"
+
+
+@pytest.mark.parametrize("service_name", _STORAGE_WORKER_SERVICES)
+def test_worker_declares_minio_env(service_name: str) -> None:
+    services = _load_services()
+    assert service_name in services, f"{service_name} service missing from docker-compose.yml"
+    missing = _REQUIRED_MINIO_KEYS - _service_env_keys(services[service_name])
+    assert not missing, (
+        f"{service_name} is missing MinIO env keys {sorted(missing)} — the worker "
+        f"reads document files back from MinIO during extraction and will raise "
+        f"StorageNotConfiguredError without them. Mirror the api service's MINIO_* env."
+    )

--- a/apps/mybookkeeper/docker-compose.yml
+++ b/apps/mybookkeeper/docker-compose.yml
@@ -92,6 +92,16 @@ services:
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
+      # Extraction reads each document's file back from MinIO (the api stores
+      # uploads there via file_storage_key), so the worker needs the same MinIO
+      # credentials the api has — sourced from the shared infra/ stack via the
+      # ``myfreeapps`` external network. Without these the worker raises
+      # StorageNotConfiguredError on every storage-backed document.
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT}
+      MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-${MINIO_ROOT_USER}}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-${MINIO_ROOT_PASSWORD}}
+      MINIO_BUCKET: ${MINIO_BUCKET}
     depends_on:
       migrate:
         condition: service_completed_successfully
@@ -109,6 +119,14 @@ services:
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
+      # Email-sourced documents are stored to MinIO during sync, so the
+      # scheduler needs the same MinIO credentials as the api and the
+      # upload-processor (see the upload-processor service for the rationale).
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT}
+      MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-${MINIO_ROOT_USER}}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-${MINIO_ROOT_PASSWORD}}
+      MINIO_BUCKET: ${MINIO_BUCKET}
     depends_on:
       migrate:
         condition: service_completed_successfully

--- a/apps/mybookkeeper/docker-compose.yml
+++ b/apps/mybookkeeper/docker-compose.yml
@@ -92,10 +92,9 @@ services:
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
-      # Extraction reads each document's file back from MinIO (the api stores
-      # uploads there via file_storage_key), so the worker needs the same MinIO
-      # credentials the api has — sourced from the shared infra/ stack via the
-      # ``myfreeapps`` external network. Without these the worker raises
+      # Workers read/write document files in MinIO (extraction downloads by
+      # file_storage_key; email sync stores attachments), so they need the same
+      # MinIO credentials as the api — without them the worker raises
       # StorageNotConfiguredError on every storage-backed document.
       MINIO_ENDPOINT: ${MINIO_ENDPOINT}
       MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT}
@@ -119,9 +118,10 @@ services:
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://mybookkeeper:${DB_PASSWORD}@postgres/mybookkeeper
-      # Email-sourced documents are stored to MinIO during sync, so the
-      # scheduler needs the same MinIO credentials as the api and the
-      # upload-processor (see the upload-processor service for the rationale).
+      # Workers read/write document files in MinIO (extraction downloads by
+      # file_storage_key; email sync stores attachments), so they need the same
+      # MinIO credentials as the api — without them the worker raises
+      # StorageNotConfiguredError on every storage-backed document.
       MINIO_ENDPOINT: ${MINIO_ENDPOINT}
       MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT}
       MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-${MINIO_ROOT_USER}}

--- a/infra/templates/docker-compose.yml.j2
+++ b/infra/templates/docker-compose.yml.j2
@@ -117,6 +117,17 @@ services:
     env_file: backend/.env.docker
     environment:
       DATABASE_URL: postgresql+asyncpg://{{ app_slug }}:${DB_PASSWORD}@postgres/{{ app_slug }}
+{%- if has_minio_subdomain %}
+      # Workers read/write document files in MinIO (extraction downloads by
+      # file_storage_key; email sync stores attachments), so they need the same
+      # MinIO credentials as the api — without them the worker raises
+      # StorageNotConfiguredError on every storage-backed document.
+      MINIO_ENDPOINT: ${MINIO_ENDPOINT}
+      MINIO_PUBLIC_ENDPOINT: ${MINIO_PUBLIC_ENDPOINT}
+      MINIO_ACCESS_KEY: ${MINIO_ACCESS_KEY:-${MINIO_ROOT_USER}}
+      MINIO_SECRET_KEY: ${MINIO_SECRET_KEY:-${MINIO_ROOT_PASSWORD}}
+      MINIO_BUCKET: ${MINIO_BUCKET}
+{%- endif %}
     depends_on:
       migrate:
         condition: service_completed_successfully


### PR DESCRIPTION
## Root cause

Document **extraction runs in the `upload-processor` worker**, which reads each document's file back from MinIO (the `api` stores uploads there and records a `file_storage_key`). MinIO credentials come from the shared `infra/` stack via compose interpolation and must be passed through **per service**. The `api` service declared them; the worker services only declared `DATABASE_URL`.

Result: uploads succeeded (the `api` has MinIO), but every storage-backed extraction failed **in the worker** with:

```
StorageNotConfiguredError: MinIO storage is required but the following env vars are unset: MINIO_ENDPOINT, MINIO_ACCESS_KEY, MINIO_SECRET_KEY
```

Retrying a failed document just re-ran the same read in the same env-starved worker, so "re-extract" always failed identically. This was surfaced via System Health → Recent Activity (the diagnostic added in #938).

## Fix

Mirror the `api` service's `MINIO_*` env onto the `upload-processor` and `scheduler` services. The `scheduler` handles email-sourced documents (stored to MinIO the same way), so it had the same latent gap.

Adds a conformance test (`test_docker_compose_worker_storage_env.py`) asserting the storage-backed worker services declare the same `MINIO_*` keys as the `api`, so this drift can't recur silently.

## Operational note

No VPS env change required — the `MINIO_*` values already exist in the shared infra environment (the `api` reads them). This PR just routes them to the workers. After deploy, previously-failed documents will re-extract successfully on the next retry.

## Follow-up (not in scope)

The `if storage is None` branches in `document_upload_service._store_file` and `document_extraction_service` are dead code — `get_storage()` raises `StorageNotConfiguredError` rather than returning `None`, so the intended inline-DB fallback never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)