### PR TITLE
fix(mbk): surface document row actions on mobile (re-extract, escrow, delete)

### DIFF
--- a/apps/mybookkeeper/frontend/e2e/document-re-extract.spec.ts
+++ b/apps/mybookkeeper/frontend/e2e/document-re-extract.spec.ts
@@ -169,4 +169,50 @@ test.describe("Documents — re-extract a failed document", () => {
       page.locator("tbody tr", { hasText: FAILED_FILE }).getByTitle("Completed"),
     ).toBeVisible({ timeout: 15000 });
   });
+
+  test("on a mobile viewport the re-extract action is reachable on the failed document card", async ({ page }) => {
+    // The desktop table is hidden below the md breakpoint; the mobile card view
+    // renders instead. Row actions used to be desktop-only, so a failed document
+    // could not be retried on a phone at all. getByRole excludes the hidden
+    // desktop table (includeHidden defaults to false), so it resolves only the
+    // visible mobile-card action.
+    await page.setViewportSize({ width: 390, height: 844 });
+    await plantValidJwtAndOrgInLocalStorage(page);
+    await stubAuthAndOrg(page);
+
+    let reExtractMethod: string | null = null;
+
+    await page.route("**/api/documents*", async (route, request) => {
+      if (request.method() !== "GET") {
+        await route.fallback();
+        return;
+      }
+      await route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify([documentRow("failed", "I couldn't read this document — the file looks corrupted.")]),
+      });
+    });
+    await page.route(`**/api/documents/${DOC_ID}/re-extract`, async (route, request) => {
+      reExtractMethod = request.method();
+      await route.fulfill({ status: 202, contentType: "application/json", body: JSON.stringify({ status: "processing" }) });
+    });
+
+    await page.goto("/documents");
+    await expect(page.getByRole("heading", { name: "Documents" })).toBeVisible({ timeout: 15000 });
+
+    // The failed document's card exposes reachable row actions. getByRole
+    // resolves only the visible mobile-card buttons (the hidden desktop table's
+    // duplicates are excluded), so a single match proves the mobile-card fix.
+    const reExtractBtn = page.getByRole("button", { name: "Re-extract this document" });
+    await expect(reExtractBtn).toBeVisible({ timeout: 15000 });
+    await expect(page.getByRole("button", { name: "Delete document" })).toBeVisible();
+
+    // Clicking it fires the real re-extract request and confirms with a toast.
+    await reExtractBtn.click();
+    await expect
+      .poll(() => reExtractMethod, { timeout: 10000, message: "re-extract request was never sent from mobile" })
+      .toBe("POST");
+    await expect(page.getByText("take another look at this one")).toBeVisible({ timeout: 10000 });
+  });
 });

--- a/apps/mybookkeeper/frontend/src/__tests__/DocumentRowActions.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/DocumentRowActions.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import DocumentRowActions from "@/app/features/documents/DocumentRowActions";
+import type { Document } from "@/shared/types/document/document";
+
+// Pass-through Button so the className/aria-label/onClick land directly on a
+// real <button>, keeping assertions about touch-target classes deterministic.
+vi.mock("@platform/ui", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@platform/ui")>();
+  return {
+    ...actual,
+    Button: ({ children, ...props }: React.PropsWithChildren<Record<string, unknown>>) =>
+      <button {...(props as object)}>{children}</button>,
+  };
+});
+
+function makeDocument(overrides: Partial<Document> = {}): Document {
+  return {
+    id: "doc-1",
+    user_id: "user-1",
+    property_id: null,
+    created_at: "2025-01-15T10:00:00Z",
+    updated_at: "2025-01-15T10:00:00Z",
+    file_name: "invoice.pdf",
+    file_type: "pdf",
+    document_type: null,
+    file_mime_type: "application/pdf",
+    email_message_id: null,
+    external_id: null,
+    external_source: null,
+    source: "upload",
+    status: "completed",
+    error_message: null,
+    batch_id: null,
+    is_escrow_paid: false,
+    deleted_at: null,
+    ...overrides,
+  };
+}
+
+describe("DocumentRowActions", () => {
+  it("renders nothing when the user cannot write", () => {
+    const { container } = render(
+      <DocumentRowActions doc={makeDocument({ status: "failed" })} onDelete={vi.fn()} onReExtract={vi.fn()} canWrite={false} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a re-extract action only for failed documents and calls onReExtract on click", () => {
+    const onReExtract = vi.fn();
+    render(<DocumentRowActions doc={makeDocument({ status: "failed" })} onDelete={vi.fn()} onReExtract={onReExtract} />);
+
+    const btn = screen.getByRole("button", { name: "Re-extract this document" });
+    fireEvent.click(btn);
+    expect(onReExtract).toHaveBeenCalledWith("doc-1");
+  });
+
+  it("does not show a re-extract action for completed documents", () => {
+    render(<DocumentRowActions doc={makeDocument({ status: "completed" })} onDelete={vi.fn()} onReExtract={vi.fn()} />);
+    expect(screen.queryByRole("button", { name: "Re-extract this document" })).toBeNull();
+  });
+
+  it("disables the re-extract action while that document is re-extracting", () => {
+    render(
+      <DocumentRowActions
+        doc={makeDocument({ status: "failed" })}
+        onDelete={vi.fn()}
+        onReExtract={vi.fn()}
+        reExtractingId="doc-1"
+      />,
+    );
+    expect(screen.getByRole("button", { name: "Re-extract this document" })).toBeDisabled();
+  });
+
+  it("renders a delete action that calls onDelete", () => {
+    const onDelete = vi.fn();
+    render(<DocumentRowActions doc={makeDocument()} onDelete={onDelete} />);
+    fireEvent.click(screen.getByRole("button", { name: "Delete document" }));
+    expect(onDelete).toHaveBeenCalledWith("doc-1");
+  });
+
+  it("renders an escrow toggle that calls onToggleEscrow with the current value", () => {
+    const onToggleEscrow = vi.fn();
+    render(<DocumentRowActions doc={makeDocument({ is_escrow_paid: true })} onDelete={vi.fn()} onToggleEscrow={onToggleEscrow} />);
+    fireEvent.click(screen.getByRole("button", { name: "Unmark as reference-only" }));
+    expect(onToggleEscrow).toHaveBeenCalledWith("doc-1", true);
+  });
+
+  it("uses >=44px touch targets in comfortable (mobile) mode", () => {
+    render(<DocumentRowActions doc={makeDocument({ status: "failed" })} onDelete={vi.fn()} onReExtract={vi.fn()} comfortable />);
+    const btn = screen.getByRole("button", { name: "Re-extract this document" });
+    // h-11/w-11 = 44px in Tailwind's default scale.
+    expect(btn.className).toContain("h-11");
+    expect(btn.className).toContain("w-11");
+  });
+});

--- a/apps/mybookkeeper/frontend/src/__tests__/Documents.test.tsx
+++ b/apps/mybookkeeper/frontend/src/__tests__/Documents.test.tsx
@@ -156,8 +156,10 @@ describe('Documents', () => {
 
   it('renders document file names from API data', () => {
     renderWithProviders(<Documents />);
-    expect(screen.getByText('invoice_jan.pdf')).toBeInTheDocument();
-    expect(screen.getByText('water_bill.pdf')).toBeInTheDocument();
+    // Names render in both the responsive mobile-card view and the desktop
+    // table (jsdom renders both), so assert presence with getAllByText.
+    expect(screen.getAllByText('invoice_jan.pdf').length).toBeGreaterThan(0);
+    expect(screen.getAllByText('water_bill.pdf').length).toBeGreaterThan(0);
   });
 
   it('shows skeleton when loading', () => {
@@ -278,7 +280,7 @@ describe('Documents — viewer role', () => {
 
   it('still renders the document table for viewer', () => {
     renderWithProviders(<Documents />);
-    expect(screen.getByText('invoice_jan.pdf')).toBeInTheDocument();
+    expect(screen.getAllByText('invoice_jan.pdf').length).toBeGreaterThan(0);
   });
 
   it('still renders the search bar for viewer', () => {

--- a/apps/mybookkeeper/frontend/src/app/features/documents/DocumentRowActions.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/DocumentRowActions.tsx
@@ -1,0 +1,75 @@
+import { FileCheck, RotateCw, Trash2 } from "lucide-react";
+import { Button } from "@platform/ui";
+import type { Document } from "@/shared/types/document/document";
+
+interface DocumentRowActionsProps {
+  doc: Document;
+  onDelete: (id: string) => void;
+  onToggleEscrow?: (id: string, currentValue: boolean) => void;
+  onReExtract?: (id: string) => void;
+  reExtractingId?: string | null;
+  canWrite?: boolean;
+  /** Larger touch targets for the mobile card view (>=44px). */
+  comfortable?: boolean;
+}
+
+/**
+ * Per-row document actions (re-extract failed docs, toggle reference-only,
+ * delete). Shared by the desktop table's actions column and the mobile card so
+ * both surfaces stay in parity — see DocumentTable.
+ */
+export default function DocumentRowActions({
+  doc,
+  onDelete,
+  onToggleEscrow,
+  onReExtract,
+  reExtractingId,
+  canWrite = true,
+  comfortable = false,
+}: DocumentRowActionsProps) {
+  if (!canWrite) return null;
+
+  const sizeClass = comfortable ? "h-11 w-11 flex items-center justify-center" : "p-1.5";
+  const iconSize = comfortable ? 18 : 14;
+  const isReExtracting = reExtractingId === doc.id;
+
+  return (
+    <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
+      {onReExtract && doc.status === "failed" && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onReExtract(doc.id)}
+          disabled={isReExtracting}
+          title="Re-extract this document"
+          aria-label="Re-extract this document"
+          className={`${sizeClass} text-muted-foreground hover:text-primary`}
+        >
+          <RotateCw size={iconSize} className={isReExtracting ? "animate-spin" : ""} />
+        </Button>
+      )}
+      {onToggleEscrow && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onToggleEscrow(doc.id, doc.is_escrow_paid)}
+          title={doc.is_escrow_paid ? "Unmark as reference-only" : "Mark as reference-only (escrow-paid)"}
+          aria-label={doc.is_escrow_paid ? "Unmark as reference-only" : "Mark as reference-only"}
+          className={`${sizeClass} ${doc.is_escrow_paid ? "text-blue-600" : "text-muted-foreground hover:text-blue-600"}`}
+        >
+          <FileCheck size={iconSize} />
+        </Button>
+      )}
+      <Button
+        variant="ghost"
+        size="sm"
+        onClick={() => onDelete(doc.id)}
+        title="Delete"
+        aria-label="Delete document"
+        className={`${sizeClass} text-destructive hover:text-destructive`}
+      >
+        <Trash2 size={iconSize} />
+      </Button>
+    </div>
+  );
+}

--- a/apps/mybookkeeper/frontend/src/app/features/documents/DocumentTable.tsx
+++ b/apps/mybookkeeper/frontend/src/app/features/documents/DocumentTable.tsx
@@ -11,6 +11,7 @@ import { PAGE_SIZE_OPTIONS, DOCUMENT_TYPE_LABELS } from "@/shared/lib/constants"
 import EmptyState from "@/shared/components/ui/EmptyState";
 import { SortIndicator, ColumnFilter } from "@/shared/components/table";
 import StatusBadge from "@/app/features/documents/StatusBadge";
+import DocumentRowActions from "@/app/features/documents/DocumentRowActions";
 import { timeAgo } from "@/shared/utils/date";
 import { cn } from "@/shared/utils/cn";
 
@@ -23,9 +24,24 @@ export interface DocumentTableProps {
   colCount: number;
   filterOptions: FilterOptions;
   onRowClick?: (doc: Document) => void;
+  onDelete?: (id: string) => void;
+  onToggleEscrow?: (id: string, currentValue: boolean) => void;
+  onReExtract?: (id: string) => void;
+  reExtractingId?: string | null;
+  canWrite?: boolean;
 }
 
-export default function DocumentTable({ table, colCount, filterOptions, onRowClick }: DocumentTableProps) {
+export default function DocumentTable({
+  table,
+  colCount,
+  filterOptions,
+  onRowClick,
+  onDelete,
+  onToggleEscrow,
+  onReExtract,
+  reExtractingId,
+  canWrite = true,
+}: DocumentTableProps) {
   const { pageIndex, pageSize } = table.getState().pagination;
   const totalRows = table.getFilteredRowModel().rows.length;
   const start = pageIndex * pageSize + 1;
@@ -44,32 +60,46 @@ export default function DocumentTable({ table, colCount, filterOptions, onRowCli
               ? (DOCUMENT_TYPE_LABELS[doc.document_type] ?? doc.document_type)
               : null;
             return (
-              <button
-                key={doc.id}
-                onClick={() => onRowClick?.(doc)}
-                className={cn(
-                  "w-full text-left p-4 hover:bg-muted/50 min-h-[44px]",
-                  onRowClick && "cursor-pointer",
-                )}
-              >
-                <div className="flex justify-between items-start gap-2">
-                  <p className="font-medium text-sm truncate min-w-0">
-                    {doc.file_name ?? "\u2014"}
-                  </p>
-                  <span className="text-xs px-2 py-0.5 rounded bg-muted whitespace-nowrap">
-                    {doc.source === "email" ? "Email" : "Upload"}
-                  </span>
-                </div>
-                <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
-                  <StatusBadge status={doc.status} errorMessage={doc.error_message} />
-                  {typeLabel && (
-                    <span className="text-xs text-muted-foreground">{typeLabel}</span>
+              <div key={doc.id} className="p-4 hover:bg-muted/50">
+                <button
+                  onClick={() => onRowClick?.(doc)}
+                  className={cn(
+                    "w-full text-left min-h-[44px]",
+                    onRowClick && "cursor-pointer",
                   )}
-                  <span className="text-xs text-muted-foreground ml-auto">
-                    {timeAgo(doc.created_at)}
-                  </span>
-                </div>
-              </button>
+                >
+                  <div className="flex justify-between items-start gap-2">
+                    <p className="font-medium text-sm truncate min-w-0">
+                      {doc.file_name ?? "\u2014"}
+                    </p>
+                    <span className="text-xs px-2 py-0.5 rounded bg-muted whitespace-nowrap">
+                      {doc.source === "email" ? "Email" : "Upload"}
+                    </span>
+                  </div>
+                  <div className="flex flex-wrap items-center gap-1.5 mt-1.5">
+                    <StatusBadge status={doc.status} errorMessage={doc.error_message} />
+                    {typeLabel && (
+                      <span className="text-xs text-muted-foreground">{typeLabel}</span>
+                    )}
+                    <span className="text-xs text-muted-foreground ml-auto">
+                      {timeAgo(doc.created_at)}
+                    </span>
+                  </div>
+                </button>
+                {canWrite && onDelete && (
+                  <div className="mt-2 flex justify-end border-t pt-2">
+                    <DocumentRowActions
+                      doc={doc}
+                      onDelete={onDelete}
+                      onToggleEscrow={onToggleEscrow}
+                      onReExtract={onReExtract}
+                      reExtractingId={reExtractingId}
+                      canWrite={canWrite}
+                      comfortable
+                    />
+                  </div>
+                )}
+              </div>
             );
           })
         )}

--- a/apps/mybookkeeper/frontend/src/app/pages/Documents.tsx
+++ b/apps/mybookkeeper/frontend/src/app/pages/Documents.tsx
@@ -264,6 +264,11 @@ export default function Documents() {
           colCount={colCount}
           filterOptions={filterOptions}
           onRowClick={(doc) => setViewingDocId(doc.id)}
+          onDelete={handleDelete}
+          onToggleEscrow={handleToggleEscrow}
+          onReExtract={handleReExtract}
+          reExtractingId={reExtractingId}
+          canWrite={canWrite}
         />
       )}
 

--- a/apps/mybookkeeper/frontend/src/shared/hooks/useDocumentColumns.tsx
+++ b/apps/mybookkeeper/frontend/src/shared/hooks/useDocumentColumns.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from "react";
 import { createColumnHelper } from "@tanstack/react-table";
 import type { ColumnDef } from "@tanstack/react-table";
-import { FileCheck, RotateCw, Trash2 } from "lucide-react";
+import { FileCheck } from "lucide-react";
 import { formatDate, timeAgo } from "@/shared/utils/date";
 import { DOCUMENT_TYPE_LABELS } from "@/shared/lib/constants";
 import type { Document } from "@/shared/types/document/document";
-import { Button } from "@platform/ui";
 import StatusBadge from "@/app/features/documents/StatusBadge";
+import DocumentRowActions from "@/app/features/documents/DocumentRowActions";
 import IndeterminateCheckbox from "@/shared/components/ui/IndeterminateCheckbox";
 
 interface ColumnActions {
@@ -131,49 +131,16 @@ export function useDocumentColumns(actions: ColumnActions): ColumnDef<Document, 
         id: "actions",
         enableSorting: false,
         header: () => null,
-        cell: ({ row }) => {
-          if (!canWrite) return null;
-          return (
-            <div className="flex items-center justify-end gap-1" onClick={(e) => e.stopPropagation()}>
-              {onReExtract && row.original.status === "failed" && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => onReExtract(row.original.id)}
-                  disabled={reExtractingId === row.original.id}
-                  title="Re-extract this document"
-                  aria-label="Re-extract this document"
-                  className="p-1.5 text-muted-foreground hover:text-primary"
-                >
-                  <RotateCw
-                    size={14}
-                    className={reExtractingId === row.original.id ? "animate-spin" : ""}
-                  />
-                </Button>
-              )}
-              {onToggleEscrow && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => onToggleEscrow(row.original.id, row.original.is_escrow_paid)}
-                  title={row.original.is_escrow_paid ? "Unmark as reference-only" : "Mark as reference-only (escrow-paid)"}
-                  className={`p-1.5 ${row.original.is_escrow_paid ? "text-blue-600" : "text-muted-foreground hover:text-blue-600"}`}
-                >
-                  <FileCheck size={14} />
-                </Button>
-              )}
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onDelete(row.original.id)}
-                title="Delete"
-                className="p-1.5 text-destructive hover:text-destructive"
-              >
-                <Trash2 size={14} />
-              </Button>
-            </div>
-          );
-        },
+        cell: ({ row }) => (
+          <DocumentRowActions
+            doc={row.original}
+            onDelete={onDelete}
+            onToggleEscrow={onToggleEscrow}
+            onReExtract={onReExtract}
+            reExtractingId={reExtractingId}
+            canWrite={canWrite}
+          />
+        ),
       }),
     ],
     [onDelete, onToggleEscrow, onReExtract, reExtractingId, canWrite],


### PR DESCRIPTION
## Problem

The Documents table renders two views: a desktop table with an **Actions** column and a **mobile card view** (`md:hidden`). The mobile card had **no action buttons at all** — it was a single tappable card that only opened the viewer. So on a phone there was no way to re-extract a failed document, delete it, or toggle reference-only; every row action (including the re-extract button shipped in #938) was desktop-only.

This is what surfaced as "I don't see the action buttons on mobile" / "can't retry."

## Fix

- Extract the row actions into a shared **`DocumentRowActions`** component, used by **both** the desktop column and the mobile card. No duplicated action logic.
- Mobile card renders the actions with **comfortable ≥44px touch targets**; the card is restructured so the buttons are siblings of the clickable content (no nested `<button>`).
- Viewer-role users still see no actions (gated on `canWrite`).

## Tests

- **`DocumentRowActions.test.tsx`** (new) — per-status/role visibility, handler dispatch, and 44px touch-target sizing in `comfortable` mode.
- **`document-re-extract.spec.ts`** (mobile E2E, already in the CI layout-spec list) — sets a 390px viewport and asserts the re-extract action is reachable on the failed-document card and fires the request. The existing desktop test still passes (`getByRole` excludes the hidden view, so no strict-mode clash).
- Fixed two pre-existing brittle `Documents.test.tsx` assertions that used `getByText` for names rendered in both responsive views (now `getAllByText`).

All affected unit tests (39) + both layout E2E tests pass locally; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)