### PR TITLE
feat(infra): first-boot env seeder (platform_shared.infra.seed_env)

### DIFF
--- a/.github/workflows/deploy-mybookkeeper.yml
+++ b/.github/workflows/deploy-mybookkeeper.yml
@@ -137,11 +137,11 @@ jobs:
 
             echo "--- Preflight: verify required env files exist ---"
             test -f /srv/myfreeapps/apps/mybookkeeper/.env || {
-              echo "::error::Missing /srv/myfreeapps/apps/mybookkeeper/.env — run setup.sh or create env files manually first"
+              echo "::error::Missing /srv/myfreeapps/apps/mybookkeeper/.env — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mybookkeeper'"
               exit 1
             }
             test -f /srv/myfreeapps/apps/mybookkeeper/backend/.env.docker || {
-              echo "::error::Missing /srv/myfreeapps/apps/mybookkeeper/backend/.env.docker — run setup.sh or create env files manually first"
+              echo "::error::Missing /srv/myfreeapps/apps/mybookkeeper/backend/.env.docker — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mybookkeeper'"
               exit 1
             }
             echo "Env files present — proceeding"

--- a/.github/workflows/deploy-mygamingassistant.yml
+++ b/.github/workflows/deploy-mygamingassistant.yml
@@ -138,11 +138,11 @@ jobs:
 
             echo "--- Preflight: verify required env files exist ---"
             test -f /srv/myfreeapps/apps/mygamingassistant/.env || {
-              echo "::error::Missing /srv/myfreeapps/apps/mygamingassistant/.env — create from .env.example first"
+              echo "::error::Missing /srv/myfreeapps/apps/mygamingassistant/.env — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mygamingassistant'"
               exit 1
             }
             test -f /srv/myfreeapps/apps/mygamingassistant/backend/.env.docker || {
-              echo "::error::Missing /srv/myfreeapps/apps/mygamingassistant/backend/.env.docker — create from .env.example first"
+              echo "::error::Missing /srv/myfreeapps/apps/mygamingassistant/backend/.env.docker — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mygamingassistant'"
               exit 1
             }
             echo "Env files present — proceeding"

--- a/.github/workflows/deploy-myjobhunter.yml
+++ b/.github/workflows/deploy-myjobhunter.yml
@@ -137,11 +137,11 @@ jobs:
 
             echo "--- Preflight: verify required env files exist ---"
             test -f /srv/myfreeapps/apps/myjobhunter/.env || {
-              echo "::error::Missing /srv/myfreeapps/apps/myjobhunter/.env — run apps/myjobhunter/scripts/seed-env-from-mbk.sh on the VPS first"
+              echo "::error::Missing /srv/myfreeapps/apps/myjobhunter/.env — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myjobhunter'"
               exit 1
             }
             test -f /srv/myfreeapps/apps/myjobhunter/backend/.env.docker || {
-              echo "::error::Missing /srv/myfreeapps/apps/myjobhunter/backend/.env.docker — run apps/myjobhunter/scripts/seed-env-from-mbk.sh on the VPS first"
+              echo "::error::Missing /srv/myfreeapps/apps/myjobhunter/backend/.env.docker — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myjobhunter'"
               exit 1
             }
             echo "Env files present — proceeding"

--- a/.github/workflows/deploy-mypizzatracker.yml
+++ b/.github/workflows/deploy-mypizzatracker.yml
@@ -132,11 +132,11 @@ jobs:
 
             echo "--- Preflight: verify required env files exist ---"
             test -f /srv/myfreeapps/apps/mypizzatracker/.env || {
-              echo "::error::Missing /srv/myfreeapps/apps/mypizzatracker/.env — create from .env.example first"
+              echo "::error::Missing /srv/myfreeapps/apps/mypizzatracker/.env — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mypizzatracker'"
               exit 1
             }
             test -f /srv/myfreeapps/apps/mypizzatracker/backend/.env.docker || {
-              echo "::error::Missing /srv/myfreeapps/apps/mypizzatracker/backend/.env.docker — create from .env.example first"
+              echo "::error::Missing /srv/myfreeapps/apps/mypizzatracker/backend/.env.docker — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mypizzatracker'"
               exit 1
             }
             echo "Env files present — proceeding"

--- a/.github/workflows/deploy-myrecipes.yml
+++ b/.github/workflows/deploy-myrecipes.yml
@@ -132,11 +132,11 @@ jobs:
 
             echo "--- Preflight: verify required env files exist ---"
             test -f /srv/myfreeapps/apps/myrecipes/.env || {
-              echo "::error::Missing /srv/myfreeapps/apps/myrecipes/.env — create from .env.example first"
+              echo "::error::Missing /srv/myfreeapps/apps/myrecipes/.env — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes'"
               exit 1
             }
             test -f /srv/myfreeapps/apps/myrecipes/backend/.env.docker || {
-              echo "::error::Missing /srv/myfreeapps/apps/myrecipes/backend/.env.docker — create from .env.example first"
+              echo "::error::Missing /srv/myfreeapps/apps/myrecipes/backend/.env.docker — seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes'"
               exit 1
             }
             echo "Env files present — proceeding"

--- a/apps/mybookkeeper/.env.example
+++ b/apps/mybookkeeper/.env.example
@@ -1,6 +1,6 @@
 # Docker Compose environment variables
-# Copy to .env and fill in values:
-#   cp .env.example .env
+# Seed it (plus backend/.env.docker) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mybookkeeper
 
 # PostgreSQL password (used by postgres container and connection strings)
 DB_PASSWORD=change-me-to-a-strong-password

--- a/apps/mybookkeeper/app.yaml
+++ b/apps/mybookkeeper/app.yaml
@@ -18,7 +18,8 @@ registry_images: true
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false
-env_seed_command: run setup.sh or create env files manually first
+env_seed_command: seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend
+  python3 -m platform_shared.infra.seed_env --app mybookkeeper'
 csp: "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://us.i.posthog.com https://challenges.cloudflare.com https://*.sentry.io; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://storage.{$DOMAIN} https:; font-src 'self'; connect-src 'self' https://storage.{$DOMAIN} https://us.i.posthog.com https://*.posthog.com https://challenges.cloudflare.com https://*.sentry.io; frame-src 'self' blob: https://storage.{$DOMAIN} https://us.posthog.com https://challenges.cloudflare.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
 workers:
   - name: upload-processor

--- a/apps/mybookkeeper/backend/.env.docker.example
+++ b/apps/mybookkeeper/backend/.env.docker.example
@@ -1,6 +1,6 @@
 # Docker environment template — consumed by docker-compose.yml `env_file:` directive
-# for the migrate and api services. Copy to backend/.env.docker and fill in values:
-#   cp backend/.env.docker.example backend/.env.docker
+# for the migrate and api services. Seed it (plus the compose-level .env) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mybookkeeper
 # DATABASE_URL is set via docker-compose.yml environment, not here.
 
 # Deployment environment — controls Sentry + Turnstile + email boot guards.

--- a/apps/mygamingassistant/.env.example
+++ b/apps/mygamingassistant/.env.example
@@ -1,6 +1,6 @@
 # Compose-level env file — only contains DB_PASSWORD.
 # The full app config lives in backend/.env.docker.
-# Copy to apps/mygamingassistant/.env:
-#   cp apps/mygamingassistant/.env.example apps/mygamingassistant/.env
+# Seed it (plus backend/.env.docker) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mygamingassistant
 
 DB_PASSWORD=change-me-random-password

--- a/apps/mygamingassistant/app.yaml
+++ b/apps/mygamingassistant/app.yaml
@@ -24,7 +24,8 @@ registry_images: true
 # matching VITE_SERVE_ONLY flag to hide all auth UI. MBK / MJH / MPT keep this
 # false — they are fully auth-gated and have no serve-only mode.
 serve_only_build_arg: true
-env_seed_command: create from .env.example first
+env_seed_command: seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend
+  python3 -m platform_shared.infra.seed_env --app mygamingassistant'
 # R2 clips/screenshots reach the browser by ONE of two serving modes, so the CSP
 # allows both hosts in img-src (screenshots), media-src (clips), and connect-src
 # (blob fetches):

--- a/apps/mygamingassistant/backend/.env.docker.example
+++ b/apps/mygamingassistant/backend/.env.docker.example
@@ -1,6 +1,6 @@
 # Docker environment template — consumed by docker-compose.yml `env_file:` directive
-# for the migrate and api services. Copy to backend/.env.docker and fill in values:
-#   cp backend/.env.docker.example backend/.env.docker
+# for the migrate and api services. Seed it (plus the compose-level .env) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mygamingassistant
 #
 # DATABASE_URL is set via docker-compose.yml `environment:` block — do NOT set it here.
 # DB_PASSWORD lives in apps/mygamingassistant/.env (same dir as docker-compose.yml) — do NOT set it here.

--- a/apps/myjobhunter/app.yaml
+++ b/apps/myjobhunter/app.yaml
@@ -17,7 +17,8 @@ registry_images: true
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false
-env_seed_command: run apps/myjobhunter/scripts/seed-env-from-mbk.sh on the VPS first
+env_seed_command: seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend
+  python3 -m platform_shared.infra.seed_env --app myjobhunter'
 csp: "default-src 'self'; script-src 'self' 'sha256-6gP5jY9WKtmx3Qr/KXGhyuG+YL86Nf6nSb7wHrV5jmk=' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self'; connect-src 'self' https://challenges.cloudflare.com; frame-src 'self' https://challenges.cloudflare.com https://www.youtube-nocookie.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
 workers:
   - name: resume-parser

--- a/apps/myjobhunter/backend/.env.docker.example
+++ b/apps/myjobhunter/backend/.env.docker.example
@@ -1,6 +1,6 @@
 # Docker environment template — consumed by docker-compose.yml `env_file:` directive
-# for the migrate and api services. Copy to backend/.env.docker and fill in values:
-#   cp backend/.env.docker.example backend/.env.docker
+# for the migrate and api services. Seed it (plus the compose-level .env) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myjobhunter
 #
 # DATABASE_URL is set via docker-compose.yml `environment:` block — do NOT set it here.
 # DB_PASSWORD lives in apps/myjobhunter/.env (same dir as docker-compose.yml) — do NOT set it here.

--- a/apps/mypizzatracker/.env.example
+++ b/apps/mypizzatracker/.env.example
@@ -1,6 +1,6 @@
 # Compose-level env file — only contains DB_PASSWORD.
 # The full app config lives in backend/.env.docker.
-# Copy to apps/mypizzatracker/.env:
-#   cp apps/mypizzatracker/.env.example apps/mypizzatracker/.env
+# Seed it (plus backend/.env.docker) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mypizzatracker
 
 DB_PASSWORD=change-me-random-password

--- a/apps/mypizzatracker/app.yaml
+++ b/apps/mypizzatracker/app.yaml
@@ -18,7 +18,8 @@ registry_images: true
 # Fully auth-gated app — no serve-only public-library mode. Keeps the
 # VITE_SERVE_ONLY build-arg chain OUT of the rendered docker files (MGA-only).
 serve_only_build_arg: false
-env_seed_command: create from .env.example first
+env_seed_command: seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend
+  python3 -m platform_shared.infra.seed_env --app mypizzatracker'
 csp: 'default-src ''self''; script-src ''self'' https://challenges.cloudflare.com;
   style-src ''self'' ''unsafe-inline''; img-src ''self'' data: blob:; font-src ''self'';
   connect-src ''self'' https://challenges.cloudflare.com; frame-src ''self'' https://challenges.cloudflare.com https://www.youtube-nocookie.com;

--- a/apps/mypizzatracker/backend/.env.docker.example
+++ b/apps/mypizzatracker/backend/.env.docker.example
@@ -1,6 +1,6 @@
 # Docker environment template -- consumed by docker-compose.yml `env_file:` directive
-# for the migrate and api services. Copy to backend/.env.docker and fill in values:
-#   cp backend/.env.docker.example backend/.env.docker
+# for the migrate and api services. Seed it (plus the compose-level .env) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app mypizzatracker
 #
 # DATABASE_URL is set via docker-compose.yml `environment:` block -- do NOT set it here.
 # DB_PASSWORD lives in apps/mypizzatracker/.env (same dir as docker-compose.yml) -- do NOT set it here.

--- a/apps/myrecipes/.env.example
+++ b/apps/myrecipes/.env.example
@@ -1,6 +1,6 @@
 # Compose-level env file — only contains DB_PASSWORD.
 # The full app config lives in backend/.env.docker.
-# Copy to apps/myrecipes/.env:
-#   cp apps/myrecipes/.env.example apps/myrecipes/.env
+# Seed it (plus backend/.env.docker) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes
 
 DB_PASSWORD=change-me-random-password

--- a/apps/myrecipes/CLAUDE.md
+++ b/apps/myrecipes/CLAUDE.md
@@ -121,6 +121,15 @@ names singular.
 | `apps/myrecipes/.env` | Compose-level -- only `DB_PASSWORD` |
 | `apps/myrecipes/backend/.env.docker` | App-level -- all other secrets; see `backend/.env.docker.example` |
 
+Seed both in one shot on the VPS -- secrets are auto-generated, deploy values
+stamped, and the command prints a checklist of operator-external values
+(Sentry DSN, SMTP, Turnstile) to fill in. Re-run with `--check` to verify:
+
+```bash
+cd /srv/myfreeapps
+PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes
+```
+
 **Critical env vars:**
 
 | Var | Required | Notes |

--- a/apps/myrecipes/app.yaml
+++ b/apps/myrecipes/app.yaml
@@ -16,7 +16,8 @@ automated_deploy: false
 # See apps/mybookkeeper/app.yaml — mbk is the first app on the registry path.
 registry_images: true
 serve_only_build_arg: false
-env_seed_command: create from .env.example first
+env_seed_command: seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend
+  python3 -m platform_shared.infra.seed_env --app myrecipes'
 csp: 'default-src ''self''; script-src ''self'' https://challenges.cloudflare.com;
   style-src ''self'' ''unsafe-inline''; img-src ''self'' data: blob:; font-src ''self'';
   connect-src ''self'' https://challenges.cloudflare.com; frame-src ''self'' https://challenges.cloudflare.com

--- a/apps/myrecipes/backend/.env.docker.example
+++ b/apps/myrecipes/backend/.env.docker.example
@@ -1,6 +1,6 @@
 # Docker environment template -- consumed by docker-compose.yml `env_file:` directive
-# for the migrate and api services. Copy to backend/.env.docker and fill in values:
-#   cp backend/.env.docker.example backend/.env.docker
+# for the migrate and api services. Seed it (plus the compose-level .env) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes
 #
 # DATABASE_URL is set via docker-compose.yml `environment:` block -- do NOT set it here.
 # DB_PASSWORD lives in apps/myrecipes/.env (same dir as docker-compose.yml) -- do NOT set it here.

--- a/infra/templates/scaffold/.env.example
+++ b/infra/templates/scaffold/.env.example
@@ -1,6 +1,6 @@
 # Compose-level env file — only contains DB_PASSWORD.
 # The full app config lives in backend/.env.docker.
-# Copy to apps/__APP_SLUG__/.env:
-#   cp apps/__APP_SLUG__/.env.example apps/__APP_SLUG__/.env
+# Seed it (plus backend/.env.docker) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app __APP_SLUG__
 
 DB_PASSWORD=change-me-random-password

--- a/infra/templates/scaffold/CLAUDE.md
+++ b/infra/templates/scaffold/CLAUDE.md
@@ -128,6 +128,15 @@ missing. If either env var is absent in production, the app refuses to start.
 | `apps/__APP_SLUG__/.env` | Compose-level -- only `DB_PASSWORD` |
 | `apps/__APP_SLUG__/backend/.env.docker` | App-level -- all other secrets; see `backend/.env.docker.example` |
 
+Seed both in one shot on the VPS -- secrets are auto-generated, deploy values
+stamped, and the command prints a checklist of operator-external values
+(Sentry DSN, SMTP, Turnstile) to fill in. Re-run with `--check` to verify:
+
+```bash
+cd /srv/myfreeapps
+PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app __APP_SLUG__
+```
+
 **Critical env vars:**
 
 | Var | Required | Notes |

--- a/infra/templates/scaffold/backend/.env.docker.example
+++ b/infra/templates/scaffold/backend/.env.docker.example
@@ -1,6 +1,6 @@
 # Docker environment template -- consumed by docker-compose.yml `env_file:` directive
-# for the migrate and api services. Copy to backend/.env.docker and fill in values:
-#   cp backend/.env.docker.example backend/.env.docker
+# for the migrate and api services. Seed it (plus the compose-level .env) on the VPS:
+#   cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app __APP_SLUG__
 #
 # DATABASE_URL is set via docker-compose.yml `environment:` block -- do NOT set it here.
 # DB_PASSWORD lives in apps/__APP_SLUG__/.env (same dir as docker-compose.yml) -- do NOT set it here.

--- a/packages/shared-backend/platform_shared/infra/new_app.py
+++ b/packages/shared-backend/platform_shared/infra/new_app.py
@@ -13,6 +13,10 @@ outputs (Caddyfile, docker-compose.yml, caddy.Dockerfile, deploy.yml)
 from `infra/templates/*.j2`. This module calls it once at the end so a
 single `new_app` invocation produces a fully-bootable app directory.
 
+Before the app's first deploy, :mod:`platform_shared.infra.seed_env`
+creates both required env files on the VPS (secrets auto-generated,
+operator-external values left blank with a checklist).
+
 CLI::
 
     python -m platform_shared.infra.new_app mypizzatracker \\
@@ -149,7 +153,10 @@ def _write_app_yaml(repo_root: Path, slug: str, *,
         # key also defaults to enabled). Flip to False to scaffold an app
         # as manual-dispatch-only.
         "automated_deploy": True,
-        "env_seed_command": "create from .env.example first",
+        "env_seed_command": (
+            "seed with 'cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend "
+            f"python3 -m platform_shared.infra.seed_env --app {slug}'"
+        ),
         "csp": (
             "default-src 'self'; "
             "script-src 'self' https://challenges.cloudflare.com; "
@@ -357,6 +364,11 @@ def _cli() -> int:
     print(f"Scaffolded app: {summary['app_dir']}")
     print(f"Files written:  {summary['files_written']}")
     print(f"Tier 3 rendered: {len(summary['rendered'])} files")
+    print(
+        "Before the first deploy, seed the env files on the VPS:\n"
+        "  cd /srv/myfreeapps && PYTHONPATH=packages/shared-backend "
+        f"python3 -m platform_shared.infra.seed_env --app {args.slug}"
+    )
     if not summary["uv_export_succeeded"]:
         print(
             "WARNING: uv was unavailable or failed. After installing uv, run:\n"

--- a/packages/shared-backend/platform_shared/infra/seed_env.py
+++ b/packages/shared-backend/platform_shared/infra/seed_env.py
@@ -1,0 +1,327 @@
+"""First-boot env seeder — create both required env files for an app in one shot.
+
+Creates ``apps/<slug>/.env`` (compose-level, DB_PASSWORD) and
+``apps/<slug>/backend/.env.docker`` (app-level) from their checked-in
+``.env.example`` / ``.env.docker.example`` templates:
+
+* AUTO-GENERATES secrets: ``DB_PASSWORD`` (hex 48), ``SECRET_KEY`` (hex 64),
+  ``ENCRYPTION_KEY`` (Fernet-format, urlsafe base64 of 32 random bytes).
+* STAMPS deploy values when the template left them blank:
+  ``ENVIRONMENT=production``, ``FRONTEND_URL`` / ``CORS_ORIGINS`` from the
+  app domain (``<slug>.myfreeapps.org`` by convention, ``--domain`` to override).
+* LEAVES operator-external values blank and exits non-zero with a checklist:
+  SENTRY_DSN, SMTP_USER/SMTP_PASSWORD/EMAIL_FROM_ADDRESS, TURNSTILE_*,
+  SEED_USER_* (whichever of those the app's template actually declares).
+
+Idempotent: an existing non-empty, non-placeholder value is NEVER overwritten,
+so re-running after the operator fills the blanks is a no-op. Keys present in
+an existing file but absent from the template are preserved. Both files are
+chmod 600.
+
+Runs on the VPS host python3 with NO third-party deps (stdlib only — do not
+import yaml/jinja2 here; unlike render.py this module must work outside a dev
+venv). From the VPS checkout:
+
+    cd /srv/myfreeapps
+    PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes
+
+Deploy-preflight / verification mode (writes nothing, exit 0 = ready):
+
+    PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes --check
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import os
+import secrets
+import sys
+from pathlib import Path
+
+# Values the operator must obtain outside the VPS (dashboards, providers).
+# Only the subset actually declared in the app's template is enforced.
+REQUIRED_OPERATOR_KEYS: tuple[str, ...] = (
+    "SENTRY_DSN",
+    "EMAIL_FROM_ADDRESS",
+    "SMTP_USER",
+    "SMTP_PASSWORD",
+    "TURNSTILE_SITE_KEY",
+    "TURNSTILE_SECRET_KEY",
+    "SEED_USER_EMAIL",
+    "SEED_USER_PASSWORD_HASH",
+)
+
+# Short operator-facing hints for the checklist output.
+_KEY_HINTS: dict[str, str] = {
+    "SENTRY_DSN": "Sentry -> Settings -> Projects -> <app>-api -> Client Keys (DSN)",
+    "EMAIL_FROM_ADDRESS": "sender address for verification/reset emails",
+    "SMTP_USER": "SMTP login (e.g. Gmail address)",
+    "SMTP_PASSWORD": "SMTP password (e.g. Gmail app password)",
+    "TURNSTILE_SITE_KEY": "Cloudflare Turnstile widget site key (public)",
+    "TURNSTILE_SECRET_KEY": "Cloudflare Turnstile secret key",
+    "SEED_USER_EMAIL": "single-user operator account email",
+    "SEED_USER_PASSWORD_HASH": "bcrypt hash of the operator password",
+}
+
+# Placeholder prefixes in the example templates that count as "not set".
+_PLACEHOLDER_PREFIXES: tuple[str, ...] = ("change-me", "__APP_SLUG__")
+
+
+class SeedEnvError(RuntimeError):
+    """Raised for user-recoverable failures (bad slug, missing templates)."""
+
+
+def _repo_root() -> Path:
+    """Return the monorepo root (the dir containing `infra/`, `apps/`, `.github/`)."""
+    # platform_shared/infra/seed_env.py -> up 4 = monorepo root
+    return Path(__file__).resolve().parents[4]
+
+
+def _is_unset(value: str) -> bool:
+    v = value.strip()
+    if not v:
+        return True
+    return any(v.startswith(p) or p in v for p in _PLACEHOLDER_PREFIXES)
+
+
+def _gen_db_password() -> str:
+    return secrets.token_hex(24)
+
+
+def _gen_secret_key() -> str:
+    return secrets.token_hex(32)
+
+
+def _gen_encryption_key() -> str:
+    # Fernet key format: urlsafe base64 of 32 random bytes. The shared PII
+    # suite HKDF-derives from this string, so the format doubles as valid
+    # direct Fernet key material.
+    return base64.urlsafe_b64encode(secrets.token_bytes(32)).decode()
+
+
+_GENERATORS = {
+    "DB_PASSWORD": _gen_db_password,
+    "SECRET_KEY": _gen_secret_key,
+    "ENCRYPTION_KEY": _gen_encryption_key,
+}
+
+
+def _parse_env(text: str) -> dict[str, str]:
+    """Parse KEY=VALUE lines into a dict. Comments/blank lines are skipped."""
+    values: dict[str, str] = {}
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            continue
+        key, _, value = stripped.partition("=")
+        values[key.strip()] = value.strip()
+    return values
+
+
+def _read_env_file(path: Path) -> dict[str, str]:
+    if not path.exists():
+        return {}
+    return _parse_env(path.read_text(encoding="utf-8"))
+
+
+def _stamps(domain: str) -> dict[str, str]:
+    return {
+        "ENVIRONMENT": "production",
+        "FRONTEND_URL": f"https://{domain}",
+        "CORS_ORIGINS": f'["https://{domain}"]',
+    }
+
+
+def _resolve_value(key: str, example_value: str, existing: dict[str, str],
+                   stamps: dict[str, str]) -> str:
+    """Pick the final value for one key. Precedence:
+
+    1. existing real value (idempotence — never overwrite operator input)
+    2. example real value (checked-in defaults like LOCKOUT_THRESHOLD=5)
+    3. generated secret
+    4. deploy stamp
+    5. blank
+    """
+    existing_value = existing.get(key, "")
+    if not _is_unset(existing_value):
+        return existing_value
+    if not _is_unset(example_value):
+        return example_value
+    if key in _GENERATORS:
+        return _GENERATORS[key]()
+    if key in stamps:
+        return stamps[key]
+    return ""
+
+
+def _render_from_example(example_text: str, existing: dict[str, str],
+                         stamps: dict[str, str]) -> tuple[str, dict[str, str]]:
+    """Rewrite the example line-by-line (comments preserved) with resolved values.
+
+    Returns (rendered_text, final_values). Keys in ``existing`` that the
+    example does not declare are appended at the end so nothing is lost.
+    """
+    out_lines: list[str] = []
+    final: dict[str, str] = {}
+    for line in example_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#") or "=" not in stripped:
+            out_lines.append(line)
+            continue
+        key, _, example_value = stripped.partition("=")
+        key = key.strip()
+        value = _resolve_value(key, example_value.strip(), existing, stamps)
+        final[key] = value
+        out_lines.append(f"{key}={value}")
+
+    extra = {k: v for k, v in existing.items() if k not in final}
+    if extra:
+        out_lines.append("")
+        out_lines.append("# --- Preserved keys not present in the example template ---")
+        for key, value in extra.items():
+            out_lines.append(f"{key}={value}")
+            final[key] = value
+
+    return "\n".join(out_lines) + "\n", final
+
+
+def _write_secure(path: Path, text: str) -> bool:
+    """Write only if content changed; chmod 600 either way. Returns True if written."""
+    changed = True
+    if path.exists():
+        changed = path.read_text(encoding="utf-8") != text
+    if changed:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(text, encoding="utf-8", newline="\n")
+    os.chmod(path, 0o600)
+    return changed
+
+
+def _blank_report(final: dict[str, str], enforced_keys: tuple[str, ...]) -> tuple[list[str], list[str]]:
+    """Split final blank keys into (required_blanks, other_blanks)."""
+    required = [k for k in enforced_keys if k in final and _is_unset(final[k])]
+    other = [k for k, v in final.items() if _is_unset(v) and k not in required]
+    return required, other
+
+
+def seed_app(repo_root: Path, slug: str, *, domain: str | None = None,
+             check_only: bool = False) -> int:
+    """Seed (or verify, with ``check_only``) both env files for one app.
+
+    Returns the process exit code: 0 = ready to deploy, 1 = operator values
+    still blank (or, in check mode, files missing/incomplete).
+    """
+    app_dir = repo_root / "apps" / slug
+    if not app_dir.is_dir():
+        raise SeedEnvError(f"No app at {app_dir}. Known apps: "
+                           + ", ".join(sorted(p.name for p in (repo_root / 'apps').iterdir() if p.is_dir())))
+
+    compose_example = app_dir / ".env.example"
+    docker_example = app_dir / "backend" / ".env.docker.example"
+    for tmpl in (compose_example, docker_example):
+        if not tmpl.exists():
+            raise SeedEnvError(f"Missing template {tmpl} — cannot seed without it.")
+
+    compose_env = app_dir / ".env"
+    docker_env = app_dir / "backend" / ".env.docker"
+    resolved_domain = domain or f"{slug}.myfreeapps.org"
+    stamps = _stamps(resolved_domain)
+
+    problems: list[str] = []
+
+    if check_only:
+        # Report-only: never write. Missing file or blank enforced key = fail.
+        for path, enforced in (
+            (compose_env, ("DB_PASSWORD",)),
+            (docker_env, ("SECRET_KEY", "ENCRYPTION_KEY", *REQUIRED_OPERATOR_KEYS)),
+        ):
+            if not path.exists():
+                problems.append(f"MISSING file: {path}")
+                continue
+            example = compose_example if path == compose_env else docker_example
+            declared = _parse_env(example.read_text(encoding="utf-8"))
+            current = _read_env_file(path)
+            for key in enforced:
+                if key not in declared and key not in current:
+                    continue  # this app doesn't use the key
+                if _is_unset(current.get(key, "")):
+                    problems.append(f"BLANK {key} in {path}")
+        if problems:
+            print(f"seed_env --check FAILED for '{slug}':")
+            for p in problems:
+                print(f"  {p}")
+            print(f"\nFix: cd {repo_root} && PYTHONPATH=packages/shared-backend "
+                  f"python3 -m platform_shared.infra.seed_env --app {slug}")
+            return 1
+        print(f"seed_env --check OK for '{slug}': both env files present, all enforced keys set.")
+        return 0
+
+    # --- seed compose-level .env ---
+    existing_compose = _read_env_file(compose_env)
+    compose_text, compose_final = _render_from_example(
+        compose_example.read_text(encoding="utf-8"), existing_compose, stamps,
+    )
+    compose_written = _write_secure(compose_env, compose_text)
+
+    # --- seed backend/.env.docker ---
+    existing_docker = _read_env_file(docker_env)
+    docker_text, docker_final = _render_from_example(
+        docker_example.read_text(encoding="utf-8"), existing_docker, stamps,
+    )
+    docker_written = _write_secure(docker_env, docker_text)
+
+    print(f"{'Seeded' if compose_written else 'Unchanged'}: {compose_env}")
+    print(f"{'Seeded' if docker_written else 'Unchanged'}: {docker_env}")
+    print("Both files chmod 600.")
+
+    required_blanks, other_blanks = _blank_report(
+        {**compose_final, **docker_final},
+        ("DB_PASSWORD", "SECRET_KEY", "ENCRYPTION_KEY", *REQUIRED_OPERATOR_KEYS),
+    )
+
+    if required_blanks:
+        print("\nREQUIRED — fill these in before the first deploy "
+              "(production boot fails loud while they are blank):")
+        for key in required_blanks:
+            hint = _KEY_HINTS.get(key, "")
+            print(f"  {key:<26}{hint}")
+        print(f"\n  vim {docker_env}")
+        print("  then re-run with --check to verify:")
+        print(f"  PYTHONPATH=packages/shared-backend python3 -m "
+              f"platform_shared.infra.seed_env --app {slug} --check")
+    if other_blanks:
+        print("\nOptional / app-specific keys still blank (fill only if the app uses them):")
+        for key in other_blanks:
+            print(f"  {key}")
+
+    return 1 if required_blanks else 0
+
+
+def _cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="platform_shared.infra.seed_env",
+        description="Create apps/<slug>/.env + backend/.env.docker with secrets "
+                    "auto-generated and a checklist for operator-external values.",
+    )
+    parser.add_argument("--app", required=True, help="App slug (matches apps/<slug>/)")
+    parser.add_argument("--check", action="store_true",
+                        help="Report-only: verify both files exist and enforced keys "
+                             "are set. Writes nothing. Exit 0 = ready to deploy.")
+    parser.add_argument("--domain", default=None,
+                        help="App domain (default: <slug>.myfreeapps.org). Used to "
+                             "stamp FRONTEND_URL/CORS_ORIGINS when the template left them blank.")
+    parser.add_argument("--repo-root", default=None,
+                        help="Monorepo root (default: resolved from this file's location).")
+    args = parser.parse_args(argv)
+
+    repo_root = Path(args.repo_root).resolve() if args.repo_root else _repo_root()
+    try:
+        return seed_app(repo_root, args.app, domain=args.domain, check_only=args.check)
+    except SeedEnvError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    sys.exit(_cli())

--- a/packages/shared-backend/tests/test_seed_env.py
+++ b/packages/shared-backend/tests/test_seed_env.py
@@ -1,0 +1,256 @@
+"""Tests for platform_shared.infra.seed_env — the first-boot env seeder."""
+
+from __future__ import annotations
+
+import base64
+import os
+import re
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+from platform_shared.infra import seed_env
+
+COMPOSE_EXAMPLE = """\
+# Compose-level env file — only contains DB_PASSWORD.
+# The full app config lives in backend/.env.docker.
+
+DB_PASSWORD=change-me-random-password
+"""
+
+DOCKER_EXAMPLE = """\
+# Docker environment template — consumed by docker-compose.yml `env_file:`.
+
+# Deployment environment
+ENVIRONMENT=production
+
+# Sentry DSN — required when ENVIRONMENT=production.
+SENTRY_DSN=
+
+SECRET_KEY=change-me-to-random-64-chars
+ENCRYPTION_KEY=change-me-to-random-64-chars
+
+# Frontend / CORS
+FRONTEND_URL=https://testapp.myfreeapps.org
+CORS_ORIGINS=["https://testapp.myfreeapps.org"]
+
+JWT_LIFETIME_SECONDS=1800
+LOCKOUT_THRESHOLD=5
+
+TURNSTILE_SECRET_KEY=
+TURNSTILE_SITE_KEY=
+
+EMAIL_BACKEND=smtp
+EMAIL_FROM_ADDRESS=
+SMTP_HOST=smtp.gmail.com
+SMTP_USER=
+SMTP_PASSWORD=
+
+# Optional feature key
+ANTHROPIC_API_KEY=
+"""
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    app = tmp_path / "apps" / "testapp"
+    (app / "backend").mkdir(parents=True)
+    (app / ".env.example").write_text(COMPOSE_EXAMPLE, encoding="utf-8")
+    (app / "backend" / ".env.docker.example").write_text(DOCKER_EXAMPLE, encoding="utf-8")
+    return tmp_path
+
+
+def run(repo: Path, *extra: str) -> int:
+    return seed_env._cli(["--app", "testapp", "--repo-root", str(repo), *extra])
+
+
+def read_env(path: Path) -> dict[str, str]:
+    return seed_env._parse_env(path.read_text(encoding="utf-8"))
+
+
+class TestFreshSeed:
+    def test_creates_both_files_and_reports_blanks(self, repo: Path, capsys):
+        rc = run(repo)
+        assert rc == 1  # operator-external values still blank
+
+        compose = repo / "apps" / "testapp" / ".env"
+        docker = repo / "apps" / "testapp" / "backend" / ".env.docker"
+        assert compose.exists() and docker.exists()
+
+        out = capsys.readouterr().out
+        assert "REQUIRED" in out
+        for key in ("SENTRY_DSN", "SMTP_USER", "SMTP_PASSWORD",
+                    "EMAIL_FROM_ADDRESS", "TURNSTILE_SITE_KEY", "TURNSTILE_SECRET_KEY"):
+            assert key in out
+        # SEED_USER_* not declared by this app — must not be demanded
+        assert "SEED_USER_EMAIL" not in out
+        # optional key listed informationally, not as required
+        assert "ANTHROPIC_API_KEY" in out
+
+    def test_generated_secret_shapes(self, repo: Path):
+        run(repo)
+        compose = read_env(repo / "apps" / "testapp" / ".env")
+        docker = read_env(repo / "apps" / "testapp" / "backend" / ".env.docker")
+
+        assert re.fullmatch(r"[0-9a-f]{48}", compose["DB_PASSWORD"])
+        assert re.fullmatch(r"[0-9a-f]{64}", docker["SECRET_KEY"])
+        # Fernet format: urlsafe b64 of exactly 32 bytes
+        raw = base64.urlsafe_b64decode(docker["ENCRYPTION_KEY"].encode())
+        assert len(raw) == 32
+
+    def test_defaults_and_stamps_preserved(self, repo: Path):
+        run(repo)
+        docker = read_env(repo / "apps" / "testapp" / "backend" / ".env.docker")
+        assert docker["ENVIRONMENT"] == "production"
+        assert docker["FRONTEND_URL"] == "https://testapp.myfreeapps.org"
+        assert docker["CORS_ORIGINS"] == '["https://testapp.myfreeapps.org"]'
+        assert docker["LOCKOUT_THRESHOLD"] == "5"
+        assert docker["EMAIL_BACKEND"] == "smtp"
+
+    def test_comments_survive(self, repo: Path):
+        run(repo)
+        text = (repo / "apps" / "testapp" / "backend" / ".env.docker").read_text(encoding="utf-8")
+        assert "# Sentry DSN — required when ENVIRONMENT=production." in text
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX file modes")
+    def test_chmod_600(self, repo: Path):
+        run(repo)
+        for rel in (".env", "backend/.env.docker"):
+            mode = stat.S_IMODE(os.stat(repo / "apps" / "testapp" / rel).st_mode)
+            assert mode == 0o600
+
+    def test_domain_override_stamps_blank_urls(self, repo: Path):
+        example = repo / "apps" / "testapp" / "backend" / ".env.docker.example"
+        example.write_text(
+            example.read_text(encoding="utf-8")
+            .replace("FRONTEND_URL=https://testapp.myfreeapps.org", "FRONTEND_URL=")
+            .replace('CORS_ORIGINS=["https://testapp.myfreeapps.org"]', "CORS_ORIGINS="),
+            encoding="utf-8",
+        )
+        run(repo, "--domain", "custom.example.org")
+        docker = read_env(repo / "apps" / "testapp" / "backend" / ".env.docker")
+        assert docker["FRONTEND_URL"] == "https://custom.example.org"
+        assert docker["CORS_ORIGINS"] == '["https://custom.example.org"]'
+
+
+class TestIdempotence:
+    def test_second_run_changes_nothing(self, repo: Path):
+        run(repo)
+        docker_path = repo / "apps" / "testapp" / "backend" / ".env.docker"
+        compose_path = repo / "apps" / "testapp" / ".env"
+        first_docker = docker_path.read_text(encoding="utf-8")
+        first_compose = compose_path.read_text(encoding="utf-8")
+
+        rc = run(repo)
+        assert rc == 1
+        assert docker_path.read_text(encoding="utf-8") == first_docker
+        assert compose_path.read_text(encoding="utf-8") == first_compose
+
+    def test_operator_values_never_overwritten(self, repo: Path):
+        run(repo)
+        docker_path = repo / "apps" / "testapp" / "backend" / ".env.docker"
+        filled = docker_path.read_text(encoding="utf-8")
+        for key, value in (
+            ("SENTRY_DSN", "https://abc@sentry.example/1"),
+            ("SMTP_USER", "ops@example.org"),
+            ("SMTP_PASSWORD", "app-password"),
+            ("EMAIL_FROM_ADDRESS", "noreply@example.org"),
+            ("TURNSTILE_SITE_KEY", "0x4AAAsite"),
+            ("TURNSTILE_SECRET_KEY", "0x4AAAsecret"),
+        ):
+            filled = filled.replace(f"{key}=", f"{key}={value}", 1)
+        docker_path.write_text(filled, encoding="utf-8")
+
+        rc = run(repo)
+        assert rc == 0  # all required values present now
+        docker = read_env(docker_path)
+        assert docker["SENTRY_DSN"] == "https://abc@sentry.example/1"
+        assert docker["TURNSTILE_SITE_KEY"] == "0x4AAAsite"
+
+    def test_placeholder_values_are_regenerated(self, repo: Path):
+        docker_path = repo / "apps" / "testapp" / "backend" / ".env.docker"
+        docker_path.parent.mkdir(parents=True, exist_ok=True)
+        docker_path.write_text("SECRET_KEY=change-me-to-random-64-chars\n", encoding="utf-8")
+        run(repo)
+        docker = read_env(docker_path)
+        assert re.fullmatch(r"[0-9a-f]{64}", docker["SECRET_KEY"])
+
+    def test_unknown_existing_keys_preserved(self, repo: Path):
+        docker_path = repo / "apps" / "testapp" / "backend" / ".env.docker"
+        docker_path.parent.mkdir(parents=True, exist_ok=True)
+        docker_path.write_text("CUSTOM_OPERATOR_KEY=keep-me\n", encoding="utf-8")
+        run(repo)
+        docker = read_env(docker_path)
+        assert docker["CUSTOM_OPERATOR_KEY"] == "keep-me"
+
+
+class TestCheckMode:
+    def test_check_fails_on_missing_files(self, repo: Path, capsys):
+        rc = run(repo, "--check")
+        assert rc == 1
+        assert "MISSING file" in capsys.readouterr().out
+        # check mode must not create anything
+        assert not (repo / "apps" / "testapp" / ".env").exists()
+
+    def test_check_fails_on_blank_required(self, repo: Path, capsys):
+        run(repo)  # seed with blanks
+        rc = run(repo, "--check")
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "BLANK SENTRY_DSN" in out
+
+    def test_check_passes_when_filled(self, repo: Path):
+        run(repo)
+        docker_path = repo / "apps" / "testapp" / "backend" / ".env.docker"
+        filled = docker_path.read_text(encoding="utf-8")
+        for key in ("SENTRY_DSN", "SMTP_USER", "SMTP_PASSWORD", "EMAIL_FROM_ADDRESS",
+                    "TURNSTILE_SITE_KEY", "TURNSTILE_SECRET_KEY"):
+            filled = filled.replace(f"{key}=", f"{key}=some-value", 1)
+        docker_path.write_text(filled, encoding="utf-8")
+        assert run(repo, "--check") == 0
+
+
+class TestErrors:
+    def test_unknown_app_exits_2(self, repo: Path, capsys):
+        rc = seed_env._cli(["--app", "nosuchapp", "--repo-root", str(repo)])
+        assert rc == 2
+        assert "No app at" in capsys.readouterr().err
+
+    def test_missing_template_exits_2(self, repo: Path, capsys):
+        (repo / "apps" / "testapp" / "backend" / ".env.docker.example").unlink()
+        rc = run(repo)
+        assert rc == 2
+        assert "Missing template" in capsys.readouterr().err
+
+
+class TestRealAppTemplates:
+    """The seeder must work against every real app's checked-in templates."""
+
+    def _real_repo_root(self) -> Path:
+        return Path(__file__).resolve().parents[3]
+
+    @pytest.mark.parametrize("slug", [
+        p.parent.name
+        for p in sorted(Path(__file__).resolve().parents[3].glob("apps/*/app.yaml"))
+    ])
+    def test_seed_real_app_into_tmp(self, slug: str, tmp_path: Path):
+        """Copy each real app's templates into a tmp repo and seed it."""
+        real = self._real_repo_root() / "apps" / slug
+        app = tmp_path / "apps" / slug
+        (app / "backend").mkdir(parents=True)
+        (app / ".env.example").write_text(
+            (real / ".env.example").read_text(encoding="utf-8"), encoding="utf-8")
+        (app / "backend" / ".env.docker.example").write_text(
+            (real / "backend" / ".env.docker.example").read_text(encoding="utf-8"),
+            encoding="utf-8")
+
+        rc = seed_env._cli(["--app", slug, "--repo-root", str(tmp_path)])
+        assert rc in (0, 1)  # 1 = operator blanks remain (expected); never 2/crash
+
+        docker = read_env(app / "backend" / ".env.docker")
+        compose = read_env(app / ".env")
+        assert re.fullmatch(r"[0-9a-f]{48}", compose["DB_PASSWORD"])
+        assert re.fullmatch(r"[0-9a-f]{64}", docker["SECRET_KEY"])
+        assert not docker["ENCRYPTION_KEY"].startswith("change-me")


### PR DESCRIPTION
## Summary

STATE.md Initiative 14's operator-requested work item: "vars should already be set, not piecemeal."

One VPS-runnable command creates both required env files for an app's first deploy:

```bash
cd /srv/myfreeapps
PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app <slug>
```

- **Auto-generates secrets**: `DB_PASSWORD` (hex 48) into `apps/<slug>/.env`, `SECRET_KEY` (hex 64) + `ENCRYPTION_KEY` (Fernet-format) into `backend/.env.docker`
- **Stamps deploy values** when the template left them blank: `ENVIRONMENT=production`, `FRONTEND_URL`/`CORS_ORIGINS` from `<slug>.myfreeapps.org` (`--domain` to override)
- **Leaves operator-external values blank** and exits non-zero with a checklist: SENTRY_DSN, SMTP_USER/SMTP_PASSWORD/EMAIL_FROM_ADDRESS, TURNSTILE_*, SEED_USER_* (only those the app's template actually declares)
- **Idempotent**: never overwrites non-empty values, preserves unknown keys, comments survive (the example file is the rendering skeleton); both files chmod 600
- **`--check` mode**: report-only verification (exit 0 = ready to deploy); writes nothing
- **stdlib-only** — runs on bare VPS host python3, no venv/yaml/jinja2 needed

## Wiring

- `env_seed_command` in every app.yaml now points at the seeder → deploy-preflight `::error::` messages tell the operator the exact command (workflows re-rendered via `render --all`; conformance drift test green)
- Scaffolder (`new_app`) default `env_seed_command` + end-of-run summary + docstring mention the seeder
- All env example headers (`.env.example` + `backend/.env.docker.example`, apps + scaffold) + scaffold/myrecipes CLAUDE.md deployment sections updated

## Not an operational migration

Purely additive: no env var renamed, no new boot guard, existing deploys unaffected. The seeder is the tool that *performs* the operational setup for MyRecipes' first deploy (next task).

## Test plan

- 19 new tests in `packages/shared-backend/tests/test_seed_env.py`: fresh seed, secret shapes, idempotence, operator-value preservation, placeholder regeneration, unknown-key preservation, --check semantics, error paths, chmod (POSIX), plus a parametrized run against **every real app's checked-in templates**
- Full shared-backend suite: 811 passed, 6 skipped (includes `TestInfraTemplateDrift` over the re-rendered workflows)
- Manual smoke: `--check` from a fresh checkout correctly reports both files missing, exit 1, no writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A64Uwpo1KAxrmjMuSqAvNk