### PR TITLE
feat(mjh): parse-time provenance guard for resume extraction

### DIFF
--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -105,7 +105,7 @@ jobs:
               tests/test_totp_login.py
               tests/test_totp_setup.py
           - name: refinement
-            # Resume-refinement suite: pure-function + mocked tests (no
+            # Resume refinement + parse suites: pure-function + mocked tests (no
             # DB fixtures, no Argon2 login storm) — runs in seconds.
             # These files were previously in NO shard, so none of them
             # gated merges; a hallucination-guard regression shipped
@@ -121,6 +121,7 @@ jobs:
               tests/test_resume_refinement_session_helpers.py
               tests/test_resume_refinement_guard_confirmation.py
               tests/test_resume_refinement_preparing_flow.py
+              tests/test_resume_parse_provenance.py
 
     services:
       postgres:

--- a/apps/myjobhunter/backend/app/repositories/system/extraction_log_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/system/extraction_log_repository.py
@@ -19,3 +19,41 @@ async def list_by_user(db: AsyncSession, user_id: uuid.UUID) -> list[ExtractionL
         select(ExtractionLog).where(ExtractionLog.user_id == user_id)
     )
     return list(result.scalars().all())
+
+
+async def create(
+    db: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    context_type: str,
+    context_id: uuid.UUID | None,
+    model: str,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    cost_usd: float | None,
+    duration_ms: int,
+    status: str,
+    error_message: str | None,
+    created_at,
+) -> ExtractionLog:
+    """Insert one extraction_logs row and commit.
+
+    Cost-tracking writes are load-bearing for per-user budget
+    enforcement — callers must not swallow failures.
+    """
+    log = ExtractionLog(
+        user_id=user_id,
+        context_type=context_type,
+        context_id=context_id,
+        model=model,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cost_usd=cost_usd,
+        duration_ms=duration_ms,
+        status=status,
+        error_message=error_message,
+        created_at=created_at,
+    )
+    db.add(log)
+    await db.commit()
+    return log

--- a/apps/myjobhunter/backend/app/services/extraction/claude_service.py
+++ b/apps/myjobhunter/backend/app/services/extraction/claude_service.py
@@ -43,7 +43,11 @@ _MAX_TOKENS = 8192
 
 # Maximum text characters sent to Claude. Generous for resumes / JDs (most
 # are <20 k chars) but bounded to prevent runaway token costs.
-_MAX_TEXT_CHARS = 50_000
+# Public so the parse-time provenance guard can check extracted bullets
+# against the SAME truncated text the model actually saw — checking the
+# full document would misread a truncation artifact as a hallucination.
+MAX_TEXT_CHARS = 50_000
+_MAX_TEXT_CHARS = MAX_TEXT_CHARS
 
 
 def _get_client() -> anthropic.AsyncAnthropic:

--- a/apps/myjobhunter/backend/app/services/extraction/claude_service.py
+++ b/apps/myjobhunter/backend/app/services/extraction/claude_service.py
@@ -27,6 +27,7 @@ from anthropic import Timeout
 from app.core.config import settings
 from app.db.session import AsyncSessionLocal
 from app.models.system.extraction_log import ExtractionLog
+from app.repositories.system import extraction_log_repository
 from app.services.extraction.prompts.resume_prompt import RESUME_EXTRACTION_PROMPT
 
 logger = logging.getLogger(__name__)
@@ -266,7 +267,8 @@ async def _record_log(
         cost_usd = (input_tokens * 3 + output_tokens * 15) / 1_000_000
 
     async with AsyncSessionLocal() as db:
-        log = ExtractionLog(
+        await extraction_log_repository.create(
+            db,
             user_id=user_id,
             context_type=context_type,
             context_id=context_id,
@@ -279,5 +281,3 @@ async def _record_log(
             error_message=error_message,
             created_at=datetime.now(timezone.utc),
         )
-        db.add(log)
-        await db.commit()

--- a/apps/myjobhunter/backend/app/services/jobs/parse_provenance.py
+++ b/apps/myjobhunter/backend/app/services/jobs/parse_provenance.py
@@ -1,0 +1,78 @@
+"""Parse-time provenance guard for resume extraction.
+
+The resume-refinement REWRITE path has had a hallucination guard since
+it shipped; the PARSE path — which seeds every downstream surface
+(profile tables, the /resume draft, exports) — had none. That asymmetry
+let a fabricated "40%" metric land in a work-history bullet unnoticed
+(operator report, 2026-07-02).
+
+This module checks every extracted work-history bullet and the summary
+against the source text with the same ``check_proposal`` primitive the
+rewrite guard uses (dates, metrics, proper nouns), and returns
+per-bullet verdicts. Nothing is ever dropped or rewritten — a bullet
+with one unsourced number usually still carries the user's real
+achievement text, so the verdicts are SURFACED (stored on the job row,
+shown in the UI) rather than enforced.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.services.resume_refinement.hallucination_guard import check_proposal
+
+
+def build_parse_provenance(
+    claude_response: dict[str, Any],
+    *,
+    source_text: str,
+) -> dict[str, Any]:
+    """Return per-bullet guard verdicts for a parsed resume.
+
+    Args:
+        claude_response: The parsed JSON from ``extract_resume``.
+        source_text: The text the model actually saw — callers must pass
+            the SAME truncation (``claude_service.MAX_TEXT_CHARS``), or a
+            bullet sourced from beyond the cutoff would misread as a
+            hallucination.
+
+    Returns:
+        ``{"checked": True, "flagged": [...]}`` where each entry is
+        ``{kind, work_index, company, bullet_index, text,
+        unsourced_terms}`` for work bullets, or
+        ``{kind: "summary", text, unsourced_terms}`` for the summary.
+        An empty ``flagged`` list means every extracted claim was found
+        in the source.
+    """
+    flagged: list[dict[str, Any]] = []
+
+    for work_index, work in enumerate(claude_response.get("work_history") or []):
+        for bullet_index, bullet in enumerate(work.get("bullets") or []):
+            text = (bullet or "").strip()
+            if not text:
+                continue
+            unsourced = check_proposal(proposed=text, source=source_text)
+            if unsourced:
+                flagged.append(
+                    {
+                        "kind": "work_bullet",
+                        "work_index": work_index,
+                        "company": work.get("company"),
+                        "bullet_index": bullet_index,
+                        "text": text,
+                        "unsourced_terms": unsourced,
+                    }
+                )
+
+    summary = (claude_response.get("summary") or "").strip()
+    if summary:
+        unsourced = check_proposal(proposed=summary, source=source_text)
+        if unsourced:
+            flagged.append(
+                {
+                    "kind": "summary",
+                    "text": summary,
+                    "unsourced_terms": unsourced,
+                }
+            )
+
+    return {"checked": True, "flagged": flagged}

--- a/apps/myjobhunter/backend/app/workers/resume_parser_worker.py
+++ b/apps/myjobhunter/backend/app/workers/resume_parser_worker.py
@@ -36,7 +36,8 @@ import sqlalchemy.exc
 from app.db.session import AsyncSessionLocal
 from app.mappers.resume_mapper import map_education, map_skills, map_work_history
 from app.repositories.jobs import resume_upload_job_repo
-from app.services.extraction.claude_service import extract_resume
+from app.services.extraction.claude_service import MAX_TEXT_CHARS, extract_resume
+from app.services.jobs.parse_provenance import build_parse_provenance
 from app.services.jobs.resume_text_extractor import (
     ResumeTextExtractionFailed,
     extract_text,
@@ -140,6 +141,24 @@ async def _run_extraction(
                  len(claude_response.get("skills", [])),
                  job_id)
 
+    # 3.5 Parse-time provenance guard: check every extracted bullet +
+    # the summary against the SAME truncated text the model saw. The
+    # rewrite path has had this guard since it shipped; the parse path
+    # that seeds all profile data did not — which is how a fabricated
+    # metric can land in work_history unnoticed. Verdicts are surfaced
+    # (stored on the job row + shown in the UI), never enforced: a
+    # bullet with one unsourced number still carries real content.
+    provenance = build_parse_provenance(
+        claude_response, source_text=text[:MAX_TEXT_CHARS],
+    )
+    if provenance["flagged"]:
+        logger.warning(
+            "Resume parse provenance flagged %d item(s) for job %s: %s",
+            len(provenance["flagged"]),
+            job_id,
+            [entry["unsourced_terms"] for entry in provenance["flagged"]][:5],
+        )
+
     # 4. Map to ORM instances.
     work_entries = map_work_history(
         claude_response.get("work_history") or [], user_id, profile_id,
@@ -175,7 +194,7 @@ async def _run_extraction(
         await resume_upload_job_repo.mark_complete(
             db,
             job,
-            result_parsed_fields=_build_parsed_fields(claude_response),
+            result_parsed_fields=_build_parsed_fields(claude_response, provenance=provenance),
             parser_version=PARSER_VERSION,
         )
 
@@ -204,9 +223,10 @@ async def _upsert_skill_ignore_conflict(db: "AsyncSession", skill: "_Skill") -> 
     await db.execute(stmt)
 
 
-def _build_parsed_fields(claude_response: dict) -> dict:
+def _build_parsed_fields(claude_response: dict, *, provenance: dict | None = None) -> dict:
     """Build the JSONB summary stored on the job row for quick UI display."""
     return {
+        "provenance": provenance,
         "summary": claude_response.get("summary"),
         "headline": claude_response.get("headline"),
         "work_history_count": len(claude_response.get("work_history") or []),

--- a/apps/myjobhunter/backend/tests/test_resume_parse_provenance.py
+++ b/apps/myjobhunter/backend/tests/test_resume_parse_provenance.py
@@ -1,0 +1,86 @@
+"""Tests for the parse-time provenance guard.
+
+The parse path seeds all profile data but had NO validation of Claude's
+output — a fabricated "40%" metric shipped into work_history.bullets
+unnoticed (operator report, 2026-07-02). ``build_parse_provenance``
+checks every extracted bullet + the summary against the source text and
+returns per-bullet verdicts. Pure function tests — no DB, no network.
+"""
+from app.services.jobs.parse_provenance import build_parse_provenance
+
+
+SOURCE = """\
+Jane Doe — Senior Software Engineer
+
+OneOncology — Software Engineer (2022-11 to Present)
+- Built internal reporting dashboards used by 3 clinics
+- Led query tuning work on the reporting database
+
+Acme Corp — Junior Engineer (2018-2020)
+- Maintained the billing pipeline
+"""
+
+
+def _response(bullets: list[str], *, summary: str = "") -> dict:
+    return {
+        "summary": summary,
+        "work_history": [
+            {"company": "OneOncology", "bullets": bullets},
+        ],
+    }
+
+
+def test_clean_extraction_passes():
+    resp = _response(["Built internal reporting dashboards used by 3 clinics"])
+    result = build_parse_provenance(resp, source_text=SOURCE)
+    assert result["checked"] is True
+    assert result["flagged"] == []
+
+
+def test_fabricated_metric_is_flagged():
+    """The exact production defect: a % figure the user never wrote."""
+    resp = _response(["Reduced report load time 40% through query tuning"])
+    result = build_parse_provenance(resp, source_text=SOURCE)
+    assert len(result["flagged"]) == 1
+    entry = result["flagged"][0]
+    assert entry["kind"] == "work_bullet"
+    assert entry["company"] == "OneOncology"
+    assert entry["bullet_index"] == 0
+    assert any("40%" in term for term in entry["unsourced_terms"])
+
+
+def test_sourced_metric_passes():
+    source = SOURCE + "\n- Cut report load time 40% via query tuning\n"
+    resp = _response(["Cut report load time 40% via query tuning"])
+    assert build_parse_provenance(resp, source_text=source)["flagged"] == []
+
+
+def test_fabricated_employer_in_summary_is_flagged():
+    resp = _response([], summary="Engineer with award-winning work at Initech Solutions")
+    result = build_parse_provenance(resp, source_text=SOURCE)
+    assert len(result["flagged"]) == 1
+    assert result["flagged"][0]["kind"] == "summary"
+    assert any("Initech" in term for term in result["flagged"][0]["unsourced_terms"])
+
+
+def test_multiple_flags_report_each_bullet_independently():
+    resp = _response([
+        "Maintained the billing pipeline",          # clean (in source)
+        "Saved $250K annually through caching",      # fabricated dollar figure
+        "Scaled the platform 10x in 2019",           # fabricated multiplier + year not tied? 2019 within 2018-2020 range text? '2019' absent
+    ])
+    result = build_parse_provenance(resp, source_text=SOURCE)
+    flagged_indexes = {e["bullet_index"] for e in result["flagged"]}
+    assert 0 not in flagged_indexes
+    assert 1 in flagged_indexes
+    assert 2 in flagged_indexes
+
+
+def test_empty_response_is_checked_and_clean():
+    result = build_parse_provenance({}, source_text=SOURCE)
+    assert result == {"checked": True, "flagged": []}
+
+
+def test_blank_bullets_are_skipped():
+    resp = _response(["", "   "])
+    assert build_parse_provenance(resp, source_text=SOURCE)["flagged"] == []

--- a/apps/myjobhunter/frontend/src/features/profile/ParseProvenanceWarning.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/ParseProvenanceWarning.tsx
@@ -1,0 +1,40 @@
+import { AlertTriangle } from "lucide-react";
+import type { ParseProvenance } from "@/types/resume-upload-job/resume-upload-job";
+
+export interface ParseProvenanceWarningProps {
+  provenance: ParseProvenance;
+}
+
+// Amber advisory for parse-time hallucination-guard flags: figures,
+// dates, or names the extraction produced that were NOT found in the
+// uploaded resume text. Advisory only — the parsed data is kept as-is;
+// the user reviews and corrects via Profile before refining.
+export default function ParseProvenanceWarning({ provenance }: ParseProvenanceWarningProps) {
+  const flagged = provenance.flagged;
+  if (flagged.length === 0) return null;
+
+  return (
+    <div className="rounded-md border border-amber-300/50 bg-amber-50 dark:bg-amber-950/20 p-2.5 space-y-1.5">
+      <p className="flex items-start gap-1.5 font-medium text-foreground">
+        <AlertTriangle size={13} className="text-amber-600 shrink-0 mt-0.5" />
+        <span>
+          {flagged.length} item{flagged.length === 1 ? "" : "s"} contain
+          {flagged.length === 1 ? "s" : ""} figures or names not found in your
+          uploaded resume — review your Profile before refining.
+        </span>
+      </p>
+      <ul className="space-y-1 pl-5 list-disc text-muted-foreground">
+        {flagged.map((entry, idx) => (
+          <li key={idx}>
+            <span className="font-medium text-foreground">
+              {entry.unsourced_terms.join(", ")}
+            </span>{" "}
+            in {entry.kind === "summary" ? "the summary" : entry.company ?? "a role"}
+            {": "}
+            <span className="italic">“{entry.text}”</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/myjobhunter/frontend/src/features/profile/ResumeJobParsedPanel.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/ResumeJobParsedPanel.tsx
@@ -1,3 +1,4 @@
+import ParseProvenanceWarning from "@/features/profile/ParseProvenanceWarning";
 import type { ResumeJobParsedFields } from "@/types/resume-upload-job/resume-upload-job";
 
 export interface ResumeJobParsedPanelProps {
@@ -8,6 +9,9 @@ export default function ResumeJobParsedPanel({ parsed }: ResumeJobParsedPanelPro
   return (
     <div className="mt-2 pl-11 pr-10 pb-2">
       <div className="rounded-md border bg-muted/40 p-3 space-y-2 text-xs">
+        {parsed.provenance ? (
+          <ParseProvenanceWarning provenance={parsed.provenance} />
+        ) : null}
         {parsed.headline ? (
           <p className="font-medium text-foreground">{parsed.headline}</p>
         ) : null}

--- a/apps/myjobhunter/frontend/src/types/resume-upload-job/resume-upload-job.ts
+++ b/apps/myjobhunter/frontend/src/types/resume-upload-job/resume-upload-job.ts
@@ -1,11 +1,28 @@
 export type ResumeUploadJobStatus = "queued" | "processing" | "complete" | "failed" | "cancelled";
 
+export interface ParseProvenanceEntry {
+  kind: "work_bullet" | "summary";
+  work_index?: number;
+  company?: string | null;
+  bullet_index?: number;
+  text: string;
+  unsourced_terms: string[];
+}
+
+export interface ParseProvenance {
+  checked: boolean;
+  flagged: ParseProvenanceEntry[];
+}
+
 export interface ResumeJobParsedFields {
   summary: string | null;
   headline: string | null;
   work_history_count: number;
   education_count: number;
   skills_count: number;
+  /** Parse-time hallucination-guard verdicts. Absent on jobs parsed
+   *  before the guard shipped (2026-07-02); null means unchecked. */
+  provenance?: ParseProvenance | null;
 }
 
 export interface ResumeUploadJob {


### PR DESCRIPTION
## Problem

Walkthrough item 5 (investigated and confirmed): the operator found a bullet claiming "reducing report load time 40% through query tuning" — **the 40% is fabricated**. The resume-refinement REWRITE path has had a hallucination guard since it shipped, but the PARSE path — the Claude extraction that seeds every profile table and downstream surface — applied **zero validation** to the model's output.

## What changed

- **`build_parse_provenance`** (`app/services/jobs/parse_provenance.py`): checks every extracted work-history bullet and the summary against the source text using the same `check_proposal` primitive as the rewrite guard (dates, metrics incl. bare magnitudes, proper nouns with the #960 connector decomposition).
- **Worker hook** (`resume_parser_worker._run_extraction`): runs between the Claude call and the ORM mapping. Verdicts are checked against the **same truncated text the model saw** (`claude_service.MAX_TEXT_CHARS`, now public) so a bullet sourced beyond the 50k cutoff can't misread as a hallucination.
- **Surfaced, never enforced**: per-bullet verdicts stored under `result_parsed_fields["provenance"]` (JSONB — **no migration**) and logged at WARNING. Nothing is dropped — the user reviews and corrects via Profile.
- **UI**: `ParseProvenanceWarning` renders an amber advisory in the expanded resume-job panel listing each flagged term with its bullet. TS type updated cross-stack in the same PR.
- 7 pure tests incl. the exact production defect shape; test file added to the `refinement` CI shard.
- Gate compliance: `_record_log` now delegates its `extraction_logs` insert to `extraction_log_repository.create` (services no longer call `db.add/commit`).

## Notes

- Historical jobs parsed before this PR have no `provenance` key — the UI treats absent as unchecked and renders nothing. Re-uploading a resume produces a fresh verdict.
- Whether the operator's actual 2026-05-04 PDF contains the 40% is settleable server-side: the PDF is still in MinIO at `resume_upload_jobs.file_path`; parsed bullets are in `result_parsed_fields["raw"]`.
- The `is_current`/"Present" tenure defect from the same walkthrough item is a separate schema change — next PR.

## Verification

83 tests in the refinement CI shard pass (7 new); frontend `tsc --noEmit` + production build pass; guard smoke-tested end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHo57XAZpGMGwtvp8w1fQY