### PR TITLE
feat(mga): Valorant agent-based lineup filtering (agent dimension)

### DIFF
--- a/apps/mygamingassistant/backend/alembic/versions/0019_agent_and_utility_agent_id.py
+++ b/apps/mygamingassistant/backend/alembic/versions/0019_agent_and_utility_agent_id.py
@@ -1,0 +1,117 @@
+"""Add agent table + utility_type.agent_id (Valorant agent dimension)
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-06-30 10:30:00.000000
+
+Adds the ``agent`` taxonomy table (Valorant playable characters) and a nullable
+``utility_type.agent_id`` FK so Valorant utilities can be filtered by agent
+(Sova → Recon Bolt / Shock Bolt). CS2 utilities keep ``agent_id = NULL``.
+
+Schema + prune ONLY. Agent rows and the ``agent_id`` *values* on Valorant
+utility types are seeded by ``load-fixtures`` (``agents.json`` +
+``utility_types.json``), which runs after this migration on every deploy — this
+matches the repo convention of keeping seed data out of migrations.
+
+The ``utility_type`` (game_id, slug) unique constraint is intentionally
+unchanged: Valorant ability slugs are globally unique within the game, so the
+lineup pack / importer keep resolving utility types by slug alone.
+
+Prune: the 3 generic Valorant utility types (``smoke`` / ``flash`` / ``molotov``)
+were placeholders and have zero lineups — they are replaced by agent-specific
+abilities in the restructured fixture. The DELETE is guarded (0013 pattern): it
+fails loud rather than orphaning rows if any environment seeded lineups against
+them.
+
+Downgrade drops the column + table. It does NOT re-create the pruned generic
+utility types (they were unused and removed from the fixture too).
+"""
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column("game_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("slug", sa.String(length=50), nullable=False),
+        sa.Column("name", sa.String(length=100), nullable=False),
+        sa.Column("role", sa.String(length=20), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(["game_id"], ["game.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("game_id", "slug", name="uq_agent_game_slug"),
+    )
+    op.create_index("ix_agent_game_id", "agent", ["game_id"])
+
+    op.add_column(
+        "utility_type",
+        sa.Column("agent_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_utility_type_agent_id",
+        "utility_type",
+        "agent",
+        ["agent_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    op.create_index("ix_utilitytype_agent_id", "utility_type", ["agent_id"])
+
+    # Guarded prune of the 3 unused generic Valorant utility types. Fail loud if
+    # any lineup references them rather than silently breaking the FK.
+    op.execute(
+        """
+        DO $$
+        DECLARE
+            ref_count INTEGER;
+        BEGIN
+            SELECT COUNT(*) INTO ref_count
+            FROM lineup l
+            JOIN utility_type ut ON l.utility_type_id = ut.id
+            JOIN game g ON ut.game_id = g.id
+            WHERE g.slug = 'valorant'
+              AND ut.slug IN ('smoke', 'flash', 'molotov');
+
+            IF ref_count > 0 THEN
+                RAISE EXCEPTION
+                    'Cannot prune generic Valorant utility types: % lineup(s) still '
+                    'reference them. Reassign those lineups to an agent ability first.',
+                    ref_count;
+            END IF;
+        END $$;
+        """
+    )
+    op.execute(
+        """
+        DELETE FROM utility_type
+        WHERE slug IN ('smoke', 'flash', 'molotov')
+          AND game_id IN (SELECT id FROM game WHERE slug = 'valorant')
+        """
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_utilitytype_agent_id", table_name="utility_type")
+    op.drop_constraint("fk_utility_type_agent_id", "utility_type", type_="foreignkey")
+    op.drop_column("utility_type", "agent_id")
+    op.drop_index("ix_agent_game_id", table_name="agent")
+    op.drop_table("agent")

--- a/apps/mygamingassistant/backend/app/api/_query_helpers.py
+++ b/apps/mygamingassistant/backend/app/api/_query_helpers.py
@@ -1,0 +1,38 @@
+"""Shared query helpers for the lineups route module.
+
+Extracted from ``lineups.py`` so that module stays under the file-size growth
+guard (see apps/mygamingassistant/CLAUDE.md → Tech Debt Policy). Pure,
+stateless query helpers — no router/request state.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def resolve_slugs_to_ids(
+    db: AsyncSession,
+    model: type,
+    raw: Optional[str],
+    game_id: Optional[uuid.UUID],
+) -> list[uuid.UUID]:
+    """Resolve a comma-separated slug CSV to game-scoped row ids.
+
+    Backs the ``utility_type_slugs`` / ``agent_slugs`` list filters — both
+    resolve a slug CSV against a game-scoped table (``UtilityType`` / ``Agent``,
+    each exposing ``game_id`` + ``slug`` columns). Returns ``[]`` when *raw* or
+    *game_id* is missing, or nothing matches, so an unknown slug yields an empty
+    filter rather than an error.
+    """
+    if not (raw and game_id):
+        return []
+    slugs = [s.strip() for s in raw.split(",") if s.strip()]
+    if not slugs:
+        return []
+    result = await db.execute(
+        select(model).where(model.game_id == game_id, model.slug.in_(slugs))
+    )
+    return [row.id for row in result.scalars().all()]

--- a/apps/mygamingassistant/backend/app/api/games.py
+++ b/apps/mygamingassistant/backend/app/api/games.py
@@ -110,6 +110,8 @@ async def get_map(
         raise HTTPException(status_code=404, detail="Map not found")
 
     utility_types = await game_repo.list_utility_types_for_game(db, game.id)
+    agents = await game_repo.list_agents_for_game(db, game.id)
+    agent_slug_by_id = {a.id: a.slug for a in agents}
 
     return {
         "id": str(map_obj.id),
@@ -130,8 +132,23 @@ async def get_map(
             for s in map_obj.sites
         ],
         "utility_types": [
-            {"id": str(u.id), "slug": u.slug, "name": u.name}
+            {
+                "id": str(u.id),
+                "slug": u.slug,
+                "name": u.name,
+                # Valorant utilities carry their agent's slug so the frontend can
+                # group the second-stage utility chips under the selected agent.
+                # CS2 utilities have no agent → None.
+                "agent_slug": agent_slug_by_id.get(u.agent_id),
+            }
             for u in utility_types
+        ],
+        # Game-wide agent catalog (Valorant only; empty for CS2). The frontend
+        # scopes the agent selector to agents that actually have lineups on this
+        # map (intersection with the loaded lineups).
+        "agents": [
+            {"id": str(a.id), "slug": a.slug, "name": a.name, "role": a.role}
+            for a in agents
         ],
     }
 

--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -40,6 +40,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.core.auth import current_active_user
 from app.db.session import get_db
+from app.models.game.agent import Agent
 from app.models.game.game import Game
 from app.models.game.map import Map
 from app.models.game.map_zone import MapZone
@@ -125,6 +126,9 @@ async def list_lineups(
     utility_type_slugs: Optional[str] = Query(
         None, description="Comma-separated utility type slugs"
     ),
+    agent_slugs: Optional[str] = Query(
+        None, description="Comma-separated Valorant agent slugs"
+    ),
     db: AsyncSession = Depends(get_db),
 ) -> list[LineupRead]:
     """List accepted lineups. Public — no auth required.
@@ -141,6 +145,7 @@ async def list_lineups(
     map_id: Optional[uuid.UUID] = None
     target_zone_id: Optional[uuid.UUID] = None
     utility_type_ids: list[uuid.UUID] = []
+    agent_ids: list[uuid.UUID] = []
 
     if game_slug:
         game_result = await db.execute(select(Game).where(Game.slug == game_slug))
@@ -180,6 +185,17 @@ async def list_lineups(
             )
             utility_type_ids = [ut.id for ut in ut_result.scalars().all()]
 
+    if agent_slugs and game_id:
+        a_slugs = [s.strip() for s in agent_slugs.split(",") if s.strip()]
+        if a_slugs:
+            agent_result = await db.execute(
+                select(Agent).where(
+                    Agent.game_id == game_id,
+                    Agent.slug.in_(a_slugs),
+                )
+            )
+            agent_ids = [a.id for a in agent_result.scalars().all()]
+
     # Validate side value
     if side and side not in ("side_a", "side_b", "any"):
         raise HTTPException(status_code=422, detail="side must be side_a, side_b, or any")
@@ -193,6 +209,7 @@ async def list_lineups(
         target_zone_id=target_zone_id,
         side=side_filter,
         utility_type_ids=utility_type_ids,
+        agent_ids=agent_ids,
         # Public route forces accepted — pending/hidden are operator-only.
         status="accepted",
     )

--- a/apps/mygamingassistant/backend/app/api/lineups.py
+++ b/apps/mygamingassistant/backend/app/api/lineups.py
@@ -38,6 +38,7 @@ from fastapi import APIRouter, Depends, HTTPException, Query
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api._query_helpers import resolve_slugs_to_ids
 from app.core.auth import current_active_user
 from app.db.session import get_db
 from app.models.game.agent import Agent
@@ -144,8 +145,6 @@ async def list_lineups(
     game_id: Optional[uuid.UUID] = None
     map_id: Optional[uuid.UUID] = None
     target_zone_id: Optional[uuid.UUID] = None
-    utility_type_ids: list[uuid.UUID] = []
-    agent_ids: list[uuid.UUID] = []
 
     if game_slug:
         game_result = await db.execute(select(Game).where(Game.slug == game_slug))
@@ -174,27 +173,10 @@ async def list_lineups(
                     return []
                 target_zone_id = zone.id
 
-    if utility_type_slugs and game_id:
-        slugs = [s.strip() for s in utility_type_slugs.split(",") if s.strip()]
-        if slugs:
-            ut_result = await db.execute(
-                select(UtilityType).where(
-                    UtilityType.game_id == game_id,
-                    UtilityType.slug.in_(slugs),
-                )
-            )
-            utility_type_ids = [ut.id for ut in ut_result.scalars().all()]
-
-    if agent_slugs and game_id:
-        a_slugs = [s.strip() for s in agent_slugs.split(",") if s.strip()]
-        if a_slugs:
-            agent_result = await db.execute(
-                select(Agent).where(
-                    Agent.game_id == game_id,
-                    Agent.slug.in_(a_slugs),
-                )
-            )
-            agent_ids = [a.id for a in agent_result.scalars().all()]
+    # Resolve the slug-CSV filters to game-scoped ids (empty when unset / no
+    # match → no filter). utility_type_slugs and agent_slugs share one helper.
+    utility_type_ids = await resolve_slugs_to_ids(db, UtilityType, utility_type_slugs, game_id)
+    agent_ids = await resolve_slugs_to_ids(db, Agent, agent_slugs, game_id)
 
     # Validate side value
     if side and side not in ("side_a", "side_b", "any"):

--- a/apps/mygamingassistant/backend/app/fixtures/agents.json
+++ b/apps/mygamingassistant/backend/app/fixtures/agents.json
@@ -1,0 +1,39 @@
+[
+  {
+    "game_slug": "valorant",
+    "agents": [
+      { "slug": "jett",      "name": "Jett",      "role": "Duelist" },
+      { "slug": "phoenix",   "name": "Phoenix",   "role": "Duelist" },
+      { "slug": "reyna",     "name": "Reyna",     "role": "Duelist" },
+      { "slug": "raze",      "name": "Raze",      "role": "Duelist" },
+      { "slug": "yoru",      "name": "Yoru",      "role": "Duelist" },
+      { "slug": "neon",      "name": "Neon",      "role": "Duelist" },
+      { "slug": "iso",       "name": "Iso",       "role": "Duelist" },
+      { "slug": "waylay",    "name": "Waylay",    "role": "Duelist" },
+
+      { "slug": "sova",      "name": "Sova",      "role": "Initiator" },
+      { "slug": "breach",    "name": "Breach",    "role": "Initiator" },
+      { "slug": "skye",      "name": "Skye",      "role": "Initiator" },
+      { "slug": "kay-o",     "name": "KAY/O",     "role": "Initiator" },
+      { "slug": "fade",      "name": "Fade",      "role": "Initiator" },
+      { "slug": "gekko",     "name": "Gekko",     "role": "Initiator" },
+      { "slug": "tejo",      "name": "Tejo",      "role": "Initiator" },
+
+      { "slug": "brimstone", "name": "Brimstone", "role": "Controller" },
+      { "slug": "omen",      "name": "Omen",      "role": "Controller" },
+      { "slug": "viper",     "name": "Viper",     "role": "Controller" },
+      { "slug": "astra",     "name": "Astra",     "role": "Controller" },
+      { "slug": "harbor",    "name": "Harbor",    "role": "Controller" },
+      { "slug": "clove",     "name": "Clove",     "role": "Controller" },
+      { "slug": "miks",      "name": "Miks",      "role": "Controller" },
+
+      { "slug": "killjoy",   "name": "Killjoy",   "role": "Sentinel" },
+      { "slug": "cypher",    "name": "Cypher",    "role": "Sentinel" },
+      { "slug": "sage",      "name": "Sage",      "role": "Sentinel" },
+      { "slug": "chamber",   "name": "Chamber",   "role": "Sentinel" },
+      { "slug": "deadlock",  "name": "Deadlock",  "role": "Sentinel" },
+      { "slug": "vyse",      "name": "Vyse",      "role": "Sentinel" },
+      { "slug": "veto",      "name": "Veto",      "role": "Sentinel" }
+    ]
+  }
+]

--- a/apps/mygamingassistant/backend/app/fixtures/utility_types.json
+++ b/apps/mygamingassistant/backend/app/fixtures/utility_types.json
@@ -2,11 +2,89 @@
   {
     "game_slug": "valorant",
     "utility_types": [
-      { "slug": "smoke",   "name": "Smoke" },
-      { "slug": "flash",   "name": "Flash" },
-      { "slug": "molotov", "name": "Molotov" },
-      { "slug": "recon",   "name": "Recon Bolt" },
-      { "slug": "shock",   "name": "Shock Bolt" }
+      { "slug": "cloudburst",       "name": "Cloudburst",       "agent_slug": "jett" },
+
+      { "slug": "curveball",        "name": "Curveball",        "agent_slug": "phoenix" },
+      { "slug": "hot-hands",        "name": "Hot Hands",        "agent_slug": "phoenix" },
+
+      { "slug": "leer",             "name": "Leer",             "agent_slug": "reyna" },
+
+      { "slug": "paint-shells",     "name": "Paint Shells",     "agent_slug": "raze" },
+
+      { "slug": "blindside",        "name": "Blindside",        "agent_slug": "yoru" },
+
+      { "slug": "relay-bolt",       "name": "Relay Bolt",       "agent_slug": "neon" },
+
+      { "slug": "undercut",         "name": "Undercut",         "agent_slug": "iso" },
+
+      { "slug": "saturate",         "name": "Saturate",         "agent_slug": "waylay" },
+
+      { "slug": "recon",            "name": "Recon Bolt",       "agent_slug": "sova" },
+      { "slug": "shock",            "name": "Shock Bolt",       "agent_slug": "sova" },
+
+      { "slug": "flashpoint",       "name": "Flashpoint",       "agent_slug": "breach" },
+      { "slug": "aftershock",       "name": "Aftershock",       "agent_slug": "breach" },
+      { "slug": "fault-line",       "name": "Fault Line",       "agent_slug": "breach" },
+
+      { "slug": "fragment",         "name": "FRAG/ment",        "agent_slug": "kay-o" },
+      { "slug": "flashdrive",       "name": "FLASH/drive",      "agent_slug": "kay-o" },
+      { "slug": "zero-point",       "name": "ZERO/point",       "agent_slug": "kay-o" },
+
+      { "slug": "seize",            "name": "Seize",            "agent_slug": "fade" },
+      { "slug": "haunt",            "name": "Haunt",            "agent_slug": "fade" },
+
+      { "slug": "mosh-pit",         "name": "Mosh Pit",         "agent_slug": "gekko" },
+
+      { "slug": "special-delivery", "name": "Special Delivery", "agent_slug": "tejo" },
+      { "slug": "guided-salvo",     "name": "Guided Salvo",     "agent_slug": "tejo" },
+
+      { "slug": "sky-smoke",        "name": "Sky Smoke",        "agent_slug": "brimstone" },
+      { "slug": "brim-incendiary",  "name": "Incendiary",       "agent_slug": "brimstone" },
+
+      { "slug": "dark-cover",       "name": "Dark Cover",       "agent_slug": "omen" },
+      { "slug": "paranoia",         "name": "Paranoia",         "agent_slug": "omen" },
+
+      { "slug": "poison-cloud",     "name": "Poison Cloud",     "agent_slug": "viper" },
+      { "slug": "snake-bite",       "name": "Snake Bite",       "agent_slug": "viper" },
+      { "slug": "toxic-screen",     "name": "Toxic Screen",     "agent_slug": "viper" },
+
+      { "slug": "nebula",           "name": "Nebula",           "agent_slug": "astra" },
+      { "slug": "nova-pulse",       "name": "Nova Pulse",       "agent_slug": "astra" },
+      { "slug": "gravity-well",     "name": "Gravity Well",     "agent_slug": "astra" },
+
+      { "slug": "cascade",          "name": "Cascade",          "agent_slug": "harbor" },
+      { "slug": "cove",             "name": "Cove",             "agent_slug": "harbor" },
+      { "slug": "high-tide",        "name": "High Tide",        "agent_slug": "harbor" },
+
+      { "slug": "ruse",             "name": "Ruse",             "agent_slug": "clove" },
+      { "slug": "meddle",           "name": "Meddle",           "agent_slug": "clove" },
+
+      { "slug": "waveform",         "name": "Waveform",         "agent_slug": "miks" },
+      { "slug": "m-pulse",          "name": "M-Pulse",          "agent_slug": "miks" },
+
+      { "slug": "nanoswarm",        "name": "Nanoswarm",        "agent_slug": "killjoy" },
+      { "slug": "alarmbot",         "name": "Alarmbot",         "agent_slug": "killjoy" },
+      { "slug": "turret",           "name": "Turret",           "agent_slug": "killjoy" },
+
+      { "slug": "cyber-cage",       "name": "Cyber Cage",       "agent_slug": "cypher" },
+      { "slug": "trapwire",         "name": "Trapwire",         "agent_slug": "cypher" },
+      { "slug": "spycam",           "name": "Spycam",           "agent_slug": "cypher" },
+
+      { "slug": "barrier-orb",      "name": "Barrier Orb",      "agent_slug": "sage" },
+      { "slug": "slow-orb",         "name": "Slow Orb",         "agent_slug": "sage" },
+
+      { "slug": "trademark",        "name": "Trademark",        "agent_slug": "chamber" },
+
+      { "slug": "gravnet",          "name": "GravNet",          "agent_slug": "deadlock" },
+      { "slug": "barrier-mesh",     "name": "Barrier Mesh",     "agent_slug": "deadlock" },
+      { "slug": "sonic-sensor",     "name": "Sonic Sensor",     "agent_slug": "deadlock" },
+
+      { "slug": "arc-rose",         "name": "Arc Rose",         "agent_slug": "vyse" },
+      { "slug": "shear",            "name": "Shear",            "agent_slug": "vyse" },
+      { "slug": "razorvine",        "name": "Razorvine",        "agent_slug": "vyse" },
+
+      { "slug": "chokehold",        "name": "Chokehold",        "agent_slug": "veto" },
+      { "slug": "interceptor",      "name": "Interceptor",      "agent_slug": "veto" }
     ]
   },
   {

--- a/apps/mygamingassistant/backend/app/models/__init__.py
+++ b/apps/mygamingassistant/backend/app/models/__init__.py
@@ -5,6 +5,7 @@ from app.models.user.user import User  # noqa: F401
 
 # Game domain — taxonomy first, then dependent tables
 from app.models.game.game import Game  # noqa: F401
+from app.models.game.agent import Agent  # noqa: F401
 from app.models.game.utility_type import UtilityType  # noqa: F401
 from app.models.game.map import Map  # noqa: F401
 from app.models.game.map_zone import MapZone  # noqa: F401

--- a/apps/mygamingassistant/backend/app/models/game/agent.py
+++ b/apps/mygamingassistant/backend/app/models/game/agent.py
@@ -1,0 +1,59 @@
+"""Agent model — a playable character within a game (Valorant only).
+
+Valorant utilities are agent-specific (Sova's Recon Bolt / Shock Bolt), unlike
+CS2's game-wide grenades. ``agent`` is the grouping dimension: each Valorant
+``utility_type`` hangs off an agent via ``utility_type.agent_id``; CS2 utility
+types have ``agent_id = NULL`` (no agents).
+
+``role`` is the Valorant class (Duelist / Initiator / Controller / Sentinel) —
+String(20), nullable so non-Valorant games (which seed no agents) never need it.
+"""
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.db.base import Base
+
+
+class Agent(Base):
+    __tablename__ = "agent"
+    __table_args__ = (
+        UniqueConstraint("game_id", "slug", name="uq_agent_game_slug"),
+        Index("ix_agent_game_id", "game_id"),
+    )
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+        server_default=func.gen_random_uuid(),
+    )
+    game_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("game.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    slug: Mapped[str] = mapped_column(String(50), nullable=False)
+    name: Mapped[str] = mapped_column(String(100), nullable=False)
+    role: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        server_default=func.now(),
+    )
+
+    game: Mapped["Game"] = relationship("Game", back_populates="agents")
+    utility_types: Mapped[list["UtilityType"]] = relationship(
+        "UtilityType",
+        foreign_keys="[UtilityType.agent_id]",
+        back_populates="agent",
+        lazy="select",
+    )
+
+
+from app.models.game.game import Game  # noqa: E402, F401
+from app.models.game.utility_type import UtilityType  # noqa: E402, F401

--- a/apps/mygamingassistant/backend/app/models/game/game.py
+++ b/apps/mygamingassistant/backend/app/models/game/game.py
@@ -38,6 +38,9 @@ class Game(Base):
     utility_types: Mapped[list["UtilityType"]] = relationship(
         "UtilityType", back_populates="game", lazy="select"
     )
+    agents: Mapped[list["Agent"]] = relationship(
+        "Agent", back_populates="game", lazy="select"
+    )
     lineups: Mapped[list["Lineup"]] = relationship(
         "Lineup",
         foreign_keys="[Lineup.game_id]",
@@ -49,4 +52,5 @@ class Game(Base):
 # Avoid circular import at module level by importing here
 from app.models.game.map import Map  # noqa: E402, F401
 from app.models.game.utility_type import UtilityType  # noqa: E402, F401
+from app.models.game.agent import Agent  # noqa: E402, F401
 from app.models.game.lineup import Lineup  # noqa: E402, F401

--- a/apps/mygamingassistant/backend/app/models/game/utility_type.py
+++ b/apps/mygamingassistant/backend/app/models/game/utility_type.py
@@ -1,7 +1,10 @@
 """UtilityType model — a throwable or ability type within a game.
 
-CS2:      smoke, flash, molly, he
-Valorant: smoke, flash, molly, wall (generic; agent-specific abilities in later phases)
+CS2:      smoke, flash, molly, he (game-wide; ``agent_id`` is NULL)
+Valorant: agent-specific abilities (Sova's recon / shock, ...) — each hangs off an
+          ``agent`` via ``agent_id``. Ability slugs are globally unique within a
+          game, so the (game_id, slug) unique constraint is kept and the pack /
+          importer continue to resolve utility types by slug alone.
 """
 import uuid
 from datetime import datetime, timezone
@@ -18,6 +21,7 @@ class UtilityType(Base):
     __table_args__ = (
         UniqueConstraint("game_id", "slug", name="uq_utilitytype_game_slug"),
         Index("ix_utilitytype_game_id", "game_id"),
+        Index("ix_utilitytype_agent_id", "agent_id"),
     )
 
     id: Mapped[uuid.UUID] = mapped_column(
@@ -31,6 +35,11 @@ class UtilityType(Base):
         ForeignKey("game.id", ondelete="CASCADE"),
         nullable=False,
     )
+    agent_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("agent.id", ondelete="SET NULL"),
+        nullable=True,
+    )
     slug: Mapped[str] = mapped_column(String(50), nullable=False)
     name: Mapped[str] = mapped_column(String(100), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -41,6 +50,11 @@ class UtilityType(Base):
     )
 
     game: Mapped["Game"] = relationship("Game", back_populates="utility_types")
+    agent: Mapped["Agent | None"] = relationship(
+        "Agent",
+        foreign_keys="[UtilityType.agent_id]",
+        back_populates="utility_types",
+    )
     lineups: Mapped[list["Lineup"]] = relationship(
         "Lineup",
         foreign_keys="[Lineup.utility_type_id]",
@@ -50,4 +64,5 @@ class UtilityType(Base):
 
 
 from app.models.game.game import Game  # noqa: E402, F401
+from app.models.game.agent import Agent  # noqa: E402, F401
 from app.models.game.lineup import Lineup  # noqa: E402, F401

--- a/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/game_repo.py
@@ -13,6 +13,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
+from app.models.game.agent import Agent
 from app.models.game.game import Game
 from app.models.game.map import Map
 from app.models.game.map_zone import MapZone
@@ -71,17 +72,80 @@ async def upsert_utility_type(
     game_id: uuid.UUID,
     slug: str,
     name: str,
+    agent_id: uuid.UUID | None = None,
 ) -> UtilityType:
     result = await db.execute(
         select(UtilityType).where(UtilityType.game_id == game_id, UtilityType.slug == slug)
     )
     existing = result.scalar_one_or_none()
     if existing is not None:
+        # Re-running load-fixtures must propagate fixture edits. (game_id, slug)
+        # is the natural key; ``name`` + ``agent_id`` are mutable. Crucially
+        # this backfills ``agent_id`` onto utility types that pre-date the agent
+        # dimension — without it the existing Sova ``recon``/``shock`` rows keep
+        # ``agent_id = NULL`` and the agent filter silently matches nothing.
+        changed = False
+        if existing.name != name:
+            existing.name = name
+            changed = True
+        if existing.agent_id != agent_id:
+            existing.agent_id = agent_id
+            changed = True
+        if changed:
+            await db.flush()
         return existing
-    ut = UtilityType(game_id=game_id, slug=slug, name=name)
+    ut = UtilityType(game_id=game_id, slug=slug, name=name, agent_id=agent_id)
     db.add(ut)
     await db.flush()
     return ut
+
+
+# ---------------------------------------------------------------------------
+# Agent (Valorant only — CS2 seeds no agents)
+# ---------------------------------------------------------------------------
+
+async def list_agents_for_game(
+    db: AsyncSession, game_id: uuid.UUID
+) -> Sequence[Agent]:
+    result = await db.execute(
+        select(Agent).where(Agent.game_id == game_id).order_by(Agent.name)
+    )
+    return result.scalars().all()
+
+
+async def get_agent_by_slug(
+    db: AsyncSession, game_id: uuid.UUID, slug: str
+) -> Agent | None:
+    result = await db.execute(
+        select(Agent).where(Agent.game_id == game_id, Agent.slug == slug)
+    )
+    return result.scalar_one_or_none()
+
+
+async def upsert_agent(
+    db: AsyncSession,
+    *,
+    game_id: uuid.UUID,
+    slug: str,
+    name: str,
+    role: str | None = None,
+) -> Agent:
+    existing = await get_agent_by_slug(db, game_id, slug)
+    if existing is not None:
+        changed = False
+        if existing.name != name:
+            existing.name = name
+            changed = True
+        if existing.role != role:
+            existing.role = role
+            changed = True
+        if changed:
+            await db.flush()
+        return existing
+    agent = Agent(game_id=game_id, slug=slug, name=name, role=role)
+    db.add(agent)
+    await db.flush()
+    return agent
 
 
 # ---------------------------------------------------------------------------

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup/filters.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup/filters.py
@@ -5,9 +5,10 @@ import uuid
 from dataclasses import dataclass, field
 from typing import Optional
 
-from sqlalchemy import Select
+from sqlalchemy import Select, select
 
 from app.models.game.lineup import Lineup
+from app.models.game.utility_type import UtilityType
 
 
 @dataclass
@@ -19,6 +20,10 @@ class LineupFilters:
     # "side_a", "side_b", or None (no filter)
     side: Optional[str] = None
     utility_type_ids: list[uuid.UUID] = field(default_factory=list)
+    # Valorant agent filter — matches lineups whose utility_type belongs to one
+    # of these agents (agent is derived from utility_type.agent_id, not stored
+    # on the lineup).
+    agent_ids: list[uuid.UUID] = field(default_factory=list)
     # None → only "accepted"; set explicitly to bypass
     status: Optional[str] = "accepted"
 
@@ -40,4 +45,13 @@ def _apply_filters(stmt: "Select[tuple[Lineup]]", f: LineupFilters) -> "Select[t
         stmt = stmt.where(Lineup.side.in_([f.side, "any"]))
     if f.utility_type_ids:
         stmt = stmt.where(Lineup.utility_type_id.in_(f.utility_type_ids))
+    if f.agent_ids:
+        # Derive via utility_type → agent: match lineups whose utility belongs
+        # to one of the requested agents. Composes with utility_type_ids (e.g.
+        # agent=Sova + utility=shock narrows to Sova's shock lineups).
+        stmt = stmt.where(
+            Lineup.utility_type_id.in_(
+                select(UtilityType.id).where(UtilityType.agent_id.in_(f.agent_ids))
+            )
+        )
     return stmt

--- a/apps/mygamingassistant/backend/app/repositories/game/lineup/lifecycle.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/lineup/lifecycle.py
@@ -15,6 +15,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
 from app.models.game.lineup import Lineup
+from app.models.game.utility_type import UtilityType
 from app.repositories.game.lineup.filters import LineupFilters, _apply_filters
 
 
@@ -110,7 +111,7 @@ async def list_lineups(
         .options(
             selectinload(Lineup.target_zone),
             selectinload(Lineup.stand_zone),
-            selectinload(Lineup.utility_type),
+            selectinload(Lineup.utility_type).selectinload(UtilityType.agent),
         )
         .order_by(Lineup.created_at.desc())
     )
@@ -130,7 +131,7 @@ async def get_lineup(
         .options(
             selectinload(Lineup.target_zone),
             selectinload(Lineup.stand_zone),
-            selectinload(Lineup.utility_type),
+            selectinload(Lineup.utility_type).selectinload(UtilityType.agent),
         )
     )
     result = await db.execute(stmt)
@@ -211,7 +212,7 @@ async def list_pending_lineups(
         .options(
             selectinload(Lineup.target_zone),
             selectinload(Lineup.stand_zone),
-            selectinload(Lineup.utility_type),
+            selectinload(Lineup.utility_type).selectinload(UtilityType.agent),
         )
     )
     if source_id is not None:

--- a/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
+++ b/apps/mygamingassistant/backend/app/schemas/game/lineup_schemas.py
@@ -30,10 +30,22 @@ class ZoneRead(BaseModel):
     model_config = {"from_attributes": True}
 
 
+class AgentRead(BaseModel):
+    id: uuid.UUID
+    slug: str
+    name: str
+    role: Optional[str] = None
+
+    model_config = {"from_attributes": True}
+
+
 class UtilityTypeRead(BaseModel):
     id: uuid.UUID
     slug: str
     name: str
+    # Valorant utilities belong to an agent (Sova's recon/shock); CS2 → None.
+    # Populated from the eager-loaded utility_type.agent relationship.
+    agent: Optional["AgentRead"] = None
 
     model_config = {"from_attributes": True}
 

--- a/apps/mygamingassistant/backend/app/services/game/fixture_loader.py
+++ b/apps/mygamingassistant/backend/app/services/game/fixture_loader.py
@@ -46,10 +46,12 @@ _SEEDED_MAP_FIXTURES: tuple[str, ...] = ("cs2_maps.json", "valorant_maps.json")
 async def load_fixtures(db: AsyncSession) -> None:
     """Load all fixture data into the database. Idempotent.
 
-    Order: games → utility_types → maps → zones + sites
-    (each step depends on the previous one).
+    Order: games → agents → utility_types → maps → zones + sites
+    (each step depends on the previous one — utility_types resolve their
+    ``agent_slug`` against agents, so agents must load first).
     """
     await _load_games(db)
+    await _load_agents(db)
     await _load_utility_types(db)
     for fixture_file in _SEEDED_MAP_FIXTURES:
         await _load_maps(db, fixture_file)
@@ -69,6 +71,31 @@ async def _load_games(db: AsyncSession) -> None:
         logger.debug("fixture_loader: upserted game %s", g["slug"])
 
 
+async def _load_agents(db: AsyncSession) -> None:
+    fixture = _load_json("agents.json")
+    for entry in fixture:
+        game = await game_repo.get_game_by_slug(db, entry["game_slug"])
+        if game is None:
+            logger.warning(
+                "fixture_loader: game %s not found, skipping agents",
+                entry["game_slug"],
+            )
+            continue
+        for a in entry["agents"]:
+            await game_repo.upsert_agent(
+                db,
+                game_id=game.id,
+                slug=a["slug"],
+                name=a["name"],
+                role=a.get("role"),
+            )
+            logger.debug(
+                "fixture_loader: upserted agent %s/%s",
+                entry["game_slug"],
+                a["slug"],
+            )
+
+
 async def _load_utility_types(db: AsyncSession) -> None:
     fixture = _load_json("utility_types.json")
     for entry in fixture:
@@ -80,8 +107,29 @@ async def _load_utility_types(db: AsyncSession) -> None:
             )
             continue
         for ut in entry["utility_types"]:
+            # Valorant utilities carry an ``agent_slug``; resolve it to the
+            # agent's id (agents were loaded above). CS2 utilities omit it →
+            # agent_id stays NULL.
+            agent_id = None
+            agent_slug = ut.get("agent_slug")
+            if agent_slug:
+                agent = await game_repo.get_agent_by_slug(db, game.id, agent_slug)
+                if agent is None:
+                    logger.warning(
+                        "fixture_loader: agent %s/%s not found for utility_type "
+                        "%s — leaving agent_id NULL",
+                        entry["game_slug"],
+                        agent_slug,
+                        ut["slug"],
+                    )
+                else:
+                    agent_id = agent.id
             await game_repo.upsert_utility_type(
-                db, game_id=game.id, slug=ut["slug"], name=ut["name"]
+                db,
+                game_id=game.id,
+                slug=ut["slug"],
+                name=ut["name"],
+                agent_id=agent_id,
             )
             logger.debug(
                 "fixture_loader: upserted utility_type %s/%s",

--- a/apps/mygamingassistant/backend/tests/test_agent_fixtures.py
+++ b/apps/mygamingassistant/backend/tests/test_agent_fixtures.py
@@ -1,0 +1,76 @@
+"""Conformance tests for the Valorant agent fixtures.
+
+Pure-JSON checks (no DB) guarding the invariants the agent-filter feature
+depends on:
+  - the roster is the full 29-agent Valorant set with valid roles;
+  - every Valorant ability's ``agent_slug`` resolves to a seeded agent;
+  - Valorant ability slugs are globally unique (the utility_type (game_id, slug)
+    unique constraint was intentionally NOT relaxed — it relies on this);
+  - Sova's ``recon`` / ``shock`` slugs are preserved (prod lineups reference them);
+  - the pruned generic Valorant utilities are gone from the fixture.
+"""
+import json
+from pathlib import Path
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "app" / "fixtures"
+_VALID_ROLES = {"Duelist", "Initiator", "Controller", "Sentinel"}
+
+
+def _load(name: str):
+    return json.loads((_FIXTURES / name).read_text(encoding="utf-8"))
+
+
+def _valorant_block(fixture: list[dict], key: str) -> list[dict]:
+    for entry in fixture:
+        if entry["game_slug"] == "valorant":
+            return entry[key]
+    raise AssertionError(f"no valorant block with key {key!r}")
+
+
+def _agents() -> list[dict]:
+    return _valorant_block(_load("agents.json"), "agents")
+
+
+def _valorant_utils() -> list[dict]:
+    return _valorant_block(_load("utility_types.json"), "utility_types")
+
+
+def test_roster_is_full_29_with_valid_roles():
+    agents = _agents()
+    assert len(agents) == 29, f"expected 29 Valorant agents, got {len(agents)}"
+    for a in agents:
+        assert a["role"] in _VALID_ROLES, f"agent {a['slug']} has invalid role {a['role']!r}"
+
+
+def test_agent_slugs_unique_and_sova_present():
+    slugs = [a["slug"] for a in _agents()]
+    assert len(slugs) == len(set(slugs)), "duplicate agent slug(s)"
+    assert "sova" in slugs
+
+
+def test_every_ability_agent_slug_resolves():
+    agent_slugs = {a["slug"] for a in _agents()}
+    for ut in _valorant_utils():
+        assert "agent_slug" in ut, f"valorant utility {ut['slug']} missing agent_slug"
+        assert ut["agent_slug"] in agent_slugs, (
+            f"utility {ut['slug']} references unknown agent {ut['agent_slug']!r}"
+        )
+
+
+def test_ability_slugs_globally_unique_within_valorant():
+    slugs = [ut["slug"] for ut in _valorant_utils()]
+    dupes = {s for s in slugs if slugs.count(s) > 1}
+    assert not dupes, f"duplicate Valorant ability slug(s) break the unique constraint: {dupes}"
+
+
+def test_sova_recon_and_shock_preserved():
+    by_slug = {ut["slug"]: ut for ut in _valorant_utils()}
+    assert by_slug.get("recon", {}).get("agent_slug") == "sova"
+    assert by_slug.get("shock", {}).get("agent_slug") == "sova"
+
+
+def test_generic_valorant_utilities_pruned():
+    slugs = {ut["slug"] for ut in _valorant_utils()}
+    assert slugs.isdisjoint({"smoke", "flash", "molotov"}), (
+        "generic Valorant smoke/flash/molotov must be removed (replaced by agent abilities)"
+    )

--- a/apps/mygamingassistant/backend/tests/test_alembic_chain.py
+++ b/apps/mygamingassistant/backend/tests/test_alembic_chain.py
@@ -24,8 +24,8 @@ def script_directory() -> ScriptDirectory:
     return ScriptDirectory.from_config(cfg)
 
 
-def test_single_head_is_0018(script_directory: ScriptDirectory) -> None:
-    """The DAG must resolve to exactly one head and it must be 0018.
+def test_single_head_is_0019(script_directory: ScriptDirectory) -> None:
+    """The DAG must resolve to exactly one head and it must be 0019.
 
     Bump this pin (and add a down_revision assertion below) in the same PR
     that adds a new migration — same per-PR contract as the fixture
@@ -37,8 +37,8 @@ def test_single_head_is_0018(script_directory: ScriptDirectory) -> None:
         "Orphan heads usually mean a migration's down_revision is stale "
         "after a merge — rebase and re-point the down_revision."
     )
-    assert heads[0] == "0018", (
-        f"Expected head 0018 (lineup.aim_ts + aim_localized_at), "
+    assert heads[0] == "0019", (
+        f"Expected head 0019 (agent table + utility_type.agent_id), "
         f"got {heads[0]}."
     )
 

--- a/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/GlanceBoardTile.test.tsx
@@ -74,7 +74,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
     stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke" },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupCard.test.tsx
@@ -86,7 +86,7 @@ const BASE_LINEUP: Lineup = {
   classification_reasoning: null,
   target_zone: { id: "zone-1", slug: "a-site", name: "A Site", polygon_points: [] },
   stand_zone: { id: "zone-2", slug: "ct-spawn", name: "CT Spawn", polygon_points: [] },
-  utility_type: { id: "util-1", slug: "smoke", name: "Smoke" },
+  utility_type: { id: "util-1", slug: "smoke", name: "Smoke", agent: null },
 };
 
 describe("LineupCard", () => {

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupDetail.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupDetail.test.tsx
@@ -76,7 +76,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "mid", name: "Mid", polygon_points: [] },
     stand_zone: null,
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke" },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListBoard.test.tsx
@@ -72,7 +72,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
     stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke" },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/LineupListRow.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/LineupListRow.test.tsx
@@ -64,7 +64,7 @@ function makeLineup(over: Partial<Lineup> = {}): Lineup {
     classification_reasoning: null,
     target_zone: { id: "z1", slug: "b-site", name: "B Site", polygon_points: [] },
     stand_zone: { id: "z2", slug: "t-spawn", name: "T Spawn", polygon_points: [] },
-    utility_type: { id: "u1", slug: "smoke", name: "Smoke" },
+    utility_type: { id: "u1", slug: "smoke", name: "Smoke", agent: null },
     ...over,
   };
 }

--- a/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
+++ b/apps/mygamingassistant/frontend/src/__tests__/ReviewCard.test.tsx
@@ -51,8 +51,8 @@ const MAP_DUST2 = { id: "m-dust2", slug: "dust2", name: "Dust II", minimap_url: 
 const ZONE_A = { id: "z-a", slug: "a-site", name: "A Site", polygon_points: [] };
 const ZONE_B = { id: "z-b", slug: "b-site", name: "B Site", polygon_points: [] };
 
-const UTIL_SMOKE = { id: "u-smoke", slug: "smoke", name: "Smoke" };
-const UTIL_FLASH = { id: "u-flash", slug: "flash", name: "Flash" };
+const UTIL_SMOKE = { id: "u-smoke", slug: "smoke", name: "Smoke", agent_slug: null };
+const UTIL_FLASH = { id: "u-flash", slug: "flash", name: "Flash", agent_slug: null };
 
 const MAP_DETAIL = {
   id: "m-mirage",
@@ -62,6 +62,7 @@ const MAP_DETAIL = {
   zones: [ZONE_A, ZONE_B],
   sites: [],
   utility_types: [UTIL_SMOKE, UTIL_FLASH],
+  agents: [],
 };
 
 /** A fully-unclassified pending lineup — no suggested_* values, all classification null. */

--- a/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/GlanceBoardTile.tsx
@@ -33,7 +33,7 @@
 import { Clock } from "lucide-react";
 import type { ReactNode } from "react";
 import type { Lineup } from "@/types/game";
-import { utilDisplay } from "@/constants/utilityDisplay";
+import { lineupUtilDisplay } from "@/constants/agentDisplay";
 import {
   AimPane,
   ClipView,
@@ -137,7 +137,7 @@ export default function GlanceBoardTile({
   knobs = DEFAULT_KNOBS,
   showOperatorOverlays = false,
 }: GlanceBoardTileProps) {
-  const ud = utilDisplay(lineup.utility_type?.slug);
+  const ud = lineupUtilDisplay(lineup.utility_type);
 
   // Knob-forced overrides: a "still" mode discards any clip URL even when
   // present, an "off" anchor-dot blanks the persisted coords. Done here

--- a/apps/mygamingassistant/frontend/src/components/lineup/LineupListRow.tsx
+++ b/apps/mygamingassistant/frontend/src/components/lineup/LineupListRow.tsx
@@ -27,7 +27,7 @@ import { useState } from "react";
 import { ChevronDown } from "lucide-react";
 import type { Lineup } from "@/types/game";
 import type { Game } from "@/types/game";
-import { utilDisplay } from "@/constants/utilityDisplay";
+import { lineupUtilDisplay } from "@/constants/agentDisplay";
 import GlanceBoardTile from "./GlanceBoardTile";
 import type { DesignKnobs } from "@/hooks/useDesignKnobs";
 import { DEFAULT_KNOBS } from "@/hooks/useDesignKnobs";
@@ -55,7 +55,7 @@ export default function LineupListRow({
 
   const target = lineup.target_zone?.name ?? "Unknown";
   const stand = lineup.stand_zone?.name ?? null;
-  const util = utilDisplay(lineup.utility_type?.slug);
+  const util = lineupUtilDisplay(lineup.utility_type);
   const technique = lineup.technique?.trim() || null;
   const side = sideLabel(lineup.side, game);
 

--- a/apps/mygamingassistant/frontend/src/components/map/AgentSelect.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/AgentSelect.tsx
@@ -1,0 +1,44 @@
+/**
+ * AgentSelect — Valorant agent picker for the MapPage top bar.
+ *
+ * A compact <select> whose options are grouped into <optgroup>s by agent role
+ * (Duelist / Initiator / Controller / Sentinel). Selecting an agent reveals
+ * that agent's ability chips downstream (the parent scopes utilOptions).
+ *
+ * Self-hides when there are no present agents — so CS2 (empty groups) and
+ * Valorant maps with no agent lineups render nothing, keeping the CS2 top bar
+ * byte-for-byte unchanged.
+ */
+import type { AgentGroup } from "@/constants/agentDisplay";
+
+interface AgentSelectProps {
+  agentGroups: AgentGroup[];
+  /** Selected agent slug; "" means "All agents". */
+  value: string;
+  onChange: (slug: string) => void;
+}
+
+export default function AgentSelect({ agentGroups, value, onChange }: AgentSelectProps) {
+  if (agentGroups.length === 0) return null;
+
+  return (
+    <select
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      aria-label="Filter lineups by agent"
+      title="Filter lineups by agent"
+      className="shrink-0 h-6 rounded-md border bg-card/40 px-1.5 text-[11px] font-medium text-foreground hover:bg-muted/60 focus:outline-none focus:ring-1 focus:ring-primary/50 transition-colors"
+    >
+      <option value="">All agents</option>
+      {agentGroups.map((group) => (
+        <optgroup key={group.role} label={group.role}>
+          {group.agents.map((agent) => (
+            <option key={agent.slug} value={agent.slug}>
+              {agent.name}
+            </option>
+          ))}
+        </optgroup>
+      ))}
+    </select>
+  );
+}

--- a/apps/mygamingassistant/frontend/src/components/map/MapPageTopBar.tsx
+++ b/apps/mygamingassistant/frontend/src/components/map/MapPageTopBar.tsx
@@ -12,6 +12,8 @@
  */
 import { ArrowLeft, HelpCircle, LayoutGrid, List } from "lucide-react";
 import GlanceBoardOperatorMenu from "@/components/lineup/GlanceBoardOperatorMenu";
+import AgentSelect from "@/components/map/AgentSelect";
+import type { AgentGroup } from "@/constants/agentDisplay";
 
 interface ChipOption {
   value: string;
@@ -28,6 +30,12 @@ interface MapPageTopBarProps {
   side: string;
   sideChips: ChipOption[];
   onSideChange: (newSide: string) => void;
+
+  // Agent filter (Valorant only) — grouped <select> before the util chips.
+  // CS2 passes empty groups, so AgentSelect renders nothing.
+  agentGroups: AgentGroup[];
+  selectedAgent: string;
+  onAgentChange: (slug: string) => void;
 
   // Utility-type filter
   utilOptions: ChipOption[];
@@ -60,6 +68,9 @@ export default function MapPageTopBar({
   side,
   sideChips,
   onSideChange,
+  agentGroups,
+  selectedAgent,
+  onAgentChange,
   utilOptions,
   selectedUtils,
   onUtilChipToggle,
@@ -110,7 +121,23 @@ export default function MapPageTopBar({
         ))}
       </div>
 
-      <span className="text-border shrink-0">|</span>
+      {/* Agent selector (Valorant only — AgentSelect self-hides for CS2). The
+          leading separator renders only when the selector does, so the CS2 bar
+          keeps its single side|util divider. */}
+      {agentGroups.length > 0 && (
+        <>
+          <span className="text-border shrink-0">|</span>
+          <AgentSelect
+            agentGroups={agentGroups}
+            value={selectedAgent}
+            onChange={onAgentChange}
+          />
+        </>
+      )}
+
+      {/* Divider before the util chips — hidden when there are no chips (e.g.
+          Valorant with no agent picked yet) so no separator dangles. */}
+      {utilOptions.length > 0 && <span className="text-border shrink-0">|</span>}
 
       {/* Utility type chips */}
       {utilOptions.length > 0 && (

--- a/apps/mygamingassistant/frontend/src/constants/agentDisplay.ts
+++ b/apps/mygamingassistant/frontend/src/constants/agentDisplay.ts
@@ -1,0 +1,99 @@
+/**
+ * agentDisplay — display metadata for Valorant agents (the agent-filter layer).
+ *
+ * Valorant utilities are agent-specific (Sova's Recon/Shock Bolt), so the map
+ * page gains an agent dimension above the utility chips. This module owns:
+ *   - the canonical role grouping + order for the agent <select>'s <optgroup>s
+ *   - per-role badge colors so a Valorant lineup's utility badge is colored by
+ *     its agent's role (the utilityDisplay slug map only covers a handful of
+ *     the ~90 abilities; unknowns would otherwise render gray "Util")
+ *   - lineupUtilDisplay(), which resolves a lineup's utility_type to a display
+ *     blob: Valorant abilities use the backend name + role color; CS2 grenades
+ *     keep the existing slug-keyed utilityDisplay verbatim.
+ *
+ * CS2 has no agent dimension — every helper here degrades to the CS2 path when
+ * the utility has no agent.
+ */
+import type { Agent, UtilityTypeRead } from "@/types/game";
+import { utilDisplay, type UtilDisplay } from "@/constants/utilityDisplay";
+
+// Valorant's canonical role order — drives the agent <select> grouping.
+export const ROLE_ORDER = ["Duelist", "Initiator", "Controller", "Sentinel"] as const;
+export type AgentRole = (typeof ROLE_ORDER)[number];
+
+interface RoleColor {
+  badgeBg: string;
+  badgeText: string;
+}
+
+// Per-role badge colors. Initiator stays teal to match utilityDisplay's
+// existing `recon` color (Sova is an Initiator) so the badge color doesn't
+// shift for the already-shipped Recon Bolt lineups.
+const ROLE_COLOR: Record<string, RoleColor> = {
+  Duelist:    { badgeBg: "bg-red-600",    badgeText: "text-white" },
+  Initiator:  { badgeBg: "bg-teal-600",   badgeText: "text-white" },
+  Controller: { badgeBg: "bg-violet-600", badgeText: "text-white" },
+  Sentinel:   { badgeBg: "bg-amber-500",  badgeText: "text-slate-900" },
+};
+
+const FALLBACK_ROLE_COLOR: RoleColor = { badgeBg: "bg-muted", badgeText: "text-foreground" };
+
+/** Badge color tokens for an agent role. Falls back to neutral for null /
+ *  unknown roles. Never throws. */
+export function agentRoleColor(role: string | null | undefined): RoleColor {
+  return (role != null && ROLE_COLOR[role]) || FALLBACK_ROLE_COLOR;
+}
+
+export interface AgentGroup {
+  role: string;
+  agents: Agent[];
+}
+
+/**
+ * Bucket agents into role groups in canonical order, alphabetised within each
+ * role, dropping empty roles. Agents with an unknown / null role are bucketed
+ * last under "Other" so they never silently vanish from the selector.
+ */
+export function groupAgentsByRole(agents: Agent[]): AgentGroup[] {
+  const groups: AgentGroup[] = [];
+  const known = new Set<string>(ROLE_ORDER);
+
+  for (const role of ROLE_ORDER) {
+    const inRole = agents
+      .filter((a) => a.role === role)
+      .sort((a, b) => a.name.localeCompare(b.name));
+    if (inRole.length > 0) groups.push({ role, agents: inRole });
+  }
+
+  const other = agents
+    .filter((a) => a.role == null || !known.has(a.role))
+    .sort((a, b) => a.name.localeCompare(b.name));
+  if (other.length > 0) groups.push({ role: "Other", agents: other });
+
+  return groups;
+}
+
+/**
+ * Resolve a lineup's utility_type to display metadata.
+ *
+ * Valorant (utility has an agent): use the backend `name` for the label and
+ * color the badge by the agent's role — the slug-keyed utilityDisplay map only
+ * covers a few abilities, so without this Shock Bolt et al. render as gray
+ * "Util". The within-zone sortOrder still comes from utilityDisplay so any
+ * CS2-style ordering of shared concepts is preserved.
+ *
+ * CS2 (no agent): the existing slug-keyed utilityDisplay, unchanged.
+ */
+export function lineupUtilDisplay(ut: UtilityTypeRead | null | undefined): UtilDisplay {
+  if (ut?.agent) {
+    const color = agentRoleColor(ut.agent.role);
+    return {
+      label: ut.name,
+      chipLabel: ut.name,
+      badgeBg: color.badgeBg,
+      badgeText: color.badgeText,
+      sortOrder: utilDisplay(ut.slug).sortOrder,
+    };
+  }
+  return utilDisplay(ut?.slug);
+}

--- a/apps/mygamingassistant/frontend/src/hooks/useAgentFilter.ts
+++ b/apps/mygamingassistant/frontend/src/hooks/useAgentFilter.ts
@@ -1,0 +1,110 @@
+/**
+ * useAgentFilter — the Valorant agent-selection layer for MapPage.
+ *
+ * Valorant utilities are agent-specific, so the glance board gains an agent
+ * dropdown (grouped by role) above the utility chips. This hook owns:
+ *   - the `?agent=` URL state (single source of truth, like `?util=`)
+ *   - the present-agent grouping: game agents ∩ agents that actually own a
+ *     lineup on the loaded map (so the dropdown only offers Sova today, and
+ *     auto-expands as other agents' lineups are authored — no extra request)
+ *   - the ability slugs owned by the selected agent, so the util-chip and
+ *     loadout strips can scope to that agent (otherwise ~90 chips render)
+ *   - a client-side `filterByAgent` applied to the already-loaded lineups
+ *
+ * Why filter client-side rather than pass `agent_slugs` to the lineups query:
+ * the agent dropdown's options derive from the loaded lineups, so scoping that
+ * query by agent would collapse the dropdown to just the selected agent. The
+ * backend `agent_slugs` param still exists for direct API consumers; the
+ * glance board filters in memory (same pattern as the zone filter).
+ *
+ * CS2 (isValorant=false): every output degrades to "no agent layer" — empty
+ * groups (so AgentSelect renders nothing), empty ability scope, identity
+ * filter — leaving the CS2 path byte-for-byte unchanged.
+ */
+import { useCallback, useMemo } from "react";
+import { useSearchParams } from "react-router-dom";
+import type { Agent, Lineup, UtilityType } from "@/types/game";
+import { groupAgentsByRole, type AgentGroup } from "@/constants/agentDisplay";
+
+interface UseAgentFilterArgs {
+  /** True only for Valorant — CS2 has no agent dimension. */
+  isValorant: boolean;
+  /** Game-wide agent catalog from the map detail (names + roles). */
+  agents: Agent[];
+  /** All utility types for the game — used to scope chips to the agent. */
+  utilityTypes: UtilityType[];
+  /** Side-scoped lineups already loaded for the map. The dropdown options and
+   *  the agent filter both derive from these, so no extra request is needed. */
+  lineups: Lineup[];
+}
+
+interface UseAgentFilterResult {
+  /** Selected agent slug; "" when none selected (always "" for CS2). */
+  selectedAgent: string;
+  /** Present agents grouped by role, in canonical role order. Empty for CS2
+   *  or when no loaded lineup references an agent. */
+  agentGroups: AgentGroup[];
+  /** Ability slugs owned by the selected agent — scopes the util-chip +
+   *  loadout strips. Empty when no agent is selected (or CS2) so those strips
+   *  collapse rather than render the full Valorant ability catalog. */
+  agentUtilSlugs: string[];
+  /** Select an agent ("" clears). Also clears `?util=` because the previous
+   *  agent's ability chips don't apply to the new agent. */
+  onAgentChange: (slug: string) => void;
+  /** Narrow a lineup list to the selected agent. Identity when no agent / CS2. */
+  filterByAgent: (lineups: Lineup[]) => Lineup[];
+}
+
+export function useAgentFilter({
+  isValorant,
+  agents,
+  utilityTypes,
+  lineups,
+}: UseAgentFilterArgs): UseAgentFilterResult {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const selectedAgent = isValorant ? searchParams.get("agent") ?? "" : "";
+
+  const agentGroups = useMemo(() => {
+    if (!isValorant) return [];
+    const present = new Set(
+      lineups
+        .map((l) => l.utility_type?.agent?.slug)
+        .filter((s): s is string => Boolean(s)),
+    );
+    return groupAgentsByRole(agents.filter((a) => present.has(a.slug)));
+  }, [isValorant, agents, lineups]);
+
+  const agentUtilSlugs = useMemo(() => {
+    if (!isValorant || !selectedAgent) return [];
+    return utilityTypes
+      .filter((u) => u.agent_slug === selectedAgent)
+      .map((u) => u.slug);
+  }, [isValorant, selectedAgent, utilityTypes]);
+
+  const onAgentChange = useCallback(
+    (slug: string) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          if (slug) next.set("agent", slug);
+          else next.delete("agent");
+          // The prior agent's ability chips don't apply to the new agent.
+          next.delete("util");
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+
+  const filterByAgent = useCallback(
+    (list: Lineup[]) => {
+      if (!isValorant || !selectedAgent) return list;
+      return list.filter((l) => l.utility_type?.agent?.slug === selectedAgent);
+    },
+    [isValorant, selectedAgent],
+  );
+
+  return { selectedAgent, agentGroups, agentUtilSlugs, onAgentChange, filterByAgent };
+}

--- a/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
+++ b/apps/mygamingassistant/frontend/src/pages/MapPage.tsx
@@ -47,6 +47,7 @@ import RoundMode from "@/pages/RoundMode";
 import StorageUnavailableBanner from "@/components/map/StorageUnavailableBanner";
 import { usePins } from "@/hooks/usePins";
 import { useLoadout, computeEffectiveUtilFilter } from "@/hooks/useLoadout";
+import { useAgentFilter } from "@/hooks/useAgentFilter";
 import { useMapKeyboardShortcuts } from "@/hooks/useMapKeyboardShortcuts";
 import { useIsSuperuser } from "@/hooks/useIsSuperuser";
 import { utilDisplay } from "@/constants/utilityDisplay";
@@ -95,6 +96,8 @@ export default function MapPage() {
 
   const { isSuperuser } = useIsSuperuser();
   const game = games?.find((g) => g.slug === gameSlug);
+  // Valorant gains an agent dimension above the utility chips; CS2 does not.
+  const isValorant = game?.slug === "valorant";
 
   // Direct-manipulation knobs for the storyboard tile (URL-backed).
   const { knobs } = useDesignKnobs();
@@ -102,12 +105,6 @@ export default function MapPage() {
   // ---------------------------------------------------------------------------
   // Filter state derived from URL
   // ---------------------------------------------------------------------------
-  const utilOptions =
-    mapDetail?.utility_types.map((u) => ({
-      value: u.slug,
-      label: utilDisplay(u.slug).chipLabel,
-    })) ?? [];
-
   const selectedUtils = util ? util.split(",").filter(Boolean) : [];
 
   // Loadout filter — persistent inline chips in the top bar.
@@ -144,6 +141,40 @@ export default function MapPage() {
     },
     { skip: !gameSlug || !mapSlug },
   );
+
+  // ---------------------------------------------------------------------------
+  // Agent dimension (Valorant only). The dropdown options + the filter derive
+  // from the already-loaded lineups, so the agent filter is applied client-side
+  // below (passing agent_slugs to the query would collapse the dropdown to the
+  // selected agent). CS2 → every output is the inert "no agent layer".
+  // ---------------------------------------------------------------------------
+  const {
+    selectedAgent,
+    agentGroups,
+    agentUtilSlugs,
+    onAgentChange,
+    filterByAgent,
+  } = useAgentFilter({
+    isValorant,
+    agents:       mapDetail?.agents ?? [],
+    utilityTypes: mapDetail?.utility_types ?? [],
+    lineups:      allMapLineups,
+  });
+
+  // Utility-chip options. Valorant: the selected agent's abilities labelled by
+  // their backend name, or none until an agent is picked (avoids ~90 chips).
+  // CS2: every utility, slug-labelled via utilityDisplay (unchanged).
+  const utilOptions = useMemo(() => {
+    const types = mapDetail?.utility_types ?? [];
+    if (isValorant) {
+      if (!selectedAgent) return [];
+      const scoped = new Set(agentUtilSlugs);
+      return types
+        .filter((u) => scoped.has(u.slug))
+        .map((u) => ({ value: u.slug, label: u.name }));
+    }
+    return types.map((u) => ({ value: u.slug, label: utilDisplay(u.slug).chipLabel }));
+  }, [mapDetail, isValorant, selectedAgent, agentUtilSlugs]);
 
   // ---------------------------------------------------------------------------
   // Pin system (used by round mode)
@@ -227,9 +258,10 @@ export default function MapPage() {
   // filtering is cheaper than another round-trip + a slug→ID resolver per
   // click. Lineups whose target_zone is null never match a zone filter.
   const visibleLineups = useMemo(() => {
-    if (!zoneFilter) return allMapLineups;
-    return allMapLineups.filter((l) => l.target_zone?.slug === zoneFilter);
-  }, [allMapLineups, zoneFilter]);
+    let list = filterByAgent(allMapLineups);
+    if (zoneFilter) list = list.filter((l) => l.target_zone?.slug === zoneFilter);
+    return list;
+  }, [allMapLineups, filterByAgent, zoneFilter]);
 
   const activeZone = zoneFilter
     ? mapDetail?.zones?.find((z) => z.slug === zoneFilter) ?? null
@@ -369,6 +401,9 @@ export default function MapPage() {
           side={side}
           sideChips={sideChips}
           onSideChange={handleSideChange}
+          agentGroups={agentGroups}
+          selectedAgent={selectedAgent}
+          onAgentChange={onAgentChange}
           utilOptions={utilOptions}
           selectedUtils={selectedUtils}
           onUtilChipToggle={handleUtilChipToggle}
@@ -426,7 +461,7 @@ export default function MapPage() {
             )}
 
             {visibleLineups.length === 0 && !allMapFetching && (
-              effectiveUtils.length > 0 || side !== "any" || zoneFilter
+              effectiveUtils.length > 0 || side !== "any" || zoneFilter || selectedAgent
             ) ? (
               /* Filtered empty state */
               <div className="flex flex-col items-center justify-center py-20 gap-3">
@@ -442,6 +477,7 @@ export default function MapPage() {
                     handleUtilToggle([]);
                     clearLoadout();
                     updateParam("zone", null);
+                    onAgentChange("");
                   }}
                   className="text-sm text-primary hover:underline"
                 >

--- a/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
+++ b/apps/mygamingassistant/frontend/src/store/lineupsApi.ts
@@ -31,6 +31,9 @@ export interface ListLineupsParams {
   target_zone_slug?: string;
   side?: string;
   utility_type_slugs?: string;
+  // Comma-separated agent slugs (Valorant only) — resolves to the agents'
+  // utility_type_ids server-side. Mirrors utility_type_slugs.
+  agent_slugs?: string;
   status?: string;
 }
 
@@ -61,6 +64,7 @@ const lineupsApi = lineupsBaseApi.injectEndpoints({
         if (params.target_zone_slug) searchParams.set("target_zone_slug", params.target_zone_slug);
         if (params.side) searchParams.set("side", params.side);
         if (params.utility_type_slugs) searchParams.set("utility_type_slugs", params.utility_type_slugs);
+        if (params.agent_slugs) searchParams.set("agent_slugs", params.agent_slugs);
         if (params.status) searchParams.set("status", params.status);
         const qs = searchParams.toString();
         return { url: `/lineups${qs ? `?${qs}` : ""}`, method: "GET" };

--- a/apps/mygamingassistant/frontend/src/types/game.ts
+++ b/apps/mygamingassistant/frontend/src/types/game.ts
@@ -27,10 +27,19 @@ export interface MapSite {
   name: string;
 }
 
+export interface Agent {
+  id: string;
+  slug: string;
+  name: string;
+  role: string | null;
+}
+
 export interface UtilityType {
   id: string;
   slug: string;
   name: string;
+  /** Agent that owns this utility (null for CS2 grenades). */
+  agent_slug: string | null;
 }
 
 export interface MapDetail {
@@ -41,6 +50,10 @@ export interface MapDetail {
   zones: MapZone[];
   sites: MapSite[];
   utility_types: UtilityType[];
+  /** Game-wide agent catalog (Valorant only; empty for CS2). The frontend
+   *  scopes the agent selector to agents that actually have lineups on the
+   *  current map (intersection with the loaded lineups). */
+  agents: Agent[];
 }
 
 export interface MinimapUploadUrlResponse {
@@ -89,6 +102,11 @@ export interface UtilityTypeRead {
   id: string;
   slug: string;
   name: string;
+  /** Agent that owns this utility (Sova's Recon/Shock Bolt); null for CS2
+   *  grenades. Populated from the backend's eager-loaded utility_type.agent
+   *  relationship — the nested shape (vs MapDetail's flat agent_slug) carries
+   *  the role so lineup tiles can color the badge per agent role. */
+  agent: Agent | null;
 }
 
 export interface Lineup {


### PR DESCRIPTION
## Summary

Valorant utilities are **agent-specific** (Sova's Recon Bolt / Shock Bolt), unlike CS2's game-wide grenades. This adds an **agent dimension** for Valorant: pick an **agent** (dropdown grouped by role) → filter by that agent's **utility** (chips scoped to the agent). **CS2 is unchanged.** The full 29-agent roster is seeded so the system is ready as lineups for other agents are authored; the dropdown only surfaces agents that actually have lineups on the current map (today: Sova).

Agent is a pure **grouping/filtering** dimension hung off `utility_type` (nullable `agent_id` FK) — no `Lineup` schema change, no lineup-pack/exporter/importer change, and the existing 39 Sova lineups carry over untouched.

## Backend (commit `44982222`)

- New `agent` model + `0019` migration (creates `agent`, adds nullable `utility_type.agent_id` `SET NULL`, **guarded prune** of 3 unused generic Valorant util types with a fail-loud check).
- `agents.json` (29 agents) + `utility_types.json` reworked to agent-specific abilities (`recon`/`shock` → Sova).
- **`upsert_utility_type` fixed** to backfill `agent_id` onto existing `recon`/`shock` rows (the existing-row branch previously early-returned, so the Sova filter would have returned nothing).
- `agent_slugs` query param on `GET /api/lineups`; `agents` added to `GET /api/games/{g}/maps/{m}`; eager-load chain `utility_type → agent` so post-commit reads don't `MissingGreenlet`.

## Frontend (commit `7d3d47bf`)

- Agent `<select>` grouped by role above the util chips (Valorant only; self-hides for CS2).
- Picking an agent scopes the util-chip + loadout strips to that agent's abilities (no ~90-chip flood) and filters the board client-side (so the dropdown stays populated).
- `lineupUtilDisplay()` labels Valorant util badges by their backend ability name + agent-role color — fixes the gray "Util" badge that `shock` previously rendered.
- `?agent=` URL state (mirrors `?util=`).

## Deploy

The deploy workflow already runs `alembic upgrade head` **and** `python -m app.cli load-fixtures`, so the 0019 migration, the 29-agent seed, and the `agent_id` backfill all run automatically — the agent filter lights up on the already-live 39 Valorant lineups with no manual step. The prune guard is safe (no lineup references the 3 pruned generic types).

## Verification

- Backend: `agent_slugs=sova` → **39**, `+ utility_type_slugs=shock` → **5**; map detail returns 29 agents (Sova = Initiator); nested `utility_type.agent` resolves "Shock Bolt"/Sova/Initiator. ✅
- Frontend: `npm run typecheck` ✅, `npm run build` ✅, 90 unit tests ✅, lint ✅.
- **Local operator eyeball** (http://localhost:5176/valorant/ascent): Sova dropdown → Recon/Shock Bolt chips → board narrows; CS2 unchanged. ✅

## Out of scope (follow-up)

Classifier prompt agent-awareness for future Valorant AI ingestion (the 39 Sova lineups are hand-curated, so not needed now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)