### PR TITLE
fix(myrecipes): cooking favicon (🍳) instead of gaming-scaffold 🎮

### DIFF
--- a/apps/myrecipes/frontend/index.html
+++ b/apps/myrecipes/frontend/index.html
@@ -7,7 +7,7 @@
     <!-- iOS add-to-homescreen polish — mirrors apps/myjobhunter/frontend/index.html. -->
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
-    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🎮</text></svg>" />
+    <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🍳</text></svg>" />
     <title>MyRecipes</title>
     <script>
       // Apply dark/light theme BEFORE React hydrates to avoid a flash of the


### PR DESCRIPTION
## What

MyRecipes was scaffolded from MyGamingAssistant and kept its 🎮 favicon. This swaps the inline-SVG data-URI glyph in `index.html` to 🍳 (frying pan) so the browser-tab icon reflects cooking.

Single-file, no behavior change.

## Scope note

This PR is intentionally just the favicon. The in-app brand badges on the auth pages (VerifyEmail / ForgotPassword / ResetPassword / NotFound) are also still gaming icons (`Gamepad2`/🎮) and want re-theming to the `ChefHat` glyph the rest of the app already uses — but those files carry pre-existing scaffold tech-debt (duplicated `CenteredCard`, magic-string state unions, missing E2E tests) that the quality gate requires fixing in the same change. That's deferred to a dedicated follow-up PR so this icon fix stays clean.

(Separately: `main`'s `0003_align_with_platform_shared` already fixed the backend scaffold/migration bugs that block local registration — not part of this PR.)