### PR TITLE
fix(mjh): extract ResendStatusAlert from Login + replace resend-status magic strings with enum

### DIFF
--- a/apps/myjobhunter/frontend/src/components/ResendStatusAlert.tsx
+++ b/apps/myjobhunter/frontend/src/components/ResendStatusAlert.tsx
@@ -1,0 +1,44 @@
+import { LoadingButton } from "@platform/ui";
+import { ResendStatusMode } from "@/constants/resendStatusModes";
+
+interface ResendStatusAlertProps {
+  status: ResendStatusMode;
+  onResend: () => void;
+}
+
+/**
+ * Resend-verification CTA and status line shown inside the Login page's
+ * "please verify your email" panel.
+ *
+ * Renders one of three states via early returns rather than a nested ternary
+ * in the parent JSX (the project forbids nested ternaries in JSX).
+ */
+export function ResendStatusAlert({ status, onResend }: ResendStatusAlertProps) {
+  if (status === ResendStatusMode.SENT) {
+    return (
+      <p className="text-emerald-700" data-testid="resend-verification-sent">
+        Verification email sent. Check your inbox.
+      </p>
+    );
+  }
+
+  if (status === ResendStatusMode.ERROR) {
+    return (
+      <p className="text-destructive">
+        Couldn't resend right now. Try again shortly.
+      </p>
+    );
+  }
+
+  return (
+    <LoadingButton
+      type="button"
+      isLoading={status === ResendStatusMode.SENDING}
+      loadingText="Sending..."
+      className="w-full"
+      onClick={onResend}
+    >
+      Resend verification email
+    </LoadingButton>
+  );
+}

--- a/apps/myjobhunter/frontend/src/constants/resendStatusModes.ts
+++ b/apps/myjobhunter/frontend/src/constants/resendStatusModes.ts
@@ -1,0 +1,8 @@
+export const ResendStatusMode = {
+  IDLE: "idle",
+  SENDING: "sending",
+  SENT: "sent",
+  ERROR: "error",
+} as const;
+
+export type ResendStatusMode = (typeof ResendStatusMode)[keyof typeof ResendStatusMode];

--- a/apps/myjobhunter/frontend/src/pages/Login.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Login.tsx
@@ -11,12 +11,12 @@ import {
 } from "@platform/ui";
 import { isUnverifiedError, useSignIn } from "@/features/auth/useSignIn";
 import { requestVerifyToken } from "@/lib/auth";
+import { ResendStatusMode } from "@/constants/resendStatusModes";
+import { ResendStatusAlert } from "@/components/ResendStatusAlert";
 
 interface LocationState {
   from?: string;
 }
-
-type ResendStatus = "idle" | "sending" | "sent" | "error";
 
 /**
  * Login page with three layered flows:
@@ -39,7 +39,9 @@ export default function Login() {
   const [needsVerification, setNeedsVerification] = useState(false);
   const [pendingEmail, setPendingEmail] = useState("");
   const [registeredEmail, setRegisteredEmail] = useState("");
-  const [resendStatus, setResendStatus] = useState<ResendStatus>("idle");
+  const [resendStatus, setResendStatus] = useState<ResendStatusMode>(
+    ResendStatusMode.IDLE,
+  );
 
   // TOTP challenge state (C5) — populated after first signIn returns totp_required
   const [pendingCredentials, setPendingCredentials] = useState<
@@ -91,7 +93,7 @@ export default function Login() {
       if (isUnverifiedError(err)) {
         setPendingEmail(email);
         setNeedsVerification(true);
-        setResendStatus("idle");
+        setResendStatus(ResendStatusMode.IDLE);
       }
       throw err;
     }
@@ -105,12 +107,12 @@ export default function Login() {
 
   async function onResendVerification() {
     if (!pendingEmail) return;
-    setResendStatus("sending");
+    setResendStatus(ResendStatusMode.SENDING);
     try {
       await requestVerifyToken(pendingEmail);
-      setResendStatus("sent");
+      setResendStatus(ResendStatusMode.SENT);
     } catch {
-      setResendStatus("error");
+      setResendStatus(ResendStatusMode.ERROR);
     }
   }
 
@@ -254,28 +256,10 @@ export default function Login() {
                   Please verify your email before signing in. Check your inbox for the
                   verification link.
                 </p>
-                {resendStatus === "sent" ? (
-                  <p
-                    className="text-emerald-700"
-                    data-testid="resend-verification-sent"
-                  >
-                    Verification email sent. Check your inbox.
-                  </p>
-                ) : resendStatus === "error" ? (
-                  <p className="text-destructive">
-                    Couldn't resend right now. Try again shortly.
-                  </p>
-                ) : (
-                  <LoadingButton
-                    type="button"
-                    isLoading={resendStatus === "sending"}
-                    loadingText="Sending..."
-                    className="w-full"
-                    onClick={onResendVerification}
-                  >
-                    Resend verification email
-                  </LoadingButton>
-                )}
+                <ResendStatusAlert
+                  status={resendStatus}
+                  onResend={onResendVerification}
+                />
               </div>
             ) : null}
           </>


### PR DESCRIPTION
## What

Mirrors the MyRecipes #943 auth-page cleanup into the **canonical** MyJobHunter `Login.tsx`, closing the last open parity follow-up from that session.

- **Magic strings → enum.** Replaces the inline `type ResendStatus = "idle" | "sending" | "sent" | "error"` union (and its raw string literals at the call sites) with a shared `ResendStatusMode` enum constant in `constants/resendStatusModes.ts` — byte-identical to the MyRecipes version. Single source of truth instead of stringly-typed values scattered through the component.
- **Nested ternary → component.** Extracts the `sent ? … : error ? … : (CTA)` nested ternary in the verify-email panel into a `ResendStatusAlert` component that renders via early returns, per the project's no-nested-ternary-in-JSX rule (`feedback_minimize_ternaries_extract_types`).

## Parity note

MyRecipes was scaffolded *from* MJH's Login page; #943 improved the MyRecipes copy and left MJH (the canonical) behind. This brings the canonical back in line. The extracted component is adapted (not copied verbatim): the **SENT** state keeps MJH's `data-testid="resend-verification-sent"`, which MyRecipes' copy doesn't carry, so existing tests keep working.

## Behaviour

Unchanged. Same three rendered states, same copy, same `data-testid`s on the banner and sent line.

## Validation (local)

- `npm run typecheck` — ✅ clean
- `npm run lint` — ✅ 0 errors (10 pre-existing warnings in unrelated `markdown-preview.tsx`)
- `npm run build` (tsc -b + vite) — ✅ built
- Resend-banner unit tests (`Login.test.tsx`: shows banner / not on bad-creds / resend POSTs + flips to sent) — ✅ pass

> **Note on local test suite:** a fresh local `npm install` surfaces ~18 pre-existing failures across 8 files I didn't touch (Profile ×10, KanbanBoard/DimensionsTable collected "0 test", ResumeJobRow, DocumentList) plus two non-resend `Login.test.tsx` interaction tests (sign-in nav, register banner). These are an environment/install artifact — none exercise resend status, and my change cannot affect untouched components. CI (clean env) is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)