### PR TITLE
fix(mjh): persist work_history.is_current + fix headline dict TypeError

### DIFF
--- a/.github/workflows/ci-myjobhunter.yml
+++ b/.github/workflows/ci-myjobhunter.yml
@@ -122,6 +122,7 @@ jobs:
               tests/test_resume_refinement_guard_confirmation.py
               tests/test_resume_refinement_preparing_flow.py
               tests/test_resume_parse_provenance.py
+              tests/test_resume_mapper.py
 
     services:
       postgres:

--- a/apps/myjobhunter/backend/alembic/versions/iscur260702_work_history_is_current.py
+++ b/apps/myjobhunter/backend/alembic/versions/iscur260702_work_history_is_current.py
@@ -1,0 +1,60 @@
+"""work_history.is_current — persist the "Present" flag explicitly.
+
+"Present" used to be derived from ``end_date IS NULL`` everywhere a work
+history row was rendered. That conflates two different states: "this role
+is ongoing" and "this role's end date is unknown". Claude's resume
+extraction already returns an ``is_current`` flag per role, but the mapper
+discarded it because there was no column to store it in — so a past role
+whose end date didn't parse rendered as "Present".
+
+Backfill sets ``is_current = TRUE`` where ``end_date IS NULL`` so existing
+rows keep rendering exactly as they did before this migration; users fix
+genuinely-wrong rows in the Profile UI.
+
+The check constraint enforces the invariant that a current role cannot
+also carry an end date, mirroring the extraction prompt's contract
+(``ends_on`` is null for current roles).
+
+Revision ID: iscur260702
+Revises: prep260702
+Create Date: 2026-07-02
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision: str = "iscur260702"
+down_revision: Union[str, None] = "prep260702"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "work_history",
+        sa.Column(
+            "is_current",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.text("false"),
+        ),
+    )
+    # Preserve pre-migration rendering: rows without an end date were
+    # displayed as "Present", so they start out flagged current.
+    op.execute("UPDATE work_history SET is_current = TRUE WHERE end_date IS NULL")
+    op.create_check_constraint(
+        "chk_work_history_current_no_end_date",
+        "work_history",
+        "NOT (is_current AND end_date IS NOT NULL)",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "chk_work_history_current_no_end_date",
+        "work_history",
+        type_="check",
+    )
+    op.drop_column("work_history", "is_current")

--- a/apps/myjobhunter/backend/app/api/profile.py
+++ b/apps/myjobhunter/backend/app/api/profile.py
@@ -60,6 +60,7 @@ from app.schemas.profile.work_history_response import WorkHistoryResponse
 from app.schemas.profile.work_history_update_request import WorkHistoryUpdateRequest
 from app.services.profile import profile_service
 from app.services.profile.profile_service import (
+    CurrentRoleEndDateError,
     DuplicateScreeningAnswerError,
     DuplicateSkillError,
     InvalidScreeningKeyError,
@@ -145,7 +146,10 @@ async def update_work_history(
     db: AsyncSession = Depends(get_db),
     user: User = Depends(current_active_user),
 ) -> WorkHistoryResponse:
-    entry = await profile_service.update_work_history(db, user.id, work_history_id, payload)
+    try:
+        entry = await profile_service.update_work_history(db, user.id, work_history_id, payload)
+    except CurrentRoleEndDateError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
     if entry is None:
         raise HTTPException(status_code=404, detail=_NOT_FOUND_WORK_HISTORY)
     return WorkHistoryResponse.model_validate(entry)

--- a/apps/myjobhunter/backend/app/mappers/resume_mapper.py
+++ b/apps/myjobhunter/backend/app/mappers/resume_mapper.py
@@ -70,6 +70,7 @@ def map_work_history(
             title=title[:200],
             start_date=start_date,
             end_date=end_date,
+            is_current=is_current,
             bullets=bullets,
         ))
     return entries

--- a/apps/myjobhunter/backend/app/models/profile/work_history.py
+++ b/apps/myjobhunter/backend/app/models/profile/work_history.py
@@ -2,6 +2,7 @@ import uuid
 from datetime import date, datetime, timezone
 
 from sqlalchemy import (
+    Boolean,
     CheckConstraint,
     Date,
     DateTime,
@@ -38,6 +39,15 @@ class WorkHistory(Base):
     start_date: Mapped[date] = mapped_column(Date, nullable=False)
     end_date: Mapped[date | None] = mapped_column(Date, nullable=True)
 
+    # Authoritative "Present" flag. ``end_date IS NULL`` alone is NOT enough:
+    # a role can legitimately have an unknown end date without being current.
+    is_current: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        default=False,
+        server_default="false",
+    )
+
     bullets: Mapped[list[str]] = mapped_column(
         ARRAY(Text),
         default=list,
@@ -62,5 +72,9 @@ class WorkHistory(Base):
         CheckConstraint(
             "cardinality(bullets) <= 30",
             name="chk_work_history_bullets_max",
+        ),
+        CheckConstraint(
+            "NOT (is_current AND end_date IS NOT NULL)",
+            name="chk_work_history_current_no_end_date",
         ),
     )

--- a/apps/myjobhunter/backend/app/repositories/demo/demo_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/demo/demo_repository.py
@@ -218,6 +218,7 @@ async def create_work_history(
             title=seed["title"],
             start_date=seed["start_date"],
             end_date=seed["end_date"],
+            is_current=seed["is_current"],
             bullets=list(seed["bullets"]),
         )
         db.add(row)

--- a/apps/myjobhunter/backend/app/repositories/profile/work_history_repository.py
+++ b/apps/myjobhunter/backend/app/repositories/profile/work_history_repository.py
@@ -19,6 +19,7 @@ _UPDATABLE_COLUMNS: frozenset[str] = frozenset({
     "title",
     "start_date",
     "end_date",
+    "is_current",
     "bullets",
 })
 

--- a/apps/myjobhunter/backend/app/schemas/profile/work_history.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/work_history.py
@@ -12,6 +12,7 @@ class WorkHistoryRead(BaseModel):
     title: str
     start_date: date
     end_date: date | None
+    is_current: bool
     created_at: datetime
 
     model_config = {"from_attributes": True}

--- a/apps/myjobhunter/backend/app/schemas/profile/work_history_create_request.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/work_history_create_request.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from datetime import date
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 _BULLET_MAX_LEN = 2000
 _BULLETS_MAX_COUNT = 30
@@ -18,6 +18,13 @@ class WorkHistoryCreateRequest(BaseModel):
     title: str = Field(min_length=1, max_length=200)
     start_date: date
     end_date: date | None = None
+    is_current: bool = False
     bullets: list[BulletItem] = Field(default_factory=list, max_length=_BULLETS_MAX_COUNT)
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _current_role_has_no_end_date(self) -> "WorkHistoryCreateRequest":
+        if self.is_current and self.end_date is not None:
+            raise ValueError("A current role cannot have an end date.")
+        return self

--- a/apps/myjobhunter/backend/app/schemas/profile/work_history_response.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/work_history_response.py
@@ -15,6 +15,7 @@ class WorkHistoryResponse(BaseModel):
     title: str
     start_date: date
     end_date: date | None = None
+    is_current: bool
     bullets: list[str]
     created_at: datetime
     updated_at: datetime

--- a/apps/myjobhunter/backend/app/schemas/profile/work_history_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/work_history_update_request.py
@@ -18,6 +18,10 @@ class WorkHistoryUpdateRequest(BaseModel):
     title: str | None = Field(default=None, min_length=1, max_length=200)
     start_date: date | None = None
     end_date: date | None = None
+    # ``is_current`` + ``end_date`` must not both be set on the merged row;
+    # the service validates against the existing entry (partial updates make
+    # a schema-level check impossible here).
+    is_current: bool | None = None
     bullets: list[BulletItem] | None = Field(default=None, max_length=_BULLETS_MAX_COUNT)
 
     model_config = ConfigDict(extra="forbid")

--- a/apps/myjobhunter/backend/app/schemas/profile/work_history_update_request.py
+++ b/apps/myjobhunter/backend/app/schemas/profile/work_history_update_request.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 from datetime import date
 from typing import Annotated
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 _BULLET_MAX_LEN = 2000
 _BULLETS_MAX_COUNT = 30
 
 # Annotated item type so each bullet is length-capped.
 BulletItem = Annotated[str, Field(min_length=1, max_length=_BULLET_MAX_LEN)]
+
+# Fields where None means "unset" in a partial update but the DB column is
+# NOT NULL — an explicit JSON null must be rejected (422), not forwarded to
+# the repository where it would blow up as an IntegrityError (500).
+_NON_NULLABLE_FIELDS = ("company_name", "title", "start_date", "is_current", "bullets")
 
 
 class WorkHistoryUpdateRequest(BaseModel):
@@ -25,6 +30,13 @@ class WorkHistoryUpdateRequest(BaseModel):
     bullets: list[BulletItem] | None = Field(default=None, max_length=_BULLETS_MAX_COUNT)
 
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _reject_explicit_null_on_non_nullable(self) -> "WorkHistoryUpdateRequest":
+        for field in _NON_NULLABLE_FIELDS:
+            if field in self.model_fields_set and getattr(self, field) is None:
+                raise ValueError(f"{field} cannot be null.")
+        return self
 
     def to_update_dict(self) -> dict[str, object]:
         return self.model_dump(exclude_unset=True)

--- a/apps/myjobhunter/backend/app/services/company/company_research_service.py
+++ b/apps/myjobhunter/backend/app/services/company/company_research_service.py
@@ -125,7 +125,12 @@ async def _build_user_context(db: AsyncSession, user_id: uuid.UUID) -> str | Non
         parts.append("Recent roles:")
         bullets_used = 0
         for w in sorted_history:
-            end_label = w.end_date.isoformat() if w.end_date else "Present"
+            if w.is_current:
+                end_label = "Present"
+            elif w.end_date:
+                end_label = w.end_date.isoformat()
+            else:
+                end_label = "end date unknown"
             parts.append(
                 f"- {w.title} at {w.company_name} "
                 f"({w.start_date.isoformat()} → {end_label})"

--- a/apps/myjobhunter/backend/app/services/demo/demo_constants.py
+++ b/apps/myjobhunter/backend/app/services/demo/demo_constants.py
@@ -116,6 +116,7 @@ class WorkHistorySeed(TypedDict):
     title: str
     start_date: date
     end_date: date | None
+    is_current: bool
     bullets: list[str]
 
 
@@ -125,6 +126,7 @@ DEMO_WORK_HISTORY: list[WorkHistorySeed] = [
         "title": "Senior Software Engineer",
         "start_date": date(2023, 3, 1),
         "end_date": None,
+        "is_current": True,
         "bullets": [
             "Led migration of monolithic billing service to event-driven microservices, cutting p99 latency by 40%.",
             "Mentored 3 junior engineers; designed onboarding curriculum now used team-wide.",
@@ -136,6 +138,7 @@ DEMO_WORK_HISTORY: list[WorkHistorySeed] = [
         "title": "Software Engineer II",
         "start_date": date(2020, 6, 1),
         "end_date": date(2023, 2, 28),
+        "is_current": False,
         "bullets": [
             "Built real-time data ingestion pipeline handling 50M events/day with Kafka + Flink.",
             "Owned the GraphQL gateway, reducing average payload size by 35% via persisted queries.",
@@ -147,6 +150,7 @@ DEMO_WORK_HISTORY: list[WorkHistorySeed] = [
         "title": "Software Engineer",
         "start_date": date(2018, 8, 1),
         "end_date": date(2020, 5, 31),
+        "is_current": False,
         "bullets": [
             "Wrote and maintained the core Rails monolith that powered the product's first $5M ARR.",
             "Improved test suite runtime from 25 minutes to 6 minutes via parallelization and DB seeding.",

--- a/apps/myjobhunter/backend/app/services/extraction/prompts/resume_prompt.py
+++ b/apps/myjobhunter/backend/app/services/extraction/prompts/resume_prompt.py
@@ -12,7 +12,7 @@ Output shape:
       "title": "string",
       "location": "string|null",
       "starts_on": "YYYY-MM-DD or YYYY-MM or null",
-      "ends_on": "YYYY-MM-DD or YYYY-MM or null (null = current)",
+      "ends_on": "YYYY-MM-DD or YYYY-MM or null",
       "is_current": true|false,
       "bullets": ["string", ...]
     }
@@ -55,7 +55,7 @@ Return exactly this JSON structure:
       "title": "string — job title",
       "location": "string or null — city/state/country if shown",
       "starts_on": "YYYY-MM-DD or YYYY-MM or null",
-      "ends_on": "YYYY-MM-DD or YYYY-MM or null — null means the role is current",
+      "ends_on": "YYYY-MM-DD or YYYY-MM or null",
       "is_current": true or false,
       "bullets": ["string — achievement or responsibility", ...]
     }
@@ -88,8 +88,10 @@ Return exactly this JSON structure:
 - Extract ALL skills mentioned anywhere in the resume (skills section, work bullets, etc.).
 - For ``starts_on`` / ``ends_on``: prefer ``YYYY-MM`` format. Use ``YYYY-MM-DD`` only \
 if the day is explicitly stated. Use ``null`` when no date is present.
-- ``is_current`` is ``true`` when the role has no end date OR uses words like \
-"Present", "Current", "Now", "–".
+- ``is_current`` is ``true`` ONLY when the resume explicitly marks the role as \
+ongoing — words like "Present", "Current", "Now", "Today", or an open-ended \
+range ("2022 –"). A role that merely OMITS its end date is NOT current: use \
+``is_current: false`` with ``ends_on: null`` (the end date is unknown, not ongoing).
 - ``ends_on`` is ``null`` for current roles (``is_current: true``).
 - For bullets: extract them verbatim from the resume. Do not paraphrase or truncate. \
 Cap at 30 bullets per role.

--- a/apps/myjobhunter/backend/app/services/job_analysis/profile_snapshot.py
+++ b/apps/myjobhunter/backend/app/services/job_analysis/profile_snapshot.py
@@ -151,6 +151,7 @@ def _work_to_dict(w: Any, *, compact: bool = False) -> dict:
         "title": w.title,
         "start_date": w.start_date.isoformat() if w.start_date else None,
         "end_date": w.end_date.isoformat() if w.end_date else None,
+        "is_current": bool(w.is_current),
     }
     if not compact:
         entry["bullets"] = list(w.bullets or [])[:_MAX_BULLETS_PER_ROLE]

--- a/apps/myjobhunter/backend/app/services/profile/profile_service.py
+++ b/apps/myjobhunter/backend/app/services/profile/profile_service.py
@@ -125,6 +125,14 @@ class InvalidScreeningKeyError(ValueError):
     """
 
 
+class CurrentRoleEndDateError(ValueError):
+    """Raised when a work-history update would leave a row both marked
+    current and carrying an end date (violates the DB check constraint).
+
+    Subclasses ``ValueError`` so the route maps it to HTTP 422.
+    """
+
+
 # ---------------------------------------------------------------------------
 # Profile CRUD
 # ---------------------------------------------------------------------------
@@ -192,6 +200,7 @@ async def create_work_history(
         title=request.title,
         start_date=request.start_date,
         end_date=request.end_date,
+        is_current=request.is_current,
         bullets=request.bullets,
     )
     entry = await work_history_repository.create(db, entry)
@@ -211,6 +220,17 @@ async def update_work_history(
         return None
     updates = request.to_update_dict()
     if updates:
+        # Partial update — validate the MERGED row, not just the patch:
+        # a patch that flips is_current on while the row still has an end
+        # date (or vice versa) must be rejected before it hits the DB
+        # check constraint.
+        merged_is_current = updates.get("is_current", entry.is_current)
+        merged_end_date = updates.get("end_date", entry.end_date)
+        if merged_is_current and merged_end_date is not None:
+            raise CurrentRoleEndDateError(
+                "A current role cannot have an end date. Clear the end date "
+                "or unset is_current in the same request."
+            )
         entry = await work_history_repository.update(db, entry, updates)
         await db.commit()
         await _refresh_profile_embedding_best_effort(db, user_id)

--- a/apps/myjobhunter/backend/app/services/resume_refinement/session_lifecycle_service.py
+++ b/apps/myjobhunter/backend/app/services/resume_refinement/session_lifecycle_service.py
@@ -271,25 +271,31 @@ def _build_renderer_input(
     - WorkHistory.company_name   → renderer["company"]
     - WorkHistory.start_date     → renderer["starts_on"] (ISO date string or "")
     - WorkHistory.end_date       → renderer["ends_on"]   (ISO date string or None)
+    - WorkHistory.is_current     → renderer["is_current"] (drives "Present")
     - Education.start_year       → renderer["starts_on"] (year as string or "")
     - Education.end_year         → renderer["ends_on"]   (year as string or "")
     - Education.gpa (float)      → renderer["gpa"]       (string representation)
 
-    ``headline`` is best-effort: we JSON-parse result_parsed_fields["raw"]
-    and pull .headline if present; otherwise it's omitted (None falls through
-    the ``if headline:`` guard in the renderer with no visible effect).
+    ``headline`` is best-effort: result_parsed_fields["raw"] holds the Claude
+    response as a dict (the worker stores it unserialized); legacy rows may
+    hold a JSON string instead, so both shapes are accepted. On any other
+    shape the headline is omitted (None falls through the ``if headline:``
+    guard in the renderer with no visible effect).
     """
-    # Best-effort headline from the raw Claude JSON blob.
+    # Best-effort headline from the raw Claude blob (dict, or legacy JSON string).
     headline: str | None = None
-    raw_str = (raw_parsed or {}).get("raw")
-    if raw_str:
+    raw_val = (raw_parsed or {}).get("raw")
+    raw_obj: Any = raw_val
+    if isinstance(raw_val, str) and raw_val:
         try:
-            raw_obj = json.loads(raw_str)
-            headline = raw_obj.get("headline") or None
-        except (json.JSONDecodeError, AttributeError, TypeError):
+            raw_obj = json.loads(raw_val)
+        except json.JSONDecodeError:
             logger.debug(
                 "result_parsed_fields['raw'] is not valid JSON — skipping headline."
             )
+            raw_obj = None
+    if isinstance(raw_obj, dict):
+        headline = raw_obj.get("headline") or None
 
     work_history_dicts = [
         {
@@ -298,7 +304,7 @@ def _build_renderer_input(
             "location": "",
             "starts_on": row.start_date.isoformat() if row.start_date else "",
             "ends_on": row.end_date.isoformat() if row.end_date else None,
-            "is_current": row.end_date is None,
+            "is_current": bool(row.is_current),
             "bullets": list(row.bullets or []),
         }
         for row in work_history_rows

--- a/apps/myjobhunter/backend/app/services/user/account_service.py
+++ b/apps/myjobhunter/backend/app/services/user/account_service.py
@@ -98,6 +98,7 @@ def _work_history_to_export_dict(item: WorkHistory) -> dict:
         "title": item.title,
         "start_date": item.start_date.isoformat() if item.start_date else None,
         "end_date": item.end_date.isoformat() if item.end_date else None,
+        "is_current": bool(item.is_current),
         "bullets": list(item.bullets or []),
         "created_at": item.created_at.isoformat() if item.created_at else None,
     }

--- a/apps/myjobhunter/backend/tests/test_job_analysis_profile_snapshot.py
+++ b/apps/myjobhunter/backend/tests/test_job_analysis_profile_snapshot.py
@@ -45,6 +45,7 @@ def _work_row(title: str, start: date, *, bullets: list[str] | None = None):
         title=title,
         start_date=start,
         end_date=None,
+        is_current=False,
         bullets=bullets if bullets is not None else ["did a thing"],
     )
 

--- a/apps/myjobhunter/backend/tests/test_profile_writes.py
+++ b/apps/myjobhunter/backend/tests/test_profile_writes.py
@@ -336,6 +336,23 @@ class TestWorkHistory:
         assert resp.status_code == 422, resp.text
 
     @pytest.mark.asyncio
+    async def test_patch_explicit_null_on_non_nullable_field_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        """Explicit JSON null on a NOT NULL column must be a clean 422,
+        not an IntegrityError 500 at the repository layer."""
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            create = await authed.post("/work-history", json=_work_history_payload())
+            assert create.status_code == 201
+            entry_id = create.json()["id"]
+            resp = await authed.patch(
+                f"/work-history/{entry_id}",
+                json={"is_current": None},
+            )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
     async def test_patch_end_date_and_not_current_together_succeeds(
         self, user_factory, as_user,
     ) -> None:

--- a/apps/myjobhunter/backend/tests/test_profile_writes.py
+++ b/apps/myjobhunter/backend/tests/test_profile_writes.py
@@ -15,6 +15,8 @@ Covers:
   - PATCH /work-history/{id} returns 404 for cross-tenant access
   - DELETE /work-history/{id} hard-deletes and returns 204
   - DELETE /work-history/{id} returns 404 for cross-tenant access
+  - is_current: create defaults false / persists true / 422 when paired
+    with an end date (create AND merged-row patch, both directions)
 
   Education:
   - POST /education happy path returns 201
@@ -245,6 +247,114 @@ class TestWorkHistory:
                 f"/work-history/{entry_id}", json={"title": "Stolen"}
             )
         assert resp.status_code == 404, resp.text
+
+    @pytest.mark.asyncio
+    async def test_create_defaults_is_current_false(self, user_factory, as_user) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.post("/work-history", json=_work_history_payload())
+        assert resp.status_code == 201, resp.text
+        assert resp.json()["is_current"] is False
+
+    @pytest.mark.asyncio
+    async def test_create_current_role_persists_flag(self, user_factory, as_user) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/work-history",
+                json=_work_history_payload(is_current=True, end_date=None),
+            )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["is_current"] is True
+        assert body["end_date"] is None
+
+    @pytest.mark.asyncio
+    async def test_create_current_role_with_end_date_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            resp = await authed.post(
+                "/work-history",
+                json=_work_history_payload(is_current=True, end_date="2022-12-31"),
+            )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_patch_is_current_true_with_null_end_date(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            create = await authed.post("/work-history", json=_work_history_payload())
+            assert create.status_code == 201
+            entry_id = create.json()["id"]
+            resp = await authed.patch(
+                f"/work-history/{entry_id}",
+                json={"is_current": True, "end_date": None},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["is_current"] is True
+        assert body["end_date"] is None
+
+    @pytest.mark.asyncio
+    async def test_patch_is_current_true_keeping_end_date_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        """The merged row is validated, not just the patch: flipping
+        is_current on while the stored row still has an end date is
+        contradictory and must be rejected."""
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            create = await authed.post("/work-history", json=_work_history_payload())
+            assert create.status_code == 201
+            entry_id = create.json()["id"]
+            resp = await authed.patch(
+                f"/work-history/{entry_id}",
+                json={"is_current": True},
+            )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_patch_end_date_onto_current_role_returns_422(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            create = await authed.post(
+                "/work-history",
+                json=_work_history_payload(is_current=True, end_date=None),
+            )
+            assert create.status_code == 201
+            entry_id = create.json()["id"]
+            resp = await authed.patch(
+                f"/work-history/{entry_id}",
+                json={"end_date": "2025-06-30"},
+            )
+        assert resp.status_code == 422, resp.text
+
+    @pytest.mark.asyncio
+    async def test_patch_end_date_and_not_current_together_succeeds(
+        self, user_factory, as_user,
+    ) -> None:
+        user = await user_factory()
+        async with await as_user(user) as authed:
+            create = await authed.post(
+                "/work-history",
+                json=_work_history_payload(is_current=True, end_date=None),
+            )
+            assert create.status_code == 201
+            entry_id = create.json()["id"]
+            resp = await authed.patch(
+                f"/work-history/{entry_id}",
+                json={"is_current": False, "end_date": "2025-06-30"},
+            )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["is_current"] is False
+        assert body["end_date"] == "2025-06-30"
 
     @pytest.mark.asyncio
     async def test_delete_happy_path_returns_204(self, user_factory, as_user) -> None:

--- a/apps/myjobhunter/backend/tests/test_resume_mapper.py
+++ b/apps/myjobhunter/backend/tests/test_resume_mapper.py
@@ -1,0 +1,71 @@
+"""Pure tests for app.mappers.resume_mapper.map_work_history.
+
+The mapper takes Claude's parsed resume JSON and returns WorkHistory model
+instances — no DB, no mocks needed. The is_current cases are the regression
+suite for the bug where Claude's flag was read (to decide whether to parse
+``ends_on``) but never persisted, so every role's "Present" rendering fell
+back to the lossy ``end_date IS NULL`` derivation.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+from app.mappers.resume_mapper import map_work_history
+
+_USER_ID = uuid.uuid4()
+_PROFILE_ID = uuid.uuid4()
+
+
+def _entry(**overrides) -> dict:
+    item = {
+        "company": "Acme Corp",
+        "title": "Senior Engineer",
+        "starts_on": "2020-01",
+        "ends_on": "2022-12",
+        "is_current": False,
+        "bullets": ["Did things"],
+    }
+    item.update(overrides)
+    return item
+
+
+def _map_one(**overrides):
+    rows = map_work_history([_entry(**overrides)], _USER_ID, _PROFILE_ID)
+    assert len(rows) == 1
+    return rows[0]
+
+
+def test_is_current_true_persists_on_model():
+    row = _map_one(is_current=True, ends_on=None)
+    assert row.is_current is True
+    assert row.end_date is None
+
+
+def test_is_current_true_ignores_ends_on():
+    """Claude occasionally emits both — the flag wins and the end date is
+    dropped, matching the DB constraint (current roles have no end date)."""
+    row = _map_one(is_current=True, ends_on="2023-05")
+    assert row.is_current is True
+    assert row.end_date is None
+
+
+def test_is_current_false_with_end_date_persists_both():
+    row = _map_one(is_current=False, ends_on="2022-12")
+    assert row.is_current is False
+    assert row.end_date == date(2022, 12, 1)
+
+
+def test_is_current_false_with_no_end_date_stays_not_current():
+    """The OneOncology case: unknown end date must NOT become "Present"."""
+    row = _map_one(is_current=False, ends_on=None)
+    assert row.is_current is False
+    assert row.end_date is None
+
+
+def test_missing_is_current_defaults_to_false():
+    item = _entry()
+    del item["is_current"]
+    rows = map_work_history([item], _USER_ID, _PROFILE_ID)
+    assert rows[0].is_current is False
+    assert rows[0].end_date == date(2022, 12, 1)

--- a/apps/myjobhunter/backend/tests/test_resume_refinement_renderer.py
+++ b/apps/myjobhunter/backend/tests/test_resume_refinement_renderer.py
@@ -34,6 +34,7 @@ def _work_history(
     title: str = "Engineer",
     start_date: date = date(2020, 1, 1),
     end_date: date | None = None,
+    is_current: bool = False,
     bullets: list[str] | None = None,
 ) -> MagicMock:
     row = MagicMock()
@@ -41,6 +42,7 @@ def _work_history(
     row.title = title
     row.start_date = start_date
     row.end_date = end_date
+    row.is_current = is_current
     row.bullets = bullets or []
     return row
 
@@ -88,6 +90,7 @@ def test_adapter_produces_correct_shape_all_sources_populated():
         title="Staff Engineer",
         start_date=date(2020, 3, 1),
         end_date=None,
+        is_current=True,
         bullets=["Led platform migration", "Reduced latency by 40%"],
     )
     edu = _education(
@@ -264,6 +267,40 @@ def test_adapter_work_history_with_end_date_marks_not_current():
     assert wh_dict["is_current"] is False
 
 
+def test_adapter_null_end_date_without_is_current_is_not_present():
+    """A missing end date must NOT imply "Present" — is_current is the
+    authoritative flag (the OneOncology wrong-tenure bug)."""
+    wh = _work_history(start_date=date(2022, 11, 1), end_date=None, is_current=False)
+    result = _build_renderer_input(
+        profile=None,
+        work_history_rows=[wh],
+        education_rows=[],
+        skill_rows=[],
+        raw_parsed=None,
+    )
+    wh_dict = result["work_history"][0]
+    assert wh_dict["ends_on"] is None
+    assert wh_dict["is_current"] is False
+
+    md = render_resume_to_markdown(result)
+    assert "Present" not in md
+
+
+def test_adapter_headline_read_from_dict_raw():
+    """The worker stores result_parsed_fields["raw"] as a dict, not a JSON
+    string. json.loads(dict) raised TypeError and the headline silently
+    never rendered — the adapter must accept the dict shape directly."""
+    raw_parsed = {"raw": {"headline": "Staff Engineer at Acme"}}
+    result = _build_renderer_input(
+        profile=None,
+        work_history_rows=[],
+        education_rows=[],
+        skill_rows=[],
+        raw_parsed=raw_parsed,
+    )
+    assert result["headline"] == "Staff Engineer at Acme"
+
+
 # ---------------------------------------------------------------------------
 # Integration-ish: start_session with all external calls mocked
 # ---------------------------------------------------------------------------
@@ -295,6 +332,7 @@ async def test_start_session_draft_contains_company_and_skill_names():
         title="Senior SWE",
         start_date=date(2021, 4, 1),
         end_date=None,
+        is_current=True,
         bullets=["Shipped the main product", "Mentored junior devs"],
     )
 

--- a/apps/myjobhunter/frontend/e2e/profile.spec.ts
+++ b/apps/myjobhunter/frontend/e2e/profile.spec.ts
@@ -8,6 +8,8 @@ import { createTestUser, deleteTestUser, loginViaUI } from "./fixtures/auth";
  *   1. Profile page loads with all 7 sections visible
  *   2. Add work history entry via dialog → appears in the list
  *   3. Edit work history entry via dialog → changes are reflected
+ *   3b. Current-role checkbox clears + disables end date, entry renders
+ *       "Present", and edit mode re-opens with the box pre-checked
  *   4. Add skill via inline form → chip appears
  *   5. Add screening answer → appears in correct group
  *   6. Tenant isolation — user B cannot see user A's data
@@ -113,6 +115,53 @@ test.describe("Work history CRUD", () => {
 
       // Updated title appears
       await expect(page.getByText("Senior Engineer")).toBeVisible({ timeout: 5_000 });
+    } finally {
+      await deleteTestUser(request, user);
+    }
+  });
+
+  test("current-role checkbox disables end date and renders Present", async ({
+    page,
+    request,
+  }) => {
+    const user = await createTestUser(request);
+
+    try {
+      await loginViaUI(page, user, request);
+      await navigateToProfile(page);
+
+      await page.getByLabel("Add work history").click();
+      await expect(
+        page.getByRole("dialog", { name: /add work history/i }),
+      ).toBeVisible();
+
+      await page.getByLabel(/^company/i).fill("CurrentCo");
+      await page.getByLabel(/^title/i).fill("Staff Engineer");
+      await page.getByLabel(/^start date/i).fill("2023-03-01");
+
+      // Type an end date, then check the current-role box — the field
+      // must be cleared and disabled so a contradictory state can't be sent.
+      const endDate = page.getByLabel(/^end date/i);
+      await endDate.fill("2024-06-30");
+      await page.getByLabel(/i currently work in this role/i).check();
+      await expect(endDate).toBeDisabled();
+      await expect(endDate).toHaveValue("");
+
+      await page.getByRole("button", { name: /add work history/i }).click();
+
+      // Entry appears with a Present tenure (is_current drives the label)
+      await expect(page.getByText("CurrentCo")).toBeVisible({ timeout: 5_000 });
+      await expect(page.getByText(/– Present/)).toBeVisible();
+
+      // Edit mode re-opens with the box pre-checked and end date disabled
+      await page.getByRole("button", { name: /edit currentco/i }).click();
+      await expect(
+        page.getByRole("dialog", { name: /edit work history/i }),
+      ).toBeVisible();
+      await expect(
+        page.getByLabel(/i currently work in this role/i),
+      ).toBeChecked();
+      await expect(page.getByLabel(/^end date/i)).toBeDisabled();
     } finally {
       await deleteTestUser(request, user);
     }

--- a/apps/myjobhunter/frontend/src/features/profile/WorkHistoryDialog.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/WorkHistoryDialog.tsx
@@ -14,6 +14,7 @@ interface FormValues {
   title: string;
   start_date: string;
   end_date: string;
+  is_current: boolean;
   bullets: string;
 }
 
@@ -46,15 +47,20 @@ export default function WorkHistoryDialog({ open, onOpenChange, existing }: Work
     handleSubmit,
     formState: { errors },
     reset,
+    setValue,
+    watch,
   } = useForm<FormValues>({
     defaultValues: {
       company_name: "",
       title: "",
       start_date: "",
       end_date: "",
+      is_current: false,
       bullets: "",
     },
   });
+
+  const isCurrent = watch("is_current");
 
   useEffect(() => {
     if (open) {
@@ -63,6 +69,7 @@ export default function WorkHistoryDialog({ open, onOpenChange, existing }: Work
         title: existing?.title ?? "",
         start_date: existing?.start_date ?? "",
         end_date: existing?.end_date ?? "",
+        is_current: existing?.is_current ?? false,
         bullets: existing ? bulletsToText(existing.bullets) : "",
       });
     }
@@ -70,6 +77,9 @@ export default function WorkHistoryDialog({ open, onOpenChange, existing }: Work
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     const bullets = textToBullets(values.bullets);
+    // The backend rejects a current role that carries an end date; the
+    // checkbox clears + disables the field, so this only guards races.
+    const endDate = values.is_current ? null : values.end_date.trim() || null;
     try {
       if (isEdit && existing) {
         await updateWorkHistory({
@@ -78,7 +88,8 @@ export default function WorkHistoryDialog({ open, onOpenChange, existing }: Work
             company_name: values.company_name.trim(),
             title: values.title.trim(),
             start_date: values.start_date || null,
-            end_date: values.end_date.trim() || null,
+            end_date: endDate,
+            is_current: values.is_current,
             bullets,
           },
         }).unwrap();
@@ -88,7 +99,8 @@ export default function WorkHistoryDialog({ open, onOpenChange, existing }: Work
           company_name: values.company_name.trim(),
           title: values.title.trim(),
           start_date: values.start_date,
-          end_date: values.end_date.trim() || null,
+          end_date: endDate,
+          is_current: values.is_current,
           bullets,
         }).unwrap();
         showSuccess("Work history added");
@@ -174,11 +186,29 @@ export default function WorkHistoryDialog({ open, onOpenChange, existing }: Work
                 <input
                   id="wh-end-date"
                   type="date"
+                  disabled={isCurrent}
                   {...register("end_date")}
-                  className="w-full border rounded-md px-3 py-2 text-sm bg-background"
+                  className="w-full border rounded-md px-3 py-2 text-sm bg-background disabled:opacity-50 disabled:cursor-not-allowed"
                 />
-                <p className="text-xs text-muted-foreground mt-1">Leave blank if current role</p>
               </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <input
+                id="wh-is-current"
+                type="checkbox"
+                {...register("is_current", {
+                  onChange: (e) => {
+                    if (e.target.checked) {
+                      setValue("end_date", "");
+                    }
+                  },
+                })}
+                className="h-4 w-4 rounded border"
+              />
+              <label htmlFor="wh-is-current" className="text-sm">
+                I currently work in this role
+              </label>
             </div>
 
             <div>

--- a/apps/myjobhunter/frontend/src/features/profile/__tests__/WorkHistoryDialog.test.tsx
+++ b/apps/myjobhunter/frontend/src/features/profile/__tests__/WorkHistoryDialog.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Unit tests for WorkHistoryDialog — the is_current checkbox logic.
+ *
+ * Covers:
+ *   - checking "I currently work in this role" disables and clears the end date
+ *   - submit sends is_current: true with a null end_date
+ *   - edit mode pre-checks the checkbox for a current entry
+ *   - submit for a past role sends is_current: false with the typed end_date
+ *
+ * Testing pattern mirrors Profile.test.tsx for the RTK Query and
+ * @platform/ui mock wiring.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { WorkHistory } from "@/types/work-history/work-history";
+
+vi.mock("@/lib/workHistoryApi", () => ({
+  useCreateWorkHistoryMutation: vi.fn(),
+  useUpdateWorkHistoryMutation: vi.fn(),
+}));
+
+// Mock @platform/ui completely — avoids importing React 19 code from
+// packages/shared-frontend into a React 18 test environment (two-copies crash).
+vi.mock("@platform/ui", () => ({
+  showSuccess: vi.fn(),
+  showError: vi.fn(),
+  extractErrorMessage: (err: unknown) => String(err),
+  LoadingButton: ({
+    children,
+    isLoading,
+    loadingText,
+    type,
+  }: {
+    children: React.ReactNode;
+    isLoading?: boolean;
+    loadingText?: string;
+    type?: "button" | "submit" | "reset";
+  }) => <button type={type}>{isLoading ? loadingText : children}</button>,
+}));
+
+import WorkHistoryDialog from "@/features/profile/WorkHistoryDialog";
+import {
+  useCreateWorkHistoryMutation,
+  useUpdateWorkHistoryMutation,
+} from "@/lib/workHistoryApi";
+
+const mockUseCreate = vi.mocked(useCreateWorkHistoryMutation);
+const mockUseUpdate = vi.mocked(useUpdateWorkHistoryMutation);
+
+const createTrigger = vi.fn();
+const updateTrigger = vi.fn();
+
+function setupMutationMocks() {
+  createTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({}) });
+  updateTrigger.mockReset().mockReturnValue({ unwrap: () => Promise.resolve({}) });
+  mockUseCreate.mockReturnValue([
+    createTrigger,
+    { isLoading: false },
+  ] as unknown as ReturnType<typeof useCreateWorkHistoryMutation>);
+  mockUseUpdate.mockReturnValue([
+    updateTrigger,
+    { isLoading: false },
+  ] as unknown as ReturnType<typeof useUpdateWorkHistoryMutation>);
+}
+
+function renderDialog(existing?: WorkHistory) {
+  return render(
+    <WorkHistoryDialog open={true} onOpenChange={() => {}} existing={existing} />,
+  );
+}
+
+const existingCurrentEntry: WorkHistory = {
+  id: "wh1",
+  user_id: "u1",
+  profile_id: "p1",
+  company_name: "CurrentCo",
+  title: "Engineer",
+  start_date: "2022-11-01",
+  end_date: null,
+  is_current: true,
+  bullets: ["Did things"],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+describe("WorkHistoryDialog — is_current", () => {
+  beforeEach(() => {
+    setupMutationMocks();
+  });
+
+  it("checking the current-role box disables and clears the end date", async () => {
+    renderDialog();
+    const endDate = screen.getByLabelText("End date") as HTMLInputElement;
+    fireEvent.change(endDate, { target: { value: "2024-05-01" } });
+    expect(endDate.value).toBe("2024-05-01");
+
+    await userEvent.click(screen.getByLabelText("I currently work in this role"));
+
+    expect(endDate).toBeDisabled();
+    expect(endDate.value).toBe("");
+  });
+
+  it("submit sends is_current true with a null end_date", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/Company/), { target: { value: "Acme" } });
+    fireEvent.change(screen.getByLabelText(/Title/), { target: { value: "SWE" } });
+    fireEvent.change(screen.getByLabelText(/Start date/), {
+      target: { value: "2023-03-01" },
+    });
+    await userEvent.click(screen.getByLabelText("I currently work in this role"));
+
+    await userEvent.click(screen.getByRole("button", { name: "Add work history" }));
+
+    await waitFor(() => expect(createTrigger).toHaveBeenCalledTimes(1));
+    expect(createTrigger).toHaveBeenCalledWith({
+      company_name: "Acme",
+      title: "SWE",
+      start_date: "2023-03-01",
+      end_date: null,
+      is_current: true,
+      bullets: [],
+    });
+  });
+
+  it("edit mode pre-checks the box for a current entry", () => {
+    renderDialog(existingCurrentEntry);
+    const checkbox = screen.getByLabelText(
+      "I currently work in this role",
+    ) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+    expect(screen.getByLabelText("End date")).toBeDisabled();
+  });
+
+  it("submit for a past role sends is_current false with the end date", async () => {
+    renderDialog();
+    fireEvent.change(screen.getByLabelText(/Company/), { target: { value: "OldCo" } });
+    fireEvent.change(screen.getByLabelText(/Title/), { target: { value: "Dev" } });
+    fireEvent.change(screen.getByLabelText(/Start date/), {
+      target: { value: "2019-01-01" },
+    });
+    fireEvent.change(screen.getByLabelText("End date"), {
+      target: { value: "2021-06-30" },
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: "Add work history" }));
+
+    await waitFor(() => expect(createTrigger).toHaveBeenCalledTimes(1));
+    expect(createTrigger).toHaveBeenCalledWith({
+      company_name: "OldCo",
+      title: "Dev",
+      start_date: "2019-01-01",
+      end_date: "2021-06-30",
+      is_current: false,
+      bullets: [],
+    });
+  });
+});

--- a/apps/myjobhunter/frontend/src/features/profile/profile-format.ts
+++ b/apps/myjobhunter/frontend/src/features/profile/profile-format.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure display helpers for the Profile page.
+ * Extracted from pages/Profile.tsx (file-size no-growth policy).
+ */
+
+export const REMOTE_PREF_LABELS: Record<string, string> = {
+  remote_only: "Remote only",
+  hybrid: "Hybrid",
+  onsite: "On-site",
+  any: "Open to all",
+};
+
+export function formatDateRange(
+  start: string,
+  end: string | null,
+  isCurrent: boolean,
+): string {
+  const fmt = (d: string) => {
+    const [year, month] = d.split("-");
+    return new Date(parseInt(year), parseInt(month) - 1).toLocaleDateString("en-US", {
+      year: "numeric",
+      month: "short",
+    });
+  };
+  if (isCurrent) {
+    return `${fmt(start)} – Present`;
+  }
+  return end ? `${fmt(start)} – ${fmt(end)}` : `${fmt(start)} – No end date`;
+}

--- a/apps/myjobhunter/frontend/src/pages/Profile.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Profile.tsx
@@ -43,7 +43,7 @@ const REMOTE_PREF_LABELS: Record<string, string> = {
   any: "Open to all",
 };
 
-function formatDateRange(start: string, end: string | null): string {
+function formatDateRange(start: string, end: string | null, isCurrent: boolean): string {
   const fmt = (d: string) => {
     const [year, month] = d.split("-");
     return new Date(parseInt(year), parseInt(month) - 1).toLocaleDateString("en-US", {
@@ -51,7 +51,10 @@ function formatDateRange(start: string, end: string | null): string {
       month: "short",
     });
   };
-  return end ? `${fmt(start)} – ${fmt(end)}` : `${fmt(start)} – Present`;
+  if (isCurrent) {
+    return `${fmt(start)} – Present`;
+  }
+  return end ? `${fmt(start)} – ${fmt(end)}` : `${fmt(start)} – No end date`;
 }
 
 // ---------------------------------------------------------------------------
@@ -293,7 +296,7 @@ export default function Profile() {
                   <p className="font-medium text-sm">{entry.title}</p>
                   <p className="text-sm text-muted-foreground">{entry.company_name}</p>
                   <p className="text-xs text-muted-foreground">
-                    {formatDateRange(entry.start_date, entry.end_date)}
+                    {formatDateRange(entry.start_date, entry.end_date, entry.is_current)}
                   </p>
                   {entry.bullets.length > 0 ? (
                     <ul className="mt-2 space-y-1 list-disc list-inside">

--- a/apps/myjobhunter/frontend/src/pages/Profile.tsx
+++ b/apps/myjobhunter/frontend/src/pages/Profile.tsx
@@ -20,6 +20,7 @@ import ScreeningAnswerDialog from "@/features/profile/ScreeningAnswerDialog";
 import ResumeUploadSection from "@/features/profile/ResumeUploadSection";
 import SkillAddForm from "@/features/profile/SkillAddForm";
 import ScreeningAnswerRow from "@/features/profile/ScreeningAnswerRow";
+import { REMOTE_PREF_LABELS, formatDateRange } from "@/features/profile/profile-format";
 import { useGetProfileQuery, useUpdateProfileMutation } from "@/lib/profileApi";
 import { useListWorkHistoryQuery, useDeleteWorkHistoryMutation } from "@/lib/workHistoryApi";
 import { useListEducationQuery, useDeleteEducationMutation } from "@/lib/educationApi";
@@ -31,31 +32,6 @@ import {
 import type { WorkHistory } from "@/types/work-history/work-history";
 import type { Education } from "@/types/education/education";
 import type { ScreeningAnswer } from "@/types/screening-answer/screening-answer";
-
-// ---------------------------------------------------------------------------
-// Display helpers
-// ---------------------------------------------------------------------------
-
-const REMOTE_PREF_LABELS: Record<string, string> = {
-  remote_only: "Remote only",
-  hybrid: "Hybrid",
-  onsite: "On-site",
-  any: "Open to all",
-};
-
-function formatDateRange(start: string, end: string | null, isCurrent: boolean): string {
-  const fmt = (d: string) => {
-    const [year, month] = d.split("-");
-    return new Date(parseInt(year), parseInt(month) - 1).toLocaleDateString("en-US", {
-      year: "numeric",
-      month: "short",
-    });
-  };
-  if (isCurrent) {
-    return `${fmt(start)} – Present`;
-  }
-  return end ? `${fmt(start)} – ${fmt(end)}` : `${fmt(start)} – No end date`;
-}
 
 // ---------------------------------------------------------------------------
 // Main Profile page

--- a/apps/myjobhunter/frontend/src/pages/__tests__/Profile.test.tsx
+++ b/apps/myjobhunter/frontend/src/pages/__tests__/Profile.test.tsx
@@ -357,6 +357,7 @@ describe("Profile page", () => {
               title: "Senior Engineer",
               start_date: "2020-01-01",
               end_date: "2022-12-31",
+              is_current: false,
               bullets: ["Led rewrite"],
               created_at: "2026-01-01T00:00:00Z",
               updated_at: "2026-01-01T00:00:00Z",
@@ -371,6 +372,33 @@ describe("Profile page", () => {
       expect(screen.getByText("Acme Corp")).toBeInTheDocument();
       expect(screen.getByText("Senior Engineer")).toBeInTheDocument();
       expect(screen.getByText("Led rewrite")).toBeInTheDocument();
+    });
+
+    it("shows Present only when is_current is set — not for a missing end date", () => {
+      setupAllMocks();
+      const base = {
+        user_id: "u1",
+        profile_id: "p1",
+        title: "Engineer",
+        start_date: "2020-01-01",
+        bullets: [],
+        created_at: "2026-01-01T00:00:00Z",
+        updated_at: "2026-01-01T00:00:00Z",
+      };
+      mockListWorkHistory.mockReturnValue({
+        data: {
+          items: [
+            { ...base, id: "wh-current", company_name: "CurrentCo", end_date: null, is_current: true },
+            { ...base, id: "wh-unknown", company_name: "UnknownCo", end_date: null, is_current: false },
+          ],
+          total: 2,
+        },
+        isLoading: false,
+      } as unknown as ReturnType<typeof useListWorkHistoryQuery>);
+
+      renderProfile();
+      expect(screen.getByText(/– Present/)).toBeInTheDocument();
+      expect(screen.getByText(/– No end date/)).toBeInTheDocument();
     });
   });
 

--- a/apps/myjobhunter/frontend/src/types/work-history/work-history-create-request.ts
+++ b/apps/myjobhunter/frontend/src/types/work-history/work-history-create-request.ts
@@ -3,5 +3,6 @@ export interface WorkHistoryCreateRequest {
   title: string;
   start_date: string;
   end_date: string | null;
+  is_current: boolean;
   bullets: string[];
 }

--- a/apps/myjobhunter/frontend/src/types/work-history/work-history-update-request.ts
+++ b/apps/myjobhunter/frontend/src/types/work-history/work-history-update-request.ts
@@ -3,5 +3,6 @@ export interface WorkHistoryUpdateRequest {
   title?: string | null;
   start_date?: string | null;
   end_date?: string | null;
+  is_current?: boolean | null;
   bullets?: string[] | null;
 }

--- a/apps/myjobhunter/frontend/src/types/work-history/work-history.ts
+++ b/apps/myjobhunter/frontend/src/types/work-history/work-history.ts
@@ -10,6 +10,7 @@ export interface WorkHistory {
   title: string;
   start_date: string;
   end_date: string | null;
+  is_current: boolean;
   bullets: string[];
   created_at: string;
   updated_at: string;


### PR DESCRIPTION
## What

PR 4b of the /resume walkthrough fix-all (follows #960/#963/#964/#965).

**Bug 1 — wrong "Present" tenure (operator's OneOncology row).** "Present" was derived from `end_date IS NULL` in every renderer, conflating "role is ongoing" with "end date unknown". Claude's resume extraction returns an `is_current` flag per role, but `resume_mapper` only used it to gate `ends_on` parsing and then discarded it — there was no column to store it.

**Bug 2 — headline never rendered (latent TypeError).** `_build_renderer_input` ran `json.loads(result_parsed_fields["raw"])`, but the worker stores `"raw"` as a **dict**; the resulting `TypeError` was swallowed by the except clause, so the resume headline silently never appeared in refinement drafts.

## How

- **`work_history.is_current` column** (migration `iscur260702`): `NOT NULL DEFAULT false`, backfill `end_date IS NULL → true` (existing rows keep rendering exactly as before; users correct genuinely-wrong rows in the Profile UI), check constraint `NOT (is_current AND end_date IS NOT NULL)`.
- **Mapper persists the flag**; when Claude emits both `is_current: true` and an `ends_on`, the flag wins and the end date is dropped (matches the constraint).
- **Every "Present" consumer now reads the flag**: refinement draft adapter, Profile page (`– Present` vs `– No end date`), company-research prompt, job-analysis snapshot, data export, demo seeds.
- **Extraction prompt tightened** (pre-commit review finding): `is_current=true` now requires an explicit ongoing signal — a merely-omitted end date maps to `is_current: false` + `ends_on: null`, killing the conflation at the source.
- **Cross-stack in the same PR**: create/update/response schemas, TS types, and `WorkHistoryDialog` gains an "I currently work in this role" checkbox that clears + disables the end-date field. Create schema 422s on current+end-date; PATCH validates the **merged** row in the service (`CurrentRoleEndDateError` → 422); explicit JSON null on a NOT NULL column is a clean 422 instead of an IntegrityError 500.
- **Headline fix**: accept dict (current worker shape) and legacy JSON-string `raw`, with a regression test.

## Tests

- New pure `tests/test_resume_mapper.py` (added to the `refinement` CI shard) — flag persistence incl. the OneOncology case.
- Renderer adapter: null-end-date-not-current stays non-Present; dict-raw headline regression.
- `test_profile_writes.py`: is_current create/patch matrix (both 422 directions + explicit-null 422).
- Frontend: `WorkHistoryDialog.test.tsx` (checkbox disable/clear + payload shape), Profile Present-vs-No-end-date rendering, and E2E coverage in `profile.spec.ts` (checkbox clears/disables end date, entry renders Present, edit re-opens pre-checked). Typecheck + build green; pure backend suites 112 passed locally (DB-bound suites are CI-gated — local PG lacks pgvector).

## Operational notes

No operational migration needed: the column is additive with a server default and the backfill preserves pre-migration rendering. Existing "unknown end date" rows stay flagged current until the user edits them — the honest state requires user input, so no data-loss-risk backfill heuristic was attempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YHo57XAZpGMGwtvp8w1fQY