### PR TITLE
feat(mjh): async session start + progressive reveal for /resume

### DIFF
--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -120,6 +120,7 @@ jobs:
               tests/test_resume_refinement_proposal_cache.py
               tests/test_resume_refinement_session_helpers.py
               tests/test_resume_refinement_guard_confirmation.py
+              tests/test_resume_refinement_preparing_flow.py
 
     services:
       postgres:

--- a/apps/myjobhunter/backend/alembic/versions/prep260702_session_preparing_status.py
+++ b/apps/myjobhunter/backend/alembic/versions/prep260702_session_preparing_status.py
@@ -1,0 +1,80 @@
+"""Async session preparation: preparing/failed statuses + claim marker.
+
+POST /resume-refinement/sessions used to run the critique pass plus a
+prefetch of EVERY target proposal synchronously — a 1-2 minute blocking
+request behind a single button spinner, fragile against the 2-minute
+Caddy timeouts. Sessions are now created in ``preparing`` and the
+expensive work runs in the background worker (same process as the
+resume parser); the session unlocks (``active``) when the first
+proposal is ready.
+
+Schema changes on ``resume_refinement_sessions``:
+
+1. Status check constraint widened with ``preparing`` and ``failed``.
+2. ``error_message`` — populated when preparation fails; drives the
+   frontend "Try again" card (mirrors ``resume_upload_jobs``).
+3. ``preparation_started_at`` — atomic worker-claim marker so
+   concurrent worker replicas never prepare the same session twice.
+
+No backfill: existing rows are all in the old statuses and keep
+working; new columns are nullable.
+
+Revision ID: prep260702
+Revises: guardfacts260702
+Create Date: 2026-07-02
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "prep260702"
+down_revision: Union[str, None] = "guardfacts260702"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "resume_refinement_sessions",
+        sa.Column("error_message", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "resume_refinement_sessions",
+        sa.Column(
+            "preparation_started_at", sa.DateTime(timezone=True), nullable=True,
+        ),
+    )
+    op.drop_constraint(
+        "chk_refinement_session_status",
+        "resume_refinement_sessions",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_refinement_session_status",
+        "resume_refinement_sessions",
+        "status IN ('preparing','active','completed','abandoned','failed')",
+    )
+
+
+def downgrade() -> None:
+    # Any rows stuck in the new statuses would violate the old
+    # constraint — resolve them to the nearest old-world equivalent
+    # before narrowing.
+    op.execute(
+        "UPDATE resume_refinement_sessions "
+        "SET status = 'abandoned' WHERE status IN ('preparing','failed')"
+    )
+    op.drop_constraint(
+        "chk_refinement_session_status",
+        "resume_refinement_sessions",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "chk_refinement_session_status",
+        "resume_refinement_sessions",
+        "status IN ('active','completed','abandoned')",
+    )
+    op.drop_column("resume_refinement_sessions", "preparation_started_at")
+    op.drop_column("resume_refinement_sessions", "error_message")

--- a/apps/myjobhunter/backend/app/api/resume_refinement.py
+++ b/apps/myjobhunter/backend/app/api/resume_refinement.py
@@ -2,7 +2,8 @@
 
 Endpoints:
 
-POST   /resume-refinement/sessions                          start a new session
+POST   /resume-refinement/sessions                          start a new session (returns status=preparing)
+POST   /resume-refinement/sessions/{id}/retry-preparation   re-queue a failed preparation
 GET    /resume-refinement/sessions                          list user's sessions
 GET    /resume-refinement/sessions/{id}                     read session state
 POST   /resume-refinement/sessions/{id}/accept              accept pending proposal
@@ -42,7 +43,6 @@ from app.services.resume_refinement.errors import (
     SessionNotFound,
     SourceJobNotFound,
     SourceJobNotReady,
-    CritiqueRetryExceeded,
 )
 from app.services.resume_refinement.export_service import (
     ExportFidelityError,
@@ -58,7 +58,12 @@ async def start_session(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
 ) -> SessionWithTurnsRead:
-    """Start a new refinement session from a completed resume upload."""
+    """Start a new refinement session from a completed resume upload.
+
+    Returns in well under a second with ``status="preparing"`` — the
+    critique + prefetch run in the background worker; poll
+    GET /sessions/{id} for the unlock (``status="active"``).
+    """
     try:
         session = await session_service.start_session(
             db=db,
@@ -69,8 +74,27 @@ async def start_session(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except SourceJobNotReady as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
-    except CritiqueRetryExceeded as exc:
-        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return SessionWithTurnsRead.model_validate(session)
+
+
+@router.post(
+    "/sessions/{session_id}/retry-preparation",
+    response_model=SessionWithTurnsRead,
+)
+async def retry_preparation(
+    session_id: uuid.UUID,
+    db: AsyncSession = Depends(get_db),
+    user: User = Depends(current_active_user),
+) -> SessionWithTurnsRead:
+    """Re-queue a failed background preparation ("Try again")."""
+    try:
+        session = await session_service.retry_preparation(
+            db=db, user_id=user.id, session_id=session_id,
+        )
+    except SessionNotFound as exc:
+        raise HTTPException(status_code=404, detail="Session not found") from exc
+    except SessionNotActive as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
     return SessionWithTurnsRead.model_validate(session)
 
 

--- a/apps/myjobhunter/backend/app/models/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/models/resume_refinement/session.py
@@ -4,8 +4,10 @@ A session ties a user to a source resume upload and tracks the
 markdown draft, the prioritized improvement targets, the pending AI
 proposal, and per-session token / cost counters.
 
-Status values: ``active`` (default), ``completed`` (user marked done),
-``abandoned`` (user explicitly walked away or auto-aged out).
+Status values: ``preparing`` (background critique + prefetch running),
+``active`` (unlocked for user mutations), ``completed`` (user marked
+done), ``abandoned`` (user explicitly walked away or auto-aged out),
+``failed`` (background preparation failed; retryable).
 """
 import uuid
 from datetime import datetime, timezone
@@ -50,6 +52,18 @@ class ResumeRefinementSession(Base):
     )
 
     status: Mapped[str] = mapped_column(String(20), default="active", nullable=False)
+
+    # Populated when background preparation fails — surfaced by the
+    # frontend's "Try again" card. Cleared on retry / unlock.
+    error_message: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Worker claim marker for the ``preparing`` state: set atomically by
+    # ``claim_next_preparing`` so concurrent worker replicas never
+    # prepare the same session twice. Cleared on transient failure so
+    # the next poll retries.
+    preparation_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
 
     # The live working markdown document. Updated whenever a user accepts
     # an AI proposal or supplies a custom rewrite for the current target.
@@ -148,9 +162,18 @@ class ResumeRefinementSession(Base):
         counts = self.guard_flag_counts or {}
         return int(counts.get(str(self.target_index), 0)) >= 2
 
+    @property
+    def proposals_ready_count(self) -> int:
+        """How many targets have a drafted proposal (or clarify) cached.
+
+        Drives the honest "Drafting suggestions — k of N ready" copy in
+        the preparing panel without exposing the raw cache payload.
+        """
+        return len(self.proposal_cache or {})
+
     __table_args__ = (
         CheckConstraint(
-            "status IN ('active','completed','abandoned')",
+            "status IN ('preparing','active','completed','abandoned','failed')",
             name="chk_refinement_session_status",
         ),
         Index("ix_refinement_session_user_status", "user_id", "status"),

--- a/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
@@ -341,6 +341,55 @@ async def add_confirmed_facts(
     return session
 
 
+async def clear_pending_state(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+) -> ResumeRefinementSession:
+    """Clear the pending_* fields without touching draft or cursor.
+
+    Used when the iteration loop runs out of targets — the user clicks
+    Complete to lock; until then the session just has nothing pending.
+    """
+    session.pending_target_section = None
+    session.pending_proposal = None
+    session.pending_rationale = None
+    session.pending_clarifying_question = None
+    session.pending_guard_flagged = None
+    session.pending_flagged_proposal = None
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def bump_turn_count(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+) -> ResumeRefinementSession:
+    """Persist a turn_count increment for a user action that appends a
+    turn row without going through ``apply_user_resolution``."""
+    session.turn_count += 1
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def persist_prefetch_results(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    *,
+    guard_flag_counts: dict,
+) -> ResumeRefinementSession:
+    """Final write of the prefetch pass: guard-flag counters plus the
+    token/cost accumulators the caller mutated on the instance."""
+    session.guard_flag_counts = guard_flag_counts
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
 async def claim_next_preparing(db: AsyncSession) -> ResumeRefinementSession | None:
     """Atomically claim one unclaimed ``preparing`` session and return it.
 

--- a/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
+++ b/apps/myjobhunter/backend/app/repositories/resume_refinement/session_repo.py
@@ -11,7 +11,7 @@ import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -26,13 +26,14 @@ async def create(
     user_id: uuid.UUID,
     source_resume_job_id: uuid.UUID | None,
     initial_draft: str,
+    status: str = "active",
 ) -> ResumeRefinementSession:
-    """Insert a new active session and return the persisted row."""
+    """Insert a new session and return the persisted row."""
     session = ResumeRefinementSession(
         user_id=user_id,
         source_resume_job_id=source_resume_job_id,
         current_draft=initial_draft,
-        status="active",
+        status=status,
     )
     db.add(session)
     await db.flush()
@@ -334,6 +335,99 @@ async def add_confirmed_facts(
             existing.append(cleaned)
             seen.add(cleaned.lower())
     session.confirmed_facts = existing
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def claim_next_preparing(db: AsyncSession) -> ResumeRefinementSession | None:
+    """Atomically claim one unclaimed ``preparing`` session and return it.
+
+    Mirrors ``resume_upload_job_repo.claim_next_queued``: an
+    ``UPDATE ... WHERE id = (subquery) RETURNING`` with
+    ``FOR UPDATE SKIP LOCKED`` so only one worker replica can claim a
+    given session. The claim marker is ``preparation_started_at``
+    (status stays ``preparing`` — the frontend keeps showing the
+    progress card either way).
+
+    Returns ``None`` when nothing is waiting.
+    """
+    now = datetime.now(timezone.utc)
+    subq = (
+        select(ResumeRefinementSession.id)
+        .where(
+            ResumeRefinementSession.status == "preparing",
+            ResumeRefinementSession.preparation_started_at.is_(None),
+        )
+        .order_by(ResumeRefinementSession.created_at.asc())
+        .limit(1)
+        .with_for_update(skip_locked=True)
+        .scalar_subquery()
+    )
+    stmt = (
+        update(ResumeRefinementSession)
+        .where(ResumeRefinementSession.id == subq)
+        .values(preparation_started_at=now, updated_at=now)
+        .returning(ResumeRefinementSession)
+    )
+    result = await db.execute(stmt)
+    row = result.scalar_one_or_none()
+    if row is not None:
+        await db.commit()
+    return row
+
+
+async def mark_active(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+) -> ResumeRefinementSession:
+    """Unlock a prepared session for user mutations."""
+    session.status = "active"
+    session.error_message = None
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def mark_preparation_failed(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    error_message: str,
+) -> ResumeRefinementSession:
+    """Permanent preparation failure — surfaced as the "Try again" card."""
+    session.status = "failed"
+    session.error_message = error_message
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def release_preparation_claim(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    note: str,
+) -> ResumeRefinementSession:
+    """Transient preparation failure — release the claim so the next
+    worker poll retries. Status stays ``preparing``."""
+    session.preparation_started_at = None
+    session.error_message = note
+    await db.flush()
+    await db.commit()
+    await db.refresh(session)
+    return session
+
+
+async def reset_for_retry(
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+) -> ResumeRefinementSession:
+    """User-initiated retry of a ``failed`` preparation: re-queue it."""
+    session.status = "preparing"
+    session.error_message = None
+    session.preparation_started_at = None
     await db.flush()
     await db.commit()
     await db.refresh(session)

--- a/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
+++ b/apps/myjobhunter/backend/app/schemas/resume_refinement/session.py
@@ -71,6 +71,10 @@ class SessionRead(BaseModel):
     total_tokens_in: int
     total_tokens_out: int
     total_cost_usd: Decimal
+    # Background-preparation surface: error for the "Try again" card,
+    # ready-count for the honest "Drafting suggestions k/N" copy.
+    error_message: str | None = None
+    proposals_ready_count: int = 0
     completed_at: datetime | None = None
     created_at: datetime
     updated_at: datetime

--- a/apps/myjobhunter/backend/app/services/resume_refinement/errors.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/errors.py
@@ -45,3 +45,9 @@ class HallucinationGuardFailed(ResumeRefinementError):
 
 class CritiqueRetryExceeded(ResumeRefinementError):
     """Claude failed to return a usable critique after retries."""
+
+
+class PreparationFailed(ResumeRefinementError):
+    """Background session preparation could not produce a usable first
+    proposal. The worker marks the session ``failed`` for the frontend's
+    "Try again" affordance."""

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_helpers.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_helpers.py
@@ -140,14 +140,7 @@ async def _generate_next_proposal(
     target = _current_target(session)
     if target is None:
         # No more targets — clear pending state. The user clicks Complete to lock.
-        session.pending_target_section = None
-        session.pending_proposal = None
-        session.pending_rationale = None
-        session.pending_clarifying_question = None
-        await db.flush()
-        await db.commit()
-        await db.refresh(session)
-        return session
+        return await session_repo.clear_pending_state(db, session)
 
     prior_turns = await turn_repo.list_for_session(db, session.id)
     prior_context = _build_prior_context(prior_turns)
@@ -333,11 +326,9 @@ async def _prefetch_all_proposals(
             guard_flagged=flagged or None,
             flagged_proposal=rewrite["rewritten_text"] if flagged else None,
         )
-    session.guard_flag_counts = flag_counts
-    await db.flush()
-    await db.commit()
-    await db.refresh(session)
-    return session
+    return await session_repo.persist_prefetch_results(
+        db, session, guard_flag_counts=flag_counts,
+    )
 
 
 def _apply_rewrite(

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_lifecycle_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_lifecycle_service.py
@@ -2,12 +2,20 @@
 
 Public entry points (called from ``app.api.resume_refinement``):
 
-- ``start_session`` — kick off a new session from a completed
-  ``resume_upload_jobs`` row. Renders the parsed fields to markdown,
-  runs the initial critique pass, and generates the first proposal.
+- ``start_session`` — create a ``preparing`` session from a completed
+  ``resume_upload_jobs`` row and return in well under a second. The
+  initial draft renders inline (profile-table read, no Claude call);
+  the expensive critique + prefetch run in the background worker.
+- ``retry_preparation`` — re-queue a ``failed`` preparation.
 - ``get_session_state`` — return the current session including pending
   proposal. Pure read.
 - ``complete_session`` — terminal: mark the session done.
+
+Worker-side entry point (called from
+``app.workers.refinement_prepare_worker`` after an atomic claim):
+
+- ``prepare_session`` — critique → prefetch → hydrate first target →
+  unlock (status ``active``). Idempotent on retry.
 """
 from __future__ import annotations
 
@@ -33,6 +41,8 @@ from app.repositories.profile import (
 from app.repositories.resume_refinement import session_repo, turn_repo
 from app.services.resume_refinement import critique_service
 from app.services.resume_refinement.errors import (
+    PreparationFailed,
+    SessionNotActive,
     SessionNotFound,
     SourceJobNotFound,
     SourceJobNotReady,
@@ -53,7 +63,17 @@ async def start_session(
     user_id: uuid.UUID,
     source_resume_job_id: uuid.UUID,
 ) -> ResumeRefinementSession:
-    """Create a new session, run critique, and queue the first proposal."""
+    """Create a ``preparing`` session and return immediately.
+
+    Rendering the initial draft from profile tables is a cheap DB read,
+    so it happens inline — the frontend shows the draft right away. The
+    critique pass and the all-targets prefetch (1-2 minutes of Claude
+    calls) run in the background worker; the session unlocks
+    (status ``active``) when the first proposal is ready. This used to
+    be one synchronous request, which meant a dead button spinner for
+    the whole wait and a fragile 90s+ request vs the 2-minute Caddy
+    timeouts.
+    """
     job = await resume_upload_job_repo.get_by_id_for_user(
         db, source_resume_job_id, user_id,
     )
@@ -67,7 +87,7 @@ async def start_session(
         )
 
     # Build the initial draft from profile tables — NOT from result_parsed_fields,
-    # which only stores {"raw": "<Claude JSON string>"} and not the structured data.
+    # which only stores the raw Claude blob and not the structured data.
     profile = await profile_repository.get_by_user_id(db, user_id)
     work_history_rows = await work_history_repository.list_by_user(db, user_id)
     education_rows = await education_repository.list_by_user(db, user_id)
@@ -87,62 +107,113 @@ async def start_session(
         user_id=user_id,
         source_resume_job_id=source_resume_job_id,
         initial_draft=initial_draft,
+        status="preparing",
     )
+    return await _with_turns(db, session)
 
-    # Run the critique pass. If it fails, the session still exists with
-    # an empty improvement_targets — the caller can retry.
-    try:
+
+async def prepare_session(
+    *,
+    db: AsyncSession,
+    session: ResumeRefinementSession,
+    user_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    """Run the expensive preparation for a claimed ``preparing`` session.
+
+    Called from the background worker. Idempotent on retry: the critique
+    pass is skipped when ``improvement_targets`` is already populated (a
+    previous attempt got that far), so a retry after a prefetch-stage
+    failure doesn't re-spend the critique call.
+
+    Raises on failure — the worker decides transient (release the claim,
+    poll retries) vs permanent (status ``failed`` + error_message).
+    """
+    if session.improvement_targets is None:
         critique = await critique_service.run_critique(
-            resume_markdown=initial_draft,
+            resume_markdown=session.current_draft,
             user_id=user_id,
             session_id=session.id,
         )
-    except Exception as exc:
-        logger.error(
-            "Critique pass failed for session %s: %s", session.id, exc,
+        session = await session_repo.update_critique(
+            db,
+            session,
+            improvement_targets=critique["targets"],
+            tokens_in=critique["input_tokens"],
+            tokens_out=critique["output_tokens"],
+            cost_usd=critique["cost_usd"],
         )
-        raise
+        await turn_repo.append(
+            db,
+            session_id=session.id,
+            turn_index=0,
+            role="ai_critique",
+            target_section=None,
+            rationale=f"Identified {len(critique['targets'])} improvement targets.",
+            draft_after=session.current_draft,
+            tokens_in=critique["input_tokens"],
+            tokens_out=critique["output_tokens"],
+        )
 
-    session = await session_repo.update_critique(
-        db,
-        session,
-        improvement_targets=critique["targets"],
-        tokens_in=critique["input_tokens"],
-        tokens_out=critique["output_tokens"],
-        cost_usd=critique["cost_usd"],
-    )
-    await turn_repo.append(
-        db,
-        session_id=session.id,
-        turn_index=0,
-        role="ai_critique",
-        target_section=None,
-        rationale=f"Identified {len(critique['targets'])} improvement targets.",
-        draft_after=initial_draft,
-        tokens_in=critique["input_tokens"],
-        tokens_out=critique["output_tokens"],
-    )
+    targets = session.improvement_targets or []
+    if not targets:
+        # Nothing to draft — unlock straight into the "nothing to flag"
+        # completion state. Waiting for a "first proposal" here would
+        # spin forever (there is no target 0).
+        return await session_repo.mark_active(db, session)
 
     # Prefetch proposals for ALL critique targets in parallel. The
     # operator's stated workflow is to browse every suggestion before
     # acting, so we pay the Claude cost up front to make navigation
-    # instant. Wall-clock latency is one Claude round-trip (capped at
-    # _PREFETCH_CONCURRENCY in flight); per-target failures are
-    # graceful — those targets generate on first visit.
-    session = await _prefetch_all_proposals(
-        db, session, user_id=user_id,
-    )
+    # instant. Per-target failures are graceful — those targets
+    # generate on first visit.
+    session = await _prefetch_all_proposals(db, session, user_id=user_id)
 
-    # Hydrate pending_* from the cache for the starting target so the
-    # session-start response includes a proposal. If the prefetch for
-    # target 0 failed, fall back to a synchronous generation (matches
-    # the pre-prefetch behavior).
+    # Hydrate pending_* from the cache for the starting target. If the
+    # prefetch for target 0 failed, fall back to a synchronous
+    # generation.
     hydrated = await session_repo.hydrate_pending_from_cache(
         db, session, target_index=session.target_index,
     )
     if hydrated is not None:
-        return await _with_turns(db, hydrated)
-    session = await _generate_next_proposal(db, session, user_id=user_id, hint=None)
+        session = hydrated
+    else:
+        session = await _generate_next_proposal(
+            db, session, user_id=user_id, hint=None,
+        )
+
+    # Unlock gate: never flip to active without real content for the
+    # current target. GET /sessions/{id} is a pure read (no
+    # generate-on-poll), so unlocking early would strand the user on a
+    # permanently-stuck "working on a suggestion" placeholder.
+    if not (session.pending_proposal or session.pending_clarifying_question):
+        raise PreparationFailed(
+            "Suggestion generation failed for the first target."
+        )
+
+    return await session_repo.mark_active(db, session)
+
+
+async def retry_preparation(
+    *,
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    session_id: uuid.UUID,
+) -> ResumeRefinementSession:
+    """Re-queue a ``failed`` background preparation (frontend "Try again").
+
+    The critique output survives the failure, so a retry after a
+    prefetch-stage failure resumes from the prefetch (see
+    ``prepare_session`` idempotency note).
+    """
+    session = await session_repo.get_by_id_for_user(db, session_id, user_id)
+    if session is None:
+        raise SessionNotFound()
+    if session.status != "failed":
+        raise SessionNotActive(
+            f"Session is in status={session.status!r}; only failed "
+            "preparations can be retried."
+        )
+    session = await session_repo.reset_for_retry(db, session)
     return await _with_turns(db, session)
 
 

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_service.py
@@ -24,6 +24,8 @@ from __future__ import annotations
 from app.services.resume_refinement.session_lifecycle_service import (
     complete_session,
     get_session_state,
+    prepare_session,
+    retry_preparation,
     start_session,
 )
 
@@ -71,6 +73,8 @@ from app.services.resume_refinement import critique_service, rewrite_service
 __all__ = [
     # Lifecycle
     "start_session",
+    "prepare_session",
+    "retry_preparation",
     "get_session_state",
     "complete_session",
     # Turn mutations

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_turn_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_turn_service.py
@@ -198,10 +198,7 @@ async def request_alternative(
         target_section=target.get("section"),
         user_text=hint,
     )
-    session.turn_count += 1
-    await db.flush()
-    await db.commit()
-    await db.refresh(session)
+    session = await session_repo.bump_turn_count(db, session)
 
     # Drop the cached proposal so this regeneration's output replaces
     # the stale one. Without invalidation, a future navigate-back to

--- a/apps/myjobhunter/backend/app/workers/refinement_prepare_worker.py
+++ b/apps/myjobhunter/backend/app/workers/refinement_prepare_worker.py
@@ -1,0 +1,89 @@
+"""Refinement-session preparation — one step of the worker polling loop.
+
+Runs inside the SAME worker process as the resume parser (see
+``resume_parser_worker.main``), so no new container or compose change
+is needed. Each poll:
+
+1. Atomically claim one ``preparing`` session whose
+   ``preparation_started_at`` is NULL (UPDATE ... RETURNING with
+   FOR UPDATE SKIP LOCKED — safe across worker replicas).
+2. Run ``session_lifecycle_service.prepare_session``: critique →
+   prefetch every target proposal → hydrate the first target →
+   unlock (status ``active``).
+3. On transient failure (rate limit, network, Claude 5xx): release the
+   claim so the next poll retries. On permanent failure: mark the
+   session ``failed`` with ``error_message`` — the frontend shows a
+   "Try again" card wired to POST /sessions/{id}/retry-preparation.
+
+The frontend's existing 3s poll on GET /sessions/{id} observes the
+status flips and the growing ``proposal_cache``, driving the staged
+progress card ("Reviewing your resume" → "Drafting suggestions k/N" →
+unlock).
+"""
+from __future__ import annotations
+
+import logging
+
+from app.db.session import AsyncSessionLocal
+from app.repositories.resume_refinement import session_repo
+from app.services.resume_refinement import session_lifecycle_service
+from app.workers.resume_parser_worker import _is_transient
+
+logger = logging.getLogger(__name__)
+
+
+async def process_one_session() -> bool:
+    """Claim and prepare one ``preparing`` session.
+
+    Returns True if a session was found, False if nothing is waiting.
+    """
+    async with AsyncSessionLocal() as db:
+        claimed = await session_repo.claim_next_preparing(db)
+        if claimed is None:
+            return False
+        session_id = claimed.id
+        user_id = claimed.user_id
+
+    logger.info(
+        "Preparing refinement session %s for user %s", session_id, user_id,
+    )
+
+    try:
+        async with AsyncSessionLocal() as db:
+            # Re-fetch in a fresh session (the claim session is closed).
+            session = await session_repo.get_by_id_for_user(
+                db, session_id, user_id,
+            )
+            if session is None or session.status != "preparing":
+                logger.warning(
+                    "Session %s vanished or changed status before "
+                    "preparation — skipping",
+                    session_id,
+                )
+                return True
+            await session_lifecycle_service.prepare_session(
+                db=db, session=session, user_id=user_id,
+            )
+        logger.info("Prepared refinement session %s", session_id)
+    except Exception as exc:  # noqa: BLE001 — worker loop must not die
+        error_msg = str(exc)[:1000]
+        logger.exception(
+            "Failed to prepare refinement session %s: %s", session_id, error_msg,
+        )
+        async with AsyncSessionLocal() as db:
+            session = await session_repo.get_by_id_for_user(
+                db, session_id, user_id,
+            )
+            if session is not None and session.status == "preparing":
+                if _is_transient(exc):
+                    await session_repo.release_preparation_claim(
+                        db,
+                        session,
+                        f"Transient error — will retry: {error_msg}",
+                    )
+                else:
+                    await session_repo.mark_preparation_failed(
+                        db, session, error_msg,
+                    )
+
+    return True

--- a/apps/myjobhunter/backend/app/workers/resume_parser_worker.py
+++ b/apps/myjobhunter/backend/app/workers/resume_parser_worker.py
@@ -217,17 +217,30 @@ def _build_parsed_fields(claude_response: dict) -> dict:
 
 
 async def main() -> None:
+    # Deferred import: refinement_prepare_worker imports _is_transient
+    # from THIS module, so a top-level import here would be circular.
+    from app.workers.refinement_prepare_worker import (  # noqa: PLC0415
+        process_one_session,
+    )
+
     logger.info(
-        "Resume parser worker started — polling every %ds", POLL_INTERVAL_SECONDS,
+        "Resume worker started (parse + refinement prepare) — polling every %ds",
+        POLL_INTERVAL_SECONDS,
     )
     while True:
         try:
-            found = await process_one()
+            found_parse = await process_one()
         except Exception:
-            logger.exception("Unexpected error in worker loop")
-            found = False
+            logger.exception("Unexpected error in resume-parse loop")
+            found_parse = False
 
-        if not found:
+        try:
+            found_prepare = await process_one_session()
+        except Exception:
+            logger.exception("Unexpected error in refinement-prepare loop")
+            found_prepare = False
+
+        if not (found_parse or found_prepare):
             await asyncio.sleep(POLL_INTERVAL_SECONDS)
 
 

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_preparing_flow.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_preparing_flow.py
@@ -1,0 +1,371 @@
+"""Tests for the async session-start flow (background preparation).
+
+POST /resume-refinement/sessions used to run critique + all-targets
+prefetch synchronously — a 1-2 minute blocking request. Now:
+
+  * ``start_session`` creates the session in ``preparing`` and returns
+    WITHOUT any Claude call.
+  * ``prepare_session`` (worker-side) runs critique → prefetch →
+    hydrates the first target → unlocks (``active``). Idempotent on
+    retry; gates the unlock on real first-target content; special-cases
+    the zero-target session.
+  * ``retry_preparation`` re-queues a ``failed`` session only.
+
+All tests mock the DB-coupled repository functions and Claude-coupled
+services — same approach as test_resume_refinement_proposal_cache.py.
+Patches target the CONSUMER module's namespace for by-name imports
+(session_lifecycle_service), and shared module objects for repo/service
+references.
+"""
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from app.services.resume_refinement import (
+    session_lifecycle_service,
+    session_service,
+)
+from app.services.resume_refinement.errors import (
+    PreparationFailed,
+    SessionNotActive,
+)
+
+
+def _fake_session(
+    *,
+    status: str = "preparing",
+    targets: list[dict] | None = None,
+    pending_proposal: str | None = None,
+    pending_clarifying_question: str | None = None,
+):
+    s = MagicMock(spec=[])
+    s.id = uuid.uuid4()
+    s.user_id = uuid.uuid4()
+    s.status = status
+    s.improvement_targets = targets
+    s.target_index = 0
+    s.current_draft = "## Resume\n- old text"
+    s.proposal_cache = {}
+    s.pending_target_section = None
+    s.pending_proposal = pending_proposal
+    s.pending_rationale = None
+    s.pending_clarifying_question = pending_clarifying_question
+    s.pending_guard_flagged = None
+    s.pending_flagged_proposal = None
+    s.confirmed_facts = []
+    s.guard_flag_counts = {}
+    s.total_tokens_in = 0
+    s.total_tokens_out = 0
+    s.total_cost_usd = Decimal("0")
+    s.turn_count = 0
+    s.error_message = None
+    s.preparation_started_at = None
+    return s
+
+
+def _target(section: str = "summary") -> dict:
+    return {
+        "section": section,
+        "current_text": "old text",
+        "improvement_type": "tighten_phrasing",
+        "severity": "medium",
+        "notes": None,
+    }
+
+
+def _critique(targets: list[dict]) -> dict:
+    return {
+        "targets": targets,
+        "input_tokens": 500,
+        "output_tokens": 200,
+        "cost_usd": Decimal("0.004"),
+    }
+
+
+def _mock_db() -> MagicMock:
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.refresh = AsyncMock()
+    return db
+
+
+# ---------------------------------------------------------------------------
+# start_session — fast return, no Claude
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_session_returns_preparing_without_claude() -> None:
+    """Session creation must NOT run critique or prefetch — that's the
+    entire point of the async flow."""
+    db = _mock_db()
+    job = MagicMock()
+    job.status = "complete"
+    job.result_parsed_fields = None
+    created = _fake_session(status="preparing")
+    create_kwargs: list[dict] = []
+
+    async def fake_create(_db, **kwargs):
+        create_kwargs.append(kwargs)
+        return created
+
+    with (
+        patch.object(
+            session_service.resume_upload_job_repo,
+            "get_by_id_for_user",
+            new=AsyncMock(return_value=job),
+        ),
+        patch.object(
+            session_service.profile_repository,
+            "get_by_user_id",
+            new=AsyncMock(return_value=None),
+        ),
+        patch.object(
+            session_service.work_history_repository,
+            "list_by_user",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            session_service.education_repository,
+            "list_by_user",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(
+            session_service.skill_repository,
+            "list_by_user",
+            new=AsyncMock(return_value=[]),
+        ),
+        patch.object(session_service.session_repo, "create", new=fake_create),
+        patch.object(
+            session_lifecycle_service,
+            "_with_turns",
+            new=AsyncMock(return_value=created),
+        ),
+        patch.object(
+            session_service.critique_service,
+            "run_critique",
+            new=AsyncMock(side_effect=AssertionError("critique must NOT run")),
+        ),
+        patch.object(
+            session_lifecycle_service,
+            "_prefetch_all_proposals",
+            new=AsyncMock(side_effect=AssertionError("prefetch must NOT run")),
+        ),
+    ):
+        result = await session_lifecycle_service.start_session(
+            db=db,
+            user_id=created.user_id,
+            source_resume_job_id=uuid.uuid4(),
+        )
+
+    assert result is created
+    assert create_kwargs[0]["status"] == "preparing"
+
+
+# ---------------------------------------------------------------------------
+# prepare_session — worker-side flow
+# ---------------------------------------------------------------------------
+
+
+def _prepare_patches(session, *, critique_mock, prefetch_mock, hydrated, generated=None):
+    """Common patch set for prepare_session tests."""
+    marked_active: list[bool] = []
+
+    async def fake_update_critique(_db, sess, *, improvement_targets, **_):
+        sess.improvement_targets = improvement_targets
+        return sess
+
+    async def fake_mark_active(_db, sess):
+        marked_active.append(True)
+        sess.status = "active"
+        return sess
+
+    patches = (
+        patch.object(
+            session_service.critique_service, "run_critique", new=critique_mock,
+        ),
+        patch.object(
+            session_service.session_repo, "update_critique", new=fake_update_critique,
+        ),
+        patch.object(session_service.turn_repo, "append", new=AsyncMock()),
+        patch.object(
+            session_lifecycle_service, "_prefetch_all_proposals", new=prefetch_mock,
+        ),
+        patch.object(
+            session_service.session_repo,
+            "hydrate_pending_from_cache",
+            new=AsyncMock(return_value=hydrated),
+        ),
+        patch.object(
+            session_lifecycle_service,
+            "_generate_next_proposal",
+            new=AsyncMock(return_value=generated or session),
+        ),
+        patch.object(
+            session_service.session_repo, "mark_active", new=fake_mark_active,
+        ),
+    )
+    return patches, marked_active
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_happy_path_unlocks() -> None:
+    session = _fake_session(targets=None)
+    db = _mock_db()
+    hydrated = _fake_session(
+        targets=[_target()], pending_proposal="drafted text",
+    )
+    critique_mock = AsyncMock(return_value=_critique([_target()]))
+    prefetch_mock = AsyncMock(return_value=session)
+
+    patches, marked_active = _prepare_patches(
+        session,
+        critique_mock=critique_mock,
+        prefetch_mock=prefetch_mock,
+        hydrated=hydrated,
+    )
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        result = await session_lifecycle_service.prepare_session(
+            db=db, session=session, user_id=session.user_id,
+        )
+
+    critique_mock.assert_awaited_once()
+    prefetch_mock.assert_awaited_once()
+    assert marked_active == [True]
+    assert result.status == "active"
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_skips_critique_on_retry() -> None:
+    """Retry idempotency: targets already persisted → critique is NOT
+    re-spent; preparation resumes from the prefetch."""
+    session = _fake_session(targets=[_target()])
+    db = _mock_db()
+    hydrated = _fake_session(
+        targets=[_target()], pending_proposal="drafted text",
+    )
+    critique_mock = AsyncMock(side_effect=AssertionError("critique must NOT re-run"))
+    prefetch_mock = AsyncMock(return_value=session)
+
+    patches, marked_active = _prepare_patches(
+        session,
+        critique_mock=critique_mock,
+        prefetch_mock=prefetch_mock,
+        hydrated=hydrated,
+    )
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        await session_lifecycle_service.prepare_session(
+            db=db, session=session, user_id=session.user_id,
+        )
+
+    prefetch_mock.assert_awaited_once()
+    assert marked_active == [True]
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_zero_targets_unlocks_immediately() -> None:
+    """0 targets → straight to active. Waiting for a 'first proposal'
+    would spin forever (there is no target 0)."""
+    session = _fake_session(targets=None)
+    db = _mock_db()
+    critique_mock = AsyncMock(return_value=_critique([]))
+    prefetch_mock = AsyncMock(side_effect=AssertionError("prefetch must NOT run"))
+
+    patches, marked_active = _prepare_patches(
+        session,
+        critique_mock=critique_mock,
+        prefetch_mock=prefetch_mock,
+        hydrated=None,
+    )
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        result = await session_lifecycle_service.prepare_session(
+            db=db, session=session, user_id=session.user_id,
+        )
+
+    assert marked_active == [True]
+    assert result.status == "active"
+
+
+@pytest.mark.asyncio
+async def test_prepare_session_gates_unlock_on_first_target_content() -> None:
+    """Cache miss + failed generation → PreparationFailed, NOT a silent
+    unlock into a permanently-stuck 'working on a suggestion' state."""
+    session = _fake_session(targets=[_target()])
+    db = _mock_db()
+    critique_mock = AsyncMock(side_effect=AssertionError("targets already set"))
+    prefetch_mock = AsyncMock(return_value=session)
+
+    # hydrate misses; generation returns the session with NO pending
+    # content (mirrors the graceful-degrade path in _generate_next_proposal).
+    patches, marked_active = _prepare_patches(
+        session,
+        critique_mock=critique_mock,
+        prefetch_mock=prefetch_mock,
+        hydrated=None,
+        generated=session,
+    )
+    with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5], patches[6]:
+        with pytest.raises(PreparationFailed):
+            await session_lifecycle_service.prepare_session(
+                db=db, session=session, user_id=session.user_id,
+            )
+
+    assert marked_active == []
+
+
+# ---------------------------------------------------------------------------
+# retry_preparation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_retry_preparation_requeues_failed_session() -> None:
+    session = _fake_session(status="failed")
+    db = _mock_db()
+    reset_calls: list[bool] = []
+
+    async def fake_reset(_db, sess):
+        reset_calls.append(True)
+        sess.status = "preparing"
+        return sess
+
+    with (
+        patch.object(
+            session_service.session_repo,
+            "get_by_id_for_user",
+            new=AsyncMock(return_value=session),
+        ),
+        patch.object(session_service.session_repo, "reset_for_retry", new=fake_reset),
+        patch.object(
+            session_lifecycle_service,
+            "_with_turns",
+            new=AsyncMock(return_value=session),
+        ),
+    ):
+        result = await session_lifecycle_service.retry_preparation(
+            db=db, user_id=session.user_id, session_id=session.id,
+        )
+
+    assert reset_calls == [True]
+    assert result.status == "preparing"
+
+
+@pytest.mark.asyncio
+async def test_retry_preparation_rejects_non_failed_session() -> None:
+    session = _fake_session(status="active")
+    db = _mock_db()
+
+    with patch.object(
+        session_service.session_repo,
+        "get_by_id_for_user",
+        new=AsyncMock(return_value=session),
+    ):
+        with pytest.raises(SessionNotActive):
+            await session_lifecycle_service.retry_preparation(
+                db=db, user_id=session.user_id, session_id=session.id,
+            )

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_renderer.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_renderer.py
@@ -322,7 +322,9 @@ async def test_start_session_draft_contains_company_and_skill_names():
     # Capture the initial_draft that session_repo.create receives.
     captured_initial_draft: list[str] = []
 
-    async def fake_session_create(db, *, user_id, source_resume_job_id, initial_draft):
+    async def fake_session_create(
+        db, *, user_id, source_resume_job_id, initial_draft, status="active",
+    ):
         captured_initial_draft.append(initial_draft)
         return fake_session
 

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ActiveSessionView.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ActiveSessionView.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useRef, useState } from "react";
+import CurrentDraftPanel from "@/features/resume_refinement/CurrentDraftPanel";
+import PendingProposalCard from "@/features/resume_refinement/PendingProposalCard";
+import CompletePanel from "@/features/resume_refinement/CompletePanel";
+import SessionPreparingPanel from "@/features/resume_refinement/SessionPreparingPanel";
+import ConversationHistory from "@/features/resume_refinement/ConversationHistory";
+import ActiveSessionLayout from "@/features/resume_refinement/ActiveSessionLayout";
+import ResumeRefinementHeader from "@/features/resume_refinement/ResumeRefinementHeader";
+import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
+
+interface ActiveSessionViewProps {
+  session: RefinementSession;
+  onStartNew: () => void;
+}
+
+export default function ActiveSessionView({ session, onStartNew }: ActiveSessionViewProps) {
+  // One-time fade on the composer zone when the background preparation
+  // unlocks the session (preparing → active). Passive transition — no
+  // focus is moved; the aria-live heading in SessionPreparingPanel and
+  // the fade are the only signals.
+  const prevStatusRef = useRef(session.status);
+  const [justUnlocked, setJustUnlocked] = useState(false);
+  useEffect(() => {
+    if (prevStatusRef.current === "preparing" && session.status === "active") {
+      setJustUnlocked(true);
+    }
+    prevStatusRef.current = session.status;
+  }, [session.status]);
+
+  const isPreparing = session.status === "preparing" || session.status === "failed";
+  const showWorkSurface = session.status === "active" || session.status === "completed";
+
+  const activeTarget =
+    session.improvement_targets &&
+    session.target_index < session.improvement_targets.length
+      ? session.improvement_targets[session.target_index]
+      : null;
+  const highlightText = activeTarget?.current_text ?? null;
+
+  const draft = (
+    <CurrentDraftPanel
+      markdown={session.current_draft}
+      highlightText={highlightText}
+    />
+  );
+
+  // RIGHT COLUMN: split into two zones.
+  //
+  // HISTORY ZONE — grows to fill available space, independently
+  // scrollable on desktop. On mobile (<lg) rendered SECOND in DOM
+  // order (order-2) so the composer stays visible above it.
+  //
+  // COMPOSER ZONE — shrinks to its natural height; never scrolls.
+  // On desktop (lg+) rendered second in visual flow (order-2).
+  // On mobile rendered first (order-1).
+  const controls = (
+    <div className="flex flex-col gap-2 min-h-0 h-full">
+      {/* History zone */}
+      <div className="order-2 lg:order-1 lg:flex-1 lg:overflow-y-auto lg:min-h-0 pr-1">
+        <ConversationHistory turns={session.turns ?? []} />
+      </div>
+
+      {/* Composer zone */}
+      <div
+        className={`order-1 lg:order-2 shrink-0 ${justUnlocked ? "unlock-fade-in" : ""}`}
+      >
+        {isPreparing && <SessionPreparingPanel session={session} />}
+        {session.status === "active" && (
+          <PendingProposalCard session={session} />
+        )}
+        {/* Gated: CompletePanel's reached-end math treats a null
+            targets list as "done", so rendering it while preparing
+            would show "Mark resume done" before the critique ran. */}
+        {showWorkSurface && <CompletePanel session={session} />}
+      </div>
+    </div>
+  );
+
+  return (
+    <ActiveSessionLayout
+      header={
+        <ResumeRefinementHeader
+          compact
+          onStartNew={onStartNew}
+          startNewLabel={
+            session.status === "preparing" ? "Cancel" : undefined
+          }
+        />
+      }
+      draft={draft}
+      controls={controls}
+    />
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/CompletePanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/CompletePanel.tsx
@@ -18,6 +18,9 @@ export default function CompletePanel({ session }: CompletePanelProps) {
   const targets = session.improvement_targets ?? [];
   const reachedEnd = session.target_index >= targets.length;
   const isCompleted = session.status === "completed";
+  // Critique found nothing to change — still a legitimately "done"
+  // resume, but the copy shouldn't claim the user reviewed anything.
+  const isEmpty = !isCompleted && targets.length === 0;
 
   const [completeSession, { isLoading: isCompleting }] = useCompleteRefinementSessionMutation();
   const [downloading, setDownloading] = useState<"pdf" | "docx" | null>(null);
@@ -66,19 +69,25 @@ export default function CompletePanel({ session }: CompletePanelProps) {
     }
   }
 
+  let heading = "All targets reviewed";
+  let body =
+    "You've gone through every suggestion. Mark the session done to lock the draft, then download.";
+  if (isCompleted) {
+    heading = "All done";
+    body = "Your refined resume is ready to download in either format.";
+  } else if (isEmpty) {
+    heading = "Nothing to flag";
+    body =
+      "We reviewed your draft and didn't find anything worth changing this pass. Mark it done as-is, or make some edits elsewhere and start a fresh session.";
+  }
+
   return (
     <section className="rounded-lg border border-emerald-300/50 bg-emerald-50 dark:bg-emerald-950/20 p-4 space-y-3">
       <header className="flex items-center gap-2">
         <Check className="size-5 text-emerald-600" />
-        <h2 className="text-sm font-semibold">
-          {isCompleted ? "All done" : "All targets reviewed"}
-        </h2>
+        <h2 className="text-sm font-semibold">{heading}</h2>
       </header>
-      <p className="text-sm text-muted-foreground">
-        {isCompleted
-          ? "Your refined resume is ready to download in either format."
-          : "You've gone through every suggestion. Mark the session done to lock the draft, then download."}
-      </p>
+      <p className="text-sm text-muted-foreground">{body}</p>
       <div className="flex flex-wrap gap-2">
         {!isCompleted && (
           <LoadingButton isLoading={isCompleting} onClick={handleComplete}>

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/NoSessionView.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/NoSessionView.tsx
@@ -1,0 +1,15 @@
+import SessionStartPanel from "@/features/resume_refinement/SessionStartPanel";
+import ResumeRefinementHeader from "@/features/resume_refinement/ResumeRefinementHeader";
+
+interface NoSessionViewProps {
+  onSessionStarted: (id: string) => void;
+}
+
+export default function NoSessionView({ onSessionStarted }: NoSessionViewProps) {
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <ResumeRefinementHeader />
+      <SessionStartPanel onSessionStarted={onSessionStarted} />
+    </main>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/PendingProposalCard.tsx
@@ -59,7 +59,12 @@ export default function PendingProposalCard({ session }: PendingProposalCardProp
     alternative.isLoading ||
     skip.isLoading;
 
-  if (totalTargets > 0 && session.target_index >= totalTargets) {
+  // Bail when every target is consumed — AND for the zero-target
+  // session, where there is nothing to suggest (CompletePanel's
+  // "nothing to flag" state owns that render). The old
+  // `totalTargets > 0 &&` clause inverted the zero case and showed a
+  // permanently-thinking "Suggestion 1 / 0" card.
+  if (session.target_index >= totalTargets) {
     return null;
   }
 

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ResumeJobOption.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ResumeJobOption.tsx
@@ -1,0 +1,34 @@
+import type { ResumeUploadJob } from "@/types/resume-upload-job/resume-upload-job";
+
+interface ResumeJobOptionProps {
+  job: ResumeUploadJob;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+export default function ResumeJobOption({ job, selected, onSelect }: ResumeJobOptionProps) {
+  const fields = job.result_parsed_fields;
+  const summary = fields
+    ? `${fields.work_history_count} role${fields.work_history_count === 1 ? "" : "s"}, ${fields.skills_count} skills`
+    : "Parsed resume";
+  const filename = job.file_filename ?? "resume";
+  const uploaded = new Date(job.created_at).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={`w-full text-left rounded-md border p-3 transition ${
+        selected ? "border-primary bg-primary/5" : "border-border hover:bg-muted"
+      }`}
+    >
+      <div className="text-sm font-medium">{filename}</div>
+      <div className="text-xs text-muted-foreground mt-0.5">
+        {summary} · uploaded {uploaded}
+      </div>
+    </button>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/ResumeRefinementHeader.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/ResumeRefinementHeader.tsx
@@ -1,0 +1,47 @@
+import { Sparkles } from "lucide-react";
+
+interface ResumeRefinementHeaderProps {
+  compact?: boolean;
+  onStartNew?: () => void;
+  /** Override the escape-hatch label — "Cancel" while preparing (it's
+   *  an exit from a wait, not a choice among sessions). */
+  startNewLabel?: string;
+}
+
+export default function ResumeRefinementHeader({
+  compact = false,
+  onStartNew,
+  startNewLabel,
+}: ResumeRefinementHeaderProps) {
+  if (compact) {
+    return (
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2">
+          <Sparkles className="size-5 text-primary" />
+          <h1 className="text-lg font-semibold">Resume refinement</h1>
+        </div>
+        {onStartNew && (
+          <button
+            type="button"
+            onClick={onStartNew}
+            className="text-xs underline text-muted-foreground hover:text-foreground"
+          >
+            {startNewLabel ?? "Start a different session"}
+          </button>
+        )}
+      </div>
+    );
+  }
+  return (
+    <header>
+      <div className="flex items-center gap-2">
+        <Sparkles className="size-6 text-primary" />
+        <h1 className="text-2xl font-semibold">Resume refinement</h1>
+      </div>
+      <p className="text-sm text-muted-foreground mt-0.5">
+        Iterate on your resume one bullet at a time. AI suggests, you accept
+        or override, and at the end you download a polished PDF or DOCX.
+      </p>
+    </header>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SessionLoadErrorView.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SessionLoadErrorView.tsx
@@ -1,0 +1,20 @@
+import ResumeRefinementHeader from "@/features/resume_refinement/ResumeRefinementHeader";
+
+interface SessionLoadErrorViewProps {
+  onStartNew: () => void;
+}
+
+export default function SessionLoadErrorView({ onStartNew }: SessionLoadErrorViewProps) {
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <ResumeRefinementHeader />
+      <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
+        We couldn't load that session.{" "}
+        <button type="button" onClick={onStartNew} className="underline">
+          Start a new one
+        </button>
+        .
+      </div>
+    </main>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SessionLoadingView.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SessionLoadingView.tsx
@@ -1,0 +1,12 @@
+import { Skeleton } from "@platform/ui";
+import ResumeRefinementHeader from "@/features/resume_refinement/ResumeRefinementHeader";
+
+export default function SessionLoadingView() {
+  return (
+    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
+      <ResumeRefinementHeader />
+      <Skeleton className="h-32 w-full" />
+      <Skeleton className="h-64 w-full" />
+    </main>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SessionPreparingPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SessionPreparingPanel.tsx
@@ -1,0 +1,124 @@
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { LoadingButton, showError, extractErrorMessage } from "@platform/ui";
+import { useRetryPreparationMutation } from "@/lib/resumeRefinementApi";
+import SuggestionProgressBar from "@/features/resume_refinement/SuggestionProgressBar";
+import {
+  SEVERITY_BADGE_CLASS,
+  SEVERITY_LABEL,
+} from "@/features/resume_refinement/improvement-target-labels";
+import type { ImprovementSeverity } from "@/types/resume-refinement/improvement-target";
+import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
+
+const SEVERITY_ORDER: ImprovementSeverity[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+];
+
+interface SessionPreparingPanelProps {
+  session: RefinementSession;
+}
+
+// Right-column card for the background-preparation window. Stage is
+// derived purely from persisted session fields (status +
+// improvement_targets + proposals_ready_count), so refresh /
+// navigate-away-and-back recompute it correctly from the 3s poll.
+// Honest progress only — no fake bars while the target count is
+// unknown.
+export default function SessionPreparingPanel({ session }: SessionPreparingPanelProps) {
+  const [retryPreparation, retry] = useRetryPreparationMutation();
+
+  async function handleRetry() {
+    try {
+      await retryPreparation(session.id).unwrap();
+    } catch (err) {
+      showError(extractErrorMessage(err));
+    }
+  }
+
+  if (session.status === "failed") {
+    return (
+      <section className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-3">
+        <header className="flex items-center gap-2" role="status" aria-live="polite">
+          <AlertTriangle className="size-5 text-destructive shrink-0" />
+          <h2 className="text-sm font-semibold">
+            Couldn't finish reviewing your resume
+          </h2>
+        </header>
+        <p className="text-sm text-muted-foreground">
+          Claude hit a snag while preparing your session. Nothing's been
+          lost — try again.
+        </p>
+        <div className="flex justify-end">
+          <LoadingButton
+            isLoading={retry.isLoading}
+            loadingText="Retrying…"
+            onClick={handleRetry}
+          >
+            Try again
+          </LoadingButton>
+        </div>
+      </section>
+    );
+  }
+
+  const targets = session.improvement_targets;
+
+  // Critiquing: target count still unknown — prose + spinner, no
+  // skeleton (there is no loaded structure to mirror yet).
+  if (targets === null) {
+    return (
+      <section className="rounded-lg border border-border bg-card p-4 space-y-2">
+        <header className="flex items-center gap-2" role="status" aria-live="polite">
+          <Loader2 className="size-4 animate-spin text-primary shrink-0" />
+          <h2 className="text-sm font-semibold">Reviewing your resume</h2>
+        </header>
+        <p className="text-sm text-muted-foreground">
+          We're finding what's worth tightening — usually takes 15 to 30
+          seconds.
+        </p>
+      </section>
+    );
+  }
+
+  // Drafting: targets known, proposals filling the cache behind the
+  // existing poll. The session unlocks as soon as the first one lands.
+  const total = targets.length;
+  const ready = Math.min(session.proposals_ready_count, total);
+  const plural = total === 1 ? "thing" : "things";
+
+  return (
+    <section className="rounded-lg border border-border bg-card p-4 space-y-3">
+      <header className="flex items-center gap-2" role="status" aria-live="polite">
+        <Loader2 className="size-4 animate-spin text-primary shrink-0" />
+        <h2 className="text-sm font-semibold">
+          Found {total} {plural} to improve
+        </h2>
+      </header>
+      <div className="flex flex-wrap gap-1.5">
+        {SEVERITY_ORDER.map((severity) => {
+          const count = targets.filter((t) => t.severity === severity).length;
+          if (count === 0) return null;
+          return (
+            <span
+              key={severity}
+              className={`inline-flex items-center px-2 py-0.5 rounded-full text-[11px] font-medium ${SEVERITY_BADGE_CLASS[severity]}`}
+            >
+              {count}× {SEVERITY_LABEL[severity]}
+            </span>
+          );
+        })}
+      </div>
+      <SuggestionProgressBar
+        completed={ready}
+        total={total}
+        ariaLabel={`${ready} of ${total} suggestions drafted`}
+      />
+      <p className="text-sm text-muted-foreground">
+        Drafting suggestions — {ready} of {total} ready. The review opens
+        as soon as the first one's done.
+      </p>
+    </section>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SessionStartPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SessionStartPanel.tsx
@@ -74,6 +74,7 @@ export default function SessionStartPanel({ onSessionStarted }: SessionStartPane
       <div className="flex justify-end">
         <LoadingButton
           isLoading={isStarting}
+          loadingText="Starting…"
           disabled={!picked}
           onClick={handleStart}
         >

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SessionStartPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SessionStartPanel.tsx
@@ -10,7 +10,7 @@ import {
 } from "@platform/ui";
 import { useListResumeJobsQuery } from "@/lib/resumesApi";
 import { useStartRefinementSessionMutation } from "@/lib/resumeRefinementApi";
-import type { ResumeUploadJob } from "@/types/resume-upload-job/resume-upload-job";
+import ResumeJobOption from "@/features/resume_refinement/ResumeJobOption";
 
 interface SessionStartPanelProps {
   onSessionStarted: (sessionId: string) => void;
@@ -82,38 +82,5 @@ export default function SessionStartPanel({ onSessionStarted }: SessionStartPane
         </LoadingButton>
       </div>
     </div>
-  );
-}
-
-interface ResumeJobOptionProps {
-  job: ResumeUploadJob;
-  selected: boolean;
-  onSelect: () => void;
-}
-
-function ResumeJobOption({ job, selected, onSelect }: ResumeJobOptionProps) {
-  const fields = job.result_parsed_fields;
-  const summary = fields
-    ? `${fields.work_history_count} role${fields.work_history_count === 1 ? "" : "s"}, ${fields.skills_count} skills`
-    : "Parsed resume";
-  const filename = job.file_filename ?? "resume";
-  const uploaded = new Date(job.created_at).toLocaleDateString(undefined, {
-    year: "numeric",
-    month: "short",
-    day: "numeric",
-  });
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      className={`w-full text-left rounded-md border p-3 transition ${
-        selected ? "border-primary bg-primary/5" : "border-border hover:bg-muted"
-      }`}
-    >
-      <div className="text-sm font-medium">{filename}</div>
-      <div className="text-xs text-muted-foreground mt-0.5">
-        {summary} · uploaded {uploaded}
-      </div>
-    </button>
   );
 }

--- a/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionProgressBar.tsx
+++ b/apps/myjobhunter/frontend/src/features/resume_refinement/SuggestionProgressBar.tsx
@@ -3,6 +3,9 @@ interface SuggestionProgressBarProps {
   completed: number;
   /** Total number of suggestions in the session. */
   total: number;
+  /** Override for non-"resolved" contexts — e.g. the preparing panel's
+   *  drafted-count bar, where nothing has been resolved yet. */
+  ariaLabel?: string;
 }
 
 /**
@@ -14,6 +17,7 @@ interface SuggestionProgressBarProps {
 export default function SuggestionProgressBar({
   completed,
   total,
+  ariaLabel,
 }: SuggestionProgressBarProps) {
   if (total <= 0) return null;
   const ratio = Math.min(Math.max(completed / total, 0), 1);
@@ -24,7 +28,7 @@ export default function SuggestionProgressBar({
       aria-valuemin={0}
       aria-valuemax={total}
       aria-valuenow={completed}
-      aria-label={`${completed} of ${total} suggestions resolved`}
+      aria-label={ariaLabel ?? `${completed} of ${total} suggestions resolved`}
     >
       <div
         className="h-full bg-primary transition-[width] duration-300 ease-out"

--- a/apps/myjobhunter/frontend/src/index.css
+++ b/apps/myjobhunter/frontend/src/index.css
@@ -101,3 +101,20 @@
   .border-border { border-color: hsl(var(--border)); }
   .ring-ring { --tw-ring-color: hsl(var(--ring)); }
 }
+
+/* One-time entrance for the composer zone when background session
+   preparation unlocks (preparing → active) — see ResumeRefinement.tsx. */
+@keyframes mjh-unlock-fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+.unlock-fade-in {
+  animation: mjh-unlock-fade-in 200ms ease-out;
+}

--- a/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
+++ b/apps/myjobhunter/frontend/src/lib/resumeRefinementApi.ts
@@ -79,6 +79,15 @@ const resumeRefinementApi = baseApi
         invalidatesTags: (_result, _err, { id }) => [{ type: REFINEMENT_TAG, id }],
       }),
 
+      retryPreparation: build.mutation<RefinementSession, string>({
+        query: (id) => ({
+          url: `/resume-refinement/sessions/${id}/retry-preparation`,
+          method: "POST",
+          data: {},
+        }),
+        invalidatesTags: (_result, _err, id) => [{ type: REFINEMENT_TAG, id }],
+      }),
+
       completeRefinementSession: build.mutation<RefinementSession, string>({
         query: (id) => ({
           url: `/resume-refinement/sessions/${id}/complete`,
@@ -99,5 +108,6 @@ export const {
   useRequestAlternativeMutation,
   useSkipTargetMutation,
   useNavigateRefinementMutation,
+  useRetryPreparationMutation,
   useCompleteRefinementSessionMutation,
 } = resumeRefinementApi;

--- a/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Sparkles } from "lucide-react";
 import { Skeleton } from "@platform/ui";
 import SessionStartPanel from "@/features/resume_refinement/SessionStartPanel";
 import CurrentDraftPanel from "@/features/resume_refinement/CurrentDraftPanel";
 import PendingProposalCard from "@/features/resume_refinement/PendingProposalCard";
 import CompletePanel from "@/features/resume_refinement/CompletePanel";
+import SessionPreparingPanel from "@/features/resume_refinement/SessionPreparingPanel";
 import ConversationHistory from "@/features/resume_refinement/ConversationHistory";
 import ActiveSessionLayout from "@/features/resume_refinement/ActiveSessionLayout";
 import { useGetRefinementSessionQuery } from "@/lib/resumeRefinementApi";
@@ -115,6 +116,22 @@ interface ActiveSessionViewProps {
 }
 
 function ActiveSessionView({ session, onStartNew }: ActiveSessionViewProps) {
+  // One-time fade on the composer zone when the background preparation
+  // unlocks the session (preparing → active). Passive transition — no
+  // focus is moved; the aria-live heading in SessionPreparingPanel and
+  // the fade are the only signals.
+  const prevStatusRef = useRef(session.status);
+  const [justUnlocked, setJustUnlocked] = useState(false);
+  useEffect(() => {
+    if (prevStatusRef.current === "preparing" && session.status === "active") {
+      setJustUnlocked(true);
+    }
+    prevStatusRef.current = session.status;
+  }, [session.status]);
+
+  const isPreparing = session.status === "preparing" || session.status === "failed";
+  const showWorkSurface = session.status === "active" || session.status === "completed";
+
   const activeTarget =
     session.improvement_targets &&
     session.target_index < session.improvement_targets.length
@@ -146,18 +163,32 @@ function ActiveSessionView({ session, onStartNew }: ActiveSessionViewProps) {
       </div>
 
       {/* Composer zone */}
-      <div className="order-1 lg:order-2 shrink-0">
+      <div
+        className={`order-1 lg:order-2 shrink-0 ${justUnlocked ? "unlock-fade-in" : ""}`}
+      >
+        {isPreparing && <SessionPreparingPanel session={session} />}
         {session.status === "active" && (
           <PendingProposalCard session={session} />
         )}
-        <CompletePanel session={session} />
+        {/* Gated: CompletePanel's reached-end math treats a null
+            targets list as "done", so rendering it while preparing
+            would show "Mark resume done" before the critique ran. */}
+        {showWorkSurface && <CompletePanel session={session} />}
       </div>
     </div>
   );
 
   return (
     <ActiveSessionLayout
-      header={<ResumeRefinementHeader compact onStartNew={onStartNew} />}
+      header={
+        <ResumeRefinementHeader
+          compact
+          onStartNew={onStartNew}
+          startNewLabel={
+            session.status === "preparing" ? "Cancel" : undefined
+          }
+        />
+      }
       draft={draft}
       controls={controls}
     />
@@ -167,9 +198,16 @@ function ActiveSessionView({ session, onStartNew }: ActiveSessionViewProps) {
 interface ResumeRefinementHeaderProps {
   compact?: boolean;
   onStartNew?: () => void;
+  /** Override the escape-hatch label — "Cancel" while preparing (it's
+   *  an exit from a wait, not a choice among sessions). */
+  startNewLabel?: string;
 }
 
-function ResumeRefinementHeader({ compact = false, onStartNew }: ResumeRefinementHeaderProps) {
+function ResumeRefinementHeader({
+  compact = false,
+  onStartNew,
+  startNewLabel,
+}: ResumeRefinementHeaderProps) {
   if (compact) {
     return (
       <div className="flex items-center justify-between gap-2">
@@ -183,7 +221,7 @@ function ResumeRefinementHeader({ compact = false, onStartNew }: ResumeRefinemen
             onClick={onStartNew}
             className="text-xs underline text-muted-foreground hover:text-foreground"
           >
-            Start a different session
+            {startNewLabel ?? "Start a different session"}
           </button>
         )}
       </div>

--- a/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
+++ b/apps/myjobhunter/frontend/src/pages/ResumeRefinement.tsx
@@ -1,15 +1,9 @@
-import { useEffect, useRef, useState } from "react";
-import { Sparkles } from "lucide-react";
-import { Skeleton } from "@platform/ui";
-import SessionStartPanel from "@/features/resume_refinement/SessionStartPanel";
-import CurrentDraftPanel from "@/features/resume_refinement/CurrentDraftPanel";
-import PendingProposalCard from "@/features/resume_refinement/PendingProposalCard";
-import CompletePanel from "@/features/resume_refinement/CompletePanel";
-import SessionPreparingPanel from "@/features/resume_refinement/SessionPreparingPanel";
-import ConversationHistory from "@/features/resume_refinement/ConversationHistory";
-import ActiveSessionLayout from "@/features/resume_refinement/ActiveSessionLayout";
+import { useState } from "react";
+import NoSessionView from "@/features/resume_refinement/NoSessionView";
+import SessionLoadErrorView from "@/features/resume_refinement/SessionLoadErrorView";
+import SessionLoadingView from "@/features/resume_refinement/SessionLoadingView";
+import ActiveSessionView from "@/features/resume_refinement/ActiveSessionView";
 import { useGetRefinementSessionQuery } from "@/lib/resumeRefinementApi";
-import type { RefinementSession } from "@/types/resume-refinement/refinement-session";
 
 const ACTIVE_SESSION_KEY = "mjh:resumeRefinementSessionId";
 const POLL_INTERVAL_MS = 3000;
@@ -19,6 +13,12 @@ export default function ResumeRefinement() {
     typeof window !== "undefined" ? window.localStorage.getItem(ACTIVE_SESSION_KEY) : null,
   );
 
+  // Polling is intentionally not stopped once the session is no
+  // longer active — the data is stable post-completion so the cost
+  // is one tiny GET every 3s, and stopping introduces a stale-cache
+  // edge case if the user returns to a completed session and
+  // downloads. During status=preparing the same poll drives the
+  // staged progress card and the unlock.
   const {
     data: session,
     isLoading,
@@ -27,15 +27,6 @@ export default function ResumeRefinement() {
     skip: !sessionId,
     pollingInterval: sessionId ? POLL_INTERVAL_MS : 0,
   });
-
-  // Polling is intentionally not stopped once the session is no
-  // longer active — the data is stable post-completion so the cost
-  // is one tiny GET every 3s, and stopping introduces a stale-cache
-  // edge case if the user returns to a completed session and
-  // downloads.
-  useEffect(() => {
-    if (!session) return;
-  }, [session]);
 
   function handleSessionStarted(id: string) {
     if (typeof window !== "undefined") {
@@ -63,180 +54,5 @@ export default function ResumeRefinement() {
     return <SessionLoadingView />;
   }
 
-  return (
-    <ActiveSessionView session={session} onStartNew={handleStartNew} />
-  );
-}
-
-interface NoSessionViewProps {
-  onSessionStarted: (id: string) => void;
-}
-
-function NoSessionView({ onSessionStarted }: NoSessionViewProps) {
-  return (
-    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
-      <ResumeRefinementHeader />
-      <SessionStartPanel onSessionStarted={onSessionStarted} />
-    </main>
-  );
-}
-
-interface SessionLoadErrorViewProps {
-  onStartNew: () => void;
-}
-
-function SessionLoadErrorView({ onStartNew }: SessionLoadErrorViewProps) {
-  return (
-    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
-      <ResumeRefinementHeader />
-      <div className="rounded-md border border-destructive/30 bg-destructive/5 p-3 text-sm">
-        We couldn't load that session.{" "}
-        <button type="button" onClick={onStartNew} className="underline">
-          Start a new one
-        </button>
-        .
-      </div>
-    </main>
-  );
-}
-
-function SessionLoadingView() {
-  return (
-    <main className="p-4 sm:p-8 space-y-6 max-w-3xl">
-      <ResumeRefinementHeader />
-      <Skeleton className="h-32 w-full" />
-      <Skeleton className="h-64 w-full" />
-    </main>
-  );
-}
-
-interface ActiveSessionViewProps {
-  session: RefinementSession;
-  onStartNew: () => void;
-}
-
-function ActiveSessionView({ session, onStartNew }: ActiveSessionViewProps) {
-  // One-time fade on the composer zone when the background preparation
-  // unlocks the session (preparing → active). Passive transition — no
-  // focus is moved; the aria-live heading in SessionPreparingPanel and
-  // the fade are the only signals.
-  const prevStatusRef = useRef(session.status);
-  const [justUnlocked, setJustUnlocked] = useState(false);
-  useEffect(() => {
-    if (prevStatusRef.current === "preparing" && session.status === "active") {
-      setJustUnlocked(true);
-    }
-    prevStatusRef.current = session.status;
-  }, [session.status]);
-
-  const isPreparing = session.status === "preparing" || session.status === "failed";
-  const showWorkSurface = session.status === "active" || session.status === "completed";
-
-  const activeTarget =
-    session.improvement_targets &&
-    session.target_index < session.improvement_targets.length
-      ? session.improvement_targets[session.target_index]
-      : null;
-  const highlightText = activeTarget?.current_text ?? null;
-
-  const draft = (
-    <CurrentDraftPanel
-      markdown={session.current_draft}
-      highlightText={highlightText}
-    />
-  );
-
-  // RIGHT COLUMN: split into two zones.
-  //
-  // HISTORY ZONE — grows to fill available space, independently
-  // scrollable on desktop. On mobile (<lg) rendered SECOND in DOM
-  // order (order-2) so the composer stays visible above it.
-  //
-  // COMPOSER ZONE — shrinks to its natural height; never scrolls.
-  // On desktop (lg+) rendered second in visual flow (order-2).
-  // On mobile rendered first (order-1).
-  const controls = (
-    <div className="flex flex-col gap-2 min-h-0 h-full">
-      {/* History zone */}
-      <div className="order-2 lg:order-1 lg:flex-1 lg:overflow-y-auto lg:min-h-0 pr-1">
-        <ConversationHistory turns={session.turns ?? []} />
-      </div>
-
-      {/* Composer zone */}
-      <div
-        className={`order-1 lg:order-2 shrink-0 ${justUnlocked ? "unlock-fade-in" : ""}`}
-      >
-        {isPreparing && <SessionPreparingPanel session={session} />}
-        {session.status === "active" && (
-          <PendingProposalCard session={session} />
-        )}
-        {/* Gated: CompletePanel's reached-end math treats a null
-            targets list as "done", so rendering it while preparing
-            would show "Mark resume done" before the critique ran. */}
-        {showWorkSurface && <CompletePanel session={session} />}
-      </div>
-    </div>
-  );
-
-  return (
-    <ActiveSessionLayout
-      header={
-        <ResumeRefinementHeader
-          compact
-          onStartNew={onStartNew}
-          startNewLabel={
-            session.status === "preparing" ? "Cancel" : undefined
-          }
-        />
-      }
-      draft={draft}
-      controls={controls}
-    />
-  );
-}
-
-interface ResumeRefinementHeaderProps {
-  compact?: boolean;
-  onStartNew?: () => void;
-  /** Override the escape-hatch label — "Cancel" while preparing (it's
-   *  an exit from a wait, not a choice among sessions). */
-  startNewLabel?: string;
-}
-
-function ResumeRefinementHeader({
-  compact = false,
-  onStartNew,
-  startNewLabel,
-}: ResumeRefinementHeaderProps) {
-  if (compact) {
-    return (
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          <Sparkles className="size-5 text-primary" />
-          <h1 className="text-lg font-semibold">Resume refinement</h1>
-        </div>
-        {onStartNew && (
-          <button
-            type="button"
-            onClick={onStartNew}
-            className="text-xs underline text-muted-foreground hover:text-foreground"
-          >
-            {startNewLabel ?? "Start a different session"}
-          </button>
-        )}
-      </div>
-    );
-  }
-  return (
-    <header>
-      <div className="flex items-center gap-2">
-        <Sparkles className="size-6 text-primary" />
-        <h1 className="text-2xl font-semibold">Resume refinement</h1>
-      </div>
-      <p className="text-sm text-muted-foreground mt-0.5">
-        Iterate on your resume one bullet at a time. AI suggests, you accept
-        or override, and at the end you download a polished PDF or DOCX.
-      </p>
-    </header>
-  );
+  return <ActiveSessionView session={session} onStartNew={handleStartNew} />;
 }

--- a/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-session.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-refinement/refinement-session.ts
@@ -1,7 +1,12 @@
 import type { ImprovementTarget } from "./improvement-target";
 import type { RefinementTurn } from "./refinement-turn";
 
-export type RefinementSessionStatus = "active" | "completed" | "abandoned";
+export type RefinementSessionStatus =
+  | "preparing"
+  | "active"
+  | "completed"
+  | "abandoned"
+  | "failed";
 
 export interface RefinementSession {
   id: string;
@@ -20,6 +25,8 @@ export interface RefinementSession {
   total_tokens_in: number;
   total_tokens_out: number;
   total_cost_usd: string;
+  error_message: string | null;
+  proposals_ready_count: number;
   completed_at: string | null;
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## Problem

Operator walkthrough item 1: **Start refinement blocks 1–2 minutes behind a dead button spinner.** `POST /resume-refinement/sessions` ran the critique pass plus a prefetch of every target proposal synchronously — also fragile as a 90s+ request against the 2-minute Caddy timeouts from #844.

## What changed

**Backend** — `start_session` creates the session in `status="preparing"` and returns in <1s (initial draft renders inline; it's a cheap profile-table read). The critique + prefetch moved to `prepare_session`, which runs in the **same worker process as the resume parser** (new poll step in `resume_parser_worker.main` → `refinement_prepare_worker.process_one_session`) — **no new container, no compose change, no operational migration**. Atomic claim (`UPDATE … FOR UPDATE SKIP LOCKED` on `preparation_started_at`) mirrors `resume_upload_jobs`; transient Claude errors release the claim for the next poll, permanent errors mark the session `failed` with `error_message`. `POST /sessions/{id}/retry-preparation` re-queues a failed preparation, resuming from the prefetch (critique output survives — retry never re-spends the critique call).

Guarantees baked in (per the g-design-ux pass):
- **Unlock gate**: never flips to `active` unless target 0 has a real proposal/clarify — `GET /sessions/{id}` is a pure read, so unlocking early would strand the user on a permanently-stuck placeholder.
- **Zero-target critique** unlocks straight into a "Nothing to flag" completion state instead of waiting for a first proposal that can't exist.

**Frontend** — new `SessionPreparingPanel` fed by the existing 3s poll, with honest staged copy (no fake progress): "Reviewing your resume" → "Found N things to improve" + severity badges + "Drafting suggestions — k of N ready" (`proposals_ready_count`, new computed field) → 200ms unlock fade (no focus stealing; `aria-live="polite"` on the stage heading). Failed state = "Try again" card. Header escape hatch reads **Cancel** while preparing. Status union widened cross-stack in the same PR.

**Two pre-existing bugs fixed** (surfaced by the design pass): `CompletePanel` rendered "Mark resume done" whenever `improvement_targets` was null (reached-end math treats null as done — it would have shown during preparing), and `PendingProposalCard`'s zero-target guard was inverted (`totalTargets > 0 &&`), showing a permanently-thinking "Suggestion 1 / 0" card.

**Gate-compliance refactor** (second commit): one component per file (page views + header + ResumeJobOption extracted) and repo-owned persistence (`clear_pending_state` / `bump_turn_count` / `persist_prefetch_results` replace direct `db.flush/commit` in services).

## Migration

`prep260702` — widens the session-status check constraint (+`preparing`/`failed`), adds `error_message` + `preparation_started_at`. Additive, no backfill, previous image keeps working on rollback. **No VPS action required.**

## Verification

- 76 refinement-shard tests pass (7 new: fast return / worker happy path / retry idempotency / zero-target / unlock gate / retry guards)
- Frontend `tsc --noEmit` + production build pass
- Local-dev note: exercising the full async flow locally requires the worker process (`python -m app.workers.resume_parser_worker`), same as resume uploads already do

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHo57XAZpGMGwtvp8w1fQY