### PR TITLE
fix(mbk): never re-ingest app-sent Gmail (rent receipts) as transactions

### DIFF
--- a/apps/mybookkeeper/backend/app/services/email/app_sent_email_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/app_sent_email_service.py
@@ -1,0 +1,68 @@
+"""Record app-sent Gmail message IDs so the sync never re-ingests them.
+
+MBK sends email through the SAME Gmail account it ingests from (rent
+receipts, inquiry replies). Those sent messages live in the user's mailbox
+and can match the ingestion search query — a rent receipt matches
+``subject:receipt`` + ``has:attachment`` — so without this record the next
+sync would feed the app's own output back into Claude extraction. A rent
+receipt would then be re-extracted as a second income transaction under the
+TENANT's name, which the payer-keyed dedup cannot match against the original
+Zelle notification when someone else (spouse, family) sent the money.
+
+Recording the exact Gmail message ID at send time is deliberately the ONLY
+mechanism: filtering by from-address (``-from:me``) or subject shape would
+also drop legitimate emails the user forwards to themselves, which the
+ingestion query explicitly supports.
+
+The recorded row lives in ``email_filter_logs`` — the same audit table the
+bounce filter writes to — and ``email_discovery_service`` excludes every
+logged message ID from discovery.
+"""
+import logging
+import uuid
+
+from app.db.session import unit_of_work
+from app.repositories import email_filter_log_repo
+from app.services.email.constants import (
+    EMAIL_FILTER_LOG_FROM_ADDRESS_MAX_LEN,
+    EMAIL_FILTER_LOG_SUBJECT_MAX_LEN,
+)
+from app.services.email.header_truncation import truncate_header
+
+logger = logging.getLogger(__name__)
+
+
+async def record_app_sent_email(
+    *,
+    organization_id: uuid.UUID,
+    user_id: uuid.UUID,
+    message_id: str,
+    from_address: str | None,
+    subject: str | None,
+    reason: str,
+) -> None:
+    """Best-effort: never raises. The email is already sent — failing the
+    caller's operation here would make the user retry and send a duplicate
+    email. On failure the message stays eligible for re-ingestion, so log
+    loudly enough for Sentry to surface it.
+    """
+    try:
+        async with unit_of_work() as db:
+            await email_filter_log_repo.insert_ignore_conflict(
+                db,
+                organization_id=organization_id,
+                user_id=user_id,
+                message_id=message_id,
+                from_address=truncate_header(
+                    from_address, EMAIL_FILTER_LOG_FROM_ADDRESS_MAX_LEN
+                ),
+                subject=truncate_header(subject, EMAIL_FILTER_LOG_SUBJECT_MAX_LEN),
+                reason=reason,
+            )
+    except Exception:
+        logger.error(
+            "Could not record app-sent email %s (reason=%s) — the Gmail sync "
+            "may re-ingest it and create a duplicate transaction",
+            message_id, reason,
+            exc_info=True,
+        )

--- a/apps/mybookkeeper/backend/app/services/email/constants.py
+++ b/apps/mybookkeeper/backend/app/services/email/constants.py
@@ -59,3 +59,12 @@ BOUNCE_BODY_FINGERPRINTS: tuple[str, ...] = (
 # Max widths for EmailFilterLog string columns — must match the model.
 EMAIL_FILTER_LOG_FROM_ADDRESS_MAX_LEN = 500
 EMAIL_FILTER_LOG_SUBJECT_MAX_LEN = 500
+
+# -- EmailFilterLog.reason values for app-sent messages --
+#
+# Written at send time by app.services.email.app_sent_email_service so the
+# Gmail sync never re-ingests mail the app itself sent (a rent receipt matches
+# the ingestion query via subject:receipt + has:attachment and would be
+# re-extracted as a duplicate income transaction).
+APP_SENT_RECEIPT_FILTER_REASON = "app_sent_receipt"
+APP_SENT_INQUIRY_REPLY_FILTER_REASON = "app_sent_inquiry_reply"

--- a/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/email_discovery_service.py
@@ -27,15 +27,9 @@ from app.services.email.gmail_service import (
     list_new_email_ids,
     persist_refreshed_token,
 )
+from app.services.email.header_truncation import truncate_header
 
 logger = logging.getLogger(__name__)
-
-
-def _truncate(value: str | None, max_len: int) -> str | None:
-    """Match a Gmail header value to a DB column width without raising."""
-    if value is None:
-        return None
-    return value if len(value) <= max_len else value[:max_len]
 
 
 async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
@@ -67,7 +61,13 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
 
         queued_ids = await email_queue_repo.get_message_ids(db, org_id)
         doc_ids = await document_repo.get_email_message_ids(db, org_id)
-        processed_ids: set[str] = queued_ids | doc_ids
+        # Filter-logged messages are permanently excluded: bounces (re-listing
+        # them would just re-run the same deterministic detection every sync)
+        # and app-sent mail (rent receipts / inquiry replies recorded at send
+        # time by app_sent_email_service — re-ingesting those would re-extract
+        # the app's own output as duplicate transactions).
+        filtered_ids = await email_filter_log_repo.get_message_ids(db, org_id)
+        processed_ids: set[str] = queued_ids | doc_ids | filtered_ids
 
         label = settings.gmail_label or None
         try:
@@ -189,8 +189,8 @@ async def discover_gmail_emails(ctx: RequestContext) -> DiscoverResult:
                     organization_id=org_id,
                     user_id=ctx.user_id,
                     message_id=message_id,
-                    from_address=_truncate(from_address, EMAIL_FILTER_LOG_FROM_ADDRESS_MAX_LEN),
-                    subject=_truncate(subject, EMAIL_FILTER_LOG_SUBJECT_MAX_LEN),
+                    from_address=truncate_header(from_address, EMAIL_FILTER_LOG_FROM_ADDRESS_MAX_LEN),
+                    subject=truncate_header(subject, EMAIL_FILTER_LOG_SUBJECT_MAX_LEN),
                     reason=bounce_result.reason,
                 )
                 filtered_count += 1

--- a/apps/mybookkeeper/backend/app/services/email/gmail_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/gmail_service.py
@@ -116,9 +116,11 @@ def list_new_email_ids(
     """Return (new_ids, total_matched).
 
     ``new_ids`` excludes any message already in ``processed_ids`` (the dedup
-    set built from email_queue + documents). ``total_matched`` is the
-    pre-dedup count Gmail returned for the configured query — surfaced to
-    the UI so '0 documents added' isn't ambiguous.
+    set built from email_queue + documents + email_filter_logs — the latter
+    covers filtered bounces and app-sent mail recorded at send time).
+    ``total_matched`` is the pre-dedup count Gmail returned for the
+    configured query — surfaced to the UI so '0 documents added' isn't
+    ambiguous.
     """
     query = settings.gmail_search_query
     label_ids: list[str] | None = None

--- a/apps/mybookkeeper/backend/app/services/email/gmail_service.py
+++ b/apps/mybookkeeper/backend/app/services/email/gmail_service.py
@@ -115,12 +115,10 @@ def list_new_email_ids(
 ) -> tuple[list[str], int]:
     """Return (new_ids, total_matched).
 
-    ``new_ids`` excludes any message already in ``processed_ids`` (the dedup
-    set built from email_queue + documents + email_filter_logs — the latter
-    covers filtered bounces and app-sent mail recorded at send time).
-    ``total_matched`` is the pre-dedup count Gmail returned for the
-    configured query — surfaced to the UI so '0 documents added' isn't
-    ambiguous.
+    ``new_ids`` excludes any message already in ``processed_ids`` (dedup set
+    from email_queue + documents + email_filter_logs — filtered bounces and
+    app-sent mail recorded at send time). ``total_matched`` is the pre-dedup
+    count Gmail returned for the query — shown so '0 added' isn't ambiguous.
     """
     query = settings.gmail_search_query
     label_ids: list[str] | None = None

--- a/apps/mybookkeeper/backend/app/services/email/header_truncation.py
+++ b/apps/mybookkeeper/backend/app/services/email/header_truncation.py
@@ -1,0 +1,8 @@
+"""Truncate Gmail header values to DB column widths."""
+
+
+def truncate_header(value: str | None, max_len: int) -> str | None:
+    """Match a Gmail header value to a DB column width without raising."""
+    if value is None:
+        return None
+    return value if len(value) <= max_len else value[:max_len]

--- a/apps/mybookkeeper/backend/app/services/inquiries/inquiry_reply_service.py
+++ b/apps/mybookkeeper/backend/app/services/inquiries/inquiry_reply_service.py
@@ -37,6 +37,8 @@ from app.repositories.user import user_repo
 from app.schemas.inquiries.inquiry_message_response import InquiryMessageResponse
 from app.schemas.inquiries.inquiry_reply_request import InquiryReplyRequest
 from app.services.email import gmail_service
+from app.services.email.app_sent_email_service import record_app_sent_email
+from app.services.email.constants import APP_SENT_INQUIRY_REPLY_FILTER_REASON
 from app.services.email.exceptions import GmailReauthRequiredError, GmailSendError, GmailSendScopeError
 from app.services.integrations import integration_service
 
@@ -131,6 +133,17 @@ async def send_reply(
         raise InquiryReplyMissingSendScopeError(str(exc)) from exc
     except GmailSendError as exc:
         raise InquiryReplySendFailedError(str(exc)) from exc
+
+    # Record the sent message ID in its own transaction so the Gmail sync
+    # never re-ingests the host's own reply, even if Phase 3 below fails.
+    await record_app_sent_email(
+        organization_id=organization_id,
+        user_id=user_id,
+        message_id=sent_message_id,
+        from_address=from_address,
+        subject=request.subject,
+        reason=APP_SENT_INQUIRY_REPLY_FILTER_REASON,
+    )
 
     # ----- Phase 3: persist message + event + stage transition (atomic) -----
     now = _dt.datetime.now(_dt.timezone.utc)

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_formatting.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_formatting.py
@@ -1,0 +1,48 @@
+"""Pure period / display-name helpers for rent receipts.
+
+Extracted from ``receipt_service`` (file-size no-growth policy); the service
+re-imports these under their original private names.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from calendar import monthrange
+
+
+def default_period(txn_date: _dt.date) -> tuple[_dt.date, _dt.date]:
+    """Return (start, end) for the full calendar month of ``txn_date``."""
+    first = txn_date.replace(day=1)
+    last_day = monthrange(txn_date.year, txn_date.month)[1]
+    last = txn_date.replace(day=last_day)
+    return first, last
+
+
+def resolve_landlord_name(host_user) -> str:  # type: ignore[no-untyped-def]
+    """Pick the landlord display name for the receipt.
+
+    Prefers the host's configured ``user.name`` (legal name they entered
+    at registration or in profile settings). Falls back to the email
+    local-part only when the user hasn't set a name yet — that fallback
+    surfaces strings like 'jasonykwon91' on the receipt, which is wrong
+    for tenant-facing artifacts. The UI nudges the user to set their
+    name on the Security page so the fallback is short-lived.
+    """
+    name = (host_user.name or "").strip() if hasattr(host_user, "name") else ""
+    if name:
+        return name
+    if host_user.email:
+        return host_user.email.split("@")[0]
+    return "Landlord"
+
+
+def format_period_short(start: _dt.date, end: _dt.date) -> str:
+    if start.year == end.year and start.month == end.month:
+        return start.strftime("%b %Y")
+    return f"{start.strftime('%b %Y')} – {end.strftime('%b %Y')}"
+
+
+def format_period_long(start: _dt.date, end: _dt.date) -> str:
+    if start.year == end.year and start.month == end.month:
+        last = monthrange(start.year, start.month)[1]
+        return f"{start.strftime('%B')} {start.day}–{last}, {start.year}"
+    return f"{start.strftime('%B %-d, %Y')} – {end.strftime('%B %-d, %Y')}"

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
@@ -44,6 +44,8 @@ from app.repositories.transactions import transaction_repo
 from app.repositories.user import user_repo
 from app.repositories.inquiries import inquiry_repo
 from app.services.email import gmail_service
+from app.services.email.app_sent_email_service import record_app_sent_email
+from app.services.email.constants import APP_SENT_RECEIPT_FILTER_REASON
 from app.services.email.exceptions import (
     GmailReauthRequiredError,
     GmailSendError,
@@ -395,7 +397,7 @@ async def send_receipt(
             f"Amount: ${txn_amount:,.2f}\n\n"
             f"Thank you,\n{landlord_name}"
         )
-        await gmail_service.send_message_with_attachment(
+        sent_gmail_message_id = await gmail_service.send_message_with_attachment(
             integration,
             from_address=from_address,
             to_address=tenant_email,
@@ -422,7 +424,20 @@ async def send_receipt(
             raise ReceiptMissingSendScopeError(str(exc)) from exc
         raise ReceiptGmailSendError(str(exc)) from exc
 
-    # Gmail succeeded — persist the attachment row and update pending receipt
+    # Gmail succeeded — record the sent message ID FIRST, in its own
+    # transaction, so the Gmail sync never re-ingests this receipt email as a
+    # duplicate income transaction even if the attachment persistence below
+    # fails and rolls back.
+    await record_app_sent_email(
+        organization_id=organization_id,
+        user_id=user_id,
+        message_id=sent_gmail_message_id,
+        from_address=from_address,
+        subject=subject,
+        reason=APP_SENT_RECEIPT_FILTER_REASON,
+    )
+
+    # Persist the attachment row and update pending receipt
     async with unit_of_work() as db:
         # We need a lease_id for the attachment — use the resolved one or
         # fall back to the first active lease. If none exists, we can't

--- a/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
+++ b/apps/mybookkeeper/backend/app/services/leases/receipt_service.py
@@ -23,7 +23,6 @@ from __future__ import annotations
 import datetime as _dt
 import logging
 import uuid
-from calendar import monthrange
 from dataclasses import dataclass
 from decimal import Decimal
 
@@ -52,6 +51,12 @@ from app.services.email.exceptions import (
     GmailSendScopeError,
 )
 from app.services.integrations import integration_service
+from app.services.leases.receipt_formatting import (
+    default_period as _default_period,
+    format_period_long as _format_period_long,
+    format_period_short as _format_period_short,
+    resolve_landlord_name as _resolve_landlord_name,
+)
 from app.services.leases.receipt_pdf_service import ReceiptData, generate_receipt_pdf
 from app.core import storage as _storage_module
 
@@ -99,32 +104,6 @@ class ReceiptSendResult:
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
-
-def _default_period(txn_date: _dt.date) -> tuple[_dt.date, _dt.date]:
-    """Return (start, end) for the full calendar month of ``txn_date``."""
-    first = txn_date.replace(day=1)
-    last_day = monthrange(txn_date.year, txn_date.month)[1]
-    last = txn_date.replace(day=last_day)
-    return first, last
-
-
-def _resolve_landlord_name(host_user) -> str:  # type: ignore[no-untyped-def]
-    """Pick the landlord display name for the receipt.
-
-    Prefers the host's configured ``user.name`` (legal name they entered
-    at registration or in profile settings). Falls back to the email
-    local-part only when the user hasn't set a name yet — that fallback
-    surfaces strings like 'jasonykwon91' on the receipt, which is wrong
-    for tenant-facing artifacts. The UI nudges the user to set their
-    name on the Security page so the fallback is short-lived.
-    """
-    name = (host_user.name or "").strip() if hasattr(host_user, "name") else ""
-    if name:
-        return name
-    if host_user.email:
-        return host_user.email.split("@")[0]
-    return "Landlord"
-
 
 async def _resolve_property_address(
     db: AsyncSession,
@@ -573,20 +552,3 @@ async def preview_receipt_pdf(
     )
     pdf_bytes = generate_receipt_pdf(receipt_data)
     return pdf_bytes, "receipt-preview.pdf"
-
-
-# ---------------------------------------------------------------------------
-# Private helpers
-# ---------------------------------------------------------------------------
-
-def _format_period_short(start: _dt.date, end: _dt.date) -> str:
-    if start.year == end.year and start.month == end.month:
-        return start.strftime("%b %Y")
-    return f"{start.strftime('%b %Y')} – {end.strftime('%b %Y')}"
-
-
-def _format_period_long(start: _dt.date, end: _dt.date) -> str:
-    if start.year == end.year and start.month == end.month:
-        last = monthrange(start.year, start.month)[1]
-        return f"{start.strftime('%B')} {start.day}–{last}, {start.year}"
-    return f"{start.strftime('%B %-d, %Y')} – {end.strftime('%B %-d, %Y')}"

--- a/apps/mybookkeeper/backend/tests/services/email/test_app_sent_email_filter.py
+++ b/apps/mybookkeeper/backend/tests/services/email/test_app_sent_email_filter.py
@@ -1,0 +1,286 @@
+"""App-sent emails must never re-enter the Gmail ingestion pipeline.
+
+MBK sends rent receipts / inquiry replies through the SAME Gmail account it
+ingests from. A sent rent receipt matches the ingestion query
+(``subject:receipt`` + ``has:attachment``), so without the send-time record
+in ``email_filter_logs`` the next sync would re-extract the app's own
+receipt as a duplicate income transaction under the tenant's name — which
+the payer-keyed dedup cannot match against the original Zelle notification
+when someone else (spouse, family member) sent the money.
+
+The exclusion is keyed on the exact Gmail message ID recorded at send time —
+NOT on from-address or subject shape — so emails the user forwards to
+themselves keep flowing into ingestion.
+"""
+
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.context import RequestContext
+from app.models.email.email_filter_log import EmailFilterLog
+from app.models.email.email_queue import EmailQueue
+from app.models.integrations.integration import Integration
+from app.models.organization.organization import Organization
+from app.models.organization.organization_member import OrgRole
+from app.models.user.user import User
+from app.repositories import email_filter_log_repo
+from app.services.email import app_sent_email_service
+from app.services.email.constants import (
+    APP_SENT_RECEIPT_FILTER_REASON,
+    EMAIL_FILTER_LOG_SUBJECT_MAX_LEN,
+)
+
+
+@pytest.fixture()
+async def gmail_integration(
+    db: AsyncSession, test_org: Organization, test_user: User
+) -> Integration:
+    integration = Integration(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        provider="gmail",
+    )
+    integration.access_token = "fake_access_token"
+    integration.refresh_token = "fake_refresh_token"
+    db.add(integration)
+    await db.commit()
+    await db.refresh(integration)
+    return integration
+
+
+@pytest.fixture()
+def request_ctx(test_org: Organization, test_user: User) -> RequestContext:
+    return RequestContext(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        org_role=OrgRole.OWNER,
+    )
+
+
+def _legit_sources_data() -> dict:
+    return {
+        "subject": "Invoice 4567 - Service on April 15",
+        "from_address": "Acme Plumbing <billing@acme.example>",
+        "headers": {
+            "From": "Acme Plumbing <billing@acme.example>",
+            "Subject": "Invoice 4567 - Service on April 15",
+        },
+        "body_preview": "Thanks for your business! Total: $123.45",
+        "sources": [
+            {
+                "attachment_id": "att_pdf_1",
+                "filename": "invoice_4567.pdf",
+                "content_type": "application/pdf",
+            },
+        ],
+    }
+
+
+def _fake_gmail_service(message_ids: list[str]) -> MagicMock:
+    """A Gmail API client whose search returns ``message_ids``."""
+    service = MagicMock()
+    messages = service.users.return_value.messages.return_value
+    messages.list.return_value.execute.return_value = {
+        "messages": [{"id": mid} for mid in message_ids],
+    }
+    # Metadata fetch used only for the discovery diagnostic log.
+    messages.get.return_value.execute.return_value = {
+        "payload": {"headers": [{"name": "Subject", "value": "s"}, {"name": "From", "value": "f"}]},
+    }
+    return service
+
+
+@pytest.mark.asyncio
+async def test_discovery_excludes_app_sent_message_ids(
+    db: AsyncSession,
+    gmail_integration: Integration,
+    request_ctx: RequestContext,
+) -> None:
+    """A send-time-recorded message ID is dropped by the REAL list_new_email_ids
+    exclusion (not a patched one); other mail keeps flowing."""
+    sent_receipt_id = "msg_receipt_sent_by_app"
+    legit_id = "msg_new_invoice"
+
+    await email_filter_log_repo.insert_ignore_conflict(
+        db,
+        organization_id=request_ctx.organization_id,
+        user_id=request_ctx.user_id,
+        message_id=sent_receipt_id,
+        from_address="host@example.com",
+        subject="Rent receipt RCPT-2026-0001 — July 1–31, 2026 — 6734 Peerless St",
+        reason=APP_SENT_RECEIPT_FILTER_REASON,
+    )
+    await db.commit()
+
+    @asynccontextmanager
+    async def _fake_uow():
+        yield db
+
+    with (
+        patch("app.services.email.email_discovery_service.unit_of_work", _fake_uow),
+        patch("app.services.email.email_discovery_service.get_gmail_service") as mock_gmail,
+        patch(
+            "app.services.email.email_discovery_service.list_email_document_sources",
+            return_value=_legit_sources_data(),
+        ) as mock_sources,
+    ):
+        # Gmail returns BOTH messages — the app-sent one must be excluded
+        # client-side via the processed_ids set.
+        mock_gmail.return_value = (
+            _fake_gmail_service([sent_receipt_id, legit_id]),
+            MagicMock(token="t0"),
+        )
+
+        from app.services.email.email_discovery_service import discover_gmail_emails
+
+        result = await discover_gmail_emails(request_ctx)
+
+    queue_rows = (await db.execute(select(EmailQueue))).scalars().all()
+    assert [row.message_id for row in queue_rows] == [legit_id]
+    # The app-sent message never even had its sources fetched.
+    fetched_ids = [call.args[1] for call in mock_sources.call_args_list]
+    assert sent_receipt_id not in fetched_ids
+
+    assert result.status == "queued"
+    assert result.count == 1
+
+
+@pytest.mark.asyncio
+async def test_record_app_sent_email_inserts_filter_log_row(
+    db: AsyncSession, test_org: Organization, test_user: User, monkeypatch,
+) -> None:
+    @asynccontextmanager
+    async def _uow():
+        try:
+            yield db
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    monkeypatch.setattr(app_sent_email_service, "unit_of_work", _uow)
+
+    long_subject = "Rent receipt " + "x" * 600
+    await app_sent_email_service.record_app_sent_email(
+        organization_id=test_org.id,
+        user_id=test_user.id,
+        message_id="sent-msg-1",
+        from_address="host@example.com",
+        subject=long_subject,
+        reason=APP_SENT_RECEIPT_FILTER_REASON,
+    )
+
+    rows = (await db.execute(select(EmailFilterLog))).scalars().all()
+    assert len(rows) == 1
+    assert rows[0].message_id == "sent-msg-1"
+    assert rows[0].reason == APP_SENT_RECEIPT_FILTER_REASON
+    assert rows[0].from_address == "host@example.com"
+    assert rows[0].subject == long_subject[:EMAIL_FILTER_LOG_SUBJECT_MAX_LEN]
+    assert rows[0].organization_id == test_org.id
+    assert rows[0].user_id == test_user.id
+
+
+@pytest.mark.asyncio
+async def test_record_app_sent_email_is_idempotent(
+    db: AsyncSession, test_org: Organization, test_user: User, monkeypatch,
+) -> None:
+    """Re-recording the same message ID (e.g. a retried flow) keeps one row."""
+    @asynccontextmanager
+    async def _uow():
+        try:
+            yield db
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    monkeypatch.setattr(app_sent_email_service, "unit_of_work", _uow)
+
+    for _ in range(2):
+        await app_sent_email_service.record_app_sent_email(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            message_id="sent-msg-dup",
+            from_address=None,
+            subject=None,
+            reason=APP_SENT_RECEIPT_FILTER_REASON,
+        )
+
+    rows = (await db.execute(select(EmailFilterLog))).scalars().all()
+    assert len(rows) == 1
+
+
+@pytest.mark.asyncio
+async def test_record_app_sent_email_never_raises(
+    db: AsyncSession, test_org: Organization, test_user: User, monkeypatch,
+) -> None:
+    """The email already went out — a recording failure must not fail the
+    caller's send flow (retrying would send a duplicate email)."""
+    @asynccontextmanager
+    async def _uow():
+        yield db
+
+    monkeypatch.setattr(app_sent_email_service, "unit_of_work", _uow)
+
+    with patch(
+        "app.services.email.app_sent_email_service.email_filter_log_repo.insert_ignore_conflict",
+        new=AsyncMock(side_effect=RuntimeError("db down")),
+    ):
+        await app_sent_email_service.record_app_sent_email(
+            organization_id=test_org.id,
+            user_id=test_user.id,
+            message_id="sent-msg-err",
+            from_address=None,
+            subject=None,
+            reason=APP_SENT_RECEIPT_FILTER_REASON,
+        )
+    # reaching here without an exception is the assertion
+
+
+@pytest.mark.asyncio
+async def test_bounce_filtered_ids_also_excluded_from_relisting(
+    db: AsyncSession,
+    gmail_integration: Integration,
+    request_ctx: RequestContext,
+) -> None:
+    """Any filter-logged message (bounce or app-sent) is permanently excluded —
+    a previously filtered bounce is not re-fetched every sync."""
+    bounce_id = "msg_bounce_old"
+    await email_filter_log_repo.insert_ignore_conflict(
+        db,
+        organization_id=request_ctx.organization_id,
+        user_id=request_ctx.user_id,
+        message_id=bounce_id,
+        from_address="MAILER-DAEMON@mail.example.com",
+        subject="Undeliverable",
+        reason="header_x_failed_recipients",
+    )
+    await db.commit()
+
+    @asynccontextmanager
+    async def _fake_uow():
+        yield db
+
+    with (
+        patch("app.services.email.email_discovery_service.unit_of_work", _fake_uow),
+        patch("app.services.email.email_discovery_service.get_gmail_service") as mock_gmail,
+        patch(
+            "app.services.email.email_discovery_service.list_email_document_sources",
+        ) as mock_sources,
+    ):
+        mock_gmail.return_value = (
+            _fake_gmail_service([bounce_id]),
+            MagicMock(token="t0"),
+        )
+
+        from app.services.email.email_discovery_service import discover_gmail_emails
+
+        result = await discover_gmail_emails(request_ctx)
+
+    assert result.status == "nothing_new"
+    mock_sources.assert_not_called()

--- a/apps/mybookkeeper/backend/tests/test_email_discovery_last_synced.py
+++ b/apps/mybookkeeper/backend/tests/test_email_discovery_last_synced.py
@@ -96,6 +96,10 @@ def _patch_discovery_dependencies(
             "app.services.email.email_discovery_service.document_repo.get_email_message_ids",
             new=AsyncMock(return_value=set()),
         ),
+        patch(
+            "app.services.email.email_discovery_service.email_filter_log_repo.get_message_ids",
+            new=AsyncMock(return_value=set()),
+        ),
     ]
 
     if list_new_ids_side_effect is not None:

--- a/apps/mybookkeeper/backend/tests/test_gmail_auth_expired.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_auth_expired.py
@@ -86,6 +86,10 @@ async def test_discover_raises_gmail_auth_expired_on_refresh_error() -> None:
             new=AsyncMock(return_value=set()),
         ),
         patch(
+            "app.services.email.email_discovery_service.email_filter_log_repo.get_message_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
             "app.services.email.email_discovery_service.list_new_email_ids",
             side_effect=RefreshError("invalid_grant: Token has been expired or revoked."),
         ),
@@ -232,6 +236,10 @@ async def test_discovery_sets_needs_reauth_on_refresh_error() -> None:
         ),
         patch(
             "app.services.email.email_discovery_service.document_repo.get_email_message_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
+            "app.services.email.email_discovery_service.email_filter_log_repo.get_message_ids",
             new=AsyncMock(return_value=set()),
         ),
         patch(

--- a/apps/mybookkeeper/backend/tests/test_gmail_skipped_messages.py
+++ b/apps/mybookkeeper/backend/tests/test_gmail_skipped_messages.py
@@ -83,6 +83,10 @@ def _base_patches(
             new=AsyncMock(return_value=set()),
         ),
         patch(
+            "app.services.email.email_discovery_service.email_filter_log_repo.get_message_ids",
+            new=AsyncMock(return_value=set()),
+        ),
+        patch(
             "app.services.email.email_discovery_service.list_new_email_ids",
             return_value=(new_ids, len(new_ids)),
         ),

--- a/apps/mybookkeeper/backend/tests/test_inquiry_reply_service.py
+++ b/apps/mybookkeeper/backend/tests/test_inquiry_reply_service.py
@@ -22,6 +22,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.email.email_filter_log import EmailFilterLog
 from app.models.inquiries.inquiry import Inquiry
 from app.models.inquiries.inquiry_event import InquiryEvent
 from app.models.inquiries.inquiry_message import InquiryMessage
@@ -30,6 +31,8 @@ from app.models.organization.organization import Organization
 from app.models.user.user import User
 from app.repositories.inquiries import inquiry_repo
 from app.schemas.inquiries.inquiry_reply_request import InquiryReplyRequest
+from app.services.email import app_sent_email_service
+from app.services.email.constants import APP_SENT_INQUIRY_REPLY_FILTER_REASON
 from app.services.email.exceptions import GmailReauthRequiredError, GmailSendError, GmailSendScopeError
 from app.services.inquiries import inquiry_reply_service
 
@@ -51,6 +54,9 @@ def patch_session(monkeypatch: pytest.MonkeyPatch, db: AsyncSession):
 
     monkeypatch.setattr(inquiry_reply_service, "AsyncSessionLocal", _factory)
     monkeypatch.setattr(inquiry_reply_service, "unit_of_work", _uow)
+    # The app-sent recorder opens its own transaction — route it to the same
+    # test session so its EmailFilterLog write is visible to assertions.
+    monkeypatch.setattr(app_sent_email_service, "unit_of_work", _uow)
     return None
 
 
@@ -142,6 +148,15 @@ async def test_send_reply_happy_path_inserts_message_event_and_advances_stage(
     rows = events.scalars().all()
     assert len(rows) == 1
     assert rows[0].actor == "host"
+
+    # Sent message recorded so the Gmail sync never re-ingests the host's
+    # own reply as a financial document.
+    filter_rows = (await db.execute(select(EmailFilterLog))).scalars().all()
+    assert len(filter_rows) == 1
+    assert filter_rows[0].message_id == "<gmail-id-123>"
+    assert filter_rows[0].reason == APP_SENT_INQUIRY_REPLY_FILTER_REASON
+    assert filter_rows[0].from_address == test_user.email
+    assert filter_rows[0].subject == "Re: Cozy Room"
 
 
 @pytest.mark.asyncio
@@ -278,6 +293,10 @@ async def test_send_reply_gmail_send_failure_no_message_no_stage_change(
     refreshed = await inquiry_repo.get_by_id(db, inquiry.id, test_org.id)
     assert refreshed is not None
     assert refreshed.stage == "new"
+
+    # Nothing was sent, so nothing was recorded as app-sent.
+    filter_rows = (await db.execute(select(EmailFilterLog))).scalars().all()
+    assert filter_rows == []
 
 
 @pytest.mark.asyncio

--- a/apps/mybookkeeper/backend/tests/test_receipt_service_app_sent.py
+++ b/apps/mybookkeeper/backend/tests/test_receipt_service_app_sent.py
@@ -1,0 +1,177 @@
+"""send_receipt must record the sent Gmail message ID as app-sent.
+
+The receipt email matches the Gmail ingestion query (``subject:receipt`` +
+``has:attachment``). Without the send-time ``email_filter_logs`` record the
+next sync would re-extract the app's own receipt as a duplicate income
+transaction under the tenant's name — which the payer-keyed dedup cannot
+match against the original Zelle notification when the actual sender was a
+different person (spouse, family member).
+
+The record is written in its OWN transaction, before the attachment
+persistence, so it survives even when the post-send DB phase fails.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import uuid
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core import storage as _storage_module
+from app.models.applicants.applicant import Applicant
+from app.models.email.email_filter_log import EmailFilterLog
+from app.models.integrations.integration import Integration
+from app.models.leases.rent_receipt_sequence import (  # noqa: F401 — registers the table on Base.metadata so conftest's create_all builds it
+    RentReceiptSequence,
+)
+from app.models.organization.organization import Organization
+from app.models.transactions.transaction import Transaction
+from app.models.user.user import User
+from app.repositories.inquiries import inquiry_repo
+from app.services.email import app_sent_email_service
+from app.services.email.constants import APP_SENT_RECEIPT_FILTER_REASON
+from app.services.leases import receipt_service
+
+
+class _NoOpStorage:
+    bucket = "mock-bucket"
+
+    def upload_file(self, key: str, content: bytes, content_type: str) -> str:
+        return key
+
+    def delete_file(self, key: str) -> None:
+        pass
+
+
+@pytest.fixture
+def patch_session(monkeypatch: pytest.MonkeyPatch, db: AsyncSession):
+    @asynccontextmanager
+    async def _factory():
+        yield db
+
+    @asynccontextmanager
+    async def _uow():
+        try:
+            yield db
+            await db.commit()
+        except Exception:
+            await db.rollback()
+            raise
+
+    monkeypatch.setattr(receipt_service, "AsyncSessionLocal", _factory)
+    monkeypatch.setattr(receipt_service, "unit_of_work", _uow)
+    # The app-sent recorder opens its own transaction — route it to the same
+    # test session so its EmailFilterLog write is visible to assertions.
+    monkeypatch.setattr(app_sent_email_service, "unit_of_work", _uow)
+    monkeypatch.setattr(_storage_module, "get_storage", lambda: _NoOpStorage())
+    return None
+
+
+async def _seed_rent_payment(
+    db: AsyncSession, *, org: Organization, user: User
+) -> Transaction:
+    """Attributed rent payment + tenant with an email + Gmail integration.
+
+    Deliberately NO signed lease — the post-send attachment phase then raises
+    LookupError, which is exactly the failure the send-time record must
+    survive.
+    """
+    inquiry = await inquiry_repo.create(
+        db,
+        organization_id=org.id,
+        user_id=user.id,
+        source="direct",
+        received_at=_dt.datetime.now(_dt.timezone.utc),
+        inquirer_name="Andrew Le",
+        inquirer_email="andrew@example.com",
+    )
+    applicant = Applicant(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        user_id=user.id,
+        stage="lease_signed",
+        legal_name="Andrew Le",
+        inquiry_id=inquiry.id,
+    )
+    db.add(applicant)
+
+    integration = Integration(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        user_id=user.id,
+        provider="gmail",
+        token_expiry=_dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(hours=1),
+        metadata_={
+            "scopes": [
+                "https://www.googleapis.com/auth/gmail.readonly",
+                "https://www.googleapis.com/auth/gmail.send",
+            ],
+        },
+    )
+    integration.access_token = "tok"
+    integration.refresh_token = "rt"
+    db.add(integration)
+
+    txn = Transaction(
+        id=uuid.uuid4(),
+        organization_id=org.id,
+        user_id=user.id,
+        transaction_date=_dt.date(2026, 7, 1),
+        tax_year=2026,
+        amount=Decimal("1500.00"),
+        transaction_type="income",
+        category="rental_revenue",
+        status="approved",
+        is_manual=False,
+        applicant_id=applicant.id,
+    )
+    db.add(txn)
+    await db.flush()
+    return txn
+
+
+@pytest.mark.asyncio
+async def test_send_receipt_records_app_sent_before_attachment_persistence(
+    db: AsyncSession, test_user: User, test_org: Organization, patch_session,
+) -> None:
+    txn = await _seed_rent_payment(db, org=test_org, user=test_user)
+    # Capture scalars before send_receipt: its failure path rolls back the
+    # session, which expires all ORM objects — a later attribute access would
+    # lazy-load from sync code and raise MissingGreenlet.
+    host_email = test_user.email
+    org_id = test_org.id
+    user_id = test_user.id
+    txn_id = txn.id
+
+    with patch(
+        "app.services.leases.receipt_service.gmail_service.send_message_with_attachment",
+        new=AsyncMock(return_value="sent-gmail-msg-42"),
+    ) as mock_send:
+        # No signed lease exists, so the attachment phase fails AFTER the
+        # email went out — the app-sent record must survive regardless.
+        with pytest.raises(LookupError, match="no signed lease"):
+            await receipt_service.send_receipt(
+                transaction_id=txn_id,
+                organization_id=org_id,
+                user_id=user_id,
+                period_start=_dt.date(2026, 7, 1),
+                period_end=_dt.date(2026, 7, 31),
+                payment_method="zelle",
+            )
+
+    assert mock_send.await_count == 1
+
+    filter_rows = (await db.execute(select(EmailFilterLog))).scalars().all()
+    assert len(filter_rows) == 1
+    row = filter_rows[0]
+    assert row.message_id == "sent-gmail-msg-42"
+    assert row.reason == APP_SENT_RECEIPT_FILTER_REASON
+    assert row.from_address == host_email
+    assert row.subject is not None and row.subject.startswith("Rent receipt ")
+    assert row.organization_id == org_id
+    assert row.user_id == user_id

--- a/apps/mybookkeeper/backend/tests/test_silent_fail_audit_fixes.py
+++ b/apps/mybookkeeper/backend/tests/test_silent_fail_audit_fixes.py
@@ -181,6 +181,10 @@ class TestEmailDiscoveryServiceExcInfo:
                 "app.services.email.email_discovery_service.document_repo.get_email_message_ids",
                 new=AsyncMock(return_value=set()),
             ),
+            patch(
+                "app.services.email.email_discovery_service.email_filter_log_repo.get_message_ids",
+                new=AsyncMock(return_value=set()),
+            ),
             # list_new_email_ids returns one new ID so we enter the per-message loop
             patch(
                 "app.services.email.email_discovery_service.list_new_email_ids",

--- a/apps/mybookkeeper/scripts/test-map.json
+++ b/apps/mybookkeeper/scripts/test-map.json
@@ -183,7 +183,8 @@
         "test_gmail_skipped_messages.py",
         "test_silent_fail_audit_fixes.py",
         "services/email/test_bounce_detector.py",
-        "services/email/test_discovery_bounce_filter.py"
+        "services/email/test_discovery_bounce_filter.py",
+        "services/email/test_app_sent_email_filter.py"
       ],
       "frontend_tests": [
         "EmailQueueSection.test.tsx"
@@ -712,7 +713,8 @@
       "backend_tests": [
         "test_receipt_pdf_service.py",
         "test_receipt_sequence_repo.py",
-        "test_receipt_routes.py"
+        "test_receipt_routes.py",
+        "test_receipt_service_app_sent.py"
       ],
       "frontend_tests": [
         "SendReceiptDialog.test.tsx",


### PR DESCRIPTION
## Problem

July 2026 revenue showed 4 transactions / \$6,000 when only 2 rent payments (\$3,000) happened. Each payment existed twice:

1. The real Zelle notification — payer = actual sender (paying on the tenant's behalf)
2. **MBK's own rent-receipt email**, re-ingested by the Gmail sync and re-extracted by Claude as a new income transaction — payer = tenant

The receipt email matches the ingestion query (`subject:receipt` + `has:attachment`), and the P2P payer-keyed dedup (`dedup_service.py`) can't match the two copies because the payer names differ — by design, since it exists to keep different payers with equal amounts separate.

## Fix

Record the exact Gmail message ID at send time and exclude it from discovery:

- New `app_sent_email_service.record_app_sent_email()` — writes an `email_filter_logs` row (reason `app_sent_receipt` / `app_sent_inquiry_reply`) in its **own transaction** right after a successful Gmail send, so the record survives even if the post-send persistence phase fails. Best-effort (never fails the send flow — retrying would email the tenant twice).
- Wired into both Gmail send paths: `receipt_service.send_receipt` and `inquiry_reply_service.send_reply`. (Welcome manuals go via SMTP — can't loop back.)
- `email_discovery_service` now unions `email_filter_logs` message IDs into `processed_ids`. Side benefit: already-filtered bounces are no longer re-fetched every 15-min sync.
- Extracted shared `truncate_header` (was private `_truncate` in discovery).

**Deliberately NOT** `-from:me` / subject filtering — the operator forwards payment notifications from their own address and those must keep flowing. Exclusion is keyed on exact message IDs of mail the app itself sent.

## Tests (158 affected tests green locally)

- Discovery exclusion exercised through the **real** `list_new_email_ids` (fake Gmail client returns an app-sent + a legit message; only the legit one queues)
- Recorder: insert + truncation, idempotency, never-raises
- Receipt wiring: record survives post-send `LookupError` rollback
- Inquiry reply wiring: recorded on success, absent on Gmail failure
- Existing discovery tests updated to mock the new repo call
- Pre-commit review (g-pre-commit): no findings

## Operational notes (no env/deploy action required)

Existing duplicates are data, not code — mark the two July "Rent payment from …" copies as duplicates (or delete) in the UI; earlier months where a receipt was issued for a Zelle payment sent by a non-tenant may have the same double-count. Receipts sent before this deploy that were already ingested stay excluded via the email_queue dedup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TpNjRrJxTHAd1jcSkTxJtU