### PR TITLE
fix(myrecipes): cooking ChefHat brand icons + auth-page debt cleanup + e2e

### DIFF
--- a/apps/myrecipes/frontend/e2e/password-reset.spec.ts
+++ b/apps/myrecipes/frontend/e2e/password-reset.spec.ts
@@ -1,0 +1,98 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Forgot Password — page layout", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/forgot-password");
+  });
+
+  test("renders the forgot password page", async ({ page }) => {
+    await expect(
+      page.getByRole("heading", { name: "Reset your password" })
+    ).toBeVisible();
+    await expect(page.getByText("send you a link")).toBeVisible();
+  });
+
+  test("has email input and submit button", async ({ page }) => {
+    await expect(page.getByLabel("Email")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Send reset link" })
+    ).toBeVisible();
+  });
+
+  test("has back to sign in link", async ({ page }) => {
+    const link = page.getByRole("link", { name: "Back to sign in" });
+    await expect(link).toBeVisible();
+    await link.click();
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  test("submitting email shows confirmation message", async ({ page }) => {
+    await page.getByLabel("Email").fill("test@example.com");
+    await page.getByRole("button", { name: "Send reset link" }).click();
+    await expect(page.getByText("Check your inbox")).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByText("test@example.com")).toBeVisible();
+  });
+});
+
+test.describe("Reset Password — page layout", () => {
+  test("shows invalid link when no token provided", async ({ page }) => {
+    await page.goto("/reset-password");
+    await expect(page.getByText("Invalid link")).toBeVisible();
+    await expect(
+      page.getByRole("link", { name: "Request new link" })
+    ).toBeVisible();
+  });
+
+  test("renders reset form when token is present", async ({ page }) => {
+    await page.goto("/reset-password?token=test-token");
+    await expect(
+      page.getByRole("heading", { name: "Choose a new password" })
+    ).toBeVisible();
+    await expect(page.getByPlaceholder("At least 12 characters")).toBeVisible();
+    await expect(page.getByPlaceholder("Confirm your password")).toBeVisible();
+    await expect(
+      page.getByRole("button", { name: "Reset password" })
+    ).toBeVisible();
+  });
+
+  test("shows error for mismatched passwords", async ({ page }) => {
+    await page.goto("/reset-password?token=test-token");
+    await page.getByPlaceholder("At least 12 characters").fill("newpassword12345");
+    const confirm = page.getByPlaceholder("Confirm your password");
+    await confirm.fill("differentpassword");
+    await confirm.blur();
+    await expect(page.getByText(/Passwords don.t match/)).toBeVisible();
+  });
+
+  test("password fields enforce minimum length", async ({ page }) => {
+    await page.goto("/reset-password?token=test-token");
+    await expect(
+      page.getByPlaceholder("At least 12 characters")
+    ).toHaveAttribute("minlength", "12");
+    await expect(
+      page.getByPlaceholder("Confirm your password")
+    ).toHaveAttribute("minlength", "12");
+  });
+
+  test("clears token from URL after page load", async ({ page }) => {
+    await page.goto("/reset-password?token=test-token");
+    await expect(
+      page.getByPlaceholder("At least 12 characters")
+    ).toBeVisible();
+    await page.waitForTimeout(500);
+    const url = page.url();
+    expect(url).not.toContain("token=");
+  });
+});
+
+test.describe("Login — forgot password link", () => {
+  test("login page has forgot password link", async ({ page }) => {
+    await page.goto("/login");
+    const link = page.getByRole("link", { name: "Forgot password?" });
+    await expect(link).toBeVisible();
+    await link.click();
+    await expect(page).toHaveURL(/\/forgot-password/);
+  });
+});

--- a/apps/myrecipes/frontend/e2e/password-reset.spec.ts
+++ b/apps/myrecipes/frontend/e2e/password-reset.spec.ts
@@ -29,10 +29,16 @@ test.describe("Forgot Password — page layout", () => {
   test("submitting email shows confirmation message", async ({ page }) => {
     await page.getByLabel("Email").fill("test@example.com");
     await page.getByRole("button", { name: "Send reset link" }).click();
-    await expect(page.getByText("Check your inbox")).toBeVisible({
-      timeout: 5000,
-    });
-    await expect(page.getByText("test@example.com")).toBeVisible();
+    // "Check your inbox" appears in both the card heading and the body copy
+    // ("...and spam folder"), so scope the assertion to the heading role.
+    await expect(
+      page.getByRole("heading", { name: "Check your inbox" })
+    ).toBeVisible({ timeout: 5000 });
+    // The submitted email is echoed in a <strong>; exact match avoids also
+    // matching the surrounding paragraph text.
+    await expect(
+      page.getByText("test@example.com", { exact: true })
+    ).toBeVisible();
   });
 });
 

--- a/apps/myrecipes/frontend/e2e/playwright.config.ts
+++ b/apps/myrecipes/frontend/e2e/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  // Cap workers at 50% of available CPUs
+  workers: "50%",
+  reporter: [["html", { open: "never" }], ["list"]],
+  use: {
+    baseURL: process.env.BASE_URL ?? "http://localhost:5180",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    storageState: { cookies: [], origins: [] },
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: process.env.BASE_URL ?? "http://localhost:5180",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120 * 1000,
+  },
+});

--- a/apps/myrecipes/frontend/src/components/CenteredCard.tsx
+++ b/apps/myrecipes/frontend/src/components/CenteredCard.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode } from "react";
+
+export interface CenteredCardProps {
+  title: string;
+  children: ReactNode;
+}
+
+export function CenteredCard({ title, children }: CenteredCardProps) {
+  return (
+    <div className="min-h-screen flex flex-col bg-muted">
+      <div className="flex-1 flex items-center justify-center p-4">
+        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm text-center">
+          <h1 className="text-2xl font-semibold mb-4">{title}</h1>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/myrecipes/frontend/src/components/ResendStatusAlert.tsx
+++ b/apps/myrecipes/frontend/src/components/ResendStatusAlert.tsx
@@ -1,0 +1,44 @@
+import { LoadingButton } from "@platform/ui";
+import { ResendStatusMode } from "@/constants/resendStatusModes";
+
+interface ResendStatusAlertProps {
+  status: ResendStatusMode;
+  onResend: () => void;
+}
+
+/**
+ * Resend-verification CTA and status line shown inside the Login page's
+ * "please verify your email" panel.
+ *
+ * Renders one of three states via early returns rather than a nested ternary
+ * in the parent JSX (the project forbids nested ternaries in JSX).
+ */
+export function ResendStatusAlert({ status, onResend }: ResendStatusAlertProps) {
+  if (status === ResendStatusMode.SENT) {
+    return (
+      <p className="text-emerald-700">
+        Verification email sent. Check your inbox.
+      </p>
+    );
+  }
+
+  if (status === ResendStatusMode.ERROR) {
+    return (
+      <p className="text-destructive">
+        Couldn't resend right now. Try again shortly.
+      </p>
+    );
+  }
+
+  return (
+    <LoadingButton
+      type="button"
+      isLoading={status === ResendStatusMode.SENDING}
+      loadingText="Sending..."
+      className="w-full"
+      onClick={onResend}
+    >
+      Resend verification email
+    </LoadingButton>
+  );
+}

--- a/apps/myrecipes/frontend/src/constants/resendStatusModes.ts
+++ b/apps/myrecipes/frontend/src/constants/resendStatusModes.ts
@@ -1,0 +1,8 @@
+export const ResendStatusMode = {
+  IDLE: "idle",
+  SENDING: "sending",
+  SENT: "sent",
+  ERROR: "error",
+} as const;
+
+export type ResendStatusMode = (typeof ResendStatusMode)[keyof typeof ResendStatusMode];

--- a/apps/myrecipes/frontend/src/constants/verifyState.ts
+++ b/apps/myrecipes/frontend/src/constants/verifyState.ts
@@ -1,0 +1,7 @@
+export const VerifyState = {
+  VERIFYING: "verifying",
+  SUCCESS: "success",
+  ERROR: "error",
+} as const;
+
+export type VerifyState = (typeof VerifyState)[keyof typeof VerifyState];

--- a/apps/myrecipes/frontend/src/pages/ForgotPassword.tsx
+++ b/apps/myrecipes/frontend/src/pages/ForgotPassword.tsx
@@ -1,7 +1,8 @@
 import { useCallback, useState } from "react";
 import { Link } from "react-router-dom";
 import { LoadingButton, TurnstileWidget } from "@platform/ui";
-import { Gamepad2 } from "lucide-react";
+import { ChefHat } from "lucide-react";
+import { CenteredCard } from "@/components/CenteredCard";
 import { forgotPassword } from "@/lib/auth";
 
 export default function ForgotPassword() {
@@ -50,7 +51,7 @@ export default function ForgotPassword() {
       <div className="flex-1 flex items-center justify-center p-4">
         <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm">
           <div className="flex items-center gap-2 mb-6">
-            <Gamepad2 className="size-6 text-primary" />
+            <ChefHat className="size-6 text-primary" />
             <h1 className="text-2xl font-semibold">Reset your password</h1>
           </div>
           <p className="text-sm text-muted-foreground mb-6">
@@ -91,24 +92,6 @@ export default function ForgotPassword() {
               Back to sign in
             </Link>
           </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-interface CenteredCardProps {
-  title: string;
-  children: React.ReactNode;
-}
-
-function CenteredCard({ title, children }: CenteredCardProps) {
-  return (
-    <div className="min-h-screen flex flex-col bg-muted">
-      <div className="flex-1 flex items-center justify-center p-4">
-        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm text-center">
-          <h1 className="text-2xl font-semibold mb-4">{title}</h1>
-          {children}
         </div>
       </div>
     </div>

--- a/apps/myrecipes/frontend/src/pages/Login.tsx
+++ b/apps/myrecipes/frontend/src/pages/Login.tsx
@@ -10,6 +10,7 @@ import {
 import { isUnverifiedError, useSignIn } from "@/features/auth/useSignIn";
 import { requestVerifyToken } from "@/lib/auth";
 import { ResendStatusMode } from "@/constants/resendStatusModes";
+import { ResendStatusAlert } from "@/components/ResendStatusAlert";
 
 interface LocationState {
   from?: string;
@@ -258,25 +259,10 @@ export default function Login() {
                   Please verify your email before signing in. Check your inbox for the
                   verification link.
                 </p>
-                {resendStatus === ResendStatusMode.SENT ? (
-                  <p className="text-emerald-700">
-                    Verification email sent. Check your inbox.
-                  </p>
-                ) : resendStatus === ResendStatusMode.ERROR ? (
-                  <p className="text-destructive">
-                    Couldn't resend right now. Try again shortly.
-                  </p>
-                ) : (
-                  <LoadingButton
-                    type="button"
-                    isLoading={resendStatus === ResendStatusMode.SENDING}
-                    loadingText="Sending..."
-                    className="w-full"
-                    onClick={onResendVerification}
-                  >
-                    Resend verification email
-                  </LoadingButton>
-                )}
+                <ResendStatusAlert
+                  status={resendStatus}
+                  onResend={onResendVerification}
+                />
               </div>
             ) : null}
           </>

--- a/apps/myrecipes/frontend/src/pages/Login.tsx
+++ b/apps/myrecipes/frontend/src/pages/Login.tsx
@@ -9,12 +9,11 @@ import {
 } from "@platform/ui";
 import { isUnverifiedError, useSignIn } from "@/features/auth/useSignIn";
 import { requestVerifyToken } from "@/lib/auth";
+import { ResendStatusMode } from "@/constants/resendStatusModes";
 
 interface LocationState {
   from?: string;
 }
-
-type ResendStatus = "idle" | "sending" | "sent" | "error";
 
 /**
  * Login page for the multi-user MyRecipes.
@@ -36,7 +35,9 @@ export default function Login() {
 
   const [needsVerification, setNeedsVerification] = useState(false);
   const [pendingEmail, setPendingEmail] = useState("");
-  const [resendStatus, setResendStatus] = useState<ResendStatus>("idle");
+  const [resendStatus, setResendStatus] = useState<ResendStatusMode>(
+    ResendStatusMode.IDLE,
+  );
 
   const [pendingCredentials, setPendingCredentials] = useState<
     { email: string; password: string } | null
@@ -78,7 +79,7 @@ export default function Login() {
       if (isUnverifiedError(err)) {
         setPendingEmail(email);
         setNeedsVerification(true);
-        setResendStatus("idle");
+        setResendStatus(ResendStatusMode.IDLE);
       } else {
         setError("Incorrect email or password. Please try again.");
       }
@@ -89,12 +90,12 @@ export default function Login() {
 
   async function onResendVerification() {
     if (!pendingEmail) return;
-    setResendStatus("sending");
+    setResendStatus(ResendStatusMode.SENDING);
     try {
       await requestVerifyToken(pendingEmail);
-      setResendStatus("sent");
+      setResendStatus(ResendStatusMode.SENT);
     } catch {
-      setResendStatus("error");
+      setResendStatus(ResendStatusMode.ERROR);
     }
   }
 
@@ -257,18 +258,18 @@ export default function Login() {
                   Please verify your email before signing in. Check your inbox for the
                   verification link.
                 </p>
-                {resendStatus === "sent" ? (
+                {resendStatus === ResendStatusMode.SENT ? (
                   <p className="text-emerald-700">
                     Verification email sent. Check your inbox.
                   </p>
-                ) : resendStatus === "error" ? (
+                ) : resendStatus === ResendStatusMode.ERROR ? (
                   <p className="text-destructive">
                     Couldn't resend right now. Try again shortly.
                   </p>
                 ) : (
                   <LoadingButton
                     type="button"
-                    isLoading={resendStatus === "sending"}
+                    isLoading={resendStatus === ResendStatusMode.SENDING}
                     loadingText="Sending..."
                     className="w-full"
                     onClick={onResendVerification}

--- a/apps/myrecipes/frontend/src/pages/NotFound.tsx
+++ b/apps/myrecipes/frontend/src/pages/NotFound.tsx
@@ -1,10 +1,10 @@
 import { Link } from "react-router-dom";
-import { Gamepad2 } from "lucide-react";
+import { ChefHat } from "lucide-react";
 
 export default function NotFound() {
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-muted/30 px-4 text-center">
-      <Gamepad2 className="h-16 w-16 text-muted-foreground mb-4" aria-hidden />
+      <ChefHat className="h-16 w-16 text-muted-foreground mb-4" aria-hidden />
       <h1 className="text-4xl font-bold mb-2">404</h1>
       <p className="text-muted-foreground mb-6">
         Page not found. It may have moved or never existed.
@@ -13,7 +13,7 @@ export default function NotFound() {
         to="/"
         className="inline-block bg-primary text-primary-foreground rounded-md px-4 py-2 text-sm font-medium hover:bg-primary/90 min-h-[44px] leading-7"
       >
-        Back to games
+        Back to recipes
       </Link>
     </div>
   );

--- a/apps/myrecipes/frontend/src/pages/ResetPassword.tsx
+++ b/apps/myrecipes/frontend/src/pages/ResetPassword.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { LoadingButton, PasswordPair, extractErrorMessage } from "@platform/ui";
-import { Gamepad2 } from "lucide-react";
+import { ChefHat } from "lucide-react";
+import { CenteredCard } from "@/components/CenteredCard";
 import { resetPassword } from "@/lib/auth";
 
 export default function ResetPassword() {
@@ -83,7 +84,7 @@ export default function ResetPassword() {
       <div className="flex-1 flex items-center justify-center p-4">
         <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm">
           <div className="flex items-center gap-2 mb-6">
-            <Gamepad2 className="size-6 text-primary" />
+            <ChefHat className="size-6 text-primary" />
             <h1 className="text-2xl font-semibold">Choose a new password</h1>
           </div>
           <form onSubmit={handleSubmit} className="space-y-4">
@@ -113,24 +114,6 @@ export default function ResetPassword() {
               Back to sign in
             </Link>
           </p>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-interface CenteredCardProps {
-  title: string;
-  children: React.ReactNode;
-}
-
-function CenteredCard({ title, children }: CenteredCardProps) {
-  return (
-    <div className="min-h-screen flex flex-col bg-muted">
-      <div className="flex-1 flex items-center justify-center p-4">
-        <div className="bg-card border rounded-lg p-8 w-full max-w-sm shadow-sm text-center">
-          <h1 className="text-2xl font-semibold mb-4">{title}</h1>
-          {children}
         </div>
       </div>
     </div>

--- a/apps/myrecipes/frontend/src/pages/VerifyEmail.tsx
+++ b/apps/myrecipes/frontend/src/pages/VerifyEmail.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from "react";
 import { useSearchParams, Link } from "react-router-dom";
+import { ChefHat } from "lucide-react";
 import { extractErrorMessage } from "@platform/ui";
+import { VerifyState } from "@/constants/verifyState";
 import api from "@/lib/api";
-
-type VerifyState = "verifying" | "success" | "error";
 
 const NO_TOKEN_MESSAGE =
   "No verification token found in the link. Please check your email and try again.";
@@ -12,7 +12,9 @@ export default function VerifyEmail() {
   const [searchParams] = useSearchParams();
   const token = searchParams.get("token");
 
-  const [state, setState] = useState<VerifyState>(token ? "verifying" : "error");
+  const [state, setState] = useState<VerifyState>(
+    token ? VerifyState.VERIFYING : VerifyState.ERROR,
+  );
   const [errorMessage, setErrorMessage] = useState(token ? "" : NO_TOKEN_MESSAGE);
 
   useEffect(() => {
@@ -20,9 +22,9 @@ export default function VerifyEmail() {
 
     api
       .post("/auth/verify", { token })
-      .then(() => setState("success"))
+      .then(() => setState(VerifyState.SUCCESS))
       .catch((err: unknown) => {
-        setState("error");
+        setState(VerifyState.ERROR);
         setErrorMessage(extractErrorMessage(err));
       });
   }, [token]);
@@ -31,13 +33,13 @@ export default function VerifyEmail() {
     <div className="min-h-screen flex flex-col items-center justify-center bg-muted/30 px-4">
       <div className="mb-8 flex flex-col items-center gap-2">
         <div className="w-12 h-12 rounded-xl bg-primary flex items-center justify-center">
-          <span className="text-primary-foreground font-bold text-xl" aria-hidden>🎮</span>
+          <ChefHat className="w-6 h-6 text-primary-foreground" aria-hidden />
         </div>
         <span className="text-xl font-semibold tracking-tight">MyRecipes</span>
       </div>
 
       <div className="w-full max-w-sm bg-background border rounded-xl p-8 shadow-xs text-center">
-        {state === "verifying" && (
+        {state === VerifyState.VERIFYING && (
           <>
             <div className="flex justify-center mb-4">
               <div
@@ -50,7 +52,7 @@ export default function VerifyEmail() {
           </>
         )}
 
-        {state === "success" && (
+        {state === VerifyState.SUCCESS && (
           <>
             <h1 className="text-lg font-semibold mb-2">You're verified.</h1>
             <p className="text-sm text-muted-foreground mb-6">
@@ -65,7 +67,7 @@ export default function VerifyEmail() {
           </>
         )}
 
-        {state === "error" && (
+        {state === VerifyState.ERROR && (
           <>
             <h1 className="text-lg font-semibold mb-2">Couldn't verify</h1>
             <p className="text-destructive text-sm mb-6" role="alert">


### PR DESCRIPTION
## What

Re-themes the remaining gaming-scaffold icons in the MyRecipes app to the `ChefHat` glyph already used in `RootLayout` + `Register`, and clears the pre-existing tech debt on the touched auth pages (which the quality gate requires fixing in the same change):

- **Icons:** `Gamepad2`/🎮 → `ChefHat` on VerifyEmail, NotFound, ForgotPassword, ResetPassword (NotFound copy "Back to games" → "Back to recipes").
- **Debt:** extracted the duplicated `CenteredCard` helper → `src/components/CenteredCard.tsx` (shared by Forgot/ResetPassword); extracted magic-string state unions → `src/constants/verifyState.ts` (VerifyEmail) and `src/constants/resendStatusModes.ts` (Login).
- **E2E bootstrap:** added the MyRecipes Playwright harness (`e2e/playwright.config.ts` + `e2e/password-reset.spec.ts`). `package.json` already had the `test:e2e` script + `@playwright/test`. The spec mirrors `apps/mybookkeeper/frontend/e2e/password-reset.spec.ts`, with every selector matched to MyRecipes' real DOM.

Completes the cooking re-theme started by the favicon PR #942.

## Testing

- `npm run typecheck --workspace=apps/myrecipes/frontend` passes; zero `Gamepad2`/🎮 references remain in `src`.
- ⚠️ The Playwright specs are typecheck-clean and mirror the canonical app's proven pattern, but were **not executed in a browser** in this change (the harness is brand-new and the spec selectors were verified against page source, not a live run). Recommend a `npm run test:e2e --workspace=apps/myrecipes/frontend` run (backend on :8008) to confirm green before relying on them in CI.