### PR TITLE
fix(infra): seed-env workflow — inject optional ANTHROPIC_API_KEY

### DIFF
--- a/.github/workflows/seed-env.yml
+++ b/.github/workflows/seed-env.yml
@@ -12,6 +12,7 @@
 #   <APP>_TURNSTILE_SECRET_KEY  Cloudflare Turnstile secret
 #   <APP>_MINIO_ACCESS_KEY      shared MinIO stack credentials
 #   <APP>_MINIO_SECRET_KEY
+#   <APP>_ANTHROPIC_API_KEY     optional — apps with AI features (sk-ant-...)
 #   <APP>_SEED_USER_EMAIL           (single-user apps only)
 #   <APP>_SEED_USER_PASSWORD_HASH   (single-user apps only)
 #
@@ -95,6 +96,7 @@ jobs:
             TURNSTILE_SITE_KEY=${{ vars[format('{0}_vite_turnstile_site_key', inputs.app)] }}
             MINIO_ACCESS_KEY=${{ secrets[format('{0}_minio_access_key', inputs.app)] }}
             MINIO_SECRET_KEY=${{ secrets[format('{0}_minio_secret_key', inputs.app)] }}
+            ANTHROPIC_API_KEY=${{ secrets[format('{0}_anthropic_api_key', inputs.app)] }}
             SEED_USER_EMAIL=${{ secrets[format('{0}_seed_user_email', inputs.app)] }}
             SEED_USER_PASSWORD_HASH=${{ secrets[format('{0}_seed_user_password_hash', inputs.app)] }}
             SEED_ENV_OVERRIDES_EOF


### PR DESCRIPTION
3-line follow-up to #956: 4 of 5 app templates declare `ANTHROPIC_API_KEY` (AI features — e.g. MyRecipes photo-import; all apps boot without it), but the seed-env workflow didn't map it. Adds `<APPUPPER>_ANTHROPIC_API_KEY` to the overrides heredoc + the header doc list. Unset secret = blank line = skipped by seed_env, same as every other key. No python/test changes — the key is already declared in the templates, so `--overrides` handles it generically (covered by the existing undeclared/blank-handling tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A64Uwpo1KAxrmjMuSqAvNk