### PR TITLE
fix(infra): host-Caddy reload trigger for myrecipes ACME (post-DNS)

### DIFF
--- a/infra/Caddyfile
+++ b/infra/Caddyfile
@@ -13,6 +13,12 @@
 #   1. Append a new <hostname> { ... reverse_proxy 127.0.0.1:<port> } block.
 #   2. Pick a unique loopback port (8094 = MBK, 8092 = MJH, 8096 = MGA, 9000 = MinIO).
 #   3. Make sure the app's docker compose binds that port on 127.0.0.1.
+#
+# Note: deploys only sync + `caddy reload` this file when it DIFFERS from
+# /etc/caddy/Caddyfile. If a block's DNS record is created AFTER the block
+# was already synced (ACME has been failing + backing off), touch this file
+# (any comment change) and dispatch a deploy to force the reload that
+# re-attempts certificate issuance. Done 2026-07-02 for myrecipes go-live.
 
 # MyBookkeeper — primary domain.
 # Both addresses listed during the myfreeapps.org cutover so existing


### PR DESCRIPTION
Comment-only change to `infra/Caddyfile`. Deploys sync+`caddy reload` the host Caddyfile only when it differs from `/etc/caddy/Caddyfile`; the myrecipes block has been synced (ACME failing on NXDOMAIN, backing off) for weeks. Merging this and dispatching `deploy-myrecipes.yml` after the DNS record exists forces the reload that re-attempts certificate issuance immediately — the same recovery the MGA 2026-06-01 go-live needed via manual `sudo caddy reload`, now done without SSH. The comment documents the pattern for future first-deploys.

Will be merged once the `myrecipes.myfreeapps.org` A record is live at Porkbun's nameservers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A64Uwpo1KAxrmjMuSqAvNk