### PR TITLE
feat(mga/classifier): agent-scope the Valorant utility candidate list

### DIFF
--- a/apps/mygamingassistant/backend/app/repositories/game/reference_repo.py
+++ b/apps/mygamingassistant/backend/app/repositories/game/reference_repo.py
@@ -22,6 +22,7 @@ from typing import Any, Optional
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.models.game.agent import Agent
 from app.models.game.game import Game
 from app.models.game.map import Map
 from app.models.game.map_zone import MapZone
@@ -37,9 +38,18 @@ async def load_reference_data(
     Returns a dict with keys:
       games: list[{slug, name, side_a_label, side_b_label}]
       maps: list[{slug, name, game_slug, zones: [{slug, name}]}]
-      utility_types: list[{slug, name, game_slug}]
+      utility_types: list[{slug, name, game_slug, agent_slug}]
+
+    ``agent_slug`` is the Valorant agent a utility ability belongs to (Sova's
+    ``recon`` / ``shock``), or ``None`` for game-wide utilities (all CS2
+    grenades). It lets the prompt builder scope the candidate ability list to a
+    single agent (Source.config_json ``agent_hint``) — the recurrence fix for a
+    Sova recon dart being mis-tagged as another agent's smoke.
     """
     game_rows = (await db.execute(select(Game).order_by(Game.slug))).scalars().all()
+    # All agents (few — 29 across the fixtures); a plain id→slug map avoids an
+    # async lazy-load of ``UtilityType.agent`` per row below.
+    agent_rows = (await db.execute(select(Agent))).scalars().all()
 
     if game_id is not None:
         map_rows = (
@@ -75,6 +85,7 @@ async def load_reference_data(
         zone_rows = []
 
     game_id_to_slug = {g.id: g.slug for g in game_rows}
+    agent_id_to_slug = {a.id: a.slug for a in agent_rows}
 
     map_id_to_zones: dict[uuid.UUID, list[dict]] = {}
     for zone in zone_rows:
@@ -107,6 +118,7 @@ async def load_reference_data(
             "slug": ut.slug,
             "name": ut.name,
             "game_slug": game_id_to_slug.get(ut.game_id, ""),
+            "agent_slug": agent_id_to_slug.get(ut.agent_id),
         }
         for ut in ut_rows
     ]

--- a/apps/mygamingassistant/backend/app/services/classification/grid_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/grid_classifier.py
@@ -46,6 +46,7 @@ from app.services.classification.response_parsing import (
     validate_grid_index,
 )
 from app.services.classification.scope_guards import (
+    apply_agent_hint,
     apply_map_hint,
     check_game_map_consistency,
 )
@@ -139,6 +140,7 @@ async def classify_frames_for_lineup_decision(
     attribution_author: Optional[str],
     game_hint: Optional[str] = None,
     map_hint: Optional[str] = None,
+    agent_hint: Optional[str] = None,
 ) -> ClassificationResult:
     """Strategy A: classify a chapter from N candidate frames at ingest time.
 
@@ -147,6 +149,14 @@ async def classify_frames_for_lineup_decision(
     :func:`app.services.classification.scope_guards.apply_map_hint`) so a
     single-map source can never spawn lineups on a different map — the
     recurrence fix for cross-map misclassification.
+
+    ``agent_hint`` is the operator's per-source Valorant agent scope
+    (Source.config_json ``agent_hint``). When set, the utility candidate list is
+    narrowed to that agent's abilities in the prompt and the classified utility
+    is hard-locked to it post-parse (see
+    :func:`app.services.classification.scope_guards.apply_agent_hint`) — the
+    recurrence fix for cross-agent utility misclassification (a Sova recon dart
+    tagged as Brimstone ``sky-smoke``).
     """
     if not settings.anthropic_api_key:
         logger.warning(
@@ -176,7 +186,7 @@ async def classify_frames_for_lineup_decision(
         _map_game = {m["slug"]: m["game_slug"] for m in ref.get("maps", [])}
         effective_game_hint = _map_game.get(map_hint, game_hint)
     reference_text = build_reference_text(
-        ref, game_hint=effective_game_hint, map_hint=map_hint
+        ref, game_hint=effective_game_hint, map_hint=map_hint, agent_hint=agent_hint
     )
 
     chapter_context_parts: list[str] = []
@@ -295,6 +305,11 @@ async def classify_frames_for_lineup_decision(
         parsed = apply_map_hint(parsed, ref, map_hint, failures, structured_codes)
     else:
         parsed = check_game_map_consistency(parsed, ref, failures, structured_codes)
+
+    # Agent scope is orthogonal to map scope — apply it regardless of which map
+    # branch ran above. No-op unless agent_hint owns an ability in the ref data.
+    if agent_hint:
+        parsed = apply_agent_hint(parsed, ref, agent_hint, failures, structured_codes)
 
     is_lineup = bool(parsed.get("is_lineup"))
 

--- a/apps/mygamingassistant/backend/app/services/classification/prompts.py
+++ b/apps/mygamingassistant/backend/app/services/classification/prompts.py
@@ -73,11 +73,12 @@ def build_reference_text(
     ref: dict[str, Any],
     game_hint: Optional[str] = None,
     map_hint: Optional[str] = None,
+    agent_hint: Optional[str] = None,
 ) -> str:
     """Build the reference text block passed to Claude.
 
-    Constant across calls for the same (game_hint, map_hint) → prime candidate
-    for prompt caching. The reference data comes from
+    Constant across calls for the same (game_hint, map_hint, agent_hint) → prime
+    candidate for prompt caching. The reference data comes from
     :func:`app.repositories.game.reference_repo.load_reference_data`; this
     function shapes it into the system-prompt text Claude reads.
 
@@ -89,8 +90,35 @@ def build_reference_text(
     :func:`app.services.classification.scope_guards.apply_map_hint` — the prompt
     scope improves zone accuracy; the post-parse lock is the load-bearing
     correctness guarantee.
+
+    ``agent_hint`` is the operator's per-source Valorant agent scope
+    (Source.config_json ``agent_hint``). When set — and the agent owns at least
+    one ability in the reference data — the utility-type candidate list is
+    restricted to that agent's abilities and a HARD scope instruction is
+    emitted. This is the recurrence fix for a Sova recon dart being tagged as
+    another agent's smoke (e.g. Brimstone ``sky-smoke``): PR #950 grew the
+    Valorant ability list from 4 to ~56 with no agent scoping, so the full menu
+    invited cross-agent contamination. As with ``map_hint``, the utility is
+    additionally hard-locked post-parse by
+    :func:`app.services.classification.scope_guards.apply_agent_hint` — the
+    prompt scope narrows the menu; the post-parse lock is the load-bearing
+    guarantee (``resolve_slugs`` is game- but not agent-scoped, so a hallucinated
+    off-agent slug would otherwise still resolve). An ``agent_hint`` with no
+    matching abilities is ignored (no filter, no scope line) so the candidate
+    list is never emptied.
     """
     lines: list[str] = []
+
+    # Abilities owned by the hinted agent. Empty when agent_hint is unset OR the
+    # hint matches no ability in the reference data (bad hint / agents not yet
+    # loaded) — in which case the filter + scope line are skipped so the utility
+    # menu is never emptied (defensive, mirroring apply_map_hint's no-op).
+    agent_ability_slugs = {
+        ut["slug"]
+        for ut in ref.get("utility_types", [])
+        if agent_hint and ut.get("agent_slug") == agent_hint
+    }
+    apply_agent_scope = bool(agent_ability_slugs)
 
     map_game = {m["slug"]: m["game_slug"] for m in ref.get("maps", [])}
     if map_hint:
@@ -107,6 +135,19 @@ def build_reference_text(
         lines.append("")
     elif game_hint:
         lines.append(f"Expected game: {game_hint}")
+        lines.append("")
+
+    if apply_agent_scope:
+        lines.append(
+            f"SOURCE AGENT SCOPE: every chapter in this source is Valorant agent "
+            f"'{agent_hint}'."
+        )
+        lines.append(
+            f"You MUST pick utility_type_slug ONLY from {agent_hint}'s abilities "
+            "listed below. Do NOT choose another agent's ability, no matter how "
+            "similar the on-screen effect looks (e.g. a recon dart's scan is NOT "
+            "a smoke)."
+        )
         lines.append("")
 
     lines.append("Valid games (slug → name):")
@@ -127,6 +168,12 @@ def build_reference_text(
     lines.append("")
     lines.append("Valid utility types (slug → name, game):")
     for ut in ref["utility_types"]:
+        # When agent-scoped, list ONLY the hinted agent's abilities. Off-agent
+        # utilities (other agents, and CS2's agent-less grenades) are dropped —
+        # an agent_hint is always a Valorant/agent source, so they're never
+        # valid candidates here.
+        if apply_agent_scope and ut.get("agent_slug") != agent_hint:
+            continue
         lines.append(f"  {ut['slug']} [{ut['game_slug']}] → {ut['name']}")
 
     return "\n".join(lines)

--- a/apps/mygamingassistant/backend/app/services/classification/scope_guards.py
+++ b/apps/mygamingassistant/backend/app/services/classification/scope_guards.py
@@ -6,9 +6,10 @@ the parsed dict + reference data — no DB, no SDK. Shared by the grid +
 single-image entrypoints.
 
 Extracted from the former ``classifier_service.py`` (a utility grab-bag) so the
-scope guards have a cohesive home with PUBLIC names. Both the cross-game
-contamination guard (``check_game_map_consistency``) and the operator map-scope
-hard-lock (``apply_map_hint``) live here.
+scope guards have a cohesive home with PUBLIC names. The cross-game
+contamination guard (``check_game_map_consistency``), the operator map-scope
+hard-lock (``apply_map_hint``), and the operator agent-scope hard-lock
+(``apply_agent_hint``) all live here.
 """
 from __future__ import annotations
 
@@ -125,4 +126,68 @@ def apply_map_hint(
             codes.append(f"map_hint_override:claude={claude_map}:forced={map_hint}")
     result["game_slug"] = map_game[map_hint]
     result["map_slug"] = map_hint
+    return result
+
+
+def apply_agent_hint(
+    parsed: dict[str, Any],
+    ref: dict[str, Any],
+    agent_hint: str,
+    failures: list[str],
+    codes: Optional[list[str]] = None,
+) -> dict[str, Any]:
+    """Hard-lock the classified utility to the operator-supplied agent scope.
+
+    The operator scopes a single-agent Valorant source by setting ``agent_hint``
+    (an agent slug) in Source.config_json. This is the load-bearing recurrence
+    fix for cross-AGENT-within-Valorant utility misclassification: PR #950 grew
+    the Valorant ability menu from 4 to ~56 with no agent scoping, and a Sova
+    recon dart's scan reads enough like a smoke deploy that the classifier
+    tagged ~1/3 of a Sova source's lineups as Brimstone ``sky-smoke``. The
+    prompt-only scope (``build_reference_text`` agent filter) narrows the menu,
+    but ``resolve_slugs`` is game- but NOT agent-scoped — a hallucinated
+    off-agent slug (still a valid Valorant utility) would otherwise resolve to
+    the wrong agent's FK. This guard makes that impossible post-parse.
+
+    Behaviour when ``agent_hint`` owns at least one ability in the reference
+    data and Claude returned a utility that belongs to a DIFFERENT agent:
+      - null out ``utility_type_slug`` (we cannot know WHICH of the hinted
+        agent's abilities it should be — several per agent — so we leave it for
+        operator review rather than guess, mirroring how ``apply_map_hint``
+        nulls an unresolvable zone)
+      - emit a structured override code + human note (visible in telemetry, per
+        rules/check-third-party-error-codes)
+      - leave every other field intact
+
+    Returns a COPY (never mutates ``parsed``), matching the sibling guards. An
+    ``agent_hint`` that owns no abilities in the reference data (bad slug, or
+    agents not yet loaded) is a no-op with a logged note — defensive, and it
+    keeps the prompt filter and this guard consistent (both fall back to
+    unscoped rather than blanking the utility).
+    """
+    ability_agent = {
+        ut["slug"]: ut.get("agent_slug") for ut in ref.get("utility_types", [])
+    }
+    if agent_hint not in ability_agent.values():
+        failures.append(
+            f"agent_hint '{agent_hint}' has no abilities in reference data — "
+            "scope not applied"
+        )
+        return parsed
+    ut_slug = parsed.get("utility_type_slug")
+    if not ut_slug or ability_agent.get(ut_slug) == agent_hint:
+        return parsed
+    result = dict(parsed)
+    actual_agent = ability_agent.get(ut_slug)
+    failures.append(
+        f"AGENT-SCOPE OVERRIDE: classifier chose utility='{ut_slug}' "
+        f"(agent '{actual_agent}') but source is scoped to agent '{agent_hint}' "
+        "— nulling utility_type_slug for operator review"
+    )
+    if codes is not None:
+        codes.append(
+            f"agent_hint_override:claude={ut_slug}:"
+            f"agent={actual_agent}:scoped={agent_hint}"
+        )
+    result["utility_type_slug"] = None
     return result

--- a/apps/mygamingassistant/backend/app/services/classification/single_image_classifier.py
+++ b/apps/mygamingassistant/backend/app/services/classification/single_image_classifier.py
@@ -34,6 +34,7 @@ from app.services.classification.prompts import (
     build_reference_text,
 )
 from app.services.classification.scope_guards import (
+    apply_agent_hint,
     apply_map_hint,
     check_game_map_consistency,
 )
@@ -72,6 +73,7 @@ async def classify_lineup(
     *,
     game_hint: Optional[str] = None,
     map_hint: Optional[str] = None,
+    agent_hint: Optional[str] = None,
 ) -> ClassificationResult:
     """Classify a single lineup and write suggestions back to the DB row.
 
@@ -84,6 +86,12 @@ async def classify_lineup(
             post-parse via ``apply_map_hint`` — mirroring the ingest grid
             classifier — so the interactive reclassify path honors a source's
             operator-set map scope exactly as ingestion does. Implies its game.
+        agent_hint: Optional Valorant agent-slug scope (the lineup's
+            Source.config_json ``agent_hint``). When set, the utility candidate
+            list is narrowed to that agent's abilities and the classified
+            utility is HARD-LOCKED to it post-parse via ``apply_agent_hint`` —
+            mirroring the ingest grid classifier — so the reclassify path honors
+            a source's operator-set agent scope.
 
     Returns:
         ClassificationResult with success=True and suggested FK values on
@@ -118,10 +126,15 @@ async def classify_lineup(
     # apply_map_hint can find the hinted map and re-resolve its zones —
     # mirroring the ingest grid classifier, which always loads all games.
     # Without a map_hint, keep the cheaper game-scoped load.
-    if map_hint:
+    if map_hint or agent_hint:
+        # Full ref: apply_map_hint may need a map from another game, and agent
+        # scoping needs every agent's abilities regardless of this row's current
+        # (possibly mis-set) game_id.
         ref = await load_reference_data(db, game_id=None)
         _map_game = {m["slug"]: m["game_slug"] for m in ref.get("maps", [])}
-        effective_game_hint = _map_game.get(map_hint, game_hint)
+        effective_game_hint = (
+            _map_game.get(map_hint, game_hint) if map_hint else game_hint
+        )
     else:
         ref = await load_reference_data(db, game_id=lineup.game_id)
         effective_game_hint = game_hint
@@ -139,7 +152,7 @@ async def classify_lineup(
         )
 
     reference_text = build_reference_text(
-        ref, game_hint=effective_game_hint, map_hint=map_hint
+        ref, game_hint=effective_game_hint, map_hint=map_hint, agent_hint=agent_hint
     )
 
     chapter_context_parts: list[str] = []
@@ -262,6 +275,11 @@ async def classify_lineup(
         parsed = apply_map_hint(parsed, ref, map_hint, failures, structured_codes)
     else:
         parsed = check_game_map_consistency(parsed, ref, failures, structured_codes)
+
+    # Agent scope is orthogonal to map scope — apply it regardless of the map
+    # branch above. No-op unless agent_hint owns an ability in the ref data.
+    if agent_hint:
+        parsed = apply_agent_hint(parsed, ref, agent_hint, failures, structured_codes)
 
     (
         game_id,

--- a/apps/mygamingassistant/backend/app/services/game/reclassify_service.py
+++ b/apps/mygamingassistant/backend/app/services/game/reclassify_service.py
@@ -41,30 +41,30 @@ _RECLASSIFY_BATCH_LIMIT = 500
 async def _source_scope(
     db: AsyncSession,
     source_id: Optional[uuid.UUID],
-) -> tuple[Optional[str], Optional[str]]:
-    """Return the (game_hint, map_hint) scope for a source id, null-safe.
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
+    """Return the (game_hint, map_hint, agent_hint) scope for a source id.
 
     The hints live in Source.config_json (set by the operator at create time or
     via ``PATCH /api/sources/{id}``). A missing source_id, or a soft-deleted
-    source, yields (None, None) — classification then runs unscoped, exactly as
-    it did before this wiring existed.
+    source, yields (None, None, None) — classification then runs unscoped,
+    exactly as it did before this wiring existed.
     """
     if source_id is None:
-        return None, None
+        return None, None, None
     source = await source_repo.get_source(db, source_id)
     if source is None:
-        return None, None
+        return None, None, None
     cfg = source.config_json or {}
-    return cfg.get("game_hint"), cfg.get("map_hint")
+    return cfg.get("game_hint"), cfg.get("map_hint"), cfg.get("agent_hint")
 
 
 async def _source_scope_for_lineup(
     db: AsyncSession,
     lineup: Optional[Lineup],
-) -> tuple[Optional[str], Optional[str]]:
+) -> tuple[Optional[str], Optional[str], Optional[str]]:
     """The source scope for a lineup (SET NULL FK / manual upload → unscoped)."""
     if lineup is None:
-        return None, None
+        return None, None, None
     return await _source_scope(db, lineup.source_id)
 
 
@@ -87,9 +87,9 @@ async def reclassify(
     On classifier failure nothing was flushed worth keeping, so no commit.
     """
     lineup = await get_lineup(db, lineup_id)
-    game_hint, map_hint = await _source_scope_for_lineup(db, lineup)
+    game_hint, map_hint, agent_hint = await _source_scope_for_lineup(db, lineup)
     result = await classify_lineup(
-        db, lineup_id, game_hint=game_hint, map_hint=map_hint
+        db, lineup_id, game_hint=game_hint, map_hint=map_hint, agent_hint=agent_hint
     )
     if result.success:
         await commit_classifier_run(db)
@@ -126,7 +126,7 @@ async def reclassify_source_pending(
     the per-call cap is surfaced via ``total > reclassified + failed`` rather
     than silently dropping the tail.
     """
-    game_hint, map_hint = await _source_scope(db, source_id)
+    game_hint, map_hint, agent_hint = await _source_scope(db, source_id)
     lineups, total = await list_pending_lineups(
         db, source_id=source_id, limit=_RECLASSIFY_BATCH_LIMIT, offset=0
     )
@@ -135,7 +135,8 @@ async def reclassify_source_pending(
     for lineup in lineups:
         try:
             result = await classify_lineup(
-                db, lineup.id, game_hint=game_hint, map_hint=map_hint
+                db, lineup.id, game_hint=game_hint, map_hint=map_hint,
+                agent_hint=agent_hint,
             )
         except Exception:
             logger.exception(

--- a/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
+++ b/apps/mygamingassistant/backend/app/services/ingestion/ingestion_orchestrator.py
@@ -259,6 +259,7 @@ async def _process_chapter(
 
     cfg = source.config_json or {}
     game_hint, map_hint = cfg.get("game_hint"), cfg.get("map_hint")
+    agent_hint = cfg.get("agent_hint")
 
     # Strategy A core: the classifier IS the lineup detector + frame picker.
     # When the classifier is disabled we cannot make the is_lineup judgement,
@@ -275,8 +276,7 @@ async def _process_chapter(
                 frames=frames,
                 chapter_title=chapter.title,
                 attribution_author=video_meta.channel_name,
-                game_hint=game_hint,
-                map_hint=map_hint,
+                game_hint=game_hint, map_hint=map_hint, agent_hint=agent_hint,
             )
             classifier_ran = True
         except Exception as exc:

--- a/apps/mygamingassistant/backend/tests/test_classifier_service.py
+++ b/apps/mygamingassistant/backend/tests/test_classifier_service.py
@@ -580,6 +580,76 @@ class TestReferenceTextBuilder:
         assert "SOURCE MAP SCOPE" in text
         assert "Expected game: valorant" not in text
 
+    def test_agent_hint_filters_utility_list_and_emits_scope(self):
+        from app.services.classification.prompts import build_reference_text
+
+        ref = {
+            "games": [
+                {"slug": "valorant", "name": "VALORANT", "side_a_label": "Attacker", "side_b_label": "Defender"},
+            ],
+            "maps": [
+                {"slug": "breeze", "name": "Breeze", "game_slug": "valorant", "zones": [{"slug": "a-site", "name": "A Site"}]},
+            ],
+            "utility_types": [
+                {"slug": "recon", "name": "Recon Bolt", "game_slug": "valorant", "agent_slug": "sova"},
+                {"slug": "shock", "name": "Shock Bolt", "game_slug": "valorant", "agent_slug": "sova"},
+                {"slug": "sky-smoke", "name": "Sky Smoke", "game_slug": "valorant", "agent_slug": "brimstone"},
+                {"slug": "smoke", "name": "Smoke", "game_slug": "cs2", "agent_slug": None},
+            ],
+        }
+        text = build_reference_text(ref, agent_hint="sova")
+        # Hard agent-scope instruction naming the agent.
+        assert "SOURCE AGENT SCOPE" in text
+        assert "'sova'" in text
+        assert "You MUST pick utility_type_slug ONLY from sova" in text
+        # Only sova's abilities appear in the utility list...
+        assert "recon" in text
+        assert "shock" in text
+        # ...off-agent abilities (other agents + CS2 grenades) are dropped.
+        assert "sky-smoke" not in text
+        assert "→ Smoke" not in text
+
+    def test_agent_hint_with_no_matching_abilities_is_noop(self):
+        from app.services.classification.prompts import build_reference_text
+
+        ref = {
+            "games": [
+                {"slug": "valorant", "name": "VALORANT", "side_a_label": "Attacker", "side_b_label": "Defender"},
+            ],
+            "maps": [],
+            "utility_types": [
+                {"slug": "recon", "name": "Recon Bolt", "game_slug": "valorant", "agent_slug": "sova"},
+            ],
+        }
+        # Unknown agent (or agents not loaded) → no filter, no scope line; the
+        # utility menu is never emptied.
+        text = build_reference_text(ref, agent_hint="no-such-agent")
+        assert "SOURCE AGENT SCOPE" not in text
+        assert "recon" in text  # full list retained
+
+    def test_agent_hint_composes_with_map_hint(self):
+        from app.services.classification.prompts import build_reference_text
+
+        ref = {
+            "games": [
+                {"slug": "valorant", "name": "VALORANT", "side_a_label": "Attacker", "side_b_label": "Defender"},
+            ],
+            "maps": [
+                {"slug": "breeze", "name": "Breeze", "game_slug": "valorant", "zones": [{"slug": "a-site", "name": "A Site"}]},
+                {"slug": "ascent", "name": "Ascent", "game_slug": "valorant", "zones": [{"slug": "market", "name": "Market"}]},
+            ],
+            "utility_types": [
+                {"slug": "recon", "name": "Recon Bolt", "game_slug": "valorant", "agent_slug": "sova"},
+                {"slug": "sky-smoke", "name": "Sky Smoke", "game_slug": "valorant", "agent_slug": "brimstone"},
+            ],
+        }
+        # Both scopes are orthogonal and both emitted; map + utility filtered.
+        text = build_reference_text(ref, map_hint="breeze", agent_hint="sova")
+        assert "SOURCE MAP SCOPE" in text
+        assert "SOURCE AGENT SCOPE" in text
+        assert "ascent" not in text  # non-hinted map filtered out
+        assert "sky-smoke" not in text  # off-agent utility filtered out
+
 
 # ---------------------------------------------------------------------------
 # Tests: Strategy A grid classifier (classify_frames_for_lineup_decision)
@@ -983,6 +1053,22 @@ _CROSS_GAME_REF: dict = {
 }
 
 
+_AGENT_REF: dict = {
+    "games": [
+        {"slug": "valorant", "name": "VALORANT", "side_a_label": "Attacker", "side_b_label": "Defender"},
+    ],
+    "maps": [
+        {"slug": "breeze", "name": "Breeze", "game_slug": "valorant", "zones": [{"slug": "a-site", "name": "A Site"}]},
+    ],
+    "utility_types": [
+        {"slug": "recon", "name": "Recon Bolt", "game_slug": "valorant", "agent_slug": "sova"},
+        {"slug": "shock", "name": "Shock Bolt", "game_slug": "valorant", "agent_slug": "sova"},
+        {"slug": "sky-smoke", "name": "Sky Smoke", "game_slug": "valorant", "agent_slug": "brimstone"},
+        {"slug": "smoke", "name": "Smoke", "game_slug": "cs2", "agent_slug": None},
+    ],
+}
+
+
 class TestGameFirstPromptWiring:
     """Both system-prompt paths must carry the visual-cue block + game-first rule."""
 
@@ -1280,6 +1366,87 @@ class TestApplyMapHint:
         assert result == parsed  # unchanged
         assert codes == []
         assert any("not found in reference data" in f for f in failures)
+
+
+class TestApplyAgentHint:
+    """Operator agent-scope hard-lock — null a utility that belongs to a
+    different agent than the source's agent_hint (recurrence fix for cross-AGENT
+    utility misclassification within Valorant, e.g. a Sova recon dart tagged as
+    Brimstone sky-smoke). resolve_slugs is game- but NOT agent-scoped, so this
+    post-parse guard is the load-bearing guarantee behind the prompt filter."""
+
+    def test_off_agent_utility_nulled_and_code_emitted(self):
+        from app.services.classification.scope_guards import apply_agent_hint
+
+        # Claude tagged a Sova source's lineup as Brimstone's sky-smoke.
+        parsed = {
+            "game_slug": "valorant",
+            "map_slug": "breeze",
+            "utility_type_slug": "sky-smoke",
+            "side": "side_a",
+            "confidence": 0.8,
+        }
+        failures: list[str] = []
+        codes: list[str] = []
+        result = apply_agent_hint(parsed, _AGENT_REF, "sova", failures, codes)
+
+        assert result["utility_type_slug"] is None
+        # Everything else untouched (only the utility is scoped).
+        assert result["map_slug"] == "breeze"
+        assert result["game_slug"] == "valorant"
+        assert result["side"] == "side_a"
+        assert result["confidence"] == pytest.approx(0.8)
+        assert codes == ["agent_hint_override:claude=sky-smoke:agent=brimstone:scoped=sova"]
+        assert any("AGENT-SCOPE OVERRIDE" in f for f in failures)
+        # Original dict not mutated (returns a copy on override).
+        assert parsed["utility_type_slug"] == "sky-smoke"
+
+    def test_on_agent_utility_kept(self):
+        from app.services.classification.scope_guards import apply_agent_hint
+
+        parsed = {"utility_type_slug": "recon", "confidence": 0.9}
+        failures: list[str] = []
+        codes: list[str] = []
+        result = apply_agent_hint(parsed, _AGENT_REF, "sova", failures, codes)
+
+        assert result["utility_type_slug"] == "recon"
+        assert codes == []
+        assert failures == []
+
+    def test_second_agent_ability_kept(self):
+        """An agent with several abilities keeps ANY of them (sova → recon+shock)."""
+        from app.services.classification.scope_guards import apply_agent_hint
+
+        parsed = {"utility_type_slug": "shock", "confidence": 0.9}
+        failures: list[str] = []
+        result = apply_agent_hint(parsed, _AGENT_REF, "sova", failures)
+
+        assert result["utility_type_slug"] == "shock"
+        assert failures == []
+
+    def test_null_utility_unchanged(self):
+        from app.services.classification.scope_guards import apply_agent_hint
+
+        parsed = {"utility_type_slug": None, "confidence": 0.5}
+        failures: list[str] = []
+        result = apply_agent_hint(parsed, _AGENT_REF, "sova", failures)
+
+        assert result == parsed
+        assert failures == []
+
+    def test_unknown_agent_hint_is_noop_with_note(self):
+        """An agent_hint owning no abilities in the ref is a defensive no-op —
+        keeps the utility rather than blanking it (mirrors the prompt filter)."""
+        from app.services.classification.scope_guards import apply_agent_hint
+
+        parsed = {"utility_type_slug": "sky-smoke", "confidence": 0.7}
+        failures: list[str] = []
+        codes: list[str] = []
+        result = apply_agent_hint(parsed, _AGENT_REF, "no-such-agent", failures, codes)
+
+        assert result == parsed  # unchanged — utility NOT blanked
+        assert codes == []
+        assert any("no abilities in reference data" in f for f in failures)
 
 
 class TestGridMaxTokens:


### PR DESCRIPTION
## Problem

PR #950 grew the Valorant ability menu from 4 to ~56 utility types but the classifier's candidate list was **not agent-scoped** — every agent's abilities were offered on every Valorant lineup. A Sova recon dart's on-screen scan reads enough like a smoke deploy that **~1/3 of a Sova source's lineups were tagged as Brimstone's `sky-smoke`**.

## Fix

Thread a per-source `agent_hint` (`Source.config_json`) through the classifier so a single-agent Valorant source only ever sees that agent's abilities:

- **`reference_repo.load_reference_data`** now carries each utility's `agent_slug` (NULL for CS2's game-wide grenades).
- **`build_reference_text`** filters the utility candidate list to the hinted agent's abilities and emits a hard `SOURCE AGENT SCOPE` line. An `agent_hint` with no matching abilities is a no-op (the menu is never emptied).
- **`scope_guards.apply_agent_hint`** (new) nulls an off-agent utility post-parse. `resolve_slugs` is game- but **not** agent-scoped, so a hallucinated off-agent slug (still a valid Valorant utility) would otherwise resolve to the wrong agent's FK. This is the load-bearing guarantee behind the prompt filter, mirroring `apply_map_hint`.
- `agent_hint` threaded through `grid_classifier`, `single_image_classifier`, `ingestion_orchestrator`, and `reclassify_service` (source scope is now a 3-tuple).

## Validation

Re-classified the Sova/Breeze pilot source (`53aacf45`)'s **41 pending rows** in place with `agent_hint=sova` (no re-ingest / re-clip):

| suggested utility | before | after |
|---|---|---|
| recon | 23 | **37** |
| sky-smoke | **14** | **0** ✅ |
| shock | 4 | 4 |

41/41 reclassified, 0 failed. All 14 misclassified recon darts corrected. **89 backend tests pass** (11 new: agent filter, `map_hint` composition, `apply_agent_hint` behaviors).

## Follow-up (not in this PR)

Expose `agent_hint` as a first-class operator source scope — source create/patch schema + slug validation + a frontend `AgentSelect` picker in the source form — so new agent-scoped sources don't need a manual `config_json` edit. For now it's set directly on `config_json` (as done for this pilot); the existing reclassify-pending endpoint already consumes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)