### PR TITLE
feat(infra): no-SSH env seeding — seed-env dispatch workflow + seed_env --overrides

### DIFF
--- a/.github/workflows/seed-env.yml
+++ b/.github/workflows/seed-env.yml
@@ -44,6 +44,9 @@ on:
 concurrency:
   group: seed-env-${{ inputs.app }}
 
+# The job authenticates purely via the SSH_* secrets; GITHUB_TOKEN is unused.
+permissions: {}
+
 jobs:
   seed:
     runs-on: ubuntu-latest
@@ -59,10 +62,12 @@ jobs:
             set -e
 
             # Same lock as the deploy workflows — never git-pull the shared
-            # /srv/myfreeapps checkout while a deploy is mid-flight.
+            # /srv/myfreeapps checkout while a deploy is mid-flight. The 9m
+            # wait stays under command_timeout (10m) so a contended lock
+            # fails HERE with this message, not via a generic SSH kill.
             exec 9>/tmp/myfreeapps-deploy.lock
-            if ! flock -w 600 9; then
-              echo "::error::Timed out (10m) waiting for the VPS deploy lock."
+            if ! flock -w 540 9; then
+              echo "::error::Timed out (9m) waiting for the VPS deploy lock."
               exit 1
             fi
 
@@ -78,6 +83,9 @@ jobs:
             # secrets produce blank lines, which seed_env ignores.
             OVERRIDES="$(mktemp)"
             chmod 600 "$OVERRIDES"
+            # Remove the secrets file however this script exits (timeout,
+            # lock contention, seeder error) — never leave it in /tmp.
+            trap 'rm -f "$OVERRIDES"' EXIT
             cat > "$OVERRIDES" <<'SEED_ENV_OVERRIDES_EOF'
             SENTRY_DSN=${{ secrets[format('{0}_sentry_dsn', inputs.app)] }}
             SMTP_USER=${{ secrets[format('{0}_smtp_user', inputs.app)] }}
@@ -92,9 +100,15 @@ jobs:
             SEED_ENV_OVERRIDES_EOF
 
             echo "--- Seed ---"
+            # Exit 1 = required values still blank (expected on partial
+            # seed; the --check below reports it). Exit >=2 = hard error
+            # (bad slug, missing template) — fail immediately with it.
+            rc=0
             PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env \
-              --app "${{ inputs.app }}" --overrides "$OVERRIDES" || true
-            rm -f "$OVERRIDES"
+              --app "${{ inputs.app }}" --overrides "$OVERRIDES" || rc=$?
+            if [ "$rc" -gt 1 ]; then
+              exit "$rc"
+            fi
 
             echo "--- Verify ---"
             PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env \

--- a/.github/workflows/seed-env.yml
+++ b/.github/workflows/seed-env.yml
@@ -1,0 +1,101 @@
+# Seed / update an app's VPS env files without SSHing in.
+#
+# Runs platform_shared.infra.seed_env on the VPS over the same SSH secrets the
+# deploy workflows use. Operator-external values are injected from per-app
+# GitHub repo secrets named <APPUPPER>_<KEY> (set them from your terminal with
+# `gh secret set <NAME>` — the value prompt keeps secrets out of chat/logs):
+#
+#   <APP>_SENTRY_DSN            Sentry -> project -> Client Keys (DSN)
+#   <APP>_SMTP_USER             SMTP login (e.g. Gmail address)
+#   <APP>_SMTP_PASSWORD         SMTP password (e.g. Gmail app password)
+#   <APP>_EMAIL_FROM_ADDRESS    sender for verification/reset emails
+#   <APP>_TURNSTILE_SECRET_KEY  Cloudflare Turnstile secret
+#   <APP>_MINIO_ACCESS_KEY      shared MinIO stack credentials
+#   <APP>_MINIO_SECRET_KEY
+#   <APP>_SEED_USER_EMAIL           (single-user apps only)
+#   <APP>_SEED_USER_PASSWORD_HASH   (single-user apps only)
+#
+# TURNSTILE_SITE_KEY (public) comes from the existing repo variable
+# <APPUPPER>_VITE_TURNSTILE_SITE_KEY. Missing secrets arrive as empty strings
+# and are skipped — a re-dispatch never erases a value. Overrides WIN over
+# existing file values, so re-dispatching after rotating a secret updates the
+# VPS file in place.
+#
+# The job FAILS (via the final --check) while required operator values are
+# still blank; the log lists the blank KEY NAMES only — values are never
+# printed by seed_env, and GitHub masks secret values regardless.
+
+name: Seed VPS env files
+
+on:
+  workflow_dispatch:
+    inputs:
+      app:
+        description: App whose VPS env files to seed/update
+        required: true
+        type: choice
+        options:
+          - mybookkeeper
+          - mygamingassistant
+          - myjobhunter
+          - mypizzatracker
+          - myrecipes
+
+concurrency:
+  group: seed-env-${{ inputs.app }}
+
+jobs:
+  seed:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Seed env files on VPS
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1.2.5
+        with:
+          host: ${{ secrets.SSH_HOST }}
+          username: ${{ secrets.SSH_USER }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          command_timeout: 10m
+          script: |
+            set -e
+
+            # Same lock as the deploy workflows — never git-pull the shared
+            # /srv/myfreeapps checkout while a deploy is mid-flight.
+            exec 9>/tmp/myfreeapps-deploy.lock
+            if ! flock -w 600 9; then
+              echo "::error::Timed out (10m) waiting for the VPS deploy lock."
+              exit 1
+            fi
+
+            cd /srv/myfreeapps
+
+            echo "--- Pull latest code ---"
+            git pull --ff-only
+
+            # Secret values are substituted by GitHub Actions before this
+            # script is sent; the quoted heredoc means the remote shell never
+            # word-splits or expands them, so spaces (Gmail app passwords),
+            # `$` (bcrypt hashes), and quotes survive byte-for-byte. Unset
+            # secrets produce blank lines, which seed_env ignores.
+            OVERRIDES="$(mktemp)"
+            chmod 600 "$OVERRIDES"
+            cat > "$OVERRIDES" <<'SEED_ENV_OVERRIDES_EOF'
+            SENTRY_DSN=${{ secrets[format('{0}_sentry_dsn', inputs.app)] }}
+            SMTP_USER=${{ secrets[format('{0}_smtp_user', inputs.app)] }}
+            SMTP_PASSWORD=${{ secrets[format('{0}_smtp_password', inputs.app)] }}
+            EMAIL_FROM_ADDRESS=${{ secrets[format('{0}_email_from_address', inputs.app)] }}
+            TURNSTILE_SECRET_KEY=${{ secrets[format('{0}_turnstile_secret_key', inputs.app)] }}
+            TURNSTILE_SITE_KEY=${{ vars[format('{0}_vite_turnstile_site_key', inputs.app)] }}
+            MINIO_ACCESS_KEY=${{ secrets[format('{0}_minio_access_key', inputs.app)] }}
+            MINIO_SECRET_KEY=${{ secrets[format('{0}_minio_secret_key', inputs.app)] }}
+            SEED_USER_EMAIL=${{ secrets[format('{0}_seed_user_email', inputs.app)] }}
+            SEED_USER_PASSWORD_HASH=${{ secrets[format('{0}_seed_user_password_hash', inputs.app)] }}
+            SEED_ENV_OVERRIDES_EOF
+
+            echo "--- Seed ---"
+            PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env \
+              --app "${{ inputs.app }}" --overrides "$OVERRIDES" || true
+            rm -f "$OVERRIDES"
+
+            echo "--- Verify ---"
+            PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env \
+              --app "${{ inputs.app }}" --check

--- a/apps/myrecipes/CLAUDE.md
+++ b/apps/myrecipes/CLAUDE.md
@@ -130,6 +130,11 @@ cd /srv/myfreeapps
 PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes
 ```
 
+No-SSH alternative: set the `MYRECIPES_*` repo secrets (`_SENTRY_DSN`,
+`_SMTP_USER`, `_SMTP_PASSWORD`, `_EMAIL_FROM_ADDRESS`, `_TURNSTILE_SECRET_KEY`,
+`_MINIO_ACCESS_KEY`, `_MINIO_SECRET_KEY`) via `gh secret set`, then dispatch
+the "Seed VPS env files" workflow: `gh workflow run seed-env.yml -f app=myrecipes`.
+
 **Critical env vars:**
 
 | Var | Required | Notes |

--- a/infra/templates/scaffold/CLAUDE.md
+++ b/infra/templates/scaffold/CLAUDE.md
@@ -137,6 +137,13 @@ cd /srv/myfreeapps
 PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app __APP_SLUG__
 ```
 
+No-SSH alternative: set the per-app repo secrets (slug uppercased +
+`_SENTRY_DSN`, `_SMTP_USER`, `_SMTP_PASSWORD`, `_EMAIL_FROM_ADDRESS`,
+`_TURNSTILE_SECRET_KEY`, `_MINIO_ACCESS_KEY`, `_MINIO_SECRET_KEY`, single-user
+apps also `_SEED_USER_EMAIL` + `_SEED_USER_PASSWORD_HASH`) via `gh secret set`,
+then dispatch the "Seed VPS env files" workflow:
+`gh workflow run seed-env.yml -f app=__APP_SLUG__`.
+
 **Critical env vars:**
 
 | Var | Required | Notes |

--- a/packages/shared-backend/platform_shared/infra/seed_env.py
+++ b/packages/shared-backend/platform_shared/infra/seed_env.py
@@ -28,6 +28,11 @@ venv). From the VPS checkout:
 Deploy-preflight / verification mode (writes nothing, exit 0 = ready):
 
     PYTHONPATH=packages/shared-backend python3 -m platform_shared.infra.seed_env --app myrecipes --check
+
+No-SSH path: the "Seed VPS env files" workflow (.github/workflows/seed-env.yml)
+runs this module on the VPS over SSH, injecting per-app GitHub repo secrets
+(``<APPUPPER>_SENTRY_DSN`` etc.) via ``--overrides``. Overrides win over
+existing values — re-dispatch after rotating a secret to update the VPS file.
 """
 
 from __future__ import annotations
@@ -134,15 +139,19 @@ def _stamps(domain: str) -> dict[str, str]:
 
 
 def _resolve_value(key: str, example_value: str, existing: dict[str, str],
-                   stamps: dict[str, str]) -> str:
+                   stamps: dict[str, str], overrides: dict[str, str]) -> str:
     """Pick the final value for one key. Precedence:
 
-    1. existing real value (idempotence — never overwrite operator input)
-    2. example real value (checked-in defaults like LOCKOUT_THRESHOLD=5)
-    3. generated secret
-    4. deploy stamp
-    5. blank
+    1. explicit override (``--overrides`` file — deliberate set/rotate,
+       so it wins even over an existing value)
+    2. existing real value (idempotence — never clobber operator input)
+    3. example real value (checked-in defaults like LOCKOUT_THRESHOLD=5)
+    4. generated secret
+    5. deploy stamp
+    6. blank
     """
+    if key in overrides:
+        return overrides[key]
     existing_value = existing.get(key, "")
     if not _is_unset(existing_value):
         return existing_value
@@ -155,8 +164,19 @@ def _resolve_value(key: str, example_value: str, existing: dict[str, str],
     return ""
 
 
+def _load_overrides(path: Path) -> dict[str, str]:
+    """Parse a KEY=VALUE overrides file; blank values are dropped (a missing
+    GitHub secret arrives as an empty string — that must mean "leave alone",
+    never "erase")."""
+    if not path.exists():
+        raise SeedEnvError(f"Overrides file not found: {path}")
+    return {k: v for k, v in _parse_env(path.read_text(encoding="utf-8")).items()
+            if v.strip()}
+
+
 def _render_from_example(example_text: str, existing: dict[str, str],
-                         stamps: dict[str, str]) -> tuple[str, dict[str, str]]:
+                         stamps: dict[str, str],
+                         overrides: dict[str, str]) -> tuple[str, dict[str, str]]:
     """Rewrite the example line-by-line (comments preserved) with resolved values.
 
     Returns (rendered_text, final_values). Keys in ``existing`` that the
@@ -171,7 +191,7 @@ def _render_from_example(example_text: str, existing: dict[str, str],
             continue
         key, _, example_value = stripped.partition("=")
         key = key.strip()
-        value = _resolve_value(key, example_value.strip(), existing, stamps)
+        value = _resolve_value(key, example_value.strip(), existing, stamps, overrides)
         final[key] = value
         out_lines.append(f"{key}={value}")
 
@@ -180,6 +200,7 @@ def _render_from_example(example_text: str, existing: dict[str, str],
         out_lines.append("")
         out_lines.append("# --- Preserved keys not present in the example template ---")
         for key, value in extra.items():
+            value = overrides.get(key, value)
             out_lines.append(f"{key}={value}")
             final[key] = value
 
@@ -206,7 +227,8 @@ def _blank_report(final: dict[str, str], enforced_keys: tuple[str, ...]) -> tupl
 
 
 def seed_app(repo_root: Path, slug: str, *, domain: str | None = None,
-             check_only: bool = False) -> int:
+             check_only: bool = False,
+             overrides: dict[str, str] | None = None) -> int:
     """Seed (or verify, with ``check_only``) both env files for one app.
 
     Returns the process exit code: 0 = ready to deploy, 1 = operator values
@@ -227,6 +249,7 @@ def seed_app(repo_root: Path, slug: str, *, domain: str | None = None,
     docker_env = app_dir / "backend" / ".env.docker"
     resolved_domain = domain or f"{slug}.myfreeapps.org"
     stamps = _stamps(resolved_domain)
+    overrides = overrides or {}
 
     problems: list[str] = []
 
@@ -260,20 +283,28 @@ def seed_app(repo_root: Path, slug: str, *, domain: str | None = None,
     # --- seed compose-level .env ---
     existing_compose = _read_env_file(compose_env)
     compose_text, compose_final = _render_from_example(
-        compose_example.read_text(encoding="utf-8"), existing_compose, stamps,
+        compose_example.read_text(encoding="utf-8"), existing_compose, stamps, overrides,
     )
     compose_written = _write_secure(compose_env, compose_text)
 
     # --- seed backend/.env.docker ---
     existing_docker = _read_env_file(docker_env)
     docker_text, docker_final = _render_from_example(
-        docker_example.read_text(encoding="utf-8"), existing_docker, stamps,
+        docker_example.read_text(encoding="utf-8"), existing_docker, stamps, overrides,
     )
     docker_written = _write_secure(docker_env, docker_text)
 
     print(f"{'Seeded' if compose_written else 'Unchanged'}: {compose_env}")
     print(f"{'Seeded' if docker_written else 'Unchanged'}: {docker_env}")
     print("Both files chmod 600.")
+
+    applied = sorted(k for k in overrides if k in compose_final or k in docker_final)
+    if applied:
+        print(f"Overrides applied: {', '.join(applied)}")
+    unapplied = sorted(set(overrides) - set(applied))
+    if unapplied:
+        print("WARNING: override keys not declared by this app's templates "
+              f"(ignored): {', '.join(unapplied)}")
 
     required_blanks, other_blanks = _blank_report(
         {**compose_final, **docker_final},
@@ -313,11 +344,18 @@ def _cli(argv: list[str] | None = None) -> int:
                              "stamp FRONTEND_URL/CORS_ORIGINS when the template left them blank.")
     parser.add_argument("--repo-root", default=None,
                         help="Monorepo root (default: resolved from this file's location).")
+    parser.add_argument("--overrides", default=None,
+                        help="Path to a KEY=VALUE file of explicit values to set. "
+                             "Overrides win over existing values (deliberate set/rotate); "
+                             "blank values in the file are ignored. Used by the "
+                             "seed-env GitHub Actions workflow to inject repo secrets.")
     args = parser.parse_args(argv)
 
     repo_root = Path(args.repo_root).resolve() if args.repo_root else _repo_root()
     try:
-        return seed_app(repo_root, args.app, domain=args.domain, check_only=args.check)
+        overrides = _load_overrides(Path(args.overrides)) if args.overrides else None
+        return seed_app(repo_root, args.app, domain=args.domain,
+                        check_only=args.check, overrides=overrides)
     except SeedEnvError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 2

--- a/packages/shared-backend/tests/test_seed_env.py
+++ b/packages/shared-backend/tests/test_seed_env.py
@@ -186,6 +186,66 @@ class TestIdempotence:
         assert docker["CUSTOM_OPERATOR_KEY"] == "keep-me"
 
 
+class TestOverrides:
+    def _overrides(self, tmp_path: Path, content: str) -> Path:
+        path = tmp_path / "overrides.env"
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_fills_required_blanks_to_green(self, repo: Path, tmp_path: Path):
+        ov = self._overrides(tmp_path, """\
+SENTRY_DSN=https://ov@sentry.example/2
+SMTP_USER=ops@example.org
+SMTP_PASSWORD=app-password
+EMAIL_FROM_ADDRESS=noreply@example.org
+TURNSTILE_SITE_KEY=0x4AAAsite
+TURNSTILE_SECRET_KEY=0x4AAAsecret
+""")
+        rc = run(repo, "--overrides", str(ov))
+        assert rc == 0  # all required values provided in one shot
+        docker = read_env(repo / "apps" / "testapp" / "backend" / ".env.docker")
+        assert docker["SENTRY_DSN"] == "https://ov@sentry.example/2"
+        assert run(repo, "--check") == 0
+
+    def test_override_wins_over_existing_value(self, repo: Path, tmp_path: Path):
+        run(repo)
+        ov = self._overrides(tmp_path, "SMTP_HOST=smtp.rotated.example\n")
+        run(repo, "--overrides", str(ov))
+        docker = read_env(repo / "apps" / "testapp" / "backend" / ".env.docker")
+        assert docker["SMTP_HOST"] == "smtp.rotated.example"  # was smtp.gmail.com
+
+    def test_blank_override_never_erases(self, repo: Path, tmp_path: Path):
+        run(repo)
+        docker_path = repo / "apps" / "testapp" / "backend" / ".env.docker"
+        docker_path.write_text(
+            docker_path.read_text(encoding="utf-8").replace(
+                "SENTRY_DSN=", "SENTRY_DSN=https://keep@sentry.example/1", 1),
+            encoding="utf-8")
+        ov = self._overrides(tmp_path, "SENTRY_DSN=\n")
+        run(repo, "--overrides", str(ov))
+        assert read_env(docker_path)["SENTRY_DSN"] == "https://keep@sentry.example/1"
+
+    def test_undeclared_override_warns_and_is_ignored(self, repo: Path, tmp_path: Path, capsys):
+        ov = self._overrides(tmp_path, "NO_SUCH_KEY=value\n")
+        run(repo, "--overrides", str(ov))
+        out = capsys.readouterr().out
+        assert "not declared" in out and "NO_SUCH_KEY" in out
+        docker_text = (repo / "apps" / "testapp" / "backend" / ".env.docker").read_text(encoding="utf-8")
+        assert "NO_SUCH_KEY" not in docker_text
+
+    def test_special_characters_survive(self, repo: Path, tmp_path: Path):
+        # Gmail app passwords contain spaces; bcrypt hashes contain `$`.
+        ov = self._overrides(tmp_path, "SMTP_PASSWORD=abcd efgh $2b$12 'quo\"te\n")
+        run(repo, "--overrides", str(ov))
+        docker = read_env(repo / "apps" / "testapp" / "backend" / ".env.docker")
+        assert docker["SMTP_PASSWORD"] == "abcd efgh $2b$12 'quo\"te"
+
+    def test_missing_overrides_file_exits_2(self, repo: Path, capsys):
+        rc = run(repo, "--overrides", str(repo / "nope.env"))
+        assert rc == 2
+        assert "Overrides file not found" in capsys.readouterr().err
+
+
 class TestCheckMode:
     def test_check_fails_on_missing_files(self, repo: Path, capsys):
         rc = run(repo, "--check")


### PR DESCRIPTION
## Summary

Follow-up to #955, answering the operator's "can we eliminate me having to log into the VPS?" — yes:

1. Operator sets per-app repo secrets **once, from their own terminal** (values never touch chat, the VPS shell, or logs):
   `MYRECIPES_SENTRY_DSN`, `MYRECIPES_SMTP_USER`, `MYRECIPES_SMTP_PASSWORD`, `MYRECIPES_EMAIL_FROM_ADDRESS`, `MYRECIPES_TURNSTILE_SECRET_KEY`, `MYRECIPES_MINIO_ACCESS_KEY`, `MYRECIPES_MINIO_SECRET_KEY` (single-user apps also `_SEED_USER_EMAIL`/`_SEED_USER_PASSWORD_HASH`) via `gh secret set`.
2. Anyone dispatches `seed-env.yml` (`gh workflow run seed-env.yml -f app=myrecipes`): it SSHes to the VPS with the **existing deploy secrets**, git-pulls under the same deploy flock, and runs `seed_env --overrides` with those values. Final `--check` fails the job while required values are still blank — the log lists blank **key names only**.

## Design notes

- **Secrets travel as a quoted-heredoc temp file** (chmod 600, trap-removed on any exit), NOT `envs:` shell exports — Gmail app passwords contain spaces and bcrypt hashes contain `$`, both of which export-forwarding can corrupt. The heredoc is substituted by Actions before upload, so the remote shell never expands values.
- **Overrides take top precedence** (win over existing file values): re-dispatching after rotating a GitHub secret updates the VPS file in place — rotation also needs no SSH. Blank overrides are dropped (a missing secret never erases a set value); undeclared keys warn + skip.
- `TURNSTILE_SITE_KEY` (public) comes from the existing `<APP>_VITE_TURNSTILE_SITE_KEY` repo variable — no duplicate secret.
- Dynamic secret lookup uses `secrets[format('{0}_sentry_dsn', inputs.app)]` — expression property access is case-insensitive per GitHub docs, so the lowercase slug matches the uppercase secret names. **This is the one thing unit tests can't cover — validate on the first myrecipes dispatch** (failure mode is loud: every override arrives blank and `--check` fails listing all keys).
- Trust boundary unchanged: repo secrets already hold `SSH_PRIVATE_KEY`; app env values are strictly less powerful.
- `appleboy/ssh-action@0ff4204d…` is the same pin every deploy workflow uses (verified upstream via `gh api` per verify-action-sha).
- Pre-commit review ran (g-pre-commit): no blocking findings; the 4 hardening items (flock/timeout buffer, trap-guarded temp file, exit-code discrimination, `permissions: {}`) are applied in the follow-up commit `fd647d06`.

## Test plan

- 6 new tests (25 total for seed_env): overrides fill required blanks to exit-0, override wins over existing (rotation), blank override never erases, undeclared key warns+skips, spaces/`$`/quotes survive byte-for-byte, missing overrides file exits 2
- Full shared-backend suite: 817 passed, 6 skipped
- Workflow YAML validated (parse + heredoc dedent lands at column 0)
- Post-merge smoke: first `myrecipes` dispatch validates the dynamic secret lookup end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A64Uwpo1KAxrmjMuSqAvNk