### PR TITLE
fix(mbk): never run rent attribution on expense transactions

### DIFF
--- a/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
+++ b/apps/mybookkeeper/backend/app/services/transactions/attribution_service.py
@@ -65,6 +65,15 @@ async def maybe_attribute_payment(
     if txn.applicant_id is not None:
         return  # already attributed
 
+    # Attribution links a rent *payment* (or payout) to a tenant/property and
+    # stamps category="rental_revenue". It must never run on an expense — e.g.
+    # a management-commission line on a property-management statement — or the
+    # row ends up transaction_type="expense" + category="rental_revenue" and
+    # violates the chk_txn_type_category constraint at insert time, failing the
+    # whole sync item.
+    if txn.transaction_type != "income":
+        return
+
     # --- Airbnb payout path ---------------------------------------------------
     if is_airbnb_payout:
         await _attribute_airbnb_payout(db, txn=txn, organization_id=organization_id, user_id=user_id)

--- a/apps/mybookkeeper/backend/tests/test_attribution_service_income_guard.py
+++ b/apps/mybookkeeper/backend/tests/test_attribution_service_income_guard.py
@@ -1,0 +1,164 @@
+"""Attribution must never run on an expense.
+
+Rent-payment attribution links a payment/payout to a tenant or property and
+stamps ``category="rental_revenue"``. A property-management statement (e.g.
+Vello) produces both a rental-income line AND a management-commission *expense*
+line. Before the income guard, the expense line was fed through attribution,
+which force-set ``category="rental_revenue"`` while leaving
+``transaction_type="expense"`` (and ``schedule_e_line="line_8_commissions"``)
+intact. That contradictory row violates the ``chk_txn_type_category`` check
+constraint at insert time and fails the whole sync item.
+
+The guard early-returns for any non-income transaction, in both the tenant
+payer-name path and the Airbnb-payout path. The positive (income still
+attributes) case is covered in ``test_attribution_service_auto_verifies.py``;
+the sanity test here just locks the boundary.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.applicants.applicant import Applicant
+from app.models.properties.property import Property
+from app.models.transactions.booking_statement import BookingStatement
+from app.models.transactions.rent_attribution_review_queue import (
+    RentAttributionReviewQueue,
+)
+from app.models.transactions.transaction import Transaction
+from app.services.transactions.attribution_service import maybe_attribute_payment
+
+_RECEIPT_PATCH = (
+    "app.services.transactions.attribution_service.receipt_service"
+    ".create_pending_receipt_in_session"
+)
+
+
+async def _make_applicant(db, org_id, user_id, name="Prince Kapoor") -> Applicant:
+    applicant = Applicant(
+        id=uuid.uuid4(), organization_id=org_id, user_id=user_id,
+        stage="lease_signed", legal_name=name,
+    )
+    db.add(applicant)
+    await db.flush()
+    return applicant
+
+
+async def _make_txn(
+    db, org_id, user_id, *,
+    transaction_type: str,
+    category: str,
+    payer_name: str | None = None,
+    description: str | None = None,
+) -> Transaction:
+    txn = Transaction(
+        id=uuid.uuid4(), organization_id=org_id, user_id=user_id,
+        transaction_date=_dt.date(2026, 6, 1), tax_year=2026, amount="444.42",
+        transaction_type=transaction_type, category=category, status="approved",
+        is_manual=False, payer_name=payer_name, description=description,
+    )
+    db.add(txn)
+    await db.flush()
+    return txn
+
+
+async def _review_rows(db: AsyncSession, txn_id: uuid.UUID) -> list:
+    return list(
+        (
+            await db.execute(
+                select(RentAttributionReviewQueue).where(
+                    RentAttributionReviewQueue.transaction_id == txn_id
+                )
+            )
+        ).scalars()
+    )
+
+
+@pytest.mark.asyncio
+async def test_expense_is_not_attributed_via_payer_name(db: AsyncSession):
+    """A management-fee expense whose payer name exactly matches a tenant must
+    NOT be attributed — category/type stay put and nothing is queued."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    # Exact-name candidate that WOULD auto-attribute were this income.
+    await _make_applicant(db, org_id, user_id, "Vello")
+    txn = await _make_txn(
+        db, org_id, user_id,
+        transaction_type="expense", category="management_fee",
+        payer_name="Vello",
+        description="Vello property management commission — billing period 6/1 to 6/15",
+    )
+
+    with patch(_RECEIPT_PATCH, new_callable=AsyncMock) as receipt_mock:
+        await maybe_attribute_payment(
+            db, txn=txn, payer_name="Vello",
+            organization_id=org_id, user_id=user_id,
+        )
+
+    assert txn.applicant_id is None
+    assert txn.attribution_source is None
+    assert txn.category == "management_fee"  # never overwritten to rental_revenue
+    assert txn.transaction_type == "expense"
+    receipt_mock.assert_not_awaited()
+    assert await _review_rows(db, txn.id) == []
+
+
+@pytest.mark.asyncio
+async def test_expense_is_not_attributed_via_airbnb_payout_path(db: AsyncSession):
+    """The same guard applies on the Airbnb-payout path: an expense line whose
+    res_code matches a booking statement must NOT be stamped rental_revenue."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prop = Property(id=uuid.uuid4(), organization_id=org_id, user_id=user_id, name="Beach House")
+    stmt = BookingStatement(
+        id=uuid.uuid4(), organization_id=org_id, property_id=prop.id, res_code="HM12345",
+        check_in=_dt.date(2026, 5, 20), check_out=_dt.date(2026, 5, 25),
+    )
+    db.add_all([prop, stmt])
+    await db.flush()
+    txn = await _make_txn(
+        db, org_id, user_id,
+        transaction_type="expense", category="management_fee",
+        description="Management fee for reservation HM12345",
+    )
+
+    with patch(
+        "app.services.transactions.attribution_service.listing_repo.list_by_channel",
+        new_callable=AsyncMock, return_value=[],
+    ):
+        await maybe_attribute_payment(
+            db, txn=txn, payer_name=None, organization_id=org_id, user_id=user_id,
+            is_airbnb_payout=True,
+        )
+
+    assert txn.property_id is None
+    assert txn.attribution_source is None
+    assert txn.category == "management_fee"
+    assert txn.transaction_type == "expense"
+    assert await _review_rows(db, txn.id) == []
+
+
+@pytest.mark.asyncio
+async def test_income_payment_is_still_attributed(db: AsyncSession):
+    """Boundary check: the guard blocks only non-income — a matching income
+    payment still auto-attributes and is stamped rental_revenue."""
+    org_id, user_id = uuid.uuid4(), uuid.uuid4()
+    prince = await _make_applicant(db, org_id, user_id, "Prince Kapoor")
+    txn = await _make_txn(
+        db, org_id, user_id,
+        transaction_type="income", category="uncategorized",
+        payer_name="Prince Kapoor",
+    )
+
+    with patch(_RECEIPT_PATCH, new_callable=AsyncMock):
+        await maybe_attribute_payment(
+            db, txn=txn, payer_name="Prince Kapoor",
+            organization_id=org_id, user_id=user_id,
+        )
+
+    assert txn.applicant_id == prince.id
+    assert txn.attribution_source == "auto_exact"
+    assert txn.category == "rental_revenue"

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -938,7 +938,8 @@
         "test_airbnb_payout_matcher.py",
         "test_attribution_service_airbnb_payout.py",
         "test_attribution_service_payer_alias.py",
-        "test_attribution_service_auto_verifies.py"
+        "test_attribution_service_auto_verifies.py",
+        "test_attribution_service_income_guard.py"
       ],
       "frontend_tests": [
         "AttributionReviewPanel.test.tsx",


### PR DESCRIPTION
## Problem

A Gmail sync (session #480) came back **Partial — 1 item failed**. The failure was a DB rejection, not an extraction error:

```
CheckViolationError: violates check constraint "chk_txn_type_category"
Failing row: ... expense, rental_revenue, ["management_fee"], ... line_8_commissions ...
```

The row is contradictory: `transaction_type=expense` but `category=rental_revenue` (an income-only category). Postgres refused the insert, so the management-commission line from a Vello property-management statement never saved (and "Retry Failed" would re-fail the same way).

## Root cause

The transaction was **built correctly** as a management-fee expense — `tags=["management_fee"]` and `schedule_e_line=line_8_commissions` (derived from `category=management_fee`). Then `category` alone was overwritten to `rental_revenue` by the **rent-attribution flow** (`attribution_source=auto_exact` on the row).

`maybe_attribute_payment` force-sets `category="rental_revenue"` in every auto-attribution branch, and `extraction_persistence.py` calls it for **any** surviving transaction when `payer_name or is_airbnb_payout` — with no check that the transaction is income. A property-management statement (airbnb channel) yields both a rental-income line and a management-commission **expense** line; the expense line went through attribution and got stamped `rental_revenue` while its `type`/`schedule_e_line` stayed expense/commissions → constraint violation.

## Fix

Income-only guard at the top of `maybe_attribute_payment` — attribution links a rent *payment/payout* and must never touch an expense:

```python
if txn.transaction_type != "income":
    return
```

This covers both the tenant payer-name path and the Airbnb-payout path. The manual confirm/link paths are transitively protected — expenses can no longer be queued for attribution review.

## Tests

`test_attribution_service_income_guard.py` (new):
- expense is **not** attributed via the payer-name path (category/type unchanged, nothing queued)
- expense is **not** attributed via the Airbnb-payout path (set up to match a `res_code` booking statement — would attribute without the guard)
- income **still** attributes and is stamped `rental_revenue` (boundary)

`test-map.json` updated. Local run: **20 attribution tests pass** (3 new + 17 existing, no regression).

## Follow-up (operator)

After deploy, re-run that Gmail sync (or "Retry Failed") so the previously-rejected $444.42 management-fee expense for 6732 Peerless St lands in the books.

🤖 Generated with [Claude Code](https://claude.com/claude-code)