### PR TITLE
docs(myrecipes): document ANTHROPIC_API_KEY in .env.docker.example

### DIFF
--- a/apps/myrecipes/backend/.env.docker.example
+++ b/apps/myrecipes/backend/.env.docker.example
@@ -84,6 +84,14 @@ MINIO_SECURE=false
 # Required on the primary in production; empty elsewhere (those apps 404 the
 # webhook so misrouted posts stop retrying).
 KOFI_VERIFICATION_TOKEN=
+
+# --- AI photo import (optional) ---
+# Standard Anthropic API key (sk-ant-...). Enables "Import from photo": Claude
+# vision extracts a recipe draft from an uploaded image. When empty, the
+# POST /recipes/extract endpoint returns 503 and the rest of the app is
+# unaffected; MyRecipes does NOT require this key to boot.
+ANTHROPIC_API_KEY=
+
 # Optional Anthropic Admin API key (sk-ant-admin...) so the daily sync pulls real
 # Claude API spend into the cost figure. Primary only; empty → Claude spend = 0
 # and only the fixed VPS + domain costs below are shown.


### PR DESCRIPTION
Follow-up to #948. Documents the optional `ANTHROPIC_API_KEY` (enables photo import; the app boots fine without it and the endpoint returns 503 until set) in MyRecipes' `.env.docker.example`, next to the existing `ANTHROPIC_ADMIN_API_KEY`. Doc-only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)