### PR TITLE
fix(mjh): hallucination-guard confirmation loop — confirmed facts, decomposition, loop breaker

### DIFF
--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -104,6 +104,22 @@ jobs:
             paths: >-
               tests/test_totp_login.py
               tests/test_totp_setup.py
+          - name: refinement
+            # Resume-refinement suite: pure-function + mocked tests (no
+            # DB fixtures, no Argon2 login storm) — runs in seconds.
+            # These files were previously in NO shard, so none of them
+            # gated merges; a hallucination-guard regression shipped
+            # because of it. The broader explicit-path-allowlist gap is
+            # logged in apps/myjobhunter/TECH_DEBT.md.
+            paths: >-
+              tests/test_resume_refinement_hallucination_guard.py
+              tests/test_resume_refinement_rewrite_service.py
+              tests/test_resume_refinement_critique_service.py
+              tests/test_resume_refinement_markdown_renderer.py
+              tests/test_resume_refinement_renderer.py
+              tests/test_resume_refinement_proposal_cache.py
+              tests/test_resume_refinement_session_helpers.py
+              tests/test_resume_refinement_guard_confirmation.py
 
     services:
       postgres:

--- a/apps/myjobhunter/TECH_DEBT.md
+++ b/apps/myjobhunter/TECH_DEBT.md
@@ -3,7 +3,7 @@
 Issues discovered during development. New entries are appended; resolved entries are
 removed and the counts in this header are updated.
 
-**Open issues: 16 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 2 [1 blocked-on-react-19, 1 public-launch cost guardrail] / Medium: 6 [4 prior + 1 triage-2026-05-28: rejection-visibility + 1 discovery content_hash dedup] / Low: 6 [6 prior] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
+**Open issues: 17 (Critical: 1 [discovery-quality P0 umbrella, triage-2026-05-28] / High: 3 [1 blocked-on-react-19, 1 public-launch cost guardrail, 1 CI shard allowlist gap 2026-07-02] / Medium: 6 [4 prior + 1 triage-2026-05-28: rejection-visibility + 1 discovery content_hash dedup] / Low: 6 [6 prior] / Feature requests: 1 [triage-2026-05-28 raw-resume-upload])**
 
 > Status (2026-05-08 PM): All actionable audit items resolved across batches PR #492-#528 (~30 PRs). Remaining open entries are either (a) blocked on the React 18→19 monorepo bump (5 items), (b) deferred-by-design conventions or follow-ups (4), (c) environmental issues unrelated to code (3: asyncpg Windows, test hang on Windows, Quality Gate false-positive), or (d) intentional accepted lint warnings (2).
 
@@ -791,3 +791,11 @@ This rules a lot of work in and out: **don't** invest in a relevance-overhaul or
 3. Relationship to `tailored_resume` (generated) and the `/resume` refinement tool — where does a raw "master resume" sit relative to those.
 **Parity note (`monorepo-parity-discipline`):** mirror MBK's Documents upload/viewer. If MBK's upload/viewer primitives are generic and now needed by 2 apps, extract to `@platform/ui` / `platform_shared` rather than copy (Tier 1/2 — auto-promote on 2nd occurrence).
 **Effort:** M — enum + migration + repo/service + a resume document UI. Upload plumbing + MinIO storage (`myjobhunter-files`, 25 MB cap) already exist.
+
+### HIGH — CI backend-test shards are an explicit-path allowlist; entire test suites silently excluded
+
+**Reported:** 2026-07-02, discovered while fixing the hallucination-guard confirmation loop (guard PR, branch `fix/mjh-guard-confirm-loop`).
+**Problem:** `.github/workflows/ci-myjobhunter.yml` runs backend tests as 4 shards (`fast` / `crud` / `login-heavy` / `totp`), each an explicit `paths:` file list. Any test file not hand-added to a shard NEVER runs in CI. Found the hard way: all 7 `tests/test_resume_refinement_*.py` files were in no shard, so (a) `hallucination_guard` shipped failing 4 of its own tests — the proper-noun regex never matched un-connectored multi-word phrases ("Acme Corp"), never flagged single-token companies ("Hooli"), and missed bare magnitude metrics ("500K"); and (b) the `test_resume_refinement_proposal_cache.py` patches went silently stale when session_service was split into sub-modules (#478) — 5 tests failing on main, invisible.
+**Fixed so far:** the guard + its tests (this PR), the stale proposal-cache patches (this PR), and a new `refinement` shard covering all 8 refinement test files (this PR).
+**Remaining:** audit every `tests/test_*.py` against the shard lists — as of 2026-07-02 the unsharded set includes (at minimum) discovery, company research, application_writes (intentionally excluded, documented above), jobs/resume-upload, documents, screening, invites, and job-analysis suites. Decide per file: add to a shard (or a new one), or document the intentional exclusion. Structural fix worth considering: replace explicit allowlists with a catch-all shard (`pytest --ignore=<sharded files>`) so a new test file runs by default and sharding is an optimization, not a gate.
+**Also:** `test_application_writes.py` remains excluded per its own entry (Argon2 fixture slowness) — unchanged by this.

--- a/apps/myjobhunter/backend/alembic/versions/guardfacts260702_guard_confirmed_facts.py
+++ b/apps/myjobhunter/backend/alembic/versions/guardfacts260702_guard_confirmed_facts.py
@@ -1,0 +1,123 @@
+"""Guard confirmation state on resume refinement sessions.
+
+Fixes the hallucination-guard clarify dead-end: the guard re-checked
+every regenerated proposal against the UNCHANGED source resume, so a
+user answering "yes, that's correct" could never unblock the loop —
+the same phrase re-flagged and the identical canned question returned,
+burning a Claude call per retry.
+
+Four columns on ``resume_refinement_sessions``:
+
+1. ``confirmed_facts`` — session-level allowlist of facts the user has
+   explicitly confirmed (clarify answers / "Use it anyway"). Passed
+   into every guard check so a confirmed fact is never re-flagged.
+2. ``guard_flag_counts`` — per-target flag counts (keyed by stringified
+   target_index). Drives the loop breaker: from the second flag on the
+   same target the frontend offers an explicit "Use it anyway" action
+   instead of re-asking.
+3. ``pending_guard_flagged`` — the phrases the guard flagged on the
+   current pending clarify (NULL when the pending state isn't
+   guard-generated).
+4. ``pending_flagged_proposal`` — the guard-held proposal text, kept so
+   "Use it anyway" can apply exactly what the user confirmed.
+
+Also widens the turn-role check constraint with ``user_accept_flagged``
+(the "Use it anyway" turn).
+
+Server defaults only, no backfill: existing sessions have no confirmed
+facts and no recorded flags, which the empty list / object encodes
+correctly.
+
+Revision ID: guardfacts260702
+Revises: discexp260528
+Create Date: 2026-07-02
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "guardfacts260702"
+down_revision: Union[str, None] = "discexp260528"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_ROLES_OLD = (
+    "'ai_critique',"
+    "'ai_proposal',"
+    "'user_accept',"
+    "'user_custom',"
+    "'user_request_alternative',"
+    "'user_skip',"
+    "'session_complete'"
+)
+_ROLES_NEW = (
+    "'ai_critique',"
+    "'ai_proposal',"
+    "'user_accept',"
+    "'user_accept_flagged',"
+    "'user_custom',"
+    "'user_request_alternative',"
+    "'user_skip',"
+    "'session_complete'"
+)
+
+
+def upgrade() -> None:
+    op.add_column(
+        "resume_refinement_sessions",
+        sa.Column(
+            "confirmed_facts",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "resume_refinement_sessions",
+        sa.Column(
+            "guard_flag_counts",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+    )
+    op.add_column(
+        "resume_refinement_sessions",
+        sa.Column(
+            "pending_guard_flagged",
+            postgresql.JSONB(astext_type=sa.Text()),
+            nullable=True,
+        ),
+    )
+    op.add_column(
+        "resume_refinement_sessions",
+        sa.Column("pending_flagged_proposal", sa.Text(), nullable=True),
+    )
+
+    op.drop_constraint(
+        "chk_refinement_turn_role", "resume_refinement_turns", type_="check",
+    )
+    op.create_check_constraint(
+        "chk_refinement_turn_role",
+        "resume_refinement_turns",
+        f"role IN ({_ROLES_NEW})",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "chk_refinement_turn_role", "resume_refinement_turns", type_="check",
+    )
+    op.create_check_constraint(
+        "chk_refinement_turn_role",
+        "resume_refinement_turns",
+        f"role IN ({_ROLES_OLD})",
+    )
+    op.drop_column("resume_refinement_sessions", "pending_flagged_proposal")
+    op.drop_column("resume_refinement_sessions", "pending_guard_flagged")
+    op.drop_column("resume_refinement_sessions", "guard_flag_counts")
+    op.drop_column("resume_refinement_sessions", "confirmed_facts")

--- a/apps/myjobhunter/backend/app/api/resume_refinement.py
+++ b/apps/myjobhunter/backend/app/api/resume_refinement.py
@@ -6,6 +6,7 @@ POST   /resume-refinement/sessions                          start a new session
 GET    /resume-refinement/sessions                          list user's sessions
 GET    /resume-refinement/sessions/{id}                     read session state
 POST   /resume-refinement/sessions/{id}/accept              accept pending proposal
+POST   /resume-refinement/sessions/{id}/accept-flagged      apply guard-held proposal ("Use it anyway")
 POST   /resume-refinement/sessions/{id}/custom              supply custom rewrite
 POST   /resume-refinement/sessions/{id}/alternative         regenerate same target
 POST   /resume-refinement/sessions/{id}/skip                skip current target
@@ -96,6 +97,31 @@ async def accept_pending(
 ) -> SessionWithTurnsRead:
     try:
         session = await session_service.accept_pending(
+            db=db, user_id=user.id, session_id=session_id,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except NoPendingProposal as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    return SessionWithTurnsRead.model_validate(session)
+
+
+@router.post("/sessions/{session_id}/accept-flagged", response_model=SessionWithTurnsRead)
+async def accept_flagged(
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionWithTurnsRead:
+    """Apply a guard-held proposal after explicit user confirmation.
+
+    The flagged phrases become session-level confirmed facts so the
+    guard never re-flags them; the held proposal is applied to the
+    draft exactly like a normal accept.
+    """
+    try:
+        session = await session_service.accept_flagged(
             db=db, user_id=user.id, session_id=session_id,
         )
     except SessionNotFound as exc:

--- a/apps/myjobhunter/backend/app/models/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/models/resume_refinement/session.py
@@ -70,6 +70,27 @@ class ResumeRefinementSession(Base):
     pending_rationale: Mapped[str | None] = mapped_column(Text, nullable=True)
     pending_clarifying_question: Mapped[str | None] = mapped_column(Text, nullable=True)
 
+    # Hallucination-guard state for the pending clarify. When the guard
+    # downgrades a proposal, the flagged phrases and the held proposal
+    # text are kept so (a) answering the clarify records the phrases as
+    # confirmed facts, and (b) "Use it anyway" can apply the held text.
+    pending_guard_flagged: Mapped[list | None] = mapped_column(JSONB, nullable=True)
+    pending_flagged_proposal: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Session-level allowlist of facts the user explicitly confirmed
+    # (clarify answers / "Use it anyway"). Passed into every guard check
+    # so a confirmed fact is never re-flagged.
+    confirmed_facts: Mapped[list] = mapped_column(
+        JSONB, nullable=False, default=list, server_default="[]",
+    )
+
+    # Per-target count of guard flags, keyed by stringified target_index.
+    # Drives the loop breaker: from the second flag on the same target,
+    # the frontend offers the explicit "Use it anyway" confirmation.
+    guard_flag_counts: Mapped[dict] = mapped_column(
+        JSONB, nullable=False, default=dict, server_default="{}",
+    )
+
     turn_count: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     total_tokens_in: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
     total_tokens_out: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
@@ -113,6 +134,19 @@ class ResumeRefinementSession(Base):
         cascade="all, delete-orphan",
         order_by="ResumeRefinementTurn.turn_index",
     )
+
+    @property
+    def guard_can_force(self) -> bool:
+        """True when the frontend should offer "Use it anyway".
+
+        The loop breaker: once the guard has flagged the same target
+        twice, re-asking the clarify question would loop forever, so the
+        user gets an explicit accept-with-confirmation escape instead.
+        """
+        if not self.pending_flagged_proposal:
+            return False
+        counts = self.guard_flag_counts or {}
+        return int(counts.get(str(self.target_index), 0)) >= 2
 
     __table_args__ = (
         CheckConstraint(

--- a/apps/myjobhunter/backend/app/models/resume_refinement/turn.py
+++ b/apps/myjobhunter/backend/app/models/resume_refinement/turn.py
@@ -8,6 +8,8 @@ Roles:
   for the session. One per session.
 - ``ai_proposal`` — Claude proposes a rewrite for the current target.
 - ``user_accept`` — user accepts the AI proposal as-is.
+- ``user_accept_flagged`` — user applies a guard-held proposal after
+  explicitly confirming the flagged facts are accurate ("Use it anyway").
 - ``user_custom`` — user supplies their own rewrite for the current target.
 - ``user_request_alternative`` — user asks Claude for a different proposal
   for the same target.
@@ -89,6 +91,7 @@ class ResumeRefinementTurn(Base):
             "'ai_critique',"
             "'ai_proposal',"
             "'user_accept',"
+            "'user_accept_flagged',"
             "'user_custom',"
             "'user_request_alternative',"
             "'user_skip',"

--- a/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
@@ -137,12 +137,22 @@ async def update_pending_proposal(
     tokens_in: int,
     tokens_out: int,
     cost_usd: Decimal,
+    guard_flagged: list[str] | None = None,
+    flagged_proposal: str | None = None,
 ) -> ResumeRefinementSession:
-    """Set the pending AI proposal on the session and bump counters."""
+    """Set the pending AI proposal on the session and bump counters.
+
+    ``guard_flagged`` / ``flagged_proposal`` carry the hallucination-guard
+    state when the proposal was downgraded to a clarify — kept so a
+    clarify answer can confirm the phrases and "Use it anyway" can apply
+    the held text.
+    """
     session.pending_target_section = target_section
     session.pending_proposal = proposal
     session.pending_rationale = rationale
     session.pending_clarifying_question = clarifying_question
+    session.pending_guard_flagged = guard_flagged
+    session.pending_flagged_proposal = flagged_proposal
     session.turn_count += 1
     session.total_tokens_in += tokens_in
     session.total_tokens_out += tokens_out
@@ -166,6 +176,8 @@ async def apply_user_resolution(
     session.pending_proposal = None
     session.pending_rationale = None
     session.pending_clarifying_question = None
+    session.pending_guard_flagged = None
+    session.pending_flagged_proposal = None
     if advance_target:
         session.target_index += 1
     session.turn_count += 1
@@ -194,6 +206,8 @@ async def set_target_index(
     session.pending_proposal = None
     session.pending_rationale = None
     session.pending_clarifying_question = None
+    session.pending_guard_flagged = None
+    session.pending_flagged_proposal = None
     await db.flush()
     await db.commit()
     await db.refresh(session)
@@ -219,6 +233,8 @@ async def hydrate_pending_from_cache(
     session.pending_proposal = entry.get("proposal")
     session.pending_rationale = entry.get("rationale")
     session.pending_clarifying_question = entry.get("clarifying_question")
+    session.pending_guard_flagged = entry.get("guard_flagged")
+    session.pending_flagged_proposal = entry.get("flagged_proposal")
     await db.flush()
     await db.commit()
     await db.refresh(session)
@@ -234,6 +250,8 @@ async def cache_proposal(
     proposal: str | None,
     rationale: str | None,
     clarifying_question: str | None,
+    guard_flagged: list[str] | None = None,
+    flagged_proposal: str | None = None,
 ) -> ResumeRefinementSession:
     """Write the just-generated proposal into ``proposal_cache`` for
     the given ``target_index`` so future navigations skip the AI call.
@@ -247,6 +265,8 @@ async def cache_proposal(
         "proposal": proposal,
         "rationale": rationale,
         "clarifying_question": clarifying_question,
+        "guard_flagged": guard_flagged,
+        "flagged_proposal": flagged_proposal,
     }
     session.proposal_cache = existing
     await db.flush()
@@ -286,6 +306,51 @@ async def mark_completed(
     session.pending_proposal = None
     session.pending_rationale = None
     session.pending_clarifying_question = None
+    session.pending_guard_flagged = None
+    session.pending_flagged_proposal = None
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def add_confirmed_facts(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    facts: list[str],
+) -> ResumeRefinementSession:
+    """Append user-confirmed facts to the session-level allowlist.
+
+    Deduplicates case-insensitively while preserving insertion order.
+    JSONB requires a fresh list assignment for SQLAlchemy to detect the
+    change — mutating in place doesn't flush.
+    """
+    existing = list(session.confirmed_facts or [])
+    seen = {f.strip().lower() for f in existing}
+    for fact in facts:
+        cleaned = (fact or "").strip()
+        if cleaned and cleaned.lower() not in seen:
+            existing.append(cleaned)
+            seen.add(cleaned.lower())
+    session.confirmed_facts = existing
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def increment_guard_flag_count(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    target_index: int,
+) -> ResumeRefinementSession:
+    """Bump the per-target hallucination-guard flag counter."""
+    counts = dict(session.guard_flag_counts or {})
+    key = str(target_index)
+    counts[key] = int(counts.get(key, 0)) + 1
+    session.guard_flag_counts = counts
     await db.flush()
     await db.commit()
     await db.refresh(session)

--- a/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
@@ -62,6 +62,11 @@ class SessionRead(BaseModel):
     pending_proposal: str | None = None
     pending_rationale: str | None = None
     pending_clarifying_question: str | None = None
+    # Hallucination-guard state: phrases flagged on the pending clarify,
+    # and whether the loop breaker should offer "Use it anyway" (the
+    # same target has been guard-flagged twice or more).
+    pending_guard_flagged: list[str] | None = None
+    guard_can_force: bool = False
     turn_count: int
     total_tokens_in: int
     total_tokens_out: int

--- a/apps/myjobhunter/backend/app/services/resume_refinement/hallucination_guard.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/hallucination_guard.py
@@ -12,19 +12,37 @@ invalid and the user is asked to retry.
 The guard is intentionally conservative: it flags facts that appear in
 the proposal but NOT in the source. False negatives (missing a real
 hallucination) are worse than false positives (flagging a sentence
-that was actually fine), so the patterns favor recall.
+that was actually fine), so the patterns favor recall. False positives
+are recoverable: when the user confirms a flagged fact is accurate, the
+caller records it in the session-level ``confirmed_facts`` allowlist and
+passes it back in — a confirmed fact is never re-flagged.
 """
 from __future__ import annotations
 
 import re
+from collections.abc import Iterable
 
-# Capitalized multi-word phrases that look like proper nouns (companies,
-# schools, products). Two- or three-token sequences where each token
-# starts with an uppercase letter. Catches "Acme Corp", "Stanford University",
-# "Senior Software Engineer" (which is fine — also in source if real).
+# One capitalized token: "Acme", "API", "R2", "C++".
+_CAP_TOKEN = r"[A-Z][A-Za-z0-9&+'-]*"
+
+# Lowercase words that legitimately join two capitalized tokens inside
+# ONE proper noun ("Bank of America", "École de Paris").
+_CONNECTOR_WORDS = "of|the|and|de|du|la|le"
+
+# A run of capitalized tokens, optionally joined by single connector
+# words: "Acme Corp", "Forrester Innovation Award", "Bank of America",
+# "API and React". Connectors may only appear BETWEEN capitalized
+# tokens, so a run never swallows the lowercase remainder of a sentence.
 _PROPER_NOUN_PATTERN = re.compile(
-    r"\b(?:[A-Z][a-zA-Z0-9&]+(?:\s+(?:of|the|and|de|du|la|le)\s+)?){1,4}\b",
+    rf"\b{_CAP_TOKEN}(?:\s+(?:(?:{_CONNECTOR_WORDS})\s+)?{_CAP_TOKEN})*",
 )
+
+# "and" joins two INDEPENDENT facts ("API and React"); the other
+# connectors are part of a single name ("Bank of America"). Runs are
+# decomposed at "and" and each side is verified on its own, so two
+# individually-sourced facts never merge into one unverifiable phrase.
+_SPLIT_CONNECTOR = "and"
+_CONNECTOR_TOKENS = set(_CONNECTOR_WORDS.split("|"))
 
 # Year ranges, single years, and YYYY-MM date strings.
 _DATE_PATTERN = re.compile(
@@ -37,32 +55,47 @@ _DATE_PATTERN = re.compile(
     r")\b",
 )
 
-# Percentages and dollar amounts that look like quantitative claims.
+# Percentages, dollar amounts, magnitude-suffixed counts, and Nx
+# multipliers that look like quantitative claims.
 _METRIC_PATTERN = re.compile(
     r"(?:"
     r"\$\s?\d[\d,]*(?:\.\d+)?\s?[KMB]?"   # $50K, $1.2M, $50,000
     r"|"
     r"\d+(?:\.\d+)?\s?%"                   # 40%, 12.5%
     r"|"
+    r"\b\d+(?:\.\d+)?\s?[KMB]\b"           # 500K, 1.2M, 3B
+    r"|"
     r"\b\d{2,}\s*(?:x|×)\b"                # 10x, 100x
     r")",
 )
 
-# Stop words to ignore when checking proper nouns — these don't carry
-# factual content.
+# Tokens that don't carry factual content on their own: pronouns,
+# articles, job-title words, and the action verbs resume bullets open
+# with. Stripped from the EDGES of a candidate phrase before checking.
 _PROPER_NOUN_STOPWORDS = {
     "I", "We", "Our", "My", "The", "A", "An", "And", "Or", "But",
     "For", "On", "In", "At", "By", "With", "From", "To", "Of",
     "Senior", "Junior", "Lead", "Principal", "Staff", "Manager",
     "Director", "Engineer", "Developer", "Analyst", "Designer",
-    "Architect", "Consultant", "Specialist", "Coordinator",
+    "Architect", "Consultant", "Specialist", "Coordinator", "Software",
     "Built", "Led", "Managed", "Developed", "Designed", "Created",
-    "Implemented", "Launched", "Shipped", "Delivered",
-    "Present", "Current", "Now",
+    "Implemented", "Launched", "Shipped", "Delivered", "Won", "Owned",
+    "Improved", "Reduced", "Increased", "Architected", "Spearheaded",
+    "Drove", "Grew", "Present", "Current", "Now",
 }
 
+# Characters that end a sentence / open a bullet — a capitalized token
+# right after one of these is ordinary sentence capitalization, not
+# evidence of a proper noun.
+_SENTENCE_BOUNDARY_CHARS = set(".!?:;\n\r-–—•*#>|([\"'`")
 
-def check_proposal(*, proposed: str, source: str) -> list[str]:
+
+def check_proposal(
+    *,
+    proposed: str,
+    source: str,
+    confirmed_facts: Iterable[str] | None = None,
+) -> list[str]:
     """Return a list of facts in ``proposed`` that don't appear in ``source``.
 
     Empty list = guard pass (no hallucination detected).
@@ -70,10 +103,15 @@ def check_proposal(*, proposed: str, source: str) -> list[str]:
     Args:
         proposed: The AI-proposed rewrite.
         source: The full resume markdown the user is iterating on.
+        confirmed_facts: Facts the user has explicitly confirmed as
+            accurate in this session. Anything matching (case- and
+            whitespace-insensitive) is never flagged, so a user answer
+            of "yes, that's correct" actually unblocks the loop.
     """
     missing: list[str] = []
 
     source_lower = source.lower()
+    source_squashed = source_lower.replace(" ", "")
 
     for date_str in _DATE_PATTERN.findall(proposed):
         if date_str.lower() not in source_lower:
@@ -81,12 +119,22 @@ def check_proposal(*, proposed: str, source: str) -> list[str]:
 
     for metric in _METRIC_PATTERN.findall(proposed):
         normalized = metric.replace(" ", "").lower()
-        if normalized not in source_lower.replace(" ", ""):
+        if normalized not in source_squashed:
             missing.append(metric)
 
     for proper in _extract_proper_nouns(proposed):
         if proper.lower() not in source_lower:
             missing.append(proper)
+
+    if confirmed_facts:
+        confirmed = {_normalize(f) for f in confirmed_facts}
+        confirmed_squashed = {c.replace(" ", "") for c in confirmed}
+        missing = [
+            item
+            for item in missing
+            if _normalize(item) not in confirmed
+            and _normalize(item).replace(" ", "") not in confirmed_squashed
+        ]
 
     # Deduplicate while preserving order.
     seen: set[str] = set()
@@ -98,21 +146,71 @@ def check_proposal(*, proposed: str, source: str) -> list[str]:
     return unique
 
 
-def _extract_proper_nouns(text: str) -> list[str]:
-    """Return capitalized multi-word phrases likely to be proper nouns.
+def _normalize(s: str) -> str:
+    return " ".join(s.lower().split())
 
-    Single-word capitalized terms (start of sentence, common job titles)
-    are stripped via the stopword list to keep false positives low.
+
+def _extract_proper_nouns(text: str) -> list[str]:
+    """Return capitalized phrases likely to be proper nouns.
+
+    Pipeline per capitalized run:
+
+    1. Decompose at "and" — it coordinates independent facts, so
+       "API and React" is checked as "API" + "React", never as one
+       phrase (the connector-merge false positive that dead-ended the
+       clarify loop in production).
+    2. Strip stopword / connector tokens from each part's edges —
+       "Won the Forrester Innovation Award" → "Forrester Innovation
+       Award".
+    3. Keep multi-token parts, and single tokens that are NOT ordinary
+       sentence capitalization (a bullet opening with "Built ..." is
+       noise; "... at Hooli" mid-sentence is a checkable fact).
     """
     out: list[str] = []
     for match in _PROPER_NOUN_PATTERN.finditer(text):
-        phrase = match.group(0).strip()
-        # Single tokens — only flag if not a stopword and not a sentence
-        # start. Heuristic: ignore.
-        if " " not in phrase:
-            continue
-        # Filter out phrases that are entirely stopwords.
-        if all(token in _PROPER_NOUN_STOPWORDS for token in phrase.split()):
-            continue
-        out.append(phrase)
+        run = match.group(0)
+        first_token = run.split()[0] if run.split() else ""
+        run_is_sentence_initial = _is_sentence_initial(text, match.start())
+
+        for part_tokens in _split_at_and(run.split()):
+            tokens = _strip_stopword_edges(part_tokens)
+            if not tokens:
+                continue
+            phrase = " ".join(tokens)
+            if len(tokens) == 1 and run_is_sentence_initial and tokens[0] == first_token:
+                # Lone capitalized word opening the sentence — can't
+                # distinguish a proper noun from ordinary capitalization.
+                continue
+            out.append(phrase)
     return out
+
+
+def _split_at_and(tokens: list[str]) -> list[list[str]]:
+    parts: list[list[str]] = [[]]
+    for token in tokens:
+        if token.lower() == _SPLIT_CONNECTOR:
+            if parts[-1]:
+                parts.append([])
+        else:
+            parts[-1].append(token)
+    return [p for p in parts if p]
+
+
+def _strip_stopword_edges(tokens: list[str]) -> list[str]:
+    def _is_noise(token: str) -> bool:
+        return token in _PROPER_NOUN_STOPWORDS or token.lower() in _CONNECTOR_TOKENS
+
+    start, end = 0, len(tokens)
+    while start < end and _is_noise(tokens[start]):
+        start += 1
+    while end > start and _is_noise(tokens[end - 1]):
+        end -= 1
+    return tokens[start:end]
+
+
+def _is_sentence_initial(text: str, match_start: int) -> bool:
+    """True when the match opens the text, a sentence, or a bullet."""
+    before = text[:match_start].rstrip()
+    if not before:
+        return True
+    return before[-1] in _SENTENCE_BOUNDARY_CHARS

--- a/apps/myjobhunter/backend/app/services/resume_refinement/rewrite_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/rewrite_service.py
@@ -28,6 +28,8 @@ async def run_rewrite(
     user_id: uuid.UUID,
     session_id: uuid.UUID,
     prior_context: list[dict] | None = None,
+    confirmed_facts: list[str] | None = None,
+    prior_flag_count: int = 0,
 ) -> dict:
     """Run one rewrite pass.
 
@@ -48,6 +50,14 @@ async def run_rewrite(
             conversation" block so Claude can honour user-stated
             constraints across targets (e.g. "keep it to one page",
             "I left X out for length").
+        confirmed_facts: Session-level allowlist of facts the user has
+            explicitly confirmed. Passed into the hallucination guard so
+            a confirmed fact is never re-flagged — without it, answering
+            the guard's clarify question could never unblock the loop.
+        prior_flag_count: How many times the guard has already flagged a
+            proposal for THIS target. On a repeat flag the clarify copy
+            stops re-asking the same question and points the user at the
+            explicit "Use it anyway" confirmation instead.
 
     Returns:
         Dict with shape:
@@ -94,18 +104,26 @@ async def run_rewrite(
         rewritten = (parsed.get("rewritten_text") or "").strip()
         rationale = (parsed.get("rationale") or "").strip() or None
 
-        flagged = check_proposal(proposed=rewritten, source=resume_markdown)
+        flagged = check_proposal(
+            proposed=rewritten,
+            source=resume_markdown,
+            confirmed_facts=confirmed_facts,
+        )
         if flagged:
             logger.warning(
-                "Hallucination guard flagged proposal for session %s: %s",
+                "Hallucination guard flagged proposal for session %s "
+                "(prior flags for target: %d): %s",
                 session_id,
+                prior_flag_count,
                 flagged[:5],
             )
             response.update(
                 kind="clarify",
                 rewritten_text=rewritten,
                 rationale=rationale,
-                question=_clarify_for_hallucination(flagged),
+                question=_clarify_for_hallucination(
+                    flagged, repeat=prior_flag_count >= 1,
+                ),
                 hallucination_flagged=flagged,
             )
             return response
@@ -195,9 +213,20 @@ def _render_prior_context(entries: list[dict]) -> str:
     return "\n".join(lines)
 
 
-def _clarify_for_hallucination(missing: list[str]) -> str:
-    """Build a user-facing clarification question from the flagged facts."""
+def _clarify_for_hallucination(missing: list[str], *, repeat: bool = False) -> str:
+    """Build a user-facing clarification question from the flagged facts.
+
+    ``repeat=True`` means the guard already flagged this target before —
+    re-asking the identical question would loop, so the copy points at
+    the explicit "Use it anyway" confirmation instead.
+    """
     preview = ", ".join(missing[:3])
+    if repeat:
+        return (
+            "I still can't verify these details against your resume "
+            f"({preview}). If they're accurate, choose \"Use it anyway\" "
+            "below to apply the rewrite as-is — or tell me what to change."
+        )
     return (
         "I almost added some details that aren't in your resume "
         f"({preview}). Could you confirm those, or tell me what's accurate "

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_helpers.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_helpers.py
@@ -160,6 +160,10 @@ async def _generate_next_proposal(
             user_id=user_id,
             session_id=session.id,
             prior_context=prior_context,
+            confirmed_facts=list(session.confirmed_facts or []),
+            prior_flag_count=int(
+                (session.guard_flag_counts or {}).get(str(session.target_index), 0)
+            ),
         )
     except Exception as exc:  # noqa: BLE001 — graceful-degrade for the iteration loop
         # Don't fail the user's action if Claude is flaky. Leave pending
@@ -173,6 +177,7 @@ async def _generate_next_proposal(
         )
         return session
 
+    flagged = list(rewrite.get("hallucination_flagged") or [])
     session = await session_repo.update_pending_proposal(
         db,
         session,
@@ -183,7 +188,15 @@ async def _generate_next_proposal(
         tokens_in=rewrite["input_tokens"],
         tokens_out=rewrite["output_tokens"],
         cost_usd=rewrite["cost_usd"],
+        guard_flagged=flagged or None,
+        flagged_proposal=rewrite["rewritten_text"] if flagged else None,
     )
+    if flagged:
+        # Loop breaker bookkeeping: from the second flag on the same
+        # target, the clarify copy + frontend offer "Use it anyway".
+        session = await session_repo.increment_guard_flag_count(
+            db, session, target_index=session.target_index,
+        )
 
     # Cache the proposal so navigating back to this target_index later
     # is instant. ``request_alternative`` invalidates this entry before
@@ -196,6 +209,8 @@ async def _generate_next_proposal(
         proposal=session.pending_proposal,
         rationale=session.pending_rationale,
         clarifying_question=session.pending_clarifying_question,
+        guard_flagged=session.pending_guard_flagged,
+        flagged_proposal=session.pending_flagged_proposal,
     )
 
     await turn_repo.append(
@@ -242,6 +257,7 @@ async def _prefetch_all_proposals(
 
     semaphore = asyncio.Semaphore(_PREFETCH_CONCURRENCY)
     current_draft = session.current_draft
+    confirmed_facts = list(session.confirmed_facts or [])
 
     # Prefetch fires right after the critique pass appends the
     # ai_critique turn, so prior_context here will contain at most the
@@ -260,6 +276,7 @@ async def _prefetch_all_proposals(
                     user_id=user_id,
                     session_id=session.id,
                     prior_context=prior_context,
+                    confirmed_facts=confirmed_facts,
                 )
             except Exception as exc:  # noqa: BLE001 — graceful per-target degrade
                 logger.warning(
@@ -281,6 +298,7 @@ async def _prefetch_all_proposals(
     # mutation is not safe across concurrent transactions on the same
     # row. Each write is fast (single round-trip) so the sequential
     # cost is negligible.
+    flag_counts = dict(session.guard_flag_counts or {})
     for entry in results:
         if entry is None:
             continue
@@ -288,6 +306,7 @@ async def _prefetch_all_proposals(
         rewrite = entry["rewrite"]
         is_proposal = rewrite.get("kind") == "proposal"
         is_clarify = rewrite.get("kind") == "clarify"
+        flagged = list(rewrite.get("hallucination_flagged") or [])
 
         # Bump session counters via update_pending_proposal — but for
         # prefetch we don't actually want the pending_* fields stamped
@@ -299,6 +318,10 @@ async def _prefetch_all_proposals(
             session.total_cost_usd or Decimal("0")
         ) + rewrite["cost_usd"]
 
+        if flagged:
+            key = str(entry["target_index"])
+            flag_counts[key] = int(flag_counts.get(key, 0)) + 1
+
         session = await session_repo.cache_proposal(
             db,
             session,
@@ -307,7 +330,10 @@ async def _prefetch_all_proposals(
             proposal=rewrite["rewritten_text"] if is_proposal else None,
             rationale=rewrite["rationale"] if is_proposal else None,
             clarifying_question=rewrite["question"] if is_clarify else None,
+            guard_flagged=flagged or None,
+            flagged_proposal=rewrite["rewritten_text"] if flagged else None,
         )
+    session.guard_flag_counts = flag_counts
     await db.flush()
     await db.commit()
     await db.refresh(session)

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
@@ -30,6 +30,7 @@ from app.services.resume_refinement.session_lifecycle_service import (
 # Public entry points — turn mutations
 from app.services.resume_refinement.session_turn_service import (
     accept_custom,
+    accept_flagged,
     accept_pending,
     navigate,
     request_alternative,
@@ -74,6 +75,7 @@ __all__ = [
     "complete_session",
     # Turn mutations
     "accept_pending",
+    "accept_flagged",
     "accept_custom",
     "request_alternative",
     "skip_target",

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_turn_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_turn_service.py
@@ -3,6 +3,8 @@
 Public entry points (called from ``app.api.resume_refinement``):
 
 - ``accept_pending`` — user accepts the AI proposal as-is.
+- ``accept_flagged`` — user applies a guard-held proposal after explicitly
+  confirming the flagged facts are accurate ("Use it anyway").
 - ``accept_custom`` — user supplies their own text instead.
 - ``request_alternative`` — regenerate the proposal for the same target.
 - ``skip_target`` — move to the next target without modifying.
@@ -75,6 +77,57 @@ async def accept_pending(
     return await _with_turns(db, session)
 
 
+async def accept_flagged(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    """Apply a guard-held proposal after explicit user confirmation.
+
+    The "Use it anyway — I confirm this is accurate" escape from the
+    clarify loop: the flagged phrases become session-level confirmed
+    facts (so they never re-flag), and the held proposal is applied to
+    the draft exactly like a normal accept.
+    """
+    session = await _load_active(db, session_id, user_id)
+    if not session.pending_flagged_proposal:
+        raise NoPendingProposal(
+            "No guard-held proposal to apply. Request a new suggestion instead."
+        )
+
+    flagged_facts = list(session.pending_guard_flagged or [])
+    if flagged_facts:
+        session = await session_repo.add_confirmed_facts(
+            db, session, facts=flagged_facts,
+        )
+
+    target = _current_target(session)
+    new_draft = _apply_rewrite(
+        session.current_draft,
+        target_current_text=target["current_text"] if target else "",
+        new_text=session.pending_flagged_proposal,
+    )
+    accepted_text = session.pending_flagged_proposal
+    target_section = session.pending_target_section
+
+    session = await session_repo.apply_user_resolution(
+        db, session, new_draft=new_draft, advance_target=True,
+    )
+    await turn_repo.append(
+        db,
+        session_id=session.id,
+        turn_index=session.turn_count,
+        role="user_accept_flagged",
+        target_section=target_section,
+        proposed_text=accepted_text,
+        draft_after=new_draft,
+    )
+
+    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+    return await _with_turns(db, session)
+
+
 async def accept_custom(
     *,
     db: AsyncSession,
@@ -124,6 +177,18 @@ async def request_alternative(
     target = _current_target(session)
     if target is None:
         raise NoMoreTargets()
+
+    # When the pending clarify was guard-generated and the user typed an
+    # answer, record the flagged phrases as session-level confirmed
+    # facts BEFORE regenerating. The regenerated proposal is checked
+    # against the allowlist, so "yes, that's correct" actually unblocks
+    # — previously the same phrase re-flagged against the unchanged
+    # source and the identical question returned forever.
+    flagged_facts = list(session.pending_guard_flagged or [])
+    if hint and hint.strip() and flagged_facts:
+        session = await session_repo.add_confirmed_facts(
+            db, session, facts=flagged_facts,
+        )
 
     await turn_repo.append(
         db,

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_guard_confirmation.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_guard_confirmation.py
@@ -1,0 +1,318 @@
+"""Tests for the hallucination-guard confirmation loop fix.
+
+The production dead-end: the guard re-checked every regenerated
+proposal against the UNCHANGED source resume, so answering "yes,
+that's correct" could never unblock — the same phrase re-flagged and
+the identical canned question returned, burning a Claude call per
+retry. Three behaviors close the loop:
+
+1. Answering a guard-generated clarify records the flagged phrases as
+   session-level confirmed facts (``request_alternative``).
+2. Generation passes the allowlist + per-target flag count into the
+   rewrite service, and persists guard state on the pending fields
+   (``_generate_next_proposal``).
+3. "Use it anyway" applies the guard-held proposal after explicit user
+   confirmation (``accept_flagged``).
+
+All tests mock the DB-coupled repository functions and the Claude-
+coupled rewrite service — same approach as
+test_resume_refinement_proposal_cache.py.
+"""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.resume_refinement import (
+    session_helpers,
+    session_service,
+    session_turn_service,
+)
+from app.services.resume_refinement.errors import NoPendingProposal
+
+
+def _fake_session(
+    *,
+    targets: list[dict] | None = None,
+    target_index: int = 0,
+    pending_guard_flagged: list[str] | None = None,
+    pending_flagged_proposal: str | None = None,
+    confirmed_facts: list[str] | None = None,
+    guard_flag_counts: dict | None = None,
+):
+    s = MagicMock(spec=[])
+    s.id = uuid.uuid4()
+    s.user_id = uuid.uuid4()
+    s.status = "active"
+    s.improvement_targets = targets or []
+    s.target_index = target_index
+    s.current_draft = "## Resume\n- old text"
+    s.proposal_cache = {}
+    s.pending_target_section = "summary"
+    s.pending_proposal = None
+    s.pending_rationale = None
+    s.pending_clarifying_question = None
+    s.pending_guard_flagged = pending_guard_flagged
+    s.pending_flagged_proposal = pending_flagged_proposal
+    s.confirmed_facts = confirmed_facts or []
+    s.guard_flag_counts = guard_flag_counts or {}
+    s.total_tokens_in = 0
+    s.total_tokens_out = 0
+    s.total_cost_usd = Decimal("0")
+    s.turn_count = 0
+    return s
+
+
+def _target(section: str = "summary") -> dict:
+    return {
+        "section": section,
+        "current_text": "old text",
+        "improvement_type": "add_metric",
+        "severity": "high",
+        "notes": None,
+    }
+
+
+def _mock_db() -> MagicMock:
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# request_alternative — clarify answers confirm the flagged facts
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_clarify_answer_records_confirmed_facts() -> None:
+    """A typed answer to a guard-generated clarify MUST land the flagged
+    phrases in the session allowlist before regeneration."""
+    session = _fake_session(
+        targets=[_target()],
+        pending_guard_flagged=["40%", "Hooli"],
+    )
+    db = _mock_db()
+    confirmed: list[list[str]] = []
+
+    async def fake_add_confirmed_facts(_db, sess, *, facts):
+        confirmed.append(list(facts))
+        sess.confirmed_facts = list(sess.confirmed_facts) + list(facts)
+        return sess
+
+    with (
+        patch.object(session_turn_service, "_load_active", new=AsyncMock(return_value=session)),
+        patch.object(session_turn_service, "_generate_next_proposal", new=AsyncMock(return_value=session)),
+        patch.object(session_turn_service, "_with_turns", new=AsyncMock(return_value=session)),
+        patch.object(session_service.session_repo, "add_confirmed_facts", new=fake_add_confirmed_facts),
+        patch.object(session_service.session_repo, "invalidate_cached_proposal", new=AsyncMock(return_value=session)),
+        patch.object(session_service.turn_repo, "append", new=AsyncMock()),
+    ):
+        await session_turn_service.request_alternative(
+            db=db,
+            user_id=session.user_id,
+            session_id=session.id,
+            hint="Yes — both of those are correct.",
+        )
+
+    assert confirmed == [["40%", "Hooli"]]
+
+
+@pytest.mark.asyncio
+async def test_plain_reroll_does_not_confirm_facts() -> None:
+    """"Another option" with NO typed answer is a reroll, not a
+    confirmation — the allowlist must not grow."""
+    session = _fake_session(
+        targets=[_target()],
+        pending_guard_flagged=["40%"],
+    )
+    db = _mock_db()
+    add_mock = AsyncMock(return_value=session)
+
+    with (
+        patch.object(session_turn_service, "_load_active", new=AsyncMock(return_value=session)),
+        patch.object(session_turn_service, "_generate_next_proposal", new=AsyncMock(return_value=session)),
+        patch.object(session_turn_service, "_with_turns", new=AsyncMock(return_value=session)),
+        patch.object(session_service.session_repo, "add_confirmed_facts", new=add_mock),
+        patch.object(session_service.session_repo, "invalidate_cached_proposal", new=AsyncMock(return_value=session)),
+        patch.object(session_service.turn_repo, "append", new=AsyncMock()),
+    ):
+        await session_turn_service.request_alternative(
+            db=db,
+            user_id=session.user_id,
+            session_id=session.id,
+            hint=None,
+        )
+
+    add_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_answer_without_guard_flags_does_not_confirm() -> None:
+    """A hint on an ordinary (non-guard) clarify or proposal must not
+    touch the allowlist — there is nothing to confirm."""
+    session = _fake_session(targets=[_target()], pending_guard_flagged=None)
+    db = _mock_db()
+    add_mock = AsyncMock(return_value=session)
+
+    with (
+        patch.object(session_turn_service, "_load_active", new=AsyncMock(return_value=session)),
+        patch.object(session_turn_service, "_generate_next_proposal", new=AsyncMock(return_value=session)),
+        patch.object(session_turn_service, "_with_turns", new=AsyncMock(return_value=session)),
+        patch.object(session_service.session_repo, "add_confirmed_facts", new=add_mock),
+        patch.object(session_service.session_repo, "invalidate_cached_proposal", new=AsyncMock(return_value=session)),
+        patch.object(session_service.turn_repo, "append", new=AsyncMock()),
+    ):
+        await session_turn_service.request_alternative(
+            db=db,
+            user_id=session.user_id,
+            session_id=session.id,
+            hint="make it more concise",
+        )
+
+    add_mock.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# accept_flagged — "Use it anyway"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_flagged_applies_held_proposal_and_confirms() -> None:
+    session = _fake_session(
+        targets=[_target()],
+        pending_guard_flagged=["40%"],
+        pending_flagged_proposal="new text with 40% improvement",
+    )
+    db = _mock_db()
+    confirmed: list[list[str]] = []
+    applied: dict = {}
+    turns: list[dict] = []
+
+    async def fake_add_confirmed_facts(_db, sess, *, facts):
+        confirmed.append(list(facts))
+        return sess
+
+    async def fake_apply_user_resolution(_db, sess, *, new_draft, advance_target):
+        applied["new_draft"] = new_draft
+        applied["advance_target"] = advance_target
+        sess.current_draft = new_draft
+        return sess
+
+    async def fake_turn_append(_db, **kwargs):
+        turns.append(kwargs)
+
+    with (
+        patch.object(session_turn_service, "_load_active", new=AsyncMock(return_value=session)),
+        patch.object(session_turn_service, "_generate_next_proposal", new=AsyncMock(return_value=session)),
+        patch.object(session_turn_service, "_with_turns", new=AsyncMock(return_value=session)),
+        patch.object(session_service.session_repo, "add_confirmed_facts", new=fake_add_confirmed_facts),
+        patch.object(session_service.session_repo, "apply_user_resolution", new=fake_apply_user_resolution),
+        patch.object(session_service.turn_repo, "append", new=fake_turn_append),
+    ):
+        await session_turn_service.accept_flagged(
+            db=db,
+            user_id=session.user_id,
+            session_id=session.id,
+        )
+
+    # Flagged phrases became confirmed facts.
+    assert confirmed == [["40%"]]
+    # The held proposal replaced the target text in the draft.
+    assert applied["new_draft"] == "## Resume\n- new text with 40% improvement"
+    assert applied["advance_target"] is True
+    # The turn is recorded with its own role so history shows the
+    # explicit confirmation.
+    assert turns and turns[0]["role"] == "user_accept_flagged"
+    assert turns[0]["proposed_text"] == "new text with 40% improvement"
+
+
+@pytest.mark.asyncio
+async def test_accept_flagged_without_held_proposal_raises() -> None:
+    session = _fake_session(targets=[_target()], pending_flagged_proposal=None)
+    db = _mock_db()
+
+    with (
+        patch.object(session_turn_service, "_load_active", new=AsyncMock(return_value=session)),
+    ):
+        with pytest.raises(NoPendingProposal):
+            await session_turn_service.accept_flagged(
+                db=db,
+                user_id=session.user_id,
+                session_id=session.id,
+            )
+
+
+# ---------------------------------------------------------------------------
+# _generate_next_proposal — guard state persistence + loop breaker count
+# ---------------------------------------------------------------------------
+
+
+def _flagged_rewrite() -> dict:
+    return {
+        "kind": "clarify",
+        "rewritten_text": "text with invented 40%",
+        "rationale": "why",
+        "question": "I almost added some details that aren't in your resume (40%)…",
+        "hallucination_flagged": ["40%"],
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "cost_usd": Decimal("0.001"),
+    }
+
+
+@pytest.mark.asyncio
+async def test_generation_persists_guard_state_and_increments_count() -> None:
+    session = _fake_session(targets=[_target()], guard_flag_counts={"0": 1})
+    db = _mock_db()
+    pending_updates: list[dict] = []
+    increments: list[int] = []
+    rewrite_kwargs: list[dict] = []
+
+    async def fake_run_rewrite(**kwargs):
+        rewrite_kwargs.append(kwargs)
+        return _flagged_rewrite()
+
+    async def fake_update_pending(_db, sess, **kwargs):
+        pending_updates.append(kwargs)
+        sess.pending_guard_flagged = kwargs.get("guard_flagged")
+        sess.pending_flagged_proposal = kwargs.get("flagged_proposal")
+        sess.pending_clarifying_question = kwargs.get("clarifying_question")
+        return sess
+
+    async def fake_increment(_db, sess, *, target_index):
+        increments.append(target_index)
+        counts = dict(sess.guard_flag_counts)
+        counts[str(target_index)] = counts.get(str(target_index), 0) + 1
+        sess.guard_flag_counts = counts
+        return sess
+
+    async def fake_cache(_db, sess, **_):
+        return sess
+
+    with (
+        patch.object(session_service.rewrite_service, "run_rewrite", new=fake_run_rewrite),
+        patch.object(session_service.session_repo, "update_pending_proposal", new=fake_update_pending),
+        patch.object(session_service.session_repo, "increment_guard_flag_count", new=fake_increment),
+        patch.object(session_service.session_repo, "cache_proposal", new=fake_cache),
+        patch.object(session_service.turn_repo, "list_for_session", new=AsyncMock(return_value=[])),
+        patch.object(session_service.turn_repo, "append", new=AsyncMock()),
+    ):
+        await session_helpers._generate_next_proposal(
+            db, session, user_id=session.user_id, hint=None,
+        )
+
+    # The rewrite saw the allowlist and the pre-existing flag count.
+    assert rewrite_kwargs[0]["confirmed_facts"] == []
+    assert rewrite_kwargs[0]["prior_flag_count"] == 1
+    # Guard state landed on the pending fields.
+    assert pending_updates[0]["guard_flagged"] == ["40%"]
+    assert pending_updates[0]["flagged_proposal"] == "text with invented 40%"
+    # And the per-target counter was bumped (1 → 2 ⇒ loop breaker arms).
+    assert increments == [0]

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_hallucination_guard.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_hallucination_guard.py
@@ -73,3 +73,117 @@ def test_flags_invented_proper_noun_phrase():
     flagged = check_proposal(proposed=proposal, source=SOURCE)
     # "Forrester Innovation Award" is not in source.
     assert any("Forrester" in item for item in flagged)
+
+
+def test_flags_multiword_proper_noun_without_connector():
+    """Consecutive capitalized words form one checkable phrase even with
+    no joining word — 'Initech Solutions' is an invented employer."""
+    proposal = "Scaled the platform during my time at Initech Solutions"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    assert any("Initech" in item for item in flagged)
+
+
+def test_flags_invented_magnitude_metric():
+    """Bare magnitude counts (500K, 1.2M) are quantitative claims."""
+    proposal = "Processed 500K transactions per day"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    assert any("500K" in item for item in flagged)
+
+
+# ---------------------------------------------------------------------------
+# Connector decomposition — regression for the production clarify dead-end.
+# The old pattern merged "API" + "React" (both individually in the source)
+# into one contiguous phrase "API and React" that wasn't, so it flagged.
+# ---------------------------------------------------------------------------
+
+
+def test_and_joined_words_individually_present_pass():
+    source = SOURCE + "\n- Built REST API integrations\n- React frontend work\n"
+    proposal = "Delivered API and React integrations for the payment system"
+    assert check_proposal(proposed=proposal, source=source) == []
+
+
+def test_and_joined_decomposition_flags_only_the_missing_part():
+    proposal = "Led projects at Acme Corp and Hooli Inc simultaneously"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    # "Acme Corp" is in source — only the invented "Hooli Inc" flags.
+    assert any("Hooli" in item for item in flagged)
+    assert not any("Acme" in item for item in flagged)
+
+
+def test_of_connector_phrase_stays_whole():
+    """'of' joins a single name — decomposing 'Bank of America' into
+    single tokens would erase the guard for invented employers."""
+    proposal = "Managed integrations with Bank of America"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    assert any("Bank of America" in item for item in flagged)
+
+
+# ---------------------------------------------------------------------------
+# Confirmed-facts allowlist — user confirmation must actually unblock.
+# ---------------------------------------------------------------------------
+
+
+def test_confirmed_metric_is_not_reflagged():
+    proposal = "Improved throughput by 87% across the fleet"
+    assert any(
+        "87%" in item
+        for item in check_proposal(proposed=proposal, source=SOURCE)
+    )
+    assert (
+        check_proposal(
+            proposed=proposal, source=SOURCE, confirmed_facts=["87%"],
+        )
+        == []
+    )
+
+
+def test_confirmed_proper_noun_is_not_reflagged_case_insensitive():
+    proposal = "Built the system at Hooli after the merger"
+    assert any(
+        "Hooli" in item
+        for item in check_proposal(proposed=proposal, source=SOURCE)
+    )
+    assert (
+        check_proposal(
+            proposed=proposal, source=SOURCE, confirmed_facts=["hooli"],
+        )
+        == []
+    )
+
+
+def test_confirmed_date_is_not_reflagged():
+    proposal = "Joined the team in 1999 as a founding engineer"
+    assert (
+        check_proposal(
+            proposed=proposal, source=SOURCE, confirmed_facts=["1999"],
+        )
+        == []
+    )
+
+
+def test_unconfirmed_facts_still_flag_alongside_confirmed():
+    proposal = "Improved throughput by 87% and saved $250K at Hooli"
+    flagged = check_proposal(
+        proposed=proposal, source=SOURCE, confirmed_facts=["87%"],
+    )
+    assert not any("87%" in item for item in flagged)
+    assert any("$250K" in item for item in flagged)
+    assert any("Hooli" in item for item in flagged)
+
+
+# ---------------------------------------------------------------------------
+# Sentence-position heuristics.
+# ---------------------------------------------------------------------------
+
+
+def test_sentence_initial_single_cap_is_not_flagged():
+    """A bullet opening with an unlisted verb is ordinary capitalization."""
+    proposal = "Spearheaded the search relevance pipeline"
+    assert check_proposal(proposed=proposal, source=SOURCE) == []
+
+
+def test_mid_sentence_single_cap_invented_company_flags():
+    proposal = "Shipped the payments integration for Vandelay last quarter"
+    flagged = check_proposal(proposed=proposal, source=SOURCE)
+    assert any("Vandelay" in item for item in flagged)

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_proposal_cache.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_proposal_cache.py
@@ -30,7 +30,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from app.services.resume_refinement import session_service
-from app.services.resume_refinement import session_helpers
+from app.services.resume_refinement import session_turn_service
 
 
 def _fake_session(
@@ -57,6 +57,10 @@ def _fake_session(
     s.pending_proposal = None
     s.pending_rationale = None
     s.pending_clarifying_question = None
+    s.pending_guard_flagged = None
+    s.pending_flagged_proposal = None
+    s.confirmed_facts = []
+    s.guard_flag_counts = {}
     s.total_tokens_in = 0
     s.total_tokens_out = 0
     s.total_cost_usd = Decimal("0")
@@ -132,7 +136,11 @@ async def test_navigate_cache_hit_skips_claude_call() -> None:
         return session
 
     with (
-        patch.object(session_helpers, "_load_active", new=fake_load_active),
+        # NOTE: ``navigate`` lives in session_turn_service and imports
+        # the private helpers BY NAME — patches must target the consumer
+        # module's namespace, not session_helpers. (These patches
+        # silently went stale when session_service was split in #478.)
+        patch.object(session_turn_service, "_load_active", new=fake_load_active),
         patch.object(
             session_service.session_repo,
             "set_target_index",
@@ -183,7 +191,7 @@ async def test_navigate_cache_miss_falls_through_to_generation() -> None:
     generate_mock = AsyncMock(return_value=session)
 
     with (
-        patch.object(session_helpers, "_load_active", new=fake_load_active),
+        patch.object(session_turn_service, "_load_active", new=fake_load_active),
         patch.object(
             session_service.session_repo,
             "set_target_index",
@@ -194,7 +202,7 @@ async def test_navigate_cache_miss_falls_through_to_generation() -> None:
             "hydrate_pending_from_cache",
             new=AsyncMock(return_value=None),  # cache miss
         ),
-        patch.object(session_helpers, "_generate_next_proposal", new=generate_mock),
+        patch.object(session_turn_service, "_generate_next_proposal", new=generate_mock),
         patch.object(
             session_service.session_repo,
             "get_with_turns_for_user",

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_rewrite_service.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_rewrite_service.py
@@ -117,6 +117,68 @@ async def test_hallucination_downgrades_proposal_to_clarify():
 
 
 @pytest.mark.asyncio
+async def test_confirmed_facts_suppress_guard_flag():
+    """A fact the user has confirmed must not re-flag — this is what
+    makes answering the guard's clarify question actually unblock."""
+    parsed = {
+        "kind": "proposal",
+        "rewritten_text": "Architected payment processing handling 500K transactions/day at Acme",
+        "rationale": "Added scope.",
+    }
+    with patch.object(
+        rewrite_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(parsed)),
+    ):
+        result = await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint="yes, 500K is correct",
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+            confirmed_facts=["500K"],
+        )
+    assert result["kind"] == "proposal"
+    assert result["hallucination_flagged"] == []
+
+
+@pytest.mark.asyncio
+async def test_repeat_flag_offers_use_it_anyway():
+    """From the second guard flag on the same target, the clarify copy
+    stops re-asking and points at the explicit confirmation action."""
+    parsed = {
+        "kind": "proposal",
+        "rewritten_text": "Architected payment processing handling 500K transactions/day at Acme",
+        "rationale": "Added scope.",
+    }
+    with patch.object(
+        rewrite_service,
+        "call_claude_with_meta",
+        new=AsyncMock(return_value=_claude_response(parsed)),
+    ):
+        first = await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+            prior_flag_count=0,
+        )
+        repeat = await rewrite_service.run_rewrite(
+            resume_markdown=_RESUME,
+            target=_TARGET,
+            hint=None,
+            user_id=_FAKE_USER_ID,
+            session_id=_FAKE_SESSION_ID,
+            prior_flag_count=1,
+        )
+    assert first["kind"] == "clarify"
+    assert "Use it anyway" not in (first["question"] or "")
+    assert repeat["kind"] == "clarify"
+    assert "Use it anyway" in (repeat["question"] or "")
+
+
+@pytest.mark.asyncio
 async def test_unknown_kind_falls_back_to_clarify():
     parsed = {"kind": "weird_unknown_kind"}
     with patch.object(

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ClarifyingPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ClarifyingPanel.tsx
@@ -7,6 +7,11 @@ interface ClarifyingPanelProps {
   onCustomTextChange: (s: string) => void;
   onSubmit: () => void;
   isPending: boolean;
+  /** Loop breaker: the guard flagged this target twice — offer applying
+   *  the held proposal with explicit user confirmation. */
+  canForce?: boolean;
+  onForce?: () => void;
+  forceIsLoading?: boolean;
 }
 
 export default function ClarifyingPanel({
@@ -15,6 +20,9 @@ export default function ClarifyingPanel({
   onCustomTextChange,
   onSubmit,
   isPending,
+  canForce = false,
+  onForce,
+  forceIsLoading = false,
 }: ClarifyingPanelProps) {
   function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
     if (e.key !== "Enter" || e.shiftKey) return;
@@ -38,13 +46,29 @@ export default function ClarifyingPanel({
       />
       <div className="flex justify-end">
         <LoadingButton
-          isLoading={isPending}
+          isLoading={isPending && !forceIsLoading}
           onClick={onSubmit}
-          disabled={!customText.trim()}
+          disabled={!customText.trim() || isPending}
         >
           Submit answer
         </LoadingButton>
       </div>
+      {canForce && onForce && (
+        <div className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border bg-muted/40 p-2">
+          <p className="text-xs text-muted-foreground">
+            Sure those details are right? Apply the held rewrite as-is.
+          </p>
+          <LoadingButton
+            variant="secondary"
+            size="sm"
+            isLoading={forceIsLoading}
+            onClick={onForce}
+            disabled={isPending && !forceIsLoading}
+          >
+            Use it anyway — I confirm this is accurate
+          </LoadingButton>
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -7,6 +7,7 @@ import {
 } from "@platform/ui";
 import {
   useAcceptPendingMutation,
+  useAcceptFlaggedMutation,
   useSupplyCustomRewriteMutation,
   useRequestAlternativeMutation,
   useSkipTargetMutation,
@@ -38,6 +39,7 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
   const [hint, setHint] = useState("");
 
   const [acceptPending, accept] = useAcceptPendingMutation();
+  const [acceptFlagged, flaggedAccept] = useAcceptFlaggedMutation();
   const [supplyCustom, custom] = useSupplyCustomRewriteMutation();
   const [requestAlternative, alternative] = useRequestAlternativeMutation();
   const [skipTarget, skip] = useSkipTargetMutation();
@@ -51,7 +53,11 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
   const rationale = session.pending_rationale;
   const clarifyingQuestion = session.pending_clarifying_question;
   const isPending =
-    accept.isLoading || custom.isLoading || alternative.isLoading || skip.isLoading;
+    accept.isLoading ||
+    flaggedAccept.isLoading ||
+    custom.isLoading ||
+    alternative.isLoading ||
+    skip.isLoading;
 
   if (totalTargets > 0 && session.target_index >= totalTargets) {
     return null;
@@ -97,6 +103,21 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
         hint: customText.trim(),
       }).unwrap();
       showSuccess("Got it — composing a suggestion with your context.");
+      resetMode();
+      setCustomText("");
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  // Guard loop breaker: the user explicitly confirms the flagged facts
+  // are accurate and applies the held proposal as-is. The backend
+  // records the phrases as session-level confirmed facts so the guard
+  // never re-flags them.
+  async function handleForceAccept() {
+    try {
+      await acceptFlagged(session.id).unwrap();
+      showSuccess("Applied. Onto the next one.");
       resetMode();
       setCustomText("");
     } catch (err) {
@@ -176,6 +197,9 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
         rationale={rationale}
         isPending={isPending}
         isRegenerating={alternative.isLoading}
+        canForce={session.guard_can_force}
+        onForce={handleForceAccept}
+        forceIsLoading={flaggedAccept.isLoading}
       />
 
       {/* Exactly one of the three action panels — mutually exclusive via mode state */}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionBody.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionBody.tsx
@@ -12,6 +12,10 @@ interface SuggestionBodyProps {
   isPending: boolean;
   /** True while an alternative is being regenerated — shows skeleton instead of stale text. */
   isRegenerating?: boolean;
+  /** Guard loop breaker: offer applying the held proposal with explicit confirmation. */
+  canForce?: boolean;
+  onForce?: () => void;
+  forceIsLoading?: boolean;
 }
 
 // Three-way render of the suggestion area: clarification request,
@@ -27,6 +31,9 @@ export default function SuggestionBody({
   rationale,
   isPending,
   isRegenerating = false,
+  canForce = false,
+  onForce,
+  forceIsLoading = false,
 }: SuggestionBodyProps) {
   const [showRationale, setShowRationale] = useState(false);
 
@@ -38,6 +45,9 @@ export default function SuggestionBody({
         onCustomTextChange={onCustomTextChange}
         onSubmit={onClarifySubmit}
         isPending={isPending}
+        canForce={canForce}
+        onForce={onForce}
+        forceIsLoading={forceIsLoading}
       />
     );
   }

--- a/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
@@ -31,6 +31,15 @@ const resumeRefinementApi = baseApi
         invalidatesTags: (_result, _err, id) => [{ type: REFINEMENT_TAG, id }],
       }),
 
+      acceptFlagged: build.mutation<RefinementSession, string>({
+        query: (id) => ({
+          url: `/resume-refinement/sessions/${id}/accept-flagged`,
+          method: "POST",
+          data: {},
+        }),
+        invalidatesTags: (_result, _err, id) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
       supplyCustomRewrite: build.mutation<RefinementSession, { id: string; user_text: string }>({
         query: ({ id, user_text }) => ({
           url: `/resume-refinement/sessions/${id}/custom`,
@@ -85,6 +94,7 @@ export const {
   useStartRefinementSessionMutation,
   useGetRefinementSessionQuery,
   useAcceptPendingMutation,
+  useAcceptFlaggedMutation,
   useSupplyCustomRewriteMutation,
   useRequestAlternativeMutation,
   useSkipTargetMutation,

--- a/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-session.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-session.ts
@@ -14,6 +14,8 @@ export interface RefinementSession {
   pending_proposal: string | null;
   pending_rationale: string | null;
   pending_clarifying_question: string | null;
+  pending_guard_flagged: string[] | null;
+  guard_can_force: boolean;
   turn_count: number;
   total_tokens_in: number;
   total_tokens_out: number;


### PR DESCRIPTION
## Problem

Operator-reported dead-end on `/resume` (walkthrough item 3, highest priority of the deferred set): "I keep confirming but nothing is happening." The guard's clarify question was architecturally impossible to answer — `run_rewrite` re-checked every regenerated proposal against the **unchanged** source resume, so the same phrase re-flagged and the identical canned question returned forever, burning a Claude call per retry.

## Fix (per the agreed plan)

1. **Confirmed facts** — answering a guard-generated clarify records the flagged phrases on the session (`confirmed_facts` JSONB). Every guard check receives the allowlist, so "yes, that's correct" actually unblocks.
2. **Connector decomposition** — `"and"`-joined capitalized runs are checked part-by-part: `"API and React"` (both individually in the source — the observed false positive) no longer merges into one unverifiable phrase. `of/de/la`-connected single names (`"Bank of America"`) stay whole.
3. **Loop breaker** — per-target `guard_flag_counts`; from the second flag on the same target, the clarify copy and a new **"Use it anyway — I confirm this is accurate"** action (`POST /resume-refinement/sessions/{id}/accept-flagged`, `user_accept_flagged` turn role) apply the held proposal instead of re-asking.

## Found while fixing

The guard was broken far beyond the loop, masked by a CI gap — **no `test_resume_refinement_*` file was in any CI shard**, so none of them gated merges:

- The proper-noun regex only merged words **across connectors**: it never matched `"Acme Corp"`-style multi-word names, never flagged single-token companies (`"Hooli"`), and false-positived on `"Architected the"` / `"Built and"` — 3 of the guard's own shipped tests fail on clean main.
- Bare magnitude metrics (`"500K"`) were never checked (1 more shipped test failing on main).
- `test_resume_refinement_proposal_cache.py` patches went silently stale in the #478 module split — 5 tests failing on main, invisible.

This PR rewrites the extraction (capitalized runs + edge-stopword stripping + sentence-initial heuristic + `and`-decomposition), adds the magnitude-metric pattern, repairs the stale patches, adds a **`refinement` CI shard** covering all 8 refinement test files, and logs the broader shard-allowlist audit as a HIGH entry in `apps/myjobhunter/TECH_DEBT.md`.

## Migration

`guardfacts260702` — 4 columns on `resume_refinement_sessions` (all server-defaulted, no backfill) + widened turn-role check constraint. **No operational migration needed**: additive and defaults-clean; old sessions keep working, the previous image keeps working on rollback.

## Verification

- 69 backend refinement tests pass locally (19 guard, incl. 11 new; 5 new confirmation-flow; repaired cache suite)
- Frontend `tsc --noEmit` + production build pass
- Pre-existing local-Windows failures in unrelated suites (Profile/Login/Kanban) reproduce identically on clean main — not touched by this diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHo57XAZpGMGwtvp8w1fQY